### PR TITLE
Support itemsize for large dtypes

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -74,7 +74,8 @@ def byte_sample(b, size, n):
         ends.append(min(start + size, starts[i + 1]))
     ends.append(starts[-1] + size)
 
-    return b''.join([b[start:end] for start, end in zip(starts, ends)])
+    parts = [b[start:end] for start, end in zip(starts, ends)]
+    return b''.join(map(ensure_bytes, parts))
 
 
 def maybe_compress(payload, compression=default_compression, min_size=1e4,

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -17,11 +17,24 @@ from . import pickle
 from ..utils import log_errors, ensure_bytes
 
 
+def itemsize(dt):
+    """ Itemsize of dtype
+
+    Try to return the itemsize of the base element, return 8 as a fallback
+    """
+    result = dt.base.itemsize
+    if result > 255:
+        result = 8
+    return result
+
+
 def serialize_numpy_ndarray(x):
     if x.dtype.hasobject:
         header = {'pickle': True}
         frames = [pickle.dumps(x)]
         return header, frames
+
+    size = itemsize(x.dtype)
 
     if x.dtype.kind == 'V':
         dt = x.dtype.descr
@@ -38,7 +51,7 @@ def serialize_numpy_ndarray(x):
         frames = frame_split_size([x.data])
         if sys.version_info.major == 2:
             frames = [ensure_bytes(frame) for frame in frames]
-        frames = [blosc.compress(frame, typesize=x.dtype.itemsize,
+        frames = [blosc.compress(frame, typesize=size,
                                  cname='lz4', clevel=5) for frame in frames]
         header['compression'] = ['blosc'] * len(frames)
     else:

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -9,6 +9,7 @@ from distributed.protocol.utils import BIG_BYTES_SHARD_SIZE
 from distributed.utils import tmpfile
 from distributed.utils_test import slow
 from distributed.protocol.numpy import itemsize
+from distributed.protocol.compression import maybe_compress
 
 import distributed.protocol.numpy
 
@@ -84,3 +85,17 @@ def test_dumps_serialize_numpy_large():
 
 def test_itemsize(dt, size):
     assert itemsize(np.dtype(dt)) == size
+
+
+def test_compress_numpy():
+    x = np.ones(10000000, dtype='i4')
+    compression, compressed = maybe_compress(x.data)
+    if compression:
+        assert len(compressed) < x.nbytes
+
+
+def test_compress_memoryview():
+    mv = memoryview(b'0' * 1000000)
+    compression, compressed = maybe_compress(mv)
+    if compression:
+        assert len(compressed) < len(mv)


### PR DESCRIPTION
Blosc fails for itemsizes greater than 255.  This defends against that case and
helps to improve itemsize identification across a broader range of dtypes.