### PR TITLE
Write atomically

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -270,10 +270,12 @@ def write(stream, msg):
 
         lengths = ([struct.pack('Q', len(frames))] +
                    [struct.pack('Q', len(frame)) for frame in frames])
-        yield stream.write(b''.join(lengths))
+        stream.write(b''.join(lengths))
 
-        for frame in frames:
-            yield stream.write(frame)
+        for frame in frames[:-1]:
+            stream.write(frame)
+
+        yield stream.write(frames[-1])
 
 
 def pingpong(stream):


### PR DESCRIPTION
This avoids multiple yields when writing to an outgoing socket.

This lacks a test

Fixes #282