### PR TITLE
Local exception replay

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -915,7 +915,7 @@ class Client(object):
             bad_keys = set()
             for key in keys:
                 if (key not in self.futures or
-                    self.futures[key].status in failed):
+                        self.futures[key].status in failed):
                     exceptions.add(key)
                     if errors == 'raise':
                         try:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -380,8 +380,8 @@ class Client(object):
 
         from distributed.channels import ChannelClient
         ChannelClient(self)  # registers itself on construction
-        from distributed.recreate_exceptions import ExceptionsClient
-        ExceptionsClient(self)
+        from distributed.recreate_exceptions import ReplayExceptionClient
+        ReplayExceptionClient(self)
 
     def __str__(self):
         if hasattr(self, '_loop_thread'):

--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -1,0 +1,98 @@
+from __future__ import print_function, division, absolute_import
+
+import logging
+from tornado import gen
+from .client import futures_of
+from.worker import _deserialize
+
+logger = logging.getLogger(__name__)
+
+
+class ExceptionScheduler(object):
+    """ A plugin for the scheduler to recreate exceptions locally
+
+    This adds the following routes to the scheduler
+
+    *  channel-subscribe
+    *  channel-unsubsribe
+    *  channel-append
+    """
+    def __init__(self, scheduler):
+        self.scheduler = scheduler
+
+        handlers = {'cause_of_failure': self.cause_of_failure}
+
+        self.scheduler.handlers.update(handlers)
+        self.scheduler.extensions['exceptions'] = self
+
+    def cause_of_failure(self, *args, keys=None, **kwargs):
+        for key in keys:
+            if key in self.scheduler.exceptions_blame:
+                cause = self.scheduler.exceptions_blame[key]
+                # cannot serialize sets
+                return {'deps': list(self.scheduler.dependencies[cause]),
+                        'cause': cause,
+                        'task': self.scheduler.tasks[cause]}
+
+
+class ExceptionsClient(object):
+    def __init__(self, client):
+        self.client = client
+        self.client.extensions['exceptions'] = self
+        # monkey patch
+        self.client.recreate_error_locally = self.recreate_error_locally
+        self.client._get_futures_error = self._get_futures_error
+        self.client.get_futures_error = self.get_futures_error
+
+    @property
+    def scheduler(self):
+        return self.client.scheduler
+
+    @gen.coroutine
+    def _get_futures_error(self, future):
+        futures = futures_of(future)
+        out = yield self.scheduler.cause_of_failure(
+            keys=[f.key for f in futures])
+        deps, cause, task = out['deps'], out['cause'], out['task']
+        function, args, kwargs = _deserialize(**task)
+        raise gen.Return((function, args, kwargs, deps))
+
+    def get_futures_error(self, future):
+        """
+        Ask the scheduler details of the sub-task of the given failed future
+
+        Parameters
+        ----------
+        future: future that failed
+
+        Returns
+        -------
+        The function that failed, its arguments, and the keys that it depends
+        on.
+        """
+        return sync(self.loop, self._get_futures_error, future)
+
+    def recreate_error_locally(self, future):
+        """
+        For a failed calculation, perform the blamed task locally for debugging.
+
+        Parameters
+        ----------
+        future: future that failed
+            The same thing as was given to ``gather``, but came back with
+            an exception/stack-trace.
+
+        Returns
+        -------
+        Nothing; the function runs and should raise an exception, allowing
+        the debugger to run.
+        """
+        function, args, kwargs, deps = get_futures_error(future)
+        futures = self._graph_to_futures({}, deps)
+        data = self.gather(futures)
+        data = dict(zip(deps, data))
+        args = pack_data(args, data)
+        kwargs = pack_data(kwargs, data)
+
+        # run the function, hopefully trigger exception.
+        func(*args, **kwargs)

--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -81,8 +81,11 @@ class ReplayExceptionClient(object):
         out = yield self.scheduler.cause_of_failure(
             keys=[f.key for f in futures])
         deps, cause, task = out['deps'], out['cause'], out['task']
-        function, args, kwargs = _deserialize(**task)
-        raise gen.Return((function, args, kwargs, deps))
+        if isinstance(task, dict):
+            function, args, kwargs = _deserialize(**task)
+            raise gen.Return((function, args, kwargs, deps))
+        else:
+            raise gen.Return(task)
 
     def get_futures_error(self, future):
         """
@@ -101,12 +104,16 @@ class ReplayExceptionClient(object):
 
     @gen.coroutine
     def _recreate_error_locally(self, future):
-        function, args, kwargs, deps = yield self._get_futures_error(future)
-        futures = self.client._graph_to_futures({}, deps)
-        data = yield self.client._gather(futures)
-        args = pack_data(args, data)
-        kwargs = pack_data(kwargs, data)
-        raise gen.Return((function, args, kwargs))
+        out = yield self._get_futures_error(future)
+        if len(out) == 4:
+            function, args, kwargs, deps = out
+            futures = self.client._graph_to_futures({}, deps)
+            data = yield self.client._gather(futures)
+            args = pack_data(args, data)
+            kwargs = pack_data(kwargs, data)
+            raise gen.Return((function, args, kwargs))
+        else:
+            raise gen.Return(out)
 
     def recreate_error_locally(self, future):
         """
