### PR TITLE
Update conda recipe for 0.8.0

### DIFF
--- a/conda-recipes/distributed/meta.yaml
+++ b/conda-recipes/distributed/meta.yaml
@@ -8,27 +8,32 @@ source:
 requirements:
   build:
     - python
-    - tornado
+    - tornado >=4.2
     - toolz
     - cloudpickle
     - dask
     - click
     - boto3
     - locket
+    - six
+    - tblib
 
   run:
     - python
-    - tornado
+    - tornado >=4.2
     - toolz
     - cloudpickle
     - dask
     - click
     - boto3
     - locket
+    - six
+    - tblib
 
 test:
   imports:
     - distributed
+    - distributed.cli
     - distributed.diagnostics
     - distributed.http
 


### PR DESCRIPTION
Distributed 0.8.0 conda packages are available for win-64, linux-64, and osx-64 for Python 2.7, 3.4, and 3.5:

```
conda install distributed -c dask
```