### PR TITLE
(WIP) Make filesystem wrapper for hdfs to match changes in dask bytes

### DIFF
--- a/continuous_integration/Dockerfile
+++ b/continuous_integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:14.04
 
 # conda
 RUN apt-get update && apt-get install -y -q curl bzip2 git
@@ -8,20 +8,20 @@ RUN rm /tmp/miniconda.sh
 ENV PATH /opt/conda/bin:$PATH
 
 # hdfs3 - python 2
-RUN apt-get install -y -q protobuf-compiler libprotobuf-dev
+RUN apt-get install -y -q protobuf-compiler libprotobuf-dev --fix-missing
 ENV LIBHDFS3_CONF /etc/hadoop/conf/hdfs-site.xml
 RUN /opt/conda/bin/conda install -y -q libxml2 krb5 boost ipython pytest pip pandas cython mock
 RUN /opt/conda/bin/conda install -y -q libhdfs3 libgsasl libntlm -c dask
 RUN /opt/conda/bin/pip install git+https://github.com/dask/hdfs3 --upgrade
 RUN /opt/conda/bin/pip install git+https://github.com/dask/s3fs --upgrade
-RUN /opt/conda/bin/pip install git+https://github.com/blaze/dask --upgrade
+RUN /opt/conda/bin/pip install git+https://github.com/dask/dask --upgrade
 # hdfs3 - python 3
 RUN conda create -n py3 -y python=3
 RUN conda install -n py3 -y -q libxml2 krb5 boost ipython pytest pip pandas cython mock
 RUN conda install -n py3 libhdfs3 libgsasl libntlm -c dask
 RUN /opt/conda/envs/py3/bin/pip install git+https://github.com/dask/hdfs3 --upgrade
 RUN /opt/conda/envs/py3/bin/pip install git+https://github.com/dask/s3fs --upgrade
-RUN /opt/conda/envs/py3/bin/pip install git+https://github.com/blaze/dask --upgrade
+RUN /opt/conda/envs/py3/bin/pip install git+https://github.com/dask/dask --upgrade
 
 # Cloudera repositories
 RUN curl -s http://archive.cloudera.com/cdh5/ubuntu/trusty/amd64/cdh/archive.key | apt-key add -

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -8,6 +8,8 @@ from warnings import warn
 
 import dask.bytes.core
 from dask.delayed import delayed
+from dask.base import tokenize
+from dask.bytes import core
 from toolz import merge
 from hdfs3 import HDFileSystem
 
@@ -17,123 +19,59 @@ from .client import default_client, ensure_default_get
 logger = logging.getLogger(__name__)
 
 
