### PR TITLE
Improve file handling

### DIFF
--- a/distributed/bokeh/application.py
+++ b/distributed/bokeh/application.py
@@ -9,7 +9,7 @@ import sys
 
 import bokeh
 import distributed.bokeh
-from toolz import get_in
+from toolz import get_in, concat
 
 from ..utils import ignoring
 from ..compatibility import logging_names
@@ -74,8 +74,9 @@ class BokehWebInterface(object):
                          'http-port': http_port,
                          'tcp-port': tcp_port,
                          'bokeh-port': bokeh_port}
-        with open(os.path.join(dask_dir, '.dask-web-ui.json'), 'w') as f:
-            json.dump(bokeh_options, f, indent=2)
+
+        args.extend(['--args'] + list(map(str, concat(bokeh_options.items()))))
+        print(args)
 
         import subprocess
         process = subprocess.Popen(args)

--- a/distributed/bokeh/application.py
+++ b/distributed/bokeh/application.py
@@ -76,7 +76,6 @@ class BokehWebInterface(object):
                          'bokeh-port': bokeh_port}
 
         args.extend(['--args'] + list(map(str, concat(bokeh_options.items()))))
-        print(args)
 
         import subprocess
         process = subprocess.Popen(args)

--- a/distributed/bokeh/status/server_lifecycle.py
+++ b/distributed/bokeh/status/server_lifecycle.py
@@ -5,8 +5,10 @@ from collections import deque
 import json
 import logging
 import os
+import sys
 from time import time
 
+from toolz import partition_all
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient, HTTPError
 from tornado.iostream import StreamClosedError
@@ -17,25 +19,17 @@ from distributed.core import read, connect, write, dumps
 from distributed.diagnostics.progress_stream import progress_stream
 from distributed.bokeh.worker_monitor import resource_append
 import distributed.bokeh
+from distributed.bokeh.utils import parse_args
 from distributed.utils import log_errors
 
 
 logger = logging.getLogger(__name__)
 
-
 client = AsyncHTTPClient()
 
 messages = distributed.bokeh.messages  # monkey-patching
 
-dask_dir = os.path.join(os.path.expanduser('~'), '.dask')
-options_path = os.path.join(dask_dir, '.dask-web-ui.json')
-if os.path.exists(options_path):
-    with open(options_path, 'r') as f:
-        options = json.load(f)
-else:
-    options = {'host': '127.0.0.1',
-               'tcp-port': 8786,
-               'http-port': 9786}
+options = parse_args(sys.argv[1:])
 
 
 @gen.coroutine

--- a/distributed/bokeh/status/server_lifecycle.py
+++ b/distributed/bokeh/status/server_lifecycle.py
@@ -8,7 +8,6 @@ import os
 import sys
 from time import time
 
-from toolz import partition_all
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient, HTTPError
 from tornado.iostream import StreamClosedError

--- a/distributed/bokeh/tasks/server_lifecycle.py
+++ b/distributed/bokeh/tasks/server_lifecycle.py
@@ -7,6 +7,7 @@ import sys
 import json
 import os
 import logging
+import sys
 from time import time
 
 from tornado import gen
@@ -18,6 +19,7 @@ from distributed.core import read
 from distributed.diagnostics.eventstream import eventstream
 from distributed.bokeh.status_monitor import task_stream_append
 import distributed.bokeh
+from distributed.bokeh.utils import parse_args
 
 
 logger = logging.getLogger(__name__)
@@ -26,17 +28,7 @@ client = AsyncHTTPClient()
 
 messages = distributed.bokeh.messages  # monkey-patching
 
-
-dask_dir = os.path.join(os.path.expanduser('~'), '.dask')
-options_path = os.path.join(dask_dir, '.dask-web-ui.json')
-
-if os.path.exists(options_path):
-    with open(options_path, 'r') as f:
-        options = json.load(f)
-else:
-    options = {'host': '127.0.0.1',
-               'tcp-port': 8786,
-               'http-port': 9786}
+options = parse_args(sys.argv[1:])
 
 
 @gen.coroutine

