### PR TITLE
This fixes issue dask/distributed#477

### DIFF
--- a/distributed/bokeh/application.py
+++ b/distributed/bokeh/application.py
@@ -19,7 +19,7 @@ paths = [os.path.join(dirname, 'bokeh', name)
          for name in ['status', 'tasks', 'workers']]
 
 binname = 'bokeh.exe' if sys.platform.startswith('win') else 'bokeh'
-binname = os.path.join(os.path.dirname(sys.argv[0]), binname)
+binname = os.path.join(os.path.dirname(sys.executable), binname)
 
 logger = logging.getLogger(__file__)
 


### PR DESCRIPTION
Getting the dirname from argv[0] sometimes fails. For example, if running unit tests in PyCharm utrunner is called from a directory that may not contain bokeh

`/home/dsidi/miniconda/envs/FOO/bin/python /home/dsidi/.local/lib/pycharm-2016.2/helpers/pycharm/utrunner.py path_to_test_file.py ...`