### PR TITLE
Add processing plot to workers/ page

### DIFF
--- a/distributed/bokeh/tests/test_worker_monitor.py
+++ b/distributed/bokeh/tests/test_worker_monitor.py
@@ -71,3 +71,45 @@ def test_worker_table(s, a, b):
     worker_table_update(source, data)
 
     assert source.data['host'] == ['127.0.0.1']
+
+
+def test_processing_update():
+    from distributed.diagnostics.scheduler import processing
+    from distributed.bokeh.worker_monitor import processing_update
+
+    class C(object):
+        pass
+
+    s = C()
+    s.stacks = {'alice': ['inc', 'inc', 'add'], 'bob': ['add', 'add']}
+    s.processing = {'alice': {'inc', 'add'}, 'bob': {'inc'}}
+    s.ready = ['a', 'b', 'c']
+    s.waiting = {'x': set()}
+    s.who_has = {'z': set()}
+    s.ncores = {'alice': 4, 'bob': 4}
+
+    msg = processing(s)
+
+    assert msg == {'processing': {'alice': 2, 'bob': 1},
+                   'stacks': {'alice': 3, 'bob': 2},
+                   'ready': 3,
+                   'waiting': 1,
+                   'memory': 1,
+                   'ncores': {'alice': 4, 'bob': 4}}
+
+    data = processing_update(msg)
+    expected = {'name': ('alice', 'bob'),
+                'processing': [2, 1],
+                'stacks': (3, 2),
+                'left': [-3, -2],
+                'right': [2, 1],
+                'top': [2, 1],
+                'bottom': [1, 0],
+                'ncores': [4, 4]}
+
+    assert data == expected
+
+
+def test_processing_plot():
+    from distributed.bokeh.worker_monitor import processing_plot
+    source, fig = processing_plot()

--- a/distributed/bokeh/tests/test_worker_monitor.py
+++ b/distributed/bokeh/tests/test_worker_monitor.py
@@ -105,7 +105,8 @@ def test_processing_update():
                 'right': [2, 1, 0],
                 'top': [2, 1, 2],
                 'bottom': [1, 0, 0],
-                'ncores': [4, 4, 8]}
+                'ncores': [4, 4, 8],
+                'alpha': [0.7, 0.7, 0.2]}
 
     assert data == expected
 

--- a/distributed/bokeh/tests/test_worker_monitor.py
+++ b/distributed/bokeh/tests/test_worker_monitor.py
@@ -83,7 +83,7 @@ def test_processing_update():
     s = C()
     s.stacks = {'alice': ['inc', 'inc', 'add'], 'bob': ['add', 'add']}
     s.processing = {'alice': {'inc', 'add'}, 'bob': {'inc'}}
-    s.ready = ['a', 'b', 'c']
+    s.ready = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
     s.waiting = {'x': set()}
     s.who_has = {'z': set()}
     s.ncores = {'alice': 4, 'bob': 4}
@@ -92,20 +92,20 @@ def test_processing_update():
 
     assert msg == {'processing': {'alice': 2, 'bob': 1},
                    'stacks': {'alice': 3, 'bob': 2},
-                   'ready': 3,
+                   'ready': 7,
                    'waiting': 1,
                    'memory': 1,
                    'ncores': {'alice': 4, 'bob': 4}}
 
     data = processing_update(msg)
-    expected = {'name': ('alice', 'bob'),
-                'processing': [2, 1],
-                'stacks': (3, 2),
-                'left': [-3, -2],
-                'right': [2, 1],
-                'top': [2, 1],
-                'bottom': [1, 0],
-                'ncores': [4, 4]}
+    expected = {'name': ['alice', 'bob', 'ready'],
+                'processing': [2, 1, 0],
+                'stacks': [3, 2, 7],
+                'left': [-3, -2, -7/2],
+                'right': [2, 1, 0],
+                'top': [2, 1, 2],
+                'bottom': [1, 0, 0],
+                'ncores': [4, 4, 8]}
 
     assert data == expected
 

--- a/distributed/bokeh/worker_monitor.py
+++ b/distributed/bokeh/worker_monitor.py
@@ -208,8 +208,8 @@ def processing_plot(**kwargs):
     source = ColumnDataSource(data)
 
     x_range = Range1d(-1, 1)
