### PR TITLE
Fast adapt

### DIFF
--- a/distributed/bokeh/status_monitor.py
+++ b/distributed/bokeh/status_monitor.py
@@ -207,8 +207,8 @@ def incrementing_index(o):
 
 
 def task_stream_append(lists, msg, workers, palette=Spectral11):
-    lists['start'].append(msg['compute-start'] * 1000)
-    lists['duration'].append(1000 * (msg['compute-stop']-msg['compute-start']))
+    lists['start'].append(msg['compute_start'] * 1000)
+    lists['duration'].append(1000 * (msg['compute_stop']-msg['compute_start']))
     key = msg['key']
     name = key_split(key)
     if msg['status'] == 'OK':
@@ -226,10 +226,10 @@ def task_stream_append(lists, msg, workers, palette=Spectral11):
         workers[worker_thread] = len(workers)
     lists['y'].append(workers[worker_thread])
 
-    if 'transfer-start' in msg:
-        lists['start'].append(msg['transfer-start'] * 1000)
-        lists['duration'].append(1000 * (msg['transfer-stop'] -
-                                        msg['transfer-start']))
+    if msg.get('transfer_start') is not None:
+        lists['start'].append(msg['transfer_start'] * 1000)
+        lists['duration'].append(1000 * (msg['transfer_stop'] -
+                                        msg['transfer_start']))
 
         lists['key'].append(key)
         lists['name'].append('transfer-to-' + name)

--- a/distributed/bokeh/tasks/server_lifecycle.py
+++ b/distributed/bokeh/tasks/server_lifecycle.py
@@ -49,11 +49,11 @@ def task_events(interval, deque, times, index, rectangles, workers, last_seen):
 
                 last_seen[0] = time()
                 for msg in msgs:
-                    if 'compute-start' in msg:
+                    if 'compute_start' in msg:
                         deque.append(msg)
-                        times.append(msg['compute-start'])
+                        times.append(msg['compute_start'])
                         index.append(i); i += 1
-                        if 'transfer-start' in msg:
+                        if msg.get('transfer_start') is not None:
                             index.append(i); i += 1
                         task_stream_append(rectangles, msg, workers)
 

--- a/distributed/bokeh/tests/test_status_monitor.py
+++ b/distributed/bokeh/tests/test_status_monitor.py
@@ -47,14 +47,14 @@ def test_task_stream_plot():
 
 
 def test_task_stream_append():