-def walk_glob(hdfs, path):
-    if '*' not in path and hdfs.info(path)['kind'] == 'directory':
-        return sorted([fn for fn in hdfs.walk(path) if fn[-1] != '/'])
-    else:
-        return sorted(hdfs.glob(path))
+class DaskHDFSFileSystem(HDFileSystem):
+
+    sep = '/'
+
+    def __init__(self, **kwargs):
+        kwargs2 = {k: v for k, v in kwargs.items()
+                   if k in ['host', 'port', 'user', 'ticket_cache',
+                            'token', 'pars']}
+        HDFileSystem.__init__(self, connect=True, **kwargs2)
+
+    def open(self, path, mode='rb', **kwargs):
+        if path.startswith('hdfs://'):
+            path = path[len('hdfs://'):]
+        return HDFileSystem.open(self, path, mode, **kwargs)
+
+    def mkdirs(self, path):
+        if path.startswith('hdfs://'):
+            path = path[len('hdfs://'):]
+        part = ['']
+        for parts in path.split('/'):
+            part.append(parts)
+            try:
+                self.mkdir('/'.join(part))
+            except:
+                pass
+
+    def glob(self, path):
+        if path.startswith('hdfs://'):
+            path = path[len('hdfs://'):]
+        return HDFileSystem.glob(self, path)
+
+    def ukey(self, path):
+        if path.startswith('hdfs://'):
+            path = path[len('hdfs://'):]
+        return tokenize(path, self.info(path)['last_mod'])
+
+    def size(self, path):
+        if path.startswith('hdfs://'):
+            path = path[len('hdfs://'):]
+        return self.info(path)['size']
+
+    def get_block_locations(self, paths):
+        offsets = []
+        lengths = []
+        machines = []
+        for path in paths:
+            if path.startswith('hdfs://'):
+                path = path[len('hdfs://'):]
+            out = HDFileSystem.get_block_locations(self, path)
+            offsets.append([o['offset'] for o in out])
+            lengths.append([o['length'] for o in out])
+            machines.append([o['hosts'] for o in out])
+        return offsets, lengths, machines
 
 
-def get_block_locations(hdfs, filename):
-    """ Get block locations from a filename or globstring """
-    return [merge({'filename': fn}, block)
-            for fn in walk_glob(hdfs, filename)
-            for block in hdfs.get_block_locations(fn)]
-
-
-def read_block_from_hdfs(filename, offset, length, host=None, port=None,
-        delimiter=None):
-    from locket import lock_file
-    with lock_file('.lock'):
-        hdfs = HDFileSystem(host=host, port=port)
-        bytes = hdfs.read_block(filename, offset, length, delimiter)
-    return bytes
-
-
-def open_file_write(paths, hdfs=None, **kwargs):
-    """ Open list of files using delayed """
-    if hdfs is None:
-        hdfs = HDFileSystem(kwargs.get('host'), kwargs.get('port'))
-    out = [delayed(hdfs.open)(path, 'wb') for path in paths]
-    return out
-
-
-def open_file_write_direct(path, hdfs=None, **kwargs):
-    if hdfs is None:
-        hdfs = HDFileSystem(kwargs.get('host'), kwargs.get('port'))
-    return hdfs.open(path, 'wb')
-
-dask.bytes.core._open_files_write['hdfs'] = open_file_write_direct
-
-
-def read_bytes(path, client=None, hdfs=None, lazy=True, delimiter=None,
-               not_zero=False, sample=True, blocksize=None, compression=None, **hdfs_auth):
-    """ Convert location in HDFS to a list of distributed futures
-
-    Parameters
-    ----------
-    path: string
-        location in HDFS
-    client: Client (optional)
-        defaults to most recently created client
-    hdfs: HDFileSystem (optional)
-    lazy: boolean (optional)
-        If True then return lazily evaluated dask Values
-    delimiter: bytes
-        An optional delimiter, like ``b'\n'`` on which to split blocks of bytes
-    not_zero: force seek of start-of-file delimiter, discarding header
-    **hdfs_auth: keyword arguments
-        Extra keywords to send to ``hdfs3.HDFileSystem``
-
-    Returns
-    -------
-    List of ``distributed.Future`` objects if ``lazy=False``
-    or ``dask.Value`` objects if ``lazy=True``
-    """
-    if compression:
-        raise NotImplementedError("hdfs compression")
-    hdfs = hdfs or HDFileSystem(**hdfs_auth)
-    client = default_client(client)
-    blocks = get_block_locations(hdfs, path)
-    filenames = [d['filename'] for d in blocks]
-    offsets = [d['offset'] for d in blocks]
-    if not_zero:
-        offsets = [max([o, 1]) for o in offsets]
-    lengths = [d['length'] for d in blocks]
-    workers = [[h.decode() for h in d['hosts']] for d in blocks]
-
-    logger.debug("Read %d blocks of binary bytes from %s", len(blocks), path)
-
-    if sample is True:
-        sample = 10000
-    if sample:
-        with hdfs.open(filenames[0], 'rb') as f:
-            sample = f.read(sample)
-    else:
-        sample = b''
-
-    f = delayed(read_block_from_hdfs, pure=True)
-    values = [f(fn, offset, length, hdfs.host, hdfs.port, delimiter)
-              for fn, offset, length in zip(filenames, offsets, lengths)]
-
-    restrictions = {v.key: w for v, w in zip(values, workers)}
-
-    client._send_to_scheduler({'op': 'update-graph',
-                                 'tasks': {},
-                                 'dependencies': [],
-                                 'keys': [],
-                                 'restrictions': restrictions,
-                                 'loose_restrictions': list(restrictions),
-                                 'client': client.id})
-
-    return sample, values
-
-dask.bytes.core._read_bytes['hdfs'] = read_bytes
-
-
-def hdfs_open_file(path, auth):
-    hdfs = HDFileSystem(**auth)
-    return hdfs.open(path, mode='rb')
-
-
-def open_files(path, hdfs=None, lazy=None, **auth):
-    if lazy is not None:
-        raise DeprecationWarning("Lazy keyword has been deprecated. "
-                                 "Now always lazy")
-    hdfs = hdfs or HDFileSystem(**auth)
-    filenames = sorted(hdfs.glob(path))
-    myopen = delayed(hdfs_open_file)
-    return [myopen(fn, auth) for fn in filenames]
-
-
-dask.bytes.core._open_files['hdfs'] = open_files
+core._filesystems['hdfs'] = DaskHDFSFileSystem

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -19,7 +19,7 @@ from .client import default_client, ensure_default_get
 logger = logging.getLogger(__name__)
 
 
