### PR TITLE
First in first out on client submission

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1425,6 +1425,11 @@ class Client(object):
         for k, v in dsk3.items():
             dependencies[k] |= get_dependencies(dsk3, task=v)
 
+        if priority is None:
+            dependencies2 = {key: {dep for dep in deps if dep in dependencies}
+                             for key, deps in dependencies.items()}
+            priority = dask.order.order(dsk3, dependencies2)
+
         self._send_to_scheduler({'op': 'update-graph',
                                  'tasks': valmap(dumps_task, dsk3),
                                  'dependencies': valmap(list, dependencies),

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3643,6 +3643,7 @@ def test_interleave_computations(c, s, a, b):
     assert_no_data_loss(s)
 
 
+@pytest.mark.xfail(reason="Now prefer first-in-first-out")
 @gen_cluster(client=True, timeout=None)
 def test_interleave_computations_map(c, s, a, b):
     xs = c.map(slowinc, range(30), delay=0.02)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1058,3 +1058,14 @@ def test_retire_nannies_close(c, s, a, b):
     yield gen.sleep(1)
     assert not any(proc.is_alive() for proc in processes)
     assert not a.process and not b.process
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 2)])
+def test_fifo_submission(c, s, w):
+    futures = []
+    for i in range(20):
+        future = c.submit(slowinc, i, delay=0.1, key='inc-%02d' % i)
+        futures.append(future)
+        yield gen.sleep(0.01)
+    yield _wait(futures[-1])
+    assert futures[10].status == 'finished'

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -982,7 +982,6 @@ class Worker(WorkerBase):
             closed = False
 
             while not closed:
-                self.priority_counter += 1
                 try:
                     msgs = yield comm.read()
                 except CommClosedError:
@@ -1003,8 +1002,6 @@ class Worker(WorkerBase):
                         break
                     elif op == 'compute-task':
                         priority = msg.pop('priority')
-                        priority = [self.priority_counter] + priority
-                        priority = tuple(-x for x in priority)
                         self.add_task(priority=priority, **msg)
                     elif op == 'release-task':
                         self.log.append((msg['key'], 'release-task'))


### PR DESCRIPTION
Given more tasks than available worker threads, we must choose between them.

There is a general tension between first-in-first-out, which prioritizes tasks
submitted earlier to tasks submitted later, and first-in-last-out, which
prioritizes tasks that have just become ready.  Generally FIFO is better for
streaming or linear computations while LIFO is better for complex computations
and reducing memory footprint.

Now the scheduler's policy is to be FILO within any atomic submission of tasks
(like compute or persist) but to be FIFO between calls.

Fixes https://github.com/dask/distributed/issues/838