### PR TITLE
Add h5py custom serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pytest coverage tornado toolz dill futures dask ipywidgets psutil bokeh requests joblib mock ipykernel jupyter_client h5py
+  - conda install pytest coverage tornado toolz dill futures dask ipywidgets psutil bokeh requests joblib mock ipykernel jupyter_client h5py netcdf4
   - pip install git+https://github.com/dask/dask.git --upgrade
   - pip install git+https://github.com/joblib/joblib.git --upgrade
   - pip install git+https://github.com/dask/s3fs.git --upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pytest coverage tornado toolz dill futures dask ipywidgets psutil bokeh requests joblib mock ipykernel jupyter_client
+  - conda install pytest coverage tornado toolz dill futures dask ipywidgets psutil bokeh requests joblib mock ipykernel jupyter_client h5py
   - pip install git+https://github.com/dask/dask.git --upgrade
   - pip install git+https://github.com/joblib/joblib.git --upgrade
   - pip install git+https://github.com/dask/s3fs.git --upgrade

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -148,6 +148,7 @@ class Server(TCPServer):
                     logger.info("Lost connection: %s", str(address))
                     break
                 except Exception as e:
+                    logger.exception(e)
                     yield write(stream, error_message(e, status='uncaught-error'))
                     continue
                 if not isinstance(msg, dict):

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -12,3 +12,6 @@ with ignoring(ImportError):
 
 with ignoring(ImportError):
     from . import h5py
+
+with ignoring(ImportError):
+    from . import netcdf4

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -5,4 +5,10 @@ from .core import dumps, loads, maybe_compress, decompress, msgpack
 from .serialize import (serialize, deserialize, Serialize, Serialized,
     to_serialize, register_serialization)
 
-from . import numpy
+from ..utils  import ignoring
+
+with ignoring(ImportError):
+    from . import numpy
+
+with ignoring(ImportError):
+    from . import h5py

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -52,7 +52,10 @@ def dumps(msg):
                 head['lengths'] = list(map(len, frames))
             if 'compression' not in head:
                 frames = frame_split_size(frames)
-                compression, frames = zip(*map(maybe_compress, frames))
+                if frames:
+                    compression, frames = zip(*map(maybe_compress, frames))
+                else:
+                    compression = []
                 head['compression'] = compression
             head['count'] = len(frames)
             header['headers'][key] = head

--- a/distributed/protocol/h5py.py
+++ b/distributed/protocol/h5py.py
@@ -1,0 +1,40 @@
+from __future__ import print_function, division, absolute_import
+
+from .serialize import register_serialization
+
+from ..utils import log_errors, ensure_bytes
+
+
+def serialize_h5py_file(f):
+    if f.mode != 'r':
+        raise ValueError("Can only serialize read-only h5py files")
+    return {'filename': f.filename}, []
+
+
+def deserialize_h5py_file(header, frames):
+    import h5py
+    return h5py.File(header['filename'], mode='r')
+
+
+register_serialization('h5py._hl.files.File', serialize_h5py_file,
+                       deserialize_h5py_file)
+
+
+
+def serialize_h5py_dataset(x):
+    header, _ = serialize_h5py_file(x.file)
+    header['name'] = x.name
+    return header, []
+
+
+def deserialize_h5py_dataset(header, frames):
+    import h5py
+    file = deserialize_h5py_file(header, frames)
+    return file[header['name']]
+
+
+register_serialization('h5py._hl.dataset.Dataset', serialize_h5py_dataset,
+                       deserialize_h5py_dataset)
+
+register_serialization('h5py._hl.group.Group', serialize_h5py_dataset,
+                       deserialize_h5py_dataset)

