### PR TITLE
Keep first finished task in double stealing event

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -725,14 +725,13 @@ class Scheduler(Server):
                                                                  DEFAULT_DATA_SIZE)
                 self.who_has[key].add(worker)
                 self.has_what[worker].add(key)
-        elif self.task_state[key] == 'memory':
+        else:
             logger.debug("Received already computed task, worker: %s, state: %s"
                          ", key: %s, who_has: %s",
-                         worker, self.task_state[key], key, self.who_has[key])
-            if worker not in self.who_has[key]:
+                         worker, self.task_state.get(key), key,
+                         self.who_has.get(key))
+            if worker not in self.who_has.get(key, ()):
                 self.worker_comms[worker].send({'op': 'release-task', 'key': key})
-            recommendations = {}
-        else:
             recommendations = {}
 
         return recommendations
@@ -1363,9 +1362,10 @@ class Scheduler(Server):
         if not missing_keys:
             result = {'status': 'OK', 'data': data}
         else:
-            logger.info("Couldn't gather keys %s state: %s workers: %s", missing_keys,
-                    [self.task_state[key] for key in missing_keys],
-                    missing_workers)
+            logger.debug("Couldn't gather keys %s state: %s workers: %s",
+                         missing_keys,
+                         [self.task_state.get(key) for key in missing_keys],
+                         missing_workers)
             result = {'status': 'error', 'keys': missing_keys}
             with log_errors():
                 for worker in missing_workers:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1359,8 +1359,13 @@ class Scheduler(Server):
             data = yield gather_from_workers(who_has, rpc=self.rpc, close=False)
             result = {'status': 'OK', 'data': data}
         except KeyError as e:
-            logger.debug("Couldn't gather keys %s", e)
+            key = e.args[0]
+            logger.info("Couldn't gather keys %s state: %s", key,
+                    self.task_state[key])
             result = {'status': 'error', 'keys': e.args}
+            with log_errors():
+                for worker in list(self.who_has[key]):
+                    self.remove_worker(address=worker)  # this is extreme
 
         raise gen.Return(result)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1374,7 +1374,7 @@ class Scheduler(Server):
                     logger.exception("Workers don't have promised keys. "
                                      "This should never occur")
                     for worker in workers:
-                        if key in self.has_what[worker]:
+                        if worker in self.workers and key in self.has_what[worker]:
                             self.has_what[worker].remove(key)
                             self.who_has[key].remove(worker)
                             self.worker_bytes[worker] -= self.nbytes.get(key, DEFAULT_DATA_SIZE)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -719,6 +719,7 @@ class Scheduler(Server):
             recommendations = self.transition(key, 'memory', worker=worker,
                                               **kwargs)
         else:
+            self.worker_comms[worker].send({'op': 'release-task', 'key': key})
             recommendations = {}
 
         if self.task_state[key] == 'memory':
@@ -2162,7 +2163,9 @@ class Scheduler(Server):
                 self.occupancy[w] -= duration
             self.check_idle_saturated(w)
             if w != worker:
-                pass
+                logger.info("Unexpected worker completed task, likely due to"
+                            " work stealing.  Expected: %s, Got: %s, Key: %s",
+                            w, worker, key)
                 # msg = {'op': 'release-task', 'key': key}
                 # self.worker_comms[w].send(msg)
 

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -286,5 +286,9 @@ class WorkStealing(SchedulerPlugin):
         self.key_stealable.clear()
         self.stealable_unknown_durations.clear()
 
+    def story(self, *keys):
+        keys = set(keys)
+        return [t for L in self.log for t in L if any(x in keys for x in t)]
+
 
 fast_tasks = {'shuffle-split'}

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -22,8 +22,8 @@ def test_gather_from_workers_permissive(s, a, b):
     with pytest.raises(KeyError):
         yield gather_from_workers({'x': [a.address], 'y': [b.address]})
 
-    data, bad = yield gather_from_workers({'x': [a.address], 'y': [b.address]},
-                                          permissive=True)
+    data, missing, bad_workers = yield gather_from_workers(
+            {'x': [a.address], 'y': [b.address]}, permissive=True)
 
     assert data == {'x': 1}
-    assert list(bad) == ['y']
+    assert list(missing) == ['y']

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -134,4 +134,4 @@ def test_async(c, s, a, b):
     start = time()
     while len(a.data) + len(b.data) > 1:
         yield gen.sleep(0.1)
-        assert time() < start + 5
+        assert time() < start + 3

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -134,4 +134,4 @@ def test_async(c, s, a, b):
     start = time()
     while len(a.data) + len(b.data) > 1:
         yield gen.sleep(0.1)
-        assert time() < start + 3
+        assert time() < start + 5

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -38,6 +38,8 @@ def gather_from_workers(who_has, rpc=rpc, close=True, permissive=False):
     _gather
     """
     bad_addresses = set()
+    missing_workers = set()
+    original_who_has = who_has
     who_has = {k: set(v) for k, v in who_has.items()}
     results = dict()
     all_bad_keys = set()
@@ -63,19 +65,26 @@ def gather_from_workers(who_has, rpc=rpc, close=True, permissive=False):
 
         rpcs = {addr: rpc(addr) for addr in d}
         try:
-            coroutines = [rpcs[address].get_data(keys=keys, close=close)
-                          for address, keys in d.items()]
-            response = yield ignore_exceptions(coroutines, EnvironmentError)
+            coroutines = {address: rpcs[address].get_data(keys=keys, close=close)
+                          for address, keys in d.items()}
+            response = {}
+            for worker, c in coroutines.items():
+                try:
+                    r = yield c
+                except EnvironmentError:
+                    missing_workers.add(worker)
+                else:
+                    response.update(r)
         finally:
             for r in rpcs.values():
                 r.close_rpc()
 
-        response = merge(response)
         bad_addresses |= {v for k, v in rev.items() if k not in response}
-        results.update(merge(response))
+        results.update(response)
 
     if permissive:
-        raise Return((results, all_bad_keys))
+        bad_keys = {k: list(original_who_has[k]) for k in all_bad_keys}
+        raise Return((results, bad_keys, list(missing_workers)))
     else:
         raise Return(results)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1653,7 +1653,7 @@ class Worker(WorkerBase):
         try:
             if key not in self.task_state:
                 return
-            if reason == 'stolen' and key in self.executing:
+            if reason == 'stolen':
                 return
             state = self.task_state.pop(key)
             if cause:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -515,12 +515,12 @@ class WorkerBase(Server):
         who_has = {k: [coerce_to_address(addr) for addr in v]
                     for k, v in who_has.items()
                     if k not in self.data}
-        try:
-            result = yield gather_from_workers(who_has)
-        except KeyError as e:
+        result, missing_keys, missing_workers = yield gather_from_workers(
+                who_has, permissive=True)
+        if missing_keys:
             logger.warn("Could not find data", e)
             raise Return({'status': 'missing-data',
-                          'keys': e.args})
+                          'keys': missing_keys})
         else:
             self.update_data(data=result, report=False)
             raise Return({'status': 'OK'})


### PR DESCRIPTION
When a task is stolen during execution we get two copies throughout the
cluster.  Previously if the task had finished by the time the "this task has
been duplicated" message arrived it would delete itself, even if it was the
first to finish (and thus the only to be saved).  This resulted in neither of
the tasks being available.

Now we keep the original task and tell all future tasks to remove themselves.