### PR TITLE
Launch tasks from other tasks

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -12,6 +12,7 @@ from .nanny import Nanny
 from .scheduler import Scheduler
 from .utils import sync
 from .worker import Worker
+from .worker_executor import local_executor
 
 try:
     from .collections import futures_to_collection

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -205,8 +205,8 @@ class Server(TCPServer):
                 try:
                     handler = self.handlers[op]
                 except KeyError:
-                    result = 'No handler found: ' + op.encode()
-                    logger.warn(result)
+                    result = "No handler found: %s" % op
+                    logger.warn(result, exc_info=True)
                 else:
                     logger.debug("Calling into handler %s", handler.__name__)
                     try:
@@ -400,6 +400,10 @@ class rpc(object):
         self.status = 'running'
         assert self.ip
         assert self.port
+
+    @property
+    def address(self):
+        return '%s:%d' % (self.ip, self.port)
 
     @gen.coroutine
     def live_stream(self):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -268,7 +268,9 @@ class Scheduler(Server):
                          'list_datasets': self.list_datasets,
                          'get_dataset': self.get_dataset,
                          'publish_dataset': self.publish_dataset,
-                         'unpublish_dataset': self.unpublish_dataset}
+                         'unpublish_dataset': self.unpublish_dataset,
+                         'update_data': self.update_data,
+                         'change_worker_cores': self.change_worker_cores}
 
         self.services = {}
         for k, v in (services or {}).items():
@@ -1470,7 +1472,7 @@ class Scheduler(Server):
                 # TODO: delete key from worker
         return 'OK'
 
-    def update_data(self, who_has=None, nbytes=None, client=None):
+    def update_data(self, stream=None, who_has=None, nbytes=None, client=None):
         """
         Learn that new data has entered the network from an external source
 
@@ -1478,30 +1480,31 @@ class Scheduler(Server):
         --------
         Scheduler.mark_key_in_memory
         """
-        who_has = {k: [self.coerce_address(vv) for vv in v]
-                   for k, v in who_has.items()}
-        logger.debug("Update data %s", who_has)
-        if client:
-            self.client_wants_keys(keys=list(who_has), client=client)
+        with log_errors():
+            who_has = {k: [self.coerce_address(vv) for vv in v]
+                       for k, v in who_has.items()}
+            logger.debug("Update data %s", who_has)
+            if client:
+                self.client_wants_keys(keys=list(who_has), client=client)
 
-        # for key, workers in who_has.items():  # TODO
-        #     self.mark_key_in_memory(key, workers)
+            # for key, workers in who_has.items():  # TODO
+            #     self.mark_key_in_memory(key, workers)
 
-        self.nbytes.update(nbytes)
+            self.nbytes.update(nbytes)
 
-        for key, workers in who_has.items():
-            if key not in self.dependents:
-                self.dependents[key] = set()
-            if key not in self.dependencies:
-                self.dependencies[key] = set()
-            self.task_state[key] = 'memory'
-            self.who_has[key] = set(workers)
-            for w in workers:
-                self.has_what[w].add(key)
-            self.waiting_data[key] = set()
-            self.report({'op': 'key-in-memory',
-                         'key': key,
-                         'workers': list(workers)})
+            for key, workers in who_has.items():
+                if key not in self.dependents:
+                    self.dependents[key] = set()
+                if key not in self.dependencies:
+                    self.dependencies[key] = set()
+                self.task_state[key] = 'memory'
+                self.who_has[key] = set(workers)
+                for w in workers:
+                    self.has_what[w].add(key)
+                self.waiting_data[key] = set()
+                self.report({'op': 'key-in-memory',
+                             'key': key,
+                             'workers': list(workers)})
 
     def report_on_key(self, key):
         if key not in self.task_state:
@@ -1614,6 +1617,15 @@ class Scheduler(Server):
 
     def get_dataset(self, stream, name=None, client=None):
         return self.datasets.get(name, {'data': [], 'keys': []})
