### PR TITLE
Set rpc status while deleting

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -563,6 +563,7 @@ class rpc(object):
     def __del__(self):
         if self.status != 'closed':
             rpc.active -= 1
+            self.status = 'closed'
             n_open = sum(not stream.closed() for stream in self.streams)
             if n_open:
                 logger.warn("rpc object %s deleted with %d open streams",


### PR DESCRIPTION
We're getting the following error, showing that rpc.active decreases
below zero.  This change is just a blind guess as to the cause.

    File "C:\projects\distributed\distributed\utils_test.py", line 326, in check_active_rpc
      assert rpc.active == rpc_active
    AssertionError: assert -1 == 0

@pitrou, any thoughts?