@@ -124,6 +131,13 @@ class ReplayExceptionClient(object):
         Nothing; the function runs and should raise an exception, allowing
         the debugger to run.
         """
-        func, args, kwargs = sync(
-                self.client.loop, self._recreate_error_locally, future)
-        func(*args, **kwargs)
+        out = sync(self.client.loop, self._recreate_error_locally, future)
+        if len(out) == 3 and isinstance(out[2], dict):
+            func, args, kwargsfunc(*args, **kwargs)
+        else:
+            exec_tuple(out)
+
+
+def exec_tuple(t):
+    newt = (exec_tuple(v) if isinstance(v, tuple) else v for v in t[1:])
+    return t[0](*newt)

--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -3,29 +3,42 @@ from __future__ import print_function, division, absolute_import
 import logging
 from tornado import gen
 from .client import futures_of
-from.worker import _deserialize
+from .utils import sync
+from .utils_comm import pack_data
+from .worker import _deserialize
 
 logger = logging.getLogger(__name__)
 
 
-class ExceptionScheduler(object):
+class ReplayExceptionScheduler(object):
     """ A plugin for the scheduler to recreate exceptions locally
 
     This adds the following routes to the scheduler
 
-    *  channel-subscribe
-    *  channel-unsubsribe
-    *  channel-append
+    *  cause_of_failure
     """
     def __init__(self, scheduler):
         self.scheduler = scheduler
-
-        handlers = {'cause_of_failure': self.cause_of_failure}
-
-        self.scheduler.handlers.update(handlers)
+        self.scheduler.handlers['cause_of_failure'] = self.cause_of_failure
         self.scheduler.extensions['exceptions'] = self
 
-    def cause_of_failure(self, *args, keys=None, **kwargs):
+    def cause_of_failure(self, *args, **kwargs):
+        """
+        Return details of first failed task required by set of keys
+
+        Parameters
+        ----------
+        keys: list of keys known to the scheduler
+
+        Returns
+        -------
+        Dictionary with:
+        cause: the key that failed
+        task: the definition of that key
+        deps: keys that the task depends on
+        """
+
+        keys = kwargs.pop('keys', [])
         for key in keys:
             if key in self.scheduler.exceptions_blame:
                 cause = self.scheduler.exceptions_blame[key]
@@ -35,12 +48,22 @@ class ExceptionScheduler(object):
                         'task': self.scheduler.tasks[cause]}
 
 
-class ExceptionsClient(object):
+class ReplayExceptionClient(object):
+    """
+    A plugin for the client allowing replay of remote exceptions locally
+
+    Adds the following methods to the given client:
+    * [_]recreate_error_locally: main user method
+    * [_]get_futures_error: gets the task, its details and dependencies,
+        responsible for failure of the given future.
+    """
+
     def __init__(self, client):
         self.client = client
         self.client.extensions['exceptions'] = self
         # monkey patch
         self.client.recreate_error_locally = self.recreate_error_locally
+        self.client._recreate_error_locally = self._recreate_error_locally
         self.client._get_futures_error = self._get_futures_error
         self.client.get_futures_error = self.get_futures_error
 
@@ -50,9 +73,11 @@ class ExceptionsClient(object):
 
     @gen.coroutine
     def _get_futures_error(self, future):
+        print('get futures')
         futures = futures_of(future)
         out = yield self.scheduler.cause_of_failure(
             keys=[f.key for f in futures])
+        print('got cause')
         deps, cause, task = out['deps'], out['cause'], out['task']
         function, args, kwargs = _deserialize(**task)
         raise gen.Return((function, args, kwargs, deps))
@@ -70,7 +95,16 @@ class ExceptionsClient(object):
         The function that failed, its arguments, and the keys that it depends
         on.
         """
-        return sync(self.loop, self._get_futures_error, future)
+        return sync(self.client.loop, self._get_futures_error, future)
+
+    @gen.coroutine
+    def _recreate_error_locally(self, future):
+        function, args, kwargs, deps = yield self._get_futures_error(future)
+        futures = self.client._graph_to_futures({}, deps)
+        data = yield self.client._gather(futures)
+        args = pack_data(args, data)
+        kwargs = pack_data(kwargs, data)
+        raise gen.Return((function, args, kwargs))
 
     def recreate_error_locally(self, future):
         """
@@ -87,12 +121,6 @@ class ExceptionsClient(object):
         Nothing; the function runs and should raise an exception, allowing
         the debugger to run.
         """
