### PR TITLE
Shard large frames in protocol

### DIFF
--- a/distributed/tests/test_protocol.py
+++ b/distributed/tests/test_protocol.py
@@ -79,3 +79,15 @@ def test_maybe_compress_sample():
     fmt, compressed = maybe_compress(payload, 'lz4')
     assert fmt == None
     assert compressed == payload
+
+
+def test_large_messages():
+    psutil = pytest.importorskip('psutil')
+    pytest.importorskip('lz4')
+    if psutil.virtual_memory().total < 8e9:
+        return
+    msg = {'x': b'0' * (2**31 + 10)}
+
+    b = dumps(msg)
+    msg2 = loads(b)
+    assert msg == msg2


### PR DESCRIPTION
Previously the protocol would fail on large values, such as might occur
when sending around 4GB numpy arrays.  While this is generally
discouraged it would be nice to avoid a complete system halt.

Now we identify these large bytestrings and shard them accordingly,
compressing each part as an individual chunk.  This incurs an extra
memory copy (we're not being overly careful) but is effective.

Fixes #321