### PR TITLE
Format CSV

### DIFF
--- a/distributed/formats/__init__.py
+++ b/distributed/formats/__init__.py
@@ -1,0 +1,1 @@
+from .csv import read_csv

--- a/distributed/formats/compression.py
+++ b/distributed/formats/compression.py
@@ -1,0 +1,9 @@
+from toolz import identity
+
+from ..compatibility import gzip_compress, gzip_decompress
+
+
+compressors = {'gzip': gzip_compress,
+               None: identity}
+decompressors = {'gzip': gzip_decompress,
+                 None: identity}

--- a/distributed/formats/csv.py
+++ b/distributed/formats/csv.py
@@ -1,0 +1,91 @@
+from __future__ import print_function, division, absolute_import
+
+from io import BytesIO
+
+from dask import do
+from dask.dataframe import from_imperative
+import pandas as pd
+
+from .compression import compressors, decompressors
+
+from ..executor import default_executor, ensure_default_get
+from ..utils import ensure_bytes, log_errors
+
+
+def bytes_read_csv(b, header, kwargs):
+    """ Convert a block of bytes to a Pandas DataFrame
+
+    Parameters
+    ----------
+    b: bytestring
+        The content to be parsed with pandas.read_csv
+    header: bytestring
+        An optional header to prepend to b
+    kwargs: dict
+        A dictionary of keyword arguments to be passed to pandas.read_csv
+
+    See Also:
+        distributed.formats.csv.read_csv
+    """
+    with log_errors():
+        compression = kwargs.pop('compression', None)
+        b2 = decompressors[compression](b)
+        bio = BytesIO()
+        if header:
+            if not header.endswith(b'\n') and not header.endswith(b'\r'):
+                header = header + ensure_bytes(kwargs.get('lineterminator', b'\n'))
+            bio.write(header)
+        bio.write(b2)
+        bio.seek(0)
+        return pd.read_csv(bio, **kwargs)
+
+
+def read_csv(block_lists, header, head, kwargs, lazy=True, collection=True,
+        executor=None):
+    """ Convert blocks of bytes to a dask.dataframe or other high-level object
+
+    This accepts a list of lists of futures/values of bytes where each list
+    corresponds to one file, and the futures/values of bytes concatenate to
+    comprise the entire file, in order.
+
+    Parameters
+    ----------
+    block_lists: list of lists of futures of bytes
+        The lists of bytestrings with each list corresponding to one logical file
+    header: bytestring
+        The header, found at the front of the first file, to be prepended to
+        all blocks
+    head: pd.DataFrame
+        An example Pandas DataFrame to be used for metadata
+    kwargs: dict
+        Keyword arguments to pass down to ``pd.read_csv``
+    lazy: boolean, optional (defaults to True)
+    collection: boolean, optional (defaults to True)
+
+    Returns
+    -------
+    A dask.dataframe, or list of futures or values, depending on the value of
+    lazy and collection.
+    """
+    executor = default_executor(executor)
+
+    dfs1 = [[do(bytes_read_csv)(blocks[0], '', kwargs)] +
+            [do(bytes_read_csv)(b, header, kwargs)
+                for b in blocks[1:]]
+            for blocks in block_lists]
+    dfs2 = sum(dfs1, [])
+
+    ensure_default_get(executor)
+
+    if collection:
+        result = from_imperative(dfs2, head)
+    else:
+        result = dfs2
+
+    if not lazy:
+        if collection:
+            result = executor.persist(result)
+        else:
+            result = executor.compute(result)
+
+    return result

--- a/distributed/formats/tests/test_compression.py
+++ b/distributed/formats/tests/test_compression.py
@@ -1,0 +1,14 @@
+from distributed.formats.compression import compressors, decompressors
+
+def test_compression():
+    assert set(compressors) == set(decompressors)
+
+    a = b'Hello, world!'
+    for k in compressors:
+        compress = compressors[k]
+        decompress = decompressors[k]
+        b = compress(a)
+        c = decompress(b)
+        assert a == c
+        if k is not None:
+            assert a != b

