### PR TITLE
add %remote magic, Executor.start_ipython_scheduler

### DIFF
--- a/continuous_integration/Dockerfile
+++ b/continuous_integration/Dockerfile
@@ -10,14 +10,14 @@ ENV PATH /opt/conda/bin:$PATH
 # hdfs3 - python 2
 RUN apt-get install -y -q protobuf-compiler libprotobuf-dev
 ENV LIBHDFS3_CONF /etc/hadoop/conf/hdfs-site.xml
-RUN /opt/conda/bin/conda install -y -q libxml2 krb5 boost ipython pytest pip pandas cython
+RUN /opt/conda/bin/conda install -y -q libxml2 krb5 boost ipython pytest pip pandas cython mock
 RUN /opt/conda/bin/conda install -y -q libhdfs3 libgsasl libntlm -c dask
 RUN /opt/conda/bin/pip install git+https://github.com/dask/hdfs3 --upgrade
 RUN /opt/conda/bin/pip install git+https://github.com/dask/s3fs --upgrade
 RUN /opt/conda/bin/pip install git+https://github.com/blaze/dask --upgrade
 # hdfs3 - python 3
 RUN conda create -n py3 -y python=3
-RUN conda install -n py3 -y -q libxml2 krb5 boost ipython pytest pip pandas cython
+RUN conda install -n py3 -y -q libxml2 krb5 boost ipython pytest pip pandas cython mock
 RUN conda install -n py3 libhdfs3 libgsasl libntlm -c dask
 RUN /opt/conda/envs/py3/bin/pip install git+https://github.com/dask/hdfs3 --upgrade
 RUN /opt/conda/envs/py3/bin/pip install git+https://github.com/dask/s3fs --upgrade

--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -155,7 +155,7 @@ def register_remote_magic(magic_name='remote'):
 
 def connect_qtconsole(connection_info, name=None, extra_args=None):
     """Open a QtConsole connected to a worker who has the given future
-    
+
     - identify worker with who_has
     - start IPython kernel on the worker
     - start qtconsole connected to the kernel

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1627,6 +1627,9 @@ class Executor(object):
         qtconsole: bool (optional)
             If True, launch a Jupyter QtConsole connected to the worker(s).
 
+        qtconsole_args: list(str) (optional)
+            Additional arguments to pass to the qtconsole on startup.
+
         Returns
         -------
         iter_connection_info: list
@@ -1658,9 +1661,40 @@ class Executor(object):
                 )
         return info_dict
 
-    def start_ipython_scheduler(self, magic_name='scheduler',
+    def start_ipython_scheduler(self, magic_name='scheduler_if_ipython',
                                 qtconsole=False, qtconsole_args=None):
+        """ Start IPython kernel on the scheduler
+
+        Parameters
+        ----------
+        magic_name: str or None (optional)
+            If defined, register IPython magic with this name for
+            executing code on the scheduler.
+            If not defined, register %scheduler magic if IPython is running.
+
+        qtconsole: bool (optional)
+            If True, launch a Jupyter QtConsole connected to the worker(s).
+
+        qtconsole_args: list(str) (optional)
+            Additional arguments to pass to the qtconsole on startup.
+
+        Returns
+        -------
+        connection_info: dict
+            connection_info dict containing info necessary
+            to connect Jupyter clients to the scheduler.
+        """
         info = sync(self.loop, self.scheduler.start_ipython)
+        if magic_name == 'scheduler_if_ipython':
+            # default to %scheduler if in IPython, no magic otherwise
+            in_ipython = False
+            if 'IPython' in sys.modules:
+                from IPython import get_ipython
+                in_ipython = bool(get_ipython())
+            if in_ipython:
+                magic_name = 'scheduler'
+            else:
+                magic_name = None
         if magic_name:
             from ._ipython_utils import register_worker_magic
             register_worker_magic(info, magic_name)

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1611,7 +1611,8 @@ class Executor(object):
         )
         raise gen.Return((workers, responses))
 
-    def start_ipython(self, workers=None, magic_names=False, qtconsole=False, qtconsole_args=None):
+    def start_ipython(self, workers=None, magic_names=False, qtconsole=False,
+                      qtconsole_args=None):
         """ Start IPython kernels on workers
 
         Parameters
