### PR TITLE
New progress bars

### DIFF
--- a/distributed/bokeh/progress_bar.py
+++ b/distributed/bokeh/progress_bar.py
@@ -25,8 +25,6 @@ class ProgressBarView extends Widget.View
             done = data.done[i]
             all = data.all[i]
             percent = parseInt(done/all * 100)
-
-            # Can use bar_class to set other colors
             if percent == 100
                 bar_class = 'bar finished'
             else
@@ -39,7 +37,7 @@ class ProgressBarView extends Widget.View
                         <span class='count'>#{done}/#{all}</span>
                     </div>
                     <div class='meter'>
-                        <span class='#{bar_class}' style='width: #{percent}%'></span>
+                        <span class='#{bar_class}' style='width: #{percent}%; background-color: #{data.color[i]}'></span>
                     </div>
                 </li>
             ")

--- a/distributed/bokeh/progress_bar.py
+++ b/distributed/bokeh/progress_bar.py
@@ -1,0 +1,68 @@
+from bokeh.core.properties import StringSpec, NumberSpec, Instance
+from bokeh.models import Widget, ColumnDataSource, DataSource
+
+IMPLEMENTATION = """
+$ = require "jquery"
+p = require "core/properties"
+Widget = require "models/widgets/widget"
+ColumnDataSource = require "models/sources/column_data_source"
+
+class ProgressBarView extends Widget.View
+    initialize: (options) ->
+        super(options)
+        @render()
+        @listenTo(@model, 'change', @render)
+        @listenTo(@model.source, 'change', @render)
+
+    render: () ->
+        super()
+        @$el.empty()
+
+        data = @model.source.data
+        $bars = $("<ul></ul>")
+        for i in [0...data.name.length]
+            console.log(i)
+            $bar = $("
+                <li>
+                    #{data.name[i]} - #{data.done[i]} / #{data.all[i]}
+                </li>
+            ")
+            $bars.prepend($bar)
+        @$el.html($bars)
+        return @
+
+class ProgressBar extends Widget.Model
+    type: "ProgressBar"
+    default_view: ProgressBarView
+    @define {
+        #function: [ p.StringSpec, {field: 'name'} ]
+        #all: [ p.NumberSpec, {field: 'all'} ]
+        #done: [p.NumberSpec, {field: 'done'} ]
+        source: [ p.Instance, () -> new ColumnDataSource.Model() ]
+    }
+module.exports =
+    Model: ProgressBar
+"""
+
+
+class ProgressBar(Widget):
+    """
+    A custom Dask progress bar
+    """
+    __implementation__ = IMPLEMENTATION
+
+    source = Instance(DataSource, default=lambda: ColumnDataSource(), help="""
+        Data source for progress bar
+    """)
+    #
+    # Prevent any configuration for now
+    #
+    #function = StringSpec(default='name', help="""
+    #    The name of the function
+    #""")
+    #all = NumberSpec(default='all', help="""
+    #    The total number of calls to be made.
+    #""")
+    #done = NumberSpec(default='done', help="""
+    #    The total number of calls made.
+    #""")

