### PR TITLE
Worker aliases

### DIFF
--- a/distributed/cli/dworker.py
+++ b/distributed/cli/dworker.py
@@ -27,8 +27,9 @@ logger = logging.getLogger('distributed.dworker')
               help="Number of threads per process. Defaults to number of cores")
 @click.option('--nprocs', type=int, default=1,
               help="Number of worker processes.  Defaults to one.")
+@click.option('--name', type=str, default='', help="Alias")
 @click.option('--no-nanny', is_flag=True)
-def main(center, host, port, http_port, nthreads, nprocs, no_nanny):
+def main(center, host, port, http_port, nthreads, nprocs, no_nanny, name):
     try:
         center_host, center_port = center.split(':')
         center_ip = socket.gethostbyname(center_host)
@@ -54,7 +55,7 @@ def main(center, host, port, http_port, nthreads, nprocs, no_nanny):
         # reach the center
         ip = get_ip(center_ip, center_port)
     nannies = [t(center_ip, center_port, ncores=nthreads, ip=ip,
-                 services=services, loop=loop)
+                 services=services, name=name, loop=loop)
                for i in range(nprocs)]
 
     for nanny in nannies:

--- a/distributed/cli/dworker.py
+++ b/distributed/cli/dworker.py
@@ -41,6 +41,10 @@ def main(center, host, port, http_port, nthreads, nprocs, no_nanny, name):
         logger.error("Failed to launch worker.  You cannot use the --port argument when nprocs > 1.")
         exit(1)
 
+    if nprocs > 1 and name:
+        logger.error("Failed to launch worker.  You cannot use the --name argument when nprocs > 1.")
+        exit(1)
+
     if not nthreads:
         nthreads = _ncores // nprocs
 

--- a/distributed/http/scheduler.py
+++ b/distributed/http/scheduler.py
@@ -41,9 +41,9 @@ class Broadcast(RequestHandler):
     """ Send call to all workers, collate their responses """
     @gen.coroutine
     def get(self, rest):
