### PR TITLE
Resolve intermittent failures

### DIFF
--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -57,7 +57,10 @@ def test_many_Progress(e, s, a, b):
 
     yield z._result()
 
-    assert all(b.status == 'finished' for b in bars)
+    start = time()
+    while not all(b.status == 'finished' for b in bars):
+        yield gen.sleep(0.1)
+        assert time() < start + 2
 
 
 @gen_cluster(executor=True)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1606,6 +1606,7 @@ class Scheduler(Server):
             self.processing[worker][key] = duration
             self.rprocessing[key].add(worker)
             self.occupancy[worker] += duration
+            self.task_state[key] = 'processing'
 
             logger.debug("Send job to worker: %s, %s", worker, key)
 
@@ -1613,9 +1614,6 @@ class Scheduler(Server):
                 self.send_task_to_worker(worker, key)
             except StreamClosedError:
                 self.remove_worker(worker)
-                return
-
-            self.task_state[key] = 'processing'
 
             return {}
         except Exception as e:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1054,7 +1054,8 @@ class Scheduler(Server):
                         self.transitions(recommendations)
 
                         if self.validate:
-                            logger.info("%s\n%s", msgs, recommendations)
+                            logger.info("Messages: %s\nRecommendations: %s",
+                                        msgs, recommendations)
                     self.ensure_occupied()
 
         except (StreamClosedError, IOError, OSError):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -737,7 +737,7 @@ class Scheduler(Server):
                     if key in self.waiting_data and not self.waiting_data[key]:
                         r = self.transition(key, 'released')
                         self.transitions(r)
-                    if not self.dependents[key]:
+                    if key in self.dependents and not self.dependents[key]:
                         r = self.transition(key, 'forgotten')
                         self.transitions(r)
 

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -83,9 +83,9 @@ def test_futures_to_dask_dataframe(loop):
 
 @gen_cluster(timeout=240, executor=True)
 def test_dataframes(e, s, a, b):
-    df = pd.DataFrame({'x': np.random.random(10000),
-                       'y': np.random.random(10000)},
-                       index=np.arange(10000))
+    df = pd.DataFrame({'x': np.random.random(1000),
+                       'y': np.random.random(1000)},
+                       index=np.arange(1000))
     ldf = dd.from_pandas(df, npartitions=10)
 
     rdf = e.persist(ldf)
@@ -109,8 +109,7 @@ def test_dataframes(e, s, a, b):
     for f in exprs:
         local = f(ldf).compute(get=dask.get)
         remote = e.compute(f(rdf))
-        remote = yield gen.with_timeout(timedelta(seconds=5),
-                                        remote._result())
+        remote = yield remote._result()
         assert_equal(local, remote)
 
 

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1996,9 +1996,9 @@ def test__cancel_collection(e, s, a, b):
 def test_cancel(loop):
     with cluster() as (s, [a, b]):
         with Executor(('127.0.0.1', s['port']), loop=loop) as e:
-            x = e.submit(slowinc, 1)
-            y = e.submit(slowinc, x)
-            z = e.submit(slowinc, y)
+            x = e.submit(slowinc, 1, key='x')
+            y = e.submit(slowinc, x, key='y')
+            z = e.submit(slowinc, y, key='z')
 
             e.cancel([y])
 


### PR DESCRIPTION
There appear to be occasional failures in the following tests:

- [x] distributed/tests/test_executor.py::test_cancel
- [x] distributed/tests/test_executor.py::test_submit_after_failed_worker
- [x] distributed/tests/test_executor.py::test_stress_creation_and_deletion
- [x] distributed/tests/test_collections.py::test_dataframes

This PR will eventually have fixes.  For now I'm just using it to trigger travis-ci builds.