### PR TITLE
Datasets 2

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -987,58 +987,89 @@ class Executor(object):
         return sync(self.loop, self._cancel, futures)
 
     @gen.coroutine
-    def _publish_dataset(self, data, name):
-        keys = [tokey(f.key) for f in futures_of(data)]
-        out = yield self.scheduler.publish_dataset(keys=keys, name=tokey(name),
-                                             data=dumps(data),
-                                             client=self.id)
-        if out['status'] != "OK":
-            raise KeyError(name)
+    def _publish_dataset(self, **kwargs):
+        coroutines = []
+        for name, data in kwargs.items():
+            keys = [tokey(f.key) for f in futures_of(data)]
+            coroutines.append(self.scheduler.publish_dataset(keys=keys,
+                name=tokey(name), data=dumps(data), client=self.id))
 
-    def publish_dataset(self, data, name):
+        outs = yield coroutines
+
+    def publish_dataset(self, **kwargs):
         """
         Store a named reference to the data in the scheduler for other executors
 
         Parameters
         ----------
-        data: list of futures or dask collection
-        name: str or container
-            handle by which the stored data should be known.
+        kwargs: dict
+            named collections to publish on the scheduler
+
+        Examples
+        --------
+
+        Publishing client:
+        >>> df = dd.read_csv('s3://...')  # doctest: +SKIP
+        >>> e.publish_dataset(my_dataset=df)  # doctest: +SKIP
+
+        Receiving client:
+        >>> e.list_datasets()  # doctest: +SKIP
+        ['my_dataset']
+        >>> df2 = e.get_dataset('my_dataset')  # doctest: +SKIP
 
         Returns
         -------
         None
+
+        See Also
+        --------
+        Executor.list_datasets
+        Executor.get_dataset
+        Executor.unpublish_dataset
         """
-        sync(self.loop, self._publish_dataset, data, name)
+        return sync(self.loop, self._publish_dataset, **kwargs)
 
     def unpublish_dataset(self, name):
         """
         Remove reference to data on the scheduler
+
+        Examples
+        --------
+        >>> e.list_datasets()  # doctest: +SKIP
+        ['my_dataset']
+        >>> e.unpublish_datasets('my_dataset')  # doctest: +SKIP
+        >>> e.list_datasets()  # doctest: +SKIP
+        []
+
+        See Also
+        --------
+        Executor.publish_dataset
         """
-        sync(self.loop, self.scheduler.unpublish_dataset, name=name)
+        return sync(self.loop, self.scheduler.unpublish_dataset, name=name)
 
     def list_datasets(self):
         """ Returns list of named datasets referenced in the scheduler
 
-        See publish_dataset()
+        See Also
+        --------
+        Executor.publish_dataset
         """
         return sync(self.loop, self.scheduler.list_datasets)
 
     @gen.coroutine
     def _get_dataset(self, name):
         out = yield self.scheduler.get_dataset(name=name, client=self.id)
-        data, keys = out['data'], out['keys']
 
-        if not data:
-            raise KeyError(name)
         with temp_default_executor(self):
-            data = loads(data)
+            data = loads(out['data'])
         raise Return(data)
 
     def get_dataset(self, name):
         """ Fetch named dataset from the scheduler.
 
-        See publish_dataset()
+        See Also
+        --------
+        Executor.publish_dataset
         """
         return sync(self.loop, self._get_dataset, tokey(name))
 

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -998,7 +998,11 @@ class Executor(object):
 
     def publish_dataset(self, **kwargs):
         """
-        Store a named reference to the data in the scheduler for other executors
+        Publish named datasets to scheduler
+
+        This stores a named reference to a dask collection or list of futures
+        on the scheduler.  These references are available to other executors
+        which can download the collection or futures with ``get_dataset``.
 
         Parameters
         ----------
@@ -1031,7 +1035,7 @@ class Executor(object):
 
     def unpublish_dataset(self, name):
         """
-        Remove reference to data on the scheduler
+        Remove named datasets from scheduler
 
         Examples
         --------
@@ -1048,11 +1052,13 @@ class Executor(object):
         return sync(self.loop, self.scheduler.unpublish_dataset, name=name)
 
     def list_datasets(self):
-        """ Returns list of named datasets referenced in the scheduler
+        """
+        List named datasets available on the scheduler
 
         See Also
         --------
         Executor.publish_dataset
+        Executor.get_dataset
         """
         return sync(self.loop, self.scheduler.list_datasets)
 
@@ -1065,11 +1071,13 @@ class Executor(object):
         raise Return(data)
 
     def get_dataset(self, name):
-        """ Fetch named dataset from the scheduler.
+        """
+        Get named dataset from the scheduler
 
         See Also
         --------
         Executor.publish_dataset
+        Executor.list_datasets
         """
         return sync(self.loop, self._get_dataset, tokey(name))
 

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1004,6 +1004,9 @@ class Executor(object):
         on the scheduler.  These references are available to other executors
         which can download the collection or futures with ``get_dataset``.
 
