### PR TITLE
Canavandl/responsive layout

### DIFF
--- a/distributed/diagnostics/status_monitor.py
+++ b/distributed/diagnostics/status_monitor.py
@@ -172,7 +172,7 @@ def task_stream_plot(height=400, width=800, follow_interval=5000, **kwargs):
 
     fig = figure(width=width, height=height, x_axis_type='datetime',
                  tools=['xwheel_zoom', 'xpan', 'reset', 'resize', 'box_zoom'],
-                 x_range=x_range, **kwargs)
+                 responsive=True, x_range=x_range, **kwargs)
     fig.rect(x='start', width='duration',
              y='y', height=0.9,
              fill_color='color', line_color='gray', source=source)
@@ -249,7 +249,7 @@ def progress_plot(height=300, width=800, **kwargs):
 
     source = ColumnDataSource(data)
     fig = figure(width=width, height=height, tools=['resize'],
-                 **kwargs)
+                 responsive=True, **kwargs)
     fig.quad(source=source, top='top', bottom='bottom',
              left=0, right=1, color='#aaaaaa', alpha=0.2)
     fig.quad(source=source, top='top', bottom='bottom',

--- a/distributed/diagnostics/tests/test_worker_monitor.py
+++ b/distributed/diagnostics/tests/test_worker_monitor.py
@@ -39,4 +39,4 @@ def test_resource_append():
            '10.10.20.87': {'cpu': 30, 'memory-percent': 70, 'time': 1000}}
 
     resource_append(lists, msg)
-    assert lists == {'time': [1500000], 'cpu': [20], 'memory-percent': [60]}
+    assert lists == {'time': [1500000], 'cpu': [0.2], 'memory-percent': [0.6]}

--- a/distributed/diagnostics/worker_monitor.py
+++ b/distributed/diagnostics/worker_monitor.py
@@ -8,7 +8,8 @@ from toolz import pluck
 from ..utils import ignoring
 
 with ignoring(ImportError):
-    from bokeh.models import ColumnDataSource, DataRange1d, Range1d
+    from bokeh.models import (ColumnDataSource, DataRange1d, Range1d,
+            NumeralTickFormatter)
     from bokeh.palettes import Spectral9
     from bokeh.plotting import figure
 
@@ -18,7 +19,7 @@ def resource_profile_plot(width=600, height=300):
     source = ColumnDataSource({k: [] for k in names})
 
     x_range = DataRange1d(follow='end', follow_interval=30000, range_padding=0)
-    y_range = Range1d(0, 100)
+    y_range = Range1d(0, 1)
     p = figure(width=width, height=height, x_axis_type='datetime',
                responsive=True, tools='xpan,xwheel_zoom,box_zoom,resize,reset',
                x_range=x_range, y_range=y_range)
@@ -27,8 +28,7 @@ def resource_profile_plot(width=600, height=300):
     p.line(x='time', y='cpu', line_width=2, line_alpha=0.8,
            color=Spectral9[0], legend='Avg CPU Usage', source=source)
     p.legend[0].location = 'top_left'
-    p.yaxis[0].axis_label = 'Percent'
-    p.xaxis[0].axis_label = 'Time'
+    p.yaxis[0].formatter = NumeralTickFormatter(format="0 %")
     p.min_border_right = 10
 
     return source, p
@@ -57,7 +57,7 @@ def resource_append(lists, msg):
     if not L:
         return
     for k in ['cpu', 'memory-percent']:
-        lists[k].append(mean(pluck(k, L)))
+        lists[k].append(mean(pluck(k, L)) / 100)
 
     lists['time'].append(mean(pluck('time', L)) * 1000)
 

--- a/distributed/diagnostics/worker_monitor.py
+++ b/distributed/diagnostics/worker_monitor.py
@@ -20,12 +20,12 @@ def resource_profile_plot(width=600, height=300):
     x_range = DataRange1d(follow='end', follow_interval=30000, range_padding=0)
     y_range = Range1d(0, 100)
     p = figure(width=width, height=height, x_axis_type='datetime',
-               tools='xpan,xwheel_zoom,box_zoom,resize,reset',
+               responsive=True, tools='xpan,xwheel_zoom,box_zoom,resize,reset',
                x_range=x_range, y_range=y_range)
     p.line(x='time', y='memory-percent', line_width=2, line_alpha=0.8,
-           color=Spectral9[7], legend='Memory Usage', source=source)
+           color=Spectral9[7], legend='Avg Memory Usage', source=source)
     p.line(x='time', y='cpu', line_width=2, line_alpha=0.8,
-           color=Spectral9[0], legend='CPU Usage', source=source)
+           color=Spectral9[0], legend='Avg CPU Usage', source=source)
     p.legend[0].location = 'top_left'
     p.yaxis[0].axis_label = 'Percent'
     p.xaxis[0].axis_label = 'Time'


### PR DESCRIPTION
* Make plots responsive (fill container and shrink down to minimum dimension, while maintaining aspect ratio). Note - THE `responsive=True` DOES NOT WORK IN FIREFOX IN THE BOKEH 0.11.1 RELEASE. We've fixed the issue in master (link), but the current release has this bug. Also note: The tables aren't responsive, just the plots.

Merging this PR, makes (in my opinion) the UI better in Chrome because it's responsive but worse in Firefox because the resulting plots are massive and cause one's CPU usage to skyrocket. I don't know if that's a non-starter.

* Nicely formats the table cells (formats memory parameters in bytes, percentages as percentages, gives reasonable significant figures)

* Prepends worker plot legend items with "Avg " 

![screen shot 2016-03-28 at 5 37 36 pm](https://cloud.githubusercontent.com/assets/2198981/14092343/cfdc787a-f50b-11e5-8634-81931ece89e3.png)


