### PR TITLE
Fix --no-nanny in dask-worker

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -76,7 +76,14 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
     services = {('http', http_port): HTTPWorker}
 
     loop = IOLoop.current()
-    t = Worker if no_nanny else Nanny
+
+    if no_nanny:
+        kwargs = {}
+        t = Worker
+    else:
+        kwargs = {'worker_port': worker_port}
+        t = Nanny
+
     if host is not None:
         ip = socket.gethostbyname(host)
     else:
@@ -84,8 +91,7 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
         # reach the scheduler
         ip = get_ip(scheduler_ip, scheduler_port)
     nannies = [t(scheduler_ip, scheduler_port, ncores=nthreads, ip=ip,
-                 services=services, name=name, loop=loop,
-                 worker_port=worker_port)
+                 services=services, name=name, loop=loop, **kwargs)
                for i in range(nprocs)]
 
     for nanny in nannies:

--- a/distributed/cli/tests/test_dworker.py
+++ b/distributed/cli/tests/test_dworker.py
@@ -29,3 +29,10 @@ def test_nanny_worker_ports(loop):
                         assert time() - start < 5
                         sleep(0.1)
                 assert d['workers']['127.0.0.1:8788']['services']['nanny'] == 8789
+
+
+def test_no_nanny(loop):
+    with popen(['dask-scheduler']) as sched:
+        with popen(['dask-worker', '127.0.0.1:8786', '--no-nanny']) as worker:
+            assert any(b'Registered' in worker.stderr.readline()
+                        for i in range(10))


### PR DESCRIPTION
Previously the --no-nanny option to dask-worker failed.

This fixes it and provides a test.

Fixes #374 