### PR TITLE
Remove slight race condition

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1518,7 +1518,6 @@ class Scheduler(Server):
                     plugin.delete(self, key)
                 except Exception as e:
                     logger.exception(e)
-            self.released.add(key)
 
         for key in keys:
             if self.who_has.get(key):
@@ -1531,6 +1530,8 @@ class Scheduler(Server):
             elif key in self.ready:  # O(n), though infrequent
                 self.ready.remove(key)
                 trigger_plugins(key)
+
+            self.released.add(key)
 
             for worker in list(self.rprocessing.get(key, ())):
                 self.mark_not_processing(key, worker)


### PR DESCRIPTION
This didn't actually halt anything.  It would result in slightly incorrect bookkeeping though which was causing a strict test to fail.