--- a/distributed/bokeh/progress_bar.py
+++ b/distributed/bokeh/progress_bar.py
@@ -1,4 +1,5 @@
-from bokeh.core.properties import StringSpec, NumberSpec, Instance
+#from bokeh.core.properties import StringSpec, NumberSpec,
+from bokeh.core.properties import Instance
 from bokeh.models import Widget, ColumnDataSource, DataSource
 
 IMPLEMENTATION = """
@@ -19,16 +20,31 @@ class ProgressBarView extends Widget.View
         @$el.empty()
 
         data = @model.source.data
-        $bars = $("<ul></ul>")
+        $bars = $("<ul class='grid'></ul>")
         for i in [0...data.name.length]
-            console.log(i)
+            done = data.done[i]
+            all = data.all[i]
+            percent = parseInt(done/all * 100)
+
+            # Can use bar_class to set other colors
+            if percent == 100
+                bar_class = 'bar finished'
+            else
+                bar_class = 'bar'
+
             $bar = $("
-                <li>
-                    #{data.name[i]} - #{data.done[i]} / #{data.all[i]}
+                <li class='grid-item'>
+                    <div class='description'>
+                        <span class='function-name'>#{data.name[i]}</span>
+                        <span class='count'>#{done}/#{all}</span>
+                    </div>
+                    <div class='meter'>
+                        <span class='#{bar_class}' style='width: #{percent}%'></span>
+                    </div>
                 </li>
             ")
             $bars.prepend($bar)
-        @$el.html($bars)
+            @$el.html($bars)
         return @
 
 class ProgressBar extends Widget.Model

--- a/distributed/bokeh/status/main.py
+++ b/distributed/bokeh/status/main.py
@@ -49,7 +49,7 @@ def resource_update():
 doc.add_periodic_callback(resource_update, messages['workers']['interval'])
 
 
-nbytes_task_source, nbytes_task_plot = nbytes_plot(sizing_mode=SIZING_MODE, width=WIDTH, height=60)
+nbytes_task_source, nbytes_task_plot = nbytes_plot(sizing_mode=SIZING_MODE, width=WIDTH, height=85)
 progress_source, progress_plot = progress_plot(sizing_mode=SIZING_MODE, width=WIDTH, height=160)
 
 

--- a/distributed/bokeh/status/main.py
+++ b/distributed/bokeh/status/main.py
@@ -8,8 +8,11 @@ from bokeh.io import curdoc
 from bokeh.layouts import column, row
 from toolz import valmap
 
-from distributed.bokeh.status_monitor import (progress_plot, task_stream_plot,
-        nbytes_plot)
+from distributed.bokeh.status_monitor import (
+    nbytes_plot,
+    progress_plot,
+    task_stream_plot,
+)
 from distributed.bokeh.worker_monitor import resource_profile_plot
 from distributed.diagnostics.progress_stream import progress_quads, nbytes_bar
 from distributed.utils import log_errors
@@ -24,6 +27,8 @@ doc = curdoc()
 
 resource_index = [0]
 resource_source, resource_plot, network_plot, combo_toolbar = resource_profile_plot(sizing_mode=SIZING_MODE, width=WIDTH, height=80)
+
+
 def resource_update():
     with log_errors():
         index = messages['workers']['index']
@@ -44,31 +49,26 @@ def resource_update():
 doc.add_periodic_callback(resource_update, messages['workers']['interval'])
 
 
-nbytes_task_source, nbytes_task_plot = nbytes_plot(sizing_mode=SIZING_MODE,
-        width=WIDTH, height=60)
+nbytes_task_source, nbytes_task_plot = nbytes_plot(sizing_mode=SIZING_MODE, width=WIDTH, height=60)
+progress_source, progress_plot = progress_plot(sizing_mode=SIZING_MODE, width=WIDTH, height=160)
 
-progress_source, progress_plot = progress_plot(sizing_mode=SIZING_MODE,
-        width=WIDTH, height=160)
+
 def progress_update():
     with log_errors():
         msg = messages['progress']
         d = progress_quads(msg)
         progress_source.data.update(d)
-        progress_plot.title.text = ("Progress -- total: %(total)s, "
-            "in-memory: %(in-memory)s, processing: %(processing)s, "
-            "ready: %(ready)s, waiting: %(waiting)s, failed: %(failed)s"
-            % messages['tasks']['deque'][-1])
-
         nb = nbytes_bar(msg['nbytes'])
         nbytes_task_source.data.update(nb)
         nbytes_task_plot.title.text = \
-                "Memory Use: %0.2f MB" % (sum(msg['nbytes'].values()) / 1e6)
+            "Memory Use: %0.2f MB" % (sum(msg['nbytes'].values()) / 1e6)
 doc.add_periodic_callback(progress_update, 50)
 
 
 task_stream_index = [0]
-task_stream_source, task_stream_plot = task_stream_plot(
-        sizing_mode=SIZING_MODE, width=WIDTH, height=300)
+task_stream_source, task_stream_plot = task_stream_plot(sizing_mode=SIZING_MODE, width=WIDTH, height=300)
+
+
 def task_stream_update():
     with log_errors():
         index = messages['task-events']['index']

--- a/distributed/bokeh/status/templates/index.html
+++ b/distributed/bokeh/status/templates/index.html
@@ -6,6 +6,9 @@
     {{ bokeh_css }}
     {{ bokeh_js }}
     <style>
+      * { 
+        box-sizing: border-box; 
+      }
       html {
         width: 100%;
         height: 100%;
@@ -48,6 +51,71 @@
       .bk-root .bk-toolbar-box .bk-toolbar-right {
         top: 4px;
         right: 4px;
+      }
+      /* ---- grid ---- */
+
+      .grid {
+        background: #EEE;
+        margin: 0px;
+        padding: 0px;
+        list-style: none;
+      }
+
+      /* ---- grid-item ---- */
+
+      .grid-item {
+        padding: 10px;
+        min-width: 200px;
+        width: 50%;
+        float: left;
+        background: whitesmoke;
+        border: 2px solid white;
+      }
+      @media all and (max-width: 420px) { 
+        .grid-item {
+          width: 100%;
+        }
+      }
+
+      .function-name {
+        word-wrap: break-word;
+      }
+      .count {
+        float: right;
+      }
+
+      .description:after {
+        content: "";
+        display: table;
+        clear: both;
+      }
+
+      .meter { 
+        height: 25px;
+        position: relative;
+        background: white;
+        border-radius: 25px;
+        padding: 2px;
+        margin-top: 5px;
+      }
+
+      .bar {
+        display: block;
+        height: 100%;
+        border-top-right-radius: 8px;
+        border-bottom-right-radius: 8px;
+        border-top-left-radius: 20px;
+        border-bottom-left-radius: 20px;
+        background-color: #C44A28;
+        box-shadow: 
+          inset 0 2px 9px  rgba(255,255,255,0.3),
+          inset 0 -2px 6px rgba(0,0,0,0.4);
+        position: relative;
+        overflow: hidden;
+      }
+      .bar.finished {
+        border-top-right-radius: 20px;
+        border-bottom-right-radius: 20px;
       }
     </style>
   </head>

--- a/distributed/bokeh/status/templates/index.html
+++ b/distributed/bokeh/status/templates/index.html
@@ -12,6 +12,7 @@
       html {
         width: 100%;
         height: 100%;
+        min-width: 625px;
       }
       body {
         width: 90%;
@@ -58,6 +59,7 @@
         background: #EEE;
         margin: 0px;
         padding: 0px;
+        padding-left: 32px;
         list-style: none;
       }
 
@@ -116,6 +118,36 @@
       .bar.finished {
         border-top-right-radius: 20px;
         border-bottom-right-radius: 20px;
+      }
+
+      /* Custom hover */
+      .bk-tooltip.bk-tooltip-custom {
+          background-color: white !important;
+          opacity: 0.95;
+          font-size: 0.8em;
+          padding: 0.5em 1.5em;
+          border-color: #D8D8D8 !important; /* WH GRAY */
+      }
+
+      .bk-tooltip.bk-tooltip-custom:before {
+          border: none !important;
+      }
+
+      .bk-tooltip.bk-tooltip-custom:after {
+          border: none !important;
+      }
+
+      .tooltip-text {
+          clear: both;
+          float: left;
+      }
+      .hover-key {
+        font-size: 14px; 
+        font-weight: bold;
+      }
+      .hover-value {
+        font-size: 10px; 
+        font-family: Monaco, monospace;
       }
     </style>
   </head>

--- a/distributed/bokeh/status/templates/index.html
+++ b/distributed/bokeh/status/templates/index.html
@@ -126,16 +126,24 @@
           opacity: 0.95;
           font-size: 0.8em;
           padding: 0.5em 1.5em;
-          border-color: #D8D8D8 !important; /* WH GRAY */
+          border-color: #D8D8D8 !important;
       }
 
-      .bk-tooltip.bk-tooltip-custom:before {
-          border: none !important;
-      }
+			.bk-tooltip.bk-tooltip-custom.bk-left::before {
+				border-right-color: #D8D8D8 !important;
+			}
 
-      .bk-tooltip.bk-tooltip-custom:after {
-          border: none !important;
-      }
+			.bk-tooltip.bk-tooltip-custom.bk-right::after {
+				border-left-color: #D8D8D8 !important;
+			}
+
+			.bk-tooltip.bk-tooltip-custom.bk-above::before {
+				border-bottom-color: #D8D8D8 !important;
+			}
+
+			.bk-tooltip.bk-tooltip-custom.bk-below::after {
+				border-top-color: #D8D8D8 !important;
+			}
 
       .tooltip-text {
           clear: both;

--- a/distributed/bokeh/status_monitor.py
+++ b/distributed/bokeh/status_monitor.py
@@ -13,6 +13,9 @@ from ..scheduler import Scheduler
 from ..diagnostics.progress_stream import (nbytes_bar, task_stream_palette,
         incrementing_index)
 
+from .progress_bar import ProgressBar
+
+
 try:
     from bokeh.palettes import Spectral11, Spectral9, viridis
     from bokeh.models import ColumnDataSource, DataRange1d, HoverTool, Range1d
@@ -141,47 +144,6 @@ def progress_plot(**kwargs):
         from ..diagnostics.progress_stream import progress_quads
         data = progress_quads({'all': {}, 'memory': {},
                                'erred': {}, 'released': {}})
-
-        y_range = Range1d(-8, 0)
         source = ColumnDataSource(data)
-        fig = figure(tools='', toolbar_location=None, y_range=y_range, **kwargs)
-        fig.quad(source=source, top='top', bottom='bottom',
-                 left='left', right='right', color='#aaaaaa', alpha=0.2)
-        fig.quad(source=source, top='top', bottom='bottom',
-                 left='left', right='released-loc', color=Spectral9[0], alpha=0.4)
-        fig.quad(source=source, top='top', bottom='bottom',
-                 left='released-loc', right='memory-loc', color=Spectral9[0], alpha=0.8)
-        fig.quad(source=source, top='top', bottom='bottom',
-                 left='erred-loc', right='erred-loc', color='#000000', alpha=0.3)
-        fig.text(source=source, text='show-name', y='bottom', x='left',
-                x_offset=5, text_font_size='10pt')
-        fig.text(source=source, text='done', y='bottom', x='right', x_offset=-5,
-                text_align='right', text_font_size='10pt')
-        fig.xaxis.visible = False
-        fig.yaxis.visible = False
-        fig.grid.grid_line_alpha = 0
-
-        hover = HoverTool()
-        fig.add_tools(hover)
-        hover = fig.select(HoverTool)
-        hover.tooltips = """
-        <div>
-            <span style="font-size: 14px; font-weight: bold;">Name:</span>&nbsp;
-            <span style="font-size: 10px; font-family: Monaco, monospace;">@name</span>
-        </div>
-        <div>
-            <span style="font-size: 14px; font-weight: bold;">All:</span>&nbsp;
-            <span style="font-size: 10px; font-family: Monaco, monospace;">@all</span>
-        </div>
-        <div>
-            <span style="font-size: 14px; font-weight: bold;">Memory:</span>&nbsp;
-            <span style="font-size: 10px; font-family: Monaco, monospace;">@memory</span>
-        </div>
-        <div>
-            <span style="font-size: 14px; font-weight: bold;">Erred:</span>&nbsp;
-            <span style="font-size: 10px; font-family: Monaco, monospace;">@erred</span>
-        </div>
-        """
-        hover.point_policy = 'follow_mouse'
-
-        return source, fig
+        progress_bar = ProgressBar(source=source)
+        return source, progress_bar

--- a/distributed/bokeh/status_monitor.py
+++ b/distributed/bokeh/status_monitor.py
@@ -54,16 +54,11 @@ def task_stream_plot(sizing_mode='scale_width', **kwargs):
     fig.add_tools(hover)
     hover = fig.select(HoverTool)
     hover.tooltips = """
