### PR TITLE
Change protocol from cloudpickle to msgpack

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - locket
     - six
     - tblib
+    - lz4
 
   run:
     - python
@@ -29,6 +30,7 @@ requirements:
     - locket
     - six
     - tblib
+    - lz4
 
 test:
   imports:

--- a/distributed/center.py
+++ b/distributed/center.py
@@ -125,7 +125,7 @@ class Center(Server):
     def unregister(self, stream, address=None):
         address = coerce_to_address(address)
         if address not in self.has_what:
-            return 'Address not found: ' + str(address).encode()
+            return 'Address not found: ' + address
         keys = self.has_what.pop(address)
         with ignoring(KeyError):
             del self.ncores[address]
@@ -198,8 +198,8 @@ class Center(Server):
             del self.who_has[key]
 
         # TODO: ignore missing workers
-        coroutines = [rpc(ip=worker[0], port=worker[1]).delete_data(
-                                keys=list(keys), report=False, close=True)
+        coroutines = [rpc(worker).delete_data(keys=list(keys), report=False,
+                                              close=True)
                       for worker, keys in d.items()]
         for worker, keys in d.items():
             logger.debug("Remove %d keys from worker %s", len(keys), worker)
@@ -211,6 +211,6 @@ class Center(Server):
     def broadcast(self, stream, msg=None):
         """ Broadcast message to workers, return all results """
         workers = list(self.ncores)
-        results = yield All([send_recv(ip=ip, port=port, close=True, **msg)
-                             for ip, port in workers])
+        results = yield All([send_recv(arg=worker, close=True, **msg)
+                             for worker in workers])
         raise Return(dict(zip(workers, results)))

--- a/distributed/center.py
+++ b/distributed/center.py
@@ -109,23 +109,23 @@ class Center(Server):
     @gen.coroutine
     def terminate(self, stream=None):
         self.stop()
-        return b'OK'
+        return 'OK'
 
     def register(self, stream, address=None, keys=(), ncores=None,
                  services=None):
-        address = coerce_to_address(address, out=str)
+        address = coerce_to_address(address)
         self.has_what[address] = set(keys)
         for key in keys:
             self.who_has[key].add(address)
         self.ncores[address] = ncores
         self.worker_services[address] = services
         logger.info("Register %s", str(address))
-        return b'OK'
+        return 'OK'
 
     def unregister(self, stream, address=None):
-        address = coerce_to_address(address, out=str)
+        address = coerce_to_address(address)
         if address not in self.has_what:
-            return b'Address not found: ' + str(address).encode()
+            return 'Address not found: ' + str(address).encode()
         keys = self.has_what.pop(address)
         with ignoring(KeyError):
             del self.ncores[address]
@@ -137,23 +137,23 @@ class Center(Server):
             if not s:
                 del self.who_has[key]
         logger.info("Unregister %s", str(address))
-        return b'OK'
+        return 'OK'
 
     def add_keys(self, stream, address=None, keys=()):
-        address = coerce_to_address(address, out=str)
+        address = coerce_to_address(address)
         self.has_what[address].update(keys)
         for key in keys:
             self.who_has[key].add(address)
-        return b'OK'
+        return 'OK'
 
     def remove_keys(self, stream, keys=(), address=None):
-        address = coerce_to_address(address, out=str)
+        address = coerce_to_address(address)
         for key in keys:
             if key in self.has_what[address]:
                 self.has_what[address].remove(key)
             with ignoring(KeyError):
                 self.who_has[key].remove(address)
-        return b'OK'
+        return 'OK'
 
     def get_who_has(self, stream, keys=None):
         if keys is not None:
@@ -163,7 +163,7 @@ class Center(Server):
 
     def get_has_what(self, stream, keys=None):
         if keys:
-            keys = [coerce_to_address(key, out=str) for key in keys]
+            keys = [coerce_to_address(key) for key in keys]
         if keys is not None:
             return {k: list(self.has_what[k]) for k in keys}
         else:
@@ -171,7 +171,7 @@ class Center(Server):
 
     def get_ncores(self, stream, addresses=None):
         if addresses:
-            addresses = [coerce_to_address(a, out=str) for a in addresses]
+            addresses = [coerce_to_address(a) for a in addresses]
         if addresses is not None:
             return {k: self.ncores.get(k, None) for k in addresses}
         else:
@@ -179,7 +179,7 @@ class Center(Server):
 
     def get_worker_services(self, stream, addresses=None):
         if addresses:
-            addresses = [coerce_to_address(a, out=str) for a in address]
+            addresses = [coerce_to_address(a) for a in address]
         if addresses is not None:
             return {k: self.worker_services.get(k, None) for k in addresses}
         else:
@@ -205,7 +205,7 @@ class Center(Server):
             logger.debug("Remove %d keys from worker %s", len(keys), worker)
         yield ignore_exceptions(coroutines, socket.error, StreamClosedError)
 
-        raise Return(b'OK')
+        raise Return('OK')
 
     @gen.coroutine
     def broadcast(self, stream, msg=None):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -207,7 +207,7 @@ def scatter_to_workers(ncores, data, report=True, serialize=True):
             try:
                 names.append(tokenize(x))
             except:
-                names.append(uuid.uuid1())
+                names.append(str(uuid.uuid1()))
 
     worker_iter = drop(_round_robin_counter[0] % len(workers), cycle(workers))
     _round_robin_counter[0] += len(data)
@@ -320,7 +320,7 @@ def unpack_remotedata(o, byte_keys=False):
 
     >>> rd = WrappedKey(('x', 1))
     >>> unpack_remotedata(rd, byte_keys=True)
-    (b"('x', 1)", {b"('x', 1)"})
+    ("('x', 1)", {"('x', 1)"})
     """
     if isinstance(o, WrappedKey):
         k = o.key

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -12,10 +12,10 @@ from tornado.ioloop import IOLoop
 from tornado.iostream import StreamClosedError
 
 from dask.base import tokenize
-from toolz import merge, concat, groupby, drop
+from toolz import merge, concat, groupby, drop, valmap
 
-from .core import rpc, coerce_to_rpc
-from .utils import ignore_exceptions, ignoring, All
+from .core import rpc, coerce_to_rpc, loads, coerce_to_address, dumps
+from .utils import ignore_exceptions, ignoring, All, log_errors, tobytes, sync
 
 
 no_default = '__no_default__'
@@ -70,13 +70,13 @@ def _gather(center, needed=[]):
         raise TypeError('Bad response from who_has: %s' % who_has)
 
     result = yield gather_from_workers(who_has)
-    raise Return([result[key] for key in needed])
+    raise Return([result[tobytes(key)] for key in needed])
 
 _gather.__doc__ = gather.__doc__
 
 
 @gen.coroutine
-def gather_from_workers(who_has):
+def gather_from_workers(who_has, deserialize=True):
     """ Gather data directly from peers
 
     Parameters
@@ -92,33 +92,36 @@ def gather_from_workers(who_has):
     _gather
     """
     bad_addresses = set()
-    who_has = who_has.copy()
+    who_has = {k: set(v) for k, v in who_has.items()}
     results = dict()
 
-    while len(results) < len(who_has):
-        d = defaultdict(list)
-        rev = dict()
-        bad_keys = set()
-        for key, addresses in who_has.items():
-            if key in results:
-                continue
-            try:
-                addr = random.choice(list(addresses - bad_addresses))
-                d[addr].append(key)
-                rev[key] = addr
-            except IndexError:
-                bad_keys.add(key)
-        if bad_keys:
-            raise KeyError(*bad_keys)
+    with log_errors():
+        while len(results) < len(who_has):
+            d = defaultdict(list)
+            rev = dict()
+            bad_keys = set()
+            for key, addresses in who_has.items():
+                if key in results:
+                    continue
+                try:
+                    addr = random.choice(list(addresses - bad_addresses))
+                    d[addr].append(key)
+                    rev[key] = addr
+                except IndexError:
+                    bad_keys.add(key)
+            if bad_keys:
+                raise KeyError(*bad_keys)
 
-        coroutines = [rpc(ip=ip, port=port).get_data(keys=keys, close=True)
-                            for (ip, port), keys in d.items()]
-        response = yield ignore_exceptions(coroutines, socket.error,
-                                                       StreamClosedError)
-        response = merge(response)
-        bad_addresses |= {v for k, v in rev.items() if k not in response}
-        results.update(merge(response))
+            coroutines = [rpc(address).get_data(keys=keys, close=True)
+                                for address, keys in d.items()]
+            response = yield ignore_exceptions(coroutines, socket.error,
+                                                           StreamClosedError)
+            response = merge(response)
+            bad_addresses |= {v for k, v in rev.items() if k not in response}
+            results.update(merge(response))
 
+    if deserialize:
+        results = valmap(loads, results)
     raise Return(results)
 
 
@@ -136,7 +139,7 @@ class WrappedKey(object):
         self.key = key
 
 
-def scatter(center, data):
+def scatter(center, data, serialize=True):
     """ Scatter data to workers
 
     Parameters
@@ -160,17 +163,21 @@ def scatter(center, data):
     distributed.client._scatter:
     distributed.client.scatter_to_workers:
     """
-    func = lambda: _scatter(center, data)
-    result = IOLoop().run_sync(func)
-    return result
+    return sync(IOLoop(), _scatter, center, data, serialize=serialize)
 
 
 @gen.coroutine
-def _scatter(center, data):
-    center = coerce_to_rpc(center)
-    ncores = yield center.ncores()
+def _scatter(center, data, serialize=True):
+    with log_errors():
+        center = coerce_to_rpc(center)
+        ncores = yield center.ncores()
 
-    result, who_has, nbytes = yield scatter_to_workers(ncores, data)
+        result, who_has, nbytes = yield scatter_to_workers(ncores, data,
+                                                           serialize=serialize)
+        print(result)
+        print(result)
+        print(result)
+        print(result)
     raise Return(result)
 
 
@@ -181,7 +188,7 @@ _round_robin_counter = [0]
 
 
 @gen.coroutine
-def scatter_to_workers(ncores, data, report=True):
+def scatter_to_workers(ncores, data, report=True, serialize=True):
     """ Scatter data directly to workers
 
     This distributes data in a round-robin fashion to a set of workers based on
@@ -192,7 +199,7 @@ def scatter_to_workers(ncores, data, report=True):
     """
     if isinstance(ncores, Iterable) and not isinstance(ncores, dict):
         k = len(data) // len(ncores)
-        ncores = {worker: k for worker in ncores}
+        ncores = {coerce_to_address(worker, out=str): k for worker in ncores}
 
     workers = list(concat([w] * nc for w, nc in ncores.items()))
     in_type = type(data)
@@ -202,22 +209,23 @@ def scatter_to_workers(ncores, data, report=True):
         names = []
         for x in data:
             try:
-                names.append(tokenize(x))
+                names.append(tobytes(tokenize(x)))
             except:
-                names.append(str(uuid.uuid1()))
+                names.append(tobytes(uuid.uuid1()))
 
     worker_iter = drop(_round_robin_counter[0] % len(workers), cycle(workers))
     _round_robin_counter[0] += len(data)
 
     L = list(zip(worker_iter, names, data))
     d = groupby(0, L)
-    d = {k: {b: c for a, b, c in v}
-          for k, v in d.items()}
+    d = {worker: {key: dumps(value) if serialize else value
+                   for _, key, value in v}
+          for worker, v in d.items()}
 
-    out = yield All([rpc(ip=w_ip, port=w_port).update_data(data=v,
+    out = yield All([rpc(address).update_data(data=v,
                                              close=True, report=report)
-                 for (w_ip, w_port), v in d.items()])
-    nbytes = merge([o[1]['nbytes'] for o in out])
+                 for address, v in d.items()])
+    nbytes = merge(o['nbytes'] for o in out)
 
     who_has = {k: [w for w, _, _ in v] for k, v in groupby(1, L).items()}
 
@@ -225,7 +233,7 @@ def scatter_to_workers(ncores, data, report=True):
 
 
 @gen.coroutine
-def broadcast_to_workers(workers, data, report=False, rpc=rpc):
+def broadcast_to_workers(workers, data, report=False, rpc=rpc, serialize=True):
     """ Broadcast data directly to all workers
 
     This sends all data to every worker.
@@ -249,15 +257,17 @@ def broadcast_to_workers(workers, data, report=False, rpc=rpc):
         names = []
         for x in data:
             try:
-                names.append(tokenize(x))
+                names.append(tobytes(tokenize(x)))
             except:
-                names.append(str(uuid.uuid1()))
+                names.append(tobytes(uuid.uuid1()))
         data = dict(zip(names, data))
 
-    out = yield All([rpc(ip=w_ip, port=w_port).update_data(data=data,
-                                                           report=report)
-                     for (w_ip, w_port) in workers])
-    nbytes = merge([o[1]['nbytes'] for o in out])
+    if serialize:
+        data = valmap(dumps, data)
+
+    out = yield All([rpc(address).update_data(data=data, report=report)
+                     for address in workers])
+    nbytes = merge([o['nbytes'] for o in out])
 
     raise Return((names, nbytes))
 
@@ -289,11 +299,13 @@ def clear(center):
     return IOLoop().run_sync(lambda: _clear(center))
 
 
-def unpack_remotedata(o):
+def unpack_remotedata(o, byte_keys=False):
     """ Unpack WrappedKey objects from collection
 
     Returns original collection and set of all found keys
 
+    Examples
+    --------
     >>> rd = WrappedKey('mykey')
     >>> unpack_remotedata(1)
     (1, set())
@@ -307,17 +319,26 @@ def unpack_remotedata(o):
     ({1: 'mykey'}, {'mykey'})
     >>> unpack_remotedata({1: [rd]})
     ({1: ['mykey']}, {'mykey'})
+
+    Use the ``byte_keys=True`` keyword to force string keys
+
+    >>> rd = WrappedKey(('x', 1))
+    >>> unpack_remotedata(rd, byte_keys=True)
+    (b"('x', 1)", {b"('x', 1)"})
     """
     if isinstance(o, WrappedKey):
-        return o.key, {o.key}
+        k = o.key
+        if byte_keys:
+            k = tobytes(k)
+        return k, {k}
     if isinstance(o, (tuple, list, set, frozenset)):
         if not o:
             return o, set()
-        out, sets = zip(*map(unpack_remotedata, o))
+        out, sets = zip(*[unpack_remotedata(item, byte_keys) for item in o])
         return type(o)(out), set.union(*sets)
     elif isinstance(o, dict):
         if o:
-            values, sets = zip(*map(unpack_remotedata, o.values()))
+            values, sets = zip(*[unpack_remotedata(v, byte_keys) for v in o.values()])
             return dict(zip(o.keys(), values)), set.union(*sets)
         else:
             return o, set()
@@ -345,11 +366,10 @@ def pack_data(o, d):
     >>> pack_data({'a': ['x'], 'b': 'y'}, data)  # doctest: +SKIP
     {'a': [1], 'b': 'y'}
     """
-    try:
-        if o in d:
-            return d[o]
-    except (TypeError, KeyError):
-        pass
+    if isinstance(o, bytes) and o in d:
+        return d[o]
+    if str(o).encode() in d:
+        return d[str(o).encode()]
 
     if isinstance(o, (tuple, list, set, frozenset)):
         return type(o)([pack_data(x, d) for x in o])

--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -199,7 +199,7 @@ def futures_to_collection(futures, executor=None, **kwargs):
 def _future_to_dask_array(future, executor=None):
     e = default_executor(executor)
 
-    name = 'array-' + future.key
+    name = 'array-' + str(future.key)
 
     shape, dtype = yield e._gather([e.submit(get_shape, future),
                                     e.submit(get_dtype, future)])
@@ -230,7 +230,7 @@ def future_to_dask_array(future, executor=None):
 def _futures_to_dask_arrays(futures, executor=None):
     e = default_executor(executor)
 
-    names = ['array-' + future.key for future in futures]
+    names = ['array-' + str(future.key) for future in futures]
 
     shapes, dtypes = yield e._gather([e.map(get_shape, futures),
                                       e.map(get_dtype, futures)])

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -8,6 +8,8 @@ if sys.version_info[0] == 2:
     from thread import get_ident as get_thread_identity
     reload = reload
     unicode = unicode
+    PY2 = True
+    PY3 = False
 
     import gzip
     def gzip_decompress(b):
@@ -26,6 +28,8 @@ if sys.version_info[0] == 3:
     from queue import Queue, Empty
     from importlib import reload
     from threading import get_ident as get_thread_identity
+    PY2 = False
+    PY3 = True
     unicode = str
     from gzip import decompress as gzip_decompress
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -9,10 +9,7 @@ import struct
 from time import sleep, time
 import uuid
 
-try:
-    from cytoolz import assoc, first, keymap
-except ImportError:
-    from toolz import assoc, first, keymap
+from toolz import assoc, first
 
 import tornado
 import pickle

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -12,7 +12,7 @@ from tornado.ioloop import PeriodicCallback, IOLoop
 from tornado import gen
 
 from .plugin import SchedulerPlugin
-from ..utils import sync, key_split, tobytes
+from ..utils import sync, key_split, tokey
 from ..executor import default_executor
 
 
@@ -64,7 +64,7 @@ class Progress(SchedulerPlugin):
     """
     def __init__(self, keys, scheduler, minimum=0, dt=0.1, complete=False):
         self.keys = {k.key if hasattr(k, 'key') else k for k in keys}
-        self.keys = {tobytes(k) for k in self.keys}
+        self.keys = {tokey(k) for k in self.keys}
         self.scheduler = scheduler
         self.complete = complete
         self._minimum = minimum
@@ -128,11 +128,8 @@ class Progress(SchedulerPlugin):
 
     def task_erred(self, scheduler, key, worker, exception):
         logger.debug("Progress sees task erred")
-        try:
-            if key in self.all_keys:
-                self.stop(exception=exception, key=key)
-        except AttributeError:
-            import pdb; pdb.set_trace()
+        if key in self.all_keys:
+            self.stop(exception=exception, key=key)
 
     def restart(self, scheduler):
         self.stop()

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -12,14 +12,15 @@ from tornado.ioloop import PeriodicCallback, IOLoop
 from tornado import gen
 
 from .plugin import SchedulerPlugin
-from ..utils import sync, key_split
+from ..utils import sync, key_split, tobytes
 from ..executor import default_executor
 
 
 logger = logging.getLogger(__name__)
 
 
-def dependent_keys(keys, who_has, processing, stacks, dependencies, exceptions, complete=False):
+def dependent_keys(keys, who_has, processing, stacks, dependencies, exceptions,
+                   complete=False):
     """ All keys that need to compute for these keys to finish """
     out = set()
     errors = set()
@@ -63,6 +64,7 @@ class Progress(SchedulerPlugin):
     """
     def __init__(self, keys, scheduler, minimum=0, dt=0.1, complete=False):
         self.keys = {k.key if hasattr(k, 'key') else k for k in keys}
+        self.keys = {tobytes(k) for k in self.keys}
         self.scheduler = scheduler
         self.complete = complete
         self._minimum = minimum
@@ -126,8 +128,11 @@ class Progress(SchedulerPlugin):
 
     def task_erred(self, scheduler, key, worker, exception):
         logger.debug("Progress sees task erred")
-        if key in self.all_keys:
-            self.stop(exception=exception, key=key)
+        try:
+            if key in self.all_keys:
+                self.stop(exception=exception, key=key)
+        except AttributeError:
+            import pdb; pdb.set_trace()
 
     def restart(self, scheduler):
         self.stop()
@@ -168,7 +173,8 @@ class MultiProgress(Progress):
     {'x': {'x-1', 'x-2', 'x-3'},
      'y': {'y-1', 'y-2'}}
     """
-    def __init__(self, keys, scheduler=None, func=key_split, minimum=0, dt=0.1, complete=False):
+    def __init__(self, keys, scheduler=None, func=key_split, minimum=0, dt=0.1,
+                 complete=False):
         self.func = func
         Progress.__init__(self, keys, scheduler, minimum=minimum, dt=dt,
                             complete=complete)

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -5,7 +5,7 @@ from timeit import default_timer
 import sys
 
 from dask.core import flatten
-from toolz import valmap, second, keymap
+from toolz import valmap
 from tornado import gen
 from tornado.ioloop import IOLoop
 

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -5,13 +5,13 @@ from timeit import default_timer
 import sys
 
 from dask.core import flatten
-from toolz import valmap, second
+from toolz import valmap, second, keymap
 from tornado import gen
 from tornado.ioloop import IOLoop
 
 from .progress import format_time, Progress, MultiProgress
 
-from ..core import connect, read, write
+from ..core import connect, read, write, dumps
 from ..executor import default_executor, futures_of
 from ..utils import sync, ignoring, key_split, is_kernel
 
@@ -51,11 +51,10 @@ class ProgressBar(object):
         @gen.coroutine
         def setup(scheduler):
             p = Progress(keys, scheduler, complete=complete)
-            scheduler.add_plugin(p)
             yield p.setup()
             raise gen.Return(p)
 
-        def func(scheduler, p):
+        def function(scheduler, p):
             return {'all': len(p.all_keys),
                     'remaining': len(p.keys),
                     'status': p.status}
@@ -64,12 +63,15 @@ class ProgressBar(object):
         logger.debug("Progressbar Connected to scheduler")
 
         yield write(self.stream, {'op': 'feed',
-                                  'setup': setup,
-                                  'function': func,
+                                  'setup': dumps(setup),
+                                  'function': dumps(function),
                                   'interval': self.interval})
 
         while True:
-            self._last_response = response = yield read(self.stream)
+            response = yield read(self.stream)
+            response = {k: v.decode() if isinstance(v, bytes) else v
+                        for k, v in response.items()}
+            self._last_response = response
             self.status = response['status']
             self._draw_bar(**response)
             if response['status'] in ('error', 'finished'):
@@ -181,12 +183,15 @@ class MultiProgressBar(object):
         logger.debug("Progressbar Connected to scheduler")
 
         yield write(self.stream, {'op': 'feed',
-                                  'setup': setup,
-                                  'function': function,
+                                  'setup': dumps(setup),
+                                  'function': dumps(function),
                                   'interval': self.interval})
 
         while True:
-            self._last_response = response = yield read(self.stream)
+            response = yield read(self.stream)
+            response = {k: v.decode() if isinstance(v, bytes) else v
+                        for k, v in response.items()}
+            self._last_response = response
             self.status = response['status']
             self._draw_bar(**response)
             if response['status'] in ('error', 'finished'):
@@ -221,11 +226,12 @@ class MultiProgressWidget(MultiProgressBar):
         from ipywidgets import FloatProgress, HBox, VBox, HTML
         import cgi
         self.elapsed_time = HTML('')
-        self.bars = {key: FloatProgress(min=0, max=1, description='', height = '10px')
+        self.bars = {key: FloatProgress(min=0, max=1, description='',
+                                        height='10px')
                         for key in all}
         self.bar_texts = {key: HTML('', width = "140px") for key in all}
-        self.bar_labels = {key: HTML('<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">'
-                                     + cgi.escape(key) + '</div>') for key in all}
+        self.bar_labels = {key: HTML('<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">' + cgi.escape(key.decode()) + '</div>')
+                            for key in all}
 
         def key(kv):
             """ Order keys by most numerous, then by string name """
@@ -233,7 +239,10 @@ class MultiProgressWidget(MultiProgressBar):
 
         key_order = [k for k, v in sorted(all.items(), key=key, reverse=True)]
 
-        self.bar_widgets = VBox([ HBox([ self.bar_texts[key], self.bars[key], self.bar_labels[key] ]) for key in key_order ])
+        self.bar_widgets = VBox([ HBox([ self.bar_texts[key],
+                                         self.bars[key],
+                                         self.bar_labels[key] ])
+                                for key in key_order ])
         self.widget.children = (self.elapsed_time, self.bar_widgets)
 
     def _ipython_display_(self, **kwargs):

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -69,8 +69,6 @@ class ProgressBar(object):
 
         while True:
             response = yield read(self.stream)
-            response = {k: v.decode() if isinstance(v, bytes) else v
-                        for k, v in response.items()}
             self._last_response = response
             self.status = response['status']
             self._draw_bar(**response)
@@ -189,8 +187,6 @@ class MultiProgressBar(object):
 
         while True:
             response = yield read(self.stream)
-            response = {k: v.decode() if isinstance(v, bytes) else v
-                        for k, v in response.items()}
             self._last_response = response
             self.status = response['status']
             self._draw_bar(**response)
@@ -230,7 +226,7 @@ class MultiProgressWidget(MultiProgressBar):
                                         height='10px')
                         for key in all}
         self.bar_texts = {key: HTML('', width = "140px") for key in all}
