### PR TITLE
Changed format of credentials code block in dec2 quickstart

### DIFF
--- a/docs/source/dec2.rst
+++ b/docs/source/dec2.rst
@@ -1,9 +1,7 @@
 EC2 Startup Script
 ==================
 
-First, add your AWS credentials to ``~/.aws/credentials`` like this:
-
-.. code-block::
+First, add your AWS credentials to ``~/.aws/credentials`` like this::
 
      [default]
      aws_access_key_id = YOUR_ACCESS_KEY


### PR DESCRIPTION
For some reason, it shows up on Github, but not on docs. See http://distributed.readthedocs.org/en/latest/dec2.html