### PR TITLE
Never call scheduler.sync_center

### DIFF
--- a/distributed/cli/dscheduler.py
+++ b/distributed/cli/dscheduler.py
@@ -48,8 +48,6 @@ def main(center, host, port, http_port, bokeh_port, show, _bokeh, bokeh_whitelis
     loop = IOLoop.current()
     scheduler = Scheduler(center, ip=ip,
                           services={('http', http_port): HTTPScheduler})
-    if center:
-        loop.run_sync(scheduler.sync_center)
     scheduler.start(port)
 
     if _bokeh:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -99,9 +99,6 @@ def run_scheduler(q, center_port=None, **kwargs):
     center = ('127.0.0.1', center_port) if center_port else None
     scheduler = Scheduler(center=center, **kwargs)
     scheduler.listen(0)
-
-    if center_port:
-        loop.run_sync(scheduler.sync_center)
     done = scheduler.start(0)
 
     q.put(scheduler.port)


### PR DESCRIPTION
`scheduler.sync_center` has been removed is the latest scheduler refactoring but there were 2 occurrences remaining in the code base.