### PR TITLE
Reify iterators in as_completed

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1593,6 +1593,7 @@ def as_completed(fs):
 
     This function does not return futures in the order in which they are input.
     """
+    fs = list(fs)
     if len(set(f.executor for f in fs)) == 1:
         loop = first(fs).executor.loop
     else:

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3158,3 +3158,11 @@ def test_get_stops_work_after_error(loop):
         sleep(0.01)
     loop2.close(all_fds=True)
     t.join()
+
+
+def test_as_completed_list(loop):
+    with cluster() as (s, [a, b]):
+        with Executor(('127.0.0.1', s['port']), loop=loop) as e:
+            seq = e.map(inc, iter(range(5)))
+            seq2 = list(as_completed(seq))
+            assert set(e.gather(seq2)) == {1, 2, 3, 4, 5}


### PR DESCRIPTION
Previously we would burn an input iterator in sanity checks.

Now we reify iterators to a list and then proceed.

Fixes #358

cc @Futrell