### PR TITLE
remove redundant catch of FileNotFoundError

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1569,7 +1569,7 @@ class Scheduler(Server):
 
                     self.ensure_idle_ready()
 
-            except (StreamClosedError, IOError, OSError, FileNotFoundError):
+            except (StreamClosedError, IOError, OSError):
                 logger.info("Worker failed from closed stream: %s", worker)
             finally:
                 if not stream.closed():


### PR DESCRIPTION
FileNotFoundError is a subclass of OSError on Python 3 (wrapping errno=ENOENT), and unavailable on Python 2.

Catching OSError already catches FileNotFoundError.

```python
In [1]: FileNotFoundError.mro()
Out[1]: [FileNotFoundError, OSError, Exception, BaseException, object]
```

closes #405