### PR TITLE
Skip joblib and threaded gather tests

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1008,6 +1008,7 @@ def test_queue_gather(loop):
             assert qout == qin
 
 
+@pytest.mark.skip(reason="intermittent blocking failures")
 def test_iterator_gather(loop):
     with cluster() as (s, [a, b]):
         with Client(('127.0.0.1', s['port']), loop=loop) as ee:

--- a/distributed/tests/test_joblib.py
+++ b/distributed/tests/test_joblib.py
@@ -16,6 +16,7 @@ def slow_raise_value_error(condition, duration=0.05):
         raise ValueError("condition evaluated to True")
 
 
+@pytest.mark.skip(reason="intermittent blocking failures")
 @pytest.mark.parametrize('joblib', joblibs)
 def test_simple(loop, joblib):
     if joblib is None:


### PR DESCRIPTION
These block intermittently, slow down development,
and are low priority.  We choose to skip them for now.

Thoughts on this @pitrou ?