### PR TITLE
Add timedelta and timeout handling to batched send_next

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -43,7 +43,8 @@ class BatchedSend(object):
         self.stream = None
         self.last_payload = []
         self.last_send = gen.sleep(0)
-        self.count = 0
+        self.message_count = 0
+        self.batch_count = 0
 
     def start(self, stream):
         self.stream = stream
@@ -64,17 +65,15 @@ class BatchedSend(object):
                                 self.interval)
                 yield gen.sleep(wait_time)
             while self.stream._write_buffer:
-                print('waiting')
                 try:
                     yield gen.with_timeout(timedelta(milliseconds=10),
                                            self.last_send)  # hangs otherwise?
                 except gen.TimeoutError:
                     pass
-            print('cleared')
             self.buffer, payload = [], self.buffer
             self.last_payload = payload
             self.last_transmission = now
-            self.count += 1
+            self.batch_count += 1
             self.last_send = write(self.stream, payload)
         except Exception as e:
             logger.exception(e)
@@ -91,6 +90,7 @@ class BatchedSend(object):
         This completes quickly and synchronously
         """
         try:
+            self.message_count += 1
             if self.stream is None:  # not yet started
                 self.buffer.append(msg)
                 return
@@ -121,7 +121,8 @@ class BatchedSend(object):
     def close(self, ignore_closed=False):
         """ Flush existing messages and then close stream """
         try:
-            yield self.last_send
+            if self.stream._write_buffer:
+                yield self.last_send
             if self.buffer:
                 self.buffer, payload = [], self.buffer
                 yield write(self.stream, payload)

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+from datetime import timedelta
 import logging
 from timeit import default_timer
 
@@ -62,8 +63,11 @@ class BatchedSend(object):
                                 self.interval)
                 yield gen.sleep(wait_time)
             while self.stream._write_buffer:
-                yield gen.with_timeout(timedelta(milliseconds=10),
-                                       self.last_send)  # hangs otherwise?
+                try:
+                    yield gen.with_timeout(timedelta(milliseconds=10),
+                                           self.last_send)  # hangs otherwise?
+                except gen.TimeoutError:
+                    pass
             self.buffer, payload = [], self.buffer
             self.last_payload = payload
             self.last_transmission = now

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -246,8 +246,7 @@ def test_stress():
 def test_sending_traffic_jam():
     np = pytest.importorskip('numpy')
     from distributed.protocol import to_serialize
-    data = np.random.randint(0, 255, dtype='u1',
-            size=(300000,)).data.tobytes()
+    data = bytes(np.random.randint(0, 255, size=(300000,)).astype('u1').data)
     with echo_server() as e:
         client = TCPClient()
         stream = yield client.connect('127.0.0.1', e.port)

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -5,7 +5,7 @@ import random
 from time import time
 
 import pytest
-from toolz import first
+from toolz import first, assoc
 from tornado import gen
 from tornado.tcpserver import TCPServer
 from tornado.tcpclient import TCPClient
@@ -32,9 +32,15 @@ class EchoServer(TCPServer):
     @gen.coroutine
     def handle_stream(self, stream, address):
         while True:
-            msg = yield read(stream)
-            self.count += 1
-            yield write(stream, msg)
+            try:
+                msg = yield read(stream)
+                self.count += 1
+                yield write(stream, msg)
+            except StreamClosedError as e:
+                pass
+            except Exception as e:
+                import pdb; pdb.set_trace()
+                raise
 
     def listen(self, port=0):
         while True:
@@ -238,3 +244,39 @@ def test_stress():
 
         assert L == list(range(0, 10000, 1))
         stream.close()
+
+
+@gen_test(timeout=20)
+def test_sending_traffic_jam():
+    np = pytest.importorskip('numpy')
+    from distributed.protocol import to_serialize
+    data = np.random.randint(0, 255, dtype='u1',
+            size=(300000,)).data.tobytes()
+    with echo_server() as e:
+        client = TCPClient()
+        stream = yield client.connect('127.0.0.1', e.port)
+
+        b = BatchedSend(interval=0.001)
+        b.start(stream)
+        yield b.last_send
+
+        n = 50
+
+        msg = {'x': to_serialize(data)}
+        for i in range(n):
+            b.send(assoc(msg, 'i', i))
+            yield gen.sleep(0.005)
+
+        results = []
+        count = 0
+        while len(results) < n:
+            L = yield gen.with_timeout(timedelta(seconds=5), read(stream))
+            count += 1
+            results.extend(L)
+
+        assert count == b.count == e.count
+
+        assert [r['i'] for r in results] == list(range(50))
+
+        stream.close()
+        yield b.close(ignore_closed=True)


### PR DESCRIPTION
There was a strict missing import in the batched send code.

It's surprising/concerning that the test suite didn't catch this.

I would expect it to occur during communication heavy workloads on batched
channels, such as on scheduler-worker or client-scheduler channels.