### PR TITLE
use extras_require for conditional dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ versionfile_source = distributed/_version.py
 versionfile_build = distributed/_version.py
 tag_prefix =
 parentdir_prefix = distributed-
+
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,18 @@ import sys
 import versioneer
 
 requires = open('requirements.txt').read().strip().split('\n')
+install_requires = []
+extras_require = {}
+for r in requires:
+    if ';' in r:
+        # requirements.txt conditional dependencies need to be reformatted for wheels
+        # to the form: `'[extra_name]:condition' : ['requirements']`
+        req, cond = r.split(';', 1)
+        cond = ':' + cond
+        cond_reqs = extras_require.setdefault(cond, [])
+        cond_reqs.append(req)
+    else:
+        install_requires.append(r)
 
 setup(name='distributed',
       version=versioneer.get_version(),
@@ -17,7 +29,8 @@ setup(name='distributed',
       license='BSD',
       package_data={ '': ['templates/index.html'], },
       include_package_data=True,
-      install_requires=requires,
+      install_requires=install_requires,
+      extras_require=extras_require,
       packages=['distributed',
                 'distributed.bokeh',
                 'distributed.bokeh.background',


### PR DESCRIPTION
needed for wheels to properly embed [conditional dependencies](https://wheel.readthedocs.io/en/latest/#defining-conditional-dependencies).

Turns

    req; python < '3.0'

into

    {':python < '3.0': [req]}

closes #771