-class DaskHDFSFileSystem(HDFileSystem):
+class DaskHDFileSystem(HDFileSystem):
 
     sep = '/'
 
@@ -48,7 +48,7 @@ class DaskHDFSFileSystem(HDFileSystem):
     def glob(self, path):
         if path.startswith('hdfs://'):
             path = path[len('hdfs://'):]
-        return HDFileSystem.glob(self, path)
+        return sorted(HDFileSystem.glob(self, path))
 
     def ukey(self, path):
         if path.startswith('hdfs://'):
@@ -74,4 +74,4 @@ class DaskHDFSFileSystem(HDFileSystem):
         return offsets, lengths, machines
 
 
-core._filesystems['hdfs'] = DaskHDFSFileSystem
+core._filesystems['hdfs'] = DaskHDFileSystem

--- a/distributed/tests/test_hdfs.py
+++ b/distributed/tests/test_hdfs.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import pytest
+from toolz import concat
 from tornado import gen
 
 from dask.delayed import Delayed
@@ -16,7 +17,7 @@ from distributed import Client
 from distributed.client import _wait, Future
 
 hdfs3 = pytest.importorskip('hdfs3')
-from distributed.hdfs import read_bytes, get_block_locations
+from dask.bytes.core import read_bytes, write_bytes
 
 try:
     hdfs = hdfs3.HDFileSystem(host='localhost', port=8020)
@@ -39,12 +40,14 @@ def test_get_block_locations():
         with hdfs.open(fn_2, 'wb', replication=1) as f:
             f.write(data)
 
-        L =  get_block_locations(hdfs, '/tmp/test/')
-        aa = get_block_locations(hdfs, fn_1)
-        bb = get_block_locations(hdfs, fn_2)
-        assert (L == aa + bb) or (L == bb +  aa)
-        assert L[0]['filename'] == L[1]['filename']
-        assert L[2]['filename'] == L[3]['filename']
+        aa = hdfs.get_block_locations(fn_1)
+        bb = hdfs.get_block_locations(fn_2)
+        assert len(aa) == len(bb) == 2
+        assert all(a['hosts'] for a in aa + bb)
+        assert aa[0]['offset'] == 0
+        assert aa[1]['offset'] == aa[0]['length']
+        assert bb[0]['offset'] == 0
+        assert bb[1]['offset'] == bb[0]['length']
 
 
 @gen_cluster([(ip, 1)], timeout=60, client=True)
@@ -58,7 +61,7 @@ def dont_test_dataframes(e, s, a):  # slow
         with hdfs.open(fn, 'wb') as f:
             f.write(data)
 
-        futures = read_bytes(fn, hdfs=hdfs, delimiter=b'\r\n', lazy=False)
+        futures = read_bytes('hdfs://' + fn, delimiter=b'\r\n', lazy=False)
         assert len(futures) > 1
 
         def load(b, **kwargs):
@@ -84,12 +87,14 @@ def test_get_block_locations_nested():
                 with hdfs.open(fn, 'wb', replication=1) as f:
                     f.write(data)
 
-        L =  get_block_locations(hdfs, '/tmp/test/')
+        L =  [hdfs.get_block_locations(fn)
+              for fn in hdfs.glob('/tmp/test/*/*.csv')]
+        L = list(concat(L))
         assert len(L) == 6
 
 
 @gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
-def test_read_bytes(e, s, a, b):
+def test_read_bytes(c, s, a, b):
     with make_hdfs() as hdfs:
         data = b'a' * int(1e8)
         fn = '/tmp/test/file'
@@ -100,25 +105,26 @@ def test_read_bytes(e, s, a, b):
         blocks = hdfs.get_block_locations(fn)
         assert len(blocks) > 1
 
-        sample, values = read_bytes(fn, hdfs=hdfs)
+        sample, values = read_bytes('hdfs://' + fn)
         assert sample[:5] == b'aaaaa'
-        assert len(values) == len(blocks)
+        assert len(values[0]) == len(blocks)
 
         while not s.restrictions:
             yield gen.sleep(0.01)
         assert not s.tasks
 
