### PR TITLE
Support cancellation of tuple keys

### DIFF
--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1949,6 +1949,16 @@ def test__cancel(e, s, a, b):
     s.validate_state()
 
 
+@gen_cluster(executor=True)
+def test__cancel_tuple_key(e, s, a, b):
+    x = e.submit(inc, 1, key=('x', 0, 1))
+
+    result = yield x._result()
+    yield e._cancel(x)
+    with pytest.raises(CancelledError):
+        yield x._result()
+
+
 @gen_cluster()
 def test__cancel_multi_client(s, a, b):
     e = Executor((s.ip, s.port), start=False)


### PR DESCRIPTION
Previously we let tuple-keys slip through to the scheduler which
can't handle them because msgpack turns them into lists.

Along the way we also improve scheduler error handling and submitting
tuple keys with submit