### PR TITLE
Timeout and check on write

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -64,12 +64,7 @@ class BatchedSend(object):
                 wait_time = min(self.last_transmission + self.interval - now,
                                 self.interval)
                 yield gen.sleep(wait_time)
-            while self.stream._write_buffer:
-                try:
-                    yield gen.with_timeout(timedelta(milliseconds=10),
-                                           self.last_send)  # hangs otherwise?
-                except gen.TimeoutError:
-                    pass
+            yield self.last_send
             self.buffer, payload = [], self.buffer
             self.last_payload = payload
             self.last_transmission = now

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -242,10 +242,12 @@ def write(stream, msg):
 
         futures.append(stream.write(frames[-1]))
 
-        if WINDOWS:
-            yield futures[-1]
-        else:
-            yield futures
+        while stream._write_buffer:
+            try:
+                yield gen.with_timeout(timedelta(seconds=0.01), futures[-1])
+                break
+            except gen.TimeoutError:
+                pass
 
 
 def pingpong(stream):


### PR DESCRIPTION
The core.write coroutine waits on IOStream.write futures.  However, there are
some cases where IOStream.write futures don't complete.  Notably if something
else writes to the same stream before we're done waiting then the first future
is forgotten and hangs forever.

    If `write` is called again before that `.Future` has resolved, the
    previous future will be orphaned and will never resolve.

This solution wraps the wait in a timeout and checks the stream's
write_buffer as a secondary check for completion.  There are probably better
solutions but this seems to work fine.

cc @pitrou 