### PR TITLE
Don't allow inconsequential byte values to determine scheduling

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -145,6 +145,13 @@ def slowadd(x, y, delay=0.02):
     return x + y
 
 
+def slowidentity(*args, **kwargs):
+    delay = kwargs.get('delay', 0.02)
+    from time import sleep
+    sleep(delay)
+    return args
+
+
 def run_scheduler(q, scheduler_port=0, **kwargs):
     from distributed import Scheduler
     from tornado.ioloop import IOLoop, PeriodicCallback


### PR DESCRIPTION
Previously very small values might have strong influence on where we
scheduled computations.  Now we ignore these and let work stealing
allocate jobs more fairly.