### PR TITLE
DOC: adds link to stackoverflow search for "dask distributed"

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,6 +1,8 @@
 Frequently Asked Questions
 ==========================
 
+More questions can be found on StackOverflow at http://stackoverflow.com/search?tab=votes&q=dask%20distributed
+
 How do I use external modules?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
In #507 we liked pointing to SO for answers. This adds a link to a SO search for "dask distributed", sorted by the number of votes.