-    <div>
-        <span style="font-size: 12px; font-weight: bold;">@name:</span>&nbsp;
-        <span style="font-size: 10px; font-family: Monaco, monospace;">@duration</span>
-        <span style="font-size: 10px;">ms</span>&nbsp;
-    </div>
+        <span class="hover-key">@name:</span>&nbsp;<span class="hover-value">@duration ms</span>
     """
     hover.point_policy = 'follow_mouse'
 
     return source, fig
-
 
 
 def task_stream_append(lists, msg, workers, palette=task_stream_palette):
@@ -103,36 +98,22 @@ def task_stream_append(lists, msg, workers, palette=task_stream_palette):
 
 
 def nbytes_plot(**kwargs):
-    data = {'name': [], 'left': [], 'right': [], 'center': [], 'color': [],
-            'percent': [], 'MB': [], 'text': []}
+    data = {'name': [], 'left': [], 'right': [], 'center': [], 'color': [], 'percent': [], 'MB': []}
     source = ColumnDataSource(data)
-    fig = figure(title='Memory Use', tools='', toolbar_location=None, **kwargs)
-    fig.quad(source=source, top=1, bottom=0,
-             left='left', right='right', color='color', alpha=0.8)
-    fig.text(source=source, x='center', y=0.5, text='text',
-             text_baseline='middle', text_align='center')
-
-    fig.grid.grid_line_color = None
-    fig.grid.grid_line_color = None
-    fig.axis.visible = None
-    fig.outline_line_color = None
+    fig = figure(
+        title='Memory Use', tools='', toolbar_location=None,
+        x_axis_location=None, y_axis_location=None, y_range=(0, 1), x_range=(0, 1),
+        min_border_bottom=30, **kwargs)
+    fig.quad(source=source, top=1, bottom=0, left='left', right='right', color='color')
+    fig.grid.visible = False
 
     hover = HoverTool()
     fig.add_tools(hover)
     hover = fig.select(HoverTool)
     hover.tooltips = """
