### PR TITLE
Allow executing-then-stolen tasks to contribute

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2097,8 +2097,6 @@ class Scheduler(Server):
 
             if worker not in self.processing:
                 return {key: 'released'}
-            if worker != self.rprocessing[key]:
-                return {}
 
             if startstops:
                 compute_start, compute_stop = [(b, c) for a, b, c in startstops

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -163,6 +163,7 @@ class WorkStealing(SchedulerPlugin):
             self.put_key_in_stealable(key)
 
             self.scheduler.worker_comms[victim].send({'op': 'release-task',
+                                                      'reason': 'stolen',
                                                       'key': key})
 
             try:

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -506,3 +506,21 @@ def test_steal_twice(c, s, a, b):
     assert max(map(len, s.has_what.values())) < 20
 
     yield [w._close() for w in workers]
+
+
+@gen_cluster(client=True)
+def test_accept_old_result_if_stolen(c, s, a, b):
+    future = c.submit(slowinc, 1, delay=0.5, workers=a.address)
+    while not a.executing:
+        yield gen.sleep(0.01)
+    steal = s.extensions['stealing']
+
+    yield gen.sleep(0.25)
+
+    steal.move_task(future.key, a.address, b.address)
+    while not b.executing:
+        yield gen.sleep(0.01)
+
+    yield gen.sleep(0.25)
+
+    assert future.key in s.who_has

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1636,9 +1636,11 @@ class Worker(WorkerBase):
                 import pdb; pdb.set_trace()
             raise
 
-    def release_key(self, key, cause=None):
+    def release_key(self, key, cause=None, reason=None):
         try:
             if key not in self.task_state:
+                return
+            if reason == 'stolen' and key in self.executing:
                 return
             state = self.task_state.pop(key)
             if cause:


### PR DESCRIPTION
This avoids loss of work when we make an unlucky stealing choice