### PR TITLE
Add serializer for keras models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ install:
   - pip install -q git+https://github.com/dask/s3fs.git --upgrade
   - pip install -q git+https://github.com/dask/zict.git --upgrade
   - pip install -q sortedcollections msgpack-python
+  - pip install -q keras --upgrade --no-deps
   - |
     if [[ $CRICK == true ]]; then
         conda install -q cython

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -21,3 +21,7 @@ def _register_h5py():
 @partial(register_serialization_lazy, "netCDF4")
 def _register_netcdf4():
     from . import netcdf4
+
+@partial(register_serialization_lazy, "keras")
+def _register_keras():
+    from . import keras

--- a/distributed/protocol/keras.py
+++ b/distributed/protocol/keras.py
@@ -6,6 +6,11 @@ from ..utils import log_errors, ensure_bytes
 
 
 def serialize_keras_model(model):
+    import keras
+    if keras.__version__ < '1.2.0':
+        raise ImportError("Need Keras >= 1.2.0. "
+                "Try pip install keras --upgrade --no-deps")
+
     header = model._updated_config()
     weights = model.get_weights()
     headers, frames = list(zip(*map(serialize, weights)))

--- a/distributed/protocol/keras.py
+++ b/distributed/protocol/keras.py
@@ -10,7 +10,7 @@ def serialize_keras_model(model):
     weights = model.get_weights()
     headers, frames = list(zip(*map(serialize, weights)))
     header['headers'] = headers
-    header['lengths'] = [len(L) for L in frames]
+    header['nframes'] = [len(L) for L in frames]
     frames = [frame for L in frames for frame in L]
     return header, frames
 
@@ -19,7 +19,7 @@ def deserialize_keras_model(header, frames):
     from keras.models import model_from_config
     n = 0
     weights = []
-    for head, length in zip(header['headers'], header['lengths']):
+    for head, length in zip(header['headers'], header['nframes']):
         x = deserialize(head, frames[n: n + length])
         weights.append(x)
         n += length

--- a/distributed/protocol/keras.py
+++ b/distributed/protocol/keras.py
@@ -1,0 +1,36 @@
+from __future__ import print_function, division, absolute_import
+
+from .serialize import register_serialization, serialize, deserialize
+
+from ..utils import log_errors, ensure_bytes
+
+
+def serialize_keras_model(model):
+    header = model._updated_config()
+    weights = model.get_weights()
+    headers, frames = list(zip(*map(serialize, weights)))
+    header['headers'] = headers
+    header['lengths'] = [len(L) for L in frames]
+    frames = [frame for L in frames for frame in L]
+    return header, frames
+
+
+def deserialize_keras_model(header, frames):
+    from keras.models import model_from_config
+    n = 0
+    weights = []
+    for head, length in zip(header['headers'], header['lengths']):
+        x = deserialize(head, frames[n: n + length])
+        weights.append(x)
+        n += length
+    model = model_from_config(header)
+    model.set_weights(weights)
+    return model
+
+
+register_serialization('keras.engine.training.Model', serialize_keras_model,
+                       deserialize_keras_model)
+register_serialization('keras.models.Model', serialize_keras_model,
+                       deserialize_keras_model)
+register_serialization('keras.models.Sequential', serialize_keras_model,
+                       deserialize_keras_model)

--- a/distributed/protocol/tests/test_keras.py
+++ b/distributed/protocol/tests/test_keras.py
@@ -1,0 +1,29 @@
+import functools
+import sys
+import traceback
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+keras = pytest.importorskip('keras')
+
+from distributed.protocol import serialize, deserialize, dumps, loads, to_serialize
+
+
+def test_serialize_deserialize_model():
+    model = keras.models.Sequential()
+    model.add(keras.layers.Dense(5, input_dim=3))
+    model.add(keras.layers.Dense(2))
+    model.compile(optimizer='sgd', loss='mse')
+    x = np.random.random((1, 3))
+    y = np.random.random((1, 2))
+    model.train_on_batch(x, y)
+
+    loaded = deserialize(*serialize(model))
+    assert_allclose(loaded.predict(x), model.predict(x))
+
+    data = {'model': to_serialize(model)}
+    frames = dumps(data)
+    result = loads(frames)
+    assert_allclose(result['model'].predict(x), model.predict(x))

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -11,3 +11,6 @@ def test_merge_frames():
 
     b = b'123'
     assert merge_frames({'lengths': [3]}, [b])[0] is b
+
+    L = [b'123', b'456']
+    assert merge_frames({'lengths': [3, 3]}, L) is L

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -44,8 +44,7 @@ def merge_frames(header, frames):
     >>> merge_frames({'lengths': [6]}, [b'123', b'456'])
     [b'123456']
     """
-    lengths = list(header['lengths'])[::-1]
-    frames = list(frames)[::-1]
+    lengths = list(header['lengths'])
 
     if not frames:
         return frames
@@ -54,6 +53,9 @@ def merge_frames(header, frames):
 
     if all(len(f) == l for f, l in zip(frames, lengths)):
         return frames
+
+    frames = frames[::-1]
+    lengths = lengths[::-1]
 
     out = []
     while lengths:


### PR DESCRIPTION
Fixes #841. Turned out to be easier than expected: `model._updated_config()` is what's used inside `model.save()` to extract the metadata, and `get_weights()` returns a list of `numpy` arrays of weight parameters.

Only weird bit I see is the repeated registrations: depending on how the model is instantiated, it could have any of those types (they all inherit from `keras.engine.training.Model` but it didn't seem to work if I didn't register all three; maybe there's a better way though?).