### PR TITLE
Remove route to change worker cores

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -293,8 +293,7 @@ class Scheduler(Server):
                          'rebalance': self.rebalance,
                          'replicate': self.replicate,
                          'start_ipython': self.start_ipython,
-                         'update_data': self.update_data,
-                         'change_worker_cores': self.change_worker_cores}
+                         'update_data': self.update_data}
 
         self.services = {}
         for k, v in (services or {}).items():
@@ -1680,14 +1679,6 @@ class Scheduler(Server):
                 result = out
 
             return result
-
-    def change_worker_cores(self, stream=None, worker=None, diff=0):
-        """ Add or remove cores from a worker
-
-        This is used when a worker wants to spin off a long-running task
-        """
-        self.ncores[worker] += diff
-        # self.ensure_occupied()
 
     #####################
     # State Transitions #

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -45,13 +45,7 @@ def local_client():
               # so that it doesn't take up a fixed resource while waiting
     worker.loop.add_callback(worker.transition, thread_state.key, 'long-running')
     with WorkerClient(address) as e:
-        worker.loop.add_callback(worker.scheduler.change_worker_cores,
-                                 worker=worker.address, diff=+1)
-        try:
-            yield e
-        finally:
-            worker.loop.add_callback(worker.scheduler.change_worker_cores,
-                                     worker=worker.address, diff=-1)
+        yield e
 
 
 def get_worker():


### PR DESCRIPTION
Previously we needed to artifically increase a worker's core count when
running long-running tasks, otherwise we would risk over-saturating the
entire network.  Now, because we oversaturate by default this isn't an
issue.