### PR TITLE
Add Executor.start_ipython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pytest coverage tornado toolz dill futures dask ipywidgets psutil bokeh requests joblib
+  - conda install pytest coverage tornado toolz dill futures dask ipywidgets psutil bokeh requests joblib mock ipykernel jupyter_client
   - pip install git+https://github.com/dask/dask.git --upgrade
   - pip install git+https://github.com/joblib/joblib.git --upgrade
   - pip install git+https://github.com/dask/s3fs.git --upgrade

--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -89,7 +89,7 @@ def register_worker_magic(connection_info, magic_name='worker'):
     ip.register_magic_function(remote, magic_kind='cell', magic_name=magic_name)
 
 
-def connect_qtconsole(connection_info, name=None):
+def connect_qtconsole(connection_info, name=None, extra_args=None):
     """Open a QtConsole connected to a worker who has the given future
     
     - identify worker with who_has
@@ -102,7 +102,10 @@ def connect_qtconsole(connection_info, name=None):
 
     path = os.path.join(runtime_dir, name + '.json')
     write_connection_file(path, **connection_info)
-    Popen(['jupyter', 'qtconsole', '--existing', path])
+    cmd = ['jupyter', 'qtconsole', '--existing', path]
+    if extra_args:
+        cmd.extend(extra_args)
+    Popen(cmd)
     def _cleanup_connection_file():
         """Cleanup our connection file when we exit."""
         try:

--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -1,0 +1,113 @@
+"""Utilities for integrating with IPython
+
+These functions should probably reside in Jupyter and IPython repositories,
+after which we can import them instead of having our own definitions.
+"""
+
+from __future__ import print_function
+
+import atexit
+import os
+try:
+    import queue
+except ImportError:
+    # Python 2
+    import Queue as queue
+from subprocess import Popen
+import sys
+from uuid import uuid4
+
+from tornado.gen import TimeoutError
+
+from IPython import get_ipython
+from jupyter_client import BlockingKernelClient, write_connection_file
+from jupyter_core.paths import jupyter_runtime_dir
+
+
+OUTPUT_TIMEOUT = 10
+
+
+def run_cell_remote(ip, kc, cell):
+    """Run a cell on a KernelClient
+
+    Any output from the cell will be redisplayed in the local session.
+    """
+    msg_id = kc.execute(cell)
+
+    in_kernel = getattr(ip, 'kernel', False)
+    if in_kernel:
+        socket = ip.display_pub.pub_socket
+        session = ip.display_pub.session
+        parent_header = ip.display_pub.parent_header
+
+    while True:
+        try:
+            msg = kc.get_iopub_msg(timeout=OUTPUT_TIMEOUT)
+        except queue.Empty:
+            raise TimeoutError("Timeout waiting for IPython output")
+
+        if msg['parent_header'].get('msg_id') != msg_id:
+            continue
+        msg_type = msg['header']['msg_type']
+        content = msg['content']
+        if msg_type == 'status':
+            if content['execution_state'] == 'idle':
+                # idle means output is done
+                break
+        elif msg_type == 'stream':
+            stream = getattr(sys, content['name'])
+            stream.write(content['text'])
+        elif msg_type in ('display_data', 'execute_result', 'error'):
+            if in_kernel:
+                session.send(socket, msg_type, content, parent=parent_header)
+            else:
+                if msg_type == 'error':
+                    print('\n'.join(content['traceback']), file=sys.stderr)
+                else:
+                    sys.stdout.write(content['data'].get('text/plain', ''))
+        else:
+            pass
+
+
+def register_worker_magic(connection_info, magic_name='worker'):
+    """Register a %worker magic, given connection_info.
+
+    Both a line and cell magic are registered,
+    which run the given cell in a remote kernel.
+    """
+    ip = get_ipython()
+    kc = BlockingKernelClient(**connection_info)
+    kc.session.key = connection_info['key']
+    kc.start_channels()
+    def remote(line, cell=None):
+        """Run the current cell on a remote IPython kernel"""
+        if cell is None:
+            # both line and cell magic
+            cell = line
+        run_cell_remote(ip, kc, cell)
+    ip.register_magic_function(remote, magic_kind='line', magic_name=magic_name)
+    ip.register_magic_function(remote, magic_kind='cell', magic_name=magic_name)
+
+
+def connect_qtconsole(connection_info, name=None):
+    """Open a QtConsole connected to a worker who has the given future
+    
+    - identify worker with who_has
+    - start IPython kernel on the worker
+    - start qtconsole connected to the kernel
+    """
+    runtime_dir = jupyter_runtime_dir()
+    if name is None:
+        name = uuid4().hex
+
+    path = os.path.join(runtime_dir, name + '.json')
+    write_connection_file(path, **connection_info)
+    Popen(['jupyter', 'qtconsole', '--existing', path])
+    def _cleanup_connection_file():
+        """Cleanup our connection file when we exit."""
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    atexit.register(_cleanup_connection_file)
+

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1497,6 +1497,29 @@ class Executor(object):
     def futures_of(self, futures):
         return futures_of(futures, executor=self)
 
+    @gen.coroutine
+    def _start_ipython(self, workers):
+        responses = yield self.scheduler.broadcast(
+            msg=dict(op='start_ipython'), workers=workers,
+        )
+        raise gen.Return(responses)
+
+    def start_ipython(self, workers=None):
+        """ Start IPython kernels on workers
+        
+        Parameters
+        ----------
+        workers: list (optional)
+            A list of worker addresses, defaults to all
+
+        Returns
+        -------
+        iter_connection_info: list
+            List of connection_info dicts containing info necessary
+            to connect Jupyter clients to the workers.
+        """
+        return sync(self.loop, self._start_ipython, workers)
+
 
 class CompatibleExecutor(Executor):
     """ A concurrent.futures-compatible Executor

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1507,7 +1507,7 @@ class Executor(object):
         )
         raise gen.Return((workers, responses))
 
