### PR TITLE
Silence workers in LocalCluster

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -65,6 +65,7 @@ class LocalCluster(object):
             services={}, worker_services={}, **kwargs):
         self.status = None
         self.nanny = nanny
+        self.silence_logs = silence_logs
         if silence_logs:
             for l in ['distributed.scheduler',
                       'distributed.worker',
@@ -128,7 +129,8 @@ class LocalCluster(object):
             kwargs['quiet'] = True
         else:
             W = Worker
-        w = W(self.scheduler.ip, self.scheduler.port, loop=self.loop, **kwargs)
+        w = W(self.scheduler.ip, self.scheduler.port, loop=self.loop,
+              silence_logs=self.silence_logs, **kwargs)
         yield w._start(port)
 
         self.workers.append(w)

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -190,6 +190,7 @@ def test_blocks_until_full(loop):
     with Client(loop=loop) as c:
         assert len(c.ncores()) > 0
 
+
 @gen_test()
 def test_scale_up_and_down():
     loop = IOLoop.current()
@@ -212,3 +213,12 @@ def test_scale_up_and_down():
 
     yield c._shutdown()
     yield cluster._close()
+
+
+def test_silent_startup(capsys, loop):
+    with LocalCluster(diagnostics_port=None, loop=loop, scheduler_port=0):
+        sleep(0.5)
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert not err

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -133,13 +133,16 @@ class WorkerBase(Server):
     def __init__(self, scheduler_ip, scheduler_port, ip=None, ncores=None,
                  loop=None, local_dir=None, services=None, service_ports=None,
                  name=None, heartbeat_interval=5000, reconnect=True,
-                 memory_limit='auto', executor=None, resources=None, **kwargs):
+                 memory_limit='auto', executor=None, resources=None,
+                 silence_logs=None, **kwargs):
         self.ip = ip or get_ip()
         self._port = 0
         self.ncores = ncores or _ncores
         self.local_dir = local_dir or tempfile.mkdtemp(prefix='worker-')
         self.total_resources = resources or {}
         self.available_resources = (resources or {}).copy()
+        if silence_logs:
+            logger.setLevel(silence_logs)
         if not os.path.exists(self.local_dir):
             os.mkdir(self.local_dir)
 


### PR DESCRIPTION
Ever since we started using forkserver LocalCluster() became more
verbose.  This is because changing log preferences in the master
process no longer affeected the child processes.

Now we explicitly pass down the logging level we want to the worker
processes.