### PR TITLE
Better check for Windows platform when finding bokeh

### DIFF
--- a/distributed/cli/dscheduler.py
+++ b/distributed/cli/dscheduler.py
@@ -60,7 +60,7 @@ def main(center, host, port, http_port, bokeh_port, show, _bokeh, bokeh_whitelis
             dirname = os.path.dirname(distributed.__file__)
             paths = [os.path.join(dirname, 'bokeh', name)
                      for name in ['status', 'tasks']]
-            binname = 'bokeh.bat' if 'win' in sys.platform else 'bokeh'
+            binname = 'bokeh.bat' if sys.platform.startswith('win') else 'bokeh'
             binname = os.path.join(os.path.dirname(sys.argv[0]), binname)
             args = ([binname, 'serve'] + paths +
                     ['--log-level', 'warning',


### PR DESCRIPTION
Slight modification to #270 -- both `darwin` and `cygwin` match `if 'win' in sys.platform`, so instead check for `'win'` as a prefix.