### PR TITLE
Test dropped messages

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2382,7 +2382,7 @@ class Scheduler(Server):
         Scheduler.work_steal
         """
         bandwidth = bandwidth if bandwidth is not None else BANDWIDTH
-        if len(self.dependencies[key]) > 10:
+        if len(self.dependencies[key]) > 100:
             return False
         if key in self.restrictions and key not in self.loose_restrictions:
             return False

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3582,7 +3582,7 @@ def vsum(*args):
     return sum(args)
 
 
-@gen_cluster(executor=True, ncores=[('127.0.0.1', 1)] * 80, timeout=100)
+@gen_cluster(executor=True, ncores=[('127.0.0.1', 1)] * 80, timeout=400)
 def test_stress_communication(e, s, *workers):
     da = pytest.importorskip('dask.array')
 


### PR DESCRIPTION
I've gotten a report that dask.distributed has dropped a message.
This happened when many workers requested data from each other,
possibly while also running GIL-holding operations.

We can resolve this by taking away the persistent worker-worker
connections, but these are nice for performance and I'd also like
to get to the bottom of the issue.

This commit starts a stress test.  So far it's passing.