### PR TITLE
S3 csv

### DIFF
--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -109,8 +109,9 @@ def bytes_read_csv(b, **kwargs):
 
 
 @gen.coroutine
-def _read_csv(path, executor=None, hdfs=None, lazy=True, lineterminator='\n',
-        collection=True, names=None, header='infer', **kwargs):
+def _read_csv(path, executor=None, hdfs=None, lazy=True, collection=True,
+        lineterminator='\n', names=None, header='infer', **kwargs):
+
     from hdfs3 import HDFileSystem
     from hdfs3.core import ensure_bytes
     from dask import do
@@ -153,7 +154,7 @@ def _read_csv(path, executor=None, hdfs=None, lazy=True, lineterminator='\n',
             raise gen.Return(futures)
 
 
-def read_csv(fn, executor=None, hdfs=None, lazy=True, **kwargs):
+def read_csv(fn, executor=None, hdfs=None, lazy=True, collection=True, **kwargs):
     """ Read CSV encoded data from bytes on HDFS
 
     Parameters
@@ -168,7 +169,7 @@ def read_csv(fn, executor=None, hdfs=None, lazy=True, **kwargs):
     List of futures of Python objects
     """
     executor = default_executor(executor)
-    return sync(executor.loop, _read_csv, fn, executor, hdfs, lazy, **kwargs)
+    return sync(executor.loop, _read_csv, fn, executor, hdfs, lazy, collection, **kwargs)
 
 
 def avro_body(data, header):

--- a/distributed/s3.py
+++ b/distributed/s3.py
@@ -557,7 +557,7 @@ def _read_csv(path, executor=None, fs=None, lazy=True, collection=True,
     executor = default_executor(executor)
 
     if kwargs.get('compression'):
-        blocksize=1e30
+        blocksize = None
 
     filenames = sorted(fs.glob(path))
     blockss = [read_bytes(fn, executor, fs, lazy=True,

--- a/distributed/tests/test_s3.py
+++ b/distributed/tests/test_s3.py
@@ -353,6 +353,19 @@ def test_read_csv(e, s, a, b):
     assert all(isinstance(v, Value) for v in values)
 
 
+@gen_cluster(timeout=60, executor=True)
+def test_read_csv_gzip(e, s, a, b):
+    dd = pytest.importorskip('dask.dataframe')
+    s3 = S3FileSystem(anon=True)
+
+    df = yield _read_csv('distributed-test/csv/gzip/', compression='gzip')
+    assert isinstance(df, dd.DataFrame)
+    assert list(df.columns) == ['name', 'amount', 'id']
+    f = e.compute(df.amount.sum())
+    result = yield f._result()
+    assert result == (100 + 200 + 300 + 400 + 500 + 600)
+
+
 def test_read_csv_sync(loop):
     dd = pytest.importorskip('dask.dataframe')
     with cluster() as (s, [a, b]):

--- a/distributed/tests/test_s3.py
+++ b/distributed/tests/test_s3.py
@@ -133,8 +133,10 @@ def test_read_s3_block(s3):
     assert s3.read_block(path, 0, 35, b'\n') == lines[0] + lines[1]
     assert s3.read_block(path, 0, 5000, b'\n') == data
     assert len(s3.read_block(path, 0, 5)) == 5
-    assert len(s3.read_block(path, 0, 5000)) == len(data)
+    assert len(s3.read_block(path, 4, 5000)) == len(data) - 4
     assert s3.read_block(path, 5000, 5010) == b''
+
+    assert s3.read_block(path, 5, None) == s3.read_block(path, 5, 1000)
 
 
 @gen_cluster(timeout=60, executor=True)
@@ -143,6 +145,13 @@ def test_read_bytes(e, s, a, b):
     assert len(futures) >= len(files)
     results = yield e._gather(futures)
     assert set(results) == set(files.values())
+
+
+@gen_cluster(timeout=60, executor=True)
+def test_read_bytes_blocksize_none(e, s, a, b):
+    futures = read_bytes(test_bucket_name+'/test/accounts.*', lazy=False,
+                         blocksize=None)
+    assert len(futures) == len(files)
 
 
 @gen_cluster(timeout=60, executor=True)


### PR DESCRIPTION
This copies the read_csv functionality over from HDFS to S3.

This is more-or-less a copy-paste-edit job.  It might be worthwhile looking into how to generalize this in the future.  There was a fair amount of code duplication.