### PR TITLE
Fix #579: avoid race condition when closing streams

### DIFF
--- a/distributed/bokeh/tests/test_application.py
+++ b/distributed/bokeh/tests/test_application.py
@@ -13,7 +13,7 @@ from distributed.utils import ignoring
 def test_BokehWebInterface(loop):
     with LocalCluster(2, loop=loop, scheduler_port=0,
                       services={('http', 0): HTTPScheduler},
-                      diagnostic_port=None) as c:
+                      diagnostics_port=None) as c:
         with pytest.raises(Exception):
             response = requests.get('http://127.0.0.1:8787/status/')
         with BokehWebInterface(

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -593,7 +593,15 @@ class ConnectionPool(object):
     def collect(self):
         logger.info("Collecting unused streams.  open: %d, active: %d",
                     self.open, self.active)
-        for k, streams in list(self.available.items()):
+        for streams in list(self.available.values()):
+            for stream in streams:
+                stream.close()
+
+    def close(self):
+        for streams in list(self.available.values()):
+            for stream in streams:
+                stream.close()
+        for streams in list(self.occupied.values()):
             for stream in streams:
                 stream.close()
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -245,6 +245,7 @@ class Nanny(Server):
         logger.info("Closing Nanny at %s:%d", self.ip, self.port)
         self.status = 'closed'
         yield self._kill(timeout=timeout)
+        self.rpc.close()
         self.scheduler.close_rpc()
         self.stop()
         raise gen.Return('OK')

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -334,9 +334,6 @@ class Scheduler(Server):
 
     __repr__ = __str__
 
-    def __del__(self):
-        self.close_streams()
-
     @property
     def address(self):
         return '%s:%d' % (self.ip, self.port)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -403,11 +403,9 @@ class Scheduler(Server):
 
     def close_streams(self):
         """ Close all active IOStreams """
-        with ignoring(AttributeError):
-            for r in self._rpcs.values():
-                r.close_rpc()
         for stream in self.streams.values():
             stream.stream.close()
+        self.rpc.close()
 
     @gen.coroutine
     def close(self, stream=None, fast=False):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -50,7 +50,7 @@ def test_administration(s, a, b):
 @gen_cluster(ncores=[])
 def test_update_state(s):
     s.add_worker(address=alice, ncores=1, coerce_address=False)
-    s.update_graph(tasks={'x': 1, 'y': (inc, 'x')},
+    s.update_graph(tasks={'x': 1, 'y': dumps_task((inc, 'x'))},
                    keys=['y'],
                    dependencies={'y': 'x', 'x': set()},
                    client='client')
@@ -67,13 +67,14 @@ def test_update_state(s):
     assert s.who_wants == {'y': {'client'}}
     assert s.wants_what == {'client': {'y'}}
 
-    s.update_graph(tasks={'a': 1, 'z': (add, 'y', 'a')},
+    s.update_graph(tasks={'a': 1, 'z': dumps_task((add, 'y', 'a'))},
                    keys=['z'],
                    dependencies={'z': {'y', 'a'}},
                    client='client')
 
 
-    assert s.tasks == {'x': 1, 'y': (inc, 'x'), 'a': 1, 'z': (add, 'y', 'a')}
+    assert s.tasks == {'x': 1, 'y': dumps_task((inc, 'x')), 'a': 1,
+                       'z': dumps_task((add, 'y', 'a'))}
     assert s.dependencies == {'x': set(), 'a': set(), 'y': {'x'}, 'z': {'a', 'y'}}
     assert s.dependents == {'z': set(), 'y': {'z'}, 'a': {'z'}, 'x': {'y'}}
 
@@ -89,7 +90,8 @@ def test_update_state(s):
 @gen_cluster(ncores=[])
 def test_update_state_with_processing(s):
     s.add_worker(address=alice, ncores=1, coerce_address=False)
-    s.update_graph(tasks={'x': 1, 'y': (inc, 'x'), 'z': (inc, 'y')},
+    s.update_graph(tasks={'x': 1, 'y': dumps_task((inc, 'x')),
+                          'z': dumps_task((inc, 'y'))},
                    keys=['z'],
                    dependencies={'y': {'x'}, 'x': set(), 'z': {'y'}},
                    client='client')
@@ -109,7 +111,8 @@ def test_update_state_with_processing(s):
 
     assert s.who_has == {'x': {alice}}
 
-    s.update_graph(tasks={'a': (inc, 'x'), 'b': (add,'a','y'), 'c': (inc, 'z')},
+    s.update_graph(tasks={'a': dumps_task((inc, 'x')), 'b': (add,'a','y'),
+                          'c': dumps_task((inc, 'z'))},
                    keys=['b', 'c'],
                    dependencies={'a': {'x'}, 'b': {'a', 'y'}, 'c': {'z'}},
                    client='client')
@@ -144,7 +147,8 @@ def test_update_state_respects_data_in_memory(c, s, a):
 @gen_cluster(ncores=[])
 def test_update_state_supports_recomputing_released_results(s):
     s.add_worker(address=alice, ncores=1, coerce_address=False)
-    s.update_graph(tasks={'x': 1, 'y': (inc, 'x'), 'z': (inc, 'x')},
+    s.update_graph(tasks={'x': 1, 'y': dumps_task((inc, 'x')),
+                          'z': dumps_task((inc, 'x'))},
                    keys=['z'],
                    dependencies={'y': {'x'}, 'x': set(), 'z': {'y'}},
                    client='client')
@@ -169,7 +173,7 @@ def test_update_state_supports_recomputing_released_results(s):
 
     assert s.who_has == {'z': {alice}}
 
-    s.update_graph(tasks={'x': 1, 'y': (inc, 'x')},
+    s.update_graph(tasks={'x': 1, 'y': dumps_task((inc, 'x'))},
                    keys=['y'],
                    dependencies={'y': {'x'}, 'x': set()},
                    client='client')
@@ -896,7 +900,9 @@ def test_file_descriptors_dont_leak(s):
 @gen_cluster()
 def test_update_graph_culls(s, a, b):
     s.add_client(client='client')
-    s.update_graph(tasks={'x': (inc, 1), 'y': (inc, 'x'), 'z': (inc, 2)},
+    s.update_graph(tasks={'x': dumps_task((inc, 1)),
+                          'y': dumps_task((inc, 'x')),
+                          'z': dumps_task((inc, 2))},
                    keys=['y'],
                    dependencies={'y': 'x', 'x': [], 'z': []},
                    client='client')

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -344,6 +344,7 @@ def end_cluster(s, workers):
             yield w._close(report=False)
         if w.local_dir and os.path.exists(w.local_dir):
             shutil.rmtree(w.local_dir)
+    yield s.close()
     s.stop()
 
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -255,6 +255,7 @@ class Worker(Server):
 
         for k, v in self.services.items():
             v.stop()
+        self.rpc.close()
         self.status = 'closed'
         self.stop()
 


### PR DESCRIPTION
Closing streams from threads other than the running loop can
cause race conditions from inside the loop (the sockets become
invalid while polling for them).  The race condition only seems
to manifest under Windows, though it is theoretically OS-independent.

The fix involves two changes:
- no explicit closing from `__del__`, since `__del__` can be called
  in basically any Python thread
- in Client.shutdown(), close streams from the running loop rather
  than the calling thread