### PR TITLE
add separate nanny-port and worker-port keywords to dworker

### DIFF
--- a/distributed/cli/dworker.py
+++ b/distributed/cli/dworker.py
@@ -18,10 +18,12 @@ logger = logging.getLogger('distributed.dworker')
 
 @click.command()
 @click.argument('center', type=str)
-@click.option('--port', type=int, default=0,
-              help="Serving port, defaults to randomly assigned")
+@click.option('--worker-port', type=int, default=0,
+              help="Serving worker port, defaults to randomly assigned")
 @click.option('--http-port', type=int, default=0,
               help="Serving http port, defaults to randomly assigned")
+@click.option('--nanny-port', type=int, default=0,
+              help="Serving nanny port, defaults to randomly assigned")
 @click.option('--host', type=str, default=None,
               help="Serving host. Defaults to an ip address that can hopefully"
                    " be visible from the center network.")
@@ -31,7 +33,7 @@ logger = logging.getLogger('distributed.dworker')
               help="Number of worker processes.  Defaults to one.")
 @click.option('--name', type=str, default='', help="Alias")
 @click.option('--no-nanny', is_flag=True)
-def main(center, host, port, http_port, nthreads, nprocs, no_nanny, name):
+def main(center, host, worker_port, http_port, nanny_port, nthreads, nprocs, no_nanny, name):
     try:
         center_host, center_port = center.split(':')
         center_ip = socket.gethostbyname(center_host)
@@ -39,7 +41,7 @@ def main(center, host, port, http_port, nthreads, nprocs, no_nanny, name):
     except IndexError:
         logger.info("Usage:  dworker center_host:center_port")
 
-    if nprocs > 1 and port != 0:
+    if nprocs > 1 and worker_port != 0:
         logger.error("Failed to launch worker.  You cannot use the --port argument when nprocs > 1.")
         exit(1)
 
@@ -61,11 +63,12 @@ def main(center, host, port, http_port, nthreads, nprocs, no_nanny, name):
         # reach the center
         ip = get_ip(center_ip, center_port)
     nannies = [t(center_ip, center_port, ncores=nthreads, ip=ip,
-                 services=services, name=name, loop=loop)
+                 services=services, name=name, loop=loop,
+                 worker_port=worker_port)
                for i in range(nprocs)]
 
     for nanny in nannies:
-        nanny.start(port)
+        nanny.start(nanny_port)
     try:
         loop.start()
     except KeyboardInterrupt:

--- a/distributed/cli/dworker.py
+++ b/distributed/cli/dworker.py
@@ -24,6 +24,8 @@ logger = logging.getLogger('distributed.dworker')
               help="Serving http port, defaults to randomly assigned")
 @click.option('--nanny-port', type=int, default=0,
               help="Serving nanny port, defaults to randomly assigned")
+@click.option('--port', type=int, default=0,
+              help="Deprecated, see --nanny-port")
 @click.option('--host', type=str, default=None,
               help="Serving host. Defaults to an ip address that can hopefully"
                    " be visible from the center network.")
@@ -33,7 +35,12 @@ logger = logging.getLogger('distributed.dworker')
               help="Number of worker processes.  Defaults to one.")
 @click.option('--name', type=str, default='', help="Alias")
 @click.option('--no-nanny', is_flag=True)
-def main(center, host, worker_port, http_port, nanny_port, nthreads, nprocs, no_nanny, name):
+def main(center, host, worker_port, http_port, nanny_port, nthreads, nprocs,
+        no_nanny, name, port):
+    if port:
+        logger.info("--port is deprecated, use --nanny-port instead")
+        assert not nanny_port
+        nanny_port = port
     try:
         center_host, center_port = center.split(':')
         center_ip = socket.gethostbyname(center_host)

--- a/distributed/cli/tests/test_dworker.py
+++ b/distributed/cli/tests/test_dworker.py
@@ -1,0 +1,38 @@
+from __future__ import print_function, division, absolute_import
+
+import requests
+from subprocess import Popen, PIPE
+from time import time, sleep
+
+from distributed import Scheduler, Executor
+from distributed.core import rpc
+from distributed.utils import sync, ignoring
+from distributed.utils_test import loop
+
+
+def test_nanny_worker_ports(loop):
+    try:
+        worker = Popen(['dworker', '127.0.0.1:8989', '--host', '127.0.0.1',
+                        '--worker-port', '8788', '--nanny-port', '8789'],
+                        stdout=PIPE, stderr=PIPE)
+        sched = Popen(['dscheduler', '--port', '8989'], stdout=PIPE, stderr=PIPE)
+        with Executor('127.0.0.1:8989', loop=loop) as e:
+            start = time()
+            while True:
+                d = sync(e.loop, e.scheduler.identity)
+                if d['workers']:
+                    break
+                else:
+                    assert time() - start < 5
+                    sleep(0.1)
+            assert d['workers']['127.0.0.1:8788']['services']['nanny'] == 8789
+    finally:
+        with ignoring(Exception):
+            w = rpc('127.0.0.1:8789')
+            sync(loop, w.terminate)
+
+        with ignoring(Exception):
+            sched.kill()
+
+        with ignoring(Exception):
+            worker.kill()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -241,7 +241,8 @@ class Scheduler(Server):
         d = {'type': type(self).__name__,
              'id': str(self.id),
              'workers': list(self.ncores),
-             'services': {key: v.port for (key, v) in self.services.items()}}
+             'services': {key: v.port for (key, v) in self.services.items()},
+             'workers': dict(self.worker_info)}
         return d
 
     def put(self, msg):


### PR DESCRIPTION
Fixes #177 

cc @nfaggian

```
mrocklin@workstation:~/workspace/distributed$ dworker 192.168.1.141:8786 --nanny-port 8001 --worker-port 8002 --http-port 8003
distributed.worker - INFO -       Start worker at:        192.168.1.141:8002
distributed.worker - INFO -              nanny at:        192.168.1.141:8001
distributed.worker - INFO -               http at:        192.168.1.141:8003
distributed.worker - INFO - Waiting to connect to:        192.168.1.141:8786
distributed.worker - INFO -         Registered to:        192.168.1.141:8786
distributed.nanny - INFO - Nanny 192.168.1.141:8001 starts worker process 192.168.1.141:8002
```