### PR TITLE
clean up docstring

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1112,7 +1112,7 @@ class Scheduler(Server):
         """
         Add external plugin to scheduler
 
-        See http://http://distributed.readthedocs.io/en/latest/plugins.html
+        See http://distributed.readthedocs.io/en/latest/plugins.html
         """
         self.plugins.append(plugin)
 


### PR DESCRIPTION
Small errror in docstring and subsequent rtd page error here: http://distributed.readthedocs.io/en/latest/scheduler.html#distributed.scheduler.Scheduler.add_plugin

> http://http://distributed.readthedocs.io/en/latest/plugins.html

to 

> http://distributed.readthedocs.io/en/latest/plugins.html