### PR TITLE
Tune scheduler performance

### DIFF
--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -273,7 +273,10 @@ class AllProgress(SchedulerPlugin):
             self.all[k].remove(key)
             if not self.all[k]:
                 del self.all[k]
-                del self.nbytes[k]
+                try:
+                    del self.nbytes[k]
+                except KeyError:
+                    pass
                 for v in self.state.values():
                     try:
                         del v[k]

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -12,6 +12,7 @@ import tempfile
 from time import time, sleep
 
 from tornado.ioloop import IOLoop
+from tornado.iostream import StreamClosedError
 from tornado import gen
 
 from .compatibility import JSONDecodeError
@@ -99,6 +100,8 @@ class Nanny(Server):
                             io_loop=self.loop)
             except gen.TimeoutError:
                 logger.info("Worker non-responsive.  Terminating.")
+            except StreamClosedError:
+                pass
             except Exception as e:
                 logger.exception(e)
 
@@ -118,6 +121,8 @@ class Nanny(Server):
                 logger.info("Nanny %s:%d failed to unregister worker %s:%d",
                         self.ip, self.port, self.ip, self.worker_port,
                         exc_info=True)
+            except StreamClosedError:
+                pass
             except Exception as e:
                 logger.exception(e)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1935,7 +1935,7 @@ def test_Future_exception_sync_2(loop, capsys):
 
 @gen_cluster(timeout=60, client=True)
 def test_async_persist(c, s, a, b):
-    from dask.imperative import delayed, Delayed
+    from dask.delayed import delayed, Delayed
     x = delayed(1)
     y = delayed(inc)(x)
     z = delayed(dec)(x)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -184,7 +184,10 @@ def key_split(s):
         s = s[0]
     try:
         words = s.split('-')
-        result = words[0].lstrip("'(\"")
+        if not words[0][0].isalpha():
+            result = words[0].lstrip("'(\"")
+        else:
+            result = words[0]
         for word in words[1:]:
             if word.isalpha() and not (len(word) == 8 and
                                        hex_pattern.match(word) is not None):


### PR DESCRIPTION
I put the scheduler through a small dask.array benchmark and ran into a
few places where performance could be improved:

1.  Remove log_errors in decide_worker
2.  Keep reverse dictionary for stealable keys
3.  Remove logger.debug lines in tight stimulus/transition functions
4.  Remove Scheduler.ready.remove in transition_ready_released
5.  Small optimizations on key_split