### PR TITLE
Only increase open file limit on linux

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -52,9 +52,10 @@ def main(host, port, http_port, bokeh_port, show, _bokeh,
                 os.remove(pid_file)
         atexit.register(del_pid_file)
 
-    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    limit = max(soft, hard // 2)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
+    if sys.platform.startswith('linux'):
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        limit = max(soft, hard // 2)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
 
     given_host = host
     host = host or get_ip()


### PR DESCRIPTION
Previously we set the open file limit to half of the hard limit.  This
used to fail on OSX because they set their hard limit at infinity and
their soft cap at what appears to be 2**13 (though this doesn't seem
documented).

Now we don't set anything on osx and stick to defaults.  Given that OSX
users typically don't run into open file limits, this should be ok