-    <div>
-        <span style="font-size: 14px; font-weight: bold;">Name:</span>&nbsp;
-        <span style="font-size: 10px; font-family: Monaco, monospace;">@name</span>
-    </div>
-    <div>
-        <span style="font-size: 14px; font-weight: bold;">Percent:</span>&nbsp;
-        <span style="font-size: 10px; font-family: Monaco, monospace;">@percent</span>
-    </div>
-    <div>
-        <span style="font-size: 14px; font-weight: bold;">MB:</span>&nbsp;
-        <span style="font-size: 10px; font-family: Monaco, monospace;">@MB</span>
-    </div>
+        <div><span class="hover-key">Name:</span>&nbsp;<span class="hover-value">@name</span></div>
+        <div><span class="hover-key">Percent:</span>&nbsp;<span class="hover-value">@percent</span></div>
+        <div><span class="hover-key">MB:</span>&nbsp;<span class="hover-value">@MB</span></div>
     """
     hover.point_policy = 'follow_mouse'
 
@@ -142,8 +123,7 @@ def nbytes_plot(**kwargs):
 def progress_plot(**kwargs):
     with log_errors():
         from ..diagnostics.progress_stream import progress_quads
-        data = progress_quads({'all': {}, 'memory': {},
-                               'erred': {}, 'released': {}})
+        data = progress_quads({'all': {}, 'memory': {}, 'erred': {}, 'released': {}})
         source = ColumnDataSource(data)
         progress_bar = ProgressBar(source=source)
         return source, progress_bar

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -113,8 +113,11 @@ def progress_quads(msg, nrows=8, ncols=3):
 
     d['name'] = names
     d['done'] = []
+    d['color'] = []
     for r, m, e in zip(d['released'], d['memory'], d['erred']):
         d['done'].append(r + m + e)
+    for name in names:
+        d['color'].append(task_stream_palette[incrementing_index(name)])
     return d
 
 

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -64,7 +64,6 @@ def nbytes_bar(nbytes):
     names = sorted(nbytes)
 
     d = {'name': [],
-         'text': [],
          'left': [],
          'right': [],
          'center': [],
@@ -83,11 +82,6 @@ def nbytes_bar(nbytes):
         d['center'].append(center)
         d['color'].append(task_stream_palette[incrementing_index(name)])
         d['name'].append(name)
-        if right - left > 0.1:
-            d['text'].append(name)
-        else:
-            d['text'].append('')
-
     return d
 
 

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -99,61 +99,35 @@ def progress_quads(msg, nrows=8, ncols=3):
     ...        'erred': {'inc': 0, 'dec': 1, 'add': 0},
     ...        'released': {'inc': 1, 'dec': 0, 'add': 1}}
 
-    >>> progress_quads(msg, nrows=2)  # doctest: +SKIP
+    >>> progress_quads(msg, nrows=2)
     {'name': ['inc', 'add', 'dec'],
-     'left': [0, 0, 1],
-     'right': [0.9, 0.9, 1.9],
-     'top': [0, -1, 0],
-     'bottom': [-.8, -1.8, -.8],
      'released': [1, 1, 0],
      'memory': [2, 1, 0],
      'erred': [0, 0, 1],
-     'done': ['3 / 5', '2 / 4', '1 / 1'],
-     'released-loc': [.2/.9, .25 / 0.9, 1],
-     'memory-loc': [3 / 5 / .9, .5 / 0.9, 1],
-     'erred-loc': [3 / 5 / .9, .5 / 0.9, 1.9]}
+     'done': [3, 2, 1],
+     'all': [5, 4, 1]}
     """