@@ -1656,6 +1657,18 @@ class Executor(object):
                                   extra_args=qtconsole_args,
                 )
         return info_dict
+
+    def start_ipython_scheduler(self, magic_name='scheduler',
+                                qtconsole=False, qtconsole_args=None):
+        info = sync(self.loop, self.scheduler.start_ipython)
+        if magic_name:
+            from ._ipython_utils import register_worker_magic
+            register_worker_magic(info, magic_name)
+        if qtconsole:
+            from ._ipython_utils import connect_qtconsole
+            connect_qtconsole(info, name='dask-scheduler',
+                              extra_args=qtconsole_args,)
+        return info
 
 
 class CompatibleExecutor(Executor):

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from functools import partial
 import logging
 import os
+import sys
 from time import sleep
 import uuid
 from threading import Thread
@@ -1638,6 +1639,10 @@ class Executor(object):
             workers = [workers]
 
         (workers, info_dict) = sync(self.loop, self._start_ipython, workers)
+
+        if 'IPython' in sys.modules:
+            from ._ipython_utils import register_remote_magic
+            register_remote_magic()
         if magic_names:
             from ._ipython_utils import register_worker_magic
             for worker, magic_name in zip(workers, magic_names):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2615,53 +2615,18 @@ class Scheduler(Server):
                 out.update({ww for ww in self.ncores if w in ww}) # TODO: quadratic
         return list(out)
 
-    def _start_ipython(self):
-        from IPython import get_ipython
-        if get_ipython() is not None:
-            raise RuntimeError("Cannot start IPython, it's already running.")
-
-        from zmq.eventloop.ioloop import ZMQIOLoop
-        from ipykernel.kernelapp import IPKernelApp
-        # save the global IOLoop instance
-        # since IPython relies on it, but we are going to put it in a thread.
-        save_inst = IOLoop.instance()
-        IOLoop.clear_instance()
-        zmq_loop = ZMQIOLoop()
-        zmq_loop.install()
-
-        # start IPython, disabling its signal handlers that won't work due to running in a thread:
-        app = self._ipython_kernel = IPKernelApp.instance(log=logger)
-        # Don't connect to the history database
-        app.config.HistoryManager.hist_file = ':memory:'
-        # listen on all interfaces, so remote clients can connect:
-        app.ip = self.ip
-        app.init_signal = lambda : None
-        app.initialize([])
-        app.kernel.pre_handler_hook = lambda : None
-        app.kernel.post_handler_hook = lambda : None
-        app.kernel.start()
-
-        # save self in the IPython namespace as 'scheduler'
-        app.kernel.shell.user_ns['scheduler'] = self
-        app.kernel.shell.user_ns['s'] = self
-
-        # start IPython's IOLoop in a thread
-        from threading import Thread
-        zmq_loop_thread = Thread(target=zmq_loop.start)
-        zmq_loop_thread.start()
-
-        # put the global IOLoop instance back:
-        IOLoop.clear_instance()
-        save_inst.install()
-        return app
-
     def start_ipython(self, stream=None):
         """Start an IPython kernel
 
         Returns Jupyter connection info dictionary.
         """
+        from ._ipython_utils import start_ipython
         if self._ipython_kernel is None:
-            self._ipython_kernel = self._start_ipython()
+            self._ipython_kernel = start_ipython(
+                ip=self.ip,
+                ns={'scheduler': self},
+                log=logger,
+            )
         return self._ipython_kernel.get_connection_info()
 
 

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3234,7 +3234,7 @@ def test_start_ipython_scheduler(loop, zmq_ctx):
 
     with cluster(1) as (s, [a]):
         with Executor(('127.0.0.1', s['port']), loop=loop) as e:
