### PR TITLE
Dynamic submission of tasks from tasks

### DIFF
--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -85,7 +85,8 @@ def test_progressbar_widget(s, a, b):
                                              'y': (inc, 'x'),
                                              'z': (inc, 'y')}),
                    keys=['z'],
-                   dependencies={'y': {'x'}, 'z': {'y'}})
+                   dependencies={'y': {'x'}, 'z': {'y'}},
+                   client='alice')
 
     progress = ProgressWidget(['z'], scheduler=(s.ip, s.port))
     yield progress.listen()
@@ -109,7 +110,8 @@ def test_multi_progressbar_widget(s, a, b):
                    keys=['e'],
                    dependencies={'x-2': ['x-1'], 'x-3': ['x-2'],
                                  'y-1': ['x-3'], 'y-2': ['y-1'],
-                                 'e': ['y-2']})
+                                 'e': ['y-2']},
+                   client='alice')
 
     p = MultiProgressWidget(['e'], scheduler=(s.ip, s.port))
     yield p.listen()
@@ -145,7 +147,8 @@ def test_multi_progressbar_widget_after_close(s, a, b):
                    keys=['e'],
                    dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'},
                                  'y-1': {'x-3'}, 'y-2': {'y-1'},
-                                 'e': {'y-2'}})
+                                 'e': {'y-2'}},
+                   client='alice')
 
     p = MultiProgressWidget(['x-1', 'x-2', 'x-3'], scheduler=(s.ip, s.port))
     yield p.listen()
@@ -218,7 +221,8 @@ def test_multibar_complete(s, a, b):
                    keys=['e'],
                    dependencies={'x-2': {'x-1'}, 'x-3': {'x-2'},
                                  'y-1': {'x-3'}, 'y-2': {'y-1'},
-                                 'e': {'y-2'}})
+                                 'e': {'y-2'}},
+                   client='alice')
 
     p = MultiProgressWidget(['e'], scheduler=(s.ip, s.port), complete=True)
     yield p.listen()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -625,6 +625,9 @@ class Scheduler(Server):
                 d = self.processing[w]
                 d[new_key] = d.pop(key)
 
+            self.transition_log.append((key, 'processing', 'evolves',
+                                       {new_key: 'memory'}))
+
             self.update_graph(client=None, tasks=tasks, keys=[key],
                     dependencies=dependencies, restrictions={key: [worker]})
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -503,9 +503,10 @@ class Scheduler(Server):
 
         original_keys = keys
         keys = set(keys)
-        for k in keys:
-            self.who_wants[k].add(client)
-            self.wants_what[client].add(k)
+        if client is not None:
+            for k in keys:
+                self.who_wants[k].add(client)
+                self.wants_what[client].add(k)
 
         n = 0
         while len(tasks) != n:  # walk thorough new tasks, cancel any bad deps

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -121,6 +121,9 @@ class Scheduler(Server):
     * **loose_retrictions:** ``{key}``:
         Set of keys for which we are allow to violate restrictions (see above)
         if not valid workers are present.
+    * **key_restrictions:** ``{key: key}``
+        Internal use only.  A key must run on the same worker where another key
+        is stored.
     *  **exceptions:** ``{key: Exception}``:
         A dict mapping keys to remote exceptions
     *  **tracebacks:** ``{key: list}``:
@@ -205,6 +208,7 @@ class Scheduler(Server):
         self.task_duration = {prefix: 0.00001 for prefix in fast_task_prefixes}
         self.restrictions = dict()
         self.loose_restrictions = set()
+        self.key_restrictions = dict()
         self.suspicious_tasks = defaultdict(lambda: 0)
         self.stacks = dict()
         self.waiting = dict()
@@ -318,7 +322,8 @@ class Scheduler(Server):
         collections = [self.tasks, self.dependencies, self.dependents,
                 self.waiting, self.waiting_data, self.released, self.priority,
                 self.nbytes, self.restrictions, self.loose_restrictions,
-                self.ready, self.who_wants, self.wants_what]
+                self.key_restrictions, self.ready,
+                self.who_wants, self.wants_what]
         for collection in collections:
             collection.clear()
 