-        function, args, kwargs, deps = get_futures_error(future)
-        futures = self._graph_to_futures({}, deps)
-        data = self.gather(futures)
-        data = dict(zip(deps, data))
-        args = pack_data(args, data)
-        kwargs = pack_data(kwargs, data)
-
-        # run the function, hopefully trigger exception.
+        func, args, kwargs = sync(
+                self.client.loop, self._recreate_error_locally, future)
         func(*args, **kwargs)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -302,7 +302,8 @@ class Scheduler(Server):
                          'start_ipython': self.start_ipython,
                          'run_function': self.run_function,
                          'update_data': self.update_data,
-                         'set_resources': self.add_resources}
+                         'set_resources': self.add_resources,
+                         'cause_of_failure': self.cause_of_failure}
 
         self._transitions = {
                  ('released', 'waiting'): self.transition_released_waiting,
@@ -2909,6 +2910,13 @@ class Scheduler(Server):
         start_time = comm_bytes / BANDWIDTH + stack_time
         return (start_time, self.worker_bytes[worker])
 
+    def cause_of_failure(self, stream=None, keys=None):
+        for key in keys:
+            if key in self.exceptions_blame:
+                cause = self.exceptions_blame[key]
+                # cannot serialize sets
+                return (list(self.dependencies[cause]), cause,
+                        self.tasks[cause])
 
 def decide_worker(dependencies, occupancy, who_has, valid_workers,
                   loose_restrictions, objective, key):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -37,7 +37,7 @@ from .metrics import time
 from .publish import PublishExtension
 from .channels import ChannelScheduler
 from .stealing import WorkStealing
-from.recreate_exceptions import ExceptionScheduler
+from .recreate_exceptions import ReplayExceptionScheduler
 from .utils import (All, ignoring, get_ip, ignore_exceptions,
         ensure_ip, get_fileno_limit, log_errors, key_split, mean,
         divide_n_among_bins, validate_key)
@@ -194,7 +194,7 @@ class Scheduler(Server):
                  delete_interval=500, synchronize_worker_interval=60000,
                  services=None, allowed_failures=ALLOWED_FAILURES,
                  extensions=[ChannelScheduler, PublishExtension, WorkStealing,
-                             ExceptionScheduler],
+                             ReplayExceptionScheduler],
                  validate=False, **kwargs):
 
         # Attributes

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1106,7 +1106,7 @@ def test_upload_file(c, s, a, b):
         for value in [123, 456]:
             with tmp_text('myfile.py', 'def f():\n    return {}'.format(value)) as fn:
                 yield c._upload_file(fn)
-        
+
             x = c.submit(g, pure=False)
             result = yield x._result()
             assert result == value
@@ -1114,7 +1114,7 @@ def test_upload_file(c, s, a, b):
         # Ensure that this test won't impact the others
         if 'myfile' in sys.modules:
             del sys.modules['myfile']
-            
+
 @gen_cluster(client=True)
 def test_upload_file_zip(c, s, a, b):
     def g():
@@ -1127,7 +1127,7 @@ def test_upload_file_zip(c, s, a, b):
                 with zipfile.ZipFile('myfile.zip', 'w') as z:
                     z.write(fn_my_file, arcname=os.path.basename(fn_my_file))
                 yield c._upload_file('myfile.zip')
-                    
+
                 x = c.submit(g, pure=False)
                 result = yield x._result()
                 assert result == value
@@ -3750,3 +3750,17 @@ def test_dont_clear_waiting_data(c, s, a, b):
     for i in range(5):
         assert s.waiting_data[x.key]
         yield gen.moment
+
+@gen_cluster(client=True)
+def test_recreate_error_simple(c, s, a, b):
+    def makes_error(x):
+        return x / 0
+
+    f = c.submit(makes_error, 0)
+    yield _wait(f)
+    assert f.status == 'error'
+
+    function, args, kwargs, deps = yield c._get_futures_error(f)
+    assert function.__name__ == 'makes_error'
+    with pytest.raises(ZeroDivisionError):
+        function(*args, **kwargs)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3843,9 +3843,9 @@ def test_recreate_error_collection(c, s, a, b):
     f = c.compute(b)
     yield _wait(f)
 
-    out = yield c._recreate_error_locally(f)
+    function, args, kwargs = yield c._recreate_error_locally(f)
     with pytest.raises(ZeroDivisionError):
