### PR TITLE
Rebalance

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -314,3 +314,15 @@ def test_error_message():
 
     msg = error_message(MyException('Hello', 'World!'))
     assert 'Hello' in str(msg['exception'])
+
+
+@gen_cluster()
+def test_gather(s, a, b):
+    b.data['x'] = 1
+    b.data['y'] = 2
+    aa = rpc(ip=a.ip, port=a.port)
+    resp = yield aa.gather(who_has={'x': [b.address], 'y': [b.address]})
+    assert resp['status'] == 'OK'
+
+    assert a.data['x'] == b.data['x']
+    assert a.data['y'] == b.data['y']


### PR DESCRIPTION
This adds a rebalance operation to the Scheduler and Executor to balance the data on the cluster so that workers share roughly equal numbers of bytes (as measured by `sizeof`).

You can optionally specify a set of futures and a set of workers to balance.

```python
In [1]: from distributed import Executor

In [2]: e = Executor('192.168.1.141:8786')

In [3]: e
Out[3]: <Executor: scheduler=192.168.1.141:8786 workers=2 threads=16>

In [4]: e.ncores()
Out[4]: {'192.168.1.141:49293': 8, '192.168.1.141:57518': 8}

In [5]: def inc(x):
    return x + 1
   ...: 

In [6]: futures = e.map(inc, range(10), workers='192.168.1.141:49293')

In [7]: e.has_what()
Out[7]: 
{'192.168.1.141:49293': ['inc-2331da85e6990c120becd8b2cb613a1a',
  'inc-249b8519655b9c9d20ca38791d8b5884',
  'inc-6891d0d77b3127c8a26b3baa27e7ab67',
  'inc-52cc7ada53ca3e3474243fd7e647c96a',
  'inc-ec040381c2aa31951cb497269b0f2eb9',
  'inc-1db43ecb22d0d8830f529e6ba7beef73',
  'inc-e6796c5cab6344970f156ffe644404aa',
  'inc-42b0e6067d724019cbabb3aa7a7d594d',
  'inc-7865dd82fe814767dd48d67d5b0d67b3',
  'inc-642e5d7d079ddbf1840d4d9a6849f97f'],
 '192.168.1.141:57518': []}

In [8]: e.rebalance()
Out[8]: (None,)

In [9]: e.has_what()
Out[9]: 
{'192.168.1.141:49293': ['inc-6891d0d77b3127c8a26b3baa27e7ab67',
  'inc-ec040381c2aa31951cb497269b0f2eb9',
  'inc-1db43ecb22d0d8830f529e6ba7beef73',
  'inc-7865dd82fe814767dd48d67d5b0d67b3',
  'inc-642e5d7d079ddbf1840d4d9a6849f97f'],
 '192.168.1.141:57518': ['inc-2331da85e6990c120becd8b2cb613a1a',
  'inc-e6796c5cab6344970f156ffe644404aa',
  'inc-249b8519655b9c9d20ca38791d8b5884',
  'inc-42b0e6067d724019cbabb3aa7a7d594d',
  'inc-52cc7ada53ca3e3474243fd7e647c96a']}
```

cc @sklam