### PR TITLE
Adapt work stealing to the number of idle workers

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2331,7 +2331,8 @@ class Scheduler(Server):
         transfer_time = nbytes / bandwidth
         try:
             compute_time = self.task_duration[key_split(key)]
-            return transfer_time < compute_time
+            factor = len(self.idle) / len(self.saturated)
+            return transfer_time < compute_time * factor
         except KeyError:
             return False
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -119,9 +119,9 @@ def randominc(x, scale=1):
     return x + 1
 
 
-def slowadd(x, y):
+def slowadd(x, y, delay=0.02):
     from time import sleep
-    sleep(0.02)
+    sleep(delay)
     return x + y
 
 


### PR DESCRIPTION
If there are many more idle workers than saturated ones then we
accept a higher communication to computation ratio imbalance.