### PR TITLE
Make scheduler functions robust to forgotten tasks

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -38,7 +38,6 @@ class BatchedSend(object):
         self.loop = loop or IOLoop.current()
         self.interval = interval / 1000.
         self.last_transmission = 0
-        self.next_send = None
         self.buffer = []
         self.stream = None
         self.last_send = gen.sleep(0)
@@ -59,7 +58,7 @@ class BatchedSend(object):
             yield self.last_send
             self.buffer, payload = [], self.buffer
             self.last_transmission = now
-            self.next_send = write(self.stream, payload)
+            self.last_send = write(self.stream, payload)
         except Exception as e:
             logger.exception(e)
 

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -95,9 +95,10 @@ class BatchedSend(object):
 
             self.buffer.append(msg)
             self.loop.add_callback(self.send_next, wait=False)
+        except StreamClosedError:
+            raise
         except Exception as e:
             logger.exception(e)
-            raise
 
     @gen.coroutine
     def close(self, ignore_closed=False):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -812,7 +812,6 @@ class Scheduler(Server):
 
         if key in self.processing[worker]:
             self.mark_key_in_memory(key, [worker], type=type)
-            self.maybe_idle.add(worker)
 
             for plugin in self.plugins[:]:
                 try:

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -877,8 +877,8 @@ def test_pragmatic_move_small_data_to_large_data(e, s, a, b):
 
     yield _wait(results)
 
-    for l, r in zip(lists, results):
-        assert s.who_has[l.key] == s.who_has[r.key]
+    assert sum(s.who_has[l.key] == s.who_has[r.key]
+               for l, r in zip(lists, results)) >= 8
 
 
 @gen_cluster(executor=True)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -26,7 +26,7 @@ from distributed.executor import (Executor, Future, CompatibleExecutor, _wait,
 from distributed.scheduler import Scheduler
 from distributed.sizeof import sizeof
 from distributed.utils import sync, tmp_text
-from distributed.utils_test import (cluster, slow,
+from distributed.utils_test import (cluster, slow, slowinc, slowadd, randominc,
         _test_scheduler, loop, inc, dec, div, throws,
         gen_cluster, gen_test, double, deep)
 
@@ -430,25 +430,6 @@ def test_recompute_released_key(e, s, a, b):
     assert x.key in e.futures
     result2 = yield x._result()
     assert result1 == result2
-
-
-def slowinc(x, delay=0.02):
-    from time import sleep
-    sleep(delay)
-    return x + 1
-
-
-def randominc(x, scale=1):
-    from time import sleep
-    from random import random
-    sleep(random() * scale)
-    return x + 1
-
-
-def slowadd(x, y):
-    from time import sleep
-    sleep(0.02)
-    return x + y
 
 
 @pytest.mark.parametrize(('func', 'n'), [(slowinc, 100), (inc, 1000)])

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -60,6 +60,7 @@ def test_update_state(loop):
     s.ensure_occupied(alice)
 
     assert set(s.processing[alice]) == {'y'}
+    assert set(s.rprocessing['y']) == {alice}
     assert not s.ready
     assert s.who_wants == {'y': {'client'}}
     assert s.wants_what == {'client': {'y'}}
@@ -151,6 +152,7 @@ def test_update_state_respects_data_in_memory(loop):
     assert s.released == set()
     assert s.waiting == {'z': {'x'}}
     assert set(s.processing[alice]) == {'x'}  # x was released need to recompute
+    assert set(s.rprocessing['x']) == {alice}  # x was released need to recompute
     assert s.waiting_data == {'x': {'z'}, 'y': {'z'}, 'z': set()}
     assert s.who_wants == {'y': {'client'}, 'z': {'client'}}
     assert s.wants_what == {'client': {'y', 'z'}}

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -15,6 +15,7 @@ from threading import Thread
 from dask import istask
 from toolz import memoize, valmap
 from tornado import gen
+from tornado.iostream import StreamClosedError
 
 from .compatibility import Queue, PY3
 
@@ -203,7 +204,7 @@ def key_split(s):
 def log_errors(pdb=False):
     try:
         yield
-    except gen.Return:
+    except (StreamClosedError, gen.Return):
         raise
     except Exception as e:
         logger.exception(e)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -62,6 +62,25 @@ def double(x):
     return x * 2
 
 
+def slowinc(x, delay=0.02):
+    from time import sleep
+    sleep(delay)
+    return x + 1
+
+
+def randominc(x, scale=1):
+    from time import sleep
+    from random import random
+    sleep(random() * scale)
+    return x + 1
+
+
+def slowadd(x, y):
+    from time import sleep
+    sleep(0.02)
+    return x + y
+
+
 def run_center(q):
     from distributed import Center
     from tornado.ioloop import IOLoop, PeriodicCallback

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -164,7 +164,7 @@ class Worker(Server):
                 resp = yield self.center.register(
                         ncores=self.ncores, address=(self.ip, self.port),
                         keys=list(self.data), services=self.service_ports,
-                        name=self.name)
+                        name=self.name, nbytes=valmap(sizeof, self.data))
                 break
             except (OSError, StreamClosedError):
                 logger.debug("Unable to register with scheduler.  Waiting")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -459,7 +459,7 @@ class Worker(Server):
                     "args:     %s\n"
                     "kwargs:   %s\n",
                     str(funcname(function))[:1000], str(args)[:1000],
-                    str(kwargs)[:1000], exc_info=True)
+                    str(kwargs)[:1000])
 
             logger.debug("Send compute response to scheduler: %s, %s", key,
                          result)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -433,6 +433,7 @@ class Worker(Server):
                 emsg['key'] = key
                 raise Return(emsg)
 
+            self.active.add(key)
             # Fill args with data
             args2 = pack_data(args, data)
             kwargs2 = pack_data(kwargs, data)


### PR DESCRIPTION
The scheduler would fail in some cases when completed tasks arrived back from workers after a client had cancelled them.