### PR TITLE
Create Connection pool

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -433,7 +433,7 @@ class rpc(object):
 
     def close_streams(self):
         for stream in self.streams:
-            with ignoring(OSError, IOError):
+            if stream and not stream.closed():
                 stream.close()
 
     def __getattr__(self, key):

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -537,7 +537,6 @@ class ConnectionPool(object):
         stream = yield connect(ip=ip, port=port, timeout=timeout)
         stream.set_close_callback(lambda: self.on_close(ip, port, stream))
         self.open += 1
-        print(self.open)
         self.occupied[ip, port].add(stream)
 
         if self.open >= self.limit:
@@ -561,6 +560,7 @@ class ConnectionPool(object):
             self.event.set()
 
     def collect(self):
+        logger.debug("Collecting unused streams")
         for k, streams in list(self.available.items()):
             for stream in streams:
                 stream.close()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1760,7 +1760,7 @@ class Scheduler(Server):
                 self.task_duration[ks] = avg_duration
                 if ks in self.stealable_unknown_durations:
                     for k in self.stealable_unknown_durations.pop(ks, ()):
-                        if self.task_state[k] == 'stacks':
+                        if self.task_state.get(k) == 'stacks':
                             self.put_key_in_stealable(k)
 
                 info['last-task'] = compute_stop

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -243,11 +243,13 @@ def test_connection_pool():
     yield [rpc(ip='127.0.0.1', port=s.port).ping() for s in servers[:5]]
     assert sum(map(len, rpc.available.values())) == 5
     assert sum(map(len, rpc.occupied.values())) == 0
+    assert rpc.active == 0
+    assert rpc.open == 5
 
     # Clear out connections to make room for more
     yield [rpc(ip='127.0.0.1', port=s.port).ping() for s in servers[5:]]
-    assert sum(map(len, rpc.available.values())) == 5
-    assert sum(map(len, rpc.occupied.values())) == 0
+    assert rpc.active == 0
+    assert rpc.open == 5
 
     s = servers[0]
     yield [rpc(ip='127.0.0.1', port=s.port).ping(delay=0.1) for i in range(3)]

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -228,7 +228,7 @@ def test_connection_pool():
     @gen.coroutine
     def ping(stream=None, delay=0.1):
         yield gen.sleep(delay)
-        return 'pong'
+        raise gen.Return('pong')
 
     servers = [Server({'ping': ping}) for i in range(10)]
     for server in servers:

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 import itertools
 from multiprocessing import Process
 from random import random, choice
-import resource
 import sys
 from threading import Thread
 from time import sleep, time
@@ -35,7 +34,7 @@ from distributed.sizeof import sizeof
 from distributed.utils import sync, tmp_text, ignoring, tokey, All
 from distributed.utils_test import (cluster, slow, slowinc, slowadd, randominc,
         _test_scheduler, loop, inc, dec, div, throws, gen_cluster, gen_test,
-        double, deep, rlimit)
+        double, deep)
 
 
 @gen_cluster(executor=True, timeout=None)
@@ -3730,7 +3729,6 @@ def vsum(*args):
 
 @gen_cluster(executor=True, ncores=[('127.0.0.1', 1)] * 80, timeout=1000)
 def test_stress_communication(e, s, *workers):
-    import resource
     s.validate = False # very slow otherwise
     da = pytest.importorskip('dask.array')
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -629,15 +629,6 @@ def test_delete_data(e, s, a, b):
         assert time() < start + 5
 
 
-@gen_cluster()
-def test_rpc(s, a, b):
-    aa = s.rpc(ip=a.ip, port=a.port)
-    aa2 = s.rpc(ip=a.ip, port=a.port)
-    bb = s.rpc(ip=b.ip, port=b.port)
-    assert aa is aa2
-    assert aa is not bb
-
-
 @gen_cluster(executor=True)
 def test_delete_callback(e, s, a, b):
     d = yield e._scatter({'x': 1}, workers=a.address)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -5,7 +5,6 @@ from glob import glob
 import logging
 from multiprocessing import Process, Queue
 import os
-import resource
 import shutil
 import signal
 import socket
@@ -555,15 +554,3 @@ def popen(*args, **kwargs):
             proc.wait()
         with ignoring(OSError):
             proc.terminate()
-
-
-@contextmanager
-def rlimit(key, value):
-    import resource
-    old = resource.getrlimit(key)
-    resource.setrlimit(key, value)
-
-    try:
-        yield
-    finally:
-        resource.setrlimit(key, old)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -301,7 +301,7 @@ class Worker(Server):
         local = {k: self.data[k] for k in who_has if k in self.data}
         who_has = {k: v for k, v in who_has.items() if k not in local}
         remote, bad_data = yield gather_from_workers(who_has,
-                permissive=True, rpc=self.rpc, close=False)
+                permissive=True)
         if remote:
             self.data.update(remote)
             yield self.scheduler.add_keys(address=self.address, keys=list(remote))
@@ -462,6 +462,7 @@ class Worker(Server):
     def compute_one(self, data, key=None, function=None, args=None, kwargs=None,
                     report=False, task=None):
         logger.debug("Compute one on %s", key)
+        self.active.add(key)
         diagnostics = dict()
         try:
             start = default_timer()
@@ -474,7 +475,6 @@ class Worker(Server):
             emsg['key'] = key
             raise Return(emsg)
 
-        self.active.add(key)
         # Fill args with data
         args2 = pack_data(args, data)
         kwargs2 = pack_data(kwargs, data)


### PR DESCRIPTION
This creates a central source of connection streams.  

The `distributed.core.Server` objects, like the `Scheduler` and `Worker` manage ad-hoc connections through a central interface, `Server.rpc('host:port').route(**kwargs)`, like `Worker.rpc('worker:port').get_data(keys=['x', 'y', 'z'])`.  Given a central interface like this we want to do two things:

1.  Maintain a pool of open connections so that we don't need to constantly reconnect (although this is typically only a millisecond or two)
2.  Make sure we don't go past our open file limits

The proposed `ConnectionPool` satisfies the interface used by the `Server` object and accomplishes these objectives.