### PR TITLE
Cleanup and reorganize docs

### DIFF
--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -48,8 +48,8 @@ class Progress(SchedulerPlugin):
     """ Tracks progress of a set of keys or futures
 
     On creation we provide a set of keys or futures that interest us as well as
-    a scheduler.  We traverse through the scheduler's depenedencies to find all
-    relevent keys on which our keys depend.  We then plug into the scheduler to
+    a scheduler.  We traverse through the scheduler's dependencies to find all
+    relevant keys on which our keys depend.  We then plug into the scheduler to
     learn when our keys become available in memory at which point we record
     their completion.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,9 +116,14 @@ todo_include_todos = True
 
 # -- Options for HTML output ----------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-html_theme = 'default'
+# Taken from docs.readthedocs.org:
+# on_rtd is whether we are on readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/executor.rst
+++ b/docs/source/executor.rst
@@ -155,7 +155,7 @@ This both resets the scheduler state and all of the worker processes.  All
 current data and computations will be lost.  All existing futures set their
 status to ``'cancelled'``.
 
-See :doc:`resilience <resilence>` for more information.
+See :doc:`resilience <resilience>` for more information.
 
 
 Internals

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,33 +41,34 @@ In particular it meets the following needs:
 Contents
 --------
 
-**User Documentation**
+.. toctree::
+   :maxdepth: 1
+   :caption: Getting Started
+
+   install
+   quickstart
+   setup
+   dec2
+   examples-overview
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
+   :caption: Using Distributed
 
-   quickstart
-   install
-   examples-overview
    executor
-   setup
    efficiency
    locality
-   api
-   web
    joblib
-
-**Developer Documentation**
+   api
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
+   :caption: Developer Documentation
 
    foundations
    worker-center
    scheduler
    resilience
    journey
-   protocol
    plugins
    related-work
-   dec2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,6 +67,7 @@ Contents
    :caption: Developer Documentation
 
    foundations
+   clients
    worker-center
    scheduler
    resilience

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,6 +49,7 @@ Contents
    quickstart
    setup
    dec2
+   web
    examples-overview
 
 .. toctree::
@@ -70,5 +71,6 @@ Contents
    scheduler
    resilience
    journey
+   protocol
    plugins
    related-work

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,5 +1,5 @@
-Install
-=======
+Install Distributed
+===================
 
 You can install distributed with ``conda``, with ``pip``, or by installing from
 source.

--- a/docs/source/joblib.rst
+++ b/docs/source/joblib.rst
@@ -43,3 +43,5 @@ as follows:
 
    with parallel_backend('distributed', scheduler_host='localhost:8786'):
        search.fit(digits.data, digits.target)
+
+.. _`Joblib`: https://pythonhosted.org/joblib/

--- a/docs/source/locality.rst
+++ b/docs/source/locality.rst
@@ -87,13 +87,13 @@ data.
 
 Valid arguments for ``workers=`` include the following:
 
-*   A single IP addresses, IP/Port pair, or hostname like the following::
+*  A single IP addresses, IP/Port pair, or hostname like the following::
 
-   192.168.1.100, 192.168.1.100:8989, alice, alice:8989
+      192.168.1.100, 192.168.1.100:8989, alice, alice:8989
 
 *  A list or set of the above::
 
-   ['alice'], ['192.168.1.100', '192.168.1.101:9999']
+      ['alice'], ['192.168.1.100', '192.168.1.101:9999']
 
 If only a hostname or IP is given then any worker on that machine will be
 considered valid.  Additionally, you can provide aliases to workers upon

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,7 +1,7 @@
 Scheduler Plugins
 =================
 
-.. autoclass:: distributed.diagnostics.SchedulerPlugin
+.. autoclass:: distributed.diagnostics.plugin.SchedulerPlugin
    :members:
 
 Progress Bar

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -3,8 +3,3 @@ Scheduler Plugins
 
 .. autoclass:: distributed.diagnostics.plugin.SchedulerPlugin
    :members:
-
-Progress Bar
-------------
-
-.. autofunction:: distributed.diagnostics.progress

--- a/docs/source/related-work.rst
+++ b/docs/source/related-work.rst
@@ -190,7 +190,6 @@ IPython Parallel has the following advantages over ``distributed``
     variety of helpful features like IPython interaction magics, ``@parallel``
     decorators, etc..
 
-.. _`IPython Parallel`: http://ipython.org/ipython-doc/dev/parallel/
 .. _`a recipe`: https://ipython.org/ipython-doc/3/parallel/dag_dependencies.html#dag-dependencies
 .. _dask: http://dask.pydata.org/en/latest/
 

--- a/docs/source/scheduler.rst
+++ b/docs/source/scheduler.rst
@@ -13,6 +13,4 @@ coroutines rounning in a single event loop.
 
 .. autoclass:: Scheduler
    :members:
-.. autofunction:: heal_missing_data
 .. autofunction:: decide_worker
-.. autofunction:: assign_many_tasks

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -5,8 +5,8 @@ A ``distributed`` network consists of one ``Scheduler`` node and several
 ``Worker`` nodes.  One can set these up in a variety of ways
 
 
-``dscheduler`` and ``dworker``
----------------------------
+Using the Command Line
+----------------------
 
 We launch the ``dscheduler`` executable in one process and the ``dworker``
 executable in several processes, possibly on different machines.
@@ -35,14 +35,9 @@ There are various mechanisms to deploy these executables on a cluster, ranging
 from manualy SSH-ing into all of the nodes to more automated systems like
 SGE/SLURM/Torque or Yarn/Mesos.
 
-EC2 Easy Startup Script
------------------------
 
-See the :doc:`EC2 quickstart <dec2>` for information on the ``dec2`` easy setup
-script to launch a canned cluster on EC2.
-
-``dcluster``
-------------
+Using SSH
+---------
 
 The convenience script ``dcluster`` opens several SSH connections to your
 target computers and initializes the network accordingly.  You can give it a
@@ -65,8 +60,8 @@ Or you can specify a hostfile that includes a list of hosts::
    $ dcluster --hostfile hostfile.txt
 
 
-``Scheduler`` and ``Worker`` objects
----------------------------------
+Using the Python API
+--------------------
 
 Alternatively you can start up the ``distributed.scheduler.Scheduler`` and
 ``distributed.worker.Worker`` objects within a Python session manually.  Both
@@ -104,6 +99,13 @@ and start one, possibly in a separate thread.
    from threading import Thread
    t = Thread(target=loop.start)
    t.start()
+
+
+Using Amazon EC2
+----------------
+
+See the :doc:`EC2 quickstart <dec2>` for information on the ``dec2`` easy setup
+script to launch a canned cluster on EC2.
 
 
 Cleanup


### PR DESCRIPTION
* Split TOC and sidebar into sections
* Set theme for local docs builds
* Cleanup `Setup Network` page
* Fix docs build warnings