### PR TITLE
WIP - Communication stress test and small fixes

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -278,6 +278,11 @@ class FutureState(object):
         self.traceback = traceback
         self.event.set()
 
+    def __str__(self):
+        return '<%s: %s>' % (self.__class__.__name__, self.status)
+
+    __repr__ = __str__
+
 
 @gen.coroutine
 def done_callback(future, callback):

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -137,8 +137,8 @@ class Server(TCPServer):
         """
         stream.set_nodelay(True)
         ip, port = address
-        logger.info("Connection from %s:%d to %s", ip, port,
-                    type(self).__name__)
+        logger.debug("Connection from %s:%d to %s", ip, port,
+                     type(self).__name__)
         try:
             while True:
                 try:
@@ -189,8 +189,8 @@ class Server(TCPServer):
                 yield close(stream)
             except Exception as e:
                 logger.warn("Failed while closing writer", exc_info=True)
-        logger.info("Close connection from %s:%d to %s", address[0], address[1],
-                    type(self).__name__)
+        logger.debug("Close connection from %s:%d to %s", address[0], address[1],
+                     type(self).__name__)
 
 
 @gen.coroutine

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -796,6 +796,7 @@ class Scheduler(Server):
 
     def client_releases_keys(self, keys=None, client=None):
         """ Remove keys from client desired list """
+        keys2 = set()
         for key in list(keys):
             if key in self.wants_what[client]:
                 self.wants_what[client].remove(key)
@@ -803,12 +804,15 @@ class Scheduler(Server):
                 s.remove(client)
                 if not s:
                     del self.who_wants[key]
-                    if key in self.waiting_data and not self.waiting_data[key]:
-                        r = self.transition(key, 'released')
-                        self.transitions(r)
-                    if key in self.dependents and not self.dependents[key]:
-                        r = self.transition(key, 'forgotten')
-                        self.transitions(r)
+                    keys2.add(key)
+
+        for key in keys2:
+            if key in self.waiting_data and not self.waiting_data[key]:
+                r = self.transition(key, 'released')
+                self.transitions(r)
+            if key in self.dependents and not self.dependents[key]:
+                r = self.transition(key, 'forgotten')
+                self.transitions(r)
 
     def client_wants_keys(self, keys=None, client=None):
         for k in keys:

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -13,7 +13,7 @@ from tornado.iostream import StreamClosedError
 
 from distributed.core import read, write
 from distributed.utils import sync, All
-from distributed.utils_test import gen_test, slow
+from distributed.utils_test import gen_test, slow, gen_cluster
 from distributed.batched import BatchedSend
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -154,7 +154,7 @@ def test_future(c, s, a, b):
     x = c.submit(inc, 10)
     assert str(x.key) in repr(x)
     assert str(x.status) in repr(x)
-    assert str(x.status) in c.futures[x.key]
+    assert str(x.status) in repr(c.futures[x.key])
 
 
 @gen_cluster(client=True)
@@ -2811,16 +2811,17 @@ def test_get_stacks_processing(c, s, a, b):
     yield gen.sleep(0.2)
 
     x = yield c.scheduler.stacks()
-    assert x == valmap(list, s.stacks)
+    assert set(x) == {a.address, b.address}
 
     x = yield c.scheduler.stacks(workers=[a.address])
-    assert x == {a.address: list(s.stacks[a.address])}
+    assert set(x) == {a.address}
+    assert isinstance(x[a.address], list)
 
     x = yield c.scheduler.processing()
-    assert x == valmap(list, s.processing)
+    assert set(x) == {a.address, b.address}
 
     x = yield c.scheduler.processing(workers=[a.address])
-    assert x == {a.address: list(s.processing[a.address])}
+    assert isinstance(x[a.address], list)
 
 @gen_cluster(client=True)
 def test_get_foo(c, s, a, b):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -154,6 +154,7 @@ def test_future(c, s, a, b):
     x = c.submit(inc, 10)
     assert str(x.key) in repr(x)
     assert str(x.status) in repr(x)
+    assert str(x.status) in c.futures[x.key]
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1012,7 +1012,7 @@ def test_launch_without_blocked_services():
 def test_scatter_no_workers(c, s):
     with pytest.raises(gen.TimeoutError):
         yield gen.with_timeout(timedelta(seconds=0.1),
-                              s.scatter(data={'x': dumps(1)}, client='alice'))
+                               s.scatter(data={'x': 1}, client='alice'))
 
     w = Worker(s.ip, s.port, ncores=3, ip='127.0.0.1')
     yield [c._scatter(data={'x': 1}),

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -44,8 +44,8 @@ def test_str(s, a, b):
     assert a.address in repr(a)
     assert str(a.ncores) in str(a)
     assert str(a.ncores) in repr(a)
-    assert str(len(a.active) in str(a)
-    assert str(len(a.active) in repr(a)
+    assert str(len(a.active)) in str(a)
+    assert str(len(a.active)) in repr(a)
 
 
 def test_identity():

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -44,6 +44,8 @@ def test_str(s, a, b):
     assert a.address in repr(a)
     assert str(a.ncores) in str(a)
     assert str(a.ncores) in repr(a)
+    assert str(len(a.active) in str(a)
+    assert str(len(a.active) in repr(a)
 
 
 def test_identity():

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -404,13 +404,13 @@ def start_cluster(ncores, loop, Worker=Worker, scheduler_kwargs={},
 @gen.coroutine
 def end_cluster(s, workers):
     logger.debug("Closing out test cluster")
-    scheduler_close = s.close()
+    scheduler_close = s.close()  # shut down periodic callbacks immediately
     for w in workers:
         with ignoring(TimeoutError, StreamClosedError, OSError):
             yield w._close(report=False)
         if w.local_dir and os.path.exists(w.local_dir):
             shutil.rmtree(w.local_dir)
-    yield scheduler_close
+    yield scheduler_close  # wait until scheduler stops completely
     s.stop()
 
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -404,12 +404,13 @@ def start_cluster(ncores, loop, Worker=Worker, scheduler_kwargs={},
 @gen.coroutine
 def end_cluster(s, workers):
     logger.debug("Closing out test cluster")
+    scheduler_close = s.close()
     for w in workers:
         with ignoring(TimeoutError, StreamClosedError, OSError):
             yield w._close(report=False)
         if w.local_dir and os.path.exists(w.local_dir):
             shutil.rmtree(w.local_dir)
-    yield s.close()
+    yield scheduler_close
     s.stop()
 
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -664,7 +664,7 @@ class Worker(Server):
             for key in keys:
                 if key in self.data:
                     del self.data[key]
-            logger.info("Deleted %d keys", len(keys))
+            logger.debug("Deleted %d keys", len(keys))
             if report:
                 logger.debug("Reporting loss of keys to scheduler")
                 yield self.scheduler.remove_keys(address=self.address,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -198,7 +198,7 @@ class Worker(Server):
         self.loop.add_callback(self.heartbeat_callback.start)
 
     def __str__(self):
-        return "<Worker: %s, threads: %d>" % (self.address, self.ncores)
+        return "<Worker: %s, threads: %d/%d>" % (self.address, len(self.active), self.ncores)
 
     __repr__ = __str__
 


### PR DESCRIPTION
This adds a communication heavy stress test with the following features:

1.  Many tasks (50k)
2.  Lots of data within the graph (many numpy arrays)
3.  Repeated submission of these graphs with low delay

I tested this and the rest of the test suite under moderate network delay (20ms roundtrip) and cleaned up a few small issues but wasn't able to find anything significant.  This was an effort to identify the cause of a report of dropped messages under similar workloads.