### PR TITLE
Yield on all stream.write futures in core.write

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -273,14 +273,18 @@ def write(stream, msg):
             logger.exception(e)
             raise
 
+        futures = []
+
         lengths = ([struct.pack('Q', len(frames))] +
                    [struct.pack('Q', len(frame)) for frame in frames])
-        stream.write(b''.join(lengths))
+        futures.append(stream.write(b''.join(lengths)))
 
         for frame in frames[:-1]:
-            stream.write(frame)
+            futures.append(stream.write(frame))
 
-        yield stream.write(frames[-1])
+        futures.append(stream.write(frames[-1]))
+
+        yield futures
 
 
 def pingpong(stream):


### PR DESCRIPTION
This waits until all writing is finished before yielding from
core.write.

Previously we would wait only on the last frame to finish, assuming
that this implied that all frames had finished writing.  This assumption
may be faulty, so we collect and wait on all futures.