### PR TITLE
Publish datasets on scheduler

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1015,16 +1015,16 @@ class Executor(object):
         """
         sync(self.loop, self.scheduler.unpublish_dataset, name=name)
 
-    def published_datasets(self):
+    def list_datasets(self):
         """ Returns list of named datasets referenced in the scheduler
 
         See publish_dataset()
         """
-        return sync(self.loop, self.scheduler.get_published_keys)
+        return sync(self.loop, self.scheduler.list_datasets)
 
     @gen.coroutine
-    def _get_published_dataset(self, name):
-        out = yield self.scheduler.get_published_dataset(name=name,
+    def _get_dataset(self, name):
+        out = yield self.scheduler.get_dataset(name=name,
                                                          client=self.id)
         data, keys = out['data'], out['keys']
 
@@ -1032,8 +1032,12 @@ class Executor(object):
             data = loads(data)
         raise Return(data)
 
-    def get_published_dataset(self, name):
-        return sync(self.loop, self._get_published_dataset, tokey(name))
+    def get_dataset(self, name):
+        """ Fetch named dataset from the scheduler.
+
+        See publish_dataset()
+        """
+        return sync(self.loop, self._get_dataset, tokey(name))
 
     @gen.coroutine
     def _run(self, function, *args, **kwargs):

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -992,7 +992,8 @@ class Executor(object):
         out = yield self.scheduler.publish_dataset(keys=keys, name=tokey(name),
                                              data=dumps(data),
                                              client=self.id)
-        raise Return(out)
+        if out['status'] != "OK":
+            raise KeyError(name)
 
     def publish_dataset(self, data, name):
         """
@@ -1008,7 +1009,7 @@ class Executor(object):
         -------
         None
         """
-        return sync(self.loop, self._publish_dataset, data, name)
+        sync(self.loop, self._publish_dataset, data, name)
 
     def unpublish_dataset(self, name):
         """
@@ -1029,7 +1030,7 @@ class Executor(object):
         data, keys = out['data'], out['keys']
 
         if not data:
-            raise Return(None)
+            raise KeyError(name)
         with temp_default_executor(self):
             data = loads(data)
         raise Return(data)

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -989,8 +989,8 @@ class Executor(object):
     @gen.coroutine
     def _publish_dataset(self, data, name):
         keys = [tokey(f.key) for f in futures_of(data)]
-        yield self.scheduler.publish_data(keys=keys, name=tokey(name),
-                                          data=pickle.dumps(data))
+        yield self.scheduler.publish_dataset(keys=keys, name=tokey(name),
+                                             data=pickle.dumps(data))
 
 
     def publish_dataset(self, data, name):
@@ -1024,7 +1024,8 @@ class Executor(object):
 
     @gen.coroutine
     def _get_published_dataset(self, name):
-        out = yield self.scheduler.get_published_data(name=name, client=self.id)
+        out = yield self.scheduler.get_published_dataset(name=name,
+                                                         client=self.id)
         data, keys = out['data'], out['keys']
 
         with temp_default_executor(self):

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1012,6 +1012,16 @@ class Executor(object):
         sync(self.loop, self._publish_dataset, data, name)
 
     @gen.coroutine
+    def _unpublish_dataset(self, name):
+        yield self.scheduler.unpublish_dataset(name=name)
+
+    def unpublish_dataset(self, name):
+        """
+        Remove reference to data on the scheduler
+        """
+        sync(self.loop, self._unpublish_dataset, name)
+
+    @gen.coroutine
     def _published_datasets(self):
         resp = yield self.scheduler.get_published_keys()
         raise Return(resp)

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -2,12 +2,14 @@ from __future__ import print_function, division, absolute_import
 
 from collections import defaultdict, Iterator, Iterable
 from concurrent.futures._base import DoneAndNotDoneFutures, CancelledError
+from contextlib import contextmanager
 import copy
 from datetime import timedelta
 from functools import partial
 import logging
 import os
 import sys
+import pickle
 from time import sleep
 import uuid
 from threading import Thread