+
+    def change_worker_cores(self, stream=None, worker=None, diff=0):
+        """ Add or remove cores from a worker
+
+        This is used when a worker wants to spin off a long-running task
+        """
+        self.ncores[worker] += diff
+        self.maybe_idle.add(worker)
+        self.ensure_occupied()
 
     #####################
     # State Transitions #

--- a/distributed/tests/test_threadpoolexecutor.py
+++ b/distributed/tests/test_threadpoolexecutor.py
@@ -1,0 +1,26 @@
+from distributed.threadpoolexecutor import ThreadPoolExecutor, secede
+from time import time, sleep
+
+def test_tpe():
+    e = ThreadPoolExecutor(2)
+    list(e.map(sleep, [0.01] * 4))
+
+    threads = e._threads.copy()
+    assert len(threads) == 2
+
+    def f():
+        secede()
+        return 1
+
+    assert e.submit(f).result() == 1
+
+    assert len(e._threads) == 1
+
+    list(e.map(sleep, [0.01] * 4))
+    assert len(threads | e._threads) == 3
+
+    start = time()
+    while all(t.is_alive() for t in threads):
+        sleep(0.01)
+        assert time() < start + 1
+

--- a/distributed/tests/test_worker_executor.py
+++ b/distributed/tests/test_worker_executor.py
@@ -1,0 +1,89 @@
+from __future__ import print_function, division, absolute_import
+
+from datetime import timedelta
+from time import time
+
+from tornado import gen
+
+from distributed import local_executor
+from distributed.utils_test import gen_cluster, inc, double
+from distributed.worker_executor import local_state
+
+
+@gen_cluster(executor=True)
+def test_submit_from_worker(e, s, a, b):
+    def func(x):
+        with local_executor() as e:
+            x = e.submit(inc, x)
+            y = e.submit(double, x)
+            result = x.result() + y.result()
+            return result
+
+    x, y = e.map(func, [10, 20])
+    xx, yy = yield e._gather([x, y])
+
+    assert xx == 10 + 1 + (10 + 1) * 2
+    assert yy == 20 + 1 + (20 + 1) * 2
+
+    assert len(s.transition_log) > 10
+    assert len(s.wants_what) == 1
+
+
+@gen_cluster(executor=True, ncores=[('127.0.0.1', 1)] * 2)
+def test_scatter_from_worker(e, s, a, b):
+    def func():
+        with local_executor() as e:
+            futures = e.scatter([1, 2, 3, 4, 5])
+            assert isinstance(futures, (list, tuple))
+            assert len(futures) == 5
+
+            x = e.worker.data.copy()
+            y = {f.key: i for f, i in zip(futures, [1, 2, 3, 4, 5])}
+            assert x == y
+
+            total = e.submit(sum, futures)
+            return total.result()
+
+    future = e.submit(func)
+    result = yield future._result()
+    assert result == sum([1, 2, 3, 4, 5])
+
+    def func():
+        with local_executor() as e:
+            correct = True
+            for data in [[1, 2], (1, 2), {1, 2}]:
+                futures = e.scatter(data)
+                correct &= type(futures) == type(data)
+
+            o = object()
+            futures = e.scatter({'x': o})
+            correct &= e.worker.data['x'] is o
+            return correct
+
+    future = e.submit(func)
+    result = yield future._result()
+    assert result is True
+
+    start = time()
+    while not all(v == 1 for v in s.ncores.values()):
+        yield gen.sleep(0.1)
+        print(s.ncores)
+        assert time() < start + 5
+
+
+@gen_cluster(executor=True, ncores=[('127.0.0.1', 1)] * 2)
+def test_gather_multi_machine(e, s, a, b):
+    a_address = b.address
+    b_address = b.address
+    def func():
+        with local_executor() as ee:
+            x = ee.submit(inc, 1, workers=a_address)
+            y = ee.submit(inc, 2, workers=b_address)
+
+            xx, yy = ee.gather([x, y])
+        return xx, yy
+
+    future = e.submit(func)
+    result = yield future._result()
+
+    assert result == (2, 3)