-    fig = figure(title='Processing and Pending', tools='', x_range=x_range,
-                 **kwargs)
+    fig = figure(title='Processing and Pending', tools='resize',
+                 x_range=x_range, **kwargs)
     fig.quad(source=source, left=0, right='right', color=Spectral9[0],
              top='top', bottom='bottom')
     fig.quad(source=source, left='left', right=0, color=Spectral9[1],

--- a/distributed/bokeh/worker_monitor.py
+++ b/distributed/bokeh/worker_monitor.py
@@ -241,12 +241,9 @@ def processing_plot(**kwargs):
 
 
 def processing_update(msg):
-    stacks = list(msg['stacks'].items())
-    if stacks:
-        names, stacks = zip(*stacks)
-    else:
-        names = []
-        stacks = []
+    names = sorted(msg['stacks'])
+    stacks = msg['stacks']
+    stacks = [stacks[name] for name in names]
     names = sorted(names)
     processing = msg['processing']
     processing = [processing[name] for name in names]

--- a/distributed/bokeh/workers/main.py
+++ b/distributed/bokeh/workers/main.py
@@ -73,7 +73,7 @@ def processing_plot_update():
         data = processing_update(msg)
         x_range = processing_plot.x_range
         max_right = max(data['right'])
-        min_left = min(data['left'])
+        min_left = min(data['left'][:-1])
         cores = max(data['ncores'])
         if min_left < x_range.start:  # not out there enough, jump ahead
             x_range.start = min_left - 2

--- a/distributed/bokeh/workers/main.py
+++ b/distributed/bokeh/workers/main.py
@@ -12,7 +12,8 @@ from toolz import valmap
 from tornado import gen
 
 from distributed.core import rpc
-from distributed.bokeh.worker_monitor import worker_table_plot, worker_table_update
+from distributed.bokeh.worker_monitor import (worker_table_plot,
+        worker_table_update, processing_plot, processing_update)
 from distributed.utils import log_errors
 import distributed.bokeh
 
@@ -36,20 +37,20 @@ else:
 scheduler = rpc(ip=options['host'], port=options['tcp-port'])
 
 
-source, [mem, table] = worker_table_plot(width=WIDTH)
+worker_source, [mem, table] = worker_table_plot(width=WIDTH)
 def worker_update():
     with log_errors():
         try:
             msg = messages['workers']['deque'][-1]
         except IndexError:
             return
-        worker_table_update(source, msg)
+        worker_table_update(worker_source, msg)
 doc.add_periodic_callback(worker_update, messages['workers']['interval'])
 
 
 """
 def f(_, old, new):
-    host = source.data['host']
+    host = worker_source.data['host']
     hosts = [host[i] for i in new['1d']['indices']]
 
     @gen.coroutine
@@ -60,10 +61,35 @@ def f(_, old, new):
 
     doc.add_next_tick_callback(_)
 
-source.on_change('selected', f)
+worker_source.on_change('selected', f)
 """
 
+processing_source, processing_plot = processing_plot(width=WIDTH, height=150)
+def processing_plot_update():
+    with log_errors():
+        msg = messages['processing']
+        if not msg['ncores']:
+            return
+        data = processing_update(msg)
+        x_range = processing_plot.x_range
+        max_right = max(data['right'])
+        min_left = min(data['left'])
+        cores = max(data['ncores'])
+        if min_left < x_range.start:  # not out there enough, jump ahead
+            x_range.start = min_left - 2
+        elif x_range.start < 2 * min_left - cores:  # way out there, walk back
+            x_range.start = x_range.start * 0.95 + min_left * 0.05
+        if x_range.end < max_right:
+            x_range.end = max_right + 2
+        elif x_range.end > 2 * max_right + cores:  # way out there, walk back
+            x_range.end = x_range.end * 0.95 + max_right * 0.05
+
+        processing_source.data.update(data)
+
+doc.add_periodic_callback(processing_plot_update, 200)
+
 layout = column(
+    processing_plot,
     mem,
     table,
     sizing_mode=SIZING_MODE

--- a/distributed/diagnostics/scheduler.py
+++ b/distributed/diagnostics/scheduler.py
@@ -3,6 +3,11 @@ from __future__ import print_function, division, absolute_import
 import os
 from time import time
 
+try:
+    from cytoolz import valmap
+except ImportError:
+    from toolz import valmap
+
 from toolz import countby, concat, dissoc
 
 from ..utils import key_split, log_errors
@@ -60,3 +65,12 @@ def workers(s):
             info['last-seen'] = (now - info['last-seen'])
 
     return result
+
+
+def processing(s):
+    return {'processing': valmap(len, s.processing),
+            'stacks': valmap(len, s.stacks),
+            'ready': len(s.ready),
+            'waiting': len(s.waiting),
+            'memory': len(s.who_has),
+            'ncores': s.ncores}


### PR DESCRIPTION
Shows the currently processing and stacked tasks.  This is decent to give a sense of how occupied the cluster is and how well the stacks are distributed.

![image](https://cloud.githubusercontent.com/assets/306380/17905193/1a2e878a-6940-11e6-8fe9-3f644fc23644.png)
