### PR TITLE
Add --no-reconnect flag to dask-worker

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -167,7 +167,7 @@ class Nanny(Server):
             self.environment = environment
 
         with log_errors():
-            if self.process and isalive(self.process):
+            if isalive(self.process):
                 raise ValueError("Existing process still alive. Please kill first")
 
             if self.environment != nanny_environment:
@@ -376,7 +376,9 @@ def run_worker_fork(q, ip, scheduler_ip, scheduler_port, ncores, nanny_port,
 
 
 def isalive(proc):
-    if isinstance(proc, subprocess.Popen):
+    if proc is None:
+        return False
+    elif isinstance(proc, subprocess.Popen):
         return proc.poll() is None
     else:
         return proc.is_alive()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -33,12 +33,13 @@ class Nanny(Server):
     """
     def __init__(self, scheduler_ip, scheduler_port, ip=None, worker_port=0,
                  ncores=None, loop=None, local_dir=None, services=None,
-                 name=None, memory_limit=TOTAL_MEMORY,
+                 name=None, memory_limit=TOTAL_MEMORY, reconnect=True,
                  environment=nanny_environment, quiet=False, **kwargs):
         self.ip = ip or get_ip()
         self.worker_port = None
         self._given_worker_port = worker_port
         self.ncores = ncores or _ncores
+        self.reconnect = reconnect
         if not local_dir:
             local_dir = tempfile.mkdtemp(prefix='nanny-')
             self._should_cleanup_local_dir = True
@@ -192,7 +193,7 @@ class Nanny(Server):
                                              self.scheduler.port, self.ncores,
                                              self.port, self._given_worker_port,
                                              self.local_dir, self.services, self.name,
-                                             self.memory_limit))
+                                             self.memory_limit, self.reconnect))
                 self.process.daemon = True
                 self.process.start()
                 while True:
@@ -235,10 +236,17 @@ class Nanny(Server):
                 yield self._close()
                 break
             elif self.process and not isalive(self.process):
-                logger.warn("Discovered failed worker.  Restarting. Status: %s",
-                            self.status)
+                logger.warn("Discovered failed worker")
                 self.cleanup()
-                yield self.scheduler.unregister(address=self.worker_address)
+                try:
+                    yield self.scheduler.unregister(address=self.worker_address)
+                except StreamClosedError:
+                    if self.reconnect:
+                        yield gen.sleep(wait_seconds)
+                    else:
+                        yield self._close()
+                        break
+                logger.warn('Restarting worker...')
                 yield self.instantiate()
             else:
                 yield gen.sleep(wait_seconds)
@@ -329,7 +337,7 @@ def run_worker_subprocess(environment, ip, scheduler_ip, scheduler_port, ncores,
 
 
 def run_worker_fork(q, ip, scheduler_ip, scheduler_port, ncores, nanny_port,
-        worker_port, local_dir, services, name, memory_limit):
+        worker_port, local_dir, services, name, memory_limit, reconnect):
     """ Function run by the Nanny when creating the worker """
     from distributed import Worker  # pragma: no cover
     from tornado.ioloop import IOLoop  # pragma: no cover
@@ -339,10 +347,10 @@ def run_worker_fork(q, ip, scheduler_ip, scheduler_port, ncores, nanny_port,
     worker = Worker(scheduler_ip, scheduler_port, ncores=ncores, ip=ip,
                     service_ports={'nanny': nanny_port}, local_dir=local_dir,
                     services=services, name=name, memory_limit=memory_limit,
-                    loop=loop)  # pragma: no cover
+                    reconnect=reconnect, loop=loop)  # pragma: no cover
 
     @gen.coroutine  # pragma: no cover
-    def start():
+    def run():
         try:  # pragma: no cover
             yield worker._start(worker_port)  # pragma: no cover
         except Exception as e:  # pragma: no cover
@@ -352,9 +360,13 @@ def run_worker_fork(q, ip, scheduler_ip, scheduler_port, ncores, nanny_port,
             assert worker.port  # pragma: no cover
             q.put({'port': worker.port, 'dir': worker.local_dir})  # pragma: no cover
 
-    loop.add_callback(start)  # pragma: no cover
+        while worker.status != 'closed':
+            yield gen.sleep(0.1)
+
+        logger.info("Worker closed")
+
     try:
-        loop.start()  # pragma: no cover
+        loop.run_sync(run)
     finally:
         loop.stop()
         loop.close(all_fds=True)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -150,5 +150,3 @@ def test_close_on_disconnect(s, w):
     while w.status != 'closed':
         yield gen.sleep(0.01)
         assert time() < start + 5
-
-    import pdb; pdb.set_trace()

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -137,3 +137,18 @@ def test_run(s):
         assert response['result'] == 1
 
     yield n._close()
+
+
+
+@gen_cluster(Worker=Nanny,
+             ncores=[('127.0.0.1', 1)],
+             worker_kwargs={'reconnect': False})
+def test_close_on_disconnect(s, w):
+    yield s.close()
+
+    start = time()
+    while w.status != 'closed':
+        yield gen.sleep(0.01)
+        assert time() < start + 5
+
+    import pdb; pdb.set_trace()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import sys
+from time import time
 import traceback
 
 import pytest
@@ -575,3 +576,14 @@ def test_str(c, s, w):
     y = c.persist(x)
     yield _wait(y)
     assert len(w.data.slow)  # something is on disk
+
+
+@gen_cluster(ncores=[('127.0.0.1', 1)],
+             worker_kwargs={'reconnect': False})
+def test_close_on_disconnect(s, w):
+    yield s.close()
+
+    start = time()
+    while w.status != 'closed':
+        yield gen.sleep(0.01)
+        assert time() < start + 5

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -318,10 +318,12 @@ from .worker import Worker
 from .client import Client
 
 @gen.coroutine
-def start_cluster(ncores, loop, Worker=Worker, scheduler_kwargs={}):
+def start_cluster(ncores, loop, Worker=Worker, scheduler_kwargs={},
+                  worker_kwargs={}):
     s = Scheduler(ip='127.0.0.1', loop=loop, validate=True, **scheduler_kwargs)
     done = s.start(0)
-    workers = [Worker(s.ip, s.port, ncores=v, ip=k, name=i, loop=loop)
+    workers = [Worker(s.ip, s.port, ncores=v, ip=k, name=i, loop=loop,
+                      **worker_kwargs)
                 for i, (k, v) in enumerate(ncores)]
     for w in workers:
         w.rpc = workers[0].rpc
@@ -349,7 +351,7 @@ def end_cluster(s, workers):
 
 
 def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)], timeout=10,
-        Worker=Worker, client=False, scheduler_kwargs={}):
+        Worker=Worker, client=False, scheduler_kwargs={}, worker_kwargs={}):
     from distributed import Client
     """ Coroutine test with small cluster
 
@@ -371,7 +373,8 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)], timeout=10,
             loop.make_current()
 
             s, workers = loop.run_sync(lambda: start_cluster(ncores, loop,
-                            Worker=Worker, scheduler_kwargs=scheduler_kwargs))
+                            Worker=Worker, scheduler_kwargs=scheduler_kwargs,
+                            worker_kwargs=worker_kwargs))
             args = [s] + workers
 
             if client:


### PR DESCRIPTION
Usually when a worker loses communication with the scheduler it sticks around trying to reconnect.  This adds an option to workers, nannies, and the dask-worker CLI to avoid this feature if desired.  

This tends to be useful in some cluster deployments when you want the workers to clean themselves up gracefully when the scheduler dies.

    dask-worker scheduler:8786 --no-reconnect