### PR TITLE
Allow double stealing

### DIFF
--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -160,6 +160,7 @@ class WorkStealing(SchedulerPlugin):
             self.scheduler.rprocessing[key] = thief
             self.scheduler.occupancy[thief] += duration
             self.scheduler.total_occupancy += duration
+            self.put_key_in_stealable(key)
 
             self.scheduler.worker_streams[victim].send({'op': 'release-task',
                                                         'key': key})


### PR DESCRIPTION
Previously we did not allow the same task two be stolen twice.
However, this case does come up in the wild.
Now we support it.