### PR TITLE
Don't delete recomputed data

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -943,7 +943,8 @@ class Scheduler(Server):
             self.deleted_keys.clear()
 
             coroutines = [self.rpc(ip=worker[0], port=worker[1]).delete_data(
-                                    keys=keys, report=False)
+                                   keys=keys - self.has_what[worker],
+                                   report=False)
                           for worker, keys in d.items()]
             for worker, keys in d.items():
                 logger.debug("Remove %d keys from worker %s", len(keys), worker)


### PR DESCRIPTION
This fixes a race condition where we would compute something, delete
it, recompute it on the same machine, and then finally the "delete data"
message would arrive late.  We fix this to keep a consistent set of
state on the scheduler.