### PR TITLE
Send traceback objects rather than lists of strings

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,6 +1,6 @@
 from distributed.utils import (All, sync, is_kernel, ensure_ip,
-        truncate_exception)
-from distributed.utils_test import loop, inc, throws
+        truncate_exception, get_traceback)
+from distributed.utils_test import loop, inc, throws, div
 import pytest
 from threading import Thread
 import threading
@@ -111,3 +111,18 @@ def test_truncate_exception():
 
     e = ValueError('a')
     assert truncate_exception(e) is e
+
+
+def test_get_traceback():
+    def a(x):
+        return div(x, 0)
+    def b(x):
+        return a(x)
+    def c(x):
+        return b(x)
+
+    try:
+        c(x)
+    except Exception as e:
+        tb = get_traceback()
+        assert type(tb).__name__ == 'traceback'

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -234,6 +234,7 @@ def get_traceback():
     exc_type, exc_value, exc_traceback = sys.exc_info()
     bad = [os.path.join('distributed', 'worker'),
            os.path.join('distributed', 'scheduler'),
+           os.path.join('tornado', 'gen.py'),
            os.path.join('concurrent', 'futures')]
     while any(b in exc_traceback.tb_frame.f_code.co_filename for b in bad):
         exc_traceback = exc_traceback.tb_next

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -7,6 +7,7 @@ import os
 import re
 import socket
 import sys
+import tblib.pickling_support
 import tempfile
 import traceback
 
@@ -226,11 +227,17 @@ def ensure_ip(hostname):
         return socket.gethostbyname(hostname)
 
 
+tblib.pickling_support.install()
+
+
 def get_traceback():
     exc_type, exc_value, exc_traceback = sys.exc_info()
-    tb = traceback.format_tb(exc_traceback)
-    tb = [line[:10000] for line in tb]
-    return tb
+    bad = [os.path.join('distributed', 'worker'),
+           os.path.join('distributed', 'scheduler'),
+           os.path.join('concurrent', 'futures')]
+    while any(b in exc_traceback.tb_frame.f_code.co_filename for b in bad):
+        exc_traceback = exc_traceback.tb_next
+    return exc_traceback
 
 
 def truncate_exception(e, n=10000):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ dask
 click
 boto3
 locket
+six
+tblib


### PR DESCRIPTION
Fixes #109 

This uses the [tblib](https://github.com/ionelmc/python-tblib) library to send traceback objects from the worker to the client.  We add two new dependencies, `six` and `tblib`, but they're both pretty lightweight.  

Now `future.result()` on an erred future raises an error with a traceback from the worker and `future.traceback()` returns a proper traceback object, rather than a list of strings.  This object is actually a bit harder to inspect than the list of strings.  I'm not sure how to point the user to the `traceback` module  for this.