### PR TITLE
Scheduler Performance: Batched Streams

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -96,7 +96,7 @@ class BatchedStream(object):
     @gen.coroutine
     def close(self):
         yield self.flush()
-        return self.stream.close()
+        raise gen.Return(self.stream.close())
 
     def closed(self):
         return self.stream.closed()

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -1,0 +1,80 @@
+from __future__ import print_function, division, absolute_import
+
+import logging
+from timeit import default_timer
+
+from tornado import gen
+from tornado.queues import Queue
+from tornado.iostream import StreamClosedError
+
+from .core import read, write
+from .utils import log_errors
+
+
+logger = logging.getLogger(__name__)
+
+
+class BatchedStream(object):
+    def __init__(self, stream, interval):
+        self.stream = stream
+        self.interval = interval / 1000.
+        self.last_transmission = default_timer()
+        self.send_q = Queue()
+        self.recv_q = Queue()
+        self._background_send_coroutine = self._background_send()
+        self._background_recv_coroutine = self._background_recv()
+
+        self._last_write = None
+
+    @gen.coroutine
+    def _background_send(self):
+        with log_errors():
+            while True:
+                msg = yield self.send_q.get()
+                msgs = [msg]
+                now = default_timer()
+                wait_time = now - self.last_transmission + self.interval
+                if wait_time > 0:
+                    yield gen.sleep(wait_time)
+                while not self.send_q.empty():
+                    msgs.append(self.send_q.get_nowait())
+
+                self._last_write = write(self.stream, msgs)
+                yield self._last_write
+                if len(msgs) > 1:
+                    logger.debug("Batched messages: %d", len(msgs))
+                for _ in msgs:
+                    self.send_q.task_done()
+
+    @gen.coroutine
+    def _background_recv(self):
+        with log_errors():
+            while True:
+                try:
+                    msgs = yield read(self.stream)
+                except StreamClosedError:
+                    break
+                assert isinstance(msgs, list)
+                if len(msgs) > 1:
+                    # logger.info("Batched messages: %d", len(msgs))
+                    print("Batched messages: %d" % len(msgs))
+                for msg in msgs:
+                    self.recv_q.put_nowait(msg)
+
+    @gen.coroutine
+    def flush(self):
+        yield self.send_q.join()
+
+    def send(self, msg):
+        self.send_q.put_nowait(msg)
+
+    def recv(self):
+        return self.recv_q.get()
+
+    @gen.coroutine
+    def close(self):
+        yield self.flush()
+        return self.stream.close()
+
+    def closed(self):
+        return self.stream.closed()

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -35,7 +35,7 @@ from .core import (read, write, connect, rpc, coerce_to_rpc, dumps,
 from .scheduler import Scheduler
 from .worker import dumps_function, dumps_task
 from .utils import (All, sync, funcname, ignoring, queue_to_iterator, _deps,
-        tokey, log_errors, str_graph)
+        tokey, log_errors, str_graph, ensure_ip)
 from .compatibility import Queue as pyQueue, Empty, isqueue
 
 logger = logging.getLogger(__name__)
@@ -287,43 +287,22 @@ class Executor(object):
         sync(self.loop, self._start, **kwargs)
 
     def _send_to_scheduler(self, msg):
-        if isinstance(self.scheduler, Scheduler):
-            self.loop.add_callback(self.scheduler_queue.put_nowait, msg)
-        elif isinstance(self.scheduler_stream, IOStream):
-            self.loop.add_callback(write, self.scheduler_stream, msg)
-        else:
-            raise NotImplementedError()
+        self.loop.add_callback(write, self.scheduler_stream, msg)
 
     @gen.coroutine
     def _start(self, timeout=3, **kwargs):
