### PR TITLE
WIP: worker lifetime initial commit

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -184,12 +184,11 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
         def retire():
             yield gen.sleep(lifetime)
             logger.info("Retiring worker...")
-            with rpc(ip=nannies[0].scheduler.ip,
-                     port=nannies[0].scheduler.port) as scheduler:
-                workers = ([n.worker_address for n in nannies
-                            if n.process and n.worker_port] if nanny else
-                           [n.address for n in nannies])
-                scheduler.retire_workers(workers=workers, remove=False)
+            workers = ([n.worker_address for n in nannies
+                        if n.process and n.worker_address] if nanny else
+                       [n.address for n in nannies])
+            with rpc(nannies[0].scheduler.address) as scheduler:
+                scheduler.retire_workers(workers=workers, remove=True)
             retired[0] = True
             logger.info("Worker retired")
 

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -99,51 +99,54 @@ def test_local_directory(loop, nanny):
 @pytest.mark.parametrize('nanny', ['--nanny', '--no-nanny'])
 def test_lifetime(loop, nanny):
     worker1_cmd = ['dask-worker', '127.0.0.1:8786', nanny, '--no-bokeh',
-                   '--nprocs=1', '--worker-port=11111', '--lifetime=s=2']
+                   '--nprocs=1', '--name=a', '--lifetime=s=5']
     worker2_cmd = ['dask-worker', '127.0.0.1:8786', nanny, '--no-bokeh',
-                   '--nprocs=1', '--worker-port=22222']
-    with popen(['dask-scheduler', '--no-bokeh']) as _:
+                   '--nprocs=1', '--name=b']
+    with popen(['dask-scheduler', '--no-bokeh']) as w1:
         with Client('127.0.0.1:8786', loop=loop) as c:
-            with popen(worker1_cmd) as _, popen(worker2_cmd) as _:
-                start = time()
-                # submit random function to ensure replication not
-                # recomputation
-                f = c.submit(randominc, 1, workers=['127.0.0.1:11111'])
+            with popen(worker1_cmd) as w1, popen(worker2_cmd) as w2:
+                # submit random function to ensure replication
+                f = c.submit(randominc, 1, workers=['a'])
                 r = f.result()
-                assert f.key not in c.has_what()['127.0.0.1:22222']
+
+                start = time()
                 while len(c.has_what()) != 1:
-                    sleep(0.01)  # wait for first worker to retire itself
-                    if time() - start > 5:  # but not too long ...
+                    sleep(0.1)
+                    if time() - start > 10:
                         raise TimeoutError
-                assert f.key in c.has_what()['127.0.0.1:22222']
+
+                assert f.status != 'lost'
                 assert f.result() == r
 
 
 @pytest.mark.parametrize('nanny', ['--nanny', '--no-nanny'])
 def test_auto_retire_multi_worker(loop, nanny):
     worker1_cmd = ['dask-worker', '127.0.0.1:8786', nanny, '--no-bokeh',
-                   '--nprocs=2', '--lifetime=s=2']
+                   '--nprocs=2', '--lifetime=s=5']
     worker2_cmd = ['dask-worker', '127.0.0.1:8786', nanny, '--no-bokeh',
                    '--nprocs=1', '--worker-port=22222']
     with popen(['dask-scheduler', '--no-bokeh']) as _:
         with Client('127.0.0.1:8786', loop=loop) as c:
             with popen(worker1_cmd) as _:
+
                 start = time()
                 while len(c.has_what()) != 2:
-                        sleep(0.1)
+                    sleep(0.1)
+                    if time() - start > 10:
+                        raise TimeoutError
+
                 worker1_addresses = c.has_what().keys()
                 fs = [c.submit(randominc, i, workers=worker1_addresses)
                       for i in range(4)]
                 rs = [f.result() for f in fs]
+
                 with popen(worker2_cmd) as _:
-                    while len(c.has_what()) != 3:
-                        sleep(0.1)
-                    assert all(f.key not in c.has_what()['127.0.0.1:22222']
-                               for f in fs)
+
+                    start = time()
                     while len(c.has_what()) != 1:
-                        sleep(0.1)  # wait for first workers to retire
-                        if time() - start > 5:  # but not too long ...
+                        sleep(0.1)
+                        if time() - start > 10:
                             raise TimeoutError
-                    assert all(f.key in c.has_what()['127.0.0.1:22222']
-                               for f in fs)
+
+                    assert all(f.status != 'lost' for f in fs)
                     assert [f.result() for f in fs] == rs

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -302,7 +302,8 @@ class Scheduler(Server):
                          'start_ipython': self.start_ipython,
                          'run_function': self.run_function,
                          'update_data': self.update_data,
-                         'set_resources': self.add_resources}
+                         'set_resources': self.add_resources,
+                         'retire_workers': self.retire_workers}
 
         self._transitions = {
                  ('released', 'waiting'): self.transition_released_waiting,

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -159,6 +159,11 @@ def randominc(x, scale=1):
     return x + 1
 
 
+def randominc(x):
+    from random import random
+    return x + random()
+
+
 def slowadd(x, y, delay=0.02):
     from time import sleep
     sleep(delay)


### PR DESCRIPTION
This adds a `--lifetime` command line option to `dask-worker`, such that the worker retires itself after this time, replicating its data to other workers. This adds a degree of resilience to e.g. long running computations on batch-systems where the workers are submitted as jobs with limited run time.

For example:

```bash
$ dask-worker ... --lifetime="hours=23 mins=55"
```

Some comments/questions:
- the name '--lifetime', maybe '--retire-after' would be more explicit? Also the specifier is currently chosen to match the --resources argument, rather than e.g. 23h55m.
- Due to the timing nature the tests are a little slow but possibly fragile if sped up.
- Docs: should this be in the resilience section or somewhere else?