### PR TITLE
WIP: worker environments

### DIFF
--- a/distributed/environments.py
+++ b/distributed/environments.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import, division, print_function
+
+
+class Environment(object):
+    def __init__(self, condition=None, setup=None):
+        self._condition = condition
+        self._setup = setup
+
+    def condition(self):
+        if self._condition:
+            return self._condition()
+        return True
+
+    def setup(self):
+        if self._setup:
+            self._setup()
+
+    def __getstate__(self):
+        return (self._condition, self._setup)
+
+    def __setstate__(self, state):
+        self._condition, self._setup = state

--- a/distributed/environments.py
+++ b/distributed/environments.py
@@ -14,9 +14,3 @@ class Environment(object):
     def setup(self):
         if self._setup:
             self._setup()
-
-    def __getstate__(self):
-        return (self._condition, self._setup)
-
-    def __setstate__(self, state):
-        self._condition, self._setup = state

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3403,7 +3403,7 @@ def test_register_environment_errors(c, s, a, b):
     try:
         response = yield c._register_environment('myenv', fails_every_other)
     except RuntimeError as e:
-        assert e.message == 'woops'
+        assert e.args == ('woops',)
 
     assert 'myenv' in s.environments
     assert 'myenv' in s.environment_workers

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -845,10 +845,8 @@ def test_worker_name():
     yield w._close()
 
 
-@gen_test()
-def test_coerce_address():
-    s = Scheduler(validate=True)
-    s.start(0)
+@gen_cluster(ncores=[])
+def test_coerce_address(s):
     a = Worker(s.ip, s.port, name='alice')
     b = Worker(s.ip, s.port, name=123)
     c = Worker(s.ip, s.port, name='charlie', ip='127.0.0.2')
@@ -872,10 +870,8 @@ def test_coerce_address():
     yield [w._close() for w in [a, b, c]]
 
 
-@gen_test()
-def test_workers_set():
-    s = Scheduler(validate=True)
-    s.start(0)
+@gen_cluster(ncores=[])
+def test_workers_set(s):
     a = Worker(s.ip, s.port, name='alice', ip='127.0.0.1')
     b = Worker(s.ip, s.port, name=123, ip='127.0.0.2')
     c = Worker(s.ip, s.port, name='charlie', ip='127.0.0.2')

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -564,4 +564,4 @@ def test_register_environments():
     assert not response['bad']
     e = loads(response['fails'])
     assert isinstance(e, RuntimeError)
-    assert e.message == 'fails'
+    assert e.args == ('fails',)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -670,15 +670,21 @@ class Worker(Server):
         return {'status': 'OK', 'nbytes': len(data)}
 
     def register_environments(self, stream=None, environments=None):
-        added = []
+        result = {}
         for name, env in environments.items():
             if name not in self.environments:
-                env = loads(env)
-                if env.condition():
-                    env.setup()
-                    added.append(name)
-                    self.environments[name] = env
-        return added
+                try:
+                    env = loads(env)
+                    if env.condition():
+                        env.setup()
+                        self.environments[name] = env
+                        result[name] = True
+                    else:
+                        result[name] = False
+                except Exception as e:
+                    logger.exception(e)
+                    result[name] = dumps(e)
+        return result
 
     def process_health(self, stream=None):
         d = {'active': len(self.active),


### PR DESCRIPTION
Todo:
- [x] `Client.register_environment` updates state on scheduler and workers
- [x] environment state updated when workers are added
- [x] environment state updated when workers are removed
- [x] tests for managing environment state
- [x] scheduler takes environments into account when assigning tasks
- [x] `Client.submit` can take environment names in `workers=`
- [ ] Tests for scheduling with environments
