### PR TITLE
Fix #582: improve computation of workers per thread when nworkers does not divide number of cores

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import logging
+import math
 from threading import Thread
 from time import sleep
 
@@ -75,7 +76,8 @@ class LocalCluster(object):
         if n_workers is None and threads_per_worker is not None:
             n_workers = max(1, _ncores // threads_per_worker)
         if n_workers and threads_per_worker is None:
-            threads_per_worker = max(1, _ncores // n_workers)
+            # Overcommit threads per worker, rather than undercommit
+            threads_per_worker = max(1, int(math.ceil(_ncores / n_workers)))
 
         self.loop = loop or IOLoop()
         if not self.loop._running:

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -90,7 +90,12 @@ def test_defaults():
 
     with LocalCluster(n_workers=2, scheduler_port=0, silence_logs=False,
             diagnostic_port=None) as c:
-        assert sum(w.ncores for w in c.workers) == max(2, _ncores)
+        if _ncores % 2 == 0:
+            expected_total_threads = max(2, _ncores)
+        else:
+            # n_workers not a divisor of _ncores => threads are overcommitted
+            expected_total_threads = max(2, _ncores + 1)
+        assert sum(w.ncores for w in c.workers) == expected_total_threads
 
     with LocalCluster(threads_per_worker=_ncores * 2, scheduler_port=0,
             silence_logs=False, diagnostic_port=None) as c:


### PR DESCRIPTION
This fixes a test failure on systems with an odd number of cores (> 1).