### PR TITLE
Add more information to worker logging startup

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -231,6 +231,12 @@ class Worker(Server):
             logger.info('  %16s at: %20s:%d' % (k, self.ip, v))
         logger.info('Waiting to connect to: %20s:%d',
                     self.scheduler.ip, self.scheduler.port)
+        logger.info('-' * 49)
+        logger.info('              Threads: %26d', self.ncores)
+        if self.memory_limit:
+            logger.info('               Memory: %23.2f GB', self.memory_limit / 1e9)
+        logger.info('      Local Directory: %26s', self.local_dir)
+        logger.info('-' * 49)
         while True:
             try:
                 resp = yield self.scheduler.register(
@@ -250,6 +256,7 @@ class Worker(Server):
             raise ValueError(resp)
         logger.info('        Registered to: %20s:%d',
                     self.scheduler.ip, self.scheduler.port)
+        logger.info('-' * 49)
         self.status = 'running'
 
     def start(self, port=0):


### PR DESCRIPTION
```
mrocklin@carbon:~/workspace/distributed$ dask-worker localhost:8786
distributed.nanny - INFO -         Start Nanny at:            127.0.0.1:46062
distributed.worker - INFO -       Start worker at:            127.0.0.1:42389
distributed.worker - INFO -              nanny at:            127.0.0.1:46062
distributed.worker - INFO -               http at:            127.0.0.1:44482
distributed.worker - INFO - Waiting to connect to:            127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -               Threads:                          4
distributed.worker - INFO -                Memory:                   10.01 GB
distributed.worker - INFO -       Local Directory:        /tmp/nanny-cj7jhg1c
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -         Registered to:            127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.core - INFO - Connection from 127.0.0.1:49746 to Worker
```