--- a/distributed/formats/tests/test_csv.py
+++ b/distributed/formats/tests/test_csv.py
@@ -1,0 +1,134 @@
+from distributed.compatibility import gzip_compress
+from distributed.utils_test import gen_cluster
+from distributed.formats.csv import read_csv, bytes_read_csv
+from distributed.executor import Future
+
+
+import pandas.util.testing as tm
+import pandas as pd
+from tornado import gen
+import pytest
+from io import BytesIO
+from toolz import partition_all
+
+dd = pytest.importorskip('dask.dataframe')
+
+
+files = {'2014-01-01.csv': (b'name,amount,id\n'
+                            b'Alice,100,1\n'
+                            b'Bob,200,2\n'
+                            b'Charlie,300,3\n'),
+         '2014-01-02.csv': (b'name,amount,id\n'),
+         '2014-01-03.csv': (b'name,amount,id\n'
+                            b'Dennis,400,4\n'
+                            b'Edith,500,5\n'
+                            b'Frank,600,6\n')}
+
+
+header = files['2014-01-01.csv'].split(b'\n')[0] + b'\n'
+
+expected = pd.concat([pd.read_csv(BytesIO(files[k])) for k in sorted(files)])
+
+
+def test_bytes_read_csv():
+    b = files['2014-01-01.csv']
+    df = bytes_read_csv(b, '', {})
+    assert list(df.columns) == ['name', 'amount', 'id']
+    assert len(df) == 3
+    assert df.id.sum() == 1 + 2 + 3
+
+
+def test_bytes_read_csv_kwargs():
+    b = files['2014-01-01.csv']
+    df = bytes_read_csv(b, '', {'usecols': ['name', 'id']})
+    assert list(df.columns) == ['name', 'id']
+
+
+def test_bytes_read_csv_with_header():
+    b = files['2014-01-01.csv']
+    header, b = b.split(b'\n', 1)
+    df = bytes_read_csv(b, header, {})
+    assert list(df.columns) == ['name', 'amount', 'id']
+    assert len(df) == 3
+    assert df.id.sum() == 1 + 2 + 3
+
+
+
+@gen_cluster(executor=True)
+def test_read_csv(e, s, a, b):
+    bytes = [files[k] for k in sorted(files)]
+    gzbytes = [gzip_compress(b) for b in bytes]
+    kwargs = {}
+    head = bytes_read_csv(files['2014-01-01.csv'], '', {})
+
+    for _blocks, compression in [(bytes, None), (gzbytes, 'gzip')]:
+        blocks = yield e._scatter(_blocks)
+        blocks = [[b] for b in blocks]
+        kwargs = {'compression': compression}
+
+        ntasks = len(s.tasks)
+        df = read_csv(blocks, header, head, kwargs, lazy=True, collection=True)
+        assert isinstance(df, dd.DataFrame)
+        assert list(df.columns) == ['name', 'amount', 'id']
+        yield gen.sleep(0.1)
+        assert len(s.tasks) == ntasks
+
+        values = read_csv(blocks, header, head, kwargs, lazy=True,
+                          collection=False)
+        assert isinstance(values, list)
+        assert len(values) == 3
+        assert all(hasattr(item, 'dask') for item in values)
+
+        f = e.compute(df.amount.sum())
+        result = yield f._result()
+        assert result == (100 + 200 + 300 + 400 + 500 + 600)
+
+        futures = read_csv(blocks, header, head, kwargs, lazy=False,
+                collection=False)
+        assert len(futures) == 3
+        assert all(isinstance(f, Future) for f in futures)
+        results = yield e._gather(futures)
+        assert results[0].id.sum() == 1 + 2 + 3
+        assert results[1].id.sum() == 0
+        assert results[2].id.sum() == 4 + 5 + 6
+
+
+@gen_cluster(executor=True)
+def test_kwargs(e, s, a, b):
+    blocks = [files[k] for k in sorted(files)]
+    blocks = yield e._scatter(blocks)
+    blocks = [[b] for b in blocks]
+    kwargs = {'usecols': ['name', 'id']}
+    head = bytes_read_csv(files['2014-01-01.csv'], '', kwargs)
+
+    df = read_csv(blocks, header, head, kwargs, lazy=False, collection=True)
+    assert list(df.columns) == ['name', 'id']
+    result = yield e.compute(df)._result()
+    assert (result.columns == df.columns).all()
+
+
+@gen_cluster(executor=True)
+def test_blocked(e, s, a, b):
+    blocks = []
+    for k in sorted(files):
+        b = files[k]
+        lines = b.split(b'\n')
+        blocks.append([b'\n'.join(bs) for bs in partition_all(2, lines)])
+
+    futures = yield [e._scatter(blks) for blks in blocks]
+
+    df = read_csv(futures, header, expected.head(), {})
+    result = yield e.compute(df)._result()
+
+    tm.assert_frame_equal(result.reset_index(drop=True),
+                          expected.reset_index(drop=True),
+                          check_dtype=False)
+
+
+    expected2 = expected[['name', 'id']]
+    df = read_csv(futures, header, expected2.head(), {'usecols': ['name', 'id']})
+    result = yield e.compute(df)._result()
+
+    tm.assert_frame_equal(result.reset_index(drop=True),
+                          expected2.reset_index(drop=True),
+                          check_dtype=False)

