### PR TITLE
Allow scheduler to launch without blocked services

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -265,8 +265,13 @@ class Scheduler(Server):
             else:
                 port = 0
 
-            self.services[k] = v(self, io_loop=self.loop)
-            self.services[k].listen(port)
+            try:
+                service = v(self, io_loop=self.loop)
+                service.listen(port)
+                self.services[k] = service
+            except Exception as e:
+                logger.info("Could not launch service: %s-%d", k, port,
+                            exc_info=True)
 
         self._transitions = {
                  ('released', 'waiting'): self.transition_released_waiting,

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3451,7 +3451,11 @@ def test_reconnect(loop):
     w.start()
     with popen(['dask-scheduler', '--port', '9393', '--no-bokeh']) as s:
         e = Executor('localhost:9393', loop=loop)
-        assert len(e.ncores()) == 1
+        start = time()
+        while  len(e.ncores()) != 1:
+            sleep(0.1)
+            assert time() < start + 3
+
         x = e.submit(inc, 1)
         assert x.result() == 2
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -963,3 +963,17 @@ def test_transition_story(e, s, a, b):
     assert all(x.key == line[0] or x.key in line[-1] for line in story)
 
     assert len(s.transition_story(x.key, y.key)) > len(story)
+
+
+@gen_test()
+def test_launch_without_blocked_services():
+    from distributed.http import HTTPScheduler
+    s = Scheduler(services={('http', 3849): HTTPScheduler})
+    s.start(0)
+
+    s2 = Scheduler(services={('http', 3849): HTTPScheduler})
+    s2.start(0)
+
+    assert not s2.services
+
+    yield [s.close(), s2.close()]


### PR DESCRIPTION
If ports like HTTP or Bokeh are blocked we still run, just without
those services running.  We log informative errors.