-        self.bar_labels = {key: HTML('<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">' + cgi.escape(key.decode()) + '</div>')
+        self.bar_labels = {key: HTML('<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">' + cgi.escape(key.decode() if isinstance(key, bytes) else key) + '</div>')
                             for key in all}
 
         def key(kv):

--- a/distributed/diagnostics/resource_monitor.py
+++ b/distributed/diagnostics/resource_monitor.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 from toolz import get
 from tornado import gen
 
-from ..core import connect, read, write, rpc
+from ..core import connect, read, write, rpc, dumps
 from ..utils import ignoring, is_kernel, key_split
 from ..executor import default_executor
 from ..scheduler import Scheduler
@@ -87,13 +87,13 @@ class Occupancy(object):
             nprocessing = list(map(len, processing))
             nstacks = [len(scheduler.stacks[w]) for w in workers]
 
-            return {'host': [host for host, port in workers],
+            return {'host': [w.split(':')[0] for w in workers],
                     'processing': processing,
                     'nprocessing': nprocessing,
                     'waiting': nstacks}
 
         yield write(self.stream, {'op': 'feed',
-                                  'function': func,
+                                  'function': dumps(func),
                                   'interval': interval})
         while True:
             try:

--- a/distributed/diagnostics/tests/test_plugin.py
+++ b/distributed/diagnostics/tests/test_plugin.py
@@ -24,15 +24,15 @@ def test_diagnostic(s, a, b):
 
     assert counter.count == 0
     sched.put_nowait({'op': 'update-graph',
-                      'tasks': {b'x': dumps_task((inc, 1)),
-                                b'y': dumps_task((inc, b'x')),
-                                b'z': dumps_task((inc, b'y'))},
-                      'dependencies': {b'y': [b'x'], b'z': [b'y']},
-                      'keys': [b'z']})
+                      'tasks': {'x': dumps_task((inc, 1)),
+                                'y': dumps_task((inc, 'x')),
+                                'z': dumps_task((inc, 'y'))},
+                      'dependencies': {'y': ['x'], 'z': ['y']},
+                      'keys': ['z']})
 
     while True:
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == b'z':
+        if msg['op'] == 'key-in-memory' and msg['key'] == 'z':
             break
 
     assert counter.count == 3

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -32,18 +32,18 @@ def test_dependent_keys():
 @gen_cluster()
 def test_many_Progresss(s, a, b):
     sched, report = Queue(), Queue(); s.handle_queues(sched, report)
-    s.update_graph(tasks=valmap(dumps_task, {b'x': (inc, 1),
-                                             b'y': (inc, b'x'),
-                                             b'z': (inc, b'y')}),
-                   keys=[b'z'],
-                   dependencies={b'y': [b'x'], b'z': [b'y']})
+    s.update_graph(tasks=valmap(dumps_task, {'x': (inc, 1),
+                                             'y': (inc, 'x'),
+                                             'z': (inc, 'y')}),
+                   keys=['z'],
+                   dependencies={'y': ['x'], 'z': ['y']})
 
     bars = [Progress(keys=['z'], scheduler=s) for i in range(10)]
     yield [b.setup() for b in bars]
 
     while True:
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == b'z':
+        if msg['op'] == 'key-in-memory' and msg['key'] == 'z':
             break
 
     assert all(b.status == 'finished' for b in bars)
@@ -52,36 +52,36 @@ def test_many_Progresss(s, a, b):
 @gen_cluster()
 def test_multiprogress(s, a, b):
     sched, report = Queue(), Queue(); s.handle_queues(sched, report)
-    s.update_graph(tasks=valmap(dumps_task, {b'x-1': (inc, 1),
-                                             b'x-2': (inc, b'x-1'),
-                                             b'x-3': (inc, b'x-2'),
-                                             b'y-1': (dec, b'x-3'),
-                                             b'y-2': (dec, b'y-1')}),
-                   keys=[b'y-2'],
-                   dependencies={b'x-2': [b'x-1'], b'x-3': [b'x-2'],
-                                 b'y-1': [b'x-3'], b'y-2': [b'y-1']})
+    s.update_graph(tasks=valmap(dumps_task, {'x-1': (inc, 1),
+                                             'x-2': (inc, 'x-1'),
+                                             'x-3': (inc, 'x-2'),
+                                             'y-1': (dec, 'x-3'),
+                                             'y-2': (dec, 'y-1')}),
+                   keys=['y-2'],
+                   dependencies={'x-2': ['x-1'], 'x-3': ['x-2'],
+                                 'y-1': ['x-3'], 'y-2': ['y-1']})
 
-    p = MultiProgress([b'y-2'], scheduler=s, func=key_split)
+    p = MultiProgress(['y-2'], scheduler=s, func=key_split)
     yield p.setup()
 
-    assert p.keys == {b'x': {b'x-1', b'x-2', b'x-3'},
-                      b'y': {b'y-1', b'y-2'}}
+    assert p.keys == {'x': {'x-1', 'x-2', 'x-3'},
+                      'y': {'y-1', 'y-2'}}
 
     while True:
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == b'x-3':
+        if msg['op'] == 'key-in-memory' and msg['key'] == 'x-3':
             break
 
-    assert p.keys == {b'x': set(),
-                      b'y': {b'y-1', b'y-2'}}
+    assert p.keys == {'x': set(),
+                      'y': {'y-1', 'y-2'}}
 
     while True:
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == b'y-2':
+        if msg['op'] == 'key-in-memory' and msg['key'] == 'y-2':
             break
 
-    assert p.keys == {b'x': set(),
-                      b'y': set()}
+    assert p.keys == {'x': set(),
+                      'y': set()}
 
     assert p.status == 'finished'
 
@@ -98,15 +98,15 @@ def test_robust_to_bad_plugin(s, a, b):
     s.add_plugin(bad)
 
     sched.put_nowait({'op': 'update-graph',
-                      'tasks': valmap(dumps_task, {b'x': (inc, 1),
-                                                   b'y': (inc, b'x'),
-                                                   b'z': (inc, b'y')}),
-                      'dependencies': {b'y': [b'x'], b'z': [b'y']},
-                      'keys': [b'z']})
+                      'tasks': valmap(dumps_task, {'x': (inc, 1),
+                                                   'y': (inc, 'x'),
+                                                   'z': (inc, 'y')}),
+                      'dependencies': {'y': ['x'], 'z': ['y']},
+                      'keys': ['z']})
 
     while True:  # normal execution
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == b'z':
+        if msg['op'] == 'key-in-memory' and msg['key'] == 'z':
             break
 
 

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -1,15 +1,17 @@
 from operator import add
 import pytest
 import sys
+from toolz import valmap
 from tornado import gen
 from tornado.queues import Queue
 
 from dask.core import get_deps
-from distributed.scheduler import Scheduler
+from distributed.scheduler import dumps_task
 from distributed.utils_test import gen_cluster, cluster, inc, dec, gen_test
-from distributed.utils import All
+from distributed.utils import All, key_split
 from distributed.diagnostics.progress import (Progress, SchedulerPlugin,
         MultiProgress, dependent_keys)
+from distributed.core import dumps
 
 def test_dependent_keys():
     a, b, c, d, e, f, g = 'abcdefg'
@@ -30,18 +32,18 @@ def test_dependent_keys():
 @gen_cluster()
 def test_many_Progresss(s, a, b):
     sched, report = Queue(), Queue(); s.handle_queues(sched, report)
-    s.update_graph(tasks={'x': (inc, 1),
-                          'y': (inc, 'x'),
-                          'z': (inc, 'y')},
-                   keys=['z'],
-                   dependencies={'y': {'x'}, 'z': {'y'}})
+    s.update_graph(tasks=valmap(dumps_task, {b'x': (inc, 1),
+                                             b'y': (inc, b'x'),
+                                             b'z': (inc, b'y')}),
+                   keys=[b'z'],
+                   dependencies={b'y': [b'x'], b'z': [b'y']})
 
     bars = [Progress(keys=['z'], scheduler=s) for i in range(10)]
     yield [b.setup() for b in bars]
 
     while True:
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'z':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'z':
             break
 
     assert all(b.status == 'finished' for b in bars)
@@ -50,36 +52,36 @@ def test_many_Progresss(s, a, b):
 @gen_cluster()
 def test_multiprogress(s, a, b):
     sched, report = Queue(), Queue(); s.handle_queues(sched, report)
-    s.update_graph(tasks={'x-1': (inc, 1),
-                          'x-2': (inc, 'x-1'),
-                          'x-3': (inc, 'x-2'),
-                          'y-1': (dec, 'x-3'),
-                          'y-2': (dec, 'y-1')},
-                   keys=['y-2'],
-                   dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
-                       {'x-3'}, 'y-2': {'y-1'}})
+    s.update_graph(tasks=valmap(dumps_task, {b'x-1': (inc, 1),
+                                             b'x-2': (inc, b'x-1'),
+                                             b'x-3': (inc, b'x-2'),
+                                             b'y-1': (dec, b'x-3'),
+                                             b'y-2': (dec, b'y-1')}),
+                   keys=[b'y-2'],
+                   dependencies={b'x-2': [b'x-1'], b'x-3': [b'x-2'],
+                                 b'y-1': [b'x-3'], b'y-2': [b'y-1']})
 
-    p = MultiProgress(['y-2'], scheduler=s, func=lambda s: s.split('-')[0])
+    p = MultiProgress([b'y-2'], scheduler=s, func=key_split)
     yield p.setup()
 
-    assert p.keys == {'x': {'x-1', 'x-2', 'x-3'},
-                      'y': {'y-1', 'y-2'}}
+    assert p.keys == {b'x': {b'x-1', b'x-2', b'x-3'},
+                      b'y': {b'y-1', b'y-2'}}
 
     while True:
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'x-3':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'x-3':
             break
 
-    assert p.keys == {'x': set(),
-                      'y': {'y-1', 'y-2'}}
+    assert p.keys == {b'x': set(),
+                      b'y': {b'y-1', b'y-2'}}
 
     while True:
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'y-2':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'y-2':
             break
 
-    assert p.keys == {'x': set(),
-                      'y': set()}
+    assert p.keys == {b'x': set(),
+                      b'y': set()}
 
     assert p.status == 'finished'
 
@@ -96,15 +98,15 @@ def test_robust_to_bad_plugin(s, a, b):
     s.add_plugin(bad)
 
     sched.put_nowait({'op': 'update-graph',
-                      'tasks': {'x': (inc, 1),
-                              'y': (inc, 'x'),
-                              'z': (inc, 'y')},
-                      'dependencies': {'y': {'x'}, 'z': {'y'}},
-                      'keys': ['z']})
+                      'tasks': valmap(dumps_task, {b'x': (inc, 1),
+                                                   b'y': (inc, b'x'),
+                                                   b'z': (inc, b'y')}),
+                      'dependencies': {b'y': [b'x'], b'z': [b'y']},
+                      'keys': [b'z']})
 
     while True:  # normal execution
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'z':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'z':
             break
 
 

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -6,6 +6,7 @@ from distributed import Executor, Scheduler, Worker
 from distributed.diagnostics.progressbar import TextProgressBar, progress
 from distributed.utils_test import (cluster, loop, inc,
         div, dec, gen_cluster)
+from distributed.scheduler import dumps_task
 from time import time, sleep
 
 
@@ -30,8 +31,8 @@ def test_text_progressbar(capsys, loop):
 
 @gen_cluster()
 def test_TextProgressBar_error(s, a, b):
