### PR TITLE
In-process communication transports

### DIFF
--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -12,8 +12,8 @@ For more information see: http://click.pocoo.org/5/python3/
 """.strip()
 
 
-from distributed.comm.core import (parse_address, unparse_address,
-                                   parse_host_port, unparse_host_port)
+from distributed.comm import (parse_address, unparse_address,
+                              parse_host_port, unparse_host_port)
 from ..utils import get_ip, ensure_ip
 
 

--- a/distributed/comm/__init__.py
+++ b/distributed/comm/__init__.py
@@ -1,5 +1,9 @@
 from __future__ import print_function, division, absolute_import
 
+from .addressing import (parse_address, unparse_address,
+                         normalize_address, parse_host_port,
+                         unparse_host_port, get_address_host_port,
+                         resolve_address)
 from .core import connect, listen, Comm, CommClosedError
 
 

--- a/distributed/comm/__init__.py
+++ b/distributed/comm/__init__.py
@@ -13,6 +13,7 @@ def is_zmq_enabled():
 
 
 def _register_transports():
+    from . import inproc
     from . import tcp
 
     if is_zmq_enabled():

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -1,0 +1,115 @@
+from __future__ import print_function, division, absolute_import
+
+import six
+
+from ..config import config
+from ..utils import ensure_ip
+
+
+DEFAULT_SCHEME = config.get('default-scheme', 'tcp')
+
+
+def parse_address(addr):
+    """
+    Split address into its scheme and scheme-dependent location string.
+    """
+    if not isinstance(addr, six.string_types):
+        raise TypeError("expected str, got %r" % addr.__class__.__name__)
+    scheme, sep, loc = addr.rpartition('://')
+    if not sep:
+        scheme = DEFAULT_SCHEME
+    return scheme, loc
+
+
+def unparse_address(scheme, loc):
+    """
+    Undo parse_address().
+    """
+    return '%s://%s' % (scheme, loc)
+
+
+def normalize_address(addr):
+    """
+    Canonicalize address, adding a default scheme if necessary.
+    """
+    return unparse_address(*parse_address(addr))
+
+
+def parse_host_port(address, default_port=None):
+    """
+    Parse an endpoint address given in the form "host:port".
+    """
+    if isinstance(address, tuple):
+        return address
+    if address.startswith('tcp:'):
+        address = address[4:]
+
+    def _fail():
+        raise ValueError("invalid address %r" % (address,))
+
+    def _default():
+        if default_port is None:
+            raise ValueError("missing port number in address %r" % (address,))
+        return default_port
+
+    if address.startswith('['):
+        host, sep, tail = address[1:].partition(']')
+        if not sep:
+            _fail()
+        if not tail:
+            port = _default()
+        else:
+            if not tail.startswith(':'):
+                _fail()
+            port = tail[1:]
+    else:
+        host, sep, port = address.partition(':')
+        if not sep:
+            port = _default()
+        elif ':' in host:
+            _fail()
+
+    return host, int(port)
+
+
+def unparse_host_port(host, port=None):
+    """
+    Undo parse_host_port().
+    """
+    if ':' in host and not host.startswith('['):
+        host = '[%s]' % host
+    if port:
+        return '%s:%s' % (host, port)
+    else:
+        return host
+
+
+def get_address_host_port(addr):
+    """
+    Get a (host, port) tuple out of the given address.
+    """
+    scheme, loc = parse_address(addr)
+    if scheme not in ('tcp', 'zmq'):
+        raise ValueError("don't know how to extract host and port "
+                         "for address %r" % (addr,))
+    return parse_host_port(loc)
+
+
+def resolve_address(addr):
+    """
+    Apply scheme-specific address resolution to *addr*, ensuring
+    all symbolic references are replaced with concrete location
+    specifiers.
+
+    In practice, this means hostnames are resolved to IP addresses.
+    """
+    # XXX circular import; reorganize APIs into a distributed.comms.addressing module?
+    #from ..utils import ensure_ip
+    scheme, loc = parse_address(addr)
+    if scheme not in ('tcp', 'zmq'):
+        return addr
+
+    host, port = parse_host_port(loc)
+    loc = unparse_host_port(ensure_ip(host), port)
+    addr = unparse_address(scheme, loc)
+    return addr

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -112,9 +112,6 @@ class Listener(with_metaclass(ABCMeta)):
         Stop listening.  This does not shutdown already established
         communications, but prevents accepting new ones.
         """
