### PR TITLE
Convert progress bars to annuli

### DIFF
--- a/distributed/bokeh/status/main.py
+++ b/distributed/bokeh/status/main.py
@@ -10,7 +10,7 @@ from toolz import valmap
 
 from distributed.bokeh.status_monitor import progress_plot, task_stream_plot
 from distributed.bokeh.worker_monitor import resource_profile_plot
-from distributed.diagnostics.progress_stream import progress_quads
+from distributed.diagnostics.progress_stream import progress_wedge
 from distributed.utils import log_errors
 import distributed.bokeh
 
@@ -71,10 +71,10 @@ progress_source, progress_plot = progress_plot(sizing_mode=SIZING_MODE,
 def progress_update():
     with log_errors():
         msg = messages['progress']
-        d = progress_quads(msg)
+        d = progress_wedge(msg)
         progress_source.data.update(d)
         progress_plot.title.text = ("Progress -- total: %(total)s, "
-            "in-memory: %(in-memory)s, processing: %(processing)s, "
+            "memory: %(in-memory)s, processing: %(processing)s, "
             "ready: %(ready)s, waiting: %(waiting)s, failed: %(failed)s"
             % messages['tasks']['deque'][-1])
 doc.add_periodic_callback(progress_update, 50)

--- a/distributed/bokeh/status/main.py
+++ b/distributed/bokeh/status/main.py
@@ -67,7 +67,7 @@ doc.add_periodic_callback(resource_update, messages['workers']['interval'])
 
 
 progress_source, progress_plot = progress_plot(sizing_mode=SIZING_MODE,
-        width=WIDTH, height=300)
+        width=WIDTH, height=210)
 def progress_update():
     with log_errors():
         msg = messages['progress']

--- a/distributed/bokeh/status_monitor.py
+++ b/distributed/bokeh/status_monitor.py
@@ -183,32 +183,44 @@ def task_stream_append(lists, msg, workers, palette=task_stream_palette):
 
 
 def progress_plot(**kwargs):
