### PR TITLE
Allow any number of transfer logs per task

### DIFF
--- a/distributed/bokeh/background/server_lifecycle.py
+++ b/distributed/bokeh/background/server_lifecycle.py
@@ -113,9 +113,8 @@ def task_events(interval, deque, times, index, rectangles, workers, last_seen):
 
             last_seen[0] = time()
             for msg in msgs:
-                if 'compute_start' in msg:
+                if 'startstops' in msg:
                     deque.append(msg)
-                    times.append(msg['compute_start'])
                     count = task_stream_append(rectangles, msg, workers)
                     for _ in range(count):
                         index.append(i)

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -50,7 +50,7 @@ def test_progress_quads_too_many():
     assert len(d['name']) == 6 * 3
 
 
-@gen_cluster(client=True, timeout=None)
+@gen_cluster(client=True)
 def test_progress_stream(c, s, a, b):
     futures = c.map(div, [1] * 10, range(10))
 
@@ -102,30 +102,3 @@ def test_progress_quads_many_functions():
     d = progress_quads(msg, nrows=2)
     color = d.pop('color')
     assert len(set(color)) < 100
-
-def test_task_stream_append():
-    msgs = [{'status': 'OK', 'compute_start': 10, 'compute_stop': 20,
-             'key':'inc-1', 'thread': 5855, 'worker':'127.0.0.1:9999'},
-            {'status': 'OK', 'compute_start': 15, 'compute_stop': 25,
-             'key':'inc-2', 'thread': 6000, 'worker':'127.0.0.1:9999'},
-            {'status': 'error', 'compute_start': 10, 'compute_stop': 14,
-             'key':'inc-3', 'thread': 6000, 'worker':'127.0.0.1:9999'},
-            {'status': 'OK', 'compute_start': 10, 'compute_stop': 30,
-             'transfer_start': 8, 'transfer_stop': 10,
-             'key':'add-1', 'thread': 4000, 'worker':'127.0.0.2:9999'}]
-
-    lists = {name: [] for name in
-            'start duration key name color worker worker_thread y alpha'.split()}
-    workers = {'127.0.0.1:9999-5855': 0}
-
-    for msg in msgs:
-        task_stream_append(lists, msg, workers)
-    assert len(lists['start']) == len(msgs) + 1  # +1 for a transfer
-    assert len(workers) == 3
-    assert set(workers) == set(lists['worker_thread'])
-    assert set(workers.values()) == set(range(len(workers)))
-    assert lists['color'][-1] == '#FF0020'
-    L = lists['color']
-    assert L[0] == L[1]
-    assert L[2] == 'black'
-    assert L[3] != L[0]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -13,9 +13,6 @@ from timeit import default_timer
 import shutil
 import sys
 
-from .core import read, write, connect, close, send_recv, error_message
-
-
 from dask.core import istask
 from dask.compatibility import apply
 try:
@@ -647,11 +644,11 @@ def apply_function(function, args, kwargs, execution_state, key):
                'status': 'OK',
                'result': result,
                'nbytes': sizeof(result),
-               'type': dumps_function(type(result)) if result is not None else None}
+               'type': type(result) if result is not None else None}
     finally:
         end = time()
-    msg['compute_start'] = start
-    msg['compute_stop'] = end
+    msg['start'] = start
+    msg['stop'] = end
     msg['thread'] = current_thread().ident
     return msg
 
@@ -789,10 +786,14 @@ class Worker(WorkerBase):
 
         self.nbytes = dict()
         self.types = dict()
+        self.threads = dict()
+        self.exceptions = dict()
+        self.tracebacks = dict()
+
         self.priorities = dict()
         self.priority_counter = 0
         self.durations = dict()
-        self.response = defaultdict(dict)
+        self.startstops = defaultdict(list)
         self.host_restrictions = dict()
         self.worker_restrictions = dict()
         self.resource_restrictions = dict()
@@ -1176,13 +1177,27 @@ class Worker(WorkerBase):
             raise
 
     def send_task_state_to_scheduler(self, key):
