### PR TITLE
This adds a better approximation to the memory consumption of scipy sparse matrices

### DIFF
--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -68,7 +68,7 @@ def register_pandas():
 def register_spmatrix():
     from scipy import sparse
     @sizeof.register(sparse.dok_matrix)
-    def sizeof_spmatrix(s):
+    def sizeof_spmatrix_dok(s):
         return s.__sizeof__()
 
     @sizeof.register(sparse.spmatrix)

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -62,3 +62,18 @@ def register_pandas():
         p = int(i.memory_usage())
         obj = len(i) * 100 if i.dtype == object else 0
         return int(p + obj) + 1000
+
+
+@sizeof.register_lazy("scipy")
+def register_spmatrix():
+    from scipy import sparse
+    @sizeof.register(sparse.dok_matrix)
+    def sizeof_spmatrix(s):
+        return s.__sizeof__()
+
+    @sizeof.register(sparse.spmatrix)
+    def sizeof_spmatrix(s):
+        return sum(
+            sizeof(v) for v in s.__dict__.values()
+        )
+

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -36,3 +36,15 @@ def test_pandas():
     assert isinstance(sizeof(df), int)
     assert isinstance(sizeof(df.x), int)
     assert isinstance(sizeof(df.index), int)
+
+
+def test_sparse_matrix():
+    sparse = pytest.importorskip('scipy.sparse')
+    sp = sparse.eye(10)
+    assert sizeof(sp.todia()) >= 152
+    assert sizeof(sp.tobsr()) >= 232
+    assert sizeof(sp.tocoo()) >= 252
+    assert sizeof(sp.tocsc()) >= 232
+    assert sizeof(sp.tocsr()) >= 260
+    assert sizeof(sp.todok()) >= 260
+    assert sizeof(sp.tolil()) >= 324


### PR DESCRIPTION
By adding new dispatches to the sizeof function we provide better support for persisting sparse matrix objects to a distributed cluster.