### PR TITLE
Avoid error in map thread

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -526,9 +526,13 @@ class Executor(object):
             raise NotImplementedError()
 
         while True:
-            args = [get(q) for q in qs_in]
+            try:
+                args = [get(q) for q in qs_in]
+            except StopIteration:
+                break
             f = self.submit(func, *args, **kwargs)
             q_out.put(f)
+
 
     def map(self, func, *iterables, **kwargs):
         """ Map a function on a sequence of arguments

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1903,11 +1903,24 @@ def test_map_iterator(e, s, a, b):
     result = yield future._result()
     assert result == (1 + 10) * 2
 
+    items = enumerate(range(10))
+    futures = e.map(lambda x: x, items)
+    result = yield next(futures)._result()
+    assert result == (0, 0)
+
 
 @gen_cluster(executor=True)
 def test_map_infinite_iterators(e, s, a, b):
     futures = e.map(add, [1, 2], itertools.repeat(10))
     assert len(futures) == 2
+
+
+def test_map_iterator_sync(loop):
+    with cluster() as (s, [a, b]):
+        with Executor(('127.0.0.1', s['port']), loop=loop) as e:
+            items = enumerate(range(10))
+            futures = e.map(lambda x: x, items)
+            next(futures).result() == (0, 0)
 
 
 @gen_cluster(executor=True)


### PR DESCRIPTION
Previously we exposed a bare StopIteration error in
Exectuor._threaded_map.  Now we catch and break appropriately.


```python
In [1]: from distributed import Executor

In [2]: e = Executor('127.0.0.1:8786')

In [3]: items = enumerate(range(10))

In [4]: futures = e.map(lambda x: x, items)

In [5]: next(futures).result()
Out[5]: (0, 0)
```

@sklam I suspect that your problem was actually with `futures[0]`.  Because you give map an iterator, its giving you back an iterator.  The error you saw, I think, was benign but has now been cleaned up regardless.