+        Datasets are not immediately computed.  You may wish to call
+        ``Executor.persist`` prior to publishing a dataset.
+
         Parameters
         ----------
         kwargs: dict
@@ -1014,6 +1017,7 @@ class Executor(object):
 
         Publishing client:
         >>> df = dd.read_csv('s3://...')  # doctest: +SKIP
+        >>> df = e.persist(df) # doctest: +SKIP
         >>> e.publish_dataset(my_dataset=df)  # doctest: +SKIP
 
         Receiving client:
@@ -1030,6 +1034,7 @@ class Executor(object):
         Executor.list_datasets
         Executor.get_dataset
         Executor.unpublish_dataset
+        Executor.persist
         """
         return sync(self.loop, self._publish_dataset, **kwargs)
 

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -1014,7 +1014,6 @@ class Executor(object):
 
         Examples
         --------
-
         Publishing client:
         >>> df = dd.read_csv('s3://...')  # doctest: +SKIP
         >>> df = e.persist(df) # doctest: +SKIP

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1600,10 +1600,10 @@ class Scheduler(Server):
     def publish_dataset(self, stream=None, keys=None, data=None, name=None,
                         client=None):
         if name in self.datasets:
-            return {'status': 'failed'}
+            raise KeyError("Dataset %s already exists" % name)
         self.client_wants_keys(keys, 'published-%s' % name)
         self.datasets[name] = {'data': data, 'keys': keys}
-        return {'status':  'OK'}
+        return {'status':  'OK', 'name': name}
 
     def unpublish_dataset(self, stream=None, name=None):
         out = self.datasets.pop(name, {'keys': []})
@@ -1613,7 +1613,10 @@ class Scheduler(Server):
         return list(sorted(self.datasets.keys()))
 
     def get_dataset(self, stream, name=None, client=None):
-        return self.datasets.get(name, {'data': [], 'keys': []})
+        if name in self.datasets:
+            return self.datasets[name]
+        else:
+            raise KeyError("Dataset '%s' not found" % name)
 
     #####################
     # State Transitions #

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3222,11 +3222,14 @@ def test_publish_simple(s, a, b):
     yield f._start()
 
     data = yield e._scatter(range(3))
-    out = yield e._publish_dataset(data, 'data')
+    out = yield e._publish_dataset(data=data)
     assert 'data' in s.datasets
 
-    with pytest.raises(KeyError):
-        out = yield e._publish_dataset(data, 'data')
+    with pytest.raises(KeyError) as exc_info:
+        out = yield e._publish_dataset(data=data)
+
+    assert "exists" in str(exc_info.value)
+    assert "data" in str(exc_info.value)
 
     result = yield e.scheduler.list_datasets()
     assert result == ['data']
@@ -3243,7 +3246,7 @@ def test_publish_roundtrip(s, a, b):
     yield f._start()
 
     data = yield e._scatter([0, 1, 2])
-    yield e._publish_dataset(data, 'data')
+    yield e._publish_dataset(data=data)
 
     assert 'published-data' in s.who_wants[data[0].key]
     result = yield f._get_dataset(name='data')
@@ -3252,14 +3255,17 @@ def test_publish_roundtrip(s, a, b):
     out = yield f._gather(result)
     assert out == [0, 1, 2]
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError) as exc_info:
         result = yield f._get_dataset(name='nonexistent')
+
+    assert "not found".lower() in str(exc_info.value)
+    assert "nonexistent".lower() in str(exc_info.value)
 
 
 @gen_cluster(executor=True)
 def test_unpublish(e, s, a, b):
     data = yield e._scatter([0, 1, 2])
-    yield e._publish_dataset(data, 'data')
+    yield e._publish_dataset(data=data)
 
     key = data[0].key
     del data
@@ -3273,8 +3279,21 @@ def test_unpublish(e, s, a, b):
         yield gen.sleep(0.01)
         assert time() < start + 5
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError) as exc_info:
         result = yield e._get_dataset(name='data')
+
+    assert "not found".lower() in str(exc_info.value)
+    assert "data".lower() in str(exc_info.value)
+
+
+@gen_cluster(executor=True)
+def test_publish_multiple_datasets(e, s, a, b):
+    x = delayed(inc)(1)
+    y = delayed(inc)(2)
+
+    yield e._publish_dataset(x=x, y=y)
+    datasets = yield e.scheduler.list_datasets()
+    assert set(datasets) == {'x', 'y'}
 
 
 @gen_cluster(executor=False)
@@ -3292,7 +3311,7 @@ def test_publish_bag(s, a, b):
     keys = {f.key for f in futures_of(bagp)}
     assert keys == set(bag.dask)
 
-    yield e._publish_dataset(bagp, 'data')
+    yield e._publish_dataset(data=bagp)
 
     # check that serialization didn't affect original bag's dask
     assert len(futures_of(bagp)) == 3

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -3258,8 +3258,8 @@ def test_publish_roundtrip(s, a, b):
     with pytest.raises(KeyError) as exc_info:
         result = yield f._get_dataset(name='nonexistent')
 
-    assert "not found".lower() in str(exc_info.value)
-    assert "nonexistent".lower() in str(exc_info.value)
+    assert "not found" in str(exc_info.value)
+    assert "nonexistent" in str(exc_info.value)
 
 
 @gen_cluster(executor=True)
@@ -3282,8 +3282,8 @@ def test_unpublish(e, s, a, b):
     with pytest.raises(KeyError) as exc_info:
         result = yield e._get_dataset(name='data')
 
-    assert "not found".lower() in str(exc_info.value)
-    assert "data".lower() in str(exc_info.value)
+    assert "not found" in str(exc_info.value)
+    assert "data" in str(exc_info.value)
 
 
 @gen_cluster(executor=True)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,10 +11,13 @@ API
    Executor.compute
    Executor.gather
    Executor.get
+   Executor.get_dataset
    Executor.has_what
+   Executor.list_datasets
    Executor.map
    Executor.ncores
    Executor.persist
+   Executor.publish_dataset
    Executor.rebalance
    Executor.replicate
    Executor.restart
@@ -24,6 +27,7 @@ API
    Executor.start_ipython_workers
    Executor.start_ipython_scheduler
    Executor.submit
+   Executor.unpublish_dataset
    Executor.upload_file
    Executor.who_has
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,6 +93,7 @@ Contents
    memory
    joblib
    ipython
+   publish
    queues
    submitting-applications
    api

--- a/docs/source/publish.rst
+++ b/docs/source/publish.rst
@@ -1,0 +1,76 @@
+Publish Datasets
+================
+
+A *dataset* is a named reference to a Dask collection or list of futures that
+has been published to the cluster.  It is available for any client to see and
+persists beyond the scope of an individual session.
+
+Motivating Example
+------------------
+
+We load CSV data from S3, manipulate it, and then persist the data to the
+cluster.
+
+.. code-block:: python
+
+   from dask.distributed import Executor
+   e = Executor('scheduler-address:8786')
+
+   import dask.dataframe as dd
+   df = dd.read_csv('s3://my-bucket/*.csv')
+   df2 = df[df.balance < 0]
+   df2 = e.persist(df2)
+
+   >>> df2.head()
+         name  balance
+   0    Alice     -100
+   1      Bob     -200
+   2  Charlie     -300
+   3   Dennis     -400
+   4    Edith     -500
+
+To share this collection with a colleague we publish it under the name
+``'negative_accounts'``
+
+.. code-block:: python
+
+   e.publish_dataset(negative_accounts=df2)
+
+Now any other client can connect to the scheduler and retrieve this published
+dataset.
+
+.. code-block:: python
+
+   >>> from dask.distributed import Executor
+   >>> e = Executor('scheduler-address:8786')
+
+   >>> e.list_datasets()
+   ['negative_accounts']
+
+   >>> df = e.get_dataset('negative_accounts')
+   >>> df.head()
+         name  balance
+   0    Alice     -100
+   1      Bob     -200
+   2  Charlie     -300
+   3   Dennis     -400
+   4    Edith     -500
+
+This allows users to easily share results.  It also allows for the persistence
+of important and commonly used datasets beyond a single session.  Published
+datasets continue to reside in distributed memory even after all clients
+requesting them have disconnected.
+
+API
+---
+
+The full dataset API is as follows:
+
+
+.. currentmodule:: distributed.executor
+
+.. autosummary::
+   Executor.publish_dataset
+   Executor.list_datasets
+   Executor.get_dataset
+   Executor.unpublish_dataset

--- a/docs/source/publish.rst
+++ b/docs/source/publish.rst
@@ -61,6 +61,20 @@ of important and commonly used datasets beyond a single session.  Published
 datasets continue to reside in distributed memory even after all clients
 requesting them have disconnected.
 
+Notes
+-----
+
+Published collections are not automatically persisted.  If you publish an
+un-persisted collection then others will still be able to get the collection
+from the scheduler, but operations on that collection will start from scratch.
+This allows you to publish views on data that do not permanently take up
+cluster memory but can be surprising if you expect "publishing" to
+automatically make a computed dataset rapidly available.
+
+Any client can publish or unpublish a dataset.
+
+Publishing too many large datasets can quickly consume a cluster's RAM.
+
 API
 ---
 

--- a/docs/source/publish.rst
+++ b/docs/source/publish.rst
@@ -78,9 +78,6 @@ Publishing too many large datasets can quickly consume a cluster's RAM.
 API
 ---
 
-The full dataset API is as follows:
-
-
 .. currentmodule:: distributed.executor
 
 .. autosummary::


### PR DESCRIPTION
Follows on https://github.com/dask/distributed/pull/453

cc @martindurant 

1.  Uses keyword arguments to name datasets
2.  Raises errors in scheduler functions, depending on these propagating down to the executor
3.  Tests errors for informative phrases
4.  Adds documentation page
5.  Tweaks docstrings to align well with sphinx documentation