### PR TITLE
Work Stealing

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -733,6 +733,8 @@ class Executor(object):
 
     @gen.coroutine
     def _scatter(self, data, workers=None, broadcast=False):
+        if isinstance(workers, str):
+            workers = [workers]
         if isinstance(data, dict) and not all(isinstance(k, (bytes, str))
                                                for k in data):
             d = yield self._scatter(keymap(tokey, data), workers, broadcast)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -215,6 +215,7 @@ class Scheduler(Server):
                          'ncores': self.get_ncores,
                          'has_what': self.get_has_what,
                          'who_has': self.get_who_has,
+                         'add_keys': self.add_keys,
                          'rebalance': self.rebalance}
 
         self.services = {}
@@ -247,6 +248,13 @@ class Scheduler(Server):
     @property
     def address_tuple(self):
         return (self.ip, self.port)
+
+    def add_keys(self, stream, address=None, keys=()):
+        address = coerce_to_address(address)
+        self.has_what[address].update(keys)
+        for key in keys:
+            self.who_has[key].add(address)
+        return 'OK'
 
     def identity(self, stream):
         """ Basic information about ourselves and our cluster """

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -389,7 +389,47 @@ class Scheduler(Server):
             self.ensure_idle_ready()
 
     def ensure_idle_ready(self):
-        """ Run ready tasks on idle workers """
+        """ Run ready tasks on idle workers
+
+        **Work stealing policy**
+
+        If some workers are idle but not others, if there are no globally ready
+        tasks, and if there are tasks in worker stacks then we start to pull
+        preferred tasks from overburdened workers and deploy them back into the
+        global pool in the following manner.
+
+        We determine the number of tasks to reclaim as the number of all tasks
+        in all stacks times the fraction of idle workers to all workers.  We
+        sort the stacks by size and walk through them, reclaiming half of each
+        stack until we have enough task to fill the global pool.  We are
+        careful not to reclaim tasks that are restricted to run on certain
+        workers.
+        """
+        if 0 < len(self.idle) < len(self.ncores) and not self.ready:
+            n = sum(map(len, self.stacks)) * len(self.idle) / len(self.ncores)
+
+            if not n:
+                return
+            stacks = sorted([(w, self.stacks[w]) for w in self.ncores
+                                                  if w not in self.idle],
+                            key=lambda kv: len(kv[1]), reverse=True)
+
+            for w, stack in stacks:
+                k = min(len(stack) // 2, len(stack) - self.ncores[w])
+                if k <= 0:
+                    continue
+                tasks = stack[:k]
+                good = [t for t in tasks if t not in self.restrictions]
+                bad = [t for t in tasks if t in self.restrictions]
+                del self.stacks[w][:k]
+                self.stacks[w][:0] = bad
+                self.ready.extend(good)
+
+                n -= len(good)
+
+                if n <= 0:
+                    break
+
         while self.idle and self.ready and self.ncores:
             worker = min(self.idle, key=lambda w: len(self.has_what[w]))
             self.ensure_occupied(worker)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -2494,3 +2494,12 @@ def test_workers_register_indirect_data(e, s, a, b):
     assert s.who_has[x.key] == {a.address, b.address}
     assert s.has_what[b.address] == {x.key, y.key}
     s.validate()
+
+
+@gen_cluster(executor=True, ncores=[('127.0.0.1', 4), ('127.0.0.2', 4)])
+def test_work_stealing(e, s, a, b):
+    [x] = yield e._scatter([1])
+    futures = e.map(slowadd, range(50), [x] * 50)
+    yield _wait(futures)
+    assert len(a.data) > 10
+    assert len(b.data) > 10

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -137,6 +137,8 @@ def test_compute_who_has(loop):
                          key='b')
         assert z.data['b'] == 2
 
+        if 'a' in z.data:
+            del z.data['a']
         yield zz.compute(function=dumps(inc),
                          args=dumps(('a',)),
                          who_has={'a': [y.address]},


### PR DESCRIPTION
Two major changes:

1.  Workers keep and report data that they've had to gather for tasks
2.  We add workstealing to the scheduler, reclaiming preferred tasks from overburdened workers