### PR TITLE
Bring back forked workers

### DIFF
--- a/distributed/bokeh/tasks/server_lifecycle.py
+++ b/distributed/bokeh/tasks/server_lifecycle.py
@@ -65,7 +65,10 @@ def task_events(interval, deque, times, index, rectangles, workers, last_seen):
     except Exception as e:
         logger.exception(e)
     finally:
-        sys.exit(0)
+        try:
+            sys.exit(0)
+        except:
+            pass
 
 
 n = 100000

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -12,6 +12,7 @@ from time import time, sleep
 
 import click
 from distributed import Nanny, Worker, sync, rpc
+from distributed.nanny import isalive
 from distributed.utils import get_ip, All
 from distributed.worker import _ncores
 from distributed.http import HTTPWorker
@@ -171,7 +172,7 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
 
     if not no_nanny:
         start = time()
-        while (any(n.process.poll() is None for n in nannies)
+        while (any(isalive(n.process) for n in nannies)
                 and time() < start + 1):
             sleep(0.1)
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -15,6 +15,7 @@ from distributed import Nanny, rpc, Scheduler
 from distributed.core import connect, read, write, dumps, loads
 from distributed.utils import ignoring
 from distributed.utils_test import gen_cluster
+from distributed.nanny import isalive
 
 
 @gen_cluster(ncores=[])
@@ -23,7 +24,7 @@ def test_nanny(s):
 
     yield n._start(0)
     nn = rpc(ip=n.ip, port=n.port)
-    assert n.process.poll() is None  # alive
+    assert isalive(n.process)  # alive
     assert s.ncores[n.worker_address] == 2
 
     assert s.worker_info[n.worker_address]['services']['nanny'] > 1024
@@ -39,7 +40,7 @@ def test_nanny(s):
     assert not n.process
 
     yield nn.instantiate()
-    assert n.process.poll() is None
+    assert isalive(n.process)
     assert s.ncores[n.worker_address] == 2
     assert s.worker_info[n.worker_address]['services']['nanny'] > 1024
 
@@ -72,7 +73,7 @@ def test_nanny_process_failure(s):
         assert time() - start < 5
 
     start = time()
-    while not n.process.poll() is None:  # wait while process comes back
+    while not isalive(n.process):  # wait while process comes back
         yield gen.sleep(0.01)
         assert time() - start < 5
 
@@ -98,7 +99,7 @@ def test_monitor_resources(s):
 
     yield n._start()
     nn = rpc(ip=n.ip, port=n.port)
-    assert n.process.poll() is None
+    assert isalive(n.process)
     d = n.resource_collect()
     assert {'cpu_percent', 'memory_percent'}.issubset(d)
 

--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -12,6 +12,7 @@ from tornado import gen
 
 from distributed.compatibility import PY3
 from distributed.client import _wait
+from distributed.nanny import isalive
 from distributed.utils import sync, ignoring
 from distributed.utils_test import (gen_cluster, cluster, inc, loop, slow, div,
         slowinc, slowadd)
@@ -65,7 +66,7 @@ def test_failed_worker_without_warning(c, s, a, b):
     original_process = a.process
     a.process.terminate()
     start = time()
-    while a.process is original_process and a.process.poll() is not None:
+    while a.process is original_process and not isalive(a.process):
         yield gen.sleep(0.01)
         assert time() - start < 10
 


### PR DESCRIPTION
Recently we switched to having Nannys create new workers with subprocess
rather than fork.  This allowed us to spawn workers in different python
environments.

However, this adds some cruft, both recent issues with cleanly stopping
workers and a non-trivial delay in startup time (multiple seconds).

Now we support both fork and subprocess, using the latter only when the
requested environment is not the same environment as the Nanny's