### PR TITLE
Restart workers in conda environments

### DIFF
--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -58,6 +58,11 @@ WINDOWS = sys.platform.startswith('win')
 
 
 try:
+    from json.decoder import JSONDecodeError
+except (ImportError, AttributeError):
+    JSONDecodeError = ValueError
+
+try:
     from functools import singledispatch
 except ImportError:
     from singledispatch import singledispatch

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -114,6 +114,7 @@ class LocalCluster(object):
     def _start_worker(self, port=0, nanny=True, **kwargs):
         if nanny:
             W = Nanny
+            kwargs['quiet'] = True
         else:
             W = Worker
         w = W(self.scheduler.ip, self.scheduler.port, loop=self.loop, **kwargs)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -46,7 +46,8 @@ class Nanny(Server):
         handlers = {'instantiate': self.instantiate,
                     'kill': self._kill,
                     'terminate': self._close,
-                    'monitor_resources': self.monitor_resources}
+                    'monitor_resources': self.monitor_resources,
+                    'run': self.run}
 
         super(Nanny, self).__init__(handlers, io_loop=self.loop, **kwargs)
 
@@ -151,6 +152,8 @@ class Nanny(Server):
             logger.info("Nanny %s:%d starts worker process %s:%d",
                         self.ip, self.port, self.ip, self.worker_port)
             raise gen.Return('OK')
+
+    run = Worker.run
 
     def cleanup(self):
         if self.worker_dir and os.path.exists(self.worker_dir):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from time import time, sleep
 
 from tornado.ioloop import IOLoop
@@ -15,7 +16,7 @@ from tornado import gen
 
 from .core import Server, rpc, write
 from .utils import get_ip, ignoring, log_errors, tmpfile
-from .worker import _ncores
+from .worker import _ncores, Worker
 
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ class Nanny(Server):
         self.worker_port = None
         self._given_worker_port = worker_port
         self.ncores = ncores or _ncores
-        self.local_dir = local_dir
+        self.local_dir = local_dir or tempfile.mkdtemp(prefix='nanny-')
         self.worker_dir = ''
         self.status = None
         self.process = None

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1223,6 +1223,7 @@ class Scheduler(Server):
     @gen.coroutine
     def restart(self):
         """ Restart all workers.  Reset local state. """
+        n = len(self.ncores)
         with log_errors():
             logger.debug("Send shutdown signal to workers")
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1266,7 +1266,8 @@ class Scheduler(Server):
                     logger.exception(e)
 
     @gen.coroutine
-    def broadcast(self, stream=None, msg=None, workers=None, hosts=None):
+    def broadcast(self, stream=None, msg=None, workers=None, hosts=None,
+            nanny=False):
         """ Broadcast message to workers, return all results """
         if workers is None:
             if hosts is None:
@@ -1278,9 +1279,19 @@ class Scheduler(Server):
                 if host in self.host_info:
                     workers.extend([host + ':' + port
                             for port in self.host_info[host]['ports']])
+        # TODO replace with worker_list
+
+        if nanny:
+            addresses = []
+            for addr in workers:
+                ip = addr.split(':')[0]
+                port = self.worker_info[addr]['services']['nanny']
+                addresses.append('%s:%d' % (ip, port))
+        else:
+            addresses = workers
 
         results = yield All([send_recv(arg=address, close=True, **msg)
-                             for address in workers])
+                             for address in addresses])
 
         raise Return(dict(zip(workers, results)))
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1221,7 +1221,7 @@ class Scheduler(Server):
         raise gen.Return(result)
 
     @gen.coroutine
-    def restart(self):
+    def restart(self, environment=None):
         """ Restart all workers.  Reset local state. """
         n = len(self.ncores)
         with log_errors():
@@ -1251,7 +1251,8 @@ class Scheduler(Server):
             logger.debug("Workers all removed.  Sending startup signal")
 
             # All quiet
-            resps = yield All([nanny.instantiate(close=True) for nanny in nannies])
+            resps = yield All([nanny.instantiate(close=True,
+                environment=environment) for nanny in nannies])
             assert all(resp == 'OK' for resp in resps)
 
             self.start()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -812,6 +812,22 @@ def test_broadcast(s, a, b):
     assert result == {a.address: b'pong', b.address: b'pong'}
 
 
