### PR TITLE
Allow KeyboardInterrupts through sync in Python 2

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -101,7 +101,8 @@ def sync(loop, func, *args, **kwargs):
             e.set()
 
     a = loop.add_callback(f)
-    e.wait()
+    while not e.is_set():
+        e.wait(1000000)
     if error[0]:
         raise result[0]
     else:


### PR DESCRIPTION
Threading.Event.wait won't break under a keyboard interrupt in Python 2
without a timeout: https://bugs.python.org/issue8844

Now we include a very long timeout and a while loop.

Fixes #99 

cc @danielfrg this turned out to be easier than expected :)