### PR TITLE
Fix #731: add ability to run coroutine on workers

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1288,6 +1288,43 @@ class Client(object):
         """
         return sync(self.loop, self._run, function, *args, **kwargs)
 
+    @gen.coroutine
+    def _run_coroutine(self, function, *args, **kwargs):
+        workers = kwargs.pop('workers', None)
+        responses = yield self.scheduler.broadcast(msg=dict(op='run_coroutine',
+                                                function=dumps(function),
+                                                args=dumps(args),
+                                                kwargs=dumps(kwargs)),
+                                                workers=workers)
+        results = {}
+        for key, resp in responses.items():
+            if resp['status'] == 'OK':
+                results[key] = resp['result']
+            elif resp['status'] == 'error':
+                raise loads(resp['exception'])
+        raise Return(results)
+
+    def run_coroutine(self, function, *args, **kwargs):
+        """
+        Spawn a coroutine on all workers.
+
+        This spaws a coroutine on all currently known workers and then waits
+        for the coroutine on each worker.  The coroutines' results are returned
+        as a dictionary keyed by worker address.
+
+        Parameters
+        ----------
+        function: a coroutine function
+            (typically a function wrapped in gen.coroutine or
+             a Python 3.5+ async function)
+        *args: arguments for remote function
+        **kwargs: keyword arguments for remote function
+        workers: list
+            Workers on which to run the function. Defaults to all known workers.
+
+        """
+        return sync(self.loop, self._run_coroutine, function, *args, **kwargs)
+
     def _graph_to_futures(self, dsk, keys, restrictions=None,
             loose_restrictions=None, allow_other_workers=True, priority=None,
             resources=None):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1250,7 +1250,7 @@ class Client(object):
             if resp['status'] == 'OK':
                 results[key] = resp['result']
             elif resp['status'] == 'error':
-                raise loads(resp['exception'])
+                six.reraise(*clean_exception(**resp))
         raise Return(results)
 
     def run(self, function, *args, **kwargs):
@@ -1301,7 +1301,7 @@ class Client(object):
             if resp['status'] == 'OK':
                 results[key] = resp['result']
             elif resp['status'] == 'error':
-                raise loads(resp['exception'])
+                six.reraise(*clean_exception(**resp))
         raise Return(results)
 
     def run_coroutine(self, function, *args, **kwargs):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2219,6 +2219,12 @@ def test_run_coroutine_sync(loop):
                                      workers=['127.0.0.1:%d' % a['port']])
             assert result == {'127.0.0.1:%d' % a['port']: 3}
 
+            t1 = time()
+            result = c.run_coroutine(geninc, 2, delay=10, wait=False)
+            t2 = time()
+            assert result is None
+            assert t2 - t1 <= 1.0
+
 
 def test_run_exception(loop):
     def raise_exception(exc_type, exc_msg):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -37,8 +37,8 @@ from distributed.scheduler import Scheduler, KilledWorker
 from distributed.sizeof import sizeof
 from distributed.utils import sync, tmp_text, ignoring, tokey, All, mp_context
 from distributed.utils_test import (cluster, slow, slowinc, slowadd, slowdec,
-        randominc, loop, inc, dec, div, throws, geninc, gen_cluster,
-        gen_test, double, deep, popen)
+        randominc, loop, inc, dec, div, throws, geninc, asyncinc,
+        gen_cluster, gen_test, double, deep, popen)
 
 
 @gen_cluster(client=True, timeout=None)
@@ -2202,6 +2202,10 @@ def test_run_coroutine(c, s, a, b):
     with pytest.raises(RuntimeError) as exc_info:
         yield c._run_coroutine(throws, 1)
     exc_info.match("hello")
+
+    if sys.version_info >= (3, 5):
+        results = yield c._run_coroutine(asyncinc, 2, delay=0.01)
+        assert results == {a.address: 3, b.address: 3}
 
 
 def test_run_coroutine_sync(loop):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -37,8 +37,8 @@ from distributed.scheduler import Scheduler, KilledWorker
 from distributed.sizeof import sizeof
 from distributed.utils import sync, tmp_text, ignoring, tokey, All, mp_context
 from distributed.utils_test import (cluster, slow, slowinc, slowadd, slowdec,
-        randominc, loop, inc, dec, div, throws, gen_cluster, gen_test, double,
-        deep, popen)
+        randominc, loop, inc, dec, div, throws, geninc, gen_cluster,
+        gen_test, double, deep, popen)
 
 
 @gen_cluster(client=True, timeout=None)
@@ -2185,6 +2185,34 @@ def test_run_sync(loop):
                               '127.0.0.1:%d' % b['port']: 3}
 
             result = c.run(func, 1, y=2, workers=['127.0.0.1:%d' % a['port']])
+            assert result == {'127.0.0.1:%d' % a['port']: 3}
+
+
+@gen_cluster(client=True)
+def test_run_coroutine(c, s, a, b):
+    results = yield c._run_coroutine(geninc, 1, delay=0.05)
+    assert results == {a.address: 2, b.address: 2}
+
+    results = yield c._run_coroutine(geninc, 1, delay=0.05, workers=[a.address])
+    assert results == {a.address: 2}
+
+    results = yield c._run_coroutine(geninc, 1, workers=[])
+    assert results == {}
+
+    with pytest.raises(RuntimeError) as exc_info:
+        yield c._run_coroutine(throws, 1)
+    exc_info.match("hello")
+
+
+def test_run_coroutine_sync(loop):
+    with cluster() as (s, [a, b]):
+        with Client(('127.0.0.1', s['port']), loop=loop) as c:
+            result = c.run_coroutine(geninc, 2, delay=0.01)
+            assert result == {'127.0.0.1:%d' % a['port']: 3,
+                              '127.0.0.1:%d' % b['port']: 3}
+
+            result = c.run_coroutine(geninc, 2,
+                                     workers=['127.0.0.1:%d' % a['port']])
             assert result == {'127.0.0.1:%d' % a['port']: 3}
 
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -13,6 +13,7 @@ import traceback
 from dask import delayed
 import pytest
 from toolz import pluck, sliding_window
+import tornado
 from tornado import gen
 from tornado.ioloop import TimeoutError
 
@@ -366,6 +367,9 @@ def test_run_dask_worker(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_run_coroutine_dask_worker(c, s, a, b):
+    if sys.version_info < (3,) and tornado.version_info < (4, 5):
+        pytest.skip("test needs Tornado 4.5+ on Python 2.7")
+
     @gen.coroutine
     def f(dask_worker=None):
         yield gen.sleep(0.001)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -364,6 +364,17 @@ def test_run_dask_worker(c, s, a, b):
     assert response == {a.address: a.id, b.address: b.id}
 
 
+@gen_cluster(client=True)
+def test_run_coroutine_dask_worker(c, s, a, b):
+    @gen.coroutine
+    def f(dask_worker=None):
+        yield gen.sleep(0.001)
+        raise gen.Return(dask_worker.id)
+
+    response = yield c._run_coroutine(f)
+    assert response == {a.address: a.id, b.address: b.id}
+
+
 @gen_cluster(client=True, ncores=[])
 def test_Executor(c, s):
     with ThreadPoolExecutor(2) as e:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from collections import Iterable
 from contextlib import contextmanager
+import inspect
 import logging
 import multiprocessing
 import os
@@ -46,6 +47,24 @@ def funcname(func):
         return func.__name__
     except:
         return str(func)
+
+
+def has_arg(func, argname):
+    """
+    Whether the function takes an argument with the given name.
+    """
+    while True:
+        try:
+            if 'dask_worker' in inspect.getargspec(func).args:
+                return True
+        except TypeError:
+            break
+        try:
+            # For Tornado coroutines and other decorated functions
+            func = func.__wrapped__
+        except AttributeError:
+            break
+    return False
 
 
 def get_fileno_limit():

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -185,6 +185,12 @@ def slowidentity(*args, **kwargs):
     return args
 
 
+@gen.coroutine
+def geninc(x, delay=0.02):
+    yield gen.sleep(delay)
+    raise gen.Return(x + 1)
+
+
 _readone_queues = {}
 
 @gen.coroutine

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -10,6 +10,7 @@ import signal
 import socket
 import subprocess
 import sys
+import textwrap
 from time import sleep
 import uuid
 
@@ -189,6 +190,25 @@ def slowidentity(*args, **kwargs):
 def geninc(x, delay=0.02):
     yield gen.sleep(delay)
     raise gen.Return(x + 1)
+
+
+def compile_snippet(code, dedent=True):
+    if dedent:
+        code = textwrap.dedent(code)
+    code = compile(code, '<dynamic>', 'exec')
+    ns = globals()
+    exec(code, ns, ns)
+
+
+if sys.version_info >= (3, 5):
+    compile_snippet("""
+        async def asyncinc(x, delay=0.02):
+            await gen.sleep(delay)
+            return x + 1
+        """)
+    assert asyncinc
+else:
+    asyncinc = None
 
 
 _readone_queues = {}

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -730,6 +730,7 @@ def run(worker, stream, function=None, args=(), kwargs={}, is_coro=False):
         kwargs = loads(kwargs)
     if has_arg(function, 'dask_worker'):
         kwargs['dask_worker'] = worker
+    logger.info("Run out-of-band function %r", funcname(function))
     try:
         result = function(*args, **kwargs)
         if is_coro:


### PR DESCRIPTION
The added API mirrors `Client.run` (though without the `nanny` parameter as I'm not sure whether that's useful). The API returns the coroutine's return value from each worker, though of course the caller can just as well ignore that.