-    def start_ipython(self, workers=None, magic_names=False, qtconsole=False):
+    def start_ipython(self, workers=None, magic_names=False, qtconsole=False, qtconsole_args=None):
         """ Start IPython kernels on workers
 
         Parameters
@@ -1544,7 +1544,9 @@ class Executor(object):
             from ._ipython_utils import connect_qtconsole
             for worker, connection_info in info_dict.items():
                 connect_qtconsole(connection_info,
-                                  name='dask-' + worker.replace(':','-'))
+                                  name='dask-' + worker.replace(':','-'),
+                                  extra_args=qtconsole_args,
+                )
         return info_dict
 
 

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1499,18 +1499,28 @@ class Executor(object):
 
     @gen.coroutine
     def _start_ipython(self, workers):
+        if workers is None:
+            workers = yield self.scheduler.ncores()
+
         responses = yield self.scheduler.broadcast(
             msg=dict(op='start_ipython'), workers=workers,
         )
-        raise gen.Return(responses)
+        raise gen.Return((workers, responses))
 
-    def start_ipython(self, workers=None):
+    def start_ipython(self, workers=None, magic_names=False, qtconsole=False):
         """ Start IPython kernels on workers
-        
+
         Parameters
         ----------
         workers: list (optional)
             A list of worker addresses, defaults to all
+
+        magic_names: str or list(str) (optional)
+            If defined, register IPython magics with these names for
+            executing code on the workers.
+
+        qtconsole: bool (optional)
+            If True, launch a Jupyter QtConsole connected to the worker(s).
 
         Returns
         -------
