### PR TITLE
Maintain fortran ordering in serialization

### DIFF
--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -43,7 +43,10 @@ def serialize_numpy_ndarray(x):
     else:
         dt = x.dtype.str
 
-    if np.isfortran(x) or not x.shape:
+    if not x.shape:
+        strides = x.strides
+        data = x.ravel().view('u1').data
+    elif np.isfortran(x):
         strides = x.strides
         data = stride_tricks.as_strided(x, shape=(np.prod(x.shape),),
                                            strides=(x.dtype.itemsize,)).view('u1').data

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -42,11 +42,14 @@ def serialize_numpy_ndarray(x):
     else:
         dt = x.dtype.str
 
+    fortran = np.isfortran(x)
+
     x = np.ascontiguousarray(x)  # cannot get .data attribute from discontiguous
 
     header = {'dtype': dt,
               'strides': x.strides,
-              'shape': x.shape}
+              'shape': x.shape,
+              'order': 'F' if fortran else 'C'}
 
     data = x.ravel().view('u1').data
 
@@ -90,6 +93,9 @@ def deserialize_numpy_ndarray(header, frames):
 
         x = np.ndarray(header['shape'], dtype=dt, buffer=frames[0],
                        strides=header['strides'])
+
+        if header['order'] == 'F':
+            x = np.asfortranarray(x)
 
         return x
 

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -30,6 +30,8 @@ def test_serialize():
         [np.ones(5),
          np.array(5),
          np.asfortranarray(np.random.random((5, 5))),
+         np.asfortranarray(np.random.random((5, 5)))[::2, :],
+         np.asfortranarray(np.random.random((5, 5)))[:, ::2],
          np.random.random(5).astype('f4'),
          np.random.random(5).astype('>i8'),
          np.random.random(5).astype('<i8'),
@@ -59,7 +61,8 @@ def test_dumps_serialize_numpy(x):
     y = deserialize(header, frames)
 
     np.testing.assert_equal(x, y)
-    assert np.isfortran(x) == np.isfortran(y)
+    if np.isfortran(x):
+        assert x.strides == y.strides
 
 
 def test_memmap():

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -59,6 +59,7 @@ def test_dumps_serialize_numpy(x):
     y = deserialize(header, frames)
 
     np.testing.assert_equal(x, y)
+    assert np.isfortran(x) == np.isfortran(y)
 
 
 def test_memmap():


### PR DESCRIPTION
Add order information in numpy serialization

This seems suboptimal though, because we're coercing to C order, sending over a wire, and then coercing back to Fortran order.  Is there a way to just move the data in whichever way it prefers?  Odd issues arise if we drop the `ascontiguousarray` call.