--- a/distributed/threadpoolexecutor.py
+++ b/distributed/threadpoolexecutor.py
@@ -1,0 +1,116 @@
+"""
+Modified ThreadPoolExecutor to support threads leaving the thread pool
+
+This includes a global `secede` method that a submitted function can call to
+have its thread leave the ThreadPoolExecutor's thread pool.  This allows the
+thread pool to allocate another thread if necessary and so is useful when a
+function realises that it is going to be a long-running job that doesn't want
+to take up space.  When the function finishes its thread will terminate
+gracefully.
+
+This code copies and modifies two functions from the
+`concurrent.futures.thread` module, notably `_worker` and
+ThreadPoolExecutor._adjust_thread_count` to allow for checking against a global
+`threading.local` state.  These functions are subject to the following license,
+which is included as a comment at the end of this file:
+
+    https://docs.python.org/3/license.html
+
+... and are under copyright by the Python Software Foundation
+
+   Copyright 2001-2016 Python Software Foundation; All Rights Reserved
+"""
+from __future__ import print_function, division, absolute_import
+
+from concurrent.futures import thread
+
+from threading import local, Thread
+from .compatibility import get_thread_identity
+
+thread_state = local()
+
+def _worker(executor, work_queue):
+    thread_state.proceed = True
+    thread_state.executor = executor
+
+    try:
+        while thread_state.proceed:
+            task = work_queue.get()
+            if task is not None:  # sentinel
+                task.run()
+                del task
+            elif thread._shutdown or executor is None or executor._shutdown:
+                work_queue.put(None)
+                return
+        del executor
+    except BaseException:
+        _base.LOGGER.critical('Exception in worker', exc_info=True)
+    finally:
+        del thread_state.proceed
+        del thread_state.executor
+
+
+class ThreadPoolExecutor(thread.ThreadPoolExecutor):
+    def _adjust_thread_count(self):
+        if len(self._threads) < self._max_workers:
+            t = Thread(target=_worker, args=(self, self._work_queue))
+            t.daemon = True
+            self._threads.add(t)
+            t.start()
+
+
+def secede():
+    """ Have this thread secede from the ThreadPoolExecutor """
+    thread_state.proceed = False
+    ident = get_thread_identity()
+    for t in thread_state.executor._threads:
+        if t.ident == ident:
+            thread_state.executor._threads.remove(t)
+            break
+
+"""
+PSF LICENSE AGREEMENT FOR PYTHON 3.5.2
+======================================
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
+   the Individual or Organization ("Licensee") accessing and otherwise using Python
+   3.5.2 software in source or binary form and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+   grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+   analyze, test, perform and/or display publicly, prepare derivative works,
+   distribute, and otherwise use Python 3.5.2 alone or in any derivative
+   version, provided, however, that PSF's License Agreement and PSF's notice of
+   copyright, i.e., "Copyright c 2001-2016 Python Software Foundation; All Rights
+   Reserved" are retained in Python 3.5.2 alone or in any derivative version
+   prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on or
+   incorporates Python 3.5.2 or any part thereof, and wants to make the
+   derivative work available to others as provided herein, then Licensee hereby
+   agrees to include in any such work a brief summary of the changes made to Python
+   3.5.2.
+
+4. PSF is making Python 3.5.2 available to Licensee on an "AS IS" basis.
+   PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
+   EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
+   WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
+   USE OF PYTHON 3.5.2 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.5.2
+   FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
+   MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.5.2, OR ANY DERIVATIVE
+   THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material breach of
+   its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any relationship
+   of agency, partnership, or joint venture between PSF and Licensee.  This License
+   Agreement does not grant permission to use PSF trademarks or trade name in a
+   trademark sense to endorse or promote products or services of Licensee, or any
+   third party.
+
+8. By copying, installing or otherwise using Python 3.5.2, Licensee agrees
+   to be bound by the terms and conditions of this License Agreement.
+"""

