### PR TITLE
Make pandas sizeof faster

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -507,7 +507,7 @@ class Scheduler(Server):
                 self.occupancy[address] = 0
                 self.check_idle_saturated(address)
 
-            if nbytes:
+            if nbytes is not None:
                 self.nbytes.update(nbytes)
 
             # for key in keys:  # TODO
@@ -1950,7 +1950,7 @@ class Scheduler(Server):
             ############################
             # Update State Information #
             ############################
-            if nbytes:
+            if nbytes is not None:
                 self.nbytes[key] = nbytes
 
             self.who_has[key] = set()
@@ -1961,9 +1961,6 @@ class Scheduler(Server):
                 self.has_what[worker].add(key)
                 self.worker_bytes[worker] += self.nbytes.get(key,
                                                              DEFAULT_DATA_SIZE)
-
-            if nbytes:
-                self.nbytes[key] = nbytes
 
             workers = self.rprocessing.pop(key)
             for w in workers:

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -42,22 +42,23 @@ def register_pandas():
     import pandas as pd
     @sizeof.register(pd.DataFrame)
     def sizeof_pandas_dataframe(df):
-        o = getsizeof(df)
-        try:
-            return int(o + df.memory_usage(index=True, deep=True).sum())
-        except:
-            return int(o + df.memory_usage(index=True).sum())
+        p = int(df.memory_usage(index=True).sum())
+        obj = int((df.dtypes == object).sum() * len(df) * 100)
+        if df.index.dtype == object:
+            obj += len(df) * 100
+        return int(p + obj) + 1000
 
     @sizeof.register(pd.Series)
     def sizeof_pandas_series(s):
-        try:
-            return int(s.memory_usage(index=True, deep=True)) # new in 0.17.1
-        except:
-            return int(sizeof(s.values) + sizeof(s.index))
+        p = int(s.memory_usage(index=True))
+        if s.dtype == object:
+            p += len(s) * 100
+        if s.index.dtype == object:
+            p += len(s) * 100
+        return int(p) + 1000
 
     @sizeof.register(pd.Index)
     def sizeof_pandas_index(i):
-        try:
-            return int(i.memory_usage(deep=True))
-        except:
-            return int(i.nbytes)
+        p = int(i.memory_usage())
+        obj = len(i) * 100 if i.dtype == object else 0
+        return int(p + obj) + 1000

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -24,13 +24,13 @@ def test_numpy():
 
 def test_pandas():
     pd = pytest.importorskip('pandas')
-    df = pd.DataFrame({'x': [1, 2, 3], 'y': ['a'*1000, 'b'*1000, 'c'*1000]},
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': ['a'*100, 'b'*100, 'c'*100]},
                       index=[10, 20, 30])
 
     assert sizeof(df) >= sizeof(df.x) + sizeof(df.y) - sizeof(df.index)
     assert sizeof(df.x) >= sizeof(df.index)
     if pd.__version__ >= '0.17.1':
-        assert sizeof(df.y) >= 1000 * 3
+        assert sizeof(df.y) >= 100 * 3
     assert sizeof(df.index) >= 20
 
     assert isinstance(sizeof(df), int)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -920,7 +920,7 @@ class Worker(WorkerBase):
                 self.resource_restrictions[key] = resource_restrictions
             self.task_state[key] = 'waiting'
 
-            if nbytes:
+            if nbytes is not None:
                 self.nbytes.update(nbytes)
 
             if who_has:


### PR DESCRIPTION
We no longer use deep=True, this was taking a long time for object dtype series