-            info = e.start_ipython_scheduler(magic_name=None)
+            info = e.start_ipython_scheduler()
             key = info.pop('key')
             kc = BlockingKernelClient(**info)
             kc.session.key = key
@@ -3248,7 +3248,7 @@ def test_start_ipython_scheduler(loop, zmq_ctx):
 def test_start_ipython_scheduler_magic(loop, zmq_ctx):
     with cluster(1) as (s, [a]):
         with Executor(('127.0.0.1', s['port']), loop=loop) as e, mock_ipython() as ip:
-            info = e.start_ipython_scheduler(magic_name='scheduler')
+            info = e.start_ipython_scheduler()
 
         expected = [
             {'magic_kind': 'line', 'magic_name': 'scheduler'},

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3211,6 +3211,7 @@ def test_as_completed_list(loop):
 @pytest.mark.ipython
 def test_start_ipython_workers(loop, zmq_ctx):
     from jupyter_client import BlockingKernelClient
+
     with cluster(1) as (s, [a]):
         with Executor(('127.0.0.1', s['port']), loop=loop) as e:
             info_dict = e.start_ipython()
@@ -3228,14 +3229,12 @@ def test_start_ipython_workers(loop, zmq_ctx):
 
 
 @pytest.mark.ipython
-def test_start_ipython_scheduler(loop):
+def test_start_ipython_scheduler(loop, zmq_ctx):
     from jupyter_client import BlockingKernelClient
-    from ipykernel.kernelapp import IPKernelApp
-    from IPython.core.interactiveshell import InteractiveShell
 
     with cluster(1) as (s, [a]):
         with Executor(('127.0.0.1', s['port']), loop=loop) as e:
-            info = e.start_ipython_scheduler()
+            info = e.start_ipython_scheduler(magic_name=None)
             key = info.pop('key')
             kc = BlockingKernelClient(**info)
             kc.session.key = key

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3245,7 +3245,24 @@ def test_start_ipython_scheduler(loop, zmq_ctx):
 
 
 @pytest.mark.ipython
-def test_start_ipython_magic(loop, zmq_ctx):
+def test_start_ipython_scheduler_magic(loop, zmq_ctx):
+    with cluster(1) as (s, [a]):
+        with Executor(('127.0.0.1', s['port']), loop=loop) as e, mock_ipython() as ip:
+            info = e.start_ipython_scheduler(magic_name='scheduler')
+
+        expected = [
+            {'magic_kind': 'line', 'magic_name': 'scheduler'},
+            {'magic_kind': 'cell', 'magic_name': 'scheduler'},
+        ]
+
+        call_kwargs_list = [ kwargs for (args, kwargs) in ip.register_magic_function.call_args_list ]
+        assert call_kwargs_list == expected
+        magic = ip.register_magic_function.call_args_list[0][0][0]
+        magic(line="", cell="scheduler")
+
+
+@pytest.mark.ipython
+def test_start_ipython_workers_magic(loop, zmq_ctx):
     with cluster(2) as (s, [a, b]):
 
         with Executor(('127.0.0.1', s['port']), loop=loop) as e, mock_ipython() as ip:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -79,6 +79,14 @@ def loop():
             print(f)
 
 
+@pytest.yield_fixture
+def zmq_ctx():
+    import zmq
+    ctx = zmq.Context.instance()
+    yield ctx
+    ctx.destroy(linger=0)
+
+
 def inc(x):
     return x + 1
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -13,6 +13,7 @@ import sys
 from time import time, sleep
 import uuid
 
+import mock
 from toolz import merge
 from tornado import gen
 from tornado.ioloop import IOLoop, TimeoutError
@@ -85,6 +86,17 @@ def zmq_ctx():
     ctx = zmq.Context.instance()
     yield ctx
     ctx.destroy(linger=0)
+
+
+@contextmanager
+def mock_ipython():
+    ip = mock.Mock()
+    ip.user_ns = {}
+    ip.kernel = None
+    get_ip = lambda : ip
+    with mock.patch('IPython.get_ipython', get_ip), \
+            mock.patch('distributed._ipython_utils.get_ipython', get_ip):
+        yield ip
 
 
 def inc(x):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -8,7 +8,7 @@ from multiprocessing.pool import ThreadPool
 import os
 import pkg_resources
 import tempfile
-from threading import current_thread, Thread, Event
+from threading import current_thread
 from time import time
 from timeit import default_timer
 import shutil
@@ -618,67 +618,18 @@ class Worker(Server):
     def get_data(self, stream, keys=None):
         return {k: dumps(self.data[k]) for k in keys if k in self.data}
 
-    def _start_ipython(self):
-        from IPython import get_ipython
-        if get_ipython() is not None:
-            raise RuntimeError("Cannot start IPython, it's already running.")
-
-        from zmq.eventloop.ioloop import ZMQIOLoop
-        from ipykernel.kernelapp import IPKernelApp
-        # save the global IOLoop instance
-        # since IPython relies on it, but we are going to put it in a thread.
-        save_inst = IOLoop.instance()
-        IOLoop.clear_instance()
-        zmq_loop = ZMQIOLoop()
-        zmq_loop.install()
-
-        # start IPython, disabling its signal handlers that won't work due to running in a thread:
-        app = self._ipython_kernel = IPKernelApp.instance(log=logger)
-        # Don't connect to the history database
-        app.config.HistoryManager.hist_file = ':memory:'
-        # listen on all interfaces, so remote clients can connect:
-        app.ip = self.ip
-        # disable some signal handling, logging
-        noop = lambda : None
-        app.init_signal = noop
-        app.log_connection_info = noop
-
-        # start IPython in a thread
-        # initialization happens in the thread to avoid threading problems
-        # with the sqlite history
-        evt = Event()
-        def _start():
-            app.initialize([])
-            app.kernel.pre_handler_hook = noop
-            app.kernel.post_handler_hook = noop
-            app.kernel.start()
-            app.kernel.loop = IOLoop.instance()
-            # save self in the IPython namespace as 'worker'
-            app.kernel.shell.user_ns['worker'] = self
-            from tornado.ioloop import PeriodicCallback
-            pc = PeriodicCallback(lambda : print(os.getpid(), file=sys.__stdout__), 1000, io_loop=zmq_loop)
-            pc.start()
-            evt.set()
-            zmq_loop.start()
-
-        zmq_loop_thread = Thread(target=_start)
-        zmq_loop_thread.daemon = True
-        zmq_loop_thread.start()
-        self._zmq_thread = zmq_loop_thread
-        assert evt.wait(timeout=5), "IPython didn't start in a reasonable amount of time."
-
-        # put the global IOLoop instance back:
-        IOLoop.clear_instance()
-        save_inst.install()
-        return app
-
     def start_ipython(self, stream):
         """Start an IPython kernel
 
         Returns Jupyter connection info dictionary.
         """
+        from ._ipython_utils import start_ipython
         if self._ipython_kernel is None:
-            self._ipython_kernel = self._start_ipython()
+            self._ipython_kernel = start_ipython(
+                ip=self.ip,
+                ns={'worker': self},
+                log=logger,
+            )
         return self._ipython_kernel.get_connection_info()
 
     def upload_file(self, stream, filename=None, data=None, load=True):


### PR DESCRIPTION
As discussed at SciPy, but it took me forever to figure out why a test wasn't passing.
registered when Executor.start_ipython is called during an IPython session.

%remote loads connection info from a dict in the IPython namespace, e.g.

    info = e.start_ipython(worker)[worker]
    %remote info print(worker.data)