### PR TITLE
Catch exceptions in Executor.run

### DIFF
--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -2171,6 +2171,18 @@ def test_run_sync(loop):
             assert result == {'127.0.0.1:%d' % a['port']: 3}
 
 
+def test_run_exception(loop):
+    def raise_exception(exc_type, exc_msg):
+        raise exc_type(exc_msg)
+
+    with cluster() as (s, [a, b]):
+        with Executor(('127.0.0.1', s['port']), loop=loop) as e:
+            for exc_type in [ValueError, RuntimeError]:
+                with pytest.raises(exc_type) as excinfo:
+                    e.run(raise_exception, exc_type, 'informative message')
+                assert 'informative message' in str(excinfo.value)
+
+
 def test_diagnostic_ui(loop):
     with cluster() as (s, [a, b]):
         a_addr = '127.0.0.1:%d' % a['port']

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -307,9 +307,23 @@ class Worker(Server):
             args = loads(args)
         if kwargs:
             kwargs = loads(kwargs)
+        try:
+            result = function(*args, **kwargs)
+        except Exception as e:
+            logger.warn(" Run Failed\n"
+                "Function: %s\n"
+                "args:     %s\n"
+                "kwargs:   %s\n",
+                str(funcname(function))[:1000], str(args)[:1000],
+                str(kwargs)[:1000], exc_info=True)
 
-        result = function(*args, **kwargs)
-        raise Return(result)
+            response = error_message(e)
+        else:
+            response = {
+                'status': 'OK',
+                'result': dumps(result),
+            }
+        raise Return(response)
 
     @gen.coroutine
     def update_data(self, stream, data=None, report=True):


### PR DESCRIPTION
re-raise them locally, rather than aborting without any reply. Avoids StreamClosedError when run would fail.

I think it makes the most sense to add this kind of error handling to [a higher level](https://github.com/dask/distributed/blob/3a49b048ae277448748fa6a14f2a4de61ed60907/distributed/core.py#L180) in the RPC dispatch, but I wasn't sure how to do that without making a mess, so I added it directly to run handler.

Folow-up on #189, including @ogrisel's test and making it pass.