--- a/distributed/protocol/netcdf4.py
+++ b/distributed/protocol/netcdf4.py
@@ -1,0 +1,63 @@
+from __future__ import print_function, division, absolute_import
+
+from .serialize import register_serialization, serialize, deserialize
+
+from ..utils import log_errors, ensure_bytes
+
+try:
+    import netCDF4
+    HAS_NETCDF4 = True
+except ImportError:
+    HAS_NETCDF4 = False
+
+
+def serialize_netcdf4_dataset(ds):
+    # assume mode is read-only
+    return {'filename': ds.filepath()}, []
+
+
+def deserialize_netcdf4_dataset(header, frames):
+    import netCDF4
+    return netCDF4.Dataset(header['filename'], mode='r')
+
+
+if HAS_NETCDF4:
+    register_serialization(netCDF4.Dataset, serialize_netcdf4_dataset,
+                           deserialize_netcdf4_dataset)
+
+
+def serialize_netcdf4_variable(x):
+    header, _ = serialize(x.group())
+    header['parent-type'] = header['type']
+    header['name'] = x.name
+    return header, []
+
+
+def deserialize_netcdf4_variable(header, frames):
+    header['type'] = header['parent-type']
+    parent = deserialize(header, frames)
+    return parent.variables[header['name']]
+
+
+if HAS_NETCDF4:
+    register_serialization(netCDF4.Variable, serialize_netcdf4_variable,
+                           deserialize_netcdf4_variable)
+
+
+def serialize_netcdf4_group(g):
+    parent = g
+    while parent.parent:
+        parent = parent.parent
+    header, _ = serialize_netcdf4_dataset(parent)
+    header['path'] = g.path
+    return header, []
+
+
+def deserialize_netcdf4_group(header, frames):
+    file = deserialize_netcdf4_dataset(header, frames)
+    return file[header['path']]
+
+
+if HAS_NETCDF4:
+    register_serialization(netCDF4.Group, serialize_netcdf4_group,
+                           deserialize_netcdf4_group)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -44,7 +44,10 @@ def register_serialization(cls, serialize, deserialize):
     serialize
     deserialize
     """
-    name = typename(cls)
+    if isinstance(cls, type):
+        name = typename(cls)
+    elif isinstance(cls, str):
+        name = cls
     serializers[name] = serialize
     deserializers[name] = deserialize
 

--- a/distributed/protocol/tests/test_h5py.py
+++ b/distributed/protocol/tests/test_h5py.py
@@ -1,0 +1,81 @@
+import pytest
+
+h5py = pytest.importorskip('h5py')
+
+from distributed.protocol import serialize, deserialize, dumps, loads
+
+from distributed.utils import tmpfile
+
+
+def test_serialize_deserialize_file():
+    with tmpfile() as fn:
+        with h5py.File(fn, mode='a') as f:
+            f.create_dataset('/x', shape=(2, 2), dtype='i4')
+        with h5py.File(fn, mode='r') as f:
+            g = deserialize(*serialize(f))
+            assert f.filename == g.filename
+            assert isinstance(g, h5py.File)
+            assert f.mode == g.mode
+
+            assert g['x'].shape == (2, 2)
+
+
+def test_serialize_deserialize_group():
+    with tmpfile() as fn:
+        with h5py.File(fn, mode='a') as f:
+            f.create_dataset('/group1/group2/x', shape=(2, 2), dtype='i4')
+        with h5py.File(fn, mode='r') as f:
+            group = f['/group1/group2']
+            group2 = deserialize(*serialize(group))
+
+            assert isinstance(group2, h5py.Group)
+            assert group.file.filename == group2.file.filename
+
+            assert group2['x'].shape == (2, 2)
+
+
+def test_serialize_deserialize_dataset():
+    with tmpfile() as fn:
+        with h5py.File(fn, mode='a') as f:
+            x = f.create_dataset('/group1/group2/x', shape=(2, 2), dtype='i4')
+        with h5py.File(fn, mode='r') as f:
+            x = f['group1/group2/x']
+            y = deserialize(*serialize(x))
+            assert isinstance(y, h5py.Dataset)
+            assert x.name == y.name
+            assert x.file.filename == y.file.filename
+            assert (x[:] == y[:]).all()
+
+
+def test_raise_error_on_serialize_write_permissions():
+    with tmpfile() as fn:
+        with h5py.File(fn, mode='a') as f:
+            x = f.create_dataset('/x', shape=(2, 2), dtype='i4')
+            f.flush()
+            with pytest.raises(ValueError):
+                serialize(x)
+            with pytest.raises(ValueError):
+                serialize(f)
+
+
+from distributed.utils_test import gen_cluster
+from distributed.client import _wait
+
+from tornado import gen
+
+import dask.array as da
+
+@gen_cluster(client=True)
+def test_h5py_serialize(c, s, a, b):
+    with tmpfile() as fn:
+        with h5py.File(fn, mode='a') as f:
+            x = f.create_dataset('/group/x', shape=(4,), dtype='i4',
+                                 chunks=(2,))
+            x[:] = [1, 2, 3, 4]
+            f.flush()
+        with h5py.File(fn, mode='r') as f:
+            dset = f['/group/x']
+            x = da.from_array(dset, chunks=x.chunks)
+            y = c.compute(x)
+            y = yield y._result()
+            assert (y[:] == dset[:]).all()

--- a/distributed/protocol/tests/test_netcdf4.py
+++ b/distributed/protocol/tests/test_netcdf4.py
@@ -1,0 +1,94 @@
+import pytest
+
+netCDF4 = pytest.importorskip('netCDF4')
+np = pytest.importorskip('numpy')
+
+from distributed.protocol import serialize, deserialize, dumps, loads
+
+from distributed.utils import tmpfile
+import distributed.protocol.netcdf4
+
+
+def create_test_dataset(fn):
+    with netCDF4.Dataset(fn, mode='w') as ds:
+        ds.createDimension('x', 3)
+        v = ds.createVariable('x', np.int32, ('x',))
+        v[:] = np.arange(3)
+
+        g = ds.createGroup('group')
+        g2 = ds.createGroup('group/group1')
+
+        v2 = ds.createVariable('group/y', np.int32, ('x',))
+        v2[:] = np.arange(3) + 1
+
+        v3 = ds.createVariable('group/group1/z', np.int32, ('x',))
+        v3[:] = np.arange(3) + 2
+
+
+def test_serialize_deserialize_dataset():
+    with tmpfile() as fn:
+        create_test_dataset(fn)
+        with netCDF4.Dataset(fn, mode='r') as f:
+            g = deserialize(*serialize(f))
+            assert f.filepath() == g.filepath()
+            assert isinstance(g, netCDF4.Dataset)
+
+            assert g.variables['x'].dimensions == ('x',)
+            assert g.variables['x'].dtype == np.int32
+            assert (g.variables['x'][:] == np.arange(3)).all()
+
+
+def test_serialize_deserialize_variable():
+    with tmpfile() as fn:
+        create_test_dataset(fn)
+        with netCDF4.Dataset(fn, mode='r') as f:
+            x = f.variables['x']
+            y = deserialize(*serialize(x))
+            assert isinstance(y, netCDF4.Variable)
+            assert y.dimensions == ('x',)
+            assert (x.dtype == y.dtype)
+            assert (x[:] == y[:]).all()
+
+
+def test_serialize_deserialize_group():
+    with tmpfile() as fn:
+        create_test_dataset(fn)
+        with netCDF4.Dataset(fn, mode='r') as f:
+            for path in ['group', 'group/group1']:
+                g = f[path]
+                h = deserialize(*serialize(g))
+                assert isinstance(h, netCDF4.Group)
+                assert h.name == g.name
+                assert list(g.groups) == list(h.groups)
+                assert list(g.variables) == list(h.variables)
+
+            vars = [f.variables['x'],
+                    f['group'].variables['y'],
+                    f['group/group1'].variables['z']]
+
+            for x in vars:
+                y = deserialize(*serialize(x))
+                assert isinstance(y, netCDF4.Variable)
+                assert y.dimensions == ('x',)
+                assert (x.dtype == y.dtype)
+                assert (x[:] == y[:]).all()
+
+
+from distributed.utils_test import gen_cluster
+from distributed.client import _wait
+
+from tornado import gen
+
+import dask.array as da
+
+
+@gen_cluster(client=True)
+def test_netcdf4_serialize(c, s, a, b):
+    with tmpfile() as fn:
+        create_test_dataset(fn)
+        with netCDF4.Dataset(fn, mode='r') as f:
+            dset = f.variables['x']
+            x = da.from_array(dset, chunks=2)
+            y = c.compute(x)
+            y = yield y._result()
+            assert (y[:] == dset[:]).all()

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -16,6 +16,9 @@ def frame_split_size(frames, n=BIG_BYTES_SHARD_SIZE):
     >>> frame_split_size([b'12345', b'678'], n=3)  # doctest: +SKIP
     [b'123', b'45', b'678']
     """
+    if not frames:
+        return frames
+
     if max(map(len, frames)) <= n:
         return frames
 
@@ -44,6 +47,9 @@ def merge_frames(header, frames):
     lengths = list(header['lengths'])[::-1]
     frames = list(frames)[::-1]
 
+    if not frames:
+        return frames
+
     assert sum(lengths) == sum(map(len, frames))
 
     if all(len(f) == l for f, l in zip(frames, lengths)):
@@ -65,4 +71,3 @@ def merge_frames(header, frames):
                 l = 0
         out.append(b''.join(map(ensure_bytes, L)))
     return out
-


### PR DESCRIPTION
This allows H5Py dataset objects to be used in dask.distributed, despite not being picklable.  We use the recent custom serialization change in #606 to encode a dataset object as the filename and datapath.  

This is a proof of concept for solving https://github.com/pydata/xarray/issues/798

cc @shoyer if would be good to get your input on this before this weekend