-    s.update_graph(tasks={'x': (div, 1, 0)},
-                   keys=['x'],
+    s.update_graph(tasks={b'x': dumps_task((div, 1, 0))},
+                   keys=[b'x'],
                    dependencies={})
 
     progress = TextProgressBar(['x'], scheduler=(s.ip, s.port),

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -31,8 +31,8 @@ def test_text_progressbar(capsys, loop):
 
 @gen_cluster()
 def test_TextProgressBar_error(s, a, b):
-    s.update_graph(tasks={b'x': dumps_task((div, 1, 0))},
-                   keys=[b'x'],
+    s.update_graph(tasks={'x': dumps_task((div, 1, 0))},
+                   keys=['x'],
                    dependencies={})
 
     progress = TextProgressBar(['x'], scheduler=(s.ip, s.port),

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -63,7 +63,10 @@ def record_display(*args):
 from operator import add
 import re
 
+from toolz import valmap
+
 from distributed.executor import Executor, wait
+from distributed.scheduler import dumps_task
 from distributed.utils_test import (cluster, loop, inc,
         div, dec, throws, gen_cluster)
 from distributed.utils import sync
@@ -73,11 +76,11 @@ from distributed.diagnostics.progressbar import (ProgressWidget,
 
 @gen_cluster()
 def test_progressbar_widget(s, a, b):
-    s.update_graph(tasks={'x': (inc, 1),
-                          'y': (inc, 'x'),
-                          'z': (inc, 'y')},
-                   keys=['z'],
-                   dependencies={'y': {'x'}, 'z': {'y'}})
+    s.update_graph(tasks=valmap(dumps_task, {b'x': (inc, 1),
+                                             b'y': (inc, b'x'),
+                                             b'z': (inc, b'y')}),
+                   keys=[b'z'],
+                   dependencies={b'y': {b'x'}, b'z': {b'y'}})
 
     progress = ProgressWidget(['z'], scheduler=(s.ip, s.port))
     yield progress.listen()
@@ -91,29 +94,30 @@ def test_progressbar_widget(s, a, b):
 
 @gen_cluster()
 def test_multi_progressbar_widget(s, a, b):
-    s.update_graph(tasks={'x-1': (inc, 1),
-                          'x-2': (inc, 'x-1'),
-                          'x-3': (inc, 'x-2'),
-                          'y-1': (dec, 'x-3'),
-                          'y-2': (dec, 'y-1'),
-                          'e': (throws, 'y-2'),
-                          'other': (inc, 123)},
-                   keys=['e'],
-                   dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
-                       {'x-3'}, 'y-2': {'y-1'}, 'e': {'y-2'}})
+    s.update_graph(tasks=valmap(dumps_task, {b'x-1': (inc, 1),
+                                             b'x-2': (inc, b'x-1'),
+                                             b'x-3': (inc, b'x-2'),
+                                             b'y-1': (dec, b'x-3'),
+                                             b'y-2': (dec, b'y-1'),
+                                             b'e': (throws, b'y-2'),
+                                             b'other': (inc, 123)}),
+                   keys=[b'e'],
+                   dependencies={b'x-2': [b'x-1'], b'x-3': [b'x-2'],
+                                 b'y-1': [b'x-3'], b'y-2': [b'y-1'],
+                                 b'e': [b'y-2']})
 
     p = MultiProgressWidget(['e'], scheduler=(s.ip, s.port))
     yield p.listen()
 
-    assert p.bars['x'].value == 1.0
-    assert p.bars['y'].value == 1.0
-    assert p.bars['e'].value == 0.0
-    assert '3 / 3' in p.bar_texts['x'].value
-    assert '2 / 2' in p.bar_texts['y'].value
-    assert '0 / 1' in p.bar_texts['e'].value
+    assert p.bars[b'x'].value == 1.0
+    assert p.bars[b'y'].value == 1.0
+    assert p.bars[b'e'].value == 0.0
+    assert '3 / 3' in p.bar_texts[b'x'].value
+    assert '2 / 2' in p.bar_texts[b'y'].value
+    assert '0 / 1' in p.bar_texts[b'e'].value
 
-    assert p.bars['x'].bar_style == 'success'
-    assert p.bars['y'].bar_style == 'success'
+    assert p.bars[b'x'].bar_style == 'success'
+    assert p.bars[b'y'].bar_style == 'success'
     # assert p.bars['e'].bar_style == 'danger'
 
     assert p.status == 'error'
@@ -126,21 +130,22 @@ def test_multi_progressbar_widget(s, a, b):
 
 @gen_cluster()
 def test_multi_progressbar_widget_after_close(s, a, b):
-    s.update_graph(tasks={'x-1': (inc, 1),
-                          'x-2': (inc, 'x-1'),
-                          'x-3': (inc, 'x-2'),
-                          'y-1': (dec, 'x-3'),
-                          'y-2': (dec, 'y-1'),
-                          'e': (throws, 'y-2'),
-                          'other': (inc, 123)},
-                   keys=['e'],
-                   dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
-                       {'x-3'}, 'y-2': {'y-1'}, 'e': {'y-2'}})
+    s.update_graph(tasks=valmap(dumps_task, {b'x-1': (inc, 1),
+                                             b'x-2': (inc, b'x-1'),
+                                             b'x-3': (inc, b'x-2'),
+                                             b'y-1': (dec, b'x-3'),
+                                             b'y-2': (dec, b'y-1'),
+                                             b'e': (throws, b'y-2'),
+                                             b'other': (inc, 123)}),
+                   keys=[b'e'],
+                   dependencies={b'x-2': {b'x-1'}, b'x-3': {b'x-2'},
+                                 b'y-1': {b'x-3'}, b'y-2': {b'y-1'},
+                                 b'e': {b'y-2'}})
 
     p = MultiProgressWidget(['x-1', 'x-2', 'x-3'], scheduler=(s.ip, s.port))
     yield p.listen()
 
-    assert 'x' in p.bars
+    assert b'x' in p.bars
 
 
 def test_values(loop):
@@ -150,11 +155,11 @@ def test_values(loop):
             wait(L)
             p = MultiProgressWidget(L)
             sync(loop, p.listen)
-            assert set(p.bars) == {'inc'}
+            assert set(p.bars) == {b'inc'}
             assert p.status == 'finished'
             assert p.stream.closed()
-            assert '5 / 5' in p.bar_texts['inc'].value
-            assert p.bars['inc'].value == 1.0
+            assert '5 / 5' in p.bar_texts[b'inc'].value
+            assert p.bars[b'inc'].value == 1.0
 
             x = e.submit(throws, 1)
             p = MultiProgressWidget([x])
@@ -185,24 +190,25 @@ def test_progressbar_done(loop):
 
 @gen_cluster()
 def test_multibar_complete(s, a, b):
-    s.update_graph(tasks={'x-1': (inc, 1),
-                          'x-2': (inc, 'x-1'),
-                          'x-3': (inc, 'x-2'),
-                          'y-1': (dec, 'x-3'),
-                          'y-2': (dec, 'y-1'),
-                          'e': (throws, 'y-2'),
-                          'other': (inc, 123)},
-                   keys=['e'],
-                   dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'}, 'y-1':
-                       {'x-3'}, 'y-2': {'y-1'}, 'e': {'y-2'}})
+    s.update_graph(tasks=valmap(dumps_task, {b'x-1': (inc, 1),
+                                             b'x-2': (inc, b'x-1'),
+                                             b'x-3': (inc, b'x-2'),
+                                             b'y-1': (dec, b'x-3'),
+                                             b'y-2': (dec, b'y-1'),
+                                             b'e': (throws, b'y-2'),
+                                             b'other': (inc, 123)}),
+                   keys=[b'e'],
+                   dependencies={b'x-2': {b'x-1'}, b'x-3': {b'x-2'},
+                                 b'y-1': {b'x-3'}, b'y-2': {b'y-1'},
+                                 b'e': {b'y-2'}})
 
     p = MultiProgressWidget(['e'], scheduler=(s.ip, s.port), complete=True)
     yield p.listen()
 
-    assert p._last_response['all'] == {'x': 3, 'y': 2, 'e': 1}
-    assert all(b.value == 1.0 for k, b in p.bars.items() if k != 'e')
-    assert '3 / 3' in p.bar_texts['x'].value
-    assert '2 / 2' in p.bar_texts['y'].value
+    assert p._last_response['all'] == {b'x': 3, b'y': 2, b'e': 1}
+    assert all(b.value == 1.0 for k, b in p.bars.items() if k != b'e')
+    assert '3 / 3' in p.bar_texts[b'x'].value
+    assert '2 / 2' in p.bar_texts[b'y'].value
 
 
 def test_fast(loop):
@@ -213,4 +219,4 @@ def test_fast(loop):
             L3 = e.map(add, L, L2)
             p = progress(L3, multi=True, complete=True, notebook=True)
             sync(loop, p.listen)
-            assert set(p._last_response['all']) == {'inc', 'dec', 'add'}
+            assert set(p._last_response['all']) == {b'inc', b'dec', b'add'}

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import cloudpickle
 from collections import defaultdict, Iterator
 from concurrent.futures._base import DoneAndNotDoneFutures, CancelledError
 from concurrent import futures
@@ -20,7 +21,7 @@ from dask.base import tokenize, normalize_token, Base
 from dask.core import flatten, istask
 from dask.compatibility import apply
 from dask.context import _globals
-from toolz import first, groupby, merge, valmap
+from toolz import first, groupby, merge, valmap, keymap
 from tornado import gen
 from tornado.gen import Return, TimeoutError
 from tornado.locks import Event
@@ -30,8 +31,9 @@ from tornado.queues import Queue
 
 from .client import (WrappedKey, unpack_remotedata, pack_data)
 from .core import read, write, connect, rpc, coerce_to_rpc, dumps
-from .scheduler import Scheduler, dumps_function, dumps_task
-from .utils import All, sync, funcname, ignoring, queue_to_iterator, _deps
+from .scheduler import Scheduler, dumps_function, dumps_task, str_graph
+from .utils import (All, sync, funcname, ignoring, queue_to_iterator, _deps,
+        tobytes, log_errors)
 from .compatibility import Queue as pyQueue, Empty, isqueue
 
 logger = logging.getLogger(__name__)
@@ -249,7 +251,7 @@ class Executor(object):
         self.refcount = defaultdict(lambda: 0)
         self.loop = loop or IOLoop() if start else IOLoop.current()
         self.coroutines = []
-        self.id = str(uuid.uuid1())
+        self.id = tobytes(uuid.uuid1())
         self._start_arg = address
 
         if start:
@@ -305,7 +307,7 @@ class Executor(object):
                 ident = yield r.identity()
             except (StreamClosedError, OSError):
                 raise IOError("Could not connect to %s:%d" % (ip, port))
-            if ident['type'] == 'Scheduler':
+            if ident['type'] == b'Scheduler':
                 self.scheduler = r
                 self.scheduler_stream = yield connect(ip, port)
                 yield write(self.scheduler_stream, {'op': 'register-client',
@@ -351,7 +353,8 @@ class Executor(object):
         if key in self.futures:
             self.futures[key]['event'].clear()
             del self.futures[key]
-        self._send_to_scheduler({'op': 'client-releases-keys', 'keys': [key],
+        self._send_to_scheduler({'op': 'client-releases-keys',
+                                 'keys': [key],
                                  'client': self.id})
 
     @gen.coroutine
@@ -364,50 +367,52 @@ class Executor(object):
         else:
             raise NotImplemented()
 
-        while True:
-            try:
-                msg = yield next_message()
-            except StreamClosedError:
-                break
+        with log_errors():
+            while True:
+                try:
+                    msg = yield next_message()
+                except StreamClosedError:
+                    logger.info("Stream closed to scheduler")
+                    break
 
-            logger.debug("Executor receives message %s", msg)
+                logger.debug("Executor receives message %s", msg)
 
-            if msg['op'] == 'stream-start':
-                start_event.set()
-            if msg['op'] == 'close':
-                break
-            if msg['op'] == 'key-in-memory':
-                if msg['key'] in self.futures:
-                    self.futures[msg['key']]['status'] = 'finished'
-                    self.futures[msg['key']]['event'].set()
-                    if (msg.get('type') and
-                        not self.futures[msg['key']].get('type')):
-                        self.futures[msg['key']]['type'] = msg['type']
-            if msg['op'] == 'lost-data':
-                if msg['key'] in self.futures:
-                    self.futures[msg['key']]['status'] = 'lost'
-                    self.futures[msg['key']]['event'].clear()
-            if msg['op'] == 'cancelled-key':
-                if msg['key'] in self.futures:
-                    self.futures[msg['key']]['event'].set()
-                    del self.futures[msg['key']]
-            if msg['op'] == 'task-erred':
-                if msg['key'] in self.futures:
-                    self.futures[msg['key']]['status'] = 'error'
-                    self.futures[msg['key']]['exception'] = msg['exception']
-                    self.futures[msg['key']]['traceback'] = msg['traceback']
-                    self.futures[msg['key']]['event'].set()
-            if msg['op'] == 'restart':
-                logger.info("Receive restart signal from scheduler")
-                events = [d['event'] for d in self.futures.values()]
-                self.futures.clear()
-                for e in events:
-                    e.set()
-                with ignoring(AttributeError):
-                    self._restart_event.set()
-            if msg['op'] == 'scheduler-error':
-                logger.warn("Scheduler exception:")
-                logger.exception(msg['exception'])
+                if msg['op'] == 'stream-start':
+                    start_event.set()
+                elif msg['op'] == 'close':
+                    break
+                elif msg['op'] == 'key-in-memory':
+                    if msg['key'] in self.futures:
+                        self.futures[msg['key']]['status'] = 'finished'
+                        self.futures[msg['key']]['event'].set()
+                        if (msg.get('type') and
+                            not self.futures[msg['key']].get('type')):
+                            self.futures[msg['key']]['type'] = cloudpickle.loads(msg['type'])
+                elif msg['op'] == 'lost-data':
+                    if msg['key'] in self.futures:
+                        self.futures[msg['key']]['status'] = 'lost'
+                        self.futures[msg['key']]['event'].clear()
+                elif msg['op'] == 'cancelled-key':
+                    if msg['key'] in self.futures:
+                        self.futures[msg['key']]['event'].set()
+                        del self.futures[msg['key']]
+                elif msg['op'] == 'task-erred':
+                    if msg['key'] in self.futures:
+                        self.futures[msg['key']]['status'] = 'error'
+                        self.futures[msg['key']]['exception'] = cloudpickle.loads(msg['exception'])
+                        self.futures[msg['key']]['traceback'] = cloudpickle.loads(msg['traceback'])
+                        self.futures[msg['key']]['event'].set()
+                elif msg['op'] == 'restart':
+                    logger.info("Receive restart signal from scheduler")
+                    events = [d['event'] for d in self.futures.values()]
+                    self.futures.clear()
+                    for e in events:
+                        e.set()
+                    with ignoring(AttributeError):
+                        self._restart_event.set()
+                elif msg['op'] == 'scheduler-error':
+                    logger.warn("Scheduler exception:")
+                    logger.exception(msg['exception'])
 
     @gen.coroutine
     def _shutdown(self, fast=False):
@@ -472,6 +477,8 @@ class Executor(object):
             else:
                 key = funcname(func) + '-' + str(uuid.uuid4())
 
+        key = tobytes(key)
+
         if key in self.futures:
             return Future(key, self)
 
@@ -482,13 +489,13 @@ class Executor(object):
             workers = [workers]
         if workers is not None:
             restrictions = {key: workers}
-            loose_restrictions = {key} if allow_other_workers else set()
+            loose_restrictions = [key] if allow_other_workers else []
         else:
             restrictions = {}
-            loose_restrictions = set()
+            loose_restrictions = []
 
-        args2, arg_dependencies = unpack_remotedata(args)
-        kwargs2, kwarg_dependencies = unpack_remotedata(kwargs)
+        args2, arg_dependencies = unpack_remotedata(args, byte_keys=True)
+        kwargs2, kwarg_dependencies = unpack_remotedata(kwargs, byte_keys=True)
         dependencies = arg_dependencies | kwarg_dependencies
 
         task = {'function': dumps_function(func)}
@@ -501,8 +508,8 @@ class Executor(object):
         self._send_to_scheduler({'op': 'update-graph',
                                  'tasks': {key: task},
                                  'keys': [key],
-                                 'dependencies': {key: dependencies},
-                                 'restrictions': restrictions,
+                                 'dependencies': {key: list(dependencies)},
+                                 'restrictions': valmap(list, restrictions),
                                  'loose_restrictions': loose_restrictions,
                                  'client': self.id})
 
@@ -579,8 +586,10 @@ class Executor(object):
                     for args in zip(*iterables)]
         else:
             uid = str(uuid.uuid4())
-            keys = [funcname(func) + '-' + uid + '-' + str(uuid.uuid4())
+            keys = [funcname(func) + '-' + uid + '-' + str(i)
                     for i in range(min(map(len, iterables)))]
+
+        keys = [tobytes(key) for key in keys]
 
         if not kwargs:
             dsk = {key: (func,) + args
@@ -589,9 +598,9 @@ class Executor(object):
             dsk = {key: (apply, func, (tuple, list(args)), kwargs)
                    for key, args in zip(keys, zip(*iterables))}
 
-        d = {key: unpack_remotedata(task) for key, task in dsk.items()}
-        dsk = {k: v[0] for k, v in d.items()}
-        dependencies = {k: v[1] for k, v in d.items()}
+        d = {key: unpack_remotedata(task, byte_keys=True) for key, task in dsk.items()}
+        dsk2 = str_graph({k: v[0] for k, v in d.items()})
+        dependencies = {tobytes(k): set(map(tobytes, v[1])) for k, v in d.items()}
 
         if isinstance(workers, str):
             workers = [workers]
@@ -614,22 +623,21 @@ class Executor(object):
         else:
             loose_restrictions = set()
 
-
         logger.debug("map(%s, ...)", funcname(func))
         self._send_to_scheduler({'op': 'update-graph',
-                                 'tasks': valmap(dumps_task, dsk),
-                                 'dependencies': dependencies,
+                                 'tasks': valmap(dumps_task, dsk2),
+                                 'dependencies': valmap(list, dependencies),
                                  'keys': keys,
-                                 'restrictions': restrictions,
-                                 'loose_restrictions': loose_restrictions,
+                                 'restrictions': valmap(list, restrictions),
+                                 'loose_restrictions': list(loose_restrictions),
                                  'client': self.id})
 
         return [Future(key, self) for key in keys]
 
     @gen.coroutine
     def _gather(self, futures, errors='raise'):
-        futures2, keys = unpack_remotedata(futures)
-        keys = list(keys)
+        futures2, keys = unpack_remotedata(futures, byte_keys=True)
+        keys = [tobytes(key) for key in keys]
         bad_data = dict()
 
         while True:
@@ -647,13 +655,13 @@ class Executor(object):
                 else:
                     raise ValueError("Bad value, `errors=%s`" % errors)
 
-            response, data = yield self.scheduler.gather(keys=keys)
+            response = yield self.scheduler.gather(keys=keys)
 
-            if response == b'error':
-                logger.debug("Couldn't gather keys %s", data)
+            if response['status'] == b'error':
+                logger.debug("Couldn't gather keys %s", response['keys'])
                 self._send_to_scheduler({'op': 'missing-data',
-                                         'missing': data.args})
-                for key in data.args:
+                                         'missing': response['keys']})
+                for key in response['keys']:
                     self.futures[key]['event'].clear()
             else:
                 break
@@ -661,6 +669,7 @@ class Executor(object):
         if bad_data and errors == 'skip' and isinstance(futures2, list):
             futures2 = [f for f in futures2 if f not in exceptions]
 
+        data = valmap(cloudpickle.loads, response['data'])
         result = pack_data(futures2, merge(data, bad_data))
         raise gen.Return(result)
 
@@ -713,7 +722,15 @@ class Executor(object):
 
     @gen.coroutine
     def _scatter(self, data, workers=None, broadcast=False):
-        keys = yield self.scheduler.scatter(data=data, workers=workers,
+        if isinstance(data, dict) and not all(isinstance(k, bytes) for k in data):
+            d = yield self._scatter(keymap(tobytes, data), workers, broadcast)
+            raise gen.Return({k: d[tobytes(k)] for k in data})
+
+        if isinstance(data, dict):
+            data2 = valmap(dumps, data)
+        if isinstance(data, (list, tuple, set, frozenset)):
+            data2 = type(data)(map(dumps, data))
+        keys = yield self.scheduler.scatter(data=data2, workers=workers,
                                             client=self.id, broadcast=broadcast)
         if isinstance(data, (tuple, list, set, frozenset)):
             out = type(data)([Future(k, self) for k in keys])
@@ -812,7 +829,7 @@ class Executor(object):
     @gen.coroutine
     def _cancel(self, futures, block=False):
         keys = {f.key for f in futures_of(futures)}
-        f = self.scheduler.cancel(keys=keys, client=self.id)
+        f = self.scheduler.cancel(keys=list(keys), client=self.id)
         if block:
             yield f
         for k in keys:
@@ -835,22 +852,26 @@ class Executor(object):
 
     @gen.coroutine
     def _get(self, dsk, keys, restrictions=None, raise_on_error=True):
-        flatkeys = list(flatten([keys]))
+        flatkeys = list(map(tobytes, flatten([keys])))
         futures = {key: Future(key, self) for key in flatkeys}
 
-        d = {k: unpack_remotedata(v) for k, v in dsk.items()}
-        dsk2 = {k: v[0] for k, v in d.items()}
+        d = {k: unpack_remotedata(v, byte_keys=True) for k, v in dsk.items()}
+        dsk2 = str_graph({k: v[0] for k, v in d.items()})
         dsk3 = {k: v for k, v in dsk2.items() if (k == v) is not True}
 
-        dependencies = {k: v[1] for k, v in d.items()}
+        if restrictions:
+            restrictions = keymap(tobytes, restrictions)
+            restrictions = valmap(list, restrictions)
+
+        dependencies = {tobytes(k): set(map(tobytes, v[1])) for k, v in d.items()}
 
         for k, v in dsk3.items():
-            dependencies[k] |= set(_deps(dsk, v))
+            dependencies[k] |= set(_deps(dsk3, v))
 
         self._send_to_scheduler({'op': 'update-graph',
                                  'tasks': valmap(dumps_task, dsk3),
-                                 'dependencies': dependencies,
-                                 'keys': flatkeys,
+                                 'dependencies': valmap(list, dependencies),
+                                 'keys': list(flatkeys),
                                  'restrictions': restrictions or {},
                                  'client': self.id})
 
@@ -943,19 +964,19 @@ class Executor(object):
         dsk = merge([opt(merge([v.dask for v in val]),
                          [v._keys() for v in val])
                     for opt, val in groups.items()])
-        names = ['finalize-%s' % tokenize(v) for v in variables]
+        names = [tobytes('finalize-%s' % tokenize(v)) for v in variables]
         dsk2 = {name: (v._finalize, v._keys()) for name, v in zip(names, variables)}
 
-        d = {k: unpack_remotedata(v) for k, v in merge(dsk, dsk2).items()}
-        dsk3 = {k: v[0] for k, v in d.items()}
-        dependencies = {k: v[1] for k, v in d.items()}
+        d = {k: unpack_remotedata(v, byte_keys=True) for k, v in merge(dsk, dsk2).items()}
+        dsk3 = str_graph({k: v[0] for k, v in d.items()})
+        dependencies = {tobytes(k): set(map(tobytes, v[1])) for k, v in d.items()}
 
         for k, v in dsk3.items():
-            dependencies[k] |= set(_deps(dsk, v))
+            dependencies[k] |= set(_deps(dsk3, v))
 
         self._send_to_scheduler({'op': 'update-graph',
                                  'tasks': valmap(dumps_task, dsk3),
-                                 'dependencies': dependencies,
+                                 'dependencies': valmap(list, dependencies),
                                  'keys': names,
                                  'client': self.id})
 
@@ -1016,21 +1037,22 @@ class Executor(object):
                          [v._keys() for v in val])
                     for opt, val in groups.items()])
 
-        d = {k: unpack_remotedata(v) for k, v in dsk.items()}
-        dsk2 = {k: v[0] for k, v in d.items()}
-        dependencies = {k: v[1] for k, v in d.items()}
+        d = {k: unpack_remotedata(v, byte_keys=True) for k, v in dsk.items()}
+        dsk2 = str_graph({k: v[0] for k, v in d.items()})
+        dependencies = {tobytes(k): set(map(tobytes, v[1])) for k, v in d.items()}
 
         for k, v in dsk2.items():
-            dependencies[k] |= set(_deps(dsk, v))
+            dependencies[k] |= set(_deps(dsk2, v))
 
-        names = list({k for c in collections for k in flatten(c._keys())})
+        names = list({tobytes(k) for c in collections for k in flatten(c._keys())})
 
         self._send_to_scheduler({'op': 'update-graph',
                                  'tasks': valmap(dumps_task, dsk2),
-                                 'dependencies': dependencies,
+                                 'dependencies': valmap(list, dependencies),
                                  'keys': names,
                                  'client': self.id})
-        result = [redict_collection(c, {k: Future(k, self)
+
+        result = [redict_collection(c, {k: Future(tobytes(k), self)
                                         for k in flatten(c._keys())})
                 for c in collections]
         if singleton:
@@ -1063,14 +1085,15 @@ class Executor(object):
                                                 'filename': fn,
                                                 'data': data})
 
-        if any(isinstance(v, Exception) for v in d.values()):
-            exception = next(v for v in d.values() if isinstance(v, Exception))
+        if any(v[b'status'] == b'error' for v in d.values()):
+            exceptions = [cloudpickle.loads(v[b'exception']) for v in d.values()
+                          if v[b'status'] == b'error']
             if raise_on_error:
-                raise exception
+                raise exceptions[0]
             else:
-                raise gen.Return(exception)
+                raise gen.Return(exceptions[0])
 
-        assert all(len(data) == v for v in d.values())
+        assert all(len(data) == v[b'nbytes'] for v in d.values())
 
     def upload_file(self, filename):
         """ Upload local package to workers

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -78,7 +78,7 @@ def read_bytes(fn, executor=None, hdfs=None, lazy=True, delimiter=None,
         offsets = [max([o, 1]) for o in offsets]
     lengths = [d['length'] for d in blocks]
     workers = [[h.decode() for h in d['hosts']] for d in blocks]
-    names = [('read-binary-%s-%d-%d' % (fn, offset, length))
+    names = ['read-binary-%s-%d-%d' % (fn, offset, length)
             for fn, offset, length in zip(filenames, offsets, lengths)]
 
     logger.debug("Read %d blocks of binary bytes from %s", len(blocks), fn)

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -78,7 +78,7 @@ def read_bytes(fn, executor=None, hdfs=None, lazy=True, delimiter=None,
         offsets = [max([o, 1]) for o in offsets]
     lengths = [d['length'] for d in blocks]
     workers = [[h.decode() for h in d['hosts']] for d in blocks]
-    names = ['read-binary-%s-%d-%d' % (fn, offset, length)
+    names = [('read-binary-%s-%d-%d' % (fn, offset, length))
             for fn, offset, length in zip(filenames, offsets, lengths)]
 
     logger.debug("Read %d blocks of binary bytes from %s", len(blocks), fn)
@@ -86,10 +86,10 @@ def read_bytes(fn, executor=None, hdfs=None, lazy=True, delimiter=None,
         restrictions = dict(zip(names, workers))
         executor._send_to_scheduler({'op': 'update-graph',
                                      'tasks': {},
-                                     'dependencies': set(),
+                                     'dependencies': [],
                                      'keys': [],
                                      'restrictions': restrictions,
-                                     'loose_restrictions': set(names),
+                                     'loose_restrictions': names,
                                      'client': executor.id})
         values = [Value(name, [{name: (read_block_from_hdfs, fn, offset, length, hdfs.host, hdfs.port, delimiter)}])
                   for name, fn, offset, length in zip(names, filenames, offsets, lengths)]

--- a/distributed/http/scheduler.py
+++ b/distributed/http/scheduler.py
@@ -14,18 +14,22 @@ from ..utils import key_split
 logger = logging.getLogger(__name__)
 
 
+def ensure_string(s):
+    if not isinstance(s, str):
+        s = s.decode()
+    return s
+
 class Info(RequestHandler):
     """ Basic info about the scheduler """
     def get(self):
-        resp = {'ncores': {'%s:%d' % k: n for k, n in self.server.ncores.items()},
-                'status': self.server.status}
-        self.write(resp)
+        self.write({'ncores': self.server.ncores,
+                    'status': self.server.status})
 
 
 class Processing(RequestHandler):
     """ Active tasks on each worker """
     def get(self):
-        resp = {'%s:%d' % addr: list(map(key_split, tasks))
+        resp = {addr: [ensure_string(key_split(t)) for t in tasks]
                 for addr, tasks in self.server.processing.items()}
         self.write(resp)
 
@@ -34,11 +38,11 @@ class Broadcast(RequestHandler):
     """ Send REST call to all workers, collate their responses """
     @gen.coroutine
     def get(self, rest):
-        addresses = [(ip, port, d['http'])
-                     for (ip, port), d in self.server.worker_services.items()
+        addresses = [addr.split(':') + [d['http']]
+                     for addr, d in self.server.worker_services.items()
                      if 'http' in d]
         client = AsyncHTTPClient()
-        responses = {'%s:%d' % (ip, tcp_port): client.fetch("http://%s:%d/%s" %
+        responses = {'%s:%s' % (ip, tcp_port): client.fetch("http://%s:%s/%s" %
                                                   (ip, http_port, rest))
                      for ip, tcp_port, http_port in addresses}
         responses2 = yield responses
@@ -50,10 +54,8 @@ class Broadcast(RequestHandler):
 class MemoryLoad(RequestHandler):
     """The total amount of data held in memory by workers"""
     def get(self):
-        out = {}
-        for worker, keys in self.server.has_what.items():
-            out["%s:%s"%worker] = sum(self.server.nbytes[k] for k in keys)
-        self.write(out)
+        self.write({worker: sum(self.server.nbytes[k] for k in keys)
+                   for worker, keys in self.server.has_what.items()})
 
 
 class MemoryLoadByKey(RequestHandler):
@@ -64,7 +66,7 @@ class MemoryLoadByKey(RequestHandler):
             d = defaultdict(lambda: 0)
             for key in keys:
                 d[key_split(key)] += self.server.nbytes[key]
-            out["%s:%d" % worker] = dict(d)
+            out[worker] = {k.decode(): v for k, v in d.items()}
         self.write(out)
 
 

--- a/distributed/http/scheduler.py
+++ b/distributed/http/scheduler.py
@@ -9,13 +9,14 @@ from tornado.httpclient import AsyncHTTPClient
 
 from .core import RequestHandler, MyApp, Resources, Proxy
 from ..utils import key_split
+from ..compatibility import unicode
 
 
 logger = logging.getLogger(__name__)
 
 
 def ensure_string(s):
-    if not isinstance(s, str):
+    if not isinstance(s, unicode):
         s = s.decode()
     return s
 
@@ -66,7 +67,7 @@ class MemoryLoadByKey(RequestHandler):
             d = defaultdict(lambda: 0)
             for key in keys:
                 d[key_split(key)] += self.server.nbytes[key]
-            out[worker] = {k.decode(): v for k, v in d.items()}
+            out[worker] = {k: v for k, v in d.items()}
         self.write(out)
 
 

--- a/distributed/http/tests/test_scheduler_http.py
+++ b/distributed/http/tests/test_scheduler_http.py
@@ -21,8 +21,8 @@ def test_simple(s, a, b):
 
     response = yield client.fetch('http://localhost:%d/info.json' % server.port)
     response = json.loads(response.body.decode())
-    assert response['ncores'] == {'%s:%d' % k: v for k, v in s.ncores.items()}
-    assert response['status'] == a.status
+    assert response == {'ncores': s.ncores,
+                        'status': s.status}
 
     server.stop()
 
@@ -33,7 +33,7 @@ def test_processing(s, a, b):
     server.listen(0)
     client = AsyncHTTPClient()
 
-    s.processing[a.address].add(('foo-1', 1))
+    s.processing[a.address_string].add(('foo-1', 1))
 
     response = yield client.fetch('http://localhost:%d/processing.json' % server.port)
     response = json.loads(response.body.decode())
@@ -68,13 +68,13 @@ def test_broadcast(s, a, b):
     aa.listen(0)
     a.services['http'] = aa
     a.service_ports['http'] = aa.port
-    s.worker_services[a.address]['http'] = aa.port
+    s.worker_services[a.address_string]['http'] = aa.port
 
     bb = HTTPWorker(b)
     bb.listen(0)
     b.services['http'] = bb
     b.service_ports['http'] = bb.port
-    s.worker_services[b.address]['http'] = bb.port
+    s.worker_services[b.address_string]['http'] = bb.port
 
     client = AsyncHTTPClient()
 
@@ -111,7 +111,7 @@ def test_with_data(s, a, b):
     yield _wait(L)
 
     client = AsyncHTTPClient()
-    response = yield client.fetch('http://localhost:%s/memory-load.json' %
+    response = yield client.fetch('http://localhost:%d/memory-load.json' %
                                   ss.port)
     out = json.loads(response.body.decode())
 

--- a/distributed/http/tests/test_scheduler_http.py
+++ b/distributed/http/tests/test_scheduler_http.py
@@ -98,13 +98,10 @@ def test_services():
     assert s.services['http'].port
 
 
-@gen_cluster()
-def test_with_data(s, a, b):
+@gen_cluster(executor=True)
+def test_with_data(e, s, a, b):
     ss = HTTPScheduler(s)
     ss.listen(0)
-
-    e = Executor((s.ip, s.port), start=False)
-    yield e._start()
 
     L = e.map(inc, [1, 2, 3])
     L2 = yield e._scatter(['Hello', 'world!'])
@@ -132,4 +129,3 @@ def test_with_data(s, a, b):
             sum(map(sys.getsizeof, [1, 2, 3, 'Hello', 'world!']))
 
     ss.stop()
-    yield e._shutdown()

--- a/distributed/http/tests/test_scheduler_http.py
+++ b/distributed/http/tests/test_scheduler_http.py
@@ -33,11 +33,11 @@ def test_processing(s, a, b):
     server.listen(0)
     client = AsyncHTTPClient()
 
-    s.processing[a.address_string].add(('foo-1', 1))
+    s.processing[a.address].add(('foo-1', 1))
 
     response = yield client.fetch('http://localhost:%d/processing.json' % server.port)
     response = json.loads(response.body.decode())
-    assert response == {a.address_string: ['foo'], b.address_string: []}
+    assert response == {a.address: ['foo'], b.address: []}
 
     server.stop()
 
@@ -68,13 +68,13 @@ def test_broadcast(s, a, b):
     aa.listen(0)
     a.services['http'] = aa
     a.service_ports['http'] = aa.port
-    s.worker_services[a.address_string]['http'] = aa.port
+    s.worker_services[a.address]['http'] = aa.port
 
     bb = HTTPWorker(b)
     bb.listen(0)
     b.services['http'] = bb
     b.service_ports['http'] = bb.port
-    s.worker_services[b.address_string]['http'] = bb.port
+    s.worker_services[b.address]['http'] = bb.port
 
     client = AsyncHTTPClient()
 
@@ -83,8 +83,8 @@ def test_broadcast(s, a, b):
     s_response = yield client.fetch('http://localhost:%d/broadcast/info.json'
                                     % ss.port)
     assert (json.loads(s_response.body.decode()) ==
-            {a.address_string: json.loads(a_response.body.decode()),
-             b.address_string: json.loads(b_response.body.decode())})
+            {a.address: json.loads(a_response.body.decode()),
+             b.address: json.loads(b_response.body.decode())})
 
     ss.stop()
     aa.stop()
@@ -116,14 +116,14 @@ def test_with_data(s, a, b):
     out = json.loads(response.body.decode())
 
     assert all(isinstance(v, int) for v in out.values())
-    assert set(out) == {a.address_string, b.address_string}
+    assert set(out) == {a.address, b.address}
     assert sum(out.values()) == sum(map(sys.getsizeof,
                                         [1, 2, 3, 'Hello', 'world!']))
 
     response = yield client.fetch('http://localhost:%s/memory-load-by-key.json'
                                   % ss.port)
     out = json.loads(response.body.decode())
-    assert set(out) == {a.address_string, b.address_string}
+    assert set(out) == {a.address, b.address}
     assert all(isinstance(v, dict) for v in out.values())
     assert all(k in {'inc', 'data'} for d in out.values() for k in d)
     assert all(isinstance(v, int) for d in out.values() for v in d.values())

--- a/distributed/http/tests/test_worker_http.py
+++ b/distributed/http/tests/test_worker_http.py
@@ -50,6 +50,6 @@ def test_services(s, a, b):
     yield c._start()
     assert isinstance(c.services['http'], HTTPServer)
     assert c.service_ports['http'] == c.services['http'].port
-    assert s.worker_services[c.address]['http'] == c.service_ports['http']
+    assert s.worker_services[c.address_string]['http'] == c.service_ports['http']
 
     yield c._close()

--- a/distributed/http/tests/test_worker_http.py
+++ b/distributed/http/tests/test_worker_http.py
@@ -50,6 +50,6 @@ def test_services(s, a, b):
     yield c._start()
     assert isinstance(c.services['http'], HTTPServer)
     assert c.service_ports['http'] == c.services['http'].port
-    assert s.worker_services[c.address_string]['http'] == c.service_ports['http']
+    assert s.worker_services[c.address]['http'] == c.service_ports['http']
 
     yield c._close()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -155,19 +155,23 @@ class Nanny(Server):
     def worker_address(self):
         return (self.ip, self.worker_port)
 
+    @property
+    def worker_address_string(self):
+        return '%s:%d' % self.worker_address
+
     def resource_collect(self):
         try:
             import psutil
         except ImportError:
             return {}
         p = psutil.Process(self.process.pid)
-        return {'timestamp': datetime.now(),
+        return {'timestamp': datetime.now().isoformat(),
                 'cpu_percent': psutil.cpu_percent(),
                 'status': p.status(),
                 'memory_percent': p.memory_percent(),
-                'memory_info_ex': p.memory_info_ex(),
-                'disk_io_counters': psutil.disk_io_counters(),
-                'net_io_counters': psutil.net_io_counters()}
+                'memory_info_ex': p.memory_info_ex()._asdict(),
+                'disk_io_counters': psutil.disk_io_counters()._asdict(),
+                'net_io_counters': psutil.net_io_counters()._asdict()}
 
     @gen.coroutine
     def monitor_resources(self, stream, interval=1):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -71,7 +71,7 @@ class Nanny(Server):
                             self.center.unregister(address=self.worker_address))
                 if result != 'OK':
                     logger.critical("Unable to unregister with center %s. "
-                            "Nanny: %s, Worker: %s", result, self.address,
+                            "Nanny: %s, Worker: %s", result, self.address_tuple,
                             self.worker_address)
                 else:
                     logger.info("Unregister worker %s:%d from center",
@@ -149,15 +149,19 @@ class Nanny(Server):
 
     @property
     def address(self):
+        return '%s:%d' % (self.ip, self.port)
+
+    @property
+    def address_tuple(self):
         return (self.ip, self.port)
 
     @property
-    def worker_address(self):
+    def worker_address_tuple(self):
         return (self.ip, self.worker_port)
 
     @property
-    def worker_address_string(self):
-        return '%s:%d' % self.worker_address
+    def worker_address(self):
+        return '%s:%d' % (self.ip, self.worker_port)
 
     def resource_collect(self):
         try:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -69,7 +69,7 @@ class Nanny(Server):
             try:
                 result = yield gen.with_timeout(timedelta(seconds=timeout),
                             self.center.unregister(address=self.worker_address))
-                if result != b'OK':
+                if result != 'OK':
                     logger.critical("Unable to unregister with center %s. "
                             "Nanny: %s, Worker: %s", result, self.address,
                             self.worker_address)
@@ -85,7 +85,7 @@ class Nanny(Server):
             logger.info("Nanny %s:%d kills worker process %s:%d",
                         self.ip, self.port, self.ip, self.worker_port)
             self.cleanup()
-        raise gen.Return(b'OK')
+        raise gen.Return('OK')
 
     @gen.coroutine
     def instantiate(self, stream=None):
@@ -115,7 +115,7 @@ class Nanny(Server):
                 yield gen.sleep(0.1)
         logger.info("Nanny %s:%d starts worker process %s:%d",
                     self.ip, self.port, self.ip, self.worker_port)
-        raise gen.Return(b'OK')
+        raise gen.Return('OK')
 
     def cleanup(self):
         if self.worker_dir and os.path.exists(self.worker_dir):
@@ -145,7 +145,7 @@ class Nanny(Server):
         self.center.close_streams()
         self.stop()
         self.status = 'closed'
-        raise gen.Return(b'OK')
+        raise gen.Return('OK')
 
     @property
     def address(self):

--- a/distributed/protocol.py
+++ b/distributed/protocol.py
@@ -35,6 +35,7 @@ except ImportError:
 from toolz import first, keymap
 
 from .utils import ignoring
+from .compatibility import unicode
 
 
 compressions = {}

--- a/distributed/protocol.py
+++ b/distributed/protocol.py
@@ -1,0 +1,112 @@
+"""
+The distributed message protocol consists of the following parts:
+
+1.  The length of the header, stored as a uint32
+2.  The header, stored as msgpack.
+    If there are no fields in the header then we skip it entirely.
+3.  The payload, stored as possibly compressed msgpack
+4.  A sentinel value
+
+**Header**
+
+The Header contains the following fields:
+
+* **compression**: string, optional
+    One of the following: ``'snappy', 'lz4', 'zlib'`` or missing for None
+
+**Payload**
+
+The payload is any msgpack serializable value.  It may be compressed based
+on the header.
+
+**Sentinel**
+
+We often terminate each message with a sentinel value.  This happens
+outside of this module though and is not baked in.
+"""
+from io import BytesIO
+import struct
+
+try:
+    import pandas.msgpack as msgpack
+except ImportError:
+    import msgpack
+
+from toolz import first, keymap
+
+from .utils import ignoring
+
+
+compressions = {}
+
+default_compression = None
+
+with ignoring(ImportError):
+    import zlib
+    compressions['zlib'] = {'compress': zlib.compress,
+                            'decompress': zlib.decompress}
+
+with ignoring(ImportError):
+    import snappy
+    compressions['snappy'] = {'compress': snappy.compress,
+                              'decompress': snappy.decompress}
+    default_compression = 'snappy'
+
+with ignoring(ImportError):
+    import lz4
+    compressions['lz4'] = {'compress': lz4.LZ4_compress,
+                           'decompress': lz4.LZ4_uncompress}
+    default_compression = 'lz4'
+
+
+def dumps(msg):
+    """ Transform Python value to bytestream suitable for communication """
+    header = {}
+
+    payload = msgpack.dumps(msg, use_bin_type=True)
+
+    if len(payload) > 1e3 and default_compression:
+        payload = compressions[default_compression]['compress'](payload)
+        header['compression'] = default_compression
+
+    if header:
+        header_bytes = msgpack.dumps(header, use_bin_type=True)
+    else:
+        header_bytes = b''
+    out = BytesIO()
+    out.write(struct.pack('I', len(header_bytes)))
+    out.write(header_bytes)
+    out.write(payload)
+
+    out.seek(0)
+    return out.read()
+
+
+def loads(b):
+    """ Transform bytestream back into Python value """
+    header_length, = struct.unpack('I', b[:4])
+    if header_length:
+        header = msgpack.loads(b[4: header_length + 4], encoding='utf8')
+    else:
+        header = {}
+    payload = b[header_length + 4:]
+
+    if header.get('compression'):
+        try:
+            decompress = compressions[header['compression']]['decompress']
+            payload = decompress(payload)
+        except KeyError:
+            raise ValueError("Data is compressed as %s but we don't have this"
+                    " installed" % header['compression'].decode())
+
+    msg = msgpack.loads(payload, encoding='utf8')
+
+    if header.get('decode'):
+        if isinstance(msg, dict) and msg:
+            msg = keymap(bytes.decode, msg)
+        elif isinstance(msg, bytes):
+            msg = msg.decode()
+        else:
+            raise TypeError("Asked to decode a %s" % type(msg).__name__)
+
+    return msg

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1552,3 +1552,21 @@ def dumps_task(task):
             return {'function': dumps_function(task[0]),
                         'args': dumps(task[1:])}
     return {'task': dumps(task)}
+
+
+def str_graph(dsk):
+    def convert(task):
+        if isinstance(task, list):
+            return [convert(v) for v in task]
+        if isinstance(task, dict):
+            return valmap(convert, task)
+        if istask(task):
+            return (task[0],) + tuple(map(convert, task[1:]))
+        try:
+            if task in dsk:
+                return str(task)
+        except TypeError:
+            pass
+        return task
+
+    return {str(k): convert(v) for k, v in dsk.items()}

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1196,8 +1196,8 @@ def decide_worker(dependencies, stacks, who_has, restrictions,
     """ Decide which worker should take task
 
     >>> dependencies = {'c': {'b'}, 'b': {'a'}}
-    >>> stacks = {('alice', 8000): ['z'], ('bob', 8000): []}
-    >>> who_has = {'a': {('alice', 8000)}}
+    >>> stacks = {'alice:8000': ['z'], 'bob:8000': []}
+    >>> who_has = {'a': {'alice:8000'}}
     >>> nbytes = {'a': 100}
     >>> restrictions = {}
     >>> loose_restrictions = set()
@@ -1206,33 +1206,33 @@ def decide_worker(dependencies, stacks, who_has, restrictions,
 
     >>> decide_worker(dependencies, stacks, who_has, restrictions,
     ...               loose_restrictions, nbytes, 'b')
-    ('alice', 8000)
+    'alice:8000'
 
     If both Alice and Bob have dependencies then we choose the less-busy worker
 
-    >>> who_has = {'a': {('alice', 8000), ('bob', 8000)}}
+    >>> who_has = {'a': {'alice:8000', 'bob:8000'}}
     >>> decide_worker(dependencies, stacks, who_has, restrictions,
     ...               loose_restrictions, nbytes, 'b')
-    ('bob', 8000)
+    'bob:8000'
 
     Optionally provide restrictions of where jobs are allowed to occur
 
     >>> restrictions = {'b': {'alice', 'charile'}}
     >>> decide_worker(dependencies, stacks, who_has, restrictions,
     ...               loose_restrictions, nbytes, 'b')
-    ('alice', 8000)
+    'alice:8000'
 
     If the task requires data communication, then we choose to minimize the
     number of bytes sent between workers. This takes precedence over worker
     occupancy.
 
     >>> dependencies = {'c': {'a', 'b'}}
-    >>> who_has = {'a': {('alice', 8000)}, 'b': {('bob', 8000)}}
+    >>> who_has = {'a': {'alice:8000'}, 'b': {'bob:8000'}}
     >>> nbytes = {'a': 1, 'b': 1000}
-    >>> stacks = {('alice', 8000): [], ('bob', 8000): []}
+    >>> stacks = {'alice:8000': [], 'bob:8000': []}
 
     >>> decide_worker(dependencies, stacks, who_has, {}, set(), nbytes, 'c')
-    ('bob', 8000)
+    'bob:8000'
     """
     deps = dependencies[key]
     workers = frequencies(w for dep in deps

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -225,6 +225,10 @@ class Scheduler(Server):
 
     @property
     def address(self):
+        return '%s:%d' % (self.ip, self.port)
+
+    @property
+    def address_tuple(self):
         return (self.ip, self.port)
 
     def identity(self, stream):

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -19,7 +19,7 @@ with ignoring(ImportError):
     import numpy as np
     @sizeof.register(np.ndarray)
     def sizeof_numpy_ndarray(x):
-        return x.nbytes
+        return int(x.nbytes)
 
 
 with ignoring(ImportError):
@@ -28,20 +28,20 @@ with ignoring(ImportError):
     def sizeof_pandas_dataframe(df):
         o = sys.getsizeof(df)
         try:
-            return o + df.memory_usage(index=True, deep=True).sum()
+            return int(o + df.memory_usage(index=True, deep=True).sum())
         except:
-            return o + df.memory_usage(index=True).sum()
+            return int(o + df.memory_usage(index=True).sum())
 
     @sizeof.register(pd.Series)
     def sizeof_pandas_series(s):
         try:
-            return s.memory_usage(index=True, deep=True) # new in 0.17.1
+            return int(s.memory_usage(index=True, deep=True)) # new in 0.17.1
         except:
-            return sizeof(s.values) + sizeof(s.index)
+            return int(sizeof(s.values) + sizeof(s.index))
 
     @sizeof.register(pd.Index)
     def sizeof_pandas_index(i):
         try:
-            return i.memory_usage(deep=True)
+            return int(i.memory_usage(deep=True))
         except:
-            return i.nbytes
+            return int(i.nbytes)

--- a/distributed/tests/test_avro.py
+++ b/distributed/tests/test_avro.py
@@ -54,11 +54,8 @@ def test_avro_body():
         assert set(L[0]) == {'key', 'value'}
 
 
-@gen_cluster(timeout=60)
-def test_avro(s, a, b):
-    e = Executor((s.ip, s.port), start=False)
-    yield e._start()
-
+@gen_cluster(timeout=60, executor=True)
+def test_avro(e, s, a, b):
     avro_files = {'/tmp/test/1.avro': avro_bytes,
                   '/tmp/test/2.avro': avro_bytes}
 
@@ -81,8 +78,6 @@ def test_avro(s, a, b):
         L = yield _read_avro('/tmp/test/*.avro', lazy=True)
         assert isinstance(L, list)
         assert all(isinstance(x, Value) for x in L)
-
-    yield e._shutdown()
 
 
 def test_avro_sync(loop):

--- a/distributed/tests/test_center.py
+++ b/distributed/tests/test_center.py
@@ -25,25 +25,23 @@ def test_metadata():
     assert alice in c.has_what
     assert c.ncores[alice] == 4
 
-    response = yield cc.add_keys(address=alice, keys=[b'x', b'y'])
-    assert response == b'OK'
+    response = yield cc.add_keys(address=alice, keys=['x', 'y'])
+    assert response == 'OK'
 
     response = yield cc.register(address=bob, ncores=4)
-    response = yield cc.add_keys(address=bob, keys=[b'y', b'z'])
-    assert response == b'OK'
+    response = yield cc.add_keys(address=bob, keys=['y', 'z'])
+    assert response == 'OK'
 
-    response = yield cc.who_has(keys=[b'x', b'y'])
+    response = yield cc.who_has(keys=['x', 'y'])
     assert valmap(set, response) == {
-                        b'x': {alice.encode()},
-                        b'y': {alice.encode(), bob.encode()}}
+                        'x': {alice},
+                        'y': {alice, bob}}
 
-    response = yield cc.remove_keys(address=bob, keys=[b'y'])
-    assert response == b'OK'
+    response = yield cc.remove_keys(address=bob, keys=['y'])
+    assert response == 'OK'
 
     response = yield cc.has_what(keys=[alice, bob])
-    assert valmap(set, response) == {
-                        alice: {b'x', b'y'},
-                        bob: {b'z'}}
+    assert valmap(set, response) == {alice: {'x', 'y'}, bob: {'z'}}
 
     response = yield cc.ncores()
     assert response == {alice: 4, bob: 4}
@@ -51,7 +49,7 @@ def test_metadata():
     assert response == {alice: 4, charlie: None}
 
     response = yield cc.unregister(address=alice, close=True)
-    assert response == b'OK'
+    assert response == 'OK'
     assert alice not in c.has_what
     assert alice not in c.ncores
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -28,8 +28,7 @@ def test_scatter_delete(loop):
         assert set(c.who_has) == set(keys)
         assert all(len(v) == 1 for v in c.who_has.values())
 
-        keys2, who_has, nbytes = yield scatter_to_workers([a.address_string,
-                                                           b.address_string],
+        keys2, who_has, nbytes = yield scatter_to_workers([a.address, b.address],
                                                           [4, 5, 6])
 
         m = merge(a.data, b.data)
@@ -38,7 +37,7 @@ def test_scatter_delete(loop):
             assert m[k] == v
 
         assert isinstance(who_has, dict)
-        assert set(concat(who_has.values())) == {a.address_string, b.address_string}
+        assert set(concat(who_has.values())) == {a.address, b.address}
         assert len(who_has) == len(keys2)
 
         assert isinstance(nbytes, dict)
@@ -62,8 +61,8 @@ def test_gather_with_missing_worker(loop):
         c.has_what[bad].add('z')
         c.ncores['z'] = 4
 
-        c.who_has['z'].add(a.address_string)
-        c.has_what[a.address_string].add('z')
+        c.who_has['z'].add(a.address)
+        c.has_what[a.address].add('z')
 
         a.data['z'] = 5
 
@@ -151,8 +150,7 @@ def test_scatter_round_robins_between_calls(loop):
 
 @gen_cluster()
 def test_broadcast_to_workers(s, a, b):
-    keys, nbytes = yield broadcast_to_workers([a.address_string,
-                                               b.address_string],
+    keys, nbytes = yield broadcast_to_workers([a.address, b.address],
                                                [1, 2, 3])
 
     assert len(keys) == 3

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -9,7 +9,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop
 
 from distributed import Center, Worker
-from distributed.utils import ignoring
+from distributed.utils import ignoring, tokey
 from distributed.utils_test import (cluster, loop, _test_cluster,
         cluster_center, gen_cluster)
 from distributed.client import (_gather, _scatter, _delete, _clear,
@@ -80,6 +80,8 @@ def test_gather_with_missing_worker(loop):
 
 
 def test_pack_data():
+    data = {'x': 1}
+    assert pack_data(('x', 'y'), data) == (1, 'y')
     data = {b'x': 1}
     assert pack_data((b'x', 'y'), data) == (1, 'y')
     assert pack_data({'a': b'x', 'b': 'y'}, data) == {'a': 1, 'b': 'y'}
@@ -87,7 +89,7 @@ def test_pack_data():
 
 
 def test_pack_data_with_key_mapping():
-    data = {str(('x', 1)).encode(): 1}
+    data = {tokey(('x', 1)): 1}
     assert pack_data((('x', 1), 'y'), data) == (1, 'y')
 
 
@@ -96,7 +98,7 @@ def test_gather_errors_voluminously(loop):
         try:
             gather(('127.0.0.1', c['port']), ['x', 'y', 'z'])
         except KeyError as e:
-            assert set(e.args) == {b'x', b'y', b'z'}
+            assert set(e.args) == {'x', 'y', 'z'}
 
 
 @pytest.mark.skipif(sys.platform!='linux',

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -54,7 +54,7 @@ def test_scatter_delete(loop):
 def test_gather_with_missing_worker(loop):
     @gen.coroutine
     def f(c, a, b):
-        bad = ('127.0.0.1', 9001)  # this worker doesn't exist
+        bad = '127.0.0.1:9001'  # this worker doesn't exist
         c.who_has['x'].add(bad)
         c.has_what[bad].add('x')
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -49,6 +49,19 @@ def test_rpc(loop):
     loop.run_sync(f)
 
 
+def test_rpc_inputs():
+    L = [rpc('127.0.0.1:8887'),
+         rpc(b'127.0.0.1:8887'),
+         rpc(('127.0.0.1', 8887)),
+         rpc((b'127.0.0.1', 8887)),
+         rpc(ip='127.0.0.1', port=8887),
+         rpc(ip=b'127.0.0.1', port=8887),
+         rpc(addr='127.0.0.1:8887'),
+         rpc(addr=b'127.0.0.1:8887')]
+
+    assert all(r.ip == '127.0.0.1' and r.port == 8887 for r in L)
+
+
 def test_rpc_with_many_connections(loop):
     remote = rpc(ip='127.0.0.1', port=8887)
 
@@ -103,7 +116,7 @@ def test_identity(loop):
         remote = rpc(ip='127.0.0.1', port=8887)
         a = yield remote.identity()
         b = yield remote.identity()
-        assert a['type'] == 'Server'
+        assert a['type'] == b'Server'
         assert a['id'] == b['id']
 
         server.stop()

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -116,7 +116,7 @@ def test_identity(loop):
         remote = rpc(ip='127.0.0.1', port=8887)
         a = yield remote.identity()
         b = yield remote.identity()
-        assert a['type'] == b'Server'
+        assert a['type'] == 'Server'
         assert a['id'] == b['id']
 
         server.stop()

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -58,7 +58,7 @@ def test_submit(s, a, b):
     yield e._shutdown()
 
 
-@gen_cluster(timeout=10000)
+@gen_cluster()
 def test_map(s, a, b):
     e = Executor((s.ip, s.port), start=False)
     yield e._start()
@@ -569,7 +569,7 @@ def test_missing_data_heals(s, a, b):
 @slow
 @gen_cluster()
 def test_missing_worker(s, a, b):
-    bad = ('bad-host', 8788)
+    bad = 'bad-host:8788'
     s.ncores[bad] = 4
     s.who_has['b'] = {bad}
     s.has_what[bad] = {'b'}

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -710,8 +710,8 @@ def test_restrictions_get(s, a, b):
 
     result = yield e._get(dsk, ['y', 'z'], restrictions)
     assert result == [2, 3]
-    assert b'y' in a.data
-    assert b'z' in b.data
+    assert 'y' in a.data
+    assert 'z' in b.data
 
     yield e._shutdown()
 
@@ -896,11 +896,11 @@ def test__scatter(s, a, b):
 
     d = yield e._scatter({'y': 20})
     assert isinstance(d['y'], Future)
-    assert a.data.get(b'y') == 20 or b.data.get(b'y') == 20
-    assert (a.address_string in s.who_has[b'y'] or
-            b.address_string in s.who_has[b'y'])
-    assert s.who_has[b'y']
-    assert s.nbytes == {b'y': sizeof(20)}
+    assert a.data.get('y') == 20 or b.data.get('y') == 20
+    assert (a.address_string in s.who_has['y'] or
+            b.address_string in s.who_has['y'])
+    assert s.who_has['y']
+    assert s.nbytes == {'y': sizeof(20)}
     yy = yield e._gather([d['y']])
     assert yy == [20]
 
@@ -911,7 +911,7 @@ def test__scatter(s, a, b):
     assert s.who_has[x.key]
     assert (a.address_string in s.who_has[x.key] or
             b.address_string in s.who_has[x.key])
-    assert s.nbytes == {b'y': sizeof(20), x.key: sizeof(10)}
+    assert s.nbytes == {'y': sizeof(20), x.key: sizeof(10)}
     assert xx == [10]
 
     z = e.submit(add, x, d['y'])  # submit works on Future
@@ -2243,11 +2243,11 @@ def test_async_persist(s, a, b):
     assert y._keys() == yy._keys()
     assert w._keys() == ww._keys()
 
-    while y.key.encode() not in s.tasks and w.key.encode() not in s.tasks:
+    while y.key not in s.tasks and w.key not in s.tasks:
         yield gen.sleep(0.01)
 
-    assert s.who_wants[y.key.encode()] == {e.id}
-    assert s.who_wants[w.key.encode()] == {e.id}
+    assert s.who_wants[y.key] == {e.id}
+    assert s.who_wants[w.key] == {e.id}
 
     yyf, wwf = e.compute([yy, ww])
     yyy, www = yield e._gather([yyf, wwf])

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -4,12 +4,13 @@ import sys
 from time import time
 
 import pytest
+from toolz import valmap
 from tornado.tcpclient import TCPClient
 from tornado.iostream import StreamClosedError
 from tornado import gen
 
 from distributed import Nanny, Center, rpc
-from distributed.core import connect, read, write
+from distributed.core import connect, read, write, dumps
 from distributed.utils import ignoring
 from distributed.utils_test import gen_test
 
@@ -23,23 +24,23 @@ def test_nanny():
     yield n._start(0)
     nn = rpc(ip=n.ip, port=n.port)
     assert n.process.is_alive()
-    assert c.ncores[n.worker_address] == 2
-    assert c.worker_services[n.worker_address]['nanny'] > 1024
+    assert c.ncores[n.worker_address_string] == 2
+    assert c.worker_services[n.worker_address_string][b'nanny'] > 1024
 
     yield nn.kill()
-    assert n.worker_address not in c.ncores
-    assert n.worker_address not in c.worker_services
+    assert n.worker_address_string not in c.ncores
+    assert n.worker_address_string not in c.worker_services
     assert not n.process
 
     yield nn.kill()
-    assert n.worker_address not in c.ncores
-    assert n.worker_address not in c.worker_services
+    assert n.worker_address_string not in c.ncores
+    assert n.worker_address_string not in c.worker_services
     assert not n.process
 
     yield nn.instantiate()
     assert n.process.is_alive()
-    assert c.ncores[n.worker_address] == 2
-    assert c.worker_services[n.worker_address]['nanny'] > 1024
+    assert c.ncores[n.worker_address_string] == 2
+    assert c.worker_services[n.worker_address_string][b'nanny'] > 1024
 
     yield nn.terminate()
     assert not n.process
@@ -63,9 +64,11 @@ def test_nanny_process_failure():
     assert os.path.exists(first_dir)
 
     ww = rpc(ip=n.ip, port=n.worker_port)
-    yield ww.update_data(data={'x': 1, 'y': 2})
+    yield ww.update_data(data=valmap(dumps, {'x': 1, 'y': 2}))
     with ignoring(StreamClosedError):
-        yield ww.compute(function=sys.exit, args=(0,), key='z')
+        yield ww.compute(function=dumps(sys.exit),
+                         args=dumps((0,)),
+                         key='z')
 
     start = time()
     while n.process.is_alive():  # wait while process dies
@@ -78,7 +81,7 @@ def test_nanny_process_failure():
         assert time() - start < 2
 
     start = time()
-    while n.worker_address not in c.ncores or n.worker_dir is None:
+    while n.worker_address_string not in c.ncores or n.worker_dir is None:
         yield gen.sleep(0.01)
         assert time() - start < 2
 
@@ -105,7 +108,7 @@ def test_monitor_resources():
     d = n.resource_collect()
     assert {'cpu_percent', 'memory_percent'}.issubset(d)
 
-    assert isinstance(d['timestamp'], datetime)
+    assert 'timestamp' in d
 
     stream = yield connect(ip=n.ip, port=n.port)
     yield write(stream, {'op': 'monitor_resources', 'interval': 0.01})

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -24,23 +24,23 @@ def test_nanny():
     yield n._start(0)
     nn = rpc(ip=n.ip, port=n.port)
     assert n.process.is_alive()
-    assert c.ncores[n.worker_address_string] == 2
-    assert c.worker_services[n.worker_address_string]['nanny'] > 1024
+    assert c.ncores[n.worker_address] == 2
+    assert c.worker_services[n.worker_address]['nanny'] > 1024
 
     yield nn.kill()
-    assert n.worker_address_string not in c.ncores
-    assert n.worker_address_string not in c.worker_services
+    assert n.worker_address not in c.ncores
+    assert n.worker_address not in c.worker_services
     assert not n.process
 
     yield nn.kill()
-    assert n.worker_address_string not in c.ncores
-    assert n.worker_address_string not in c.worker_services
+    assert n.worker_address not in c.ncores
+    assert n.worker_address not in c.worker_services
     assert not n.process
 
     yield nn.instantiate()
     assert n.process.is_alive()
-    assert c.ncores[n.worker_address_string] == 2
-    assert c.worker_services[n.worker_address_string]['nanny'] > 1024
+    assert c.ncores[n.worker_address] == 2
+    assert c.worker_services[n.worker_address]['nanny'] > 1024
 
     yield nn.terminate()
     assert not n.process
@@ -81,7 +81,7 @@ def test_nanny_process_failure():
         assert time() - start < 2
 
     start = time()
-    while n.worker_address_string not in c.ncores or n.worker_dir is None:
+    while n.worker_address not in c.ncores or n.worker_dir is None:
         yield gen.sleep(0.01)
         assert time() - start < 2
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -25,7 +25,7 @@ def test_nanny():
     nn = rpc(ip=n.ip, port=n.port)
     assert n.process.is_alive()
     assert c.ncores[n.worker_address_string] == 2
-    assert c.worker_services[n.worker_address_string][b'nanny'] > 1024
+    assert c.worker_services[n.worker_address_string]['nanny'] > 1024
 
     yield nn.kill()
     assert n.worker_address_string not in c.ncores
@@ -40,7 +40,7 @@ def test_nanny():
     yield nn.instantiate()
     assert n.process.is_alive()
     assert c.ncores[n.worker_address_string] == 2
-    assert c.worker_services[n.worker_address_string][b'nanny'] > 1024
+    assert c.worker_services[n.worker_address_string]['nanny'] > 1024
 
     yield nn.terminate()
     assert not n.process

--- a/distributed/tests/test_protocol.py
+++ b/distributed/tests/test_protocol.py
@@ -1,0 +1,21 @@
+from distributed.protocol import loads, dumps
+import pytest
+
+def test_protocol():
+    for msg in [1, 'a', b'a', {'x': 1}, {b'x': 1}, {}]:
+        assert loads(dumps(msg)) == msg
+
+
+def test_compression():
+    pytest.importorskip('lz4')
+    np = pytest.importorskip('numpy')
+    x = np.ones(1000000)
+    b = dumps(x.tobytes())
+    assert len(b) < x.nbytes
+    y = loads(b)
+    assert x.tobytes() == y
+
+
+def test_small():
+    assert len(dumps(b'')) < 10
+    assert len(dumps(1)) < 10

--- a/distributed/tests/test_s3.py
+++ b/distributed/tests/test_s3.py
@@ -69,25 +69,17 @@ def test_list_summary_object_with_prefix_and_delimiter():
                                      u'nested/nested2/file2']
 
 
-@gen_cluster(timeout=60)
-def test_read_bytes(s, a, b):
-    e = Executor((s.ip, s.port), start=False)
-    yield e._start()
-
+@gen_cluster(timeout=60, executor=True)
+def test_read_bytes(e, s, a, b):
     futures = read_bytes(test_bucket_name, prefix='test/', anon=True,
                          lazy=False)
     assert len(futures) >= len(files)
     results = yield e._gather(futures)
     assert set(results).issuperset(set(files.values()))
 
-    yield e._shutdown()
 
-
-@gen_cluster(timeout=60)
-def test_read_bytes_lazy(s, a, b):
-    e = Executor((s.ip, s.port), start=False)
-    yield e._start()
-
+@gen_cluster(timeout=60, executor=True)
+def test_read_bytes_lazy(e, s, a, b):
     values = read_bytes(test_bucket_name, 'test/', lazy=True, anon=True)
     assert all(isinstance(v, Value) for v in values)
 
@@ -95,8 +87,6 @@ def test_read_bytes_lazy(s, a, b):
     results = yield e._gather(results)
 
     assert set(results).issuperset(set(files.values()))
-
-    yield e._shutdown()
 
 
 def test_get_s3():
@@ -114,13 +104,11 @@ def test_get_s3_threadsafe():
     assert len(set(map(id, s3s))) <= 4
 
 
-@gen_cluster(timeout=60)
-def test_read_text(s, a, b):
+@gen_cluster(timeout=60, executor=True)
+def test_read_text(e, s, a, b):
     pytest.importorskip('dask.bag')
     import dask.bag as db
     from dask.imperative import Value
-    e = Executor((s.ip, s.port), start=False)
-    yield e._start()
 
     b = read_text(test_bucket_name, 'test/accounts', lazy=True,
                   collection=True, anon=True)
@@ -140,8 +128,6 @@ def test_read_text(s, a, b):
     text = read_text(test_bucket_name, 'test/accounts', lazy=False,
                      collection=False, anon=True)
     assert all(isinstance(v, Future) for v in text)
-
-    yield e._shutdown()
 
 
 def test_read_text_sync(loop):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -15,7 +15,7 @@ from tornado import gen
 import pytest
 
 from distributed import Nanny, Worker
-from distributed.core import connect, read, write, rpc, loads
+from distributed.core import connect, read, write, rpc, dumps
 from distributed.client import WrappedKey
 from distributed.scheduler import (validate_state, heal,
         decide_worker, heal_missing_data, Scheduler,
@@ -25,8 +25,8 @@ from distributed.utils_test import (inc, ignoring, dec, gen_cluster, gen_test,
 from distributed.utils import All
 
 
-alice = 'alice'
-bob = 'bob'
+alice = 'alice:1234'
+bob = 'bob:1234'
 
 
 def test_heal():
@@ -35,8 +35,8 @@ def test_heal():
     dependents = {'x': {'y'}, 'y': set()}
 
     who_has = dict()
-    stacks = {'alice': [], 'bob': []}
-    processing = {'alice': set(), 'bob': set()}
+    stacks = {alice: [], bob: []}
+    processing = {alice: set(), bob: set()}
 
     waiting = {'y': {'x'}}
     ready = {'x'}
@@ -57,8 +57,8 @@ def test_heal():
     assert output['released'] == set()
 
     state = {'who_has': dict(),
-             'stacks': {'alice': ['x'], 'bob': []},
-             'processing': {'alice': set(), 'bob': set()},
+             'stacks': {alice: ['x'], bob: []},
+             'processing': {alice: set(), bob: set()},
              'waiting': {}, 'waiting_data': {}, 'ready': set()}
 
     heal(dependencies, dependents, **state)
@@ -76,8 +76,8 @@ def test_heal_2():
                   'result': set()}
 
     state = {'who_has': {'y': {alice}, 'a': {alice}},  # missing 'b'
-             'stacks': {'alice': ['z'], 'bob': []},
-             'processing': {'alice': set(), 'bob': set(['c'])},
+             'stacks': {alice: ['z'], bob: []},
+             'processing': {alice: set(), bob: set(['c'])},
              'waiting': {}, 'waiting_data': {}, 'ready': set()}
 
     output = heal(dependencies, dependents, **state)
@@ -87,8 +87,8 @@ def test_heal_2():
                                       'y': {'z'}, 'z': {'result'},
                                       'result': set()}
     assert output['who_has'] == {'y': {alice}, 'a': {alice}}
-    assert output['stacks'] == {'alice': ['z'], 'bob': []}
-    assert output['processing'] == {'alice': set(), 'bob': set()}
+    assert output['stacks'] == {alice: ['z'], bob: []}
+    assert output['processing'] == {alice: set(), bob: set()}
     assert output['released'] == {'x'}
 
 
@@ -98,12 +98,12 @@ def test_heal_restarts_leaf_tasks():
     dependents, dependencies = get_deps(dsk)
 
     state = {'who_has': dict(),  # missing 'b'
-             'stacks': {'alice': ['a'], 'bob': ['x']},
-             'processing': {'alice': set(), 'bob': set()},
+             'stacks': {alice: ['a'], bob: ['x']},
+             'processing': {alice: set(), bob: set()},
              'waiting': {}, 'waiting_data': {}, 'ready': set()}
 
-    del state['stacks']['bob']
-    del state['processing']['bob']
+    del state['stacks'][bob]
+    del state['processing'][bob]
 
     output = heal(dependencies, dependents, **state)
     assert 'x' in output['waiting']
@@ -115,15 +115,15 @@ def test_heal_culls():
     dependencies, dependents = get_deps(dsk)
 
     state = {'who_has': {'c': {alice}, 'y': {alice}},
-             'stacks': {'alice': ['a'], 'bob': []},
-             'processing': {'alice': set(), 'bob': set('y')},
+             'stacks': {alice: ['a'], bob: []},
+             'processing': {alice: set(), bob: set('y')},
              'waiting': {}, 'waiting_data': {}, 'ready': set()}
 
     output = heal(dependencies, dependents, **state)
-    assert 'a' not in output['stacks']['alice']
+    assert 'a' not in output['stacks'][alice]
     assert output['released'] == {'a', 'b', 'x'}
     assert output['finished_results'] == {'c'}
-    assert 'y' not in output['processing']['bob']
+    assert 'y' not in output['processing'][bob]
 
     assert output['ready'] == {'z'}
 
@@ -131,25 +131,26 @@ def test_heal_culls():
 @gen_cluster()
 def test_ready_add_worker(s, a, b):
     s.add_client(client='client')
-    s.add_worker(address='alice')
+    s.add_worker(address=alice)
 
     s.update_graph(tasks={'x-%d' % i: dumps_task((inc, i)) for i in range(20)},
                    keys=['x-%d' % i for i in range(20)],
                    client='client',
                    dependencies={'x-%d' % i: set() for i in range(20)})
 
+
 def test_update_state(loop):
     s = Scheduler()
     s.start(0)
-    s.add_worker(address='alice', ncores=1)
+    s.add_worker(address=alice, ncores=1)
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x')},
                    keys=['y'],
                    dependencies={'y': 'x', 'x': set()},
                    client='client')
 
-    s.mark_task_finished('x', 'alice', nbytes=10, type=int)
+    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int))
 
-    assert s.processing['alice'] == {'y'}
+    assert s.processing[alice] == {'y'}
     assert not s.ready
     assert s.who_wants == {'y': {'client'}}
     assert s.wants_what == {'client': {'y'}}
@@ -179,13 +180,13 @@ def test_update_state(loop):
 def test_update_state_with_processing(loop):
     s = Scheduler()
     s.start(0)
-    s.add_worker(address='alice', ncores=1)
+    s.add_worker(address=alice, ncores=1)
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x'), 'z': (inc, 'y')},
                    keys=['z'],
                    dependencies={'y': {'x'}, 'x': set(), 'z': {'y'}},
                    client='client')
 
-    s.mark_task_finished('x', 'alice', nbytes=10, type=int)
+    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int))
 
     assert s.waiting == {'z': {'y'}}
     assert s.waiting_data == {'x': {'y'}, 'y': {'z'}, 'z': set()}
@@ -194,7 +195,7 @@ def test_update_state_with_processing(loop):
     assert s.who_wants == {'z': {'client'}}
     assert s.wants_what == {'client': {'z'}}
 
-    assert s.who_has == {'x': {'alice'}}
+    assert s.who_has == {'x': {alice}}
     assert s.in_play == {'z', 'x', 'y'}
 
     s.update_graph(tasks={'a': (inc, 'x'), 'b': (add,'a','y'), 'c': (inc, 'z')},
@@ -203,7 +204,7 @@ def test_update_state_with_processing(loop):
                    client='client')
 
     assert s.waiting == {'z': {'y'}, 'b': {'a', 'y'}, 'c': {'z'}}
-    assert s.stacks['alice'] == ['a']
+    assert s.stacks[alice] == ['a']
     assert not s.ready
     assert s.waiting_data == {'x': {'y', 'a'}, 'y': {'z', 'b'}, 'z': {'c'},
                               'a': {'b'}, 'b': set(), 'c': set()}
@@ -218,16 +219,16 @@ def test_update_state_with_processing(loop):
 def test_update_state_respects_data_in_memory(loop):
     s = Scheduler()
     s.start(0)
-    s.add_worker(address='alice', ncores=1)
+    s.add_worker(address=alice, ncores=1)
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x')},
                    keys=['y'],
                    dependencies={'y': {'x'}, 'x': set()},
                    client='client')
 
-    s.mark_task_finished('x', 'alice', nbytes=10, type=int)
-    s.mark_task_finished('y', 'alice', nbytes=10, type=int)
+    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('y', alice, nbytes=10, type=dumps(int))
 
-    assert s.who_has == {'y': {'alice'}}
+    assert s.who_has == {'y': {alice}}
 
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x'), 'z': (add, 'y', 'x')},
                    keys=['z'],
@@ -235,7 +236,7 @@ def test_update_state_respects_data_in_memory(loop):
                    client='client')
 
     assert s.waiting == {'z': {'x'}}
-    assert s.processing['alice'] == {'x'}  # x was released, need to recompute
+    assert s.processing[alice] == {'x'}  # x was released, need to recompute
     assert s.waiting_data == {'x': {'z'}, 'y': {'z'}, 'z': set()}
     assert s.who_wants == {'y': {'client'}, 'z': {'client'}}
     assert s.wants_what == {'client': {'y', 'z'}}
@@ -247,21 +248,21 @@ def test_update_state_respects_data_in_memory(loop):
 def test_update_state_supports_recomputing_released_results(loop):
     s = Scheduler()
     s.start(0)
-    s.add_worker(address='alice', ncores=1)
+    s.add_worker(address=alice, ncores=1)
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x'), 'z': (inc, 'x')},
                    keys=['z'],
                    dependencies={'y': {'x'}, 'x': set(), 'z': {'y'}},
                    client='client')
 
-    s.mark_task_finished('x', 'alice', nbytes=10, type=int)
-    s.mark_task_finished('y', 'alice', nbytes=10, type=int)
-    s.mark_task_finished('z', 'alice', nbytes=10, type=int)
+    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('y', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('z', alice, nbytes=10, type=dumps(int))
 
     assert not s.waiting
     assert not s.ready
     assert s.waiting_data == {'z': set()}
 
-    assert s.who_has == {'z': {'alice'}}
+    assert s.who_has == {'z': {alice}}
 
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x')},
                    keys=['y'],
@@ -272,7 +273,7 @@ def test_update_state_supports_recomputing_released_results(loop):
     assert s.waiting_data == {'x': {'y'}, 'y': set(), 'z': set()}
     assert s.who_wants == {'z': {'client'}, 'y': {'client'}}
     assert s.wants_what == {'client': {'y', 'z'}}
-    assert s.processing['alice'] == {'x'}
+    assert s.processing[alice] == {'x'}
 
     s.stop()
 
@@ -281,24 +282,24 @@ def test_decide_worker_with_many_independent_leaves():
     dsk = merge({('y', i): (inc, ('x', i)) for i in range(100)},
                 {('x', i): i for i in range(100)})
     dependencies, dependents = get_deps(dsk)
-    stacks = {'alice': [], 'bob': []}
-    who_has = merge({('x', i * 2): {'alice'} for i in range(50)},
-                    {('x', i * 2 + 1): {'bob'} for i in range(50)})
+    stacks = {alice: [], bob: []}
+    who_has = merge({('x', i * 2): {alice} for i in range(50)},
+                    {('x', i * 2 + 1): {bob} for i in range(50)})
     nbytes = {k: 0 for k in who_has}
 
     for key in dsk:
         worker = decide_worker(dependencies, stacks, who_has, {}, set(), nbytes, key)
         stacks[worker].append(key)
 
-    nhits = (len([k for k in stacks['alice'] if 'alice' in who_has[('x', k[1])]])
-             + len([k for k in stacks['bob'] if 'bob' in who_has[('x', k[1])]]))
+    nhits = (len([k for k in stacks[alice] if alice in who_has[('x', k[1])]])
+             + len([k for k in stacks[bob] if bob in who_has[('x', k[1])]]))
 
     assert nhits > 90
 
 
 def test_decide_worker_with_restrictions():
     dependencies = {'x': set()}
-    alice, bob, charlie = ('alice', 8000), ('bob', 8000), ('charlie', 8000)
+    alice, bob, charlie = 'alice:8000', 'bob:8000', 'charlie:8000'
     stacks = {alice: [], bob: [], charlie: []}
     who_has = {}
     restrictions = {'x': {'alice', 'charlie'}}
@@ -320,7 +321,7 @@ def test_decide_worker_with_restrictions():
 
 def test_decide_worker_with_loose_restrictions():
     dependencies = {'x': set()}
-    alice, bob, charlie = ('alice', 8000), ('bob', 8000), ('charlie', 8000)
+    alice, bob, charlie = 'alice:8000', 'bob:8000', 'charlie:8000'
     stacks = {alice: [1, 2, 3], bob: [], charlie: [1]}
     who_has = {}
     nbytes = {}
@@ -358,8 +359,8 @@ def test_validate_state():
     dependents = {'x': {'y'}, 'y': set()}
     waiting_data = {'x': {'y'}}
     who_has = dict()
-    stacks = {'alice': [], 'bob': []}
-    processing = {'alice': set(), 'bob': set()}
+    stacks = {alice: [], bob: []}
+    processing = {alice: set(), bob: set()}
     finished_results = set()
     released = set()
     in_play = {'x', 'y'}
@@ -384,21 +385,21 @@ def test_validate_state():
     ready.appendleft('y')
     validate_state(**locals())
 
-    stacks['alice'].append('y')
+    stacks[alice].append('y')
     with pytest.raises(Exception):
         validate_state(**locals())
 
     ready.remove('y')
     validate_state(**locals())
 
-    stacks['alice'].pop()
+    stacks[alice].pop()
     with pytest.raises(Exception):
         validate_state(**locals())
 
-    processing['alice'].add('y')
+    processing[alice].add('y')
     validate_state(**locals())
 
-    processing['alice'].pop()
+    processing[alice].pop()
     with pytest.raises(Exception):
         validate_state(**locals())
 
@@ -448,47 +449,47 @@ def div(x, y):
 @gen_cluster()
 def test_scheduler(s, a, b):
     stream = yield connect(s.ip, s.port)
-    yield write(stream, {'op': 'register-client', 'client': 'ident'})
+    yield write(stream, {'op': 'register-client', 'client': b'ident'})
     msg = yield read(stream)
     assert msg['op'] == 'stream-start'
 
     # Test update graph
     yield write(stream, {'op': 'update-graph',
-                         'tasks': {'x': (inc, 1),
-                                   'y': (inc, 'x'),
-                                   'z': (inc, 'y')},
-                         'dependencies': {'x': set(),
-                                          'y': {'x'},
-                                          'z': {'y'}},
-                         'keys': ['x', 'z'],
-                         'client': 'ident'})
+                         'tasks': valmap(dumps_task, {b'x': (inc, 1),
+                                                      b'y': (inc, 'x'),
+                                                      b'z': (inc, 'y')}),
+                         'dependencies': {b'x': [],
+                                          b'y': [b'x'],
+                                          b'z': [b'y']},
+                         'keys': [b'x', b'z'],
+                         'client': b'ident'})
     while True:
         msg = yield read(stream)
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'z':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'z':
             break
 
-    assert a.data.get('x') == 2 or b.data.get('x') == 2
+    assert a.data.get(b'x') == 2 or b.data.get(b'x') == 2
 
     # Test erring tasks
     yield write(stream, {'op': 'update-graph',
-                         'tasks': {'a': (div, 1, 0),
-                                 'b': (inc, 'a')},
-                         'dependencies': {'a': set(),
-                                          'b': {'a'}},
-                         'keys': ['a', 'b'],
-                         'client': 'ident'})
+                         'tasks': valmap(dumps_task, {b'a': (div, 1, 0),
+                                                       b'b': (inc, b'a')}),
+                         'dependencies': {b'a': [],
+                                           b'b': ['a']},
+                         'keys': [b'a', b'b'],
+                         'client': b'ident'})
 
     while True:
         msg = yield read(stream)
-        if msg['op'] == 'task-erred' and msg['key'] == 'b':
+        if msg['op'] == 'task-erred' and msg['key'] == b'b':
             break
 
     # Test missing data
-    yield write(stream, {'op': 'missing-data', 'missing': ['z']})
+    yield write(stream, {'op': 'missing-data', 'missing': [b'z']})
 
     while True:
         msg = yield read(stream)
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'z':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'z':
             break
 
     # Test missing data without being informed
@@ -496,13 +497,13 @@ def test_scheduler(s, a, b):
         if 'z' in w.data:
             del w.data['z']
     yield write(stream, {'op': 'update-graph',
-                         'tasks': {'zz': (inc, 'z')},
-                         'dependencies': {'zz': {'z'}},
-                         'keys': ['zz'],
-                         'client': 'ident'})
+                         'tasks': {b'zz': dumps_task((inc, b'z'))},
+                         'dependencies': {b'zz': [b'z']},
+                         'keys': [b'zz'],
+                         'client': b'ident'})
     while True:
         msg = yield read(stream)
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'zz':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'zz':
             break
 
     write(stream, {'op': 'close'})
@@ -519,17 +520,17 @@ def test_multi_queues(s, a, b):
 
     # Test update graph
     sched.put_nowait({'op': 'update-graph',
-                      'tasks': {'x': (inc, 1),
-                              'y': (inc, 'x'),
-                              'z': (inc, 'y')},
-                      'dependencies': {'x': set(),
-                                       'y': {'x'},
-                                       'z': {'y'}},
-                      'keys': ['z']})
+                      'tasks': valmap(dumps_task, {b'x': (inc, 1),
+                                                   b'y': (inc, b'x'),
+                                                   b'z': (inc, b'y')}),
+                      'dependencies': {b'x': [],
+                                       b'y': [b'x'],
+                                       b'z': [b'y']},
+                      'keys': [b'z']})
 
     while True:
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'z':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'z':
             break
 
     slen, rlen = len(s.scheduler_queues), len(s.report_queues)
@@ -539,30 +540,31 @@ def test_multi_queues(s, a, b):
     assert rlen + 1 == len(s.report_queues)
 
     sched2.put_nowait({'op': 'update-graph',
-                       'tasks': {'a': (inc, 10)},
-                       'dependencies': {'a': set()},
-                       'keys': ['a']})
+                       'tasks': {b'a': dumps_task((inc, 10))},
+                       'dependencies': {b'a': []},
+                       'keys': [b'a']})
 
     for q in [report, report2]:
         while True:
             msg = yield q.get()
-            if msg['op'] == 'key-in-memory' and msg['key'] == 'a':
+            if msg['op'] == 'key-in-memory' and msg['key'] == b'a':
                 break
 
 
 @gen_cluster()
 def test_server(s, a, b):
     stream = yield connect('127.0.0.1', s.port)
-    yield write(stream, {'op': 'register-client', 'client': 'ident'})
+    yield write(stream, {'op': 'register-client', 'client': b'ident'})
     yield write(stream, {'op': 'update-graph',
-                         'tasks': {'x': (inc, 1), 'y': (inc, 'x')},
-                         'dependencies': {'x': set(), 'y': {'x'}},
-                         'keys': ['y'],
-                         'client': 'ident'})
+                         'tasks': {b'x': dumps_task((inc, 1)),
+                                   b'y': dumps_task((inc, b'x'))},
+                         'dependencies': {b'x': [], b'y': [b'x']},
+                         'keys': [b'y'],
+                         'client': b'ident'})
 
     while True:
         msg = yield read(stream)
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'y':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'y':
             break
 
     yield write(stream, {'op': 'close-stream'})
@@ -576,7 +578,7 @@ def test_server(s, a, b):
 def test_server_listens_to_other_ops(s, a, b):
     r = rpc(ip='127.0.0.1', port=s.port)
     ident = yield r.identity()
-    assert ident['type'] == 'Scheduler'
+    assert ident['type'] == b'Scheduler'
 
 
 @gen_cluster()
@@ -587,10 +589,10 @@ def test_remove_worker_from_scheduler(s, a, b):
     assert s.ready
     assert not any(stack for stack in s.stacks.values())
 
-    assert a.address in s.worker_queues
-    s.remove_worker(address=a.address)
-    assert a.address not in s.ncores
-    assert len(s.ready) + len(s.processing[b.address]) == \
+    assert a.address_string in s.worker_queues
+    s.remove_worker(address=a.address_string)
+    assert a.address_string not in s.ncores
+    assert len(s.ready) + len(s.processing[b.address_string]) == \
             len(dsk)  # b owns everything
     assert all(k in s.in_play for k in dsk)
     s.validate()
@@ -599,19 +601,19 @@ def test_remove_worker_from_scheduler(s, a, b):
 @gen_cluster()
 def test_add_worker(s, a, b):
     w = Worker(s.ip, s.port, ncores=3, ip='127.0.0.1')
-    w.data[('x', 5)] = 6
-    w.data['y'] = 1
+    w.data[b'x-5'] = 6
+    w.data[b'y'] = 1
     yield w._start(0)
 
-    dsk = {('x', i): (inc, i) for i in range(10)}
+    dsk = {('x-%d' % i).encode(): (inc, i) for i in range(10)}
     s.update_graph(tasks=valmap(dumps_task, dsk), keys=list(dsk), client='client',
                    dependencies={k: set() for k in dsk})
 
-    s.add_worker(address=w.address, keys=list(w.data),
+    s.add_worker(address=w.address_string, keys=list(w.data),
                  ncores=w.ncores, services=s.services)
 
     for k in w.data:
-        assert w.address in s.who_has[k]
+        assert w.address_string in s.who_has[k]
 
     s.validate(allow_overlap=True)
 
@@ -619,16 +621,17 @@ def test_add_worker(s, a, b):
 @gen_cluster()
 def test_feed(s, a, b):
     def func(scheduler):
-        return scheduler.processing, scheduler.stacks
+        return dumps((scheduler.processing, scheduler.stacks))
 
     stream = yield connect(s.ip, s.port)
     yield write(stream, {'op': 'feed',
-                         'function': func,
+                         'function': dumps(func),
                          'interval': 0.01})
 
     for i in range(5):
         response = yield read(stream)
         expected = s.processing, s.stacks
+        assert cloudpickle.loads(response) == expected
 
     stream.close()
 
@@ -647,9 +650,9 @@ def test_feed_setup_teardown(s, a, b):
 
     stream = yield connect(s.ip, s.port)
     yield write(stream, {'op': 'feed',
-                         'function': func,
-                         'setup': setup,
-                         'teardown': teardown,
+                         'function': dumps(func),
+                         'setup': dumps(setup),
+                         'teardown': dumps(teardown),
                          'interval': 0.01})
 
     for i in range(5):
@@ -668,23 +671,23 @@ def test_scheduler_as_center():
     s = Scheduler()
     done = s.start(0)
     a = Worker('127.0.0.1', s.port, ip='127.0.0.1', ncores=1)
-    a.data.update({'x': 1, 'y': 2})
+    a.data.update({b'x': 1, b'y': 2})
     b = Worker('127.0.0.1', s.port, ip='127.0.0.1', ncores=2)
-    b.data.update({'y': 2, 'z': 3})
+    b.data.update({b'y': 2, b'z': 3})
     c = Worker('127.0.0.1', s.port, ip='127.0.0.1', ncores=3)
     yield [w._start(0) for w in [a, b, c]]
 
-    assert s.ncores == {w.address: w.ncores for w in [a, b, c]}
-    assert s.who_has == {'x': {a.address},
-                         'y': {a.address, b.address},
-                         'z': {b.address}}
+    assert s.ncores == {w.address_string: w.ncores for w in [a, b, c]}
+    assert s.who_has == {b'x': {a.address_string},
+                         b'y': {a.address_string, b.address_string},
+                         b'z': {b.address_string}}
 
-    s.update_graph(tasks={'a': dumps_task((inc, 1))},
-                   keys=['a'],
-                   dependencies={'a': set()})
-    while not s.who_has['a']:
+    s.update_graph(tasks={b'a': dumps_task((inc, 1))},
+                   keys=[b'a'],
+                   dependencies={b'a': []})
+    while not s.who_has[b'a']:
         yield gen.sleep(0.01)
-    assert 'a' in a.data or 'a' in b.data or 'a' in c.data
+    assert b'a' in a.data or b'a' in b.data or b'a' in c.data
 
     with ignoring(StreamClosedError):
         yield [w._close() for w in [a, b, c]]
@@ -697,12 +700,13 @@ def test_scheduler_as_center():
 
 @gen_cluster()
 def test_delete_data(s, a, b):
-    yield s.scatter(data={'x': 1, 'y': 2, 'z': 3})
-    assert set(a.data) | set(b.data) == {'x', 'y', 'z'}
+    yield s.scatter(data=valmap(dumps, {b'x': 1, b'y': 2, b'z': 3}))
+    assert set(a.data) | set(b.data) == {b'x', b'y', b'z'}
+    assert merge(a.data, b.data) == {b'x': 1, b'y': 2, b'z': 3}
 
-    s.delete_data(keys=['x', 'y'])
+    s.delete_data(keys=[b'x', b'y'])
     yield s.clear_data_from_workers()
-    assert set(a.data) | set(b.data) == {'z'}
+    assert set(a.data) | set(b.data) == {b'z'}
 
 
 @gen_cluster()
@@ -716,15 +720,15 @@ def test_rpc(s, a, b):
 
 @gen_cluster()
 def test_delete_callback(s, a, b):
-    a.data['x'] = 1
-    s.who_has['x'].add(a.address)
-    s.has_what[a.address].add('x')
+    a.data[b'x'] = 1
+    s.who_has[b'x'].add(a.address_string)
+    s.has_what[a.address_string].add(b'x')
 
-    s.delete_data(keys=['x'])
-    assert not s.who_has['x']
-    assert not s.has_what['y']
-    assert a.data['x'] == 1  # still in memory
-    assert s.deleted_keys == {a.address: {'x'}}
+    s.delete_data(keys=[b'x'])
+    assert not s.who_has[b'x']
+    assert not s.has_what[b'y']
+    assert a.data[b'x'] == 1  # still in memory
+    assert s.deleted_keys == {a.address_string: {b'x'}}
     yield s.clear_data_from_workers()
     assert not s.deleted_keys
     assert not a.data
@@ -734,11 +738,12 @@ def test_delete_callback(s, a, b):
 
 @gen_cluster()
 def test_self_aliases(s, a, b):
-    a.data['a'] = 1
-    s.update_data(who_has={'a': {a.address}}, nbytes={'a': 10}, client='client')
-    s.update_graph(tasks=valmap(dumps_task, {'a': 'a', 'b': (inc, 'a')}),
-                   keys=['b'], client='client',
-                   dependencies={'b': {'a'}})
+    a.data[b'a'] = 1
+    s.update_data(who_has={b'a': [a.address_string]},
+                  nbytes={b'a': 10}, client=b'client')
+    s.update_graph(tasks=valmap(dumps_task, {b'a': b'a', b'b': (inc, b'a')}),
+                   keys=[b'b'], client=b'client',
+                   dependencies={b'b': [b'a']})
 
     sched, report = Queue(), Queue()
     s.handle_queues(sched, report)
@@ -747,7 +752,7 @@ def test_self_aliases(s, a, b):
 
     while True:
         msg = yield report.get()
-        if msg['op'] == 'key-in-memory' and msg['key'] == 'b':
+        if msg['op'] == 'key-in-memory' and msg['key'] == b'b':
             break
 
 
@@ -755,31 +760,33 @@ def test_self_aliases(s, a, b):
 def test_filtered_communication(s, a, b):
     e = yield connect(ip=s.ip, port=s.port)
     f = yield connect(ip=s.ip, port=s.port)
-    yield write(e, {'op': 'register-client', 'client': 'e'})
-    yield write(f, {'op': 'register-client', 'client': 'f'})
+    yield write(e, {'op': 'register-client', 'client': b'e'})
+    yield write(f, {'op': 'register-client', 'client': b'f'})
     yield read(e)
     yield read(f)
 
-    assert set(s.streams) == {'e', 'f'}
+    assert set(s.streams) == {b'e', b'f'}
 
     yield write(e, {'op': 'update-graph',
-                    'tasks': {'x': (inc, 1), 'y': (inc, 'x')},
-                    'dependencies': {'x': set(), 'y': {'x'}},
-                    'client': 'e',
-                    'keys': ['y']})
+                    'tasks': {b'x': dumps_task((inc, 1)),
+                              b'y': dumps_task((inc, b'x'))},
+                    'dependencies': {b'x': [], b'y': [b'x']},
+                    'client': b'e',
+                    'keys': [b'y']})
 
     yield write(f, {'op': 'update-graph',
-                    'tasks': {'x': (inc, 1), 'z': (add, 'x', 10)},
-                    'dependencies': {'x': set(), 'z': {'x'}},
-                    'client': 'f',
-                    'keys': ['z']})
+                    'tasks': {b'x': dumps_task((inc, 1)),
+                              b'z': dumps_task((add, b'x', 10))},
+                    'dependencies': {b'x': [], b'z': [b'x']},
+                    'client': b'f',
+                    'keys': [b'z']})
 
     msg = yield read(e)
     assert msg['op'] == 'key-in-memory'
-    assert msg['key'] == 'y'
+    assert msg['key'] == b'y'
     msg = yield read(f)
     assert msg['op'] == 'key-in-memory'
-    assert msg['key'] == 'z'
+    assert msg['key'] == b'z'
 
 
 def test_maybe_complex():
@@ -793,7 +800,7 @@ def test_maybe_complex():
 
 def test_dumps_function():
     a = dumps_function(inc)
-    assert loads(a)(10) == 11
+    assert cloudpickle.loads(a)(10) == 11
 
     b = dumps_function(inc)
     assert a is b
@@ -824,20 +831,20 @@ def test_ready_remove_worker(s, a, b):
     s.update_graph(tasks={'x-%d' % i: dumps_task((inc, i)) for i in range(20)},
                    keys=['x-%d' % i for i in range(20)],
                    client='client',
-                   dependencies={'x-%d' % i: set() for i in range(20)})
+                   dependencies={'x-%d' % i: [] for i in range(20)})
 
     assert all(len(s.processing[w]) == s.ncores[w]
                 for w in s.ncores)
     assert not any(stack for stack in s.stacks.values())
     assert len(s.ready) + sum(map(len, s.processing.values())) == 20
 
-    s.remove_worker(address=a.address)
+    s.remove_worker(address=a.address_string)
 
     for collection in [s.ncores, s.stacks, s.processing]:
-        assert set(collection) == {b.address}
+        assert set(collection) == {b.address_string}
     assert all(len(s.processing[w]) == s.ncores[w]
                 for w in s.ncores)
-    assert set(s.processing) == {b.address}
+    assert set(s.processing) == {b.address_string}
     assert not any(stack for stack in s.stacks.values())
     assert len(s.ready) + sum(map(len, s.processing.values())) == 20
 
@@ -848,7 +855,7 @@ def test_restart(s, a, b):
     s.update_graph(tasks={'x-%d' % i: dumps_task((inc, i)) for i in range(20)},
                    keys=['x-%d' % i for i in range(20)],
                    client='client',
-                   dependencies={'x-%d' % i: set() for i in range(20)})
+                   dependencies={'x-%d' % i: [] for i in range(20)})
 
     assert len(s.ready) + sum(map(len, s.processing.values())) == 20
     assert s.ready
@@ -872,7 +879,7 @@ def test_ready_add_worker(s, a, b):
     s.update_graph(tasks={'x-%d' % i: dumps_task((inc, i)) for i in range(20)},
                    keys=['x-%d' % i for i in range(20)],
                    client='client',
-                   dependencies={'x-%d' % i: set() for i in range(20)})
+                   dependencies={'x-%d' % i: [] for i in range(20)})
 
     assert all(len(s.processing[w]) == s.ncores[w]
                 for w in s.ncores)
@@ -880,24 +887,24 @@ def test_ready_add_worker(s, a, b):
 
     w = Worker(s.ip, s.port, ncores=3, ip='127.0.0.1')
     w.listen(0)
-    s.add_worker(address=w.address, ncores=w.ncores)
+    s.add_worker(address=w.address_string, ncores=w.ncores)
 
-    assert w.address in s.ncores
+    assert w.address_string in s.ncores
     assert all(len(s.processing[w]) == s.ncores[w]
                 for w in s.ncores)
     assert len(s.ready) + sum(map(len, s.processing.values())) == 20
 
 
 def test_str_graph():
-    dsk = {'x': 1}
+    dsk = {b'x': 1}
     assert str_graph(dsk) == dsk
 
     dsk = {('x', 1): (inc, 1)}
-    assert str_graph(dsk) == {str(('x', 1)): (inc, 1)}
+    assert str_graph(dsk) == {str(('x', 1)).encode(): (inc, 1)}
 
     dsk = {('x', 1): (inc, 1), ('x', 2): (inc, ('x', 1))}
-    assert str_graph(dsk) == {str(('x', 1)): (inc, 1),
-                              str(('x', 2)): (inc, str(('x', 1)))}
+    assert str_graph(dsk) == {str(('x', 1)).encode(): (inc, 1),
+                              str(('x', 2)).encode(): (inc, str(('x', 1)).encode())}
 
     dsks = [{'x': 1},
             {('x', 1): (inc, 1), ('x', 2): (inc, ('x', 1))},
@@ -906,6 +913,6 @@ def test_str_graph():
     for dsk in dsks:
         sdsk = str_graph(dsk)
         keys = list(dsk)
-        skeys = list(map(str, keys))
-        assert all(isinstance(k, str) for k in sdsk)
+        skeys = [str(k).encode() for k in keys]
+        assert all(isinstance(k, bytes) for k in sdsk)
         assert dask.get(dsk, keys) == dask.get(sdsk, skeys)

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -28,3 +28,7 @@ def test_pandas():
     if pd.__version__ >= '0.17.1':
         assert sizeof(df.y) >= 1000 * 3
     assert sizeof(df.index) >= 20
+
+    assert isinstance(sizeof(df), int)
+    assert isinstance(sizeof(df.x), int)
+    assert isinstance(sizeof(df.index), int)

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1,7 +1,7 @@
 from distributed.utils_test import (cluster, loop, gen_cluster,
         gen_test)
 from distributed.core import rpc
-from distributed import Scheduler, Worker
+from distributed import Scheduler, Worker, Executor
 from tornado import gen
 
 def test_cluster(loop):
@@ -12,13 +12,20 @@ def test_cluster(loop):
         assert len(ident['workers']) == 2
 
 
-@gen_cluster()
-def test_gen_cluster(s, a, b):
+@gen_cluster(executor=True)
+def test_gen_cluster(e, s, a, b):
+    assert isinstance(e, Executor)
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
     assert s.ncores == {w.address: w.ncores for w in [a, b]}
 
+@gen_cluster(executor=False)
+def test_gen_cluster_without_executor(s, a, b):
+    assert isinstance(s, Scheduler)
+    for w in [a, b]:
+        assert isinstance(w, Worker)
+    assert s.ncores == {w.address: w.ncores for w in [a, b]}
 
 @gen_test()
 def test_gen_test():

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -8,7 +8,7 @@ def test_cluster(loop):
     with cluster() as (s, [a, b]):
         s = rpc(ip='127.0.0.1', port=s['port'])
         ident = loop.run_sync(s.identity)
-        assert ident['type'] == 'Scheduler'
+        assert ident['type'] == b'Scheduler'
         assert len(ident['workers']) == 2
 
 
@@ -17,7 +17,7 @@ def test_gen_cluster(s, a, b):
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
-    assert s.ncores == {w.address: w.ncores for w in [a, b]}
+    assert s.ncores == {w.address_string: w.ncores for w in [a, b]}
 
 
 @gen_test()

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -17,7 +17,7 @@ def test_gen_cluster(s, a, b):
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
-    assert s.ncores == {w.address_string: w.ncores for w in [a, b]}
+    assert s.ncores == {w.address: w.ncores for w in [a, b]}
 
 
 @gen_test()

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -8,7 +8,7 @@ def test_cluster(loop):
     with cluster() as (s, [a, b]):
         s = rpc(ip='127.0.0.1', port=s['port'])
         ident = loop.run_sync(s.identity)
-        assert ident['type'] == b'Scheduler'
+        assert ident['type'] == 'Scheduler'
         assert len(ident['workers']) == 2
 
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -48,15 +48,15 @@ def test_worker(loop):
         assert not a.active
         assert response['status'] == 'OK'
         assert a.data['x'] == 3
-        assert c.who_has['x'] == {a.address_string}
+        assert c.who_has['x'] == {a.address}
 
         response = yield bb.compute(key='y',
                                     function=dumps(add),
                                     args=dumps(['x', 10]),
-                                    who_has={'x': [a.address_string]})
+                                    who_has={'x': [a.address]})
         assert response['status'] == 'OK'
         assert b.data['y'] == 13
-        assert c.who_has['y'] == {b.address_string}
+        assert c.who_has['y'] == {b.address}
         assert response['nbytes'] == sizeof(b.data['y'])
 
         def bad_func():
@@ -78,13 +78,13 @@ def test_worker(loop):
         aa.close_streams()
         yield a._close()
 
-        assert a.address_string not in c.ncores and b.address_string in c.ncores
+        assert a.address not in c.ncores and b.address in c.ncores
 
-        assert list(c.ncores.keys()) == [b.address_string]
+        assert list(c.ncores.keys()) == [b.address]
 
-        assert isinstance(b.address_string, str)
-        assert b.ip in b.address_string
-        assert str(b.port) in b.address_string
+        assert isinstance(b.address, str)
+        assert b.ip in b.address
+        assert str(b.port) in b.address
 
         bb.close_streams()
         yield b._close()
@@ -107,13 +107,13 @@ def test_compute_who_has(loop):
         zz = rpc(ip=z.ip, port=z.port)
         yield zz.compute(function=dumps(inc),
                          args=dumps(('a',)),
-                         who_has={'a': [x.address_string]},
+                         who_has={'a': [x.address]},
                          key='b')
         assert z.data['b'] == 2
 
         yield zz.compute(function=dumps(inc),
                          args=dumps(('a',)),
-                         who_has={'a': [y.address_string]},
+                         who_has={'a': [y.address]},
                          key='c')
         assert z.data['c'] == 3
 
@@ -133,9 +133,9 @@ def test_workers_update_center(loop):
         assert response['nbytes'] == {'x': sizeof(1), 'y': sizeof(2)}
 
         assert a.data == {'x': 1, 'y': 2}
-        assert c.who_has == {'x': {a.address_string},
-                             'y': {a.address_string}}
-        assert c.has_what[a.address_string] == {'x', 'y'}
+        assert c.who_has == {'x': {a.address},
+                             'y': {a.address}}
+        assert c.has_what[a.address] == {'x', 'y'}
 
         yield aa.delete_data(keys=['x'], close=True)
         assert not c.who_has['x']
@@ -152,9 +152,9 @@ def dont_test_delete_data_with_missing_worker(loop):
     def f(c, a, b):
         bad = '127.0.0.1:9001'  # this worker doesn't exist
         c.who_has['z'].add(bad)
-        c.who_has['z'].add(a.address_string)
+        c.who_has['z'].add(a.address)
         c.has_what[bad].add('z')
-        c.has_what[a.address_string].add('z')
+        c.has_what[a.address].add('z')
         a.data['z'] = 5
 
         cc = rpc(ip=c.ip, port=c.port)
@@ -163,7 +163,7 @@ def dont_test_delete_data_with_missing_worker(loop):
         assert 'z' not in a.data
         assert not c.who_has['z']
         assert not c.has_what[bad]
-        assert not c.has_what[a.address_string]
+        assert not c.has_what[a.address]
 
         cc.close_streams()
 
@@ -244,7 +244,7 @@ def test_broadcast(loop):
     def f(c, a, b):
         cc = rpc(ip=c.ip, port=c.port)
         results = yield cc.broadcast(msg={'op': 'ping'})
-        assert results == {a.address_string: b'pong', b.address_string: b'pong'}
+        assert results == {a.address: b'pong', b.address: b'pong'}
 
         cc.close_streams()
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -202,7 +202,7 @@ def key_split(s):
     'Other'
     """
     if isinstance(s, bytes):
-        return key_split(s.decode()).encode()
+        return key_split(s.decode())
     if isinstance(s, tuple):
         return key_split(s[0])
     try:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -194,11 +194,15 @@ def key_split(s):
     'x'
     >>> key_split('hello-world-1')
     'hello-world'
+    >>> key_split(b'hello-world-1')
+    'hello-world'
     >>> key_split('ae05086432ca935f6eba409a8ecd4896')
     'data'
     >>> key_split(None)
     'Other'
     """
+    if isinstance(s, bytes):
+        return key_split(s.decode()).encode()
     if isinstance(s, tuple):
         return key_split(s[0])
     try:
@@ -233,10 +237,12 @@ def ensure_ip(hostname):
     """ Ensure that address is an IP address
 
     >>> ensure_ip('localhost')
-    '127.0.0.1'
+    b'127.0.0.1'
     >>> ensure_ip('123.123.123.123')  # pass through IP addresses
-    '123.123.123.123'
+    b'123.123.123.123'
     """
+    if isinstance(hostname, bytes):
+        hostname = hostname.decode()
     if re.match('\d+\.\d+\.\d+\.\d+', hostname):  # is IP
         return hostname
     else:
@@ -252,7 +258,8 @@ def get_traceback():
            os.path.join('distributed', 'scheduler'),
            os.path.join('tornado', 'gen.py'),
            os.path.join('concurrent', 'futures')]
-    while any(b in exc_traceback.tb_frame.f_code.co_filename for b in bad):
+    while exc_traceback and any(b in exc_traceback.tb_frame.f_code.co_filename
+                                for b in bad):
         exc_traceback = exc_traceback.tb_next
     return exc_traceback
 
@@ -292,9 +299,28 @@ def iterator_to_queue(seq, maxsize=0):
     return q
 
 
+def tobytes(o):
+    """ Convert an object to a bytestring, using str
+
+    Examples
+    --------
+
+    >>> tobytes(b'x')
+    b'x'
+    >>> tobytes('x')
+    b'x'
+    >>> tobytes(1)
+    b'1'
+    """
+    if isinstance(o, bytes):
+        return o
+    else:
+        return str(o).encode()
+
+
 import logging
 logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s',
-                    level=logging.INFO)
+                    level=logging.DEBUG)
 
 # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
 stream = logging.StreamHandler(sys.stderr)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -299,28 +299,28 @@ def iterator_to_queue(seq, maxsize=0):
     return q
 
 
-def tobytes(o):
+def tokey(o):
     """ Convert an object to a bytestring, using str
 
     Examples
     --------
 
-    >>> tobytes(b'x')
+    >>> tokey(b'x')
     b'x'
-    >>> tobytes('x')
-    b'x'
-    >>> tobytes(1)
-    b'1'
+    >>> tokey('x')
+    'x'
+    >>> tokey(1)
+    '1'
     """
-    if isinstance(o, bytes):
+    if isinstance(o, (str, bytes)):
         return o
     else:
-        return str(o).encode()
+        return str(o)
 
 
 import logging
 logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s',
-                    level=logging.DEBUG)
+                    level=logging.INFO)
 
 # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
 stream = logging.StreamHandler(sys.stderr)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -272,6 +272,8 @@ def _test_cluster(f, loop=None, b_ip='127.0.0.1'):
                     raise Exception("Cluster creation timeout")
 
             yield f(c, a, b)
+        except Exception as e:
+            logger.exception(e)
         finally:
             logger.debug("Closing out test cluster")
             for w in [a, b]:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -274,6 +274,7 @@ def _test_cluster(f, loop=None, b_ip='127.0.0.1'):
             yield f(c, a, b)
         except Exception as e:
             logger.exception(e)
+            raise
         finally:
             logger.debug("Closing out test cluster")
             for w in [a, b]:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -379,7 +379,8 @@ def end_cluster(s, workers):
 
 
 def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)], timeout=10,
-        Worker=Worker):
+        Worker=Worker, executor=False):
+    from distributed import Executor
     """ Coroutine test with small cluster
 
     @gen_cluster()
@@ -400,9 +401,17 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)], timeout=10,
 
             s, workers = loop.run_sync(lambda: start_cluster(ncores,
                                                              Worker=Worker))
+            args = [s] + workers
+
+            if executor:
+                e = Executor((s.ip, s.port), loop=loop, start=False)
+                loop.run_sync(e._start)
+                args = [e] + args
             try:
-                loop.run_sync(lambda: cor(s, *workers), timeout=timeout)
+                loop.run_sync(lambda: cor(*args), timeout=timeout)
             finally:
+                if executor:
+                    loop.run_sync(e._shutdown)
                 loop.run_sync(lambda: end_cluster(s, workers))
                 loop.stop()
                 loop.close()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -179,11 +179,11 @@ class Worker(Server):
 
     @property
     def address(self):
-        return (self.ip, self.port)
+        return '%s:%d' % (self.ip, self.port)
 
     @property
-    def address_string(self):
-        return '%s:%d' % (self.ip, self.port)
+    def address_tuple(self):
+        return (self.ip, self.port)
 
     @gen.coroutine
     def compute(self, stream, function=None, key=None, args=(), kwargs={},

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -19,7 +19,7 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.iostream import StreamClosedError
 
 from .client import pack_data, gather_from_workers
-from .compatibility import reload, PY3
+from .compatibility import reload, PY3, unicode
 from .core import rpc, Server, pingpong, dumps, loads, coerce_to_address
 from .sizeof import sizeof
 from .utils import (funcname, get_ip, get_traceback, truncate_exception,
@@ -325,9 +325,9 @@ class Worker(Server):
         return {k: dumps(self.data[k]) for k in keys if k in self.data}
 
     def upload_file(self, stream, filename=None, data=None, load=True):
-        if PY3 and isinstance(filename, bytes):
-            filename = filename.decode()
         out_filename = os.path.join(self.local_dir, filename)
+        if isinstance(data, unicode):
+            data = data.encode()
         with open(out_filename, 'wb') as f:
             f.write(data)
             f.flush()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -12,15 +12,15 @@ import shutil
 import sys
 
 from dask.core import istask
-from toolz import merge
+from toolz import merge, valmap
 from tornado.gen import Return
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.iostream import StreamClosedError
 
-from .client import _gather, pack_data, gather_from_workers
+from .client import pack_data, gather_from_workers
 from .compatibility import reload
-from .core import rpc, Server, pingpong, dumps, loads
+from .core import rpc, Server, pingpong, dumps, loads, coerce_to_address
 from .sizeof import sizeof
 from .utils import (funcname, get_ip, get_traceback, truncate_exception,
     ignoring)
@@ -175,7 +175,7 @@ class Worker(Server):
     @gen.coroutine
     def terminate(self, stream, report=True):
         yield self._close(report=report)
-        raise Return(b'OK')
+        raise Return('OK')
 
     @property
     def address(self):
@@ -187,12 +187,14 @@ class Worker(Server):
 
     @gen.coroutine
     def compute(self, stream, function=None, key=None, args=(), kwargs={},
-            task=None, who_has=None, report=True, serialized=False):
+            task=None, who_has=None, report=True):
         """ Execute function """
         self.active.add(key)
         if who_has:
             local_data = {k: self.data[k] for k in who_has if k in self.data}
-            who_has = {k: v for k, v in who_has.items() if k not in self.data}
+            who_has = {k: set(map(coerce_to_address, v))
+                       for k, v in who_has.items()
+                       if k not in self.data}
             try:
                 logger.info("gather %d keys from peers: %s",
                             len(who_has), str(who_has))
@@ -201,27 +203,29 @@ class Worker(Server):
                 logger.warn("Could not find data during gather in compute",
                             exc_info=True)
                 self.active.remove(key)
-                raise Return((b'missing-data', e))
+                raise Return({'status': 'missing-data',
+                              'keys': e.args})
             data = merge(local_data, other)
         else:
             data = {}
 
-        if serialized:
-            try:
-                if task is not None:
-                    task = loads(task)
-                if function is not None:
-                    function = loads(function)
-                if args:
-                    args = loads(args)
-                if kwargs:
-                    kwargs = loads(kwargs)
-            except Exception as e:
-                logger.warn("Could not deserialize task", exc_info=True)
-                tb = get_traceback()
-                e2 = truncate_exception(e, 1000)
-                self.active.remove(key)
-                raise Return((b'error', {'exception': e2, 'traceback': tb}))
+        try:
+            if task is not None:
+                task = loads(task)
+            if function is not None:
+                function = loads(function)
+            if args:
+                args = loads(args)
+            if kwargs:
+                kwargs = loads(kwargs)
+        except Exception as e:
+            logger.warn("Could not deserialize task", exc_info=True)
+            tb = get_traceback()
+            e2 = truncate_exception(e, 1000)
+            self.active.remove(key)
+            raise Return({'error': 'error',
+                          'exception': dumps(e2),
+                          'traceback': dumps(tb)})
 
         if task is not None:
             assert not function and not args and not kwargs
@@ -264,9 +268,10 @@ class Worker(Server):
                 if not response == b'OK':
                     logger.warn('Could not report results to center: %s',
                                 response.decode())
-            out = (b'OK', {'nbytes': sizeof(result)})
+            out = {'status': 'OK',
+                   'nbytes': sizeof(result)}
             if result is not None:
-                out[1]['type'] = type(result)
+                out['type'] = dumps(type(result))
         except Exception as e:
             tb = get_traceback()
             e2 = truncate_exception(e, 1000)
@@ -283,22 +288,26 @@ class Worker(Server):
             except:
                 tb = None
 
-            out = (b'error', {'exception': e2, 'traceback': tb})
+            out = {'status': b'error',
+                   'exception': dumps(e2),
+                   'traceback': dumps(tb)}
 
-        logger.debug("Send compute response to client: %s, %s", key, out)
+        logger.debug("Send compute response to scheduler: %s, %s", key, out)
         with ignoring(KeyError):
             self.active.remove(key)
         raise Return(out)
 
     @gen.coroutine
     def update_data(self, stream, data=None, report=True):
+        data = valmap(loads, data)
         self.data.update(data)
         if report:
             response = yield self.center.add_keys(address=(self.ip, self.port),
                                                   keys=list(data))
             assert response == b'OK'
-        info = {'nbytes': {k: sizeof(v) for k, v in data.items()}}
-        raise Return((b'OK', info))
+        info = {'nbytes': {k: sizeof(v) for k, v in data.items()},
+                'status': b'OK'}
+        raise Return(info)
 
     @gen.coroutine
     def delete_data(self, stream, keys=None, report=True):
@@ -308,14 +317,16 @@ class Worker(Server):
         logger.info("Deleted %d keys", len(keys))
         if report:
             logger.debug("Reporting loss of keys to center")
-            yield self.center.remove_keys(address=(self.ip, self.port),
-                                          keys=keys)
+            yield self.center.remove_keys(address=self.address,
+                                          keys=list(keys))
         raise Return(b'OK')
 
     def get_data(self, stream, keys=None):
-        return {k: self.data[k] for k in keys if k in self.data}
+        return {k: dumps(self.data[k]) for k in keys if k in self.data}
 
     def upload_file(self, stream, filename=None, data=None, load=True):
+        if isinstance(filename, bytes):
+            filename = filename.decode()
         out_filename = os.path.join(self.local_dir, filename)
         with open(out_filename, 'wb') as f:
             f.write(data)
@@ -338,8 +349,8 @@ class Worker(Server):
                         logger.warning("Found no packages in egg file")
             except Exception as e:
                 logger.exception(e)
-                return e
-        return len(data)
+                return {'status': 'error', 'exception': dumps(e)}
+        return {'status': 'OK', 'nbytes': len(data)}
 
 
 job_counter = [0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 tornado >= 4.2
 toolz
+msgpack-python
 cloudpickle
 dask
 click


### PR DESCRIPTION
I've been changing distributed from cloudpickle to msgpack for message serialization (though keeping cloudpickle for function and data serialization for tasks).  This has been for a few reasons

1.  Cloudpickle *might* be a bottleneck (profiling is hard at this stage)
2.  Cloudpickle introduces some security issues in the scheduler
3.  Msgpack allows us, in the future, to use the scheduler for other languages, like R

Unfortunately msgpack understands less of Python than cloudpickle does, so this change was expensive to implement and messes things up a bit.  For example, msgpack coreces strings to bytestrings, so everywhere in the code that said this `d['status']` now says  this `d[b'status']` and other bit like that.

The transformation is mostly done.  It does not seem to speed up benchmarks considerably, so our bet that this was a bottleneck didn't pay off.  It does make us seem more serious and opens up other language client/workers, which is good.  It will slow down development for the near future though as we pick up lingering bugs from the change and teach ourselves to only use constructs that can flow through msgpack well.

My plan is to see how much I can clean this up for the next half day and then make a decision.  I would welcome thoughts from people that have experience with virtues of various message protocols.  Should we be doing something else?