@@ -1518,7 +1528,24 @@ class Executor(object):
             List of connection_info dicts containing info necessary
             to connect Jupyter clients to the workers.
         """
-        return sync(self.loop, self._start_ipython, workers)
+
+        if magic_names and isinstance(magic_names, six.string_types):
+            magic_names = [magic_names]
+        if isinstance(workers, six.string_types):
+            workers = [workers]
+
+        (workers, info_dict) = sync(self.loop, self._start_ipython, workers)
+        if magic_names:
+            from ._ipython_utils import register_worker_magic
+            for worker, magic_name in zip(workers, magic_names):
+                connection_info = info_dict[worker]
+                register_worker_magic(connection_info, magic_name)
+        if qtconsole:
+            from ._ipython_utils import connect_qtconsole
+            for worker, connection_info in info_dict.items():
+                connect_qtconsole(connection_info,
+                                  name='dask-' + worker.replace(':','-'))
+        return info_dict
 
 
 class CompatibleExecutor(Executor):

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -11,6 +11,8 @@ from threading import Thread
 from time import sleep, time
 import traceback
 
+
+import mock
 import pytest
 from toolz import (identity, isdistinct, first, concat, pluck, valmap,
         partition_all)
@@ -3168,3 +3170,56 @@ def test_as_completed_list(loop):
             seq = e.map(inc, iter(range(5)))
             seq2 = list(as_completed(seq))
             assert set(e.gather(seq2)) == {1, 2, 3, 4, 5}
+
+
+@pytest.mark.ipython
+def test_start_ipython(loop):
+    from jupyter_client import BlockingKernelClient
+    from ipykernel.kernelapp import IPKernelApp
+    from IPython.core.interactiveshell import InteractiveShell
+    
+    with cluster(1) as (s, [a]):
+        with Executor(('127.0.0.1', s['port']), loop=loop) as e:
+            info_dict = e.start_ipython()
+            info = first(info_dict.values())
+            key = info.pop('key')
+            kc = BlockingKernelClient(**info)
+            kc.session.key = key
+            kc.start_channels()
+            msg_id = kc.execute("worker")
+            reply = kc.get_shell_msg(timeout=10)
+            kc.stop_channels()
+
+@pytest.mark.ipython
+def test_start_ipython_magic(loop):
+    ip = mock.Mock()
+    with cluster() as (s, [a, b]):
+        with mock.patch('IPython.get_ipython', lambda : ip), Executor(('127.0.0.1', s['port']), loop=loop) as e:
+            workers = list(e.ncores())[:2]
+            names = [ 'magic%i' % i for i in range(len(workers)) ]
+            e.start_ipython(workers, magic_names=names)
+    assert ip.register_magic_function.call_count == 4
+    expected = [
+        {'magic_kind': 'line', 'magic_name': 'magic0'},
+        {'magic_kind': 'cell', 'magic_name': 'magic0'},
+        {'magic_kind': 'line', 'magic_name': 'magic1'},
+        {'magic_kind': 'cell', 'magic_name': 'magic1'},
+    ]
+    call_kwargs_list = [ kwargs for (args, kwargs) in ip.register_magic_function.call_args_list ]
+    assert call_kwargs_list == expected
+
+
+@pytest.mark.ipython
+def test_start_ipython_qtconsole(loop):
+    Popen = mock.Mock()
+    with cluster() as (s, [a, b]):
+        with mock.patch('distributed._ipython_utils.Popen', Popen), Executor(('127.0.0.1', s['port']), loop=loop) as e:
+            worker = first(e.ncores())
+            e.start_ipython(worker, qtconsole=True)
+            e.start_ipython(worker, qtconsole=True, qtconsole_args=['--debug'])
+    assert Popen.call_count == 2
+    (cmd,), kwargs = Popen.call_args_list[0]
+    assert cmd[:3] == [ 'jupyter', 'qtconsole', '--existing' ]
+    (cmd,), kwargs = Popen.call_args_list[1]
+    assert cmd[-1:] == [ '--debug' ]
+

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -8,7 +8,7 @@ from multiprocessing.pool import ThreadPool
 import os
 import pkg_resources
 import tempfile
-from threading import current_thread
+from threading import current_thread, Thread
 from time import time
 from timeit import default_timer
 import shutil
@@ -116,6 +116,7 @@ class Worker(Server):
         self.heartbeat_interval = heartbeat_interval
         self._last_disk_io = None
         self._last_net_io = None
+        self._ipython_kernel = None
 
         if not os.path.exists(self.local_dir):
             os.mkdir(self.local_dir)
@@ -145,7 +146,9 @@ class Worker(Server):
                     'terminate': self.terminate,
                     'ping': pingpong,
                     'health': self.host_health,
-                    'upload_file': self.upload_file}
+                    'upload_file': self.upload_file,
+                    'start_ipython': self.start_ipython,
+                }
 
         super(Worker, self).__init__(handlers, io_loop=self.loop, **kwargs)
 
@@ -604,6 +607,51 @@ class Worker(Server):
 
     def get_data(self, stream, keys=None):
         return {k: dumps(self.data[k]) for k in keys if k in self.data}
+
+    def _start_ipython(self):
+        from IPython import get_ipython
+        if get_ipython() is not None:
+            raise RuntimeError("Cannot start IPython, it's already running.")
+
+        from zmq.eventloop.ioloop import ZMQIOLoop
+        from ipykernel.kernelapp import IPKernelApp
+        # save the global IOLoop instance
+        # since IPython relies on it, but we are going to put it in a thread.
+        save_inst = IOLoop.instance()
+        IOLoop.clear_instance()
+        zmq_loop = ZMQIOLoop()
+        zmq_loop.install()
+
+        # start IPython, disabling its signal handlers that won't work due to running in a thread:
+        app = self._ipython_kernel = IPKernelApp.instance(log=logger)
+        # listen on all interfaces, so remote clients can connect:
+        app.ip = self.ip
+        app.init_signal = lambda : None
+        app.initialize([])
+        app.kernel.pre_handler_hook = lambda : None
+        app.kernel.post_handler_hook = lambda : None
+        app.kernel.start()
+
+        # save self in the IPython namespace as 'worker'
+        app.kernel.shell.user_ns['worker'] = self
+
+        # start IPython's IOLoop in a thread
+        zmq_loop_thread = Thread(target=zmq_loop.start)
+        zmq_loop_thread.start()
+
+        # put the global IOLoop instance back:
+        IOLoop.clear_instance()
+        save_inst.install()
+        return app
+
+    def start_ipython(self, stream):
+        """Start an IPython kernel
+
+        Returns Jupyter connection info dictionary.
+        """
+        if self._ipython_kernel is None:
+            self._ipython_kernel = self._start_ipython()
+        return self._ipython_kernel.get_connection_info()
 
     def upload_file(self, stream, filename=None, data=None, load=True):
         out_filename = os.path.join(self.local_dir, filename)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -624,6 +624,8 @@ class Worker(Server):
 
         # start IPython, disabling its signal handlers that won't work due to running in a thread:
         app = self._ipython_kernel = IPKernelApp.instance(log=logger)
+        # Don't connect to the history database
+        app.config.HistoryManager.hist_file = ':memory:'
         # listen on all interfaces, so remote clients can connect:
         app.ip = self.ip
         app.init_signal = lambda : None


### PR DESCRIPTION
- Starts an IPython kernel on worker(s).
- Doesn't work for local (ThreadPool) workers due to singleton checks in IPython.
-  Returns connection info for connecting Jupyter clients to the kernel.
- IPython runs in its own thread on the worker due to requiring the zmq poller to be in use by tornado.
- `e.start_ipython([workers], magic_names=['w1', 'w2'])` defines IPython magics for each specified worker that performs execution on the worker. Any output from the worker, including images and HTML output, will be properly redisplayed (widgets not included).
- `e.start_ipython([worker], qtconsole=True)` starts a QtConsole connected to the worker(s)

TODO:

- [x] what actions do we want the Executor to take? Return connected Client objects? Open qtconsole and/or jupyter console? Hook up local IPython execution to the worker?
- [x] what entrypoints should we have for starting IPython? Should there be methods on Futures to interact with the worker that ran them?