-        addresses = [addr.split(':') + [d['http']]
-                     for addr, d in self.server.worker_services.items()
-                     if 'http' in d]
+        addresses = [addr.split(':') + [d['services']['http']]
+                     for addr, d in self.server.worker_info.items()
+                     if 'http' in d['services']]
         client = AsyncHTTPClient()
         responses = {'%s:%s' % (ip, tcp_port): client.fetch("http://%s:%s/%s" %
                                                   (ip, http_port, rest))

--- a/distributed/http/tests/test_scheduler_http.py
+++ b/distributed/http/tests/test_scheduler_http.py
@@ -68,13 +68,13 @@ def test_broadcast(s, a, b):
     aa.listen(0)
     a.services['http'] = aa
     a.service_ports['http'] = aa.port
-    s.worker_services[a.address]['http'] = aa.port
+    s.worker_info[a.address]['services']['http'] = aa.port
 
     bb = HTTPWorker(b)
     bb.listen(0)
     b.services['http'] = bb
     b.service_ports['http'] = bb.port
-    s.worker_services[b.address]['http'] = bb.port
+    s.worker_info[b.address]['services']['http'] = bb.port
 
     client = AsyncHTTPClient()
 

--- a/distributed/http/tests/test_worker_http.py
+++ b/distributed/http/tests/test_worker_http.py
@@ -50,7 +50,7 @@ def test_services(s, a, b):
     yield c._start()
     assert isinstance(c.services['http'], HTTPServer)
     assert c.service_ports['http'] == c.services['http'].port
-    assert s.worker_services[c.address]['http'] == c.service_ports['http']
+    assert s.worker_info[c.address]['services']['http'] == c.service_ports['http']
 
     yield c._close()
 
@@ -63,7 +63,7 @@ def test_services_port(s, a, b):
     assert isinstance(c.services['http'], HTTPServer)
     assert (c.service_ports['http']
          == c.services['http'].port
-         == s.worker_services[c.address]['http']
+         == s.worker_info[c.address]['services']['http']
          == 9898)
 
     c.services['http'].stop()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -23,7 +23,8 @@ class Nanny(Server):
     them as necessary.
     """
     def __init__(self, center_ip, center_port, ip=None,
-                ncores=None, loop=None, local_dir=None, services=None, **kwargs):
+                ncores=None, loop=None, local_dir=None, services=None,
+                name=None, **kwargs):
         self.ip = ip or get_ip()
         self.worker_port = None
         self.ncores = ncores
@@ -34,6 +35,7 @@ class Nanny(Server):
         self.loop = loop or IOLoop.current()
         self.center = rpc(ip=center_ip, port=center_port)
         self.services = services
+        self.name = name
 
         handlers = {'instantiate': self.instantiate,
                     'kill': self._kill,
@@ -99,7 +101,8 @@ class Nanny(Server):
         self.process = Process(target=run_worker,
                                args=(q, self.ip, self.center.ip,
                                      self.center.port, self.ncores,
-                                     self.port, self.local_dir, self.services))
+                                     self.port, self.local_dir, self.services,
+                                     self.name))
         self.process.daemon = True
         self.process.start()
         while True:
@@ -186,7 +189,7 @@ class Nanny(Server):
 
 
 def run_worker(q, ip, center_ip, center_port, ncores, nanny_port,
-        local_dir, services):
+        local_dir, services, name):
     """ Function run by the Nanny when creating the worker """
     from distributed import Worker  # pragma: no cover
     from tornado.ioloop import IOLoop  # pragma: no cover
@@ -195,7 +198,7 @@ def run_worker(q, ip, center_ip, center_port, ncores, nanny_port,
     loop.make_current()  # pragma: no cover
     worker = Worker(center_ip, center_port, ncores=ncores, ip=ip,
                     service_ports={'nanny': nanny_port}, local_dir=local_dir,
-                    services=services)  # pragma: no cover
+                    services=services, name=name)  # pragma: no cover
 
     @gen.coroutine  # pragma: no cover
     def start():

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1270,9 +1270,9 @@ def decide_worker(dependencies, stacks, who_has, restrictions,
         workers = stacks
     if key in restrictions:
         r = restrictions[key]
-        workers = {w for w in workers if w.split(':')[0] in r}  # TODO: nonlinear
+        workers = {w for w in workers if w in r or w.split(':')[0] in r}  # TODO: nonlinear
         if not workers:
-            workers = {w for w in stacks if w.split(':')[0] in r}
+            workers = {w for w in stacks if w in r or w.split(':')[0] in r}
             if not workers:
                 if key in loose_restrictions:
                     return decide_worker(dependencies, stacks, who_has,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -16,7 +16,7 @@ from tornado.queues import Queue
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.iostream import StreamClosedError, IOStream
 
-from dask.compatibility import PY3
+from dask.compatibility import PY3, unicode
 from dask.core import get_deps, reverse_dict, istask
 from dask.order import order
 
@@ -1246,7 +1246,7 @@ class Scheduler(Server):
             addr = addr.decode()
         if addr in self.aliases:
             addr = self.aliases[addr]
-        if isinstance(addr, str):
+        if isinstance(addr, unicode):
             if ':' in addr:
                 addr = tuple(addr.rsplit(':', 1))
             else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -308,6 +308,7 @@ class Scheduler(Server):
         yield self.cleanup()
         yield self.finished()
         self.status = 'closed'
+        self.stop()
 
     @gen.coroutine
     def cleanup(self):

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -913,6 +913,9 @@ def test_directed_scatter(e, s, a, b):
     assert len(a.data) == 3
     assert not b.data
 
+    yield e._scatter([4, 5], workers=[b.name])
+    assert len(b.data) == 2
+
 
 def test_directed_scatter_sync(loop):
     with cluster() as (s, [a, b]):
@@ -2177,7 +2180,7 @@ def test_diagnostic_ui(loop):
 @gen_test()
 def test_worker_aliases():
     s = Scheduler()
-    s.start()
+    s.start(0)
     a = Worker(s.ip, s.port, name='alice')
     b = Worker(s.ip, s.port, name='bob')
     yield [a._start(), b._start()]

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -570,6 +570,19 @@ def test_restrictions_submit(e, s, a, b):
     assert y.key in b.data
 
 
+@gen_cluster(executor=True)
+def test_restrictions_ip_port(e, s, a, b):
+    x = e.submit(inc, 1, workers={a.address})
+    y = e.submit(inc, x, workers={b.address})
+    yield _wait([x, y])
+
+    assert s.restrictions[x.key] == {a.address}
+    assert x.key in a.data
+
+    assert s.restrictions[y.key] == {b.address}
+    assert y.key in b.data
+
+
 @pytest.mark.skipif(sys.platform!='linux',
                     reason="Need 127.0.0.2 to mean localhost")
 @gen_cluster([('127.0.0.1', 1), ('127.0.0.2', 2)], executor=True)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -25,22 +25,22 @@ def test_nanny():
     nn = rpc(ip=n.ip, port=n.port)
     assert n.process.is_alive()
     assert c.ncores[n.worker_address] == 2
-    assert c.worker_services[n.worker_address]['nanny'] > 1024
+    assert c.worker_info[n.worker_address]['services']['nanny'] > 1024
 
     yield nn.kill()
     assert n.worker_address not in c.ncores
-    assert n.worker_address not in c.worker_services
+    assert n.worker_address not in c.worker_info
     assert not n.process
 
     yield nn.kill()
     assert n.worker_address not in c.ncores
-    assert n.worker_address not in c.worker_services
+    assert n.worker_address not in c.worker_info
     assert not n.process
 
     yield nn.instantiate()
     assert n.process.is_alive()
     assert c.ncores[n.worker_address] == 2
-    assert c.worker_services[n.worker_address]['nanny'] > 1024
+    assert c.worker_info[n.worker_address]['services']['nanny'] > 1024
 
     yield nn.terminate()
     assert not n.process

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -933,6 +933,7 @@ def test_coerce_address():
     assert s.coerce_address(('127.0.0.1', '8000')) == '127.0.0.1:8000'
     assert s.coerce_address(b'localhost') == '127.0.0.1'
     assert s.coerce_address('localhost') == '127.0.0.1'
+    assert s.coerce_address(u'localhost') == '127.0.0.1'
     assert s.coerce_address('localhost:8000') == '127.0.0.1:8000'
     assert s.coerce_address(a.address) == a.address
     assert s.coerce_address(a.address_tuple) == a.address

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -898,3 +898,15 @@ def test_ready_add_worker(s, a, b):
 
     result = yield s.broadcast(msg={'op': 'ping'}, workers=[a.address])
     assert result == {a.address: b'pong'}
+
+
+@gen_test()
+def test_worker_name():
+    s = Scheduler()
+    s.start()
+    w = Worker(s.ip, s.port, name='alice')
+    yield w._start()
+    assert s.worker_info[w.address]['name'] == 'alice'
+
+    yield s.close()
+    yield w._close()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -132,7 +132,7 @@ def test_heal_culls():
 @gen_cluster()
 def test_ready_add_worker(s, a, b):
     s.add_client(client='client')
-    s.add_worker(address=alice)
+    s.add_worker(address=alice, coerce_address=False)
 
     s.update_graph(tasks={'x-%d' % i: dumps_task((inc, i)) for i in range(20)},
                    keys=['x-%d' % i for i in range(20)],
@@ -143,7 +143,7 @@ def test_ready_add_worker(s, a, b):
 def test_update_state(loop):
     s = Scheduler()
     s.start(0)
-    s.add_worker(address=alice, ncores=1)
+    s.add_worker(address=alice, ncores=1, coerce_address=False)
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x')},
                    keys=['y'],
                    dependencies={'y': 'x', 'x': set()},
@@ -181,7 +181,7 @@ def test_update_state(loop):
 def test_update_state_with_processing(loop):
     s = Scheduler()
     s.start(0)
-    s.add_worker(address=alice, ncores=1)
+    s.add_worker(address=alice, ncores=1, coerce_address=False)
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x'), 'z': (inc, 'y')},
                    keys=['z'],
                    dependencies={'y': {'x'}, 'x': set(), 'z': {'y'}},
@@ -220,7 +220,7 @@ def test_update_state_with_processing(loop):
 def test_update_state_respects_data_in_memory(loop):
     s = Scheduler()
     s.start(0)
-    s.add_worker(address=alice, ncores=1)
+    s.add_worker(address=alice, ncores=1, coerce_address=False)
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x')},
                    keys=['y'],
                    dependencies={'y': {'x'}, 'x': set()},
@@ -249,7 +249,7 @@ def test_update_state_respects_data_in_memory(loop):
 def test_update_state_supports_recomputing_released_results(loop):
     s = Scheduler()
     s.start(0)
-    s.add_worker(address=alice, ncores=1)
+    s.add_worker(address=alice, ncores=1, coerce_address=False)
     s.update_graph(tasks={'x': 1, 'y': (inc, 'x'), 'z': (inc, 'x')},
                    keys=['z'],
                    dependencies={'y': {'x'}, 'x': set(), 'z': {'y'}},
@@ -615,7 +615,7 @@ def test_add_worker(s, a, b):
                    dependencies={k: set() for k in dsk})
 
     s.add_worker(address=w.address, keys=list(w.data),
-                 ncores=w.ncores, services=s.services)
+                 ncores=w.ncores, services=s.services, coerce_address=False)
 
     for k in w.data:
         assert w.address in s.who_has[k]
@@ -883,7 +883,7 @@ def test_ready_add_worker(s, a, b):
 
     w = Worker(s.ip, s.port, ncores=3, ip='127.0.0.1')
     w.listen(0)
-    s.add_worker(address=w.address, ncores=w.ncores)
+    s.add_worker(address=w.address, ncores=w.ncores, coerce_address=False)
 
     assert w.address in s.ncores
     assert all(len(s.processing[w]) == s.ncores[w]
@@ -903,10 +903,41 @@ def test_ready_add_worker(s, a, b):
 @gen_test()
 def test_worker_name():
     s = Scheduler()
-    s.start()
+    s.start(0)
     w = Worker(s.ip, s.port, name='alice')
     yield w._start()
     assert s.worker_info[w.address]['name'] == 'alice'
+    assert s.aliases['alice'] == w.address
+
+    with pytest.raises(ValueError):
+        w = Worker(s.ip, s.port, name='alice')
+        yield w._start()
 
     yield s.close()
     yield w._close()
+
+
+@gen_test()
+def test_coerce_address():
+    s = Scheduler()
+    s.start(0)
+    a = Worker(s.ip, s.port, name='alice')
+    b = Worker(s.ip, s.port, name=123)
+    c = Worker(s.ip, s.port, name='charlie', ip='127.0.0.2')
+    yield [a._start(), b._start(), c._start()]
+
+    assert s.coerce_address(b'127.0.0.1') == '127.0.0.1'
+    assert s.coerce_address(('127.0.0.1', 8000)) == '127.0.0.1:8000'
+    assert s.coerce_address(['127.0.0.1', 8000]) == '127.0.0.1:8000'
+    assert s.coerce_address([b'127.0.0.1', 8000]) == '127.0.0.1:8000'
+    assert s.coerce_address(('127.0.0.1', '8000')) == '127.0.0.1:8000'
+    assert s.coerce_address(b'localhost') == '127.0.0.1'
+    assert s.coerce_address('localhost') == '127.0.0.1'
+    assert s.coerce_address('localhost:8000') == '127.0.0.1:8000'
+    assert s.coerce_address(a.address) == a.address
+    assert s.coerce_address(a.address_tuple) == a.address
+    assert s.coerce_address(123) == b.address
+    assert s.coerce_address('charlie') == c.address
+
+    yield s.close()
+    yield [w._close() for w in [a, b, c]]

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -238,11 +238,18 @@ def log_errors():
 def ensure_ip(hostname):
     """ Ensure that address is an IP address
 
+    Examples
+    --------
     >>> ensure_ip('localhost')
-    b'127.0.0.1'
+    '127.0.0.1'
     >>> ensure_ip('123.123.123.123')  # pass through IP addresses
-    b'123.123.123.123'
+    '123.123.123.123'
+    >>> ensure_ip('localhost:5000')
+    '127.0.0.1:5000'
     """
+    if ':' in hostname:
+        host, port = hostname.split(':')
+        return ':'.join([ensure_ip(host), port])
     if isinstance(hostname, bytes):
         hostname = hostname.decode()
     if re.match('\d+\.\d+\.\d+\.\d+', hostname):  # is IP

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -347,7 +347,6 @@ def gen_test(timeout=10):
     return _
 
 
-
 from .scheduler import Scheduler
 from .worker import Worker
 from .executor import Executor
@@ -356,7 +355,8 @@ from .executor import Executor
 def start_cluster(ncores, Worker=Worker):
     s = Scheduler(ip='127.0.0.1')
     done = s.start(0)
-    workers = [Worker(s.ip, s.port, ncores=v, ip=k) for k, v in ncores]
+    workers = [Worker(s.ip, s.port, ncores=v, ip=k, name=i)
+                for i, (k, v) in enumerate(ncores)]
 
     yield [w._start() for w in workers]
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -157,9 +157,10 @@ class Worker(Server):
                         name=self.name)
                 break
             except (OSError, StreamClosedError):
-                logger.debug("Unable to register with center.  Waiting")
+                logger.debug("Unable to register with scheduler.  Waiting")
                 yield gen.sleep(0.5)
-        assert resp == 'OK'
+        if resp != 'OK':
+            raise ValueError(resp)
         logger.info('        Registered to: %20s:%d',
                     self.center.ip, self.center.port)
         self.status = 'running'

--- a/docs/source/locality.rst
+++ b/docs/source/locality.rst
@@ -51,8 +51,8 @@ For example the existence of specialized hardware such as GPUs or database
 connections may restrict the set of valid workers for a particular task.
 
 In these cases use the ``workers=`` keyword argument to the ``submit``,
-``map``, or ``scatter`` functions, providing a hostname or IP address as
-follows:
+``map``, or ``scatter`` functions, providing a hostname, IP address, or alias
+as follows:
 
 .. code-block:: python
 
@@ -83,5 +83,28 @@ data.
 
 *  Alice: ``[1, 2, 3]``
 *  Bob: ``[1, 2, 3]``
+
+
+Valid arguments for ``workers=`` include the following:
+
+*   A single IP addresses, IP/Port pair, or hostname like the following::
+
+   192.168.1.100, 192.168.1.100:8989, alice, alice:8989
+
+*  A list or set of the above::
+
+   ['alice'], ['192.168.1.100', '192.168.1.101:9999']
+
+If only a hostname or IP is given then any worker on that machine will be
+considered valid.  Additionally, you can provide aliases to workers upon
+creation.::
+
+    $ dworker scheduler_address:8786 --name worker_1
+
+And then use this name when specifying workers instead.
+
+.. code-block:: python
+
+   e.map(func, sequence, workers='worker_1')
 
 See the :doc:`efficiency <efficiency>` page to learn about best practices.


### PR DESCRIPTION
This allows the assignment of names to workers either through the programming or command line interfaces:

```python
Worker(ip, port, name='alice')
```
```
$ dworker ip:port --name alice
```

These names can be used directly within computational calls like map or submit

```python
e.map(func, sequence, workers='alice')
```

I haven't yet propagated this throughout all user options, nor have I added sufficient state to make it constant time.

cc @minrk @seibert