### PR TITLE
Add run function

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -142,9 +142,9 @@ class Future(WrappedKey):
         """
         return sync(self.executor.loop, self._exception)
 
-    def cancel(self, block=False):
+    def cancel(self):
         """ Returns True if the future has been cancelled """
-        return self.executor.cancel([self], block=False)
+        return self.executor.cancel([self])
 
     def cancelled(self):
         """ Returns True if the future has been cancelled """
@@ -828,16 +828,14 @@ class Executor(object):
             return sync(self.loop, self._scatter, data, workers=workers,
                         broadcast=broadcast)
     @gen.coroutine
-    def _cancel(self, futures, block=False):
+    def _cancel(self, futures):
         keys = {f.key for f in futures_of(futures)}
         f = self.scheduler.cancel(keys=list(keys), client=self.id)
-        if block:
-            yield f
         for k in keys:
             with ignoring(KeyError):
                 del self.futures[k]
 
-    def cancel(self, futures, block=False):
+    def cancel(self, futures):
         """
         Cancel running futures
 
@@ -849,7 +847,7 @@ class Executor(object):
         ----------
         futures: list of Futures
         """
-        return sync(self.loop, self._cancel, futures, block=False)
+        return sync(self.loop, self._cancel, futures)
 
     @gen.coroutine
     def _run(self, function, *args, **kwargs):

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -861,6 +861,12 @@ class Executor(object):
         """
         Run a function on all workers outside of task scheduling system
 
+        This calls a function on all currently known workers immediately,
+        blocks until those results come back, and returns the results
+        asynchronously as a dictionary keyed by worker address.  This method
+        if generally used for side effects, such and collecting diagnostic
+        information or installing libraries.
+
         Examples
         --------
         >>> e.run(os.getpid)  # doctest: +SKIP

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -830,7 +830,7 @@ class Executor(object):
     @gen.coroutine
     def _cancel(self, futures):
         keys = {f.key for f in futures_of(futures)}
-        f = self.scheduler.cancel(keys=list(keys), client=self.id)
+        f = yield self.scheduler.cancel(keys=list(keys), client=self.id)
         for k in keys:
             with ignoring(KeyError):
                 del self.futures[k]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1187,9 +1187,9 @@ class Scheduler(Server):
             return self.ncores
 
     @gen.coroutine
-    def broadcast(self, stream, msg=None):
+    def broadcast(self, stream=None, msg=None, workers=None):
         """ Broadcast message to workers, return all results """
-        workers = list(self.ncores)
+        workers = workers or list(self.ncores)
         results = yield All([send_recv(arg=address, close=True, **msg)
                              for address in workers])
         raise Return(dict(zip(workers, results)))

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1189,7 +1189,8 @@ class Scheduler(Server):
     @gen.coroutine
     def broadcast(self, stream=None, msg=None, workers=None):
         """ Broadcast message to workers, return all results """
-        workers = workers or list(self.ncores)
+        if workers is None:
+            workers = list(self.ncores)
         results = yield All([send_recv(arg=address, close=True, **msg)
                              for address in workers])
         raise Return(dict(zip(workers, results)))

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1765,7 +1765,10 @@ def test__cancel_multi_client(s, a, b):
     assert x.cancelled()
     assert not y.cancelled()
 
-    assert y.key in s.tasks
+    start = time()
+    while y.key not in s.tasks:
+        yield gen.sleep(0.01)
+        assert time() < start + 5
 
     out = yield y._result()
     assert out == 2

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1733,7 +1733,7 @@ def test__cancel(e, s, a, b):
     while y.key not in s.tasks:
         yield gen.sleep(0.01)
 
-    yield e._cancel([x], block=True)
+    yield e._cancel([x])
 
     assert x.cancelled()
     assert 'cancel' in str(x)
@@ -1760,7 +1760,7 @@ def test__cancel_multi_client(s, a, b):
 
     assert x.key == y.key
 
-    yield e._cancel([x], block=True)
+    yield e._cancel([x])
 
     assert x.cancelled()
     assert not y.cancelled()