--- a/distributed/tests/test_hdfs.py
+++ b/distributed/tests/test_hdfs.py
@@ -12,7 +12,7 @@ from distributed.compatibility import unicode
 from distributed.utils_test import gen_cluster, cluster, loop, make_hdfs
 from distributed.utils import get_ip
 from distributed.hdfs import (read_bytes, get_block_locations, write_bytes,
-        _read_csv, read_csv, _read_text, read_text)
+        read_csv, _read_text, read_text)
 from distributed import Executor
 from distributed.executor import _wait, Future
 
@@ -242,8 +242,7 @@ def test_read_csv(e, s, a, b):
         with hdfs.open('/tmp/test/2.csv', 'wb') as f:
             f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
 
-        df = yield _read_csv('/tmp/test/*.csv',
-                lineterminator='\n', lazy=False)
+        df = read_csv('/tmp/test/*.csv', lineterminator='\n', lazy=False)
         assert df._known_dtype
         result = e.compute(df.id.sum(), sync=False)
         result = yield result._result()
@@ -256,7 +255,7 @@ def test_read_csv_with_names(e, s, a, b):
         with hdfs.open('/tmp/test/1.csv', 'wb') as f:
             f.write(b'name,amount,id\nAlice,100,1\nBob,200,2')
 
-        df = yield _read_csv('/tmp/test/*.csv', names=['amount', 'name'],
+        df = read_csv('/tmp/test/*.csv', names=['amount', 'name'],
                              lineterminator='\n', lazy=False)
         assert list(df.columns) == ['amount', 'name']
 
@@ -270,8 +269,7 @@ def test_read_csv_lazy(e, s, a, b):
         with hdfs.open('/tmp/test/2.csv', 'wb') as f:
             f.write(b'name,amount,id\nCharlie,300,3\nDennis,400,4')
 
-        df = yield _read_csv('/tmp/test/*.csv', lazy=True,
-                             lineterminator='\n')
+        df = read_csv('/tmp/test/*.csv', lazy=True, lineterminator='\n')
         assert df._known_dtype
         yield gen.sleep(0.5)
         assert not s.tasks

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -475,3 +475,19 @@ def tmpfile(extension=''):
                 os.remove(filename)
             except OSError:  # sometimes we can't remove a generated temp file
                 pass
+
+
+def ensure_bytes(s):
+    """ Turn string or bytes to bytes
+
+    >>> ensure_bytes('123')
+    b'123'
+    >>> ensure_bytes(b'123')
+    b'123'
+    """
+    if isinstance(s, bytes):
+        return s
+    if hasattr(s, 'encode'):
+        return s.encode()
+    raise TypeError(
+            "Object %s is neither a bytes object nor has an encode method" % s)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(name='distributed',
       maintainer_email='mrocklin@gmail.com',
       license='BSD',
       install_requires=requires,
-      packages=['distributed', 'distributed.cli', 'distributed.diagnostics', 'distributed.http'],
+      packages=['distributed', 'distributed.cli', 'distributed.diagnostics',
+          'distributed.http', 'distributed.formats'],
       long_description=(open('README.md').read() if os.path.exists('README.md')
                         else ''),
       entry_points='''


### PR DESCRIPTION
This adds a new formats submodule with a read_csv function intended to share code between s3/hdfs and to separate out tricky logic.

`formats.csv.read_csv` consumes the following:

    Parameters
    ----------
    block_lists: list of lists of futures of bytes
        The lists of bytestrings with each list corresponding to one logical file
    header: bytestring
        The header, found at the front of the first file, to be prepended to
        all blocks
    head: pd.DataFrame
        An example Pandas DataFrame to be used for metadata
    kwargs: dict
        Keyword arguments to pass down to ``pd.read_csv``
    lazy: boolean, optional (defaults to True)
    collection: boolean, optional (defaults to True)

We then use this within S3 as a proof of concept.  I'll move on to hdfs3 shortly if people think that this is a reasonable step forward.