-    width = 0.9
     names = sorted(msg['all'], key=msg['all'].get, reverse=True)
     names = names[:nrows * ncols]
-    n = len(names)
     d = {k: [v.get(name, 0) for name in names] for k, v in msg.items()}
 
     d['name'] = names
-    d['show-name'] = [name if len(name) <= 15 else name[:12] + '...'
-                      for name in names]
-    d['left'] = [i // nrows for i in range(n)]
-    d['right'] = [i // nrows + width for i in range(n)]
-    d['top'] = [-(i % nrows) for i in range(n)]
-    d['bottom'] = [-(i % nrows) - 0.8 for i in range(n)]
-
-
-    d['released-loc'] = []
-    d['memory-loc'] = []
-    d['erred-loc'] = []
     d['done'] = []
-    for r, m, e, a, l in zip(d['released'], d['memory'],
-                             d['erred'], d['all'], d['left']):
-        rl = width * r / a + l
-        ml = width * (r + m) / a + l
-        el = width * (r + m + e) / a + l
-        done = '%d / %d' % (r + m + e, a)
-        d['released-loc'].append(rl)
-        d['memory-loc'].append(ml)
-        d['erred-loc'].append(el)
-        d['done'].append(done)
-
+    for r, m, e in zip(d['released'], d['memory'], d['erred']):
+        d['done'].append(r + m + e)
     return d
 
 
 from toolz import memoize
-from bokeh.palettes import Spectral11, Spectral9, viridis
+from bokeh.palettes import viridis
 import random
 task_stream_palette = list(viridis(25))
 random.shuffle(task_stream_palette)
 
 import itertools
 counter = itertools.count()
+
+
 @memoize
 def incrementing_index(o):
     return next(counter)


### PR DESCRIPTION
@mrocklin - weekend surprise - awesome progress bars.

<img width="646" alt="screen shot 2016-08-27 at 10 06 43 pm" src="https://cloud.githubusercontent.com/assets/1796208/18031735/c2866550-6ca2-11e6-8625-22631a50b032.png">

The claims:
- These are made by your very own custom model - `ProgressBar`
- They are real html elements and will all be the same size growing the page as they need to.
- They are colored so they form a legend for the other two plots
- The legending means that I've cleaned up the memory plot.
- I also cleaned up the hover styling slightly.
- Much less data processing and less data going to the front end (see distributed/diagnostics/progress_stream.py)

The caveats:
- This makes a whole bunch of new dom elements. Having tried it out, it doesn't seem that performance is a problem. But if it is, we could optimize this.
- I also haven't done the thing where the progress bar shows the unallocated memory (or whatever the light blue bar thing is) because I wasn't entirely sure about that. But we can certainly iterate.
- I also haven't done anything about displaying errored counts - but of course we can.
