### PR TITLE
Close dask workers at exit

### DIFF
--- a/distributed/bokeh/tests/test_application.py
+++ b/distributed/bokeh/tests/test_application.py
@@ -42,10 +42,7 @@ def test_bokeh_shutsdown_without_cluster___del__(loop):
     del c
     start = time()
     while True:
-        if sys.version_info[0] >= 3:
-            if not proc.is_alive():
-                break
-        elif proc.poll() is not None:
+        if proc.poll() is not None:
             break
         assert time() < start + 5
         sleep(0.01)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -295,11 +295,10 @@ processes_to_close = []
 
 def _closing():
     for proc in processes_to_close:
-        if proc.poll() is not None:
-            try:
-                proc.terminate()
-            except OSError:
-                pass
+        try:
+            proc.terminate()
+        except OSError:
+            pass
 
     closing[0] = True
 


### PR DESCRIPTION
We had all of the machinery to kill worker processes at exit, we were
just misusing it.