### PR TITLE
As completed

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2465,6 +2465,8 @@ class AsCompleted(object):
                 raise StopIteration()
         return self.queue.get()
 
+    next = __next__
+
 
 as_completed = AsCompleted
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -13,7 +13,7 @@ import os
 import sys
 from time import sleep
 import uuid
-from threading import Thread
+from threading import Thread, Lock
 import six
 import socket
 
@@ -2388,36 +2388,85 @@ def _first_completed(futures):
     raise gen.Return(result)
 
 
-def as_completed(fs):
-    """ Return futures in the order in which they complete
+class AsCompleted(object):
+    """
+    Return futures in the order in which they complete
 
     This returns an iterator that yields the input future objects in the order
     in which they complete.  Calling ``next`` on the iterator will block until
     the next future completes, irrespective of order.
 
-    This function does not return futures in the order in which they are input.
+    Additionally, you can also add more futures to this object during
+    computation with the ``.add`` method
+
+    Examples
+    --------
+    >>> x, y, z = client.map(inc, [1, 2, 3])  # doctest: +SKIP
+    >>> for future in as_completed([x, y, z]):  # doctest: +SKIP
+    ...     print(future.result())  # doctest: +SKIP
+    3
+    2
+    4
+
+    Add more futures during computation
+
+    >>> x, y, z = client.map(inc, [1, 2, 3])  # doctest: +SKIP
+    >>> ac = as_completed([x, y, z])  # doctest: +SKIP
+    >>> for future in ac:  # doctest: +SKIP
+    ...     print(future.result())  # doctest: +SKIP
+    ...     if random.random() < 0.5:  # doctest: +SKIP
+    ...         ac.add(c.submit(double, future))  # doctest: +SKIP
+    4
+    2
+    8
+    3
+    6
+    12
+    24
     """
-    fs = list(fs)
-    if not fs:
-        return
-    non_futures = [f for f in fs if not isinstance(f, Future)]
-    if non_futures:
-        raise TypeError("Using as_completed on non-future objects: %s" %
-                        non_futures)
-    if len(set(f.client for f in fs)) == 1:
-        loop = first(fs).client.loop
-    else:
-        # TODO: Groupby client, spawn many _as_completed coroutines
-        raise NotImplementedError(
-        "as_completed on many event loops not yet supported")
+    def __init__(self, futures=None, loop=None):
+        if futures is None:
+            futures = []
+        self.futures = defaultdict(lambda: 0)
+        self.queue = pyQueue()
+        self.lock = Lock()
+        self.loop = loop or default_client().loop
 
-    queue = pyQueue()
+        if futures:
+            for future in futures:
+                self.add(future)
 
-    coroutine = lambda: _as_completed(fs, queue)
-    loop.add_callback(coroutine)
+    @gen.coroutine
+    def track_future(self, future):
+        yield _wait(future)
+        with self.lock:
+            self.futures[future] -= 1
+            if not self.futures[future]:
+                del self.futures[future]
+            self.queue.put_nowait(future)
 
-    for i in range(len(fs)):
-        yield queue.get()
+    def add(self, future):
+        """ Add a future to the collection
+
+        This future will emit from the iterator once it finishes
+        """
+        if type(future) is not Future:
+            raise TypeError("Input must be a future, got %s" % str(future))
+        with self.lock:
+            self.futures[future] += 1
+        self.loop.add_callback(self.track_future, future)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self.lock:
+            if not self.futures and self.queue.empty():
+                raise StopIteration()
+        return self.queue.get()
+
+
+as_completed = AsCompleted
 
 
 def default_client(c=None):

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -52,14 +52,17 @@ def test_as_completed_add(loop):
     with cluster() as (s, [a, b]):
         with Client(('127.0.0.1', s['port']), loop=loop) as c:
             total = 0
-            futures = c.map(inc, range(20))
+            expected = sum(map(inc, range(10)))
+            futures = c.map(inc, range(10))
             ac = AsCompleted(futures)
             for future in ac:
-                total += future.result()
+                result = future.result()
+                total += result
                 if random.random() < 0.5:
                     future = c.submit(add, future, 10)
                     ac.add(future)
-            assert total > sum(map(inc, range(10)))
+                    expected += result + 10
+            assert total == expected
 
 
 def test_as_completed_repeats(loop):

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -1,9 +1,12 @@
 from collections import Iterator
+from operator import add
+import random
 
 import pytest
 
 from distributed import Client
-from distributed.client import _as_completed, as_completed, _first_completed
+from distributed.client import (_as_completed, as_completed, _first_completed,
+        AsCompleted)
 from distributed.utils_test import gen_cluster, inc, dec, loop, cluster
 from distributed.compatibility import Queue
 
@@ -44,3 +47,34 @@ def test_as_completed_with_non_futures(loop):
             with pytest.raises(TypeError):
                 list(as_completed([1, 2, 3]))
 
+
+def test_as_completed_add(loop):
+    with cluster() as (s, [a, b]):
+        with Client(('127.0.0.1', s['port']), loop=loop) as c:
+            total = 0
+            futures = c.map(inc, range(20))
+            ac = AsCompleted(futures)
+            for future in ac:
+                total += future.result()
+                if random.random() < 0.5:
+                    future = c.submit(add, future, 10)
+                    ac.add(future)
+            assert total > sum(map(inc, range(10)))
+
+
+def test_as_completed_repeats(loop):
+    with cluster() as (s, [a, b]):
+        with Client(('127.0.0.1', s['port']), loop=loop) as c:
+            ac = AsCompleted()
+            x = c.submit(inc, 1)
+            ac.add(x)
+            ac.add(x)
+
+            assert next(ac) is x
+            assert next(ac) is x
+
+            with pytest.raises(StopIteration):
+                next(ac)
+
+            ac.add(x)
+            assert next(ac) is x

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -1,0 +1,46 @@
+from collections import Iterator
+
+import pytest
+
+from distributed import Client
+from distributed.client import _as_completed, as_completed, _first_completed
+from distributed.utils_test import gen_cluster, inc, dec, loop, cluster
+from distributed.compatibility import Queue
+
+
+@gen_cluster(client=True)
+def test__as_completed(c, s, a, b):
+    x = c.submit(inc, 1)
+    y = c.submit(inc, 1)
+    z = c.submit(inc, 2)
+
+    queue = Queue()
+    yield _as_completed([x, y, z], queue)
+
+    assert queue.qsize() == 3
+    assert {queue.get(), queue.get(), queue.get()} == {x, y, z}
+
+    result = yield _first_completed([x, y, z])
+    assert result in [x, y, z]
+
+
+def test_as_completed(loop):
+    with cluster() as (s, [a, b]):
+        with Client(('127.0.0.1', s['port']), loop=loop) as c:
+            x = c.submit(inc, 1)
+            y = c.submit(inc, 2)
+            z = c.submit(inc, 1)
+
+            seq = as_completed([x, y, z])
+            assert isinstance(seq, Iterator)
+            assert set(seq) == {x, y, z}
+
+            assert list(as_completed([])) == []
+
+
+def test_as_completed_with_non_futures(loop):
+    with cluster() as (s, [a, b]):
+        with Client(('127.0.0.1', s['port']), loop=loop) as c:
+            with pytest.raises(TypeError):
+                list(as_completed([1, 2, 3]))
+

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -372,44 +372,6 @@ def test_wait(c, s, a, b):
     assert x.status == y.status == 'finished'
 
 
-@gen_cluster(client=True)
-def test__as_completed(c, s, a, b):
-    x = c.submit(inc, 1)
-    y = c.submit(inc, 1)
-    z = c.submit(inc, 2)
-
-    from distributed.compatibility import Queue
-    queue = Queue()
-    yield _as_completed([x, y, z], queue)
-
-    assert queue.qsize() == 3
-    assert {queue.get(), queue.get(), queue.get()} == {x, y, z}
-
-    result = yield _first_completed([x, y, z])
-    assert result in [x, y, z]
-
-
-def test_as_completed(loop):
-    with cluster() as (s, [a, b]):
-        with Client(('127.0.0.1', s['port']), loop=loop) as c:
-            x = c.submit(inc, 1)
-            y = c.submit(inc, 2)
-            z = c.submit(inc, 1)
-
-            seq = as_completed([x, y, z])
-            assert isinstance(seq, Iterator)
-            assert set(seq) == {x, y, z}
-
-            assert list(as_completed([])) == []
-
-
-def test_as_completed_with_non_futures(loop):
-    with cluster() as (s, [a, b]):
-        with Client(('127.0.0.1', s['port']), loop=loop) as c:
-            with pytest.raises(TypeError):
-                list(as_completed([1, 2, 3]))
-
-
 def test_wait_sync(loop):
     with cluster() as (s, [a, b]):
         with Client(('127.0.0.1', s['port']), loop=loop) as c:


### PR DESCRIPTION
This extends the concurrent.futures `as_completed` iterator to allow us to add new futures in the middle of the computation.  This is useful for some upcoming machine learning work.

cc @pitrou do you have some time to give this a quick review?