### PR TITLE
Add one second delay to worker data sync

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1403,14 +1403,20 @@ class Scheduler(Server):
         else:
             keys = yield self.rpc(addr=worker).keys()
             keys = set(keys)
-            extra = keys - self.has_what[worker] - self.deleted_keys[worker]
-            if extra:
-                yield self.rpc(addr=worker).delete_data(keys=list(extra),
-                        report=False)
 
             missing = self.has_what[worker] - keys
             if missing:
                 self.stimulus_missing_data(keys=missing)
+
+            extra = keys - self.has_what[worker] - self.deleted_keys[worker]
+            if extra:
+                yield gen.sleep(1)  # maybe haven't yet received news of keys?
+                keys = yield self.rpc(addr=worker).keys()  # check again
+                extra &= set(keys)  # make sure the keys are still on worker
+                extra -= self.has_what[worker]  # and still unknown to scheduler
+                if extra:  # still around?  delete them
+                    yield self.rpc(addr=worker).delete_data(keys=list(extra),
+                            report=False)
 
             raise Return({'extra': list(extra), 'missing': list(missing)})
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1410,7 +1410,7 @@ class Scheduler(Server):
 
             extra = keys - self.has_what[worker] - self.deleted_keys[worker]
             if extra:
-                yield gen.sleep(1)  # maybe haven't yet received news of keys?
+                yield gen.sleep(self.synchronize_worker_interval / 1000)  # delay
                 keys = yield self.rpc(addr=worker).keys()  # check again
                 extra &= set(keys)  # make sure the keys are still on worker
                 extra -= self.has_what[worker]  # and still unknown to scheduler

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3423,24 +3423,41 @@ def test_scatter_raises_if_no_workers(e, s):
         yield e._scatter([1])
 
 
-@gen_cluster(executor=True)
-def test_synchronize_worker_data(e, s, a, b):
+@gen_test()
+def test_synchronize_worker_data():
+    s = Scheduler(synchronize_worker_interval=50)
+    s.start(0)
+    a = Worker(s.ip, s.port, name='alice')
+    yield a._start()
+
     a.data['x'] = 1
     response = yield s.synchronize_worker_data()
+
     assert response == {a.address: {'extra': ['x'], 'missing': []}}
     assert not a.data
 
+    yield a._close()
+    s.stop()
 
-@gen_cluster(executor=True)
-def test_synchronize_worker_data_race_condition(e, s, a, b):
+
+@gen_test()
+def test_synchronize_worker_data_race_condition():
+    s = Scheduler(synchronize_worker_interval=50)
+    s.start(0)
+    a = Worker(s.ip, s.port, name='alice')
+    yield a._start()
+
     a.data['x'] = 1
     s.loop.add_callback(s.synchronize_worker_data)
-    yield gen.sleep(0.1)
+    yield gen.sleep(0.020)
     s.has_what[a.address].add('x')
     s.who_has['x'] = {a.address}
 
-    yield gen.sleep(1)
+    yield gen.sleep(0.100)
     assert a.data == {'x': 1}
+
+    yield a._close()
+    s.stop()
 
 
 @gen_test()
@@ -3456,6 +3473,8 @@ def test_synchronize_worker_data_callback():
 
     assert not a.data
 
+    yield a._close()
+    s.stop()
 
 from distributed.utils_test import popen
 def test_reconnect(loop):

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3431,6 +3431,18 @@ def test_synchronize_worker_data(e, s, a, b):
     assert not a.data
 
 
+@gen_cluster(executor=True)
+def test_synchronize_worker_data_race_condition(e, s, a, b):
+    a.data['x'] = 1
+    s.loop.add_callback(s.synchronize_worker_data)
+    yield gen.sleep(0.1)
+    s.has_what[a.address].add('x')
+    s.who_has['x'] = {a.address}
+
+    yield gen.sleep(1)
+    assert a.data == {'x': 1}
+
+
 @gen_test()
 def test_synchronize_worker_data_callback():
     s = Scheduler(synchronize_worker_interval=50)


### PR DESCRIPTION
We now only delete extra worker data if it still is extraneous after
a second of waiting for extra messages to filter in.