### PR TITLE
Treat large bytestrings separately in protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - conda install pytest coverage tornado toolz dill futures dask ipywidgets psutil bokeh requests joblib
   - pip install git+https://github.com/dask/dask.git --upgrade
   - pip install git+https://github.com/joblib/joblib.git --upgrade
-  - pip install s3fs
+  - pip install git+https://github.com/dask/s3fs.git --upgrade
 
   # Install distributed
   - python setup.py install

--- a/distributed/protocol.py
+++ b/distributed/protocol.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     import msgpack
 
-from toolz import first, keymap, identity
+from toolz import first, keymap, identity, merge
 
 from .utils import ignoring
 from .compatibility import unicode
@@ -96,6 +96,13 @@ def loads(frames):
 
 
 def dumps_msgpack(msg):
+    """ Dump msg into header and payload, both bytestrings
+
+    All of the message must be msgpack encodable
+
+    See Also:
+        loads_msgpack
+    """
     header = {}
     payload = msgpack.dumps(msg, use_bin_type=True)
 
@@ -114,7 +121,11 @@ def dumps_msgpack(msg):
 
 
 def loads_msgpack(header, payload):
-    """ Transform bytestream back into Python value """
+    """ Read msgpack header and payload back to Python object
+
+    See Also:
+        dumps_msgpack
+    """
     if header:
         header = msgpack.loads(header, encoding='utf8')
     else:
@@ -132,7 +143,16 @@ def loads_msgpack(header, payload):
 
 
 def dumps_big_byte_dict(d):
-    """ Serialize large byte dictionary to sequence of frames """
+    """ Serialize large byte dictionary to sequence of frames
+
+    The input must be a dictionary and all values of that dictionary must be
+    bytestrings.  These should probably be large.
+
+    Returns a sequence of frames, one header followed by each of the values
+
+    See Also:
+        loads_big_byte_dict
+    """
     assert isinstance(d, dict) and all(isinstance(v, bytes) for v in d.values())
     keys, values = zip(*d.items())
 
@@ -156,7 +176,11 @@ def dumps_big_byte_dict(d):
 
 
 def loads_big_byte_dict(header, *values):
