### PR TITLE
Add refresh button to the tasks web interface

### DIFF
--- a/distributed/bokeh/tasks/main.py
+++ b/distributed/bokeh/tasks/main.py
@@ -4,6 +4,8 @@ from __future__ import print_function, division, absolute_import
 
 from toolz import valmap
 from bokeh.io import curdoc
+from bokeh.layouts import column
+from bokeh.models.widgets import Button
 
 from distributed.bokeh.status_monitor import task_stream_plot
 import distributed.bokeh
@@ -13,8 +15,15 @@ doc = curdoc()
 task_stream_source, task_stream_plot = task_stream_plot(sizing_mode='stretch_both')
 task_stream_index = [0]
 
-rectangles = messages['task-events']['rectangles']
-rectangles = valmap(list, rectangles)
-task_stream_source.data.update(rectangles)
+def update():
+    rectangles = messages['task-events']['rectangles']
+    rectangles = valmap(list, rectangles)
+    task_stream_source.data.update(rectangles)
 
-doc.add_root(task_stream_plot)
+update()
+
+button = Button(label='Refresh')
+button.on_click(update)
+
+layout = column(button, task_stream_plot, sizing_mode='stretch_both')
+doc.add_root(layout)


### PR DESCRIPTION
This adds a refresh button that updates the tasks in the tasks/
pane of the web interface.

Currently this takes up half of the space because columns in `stretch_both` mode split space evenly.  This is a known not-yet-implemented feature in Bokeh.  Perhaps there is a way around, given that the button itself doesn't need to scale and can possibly be placed outside of the general layout space?

cc @birdsarah 