-        d = self.response[key]
-        if 'op' not in d and key in self.data:
-            d.update({'op': 'task-finished',
-                      'status': 'OK',
-                      'key': key,
-                      'nbytes': self.nbytes[key],
-                      'type': dumps_function(type(self.data[key]))})
+        if key in self.nbytes:
+            d = {'op': 'task-finished',
+                 'status': 'OK',
+                 'key': key,
+                 'nbytes': self.nbytes[key],
+                 'thread': self.threads.get(key),
+                 'type': dumps_function(type(self.data[key]))}
+        elif key in self.exceptions:
+            d = {'op': 'task-erred',
+                 'status': 'error',
+                 'key': key,
+                 'thread': self.threads.get(key),
+                 'exception': self.exceptions[key],
+                 'traceback': self.tracebacks[key]}
+        else:
+            logger.error("Key not ready to send to worker, %s: %s",
+                         key, self.task_state[key])
+            return
+
+        if key in self.startstops:
+            d['startstops'] = self.startstops[key]
         self.batched_stream.send(d)
 
     def put_key_in_memory(self, key, value):
@@ -1193,6 +1208,9 @@ class Worker(WorkerBase):
 
         if key not in self.nbytes:
             self.nbytes[key] = sizeof(value)
+
+        if key not in self.types:
+            self.types[key] = type(value)
 
         self.types[key] = type(value)
 
@@ -1251,8 +1269,7 @@ class Worker(WorkerBase):
                 stop = time()
 
                 if cause:
-                    self.response[cause].update({'transfer_start': start,
-                                                 'transfer_stop': stop})
+                    self.startstops[cause].append(('transfer', start, stop))
 
                 total_bytes = sum(self.nbytes.get(dep, 0) for dep in response)
                 duration = (stop - start) or 0.5
@@ -1428,17 +1445,23 @@ class Worker(WorkerBase):
                     if not self.has_what[worker]:
                         del self.has_what[worker]
 
-            if key not in self.dependents:
-                if key in self.nbytes:
-                    del self.nbytes[key]
-                if key in self.types:
-                    del self.types[key]
-                if key in self.priorities:
-                    del self.priorities[key]
-                if key in self.durations:
-                    del self.durations[key]
-                if key in self.response:
-                    del self.response[key]
+            if key in self.nbytes:
+                del self.nbytes[key]
+            if key in self.types:
+                del self.types[key]
+            if key in self.threads:
+                del self.threads[key]
+            if key in self.priorities:
+                del self.priorities[key]
+            if key in self.durations:
+                del self.durations[key]
+            if key in self.exceptions:
+                del self.exceptions[key]
+            if key in self.tracebacks:
+                del self.tracebacks[key]
+
+            if key in self.startstops:
+                del self.startstops[key]
 
             if key in self.host_restrictions:
                 del self.host_restrictions[key]
@@ -1533,8 +1556,7 @@ class Worker(WorkerBase):
             kwargs2 = pack_data(kwargs, self.data, key_types=str)
             stop = time()
             if stop - start > 0.005:
-                self.response[key]['disk_load_start'] = start
-                self.response[key]['disk_load_stop'] = stop
+                self.startstops[key].append(('disk', start, stop))
                 if self.digests is not None:
                     self.digests['disk-load-duration'].add(stop - start)
 
@@ -1545,15 +1567,21 @@ class Worker(WorkerBase):
 
             result['key'] = key
             value = result.pop('result', None)
-            self.response[key].update(result)
+            self.startstops[key].append(('compute', result['start'],
+                                                    result['stop']))
+            self.threads[key] = result['thread']
 
             if result['op'] == 'task-finished':
+                self.nbytes[key] = result['nbytes']
+                self.types[key] = result['type']
                 self.put_key_in_memory(key, value)
                 self.transition(key, 'memory')
                 if self.digests is not None:
-                    self.digests['task-duration'].add(result['compute_stop'] -
-                                                      result['compute_start'])
+                    self.digests['task-duration'].add(result['stop'] -
+                                                      result['start'])
             else:
+                self.exceptions[key] = result['exception']
+                self.tracebacks[key] = result['traceback']
                 logger.warn(" Compute Failed\n"
                     "Function: %s\n"
                     "args:     %s\n"
@@ -1564,7 +1592,7 @@ class Worker(WorkerBase):
                 self.transition(key, 'error')
 
             logger.debug("Send compute response to scheduler: %s, %s", key,
-                         self.response[key])
+                         result)
 
             if self.validate:
                 assert key not in self.executing


### PR DESCRIPTION
Previously a task-finished message from the worker to the scheduler could
contain three timings:

1.  compute_start/compute_stop
2.  transfer_start/transfer_stop
3.  disk_load_start/disk_load_stop

These would appear on the task stream plot for visual diagnostics.

This was fine, except that some tasks had multiple transfers, and so we were
only seeing the most recent one.

Now we include a list of arbitrary events that have occurred in support of any
particular task.  This can include multiple transfer events or even other
events that we haven't considered here, like serialization cost or some other
hardware cost that might come up in the future.