### PR TITLE
DOC: adds note to start at least one worker

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -21,6 +21,9 @@ Set up scheduler and worker processes on your local computer::
    $ dask-worker 127.0.0.1:8786
    $ dask-worker 127.0.0.1:8786
    $ dask-worker 127.0.0.1:8786
+   
+.. note:: At least one ``dask-worker`` must be running after launching a
+          scheduler.
 
 Launch an Executor and point it to the IP/port of the scheduler.
 


### PR DESCRIPTION
Added a note in quickstart.rst that at least one worker had to be started.