### PR TITLE
Add Client.run_on_scheduler method

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -296,6 +296,7 @@ class Scheduler(Server):
                          'rebalance': self.rebalance,
                          'replicate': self.replicate,
                          'start_ipython': self.start_ipython,
+                         'run_function': self.run_function,
                          'update_data': self.update_data}
 
         self.services = {}
@@ -1754,6 +1755,16 @@ class Scheduler(Server):
                 result = out
 
             return result
+
+    def run_function(self, stream, function, args=(), kwargs={}):
+        """ Run a function within this process
+
+        See Also
+        --------
+        Client.run_on_scheduler:
+        """
+        from .worker import run
+        return run(self, stream, function=function, args=args, kwargs=kwargs)
 
     #####################
     # State Transitions #

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -55,7 +55,7 @@ def has_arg(func, argname):
     """
     while True:
         try:
-            if 'dask_worker' in inspect.getargspec(func).args:
+            if argname in inspect.getargspec(func).args:
                 return True
         except TypeError:
             break

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -308,7 +308,6 @@ class WorkerBase(Server):
         # logger.info("Finish job %d, %s", i, key)
         raise gen.Return(result)
 
-
     def run(self, stream, function, args=(), kwargs={}):
         return run(self, stream, function=function, args=args, kwargs=kwargs)
 
@@ -667,7 +666,7 @@ def weight(k, v):
 
 
 @gen.coroutine
-def run(worker, stream, function, args=(), kwargs={}, is_coro=False, wait=True):
+def run(server, stream, function, args=(), kwargs={}, is_coro=False, wait=True):
     assert wait or is_coro, "Combination not supported"
     function = loads(function)
     if args:
@@ -675,7 +674,9 @@ def run(worker, stream, function, args=(), kwargs={}, is_coro=False, wait=True):
     if kwargs:
         kwargs = loads(kwargs)
     if has_arg(function, 'dask_worker'):
-        kwargs['dask_worker'] = worker
+        kwargs['dask_worker'] = server
+    if has_arg(function, 'dask_scheduler'):
+        kwargs['dask_scheduler'] = server
     logger.info("Run out-of-band function %r", funcname(function))
     try:
         result = function(*args, **kwargs)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -22,6 +22,7 @@ API
    Client.replicate
    Client.restart
    Client.run
+   Client.run_on_scheduler
    Client.scatter
    Client.shutdown
    Client.scheduler_info


### PR DESCRIPTION
This allows users to run arbitrary Python functions on the scheduler process

This is typically used for live debugging.  The function should take a
keyword argument ``dask_scheduler=``, which will be given the scheduler
object itself.

Examples
--------

        >>> def get_number_of_tasks(dask_scheduler=None):
        ...     return len(dask_scheduler.task_state)

        >>> client.run_on_scheduler(get_number_of_tasks)  # doctest: +SKIP
        100
