### PR TITLE
Reduce administrative overhead in many-workers case

### DIFF
--- a/distributed/bokeh/status/server_lifecycle.py
+++ b/distributed/bokeh/status/server_lifecycle.py
@@ -107,7 +107,7 @@ def processing():
 
 def on_server_loaded(server_context):
     n = 60
-    messages['workers'] = {'interval': 500,
+    messages['workers'] = {'interval': 1000,
                            'deque': deque(maxlen=n),
                            'times': deque(maxlen=n),
                            'index': deque(maxlen=n),
@@ -118,7 +118,7 @@ def on_server_loaded(server_context):
                                          'network-recv': deque(maxlen=n)}}
     server_context.add_periodic_callback(workers, 500)
 
-    messages['tasks'] = {'interval': 100,
+    messages['tasks'] = {'interval': 150,
                          'deque': deque(maxlen=100),
                          'times': deque(maxlen=100)}
     server_context.add_periodic_callback(lambda: http_get('tasks'), 100)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -173,7 +173,7 @@ class Scheduler(Server):
 
     def __init__(self, center=None, loop=None,
             max_buffer_size=MAX_BUFFER_SIZE, delete_interval=500,
-            synchronize_worker_interval=5000,
+            synchronize_worker_interval=60000,
             ip=None, services=None, allowed_failures=ALLOWED_FAILURES,
             validate=False, **kwargs):
 
@@ -1157,7 +1157,8 @@ class Scheduler(Server):
                                    keys=list(keys - self.has_what.get(worker,
                                                                       set())),
                                    report=False)
-                          for worker, keys in d.items()]
+                          for worker, keys in d.items()
+                          if keys]
             for worker, keys in d.items():
                 logger.debug("Remove %d keys from worker %s", len(keys), worker)
             yield ignore_exceptions(coroutines, socket.error, StreamClosedError)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -102,7 +102,7 @@ class Worker(Server):
 
     def __init__(self, scheduler_ip, scheduler_port, ip=None, ncores=None,
                  loop=None, local_dir=None, services=None, service_ports=None,
-                 name=None, heartbeat_interval=1000, memory_limit=None, **kwargs):
+                 name=None, heartbeat_interval=5000, memory_limit=None, **kwargs):
         self.ip = ip or get_ip()
         self._port = 0
         self.ncores = ncores or _ncores


### PR DESCRIPTION
While running around 500 workers on my local laptop my scheduler tends
to run at around 50% capacity.  A few changes to lengthen heartbeat
intervals, reduce data sync checks, and clean up bokeh diagnostic
intervals brings this down to about 20%