### PR TITLE
Test large uneven frames through whole pipeline

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -189,7 +189,6 @@ class Serialized(object):
     def __init__(self, header, frames):
         self.header = header
         self.frames = frames
-        assert len(header['lengths']) == header['count'] == len(self.frames)
 
     def deserialize(self):
         from .core import decompress

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -144,7 +144,7 @@ def test_dont_compress_uncompressable_data():
         assert data.obj.ctypes.data == x.ctypes.data
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, timeout=60)
 def test_dumps_large_blosc(c, s, a, b):
     x = c.submit(np.ones, BIG_BYTES_SHARD_SIZE * 2, dtype='u1')
     result = yield x._result()

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -9,7 +9,7 @@ from distributed.protocol import (serialize, deserialize, decompress, dumps,
         loads, to_serialize)
 from distributed.protocol.utils import BIG_BYTES_SHARD_SIZE
 from distributed.utils import tmpfile
-from distributed.utils_test import slow
+from distributed.utils_test import slow, gen_cluster
 from distributed.protocol.numpy import itemsize
 from distributed.protocol.compression import maybe_compress
 
@@ -142,3 +142,9 @@ def test_dont_compress_uncompressable_data():
     assert 'compression' not in header
     if isinstance(data, memoryview):
         assert data.obj.ctypes.data == x.ctypes.data
+
+
+@gen_cluster(client=True)
+def test_dumps_large_blosc(c, s, a, b):
+    x = c.submit(np.ones, BIG_BYTES_SHARD_SIZE * 2, dtype='u1')
+    result = yield x._result()


### PR DESCRIPTION
Previously we weren't testing moving large amounts of data through
non-deserializing channels.  This was problematic because we set up an
erroneous assertion in a previous PR.  This removes that assertion and
adds a regression test.