### PR TITLE
Use a default StreamHandler for all loggers

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -360,7 +360,7 @@ def str_graph(dsk, extra_values=()):
 import logging
 from .compatibility import logging_names
 
-handler = logging.StreamHandler(sys.stdout)
+handler = logging.StreamHandler(sys.stderr)
 handler.setLevel(logging.INFO)
 fmt = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
 handler.setFormatter(fmt)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -360,7 +360,7 @@ def str_graph(dsk, extra_values=()):
 import logging
 from .compatibility import logging_names
 
-handler = logging.StreamHandler()
+handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.INFO)
 fmt = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
 handler.setFormatter(fmt)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -359,12 +359,17 @@ def str_graph(dsk, extra_values=()):
 
 import logging
 from .compatibility import logging_names
-logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s',
-                    level=logging.INFO)
+
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
+fmt = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(fmt)
 
 for name, level in config.get('logging', {}).items():
     LEVEL = logging_names[level.upper()]
-    logging.getLogger(name).setLevel(LEVEL)
+    logger = logging.getLogger(name)
+    logger.setLevel(LEVEL)
+    logger.addHandler(handler)
 
 # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
 stream = logging.StreamHandler(sys.stderr)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -360,16 +360,19 @@ def str_graph(dsk, extra_values=()):
 import logging
 from .compatibility import logging_names
 
-handler = logging.StreamHandler(sys.stderr)
-handler.setLevel(logging.INFO)
-fmt = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
-handler.setFormatter(fmt)
-
-for name, level in config.get('logging', {}).items():
-    LEVEL = logging_names[level.upper()]
-    logger = logging.getLogger(name)
-    logger.setLevel(LEVEL)
-    logger.addHandler(handler)
+loggers = config.get('logging', None)
+fmt = '%(name)s - %(levelname)s - %(message)s'
+if loggers is None:
+    logging.basicConfig(format=fmt, level=logging.INFO)
+else:
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter(fmt))
+    for name, level in loggers.items():
+        LEVEL = logging_names[level.upper()]
+        logger = logging.getLogger(name)
+        logger.setLevel(LEVEL)
+        logger.addHandler(handler)
 
 # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
 stream = logging.StreamHandler(sys.stderr)


### PR DESCRIPTION
- Remove use of basicConfig which can affect the root logger