### PR TITLE
[WIP] fix/bokeh_whitelist

### DIFF
--- a/distributed/bokeh/application.py
+++ b/distributed/bokeh/application.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__file__)
 
 class BokehWebInterface(object):
     def __init__(self, host='127.0.0.1', http_port=9786, tcp_port=8786,
-                 bokeh_port=8787, bokeh_whitelist=[], log_level='info', show=False):
+                 bokeh_port=8787, bokeh_whitelist=[], log_level='info',
+                 show=False, prefix=None, use_xheaders=False):
         self.port = bokeh_port
         ip = socket.gethostbyname(host)
 
@@ -29,6 +30,7 @@ class BokehWebInterface(object):
                  '127.0.0.1',
                  ip,
                  host]
+
         with ignoring(Exception):
             hosts.append(socket.gethostbyname(ip))
         with ignoring(Exception):
@@ -46,8 +48,15 @@ class BokehWebInterface(object):
                  '--unused-session-lifetime=1',
                  '--port', str(bokeh_port)] +
                  sum([['--host', h] for h in hosts], []))
+
+        if prefix:
+            args.extend(['--prefix', prefix])
+
         if show:
             args.append('--show')
+
+        if use_xheaders:
+            args.append('--use-xheaders')
 
         if log_level in ('debug', 'info', 'warning', 'error', 'critical'):
             args.extend(['--log-level', log_level])

--- a/distributed/bokeh/application.py
+++ b/distributed/bokeh/application.py
@@ -28,7 +28,7 @@ class BokehWebInterface(object):
         hosts = ['localhost',
                  '127.0.0.1',
                  ip,
-                 host] + list(map(str, bokeh_whitelist))
+                 host]
         with ignoring(Exception):
             hosts.append(socket.gethostbyname(ip))
         with ignoring(Exception):
@@ -37,6 +37,8 @@ class BokehWebInterface(object):
         hosts = ['%s:%d' % (h, bokeh_port) for h in hosts]
 
         hosts.append("*")
+
+        hosts.extend(map(str, bokeh_whitelist))
 
         args = ([binname, 'serve'] + paths +
                 ['--log-level', 'warning',

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -41,7 +41,12 @@ signal.signal(signal.SIGTERM, handle_signal)
 @click.option('--show/--no-show', default=False, help="Show web UI")
 @click.option('--bokeh-whitelist', default=None, multiple=True,
               help="IP addresses to whitelist for bokeh.")
-def main(center, host, port, http_port, bokeh_port, show, _bokeh, bokeh_whitelist):
+@click.option('--prefix', type=str, default=None,
+              help="Prefix for the bokeh app")
+@click.option('--use-xheaders', type=bool, default=False, show_default=True,
+              help="User xheaders in bokeh app for ssl termination in header")
+def main(center, host, port, http_port, bokeh_port, show, _bokeh,
+         bokeh_whitelist, prefix, use_xheaders):
     given_host = host
     host = host or get_ip()
     if ':' in host and port == 8786:
@@ -60,7 +65,8 @@ def main(center, host, port, http_port, bokeh_port, show, _bokeh, bokeh_whitelis
             from distributed.bokeh.application import BokehWebInterface
             bokeh_proc = BokehWebInterface(host=host, http_port=http_port,
                     tcp_port=port, bokeh_port=bokeh_port,
-                    bokeh_whitelist=bokeh_whitelist, show=show)
+                    bokeh_whitelist=bokeh_whitelist, show=show, prefix=prefix,
+                    use_xheaders=use_xheaders)
         except ImportError:
             logger.info("Please install Bokeh to get Web UI")
         except Exception as e:

--- a/distributed/cli/tests/test_dscheduler.py
+++ b/distributed/cli/tests/test_dscheduler.py
@@ -98,8 +98,8 @@ def test_bokeh_whitelist(loop):
     with pytest.raises(Exception):
         requests.get('http://localhost:8787/status/').ok
 
-    with popen(['dask-scheduler', '--bokeh-whitelist', '127.0.0.2',
-                                  '--bokeh-whitelist', '127.0.0.3']) as proc:
+    with popen(['dask-scheduler', '--bokeh-whitelist', '127.0.0.2:8787',
+                                  '--bokeh-whitelist', '127.0.0.3:8787']) as proc:
         with Executor('127.0.0.1:%d' % Scheduler.default_port, loop=loop) as e:
             pass
 


### PR DESCRIPTION
PR fixes a small annoyance with whitelisting for distributed.  Previously, if one type

```
dask-scheduler --bokeh-port=9000 --bokeh-whitelist="*"
```

This would only proxy for host connections on `"*:9000`.  If a user is proxied (as often is the case inside docker containers) then it is likely they will be hitting some other host *usually* on port 80.  With this PR, a user can now type the following

```
dask-scheduler --bokeh-port=9000 --bokeh-whitelist="*" --prefix=/some_prefix
```

And expect all `host:port` combos to be available hosts and an optional prefix
