### PR TITLE
Add ssl configurations for Server and rpc connections

### DIFF
--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -11,3 +11,7 @@ allowed-failures: 3     # number of retries before a task is considered bad
 pdb-on-err: False       # enter debug mode on scheduling error
 transition-log-length: 100000 
 
+# SSL Options
+ssl-enabled: False
+ssl-key-file:
+ssl-cert-file:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -22,10 +22,10 @@ from tornado.locks import Event
 from tornado.tcpserver import TCPServer
 from tornado.tcpclient import TCPClient
 from tornado.ioloop import IOLoop
-from tornado.iostream import IOStream, StreamClosedError
+from tornado.iostream import IOStream, StreamClosedError, SSLIOStream
 
 from .compatibility import PY3, unicode, WINDOWS
-from .utils import get_traceback, truncate_exception, ignoring
+from .utils import get_traceback, truncate_exception, ignoring, create_ssl_context
 from . import protocol
 
 pickle_types = [str, bytes]
@@ -132,12 +132,12 @@ class Server(TCPServer):
     default_port = 0
 
     def __init__(self, handlers, max_buffer_size=MAX_BUFFER_SIZE,
-            connection_limit=512, **kwargs):
+            connection_limit=512, ssl_context_creator= create_ssl_context, **kwargs):
         self.handlers = assoc(handlers, 'identity', self.identity)
         self.id = str(uuid.uuid1())
         self._port = None
         self.rpc = ConnectionPool(limit=connection_limit)
-        super(Server, self).__init__(max_buffer_size=max_buffer_size, **kwargs)
+        super(Server, self).__init__(max_buffer_size=max_buffer_size, ssl_options=ssl_context_creator(), **kwargs)
 
     @property
     def port(self):
@@ -299,7 +299,7 @@ def connect(ip, port, timeout=3):
     client = TCPClient()
     start = time()
     while True:
-        future = client.connect(ip, port, max_buffer_size=MAX_BUFFER_SIZE)
+        future = client.connect(ip, port, max_buffer_size=MAX_BUFFER_SIZE, ssl_options=create_ssl_context())
         try:
             stream = yield gen.with_timeout(timedelta(seconds=timeout), future)
             stream.set_nodelay(True)
@@ -608,7 +608,7 @@ def coerce_to_rpc(o, **kwargs):
     if isinstance(o, (bytes, str, tuple, list)):
         ip, port = coerce_to_address(o, out=tuple)
         return rpc(ip=ip, port=int(port), **kwargs)
-    elif isinstance(o, IOStream):
+    elif isinstance(o, IOStream) or isinstance(o, SSLIOStream):
         return rpc(stream=o, **kwargs)
     elif isinstance(o, rpc):
         return o

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -22,7 +22,7 @@ from tornado import gen
 from tornado.gen import Return
 from tornado.queues import Queue
 from tornado.ioloop import IOLoop, PeriodicCallback
-from tornado.iostream import StreamClosedError, IOStream
+from tornado.iostream import StreamClosedError, IOStream, SSLIOStream
 
 from dask.compatibility import PY3, unicode
 from dask.core import reverse_dict
@@ -955,14 +955,14 @@ class Scheduler(Server):
         with log_errors(pdb=LOG_PDB):
             if isinstance(in_queue, Queue):
                 next_message = in_queue.get
-            elif isinstance(in_queue, IOStream):
+            elif isinstance(in_queue, IOStream) or isinstance(in_queue, SSLIOStream):
                 next_message = lambda: read(in_queue)
             else:
                 raise NotImplementedError()
 
             if isinstance(report, Queue):
                 put = report.put_nowait
-            elif isinstance(report, IOStream):
+            elif isinstance(report, IOStream) or isinstance(report, SSLIOStream):
                 put = lambda msg: write(report, msg)
             elif isinstance(report, BatchedSend):
                 put = report.send

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -11,7 +11,7 @@ import pytest
 
 from distributed.core import (read, write, pingpong, Server, rpc, connect,
         coerce_to_rpc, send_recv, coerce_to_address, ConnectionPool)
-from distributed.utils_test import slow, loop, gen_test
+from distributed.utils_test import slow, loop, gen_test, certs
 
 def test_server(loop):
     @gen.coroutine
@@ -163,7 +163,6 @@ def test_errors(loop):
     except OSError as e:
         assert '.listen' in str(e)
 
