### PR TITLE
Allow worker failures in adaptive test

### DIFF
--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -38,6 +38,7 @@ def test_adaptive_local_cluster_multi_workers():
     loop = IOLoop.current()
     cluster = LocalCluster(0, scheduler_port=0, silence_logs=False, nanny=False,
                       diagnostic_port=None, loop=loop, start=False)
+    cluster.scheduler.allowed_failures = 1000
     alc = Adaptive(cluster.scheduler, cluster, interval=100)
     c = Client(cluster, start=False, loop=loop)
     yield c._start()


### PR DESCRIPTION
This was an intermittent failure before if we killed the same worker
many times.