-    from ..diagnostics.progress_stream import progress_quads
-    data = progress_quads({'all': {}, 'memory': {},
+    from ..diagnostics.progress_stream import progress_wedge
+    data = progress_wedge({'all': {}, 'memory': {},
                            'erred': {}, 'released': {}})
-
-    x_range = Range1d(-0.5, 1.5)
-    y_range = Range1d(5.1, -0.1)
     source = ColumnDataSource(data)
-    fig = figure(tools='', toolbar_location=None, y_range=y_range, x_range=x_range, **kwargs)
-    fig.quad(source=source, top='top', bottom='bottom',
-             left=0, right=1, color='#aaaaaa', alpha=0.2)
-    fig.quad(source=source, top='top', bottom='bottom',
-             left=0, right='released_right', color=Spectral9[0], alpha=0.4)
-    fig.quad(source=source, top='top', bottom='bottom',
-             left='released_right', right='memory_right',
-             color=Spectral9[0], alpha=0.8)
-    fig.quad(source=source, top='top', bottom='bottom',
-             left='erred_left', right=1,
-             color='#000000', alpha=0.3)
-    fig.text(source=source, text='fraction', y='center', x=-0.01,
-             text_align='right', text_baseline='middle')
-    fig.text(source=source, text='name', y='center', x=1.01,
-             text_align='left', text_baseline='middle')
-    fig.xgrid.grid_line_color = None
-    fig.ygrid.grid_line_color = None
-    fig.axis.visible = None
-    fig.outline_line_color = None
+
+    inner, outer = 0.2, 0.4
+
+    fig = figure(**kwargs)
+    fig.annular_wedge(source=source, x='x', y='y',
+                      inner_radius=inner, outer_radius=outer,
+                      start_angle=90, end_angle=90.001,
+                      direction='clock', color='#444444', alpha=0.1,
+                      start_angle_units='deg', end_angle_units='deg')
+    fig.annular_wedge(source=source, x='x', y='y',
+                      inner_radius=inner, outer_radius=outer,
+                      start_angle=90, end_angle='released-angle',
+                      direction='clock', color=Spectral9[0], alpha=0.3,
+                      start_angle_units='deg', end_angle_units='deg')
+    fig.annular_wedge(source=source, x='x', y='y',
+                      inner_radius=inner, outer_radius=outer,
+                      start_angle='released-angle', end_angle='memory-angle',
+                      direction='clock', color=Spectral9[0], alpha=0.8,
+                      start_angle_units='deg', end_angle_units='deg')
+    fig.annular_wedge(source=source, x='x', y='y',
+                      inner_radius=inner, outer_radius=outer,
+                      start_angle='memory-angle', end_angle='erred-angle',
+                      direction='clock', color='#000000', alpha=0.3,
+                      start_angle_units='deg', end_angle_units='deg')
+    fig.text(source=source, x='x', y='y', text_align='center',
+             text_baseline='bottom', text='done')
+    fig.text(source=source, x='x', y='y', text_align='center',
+             text_baseline='top', text='all')
+    fig.text(source=source, x='x', y='lower-y', text_align='center',
+             text='name')
+
+    fig.xaxis.visible = False
+    fig.yaxis.visible = False
+    fig.grid.grid_line_alpha = 0
 
     hover = HoverTool()
     fig.add_tools(hover)

--- a/distributed/bokeh/status_monitor.py
+++ b/distributed/bokeh/status_monitor.py
@@ -187,10 +187,12 @@ def progress_plot(**kwargs):
     data = progress_wedge({'all': {}, 'memory': {},
                            'erred': {}, 'released': {}})
     source = ColumnDataSource(data)
+    x_range = Range1d(-0.5, 5.5)
+    y_range = Range1d(-1.55, 0.4)
 
     inner, outer = 0.2, 0.4
 
-    fig = figure(**kwargs)
+    fig = figure(x_range=x_range, y_range=y_range, **kwargs)
     fig.annular_wedge(source=source, x='x', y='y',
                       inner_radius=inner, outer_radius=outer,
                       start_angle=90, end_angle=90.001,

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -76,7 +76,7 @@ def progress_quads(msg):
     return d
 
 
-def progress_wedge(msg, row_length=10):
+def progress_wedge(msg, nrows=2, ncols=6):
     """
 
     >>> msg = {'all': {'inc': 4, 'dec': 1},
@@ -96,13 +96,14 @@ def progress_wedge(msg, row_length=10):
      'released-angle': [0, 90],
      'erred-angle': [90, 180]}
     """
-    names = sorted(msg['all'], key=msg['all'].get, reverse=True)
+    names = sorted(msg['all'], key=msg['all'].get, reverse=True)[:nrows * ncols]
     n = len(names)
     d = {k: [v.get(name, 0) for name in names] for k, v in msg.items()}
     d['name'] = names
-    d['x'] = [i % row_length for i in range(n)]
-    d['y'] = [i // row_length for i in range(n)]
-    d['lower-y'] = [y - 0.5 for y in d['y']]
+    d['x'] = [i % ncols for i in range(n)]
+    d['y'] = [-(i // ncols) for i in range(n)]
+    d['lower-y'] = [y - (0.53 if i % 2 == 0 else 0.45)
+                    for i, y in enumerate(d['y'])]
     for state in ['memory', 'erred', 'released', 'all']:
         d[state] = [msg[state].get(name, 0) for name in names]
     d['done'] = [m + r + e for m, r, e in zip(d['memory'], d['released'], d['erred'])]

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -79,26 +79,22 @@ def progress_quads(msg):
 def progress_wedge(msg, row_length=10):
     """
 
-    Consumes messages like the following::
+    >>> msg = {'all': {'inc': 4, 'dec': 1},
+    ...        'memory': {'inc': 2, 'dec': 0},
+    ...        'erred': {'inc': 0, 'dec': 1},
+    ...        'released': {'inc': 1, 'dec': 0}}
 
-          {'all': {'inc': 4, 'dec': 1},
-           'memory': {'inc': 2, 'dec': 0},
-           'erred': {'inc': 0, 'dec': 1},
-           'released': {'inc': 1, 'dec': 0}}
-
-    Produces result like the following:
-
-        {'x': [0, 1],
-         'y': [0, 0],
-         'lower-y': [-.5, -.5],
-         'name': ['inc', 'dec'],
-         'memory': [2, 0],
-         'released': [1, 0],
-         'erred': [0, 1],
-         'memory-angle': [180, 180]  # start at 90 go clockwise
-         'released-angle': [0, 90],
-         'erred-angle': [90, 180]}
-
+    >>> progress_wedge(msg)  # doctest: +SKIP
+    {'x': [0, 1],
+     'y': [0, 0],
+     'lower-y': [-.5, -.5],
+     'name': ['inc', 'dec'],
+     'memory': [2, 0],
+     'released': [1, 0],
+     'erred': [0, 1],
+     'memory-angle': [180, 180]  # start at 90 go clockwise
+     'released-angle': [0, 90],
+     'erred-angle': [90, 180]}
     """
     names = sorted(msg['all'], key=msg['all'].get, reverse=True)
     n = len(names)

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -74,3 +74,51 @@ def progress_quads(msg):
                    for im, r, a in zip(d['memory'], d['released'], d['all'])]
     d['erred_left'] = [1 - e / a for e, a in zip(d['erred'], d['all'])]
     return d
+
+
+def progress_wedge(msg, row_length=10):
+    """
+
+    Consumes messages like the following::
+
+          {'all': {'inc': 4, 'dec': 1},
+           'memory': {'inc': 2, 'dec': 0},
+           'erred': {'inc': 0, 'dec': 1},
+           'released': {'inc': 1, 'dec': 0}}
+
+    Produces result like the following:
+
+        {'x': [0, 1],
+         'y': [0, 0],
+         'lower-y': [-.5, -.5],
+         'name': ['inc', 'dec'],
+         'memory': [2, 0],
+         'released': [1, 0],
+         'erred': [0, 1],
+         'memory-angle': [180, 180]  # start at 90 go clockwise
+         'released-angle': [0, 90],
+         'erred-angle': [90, 180]}
+
+    """
+    names = sorted(msg['all'], key=msg['all'].get, reverse=True)
+    n = len(names)
+    d = {k: [v.get(name, 0) for name in names] for k, v in msg.items()}
+    d['name'] = names
+    d['x'] = [i % row_length for i in range(n)]
+    d['y'] = [i // row_length for i in range(n)]
+    d['lower-y'] = [y - 0.5 for y in d['y']]
+    for state in ['memory', 'erred', 'released', 'all']:
+        d[state] = [msg[state].get(name, 0) for name in names]
+    d['done'] = [m + r + e for m, r, e in zip(d['memory'], d['released'], d['erred'])]
+
+    for angle in ['released-angle', 'memory-angle', 'erred-angle']:
+        d[angle] = []
+
+    for a, r, m, e in zip(d['all'], d['released'], d['memory'], d['erred']):
+        ra = (90 - 360 * (r / a)) % 360 if r < a else 90.001
+        ma = (ra - 360 * (m / a)) % 360 if m + r < a else 90.001
+        ea = (ma - 360 * (e / a)) % 360 if e + m + r < a else 90.001
+        d['released-angle'].append(ra)
+        d['memory-angle'].append(ma)
+        d['erred-angle'].append(ea)
+    return d

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -38,16 +38,16 @@ def test_progress_annular_wedge():
            'released': {'inc': 1, 'dec': 0, 'add': 1}}
     expected = {'x': [0, 1, 2],
                 'y': [0, 0, 0],
-                'lower-y': [-.5, -.5, -.5],
+                'lower-y': [-.53, -.45, -.53],
                 'name': ['inc', 'dec', 'add'],
                 'all': [4, 2, 1],
                 'memory': [2, 0, 0],
                 'released': [1, 0, 1],
                 'erred': [0, 1, 0],
                 'done': [3, 1, 1],
-                'released-angle': [0, 90, 90.001],
-                'memory-angle': [180, 90, 90.001],  # start at 90 go clockwise
-                'erred-angle': [180, 270, 90.001]}
+                'released-angle': [0.0, 90.0, 90.001],
+                'memory-angle': [180.0, 90.0, 90.001],  # start at 90 go clockwise
+                'erred-angle': [180.0, 270.0, 90.001]}
 
     result = progress_wedge(msg)
     assert result == expected

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -8,7 +8,7 @@ from dask import do
 from distributed.core import read
 from distributed.executor import _wait
 from distributed.diagnostics.progress_stream import (progress_quads,
-        progress_stream)
+        progress_stream, progress_wedge)
 from distributed.utils_test import inc, div, dec, gen_cluster
 from distributed.worker import dumps_task
 from time import time, sleep
@@ -29,6 +29,28 @@ def test_progress_quads():
     assert d['released_right'] == [1/5, 0]
     assert d['memory_right'] == [3 / 5, 0]
     assert d['erred_left'] == [1, 0]
+
+
+def test_progress_annular_wedge():
+    msg = {'all': {'inc': 4, 'dec': 2, 'add': 1},
+           'memory': {'inc': 2, 'dec': 0, 'add': 0},
+           'erred': {'inc': 0, 'dec': 1, 'add': 0},
+           'released': {'inc': 1, 'dec': 0, 'add': 1}}
+    expected = {'x': [0, 1, 2],
+                'y': [0, 0, 0],
+                'lower-y': [-.5, -.5, -.5],
+                'name': ['inc', 'dec', 'add'],
+                'all': [4, 2, 1],
+                'memory': [2, 0, 0],
+                'released': [1, 0, 1],
+                'erred': [0, 1, 0],
+                'done': [3, 1, 1],
+                'released-angle': [0, 90, 90.001],
+                'memory-angle': [180, 90, 90.001],  # start at 90 go clockwise
+                'erred-angle': [180, 270, 90.001]}
+
+    result = progress_wedge(msg)
+    assert result == expected
 
 
 @gen_cluster(executor=True, timeout=None)


### PR DESCRIPTION
This allows us to fit more progress formation in the same horiztonal
space.

TODO
----

- [x] Figure out how to snap the view on the wedges.  Currently when the plot comes up we need to pan and zoom around to get a good fit.
- [x] Align names (inc, dec, ...) more consistently just below wedges.  This seems to shift a bit based on aspect ratio
- [ ] Style check with a viz person
- [ ] Maybe add a line between done and final counts, e.g. `1000 / 1000`

![image](https://cloud.githubusercontent.com/assets/306380/17778147/07f56268-6531-11e6-9222-b9c8f09caca2.png)
