### PR TITLE
Use ndarray instead of frombuffer for numpy serialization

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -40,8 +40,8 @@ def dumps(msg):
                if type(value) is Serialized}
 
         data = {key: serialize(value.data)
-                     for key, value in data.items()
-                     if type(value) is Serialize}
+                for key, value in data.items()
+                if type(value) is Serialize}
 
         header = {'headers': {},
                   'keys': [],

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -41,7 +41,7 @@ def serialize_numpy_ndarray(x):
     else:
         dt = x.dtype.str
 
-    x = np.ascontiguousarray(x)  # np.frombuffer requires this
+    x = np.ascontiguousarray(x)  # cannot get .data attribute from discontiguous
 
     header = {'dtype': dt,
               'strides': x.strides,
@@ -74,12 +74,9 @@ def deserialize_numpy_ndarray(header, frames):
         dt = header['dtype']
         if isinstance(dt, tuple):
             dt = list(dt)
-        dt = np.dtype(dt)
 
-        buffer = frames[0]
-
-        x = np.frombuffer(buffer, dt)
-        x = np.lib.stride_tricks.as_strided(x, header['shape'], header['strides'])
+        x = np.ndarray(header['shape'], dtype=dt, buffer=frames[0],
+                       strides=header['strides'])
 
         return x
 


### PR DESCRIPTION
These are a few minor edits I made while reviewing dask serialization in preparation for a talk.  

the numpy.ndarray constructor is exactly the right approach to building a new array from the data stored in headers + bytestring.   Behavior should be equivalent, but it avoids using "stride_tricks" which is not a standard API.