### PR TITLE
Add blocked reading to s3.read_bytes

### DIFF
--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -9,6 +9,7 @@ import io
 import sys
 
 from dask.imperative import Value
+from dask.base import tokenize
 from tornado import gen
 from toolz import merge
 
@@ -78,7 +79,7 @@ def read_bytes(fn, executor=None, hdfs=None, lazy=True, delimiter=None,
         offsets = [max([o, 1]) for o in offsets]
     lengths = [d['length'] for d in blocks]
     workers = [[h.decode() for h in d['hosts']] for d in blocks]
-    names = ['read-binary-%s-%d-%d' % (fn, offset, length)
+    names = ['read-binary-hdfs3-%s-%s' % (fn, tokenize(offset, length, delimiter, not_zero))
             for fn, offset, length in zip(filenames, offsets, lengths)]
 
     logger.debug("Read %d blocks of binary bytes from %s", len(blocks), fn)

--- a/distributed/s3.py
+++ b/distributed/s3.py
@@ -372,8 +372,8 @@ class S3File(object):
             if end > self.end:
                 if end > self.size:
                     return
-                new = self.s3.s3.get_object.get(Bucket=self.bucket, Key=self.key,
-                                             Range='bytes=%i-%i' % (self.end, end + self.blocksize - 1)
+                new = self.s3.s3.get_object(Bucket=self.bucket, Key=self.key,
+                                            Range='bytes=%i-%i' % (self.end, end + self.blocksize - 1)
                                              )['Body'].read()
                 self.end = end + self.blocksize
                 self.cache = self.cache + new

--- a/distributed/s3.py
+++ b/distributed/s3.py
@@ -2,16 +2,22 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 import threading
+import re
+import json
+import io
+import sys
 
 import boto3
-from botocore.handlers import disable_signing
+from botocore.exceptions import ClientError
 from tornado import gen
 
 from dask.imperative import Value
+from dask.base import tokenize
 
-from .compatibility import get_thread_identity
+from .utils import read_block, seek_delimiter
 from .executor import default_executor, ensure_default_get
-
+from .utils import ignoring, sync
+from .compatibility import unicode
 
 logger = logging.getLogger(__name__)
 
@@ -26,148 +32,525 @@ _conn = dict()
 
 get_s3_lock = threading.Lock()
 
-
-def get_s3(anon):
-    """ Get S3 connection
-
-    Caches connection for future use
+def split_path(path):
     """
-    if anon is None:
-        try:
-            return get_s3(True)
-        except:
-            return get_s3(False)
-
-    with get_s3_lock:
-        key = anon, get_thread_identity()
-        if not _conn.get(key):
-            logger.debug("Open S3 connection.  Anonymous: %s.  Thread ID: %d",
-                         *key)
-            s3 = boto3.resource('s3')
-            if anon:
-                s3.meta.client.meta.events.register('choose-signer.s3.*',
-                        disable_signing)
-            _conn[key] = s3
-        return _conn[key]
-
-
-def get_list_of_summary_objects(bucket_name, prefix='', delimiter='',
-        page_size=DEFAULT_PAGE_LENGTH, anon=None):
-    s3 = get_s3(anon)
-    if bucket_name.startswith('s3://'):
-        bucket_name = bucket_name[len('s3://'):]
-    if prefix.startswith('/'):
-        prefix = prefix[1:]
-
-    L = list(s3.Bucket(bucket_name)
-               .objects.filter(Prefix=prefix, Delimiter=delimiter)
-               .page_size(page_size))
-    return [s for s in L if s.key[-1] != '/']
-
-
-def read_content_from_keys(bucket, key, anon=None):
-    if bucket.startswith('s3://'):
-        bucket = bucket[len('s3://'):]
-    s3 = get_s3(anon)
-    return s3.Object(bucket, key).get()['Body'].read()
-
-
-def read_bytes(bucket_name, prefix='', path_delimiter='', executor=None,
-               lazy=True, anon=None):
-    """ Read data on S3 into bytes in distributed memory
+    Normalise S3 path string into bucket and key.
 
     Parameters
     ----------
-    bucket_name: string
-        Name of S3 bucket like ``'my-bucket'``
-    prefix: string
-        Prefix of key name to match like ``'/data/2016/``
-    path_delimiter: string (optional)
-        Delimiter like ``'/'`` to define implicit S3 directory structure
-    executor: Executor (optional)
-        defaults to most recently created executor
-    lazy: boolean (optional)
-        If True then return lazily evaluated dask Values
-    anon: boolean (optional)
-        If True then don't try to authenticate with AWS
-
-    Returns
-    -------
-    list of Futures.  Each future holds bytes for one key within the bucket
+    path : string
+        Input path, like `s3://mybucket/path/to/file`
 
     Examples
     --------
-    >>> futures = read_bytes('distributed-test', 'test')  # doctest: +SKIP
-    >>> futures  # doctest: +SKIP
-    [<Future: status: finished, key: read_content_from_keys-00092e8a75141837c1e9b717b289f9d2>,
-     <Future: status: finished, key: read_content_from_keys-4f0f2cbcf4573a373cc62467ffbfd30d>]
-    >>> futures[0].result()  # doctest: +SKIP
-    b'{"amount": 100, "name": "Alice"}\\n{"amount": 200, "name": "Bob"}\\n
-      {"amount": 300, "name": "Charlie"}\\n{"amount": 400, "name": "Dennis"}\\n'
+    >>> split_path("s3://mybucket/path/to/file")
+    ("mybucket", "path/to/file")
     """
-    executor = default_executor(executor)
-    s3_objects = get_list_of_summary_objects(bucket_name, prefix,
-                                             path_delimiter, anon=anon)
-    keys = [obj.key for obj in s3_objects]
-
-    names = ['read-bytes-{0}'.format(key) for key in keys]
-
-    if lazy:
-        values = [Value(name, [{name: (read_content_from_keys, bucket_name,
-                                       key, anon)}])
-                  for name, key in zip(names, keys)]
-        return values
+    if path.startswith('s3://'):
+        path = path[5:]
+    if '/' not in path:
+        return path, ""
     else:
-        return executor.map(read_content_from_keys, [bucket_name] * len(keys),
-                keys, anon=anon)
+        return path.split('/', 1)
 
 
-def read_text(bucket_name, prefix='', path_delimiter='', encoding='utf-8',
-        errors='strict', lineterminator='\n', executor=None, anon=None,
-        collection=True, lazy=True, compression=None):
+class S3FileSystem(object):
     """
-    Read lines of text from S3
+    Access S3 data as if it were a file system.
+    """
+    _conn = {}
+
+    def __init__(self, anon=True, key=None, secret=None, **kwargs):
+        """
+        Create connection object to S3
+
+        Will use configured key/secret (typically in ~/.aws, see the
+        boto3 documentation) unless specified
+
+        Parameters
+        ----------
+        anon : bool (True)
+            whether to use anonymous connection (public buckets only)
+        key : string (None)
+            if not anonymouns, use this key, if specified
+        secret : string (None)
+            if not anonymous, use this password, if specified
+        kwargs : other parameters for boto3 session
+        """
+        self.anon = anon
+        self.key = key
+        self.secret = secret
+        self.kwargs = kwargs
+        self.connect(anon, key, secret, kwargs)
+        self.dirs = {}
+        self.s3 = self.connect(anon, key, secret, kwargs)
+
+    def connect(self, anon, key, secret, kwargs):
+        tok = tokenize(anon, key, secret, kwargs)
+        if tok not in self._conn:
+            logger.debug("Open S3 connection.  Anonymous: %s",
+                         self.anon)
+            if self.anon:
+                from botocore import UNSIGNED
+                from botocore.client import Config
+                s3 = boto3.Session().client('s3',
+                         config=Config(signature_version=UNSIGNED))
+            else:
+                s3 = boto3.Session(self.key, self.secret,
+                                   **self.kwargs).client('s3')
+            self._conn[tok] = s3
+        return self._conn[tok]
+
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        del d['s3']
+        logger.debug("Serialize with state: %s", d)
+        return d
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.connect(self.anon, self.key, self.secret, self.kwargs)
+
+    def open(self, path, mode='rb', block_size=4*1024**2):
+        """ Open a file for reading or writing
+
+        Parameters
+        ----------
+        path: string
+            Path of file on S3
+        mode: string
+            One of 'rb' or 'wb'
+        block_size: int
+            Size of data-node blocks if reading
+        """
+        if 'b' not in mode:
+            raise NotImplementedError("Text mode not supported, use mode='%s'"
+                    " and manage bytes" % (mode + 'b'))
+        return S3File(self, path, mode, block_size=block_size)
+
+    def _ls(self, path, refresh=False):
+        """ List files below path
+
+        Parameters
+        ----------
+        path : string/bytes
+            location at which to list files
+        detail : bool (=True)
+            if True, each list item is a dict of file properties;
+            otherwise, returns list of filenames
+        refresh : bool (=False)
+            if False, look in local cache for file details first
+        """
+        path = path.lstrip('s3://').lstrip('/')
+        bucket, key = split_path(path)
+        if bucket not in self.dirs or refresh:
+            if bucket == '':
+                # list of buckets
+                if self.anon:
+                    # cannot list buckets if not logged in
+                    return []
+                files = self.s3.list_buckets()['Buckets']
+                for f in files:
+                    f['Key'] = f['Name']
+                    f['Size'] = 0
+                    del f['Name']
+            else:
+                files = self.s3.list_objects(Bucket=bucket).get('Contents', [])
+                for f in files:
+                    f['Key'] = "/".join([bucket, f['Key']])
+            self.dirs[bucket] = list(sorted(files, key=lambda x: x['Key']))
+        files = self.dirs[bucket]
+        return files
+
+    def ls(self, path, detail=False):
+        path = path.lstrip('s3://').rstrip('/')
+        try:
+            files = self._ls(path)
+        except ClientError:
+            files = []
+        if path:
+            pattern = re.compile(path + '/[^/]*.$')
+            files = [f for f in files if pattern.match(f['Key']) is not None]
+            if not files:
+                try:
+                    files = [self.info(path)]
+                except (OSError, IOError):
+                    files = []
+        if detail:
+            return files
+        else:
+            return [f['Key'] for f in files]
+
+    def info(self, path):
+        path = path.lstrip('s3://').rstrip('/')
+        files = self._ls(path)
+        files = [f for f in files if f['Key'].rstrip('/') == path]
+        if len(files) == 1:
+            return files[0]
+        else:
+            raise IOError("File not found: %s" %path)
+
+    def walk(self, path):
+        return [f['Key'] for f in self._ls(path) if f['Key'].rstrip('/'
+                ).startswith(path.rstrip('/') + '/')]
+
+    def glob(self, path):
+        """
+        Find files by glob-matching.
+
+        Note that the bucket part of the path must not contain a "*"
+        """
+        path0 = path
+        path = path.lstrip('s3://').lstrip('/')
+        bucket, key = split_path(path)
+        if "*" in bucket:
+            raise ValueError('Bucket cannot contain a "*"')
+        if '*' not in path:
+            path = path.rstrip('/') + '/*'
+        if '/' in path[:path.index('*')]:
+            ind = path[:path.index('*')].rindex('/')
+            root = path[:ind+1]
+        else:
+            root = '/'
+        allfiles = self.walk(root)
+        pattern = re.compile("^" + path.replace('//', '/')
+                                        .rstrip('/')
+                                        .replace('*', '[^/]*')
+                                        .replace('?', '.') + "$")
+        out = [f for f in allfiles if re.match(pattern,
+               f.replace('//', '/').rstrip('/'))]
+        if not out:
+            out = self.ls(path0)
+        return out
+
+    def du(self, path, total=False, deep=False):
+        if deep:
+            files = self.walk(path)
+            files = [self.info(f) for f in files]
+        else:
+            files = self.ls(path, detail=True)
+        if total:
+            return sum(f.get('Size', 0) for f in files)
+        else:
+            return {p['Key']: p['Size'] for p in files}
+
+    def df(self):
+        total = 0
+        for files in self.dirs.values():
+            total += sum(f['Size'] for f in files)
+        return {'capacity': None, 'used': total, 'percent-free': None}
+
+    def __repr__(self):
+        return 'S3 File System'
+
+    def exists(self, path):
+        return bool(self.ls(path))
+
+    def get(self, s3_path, local_path, blocksize=2**16):
+        """ Copy S3 file to local """
+        if not self.exists(s3_path):
+            raise IOError(s3_path)
+        with self.open(s3_path, 'rb') as f:
+            with open(local_path, 'wb') as f2:
+                out = 1
+                while out:
+                    out = f.read(blocksize)
+                    f2.write(out)
+
+    def cat(self, path):
+        with self.open(path, 'rb') as f:
+            return f.read()
+
+    def getmerge(self, path, filename, blocksize=2**27):
+        """ Concat all files in path (a directory) to output file """
+        files = self.ls(path)
+        with open(filename, 'wb') as f2:
+            for apath in files:
+                with self.open(apath['name'], 'rb') as f:
+                    out = 1
+                    while out:
+                        out = f.read(blocksize)
+                        f2.write(out)
+
+    def tail(self, path, size=1024):
+        """ Return last bytes of file """
+        length = self.info(path)['Size']
+        if size > length:
+            return self.cat(path)
+        with self.open(path, 'rb') as f:
+            f.seek(length - size)
+            return f.read(size)
+
+    def head(self, path, size=1024):
+        """ Return first bytes of file """
+        with self.open(path, 'rb', block_size=size) as f:
+            return f.read(size)
+
+    def read_block(self, fn, offset, length, delimiter=None):
+        """ Read a block of bytes from an S3 file
+
+        Starting at ``offset`` of the file, read ``length`` bytes.  If
+        ``delimiter`` is set then we ensure that the read starts and stops at
+        delimiter boundaries that follow the locations ``offset`` and ``offset
+        + length``.  If ``offset`` is zero then we start at zero.  The
+        bytestring returned WILL include the end delimiter string.
+
+        If offset+length is beyond the eof, reads to eof.
+
+        Parameters
+        ----------
+        fn: string
+            Path to filename on S3
+        offset: int
+            Byte offset to start read
+        length: int
+            Number of bytes to read
+        delimiter: bytes (optional)
+            Ensure reading starts and stops at delimiter bytestring
+
+        Examples
+        --------
+        >>> s3.read_block('data/file.csv', 0, 13)  # doctest: +SKIP
+        b'Alice, 100\\nBo'
+        >>> s3.read_block('data/file.csv', 0, 13, delimiter=b'\\n')  # doctest: +SKIP
+        b'Alice, 100\\nBob, 200\\n'
+
+        See Also
+        --------
+        distributed.utils.read_block
+        """
+        with self.open(fn, 'rb') as f:
+            size = f.info()['Size']
+            if offset + length > size:
+                length = size - offset
+            bytes = read_block(f, offset, length, delimiter)
+        return bytes
+
+
+class S3File(object):
+    """
+    Cached read-only interface to a key in S3, behaving like a seekable file.
+
+    Optimized for a single continguous block.
+    """
+
+    def __init__(self, s3, path, mode='rb', block_size=4*2**20):
+        """
+        Open S3 as a file. Data is only loaded and cached on demand.
+
+        Parameters
+        ----------
+        s3 : boto3 connection
+        bucket : string
+            S3 bucket to access
+        key : string
+            S3 key to access
+        blocksize : int
+            read-ahead size for finding delimiters
+        """
+        self.mode = mode
+        if mode != 'rb':
+            raise NotImplementedError("File mode must be 'rb', not %s" % mode)
+        self.path = path
+        bucket, key = split_path(path)
+        self.s3 = s3
+        self.size = self.info()['Size']
+        self.bucket = bucket
+        self.key = key
+        self.blocksize = block_size
+        self.cache = b""
+        self.loc = 0
+        self.start = None
+        self.end = None
+        self.closed = False
+
+    def info(self):
+        return self.s3.info(self.path)
+
+    def tell(self):
+        return self.loc
+
+    def seek(self, loc, whence=0):
+        if whence == 0:
+            self.loc = loc
+        elif whence == 1:
+            self.loc += loc
+        elif whence == 2:
+            self.loc = self.size + loc
+        else:
+            raise ValueError("invalid whence (%s, should be 0, 1 or 2)" % whence)
+        if self.loc < 0:
+            self.loc = 0
+        return self.loc
+
+    def _fetch(self, start, end):
+        try:
+            if self.start is None and self.end is None:
+                # First read
+                self.start = start
+                self.end = end + self.blocksize
+                self.cache = self.s3.s3.get_object(Bucket=self.bucket, Key=self.key,
+                                                Range='bytes=%i-%i' % (start, self.end - 1)
+                                                )['Body'].read()
+            if start < self.start:
+                new = self.s3.s3.get_object(Bucket=self.bucket, Key=self.key,
+                                         Range='bytes=%i-%i' % (start, self.start - 1)
+                                         )['Body'].read()
+                self.start = start
+                self.cache = new + self.cache
+            if end > self.end:
+                if end > self.size:
+                    return
+                new = self.s3.s3.get_object.get(Bucket=self.bucket, Key=self.key,
+                                             Range='bytes=%i-%i' % (self.end, end + self.blocksize - 1)
+                                             )['Body'].read()
+                self.end = end + self.blocksize
+                self.cache = self.cache + new
+        except ClientError:
+            self.start = min([start, self.start or self.size])
+            self.end = max(end, self.end or self.size)
+
+    def read(self, length=-1):
+        """
+        Return data from cache, or fetch pieces as necessary
+        """
+        if self.mode != 'rb':
+            raise ValueError('File not in read mode')
+        if length < 0:
+            length = self.size
+        if self.closed:
+            raise ValueError('I/O operation on closed file.')
+        self._fetch(self.loc, self.loc + length)
+        out = self.cache[self.loc - self.start:
+                         self.loc - self.start + length]
+        self.loc += len(out)
+        return out
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.flush()
+        self.cache = None
+        self.closed = True
+
+    def __repr__(self):
+        return "Cached S3 key %s/%s" % (self.bucket, self.key)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def read_bytes(fn, executor=None, s3=None, lazy=True, delimiter=None,
+               not_zero=False, blocksize=2**27, **s3pars):
+    """ Convert location in S3 to a list of distributed futures
 
     Parameters
     ----------
-    bucket_name: string
-        Name of S3 bucket like ``'my-bucket'``
-    prefix: string
-        Prefix of key name to match like ``'/data/2016/``
-    path_delimiter: string (optional)
-        Delimiter like ``'/'`` to define implicit S3 directory structure
-    compression: {None, 'gzip'}
+    fn: string
+        location in S3
+    executor: Executor (optional)
+        defaults to most recently created executor
+    s3: S3FileSystem (optional)
+    lazy: boolean (optional)
+        If True then return lazily evaluated dask Values
+    delimiter: bytes
+        An optional delimiter, like ``b'\n'`` on which to split blocks of bytes
+    not_zero: force seek of start-of-file delimiter, discarding header
+    blocksize: int (=128MB)
+        Chunk size
+    **s3pars: keyword arguments
+        Extra keywords to send to boto3 session (anon, key, secret...)
 
     Returns
     -------
-    Dask bag
+    List of ``distributed.Future`` objects if ``lazy=False``
+    or ``dask.Value`` objects if ``lazy=True``
     """
+    if s3 is None:
+        s3 = S3FileSystem(**s3pars)
+    executor = default_executor(executor)
+    filenames, lengths, offsets = [], [], []
+    for afile in s3.glob(fn):
+        size = s3.info(afile)['Size']
+        offset = list(range(0, size, blocksize))
+        if not_zero:
+            offset[0] = 1
+        offsets.extend(offset)
+        filenames.extend([afile]*len(offset))
+        lengths.extend([blocksize]*len(offset))
+    names = ['read-binary-s3-%s-%s' % (fn, tokenize(offset, length, delimiter, not_zero))
+            for fn, offset, length in zip(filenames, offsets, lengths)]
+
+    logger.debug("Read %d blocks of binary bytes from %s", len(names), fn)
+    if lazy:
+        values = [Value(name, [{name: (read_block_from_s3, fn, offset, length, s3pars, delimiter)}])
+                  for name, fn, offset, length in zip(names, filenames, offsets, lengths)]
+        return values
+    else:
+        return executor.map(read_block_from_s3, filenames, offsets, lengths,
+                s3pars=s3pars, delimiter=delimiter)
+
+
+def read_block_from_s3(filename, offset, length, s3pars={}, delimiter=None):
+    s3 = S3FileSystem(**s3pars)
+    bytes = s3.read_block(filename, offset, length, delimiter)
+    return bytes
+
+
+@gen.coroutine
+def _read_text(fn, encoding='utf-8', errors='strict', lineterminator='\n',
+               executor=None, fs=None, lazy=True, collection=True):
     from dask import do
-    import dask.bag as db
+    fs = fs or S3FileSystem()
     executor = default_executor(executor)
 
-    blocks = read_bytes(bucket_name, prefix, path_delimiter, executor=executor,
-                        lazy=True, anon=anon)
+    filenames = sorted(fs.glob(fn))
+    blocks = [block for fn in filenames
+                    for block in read_bytes(fn, executor, fs, lazy=True,
+                                            delimiter=lineterminator.encode())]
+    strings = [do(bytes.decode)(b, encoding, errors) for b in blocks]
+    lines = [do(unicode.split)(s, lineterminator) for s in strings]
 
-    if compression:
-        blocks = map(do(decompress[compression]), blocks)
-
-    lists = [b.decode(encoding, errors).split(lineterminator) for b in blocks]
-
-    if collection:
-        ensure_default_get(executor)
-        b = db.from_imperative(lists).filter(None)
-        if lazy:
-            return b
-        else:
-            return executor.persist(b)[0]
-    else:
-        if lazy:
+    if lazy:
+        from dask.bag import from_imperative
+        if collection:
             ensure_default_get(executor)
-            return lists
+            raise gen.Return(from_imperative(lines))
         else:
-            return executor.compute(lists)
+            raise gen.Return(lines)
+
+    else:
+        futures = executor.compute(lines)
+        from distributed.collections import _futures_to_dask_bag
+        if collection:
+            ensure_default_get(executor)
+            b = yield _futures_to_dask_bag(futures)
+            raise gen.Return(b)
+        else:
+            raise gen.Return(futures)
 
 
-from .compatibility import gzip_decompress
-decompress = {'gzip': gzip_decompress}
+def read_text(fn, encoding='utf-8', errors='strict', lineterminator='\n',
+              executor=None, fs=None, lazy=False, collection=True, **kwargs):
+    """ Read text lines from S3
+
+    Parameters
+    ----------
+    fn: string
+        filename or globstring of files on S3
+    collection: boolean, optional
+        Whether or not to return a high level collection
+    lazy: boolean, optional
+        Whether or not to start reading immediately
+
+    Returns
+    -------
+    Dask bag (if collection=True) or Futures or dask values
+    """
+    executor = default_executor(executor)
+    return sync(executor.loop, _read_text, fn, encoding, errors,
+            lineterminator, executor, fs, lazy, collection)

--- a/distributed/tests/test_s3.py
+++ b/distributed/tests/test_s3.py
@@ -291,3 +291,12 @@ def test_repr(s3):
     with s3.open('distributed-test/test/accounts.1.json', mode='rb') as f:
         assert 'distributed-test' in repr(f)
         assert 'accounts.1.json' in repr(f)
+
+
+def test_read_past_location(s3):
+    with s3.open('distributed-test/test/accounts.1.json', block_size=20) as f:
+        while f.read(10):
+            pass
+        f.seek(5000)
+        out = f.read(10)
+        assert out == b''

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,5 +1,6 @@
 from collections import Iterator
 import pytest
+import io
 from threading import Thread
 import threading
 from tornado import gen
@@ -10,7 +11,7 @@ from time import time, sleep
 import dask
 from distributed.utils import (All, sync, is_kernel, ensure_ip, str_graph,
         truncate_exception, get_traceback, queue_to_iterator,
-        iterator_to_queue, _maybe_complex)
+        iterator_to_queue, _maybe_complex, read_block, seek_delimiter)
 from distributed.utils_test import loop, inc, throws, div
 from distributed.compatibility import Queue, isqueue
 
@@ -183,3 +184,52 @@ def test_maybe_complex():
     assert _maybe_complex([(inc, 1)])
     assert _maybe_complex([(inc, 1)])
     assert _maybe_complex({'x': (inc, 1)})
+
+
+def test_read_block():
+    delimiter = b'\n'
+    data = delimiter.join([b'123', b'456', b'789'])
+    f = io.BytesIO(data)
+
+    assert read_block(f, 1, 2) == b'23'
+    assert read_block(f, 0, 1, delimiter=b'\n') == b'123\n'
+    assert read_block(f, 0, 2, delimiter=b'\n') == b'123\n'
+    assert read_block(f, 0, 3, delimiter=b'\n') == b'123\n'
+    assert read_block(f, 0, 5, delimiter=b'\n') == b'123\n456\n'
+    assert read_block(f, 0, 8, delimiter=b'\n') == b'123\n456\n789'
+    assert read_block(f, 0, 100, delimiter=b'\n') == b'123\n456\n789'
+    assert read_block(f, 1, 1, delimiter=b'\n') == b''
+    assert read_block(f, 1, 5, delimiter=b'\n') == b'456\n'
+    assert read_block(f, 1, 8, delimiter=b'\n') == b'456\n789'
+
+    for ols in [[(0, 3), (3, 3), (6, 3), (9, 2)],
+                [(0, 4), (4, 4), (8, 4)]]:
+        out = [read_block(f, o, l, b'\n') for o, l in ols]
+        assert b"".join(filter(None, out)) == data
+
+
+def test_seek_delimiter_endline():
+    f = io.BytesIO(b'123\n456\n789')
+
+    # if at zero, stay at zero
+    seek_delimiter(f, b'\n', 5)
+    assert f.tell() == 0
+
+    # choose the first block
+    for bs in [1, 5, 100]:
+        f.seek(1)
+        seek_delimiter(f, b'\n', blocksize=bs)
+        assert f.tell() == 4
+
+    # handle long delimiters well, even with short blocksizes
+    f = io.BytesIO(b'123abc456abc789')
+    for bs in [1, 2, 3, 4, 5, 6, 10]:
+        f.seek(1)
+        seek_delimiter(f, b'abc', blocksize=bs)
+        assert f.tell() == 6
+
+    # End at the end
+    f = io.BytesIO(b'123\n456')
+    f.seek(5)
+    seek_delimiter(f, b'\n', 5)
+    assert f.tell() == 7

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -352,3 +352,112 @@ stream = logging.StreamHandler(sys.stderr)
 stream.setLevel(logging.CRITICAL)
 logging.getLogger('tornado').addHandler(stream)
 logging.getLogger('tornado').propagate = False
+
+
+from contextlib import contextmanager
+import shutil
+
+
+def seek_delimiter(file, delimiter, blocksize):
+    """ Seek current file to next byte after a delimiter bytestring
+
+    This seeks the file to the next byte following the delimiter.  It does
+    not return anything.  Use ``file.tell()`` to see location afterwards.
+
+    Parameters
+    ----------
+    file: a file
+    delimiter: bytes
+        a delimiter like ``b'\n'`` or message sentinel
+    blocksize: int
+        Number of bytes to read from the file at once.
+    """
+
+    if file.tell() == 0:
+        return
+
+    last = b''
+    while True:
+        current = file.read(blocksize)
+        if not current:
+            return
+        full = last + current
+        try:
+            i = full.index(delimiter)
+            file.seek(file.tell() - (len(full) - i) + len(delimiter))
+            return
+        except ValueError:
+            pass
+        last = full[-len(delimiter):]
+
+
+def read_block(f, offset, length, delimiter=None):
+    """ Read a block of bytes from a file
+
+    Parameters
+    ----------
+    fn: string
+        Path to filename on S3
+    offset: int
+        Byte offset to start read
+    length: int
+        Number of bytes to read
+    delimiter: bytes (optional)
+        Ensure reading starts and stops at delimiter bytestring
+
+    If using the ``delimiter=`` keyword argument we ensure that the read
+    starts and stops at delimiter boundaries that follow the locations
+    ``offset`` and ``offset + length``.  If ``offset`` is zero then we
+    start at zero.  The bytestring returned WILL include the
+    terminating delimiter string.
+
+    Examples
+    --------
+
+    >>> from io import BytesIO  # doctest: +SKIP
+    >>> f = BytesIO(b'Alice, 100\\nBob, 200\\nCharlie, 300')  # doctest: +SKIP
+    >>> read_block(f, 0, 13)  # doctest: +SKIP
+    b'Alice, 100\\nBo'
+
+    >>> read_block(f, 0, 13, delimiter=b'\\n')  # doctest: +SKIP
+    b'Alice, 100\\nBob, 200\\n'
+
+    >>> read_block(f, 10, 10, delimiter=b'\\n')  # doctest: +SKIP
+    b'Bob, 200\\nCharlie, 300'
+    """
+    if delimiter:
+        f.seek(offset)
+        seek_delimiter(f, delimiter, 2**16)
+        start = f.tell()
+        length -= start - offset
+
+        f.seek(start + length)
+        seek_delimiter(f, delimiter, 2**16)
+        end = f.tell()
+        eof = not f.read(1)
+
+        offset = start
+        length = end - start
+
+    f.seek(offset)
+    bytes = f.read(length)
+    return bytes
+
+
+@contextmanager
+def tmpfile(extension=''):
+    extension = '.' + extension.lstrip('.')
+    handle, filename = tempfile.mkstemp(extension)
+    os.close(handle)
+    os.remove(filename)
+
+    yield filename
+
+    if os.path.exists(filename):
+        if os.path.isdir(filename):
+            shutil.rmtree(filename)
+        else:
+            try:
+                os.remove(filename)
+            except OSError:  # sometimes we can't remove a generated temp file
+                pass


### PR DESCRIPTION
This adds `S3File` and `S3FileSystem` abstractions that end up providing blocked reading to `s3.read_bytes`

This is a rehash of #159 by @martindurant 

Martin, if you have a moment can you review this to make sure I didn't corrupt anything?  Going commit by commit is probably a decent way to review rather than looking at the whole diff at once.