### PR TITLE
WIP: Use Arrow for Pandas serialization

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -15,3 +15,6 @@ with ignoring(ImportError):
 
 with ignoring(ImportError):
     from . import netcdf4
+
+with ignoring(ImportError):
+    from . import pandas

--- a/distributed/protocol/pandas.py
+++ b/distributed/protocol/pandas.py
@@ -1,0 +1,48 @@
+from __future__ import print_function, division, absolute_import
+
+from .serialize import register_serialization
+
+import pandas as pd
+from io import BytesIO
+
+import pyarrow as pa
+import pyarrow.io as io
+import pyarrow.ipc as ipc
+
+
+def serialize_pandas_dataframe(df):
+    batch = pa.RecordBatch.from_pandas(df)
+    buf = BytesIO()
+    writer = ipc.ArrowFileWriter(buf, batch.schema)
+    writer.write_record_batch(batch)
+    writer.close()
+    frames = [buf.getvalue()]  # is there a memoryview we can pass instead?
+    header = {}
+
+    return header, frames
+
+
+def deserialize_pandas_dataframe(header, frames):
+    buf = frames[0]
+    reader = ipc.ArrowFileReader(buf)
+    return [reader.get_record_batch(i).to_pandas()
+            for i in range(reader.num_record_batches)][0]  # what is each batch?
+
+
+register_serialization(pd.DataFrame,
+                       serialize_pandas_dataframe,
+                       deserialize_pandas_dataframe)
+
+
+def serialize_pandas_series(s):
+    return serialize_pandas_dataframe(s.to_frame())  # unfortunate copy here
+
+
+def deserialize_pandas_series(header, frames):
+    df = deserialize_pandas_dataframe(header, frames)
+    return df[df.columns[0]]  # unfortunate copy here
+
+
+register_serialization(pd.Series,
+                       serialize_pandas_series,
+                       deserialize_pandas_series)

--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -1,0 +1,34 @@
+from __future__ import print_function, division, absolute_import
+
+import pytest
+
+pd = pytest.importorskip('pandas')
+
+from dask.dataframe.utils import assert_eq
+from distributed.protocol import serialize, deserialize
+
+
+examples = []
+
+df = pd.DataFrame({'x': [1, 2, 3],
+                   'y': ['a', 'b', 'c'],
+                   'z': ['a', 'a', 'b'],
+                   'w': [1.0, 2.0, 3.0]})
+examples.append(df)
+
+for col in df.columns:
+    examples.append(df[col])
+
+
+examples.append(pytest.mark.xfail(df.z.astype('category')))
+
+df = pd.DataFrame({}, index=[10, 20, 30])
+examples.append(pytest.mark.xfail(df))
+
+
+@pytest.mark.parametrize('df', examples)
+def test_simple(df):
+    header, frames = serialize(df)
+    assert header['type']
+    df2 = deserialize(header, frames)
+    assert_eq(df, df2)


### PR DESCRIPTION
This adds experimental support for custom Pandas serialization using Arrow.

There is some missing functionality here.  I'm not sure if this is due to things missing within Arrow or my naive use of arrow (I'm just copy-pasting a solution from #614 ):

1.  Indexes
2.  Categoricals
3.  Series without an extra copy

cc @wesm