### PR TITLE
Add ready deque to scheduler

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -11,7 +11,7 @@ from tornado.ioloop import IOLoop
 from tornado import gen
 
 from .core import Server, rpc, write
-from .utils import get_ip
+from .utils import get_ip, ignoring
 
 
 logger = logging.getLogger(__name__)
@@ -201,4 +201,5 @@ def run_worker(q, ip, center_ip, center_port, ncores, nanny_port,
             q.put({'port': worker.port, 'dir': worker.local_dir})  # pragma: no cover
 
     loop.add_callback(start)  # pragma: no cover
-    loop.start()  # pragma: no cover
+    with ignoring(KeyboardInterrupt):
+        loop.start()  # pragma: no cover

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -428,7 +428,7 @@ class Scheduler(Server):
             key = self.stacks[worker].pop()
             if key not in self.tasks:
                 continue
-            if self.who_has[key]:
+            if self.who_has.get(key):
                 continue
             self.processing[worker].add(key)
             logger.debug("Send job to worker: %s, %s, %s", worker, key)
@@ -444,7 +444,7 @@ class Scheduler(Server):
             key = self.ready.pop()
             if key not in self.tasks:
                 continue
-            if self.who_has[key]:
+            if self.who_has.get(key):
                 continue
             self.processing[worker].add(key)
             logger.debug("Send job to worker: %s, %s, %s", worker, key)
@@ -666,7 +666,7 @@ class Scheduler(Server):
                     self.mark_failed(key, self.exceptions_blame[dep])
 
         for key in keys:
-            if self.who_has[key]:
+            if self.who_has.get(key):
                 self.mark_key_in_memory(key)
 
         for plugin in self.plugins[:]:
@@ -1263,7 +1263,7 @@ def update_state(tasks, dependencies, dependents, who_wants, wants_what,
     in_play |= exterior
     for key in exterior:
         deps = dependencies[key]
-        wait_keys = {d for d in deps if not (d in who_has and who_has[d])}
+        wait_keys = {d for d in deps if not who_has.get(d)}
         if wait_keys:
             waiting[key] = wait_keys
         else:

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1103,17 +1103,21 @@ def test_directed_scatter_sync(loop):
 
 def test_iterator_scatter(loop):
     with cluster() as (s, [a, b]):
-        with Executor(('127.0.0.1', s['port']), loop=loop) as ee:
+        with Executor(('127.0.0.1', s['port']), loop=loop) as e:
 
-            aa = ee.scatter([1,2,3])
-            assert [1,2,3] == ee.gather(aa)
+            aa = e.scatter([1,2,3])
+            assert [1,2,3] == e.gather(aa)
 
             g = (i for i in range(10))
-            futures = ee.scatter(g)
+            futures = e.scatter(g)
             assert isinstance(futures, Iterator)
 
             a = next(futures)
-            assert ee.gather(a) == 0
+            assert e.gather(a) == 0
+
+            futures = list(futures)
+            assert len(futures) == 9
+            assert e.gather(futures) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 
 def test_queue_scatter(loop):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -190,12 +190,12 @@ class Worker(Server):
             task=None, needed=[], who_has=None, report=True, serialized=False):
         """ Execute function """
         self.active.add(key)
-        if needed:
-            local_data = {k: self.data[k] for k in needed if k in self.data}
-            needed = [n for n in needed if n not in self.data]
-        elif who_has:
+        if who_has:
             local_data = {k: self.data[k] for k in who_has if k in self.data}
-            who_has = {k: v for k, v in who_has.items() if k not in self.data}
+            who_has2 = {k: v for k, v in who_has.items() if k not in self.data}
+        elif needed:
+            local_data = {k: self.data[k] for k in needed if k in self.data}
+            needed2 = [n for n in needed if n not in self.data]
         else:
             local_data = {}
 
@@ -204,13 +204,13 @@ class Worker(Server):
             try:
                 if who_has:
                     logger.info("gather %d keys from peers: %s",
-                                len(who_has), str(who_has))
-                    other = yield gather_from_workers(who_has)
+                                len(who_has2), str(who_has2))
+                    other = yield gather_from_workers(who_has2)
                 elif needed:
                     logger.info("gather %d keys from peers: %s",
-                                len(needed), str(needed))
-                    other = yield _gather(self.center, needed=needed)
-                    other = dict(zip(needed, other))
+                                len(needed2), str(needed2))
+                    other = yield _gather(self.center, needed=needed2)
+                    other = dict(zip(needed2, other))
                 else:
                     raise ValueError()
             except KeyError as e:


### PR DESCRIPTION
Previously we assigned a task to a worker once that task was ready to
run.  It would then linger in that worker's stack, possibly for a long
time.  If in the future another worker capable of running that task
became free we had no mechanism for it to steal work.  There was good
reason for this, it's tricky to find good tasks to steal in constant
time.

However, in the common case of leaf tasks that have neither dependent
tasks nor restrictions it makes sense to keep these ready tasks in a
common pool from which all workers can draw.  This is the new `ready`
collection on the scheduler, stored as a FIFO deque.

This enables workers to load balance more effectivley in this common
case and provides newly arrived workers with a pool of available work.

Fixes #148 

Screencast of things working:  https://www.youtube.com/watch?v=x7ehRDYBing&feature=youtu.be