+@gen_cluster(Worker=Nanny)
+def test_broadcast_nanny(s, a, b):
+    result1 = yield s.broadcast(msg={'op': 'identity'}, nanny=True)
+    assert all(d['type'] == 'Nanny' for d in result1.values())
+
+    result2 = yield s.broadcast(msg={'op': 'identity'},
+                               workers=[a.worker_address],
+                               nanny=True)
+    assert len(result2) == 1
+    assert first(result2.values())['id'] == a.id
+
+    result3 = yield s.broadcast(msg={'op': 'identity'}, hosts=[a.ip],
+                                nanny=True)
+    assert result1 == result3
+
+
 @gen_test()
 def test_worker_name():
     s = Scheduler(validate=True)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -531,3 +531,12 @@ def test_access_key(c, s, a, b):
     futures = [c.submit(f, i, key='x-%d' % i) for i in range(20)]
     results = yield c._gather(futures)
     assert list(results) == ['x-%d' % i for i in range(20)]
+
+
+@gen_cluster(client=True)
+def test_run_dask_worker(c, s, a, b):
+    def f(dask_worker=None):
+        return dask_worker.id
+
+    response = yield c._run(f)
+    assert response == {a.address: a.id, b.address: b.id}

--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from concurrent.futures import CancelledError
 from operator import add
+import os
 from time import time, sleep
 
 from dask import delayed
@@ -286,3 +287,11 @@ def test_restart_during_computation(c, s, a, b):
 
     assert len(s.ncores) == 2
     assert not s.task_state
+
+
+@gen_cluster(client=True, Worker=Nanny, timeout=1000)
+def test_upload_environment(c, s, a, b):
+    responses = yield c._upload_environment('copyenv',
+            '/home/mrocklin/workspace/play/copyenv.zip')
+    assert os.path.exists(os.path.join(a.local_dir, 'copyenv'))
+    assert os.path.exists(os.path.join(b.local_dir, 'copyenv'))

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -279,7 +279,7 @@ try:
     slow = pytest.mark.skipif(
                 not pytest.config.getoption("--runslow"),
                 reason="need --runslow option to run")
-except AttributeError:
+except (AttributeError, ValueError):
     def slow(*args):
         pass
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -599,6 +599,12 @@ class Worker(Server):
         if kwargs:
             kwargs = loads(kwargs)
         try:
+            import inspect
+            if 'dask_worker' in inspect.getargspec(function).args:
+                kwargs['dask_worker'] = self
+        except:
+            pass
+        try:
             result = function(*args, **kwargs)
         except Exception as e:
             logger.warn(" Run Failed\n"


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/300

This uses the dask.distributed to distribute zipped python executable environments and then restart the workers within those environments.  This allows for the relatively easy distribution of software across distributed deployment solutions.

Example
---------

```python
In [1]: from distributed import Executor

In [2]: e = Executor('localhost:8786')

In [3]: def f():
   ...:     import sys
   ...:     return sys.executable
   ...: 

In [4]: e
Out[4]: <Client: scheduler="localhost:8786" processes=2 cores=8>

In [5]: e.run(f)
Out[5]: 
{'127.0.0.1:41274': '/home/mrocklin/Software/anaconda/bin/python',
 '127.0.0.1:43322': '/home/mrocklin/Software/anaconda/bin/python'}

In [6]: %time e.restart('/home/mrocklin/workspace/play/copyenv.zip')  # this takes a while
distributed.client - INFO - Receive restart signal from scheduler
CPU times: user 160 ms, sys: 152 ms, total: 312 ms
Wall time: 13.3 s
Out[6]: <Client: scheduler="localhost:8786" processes=2 cores=8>

In [7]: e.run(f)
Out[7]: 
{'127.0.0.1:33287': '/tmp/nanny-_y27fcj0/copyenv/bin/python',
 '127.0.0.1:41862': '/tmp/nanny-cbdz2fff/copyenv/bin/python'}
```


- [x] Refactor nanny to accept different python executables
- [x] Support `environment=` option in restart
- [x] Send out environments from the client to all workers
- [ ] Persist environment on cluster for newly arriving workers
- [ ] Design a test that we can put on travis.ci
- [ ] Test against virtualenv
- [ ] write docs with constraints and suggestions on how to build an environment zip file