@@ -489,7 +494,7 @@ class Scheduler(Server):
 
     def update_graph(self, client=None, tasks=None, keys=None,
                      dependencies=None, restrictions=None, priority=None,
-                     loose_restrictions=None):
+                     loose_restrictions=None, key_restrictions=None):
         """
         Add new computations to the internal dask graph
 
@@ -559,6 +564,9 @@ class Scheduler(Server):
             if loose_restrictions:
                 self.loose_restrictions |= set(loose_restrictions)
 
+        if key_restrictions:
+            self.key_restrictions.update(key_restrictions)
+
         for key in sorted(touched | keys, key=self.priority.get):
             if self.task_state[key] == 'released':
                 recommendations[key] = 'waiting'
@@ -623,6 +631,7 @@ class Scheduler(Server):
             self.tasks[new_key] = wrapped_task
             self.waiting_data[new_key] = set()
             self.rprocessing[new_key] = self.rprocessing.pop(key)
+            self.key_restrictions[key] = new_key
             for w in self.rprocessing[new_key]:
                 d = self.processing[w]
                 d[new_key] = d.pop(key)
@@ -1654,11 +1663,13 @@ class Scheduler(Server):
 
             del self.waiting[key]
 
-            if self.dependencies.get(key, None) or key in self.restrictions:
+            if (self.dependencies.get(key, None) or
+                    key in self.restrictions or
+                    key in self.key_restrictions):
                 new_worker = decide_worker(self.dependencies, self.stacks,
                         self.processing, self.who_has, self.has_what,
-                        self.restrictions, self.loose_restrictions, self.nbytes,
-                        key)
+                        self.restrictions, self.key_restrictions,
+                        self.loose_restrictions, self.nbytes, key)
                 if not new_worker:
                     self.unrunnable.add(key)
                     self.task_state[key] = 'no-worker'
@@ -2090,6 +2101,8 @@ class Scheduler(Server):
             del self.dependents[key]
             if key in self.restrictions:
                 del self.restrictions[key]
+            if key in self.key_restrictions:
+                del self.key_restrictions[key]
             if key in self.loose_restrictions:
                 self.loose_restrictions.remove(key)
             if key in self.priority:
@@ -2411,7 +2424,8 @@ class Scheduler(Server):
         bandwidth = bandwidth if bandwidth is not None else BANDWIDTH
         if len(self.dependencies[key]) > 10:
             return False
-        if key in self.restrictions and key not in self.loose_restrictions:
+        if ((key in self.restrictions or key in self.key_restrictions)
+                and key not in self.loose_restrictions):
             return False
 
         nbytes = sum(self.nbytes.get(k, 1000) for k in self.dependencies[key])
@@ -2495,7 +2509,7 @@ class Scheduler(Server):
 
 
 def decide_worker(dependencies, stacks, processing, who_has, has_what, restrictions,
-                  loose_restrictions, nbytes, key):
+                  key_restrictions, loose_restrictions, nbytes, key):
     """ Decide which worker should take task
 
     >>> dependencies = {'c': {'b'}, 'b': {'a'}}
@@ -2505,12 +2519,13 @@ def decide_worker(dependencies, stacks, processing, who_has, has_what, restricti
     >>> has_what = {'alice:8000': {'a'}}
     >>> nbytes = {'a': 100}
     >>> restrictions = {}
+    >>> key_restrictions = {}
     >>> loose_restrictions = set()
 
     We choose the worker that has the data on which 'b' depends (alice has 'a')
 
     >>> decide_worker(dependencies, stacks, processing, who_has, has_what,
-    ...               restrictions, loose_restrictions, nbytes, 'b')
+    ...               restrictions, key_restrictions, loose_restrictions, nbytes, 'b')
     'alice:8000'
 
     If both Alice and Bob have dependencies then we choose the less-busy worker
@@ -2518,14 +2533,14 @@ def decide_worker(dependencies, stacks, processing, who_has, has_what, restricti
     >>> who_has = {'a': {'alice:8000', 'bob:8000'}}
     >>> has_what = {'alice:8000': {'a'}, 'bob:8000': {'a'}}
     >>> decide_worker(dependencies, stacks, processing, who_has, has_what,
-    ...               restrictions, loose_restrictions, nbytes, 'b')
+    ...               restrictions, key_restrictions, loose_restrictions, nbytes, 'b')
     'bob:8000'
 
     Optionally provide restrictions of where jobs are allowed to occur
 
     >>> restrictions = {'b': {'alice', 'charlie'}}
     >>> decide_worker(dependencies, stacks, processing, who_has, has_what,
-    ...               restrictions, loose_restrictions, nbytes, 'b')
+    ...               restrictions, key_restrictions, loose_restrictions, nbytes, 'b')
     'alice:8000'
 
     If the task requires data communication, then we choose to minimize the