--- a/distributed/worker_executor.py
+++ b/distributed/worker_executor.py
@@ -1,0 +1,165 @@
+from __future__ import print_function, division, absolute_import
+
+from contextlib import contextmanager
+from tornado import gen
+from toolz import keymap, valmap, merge
+import uuid
+import uuid
+
+from dask.base import tokenize
+from tornado import gen
+
+from .executor import Executor, Future, pack_data, unpack_remotedata
+from .sizeof import sizeof
+from .threadpoolexecutor import secede
+from .utils import log_errors, sync, tokey, ignoring
+from .worker import local_state
+
+
+@contextmanager
+def local_executor():
+    """ Get executor for this thread
+
+    This context manager is intended to be called within functions that we run
+    on workers.  When run as a context manager it delivers a client
+    ``Executor`` object that can submit other tasks directly from that worker.
+
+    Examples
+    --------
+
+    >>> def func(x):
+    ...     with local_executor() as e:  # connect from worker back to scheduler
+    ...         a = e.submit(inc, x)     # this task can submit more tasks
+    ...         b = e.submit(dec, x)
+    ...         result = e.gather([a, b])  # and gather results
+    ...     return result
+
+    >>> future = e.submit(func, 1)  # submit func(1) on cluster
+    """
+    address = local_state.execution_state['scheduler']
+    secede()  # have this thread secede from the thread pool
+              # so that it doesn't take up a fixed resource while waiting
+    with WorkerExecutor(address) as e:
+        e.worker.loop.add_callback(e.worker.scheduler.change_worker_cores,
+                                   worker=e.worker.address, diff=+1)
+        try:
+            yield e
+        finally:
+            e.worker.loop.add_callback(e.worker.scheduler.change_worker_cores,
+                                       worker=e.worker.address, diff=-1)
+
+
+def get_worker():
+    return local_state.execution_state['worker']
+
+
+class WorkerExecutor(Executor):
+    """ An Executor designed to operate from a Worker process
+
+    This executor has had a few methods altered to make it more efficient for
+    working directly from the worker nodes.  In particular scatter/gather first
+    look to the local data dictionary rather than sending data over the network
+    """
+    def __init__(self, *args, **kwargs):
+        self.worker = get_worker()
+        Executor.__init__(self, *args, **kwargs)
+
+    @gen.coroutine
+    def _scatter(self, data, workers=None, broadcast=False):
+        """ Scatter data to local data dictionary
+
+        Rather than send data out to the cluster we keep data local.  However
+        we do report to the scheduler that the local worker has the scattered
+        data.  This allows other workers to come by and steal this data if
+        desired.
+
+        Keywords like ``broadcast=`` do not work, however operations like
+        ``.replicate`` work fine after calling scatter, which can fill in for
+        this functionality.
+        """
+        with log_errors():
+            if not (workers is None and broadcast is False):
+                raise NotImplementedError("Scatter from worker doesn't support workers or broadcast keywords")
+
+            if isinstance(data, dict) and not all(isinstance(k, (bytes, str))
+                                                   for k in data):
+                d = yield self._scatter(keymap(tokey, data), workers, broadcast)
+                raise gen.Return({k: d[tokey(k)] for k in data})
+
+            if isinstance(data, (list, tuple, set, frozenset)):
+                keys = []
+                for x in data:
+                    try:
+                        keys.append(tokenize(x))
+                    except:
+                        keys.append(str(uuid.uuid1()))
+                data2 = dict(zip(keys, data))
+            elif isinstance(data, dict):
+                keys = set(data)
+                data2 = data
+            else:
+                raise TypeError("Don't know how to scatter %s" % type(data))
+
+            nbytes = valmap(sizeof, data2)
+
+            # self.worker.data.update(data2)  # thread safety matters
+            self.worker.loop.add_callback(self.worker.data.update, data2)
+
+            yield self.scheduler.update_data(
+                    who_has={key: [self.worker.address] for key in data2},
+                    nbytes=valmap(sizeof, data2),
+                    client=self.id)
+
+            if isinstance(data, dict):
+                out = {k: Future(k, self) for k in data}
+            elif isinstance(data, (tuple, list, set, frozenset)):
+                out = type(data)([Future(k, self) for k in keys])
+            else:
+                raise TypeError(
+                        "Input to scatter must be a list or dict")
+
+            for key in keys:
+                self.futures[key]['status'] = 'finished'
+                self.futures[key]['event'].set()
+
+            raise gen.Return(out)
+
+    @gen.coroutine
+    def _gather(self, futures, errors='raise'):
+        """
+
+        Exactly like Executor._gather, but get data directly from the local
+        workrer data dictionary directly rather than through the scheduler.
+
+        TODO: avoid scheduler for other communications, and assume that we can
+        communicate directly with the other workers.
+        """
+        futures2, keys = unpack_remotedata(futures, byte_keys=True)
+        keys = [tokey(k) for k in keys]
+
+        @gen.coroutine
+        def wait(k):
+            """ Want to stop the All(...) early if we find an error """
+            yield self.futures[k]['event'].wait()
+            if self.futures[k]['status'] != 'finished':
+                raise Exception()
+
+        with ignoring(Exception):
+            yield All([wait(key) for key in keys if key in self.futures])
+
+        while True:  # not threadsafe, so try until success
+            try:
+                local = {k: self.worker.data[k] for k in keys
+                         if k in self.worker.data}
+                break
+            except KeyError as e:
+                pass
+
+        futures3 = {k: Future(k, self) for k in keys if k not in local}
+
+        futures4 = pack_data(futures2, merge(local, futures3))
+        if not futures3:
+            raise gen.Return(futures4)
+
+        result = yield Executor._gather(self, futures4, errors=errors)
+        raise gen.Return(result)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -94,6 +94,7 @@ Contents
    joblib
    ipython
    queues