@@ -1797,7 +1797,7 @@ def test_cancel(loop):
             y = e.submit(slowinc, x)
             z = e.submit(slowinc, y)
 
-            e.cancel([y], block=True)
+            e.cancel([y])
 
             start = time()
             while not z.cancelled():
@@ -1806,7 +1806,7 @@ def test_cancel(loop):
 
             assert x.result() == 2
 
-            z.cancel(block=True)
+            z.cancel()
             assert z.cancelled()
 
 

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -2049,6 +2049,12 @@ def test_run(e, s, a, b):
     results = yield e._run(inc, 1)
     assert results == {a.address: 2, b.address: 2}
 
+    results = yield e._run(inc, 1, workers=[a.address])
+    assert results == {a.address: 2}
+
+    results = yield e._run(inc, 1, workers=[])
+    assert results == {}
+
 
 def test_run_sync(loop):
     def func(x, y=10):
@@ -2057,5 +2063,8 @@ def test_run_sync(loop):
     with cluster() as (s, [a, b]):
         with Executor(('127.0.0.1', s['port']), loop=loop) as e:
             result = e.run(func, 1, y=2)
-            assert result == {('127.0.0.1', a['port']): 3,
-                              ('127.0.0.1', b['port']): 3}
+            assert result == {'127.0.0.1:%d' % a['port']: 3,
+                              '127.0.0.1:%d' % b['port']: 3}
+
+            result = e.run(func, 1, y=2, workers=['127.0.0.1:%d' % a['port']])
+            assert result == {'127.0.0.1:%d' % a['port']: 3}

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -2042,3 +2042,20 @@ def test_balance_tasks_by_stacks(e, s, a, b):
     yield _wait(y)
 
     assert len(a.data) == len(b.data) == 1
+
+
+@gen_cluster(executor=True)
+def test_run(e, s, a, b):
+    results = yield e._run(inc, 1)
+    assert results == {a.address: 2, b.address: 2}
+
+
+def test_run_sync(loop):
+    def func(x, y=10):
+        return x + y
+
+    with cluster() as (s, [a, b]):
+        with Executor(('127.0.0.1', s['port']), loop=loop) as e:
+            result = e.run(func, 1, y=2)
+            assert result == {('127.0.0.1', a['port']): 3,
+                              ('127.0.0.1', b['port']): 3}

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -916,3 +916,12 @@ def test_str_graph():
         skeys = [str(k) for k in keys]
         assert all(isinstance(k, (str, bytes)) for k in sdsk)
         assert dask.get(dsk, keys) == dask.get(sdsk, skeys)
+
+
+@gen_cluster()
+def test_ready_add_worker(s, a, b):
+    result = yield s.broadcast(msg={'op': 'ping'})
+    assert result == {a.address: b'pong', b.address: b'pong'}
+
+    result = yield s.broadcast(msg={'op': 'ping'}, workers=[a.address])
+    assert result == {a.address: b'pong'}

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -115,6 +115,7 @@ class Worker(Server):
             sys.path.insert(0, self.local_dir)
 
         handlers = {'compute': self.compute,
+                    'run': self.run,
                     'get_data': self.get_data,
                     'update_data': self.update_data,
                     'delete_data': self.delete_data,
@@ -296,6 +297,17 @@ class Worker(Server):
         with ignoring(KeyError):
             self.active.remove(key)
         raise Return(out)
+
+    @gen.coroutine
+    def run(self, stream, function=None, args=(), kwargs={}):
+        function = loads(function)
+        if args:
+            args = loads(args)
+        if kwargs:
+            kwargs = loads(kwargs)
+
+        result = function(*args, **kwargs)
+        raise Return(result)
 
     @gen.coroutine
     def update_data(self, stream, data=None, report=True):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -15,6 +15,7 @@ API
    Executor.map
    Executor.persist
    Executor.restart
+   Executor.run
    Executor.scatter
    Executor.shutdown
    Executor.submit


### PR DESCRIPTION
This lets users run arbitrary functions on all workers immediately.
This does not interact with the task scheduling system.

Fixes #156 

cc @quasiben @ogrisel 