@@ -191,6 +193,15 @@ class Future(WrappedKey):
         if not self._cleared and self.executor.generation == self._generation:
             self._cleared = True
             self.executor._dec_ref(tokey(self.key))
+
+    def __getstate__(self):
+        return self.key
+
+    def __setstate__(self, key):
+        e = default_executor()
+        Future.__init__(self, key, e)
+        e._send_to_scheduler({'op': 'update-graph', 'tasks': {},
+                              'keys': [tokey(self.key)], 'client': e.id})
 
     def __del__(self):
         self.release()
@@ -974,6 +985,54 @@ class Executor(object):
         futures: list of Futures
         """
         return sync(self.loop, self._cancel, futures)
+
+    @gen.coroutine
+    def _publish_dataset(self, data, name):
+        keys = [tokey(f.key) for f in futures_of(data)]
+        yield self.scheduler.publish_data(keys=keys, name=tokey(name),
+                                          data=pickle.dumps(data))
+
+
+    def publish_dataset(self, data, name):
+        """
+        Store a named reference to the data in the scheduler for other executors
+
+        Parameters
+        ----------
+        data: list of futures or dask collection
+        name: str or container
+            handle by which the stored data should be known. If not a string,
+            will be wrapped by tokey() to deterministically turn into one.
+
+        Returns
+        -------
+        None
+        """
+        sync(self.loop, self._publish_dataset, data, name)
+
+    @gen.coroutine
+    def _published_datasets(self):
+        resp = yield self.scheduler.get_published_keys()
+        raise Return(resp)
+
+    def published_datasets(self):
+        """ Returns list of named datasets referenced in the scheduler
+
+        See publish_dataset()
+        """
+        return sync(self.loop, self._published_datasets)
+
+    @gen.coroutine
+    def _get_published_dataset(self, name):
+        out = yield self.scheduler.get_published_data(name=name, client=self.id)
+        data, keys = out['data'], out['keys']
+
+        with temp_default_executor(self):
+            data = pickle.loads(data)
+        raise Return(data)
+
+    def get_published_dataset(self, name):
+        return sync(self.loop, self._get_published_dataset, tokey(name))
 
     @gen.coroutine
     def _run(self, function, *args, **kwargs):
@@ -1872,3 +1931,20 @@ def futures_of(o, executor=None):
             raise CancelledError(bad)
 
     return list(futures)
+
+
+@contextmanager
+def temp_default_executor(e):
+    """ Set the default executor for the duration of the context
+
+    Parameters
+    ----------
+    e : Executor
+        This is what default_executor() will return within the with-block.
+    """
+    old_exec = default_executor()
+    _global_executor[0] = e
+    try:
+        yield
+    finally:
+        _global_executor[0] = old_exec

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -990,7 +990,8 @@ class Executor(object):
     def _publish_dataset(self, data, name):
         keys = [tokey(f.key) for f in futures_of(data)]
         yield self.scheduler.publish_dataset(keys=keys, name=tokey(name),
-                                             data=pickle.dumps(data))
+                                             data=pickle.dumps(data),
+                                             client=self.id)
 
 
     def publish_dataset(self, data, name):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -223,7 +223,7 @@ class Scheduler(Server):
         self.exceptions = dict()
         self.tracebacks = dict()
         self.exceptions_blame = dict()
-        self.published_data = dict()
+        self.datasets = dict()
         self.stealable = [set() for i in range(12)]
         self.stealable_unknown_durations = defaultdict(set)
 
@@ -1599,28 +1599,28 @@ class Scheduler(Server):
     def publish_dataset(self, stream=None, keys=None, data=None, name=None,
                         client=None):
         self.client_wants_keys(keys, 'published-%s' % name)
-        self.published_data[name] = {'data': data, 'keys': keys,
+        self.datasets[name] = {'data': data, 'keys': keys,
                                      'clients': {client}}
 
     def unpublish_dataset(self, stream=None, name=None):
-        out = self.published_data.pop(name, {'keys': []})
+        out = self.datasets.pop(name, {'keys': []})
         self.client_releases_keys(out['keys'], 'published-%s' % name)
 
     def list_datasets(self, *args):
-        return list(sorted(self.published_data.keys()))
+        return list(sorted(self.datasets.keys()))
 
     def get_dataset(self, stream, name=None, client=None):
-        self.published_data[name]['clients'].add(client)
-        data = self.published_data[name].copy()
+        self.datasets[name]['clients'].add(client)
+        data = self.datasets[name].copy()
         del data['clients']
         return data
 
     def check_published_datasets(self, client):
-        for key, data in self.published_data.copy().items():
+        for key, data in self.datasets.copy().items():
             with ignoring(KeyError):
                 data['clients'].remove(client)
             if not(data['clients']):
-                del self.published_data[key]
+                del self.datasets[key]
                 self.client_releases_keys(data['keys'], 'published-%s' % key)
 
     #####################

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1598,10 +1598,10 @@ class Scheduler(Server):
     def publish_dataset(self, stream=None, keys=None, data=None, name=None,
                         client=None):
         if name in self.datasets:
-            return {'success': 'false'}
+            return {'status': 'failed'}
         self.client_wants_keys(keys, 'published-%s' % name)
         self.datasets[name] = {'data': data, 'keys': keys}
-        return {'success':  'true'}
+        return {'status':  'OK'}
 
     def unpublish_dataset(self, stream=None, name=None):
         out = self.datasets.pop(name, {'keys': []})

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -928,6 +928,7 @@ class Scheduler(Server):
         """ Remove client from network """
         logger.info("Remove client %s", client)
         self.client_releases_keys(self.wants_what.get(client, ()), client)
+        self.check_published_datasets(client)
         with ignoring(KeyError):
             del self.wants_what[client]
 
@@ -1594,15 +1595,26 @@ class Scheduler(Server):
 
             return result
 
-    def publish_dataset(self, stream=None, keys=None, data=None, name=None):
-        self.published_data[name] = {'data': data, 'keys': keys}
-        # TODO: add guards against deletion of keys?
+    def publish_dataset(self, stream=None, keys=None, data=None, name=None,
+                        client=None):
+        self.published_data[name] = {'data': data, 'keys': keys,
+                                     'clients': {client}}
 
     def get_published_keys(self, *args):
         return list(sorted(self.published_data.keys()))
 
     def get_published_dataset(self, stream, name=None, client=None):
-        return self.published_data[name]
+        self.published_data[name]['clients'].add(client)
+        data = self.published_data[name].copy()
+        del data['clients']
+        return data
+
+    def check_published_datasets(self, client):
+        for key, data in self.published_data.copy().items():
+            with ignoring(KeyError):
+                data['clients'].remove(client)
+                if not(data['clients']):
+                    del self.published_data[key]
 
     #####################
     # State Transitions #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -263,8 +263,8 @@ class Scheduler(Server):
                          'rebalance': self.rebalance,
                          'replicate': self.replicate,
                          'start_ipython': self.start_ipython,
-                         'get_published_keys': self.get_published_keys,
-                         'get_published_dataset': self.get_published_dataset,
+                         'list_datasets': self.list_datasets,
+                         'get_dataset': self.get_dataset,
                          'publish_dataset': self.publish_dataset,
                          'unpublish_dataset': self.unpublish_dataset}
 
@@ -1606,10 +1606,10 @@ class Scheduler(Server):
         out = self.published_data.pop(name, {'keys': []})
         self.client_releases_keys(out['keys'], 'published-%s' % name)
 
-    def get_published_keys(self, *args):
+    def list_datasets(self, *args):
         return list(sorted(self.published_data.keys()))
 
-    def get_published_dataset(self, stream, name=None, client=None):
+    def get_dataset(self, stream, name=None, client=None):
         self.published_data[name]['clients'].add(client)
         data = self.published_data[name].copy()
         del data['clients']

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -264,8 +264,8 @@ class Scheduler(Server):
                          'replicate': self.replicate,
                          'start_ipython': self.start_ipython,
                          'get_published_keys': self.get_published_keys,
-                         'get_published_data': self.get_published_data,
-                         'publish_data': self.publish_data}
+                         'get_published_dataset': self.get_published_dataset,
+                         'publish_dataset': self.publish_dataset}
 
         self.services = {}
         for k, v in (services or {}).items():
@@ -1594,14 +1594,14 @@ class Scheduler(Server):
 
             return result
 
-    def publish_data(self, stream=None, keys=None, data=None, name=None):
+    def publish_dataset(self, stream=None, keys=None, data=None, name=None):
         self.published_data[name] = {'data': data, 'keys': keys}
         # TODO: add guards against deletion of keys?
 
     def get_published_keys(self, *args):
         return list(sorted(self.published_data.keys()))
 
-    def get_published_data(self, stream, name=None, client=None):
+    def get_published_dataset(self, stream, name=None, client=None):
         return self.published_data[name]
 
     #####################

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1597,8 +1597,11 @@ class Scheduler(Server):
 
     def publish_dataset(self, stream=None, keys=None, data=None, name=None,
                         client=None):
+        if name in self.datasets:
+            return {'success': 'false'}
         self.client_wants_keys(keys, 'published-%s' % name)
         self.datasets[name] = {'data': data, 'keys': keys}
+        return {'success':  'true'}
 
     def unpublish_dataset(self, stream=None, name=None):
         out = self.datasets.pop(name, {'keys': []})
@@ -1608,7 +1611,7 @@ class Scheduler(Server):
         return list(sorted(self.datasets.keys()))
 
     def get_dataset(self, stream, name=None, client=None):
-        return self.datasets[name]
+        return self.datasets.get(name, {'data': [], 'keys': []})
 
     #####################
     # State Transitions #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -223,6 +223,7 @@ class Scheduler(Server):
         self.exceptions = dict()
         self.tracebacks = dict()
         self.exceptions_blame = dict()
+        self.published_data = dict()
         self.stealable = [set() for i in range(12)]
         self.stealable_unknown_durations = defaultdict(set)
 
@@ -261,7 +262,10 @@ class Scheduler(Server):
                          'add_keys': self.add_keys,
                          'rebalance': self.rebalance,
                          'replicate': self.replicate,
-                         'start_ipython': self.start_ipython}
+                         'start_ipython': self.start_ipython,
+                         'get_published_keys': self.get_published_keys,
+                         'get_published_data': self.get_published_data,
+                         'publish_data': self.publish_data}
 
         self.services = {}
         for k, v in (services or {}).items():
@@ -932,7 +936,7 @@ class Scheduler(Server):
         """
         The master client coroutine.  Handles all inbound messages from clients.
 
