### PR TITLE
Avoid deserialization in scheduler

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -294,7 +294,7 @@ def unpack_remotedata(o):
 
     Returns original collection and set of all found keys
 
-    >>> rd = RemoteData('mykey', '127.0.0.1', 8787)
+    >>> rd = WrappedKey('mykey')
     >>> unpack_remotedata(1)
     (1, set())
     >>> unpack_remotedata(())

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -25,8 +25,7 @@ def dumps(x):
     try:
         return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
     except Exception as e:
-        logger.info("Failed to serialize %s", x)
-        logger.exception(e)
+        logger.info("Failed to serialize %s", x, exc_info=True)
         raise
 
 
@@ -34,7 +33,7 @@ def loads(x):
     try:
         return cloudpickle.loads(x)
     except Exception as e:
-        logger.exception(e)
+        logger.info("Failed to deserialize %s", x, exc_info=True)
         raise
 
 

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -76,7 +76,7 @@ class Progress(SchedulerPlugin):
     def setup(self):
         keys = self.keys
 
-        while not keys.issubset(self.scheduler.dask):
+        while not keys.issubset(self.scheduler.tasks):
             yield gen.sleep(0.05)
 
         self.keys = None
@@ -177,7 +177,7 @@ class MultiProgress(Progress):
     def setup(self):
         keys = self.keys
 
-        while not keys.issubset(self.scheduler.dask):
+        while not keys.issubset(self.scheduler.tasks):
             yield gen.sleep(0.05)
 
         self.keys = None

--- a/distributed/diagnostics/tests/test_plugin.py
+++ b/distributed/diagnostics/tests/test_plugin.py
@@ -28,10 +28,11 @@ def test_diagnostic(loop):
 
         assert counter.count == 0
         sched.put_nowait({'op': 'update-graph',
-               'dsk': {'x': (inc, 1),
-                       'y': (inc, 'x'),
-                       'z': (inc, 'y')},
-               'keys': ['z']})
+                          'dsk': {'x': (inc, 1),
+                                  'y': (inc, 'x'),
+                                  'z': (inc, 'y')},
+                          'dependencies': {'y': {'x'}, 'z': {'y'}},
+                          'keys': ['z']})
 
         while True:
             msg = yield report.get()

--- a/distributed/diagnostics/tests/test_plugin.py
+++ b/distributed/diagnostics/tests/test_plugin.py
@@ -28,7 +28,7 @@ def test_diagnostic(loop):
 
         assert counter.count == 0
         sched.put_nowait({'op': 'update-graph',
-                          'dsk': {'x': (inc, 1),
+                          'tasks': {'x': (inc, 1),
                                   'y': (inc, 'x'),
                                   'z': (inc, 'y')},
                           'dependencies': {'y': {'x'}, 'z': {'y'}},

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -30,9 +30,9 @@ def test_dependent_keys():
 @gen_cluster()
 def test_many_Progresss(s, a, b):
     sched, report = Queue(), Queue(); s.handle_queues(sched, report)
-    s.update_graph(dsk={'x': (inc, 1),
-                        'y': (inc, 'x'),
-                        'z': (inc, 'y')},
+    s.update_graph(tasks={'x': (inc, 1),
+                          'y': (inc, 'x'),
+                          'z': (inc, 'y')},
                    keys=['z'],
                    dependencies={'y': {'x'}, 'z': {'y'}})
 
@@ -50,11 +50,11 @@ def test_many_Progresss(s, a, b):
 @gen_cluster()
 def test_multiprogress(s, a, b):
     sched, report = Queue(), Queue(); s.handle_queues(sched, report)
-    s.update_graph(dsk={'x-1': (inc, 1),
-                        'x-2': (inc, 'x-1'),
-                        'x-3': (inc, 'x-2'),
-                        'y-1': (dec, 'x-3'),
-                        'y-2': (dec, 'y-1')},
+    s.update_graph(tasks={'x-1': (inc, 1),
+                          'x-2': (inc, 'x-1'),
+                          'x-3': (inc, 'x-2'),
+                          'y-1': (dec, 'x-3'),
+                          'y-2': (dec, 'y-1')},
                    keys=['y-2'],
                    dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
                        {'x-3'}, 'y-2': {'y-1'}})
@@ -96,7 +96,7 @@ def test_robust_to_bad_plugin(s, a, b):
     s.add_plugin(bad)
 
     sched.put_nowait({'op': 'update-graph',
-                      'dsk': {'x': (inc, 1),
+                      'tasks': {'x': (inc, 1),
                               'y': (inc, 'x'),
                               'z': (inc, 'y')},
                       'dependencies': {'y': {'x'}, 'z': {'y'}},

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -33,7 +33,8 @@ def test_many_Progresss(s, a, b):
     s.update_graph(dsk={'x': (inc, 1),
                         'y': (inc, 'x'),
                         'z': (inc, 'y')},
-                   keys=['z'])
+                   keys=['z'],
+                   dependencies={'y': {'x'}, 'z': {'y'}})
 
     bars = [Progress(keys=['z'], scheduler=s) for i in range(10)]
     yield [b.setup() for b in bars]
@@ -54,7 +55,9 @@ def test_multiprogress(s, a, b):
                         'x-3': (inc, 'x-2'),
                         'y-1': (dec, 'x-3'),
                         'y-2': (dec, 'y-1')},
-                   keys=['y-2'])
+                   keys=['y-2'],
+                   dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
+                       {'x-3'}, 'y-2': {'y-1'}})
 
     p = MultiProgress(['y-2'], scheduler=s, func=lambda s: s.split('-')[0])
     yield p.setup()
@@ -96,6 +99,7 @@ def test_robust_to_bad_plugin(s, a, b):
                       'dsk': {'x': (inc, 1),
                               'y': (inc, 'x'),
                               'z': (inc, 'y')},
+                      'dependencies': {'y': {'x'}, 'z': {'y'}},
                       'keys': ['z']})
 
     while True:  # normal execution

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -36,7 +36,8 @@ def test_TextProgressBar_error(loop, capsys):
         done = s.start(0)
 
         s.update_graph(dsk={'x': (div, 1, 0)},
-                       keys=['x'])
+                       keys=['x'],
+                       dependencies={})
 
         progress = TextProgressBar(['x'], scheduler=(s.ip, s.port),
                                    start=False, interval=0.01)

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -35,7 +35,7 @@ def test_TextProgressBar_error(loop, capsys):
         yield s.sync_center()
         done = s.start(0)
 
