### PR TITLE
DOC: documents using external modules

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,6 +1,18 @@
 Frequently Asked Questions
 ==========================
 
+How do I use external modules?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``client.upload_file``. For more detail, see the `API docs`_ and a 
+StackOverflow question
+`"Can I use functions imported from .py files in Dask/Distributed?"`__
+This function supports both standalone file and setuptools's ``.egg`` files
+for larger modules.
+
+__ http://stackoverflow.com/questions/39295200/can-i-use-functions-imported-from-py-files-in-dask-distributed
+.. _API docs: http://distributed.readthedocs.io/en/latest/api.html#distributed.executor.Executor.upload_file
+
 Too many open file descriptors?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -93,6 +93,17 @@ once.
    -285
    >>> executor.gather(A) # gather for many futures
    [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
+   
+Using external modulers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``client.upload_file``  to use external Python files or .egg files.
+
+.. code-block:: python
+
+    >>> executor.upload_file('external_module.py')
+    
+See :doc:`executor <executor>` for advanced use.
 
 
 Restart


### PR DESCRIPTION
Adds a section in the {quick start, FAQ} about using external modules. This addresses #501, an issue the @blakemas and I ran into.