### PR TITLE
Changed queue_to_iterator to pass StopIteration instances.

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -523,8 +523,8 @@ class Executor(object):
         while True:
             try:
                 args = [get(q) for q in qs_in]
-            except StopIteration:
-                q_out.put(StopIteration)
+            except StopIteration as e:
+                q_out.put(e)
                 break
             f = self.submit(func, *args, **kwargs)
             q_out.put(f)
@@ -781,9 +781,8 @@ class Executor(object):
             else:
                 try:
                     L = [next(q_or_i)]
-                except StopIteration:
-                    L = [StopIteration]
-                    qout.put(StopIteration)
+                except StopIteration as e:
+                    qout.put(e)
                     break
 
             futures = self.scatter(L, **kwargs)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -270,8 +270,8 @@ def truncate_exception(e, n=10000):
 def queue_to_iterator(q):
     while True:
         result = q.get()
-        if result == StopIteration:
-            break
+        if isinstance(result, StopIteration):
+            raise result
         yield result
 
 def _dump_to_queue(seq, q):


### PR DESCRIPTION
Now, instead of passing the StopIteration class to signal the end of the queue, we will pass a  StopIteration instance. Since in many cases, this queue is populated by some upstream iterator, we can simple pass the StopIteration that iterator issued downstream.

I updated the current test which checks that scattering StopIteration doesn't break, now it also scatters a StopIteration instance.

I also added another test which checks that indeed the proper StopIteration (with args) is being raised downstream.