### PR TITLE
Remove race conditions when workers fail

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -36,6 +36,10 @@ with ignoring(ImportError):
 pickle_types = tuple(pickle_types)
 
 
+class RPCClosed(IOError):
+    pass
+
+
 def dumps(x):
     """ Manage between cloudpickle and pickle
 
@@ -388,6 +392,7 @@ class rpc(object):
         self.ip = ip
         self.port = port
         self.timeout = timeout
+        self.status = 'running'
         assert self.ip
         assert self.port
 
@@ -410,6 +415,8 @@ class rpc(object):
 
         As is done in __getattr__ below.
         """
+        if self.status == 'closed':
+            raise RPCClosed("RPC Closed")
         to_clear = set()
         open = False
         for stream, open in self.streams.items():
@@ -442,6 +449,11 @@ class rpc(object):
 
     def __del__(self):
         self.close_streams()
+
+    def close_rpc(self):
+        self.status = 'closed'
+        self.close_streams()
+
 
 
 def coerce_to_address(o, out=str):

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -446,7 +446,7 @@ class Executor(object):
         with ignoring(AttributeError):
             yield self.scheduler_stream.close(ignore_closed=True)
         with ignoring(AttributeError):
-            self.scheduler.close()
+            self.scheduler.close_rpc()
 
     def shutdown(self, timeout=10):
         """ Send shutdown signal and wait until scheduler terminates """

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -446,7 +446,7 @@ class Executor(object):
         with ignoring(AttributeError):
             yield self.scheduler_stream.close(ignore_closed=True)
         with ignoring(AttributeError):
-            self.scheduler.close_streams()
+            self.scheduler.close()
 
     def shutdown(self, timeout=10):
         """ Send shutdown signal and wait until scheduler terminates """
@@ -458,7 +458,7 @@ class Executor(object):
                                    {'op': 'close-stream'})
             sync(self.loop, self.scheduler_stream.close)
         with ignoring(AttributeError):
-            self.scheduler.close_streams()
+            self.scheduler.close_rpc()
         if self._should_close_loop:
             sync(self.loop, self.loop.stop)
             self.loop.close(all_fds=True)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1865,7 +1865,7 @@ class Scheduler(Server):
             recipient = next(recipients)
             msgs = []  # (sender, recipient, key)
             for sender in sorted_workers[:len(workers) // 2]:
-                sender_keys = {k: self.nbytes(k, 1000) for k in keys_by_worker[sender]}
+                sender_keys = {k: self.nbytes.get(k, 1000) for k in keys_by_worker[sender]}
                 sender_keys = iter(sorted(sender_keys.items(),
                                           key=second, reverse=True))
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1124,11 +1124,10 @@ class Scheduler(Server):
 
             if k in self.released:
                 for dep in self.dependencies[k]:
-                    if not self.who_has.get(dep):
-                        try:
-                            self.waiting_data[dep].add(k)
-                        except KeyError:
-                            self.waiting_data[dep] = {k}
+                    try:
+                        self.waiting_data[dep].add(k)
+                    except KeyError:
+                        self.waiting_data[dep] = {k}
 
                 waiting = {dep for dep in self.dependencies[k]
                             if not self.who_has.get(dep)}

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -309,7 +309,7 @@ def test_dataframe_set_index_sync(loop):
                         freq='2H', partition_freq='1M', seed=1)
                 df = e.persist(df)
 
-                df2 = df.set_index('name', method='tasks')
+                df2 = df.set_index('name', shuffle='tasks')
                 df2 = e.persist(df2)
 
                 df2.head()

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3187,7 +3187,7 @@ def test_start_ipython(loop):
     from jupyter_client import BlockingKernelClient
     from ipykernel.kernelapp import IPKernelApp
     from IPython.core.interactiveshell import InteractiveShell
-    
+
     with cluster(1) as (s, [a]):
         with Executor(('127.0.0.1', s['port']), loop=loop) as e:
             info_dict = e.start_ipython()
@@ -3233,3 +3233,29 @@ def test_start_ipython_qtconsole(loop):
     (cmd,), kwargs = Popen.call_args_list[1]
     assert cmd[-1:] == [ '--debug' ]
 