@@ -2539,25 +2554,35 @@ def decide_worker(dependencies, stacks, processing, who_has, has_what, restricti
     >>> stacks = {'alice:8000': [], 'bob:8000': []}
 
     >>> decide_worker(dependencies, stacks, processing, who_has, has_what,
-    ...               {}, set(), nbytes, 'c')
+    ...               {}, set(), {}, nbytes, 'c')
     'bob:8000'
     """
-    with log_errors(): # removeme
+    with log_errors(pdb=True): # removeme
         deps = dependencies[key]
         assert all(d in who_has for d in deps)
         workers = frequencies([w for dep in deps
                                  for w in who_has[dep]])
         if not workers:
             workers = stacks
-        if key in restrictions:
+
+        # Handle restrictions
+        if key in restrictions and key in key_restrictions:
+            r = restrictions[key] & who_has[key_restrictions[key]]
+        elif key in restrictions:
             r = restrictions[key]
+        elif key in key_restrictions:
+            r = who_has[key_restrictions[key]]
+        else:
+            r = None
+
+        if r is not None:
             workers = {w for w in workers if w in r or w.split(':')[0] in r}  # TODO: nonlinear
             if not workers:
                 workers = {w for w in stacks if w in r or w.split(':')[0] in r}
                 if not workers:
                     if key in loose_restrictions:
                         return decide_worker(dependencies, stacks, processing,
-                                who_has, has_what, {}, set(), nbytes, key)
+                                who_has, has_what, {}, {}, set(), nbytes, key)
                     else:
                         return None
         if not workers or not stacks:

--- a/distributed/tests/test_dynamic_submission.py
+++ b/distributed/tests/test_dynamic_submission.py
@@ -2,6 +2,7 @@ from operator import sub
 
 from dask import delayed
 import pytest
+from tornado import gen
 
 from distributed.utils_test import gen_cluster, cluster, loop
 from distributed import Executor
@@ -50,7 +51,6 @@ def test_compound_sync(loop):
             assert result == 55
 
 
-@pytest.mark.skipif(True, reason="can not yet reverse graph building")
 @gen_cluster(executor=True)
 def test_resilience(e, s, a, b):
     future = e.submit(range, 10, 20)

--- a/distributed/tests/test_dynamic_submission.py
+++ b/distributed/tests/test_dynamic_submission.py
@@ -3,7 +3,9 @@ from operator import sub
 from dask import delayed
 import pytest
 
-from distributed.utils_test import gen_cluster
+from distributed.utils_test import gen_cluster, cluster, loop
+from distributed import Executor
+
 
 def range(x, y):
     a, b = yield delayed(min)(x, y), delayed(max)(x, y)
@@ -38,6 +40,14 @@ def test_compound(e, s, a, b):
     future = e.submit(fib, 10)
     result = yield future._result()
     assert result == 55
+
+
+def test_compound_sync(loop):
+    with cluster() as (s, [a, b]):
+        with Executor(('127.0.0.1', s['port']), loop=loop) as e:
+            future = e.submit(fib, 10)
+            result = future.result()
+            assert result == 55
 
 
 @pytest.mark.skipif(True, reason="can not yet reverse graph building")

--- a/distributed/tests/test_dynamic_submission.py
+++ b/distributed/tests/test_dynamic_submission.py
@@ -1,0 +1,53 @@
+from operator import sub
+
+from dask import delayed
+
+from distributed.utils_test import gen_cluster
+
+def range(x, y):
+    a, b = yield delayed(min)(x, y), delayed(max)(x, y)
+    diff = yield delayed(sub)(a, b)
+    return abs(diff)
+
+
+@gen_cluster(executor=True)
+def test_simple(e, s, a, b):
+    x, y = yield e._scatter([10, 20])
+
+    future = e.submit(range, x, y)
+    result = yield future._result()
+    assert result == 10
+
+    assert len(s.task_state) >= 3
+    assert s.dependencies[future.key]
+    assert s.who_wants[future.key] == {e.id}
+
+
+@gen_cluster(executor=True)
+def test_resilience(e, s, a, b):
+    future = e.submit(range, 10, 20)
+    result = yield future._result()
+    assert result == 10
+
+    if s.who_has[future.key] == {a.address}:
+        yield a._close()
+    elif s.who_has[future.key] == {b.address}:
+        yield b._close()
+
+    result = yield future._result()
+    import pdb; pdb.set_trace()
+    assert result == 10
+
+"""
+i-- range_x
+j--/
+
+    min -----\
+i-- range_0 -- range_x
+j-/ max -----/
+
+                 a-\
+    min -----\   b--sub --\
+i-- range_0  --   range_1 -- range_x
+j-/ max -----/
+"""

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -199,7 +199,7 @@ def test_decide_worker_with_many_independent_leaves():
 
     for key in dsk:
         worker = decide_worker(dependencies, stacks, processing, who_has, {},
-                               {}, set(), nbytes, key)
+                               {}, {}, set(), nbytes, key)
         stacks[worker].append(key)
 
     nhits = (len([k for k in stacks[alice] if alice in who_has[('x', k[1])]])
@@ -217,20 +217,20 @@ def test_decide_worker_with_restrictions():
     restrictions = {'x': {'alice', 'charlie'}}
     nbytes = {}
     result = decide_worker(dependencies, stacks, processing, who_has, {},
-                           restrictions, set(), nbytes, 'x')
+                           restrictions, {}, set(), nbytes, 'x')
     assert result in {alice, charlie}
 
 
     stacks = {alice: [1, 2, 3], bob: [], charlie: [4, 5, 6]}
     result = decide_worker(dependencies, stacks, processing, who_has, {},
-                           restrictions, set(), nbytes, 'x')
+                           restrictions, {}, set(), nbytes, 'x')
     assert result in {alice, charlie}
 
     dependencies = {'x': {'y'}}
     who_has = {'y': {bob}}
     nbytes = {'y': 0}
     result = decide_worker(dependencies, stacks, processing, who_has, {},
-                           restrictions, set(), nbytes, 'x')
+                           restrictions, {}, set(), nbytes, 'x')
     assert result in {alice, charlie}
 
 
@@ -244,27 +244,27 @@ def test_decide_worker_with_loose_restrictions():
     restrictions = {'x': {'alice', 'charlie'}}
 
     result = decide_worker(dependencies, stacks, processing, who_has, {},
-                           restrictions, set(), nbytes, 'x')
+                           restrictions, {}, set(), nbytes, 'x')
     assert result == charlie
 
     result = decide_worker(dependencies, stacks, processing, who_has, {},
-                           restrictions, {'x'}, nbytes, 'x')
+                           restrictions, {}, {'x'}, nbytes, 'x')
     assert result == charlie
 
     restrictions = {'x': {'david', 'ethel'}}
     result = decide_worker(dependencies, stacks, processing, who_has, {},
-                           restrictions, set(), nbytes, 'x')
+                           restrictions, {}, set(), nbytes, 'x')
     assert result is None
 
     restrictions = {'x': {'david', 'ethel'}}
     result = decide_worker(dependencies, stacks, processing, who_has, {},
-                           restrictions, {'x'}, nbytes, 'x')
+                           restrictions, {}, {'x'}, nbytes, 'x')
     assert result == bob
 
 
 
 def test_decide_worker_without_stacks():
-    assert not decide_worker({'x': []}, {}, {}, {}, {}, {}, set(), {}, 'x')
+    assert not decide_worker({'x': []}, {}, {}, {}, {}, {}, {}, set(), {}, 'x')
 
 
 def test_validate_state():

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -419,7 +419,8 @@ def test_multi_queues(s, a, b):
                       'dependencies': {'x': [],
                                        'y': ['x'],
                                        'z': ['y']},
-                      'keys': ['z']})
+                      'keys': ['z'],
+                      'client': 'alice'})
 
     while True:
         msg = yield report.get()
@@ -435,7 +436,8 @@ def test_multi_queues(s, a, b):
     sched2.put_nowait({'op': 'update-graph',
                        'tasks': {'a': dumps_task((inc, 10))},
                        'dependencies': {'a': []},
-                       'keys': ['a']})
+                       'keys': ['a'],
+                       'client': 'alice'})
 
     for q in [report, report2]:
         while True:
@@ -497,7 +499,8 @@ def test_server_listens_to_other_ops(s, a, b):
 def test_remove_worker_from_scheduler(s, a, b):
     dsk = {('x', i): (inc, i) for i in range(20)}
     s.update_graph(tasks=valmap(dumps_task, dsk), keys=list(dsk),
-                   dependencies={k: set() for k in dsk})
+                   dependencies={k: set() for k in dsk},
+                   client='alice')
     assert s.ready
     assert not any(stack for stack in s.stacks.values())
 
@@ -593,7 +596,8 @@ def test_scheduler_as_center():
 
     s.update_graph(tasks={'a': dumps_task((inc, 1))},
                    keys=['a'],
-                   dependencies={'a': []})
+                   dependencies={'a': []},
+                   client='alice')
     start = time()
     while not 'a' in s.who_has:
         assert time() - start < 5

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -152,6 +152,7 @@ def is_kernel():
 
 hex_pattern = re.compile('[a-f]+')
 
+
 def key_split(s):
     """
     >>> key_split('x')

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -500,8 +500,9 @@ class Worker(Server):
         result['key'] = key
         result.update(diagnostics)
 