-        assert {v.key for v in values} == set(s.restrictions)
-        assert {v.key for v in values} == set(s.loose_restrictions)
+        assert {v.key for v in values[0]} == set(s.restrictions)
+        assert {v.key for v in values[0]} == set(s.loose_restrictions)
 
-        futures = e.compute(values)
-        results = yield e._gather(futures)
+        futures = c.compute(values[0])
+        results = yield c._gather(futures)
         assert b''.join(results) == data
         assert s.restrictions
 
 
-def test_read_bytes_sync(loop):
-    with cluster(nworkers=3) as (s, [a, b, c]):
+@pytest.mark.parametrize('nworkers', [1, 3])
+def test_read_bytes_sync(loop, nworkers):
+    with cluster(nworkers=nworkers) as (s, workers):
         with make_hdfs() as hdfs:
             data = b'a' * int(1e3)
 
@@ -127,10 +133,9 @@ def test_read_bytes_sync(loop):
                     f.write(data)
 
             with Client(('127.0.0.1', s['port']), loop=loop) as e:
-                sample, values = read_bytes('/tmp/test/file.*')
-                futures = e.compute(values)
-                results = e.gather(futures)
-                assert b''.join(results) == 100 * data
+                sample, values = read_bytes('hdfs:///tmp/test/file.*')
+                results = delayed(values).compute()
+                assert [b''.join(r) for r in results] == 100 * [data]
 
 
 @gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
@@ -145,11 +150,12 @@ def test_get_block_locations_nested_2(e, s, a, b):
                 with hdfs.open(fn, 'wb', replication=1) as f:
                     f.write(data)
 
-        L =  get_block_locations(hdfs, '/tmp/test/')
+        L =  list(concat(hdfs.get_block_locations(fn)
+                         for fn in hdfs.glob('/tmp/test/data-*/*.csv')))
         assert len(L) == 6
 
-        sample, values = read_bytes('/tmp/test/', hdfs=hdfs)
-        futures = e.compute(values)
+        sample, values = read_bytes('hdfs:///tmp/test/*/*.csv')
+        futures = e.compute(list(concat(values)))
         results = yield e._gather(futures)
         assert len(results) == 6
         assert all(x == b'a' for x in results)
@@ -167,33 +173,40 @@ def test_lazy_values(e, s, a, b):
                 with hdfs.open(fn, 'wb', replication=1) as f:
                     f.write(data)
 
-        sample, values = read_bytes('/tmp/test/', hdfs=hdfs)
-        assert all(isinstance(v, Delayed) for v in values)
+        sample, values = read_bytes('hdfs:///tmp/test/*/*.csv')
+        assert all(isinstance(v, list) for v in values)
+        assert all(isinstance(v, Delayed) for vv in values for v in vv)
 
         while not s.restrictions:
             yield gen.sleep(0.01)
         assert not s.tasks
 
-        results = e.compute(values, sync=False)
+        results = e.compute(list(concat(values)), sync=False)
         results = yield e._gather(results)
         assert len(results) == 6
         assert all(x == b'a' for x in results)
 
 
 @gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
-def test_write_bytes(e, s, a, b):
+def test_write_bytes(c, s, a, b):
     with make_hdfs() as hdfs:
+        hdfs.mkdir('/tmp/test/data/')
         data = [b'123', b'456', b'789']
-        remote_data = yield e._scatter(data)
+        remote_data = yield c._scatter(data)
 
-        futures = write_bytes('/tmp/test/data/file.*.dat', remote_data, hdfs=hdfs)
+        futures = c.compute(write_bytes(remote_data,
+            'hdfs:///tmp/test/data/file.*.dat'))
         yield _wait(futures)
+
+        yield futures[0]._result()
 
         assert len(hdfs.ls('/tmp/test/data/')) == 3
         with hdfs.open('/tmp/test/data/file.1.dat') as f:
             assert f.read() == b'456'
 
-        futures = write_bytes('/tmp/test/data2/', remote_data, hdfs=hdfs)
+        hdfs.mkdir('/tmp/test/data2/')
+        futures = c.compute(write_bytes(remote_data,
+            'hdfs:///tmp/test/data2/'))
         yield _wait(futures)
 
         assert len(hdfs.ls('/tmp/test/data2/')) == 3
@@ -283,7 +296,7 @@ def test_read_csv_lazy(e, s, a, b):
 
 
 @gen_cluster([(ip, 1), (ip, 1)], timeout=60, client=True)
