### PR TITLE
Protocol supports large bytes in nested objects

### DIFF
--- a/distributed/protocol.py
+++ b/distributed/protocol.py
@@ -27,17 +27,15 @@ outside of this module though and is not baked in.
 from __future__ import print_function, division, absolute_import
 
 import random
-import struct
 
 try:
     import pandas.msgpack as msgpack
 except ImportError:
     import msgpack
 
-from toolz import first, keymap, identity, merge
+from toolz import identity, get_in
 
 from .utils import ignoring
-from .compatibility import unicode
 
 
 compressions = {None: {'compress': identity,
@@ -64,35 +62,77 @@ with ignoring(ImportError):
     default_compression = 'lz4'
 
 
+def _extract_big_bytes(x, big, path=()):
+    if type(x) is dict:
+        for k, v in x.items():
+            if isinstance(v, (list, dict)):
+                _extract_big_bytes(v, big, path + (k,))
+            elif type(v) is bytes and len(v) >= 2**31:
+                big[path + (k,)] = v
+                del x[k]
+    elif type(x) is list:
+        for k, v in enumerate(x):
+            if isinstance(v, (list, dict)):
+                _extract_big_bytes(v, big, path + (k,))
+            elif type(v) is bytes and len(v) >= 2**31:
+                big[path + (k,)] = v
+                x[k] = None
+
+
 def dumps(msg):
     """ Transform Python value to bytestream suitable for communication """
-    small_header = {}
-
+    big = {}
+    # Only dicts can contain big values
     if isinstance(msg, dict):
-        big = {k: v for k, v in msg.items()
-                    if isinstance(v, bytes) and len(v) > 1e6}
-    else:
-        big = False
-    if big:
-        small = {k: v for k, v in msg.items() if k not in big}
-    else:
-        small = msg
+        _extract_big_bytes(msg, big)
+    small_header, small_payload = dumps_msgpack(msg)
+    if not big:
+        return small_header, small_payload
 
-    frames = dumps_msgpack(small)
-    if big:
-        frames += dumps_big_byte_dict(big)
+    # Shard the big segments
+    shards = []
+    res = {}
+    for k, v in list(big.items()):
+        L = []
+        for i, j in enumerate(range(0, len(v), 2**30)):
+            key = '.shard-%d-%s' % (i, k)
+            res[key] = v[j: j + 2**30]
+            L.append(key)
+        shards.append((k, L))
 
-    return frames
+    keys, values = zip(*res.items())
+
+    compression = []
+    values2 = []
+    for v in values:
+        fmt, vv = maybe_compress(v)
+        compression.append(fmt)
+        values2.append(vv)
+
+    header = {'encoding': 'big-byte-dict',
+              'keys': keys,
+              'compression': compression,
+              'shards': shards}
+
+    return [small_header, small_payload,
+            msgpack.dumps(header, use_bin_type=True)] + values2
 
 
 def loads(frames):
     """ Transform bytestream back into Python value """
-    header, payload, frames = frames[0], frames[1], frames[2:]
-    msg = loads_msgpack(header, payload)
+    small_header, small_payload, frames = frames[0], frames[1], frames[2:]
+    msg = loads_msgpack(small_header, small_payload)
 
     if frames:
-        big = loads_big_byte_dict(*frames)
-        msg.update(big)
+        header = msgpack.loads(frames[0], encoding='utf8')
+
+        values2 = [compressions[c]['decompress'](v)
+                   for c, v in zip(header['compression'], frames[1:])]
+        lk = dict(zip(header['keys'], values2))
+
+        for k, keys in header['shards']:
+            v = b''.join(lk.pop(kk) for kk in keys)
+            get_in(k[:-1], msg)[k[-1]] = v
 
     return msg
 
@@ -109,7 +149,7 @@ def byte_sample(b, size, n):
 
 
 def maybe_compress(payload, compression=default_compression, min_size=1e4,
-        sample_size=1e4, nsamples=5):
+                   sample_size=1e4, nsamples=5):
     """ Maybe compress payload
 
     1.  We don't compress small messages
@@ -183,65 +223,6 @@ def loads_msgpack(header, payload):
             payload = decompress(payload)
         except KeyError:
             raise ValueError("Data is compressed as %s but we don't have this"
-                    " installed" % header['compression'].decode())
+                             " installed" % header['compression'].decode())
 
     return msgpack.loads(payload, encoding='utf8')
-
-
-def dumps_big_byte_dict(d):
-    """ Serialize large byte dictionary to sequence of frames
-
-    The input must be a dictionary and all values of that dictionary must be
-    bytestrings.  These should probably be large.
-
-    Returns a sequence of frames, one header followed by each of the values
-
-    See Also:
-        loads_big_byte_dict
-    """
-    assert isinstance(d, dict) and all(isinstance(v, bytes) for v in d.values())
-    shards = {}
-    for k, v in list(d.items()):
-        if len(v) >= 2**31:
-            L = []
-            for i, j in enumerate(range(0, len(v), 2**30)):
-                key = '.shard-%d-%s' % (i, k)
-                d[key] = v[j: j + 2**30]
-                L.append(key)
-            del d[k]
-            shards[k] = L
-
-    keys, values = zip(*d.items())
-
-    compress = compressions[default_compression]['compress']
-    compression = []
-    values2 = []
-    for v in values:
-        fmt, vv = maybe_compress(v)
-        compression.append(fmt)
-        values2.append(vv)
-
-    header = {'encoding': 'big-byte-dict',
-              'keys': keys,
-              'compression': compression}
-    if shards:
-        header['shards'] = shards
-
-    return [msgpack.dumps(header, use_bin_type=True)] + values2
-
-
-def loads_big_byte_dict(header, *values):
-    """ Deserialize big-byte frames to large byte dictionary
-
-    See Also:
-        dumps_big_byte_dict
-    """
-    header = msgpack.loads(header, encoding='utf8')
-
-    values2 = [compressions[c]['decompress'](v)
-               for c, v in zip(header['compression'], values)]
-    result = dict(zip(header['keys'], values2))
-
-    for k, keys in header.get('shards', {}).items():
-        result[k] = b''.join(result.pop(kk) for kk in keys)
-    return result

--- a/distributed/protocol.py
+++ b/distributed/protocol.py
@@ -63,6 +63,10 @@ with ignoring(ImportError):
     default_compression = 'lz4'
 
 
+BIG_BYTES_SIZE = 2**20
+BIG_BYTES_SHARD_SIZE = 2**28
+
+
 def extract_big_bytes(x):
     big = {}
     _extract_big_bytes(x, big)
@@ -82,13 +86,13 @@ def _extract_big_bytes(x, big, path=()):
         for k, v in x.items():
             if isinstance(v, (list, dict)):
                 _extract_big_bytes(v, big, path + (k,))
-            elif type(v) is bytes and len(v) >= 2**31:
+            elif type(v) is bytes and len(v) >= BIG_BYTES_SIZE:
                 big[path + (k,)] = v
     elif type(x) is list:
         for k, v in enumerate(x):
             if isinstance(v, (list, dict)):
                 _extract_big_bytes(v, big, path + (k,))
-            elif type(v) is bytes and len(v) >= 2**31:
+            elif type(v) is bytes and len(v) >= BIG_BYTES_SIZE:
                 big[path + (k,)] = v
 
 
@@ -107,9 +111,9 @@ def dumps(msg):
     res = {}
     for k, v in list(big.items()):
         L = []
-        for i, j in enumerate(range(0, len(v), 2**30)):
+        for i, j in enumerate(range(0, len(v), BIG_BYTES_SHARD_SIZE)):
             key = '.shard-%d-%s' % (i, k)
-            res[key] = v[j: j + 2**30]
+            res[key] = v[j: j + BIG_BYTES_SHARD_SIZE]
             L.append(key)
         shards.append((k, L))
 

--- a/distributed/tests/test_protocol.py
+++ b/distributed/tests/test_protocol.py
@@ -1,15 +1,16 @@
 from __future__ import print_function, division, absolute_import
+from copy import deepcopy
 
-from distributed.protocol import (loads, dumps, dumps_msgpack, loads_msgpack,
-        dumps_big_byte_dict, loads_big_byte_dict, msgpack, maybe_compress)
+from distributed.protocol import loads, dumps, msgpack, maybe_compress
 import pytest
+
 
 def test_protocol():
     for msg in [1, 'a', b'a', {'x': 1}, {b'x': 1}, {'x': b''}, {}]:
         assert loads(dumps(msg)) == msg
 
 
-def test_compression():
+def test_compression_1():
     pytest.importorskip('lz4')
     np = pytest.importorskip('numpy')
     x = np.ones(1000000)
@@ -19,7 +20,7 @@ def test_compression():
     assert x.tobytes() == y
 
 
-def test_compression():
+def test_compression_2():
     pytest.importorskip('lz4')
     np = pytest.importorskip('numpy')
     x = np.random.random(10000)
@@ -41,21 +42,12 @@ def test_small_and_big():
     # assert loads([big_header, big]) == {'y': d['y']}
 
 
-def test_big_bytes():
-    d = {'x': b'123', b'y': b'4567'}
-    L = dumps_big_byte_dict(d)
-    assert isinstance(L, (tuple, list))
-    assert all(isinstance(item, bytes) for item in L)
-    dd = loads_big_byte_dict(*L)
-    assert dd == d
-
-
 def test_big_bytes_protocol():
     np = pytest.importorskip('numpy')
     data = np.random.randint(0, 255, dtype='u1', size=2000000).tobytes()
     d = {'x': data, 'y': b'1' * 2000000}
-    L = dumps(d)
-    assert d['x'] in L
+    L = dumps(d.copy())
+    assert d['x'] in L[1]
     dd = loads(L)
     assert dd == d
 
@@ -86,8 +78,16 @@ def test_large_messages():
     pytest.importorskip('lz4')
     if psutil.virtual_memory().total < 8e9:
         return
-    msg = {'x': b'0' * (2**31 + 10)}
 
-    b = dumps(msg)
+    big_bytes = b'0' * (2**31 + 10)
+    msg = {'x': [big_bytes, b'small_bytes'],
+           'y': {'a': big_bytes, 'b': b'small_bytes'}}
+
+    b = dumps(deepcopy(msg))
     msg2 = loads(b)
     assert msg == msg2
+
+    assert len(b) >= 2
+    big_header = msgpack.loads(b[2], encoding='utf8')
+    assert len(big_header['shards']) == 2
+    assert len(big_header['keys']) + 2 + 1 == len(b)

--- a/distributed/tests/test_protocol.py
+++ b/distributed/tests/test_protocol.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division, absolute_import
-from copy import deepcopy
 
 from distributed.protocol import loads, dumps, msgpack, maybe_compress
 import pytest
@@ -46,7 +45,7 @@ def test_big_bytes_protocol():
     np = pytest.importorskip('numpy')
     data = np.random.randint(0, 255, dtype='u1', size=2000000).tobytes()
     d = {'x': data, 'y': b'1' * 2000000}
-    L = dumps(d.copy())
+    L = dumps(d)
     assert d['x'] in L[1]
     dd = loads(L)
     assert dd == d
@@ -83,7 +82,7 @@ def test_large_messages():
     msg = {'x': [big_bytes, b'small_bytes'],
            'y': {'a': big_bytes, 'b': b'small_bytes'}}
 
-    b = dumps(deepcopy(msg))
+    b = dumps(msg)
     msg2 = loads(b)
     assert msg == msg2
 


### PR DESCRIPTION
Previously the distributed protocol would only shard large bytestrings
if they were values in the top level dictionary. This would cause
problems if there were large bytestrings in nested objects.

To overcome this, we now shard all large bytestrings if they meet the
following requirements:

- The top level of the message is a dictionary
- They are contained in any level of `dict`/`list` nesting. Other
  objects aren't traversed.

Fixes #393.