### PR TITLE
Avoid multiple data connections to the same worker

### DIFF
--- a/distributed/bokeh/worker.py
+++ b/distributed/bokeh/worker.py
@@ -53,7 +53,7 @@ class StateTable(DashboardComponent):
                  'Executing': ['%d / %d' % (len(w.executing), w.ncores)],
                  'Ready': [len(w.ready)],
                  'Waiting': [len(w.waiting_for_data)],
-                 'Connections': [len(w.connections)],
+                 'Connections': [len(w.in_flight_workers)],
                  'Serving': [len(w._listen_streams)]}
             self.source.data.update(d)
 
@@ -169,7 +169,7 @@ class CommunicatingTimeSeries(DashboardComponent):
         with log_errors():
             self.source.stream({'x': [time() * 1000],
                                 'out': [len(self.worker._listen_streams)],
-                                'in': [len(self.worker.connections)]},
+                                'in': [len(self.worker.in_flight_workers)]},
                                 10000)
 
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1100,11 +1100,6 @@ class Scheduler(Server):
                    'key': key,
                    'priority': self.priority[key],
                    'duration': self.task_duration.get(key_split(key), 0.5)}
-            if key not in self.loose_restrictions:
-                if key in self.host_restrictions:
-                    msg['host_restrictions'] = list(self.host_restrictions[key])
-                if key in self.worker_restrictions:
-                    msg['worker_restrictions'] = list(self.worker_restrictions[key])
             if key in self.resource_restrictions:
                 msg['resource_restrictions'] = self.resource_restrictions[key]
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -507,43 +507,12 @@ def test_system_monitor(s, a, b):
 
 
 
-@pytest.mark.skipif(not sys.platform.startswith('linux'),
-                    reason="Need 127.0.0.2 to mean localhost")
 @gen_cluster(client=True, ncores=[('127.0.0.1', 2, {'resources': {'A': 1}}),
-                                  ('127.0.0.2', 1)])
+                                  ('127.0.0.1', 1)])
 def test_restrictions(c, s, a, b):
-    # Worker restrictions
-    x = c.submit(inc, 1, workers=a.address)
-    yield x._result()
-    assert a.host_restrictions == {}
-    assert a.worker_restrictions == {x.key: {a.address}}
-    assert a.resource_restrictions == {}
-
-    yield c._cancel(x)
-
-    while x.key in a.task_state:
-        yield gen.sleep(0.01)
-
-    assert a.worker_restrictions == {}
-
-    # Host restrictions
-    x = c.submit(inc, 1, workers=['127.0.0.1'])
-    yield x._result()
-    assert a.host_restrictions == {x.key: {'127.0.0.1'}}
-    assert a.worker_restrictions == {}
-    assert a.resource_restrictions == {}
-    yield c._cancel(x)
-
-    while x.key in a.task_state:
-        yield gen.sleep(0.01)
-
-    assert a.host_restrictions == {}
-
     # Resource restrictions
     x = c.submit(inc, 1, resources={'A': 1})
     yield x._result()
-    assert a.host_restrictions == {}
-    assert a.worker_restrictions == {}
     assert a.resource_restrictions == {x.key: {'A': 1}}
     yield c._cancel(x)
 


### PR DESCRIPTION
The workers manage multiple concurrent peer-to-peer connections.  Each connection can gather multiple pieces of data from that worker  Workers limit the number of simultaneously open connections at once to avoid spreading network bandwidth too thinly.  They avoid gathering more than 200MB of extra data from a worker at once in order to keep high priority tasks from waiting on data of low priority tasks.

However, previously they might open several connections to the same worker, each collecting 200MB.  This can overwhelm the connection, resulting in slower overall performance.

Now we restrict workers to only have one connection to a particular peer at a time.  They can still have many connections open, but they must be to different peers.