### PR TITLE
Extract large byte sequences in top-level lists

### DIFF
--- a/distributed/protocol.py
+++ b/distributed/protocol.py
@@ -110,8 +110,8 @@ def _extract_big_bytes(x, big, path=()):
 def dumps(msg):
     """ Transform Python value to bytestream suitable for communication """
     big = {}
-    # Only dicts can contain big values
-    if isinstance(msg, dict):
+    # Only lists and dicts can contain big values
+    if isinstance(msg, (list, dict)):
         msg, big = extract_big_bytes(msg)
     small_header, small_payload = dumps_msgpack(msg)
     if not big:

--- a/distributed/tests/test_protocol.py
+++ b/distributed/tests/test_protocol.py
@@ -115,3 +115,13 @@ def test_large_messages():
     big_header = msgpack.loads(b[2], encoding='utf8')
     assert len(big_header['shards']) == 2
     assert len(big_header['keys']) + 2 + 1 == len(b)
+
+    msg = [big_bytes, {'x': big_bytes, 'y': b'small_bytes'}]
+    b = dumps(msg)
+    msg2 = loads(b)
+    assert msg == msg2
+
+    assert len(b) >= 2
+    big_header = msgpack.loads(b[2], encoding='utf8')
+    assert len(big_header['shards']) == 2
+    assert len(big_header['keys']) + 2 + 1 == len(b)


### PR DESCRIPTION
Previously we only extracted large bytestrings in messages with
top-level dictionaries. Some operations use lists as the top-level
message container instead, which could cause problems if these messages
contained large data.

Fixes #527.