-        if (isinstance(result['result'], dict) and
-                'tasks' in result['result']):
+        if ('result' in result and
+            isinstance(result['result'], dict) and
+            'tasks' in result['result']):
             result.update(result.pop('result'))
             new_key = '%s-%d' % (key, len(self.generators[key]['keys']))
             result['tasks'][key] = (partial_compute, new_key, result['arg_key'])

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1002,8 +1002,13 @@ def partial_message_from_values(values):
 def partial_compute(gen, args=None):
     with log_errors():
         if args is None:  # just started
-            values = next(gen)
-            return partial_message_from_values(values)
+            try:
+                values = next(gen)
+            except StopIteration as e:
+                result = e.args[0]
+                return {'result': result}
+            else:
+                return partial_message_from_values(values)
         else:
             try:
                 values = gen.send(args)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -463,86 +463,7 @@ class Worker(Server):
     @gen.coroutine
     def compute_one(self, data, key=None, function=None, args=None, kwargs=None,
                     report=False, task=None):
-        with log_errors():
-            logger.debug("Compute one on %s", key)
-            diagnostics = dict()
-            try:
-                start = default_timer()
-                function, args, kwargs = self.deserialize(function, args, kwargs,
-                        task)
-                diagnostics['deserialization'] = default_timer() - start
-            except Exception as e:
-                logger.warn("Could not deserialize task", exc_info=True)
-                emsg = error_message(e)
-                emsg['key'] = key
-                raise Return(emsg)
-
-            self.active.add(key)
-            # Fill args with data
-            args2 = pack_data(args, data)
-            kwargs2 = pack_data(kwargs, data)
-
-            if inspect.isgeneratorfunction(function):
-                self.generators[key] = {'gen': function(*args2, **kwargs2),
-                                        'keys': []}
-                result = yield self.executor_submit(key, apply_function,
-                        partial_compute, (self.generators[key]['gen'], None), {})
-                result.update(result.pop('result'))
-            elif key in self.generators:
-                assert len(args2) == 2 and not kwargs2
-                assert args[0] == self.generators[key]['keys'][-1]
-                result = yield self.executor_submit(key, apply_function,
-                        partial_compute, (self.generators[key]['gen'],
-                            args2[1]), {})
-                result.update(result.pop('result'))
-
-            else:
-                result = yield self.executor_submit(key, apply_function, function,
-                                                    args2, kwargs2)
-
-            result['key'] = key
-            result.update(diagnostics)
-
-            if 'tasks' in result:
-                new_key = '%s-%d' % (key, len(self.generators[key]['keys']))
-                result['tasks'][key] = (dummy, new_key, result['arg_key'])
-                result['new_key'] = new_key
-                self.data[new_key] = None
-                self.generators[key]['keys'].append(new_key)
-                result['dependencies'][key] = [new_key, result['arg_key']]
-                result['tasks'] = valmap(dumps_task, result['tasks'])
-                result['dependencies'] = valmap(list, result['dependencies'])
-                # TODO, handle leaves with sync
-
-            elif result['status'] == 'OK':
-                self.data[key] = result.pop('result')
-                if report:
-                    response = yield self.scheduler.add_keys(keys=[key],
-                                            address=(self.ip, self.port))
-                    if not response == 'OK':
-                        logger.warn('Could not report results to scheduler: %s',
-                                    str(response))
-            else:
-                logger.warn(" Compute Failed\n"
-                    "Function: %s\n"
-                    "args:     %s\n"
-                    "kwargs:   %s\n",
-                    str(funcname(function))[:1000],
-                    convert_args_to_str(args, max_len=1000),
-                    convert_kwargs_to_str(kwargs, max_len=1000), exc_info=True)
-
-            logger.debug("Send compute response to scheduler: %s, %s", key,
-                         result)
-            try:
-                self.active.remove(key)
-            except KeyError:
-                pass
-            raise Return(result)
-
-    @gen.coroutine
-    def compute_coroutine(self, data, key=None, function=None, args=None,
-            kwargs=None, report=False, task=None):
-        logger.debug("Compute coroutine on %s", key)
+        logger.debug("Compute one on %s", key)
         diagnostics = dict()
         try:
             start = default_timer()