-        s.update_graph(dsk={'x': (div, 1, 0)},
+        s.update_graph(tasks={'x': (div, 1, 0)},
                        keys=['x'],
                        dependencies={})
 

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -73,9 +73,9 @@ from distributed.diagnostics.progressbar import (ProgressWidget,
 
 @gen_cluster()
 def test_progressbar_widget(s, a, b):
-    s.update_graph(dsk={'x': (inc, 1),
-                        'y': (inc, 'x'),
-                        'z': (inc, 'y')},
+    s.update_graph(tasks={'x': (inc, 1),
+                          'y': (inc, 'x'),
+                          'z': (inc, 'y')},
                    keys=['z'],
                    dependencies={'y': {'x'}, 'z': {'y'}})
 
@@ -91,13 +91,13 @@ def test_progressbar_widget(s, a, b):
 
 @gen_cluster()
 def test_multi_progressbar_widget(s, a, b):
-    s.update_graph(dsk={'x-1': (inc, 1),
-                        'x-2': (inc, 'x-1'),
-                        'x-3': (inc, 'x-2'),
-                        'y-1': (dec, 'x-3'),
-                        'y-2': (dec, 'y-1'),
-                        'e': (throws, 'y-2'),
-                        'other': (inc, 123)},
+    s.update_graph(tasks={'x-1': (inc, 1),
+                          'x-2': (inc, 'x-1'),
+                          'x-3': (inc, 'x-2'),
+                          'y-1': (dec, 'x-3'),
+                          'y-2': (dec, 'y-1'),
+                          'e': (throws, 'y-2'),
+                          'other': (inc, 123)},
                    keys=['e'],
                    dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
                        {'x-3'}, 'y-2': {'y-1'}, 'e': {'y-2'}})
@@ -126,13 +126,13 @@ def test_multi_progressbar_widget(s, a, b):
 
 @gen_cluster()
 def test_multi_progressbar_widget_after_close(s, a, b):
-    s.update_graph(dsk={'x-1': (inc, 1),
-                        'x-2': (inc, 'x-1'),
-                        'x-3': (inc, 'x-2'),
-                        'y-1': (dec, 'x-3'),
-                        'y-2': (dec, 'y-1'),
-                        'e': (throws, 'y-2'),
-                        'other': (inc, 123)},
+    s.update_graph(tasks={'x-1': (inc, 1),
+                          'x-2': (inc, 'x-1'),
+                          'x-3': (inc, 'x-2'),
+                          'y-1': (dec, 'x-3'),
+                          'y-2': (dec, 'y-1'),
+                          'e': (throws, 'y-2'),
+                          'other': (inc, 123)},
                    keys=['e'],
                    dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
                        {'x-3'}, 'y-2': {'y-1'}, 'e': {'y-2'}})
@@ -185,13 +185,13 @@ def test_progressbar_done(loop):
 
 @gen_cluster()
 def test_multibar_complete(s, a, b):
-    s.update_graph(dsk={'x-1': (inc, 1),
-                        'x-2': (inc, 'x-1'),
-                        'x-3': (inc, 'x-2'),
-                        'y-1': (dec, 'x-3'),
-                        'y-2': (dec, 'y-1'),
-                        'e': (throws, 'y-2'),
-                        'other': (inc, 123)},
+    s.update_graph(tasks={'x-1': (inc, 1),
+                          'x-2': (inc, 'x-1'),
+                          'x-3': (inc, 'x-2'),
+                          'y-1': (dec, 'x-3'),
+                          'y-2': (dec, 'y-1'),
+                          'e': (throws, 'y-2'),
+                          'other': (inc, 123)},
                    keys=['e'],
                    dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
                        {'x-3'}, 'y-2': {'y-1'}, 'e': {'y-2'}})

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -76,7 +76,8 @@ def test_progressbar_widget(s, a, b):
     s.update_graph(dsk={'x': (inc, 1),
                         'y': (inc, 'x'),
                         'z': (inc, 'y')},
-                   keys=['z'])
+                   keys=['z'],
+                   dependencies={'y': {'x'}, 'z': {'y'}})
 
     progress = ProgressWidget(['z'], scheduler=(s.ip, s.port))
     yield progress.listen()
@@ -97,7 +98,9 @@ def test_multi_progressbar_widget(s, a, b):
                         'y-2': (dec, 'y-1'),
                         'e': (throws, 'y-2'),
                         'other': (inc, 123)},
-                   keys=['e'])
+                   keys=['e'],
+                   dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
+                       {'x-3'}, 'y-2': {'y-1'}, 'e': {'y-2'}})
 
     p = MultiProgressWidget(['e'], scheduler=(s.ip, s.port))
     yield p.listen()
