### PR TITLE
Adding paramiko to docs when SSH is used

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -21,7 +21,8 @@ Set up a fake cluster on your local computer::
    $ dworker 127.0.0.1:8786
 
 Or if you can ssh into your own computer (or others) then use the ``dcluster``
-command, providing hostnames or IP addresses::
+command, providing hostnames or IP addresses (`paramiko` library must 
+be installed. See SSH :doc:`setup <setup>`)::
 
    $ dcluster 127.0.0.1 127.0.0.1 127.0.0.1 127.0.0.1
 

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -39,9 +39,12 @@ SGE/SLURM/Torque or Yarn/Mesos.
 Using SSH
 ---------
 
+For this functionality, `paramiko` library must be installed (e.g. by 
+running `pip install paramiko`).
+
 The convenience script ``dcluster`` opens several SSH connections to your
-target computers and initializes the network accordingly.  You can give it a
-list of hostnames or IP addresses::
+target computers and initializes the network accordingly. You can 
+give it a list of hostnames or IP addresses::
 
    $ dcluster 192.168.0.1 192.168.0.2 192.168.0.3 192.168.0.4
 


### PR DESCRIPTION
Just mentioning `paramiko` in docs when SSH is used.

Solves https://github.com/dask/distributed/issues/292#issuecomment-221884674.