### PR TITLE
Add futures to requirements.txt for python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ psutil
 locket
 zict >= 0.1.0
 sortedcollections
+futures; python_version < '3.0'


### PR DESCRIPTION
distributed/client.py  has a dependency on concurrent.futures; for python 2.7 the futures module seems to be needed.