-    msgs = [{'status': 'OK', 'compute-start': 10, 'compute-stop': 20,
+    msgs = [{'status': 'OK', 'compute_start': 10, 'compute_stop': 20,
              'key':'inc-1', 'thread': 5855, 'worker':'127.0.0.1:9999'},
-            {'status': 'OK', 'compute-start': 15, 'compute-stop': 25,
+            {'status': 'OK', 'compute_start': 15, 'compute_stop': 25,
              'key':'inc-2', 'thread': 6000, 'worker':'127.0.0.1:9999'},
-            {'status': 'error', 'compute-start': 10, 'compute-stop': 14,
+            {'status': 'error', 'compute_start': 10, 'compute_stop': 14,
              'key':'inc-3', 'thread': 6000, 'worker':'127.0.0.1:9999'},
-            {'status': 'OK', 'compute-start': 10, 'compute-stop': 30,
-             'transfer-start': 8, 'transfer-stop': 10,
+            {'status': 'OK', 'compute_start': 10, 'compute_stop': 30,
+             'transfer_start': 8, 'transfer_stop': 10,
              'key':'add-1', 'thread': 4000, 'worker':'127.0.0.2:9999'}]
 
     lists = {name: [] for name in

--- a/distributed/diagnostics/eventstream.py
+++ b/distributed/diagnostics/eventstream.py
@@ -46,8 +46,8 @@ def eventstream(address, interval):
     form::
 
         {'key': 'mykey', 'worker': 'host:port', 'status': status,
-         'compute-start': time(), 'compute-stop': time(),
-         'transfer-start': time(), 'transfer-stop': time(),
+         'compute_start': time(), 'compute_stop': time(),
+         'transfer_start': time(), 'transfer_stop': time(),
          'other': 'junk'}
 
     Where ``status`` is either 'OK', or 'error'

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -634,8 +634,8 @@ class Scheduler(Server):
                 gap > max(10e-3, info.get('latency', 0), old_duration)):
                 avg_duration = new_duration
             else:
-                avg_duration = (0.95 * old_duration
-                              + 0.05 * new_duration)
+                avg_duration = (0.5 * old_duration
+                              + 0.5 * new_duration)
 
             info['avg-task-duration'] = avg_duration
             info['last-task'] = compute_stop
@@ -1345,7 +1345,7 @@ class Scheduler(Server):
         delay = (end_time + start_time) / 2 - d['time']
         try:
             avg_delay = self.host_info[host]['time-delay']
-            avg_delay = (0.95 * avg_delay + 0.05 * delay)
+            avg_delay = (0.90 * avg_delay + 0.10 * delay)
         except KeyError:
             avg_delay = delay
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -616,33 +616,46 @@ class Scheduler(Server):
             self.mark_failed(dep, failing_key)
 
     def mark_task_finished(self, key=None, worker=None, nbytes=None, type=None,
-            **kwargs):
+            compute_start=None, compute_stop=None, transfer_start=None,
+            transfer_stop=None, **kwargs):
         """ Mark that a task has finished execution on a particular worker """
         logger.debug("Mark task as finished %s, %s", key, worker)
         if worker in self.processing and key in self.processing[worker]:
             self.nbytes[key] = nbytes
             self.mark_key_in_memory(key, [worker], type=type)
             self.maybe_ready.add(worker)
-            # self.ensure_occupied(worker)
-            self.worker_info[worker]['last-task'] = time()
-            try:
-                self.worker_info[worker]['avg-task-duration'] = (
-                    0.95 * self.worker_info[worker]['avg-task-duration'] +
-                    0.05 * (kwargs['compute_stop'] - kwargs['compute_start']))
-            except KeyError:
-                pass
+
+            # Update average task duration for worker
+            info = self.worker_info[worker]
+            gap = (transfer_start or compute_start) - info.get('last-task', 0)
+            old_duration = info.get('avg-task-duration', 0)
+            new_duration = compute_stop - compute_start
+            if (not old_duration or
+                gap > max(10e-3, info.get('latency', 0), old_duration)):
+                avg_duration = new_duration
+            else:
+                avg_duration = (0.95 * old_duration
+                              + 0.05 * new_duration)
+
+            info['avg-task-duration'] = avg_duration
+            info['last-task'] = compute_stop
             for plugin in self.plugins[:]:
                 try:
                     plugin.task_finished(self, key=key, worker=worker,
-                            nbytes=nbytes, type=type, **kwargs)
+                            nbytes=nbytes, type=type,
+                            compute_start=compute_start,
+                            compute_stop=compute_stop,
+                            transfer_start=transfer_start,
+                            transfer_stop=transfer_stop,
+                            **kwargs)
+
+
                 except Exception as e:
                     logger.exception(e)
         else:
             logger.debug("Key not found in processing, %s, %s, %s",
                          key, worker, self.processing[worker])
             self.maybe_ready.add(worker)
-            # self.ensure_occupied(worker)
-        # self.validate(allow_overlap=True, allow_bad_stacks=True)
 
     def recover_missing(self, key):
         """ Recover a recently lost piece of data
@@ -805,7 +818,6 @@ class Scheduler(Server):
 
         info['name'] = name
         self.worker_info[address] = info
-        self.worker_info[address]['avg-task-duration'] = 1.0
 
         if address not in self.processing:
             self.has_what[address] = set()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -628,7 +628,7 @@ class Scheduler(Server):
             try:
                 self.worker_info[worker]['avg-task-duration'] = (
                     0.95 * self.worker_info[worker]['avg-task-duration'] +
-                    0.05 * (kwargs['compute-stop'] - kwargs['compute-start']))
+                    0.05 * (kwargs['compute_stop'] - kwargs['compute_start']))
             except KeyError:
                 pass
             for plugin in self.plugins[:]:
@@ -1217,8 +1217,8 @@ class Scheduler(Server):
         """
         if 'time-delay' in self.host_info[worker]:
             delay = self.host_info[worker]['time-delay']
-            for key in ['transfer-start', 'transfer-stop', 'time', 'compute-start',
-                    'compute-stop']:
+            for key in ['transfer_start', 'transfer_stop', 'time',
+                        'compute_start', 'compute_stop']:
                 if key in msg:
                     msg[key] += delay
 

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -432,9 +432,9 @@ def test_recompute_released_key(e, s, a, b):
     assert result1 == result2
 
 
-def slowinc(x):
+def slowinc(x, delay=0.02):
     from time import sleep
-    sleep(0.02)
+    sleep(delay)
     return x + 1
 
 
@@ -2661,3 +2661,22 @@ def test_task_load(e, s, a):
     assert 0.0001 < s.worker_info[a.address]['avg-task-duration'] < 0.2
 
     assert 4 < s.task_load(a.address) < 100
+
+
+@gen_cluster(executor=True, ncores=[('127.0.0.1', 4)] * 1)
+def test_task_load_adapts_quickly(e, s, a):
+    future = e.submit(inc, 1)  # very fast
+    yield _wait(future)
+    assert 0 < s.worker_info[a.address]['avg-task-duration'] < 0.1
+
+    yield gen.sleep(0.200)  # a sizable gap, compared to latency and task time
+
+    future = e.submit(slowinc, 1, delay=0.500)  # slowish
+    yield _wait(future)
+    assert 0.45 < s.worker_info[a.address]['avg-task-duration'] < 1
+
+    yield gen.sleep(0.200)  # a not-so-sizable gap, compared to task time
+
+    future = e.submit(inc, 2)  # fast but soon, defers to old average
+    yield _wait(future)
+    assert 0.3 < s.worker_info[a.address]['avg-task-duration'] < 1

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -2664,7 +2664,7 @@ def test_task_load(e, s, a):
 
 
 @gen_cluster(executor=True, ncores=[('127.0.0.1', 4)] * 1)
-def test_task_load_adapts_quickly(e, s, a):
+def test_task_load_adapts_quickly_after_delay(e, s, a):
     future = e.submit(inc, 1)  # very fast
     yield _wait(future)
     assert 0 < s.worker_info[a.address]['avg-task-duration'] < 0.1
@@ -2679,4 +2679,4 @@ def test_task_load_adapts_quickly(e, s, a):
 
     future = e.submit(inc, 2)  # fast but soon, defers to old average
     yield _wait(future)
-    assert 0.3 < s.worker_info[a.address]['avg-task-duration'] < 1
+    assert 0.2 < s.worker_info[a.address]['avg-task-duration'] < 1

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -55,7 +55,8 @@ def test_update_state(loop):
                    dependencies={'y': 'x', 'x': set()},
                    client='client')
 
-    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int),
+            compute_start=10, compute_stop=11)
     s.ensure_occupied(alice)
 
     assert s.processing[alice] == {'y'}
