### PR TITLE
Make sure worker selected IP is on the same network as scheduler

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -10,7 +10,6 @@ import sys
 import tblib.pickling_support
 import tempfile
 from threading import Thread
-import traceback
 
 from dask import istask
 from toolz import memoize
@@ -31,10 +30,9 @@ def funcname(func):
         return str(func)
 
 
-def get_ip():
-    return [(s.connect(('8.8.8.8', 80)), s.getsockname()[0], s.close())
-        for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]
-
+def get_ip(host='8.8.8.8', port=80):
+    return [(s.connect((host, port)), s.getsockname()[0], s.close())
+            for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]
 
 
 @contextmanager


### PR DESCRIPTION
If the dworker host has many network interfaces with complex setups (e.g.
docker swarm or VM bridge networks) it is unlikely that the worker will select
the interface that has an address that is visible from the scheduler. Instead,
we change the `get_ip` function to be able to target the center ip address to select
an ip that is visible from it automatically.

Alternatively make it possible to explicitly pass a specific IP or hostname to
the dworker commandline argument.