### PR TITLE
Clean up rpc objects explicitly

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -8,10 +8,10 @@ from tornado import gen
 
 def test_cluster(loop):
     with cluster() as (s, [a, b]):
-        s = rpc(ip='127.0.0.1', port=s['port'])
-        ident = loop.run_sync(s.identity)
-        assert ident['type'] == 'Scheduler'
-        assert len(ident['workers']) == 2
+        with rpc(ip='127.0.0.1', port=s['port']) as s:
+            ident = loop.run_sync(s.identity)
+            assert ident['type'] == 'Scheduler'
+            assert len(ident['workers']) == 2
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -237,6 +237,13 @@ def test_multiple_clients_restart(s, a, b):
     yield e2._shutdown(fast=True)
 
 
+@gen_cluster(Worker=Nanny)
+def test_restart_scheduler(s, a, b):
+    import gc; gc.collect()
+    yield s.restart()
+    assert len(s.ncores) == 2
+
+
 @gen_cluster(Worker=Nanny, client=True)
 def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
     x = c.submit(inc, 1)


### PR DESCRIPTION
Previously we depended on `__del__` and garbage collection to clean up
rpc objects.  This caused some difficulties, particularly on Windows.

Now we clean up all rpc objects explicitly.  Most of this PR commit is
just tweaking other tests to be more robust.

We test this by explicitly checking the rpc count in the gen_cluster decorator
and the cluster testing context manager.