### PR TITLE
Fix distributed for ShareDict

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1518,7 +1518,7 @@ class Client(object):
             if tokey(key) in self.futures:
                 if not changed:
                     changed = True
-                    dsk = dsk.copy()
+                    dsk = dict(dsk)
                 dsk[key] = Future(key, self)
 
         if changed:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3550,7 +3550,7 @@ def test_normalize_collection_dask_array(c, s, a, b):
     yy = c.persist(y)
 
     z = y.sum()
-    zdsk = z.dask.copy()
+    zdsk = dict(z.dask)
     zz = c.normalize_collection(z)
     assert z.dask == zdsk  # do not mutate input
 


### PR DESCRIPTION
`ShareDict.copy()` is not defined. Since copying should remove the sharing, we could define it to return a plain `dict` instead, but that would be a slightly weird API. Conversely, returning a ShareDict with a single underlying `dict` would be a tad sub-optimal...