### PR TITLE
Pass kwargs through Client.start into LocalCluster invocation

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -423,10 +423,10 @@ class Client(object):
         if self._start_arg is None:
             from distributed.deploy import LocalCluster
             try:
-                self.cluster = LocalCluster(loop=self.loop, start=False)
+                self.cluster = LocalCluster(loop=self.loop, start=False, **kwargs)
             except (OSError, socket.error):
                 self.cluster = LocalCluster(scheduler_port=0, loop=self.loop,
-                                            start=False)
+                                            start=False, **kwargs)
             self._start_arg = self.cluster.scheduler_address
             while (not self.cluster.workers or
                len(self.cluster.scheduler.ncores) < len(self.cluster.workers)):


### PR DESCRIPTION
I'm creating a client that lives within a tornado webapp, and so I'm creating the client in its own thread (with its own IOLoop). With my current setup, the following works for a single tornado listener:

```
import threading

import dask.distributed as dd
import tornado.ioloop
import tornado.web


class MainHandler(tornado.web.RequestHandler):
    def get(self):
        self.write("<code>{}</code>"
                   "".format(self.settings['client']))


def make_app():
    return tornado.web.Application([
        (r"/", MainHandler),
    ], debug=True)


class ThreadedClient(threading.Thread):
    daemon = False
    def __init__(self, address=None, **kwargs):
        if address is not None:
            assert 'address' not in kwargs
        kwargs['address'] = address
        self.kwargs = kwargs
        super(ThreadedClient, self).__init__()

    def run(self):
        # Create a loop for this thread.
        self.loop = tornado.ioloop.IOLoop()
        self.loop.make_current()

        # Update the kwargs with appropriate entries for starting in a background thread.
        kwargs = self.kwargs.copy()
        kwargs.update(dict(start=False, loop=self.loop))

        # Define the client (without starting it), so that we can access it from other threads.
        self.cli = dd.Client(**kwargs)

        # Run the client's loop this thread. 
        self.cli.start()


if __name__ == "__main__":
    app = make_app()
    app.listen(8888)

    client_thread = ThreadedClient()
    client_thread.run()

    app.settings['client'] = client_thread.cli

    tornado.ioloop.IOLoop.instance().start()
```

It would be useful to be able to control parts of the resulting LocalCluster that occurs from not passing an address to the Client - for example, I'd like to be able to disable the diagnostics, and so with this change, am able to ``self.cli.start(diagnostics_port=None)``.

One motivator for this, that I can't reproduce easily, is that I was getting the following exception when starting the cluster in a tornado multi-process httpserver environment:

```
  File "webapp.py", line 466, in run
    self.cli.start(nanny=False, diagnostics_port=None)
  File "/Users/pelson/dev/dask/distributed/distributed/client.py", line 410, in start
    sync(self.loop, self._start, **kwargs)
  File "/Users/pelson/dev/dask/distributed/distributed/utils.py", line 163, in sync
    six.reraise(type(error[0]), error[0], traceback[0])
  File "/Users/pelson/miniconda/lib/python3.5/site-packages/six.py", line 686, in reraise
    raise value
  File "/Users/pelson/dev/dask/distributed/distributed/utils.py", line 149, in f
    result[0] = yield gen.maybe_future(func(*args, **kwargs))
  File "/Users/pelson/miniconda/lib/python3.5/site-packages/tornado/gen.py", line 1015, in run
    value = future.result()
  File "/Users/pelson/miniconda/lib/python3.5/site-packages/tornado/concurrent.py", line 237, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
  File "/Users/pelson/miniconda/lib/python3.5/site-packages/tornado/gen.py", line 285, in wrapper
    yielded = next(result)
  File "/Users/pelson/dev/dask/distributed/distributed/client.py", line 429, in _start
    start=False)
  File "/Users/pelson/dev/dask/distributed/distributed/deploy/local.py", line 113, in __init__
    silence=silence_logs)
  File "/Users/pelson/dev/dask/distributed/distributed/deploy/local.py", line 208, in start_diagnostics_server
    log_level=logging.getLevelName(silence).lower())
  File "/Users/pelson/dev/dask/distributed/distributed/bokeh/application.py", line 84, in __init__
    process = subprocess.Popen(args)
  File "/Users/pelson/miniconda/lib/python3.5/site-packages/gevent/subprocess.py", line 555, in __init__
    restore_signals, start_new_session)
  File "/Users/pelson/miniconda/lib/python3.5/site-packages/gevent/subprocess.py", line 1161, in _execute_child
    self.pid = fork_and_watch(self._on_child, self._loop, True, fork)
  File "/Users/pelson/miniconda/lib/python3.5/site-packages/gevent/os.py", line 375, in fork_and_watch
    watcher = loop.child(pid, ref=ref)
  File "gevent.libev.corecext.pyx", line 518, in gevent.libev.corecext.loop.child (src/gevent/libev/gevent.corecext.c:7574)
  File "gevent.libev.corecext.pyx", line 1886, in gevent.libev.corecext.child.__init__ (src/gevent/libev/gevent.corecext.c:21631)

TypeError: child watchers are only available on the default loop
```

If it would be helpful, I can dig into making this reproducibly - but for me, just being able to turn off the diagnostics solves the problem.