### PR TITLE
Ensure bokeh application shuts down

### DIFF
--- a/distributed/bokeh/application.py
+++ b/distributed/bokeh/application.py
@@ -85,8 +85,7 @@ class BokehWebInterface(object):
             self.process.start()
         else:
             import subprocess
-            self.process = subprocess.Popen(args, stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE)
+            self.process = subprocess.Popen(args)
 
         if not quiet:
             logger.info(" Bokeh UI at:  http://%s:%d/status/"


### PR DESCRIPTION
Due to reference cycles `Executor.__del__` won't be run on cleanup. When
using a `LocalCluster` and not run as a contextmanager, this method was
responsible for shutting down the bokeh diagnostics application. To
remedy this, the bokeh application will now shut itself down upon
connection failure to the scheduler.