-        This runs once per Cleint IOStream or Queue.
+        This runs once per Client IOStream or Queue.
 
         See Also
         --------
@@ -1589,6 +1593,16 @@ class Scheduler(Server):
                 result = out
 
             return result
+
+    def publish_data(self, stream=None, keys=None, data=None, name=None):
+        self.published_data[name] = {'data': data, 'keys': keys}
+        # TODO: add guards against deletion of keys?
+
+    def get_published_keys(self, *args):
+        return list(sorted(self.published_data.keys()))
+
+    def get_published_data(self, stream, name=None, client=None):
+        return self.published_data[name]
 
     #####################
     # State Transitions #

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3234,6 +3234,7 @@ def test_publish_roundtrip(s, a, b):
     data = yield e._scatter([0, 1, 2])
     yield e._publish_dataset(data, 'data')
 
+    assert 'published-data' in s.who_wants[data[0].key]
     result = yield f._get_published_dataset('data')
 
     assert len(result) == len(data)
@@ -3245,6 +3246,27 @@ def test_publish_roundtrip(s, a, b):
 
     yield f._shutdown()
     assert 'data' not in s.published_data
+
+    assert 'published-data' not in s.who_wants[data[0].key]
+
+    e = Executor((s.ip, s.port), start=False)
+    yield e._start()
+
+
+@gen_cluster(executor=False)
+def test_unpublish(s, a, b):
+    e = Executor((s.ip, s.port), start=False)
+    yield e._start()
+    data = yield e._scatter([0, 1, 2])
+    yield e._publish_dataset(data, 'data')
+
+    key = data[0].key
+    del data
+
+    yield e._unpublish_dataset(name='data')
+
+    assert 'data' not in s.published_data
+    assert not s.who_wants[key]
 
 
 @gen_cluster(executor=False)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3214,8 +3214,8 @@ def test_publish_simple(s, a, b):
 
     data = yield e._scatter(range(3))
     yield e._publish_dataset(data, 'data')