-    """ Deserialize frames to large byte dictionary """
+    """ Deserialize big-byte frames to large byte dictionary
+
+    See Also:
+        dumps_big_byte_dict
+    """
     header = msgpack.loads(header, encoding='utf8')
 
     values2 = [compressions[c]['decompress'](v)

--- a/distributed/protocol.py
+++ b/distributed/protocol.py
@@ -77,11 +77,12 @@ def dumps(msg):
         header_bytes = msgpack.dumps(header, use_bin_type=True)
     else:
         header_bytes = b''
-    return header_bytes, payload
+    return [header_bytes] + payload
 
 
-def loads(header, payload):
+def loads(frames):
     """ Transform bytestream back into Python value """
+    header, payload = frames[0], frames[1:]
     if header:
         header = msgpack.loads(header, encoding='utf8')
     else:
@@ -90,7 +91,7 @@ def loads(header, payload):
     if header.get('compression'):
         try:
             decompress = compressions[header['compression']]['decompress']
-            payload = decompress(payload)
+            payload = list(map(decompress, payload))
         except KeyError:
             raise ValueError("Data is compressed as %s but we don't have this"
                     " installed" % header['compression'].decode())

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -99,10 +99,13 @@ def test_large_packets(loop):
         server.listen(8887)
 
         data = b'0' * int(200e6)  # slightly more than 100MB
-
         conn = rpc(ip='127.0.0.1', port=8887)
         result = yield conn.echo(x=data)
         assert result == data
+
+        d = {'x': data}
+        result = yield conn.echo(x=d)
+        assert result == d
 
         server.stop()
 

--- a/distributed/tests/test_protocol.py
+++ b/distributed/tests/test_protocol.py
@@ -5,7 +5,7 @@ import pytest
 
 def test_protocol():
     for msg in [1, 'a', b'a', {'x': 1}, {b'x': 1}, {}]:
-        assert loads(*dumps(msg)) == msg
+        assert loads(dumps(msg)) == msg
 
 
 def test_compression():


### PR DESCRIPTION
This tweaks the protocol to handle large bytestrings separately from normal data that gets passed to msgpack.

### TODO

- [x] rebase
- [x] document


### Script

```python
# myscript.py
from distributed import Worker, rpc, Scheduler

s = Scheduler()
s.start(8989)
w = Worker(s.ip, s.port)
w.listen()

import numpy as np
x = np.random.randint(0, 255, dtype='u1', size=1000000000)
w.data['x'] = x

from tornado.ioloop import IOLoop
from tornado import gen
IOLoop.current().run_sync(lambda: gen.sleep(0.5))
```

### IPython session

```python
In [1]: from myscript import *
distributed.scheduler - INFO - Start Scheduler at:        192.168.1.141:8989

In [2]: %prun IOLoop.current().run_sync(lambda: rpc(w.address).get_data(keys=['x']))
distributed.core - INFO - Connection from 192.168.1.141:41832 to Worker
```

### Profile results

```
         381811 function calls (381774 primitive calls) in 1.718 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.384    0.384    0.384    0.384 {built-in method dumps}
        8    0.309    0.039    0.311    0.039 iostream.py:360(write)
    15358    0.229    0.000    0.229    0.000 {method 'join' of 'bytes' objects}
        1    0.196    0.196    0.196    0.196 {built-in method LZ4_compress}
    15362    0.174    0.000    0.174    0.000 {method 'recv' of '_socket.socket' objects}
    15368    0.163    0.000    0.405    0.000 iostream.py:1510(_merge_prefix)
     7769    0.105    0.000    0.105    0.000 {method 'send' of '_socket.socket' objects}
        1    0.040    0.040    1.718    1.718 ioloop.py:746(start)
        8    0.020    0.002    0.205    0.026 iostream.py:876(_consume)
    15362    0.020    0.000    0.204    0.000 iostream.py:721(_read_to_buffer)
       98    0.018    0.000    0.347    0.004 iostream.py:827(_handle_write)
       96    0.014    0.000    0.222    0.002 iostream.py:585(_read_to_buffer_loop)
   122593    0.009    0.000    0.009    0.000 {built-in method len}
    15362    0.007    0.000    0.181    0.000 iostream.py:1010(read_from_fd)
     7769    0.004    0.000    0.108    0.000 iostream.py:1023(write_to_fd)
    38379    0.004    0.000    0.004    0.000 {method 'append' of 'list' objects}
    15278    0.002    0.000    0.002    0.000 iostream.py:754(_run_streaming_callback)
    46004    0.002    0.000    0.002    0.000 {method 'popleft' of 'collections.deque' objects}
    16213    0.002    0.000    0.002    0.000 iostream.py:478(closed)
        2    0.002    0.001    0.199    0.099 protocol.py:65(dumps)
      182    0.002    0.000    0.775    0.004 iostream.py:497(_handle_events)
    22904    0.002    0.000    0.002    0.000 {method 'append' of 'collections.deque' objects}
    23100    0.001    0.000    0.001    0.000 {method 'appendleft' of 'collections.deque' objects}
      207    0.001    0.000    1.675    0.008 stack_context.py:271(null_wrapper)
      188    0.001    0.000    0.001    0.000 {method 'poll' of 'select.epoll' objects}
      191    0.001    0.000    0.001    0.000 {method 'update' of 'dict' objects}
      372    0.000    0.000    0.001    0.000 ioloop.py:908(time)
      181    0.000    0.000    0.000    0.000 iostream.py:474(writing)
       92    0.000    0.000    0.427    0.005 iostream.py:645(_handle_read)
        1    0.000    0.000    0.385    0.385 core.py:43(dumps)
        1    0.000    0.000    0.197    0.197 protocol.py:134(dumps_big_byte_dict)
      374    0.000    0.000    0.000    0.000 {built-in method time}
      187    0.000    0.000    0.000    0.000 {built-in method min}
      199    0.000    0.000    0.000    0.000 iostream.py:772(_find_read_pos)
    17/14    0.000    0.000    0.897    0.064 gen.py:990(run)
```