+
+@gen_cluster(ncores=[], executor=True, timeout=None)
+def test_stress_creation_and_deletion(e, s):
+    da = pytest.importorskip('dask.array')
+
+    x = da.random.random(size=(2000, 2000), chunks=(100, 100))
+    y = (x + 1).T + (x * 2) - x.mean(axis=1)
+
+    z = e.persist(y)
+
+    @gen.coroutine
+    def create_and_destroy_worker(delay):
+        while True:
+            n = Nanny(s.ip, s.port, ncores=2, loop=s.loop)
+            n.start(0)
+
+            yield gen.sleep(delay)
+
+            yield n._close()
+            print("Killed nanny")
+
+    for i in range(10):
+        s.loop.add_callback(create_and_destroy_worker, 0.1 * i)
+
+    for i in range(10):
+        yield gen.sleep(1)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3245,7 +3245,8 @@ def test_stress_creation_and_deletion(e, s):
 
     @gen.coroutine
     def create_and_destroy_worker(delay):
-        while True:
+        start = time()
+        while time() < start + 10:
             n = Nanny(s.ip, s.port, ncores=2, loop=s.loop)
             n.start(0)
 
@@ -3254,8 +3255,4 @@ def test_stress_creation_and_deletion(e, s):
             yield n._close()
             print("Killed nanny")
 
-    for i in range(10):
-        s.loop.add_callback(create_and_destroy_worker, 0.1 * i)
-
-    for i in range(10):
-        yield gen.sleep(1)
+    yield [create_and_destroy_worker(0.1 * i) for i in range(10)]

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -201,7 +201,7 @@ def key_split(s):
 
 
 @contextmanager
-def log_errors(pdb=False):
+def log_errors(pdb=True):
     try:
         yield
     except (StreamClosedError, gen.Return):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -201,7 +201,7 @@ def key_split(s):
 
 
 @contextmanager
-def log_errors(pdb=True):
+def log_errors(pdb=False):
     try:
         yield
     except (StreamClosedError, gen.Return):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -409,21 +409,7 @@ class Worker(Server):
                     else:
                         logger.warning("Unknown operation %s, %s", op, msg)
                 # self.loop.add_callback(self.compute_many, bstream, msgs)
-                try:
-                    last = self.compute_many(bstream, msgs)
-                except RuntimeError as e:
-                    if 'shutdown' in str(e):
-                        break
-                    else:
-                        for i in range(100):
-                            print(e)
-                            print(type(e))
-                            print('shutdown' in str(e))
-                except Exception as e:
-                    for i in range(10):
-                        print(e)
-                        print(type(e))
-                        print(type(e).mro())
+                last = self.compute_many(bstream, msgs)
 
             try:
                 yield last  # TODO: there might be more than one lingering

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -29,7 +29,7 @@ from .batched import BatchedSend
 from .client import pack_data, gather_from_workers
 from .compatibility import reload, unicode
 from .core import (rpc, Server, pingpong, dumps, loads, coerce_to_address,
-        error_message, read)
+        error_message, read, RPCClosed)
 from .sizeof import sizeof
 from .utils import funcname, get_ip, _maybe_complex, log_errors, All
 
@@ -218,8 +218,8 @@ class Worker(Server):
             yield gen.with_timeout(timedelta(seconds=timeout),
                     self.scheduler.unregister(address=(self.ip, self.port)),
                     io_loop=self.loop)
+        self.scheduler.close_rpc()
         self.heartbeat_callback.stop()
-        self.scheduler.close_streams()
         self.stop()
         self.executor.shutdown()
         if os.path.exists(self.local_dir):
