### PR TITLE
Use fraction of hard connection limit

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -5,6 +5,7 @@ import json
 import logging
 import multiprocessing
 import os
+import resource
 import socket
 import subprocess
 import sys
@@ -50,6 +51,10 @@ def main(host, port, http_port, bokeh_port, show, _bokeh,
             if os.path.exists(pid_file):
                 os.remove(pid_file)
         atexit.register(del_pid_file)
+
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    limit = max(soft, hard // 2)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
 
     given_host = host
     host = host or get_ip()

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -131,11 +131,12 @@ class Server(TCPServer):
     """
     default_port = 0
 
-    def __init__(self, handlers, max_buffer_size=MAX_BUFFER_SIZE, **kwargs):
+    def __init__(self, handlers, max_buffer_size=MAX_BUFFER_SIZE,
+            connection_limit=512, **kwargs):
         self.handlers = assoc(handlers, 'identity', self.identity)
         self.id = str(uuid.uuid1())
         self._port = None
-        self.rpc = ConnectionPool()
+        self.rpc = ConnectionPool(limit=connection_limit)
         super(Server, self).__init__(max_buffer_size=max_buffer_size, **kwargs)
 
     @property

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8,6 +8,7 @@ from math import log
 import os
 import pickle
 import random
+import resource
 import socket
 from time import time
 from timeit import default_timer
@@ -307,8 +308,11 @@ class Scheduler(Server):
                  ('released', 'erred'): self.transition_released_erred
         }
 
+        connection_limit = resource.getrlimit(resource.RLIMIT_NOFILE)[0] / 2
+
         super(Scheduler, self).__init__(handlers=self.handlers,
-                max_buffer_size=max_buffer_size, io_loop=self.loop, **kwargs)
+                max_buffer_size=max_buffer_size, io_loop=self.loop,
+                connection_limit=connection_limit, **kwargs)
 
     ##################
     # Administration #


### PR DESCRIPTION
Previously the scheduler would limit the number of ad-hoc connections to
512 by default.  Now we change the soft limit of the process to use up
to half of the available open files and we set the ad-hoc connection
limit to half of that.  On linux by default this is 65k / 4.

Maybe Fixes https://github.com/dask/distributed/issues/499

cc @hussainsultan 