--- a/distributed/bokeh/utils.py
+++ b/distributed/bokeh/utils.py
@@ -1,0 +1,11 @@
+from __future__ import print_function, division, absolute_import
+
+from toolz import partition
+
+def parse_args(args):
+    options = dict(partition(2, args))
+    for k, v in options.items():
+        if v.isnumeric():
+            options[k] = int(v)
+
+    return options

--- a/distributed/bokeh/utils.py
+++ b/distributed/bokeh/utils.py
@@ -5,7 +5,7 @@ from toolz import partition
 def parse_args(args):
     options = dict(partition(2, args))
     for k, v in options.items():
-        if v.isnumeric():
+        if v.isdigit():
             options[k] = int(v)
 
     return options

--- a/distributed/bokeh/workers/main.py
+++ b/distributed/bokeh/workers/main.py
@@ -4,6 +4,7 @@ from __future__ import print_function, division, absolute_import
 
 import json
 import os
+import sys
 
 from bokeh.io import curdoc
 from bokeh.layouts import column, row
@@ -15,24 +16,17 @@ from distributed.core import rpc
 from distributed.bokeh.worker_monitor import (worker_table_plot,
         worker_table_update, processing_plot, processing_update)
 from distributed.utils import log_errors
+from distributed.bokeh.utils import parse_args
 import distributed.bokeh
 
 SIZING_MODE = 'scale_width'
 WIDTH = 600
 
 messages = distributed.bokeh.messages  # global message store
+
+options = parse_args(sys.argv[1:])
+
 doc = curdoc()
-
-
-dask_dir = os.path.join(os.path.expanduser('~'), '.dask')
-options_path = os.path.join(dask_dir, '.dask-web-ui.json')
-if os.path.exists(options_path):
-    with open(options_path, 'r') as f:
-        options = json.load(f)
-else:
-    options = {'host': '127.0.0.1',
-               'tcp-port': 8786,
-               'http-port': 9786}
 
 scheduler = rpc(ip=options['host'], port=options['tcp-port'])
 

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -12,6 +12,7 @@ if sys.version_info[0] == 2:
     PY2 = True
     PY3 = False
     ConnectionRefusedError = OSError
+    FileExistsError = OSError
 
     import gzip
     def gzip_decompress(b):
@@ -46,6 +47,7 @@ if sys.version_info[0] == 3:
     from gzip import decompress as gzip_decompress
     from gzip import compress as gzip_compress
     ConnectionRefusedError = ConnectionRefusedError
+    FileExistsError = FileExistsError
 
     def isqueue(o):
         return isinstance(o, Queue)

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import os
+from .compatibility import FileExistsError
 try:
     import yaml
 except ImportError:
@@ -15,7 +16,10 @@ else:
         if not os.path.exists(destination):
             import shutil
             if not os.path.exists(os.path.dirname(destination)):
-                os.mkdir(os.path.dirname(destination))
+                try:
+                    os.mkdir(os.path.dirname(destination))
+                except FileExistsError:
+                    pass
             shutil.copy(default_path, destination)
 
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -201,8 +201,6 @@ class Nanny(Server):
                     except queues.Empty:
                         yield gen.sleep(0.1)
 
-
-
             logger.info("Nanny %s:%d starts worker process %s:%d",
                         self.ip, self.port, self.ip, self.worker_port)
             raise gen.Return('OK')
@@ -242,6 +240,8 @@ class Nanny(Server):
     @gen.coroutine
     def _close(self, stream=None, timeout=5, report=None):
         """ Close the nanny process, stop listening """
+        if self.status == 'closed':
+            raise gen.Return('OK')
         logger.info("Closing Nanny at %s:%d", self.ip, self.port)
         self.status = 'closed'
         yield self._kill(timeout=timeout)


### PR DESCRIPTION
We used to generate files in two cases:

1.  the `~/.dask/config.yaml' file
2.  the `~/.dask/.dask-web-ui.yaml` file that held the scheduler address

These would break in some cases when the file system was used simultaneously by several systems.  

In the first case we are now robust to overwrites

In the second case we have switched to using command line arguments in bokeh