-        recreate_exceptions.exec_tuple(out)
+        function(*args, **kwargs)
 
     dd = pytest.importorskip('dask.dataframe')
     import pandas as pd

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1078,7 +1078,7 @@ class Worker(WorkerBase):
             self.log.append((key, 'new'))
             try:
                 start = time()
-                self.tasks[key] = self._deserialize(function, args, kwargs, task)
+                self.tasks[key] = _deserialize(function, args, kwargs, task)
                 stop = time()
 
                 if stop - start > 0.010:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -288,22 +288,6 @@ class WorkerBase(Server):
         yield self._closed.wait()
         assert self.status == 'closed'
 
-    def _deserialize(self, function=None, args=None, kwargs=None, task=None):
-        """ Deserialize task inputs and regularize to func, args, kwargs """
-        if function is not None:
-            function = loads(function)
-        if args:
-            args = loads(args)
-        if kwargs:
-            kwargs = loads(kwargs)
-
-        if task is not None:
-            assert not function and not args and not kwargs
-            function = execute_task
-            args = (task,)
-
-        return function, args or (), kwargs or {}
-
     @gen.coroutine
     def executor_submit(self, key, function, *args, **kwargs):
         """ Safely run function in thread pool executor
@@ -469,7 +453,7 @@ class WorkerBase(Server):
                             names_to_import.append(pkg.project_name)
                     elif ext == '.zip':
                         names_to_import.append(name)
-                
+
                 if not names_to_import:
                     logger.warning("Found nothing to import from %s", filename)
                 else:
@@ -539,6 +523,23 @@ class WorkerBase(Server):
 
 
 job_counter = [0]
+
+
+def _deserialize(function=None, args=None, kwargs=None, task=None):
+    """ Deserialize task inputs and regularize to func, args, kwargs """
+    if function is not None:
+        function = loads(function)
+    if args:
+        args = loads(args)
+    if kwargs:
+        kwargs = loads(kwargs)
+
+    if task is not None:
+        assert not function and not args and not kwargs
+        function = execute_task
+        args = (task,)
+
+    return function, args or (), kwargs or {}
 
 
 def execute_task(task):
@@ -1075,7 +1076,7 @@ class Worker(WorkerBase):
 
             self.log.append((key, 'new'))
             try:
-                self.tasks[key] = self._deserialize(function, args, kwargs, task)
+                self.tasks[key] = _deserialize(function, args, kwargs, task)
                 raw = {'function': function, 'args': args, 'kwargs': kwargs,
                         'task': task}
             except Exception as e:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -12,6 +12,7 @@ API
    Client.gather
    Client.get
    Client.get_dataset
+   Client.get_futures_error
    Client.has_what
    Client.list_datasets
    Client.map
@@ -19,6 +20,7 @@ API
    Client.persist
    Client.publish_dataset
    Client.rebalance
+   Client.recreate_error_locally
    Client.replicate
    Client.restart
    Client.run

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -12,7 +12,6 @@ API
    Client.gather
    Client.get
    Client.get_dataset
-   Client.get_futures_error
    Client.has_what
    Client.list_datasets
    Client.map
@@ -20,7 +19,6 @@ API
    Client.persist
    Client.publish_dataset
    Client.rebalance
-   Client.recreate_error_locally
    Client.replicate
    Client.restart
    Client.run
@@ -35,6 +33,15 @@ API
    Client.unpublish_dataset
    Client.upload_file
    Client.who_has
+
+.. currentmodule:: distributed.recreate_exceptions
+
+.. autosummary::
+   ReplayExceptionClient.get_futures_error
+   ReplayExceptionClient.recreate_error_locally
+
+.. currentmodule:: distributed.client
+
 
 **Future**
 
@@ -74,6 +81,9 @@ Client
 --------
 
 .. autoclass:: Client
+   :members:
+
+.. autoclass:: distributed.recreate_exceptions.ReplayExceptionClient
    :members:
 
 CompatibleExecutor


### PR DESCRIPTION
Fixes #868 

Could probably do with more complex test cases.

Example
------

```python
In [1]: from distributed import Client
In [2]: c = Client()
In [3]: def div(x, y):
   ...:     return x / y
   ...: 
In [4]: def inc(x):
   ...:     return x + 1
   ...: 
In [5]: x = c.submit(div, 1, 0)
In [6]: y = c.submit(inc, x)
In [7]: y.result()  # should err
ZeroDivisionError: division by zero

In [8]: pdb
Automatic pdb calling has been turned ON

In [9]: c.recreate_error_locally(y)
ZeroDivisionError: division by zero
> <ipython-input-3-398a43a7781e>(2)div()
      1 def div(x, y):
----> 2     return x / y

ipdb> pp x
1
ipdb> pp y
0
```