### PR TITLE
Expose replication to users through Executor

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -217,7 +217,8 @@ class Scheduler(Server):
                          'has_what': self.get_has_what,
                          'who_has': self.get_who_has,
                          'add_keys': self.add_keys,
-                         'rebalance': self.rebalance}
+                         'rebalance': self.rebalance,
+                         'replicate': self.replicate}
 
         self.services = {}
         for k, v in (services or {}).items():
@@ -1575,6 +1576,9 @@ class Scheduler(Server):
                 n = len(self.ncores)
             n = min(n, len(self.ncores))
             keys = set(keys)
+
+            if n == 0:
+                raise ValueError("Can not use replicate to delete data")
 
             if not keys.issubset(self.who_has):
                 raise Return({'status': 'missing-data',

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -2557,6 +2557,27 @@ def test_replicate_workers(e, s, *workers):
     assert sum(a.key in w.data for w in workers[5:]) == 0
     assert sum(b.key in w.data for w in workers[5:]) == 0
 
+    yield s.replicate(keys=[a.key, b.key], n=1)
+
+    assert len(s.who_has[a.key]) == 1
+    assert len(s.who_has[b.key]) == 1
+    assert sum(a.key in w.data for w in workers) == 1
+    assert sum(b.key in w.data for w in workers) == 1
+
+    s.validate()
+
+    yield s.replicate(keys=[a.key, b.key], n=None) # all
+    assert len(s.who_has[a.key]) == 10
+    assert len(s.who_has[b.key]) == 10
+    s.validate()
+
+    yield s.replicate(keys=[a.key, b.key], n=1,
+                      workers=[w.address for w in workers[:5]])
+    assert sum(a.key in w.data for w in workers[:5]) == 1
+    assert sum(b.key in w.data for w in workers[:5]) == 1
+    assert sum(a.key in w.data for w in workers[5:]) == 5
+    assert sum(b.key in w.data for w in workers[5:]) == 5
+
 
 class CountSerialization(object):
     def __init__(self):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -14,8 +14,10 @@ API
    Executor.get
    Executor.has_what
    Executor.map
-   Executor.persist
    Executor.ncores
+   Executor.persist
+   Executor.rebalance
+   Executor.replicate
    Executor.restart
    Executor.run
    Executor.scatter


### PR DESCRIPTION
Examples
--------

```python
>>> x = e.submit(func, *args) 
>>> e.replicate([x])  # send to all workers
>>> e.replicate([x], n=3)  # send to three workers
>>> e.replicate([x], workers=['alice', 'bob'])  # send to specific workers
>>> e.replicate([x], n=1, workers=['alice', 'bob'])  # send to one of specific workers
>>> e.replicate([x], n=1)  # reduce replications
```