### PR TITLE
keep type information for scattered data

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3551,3 +3551,12 @@ def test_get_restrictions():
     r1, loose = get_restrictions(L2, {(total,): '127.0.0.1'}, True)
     assert r1 == {total.key: ['127.0.0.1']}
     assert loose == [total.key]
+
+
+@gen_cluster(client=True)
+def test_scatter_type(c, s, a, b):
+    [future] = yield c._scatter([1])
+    assert future.type == int
+
+    d = yield c._scatter({'x': 1.0})
+    assert d['x'].type == float


### PR DESCRIPTION
This only works on the client that scattered the data.  

The scheduler doesn't maintain type metadata for tasks so all of this information is just kept if we happen to be around as it was published.  We *could* start keeping this data around and do a more thorough job, but I'd like to wait for a motivating use case before accepting the higher maintenance burden.

cc @stefanseefeld 

Fixes #521 


```python
In [1]: from distributed import Client
In [2]: c = Client()
In [3]: [x] = c.scatter([1])
In [4]: x
Out[4]: <Future: status: finished, type: int, key: 8068024105615db5ba4cbd263d42a6db>
```