### PR TITLE
Connect to ipython kernel in scheduler

### DIFF
--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -91,7 +91,7 @@ def register_worker_magic(connection_info, magic_name='worker'):
 
 def connect_qtconsole(connection_info, name=None, extra_args=None):
     """Open a QtConsole connected to a worker who has the given future
-    
+
     - identify worker with who_has
     - start IPython kernel on the worker
     - start qtconsole connected to the kernel

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1610,7 +1610,8 @@ class Executor(object):
         )
         raise gen.Return((workers, responses))
 
-    def start_ipython(self, workers=None, magic_names=False, qtconsole=False, qtconsole_args=None):
+    def start_ipython(self, workers=None, magic_names=False, qtconsole=False,
+                      qtconsole_args=None):
         """ Start IPython kernels on workers
 
         Parameters
@@ -1651,6 +1652,18 @@ class Executor(object):
                                   extra_args=qtconsole_args,
                 )
         return info_dict
+
+    def start_ipython_scheduler(self, magic_name='scheduler',
+                                qtconsole=False, qtconsole_args=None):
+        info = sync(self.loop, self.scheduler.start_ipython)
+        if magic_name:
+            from ._ipython_utils import register_worker_magic
+            register_worker_magic(info, magic_name)
+        if qtconsole:
+            from ._ipython_utils import connect_qtconsole
+            connect_qtconsole(info, name='dask-scheduler',
+                              extra_args=qtconsole_args,)
+        return info
 
 
 class CompatibleExecutor(Executor):

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3209,7 +3209,7 @@ def test_as_completed_list(loop):
 
 
 @pytest.mark.ipython
-def test_start_ipython(loop):
+def test_start_ipython_workers(loop):
     from jupyter_client import BlockingKernelClient
     from ipykernel.kernelapp import IPKernelApp
     from IPython.core.interactiveshell import InteractiveShell
@@ -3225,6 +3225,25 @@ def test_start_ipython(loop):
             msg_id = kc.execute("worker")
             reply = kc.get_shell_msg(timeout=10)
             kc.stop_channels()
+
+
+@pytest.mark.ipython
+def test_start_ipython_scheduler(loop):
+    from jupyter_client import BlockingKernelClient
+    from ipykernel.kernelapp import IPKernelApp
+    from IPython.core.interactiveshell import InteractiveShell
+
+    with cluster(1) as (s, [a]):
+        with Executor(('127.0.0.1', s['port']), loop=loop) as e:
+            info = e.start_ipython_scheduler()
+            key = info.pop('key')
+            kc = BlockingKernelClient(**info)
+            kc.session.key = key
+            kc.start_channels()
+            msg_id = kc.execute("scheduler")
+            reply = kc.get_shell_msg(timeout=10)
+            kc.stop_channels()
+
 
 @pytest.mark.ipython
 def test_start_ipython_magic(loop):


### PR DESCRIPTION
This starts an IPython kernel within the scheduler and adds a
convenience function to the Executor to start and connect to it.

I've tried to copy the worker tests faithfully but this is behaving oddly for me.