@@ -560,14 +481,39 @@ class Worker(Server):
         args2 = pack_data(args, data)
         kwargs2 = pack_data(kwargs, data)
 
-        # Log and compute in separate thread
-        result = yield self.executor_submit(key, apply_function, function,
-                                            args2, kwargs2)
+        if inspect.isgeneratorfunction(function):
+            self.generators[key] = {'gen': function(*args2, **kwargs2),
+                                    'keys': []}
+            result = yield self.executor_submit(key, apply_function,
+                    partial_compute, (self.generators[key]['gen'], None), {})
+            result.update(result.pop('result'))
+        elif key in self.generators:
+            assert len(args2) == 2 and not kwargs2
+            assert args[0] == self.generators[key]['keys'][-1]
+            result = yield self.executor_submit(key, apply_function,
+                    partial_compute, (self.generators[key]['gen'],
+                        args2[1]), {})
+            result.update(result.pop('result'))
+
+        else:
+            result = yield self.executor_submit(key, apply_function, function,
+                                                args2, kwargs2)
 
         result['key'] = key
         result.update(diagnostics)
 
-        if result['status'] == 'OK':
+        if 'tasks' in result:
+            new_key = '%s-%d' % (key, len(self.generators[key]['keys']))
+            result['tasks'][key] = (dummy, new_key, result['arg_key'])
+            result['new_key'] = new_key
+            self.data[new_key] = None
+            self.generators[key]['keys'].append(new_key)
+            result['dependencies'][key] = [new_key, result['arg_key']]
+            result['tasks'] = valmap(dumps_task, result['tasks'])
+            result['dependencies'] = valmap(list, result['dependencies'])
+            # TODO, handle leaves with sync
+
+        elif result['status'] == 'OK':
             self.data[key] = result.pop('result')
             if report:
                 response = yield self.scheduler.add_keys(keys=[key],
@@ -977,17 +923,10 @@ def partial_message_from_values(values):
 
         value = delayed(values)
         dsk = value.dask
-
-        # TODO: unpack_remotedata stuff is unnecessary
-        d = {k: unpack_remotedata(v) for k, v in dsk.items()}
-        extra_keys = set.union(*[v[1] for v in d.values()]) if d else set()
-        dsk2 = str_graph({k: v[0] for k, v in d.items()}, extra_keys)
+        dsk2 = str_graph(dsk, set())
         dsk3 = {k: v for k, v in dsk2.items() if k is not v}
 
-        dependencies = {tokey(k): set(map(tokey, v[1])) for k, v in d.items()}
-
-        for k, v in dsk3.items():
-            dependencies[k] |= set(_deps(dsk3, v))
+        dependencies = {k: set(_deps(dsk3, v)) for k, v in dsk3.items()}
 
         # leaves = {k: v for k, v in dsk.items() if not istask(v)}
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -512,6 +512,59 @@ class Worker(Server):
         raise Return(result)
 
     @gen.coroutine
+    def compute_coroutine(self, data, key=None, function=None, args=None,
+            kwargs=None, report=False, task=None):
+        logger.debug("Compute coroutine on %s", key)
+        diagnostics = dict()
+        try:
+            start = default_timer()
+            function, args, kwargs = self.deserialize(function, args, kwargs,
+                    task)
+            diagnostics['deserialization'] = default_timer() - start
+        except Exception as e:
+            logger.warn("Could not deserialize task", exc_info=True)
+            emsg = error_message(e)
+            emsg['key'] = key
+            raise Return(emsg)
+
+        self.active.add(key)
+        # Fill args with data
+        args2 = pack_data(args, data)
+        kwargs2 = pack_data(kwargs, data)
+
+        # Log and compute in separate thread
+        result = yield self.executor_submit(key, apply_function, function,
+                                            args2, kwargs2)
+
+        result['key'] = key
+        result.update(diagnostics)
+
+        if result['status'] == 'OK':
+            self.data[key] = result.pop('result')
+            if report:
+                response = yield self.scheduler.add_keys(keys=[key],
+                                        address=(self.ip, self.port))
+                if not response == 'OK':
+                    logger.warn('Could not report results to scheduler: %s',
+                                str(response))
+        else:
+            logger.warn(" Compute Failed\n"
+                "Function: %s\n"
+                "args:     %s\n"
+                "kwargs:   %s\n",
+                str(funcname(function))[:1000],
+                convert_args_to_str(args, max_len=1000),
+                convert_kwargs_to_str(kwargs, max_len=1000), exc_info=True)
+
+        logger.debug("Send compute response to scheduler: %s, %s", key,
+                     result)
+        try:
+            self.active.remove(key)
+        except KeyError:
+            pass
+        raise Return(result)
+
+    @gen.coroutine
     def compute(self, stream=None, function=None, key=None, args=(), kwargs={},
             task=None, who_has=None, report=True):
         """ Execute function """
@@ -885,3 +938,26 @@ def convert_kwargs_to_str(kwargs, max_len=None):
             return "{{{}".format(", ".join(strs[:i+1]))[:max_len]
     else:
         return "{{{}}}".format(", ".join(strs))
+
+
+def partial_message_from_values(values):
+    dsk = merge(v.dask for v in values)  # add opt/finalize
+    keys = [finalize(v) for v in values]  # todo
+    leaves = {k: v for k, v in dsk if not istask(v)}
+    self.data.update(leaves)
+    msg = {'status': 'partial-computation',
+           'graph': dsk,
+           'keys': keys,
+           'leaves': list(leaves),
+            }
+    return msg
+
+
+def coroutine_first_step(function, *args, **kwargs):
+    g = function(*args, **kwargs)
+    try:
+        values = next(g)
+        return partial_message_from_values(values)
+    except StopIteration as e:
+        values = e.args
+        return final_message_from_values(values)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -490,9 +490,9 @@ class Worker(Server):
         elif key in self.generators:
             assert len(args2) == 2 and not kwargs2
             assert args[0] == self.generators[key]['keys'][-1]
-            result = yield self.executor_submit(key, apply_function,
-                    partial_compute, (self.generators[key]['gen'],
-                        args2[1]), {})
+            result = yield self.executor_submit(
+                    key, apply_function, partial_compute,
+                    (self.generators[key]['gen'], args2[1]), {})
             result.update(result.pop('result'))
 
         else:


### PR DESCRIPTION
This allows tasks to submit and depend on other tasks.  We emit and depend on new tasks by yielding dask collections.

### Examples

```python
def range(x, y):
    a, b = yield delayed(min)(x, y), delayed(max)(x, y)  # deploy new tasks to scheduler
    diff = yield delayed(sub)(a, b)  # deploy new task to scheduler
    return abs(diff)

future = e.submit(range, 10, 20)
```

```python
@delayed(pure=True)
def fib(n):
    if n in (0, 1):
        return n
    else:
        a, b = yield fib(n - 1), fib(n - 2)
        return a + b

future = e.compute(fib(10))
```

We spawn new tasks by yielding dask collections.  These tasks can themselves spawn more tasks (as shown in the fib example).  The final task waits for these tasks to finish before moving on to the next yield point.  This looks like tornado or asyncio. 

A worker identifies a self-expanding tasks as generator functions.  It uses `next` and `send` to run bits of the function piece by piece.   

This works with both submit and with compute/persist.  This only works with the distributed scheduler.  We will need to provide loud disclaimers that this doesn't work with the single-machine scheduler.

### Scheduling

This works by tricking the scheduler, and altering state like `tasks` and `dependencies` that was previously considered immutable.  Instead of getting a task-completed message we get a task-evolved message and tweak the scheduler state so that the submitted key is pushed back a bit, now with more dependencies that need to be computed.

This feels dangerous.  However we're able to achieve self-expanding tasks with much less invasion into the scheduler than was previously anticipated.

### TODO

- [x] Resilience to failure
- [x] Avoid moving generators around - this is like `restrictions` but has to be more about "always compute this task where this other task lives" rather than "always compute this task on these machines"
- [ ] Publish data through workers, not the task graph.  Currently data is submitted directly with the graph.  Instead we should put data into the local worker data dictionary and include a key reference.  This will avoid worker-scheduler I/O, data on the scheduler, and will enable data sharing more easily.