-    assert 'data' in s.published_data
-    assert e.id in s.published_data['data']['clients']
+    assert 'data' in s.datasets
+    assert e.id in s.datasets['data']['clients']
 
     result = yield e.scheduler.list_datasets()
     assert result == ['data']
@@ -3242,18 +3242,16 @@ def test_publish_roundtrip(s, a, b):
     assert out == [0, 1, 2]
 
     yield e._shutdown()
-    assert e.id not in s.published_data['data']['clients']
+    assert e.id not in s.datasets['data']['clients']
 
     yield f._shutdown()
-    assert 'data' not in s.published_data
+    assert 'data' not in s.datasets
 
     assert 'published-data' not in s.who_wants[data[0].key]
 
 
-@gen_cluster(executor=False)
-def test_unpublish(s, a, b):
-    e = Executor((s.ip, s.port), start=False)
-    yield e._start()
+@gen_cluster(executor=True)
+def test_unpublish(e, s, a, b):
     data = yield e._scatter([0, 1, 2])
     yield e._publish_dataset(data, 'data')
 
@@ -3262,7 +3260,7 @@ def test_unpublish(s, a, b):
 
     yield e.scheduler.unpublish_dataset(name='data')
 
-    assert 'data' not in s.published_data
+    assert 'data' not in s.datasets
     assert not s.who_wants[key]
 
 

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3249,9 +3249,6 @@ def test_publish_roundtrip(s, a, b):
 
     assert 'published-data' not in s.who_wants[data[0].key]
 
