### PR TITLE
Add coroutine to synchronize worker data

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -169,6 +169,7 @@ class Scheduler(Server):
 
     def __init__(self, center=None, loop=None,
             max_buffer_size=MAX_BUFFER_SIZE, delete_interval=500,
+            synchronize_worker_interval=5000,
             ip=None, services=None, allowed_failures=ALLOWED_FAILURES,
             validate=False, **kwargs):
 
@@ -178,6 +179,7 @@ class Scheduler(Server):
         self.validate = validate
         self.status = None
         self.delete_interval = delete_interval
+        self.synchronize_worker_interval = synchronize_worker_interval
 
         # Communication state
         self.loop = loop or IOLoop.current()
@@ -330,6 +332,12 @@ class Scheduler(Server):
                                  io_loop=self.loop)
         self._delete_periodic_callback.start()
 
+        self._synchronize_data_periodic_callback = \
+                PeriodicCallback(callback=self.synchronize_worker_data,
+                                 callback_time=self.synchronize_worker_interval,
+                                 io_loop=self.loop)
+        self._synchronize_data_periodic_callback.start()
+
         if start_queues:
             self.loop.add_callback(self.handle_queues, self.scheduler_queues[0], None)
 
@@ -371,6 +379,8 @@ class Scheduler(Server):
         --------
         Scheduler.cleanup
         """
+        self._delete_periodic_callback.stop()
+        self._synchronize_data_periodic_callback.stop()
         for service in self.services.values():
             service.stop()
         yield self.cleanup()
@@ -1371,7 +1381,10 @@ class Scheduler(Server):
         if worker is None:
             result = yield {w: self.synchronize_worker_data(worker=w)
                     for w in self.worker_info}
-            raise Return({k: v for k, v in result.items() if any(v.values())})
+            result = {k: v for k, v in result.items() if any(v.values())}
+            if result:
+                logger.info("Excess keys found on workers: %s", result)
+            raise Return(result)
         else:
             keys = yield self.rpc(addr=worker).keys()
             keys = set(keys)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3421,6 +3421,20 @@ def test_synchronize_worker_data(e, s, a, b):
     assert not a.data
 
 
+@gen_test()
+def test_synchronize_worker_data_callback():
+    s = Scheduler(synchronize_worker_interval=50)
+    s.start(0)
+    a = Worker(s.ip, s.port, name='alice')
+    yield a._start()
+
+    a.data['x'] = 1
+
+    yield gen.sleep(0.200)
+
+    assert not a.data
+
+
 from distributed.utils_test import popen
 def test_reconnect(loop):
     w = Worker('127.0.0.1', 9393, loop=loop)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3413,6 +3413,14 @@ def test_scatter_raises_if_no_workers(e, s):
         yield e._scatter([1])
 
 
+@gen_cluster(executor=True)
+def test_synchronize_worker_data(e, s, a, b):
+    a.data['x'] = 1
+    response = yield s.synchronize_worker_data()
+    assert response == {a.address: {'extra': ['x'], 'missing': []}}
+    assert not a.data
+
+
 from distributed.utils_test import popen
 def test_reconnect(loop):
     w = Worker('127.0.0.1', 9393, loop=loop)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -149,6 +149,7 @@ class Worker(Server):
                     'health': self.host_health,
                     'upload_file': self.upload_file,
                     'start_ipython': self.start_ipython,
+                    'keys': self.keys,
                 }
 
         super(Worker, self).__init__(handlers, io_loop=self.loop, **kwargs)
@@ -733,6 +734,9 @@ class Worker(Server):
         except ImportError:
             pass
         return d
+
+    def keys(self, stream=None):
+        return list(self.data)
 
 
 job_counter = [0]


### PR DESCRIPTION
It's possible that some extra data is getting lost on the workers.
This adds a scheduler coroutine that does a proper synchronization with
the worker.

It's not clear yet whether or not this is necessary.  If it is
necessary then we can put it in a long running PeriodicCallback.

Fixes https://github.com/dask/distributed/issues/333