### PR TITLE
Improve import time

### DIFF
--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -3,11 +3,7 @@ from __future__ import print_function, division, absolute_import
 
 from itertools import product
 
-import dask.array as da
-import dask.bag as db
-import dask.dataframe as dd
 from dask.base import tokenize
-import numpy as np
 from tornado import gen
 
 from .client import (default_client, Future, _first_completed,
@@ -26,6 +22,8 @@ def get_empty(df):
 
 @gen.coroutine
 def _futures_to_dask_dataframe(futures, divisions=None, client=None):
+    import dask.dataframe as dd
+
     client = default_client(client)
     f = yield _first_completed(futures)
     empty = client.submit(get_empty, f)
@@ -77,6 +75,9 @@ def get_dtype(x):
 
 @gen.coroutine
 def _futures_to_dask_array(futures, client=None):
+    import numpy as np
+    import dask.array as da
+
     client = default_client(client)
     futures = np.array(futures, dtype=object)
 
@@ -126,6 +127,8 @@ def futures_to_dask_array(futures, client=None):
 
 @gen.coroutine
 def _futures_to_dask_bag(futures, client=None):
+    import dask.bag as db
+
     client = default_client(client)
 
     name = 'bag-from-futures-' + tokenize(*futures)
@@ -192,6 +195,8 @@ def futures_to_collection(futures, client=None, **kwargs):
 
 @gen.coroutine
 def _future_to_dask_array(future, client=None):
+    import dask.array as da
+
     e = default_client(client)
 
     name = 'array-' + str(future.key)
@@ -223,6 +228,8 @@ def future_to_dask_array(future, client=None):
 
 @gen.coroutine
 def _futures_to_dask_arrays(futures, client=None):
+    import dask.array as da
+
     e = default_client(client)
 
     names = ['array-' + str(future.key) for future in futures]

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -191,6 +191,7 @@ class LocalCluster(object):
         except ImportError:
             logger.info("To start diagnostics web server please install Bokeh")
             return
+        from ..http.scheduler import HTTPScheduler
 
         assert self.diagnostics is None
         if 'http' not in self.scheduler.services:

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -10,7 +10,6 @@ from tornado.ioloop import IOLoop
 from tornado.iostream import StreamClosedError
 from tornado import gen
 
-from ..http.scheduler import HTTPScheduler
 from ..utils import sync, ignoring, All
 from ..client import Client
 from ..nanny import Nanny
@@ -63,7 +62,7 @@ class LocalCluster(object):
     def __init__(self, n_workers=None, threads_per_worker=None, nanny=True,
             loop=None, start=True, scheduler_port=8786,
             silence_logs=logging.CRITICAL, diagnostics_port=8787,
-            services={'http': HTTPScheduler}, **kwargs):
+            services={}, **kwargs):
         self.status = None
         self.nanny = nanny
         if silence_logs:

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -1,17 +1,23 @@
 from __future__ import print_function, division, absolute_import
 
+from functools import partial
+
 from .compression import compressions, default_compression
 from .core import dumps, loads, maybe_compress, decompress, msgpack
 from .serialize import (serialize, deserialize, Serialize, Serialized,
-    to_serialize, register_serialization)
+    to_serialize, register_serialization, register_serialization_lazy)
 
 from ..utils  import ignoring
 
-with ignoring(ImportError):
+
+@partial(register_serialization_lazy, "numpy")
+def _register_numpy():
     from . import numpy
 
-with ignoring(ImportError):
+@partial(register_serialization_lazy, "h5py")
+def _register_h5py():
     from . import h5py
 
-with ignoring(ImportError):
+@partial(register_serialization_lazy, "netCDF4")
+def _register_netcdf4():
     from . import netcdf4

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -4,9 +4,9 @@ from functools import partial
 import logging
 
 try:
-    import pandas.msgpack as msgpack
-except ImportError:
     import msgpack
+except ImportError:
+    import pandas.msgpack as msgpack
 
 from toolz import get_in
 

--- a/distributed/protocol/tests/test_netcdf4.py
+++ b/distributed/protocol/tests/test_netcdf4.py
@@ -6,7 +6,6 @@ np = pytest.importorskip('numpy')
 from distributed.protocol import serialize, deserialize, dumps, loads
 
 from distributed.utils import tmpfile
-import distributed.protocol.netcdf4
 
 
 def create_test_dataset(fn):

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -13,8 +13,6 @@ from distributed.utils_test import slow
 from distributed.protocol.numpy import itemsize
 from distributed.protocol.compression import maybe_compress
 
-import distributed.protocol.numpy
-
 
 def test_serialize():
     x = np.ones((5, 5))

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -17,7 +17,9 @@ def test_containers():
 
 def test_numpy():
     np = pytest.importorskip('numpy')
-    assert sizeof(np.empty(1000, dtype='f8')) >= 8000
+    assert sizeof(np.empty(1000, dtype='f8')) == 8000
+    dt = np.dtype('f8')
+    assert sizeof(dt) == sys.getsizeof(dt)
 
 
 def test_pandas():

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -6,7 +6,6 @@ from importlib import import_module
 import heapq
 import logging
 import os
-import pkg_resources
 import random
 import tempfile
 from threading import current_thread, Lock, local
@@ -467,6 +466,7 @@ class WorkerBase(Server):
                     name = name.split('-')[0]
                     reload(import_module(name))
                 if ext == '.egg':
+                    import pkg_resources
                     sys.path.append(out_filename)
                     pkgs = pkg_resources.find_distributions(out_filename)
                     for pkg in pkgs:


### PR DESCRIPTION
Achieves its effects in combination with https://github.com/dask/dask/pull/1833 (which it needs merged).
Before:
```
$ time python -c "import sys, distributed; print(len(sys.modules))"
890

real	0m0.954s
user	0m0.904s
sys	0m0.028s
```
After:
```
$ time python -c "import sys, distributed; print(len(sys.modules))"
454

real	0m0.398s
user	0m0.364s
sys	0m0.020s
```

Note Numpy is still imported by `blosc`.
```
$ time python -c "import sys, blosc; print(len(sys.modules))"
221

real	0m0.202s
user	0m0.172s
sys	0m0.028s
```
