### PR TITLE
Start Diagnostics server by default

### DIFF
--- a/distributed/bokeh/status/main.py
+++ b/distributed/bokeh/status/main.py
@@ -8,10 +8,7 @@ from bokeh.io import curdoc
 from bokeh.layouts import column, row
 from toolz import valmap
 
-from distributed.bokeh.status_monitor import (
-    worker_table_plot, worker_table_update, task_table_plot,
-    task_table_update, progress_plot, task_stream_plot
-)
+from distributed.bokeh.status_monitor import progress_plot, task_stream_plot
 from distributed.bokeh.worker_monitor import resource_profile_plot
 from distributed.diagnostics.progress_stream import progress_quads
 from distributed.utils import log_errors
@@ -23,6 +20,7 @@ WIDTH = 600
 messages = distributed.bokeh.messages  # global message store
 doc = curdoc()
 
+"""
 worker_source, worker_table = worker_table_plot()
 def worker_update():
     with log_errors():
@@ -43,6 +41,7 @@ def task_update():
             return
         task_table_update(task_source, msg)
 doc.add_periodic_callback(task_update, messages['tasks']['interval'])
+"""
 
 
 resource_index = [0]

--- a/distributed/bokeh/status/server_lifecycle.py
+++ b/distributed/bokeh/status/server_lifecycle.py
@@ -27,8 +27,10 @@ client = AsyncHTTPClient()
 
 messages = distributed.bokeh.messages  # monkey-patching
 
-if os.path.exists('.dask-web-ui.json'):
-    with open('.dask-web-ui.json', 'r') as f:
+dask_dir = os.path.join(os.path.expanduser('~'), '.dask')
+options_path = os.path.join(dask_dir, '.dask-web-ui.json')
+if os.path.exists(options_path):
+    with open(options_path, 'r') as f:
         options = json.load(f)
 else:
     options = {'host': '127.0.0.1',
@@ -40,11 +42,11 @@ else:
 def http_get(route):
     """ Get data from JSON route, store in messages deques """
     try:
-        response = yield client.fetch(
-                'http://%(host)s:%(http-port)d/' % options
-                 + route + '.json')
-    except ConnectionRefusedError:
-        import sys; sys.exit(0)
+        url = 'http://%(host)s:%(http-port)d/' % options + route + '.json'
+        response = yield client.fetch(url)
+    except ConnectionRefusedError as e:
+        logger.info("Can not connect to %s", url, exc_info=True)
+        return
     except HTTPError:
         logger.warn("http route %s failed", route)
         return

--- a/distributed/bokeh/tests/test_application.py
+++ b/distributed/bokeh/tests/test_application.py
@@ -1,6 +1,8 @@
 import requests
 from time import time, sleep
 
+import pytest
+
 from distributed.bokeh.application import BokehWebInterface
 from distributed import LocalCluster
 from distributed.http import HTTPScheduler
@@ -9,17 +11,21 @@ from distributed.utils import ignoring
 
 def test_BokehWebInterface(loop):
     with LocalCluster(2, loop=loop, scheduler_port=0,
-                      services={('http', 0): HTTPScheduler}) as c:
-        w = BokehWebInterface(
+                      services={('http', 0): HTTPScheduler},
+                      diagnostic_port=None) as c:
+        with pytest.raises(Exception):
+            response = requests.get('http://127.0.0.1:8787/status/')
+        with BokehWebInterface(
                 tcp_port=c.scheduler.port,
                 http_port=c.scheduler.services['http'].port,
-                bokeh_port=8787)
-
-        start = time()
-        while True:
-            with ignoring(Exception):
-                response = requests.get('http://127.0.0.1:8787/status/')
-                if response.ok:
-                    break
-            assert time() < start + 5
-            sleep(0.01)
+                bokeh_port=8787) as w:
+            start = time()
+            while True:
+                with ignoring(Exception):
+                    response = requests.get('http://127.0.0.1:8787/status/')
+                    if response.ok:
+                        break
+                assert time() < start + 5
+                sleep(0.01)
+    with pytest.raises(Exception):
+        response = requests.get('http://127.0.0.1:8787/status/')

