### PR TITLE
Normalize collections against futures

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1393,17 +1393,9 @@ class Client(object):
 
         variables = [a for a in collections if isinstance(a, Base)]
 
-        if optimize_graph:
-            groups = groupby(lambda x: x._optimize, variables)
-            dsk = merge([opt(merge([v.dask for v in val]),
-                             [v._keys() for v in val], **kwargs)
-                        for opt, val in groups.items()])
-        else:
-            dsk = merge(c.dask for c in variables)
-
+        dsk = collections_to_dsk(variables, optimize_graph, **kwargs)
         names = ['finalize-%s' % tokenize(v) for v in variables]
         dsk2 = {name: (v._finalize, v._keys()) for name, v in zip(names, variables)}
-
 
         restrictions, loose_restrictions = get_restrictions(collections,
                 workers, allow_other_workers)
@@ -1478,13 +1470,7 @@ class Client(object):
 
         assert all(isinstance(c, Base) for c in collections)
 
-        if optimize_graph:
-            groups = groupby(lambda x: x._optimize, collections)
-            dsk = merge([opt(merge([v.dask for v in val]),
-                             [v._keys() for v in val], **kwargs)
-                        for opt, val in groups.items()])
-        else:
-            dsk = merge(c.dask for c in collections)
+        dsk = collections_to_dsk(collections, optimize_graph, **kwargs)
 
         names = {k for c in collections for k in flatten(c._keys())}
 
@@ -2249,3 +2235,24 @@ def get_restrictions(collections, workers, allow_other_workers):
         loose_restrictions = []
 
     return restrictions, loose_restrictions
+
+
+def collections_to_dsk(collections, optimize_graph=True, **kwargs):
+    """
+    Convert many collections into a single dask graph, after optimization
+    """
+    optimizations = _globals.get('optimizations', [])
+    if optimize_graph:
+        groups = groupby(lambda x: x._optimize, collections)
+        groups = {opt: [merge([v.dask for v in val]),
+                       [v._keys() for v in val]]
+                  for opt, val in groups.items()}
+        for opt in optimizations:
+            groups = {k: [opt(dsk, keys), keys]
+                      for k, (dsk, keys) in groups.items()}
+        dsk = merge([opt(dsk, keys, **kwargs)
+                     for opt, (dsk, keys) in groups.items()])
+    else:
+        dsk = merge(c.dask for c in collections)
+
+    return dsk

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1290,7 +1290,7 @@ class Client(object):
         results2 = pack_data(keys, results)
         return results2
 
-    def _insert_futures_to_graph(self, dsk, keys):
+    def _optimize_insert_futures(self, dsk, keys):
         """ Replace known keys in dask graph with Futures
 
         When given a Dask graph that might have overlapping keys with our known
@@ -1336,7 +1336,7 @@ class Client(object):
         --------
         Client.persist: trigger computation of collection's tasks
         """
-        dsk = self._insert_futures_to_graph(collection.dask, collection._keys())
+        dsk = self._optimize_insert_futures(collection.dask, collection._keys())
 
         if dsk is collection.dask:
             return collection

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1291,6 +1291,15 @@ class Client(object):
         return results2
 
     def _insert_futures_to_graph(self, dsk, keys):
+        """ Replace known keys in dask graph with Futures
+
+        When given a Dask graph that might have overlapping keys with our known
+        results we replace the values of that graph with futures.  This can be
+        used as an optimization to avoid recomputation.
+
+        This returns the same graph if unchanged but a new graph if any changes
+        were necessary.
+        """
         changed = False
         for key in list(dsk):
             if tokey(key) in self.futures:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3725,7 +3725,7 @@ def test_auto_normalize_collection(c, s, a, b):
     x = da.ones(10, chunks=5)
     assert len(x.dask) == 2
 
-    with dask.set_options(optimizations=[c._insert_futures_to_graph]):
+    with dask.set_options(optimizations=[c._optimize_insert_futures]):
         y = x.map_blocks(slowinc, delay=1, dtype=x.dtype)
         yy = c.persist(y)
 
@@ -3755,7 +3755,7 @@ def test_auto_normalize_collection_sync(loop):
 
             wait(yy)
 
-            with dask.set_options(optimizations=[c._insert_futures_to_graph]):
+            with dask.set_options(optimizations=[c._optimize_insert_futures]):
                 start = time()
                 y.sum().compute()
                 end = time()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3678,3 +3678,18 @@ def test_add_done_callback(c, s, a, b):
     yield _wait(x)
 
     assert L == [x.key, x.status]
+
+
+@gen_cluster(client=True)
+def test_normalize_collection(c, s, a, b):
+    x = delayed(inc)(1)
+    y = delayed(inc)(x)
+    z = delayed(inc)(y)
+
+    yy = c.persist(y)
+
+    zz = c.normalize_collection(z)
+    assert len(z.dask) == len(y.dask) + 1
+
+    assert isinstance(zz.dask[y.key], Future)
+    assert len(zz.dask) < len(z.dask)


### PR DESCRIPTION
The client is smart enough to find already-computed tasks within incoming collections and deduplicate work.  However, this fails if the matching keys end up being optimized away.  This can lead to needless work.

We can resolve this if we check for duplicate tasks before the optimization step.  That is what is implemented here.

However, there are a few problems with this:

1.  It is a bit slow, especially for large graphs.  This will measurably slow down computations with many small tasks.
2.  We can't do anything if the user uses the `dask.compute` function or the `.compute()` method, as these optimize before they ever send the graph to the client.

As an alternative, we could make this operation manual and explicit:

    x = client.normalize_collection(x)

This is what is done in the first commit here.  I'm leaning towards this solution for now.

This only seems to be an issue in collections that heavily optimize away intermediate tasks.  This is mostly an issue for dask.arrays and less of an issue for dask.delayed and dask.dataframe.