### PR TITLE
Add stacks and processing to executor

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1326,6 +1326,7 @@ class Executor(object):
         Examples
         --------
         >>> x, y, z = e.map(inc, [1, 2, 3])  # doctest: +SKIP
+        >>> wait([x, y, z])  # doctest: +SKIP
         >>> e.who_has()  # doctest: +SKIP
         {'inc-1c8dd6be1c21646c71f76c16d09304ea': ['192.168.1.141:46784'],
          'inc-1e297fc27658d7b67b3a758f16bcf47a': ['192.168.1.141:46784'],
@@ -1358,6 +1359,7 @@ class Executor(object):
         Examples
         --------
         >>> x, y, z = e.map(inc, [1, 2, 3])  # doctest: +SKIP
+        >>> wait([x, y, z])  # doctest: +SKIP
         >>> e.has_what()  # doctest: +SKIP
         {'192.168.1.141:46784': ['inc-1c8dd6be1c21646c71f76c16d09304ea',
                                  'inc-fd65c238a7ea60f6a01bf4c8a5fcf44b',
@@ -1374,6 +1376,67 @@ class Executor(object):
         if workers is not None and not isinstance(workers, (list, set)):
             workers = [workers]
         return sync(self.loop, self.scheduler.has_what, keys=workers)
+
+    def stacks(self, workers=None):
+        """ The task queues on each worker
+
+        Parameters
+        ----------
+        workers: list (optional)
+            A list of worker addresses, defaults to all
+
+        Examples
+        --------
+        >>> x, y, z = e.map(inc, [1, 2, 3])  # doctest: +SKIP
+        >>> e.stacks()  # doctest: +SKIP
+        {'192.168.1.141:46784': ['inc-1c8dd6be1c21646c71f76c16d09304ea',
+                                 'inc-fd65c238a7ea60f6a01bf4c8a5fcf44b',
+                                 'inc-1e297fc27658d7b67b3a758f16bcf47a']}
+
+        See Also
+        --------
+        Executor.processing
+        Executor.who_has
+        Executor.has_what
+        Executor.ncores
+        """
+        if (isinstance(workers, tuple)
+            and all(isinstance(i, (str, tuple)) for i in workers)):
+            workers = list(workers)
+        if workers is not None and not isinstance(workers, (list, set)):
+            workers = [workers]
+        return sync(self.loop, self.scheduler.stacks, workers=workers)
+
+    def processing(self, workers=None):
+        """ The tasks currently running on each worker
+
+        Parameters
+        ----------
+        workers: list (optional)
+            A list of worker addresses, defaults to all
+
+        Examples
+        --------
+        >>> x, y, z = e.map(inc, [1, 2, 3])  # doctest: +SKIP
+        >>> e.processing()  # doctest: +SKIP
+        {'192.168.1.141:46784': ['inc-1c8dd6be1c21646c71f76c16d09304ea',
+                                 'inc-fd65c238a7ea60f6a01bf4c8a5fcf44b',
+                                 'inc-1e297fc27658d7b67b3a758f16bcf47a']}
+
+        See Also
+        --------
+        Executor.stacks
+        Executor.who_has
+        Executor.has_what
+        Executor.ncores
+        """
+        if (isinstance(workers, tuple)
+            and all(isinstance(i, (str, tuple)) for i in workers)):
+            workers = list(workers)
+        if workers is not None and not isinstance(workers, (list, set)):
+            workers = [workers]
+        return valmap(set, sync(self.loop, self.scheduler.processing,
+                                workers=workers))
 
     def nbytes(self, keys=None, summary=True):
         """ The bytes taken up by each key on the cluster

--- a/distributed/http/scheduler.py
+++ b/distributed/http/scheduler.py
@@ -36,6 +36,14 @@ class Processing(RequestHandler):
         self.write(resp)
 
 
+class Stacks(RequestHandler):
+    """ Active tasks on each worker """
+    def get(self):
+        resp = {addr: [ensure_string(key_split(t)) for t in tasks]
+                for addr, tasks in self.server.stacks.items()}
+        self.write(resp)
+
+
 class Broadcast(RequestHandler):
     """ Send call to all workers, collate their responses """
     @gen.coroutine
@@ -93,6 +101,7 @@ def HTTPScheduler(scheduler):
         (r'/info.json', Info, {'server': scheduler}),
         (r'/resources.json', Resources, {'server': scheduler}),
         (r'/processing.json', Processing, {'server': scheduler}),
+        (r'/stacks.json', Stacks, {'server': scheduler}),
         (r'/proxy/([\w.-]+):(\d+)/(.+)', Proxy),
         (r'/broadcast/(.+)', Broadcast, {'server': scheduler}),
         (r'/tasks.json', Tasks, {'server': scheduler}),

--- a/distributed/http/tests/test_scheduler_http.py
+++ b/distributed/http/tests/test_scheduler_http.py
@@ -31,7 +31,7 @@ def test_simple(s, a, b):
 
 
 @gen_cluster()
-def test_processing(s, a, b):
+def test_processing_stacks(s, a, b):
     server = HTTPScheduler(s)
     server.listen(0)
     client = AsyncHTTPClient()
@@ -39,6 +39,11 @@ def test_processing(s, a, b):
     s.processing[a.address][('foo-1', 1)] = 1
 
     response = yield client.fetch('http://localhost:%d/processing.json' % server.port)
+    response = json.loads(response.body.decode())
+    assert response == {a.address: ['foo'], b.address: []}
+
+    s.stacks[a.address].append(('foo-1', 2))
+    response = yield client.fetch('http://localhost:%d/stacks.json' % server.port)
     response = json.loads(response.body.decode())
     assert response == {a.address: ['foo'], b.address: []}
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -228,6 +228,8 @@ class Scheduler(Server):
                          'ncores': self.get_ncores,
                          'has_what': self.get_has_what,
                          'who_has': self.get_who_has,
+                         'stacks': self.get_stacks,
+                         'processing': self.get_processing,
                          'nbytes': self.get_nbytes,
                          'add_keys': self.add_keys,
                          'rebalance': self.rebalance,
@@ -1698,6 +1700,20 @@ class Scheduler(Server):
         except (OSError, IOError, StreamClosedError):
             if teardown:
                 teardown(self, state)
+
+    def get_stacks(self, stream=None, workers=None):
+        if workers is not None:
+            workers = set(map(self.coerce_address, workers))
+            return {w: list(self.stacks[w]) for w in workers}
+        else:
+            return valmap(list, self.stacks)
+
+    def get_processing(self, stream=None, workers=None):
+        if workers is not None:
+            workers = set(map(self.coerce_address, workers))
+            return {w: list(self.processing[w]) for w in workers}
+        else:
+            return valmap(list, self.processing)
 
     def get_who_has(self, stream=None, keys=None):
         if keys is not None:


### PR DESCRIPTION
cc @ogrisel 

```python
In [1]: from dask.distributed import Executor

In [2]: e = Executor('localhost:8786')

In [3]: e.stacks()
Out[3]: {'127.0.0.1:35714': [], '127.0.0.1:39465': []}

In [4]: e.processing()
Out[4]: {'127.0.0.1:35714': set(), '127.0.0.1:39465': set()}

In [5]: from time import sleep

In [6]: futures = e.map(sleep, range(10), workers='127.0.0.1:35714')

In [7]: e.processing()
Out[7]: 
{'127.0.0.1:35714': {'sleep-4dcba91126ee0a40300db246392580ff',
  'sleep-52b1e75b588b1a41cdc3b8c99b01a836'},
 '127.0.0.1:39465': set()}

In [8]: e.stacks()
Out[8]: 
{'127.0.0.1:35714': ['sleep-67445d261451a5f5ca8e0e7c79e15ee1',
  'sleep-a036fffe01652e17cc173f942d5e1af4',
  'sleep-f70f660c953f8f03abf8a6c7f81f87b6',
  'sleep-e635da88d170b4ea84f0c729f0b10545',
  'sleep-3249369cae58a53d25e25af9d8f2dc0b',
  'sleep-5304bd144a330689d30982dda9504554',
  'sleep-7e3b20099349816d507df47b23b6e5f2',
  'sleep-4be9103e0960090bf284a6cf5665d3d1'],
 '127.0.0.1:39465': []}

In [9]: e.stacks()
Out[9]: 
{'127.0.0.1:35714': ['sleep-67445d261451a5f5ca8e0e7c79e15ee1',
  'sleep-a036fffe01652e17cc173f942d5e1af4',
  'sleep-f70f660c953f8f03abf8a6c7f81f87b6',
  'sleep-e635da88d170b4ea84f0c729f0b10545',
  'sleep-3249369cae58a53d25e25af9d8f2dc0b',
  'sleep-5304bd144a330689d30982dda9504554'],
 '127.0.0.1:39465': []}
```