### PR TITLE
Tree scatter

### DIFF
--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1848,6 +1848,13 @@ def test__broadcast(e, s, a, b):
     assert a.data == b.data == {x.key: 1, y.key: 2}
 
 
+@gen_cluster(executor=True, ncores=[('127.0.0.1', 1)] * 4)
+def test__broadcast_integer(e, s, *workers):
+    x, y = yield e._scatter([1, 2], broadcast=2)
+    assert len(s.who_has[x.key]) == 2
+    assert len(s.who_has[y.key]) == 2
+
+
 @gen_cluster(executor=True)
 def test__broadcast_dict(e, s, a, b):
     d = yield e._scatter({'x': 1}, broadcast=True)


### PR DESCRIPTION
When scattering out large data to all nodes we now scatter to one node and then start a tree-based data sharing system where two nodes gather from the single node, then six nodes gather from all of those, etc..

This isn't maximally efficient for the following reasons:

1.  We wait until the full dataset is moved rather than sharing bits and pieces a la bittorrent
2.  We fully reserialize and deserialize the data on each worker for each transmission
3.  We do this in a bulk synchronous way instead of triggering new transfers after every small transfer completes.

Still, it should be much nicer than the one-to-all solution we had before.

cc @broxtronix 