-        if isinstance(self._start_arg, Scheduler):
-            self.scheduler = self._start_arg
-        if isinstance(self._start_arg, str):
-            host, port = tuple(self._start_arg.split(':'))
-            self._start_arg = (host, int(port))
-        if isinstance(self._start_arg, tuple):
-            host, port = self._start_arg
-            ip = socket.gethostbyname(host)
-            r = coerce_to_rpc((ip, port), timeout=timeout)
-            try:
-                ident = yield r.identity()
-            except (StreamClosedError, OSError):
-                raise IOError("Could not connect to %s:%d" % (ip, port))
-            if ident['type'] == 'Scheduler':
-                self.scheduler = r
-                self.scheduler_stream = yield connect(ip, port)
-                yield write(self.scheduler_stream, {'op': 'register-client',
-                                                    'client': self.id})
-            else:
-                raise ValueError("Unknown Type")
-
-        if isinstance(self.scheduler, Scheduler):
-            if self.scheduler.status != 'running':
-                self.scheduler.start(0)
-            self.scheduler_queue = Queue()
-            self.report_queue = Queue()
-            self.coroutines.append(self.scheduler.handle_queues(
-                self.scheduler_queue, self.report_queue))
+        r = coerce_to_rpc(self._start_arg, timeout=timeout)
+        try:
+            ident = yield r.identity()
+        except (StreamClosedError, OSError):
+            raise IOError("Could not connect to %s:%d" % (r.ip, r.port))
+        if ident['type'] == 'Scheduler':
+            self.scheduler = r
+            self.scheduler_stream = yield connect(r.ip, r.port)
+            yield write(self.scheduler_stream, {'op': 'register-client',
+                                                'client': self.id})
+        else:
+            raise ValueError("Unknown Type")
 
         start_event = Event()
         self.coroutines.append(self._handle_report(start_event))
@@ -362,17 +341,10 @@ class Executor(object):
     @gen.coroutine
     def _handle_report(self, start_event):
         """ Listen to scheduler """
-        if isinstance(self.scheduler, Scheduler):
-            next_message = self.report_queue.get
-        elif isinstance(self.scheduler_stream, IOStream):
-            next_message = lambda: read(self.scheduler_stream)
-        else:
-            raise NotImplemented()
-
         with log_errors():
             while True:
                 try:
-                    msg = yield next_message()
+                    msg = yield read(self.scheduler_stream)
                 except StreamClosedError:
                     logger.debug("Stream closed to scheduler", exc_info=True)
                     break

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -29,14 +29,15 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.iostream import StreamClosedError, IOStream
 from tornado.queues import Queue
 
+from .batched import BatchedStream
 from .client import (WrappedKey, unpack_remotedata, pack_data)
+from .compatibility import Queue as pyQueue, Empty, isqueue
 from .core import (read, write, connect, rpc, coerce_to_rpc, dumps,
         clean_exception)
 from .scheduler import Scheduler
 from .worker import dumps_function, dumps_task
 from .utils import (All, sync, funcname, ignoring, queue_to_iterator, _deps,
         tokey, log_errors, str_graph, ensure_ip)
-from .compatibility import Queue as pyQueue, Empty, isqueue
 
 logger = logging.getLogger(__name__)
 
@@ -287,7 +288,7 @@ class Executor(object):
         sync(self.loop, self._start, **kwargs)
 
     def _send_to_scheduler(self, msg):
-        self.loop.add_callback(write, self.scheduler_stream, msg)
+        self.loop.add_callback(self.scheduler_stream.send, msg)
 
     @gen.coroutine
     def _start(self, timeout=3, **kwargs):
@@ -299,8 +300,10 @@ class Executor(object):
         if ident['type'] == 'Scheduler':
             self.scheduler = r
             self.scheduler_stream = yield connect(r.ip, r.port)
-            yield write(self.scheduler_stream, {'op': 'register-client',
-                                                'client': self.id})
+            write(self.scheduler_stream, {'op': 'register-client',
+                                          'client': self.id,
+                                          'batched': True})
+            self.scheduler_stream = BatchedStream(self.scheduler_stream, 10)
         else:
             raise ValueError("Unknown Type")
 
@@ -344,7 +347,7 @@ class Executor(object):
         with log_errors():
             while True:
                 try:
-                    msg = yield read(self.scheduler_stream)
+                    msg = yield self.scheduler_stream.recv()
                 except StreamClosedError:
                     logger.debug("Stream closed to scheduler", exc_info=True)
                     break
