### PR TITLE
Improve PyPy support for tests

### DIFF
--- a/distributed/bokeh/status_monitor.py
+++ b/distributed/bokeh/status_monitor.py
@@ -15,14 +15,15 @@ from ..utils import ignoring, is_kernel, log_errors, key_split
 from ..executor import default_executor
 from ..scheduler import Scheduler
 
-with ignoring(ImportError):
+try:
     from bokeh.palettes import Spectral11
     from bokeh.models import (ColumnDataSource, FactorRange, DataRange1d,
             HoverTool)
     from bokeh.models.widgets import DataTable, TableColumn, NumberFormatter
     from bokeh.plotting import vplot, output_notebook, show, figure
     from bokeh.io import curstate, push_notebook
-
+except ImportError:
+    Spectral11 = None
 
 class Status_Monitor(object):
     """ Display the tasks running and waiting on each worker

--- a/distributed/bokeh/tests/test_status_monitor.py
+++ b/distributed/bokeh/tests/test_status_monitor.py
@@ -1,3 +1,8 @@
+from __future__ import print_function, division, absolute_import
+
+import pytest
+pytest.importorskip('bokeh')
+
 from distributed.bokeh.status_monitor import (worker_table_plot,
         worker_table_update, task_table_plot, task_table_update,
         task_stream_plot, task_stream_append, progress_plot)

--- a/distributed/bokeh/tests/test_worker_monitor.py
+++ b/distributed/bokeh/tests/test_worker_monitor.py
@@ -1,3 +1,8 @@
+from __future__ import print_function, division, absolute_import
+
+import pytest
+pytest.importorskip('bokeh')
+
 from collections import deque
 import datetime
 

--- a/distributed/cli/tests/test_dscheduler.py
+++ b/distributed/cli/tests/test_dscheduler.py
@@ -1,5 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
+import pytest
+pytest.importorskip('requests')
+
 import os
 import requests
 import signal
@@ -7,7 +10,6 @@ import socket
 from subprocess import Popen, PIPE
 from time import sleep, time
 
-import pytest
 
 from distributed import Scheduler, Executor
 from distributed.utils import get_ip, ignoring

--- a/distributed/cli/tests/test_dworker.py
+++ b/distributed/cli/tests/test_dworker.py
@@ -1,5 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
+import pytest
+pytest.importorskip('requests')
+
 import os
 import requests
 from subprocess import Popen, PIPE

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -159,6 +159,7 @@ def test_AllProgress(e, s, a, b):
 
     for i in range(4):
         future = e.submit(f, i)
+    import gc; gc.collect()
 
     yield gen.sleep(1)
 

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -1,5 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
+import pytest
+pytest.importorskip('ipywidgets')
+
 from ipykernel.comm import Comm
 import ipywidgets as widgets
 from ipywidgets import Widget

--- a/distributed/http/tests/test_scheduler_http.py
+++ b/distributed/http/tests/test_scheduler_http.py
@@ -10,6 +10,7 @@ from tornado.httpserver import HTTPServer
 
 from distributed import Scheduler, Executor
 from distributed.executor import _wait
+from distributed.sizeof import getsizeof
 from distributed.utils_test import gen_cluster, gen_test, inc, div
 from distributed.http.scheduler import HTTPScheduler
 from distributed.http.worker import HTTPWorker
@@ -123,7 +124,7 @@ def test_with_data(e, s, a, b):
 
     assert all(isinstance(v, int) for v in out.values())
     assert set(out) == {a.address, b.address}
-    assert sum(out.values()) == sum(map(sys.getsizeof,
+    assert sum(out.values()) == sum(map(getsizeof,
                                         [1, 2, 3, 'Hello', 'world!']))
 
     response = yield client.fetch('http://localhost:%s/memory-load-by-key.json'
@@ -135,7 +136,7 @@ def test_with_data(e, s, a, b):
     assert all(isinstance(v, int) for d in out.values() for v in d.values())
 
     assert sum(v for d in out.values() for v in d.values()) == \
-            sum(map(sys.getsizeof, [1, 2, 3, 'Hello', 'world!']))
+            sum(map(getsizeof, [1, 2, 3, 'Hello', 'world!']))
 
     ss.stop()
 

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -2509,3 +2509,15 @@ def test_work_stealing(e, s, a, b):
     yield _wait(futures)
     assert len(a.data) > 10
     assert len(b.data) > 10
+
+
+@gen_cluster(executor=True)
+def test_submit_on_cancelled_future(e, s, a, b):
+    x = e.submit(inc, 1)
+    yield x._result()
+
+    yield e._cancel(x)
+
+    y = e.submit(inc, x)
+    yield _wait(y)
+    assert y.cancelled()

--- a/distributed/tests/test_s3.py
+++ b/distributed/tests/test_s3.py
@@ -1,9 +1,11 @@
 from __future__ import print_function, division, absolute_import
 
+import pytest
+pytest.importorskip('s3fs')
+
 import io
 import json
 from math import ceil
-import pytest
 
 import boto3
 from tornado import gen

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -4,15 +4,15 @@ import sys
 
 import pytest
 
-from distributed.sizeof import sizeof
+from distributed.sizeof import sizeof, getsizeof
 
 
 def test_base():
-    assert sizeof(1) == sys.getsizeof(1)
+    assert sizeof(1) == getsizeof(1)
 
 
 def test_containers():
-    assert sizeof([1, 2, [3]]) > (sys.getsizeof(3) * 3 + sys.getsizeof([]))
+    assert sizeof([1, 2, [3]]) > (getsizeof(3) * 3 + getsizeof([]))
 
 
 def test_numpy():

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+from numbers import Integral
 from operator import add
 import os
 import shutil
@@ -72,7 +73,7 @@ def test_worker(loop):
         assert c.who_has['x'] == {a.address}
         assert isinstance(response['compute-start'], float)
         assert isinstance(response['compute-stop'], float)
-        assert isinstance(response['thread'], int)
+        assert isinstance(response['thread'], Integral)
 
         response = yield bb.compute(key='y',
                                     function=dumps(add),


### PR DESCRIPTION
This involves the following changes:

1.  Use sys.getsizeof hack if not available
2.  Skip imports more aggressively for optional libraries
3.  Be more careful with abstract types