### PR TITLE
Fix CLI tests under Windows

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -81,13 +81,15 @@ def main(host, port, http_port, bokeh_port, show, _bokeh,
         except Exception as e:
             logger.warn("Could not start Bokeh web UI", exc_info=True)
 
-    loop.start()
-    loop.close()
-    scheduler.stop()
-    if bokeh_proc:
-        bokeh_proc.close()
+    try:
+        loop.start()
+        loop.close()
+    finally:
+        scheduler.stop()
+        if bokeh_proc:
+            bokeh_proc.close()
 
-    logger.info("End scheduler at %s:%d", ip, port)
+        logger.info("End scheduler at %s:%d", ip, port)
 
 
 def go():


### PR DESCRIPTION
Note that process cleanup seems quite different under Windows than it is under Unix. A child process can apparently continue running even though the parent disappeared. Making things really robust is out of the picture for this PR.