### PR TITLE
Remove first message from 'progress' message stream

### DIFF
--- a/distributed/bokeh/status/main.py
+++ b/distributed/bokeh/status/main.py
@@ -52,6 +52,8 @@ progress_source, progress_plot = progress_plot(sizing_mode=SIZING_MODE,
 def progress_update():
     with log_errors():
         msg = messages['progress']
+        if not msg:
+            return
         d = progress_quads(msg)
         progress_source.data.update(d)
         progress_plot.title.text = ("Progress -- total: %(total)s, "

--- a/distributed/bokeh/status/server_lifecycle.py
+++ b/distributed/bokeh/status/server_lifecycle.py
@@ -123,8 +123,7 @@ def on_server_loaded(server_context):
                          'times': deque(maxlen=100)}
     server_context.add_periodic_callback(lambda: http_get('tasks'), 100)
 
-    messages['progress'] = {'all': {}, 'memory': {},
-                            'erred': {}, 'released': {}}
+    messages['progress'] = {}
 
     messages['processing'] = {'stacks': {}, 'processing': {},
                               'memory': 0, 'waiting': 0, 'ready': 0}


### PR DESCRIPTION
We now just avoid computing anything if we haven't yet received a message

cc @hussainsultan 