@@ -287,26 +287,25 @@ class Worker(Server):
         data: The scope in which to run tasks
         len(remote): the number of new keys we've gathered
         """
-        with log_errors():
-            who_has = merge(msg['who_has'] for msg in msgs if 'who_has' in msg)
-            local = {k: self.data[k] for k in who_has if k in self.data}
-            who_has = {k: v for k, v in who_has.items() if k not in local}
-            remote, bad_data = yield gather_from_workers(who_has,
-                    permissive=True, rpc=self.rpc, close=False)
-            if remote:
-                self.data.update(remote)
-                yield self.scheduler.add_keys(address=self.address, keys=list(remote))
+        who_has = merge(msg['who_has'] for msg in msgs if 'who_has' in msg)
+        local = {k: self.data[k] for k in who_has if k in self.data}
+        who_has = {k: v for k, v in who_has.items() if k not in local}
+        remote, bad_data = yield gather_from_workers(who_has,
+                permissive=True, rpc=self.rpc, close=False)
+        if remote:
+            self.data.update(remote)
+            yield self.scheduler.add_keys(address=self.address, keys=list(remote))
 
-            data = merge(local, remote)
+        data = merge(local, remote)
 
-            if bad_data:
-                missing = {msg['key']: {k for k in msg['who_has'] if k in bad_data}
-                            for msg in msgs if 'who_has' in msg}
-                bad = {k: v for k, v in missing.items() if v}
-                good = [msg for msg in msgs if not missing.get(msg['key'])]
-            else:
-                good, bad = msgs, {}
-            raise Return([good, bad, data, len(remote)])
+        if bad_data:
+            missing = {msg['key']: {k for k in msg['who_has'] if k in bad_data}
+                        for msg in msgs if 'who_has' in msg}
+            bad = {k: v for k, v in missing.items() if v}
+            good = [msg for msg in msgs if not missing.get(msg['key'])]
+        else:
+            good, bad = msgs, {}
+        raise Return([good, bad, data, len(remote)])
 
     @gen.coroutine
     def _ready_task(self, function=None, key=None, args=(), kwargs={},
@@ -387,7 +386,6 @@ class Worker(Server):
             bstream = BatchedSend(interval=2, loop=self.loop)
             bstream.start(stream)
 
-        with log_errors():
             closed = False
             last = gen.sleep(0)
             while not closed:
@@ -411,95 +409,111 @@ class Worker(Server):
                     else:
                         logger.warning("Unknown operation %s, %s", op, msg)
                 # self.loop.add_callback(self.compute_many, bstream, msgs)
-                last = self.compute_many(bstream, msgs)
+                try:
+                    last = self.compute_many(bstream, msgs)
+                except RuntimeError as e:
+                    if 'shutdown' in str(e):
+                        break
+                    else:
+                        for i in range(100):
+                            print(e)
+                            print(type(e))
+                            print('shutdown' in str(e))
+                except Exception as e:
+                    for i in range(10):
+                        print(e)
+                        print(type(e))
+                        print(type(e).mro())
 
-            yield last  # TODO: there might be more than one lingering
+            try:
+                yield last  # TODO: there might be more than one lingering
+            except (RPCClosed, RuntimeError):
+                pass
+
             yield bstream.close()
             logger.info("Close compute stream")
 
     @gen.coroutine
     def compute_many(self, bstream, msgs, report=False):
-        with log_errors():
-            transfer_start = time()
-            good, bad, data, num_transferred = yield self.gather_many(msgs)
-            transfer_end = time()
+        transfer_start = time()
+        good, bad, data, num_transferred = yield self.gather_many(msgs)
+        transfer_end = time()
 
-            for msg in msgs:
-                msg.pop('who_has', None)
+        for msg in msgs:
+            msg.pop('who_has', None)
 
-            if bad:
-                logger.warn("Could not find data for %s", sorted(bad))
-            for k, v in bad.items():
-                bstream.send({'status': 'missing-data',
-                              'key': k,
-                              'keys': list(v)})
+        if bad:
+            logger.warn("Could not find data for %s", sorted(bad))
+        for k, v in bad.items():
+            bstream.send({'status': 'missing-data',
+                          'key': k,
+                          'keys': list(v)})
 
-            if good:
-                futures = [self.compute_one(data, report=report, **msg)
-                                         for msg in good]
-                wait_iterator = gen.WaitIterator(*futures)
-                result = yield wait_iterator.next()
-                if num_transferred:
-                    result['transfer_start'] = transfer_start
-                    result['transfer_stop'] = transfer_end
-                bstream.send(result)
-                while not wait_iterator.done():
-                    msg = yield wait_iterator.next()
-                    bstream.send(msg)
+        if good:
+            futures = [self.compute_one(data, report=report, **msg)
+                                     for msg in good]
+            wait_iterator = gen.WaitIterator(*futures)
+            result = yield wait_iterator.next()
+            if num_transferred:
+                result['transfer_start'] = transfer_start
+                result['transfer_stop'] = transfer_end
+            bstream.send(result)
+            while not wait_iterator.done():
+                msg = yield wait_iterator.next()
+                bstream.send(msg)
 
     @gen.coroutine
     def compute_one(self, data, key=None, function=None, args=None, kwargs=None,
                     report=False, task=None):
         logger.debug("Compute one on %s", key)
-        with log_errors():
-            diagnostics = dict()
-            try:
-                start = default_timer()
-                function, args, kwargs = self.deserialize(function, args, kwargs,
-                        task)
-                diagnostics['deserialization'] = default_timer() - start
-            except Exception as e:
-                logger.warn("Could not deserialize task", exc_info=True)
-                emsg = error_message(e)
-                emsg['key'] = key
-                raise Return(emsg)
+        diagnostics = dict()
+        try:
+            start = default_timer()
+            function, args, kwargs = self.deserialize(function, args, kwargs,
+                    task)
+            diagnostics['deserialization'] = default_timer() - start
+        except Exception as e:
+            logger.warn("Could not deserialize task", exc_info=True)
+            emsg = error_message(e)
+            emsg['key'] = key
+            raise Return(emsg)
 
-            self.active.add(key)
-            # Fill args with data
-            args2 = pack_data(args, data)
-            kwargs2 = pack_data(kwargs, data)
+        self.active.add(key)
+        # Fill args with data
+        args2 = pack_data(args, data)
+        kwargs2 = pack_data(kwargs, data)
 
-            # Log and compute in separate thread
-            result = yield self.executor_submit(key, apply_function, function,
-                                                args2, kwargs2)
+        # Log and compute in separate thread
+        result = yield self.executor_submit(key, apply_function, function,
+                                            args2, kwargs2)
 
-            result['key'] = key
-            result.update(diagnostics)
+        result['key'] = key
+        result.update(diagnostics)
 
-            if result['status'] == 'OK':
-                self.data[key] = result.pop('result')
-                if report:
-                    response = yield self.scheduler.add_keys(keys=[key],
-                                            address=(self.ip, self.port))
-                    if not response == 'OK':
-                        logger.warn('Could not report results to scheduler: %s',
-                                    str(response))
-            else:
-                logger.warn(" Compute Failed\n"
-                    "Function: %s\n"
-                    "args:     %s\n"
-                    "kwargs:   %s\n",
-                    str(funcname(function))[:1000],
-                    convert_args_to_str(args, max_len=1000),
-                    convert_kwargs_to_str(kwargs, max_len=1000), exc_info=True)
+        if result['status'] == 'OK':
+            self.data[key] = result.pop('result')
+            if report:
+                response = yield self.scheduler.add_keys(keys=[key],
+                                        address=(self.ip, self.port))
+                if not response == 'OK':
+                    logger.warn('Could not report results to scheduler: %s',
+                                str(response))
+        else:
+            logger.warn(" Compute Failed\n"
+                "Function: %s\n"
+                "args:     %s\n"
+                "kwargs:   %s\n",
+                str(funcname(function))[:1000],
+                convert_args_to_str(args, max_len=1000),
+                convert_kwargs_to_str(kwargs, max_len=1000), exc_info=True)
 
-            logger.debug("Send compute response to scheduler: %s, %s", key,
-                         result)
-            try:
-                self.active.remove(key)
-            except KeyError:
-                pass
-            raise Return(result)
+        logger.debug("Send compute response to scheduler: %s, %s", key,
+                     result)
+        try:
+            self.active.remove(key)
+        except KeyError:
+            pass
+        raise Return(result)
 
     @gen.coroutine
     def compute(self, stream=None, function=None, key=None, args=(), kwargs={},


### PR DESCRIPTION
This adds a new, fairly intense test for resilience to massive and repeated worker failure.  This uncovers a large number of tiny flaws in our resilience that add up.  

This PR doesn't resolve the problem.  There are still more issues.

However, the costly experience of tracking these down also demonstrates that the scheduler has grown too complex to make debugging convenient.  I'm spending a lot more time on this than I used to.  It may be time for a large refactor / redesign.

cc @frol 