-
 def test_coerce_to_rpc():
     r = coerce_to_rpc(('127.0.0.1', 8000))
     assert (r.ip, r.port) == ('127.0.0.1', 8000)
@@ -172,9 +171,9 @@ def test_coerce_to_rpc():
     r = coerce_to_rpc('foo:bar:8000')
     assert (r.ip, r.port) == ('foo:bar', 8000)
 
-
 def stream_div(stream=None, x=None, y=None):
     return x / y
+
 
 @gen_test()
 def test_errors():
@@ -186,7 +185,6 @@ def test_errors():
         yield r.div(x=1, y=0)
 
     r.close_streams()
-
 
 @gen_test()
 def test_connect_raises():
@@ -220,6 +218,11 @@ def test_coerce_to_address():
                 ('127.0.0.1', 8786),
                 ('127.0.0.1', '8786')]:
         assert coerce_to_address(arg) == '127.0.0.1:8786'
+
+
+def test_ssl(certs):
+    s= Server({}, ssl_context_creator=lambda: {'certfile': str(certs)})
+    assert s.ssl_options == {'certfile': str(certs)}
 
 
 @gen_test()

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -15,8 +15,9 @@ from tornado.locks import Event
 
 import dask
 from distributed.utils import (All, sync, is_kernel, ensure_ip, str_graph,
-        truncate_exception, get_traceback, queue_to_iterator,
-        iterator_to_queue, _maybe_complex, read_block, seek_delimiter, funcname)
+                               truncate_exception, get_traceback, queue_to_iterator,
+                               iterator_to_queue, _maybe_complex, read_block, seek_delimiter, funcname,
+                               create_ssl_context)
 from distributed.utils_test import loop, inc, throws, div
 from distributed.compatibility import Queue, isqueue
 
@@ -138,7 +139,7 @@ def test_ensure_ip():
 
 
 def test_truncate_exception():
-    e = ValueError('a'*1000)
+    e = ValueError('a' * 1000)
     assert len(str(e)) >= 1000
     f = truncate_exception(e, 100)
     assert type(f) == type(e)
@@ -271,3 +272,13 @@ def test_funcname():
     assert funcname(f) == 'f'
     assert funcname(partial(f)) == 'f'
     assert funcname(partial(partial(f))) == 'f'
+
+
+def test_create_ssl_context_enabled():
+    output = create_ssl_context(True,  'test.key','test.cert')
+    assert output == {'certfile': 'test.cert', 'keyfile': 'test.key'}
+
+
+def test_create_ssl_context_disabled():
+    output = create_ssl_context(False,  'test.key', 'test.cert',)
+    assert output == None

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -509,3 +509,14 @@ def divide_n_among_bins(n, bins):
 def mean(seq):
     seq = list(seq)
     return sum(seq) / len(seq)
+
+
+SSL_ENABLED = config.get('ssl-enabled') or os.environ.get('DASK_SSL_ENABLED', False)
+SSL_KEY_FILE = config.get('ssl-key-file') or os.environ.get('DASK_SSL_KEY_FILE', False)
+SSL_CERT_FILE = config.get('ssl-cert-file') or os.environ.get('DASK_SSL_CERT_FILE', False)
+
+
+def create_ssl_context(ssl_enabled=SSL_ENABLED, ssl_key_file=SSL_KEY_FILE, ssl_cert_file=SSL_CERT_FILE):
+    if ssl_enabled:
+        return {'certfile': ssl_cert_file, 'keyfile': ssl_key_file}
+    return None

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -46,6 +46,11 @@ def invalid_python_script(tmpdir_factory):
     local_file.write("a+1")
     return local_file
 
+@pytest.fixture(scope='session')
+def certs(tmpdir_factory):
+    local_file = tmpdir_factory.mktemp('data').join('test.cert')
+    local_file.write("test")
+    return local_file
 
 @pytest.yield_fixture
 def current_loop():


### PR DESCRIPTION
Add minimal SSL configuration options for `dask.distributed` cluster.  

For production deployments, this PR allows for setting up different TLS certificate for every dask worker node in your cluster, scheduler node and client node. It assumes that all certificates are signed by a single "root/cluster" CA authority.  This does not include verification of certificates  when presented.

This PR does not add SSL for Bokeh Interface.  Needs docs. 