@@ -93,7 +94,8 @@ def test_update_state_with_processing(loop):
                    dependencies={'y': {'x'}, 'x': set(), 'z': {'y'}},
                    client='client')
 
-    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int),
+            compute_start=10, compute_stop=11)
     s.ensure_occupied(alice)
 
     assert s.waiting == {'z': {'y'}}
@@ -131,9 +133,11 @@ def test_update_state_respects_data_in_memory(loop):
                    dependencies={'y': {'x'}, 'x': set()},
                    client='client')
 
-    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int),
+                         compute_start=10, compute_stop=11)
     s.ensure_occupied(alice)
-    s.mark_task_finished('y', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('y', alice, nbytes=10, type=dumps(int),
+                         compute_start=11, compute_stop=12)
     s.ensure_occupied(alice)
 
     assert s.released == {'x'}
@@ -163,11 +167,14 @@ def test_update_state_supports_recomputing_released_results(loop):
                    dependencies={'y': {'x'}, 'x': set(), 'z': {'y'}},
                    client='client')
 
-    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('x', alice, nbytes=10, type=dumps(int),
+                         compute_start=10, compute_stop=11)
     s.ensure_occupied(alice)
-    s.mark_task_finished('y', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('y', alice, nbytes=10, type=dumps(int),
+                         compute_start=10, compute_stop=11)
     s.ensure_occupied(alice)
-    s.mark_task_finished('z', alice, nbytes=10, type=dumps(int))
+    s.mark_task_finished('z', alice, nbytes=10, type=dumps(int),
+                         compute_start=10, compute_stop=11)
     s.ensure_occupied(alice)
 
     assert not s.waiting

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -71,8 +71,8 @@ def test_worker(loop):
         assert response['status'] == 'OK'
         assert a.data['x'] == 3
         assert c.who_has['x'] == {a.address}
-        assert isinstance(response['compute-start'], float)
-        assert isinstance(response['compute-stop'], float)
+        assert isinstance(response['compute_start'], float)
+        assert isinstance(response['compute_stop'], float)
         assert isinstance(response['thread'], Integral)
 
         response = yield bb.compute(key='y',
@@ -83,8 +83,8 @@ def test_worker(loop):
         assert b.data['y'] == 13
         assert c.who_has['y'] == {b.address}
         assert response['nbytes'] == sizeof(b.data['y'])
-        assert isinstance(response['transfer-start'], float)
-        assert isinstance(response['transfer-stop'], float)
+        assert isinstance(response['transfer_start'], float)
+        assert isinstance(response['transfer_stop'], float)
 
         def bad_func():
             1 / 0

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -289,9 +289,9 @@ class Worker(Server):
         if who_has:
             try:
                 logger.info("gather %d keys from peers", len(who_has))
-                diagnostics['transfer-start'] = time()
+                diagnostics['transfer_start'] = time()
                 other = yield gather_from_workers(who_has)
-                diagnostics['transfer-stop'] = time()
+                diagnostics['transfer_stop'] = time()
                 self.data.update(other)
                 yield self.center.add_keys(address=self.address,
                                            keys=list(other))
@@ -407,8 +407,8 @@ class Worker(Server):
                                  for msg in good])
 
             if results and num_transferred:
-                results[0]['transfer-start'] = transfer_start
-                results[0]['transfer-stop'] = transfer_end
+                results[0]['transfer_start'] = transfer_start
+                results[0]['transfer_stop'] = transfer_end
 
             for msg in results:
                 bstream.send(msg)
@@ -712,7 +712,7 @@ def apply_function(function, args, kwargs):
                'type': dumps_function(type(result)) if result is not None else None}
     finally:
         end = time()
-    msg['compute-start'] = start
-    msg['compute-stop'] = end
+    msg['compute_start'] = start
+    msg['compute_stop'] = end
     msg['thread'] = current_thread().ident
     return msg


### PR DESCRIPTION
We reset the average task time to gaps in received tasks.  This occurs when we shift from short tasks to long tasks or when we start a new computation.