### PR TITLE
Remove _read_foo functions

### DIFF
--- a/distributed/tests/test_avro.py
+++ b/distributed/tests/test_avro.py
@@ -17,7 +17,7 @@ except:
 import fastavro
 from dask.imperative import Value
 
-from distributed.hdfs import _read_avro, avro_body, read_avro
+from distributed.hdfs import avro_body, read_avro
 from distributed.utils_test import gen_cluster, cluster, make_hdfs, loop
 from distributed import Executor
 from distributed.executor import Future
@@ -67,7 +67,7 @@ def test_avro(e, s, a, b):
 
             assert hdfs.info(k)['size'] > 0
 
-        L = yield _read_avro('/tmp/test/*.avro', lazy=False)
+        L = read_avro('/tmp/test/*.avro', lazy=False)
         assert isinstance(L, list)
         assert all(isinstance(x, Future) for x in L)
 
@@ -76,7 +76,7 @@ def test_avro(e, s, a, b):
         assert results[0][:5] == data[:5]
         assert results[-1][-5:] == data[-5:]
 
-        L = yield _read_avro('/tmp/test/*.avro', lazy=True)
+        L = read_avro('/tmp/test/*.avro', lazy=True)
         assert isinstance(L, list)
         assert all(isinstance(x, Value) for x in L)
 

--- a/distributed/tests/test_hdfs.py
+++ b/distributed/tests/test_hdfs.py
@@ -12,7 +12,7 @@ from distributed.compatibility import unicode
 from distributed.utils_test import gen_cluster, cluster, loop, make_hdfs
 from distributed.utils import get_ip
 from distributed.hdfs import (read_bytes, get_block_locations, write_bytes,
-        read_csv, _read_text, read_text)
+        read_csv, read_text)
 from distributed import Executor
 from distributed.executor import _wait, Future
 
@@ -290,7 +290,7 @@ def test__read_text(e, s, a, b):
         with hdfs.open('/tmp/test/other.txt', 'wb') as f:
             f.write('a b\nc d'.encode())
 
-        b = yield _read_text('/tmp/test/text.*.txt',
+        b = read_text('/tmp/test/text.*.txt',
                              collection=True, lazy=True)
         yield gen.sleep(0.5)
         assert not s.tasks
@@ -299,17 +299,17 @@ def test__read_text(e, s, a, b):
         result = yield future._result()
         assert result == [2, 2, 2, 2, 2, 2]
 
-        b = yield _read_text('/tmp/test/other.txt',
+        b = read_text('/tmp/test/other.txt',
                              collection=True, lazy=False)
         future = e.compute(b.str.split().concat())
         result = yield future._result()
         assert result == ['a', 'b', 'c', 'd']
 
-        L = yield _read_text('/tmp/test/text.*.txt',
+        L = read_text('/tmp/test/text.*.txt',
                              collection=False, lazy=False)
         assert all(isinstance(x, Future) for x in L)
 
-        L = yield _read_text('/tmp/test/text.*.txt',
+        L = read_text('/tmp/test/text.*.txt',
                              collection=False, lazy=True)
         assert all(isinstance(x, Value) for x in L)
 
@@ -322,7 +322,7 @@ def test__read_text_unicode(e, s, a, b):
         with hdfs.open(fn, 'wb') as f:
             f.write(b'\n'.join([data, data]))
 
-        f = yield _read_text(fn, collection=False, lazy=False)
+        f = read_text(fn, collection=False, lazy=False)
         result = yield f[0]._result()
         assert len(result) == 2
         assert list(map(unicode.strip, result)) == [data.decode('utf-8')] * 2


### PR DESCRIPTION
Remove the asynchronous `_read_foo` functions from the s3/hdfs APIs.

We now handle things better so that we don't actually need to go asynchronous at any point.  All metadata collection happens synchronously (and quickly) through the hdfs or s3 APIs.