+   task-launch
    submitting-applications
    api
    faq

--- a/docs/source/task-launch.rst
+++ b/docs/source/task-launch.rst
@@ -1,0 +1,151 @@
+Launch Tasks from Tasks
+=======================
+
+Sometimes it is convenient to launch tasks from other tasks.
+For example you may not know what computations to run until you have the
+results of some initial computations.
+
+Motivating example
+------------------
+
+We want to download one piece of data and turn it into a list.  Then we want to
+submit one task for every element of that list.  We don't know how long the
+list will be until we have the data.
+
+So we send off our original ``download_and_convert_to_list`` function, which
+downloads the data and converts it to a list on one of our worker machines:
+
+.. code-block:: python
+
+   future = e.submit(download_and_convert_to_list, uri)
+
+But now we need to submit new tasks for individual parts of this data.  We have
+three options.
+
+1.  Gather the data back to the local process and then submit new jobs from the
+    local process
+2.  Gather only enough information about the data back to the local process and
+    submit jobs from the local process
+3.  Submit a task to the cluster that will submit other tasks directly from
+    that worker
+
+Gather the data locally
+-----------------------
+
+If the data is not large then we can bring it back to the client to perform the
+necessary logic on our local machine:
+
+.. code-block:: python
+
+   >>> data = future.result()                  # gather data to local process
+   >>> data                                    # data is a list
+   [...]
+
+   >>> futures = e.map(process_element, data)  # submit new tasks on data
+   >>> analysis = e.submit(aggregate, futures) # submit final aggregation task
+
+This is straightforward and, if ``data`` is small then it is probably the
+simplest, and therefore correct choice.  However, if ``data`` is large then we
+have to choose another option.
+
+
+Submit tasks from client
+------------------------
+
+We can run small functions on our remote data to determine enough to submit the
+right kinds of tasks.  In the following example we compute the ``len`` function
+on ``data`` remotely and then break up data into its various elements.
+
+.. code-block:: python
+
+   >>> n = e.submit(len, data)                 # compute number of elements
+   >>> n = n.result()                          # gather n (small) locally
+
+   >>> from operator import getitem
+   >>> elements = [e.submit(getitem, data, i) for i in range(n)]  # split data
+
+   >>> futures = e.map(process_element, elements)
+   >>> analysis = e.submit(aggregate, futures)
+
+We compute the length remotely, gather back this very small result, and then
+use it to submit more tasks to break up the data and process on the cluster.
+This is more complex because we had to go back and forth a couple of times
+between the cluster and the local process, but the data moved was very small,
+and so this only added a few milliseconds to our total processing time.
+
+
+Submit tasks from worker
+------------------------
+
+Alternatively we submit tasks from other tasks.  This allows us to make
+decisions while on worker nodes.  To do this we will make a new client object
+on the worker itself.  There is a convenience function for this that will
+connect you to the correct scheduler that the worker is connected to.
+
+.. code-block:: python
+
+   from distributed import local_executor
+
+   def process_all(data):
+       with local_executor() as e:
+           elements = e.scatter(data)
+           futures = e.map(process_element, elements)
+           analysis = e.submit(aggregate, futures)
+           result = analysis.result()
+       return result
+
+    analysis = e.submit(process_all, data)  # spawns many tasks
+
+This approach is more complex, but very powerful.  It allows you to spawn tasks
+that themselves act as potentially long-running clients, managing their own
+independent workloads.
+
+Extended Example
+~~~~~~~~~~~~~~~~
+
+This example computing the fibonacci numbers creates tasks that submit tasks
+that submit tasks that submit other tasks, etc..
+
+```python
+In [1]: from distributed import Executor, local_executor
+
+In [2]: e = Executor()
+
+In [3]: def fib(n):
+   ...:     if n < 2:
+   ...:         return n
+   ...:     else:
+   ...:         with local_executor() as ee:
+   ...:             a = ee.submit(fib, n - 1)
+   ...:             b = ee.submit(fib, n - 2)
+   ...:             a, b = ee.gather([a, b])
+   ...:             return a + b
+   ...:
+
+In [4]: future = e.submit(fib, 100)
+
+In [5]: future
+Out[5]: <Future: status: finished, type: int, key: fib-7890e9f06d5f4e0a8fc7ec5c77590ace>
+
+In [6]: future.result()
+Out[6]: 354224848179261915075
+```
+
+Technical details
+~~~~~~~~~~~~~~~~~
+
+Tasks that invoke ``local_executor`` are conservatively assumed to be
+*long running*.  They can take a long time blocking, waiting for other tasks to
+finish.  In order to avoid having them take up processing slots the following
+actions occur whenever a task invokes ``local_executor``.
+
+1.  The thread on the worker that runs this functions *secedes* from the thread
+    pool and goes off on its own.  This allows the thread pool to populate that
+    slot with a new thread and continue processing tasks without counting this
+    long running task against its normal quota.
+2.  The Worker sends a message back to the scheduler temporarily increasing its
+    allowed number of tasks by one.  This likewise lets the scheduler allocate
+    more tasks to this worker, not counting this long running task against it.
+
+Because of this behavior you can happily launch long running control tasks that
+manage worker-side clients happily, without fear of deadlocking the cluster.


### PR DESCRIPTION
This allows the spawning of tasks from other tasks.  We don't add any new scheduling functionality. Instead we make it more convenient to start a client from a task.  

```python
In [1]: from distributed import Executor, local_executor

In [2]: e = Executor()

In [3]: def fib(n):
   ...:     if n < 2:
   ...:         return n
   ...:     else:
   ...:         with local_executor() as ee:
   ...:             a, b = ee.submit(fib, n - 1), ee.submit(fib, n - 2)
   ...:             a, b = ee.gather([a, b])
   ...:             return a + b
   ...:         

In [4]: future = e.submit(fib, 100)

In [5]: future
Out[5]: <Future: status: finished, type: int, key: fib-7890e9f06d5f4e0a8fc7ec5c77590ace>

In [6]: future.result()
Out[6]: 354224848179261915075
```

See associated doc page for more information.