### PR TITLE
Don't register hdfs backend if hdfs3 not installed

### DIFF
--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -2,20 +2,16 @@
 from __future__ import print_function, division, absolute_import
 
 import logging
-import json
 from math import log
 import os
-import io
 from warnings import warn
 
-from dask.delayed import delayed
-from dask.base import tokenize
 import dask.bytes.core
+from dask.delayed import delayed
 from toolz import merge
+from hdfs3 import HDFileSystem
 
-from .compatibility import unicode
 from .executor import default_executor, ensure_default_get
-from .utils import ensure_bytes
 
 
 logger = logging.getLogger(__name__)
@@ -37,7 +33,6 @@ def get_block_locations(hdfs, filename):
 
 def read_block_from_hdfs(filename, offset, length, host=None, port=None,
         delimiter=None):
-    from hdfs3 import HDFileSystem
     from locket import lock_file
     with lock_file('.lock'):
         hdfs = HDFileSystem(host=host, port=port)
@@ -71,7 +66,6 @@ def read_bytes(path, executor=None, hdfs=None, lazy=True, delimiter=None,
     """
     if compression:
         raise NotImplementedError("hdfs compression")
-    from hdfs3 import HDFileSystem
     hdfs = hdfs or HDFileSystem(**hdfs_auth)
     executor = default_executor(executor)
     blocks = get_block_locations(hdfs, path)
@@ -112,7 +106,6 @@ dask.bytes.core._read_bytes['hdfs'] = read_bytes
 
 
 def hdfs_open_file(path, auth):
-    from hdfs3 import HDFileSystem
     hdfs = HDFileSystem(**auth)
     return hdfs.open(path, mode='rb')
 
@@ -121,7 +114,6 @@ def open_files(path, hdfs=None, lazy=None, **auth):
     if lazy is not None:
         raise DeprecationWarning("Lazy keyword has been deprecated. "
                                  "Now always lazy")
-    from hdfs3 import HDFileSystem
     hdfs = hdfs or HDFileSystem(**auth)
     filenames = sorted(hdfs.glob(path))
     myopen = delayed(hdfs_open_file)
@@ -165,7 +157,6 @@ def write_bytes(path, futures, executor=None, hdfs=None, **hdfs_auth):
     >>> write_bytes('/data/file.*.dat', futures, hdfs=hdfs)  # doctest: +SKIP
     >>> write_bytes('/data/', futures, hdfs=hdfs)  # doctest: +SKIP
     """
-    from hdfs3 import HDFileSystem
     hdfs = hdfs or HDFileSystem(**hdfs_auth)
     executor = default_executor(executor)
 

--- a/distributed/tests/test_hdfs.py
+++ b/distributed/tests/test_hdfs.py
@@ -11,20 +11,18 @@ from distributed.compatibility import unicode
 from distributed.utils_test import gen_cluster, cluster, make_hdfs
 from distributed.utils import get_ip
 from distributed.utils_test import loop
-from distributed.hdfs import (read_bytes, get_block_locations, write_bytes)
 from distributed import Executor
 from distributed.executor import _wait, Future
 
+hdfs3 = pytest.importorskip('hdfs3')
+from distributed.hdfs import read_bytes, get_block_locations, write_bytes
 
-pytest.importorskip('hdfs3')
-from hdfs3 import HDFileSystem
 try:
-    hdfs = HDFileSystem(host='localhost', port=8020)
+    hdfs = hdfs3.HDFileSystem(host='localhost', port=8020)
     hdfs.df()
     del hdfs
 except:
-    pytestmark = pytest.mark.skipif('True')
-
+    pytestmark = pytest.skip()
 
 ip = get_ip()
 


### PR DESCRIPTION
Previously importing `distributed.hdfs` would cause `dask.core.bytes` to have `hdfs` registered *even if* `hdfs3` wasn't installed. This was causing problems with the function that checks if the backend is available, leading to hard to diagnose bugs. This was discovered in https://github.com/dask/dask/pull/1464, where the test failed only if the doctests were run *and* the whole test suite was run (ordering dependent). A hack to deal with the issue was added in https://github.com/dask/dask/pull/1464/commits/a353995fbe39822876e8cc35ac800180ffeac83b, but it's not ideal.

This fixes the issue, only registering the hdfs backend if hdfs3 is installed.