### PR TITLE
Scale auto memory limit based on fraction of cores

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -104,18 +104,6 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
 
     loop = IOLoop.current()
 
-    if memory_limit == 'auto':
-        import psutil
-        memory_limit = psutil.virtual_memory().total * 0.60
-
-    if memory_limit:
-        memory_limit = float(memory_limit)
-        if memory_limit < 1.0:
-            import psutil
-            memory_limit = psutil.virtual_memory().total * memory_limit
-        memory_limit /= nprocs
-        memory_limit = int(memory_limit)
-
     if nanny:
         kwargs = {'worker_port': worker_port}
         t = Nanny

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -586,3 +586,17 @@ def test_close_on_disconnect(s, w):
     while w.status != 'closed':
         yield gen.sleep(0.01)
         assert time() < start + 5
+
+
+def test_memory_limit_auto():
+    a = Worker('127.0.0.1', 8099, ncores=1)
+    b = Worker('127.0.0.1', 8099, ncores=2)
+    c = Worker('127.0.0.1', 8099, ncores=100)
+    d = Worker('127.0.0.1', 8099, ncores=200)
+
+    assert isinstance(a.memory_limit, int)
+    assert isinstance(b.memory_limit, int)
+
+    assert a.memory_limit < b.memory_limit
+
+    assert c.memory_limit == d.memory_limit


### PR DESCRIPTION
Previously every Worker would get 60% of the total memory by default.
This would cause problems when we launched many single-threaded workers
on larger compute nodes.

Now we scale the available memory to match the fraction of cores that we
claim.