### PR TITLE
Make default ip / port values in docstrings match code and online doc

### DIFF
--- a/distributed/center.py
+++ b/distributed/center.py
@@ -45,15 +45,11 @@ class Center(Server):
 
     Examples
     --------
-    You can start a center with the ``dcenter`` command line application::
+    You can create one in Python:
 
-       $ dcenter
-       Start center at 127.0.0.1:8787
-
-    Of you can create one in Python:
-
+    >>> from distributed.center import Center
     >>> center = Center('192.168.0.123')  # doctest: +SKIP
-    >>> center.listen(8787)  # doctest: +SKIP
+    >>> center.listen(8786)  # doctest: +SKIP
 
     >>> center.has_what  # doctest: +SKIP
     {('alice', 8788):   {'x', 'y'}

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -38,7 +38,7 @@ class LocalCluster(object):
     --------
     >>> c = LocalCluster()  # Create a local cluster with as many workers as cores  # doctest: +SKIP
     >>> c  # doctest: +SKIP
-    LocalCluster("192.168.1.141:8786", workers=8, ncores=8)
+    LocalCluster("127.0.0.1:8786", workers=8, ncores=8)
 
     >>> e = Executor(c)  # connect to local cluster  # doctest: +SKIP
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -64,7 +64,7 @@ class Scheduler(Server):
 
     Or as part of when an Executor starts up and connects to a Center::
 
-        >>> e = Executor('127.0.0.1:8787')  # doctest: +SKIP
+        >>> e = Executor('127.0.0.1:8786')  # doctest: +SKIP
         >>> e.scheduler  # doctest: +SKIP
         Scheduler(...)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -81,17 +81,17 @@ class Worker(Server):
     Create schedulers and workers in Python:
 
     >>> from distributed import Scheduler, Worker
-    >>> c = Scheduler('192.168.0.100', 8787)  # doctest: +SKIP
+    >>> c = Scheduler('192.168.0.100', 8786)  # doctest: +SKIP
     >>> w = Worker(c.ip, c.port)  # doctest: +SKIP
-    >>> yield w._start(port=8788)  # doctest: +SKIP
+    >>> yield w._start(port=8786)  # doctest: +SKIP
 
     Or use the command line::
 
         $ dask-scheduler
-        Start scheduler at 127.0.0.1:8787
+        Start scheduler at 127.0.0.1:8786
 
-        $ dask-worker 127.0.0.1:8787
-        Start worker at:               127.0.0.1:8788
+        $ dask-worker 127.0.0.1:8786
+        Start worker at:               127.0.0.1:8786
         Registered with scheduler at:  127.0.0.1:8787
 
     See Also
@@ -486,7 +486,7 @@ class Worker(Server):
                     "Function: %s\n"
                     "args:     %s\n"
                     "kwargs:   %s\n",
-                    str(funcname(function))[:1000], 
+                    str(funcname(function))[:1000],
                     convert_args_to_str(args, max_len=1000),
                     convert_kwargs_to_str(kwargs, max_len=1000), exc_info=True)
 
@@ -538,7 +538,7 @@ class Worker(Server):
                 "Function: %s\n"
                 "args:     %s\n"
                 "kwargs:   %s\n",
-                str(funcname(function))[:1000], 
+                str(funcname(function))[:1000],
                 convert_args_to_str(args, max_len=1000),
                 convert_kwargs_to_str(kwargs, max_len=1000), exc_info=True)
 
@@ -564,7 +564,7 @@ class Worker(Server):
                 "Function: %s\n"
                 "args:     %s\n"
                 "kwargs:   %s\n",
-                str(funcname(function))[:1000], 
+                str(funcname(function))[:1000],
                 convert_args_to_str(args, max_len=1000),
                 convert_kwargs_to_str(kwargs, max_len=1000), exc_info=True)
 


### PR DESCRIPTION
Tiny PR to make examples in docstrings less surprising by using default values used elsewhere in the code and the online doc.