### PR TITLE
Avoid dropped message

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -116,7 +116,8 @@ def gather_from_workers(who_has, deserialize=True, rpc=rpc, close=True,
             else:
                 raise KeyError(*bad_keys)
 
-        coroutines = [rpc(address).get_data(keys=keys, close=close)
+        rpcs = {address: rpc(address) for address in d}
+        coroutines = [rpcs[address].get_data(keys=keys, close=close)
                             for address, keys in d.items()]
         response = yield ignore_exceptions(coroutines, socket.error,
                                            StreamClosedError)


### PR DESCRIPTION
This was reported by a private user.  There are some cases where a message appears to be dropped when gathering data between workers.

The requester sends off hundreds of requests to various other workers, all but one comes back, and the worker waits forever for the missing message.  Looking at traces it looks like the requester definitely sent the message and the network on the other side definitely received it, however the worker itself never actually called `read` on the message to respond to it correctly.

Replacing the rpc mechanism with straight IOStreams seems to remove the issue.  It's unclear why however; this may point to a deeper issue within our communication system.