### PR TITLE
Pass extra LocalCluster arguments to Worker

### DIFF
--- a/distributed/bokeh/tests/test_application.py
+++ b/distributed/bokeh/tests/test_application.py
@@ -34,8 +34,7 @@ def test_BokehWebInterface(loop):
 
 def test_bokeh_shutsdown_without_cluster___del__(loop):
     c = LocalCluster(2, loop=loop, scheduler_port=0,
-                     services={('http', 0): HTTPScheduler},
-                     diagnostic_port=None)
+                     services={('http', 0): HTTPScheduler})
     proc = c.diagnostics.process
     # don't run the del, as it isn't ever run in python < 3.5 due to cycles
     c.__del__ = lambda self: None

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+from functools import partial
 import logging
 import math
 from threading import Thread
@@ -36,6 +37,8 @@ class LocalCluster(object):
         If False keep the workers in the main calling process
     scheduler_port: int
         Port of the scheduler.  8786 by default, use 0 to choose a random port
+    kwargs: dict
+        Extra worker arguments, will be passed to the Worker constructor.
 
     Examples
     --------
@@ -95,9 +98,9 @@ class LocalCluster(object):
         if start:
             _start_worker = self.start_worker
         else:
-            _start_worker = lambda *args, **kwargs: self.loop.add_callback(self._start_worker, *args, **kwargs)
+            _start_worker = partial(self.loop.add_callback, self._start_worker)
         for i in range(n_workers):
-            _start_worker(ncores=threads_per_worker, nanny=nanny)
+            _start_worker(ncores=threads_per_worker, nanny=nanny, **kwargs)
         self.status = 'running'
 
         self.diagnostics = None

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -12,7 +12,7 @@ from distributed.utils_test import loop, slowinc, gen_test
 
 def test_adaptive_local_cluster(loop):
     with LocalCluster(0, scheduler_port=0, silence_logs=False,
-                      diagnostic_port=None, loop=loop) as cluster:
+                      diagnostics_port=None, loop=loop) as cluster:
         alc = Adaptive(cluster.scheduler, cluster, interval=100)
         with Client(cluster, loop=loop) as c:
             assert not c.ncores()
@@ -37,7 +37,7 @@ def test_adaptive_local_cluster(loop):
 def test_adaptive_local_cluster_multi_workers():
     loop = IOLoop.current()
     cluster = LocalCluster(0, scheduler_port=0, silence_logs=False, nanny=False,
-                      diagnostic_port=None, loop=loop, start=False)
+                           diagnostics_port=None, loop=loop, start=False)
     cluster.scheduler.allowed_failures = 1000
     alc = Adaptive(cluster.scheduler, cluster, interval=100)
     c = Client(cluster, start=False, loop=loop)


### PR DESCRIPTION
This seems to be an oversight -- `LocalCluster` accepts arbitrary additional arguments but didn't do anything with them.
Also fixes a typo in tests (`diagnostic_port` isn't a recognized argument, `diagnostics_port` is).