--- a/distributed/bokeh/tests/test_worker_monitor.py
+++ b/distributed/bokeh/tests/test_worker_monitor.py
@@ -13,6 +13,7 @@ from distributed.bokeh.worker_monitor import (resource_profile_plot,
 from distributed.diagnostics.scheduler import workers, tasks
 from distributed.utils_test import gen_cluster
 
+
 @gen_cluster()
 def test_resource_monitor_plot(s, a, b):
     while any('last-seen' not in v for v in s.host_info.values()):

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -58,7 +58,7 @@ def main(center, host, port, http_port, bokeh_port, show, _bokeh,
             bokeh_proc = BokehWebInterface(host=host, http_port=http_port,
                     tcp_port=port, bokeh_port=bokeh_port,
                     bokeh_whitelist=bokeh_whitelist, show=show, prefix=prefix,
-                    use_xheaders=use_xheaders)
+                    use_xheaders=use_xheaders, quiet=False)
         except ImportError:
             logger.info("Please install Bokeh to get Web UI")
         except Exception as e:

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -23,6 +23,10 @@ def test_defaults(loop):
             response = requests.get('http://127.0.0.1:9786/info.json')
             assert response.ok
             assert response.json()['status'] == 'running'
+    with pytest.raises(Exception):
+        requests.get('http://127.0.0.1:9786/info.json')
+    with pytest.raises(Exception):
+        requests.get('http://127.0.0.1:8787/status/')
 
 
 def test_hostport(loop):
@@ -38,6 +42,8 @@ def test_no_bokeh(loop):
             for i in range(3):
                 line = proc.stderr.readline()
                 assert b'bokeh' not in line.lower()
+            with pytest.raises(Exception):
+                requests.get('http://127.0.0.1:8787/status/')
 
 
 def test_bokeh(loop):
@@ -63,6 +69,8 @@ def test_bokeh(loop):
                 print(f)
                 sleep(0.1)
                 assert time() < start + 10
+    with pytest.raises(Exception):
+        requests.get('http://127.0.0.1:8787/status/')
 
 
 def test_bokeh_non_standard_ports(loop):
@@ -89,6 +97,8 @@ def test_bokeh_non_standard_ports(loop):
             except:
                 sleep(0.1)
                 assert time() < start + 20
+    with pytest.raises(Exception):
+        requests.get('http://127.0.0.1:4832/status/')
 
 
 @pytest.mark.skipif(not sys.platform.startswith('linux'),

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -53,7 +53,8 @@ class LocalCluster(object):
     """
     def __init__(self, n_workers=None, threads_per_worker=None, nanny=True,
             loop=None, start=True, scheduler_port=8786,
-            silence_logs=logging.CRITICAL, diagnostics_port=None, **kwargs):
+            silence_logs=logging.CRITICAL, diagnostics_port=8787,
+            services={'http': HTTPScheduler}, **kwargs):
         if silence_logs:
             for l in ['distributed.scheduler',
                       'distributed.worker',
@@ -80,10 +81,8 @@ class LocalCluster(object):
             while not self.loop._running:
                 sleep(0.001)
 
-        if diagnostics_port and 'services' not in kwargs:  # bokeh needs http
-            kwargs['services'] = {('http', 0): HTTPScheduler}
-
-        self.scheduler = Scheduler(loop=self.loop, ip='127.0.0.1', **kwargs)
+        self.scheduler = Scheduler(loop=self.loop, ip='127.0.0.1',
+                                   services=services)
         self.scheduler.start(scheduler_port)
         self.workers = []
 

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -81,7 +81,7 @@ def test_futures_to_dask_dataframe(loop):
             assert ddf.dask == ddf2.dask
 
 
-@gen_cluster(timeout=120, executor=True)
+@gen_cluster(timeout=240, executor=True)
 def test_dataframes(e, s, a, b):
     df = pd.DataFrame({'x': np.random.random(10000),
                        'y': np.random.random(10000)},
@@ -109,7 +109,8 @@ def test_dataframes(e, s, a, b):
     for f in exprs:
         local = f(ldf).compute(get=dask.get)
         remote = e.compute(f(rdf))
-        remote = yield gen.with_timeout(timedelta(seconds=5), remote._result())
+        remote = yield gen.with_timeout(timedelta(seconds=5),
+                                        remote._result())
         assert_equal(local, remote)
 
 


### PR DESCRIPTION
Previously when calling `Executor()` or `LocalCluster()` we wouldn't
start up a bokeh server by default, instead asking users to find
`e.cluster.start_diagnostics_server()`.  Now we start this by default.

Additionally, we used to pass information via a `.dask-web-ui.json` file
which was written to the local directory, but searched for in the
install directory.  Now we write this to a `~/.dask/` directory instead
for global access.

Finally we turn off bokeh logging to clean up the interactive experience
and remove some unused bokeh plots (tables) that were using deprecated
functionality and causing warnings to pop up.

Fixes #402