### PR TITLE
Use encapsulation for Adaptive cluster

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -218,6 +218,35 @@ class LocalCluster(object):
                 self.loop.close()
                 del self._thread
 
+    @gen.coroutine
+    def scale_up(self, n, **kwargs):
+        """ Bring the total count of workers up to ``n``
+
+        This function/coroutine should bring the total number of workers up to
+        the number ``n``.
+
+        This can be implemented either as a function or as a Tornado coroutine.
+        """
+        yield [self._start_worker(**kwargs)
+                for i in range(n - len(self.workers))]
+
+    @gen.coroutine
+    def scale_down(self, workers):
+        """ Remove ``workers`` from the cluster
+
+        Given a list of worker addresses this function should remove those
+        workers from the cluster.  This may require tracking which jobs are
+        associated to which worker address.
+
+        This can be implemented either as a function or as a Tornado coroutine.
+        """
+        workers = set(workers)
+        yield [self._stop_worker(w)
+                for w in self.workers
+                if w.worker_address in workers]
+        while workers & set(self.workers):
+            yield gen.sleep(0.01)
+
     def __del__(self):
         self.close()
 

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -10,31 +10,10 @@ from distributed.deploy import Adaptive, LocalCluster
 from distributed.utils_test import loop, slowinc, gen_test
 
 
-class AdaptiveLocalCluster(Adaptive):
-    def __init__(self, cluster, **kwargs):
-        self.cluster = cluster
-        self.scheduler = cluster.scheduler
-        super(AdaptiveLocalCluster, self).__init__(**kwargs)
-
-    @gen.coroutine
-    def scale_up(self, n):
-        yield [self.cluster._start_worker()
-                for i in range(n - len(self.cluster.workers))]
-
-    @gen.coroutine
-    def scale_down(self, workers):
-        workers = set(workers)
-        yield [self.cluster._stop_worker(w)
-                for w in self.cluster.workers
-                if w.worker_address in workers]
-        while workers & set(self.cluster.workers):
-            yield gen.sleep(0.01)
-
-
 def test_adaptive_local_cluster(loop):
     with LocalCluster(0, scheduler_port=0, silence_logs=False,
                       diagnostic_port=None, loop=loop) as cluster:
-        alc = AdaptiveLocalCluster(cluster, interval=100)
+        alc = Adaptive(cluster.scheduler, cluster, interval=100)
         with Client(cluster, loop=loop) as c:
             assert not c.ncores()
             future = c.submit(lambda x: x + 1, 1)
@@ -59,7 +38,7 @@ def test_adaptive_local_cluster_multi_workers():
     loop = IOLoop.current()
     cluster = LocalCluster(0, scheduler_port=0, silence_logs=False, nanny=False,
                       diagnostic_port=None, loop=loop, start=False)
-    alc = AdaptiveLocalCluster(cluster, interval=100)
+    alc = Adaptive(cluster.scheduler, cluster, interval=100)
     c = Client(cluster, start=False, loop=loop)
     yield c._start()
 


### PR DESCRIPTION
Previously we used subclassing to marry policies like `Adaptive` with deployment strategies like `Marathon`.  Now we use encapsulation.  This helps to separate concerns a bit.