### PR TITLE
Fix #564: allow using distributed on Windows

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -5,7 +5,6 @@ import json
 import logging
 import multiprocessing
 import os
-import resource
 import socket
 import subprocess
 import sys
@@ -53,6 +52,7 @@ def main(host, port, http_port, bokeh_port, show, _bokeh,
         atexit.register(del_pid_file)
 
     if sys.platform.startswith('linux'):
+        import resource   # module fails importing on Windows
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
         limit = max(soft, hard // 2)
         resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8,7 +8,6 @@ from math import log
 import os
 import pickle
 import random
-import resource
 import socket
 from time import time
 from timeit import default_timer
@@ -33,7 +32,8 @@ from .utils_comm import (scatter_to_workers, gather_from_workers)
 from .core import (rpc, connect, read, write, MAX_BUFFER_SIZE,
         Server, send_recv, coerce_to_address, error_message)
 from .utils import (All, ignoring, clear_queue, get_ip, ignore_exceptions,
-        ensure_ip, log_errors, key_split, mean, divide_n_among_bins)
+        ensure_ip, get_fileno_limit, log_errors, key_split, mean,
+        divide_n_among_bins)
 from .config import config
 
 
@@ -318,7 +318,7 @@ class Scheduler(Server):
                  ('released', 'erred'): self.transition_released_erred
         }
 
-        connection_limit = resource.getrlimit(resource.RLIMIT_NOFILE)[0] / 2
+        connection_limit = get_fileno_limit() / 2
 
         super(Scheduler, self).__init__(handlers=self.handlers,
                 max_buffer_size=max_buffer_size, io_loop=self.loop,

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -12,6 +12,11 @@ import tblib.pickling_support
 import tempfile
 from threading import Thread
 
+try:
+    import resource
+except ImportError:
+    resource = None
+
 from dask import istask
 from toolz import memoize, valmap
 from tornado import gen
@@ -31,6 +36,18 @@ def funcname(func):
         return func.__name__
     except:
         return str(func)
+
+
+def get_fileno_limit():
+    """
+    Get the maximum number of open files per process.
+    """
+    if resource is not None:
+        return resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+    else:
+        # Default ceiling for Windows when using the CRT, though it
+        # is settable using _setmaxstdio().
+        return 512
 
 
 def get_ip(host='8.8.8.8', port=80):


### PR DESCRIPTION
This allows importing distributed and lets a couple tests pass, though the test suite hangs at some point.