### PR TITLE
Add config.yaml file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,5 +6,6 @@ include README.rst
 include LICENSE.txt
 include MANIFEST.in
 include requirements.txt
+include distributed/config.yaml
 
 prune docs/_build

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+from .config import config
 from .center import Center
 from .client import scatter, gather, delete, clear, rpc
 from .core import connect, read, write

--- a/distributed/bokeh/application.py
+++ b/distributed/bokeh/application.py
@@ -8,7 +8,10 @@ import sys
 
 import bokeh
 import distributed.bokeh
+from toolz import get_in
+
 from ..utils import ignoring
+from ..config import config
 
 dirname = os.path.dirname(distributed.__file__)
 paths = [os.path.join(dirname, 'bokeh', name)
@@ -23,10 +26,13 @@ dask_dir = os.path.join(os.path.expanduser('~'), '.dask')
 if not os.path.exists(dask_dir):
     os.mkdir(dask_dir)
 
+logging_level = get_in(['logging', 'bokeh'], config, 'critical')
+logging_level = logging._nameToLevel[logging_level.upper()]
+
 
 class BokehWebInterface(object):
     def __init__(self, host='127.0.0.1', http_port=9786, tcp_port=8786,
-                 bokeh_port=8787, bokeh_whitelist=[], log_level='critical',
+                 bokeh_port=8787, bokeh_whitelist=[], log_level=logging_level,
                  show=False, prefix=None, use_xheaders=False, quiet=True):
         self.port = bokeh_port
         ip = socket.gethostbyname(host)
@@ -48,8 +54,7 @@ class BokehWebInterface(object):
         hosts.extend(map(str, bokeh_whitelist))
 
         args = ([binname, 'serve'] + paths +
-                ['--log-level', 'warning',
-                 '--check-unused-sessions=50',
+                ['--check-unused-sessions=50',
                  '--unused-session-lifetime=1',
                  '--port', str(bokeh_port)] +
                  sum([['--host', h] for h in hosts], []))
@@ -111,6 +116,4 @@ class BokehWebInterface(object):
 
 def bokeh_main(args):
     from bokeh.command.bootstrap import main
-    import logging
-    logger = logging.getLogger('bokeh').setLevel(logging.CRITICAL)
     main(args)

--- a/distributed/bokeh/application.py
+++ b/distributed/bokeh/application.py
@@ -11,6 +11,7 @@ import distributed.bokeh
 from toolz import get_in
 
 from ..utils import ignoring
+from ..compatibility import logging_names
 from ..config import config
 
 dirname = os.path.dirname(distributed.__file__)
@@ -27,7 +28,7 @@ if not os.path.exists(dask_dir):
     os.mkdir(dask_dir)
 
 logging_level = get_in(['logging', 'bokeh'], config, 'critical')
-logging_level = logging._nameToLevel[logging_level.upper()]
+logging_level = logging_names[logging_level.upper()]
 
 
 class BokehWebInterface(object):

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('distributed.scheduler')
 @click.argument('center', type=str, default='')
 @click.option('--port', type=int, default=8786, help="Serving port")
 @click.option('--http-port', type=int, default=9786, help="HTTP port")
-@click.option('--bokeh-port', type=int, default=8787, help="HTTP port")
+@click.option('--bokeh-port', type=int, default=8787, help="Bokeh port")
 @click.option('--bokeh/--no-bokeh', '_bokeh', default=True, show_default=True,
               required=False, help="Launch Bokeh Web UI")
 @click.option('--host', type=str, default=None,

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import logging
 import sys
 
 if sys.version_info[0] == 2:
@@ -33,6 +34,7 @@ if sys.version_info[0] == 2:
                 hasattr(o, '__module__') and
                 o.__module__ == 'Queue')
 
+    logging_names = logging._levelNames
 
 if sys.version_info[0] == 3:
     from queue import Queue, Empty
@@ -48,6 +50,8 @@ if sys.version_info[0] == 3:
     def isqueue(o):
         return isinstance(o, Queue)
 
+    logging_names = logging._levelToName.copy()
+    logging_names.update(logging._nameToLevel)
 
 try:
     from functools import singledispatch

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -1,29 +1,31 @@
 from __future__ import print_function, division, absolute_import
 
 import os
-import yaml
+try:
+    import yaml
+except ImportError:
+    config = {}
+else:
+    dirname = os.path.dirname(__file__)
+    default_path = os.path.join(dirname, 'config.yaml')
+    dask_config_path = os.path.join(os.path.expanduser('~'), '.dask', 'config.yaml')
 
 
-dirname = os.path.dirname(__file__)
-default_path = os.path.join(dirname, 'config.yaml')
-dask_config_path = os.path.join(os.path.expanduser('~'), '.dask', 'config.yaml')
+    def ensure_config_file(destination=dask_config_path):
+        if not os.path.exists(destination):
+            import shutil
+            if not os.path.exists(os.path.dirname(destination)):
+                os.mkdir(os.path.dirname(destination))
+            shutil.copy(default_path, destination)
 
 
-def ensure_config_file(destination=dask_config_path):
-    if not os.path.exists(destination):
-        import shutil
-        if not os.path.exists(os.path.dirname(destination)):
-            os.mkdir(os.path.dirname(destination))
-        shutil.copy(default_path, destination)
+    def load_config_file(path=dask_config_path):
+        if not os.path.exists(path):
+            path = default_path
+        with open(path) as f:
+            text = f.read()
+            return yaml.load(text)
 
 
-def load_config_file(path=dask_config_path):
-    if not os.path.exists(path):
-        path = default_path
-    with open(path) as f:
-        text = f.read()
-        return yaml.load(text)
-
-
-ensure_config_file()
-config = load_config_file()
+    ensure_config_file()
+    config = load_config_file()

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -1,0 +1,29 @@
+from __future__ import print_function, division, absolute_import
+
+import os
+import yaml
+
+
+dirname = os.path.dirname(__file__)
+default_path = os.path.join(dirname, 'config.yaml')
+dask_config_path = os.path.join(os.path.expanduser('~'), '.dask', 'config.yaml')
+
+
+def ensure_config_file(destination=dask_config_path):
+    if not os.path.exists(destination):
+        import shutil
+        if not os.path.exists(os.path.dirname(destination)):
+            os.mkdir(os.path.dirname(destination))
+        shutil.copy(default_path, destination)
+
+
+def load_config_file(path=dask_config_path):
+    if not os.path.exists(path):
+        path = default_path
+    with open(path) as f:
+        text = f.read()
+        return yaml.load(text)
+
+
+ensure_config_file()
+config = load_config_file()

--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -1,0 +1,13 @@
+logging: 
+  distributed: info
+  distributed.executor: warning
+  bokeh: critical
+
+compression: auto
+
+# Scheduler options
+bandwidth: 100000000    # 100 MB/s estimated worker-worker bandwidth
+allowed-failures: 3     # number of retries before a task is considered bad
+pdb-on-err: False       # enter debug mode on scheduling error
+transition-log-length: 100000 
+

--- a/distributed/protocol.py
+++ b/distributed/protocol.py
@@ -63,6 +63,17 @@ with ignoring(ImportError):
     default_compression = 'lz4'
 
 
+from .config import config
+default = config.get('compression', 'auto')
+if default != 'auto':
+    if default in compressions:
+        default_compression = default
+    else:
+        raise ValueError("Default compression '%s' not found.\n"
+                "Choices include auto, %s" % (
+                    default, ', '.join(sorted(map(str, compressions)))))
+
+
 BIG_BYTES_SIZE = 2**20
 BIG_BYTES_SHARD_SIZE = 2**28
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -33,14 +33,15 @@ from .core import (rpc, connect, read, write, MAX_BUFFER_SIZE,
         Server, send_recv, coerce_to_address, error_message)
 from .utils import (All, ignoring, clear_queue, get_ip, ignore_exceptions,
         ensure_ip, log_errors, key_split, mean, divide_n_among_bins)
+from .config import config
 
 
 logger = logging.getLogger(__name__)
 
-BANDWIDTH = 100e6
-ALLOWED_FAILURES = 3
+BANDWIDTH = config.get('bandwidth', 100e6)
+ALLOWED_FAILURES = config.get('allowed-failures', 3)
 
-LOG_PDB = os.environ.get('DASK_ERROR_PDB', False)
+LOG_PDB = config.get('pdb-on-err') or os.environ.get('DASK_ERROR_PDB', False)
 
 
 class Scheduler(Server):
@@ -235,7 +236,8 @@ class Scheduler(Server):
         self.occupancy = dict()
 
         self.plugins = []
-        self.transition_log = deque(maxlen=100000)
+        self.transition_log = deque(maxlen=config.get('transition-log-length',
+                                                      100000))
 
         self.compute_handlers = {'update-graph': self.update_graph,
                                  'update-data': self.update_data,

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -339,11 +339,12 @@ def str_graph(dsk, extra_values=()):
 
 
 import logging
+from .compatibility import logging_names
 logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s',
                     level=logging.INFO)
 
 for name, level in config.get('logging', {}).items():
-    LEVEL = logging._nameToLevel[level.upper()]
+    LEVEL = logging_names[level.upper()]
     logging.getLogger(name).setLevel(LEVEL)
 
 # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -18,6 +18,7 @@ from tornado import gen
 from tornado.iostream import StreamClosedError
 
 from .compatibility import Queue, PY3
+from .config import config
 
 logger = logging.getLogger(__name__)
 
@@ -340,6 +341,10 @@ def str_graph(dsk, extra_values=()):
 import logging
 logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s',
                     level=logging.INFO)
+
+for name, level in config.get('logging', {}).items():
+    LEVEL = logging._nameToLevel[level.upper()]
+    logging.getLogger(name).setLevel(LEVEL)
 
 # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
 stream = logging.StreamHandler(sys.stderr)


### PR DESCRIPTION
This puts a new config.yaml file in `~/.dask/config.yaml` on import if it
is not present.  These options gets loaded into a module-level global,
``distributed.config`` and are used in various places where constants
used to be hard coded.  So far I've only added support for constants
that I change frequently.

At the moment the config file looks like the following:

```yaml
logging:
  distributed: info
  distributed.executor: warning
  bokeh: critical

compression: auto

 # Scheduler specific options

bandwidth: 100000000    # 100 MB/s estimated worker-worker bandwidth
allowed-failures: 3     # number of retries before a task is considered bad
pdb-on-err: False       # enter debug mode on scheduling error
transition-log-length: 100000
```