@@ -411,7 +414,8 @@ class Executor(object):
     def shutdown(self, timeout=10):
         """ Send shutdown signal and wait until scheduler terminates """
         with ignoring(AttributeError):
-            sync(self.loop, write, self.scheduler_stream, {'op': 'close-stream'})
+            self.scheduler_stream.send({'op': 'close-stream'})
+            sync(self.loop, self.scheduler_stream.flush)
             self.scheduler_stream.close()
         with ignoring(AttributeError):
             self.scheduler.close_streams()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -629,6 +629,7 @@ class Scheduler(Server):
                 self.who_has.pop(key)
                 missing_keys.add(key)
 
+        missing_keys = {k for k in missing_keys if k in self.tasks}
         self.my_heal_missing_data(missing_keys)
 
         # self.validate()
@@ -997,6 +998,7 @@ class Scheduler(Server):
                     msg = yield self.worker_queues[ident].get()
                 except KeyError:
                     break
+
                 yield write(stream, msg)
 
                 if msg['op'] == 'close':

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1496,49 +1496,6 @@ def validate_state(dependencies, dependents, waiting, waiting_data, ready,
     assert all(map(check_key, keys))
 
 
-def keys_outside_frontier(dependencies, keys, frontier):
-    """ All keys required by terminal keys within graph up to frontier
-
-    Given:
-
-    1. A graph
-    2. A set of desired keys
-    3. A frontier/set of already-computed (or already-about-to-be-computed) keys
-
-    Find all keys necessary to compute the desired set that are outside of the
-    frontier.
-
-    Parameters
-    ----------
-    tasks: dict
-    keys: iterable of keys
-    frontier: set of keys
-
-    Examples
-    --------
-    >>> f = lambda:1
-    >>> dsk = {'x': 1, 'a': 2, 'y': (f, 'x'), 'b': (f, 'a'),
-    ...        'z': (f, 'b', 'y')}
-    >>> dependencies, dependents = get_deps(dsk)
-    >>> keys = {'z', 'b'}
-    >>> frontier = {'y', 'a'}
-    >>> list(sorted(keys_outside_frontier(dependencies, keys, frontier)))
-    ['b', 'z']
-    """
-    assert isinstance(keys, set)
-    assert isinstance(frontier, set)
-    stack = list(keys - frontier)
-    result = set()
-    while stack:
-        x = stack.pop()
-        if x in result or x in frontier:
-            continue
-        result.add(x)
-        stack.extend(dependencies[x])
-
-    return result
-
-
 _round_robin = [0]
 
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -806,6 +806,7 @@ class Scheduler(Server):
                 s = self.dependents[dep]
                 s.remove(key)
                 if not s and dep not in self.who_wants:
+                    assert dep is not key
                     self.forget(dep)
             del self.dependencies[key]
             if key in self.restrictions:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -393,15 +393,20 @@ class Scheduler(Server):
         for worker in workers:
             self.who_has[key].add(worker)
             self.has_what[worker].add(key)
-            with ignoring(KeyError):
+            try:
                 self.processing[worker].remove(key)
+            except KeyError:
+                pass
 
-        for dep in sorted(self.dependents.get(key, []), key=self.keyorder.get,
+        for dep in sorted(self.dependents.get(key, []),
+                          key=self.keyorder.get,
                           reverse=True):
             if dep in self.waiting:
                 s = self.waiting[dep]
-                with ignoring(KeyError):
+                try:
                     s.remove(key)
+                except KeyError:
+                    pass
                 if not s:  # new task ready to run
                     self.mark_ready_to_run(dep)
 
@@ -749,10 +754,14 @@ class Scheduler(Server):
 
     def client_releases_keys(self, keys=None, client=None):
         for k in list(keys):
-            with ignoring(KeyError):
+            try:
                 self.wants_what[client].remove(k)
-            with ignoring(KeyError):
+            except KeyError:
+                pass
+            try:
                 self.who_wants[k].remove(client)
+            except KeyError:
+                pass
             if not self.who_wants[k]:
                 del self.who_wants[k]
                 self.release_held_data([k])

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1010,7 +1010,6 @@ class Scheduler(Server):
         @gen.coroutine
         def recv():
             while True:
-                assert not stream._closed
                 msg = yield read(stream)
 
                 logger.debug("Compute response from worker %s, %s",
@@ -1034,10 +1033,9 @@ class Scheduler(Server):
 
                 self.ensure_occupied(ident)
         try:
-            with log_errors():
-                yield All([send(), recv()])
+            yield All([send(), recv()])
             stream.close()
-        except (IOError, OSError):
+        except (StreamClosedError, IOError, OSError):
             logger.info("Worker failed from closed stream: %s", ident)
         finally:
             self.remove_worker(address=ident)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -541,7 +541,7 @@ class Scheduler(Server):
     def mark_task_finished(self, key, worker, nbytes, type=None):
         """ Mark that a task has finished execution on a particular worker """
         logger.debug("Mark task as finished %s, %s", key, worker)
-        if key in self.processing[worker]:
+        if worker in self.processing and key in self.processing[worker]:
             self.nbytes[key] = nbytes
             self.mark_key_in_memory(key, [worker], type=type)
             self.ensure_occupied(worker)

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -1,8 +1,12 @@
-from distributed.utils_test import gen_test
-from distributed.batched import BatchedStream
+
+import pytest
 from tornado import gen
 from tornado.tcpserver import TCPServer
 from tornado.tcpclient import TCPClient
+from tornado.iostream import StreamClosedError
+
+from distributed.utils_test import gen_test
+from distributed.batched import BatchedStream
 
 
 class MyServer(TCPServer):
@@ -34,3 +38,21 @@ def test_BatchedStream():
     result = yield b.recv(); assert result == 'world'
 
     b.close()
+
+@gen_test(timeout=10)
+def test_BatchedStream_raises():
+    port = 3435
+    server = MyServer()
+    server.listen(port)
+
+    client = TCPClient()
+    stream = yield client.connect('127.0.0.1', port)
+    b = BatchedStream(stream, interval=20)
+
+    stream.close()
+
+    with pytest.raises(StreamClosedError):
+        yield b.recv()
+
+    with pytest.raises(StreamClosedError):
+        yield b.send('123')

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -1,0 +1,36 @@
+from distributed.utils_test import gen_test
+from distributed.batched import BatchedStream
+from tornado import gen
+from tornado.tcpserver import TCPServer
+from tornado.tcpclient import TCPClient
+
+
+class MyServer(TCPServer):
+    @gen.coroutine
+    def handle_stream(self, stream, address):
+        batched = BatchedStream(stream, interval=10)
+        while True:
+            msg = yield batched.recv()
+            batched.send(msg)
+            batched.send(msg)
+
+
+@gen_test(timeout=10)
+def test_BatchedStream():
+    port = 3434
+    server = MyServer()
+    server.listen(port)
+
+    client = TCPClient()
+    stream = yield client.connect('127.0.0.1', port)
+    b = BatchedStream(stream, interval=20)
+
+    b.send('hello')
+    b.send('world')
+
+    result = yield b.recv(); assert result == 'hello'
+    result = yield b.recv(); assert result == 'hello'
+    result = yield b.recv(); assert result == 'world'
+    result = yield b.recv(); assert result == 'world'
+
+    b.close()

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1696,6 +1696,7 @@ def test_multi_executor(s, a, b):
 def test_broken_worker_during_computation(e, s, a, b):
     n = Nanny(s.ip, s.port, ncores=2, loop=s.loop)
     n.start(0)
+
     start = time()
     while len(s.ncores) < 3:
         yield gen.sleep(0.01)
@@ -1706,12 +1707,13 @@ def test_broken_worker_during_computation(e, s, a, b):
         L = e.map(add, *zip(*partition_all(2, L)))
 
     yield gen.sleep(0.3)
-    s.validate()
     n.process.terminate()
-    yield gen.sleep(0.1)
-    s.validate()
+    yield gen.sleep(0.3)
+    n.process.terminate()
 
-    result = e._gather(L)
+    result = yield e._gather(L)
+    assert isinstance(result[0], int)
+
 
 @gen_cluster()
 def test_cleanup_after_broken_executor_connection(s, a, b):

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1284,17 +1284,6 @@ def test_remote_scheduler(e, s, a, b):
     result = yield x._result()
 
 
-@gen_cluster()
-def test_start_with_scheduler(s, a, b):
-    e2 = Executor(s, start=False, loop=loop)
-    yield e2._start()
-    assert isinstance(e2.scheduler, Scheduler)
-
-    future = e2.submit(inc, 1)
-    result = yield future._result()
-    assert result == inc(1)
-
-
 @gen_cluster(executor=True)
 def test_remote_scatter_gather(e, s, a, b):
     x, y, z = yield e._scatter([1, 2, 3])

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -18,7 +18,6 @@ import pytest
 from toolz import (identity, isdistinct, first, concat, pluck, keymap, valmap,
         partition_all)
 from tornado.ioloop import IOLoop
-from tornado.iostream import IOStream
 from tornado import gen
 
 from dask import do, value
@@ -1273,15 +1272,6 @@ def test_sync_compute(loop):
 
             yy, zz = e.compute([y, z], sync=True)
             assert (yy, zz) == (2, 0)
-
-
-@gen_cluster(executor=True)
-def test_remote_scheduler(e, s, a, b):
-    assert isinstance(e.scheduler_stream, IOStream)
-    assert s.streams
-
-    x = e.submit(inc, 1)
-    result = yield x._result()
 
 
 @gen_cluster(executor=True)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -17,6 +17,7 @@ from tornado import gen
 import pytest
 
 from distributed import Nanny, Worker
+from distributed.batched import BatchedStream
 from distributed.core import connect, read, write, rpc, dumps
 from distributed.client import WrappedKey
 from distributed.scheduler import (validate_state, decide_worker,
@@ -462,8 +463,10 @@ def test_multi_queues(s, a, b):
 @gen_cluster()
 def test_server(s, a, b):
     stream = yield connect('127.0.0.1', s.port)
-    yield write(stream, {'op': 'register-client', 'client': 'ident'})
-    yield write(stream, {'op': 'update-graph',
+    write(stream, {'op': 'register-client', 'client': 'ident',
+                         'batched': True})
+    stream = BatchedStream(stream, 0)
+    write(stream, {'op': 'update-graph',
                          'tasks': {'x': dumps_task((inc, 1)),
                                    'y': dumps_task((inc, 'x'))},
                          'dependencies': {'x': [], 'y': ['x']},
@@ -475,7 +478,7 @@ def test_server(s, a, b):
         if msg['op'] == 'key-in-memory' and msg['key'] == 'y':
             break
 
-    yield write(stream, {'op': 'close-stream'})
+    write(stream, {'op': 'close-stream'})
     msg = yield read(stream)
     assert msg == {'op': 'stream-closed'}
     assert stream.closed()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -573,7 +573,7 @@ def test_feed_setup_teardown(s, a, b):
         assert time() - start < 5
 
 
-@gen_test()
+@gen_test(timeout=None)
 def test_scheduler_as_center():
     s = Scheduler()
     done = s.start(0)
@@ -592,7 +592,9 @@ def test_scheduler_as_center():
     s.update_graph(tasks={'a': dumps_task((inc, 1))},
                    keys=['a'],
                    dependencies={'a': []})
+    start = time()
     while not s.who_has['a']:
+        assert time() - start < 5
         yield gen.sleep(0.01)
     assert 'a' in a.data or 'a' in b.data or 'a' in c.data
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -486,6 +486,24 @@ def test_server(s, a, b):
 
 
 @gen_cluster()
+def test_remove_client(s, a, b):
+    s.add_client(client='ident')
+    s.update_graph(tasks={'x': dumps_task((inc, 1)),
+                          'y': dumps_task((inc, 'x'))},
+                   dependencies={'x': [], 'y': ['x']},
+                   keys=['y'],
+                   client='ident')
+
+    assert s.tasks
+    assert s.dependencies
+
+    s.remove_client(client='ident')
+
+    assert not s.tasks
+    assert not s.dependencies
+
+
+@gen_cluster()
 def test_server_listens_to_other_ops(s, a, b):
     r = rpc(ip='127.0.0.1', port=s.port)
     ident = yield r.identity()
@@ -525,7 +543,7 @@ def test_add_worker(s, a, b):
     for k in w.data:
         assert w.address in s.who_has[k]
 
-    s.validate(allow_overlap=True)
+    s.validate()
 
 
 @gen_cluster()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -281,7 +281,7 @@ def test_worker_waits_for_center_to_come_up(loop):
 @gen_cluster()
 def test_worker_task(s, a, b):
     aa = rpc(ip=a.ip, port=a.port)
-    yield aa.compute(task=dumps((inc, 1)), key='x')
+    yield aa.compute(task=dumps((inc, 1)), key='x', report=False)
 
     assert a.data['x'] == 2
 
@@ -289,7 +289,7 @@ def test_worker_task(s, a, b):
 @gen_cluster()
 def test_worker_task_data(s, a, b):
     aa = rpc(ip=a.ip, port=a.port)
-    yield aa.compute(task=dumps(2), key='x')
+    yield aa.compute(task=dumps(2), key='x', report=False)
 
     assert a.data['x'] == 2
 
@@ -298,10 +298,11 @@ def test_worker_task_data(s, a, b):
 def test_worker_task_bytes(s, a, b):
     aa = rpc(ip=a.ip, port=a.port)
 
-    yield aa.compute(task=dumps((inc, 1)), key='x')
+    yield aa.compute(task=dumps((inc, 1)), key='x', report=False)
     assert a.data['x'] == 2
 
-    yield aa.compute(function=dumps(inc), args=dumps((10,)), key='y')
+    yield aa.compute(function=dumps(inc), args=dumps((10,)), key='y',
+            report=False)
     assert a.data['y'] == 11
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -224,13 +224,15 @@ def key_split(s):
 
 
 @contextmanager
-def log_errors():
+def log_errors(pdb=False):
     try:
         yield
     except gen.Return:
         raise
     except Exception as e:
         logger.exception(e)
+        if pdb:
+            import pdb; pdb.set_trace()
         raise
 
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -542,7 +542,7 @@ def apply_function(function, args, kwargs):
         msg = {'status': 'OK',
                'result': result,
                'nbytes': sizeof(result),
-               'type': dumps(type(result)) if result is not None else None}
+               'type': dumps_function(type(result)) if result is not None else None}
     finally:
         end = default_timer()
     msg['compute-time'] = end - start

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -376,8 +376,10 @@ class Worker(Server):
                     str(kwargs)[:1000], exc_info=True)
 
             logger.debug("Send compute response to scheduler: %s, %s", key, msg)
-            with ignoring(KeyError):
+            try:
                 self.active.remove(key)
+            except KeyError:
+                pass
             raise Return(result)
 
     @gen.coroutine

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -8,13 +8,14 @@ from multiprocessing.pool import ThreadPool
 import os
 import pkg_resources
 import tempfile
+from timeit import default_timer
 import traceback
 import shutil
 import sys
 
 from dask.core import istask
 from dask.compatibility import apply
-from toolz import merge, valmap
+from toolz import merge, valmap, dissoc
 from tornado.gen import Return
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
@@ -26,7 +27,7 @@ from .core import (rpc, Server, pingpong, dumps, loads, coerce_to_address,
         error_message)
 from .sizeof import sizeof
 from .utils import (funcname, get_ip, get_traceback, truncate_exception,
-    ignoring, _maybe_complex)
+    ignoring, _maybe_complex, log_errors)
 
 _ncores = ThreadPool()._processes
 
@@ -220,10 +221,8 @@ class Worker(Server):
             raise Return({'status': 'OK'})
 
     @gen.coroutine
-    def compute(self, stream, function=None, key=None, args=(), kwargs={},
-            task=None, who_has=None, report=True):
-        """ Execute function """
-        self.active.add(key)
+    def _ready_task(self, function=None, key=None, args=(), kwargs={},
+            task=None, who_has=None):
         if who_has:
             local_data = {k: self.data[k] for k in who_has if k in self.data}
             who_has = {k: set(map(coerce_to_address, v))
@@ -232,18 +231,21 @@ class Worker(Server):
             try:
                 logger.info("gather %d keys from peers: %s",
                             len(who_has), str(who_has))
+                start = default_timer()
                 other = yield gather_from_workers(who_has)
+                transfer_time = default_timer() - start
+                data = merge(local_data, other)
             except KeyError as e:
                 logger.warn("Could not find data during gather in compute",
                             exc_info=True)
-                self.active.remove(key)
                 raise Return({'status': 'missing-data',
-                              'keys': e.args})
-            data = merge(local_data, other)
+                              'keys': e.args,
+                              'key': key})
         else:
             data = {}
-
+            transfer_time = 0
         try:
+            start = default_timer()
             if task is not None:
                 task = loads(task)
             if function is not None:
@@ -252,9 +254,9 @@ class Worker(Server):
                 args = loads(args)
             if kwargs:
                 kwargs = loads(kwargs)
+            deserialization_time = default_timer() - start
         except Exception as e:
             logger.warn("Could not deserialize task", exc_info=True)
-            self.active.remove(key)
             raise Return(error_message(e))
 
         if task is not None:
@@ -266,56 +268,92 @@ class Worker(Server):
         args2 = pack_data(args, data)
         kwargs2 = pack_data(kwargs, data)
 
-        # Log and compute in separate thread
+        raise Return({'status': 'OK',
+                      'function': function,
+                      'args': args2,
+                      'kwargs': kwargs2,
+                      'diagnostics': {'transfer': transfer_time,
+                                      'deserialization': deserialization_time},
+                      'key': key})
+
+    @gen.coroutine
+    def executor_submit(self, key, function, *args, **kwargs):
+        """ Safely run function in thread pool executor
+
+        We've run into issues running concurrent.future futures within
+        tornado.  Apparently it's advantageous to use timeouts and periodic
+        callbacks to ensure things run smoothly.  This can get tricky, so we
+        pull it off into an separate method.
+        """
+        job_counter[0] += 1
+        i = job_counter[0]
+        logger.info("Start job %d, %s", i, key)
+        future = self.executor.submit(function, *args, **kwargs)
+        pc = PeriodicCallback(lambda: logger.debug("future state: %s - %s",
+            key, future._state), 1000); pc.start()
         try:
-            job_counter[0] += 1
-            i = job_counter[0]
-            logger.info("Start job %d: %s - %s", i, funcname(function), key)
-            future = self.executor.submit(function, *args2, **kwargs)
-            pc = PeriodicCallback(lambda: logger.debug("future state: %s - %s",
-                key, future._state), 1000)
-            pc.start()
-            try:
-                if sys.version_info < (3, 2):
-                    yield future
-                else:
-                    while not future.done() and future._state != 'FINISHED':
-                        try:
-                            yield gen.with_timeout(timedelta(seconds=1), future)
-                            break
-                        except gen.TimeoutError:
-                            logger.info("work queue size: %d", self.executor._work_queue.qsize())
-                            logger.info("future state: %s", future._state)
-                            logger.info("Pending job %d: %s", i, future)
-            finally:
-                pc.stop()
-            result = future.result()
-            logger.info("Finish job %d: %s - %s", i, funcname(function), key)
-            self.data[key] = result
-            if report:
-                response = yield self.center.add_keys(address=(self.ip, self.port),
-                                                      keys=[key])
-                if not response == 'OK':
-                    logger.warn('Could not report results to center: %s',
-                                response.decode())
-            out = {'status': 'OK',
-                   'nbytes': sizeof(result)}
-            if result is not None:
-                out['type'] = dumps(type(result))
-        except Exception as e:
-            logger.warn(" Compute Failed\n"
-                "Function: %s\n"
-                "args:     %s\n"
-                "kwargs:   %s\n",
-                str(funcname(function))[:1000], str(args2)[:1000],
-                str(kwargs2)[:1000], exc_info=True)
+            if sys.version_info < (3, 2):
+                yield future
+            else:
+                while not future.done() and future._state != 'FINISHED':
+                    try:
+                        yield gen.with_timeout(timedelta(seconds=1), future)
+                        break
+                    except gen.TimeoutError:
+                        logger.info("work queue size: %d", self.executor._work_queue.qsize())
+                        logger.info("future state: %s", future._state)
+                        logger.info("Pending job %d: %s", i, future)
+        finally:
+            pc.stop()
 
-            out = error_message(e)
+        result = future.result()
+        logger.info("Finish job %d, %s", i, key)
+        return result
 
-        logger.debug("Send compute response to scheduler: %s, %s", key, out)
-        with ignoring(KeyError):
-            self.active.remove(key)
-        raise Return(out)
+    @gen.coroutine
+    def compute(self, stream, function=None, key=None, args=(), kwargs={},
+            task=None, who_has=None, report=True):
+        """ Execute function """
+        with log_errors():
+            self.active.add(key)
+
+            # Ready function for computation
+            msg = yield self._ready_task(function=function, key=key, args=args,
+                kwargs=kwargs, task=task, who_has=who_has)
+            if msg['status'] != 'OK':
+                self.active.remove(key)
+                raise Return(msg)
+            else:
+                function = msg['function']
+                args = msg['args']
+                kwargs = msg['kwargs']
+
+            # Log and compute in separate thread
+            result = yield self.executor_submit(key, apply_function, function,
+                                                args, kwargs)
+            result['key'] = key
+            result.update(msg['diagnostics'])
+
+            if result['status'] == 'OK':
+                self.data[key] = result.pop('result')
+                if report:
+                    response = yield self.center.add_keys(address=(self.ip, self.port),
+                                                          keys=[key])
+                    if not response == 'OK':
+                        logger.warn('Could not report results to center: %s',
+                                    response.decode())
+            else:
+                logger.warn(" Compute Failed\n"
+                    "Function: %s\n"
+                    "args:     %s\n"
+                    "kwargs:   %s\n",
+                    str(funcname(function))[:1000], str(args)[:1000],
+                    str(kwargs)[:1000], exc_info=True)
+
+            logger.debug("Send compute response to scheduler: %s, %s", key, msg)
+            with ignoring(KeyError):
+                self.active.remove(key)
+            raise Return(result)
 
     @gen.coroutine
     def run(self, stream, function=None, args=(), kwargs={}):
@@ -461,3 +499,26 @@ def dumps_task(task):
             return {'function': dumps_function(task[0]),
                         'args': dumps(task[1:])}
     return {'task': dumps(task)}
+
+
+def apply_function(function, args, kwargs):
+    """ Run a function, collect information
+
+    Returns
+    -------
+    msg: dictionary with status, result/error, timings, etc..
+    """
+    start = default_timer()
+    try:
+        result = function(*args, **kwargs)
+    except Exception as e:
+        msg = error_message(e)
+    else:
+        msg = {'status': 'OK',
+               'result': result,
+               'nbytes': sizeof(result),
+               'type': dumps(type(result)) if result is not None else None}
+    finally:
+        end = default_timer()
+    msg['compute-time'] = end - start
+    return msg


### PR DESCRIPTION
A few significant changes to inter-node communication

1.  Add a batched stream object that time-batches messages by an interval
2.  Use Batched streams between the Executor and Scheduler as a first case.  Will generalize to workers later
3.  Refactor the worker logic within the scheduler to operate asynchronously so that they send and receive many messages over the same stream
4.  Various small performance enhancements

Overall on same-machine scheduling I can get `e.map(inc, e.map(inc, range(1000))` to run about twice as fast with these changes.  They also set up some nice improvements for the future, like batched streams to the workers.