### PR TITLE
Add IP keyword to LocalCluster to enable remote access

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -38,6 +38,8 @@ class LocalCluster(object):
     silence_logs: logging level
         Level of logs to print out to stdout.  ``logging.CRITICAL`` by default.
         Use a falsey value like False or None for no change.
+    ip: string
+        IP range on which the scheduler will listen, defaults to only localhost
     kwargs: dict
         Extra worker arguments, will be passed to the Worker constructor.
 
@@ -59,7 +61,7 @@ class LocalCluster(object):
     >>> c.start_diagnostics_server(show=True)  # doctest: +SKIP
     """
     def __init__(self, n_workers=None, threads_per_worker=None, nanny=True,
-                 loop=None, start=True, scheduler_port=8786,
+                 loop=None, start=True, ip='127.0.0.1', scheduler_port=8786,
                  silence_logs=logging.CRITICAL, diagnostics_port=8787,
                  services={}, worker_services={}, **worker_kwargs):
         self.status = None
@@ -106,7 +108,7 @@ class LocalCluster(object):
         self.worker_kwargs = worker_kwargs
 
         if start:
-            sync(self.loop, self._start)
+            sync(self.loop, self._start, ip)
 
     def __str__(self):
         return ('LocalCluster(%r, workers=%d, ncores=%d)' %
@@ -117,7 +119,7 @@ class LocalCluster(object):
     __repr__ = __str__
 
     @gen.coroutine
-    def _start(self):
+    def _start(self, ip='127.0.0.1'):
         """
         Start all cluster services.
         Wait on this if you passed `start=False` to the LocalCluster
@@ -125,7 +127,7 @@ class LocalCluster(object):
         """
         if self.status == 'running':
             return
-        self.scheduler.start(('127.0.0.1', self.scheduler_port))
+        self.scheduler.start((ip, self.scheduler_port))
 
         yield self._start_all_workers(
             self.n_workers, ncores=self.threads_per_worker,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -39,7 +39,7 @@ class LocalCluster(object):
         Level of logs to print out to stdout.  ``logging.CRITICAL`` by default.
         Use a falsey value like False or None for no change.
     ip: string
-        IP range on which the scheduler will listen, defaults to only localhost
+        IP address on which the scheduler will listen, defaults to only localhost
     kwargs: dict
         Extra worker arguments, will be passed to the Worker constructor.
 

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -227,18 +227,12 @@ def test_silent_startup(capsys, loop):
 
 
 def test_only_local_access(loop):
-    from distributed.http import HTTPScheduler
-    import requests
     with LocalCluster(scheduler_port=0, silence_logs=False,
-            services={('http', 3485): HTTPScheduler}, diagnostics_port=None,
-            loop=loop) as c:
+                      diagnostics_port=None, loop=loop) as c:
         sync(loop, assert_can_connect_locally_4, c.scheduler.port)
 
 
 def test_remote_access(loop):
-    from distributed.http import HTTPScheduler
-    import requests
     with LocalCluster(scheduler_port=0, silence_logs=False,
-            services={('http', 3485): HTTPScheduler}, diagnostics_port=None,
-            ip='*', loop=loop) as c:
+                      diagnostics_port=None, ip='', loop=loop) as c:
         sync(loop, assert_can_connect_from_everywhere_4_6, c.scheduler.port)

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -12,8 +12,9 @@ import pytest
 from distributed import Client, Worker, Nanny
 from distributed.deploy.local import LocalCluster
 from distributed.metrics import time
-from distributed.utils_test import inc, loop, raises, gen_test
-from distributed.utils import ignoring
+from distributed.utils_test import (inc, loop, raises, gen_test,
+        assert_can_connect_locally_4, assert_can_connect_from_everywhere_4_6)
+from distributed.utils import ignoring, sync
 
 from distributed.deploy.utils_test import ClusterTest
 
@@ -223,3 +224,21 @@ def test_silent_startup(capsys, loop):
     assert not out
     for line in err.split('\n'):
         assert 'worker' not in line
+
+
+def test_only_local_access(loop):
+    from distributed.http import HTTPScheduler
+    import requests
+    with LocalCluster(scheduler_port=0, silence_logs=False,
+            services={('http', 3485): HTTPScheduler}, diagnostics_port=None,
+            loop=loop) as c:
+        sync(loop, assert_can_connect_locally_4, c.scheduler.port)
+
+
+def test_remote_access(loop):
+    from distributed.http import HTTPScheduler
+    import requests
+    with LocalCluster(scheduler_port=0, silence_logs=False,
+            services={('http', 3485): HTTPScheduler}, diagnostics_port=None,
+            ip='*', loop=loop) as c:
+        sync(loop, assert_can_connect_from_everywhere_4_6, c.scheduler.port)


### PR DESCRIPTION
Previously the scheduler in the localcluster could only receive connections
from localhost.  This adds a keyword to enable remote access.

This is important because LocalCluster is often a base for other cluster
implementations.

cc @pitrou 