-        tcp_server, self.tcp_server = self.tcp_server, None
-        if tcp_server is not None:
-            tcp_server.stop()
 
     @abstractproperty
     def listen_address(self):

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -127,6 +127,13 @@ class Listener(with_metaclass(ABCMeta)):
         address such as 'tcp://0.0.0.0:123'.
         """
 
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *exc):
+        self.stop()
+
 
 def parse_address(addr):
     """

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -4,13 +4,14 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from datetime import timedelta
 import logging
 
-from six import string_types, with_metaclass
+from six import with_metaclass
 
 from tornado import gen
 from tornado.ioloop import IOLoop
 
 from ..config import config
 from ..metrics import time
+from .addressing import parse_address
 
 
 logger = logging.getLogger(__name__)
@@ -29,9 +30,6 @@ listeners = {
     #'tcp': ...,
     # 'zmq': ...,
     }
-
-
-DEFAULT_SCHEME = config.get('default-scheme', 'tcp')
 
 
 class CommClosedError(IOError):
@@ -133,112 +131,6 @@ class Listener(with_metaclass(ABCMeta)):
 
     def __exit__(self, *exc):
         self.stop()
-
-
-def parse_address(addr):
-    """
-    Split address into its scheme and scheme-dependent location string.
-    """
-    if not isinstance(addr, string_types):
-        raise TypeError("expected str, got %r" % addr.__class__.__name__)
-    scheme, sep, loc = addr.rpartition('://')
-    if not sep:
-        scheme = DEFAULT_SCHEME
-    return scheme, loc
-
-
-def unparse_address(scheme, loc):
-    """
-    Undo parse_address().
-    """
-    return '%s://%s' % (scheme, loc)
-
-
-def parse_host_port(address, default_port=None):
-    """
-    Parse an endpoint address given in the form "host:port".
-    """
-    if isinstance(address, tuple):
-        return address
-    if address.startswith('tcp:'):
-        address = address[4:]
-
-    def _fail():
-        raise ValueError("invalid address %r" % (address,))
-
-    def _default():
-        if default_port is None:
-            raise ValueError("missing port number in address %r" % (address,))
-        return default_port
-
-    if address.startswith('['):
-        host, sep, tail = address[1:].partition(']')
-        if not sep:
-            _fail()
-        if not tail:
-            port = _default()
-        else:
-            if not tail.startswith(':'):
-                _fail()
-            port = tail[1:]
-    else:
-        host, sep, port = address.partition(':')
-        if not sep:
-            port = _default()
-        elif ':' in host:
-            _fail()
-
-    return host, int(port)
-
-
-def unparse_host_port(host, port=None):
-    """
-    Undo parse_host_port().
-    """
-    if ':' in host and not host.startswith('['):
-        host = '[%s]' % host
-    if port:
-        return '%s:%s' % (host, port)
-    else:
-        return host
-
-
-def get_address_host_port(addr):
-    """
-    Get a (host, port) tuple out of the given address.
-    """
-    scheme, loc = parse_address(addr)
-    if scheme not in ('tcp', 'zmq'):
-        raise ValueError("don't know how to extract host and port "
-                         "for address %r" % (addr,))
-    return parse_host_port(loc)
-
-
-def normalize_address(addr):
-    """
-    Canonicalize address, adding a default scheme if necessary.
-    """
-    return unparse_address(*parse_address(addr))
-
-
-def resolve_address(addr):
-    """
-    Apply scheme-specific address resolution to *addr*, ensuring
-    all symbolic references are replaced with concrete location
-    specifiers.
-
-    In practice, this means hostnames are resolved to IP addresses.
-    """
-    # XXX circular import; reorganize APIs into a distributed.comms.addressing module?
-    from ..utils import ensure_ip
-    scheme, loc = parse_address(addr)
-    if scheme not in ('tcp', 'zmq'):
-        raise ValueError("don't know how to extract host and port "
-                         "for address %r" % (addr,))
-    host, port = parse_host_port(loc)
-    loc = unparse_host_port(ensure_ip(host), port)
-    addr = unparse_address(scheme, loc)
-    return addr
 
 
 @gen.coroutine

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -1,0 +1,230 @@
+from __future__ import print_function, division, absolute_import
+
+from collections import namedtuple
+import itertools
+import os
+import sys
+import threading
+import weakref
+
+from tornado import gen, locks
+from tornado.ioloop import IOLoop
+from tornado.queues import Queue
+
+from ..compatibility import finalize
+from ..utils import get_ip
+from .core import (connectors, listeners, Comm, Listener, CommClosedError,
+                   )
+
+
+ConnectionRequest = namedtuple('ConnectionRequest',
+                               ('c2s_q', 's2c_q', 'c_loop', 'c_addr',
+                                'conn_event', 'close_request'))
+
+_Close = object()
+
+
+class Manager(object):
+
+    def __init__(self):
+        self.listeners = weakref.WeakValueDictionary()
+        self.addr_suffixes = itertools.count(1)
+        self.ip = get_ip()
+        self.lock = threading.Lock()
+
+    def add_listener(self, addr, listener):
+        with self.lock:
+            if addr in self.listeners:
+                raise RuntimeError("already listening on %r" % (addr,))
+            self.listeners[addr] = listener
+
+    def remove_listener(self, addr):
+        with self.lock:
+            del self.listeners[addr]
+
+    def get_listener_for(self, addr):
+        with self.lock:
+            self.validate_address(addr)
+            return self.listeners.get(addr)
+
+    def new_address(self):
+        return "%s/%d/%s" % (self.ip, os.getpid(), next(self.addr_suffixes))
+
+    def validate_address(self, addr):
+        """
+        Validate the address' IP and pid.
+        """
+        ip, pid, suffix = addr.split('/')
+        if ip != self.ip or int(pid) != os.getpid():
+            raise ValueError("inproc address %r does not match host (%r) or pid (%r)"
+                             % (addr, self.ip, os.getpid()))
+
+
+global_manager = Manager()
+
+def new_address():
+    """
+    Generate a new address.
+    """
+    return 'inproc://' + global_manager.new_address()
+
+
+class InProc(Comm):
+    """
+    An established communication based on a pair of in-process queues.
+    """
+
+    def __init__(self, peer_addr, read_q, write_q, write_loop,
+                 close_request, deserialize=True):
+        self._peer_addr = peer_addr
+        self.deserialize = deserialize
+        self._read_q = read_q
+        self._write_q = write_q
+        self._write_loop = write_loop
+        self._closed = False
+        # A "close request" event shared between both comms
+        self._close_request = close_request
+
+        self._finalizer = finalize(self, self._get_finalizer())
+        self._finalizer.atexit = False
+
+    def _get_finalizer(self):
+        def finalize(write_q=self._write_q, write_loop=self._write_loop,
+                     close_request=self._close_request):
+            if not close_request.is_set():
+                logger.warn("Closing dangling queue in %s" % (r,))
+                close_request.set()
+                write_loop.add_callback(write_q.put_nowait, _Close)
+
+        return finalize
+
+    def __repr__(self):
+        return "<InProc %r>" % (self._peer_addr,)
+
+    @property
+    def peer_address(self):
+        return self._peer_addr
+
+    @gen.coroutine
+    def read(self, deserialize=None):
+        if self._closed:
+            raise CommClosedError
+
+        msg = yield self._read_q.get()
+        if msg is _Close:
+            assert self._close_request.is_set()
+            self._closed = True
+            self._finalizer.detach()
+            raise CommClosedError
+
+        # XXX does deserialize matter?
+        raise gen.Return(msg)
+
+    @gen.coroutine
+    def write(self, msg):
+        if self._close_request.is_set():
+            self._closed = True
+            self._finalizer.detach()
+            raise CommClosedError
+
+        self._write_loop.add_callback(self._write_q.put_nowait, msg)
+
+        raise gen.Return(1)
+
+    @gen.coroutine
+    def close(self):
+        self.abort()
+
+    def abort(self):
+        if not self._closed:
+            self._close_request.set()
+            self._write_loop.add_callback(self._write_q.put_nowait, _Close)
+            self._write_q = self._read_q = None
+            self._closed = True
+            self._finalizer.detach()
+
+    def closed(self):
+        return self._closed
+
+
+class InProcListener(Listener):
+
+    def __init__(self, address, comm_handler, deserialize=True):
+        self.manager = global_manager
+        self.address = address or self.manager.new_address()
+        self.comm_handler = comm_handler
+        self.deserialize = deserialize
+        self.listen_q = Queue()
+
+    @gen.coroutine
+    def _listen(self):
+        while True:
+            conn_req = yield self.listen_q.get()
+            if conn_req is None:
+                break
+            comm = InProc(peer_addr='inproc://' + conn_req.c_addr,
+                          read_q=conn_req.c2s_q,
+                          write_q=conn_req.s2c_q,
+                          write_loop=conn_req.c_loop,
+                          close_request=conn_req.close_request,
+                          deserialize=self.deserialize)
+            # Notify connector
+            conn_req.c_loop.add_callback(conn_req.conn_event.set)
+            self.comm_handler(comm)
+
+    def connect_threadsafe(self, conn_req):
+        self.loop.add_callback(self.listen_q.put_nowait, conn_req)
+
+    def start(self):
+        self.loop = IOLoop.current()
+        self.loop.add_callback(self._listen)
+        self.manager.add_listener(self.address, self)
+
+    def stop(self):
+        self.listen_q.put_nowait(None)
+        self.manager.remove_listener(self.address)
+
+    @property
+    def listen_address(self):
+        return 'inproc://' + self.address
+
+    @property
+    def contact_address(self):
+        return 'inproc://' + self.address
+
+
+class InProcConnector(object):
+
+    def __init__(self, manager):
+        self.manager = manager
+
+    @gen.coroutine
+    def connect(self, address, deserialize=True):
+        listener = self.manager.get_listener_for(address)
+        if listener is None:
+            raise IOError("no endpoint for inproc address %r")
+
+        conn_req = ConnectionRequest(c2s_q=Queue(),
+                                     s2c_q=Queue(),
+                                     c_loop=IOLoop.current(),
+                                     c_addr=global_manager.new_address(),
+                                     conn_event=locks.Event(),
+                                     close_request=threading.Event(),
+                                     )
+        listener.connect_threadsafe(conn_req)
+        # Wait for connection acknowledgement
+        # (do not pretend we're connected if the other comm never gets
+        #  created, for example if the listener was stopped in the meantime)
+        yield conn_req.conn_event.wait()
+
+        comm = InProc(peer_addr='inproc://' + address,
+                      read_q=conn_req.s2c_q,
+                      write_q=conn_req.c2s_q,
+                      write_loop=listener.loop,
+                      close_request=conn_req.close_request,
+                      deserialize=deserialize)
+        raise gen.Return(comm)
+
+
+connectors['inproc'] = InProcConnector(global_manager)
+listeners['inproc'] = InProcListener

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -309,7 +309,7 @@ class InProcConnector(object):
     def connect(self, address, deserialize=True):
         listener = self.manager.get_listener_for(address)
         if listener is None:
-            raise IOError("no endpoint for inproc address %r")
+            raise IOError("no endpoint for inproc address %r" % (address,))
 
         conn_req = ConnectionRequest(c2s_q=Queue(),
                                      s2c_q=Queue(),

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -168,6 +168,9 @@ _EOF = object()
 class InProc(Comm):
     """
     An established communication based on a pair of in-process queues.
+
+    Reminder: a Comm must always be used from a single thread.
+    Its peer Comm can be running in any thread.
     """
 
     def __init__(self, peer_addr, read_q, write_q, write_loop,
@@ -218,6 +221,7 @@ class InProc(Comm):
         if self.closed():
             raise CommClosedError
 
+        # Ensure we feed the queue in the same thread it is read from.
         self._write_loop.add_callback(self._write_q.put_nowait, msg)
 
         raise gen.Return(1)
@@ -236,7 +240,7 @@ class InProc(Comm):
 
     def closed(self):
         """
-        Whether this InProc comm is closed.  It is closed iff:
+        Whether this comm is closed.  An InProc comm is closed if:
             1) close() or abort() was called on this comm
             2) close() or abort() was called on the other end and the
                read queue is empty

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -13,7 +13,7 @@ from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 
 from ..compatibility import finalize
-from ..protocol import deserialize, Serialize, Serialized
+from ..protocol import nested_deserialize, Serialize, Serialized
 from ..utils import get_ip
 from .core import (connectors, listeners, Comm, Listener, CommClosedError,
                    )
@@ -130,38 +130,6 @@ class Queue(object):
             raise QueueEmpty
 
 
-def _maybe_deserialize(msg):
-    """
-    Replace all nested Serialize and Serialized values in *msg*
-    with their original object.  Returns a copy of *msg*.
-    """
-    def replace_inner(x):
-        if type(x) is dict:
-            x = x.copy()
-            for k, v in x.items():
-                typ = type(v)
-                if typ is dict or typ is list:
-                    x[k] = replace_inner(v)
-                elif typ is Serialize:
-                    x[k] = v.data
-                elif typ is Serialized:
-                    x[k] = deserialize(v.header, v.frames)
-
-        elif type(x) is list:
-            x = list(x)
-            for k, v in enumerate(x):
-                typ = type(v)
-                if typ is dict or typ is list:
-                    x[k] = replace_inner(v)
-                elif typ is Serialize:
-                    x[k] = v.data
-                elif typ is Serialized:
-                    x[k] = deserialize(v.header, v.frames)
-
-        return x
-
-    return replace_inner(msg)
-
 _EOF = object()
 
 
@@ -213,7 +181,7 @@ class InProc(Comm):
 
         deserialize = deserialize if deserialize is not None else self.deserialize
         if deserialize:
-            msg = _maybe_deserialize(msg)
+            msg = nested_deserialize(msg)
         raise gen.Return(msg)
 
     @gen.coroutine

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -15,8 +15,8 @@ from tornado.tcpserver import TCPServer
 from .. import config
 from ..compatibility import finalize
 from ..utils import ensure_bytes
-from .core import (connectors, listeners, Comm, Listener, CommClosedError,
-                   parse_host_port, unparse_host_port)
+from .addressing import parse_host_port, unparse_host_port
+from .core import connectors, listeners, Comm, Listener, CommClosedError
 from .utils import (to_frames, from_frames,
                     get_tcp_server_address, ensure_concrete_host)
 

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -760,6 +760,7 @@ def check_deserialize(addr):
 def test_tcp_deserialize():
     yield check_deserialize('tcp://')
 
+@requires_zmq
 @gen_test()
 def test_zmq_deserialize():
     yield check_deserialize('zmq://0.0.0.0')

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -527,8 +527,7 @@ def test_inproc_comm_closed_explicit_2():
     comm = yield connect(contact_addr)
     comm.write("foo")
     yield gen.sleep(0.01)
-    # XXX comm.closed() is only true after the first time read() raises CommClosedError
-    #assert comm.closed()
+    assert comm.closed()
 
     comm.close()
     comm.close()

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -20,9 +20,8 @@ from distributed.protocol import (loads, dumps,
                                   to_serialize, Serialized, serialize, deserialize)
 
 from distributed.comm import (tcp, inproc, connect, listen, CommClosedError,
-                              is_zmq_enabled)
-from distributed.comm.core import (parse_address, parse_host_port,
-                                   unparse_host_port, resolve_address)
+                              is_zmq_enabled, parse_address, parse_host_port,
+                              unparse_host_port, resolve_address)
 
 if is_zmq_enabled():
     from distributed.comm import zmq

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -689,17 +689,12 @@ def check_connector_deserialize(addr, deserialize, in_value, check_out):
 
 @gen.coroutine
 def check_deserialize(addr):
-    # Create a valid Serialized object
-    # (if using serialize(), it will lack a compression header)
-    ser = loads(dumps({'x': to_serialize(456)}), deserialize=False)['x']
-    assert isinstance(ser, Serialized)
-
     # Test with Serialize and Serialized objects
 
     msg = {'op': 'update',
            'x': b'abc',
            'to_ser': [to_serialize(123)],
-           'ser': ser,
+           'ser': Serialized(*serialize(456)),
            }
     msg_orig = msg.copy()
 

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import
 
 import logging
 import socket

--- a/distributed/comm/zmq.py
+++ b/distributed/comm/zmq.py
@@ -13,8 +13,8 @@ from zmq.eventloop.future import Context
 
 from .. import config
 from ..utils import PY3
-from .core import (connectors, listeners, Comm, CommClosedError, Listener,
-                   parse_host_port, unparse_host_port)
+from .addressing import parse_host_port, unparse_host_port
+from .core import connectors, listeners, Comm, CommClosedError, Listener
 from .utils import to_frames, from_frames, ensure_concrete_host
 from . import zmqimpl
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -24,9 +24,10 @@ from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.locks import Event
 
-from .comm import connect, listen, CommClosedError
-from .comm.core import (parse_address, normalize_address, Comm,
-                        unparse_host_port, get_address_host_port)
+from .comm import (connect, listen, CommClosedError,
+                   parse_address, normalize_address,
+                   unparse_host_port, get_address_host_port)
+from .comm.core import Comm
 from .compatibility import PY3, unicode, WINDOWS
 from .config import config
 from .metrics import time

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -14,7 +14,7 @@ import weakref
 from tornado.ioloop import IOLoop
 from tornado import gen
 
-from .comm.core import get_address_host_port
+from .comm import get_address_host_port
 from .compatibility import JSONDecodeError
 from .core import Server, rpc, RPCClosed, CommClosedError, coerce_to_address
 from .metrics import disk_io_counters, net_io_counters, time

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -4,7 +4,8 @@ from functools import partial
 
 from .compression import compressions, default_compression
 from .core import dumps, loads, maybe_compress, decompress, msgpack
-from .serialize import (serialize, deserialize, Serialize, Serialized,
+from .serialize import (
+    serialize, deserialize, nested_deserialize, Serialize, Serialized,
     to_serialize, register_serialization, register_serialization_lazy)
 
 from ..utils  import ignoring

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -55,7 +55,7 @@ def dumps(msg):
 
         for key, (head, frames) in data.items():
             if 'lengths' not in head:
-                head['lengths'] = list(map(len, frames))
+                head['lengths'] = tuple(map(len, frames))
             if 'compression' not in head:
                 frames = frame_split_size(frames)
                 if frames:
@@ -70,7 +70,7 @@ def dumps(msg):
 
         for key, (head, frames) in pre.items():
             if 'lengths' not in head:
-                head['lengths'] = list(map(len, frames))
+                head['lengths'] = tuple(map(len, frames))
             head['count'] = len(frames)
             header['headers'][key] = head
             header['keys'].append(key)
@@ -112,7 +112,8 @@ def loads(frames, deserialize=True):
                 fs = []
 
             if deserialize or key in bytestrings:
-                fs = decompress(head, fs)
+                if 'compression' in head:
+                    fs = decompress(head, fs)
                 fs = merge_frames(head, fs)
                 value = _deserialize(head, fs)
             else:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -181,6 +181,9 @@ class Serialize(object):
     def __ne__(self, other):
         return not (self == other)
 
+    def __hash__(self):
+        return hash(self.data)
+
 
 to_serialize = Serialize
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -174,6 +174,13 @@ class Serialize(object):
 
     __repr__ = __str__
 
+    def __eq__(self, other):
+        return (isinstance(other, Serialize) and
+                other.data == self.data)
+
+    def __ne__(self, other):
+        return not (self == other)
+
 
 to_serialize = Serialize
 
@@ -194,6 +201,14 @@ class Serialized(object):
         from .core import decompress
         frames = decompress(self.header, self.frames)
         return deserialize(self.header, frames)
+
+    def __eq__(self, other):
+        return (isinstance(other, Serialized) and
+                other.header == self.header and
+                other.frames == self.frames)
+
+    def __ne__(self, other):
+        return not (self == other)
 
 
 def container_copy(c):

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -6,7 +6,8 @@ import pytest
 
 from distributed.protocol import (loads, dumps, msgpack, maybe_compress,
         to_serialize)
-from distributed.protocol.serialize import Serialize, Serialized, deserialize
+from distributed.protocol.serialize import (Serialize, Serialized,
+                                            serialize, deserialize)
 from distributed.utils_test import slow
 
 
@@ -165,6 +166,25 @@ def test_dumps_loads_Serialize():
     assert any(a is b
                for a in result2['data'].frames
                for b in frames)
+
+    frames2 = dumps(result2)
+    assert all(map(eq_frames, frames, frames2))
+
+    result3 = loads(frames2)
+    assert result == result3
+
+
+def test_dumps_loads_Serialized():
+    msg = {'x': 1,
+           'data': Serialized(*serialize(123)),
+           }
+    frames = dumps(msg)
+    assert len(frames) > 2
+    result = loads(frames)
+    assert result == {'x': 1, 'data': 123}
+
+    result2 = loads(frames, deserialize=False)
+    assert result2 == msg
 
     frames2 = dumps(result2)
     assert all(map(eq_frames, frames, frames2))

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -58,8 +58,24 @@ def test_Serialize():
     assert '123' in str(s)
     assert s.data == 123
 
-    s = Serialize((1, 2))
-    assert str(s)
+    t = Serialize((1, 2))
+    assert str(t)
+
+    u = Serialize(123)
+    assert s == u
+    assert not (s != u)
+    assert s != t
+    assert not (s == t)
+
+
+def test_Serialized():
+    s = Serialized(*serialize(123))
+    t = Serialized(*serialize((1, 2)))
+    u = Serialized(*serialize(123))
+    assert s == u
+    assert not (s != u)
+    assert s != t
+    assert not (s == t)
 
 
 from distributed.utils_test import gen_cluster

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -67,6 +67,8 @@ def test_Serialize():
     assert not (s != u)
     assert s != t
     assert not (s == t)
+    assert hash(s) == hash(u)
+    assert hash(s) != hash(t)  # most probably
 
 
 def test_Serialized():

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import copy
 import pickle
 
 import numpy as np
@@ -7,7 +8,7 @@ import pytest
 from toolz import identity
 
 from distributed.protocol import (register_serialization, serialize,
-        deserialize, Serialize, Serialized, to_serialize)
+        deserialize, nested_deserialize, Serialize, Serialized, to_serialize)
 from distributed.protocol import decompress
 
 
@@ -76,6 +77,22 @@ def test_Serialized():
     assert not (s != u)
     assert s != t
     assert not (s == t)
+
+
+def test_nested_deserialize():
+    x = {'op': 'update',
+         'x': [to_serialize(123), to_serialize(456), 789],
+         'y': {'a': ['abc', Serialized(*serialize('def'))],
+               'b': 'ghi'}
+         }
+    x_orig = copy.deepcopy(x)
+
+    assert nested_deserialize(x) == {'op': 'update',
+                                     'x': [123, 456, 789],
+                                     'y': {'a': ['abc', 'def'],
+                                           'b': 'ghi'}
+                                     }
+    assert x == x_orig  # x wasn't mutated
 
 
 from distributed.utils_test import gen_cluster

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -28,8 +28,8 @@ from dask.core import reverse_dict
 from dask.order import order
 
 from .batched import BatchedSend
-from .comm.core import (normalize_address, resolve_address,
-                        get_address_host_port, unparse_host_port)
+from .comm import (normalize_address, resolve_address,
+                   get_address_host_port, unparse_host_port)
 from .config import config
 from .core import (rpc, connect, Server, send_recv,
                    error_message, clean_exception, CommClosedError)
@@ -412,7 +412,11 @@ class Scheduler(Server):
                 self.listen(('', addr_or_port))
             else:
                 self.listen(addr_or_port)
-                self.ip, _ = get_address_host_port(self.listen_address)
+                try:
+                    self.ip, _ = get_address_host_port(self.listen_address)
+                except ValueError:
+                    # Address scheme does not have a notion of host and port
+                    self.ip = get_ip()
 
             # Services listen on all addresses
             self.start_services()

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -28,7 +28,6 @@ from tornado import gen
 
 from .compatibility import Queue, PY3, PY2, get_thread_identity
 from .config import config
-from .comm import CommClosedError
 
 
 logger = logging.getLogger(__name__)
@@ -301,6 +300,7 @@ else:
 
 @contextmanager
 def log_errors(pdb=False):
+    from .comm import CommClosedError
     try:
         yield
     except (CommClosedError, gen.Return):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -25,7 +25,7 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.locks import Event
 
 from .batched import BatchedSend
-from .comm.core import get_address_host_port
+from .comm import get_address_host_port
 from .config import config
 from .compatibility import reload, unicode
 from .core import (connect, send_recv, error_message, CommClosedError,
@@ -212,13 +212,18 @@ class WorkerBase(Server):
         # XXX Factor this out
         if isinstance(addr_or_port, int):
             # Default ip is the required one to reach the scheduler
+            # XXX get local listening address
             self.ip = get_ip(
                 get_address_host_port(self.scheduler.address)[0]
                 )
             self.listen((self.ip, addr_or_port))
         else:
             self.listen(addr_or_port)
-            self.ip = get_address_host_port(self.address)[0]
+            try:
+                self.ip = get_address_host_port(self.address)[0]
+            except ValueError:
+                # Address scheme does not have a notion of host and port
+                self.ip = get_ip()
 
         self.name = self.name or self.address
         # Services listen on all addresses


### PR DESCRIPTION
This adds a new communication transport named `inproc` that is backed by in-process queues. The aim is to later allow local cluster instances to use such communication channels instead of TCP, to reduce the I/O overhead. That will be a bit more involved than I initially assumed, though, due to the notion of host and port being ingrained in some places (especially the scheduler).