@@ -130,7 +133,9 @@ def test_multi_progressbar_widget_after_close(s, a, b):
                         'y-2': (dec, 'y-1'),
                         'e': (throws, 'y-2'),
                         'other': (inc, 123)},
-                   keys=['e'])
+                   keys=['e'],
+                   dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
+                       {'x-3'}, 'y-2': {'y-1'}, 'e': {'y-2'}})
 
     p = MultiProgressWidget(['x-1', 'x-2', 'x-3'], scheduler=(s.ip, s.port))
     yield p.listen()
@@ -187,7 +192,9 @@ def test_multibar_complete(s, a, b):
                         'y-2': (dec, 'y-1'),
                         'e': (throws, 'y-2'),
                         'other': (inc, 123)},
-                   keys=['e'])
+                   keys=['e'],
+                   dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
+                       {'x-3'}, 'y-2': {'y-1'}, 'e': {'y-2'}})
 
     p = MultiProgressWidget(['e'], scheduler=(s.ip, s.port), complete=True)
     yield p.listen()

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -508,7 +508,7 @@ class Executor(object):
 
         logger.debug("Submit %s(...), %s", funcname(func), key)
         self._send_to_scheduler({'op': 'update-graph',
-                                 'dsk': {key: task},
+                                 'tasks': {key: task},
                                  'keys': [key],
                                  'dependencies': {key: dependencies},
                                  'restrictions': restrictions,
@@ -626,7 +626,7 @@ class Executor(object):
 
         logger.debug("map(%s, ...)", funcname(func))
         self._send_to_scheduler({'op': 'update-graph',
-                                 'dsk': valmap(dumps_task, dsk),
+                                 'tasks': valmap(dumps_task, dsk),
                                  'dependencies': dependencies,
                                  'keys': keys,
                                  'restrictions': restrictions,
@@ -856,7 +856,7 @@ class Executor(object):
             dependencies[k] |= set(_deps(dsk, v))
 
         self._send_to_scheduler({'op': 'update-graph',
-                                 'dsk': valmap(dumps_task, dsk3),
+                                 'tasks': valmap(dumps_task, dsk3),
                                  'dependencies': dependencies,
                                  'keys': flatkeys,
                                  'restrictions': restrictions or {},
@@ -962,7 +962,7 @@ class Executor(object):
             dependencies[k] |= set(_deps(dsk, v))
 
         self._send_to_scheduler({'op': 'update-graph',
-                                 'dsk': valmap(dumps_task, dsk3),
+                                 'tasks': valmap(dumps_task, dsk3),
                                  'dependencies': dependencies,
                                  'keys': names,
                                  'client': self.id})
@@ -1034,7 +1034,7 @@ class Executor(object):
         names = list({k for c in collections for k in flatten(c._keys())})
 
         self._send_to_scheduler({'op': 'update-graph',
-                                 'dsk': valmap(dumps_task, dsk2),
+                                 'tasks': valmap(dumps_task, dsk2),
                                  'dependencies': dependencies,
                                  'keys': names,
                                  'client': self.id})

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -86,6 +86,7 @@ def read_bytes(fn, executor=None, hdfs=None, lazy=True, delimiter=None,
         restrictions = dict(zip(names, workers))
         executor._send_to_scheduler({'op': 'update-graph',
                                      'dsk': {},
+                                     'dependencies': set(),
                                      'keys': [],
                                      'restrictions': restrictions,
                                      'loose_restrictions': set(names),

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -85,7 +85,7 @@ def read_bytes(fn, executor=None, hdfs=None, lazy=True, delimiter=None,
     if lazy:
         restrictions = dict(zip(names, workers))
         executor._send_to_scheduler({'op': 'update-graph',
-                                     'dsk': {},
+                                     'tasks': {},
                                      'dependencies': set(),
                                      'keys': [],
                                      'restrictions': restrictions,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1536,14 +1536,14 @@ def dumps_task(task):
     Either returns a task as a function, args, kwargs dict
 
     >>> from operator import add
-    >>> dumps_task((add, 1))
-    {'function': b'\x80\x04\x95\x15\x00\x00\x00\x00\x00\x00\x00\x8c\t_operator\x94\x8c\x03add\x94\x93\x94.'
-     'args': b'\x80\x04\x95\x07\x00\x00\x00\x00\x00\x00\x00K\x01K\x02\x86\x94.'}
+    >>> dumps_task((add, 1))  # doctest: +SKIP
+    {'function': b'\x80\x04\x95\x00\x8c\t_operator\x94\x8c\x03add\x94\x93\x94.'
+     'args': b'\x80\x04\x95\x07\x00\x00\x00K\x01K\x02\x86\x94.'}
 
     Or as a single task blob if it can't easily decompose the result.  This
     happens either if the task is highly nested, or if it isn't a task at all
 
-    >>> dumps_task(1)
+    >>> dumps_task(1)  # doctest: +SKIP
     {'task': b'\x80\x04\x95\x03\x00\x00\x00\x00\x00\x00\x00K\x01.'}
     """
     if istask(task):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -393,7 +393,7 @@ class Scheduler(Server):
             if key not in self.dask:
                 continue
             self.processing[worker].add(key)
-            logger.debug("Send job to worker: %s, %s, %s", worker, key, self.dask[key])
+            logger.debug("Send job to worker: %s, %s, %s", worker, key)
             self.worker_queues[worker].put_nowait(
                     {'op': 'compute-task',
                      'key': key,
@@ -899,7 +899,8 @@ class Scheduler(Server):
                                                          who_has=who_has,
                                                          key=key,
                                                          report=self.center
-                                                                 is not None)
+                                                                 is not None,
+                                            serialized=isinstance(task, bytes))
                 if response == b'OK':
                     nbytes = content['nbytes']
                 logger.debug("Compute response from worker %s, %s, %s, %s",

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -951,8 +951,6 @@ class Scheduler(Server):
         raise Return(b'OK')
 
     def delete_data(self, stream=None, keys=None):
-        who_has2 = {k: v for k, v in self.who_has.items() if k in keys}
-
         for key in keys:
             for worker in self.who_has[key]:
                 self.has_what[worker].remove(key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -901,11 +901,9 @@ class Scheduler(Server):
                     assert response == b'OK', response
                     nbytes = content['nbytes'][key]
                 else:
-                    response, content = yield worker.compute(function=execute_task,
-                                                             args=(task,),
+                    response, content = yield worker.compute(task=task,
                                                              who_has=who_has,
                                                              key=key,
-                                                             kwargs={},
                                                              report=self.center
                                                                      is not None)
                     if response == b'OK':
@@ -1527,21 +1525,3 @@ def cover_aliases(dsk, new_keys):
             pass
 
     return dsk
-
-
-def execute_task(task):
-    """ Evaluate a nested task
-
-    >>> inc = lambda x: x + 1
-    >>> execute_task((inc, 1))
-    2
-    >>> execute_task((sum, [1, 2, (inc, 3)]))
-    7
-    """
-    if istask(task):
-        func, args = task[0], task[1:]
-        return func(*map(execute_task, args))
-    elif isinstance(task, list):
-        return list(map(execute_task, task))
-    else:
-        return task

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -16,7 +16,7 @@ from tornado.queues import Queue
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.iostream import StreamClosedError, IOStream
 
-from dask.core import istask, get_deps, reverse_dict
+from dask.core import get_deps, reverse_dict
 from dask.order import order
 
 from .core import (rpc, coerce_to_rpc, connect, read, write, MAX_BUFFER_SIZE,
@@ -895,19 +895,13 @@ class Scheduler(Server):
                 key = msg['key']
                 who_has = msg['who_has']
                 task = msg['task']
-                if not istask(task):
-                    response, content = yield worker.update_data(
-                            data={key: task}, report=self.center is not None)
-                    assert response == b'OK', response
-                    nbytes = content['nbytes'][key]
-                else:
-                    response, content = yield worker.compute(task=task,
-                                                             who_has=who_has,
-                                                             key=key,
-                                                             report=self.center
-                                                                     is not None)
-                    if response == b'OK':
-                        nbytes = content['nbytes']
+                response, content = yield worker.compute(task=task,
+                                                         who_has=who_has,
+                                                         key=key,
+                                                         report=self.center
+                                                                 is not None)
+                if response == b'OK':
+                    nbytes = content['nbytes']
                 logger.debug("Compute response from worker %s, %s, %s, %s",
                              ident, key, response, content)
                 if response == b'error':

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -608,8 +608,6 @@ class Scheduler(Server):
                 self.waiting, self.waiting_data, dsk, keys, dependencies,
                 client)
 
-        cover_aliases(self.dask, dsk)
-
         if restrictions:
             restrictions = {k: set(map(ensure_ip, v))
                             for k, v in restrictions.items()}
@@ -1503,22 +1501,3 @@ def heal_missing_data(dsk, dependencies, dependents,
         ensure_key(key)
 
     assert set(missing).issubset(in_play)
-
-
-def cover_aliases(dsk, new_keys):
-    """ Replace aliases with calls to identity
-
-    Warning: operates in place
-
-    >>> dsk = {'x': 1, 'y': 'x'}
-    >>> cover_aliases(dsk, ['y'])  # doctest: +SKIP
-    {'x': 1, 'y': (<function identity ...>, 'x')}
-    """
-    for key in new_keys:
-        try:
-            if dsk[key] in dsk:
-                dsk[key] = (identity, dsk[key])
-        except TypeError:
-            pass
-
-    return dsk

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -12,20 +12,20 @@ def sizeof(o):
 @sizeof.register(tuple)
 @sizeof.register(set)
 @sizeof.register(frozenset)
-def _(seq):
+def sizeof_python_collection(seq):
     return sys.getsizeof(seq) + sum(map(sizeof, seq))
 
 with ignoring(ImportError):
     import numpy as np
     @sizeof.register(np.ndarray)
-    def _(x):
+    def sizeof_numpy_ndarray(x):
         return x.nbytes
 
 
 with ignoring(ImportError):
     import pandas as pd
     @sizeof.register(pd.DataFrame)
-    def _(df):
+    def sizeof_pandas_dataframe(df):
         o = sys.getsizeof(df)
         try:
             return o + df.memory_usage(index=True, deep=True).sum()
@@ -33,14 +33,14 @@ with ignoring(ImportError):
             return o + df.memory_usage(index=True).sum()
 
     @sizeof.register(pd.Series)
-    def _(s):
+    def sizeof_pandas_series(s):
         try:
             return s.memory_usage(index=True, deep=True) # new in 0.17.1
         except:
             return sizeof(s.values) + sizeof(s.index)
 
     @sizeof.register(pd.Index)
-    def _(i):
+    def sizeof_pandas_index(i):
         try:
             return i.memory_usage(deep=True)
         except:

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -74,7 +74,7 @@ def test_map(s, a, b):
     result = yield L2[1]._result()
     assert result == inc(inc(1))
     assert len(s.dask) == 10
-    assert L1[0].key in s.dask[L2[0].key]
+    # assert L1[0].key in s.dask[L2[0].key]
 
     total = e.submit(sum, L2)
     result = yield total._result()

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -68,14 +68,14 @@ def test_map(s, a, b):
 
     result = yield L1[0]._result()
     assert result == inc(0)
-    assert len(s.dask) == 5
+    assert len(s.tasks) == 5
 
     L2 = e.map(inc, L1)
 
     result = yield L2[1]._result()
     assert result == inc(inc(1))
-    assert len(s.dask) == 10
-    # assert L1[0].key in s.dask[L2[0].key]
+    assert len(s.tasks) == 10
+    # assert L1[0].key in s.tasks[L2[0].key]
 
     total = e.submit(sum, L2)
     result = yield total._result()
@@ -1312,7 +1312,7 @@ def test_restart_fast(loop):
 
             start = time()
             e.restart()
-            assert not e.scheduler.dask
+            assert not e.scheduler.tasks
             assert time() - start < 5
 
             assert all(x.status == 'cancelled' for x in L)
@@ -1854,12 +1854,12 @@ def test_forget_simple(s, a, b):
     assert not s.waiting_data[x.key]
     assert not s.waiting_data[y.key]
 
-    assert set(s.dask) == {x.key, y.key, z.key}
+    assert set(s.tasks) == {x.key, y.key, z.key}
 
     s.client_releases_keys(keys=[x.key], client=e.id)
-    assert x.key in s.dask
+    assert x.key in s.tasks
     s.client_releases_keys(keys=[z.key], client=e.id)
-    for coll in [s.dask, s.dependencies, s.dependents, s.waiting,
+    for coll in [s.tasks, s.dependencies, s.dependents, s.waiting,
             s.waiting_data, s.who_has, s.restrictions, s.loose_restrictions,
             s.in_play, s.keyorder, s.exceptions, s.who_wants,
             s.exceptions_blame]:
@@ -1869,7 +1869,7 @@ def test_forget_simple(s, a, b):
     assert z.key not in s.dependents[y.key]
 
     s.client_releases_keys(keys=[y.key], client=e.id)
-    assert not s.dask
+    assert not s.tasks
 
     yield e._shutdown()
 
@@ -1887,16 +1887,16 @@ def test_forget_complex(s, A, B):
 
     yield _wait([a,b,c,d,ab,ac,cd,acab])
 
-    assert set(s.dask) == {f.key for f in [ab,ac,cd,acab]}
+    assert set(s.tasks) == {f.key for f in [ab,ac,cd,acab]}
 
     s.client_releases_keys(keys=[ab.key], client=e.id)
-    assert set(s.dask) == {f.key for f in [ab,ac,cd,acab]}
+    assert set(s.tasks) == {f.key for f in [ab,ac,cd,acab]}
 
     s.client_releases_keys(keys=[b.key], client=e.id)
-    assert set(s.dask) == {f.key for f in [ab,ac,cd,acab]}
+    assert set(s.tasks) == {f.key for f in [ab,ac,cd,acab]}
 
     s.client_releases_keys(keys=[acab.key], client=e.id)
-    assert set(s.dask) == {f.key for f in [ac,cd]}
+    assert set(s.tasks) == {f.key for f in [ac,cd]}
     assert b.key not in s.who_has
 
     start = time()
@@ -1905,7 +1905,7 @@ def test_forget_complex(s, A, B):
         assert time() < start + 10
 
     s.client_releases_keys(keys=[ac.key], client=e.id)
-    assert set(s.dask) == {f.key for f in [cd]}
+    assert set(s.tasks) == {f.key for f in [cd]}
 
     yield e._shutdown()
 
@@ -1974,7 +1974,7 @@ def test_multi_executor(s, a, b):
 
     yield f._shutdown()
 
-    assert not s.dask
+    assert not s.tasks
 
 
 @gen_cluster()
@@ -1990,14 +1990,14 @@ def test_cleanup_after_broken_executor_connection(s, a, b):
     proc.start()
 
     start = time()
-    while not s.dask:
+    while not s.tasks:
         yield gen.sleep(0.01)
         assert time() < start + 5
 
     proc.terminate()
 
     start = time()
-    while s.dask:
+    while s.tasks:
         yield gen.sleep(0.01)
         assert time() < start + 5
 
@@ -2090,7 +2090,7 @@ def test__cancel(s, a, b):
     x = e.submit(slowinc, 1)
     y = e.submit(slowinc, x)
 
-    while y.key not in s.dask:
+    while y.key not in s.tasks:
         yield gen.sleep(0.01)
 
     yield e._cancel([x], block=True)
@@ -2104,7 +2104,7 @@ def test__cancel(s, a, b):
         yield gen.sleep(0.01)
         assert time() < start + 5
 
-    assert not s.dask
+    assert not s.tasks
     s.validate()
 
     yield e._shutdown()
@@ -2127,7 +2127,7 @@ def test__cancel_multi_client(s, a, b):
     assert x.cancelled()
     assert not y.cancelled()
 
-    assert y.key in s.dask
+    assert y.key in s.tasks
 
     out = yield y._result()
     assert out == 2
@@ -2152,7 +2152,7 @@ def test__cancel_collection(s, a, b):
     yield e._cancel(x)
     yield e._cancel([x])
     assert all(f.cancelled() for f in L)
-    assert not s.dask
+    assert not s.tasks
 
     yield e._shutdown()
 
@@ -2242,7 +2242,7 @@ def test_map_iterator(s, a, b):
     assert isinstance(f1, Iterator)
 
     start = time()  # ensure that we compute eagerly
-    while not s.dask:
+    while not s.tasks:
         yield gen.sleep(0.01)
         assert time() < start + 5
 
@@ -2307,7 +2307,7 @@ def test_async_persist(s, a, b):
     assert y._keys() == yy._keys()
     assert w._keys() == ww._keys()
 
-    while y.key not in s.dask and w.key not in s.dask:
+    while y.key not in s.tasks and w.key not in s.tasks:
         yield gen.sleep(0.01)
 
     assert s.who_wants[y.key] == {e.id}
@@ -2420,7 +2420,7 @@ def test_fatally_serialized_input(s):
 
     future = e.submit(inc, o)
 
-    while not s.dask:
+    while not s.tasks:
         yield gen.sleep(0.01)
 
     yield e._shutdown()

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -26,8 +26,7 @@ from distributed.core import rpc, dumps, loads
 from distributed.client import WrappedKey
 from distributed.executor import (Executor, Future, CompatibleExecutor, _wait,
         wait, _as_completed, as_completed, tokenize, _global_executor,
-        default_executor, _first_completed, ensure_default_get, futures_of,
-        _maybe_complex, dumps_function, dumps_task)
+        default_executor, _first_completed, ensure_default_get, futures_of)
 from distributed.scheduler import Scheduler
 from distributed.sizeof import sizeof
 from distributed.utils import ignoring, sync, tmp_text
@@ -2401,34 +2400,3 @@ def test_dont_delete_recomputed_results(s, w):
         yield gen.sleep(0.01)
 
     yield e._shutdown()
-
-
-def test_maybe_complex():
-    assert not _maybe_complex(1)
-    assert not _maybe_complex('x')
-    assert _maybe_complex((inc, 1))
-    assert _maybe_complex([(inc, 1)])
-    assert _maybe_complex([(inc, 1)])
-    assert _maybe_complex({'x': (inc, 1)})
-
-
-def test_dumps_function():
-    a = dumps_function(inc)
-    assert loads(a)(10) == 11
-
-    b = dumps_function(inc)
-    assert a is b
-
-    c = dumps_function(dec)
-    assert a != c
-
-
-def test_dumps_task():
-    d = dumps_task((inc, 1))
-    assert set(d) == {'function', 'args'}
-
-    f = lambda x, y=2: x + y
-    d = dumps_task((apply, f, (1,), {'y': 10}))
-    assert loads(d['function'])(1, 2) == 3
-    assert loads(d['args']) == (1,)
-    assert loads(d['kwargs']) == {'y': 10}

--- a/distributed/tests/test_hdfs.py
+++ b/distributed/tests/test_hdfs.py
@@ -182,7 +182,7 @@ def test_lazy_values(s, a, b):
 
         while not s.restrictions:
             yield gen.sleep(0.01)
-        assert not s.dask
+        assert not s.tasks
 
         results = e.compute(values, sync=False)
         results = yield e._gather(results)
@@ -276,7 +276,7 @@ def test_read_csv_lazy(s, a, b):
         df = yield _read_csv('/tmp/test/*.csv', header=True, lazy=True,
                              lineterminator='\n')
         yield gen.sleep(0.5)
-        assert not s.dask
+        assert not s.tasks
 
         result = yield e.compute(df.id.sum(), sync=False)._result()
         assert result == 1 + 2 + 3 + 4
@@ -302,7 +302,7 @@ def test__read_text(s, a, b):
         b = yield _read_text('/tmp/test/text.*.txt',
                              collection=True, lazy=True)
         yield gen.sleep(0.5)
-        assert not s.dask
+        assert not s.tasks
 
         future = e.compute(b.str.strip().str.split().map(len))
         result = yield future._result()

--- a/distributed/tests/test_s3.py
+++ b/distributed/tests/test_s3.py
@@ -126,7 +126,7 @@ def test_read_text(s, a, b):
                   collection=True, anon=True)
     assert isinstance(b, db.Bag)
     yield gen.sleep(0.2)
-    assert not s.dask
+    assert not s.tasks
 
     future = e.compute(b.filter(None).map(json.loads).pluck('amount').sum())
     result = yield future._result()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -268,3 +268,11 @@ def test_worker_task(s, a, b):
     yield aa.compute(task=(inc, 1), key='x')
 
     assert a.data['x'] == 2
+
+
+@gen_cluster()
+def test_worker_task_data(s, a, b):
+    aa = rpc(ip=a.ip, port=a.port)
+    yield aa.compute(task=2, key='x')
+
+    assert a.data['x'] == 2

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -276,3 +276,14 @@ def test_worker_task_data(s, a, b):
     yield aa.compute(task=2, key='x')
 
     assert a.data['x'] == 2
+
+
+@gen_cluster()
+def test_worker_task_bytes(s, a, b):
+    aa = rpc(ip=a.ip, port=a.port)
+
+    yield aa.compute(task=dumps((inc, 1)), key='x', serialized=True)
+    assert a.data['x'] == 2
+
+    yield aa.compute(function=dumps(inc), args=dumps((10,)), key='y', serialized=True)
+    assert a.data['y'] == 11

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -223,14 +223,21 @@ class Worker(Server):
             data2 = local_data
 
         if serialized:
-            if task is not None:
-                task = loads(task)
-            if function is not None:
-                function = loads(function)
-            if args:
-                args = loads(args)
-            if kwargs:
-                kwargs = loads(kwargs)
+            try:
+                if task is not None:
+                    task = loads(task)
+                if function is not None:
+                    function = loads(function)
+                if args:
+                    args = loads(args)
+                if kwargs:
+                    kwargs = loads(kwargs)
+            except Exception as e:
+                logger.warn("Could not deserialize task", exc_info=True)
+                tb = get_traceback()
+                e2 = truncate_exception(e, 1000)
+                self.active.remove(key)
+                raise Return((b'error', {'exception': e2, 'traceback': tb}))
 
         if task is not None:
             assert not function and not args and not kwargs

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -20,7 +20,7 @@ from tornado.iostream import StreamClosedError
 
 from .client import _gather, pack_data, gather_from_workers
 from .compatibility import reload
-from .core import rpc, Server, pingpong, dumps
+from .core import rpc, Server, pingpong, dumps, loads
 from .sizeof import sizeof
 from .utils import (funcname, get_ip, get_traceback, truncate_exception,
     ignoring)
@@ -187,7 +187,7 @@ class Worker(Server):
 
     @gen.coroutine
     def compute(self, stream, function=None, key=None, args=(), kwargs={},
-            task=None, needed=[], who_has=None, report=True):
+            task=None, needed=[], who_has=None, report=True, serialized=False):
         """ Execute function """
         self.active.add(key)
         if needed:
@@ -221,6 +221,16 @@ class Worker(Server):
             data2 = merge(local_data, other)
         else:
             data2 = local_data
+
+        if serialized:
+            if task is not None:
+                task = loads(task)
+            if function is not None:
+                function = loads(function)
+            if args:
+                args = loads(args)
+            if kwargs:
+                kwargs = loads(kwargs)
 
         if task is not None:
             assert not function and not args and not kwargs

--- a/docs/source/journey.rst
+++ b/docs/source/journey.rst
@@ -27,7 +27,7 @@ Step 1: Executor
 message to the ``Scheduler``::
 
     {'op': 'update-graph',
-     'dsk': {'z': (add, x, y)},
+     'tasks': {'z': (add, x, y)},
      'keys': ['z']}
 
 The executor then creates a ``Future`` object with the key ``'z'`` and returns
@@ -43,7 +43,7 @@ A few milliseconds later, the scheduler receives this message on an open socket.
 The scheduler updates its state with this little graph that shows how to compute
 ``z``.::
 
-    scheduler.dask.update[msg['dsk']]
+    scheduler.tasks.update[msg['tasks']]
 
 The scheduler also updates *a lot* of other state.  Notably, it has to identify
 that ``x`` and ``y`` are themselves variables, and connect all of those


### PR DESCRIPTION
Problem
--------

Previously all tasks were sent to the scheduler where they were deserialized and stored in a dask graph.   Then these tasks would be re-serialized as they were sent to the appropriate worker.

This was good because it was simple and because we could inspect the tasks during debugging.

This was bad because it exposed the scheduler to possibly poorly serialized functions and because it added a significant computational burden, serializing a bunch of dynamically made functions, onto the scheduler, which is generally under critical load.

Solution
------- 

The client now pre-serializes all tasks and sends these bytestrings up to the scheduler, who forwards them along to the appropriate worker, who deserializes them before computation.

### Good

*  Benchmarks with many empty dataframe computations show a 5x speed boost
*  The scheduler is protected against badly serialized functions
*  This is a step towards making the scheduler language agnostic
*  Scheduler load is much lighter, increasing scalability

### Bad

* The client now has to serialize each task independently, this is a bit inefficient when there is potential reuse as in `e.map(lambda x: x + 1, range(1000))`.  We can get around this a bit by memoizing around function serialization and by using a bit of compression (not yet implemented)
*  We can't easily inspect the task graph
*  Things are getting more complex
*  The test suite just slowed down by 20%