### PR TITLE
fixed publist_delete : publish_delete typo in client.py

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,11 @@
+joblib >= 0.10.2
+mock >= 2.0.0
+pandas >= 0.19.2
+numpy >= 1.11.0
+bokeh >= 0.12.3
+requests >= 2.12.4
+pyzmq >= 16.0.2
+ipython >= 5.0.0
+jupyter_client >= 4.4.0
+ipykernel >= 4.5.2
+pytest >= 3.0.5

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1204,7 +1204,7 @@ class Client(object):
         --------
         Client.publish_dataset
         """
-        return sync(self.loop, self.scheduler.publist_delete, name=name)
+        return sync(self.loop, self.scheduler.publish_delete, name=name)
 
     def list_datasets(self):
         """


### PR DESCRIPTION
Fixes typo #782 that prevents using Client.unpublish_dataset()