-def test__read_text(e, s, a, b):
+def test__read_text(c, s, a, b):
     with make_hdfs() as hdfs:
         with hdfs.open('/tmp/test/text.1.txt', 'wb') as f:
             f.write('Alice 100\nBob 200\nCharlie 300'.encode())
@@ -294,27 +307,25 @@ def test__read_text(e, s, a, b):
         with hdfs.open('/tmp/test/other.txt', 'wb') as f:
             f.write('a b\nc d'.encode())
 
-        b = db.read_text('hdfs:///tmp/test/text.*.txt',
-                         collection=True)
+        b = db.read_text('hdfs:///tmp/test/text.*.txt')
         yield gen.sleep(0.5)
         assert not s.tasks
 
         import dask
         b.compute(get=dask.get)
 
-        future = e.compute(b.str.strip().str.split().map(len))
+        coll = b.str.strip().str.split().map(len)
+
+        future = c.compute(coll)
         yield gen.sleep(0.5)
         result = yield future._result()
         assert result == [2, 2, 2, 2, 2, 2]
 
-        b = db.read_text('hdfs:///tmp/test/other.txt', collection=True)
-        b = e.persist(b)
-        future = e.compute(b.str.split().concat())
+        b = db.read_text('hdfs:///tmp/test/other.txt')
+        b = c.persist(b)
+        future = c.compute(b.str.split().concat())
         result = yield future._result()
         assert result == ['a', 'b', 'c', 'd']
-
-        L = db.read_text('hdfs:///tmp/test/text.*.txt', collection=False)
-        assert all(isinstance(x, Delayed) for x in L)
 
 
 @gen_cluster([(ip, 1)], timeout=60, client=True)
@@ -366,28 +377,26 @@ def test_deterministic_key_names(e, s, a, b):
         with hdfs.open(fn, 'wb', replication=1) as f:
             f.write(data)
 
-        _, x = read_bytes('/tmp/test/', hdfs=hdfs, lazy=True, delimiter=b'\n')
-        _, y = read_bytes('/tmp/test/', hdfs=hdfs, lazy=True, delimiter=b'\n')
-        _, z = read_bytes('/tmp/test/', hdfs=hdfs, lazy=True, delimiter=b'c')
+        _, x = read_bytes('hdfs:///tmp/test/*', delimiter=b'\n')
+        _, y = read_bytes('hdfs:///tmp/test/*', delimiter=b'\n')
+        _, z = read_bytes('hdfs:///tmp/test/*', delimiter=b'c')
 
-        assert [f.key for f in x] == [f.key for f in y]
-        assert [f.key for f in x] != [f.key for f in z]
+        assert [f.key for f in concat(x)] == [f.key for f in concat(y)]
+        assert [f.key for f in concat(x)] != [f.key for f in concat(z)]
 
 
 @gen_cluster([(ip, 1), (ip, 2)], timeout=60, client=True)
-def test_write_bytes(e, s, a, b):
-    from dask.bytes.core import write_bytes, read_bytes
+def test_write_bytes_2(c, s, a, b):
     with make_hdfs() as hdfs:
         path = 'hdfs:///tmp/test/'
         data = [b'test data %i' % i for i in range(5)]
         values = [delayed(d) for d in data]
-        out = write_bytes(values, path, hdfs=hdfs)
-        futures = e.compute(out)
-        results = yield e._gather(futures)
+        out = write_bytes(values, path)
+        futures = c.compute(out)
+        results = yield c._gather(futures)
         assert len(hdfs.ls('/tmp/test/')) == 5
 
-        sample, vals = read_bytes('hdfs:///tmp/test/*.part',
-                                    hdfs=hdfs, lazy=True)
-        futures = e.compute(vals)
-        results = yield e._gather(futures)
+        sample, vals = read_bytes('hdfs:///tmp/test/*.part')
+        futures = c.compute(list(concat(vals)))
+        results = yield c._gather(futures)
         assert data == results

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -394,6 +394,7 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)], timeout=10,
 @contextmanager
 def make_hdfs():
     from hdfs3 import HDFileSystem
+    # from .hdfs import DaskHDFileSystem
     hdfs = HDFileSystem(host='localhost', port=8020)
     if hdfs.exists('/tmp/test'):
         hdfs.rm('/tmp/test')


### PR DESCRIPTION
Tests relying on previous functions will fail - should all be calling dask.bytes.core now.