### PR TITLE
PermissionError on startup under supervisor

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -70,3 +70,9 @@ users use high-level functions like
 HDFS name node, finds the locations of all of the blocks of data, and sends
 that information to the scheduler so that it can make smarter decisions and
 improve load times for users.
+
+
+PermissionError [Errno 13] Permission Denied: `/root/.dask`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This error can be seen when starting distributed through the stardard process control tool supervisor and running as a non-root suer. This is caused by supervisor not passing the shell environment variables through to the subprocess, head to [this section](http://supervisord.org/subprocess.html#subprocess-environment) of the supervisor documentation to see how to pass the $HOME and $USER variables through.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -75,4 +75,6 @@ improve load times for users.
 PermissionError [Errno 13] Permission Denied: `/root/.dask`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This error can be seen when starting distributed through the stardard process control tool supervisor and running as a non-root suer. This is caused by supervisor not passing the shell environment variables through to the subprocess, head to [this section](http://supervisord.org/subprocess.html#subprocess-environment) of the supervisor documentation to see how to pass the $HOME and $USER variables through.
+This error can be seen when starting distributed through the stardard process control tool supervisor and running as a non-root suer. This is caused by supervisor not passing the shell environment variables through to the subprocess, head to `this section`_ of the supervisor documentation to see how to pass the $HOME and $USER variables through.
+
+.. _this section: http://supervisord.org/subprocess.html#subprocess-environment

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -72,7 +72,7 @@ that information to the scheduler so that it can make smarter decisions and
 improve load times for users.
 
 
-PermissionError [Errno 13] Permission Denied: `/root/.dask`
+PermissionError [Errno 13] Permission Denied: \`/root/.dask\`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This error can be seen when starting distributed through the stardard process control tool supervisor and running as a non-root suer. This is caused by supervisor not passing the shell environment variables through to the subprocess, head to `this section`_ of the supervisor documentation to see how to pass the $HOME and $USER variables through.


### PR DESCRIPTION
I have experienced this issue a few times and it is inconsistent between different OSs. I am aware that it is not a Distributed issue but also that supervisor is pretty popular and used in some docker containers etc.