### PR TITLE
Various small changes

### DIFF
--- a/distributed/cli/dscheduler.py
+++ b/distributed/cli/dscheduler.py
@@ -67,7 +67,7 @@ def main(center, host, port, http_port, bokeh_port, show, _bokeh, bokeh_whitelis
                      '--check-unused-sessions=50',
                      '--unused-session-lifetime=1',
                      '--port', str(bokeh_port)] +
-                     sum([['--host', host] for host in hosts], []))
+                     sum([['--host', h] for h in hosts], []))
             if show:
                 args.append('--show')
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -317,7 +317,7 @@ def send_recv(stream=None, arg=None, ip=None, port=None, addr=None, reply=True, 
         assert not ip and not port
         if PY3 and isinstance(addr, bytes):
             addr = addr.decode()
-        ip, port = addr.split(':')
+        ip, port = addr.rsplit(':', 1)
         port = int(port)
     if PY3 and isinstance(ip, bytes):
         ip = ip.decode()
@@ -379,7 +379,7 @@ class rpc(object):
             if PY3 and isinstance(addr, bytes):
                 addr = addr.decode()
             assert not ip and not port
-            ip, port = addr.split(':')
+            ip, port = addr.rsplit(':', 1)
             port = int(port)
         if PY3 and isinstance(ip, bytes):
             ip = ip.decode()
@@ -449,7 +449,7 @@ def coerce_to_address(o, out=str):
     if PY3 and isinstance(o, bytes):
         o = o.decode()
     if isinstance(o, (unicode, str)):
-        ip, port = o.split(':')
+        ip, port = o.rsplit(':', 1)
         port = int(port)
         o = (ip, port)
     if isinstance(o, list):

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -8,7 +8,7 @@ import os
 import io
 from warnings import warn
 
-from dask.delayed import Delayed, delayed
+from dask.delayed import delayed
 from dask.base import tokenize
 import dask.bytes.core
 from toolz import merge
@@ -81,11 +81,8 @@ def read_bytes(path, executor=None, hdfs=None, lazy=True, delimiter=None,
         offsets = [max([o, 1]) for o in offsets]
     lengths = [d['length'] for d in blocks]
     workers = [[h.decode() for h in d['hosts']] for d in blocks]
-    names = ['read-binary-hdfs3-%s-%s' % (path, tokenize(offset, length, delimiter, not_zero))
-            for fn, offset, length in zip(filenames, offsets, lengths)]
 
     logger.debug("Read %d blocks of binary bytes from %s", len(blocks), path)
-    restrictions = dict(zip(names, workers))
 
     if sample is True:
         sample = 10000
@@ -95,15 +92,19 @@ def read_bytes(path, executor=None, hdfs=None, lazy=True, delimiter=None,
     else:
         sample = b''
 
+    f = delayed(read_block_from_hdfs, pure=True)
+    values = [f(fn, offset, length, hdfs.host, hdfs.port, delimiter)
+              for fn, offset, length in zip(filenames, offsets, lengths)]
+
+    restrictions = {v.key: w for v, w in zip(values, workers)}
+
     executor._send_to_scheduler({'op': 'update-graph',
                                  'tasks': {},
                                  'dependencies': [],
                                  'keys': [],
                                  'restrictions': restrictions,
-                                 'loose_restrictions': names,
+                                 'loose_restrictions': list(restrictions),
                                  'client': executor.id})
-    values = [Delayed(name, [{name: (read_block_from_hdfs, fn, offset, length, hdfs.host, hdfs.port, delimiter)}])
-              for name, fn, offset, length in zip(names, filenames, offsets, lengths)]
 
     return sample, values
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -164,6 +164,8 @@ def test_coerce_to_rpc():
     assert (r.ip, r.port) == ('127.0.0.1', 8000)
     r = coerce_to_rpc('127.0.0.1:8000')
     assert (r.ip, r.port) == ('127.0.0.1', 8000)
+    r = coerce_to_rpc('foo:bar:8000')
+    assert (r.ip, r.port) == ('foo:bar', 8000)
 
 
 def stream_div(stream=None, x=None, y=None):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -227,7 +227,7 @@ def ensure_ip(hostname):
     '127.0.0.1:5000'
     """
     if ':' in hostname:
-        host, port = hostname.split(':')
+        host, port = hostname.rsplit(':', 1)
         return ':'.join([ensure_ip(host), port])
     if PY3 and isinstance(hostname, bytes):
         hostname = hostname.decode()


### PR DESCRIPTION
1.  Be robust to colons in host:port names
2.  Handle a bug where we reused the `host` variable as a pronoun in a loop, overwriting valuable information
3.  Use delayed in hdfs rather than Delayed