### PR TITLE
Update resilience

### DIFF
--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1551,7 +1551,7 @@ def test_forget_simple(e, s, a, b):
     s.client_releases_keys(keys=[z.key], client=e.id)
     for coll in [s.tasks, s.dependencies, s.dependents, s.waiting,
             s.waiting_data, s.who_has, s.restrictions, s.loose_restrictions,
-            s.in_play, s.keyorder, s.exceptions, s.who_wants,
+            s.released, s.keyorder, s.exceptions, s.who_wants,
             s.exceptions_blame]:
         assert x.key not in coll
         assert z.key not in coll


### PR DESCRIPTION
The scheduler was not always gracefully recovering from a worker
failure.  We implement the following changes:

1.  Remove old heal functions replace with heal_missing_data only
2.  Call ensure_occupied within worker_core
3.  Be more careful about using who_has[key].  This has negative
    consequences  because it is a defaultdict.
4.  Add more validation checks, particularly around idle workers
5.  Add better test that kills worker mid-computation but still gives
    us debuggability using coroutines