-    e = Executor((s.ip, s.port), start=False)
-    yield e._start()
-
 
 @gen_cluster(executor=False)
 def test_unpublish(s, a, b):

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3217,10 +3217,10 @@ def test_publish_simple(s, a, b):
     assert 'data' in s.published_data
     assert e.id in s.published_data['data']['clients']
 
-    result = yield e._published_datasets()
+    result = yield e.scheduler.get_published_keys()
     assert result == ['data']
 
-    result = yield f._published_datasets()
+    result = yield f.scheduler.get_published_keys()
     assert result == ['data']
 
 
@@ -3235,7 +3235,7 @@ def test_publish_roundtrip(s, a, b):
     yield e._publish_dataset(data, 'data')
 
     assert 'published-data' in s.who_wants[data[0].key]
-    result = yield f._get_published_dataset('data')
+    result = yield f._get_published_dataset(name='data')
 
     assert len(result) == len(data)
     out = yield f._gather(result)
@@ -3260,7 +3260,7 @@ def test_unpublish(s, a, b):
     key = data[0].key
     del data
 
-    yield e._unpublish_dataset(name='data')
+    yield e.scheduler.unpublish_dataset(name='data')
 
     assert 'data' not in s.published_data
     assert not s.who_wants[key]

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3639,6 +3639,7 @@ def test_publish_simple(s, a, b):
     data = yield e._scatter(range(3))
     yield e._publish_dataset(data, 'data')
     assert 'data' in s.published_data
+    assert e.id in s.published_data['data']['clients']
 
     result = yield e._published_datasets()
     assert result == ['data']
@@ -3662,6 +3663,12 @@ def test_publish_roundtrip(s, a, b):
     assert len(result) == len(data)
     out = yield f._gather(result)
     assert out == [0, 1, 2]
+
+    yield e._shutdown()
+    assert e.id not in s.published_data['data']['clients']
+
+    yield f._shutdown()
+    assert 'data' not in s.published_data
 
 
 @gen_cluster(executor=False)


### PR DESCRIPTION
Allows for the publication of datasets on the scheduler

### Client 1

```python
df = dd.read_csv('s3://...')
df = e.persist(df)

e.publish_dataset(df, 'my-data')
```

### Client 2

```python
df = e.get_dataset('my-data')
```


Fixes #444 