### PR TITLE
Rename local_client to worker_client

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -10,7 +10,7 @@ from .nanny import Nanny
 from .scheduler import Scheduler
 from .utils import sync
 from .worker import Worker
-from .worker_client import local_client
+from .worker_client import local_client, worker_client
 
 try:
     from .collections import futures_to_collection

--- a/distributed/tests/test_channels.py
+++ b/distributed/tests/test_channels.py
@@ -8,7 +8,7 @@ from toolz import take
 from tornado import gen
 
 from distributed import Client
-from distributed import local_client
+from distributed import worker_client
 from distributed.metrics import time
 from distributed.utils_test import gen_cluster, inc, loop, cluster, slowinc
 
@@ -52,9 +52,9 @@ def test_channel(c, s, a, b):
     assert '1' in repr(x)
 
 
-def test_local_client(loop):
+def test_worker_client(loop):
     def produce(n):
-        with local_client() as c:
+        with worker_client() as c:
             x = c.channel('x')
             for i in range(n):
                 future = c.submit(slowinc, i, delay=0.01, key='f-%d' % i)
@@ -63,7 +63,7 @@ def test_local_client(loop):
             x.flush()
 
     def consume():
-        with local_client() as c:
+        with worker_client() as c:
             x = c.channel('x')
             y = c.channel('y')
             last = 0
@@ -157,7 +157,7 @@ def test_multiple_maxlen(c, s, a, b):
 
 def test_stop(loop):
     def produce(n):
-        with local_client() as c:
+        with worker_client() as c:
             x = c.channel('x')
             for i in range(n):
                 future = c.submit(slowinc, i, delay=0.01, key='f-%d' % i)

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -13,7 +13,7 @@ from tornado import gen
 
 import dask
 from dask import delayed
-from distributed import Worker, Nanny, local_client
+from distributed import Worker, Nanny, worker_client
 from distributed.config import config
 from distributed.client import Client, _wait, wait
 from distributed.metrics import time
@@ -531,7 +531,7 @@ def test_accept_old_result_if_stolen(c, s, a, b):
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 2)
 def test_dont_steal_long_running_tasks(c, s, a, b):
     def long(delay):
-        with local_client() as c:
+        with worker_client() as c:
             sleep(delay)
 
     yield c.submit(long, 0.1)._result()  # learn duration

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -18,7 +18,7 @@ from .worker import thread_state
 
 
 @contextmanager
-def local_client(timeout=3):
+def worker_client(timeout=3):
     """ Get client for this thread
 
     Note: This interface is new and experimental.  It may change without
@@ -32,7 +32,7 @@ def local_client(timeout=3):
     --------
 
     >>> def func(x):
-    ...     with local_client() as e:  # connect from worker back to scheduler
+    ...     with worker_client() as e:  # connect from worker back to scheduler
     ...         a = e.submit(inc, x)     # this task can submit more tasks
     ...         b = e.submit(dec, x)
     ...         result = e.gather([a, b])  # and gather results
@@ -52,6 +52,8 @@ def local_client(timeout=3):
         assert wc.status == 'running'
         yield wc
 
+
+local_client = worker_client
 
 def get_worker():
     return thread_state.execution_state['worker']

--- a/docs/source/channels.rst
+++ b/docs/source/channels.rst
@@ -64,27 +64,27 @@ fully registered with the scheduler.
     >>> chan.flush()
 
 
-Example with local_client
+Example with worker_client
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Using channels with `local client`_ allows for a more decoupled version
+Using channels with `worker client`_ allows for a more decoupled version
 of what is possible with :doc:`Data Streams with Queues<queues>`
 in that independent worker clients can build up a set of results
 which can be read later by a different client.
 This opens up Dask/Distributed to being integrated in a wider application
 environment similar to other python task queues such as Celery_.
 
-.. _local client: http://distributed.readthedocs.io/en/latest/task-launch.html#submit-tasks-from-worker
+.. _worker client: http://distributed.readthedocs.io/en/latest/task-launch.html#submit-tasks-from-worker
 .. _Celery: http://www.celeryproject.org/
 
 .. code-block:: python
 
     import random, time, operator
-    from distributed import Client, local_client
+    from distributed import Client, worker_client
     from time import sleep
 
     def emit(name):
-        with local_client() as c:
+        with worker_client() as c:
            chan = c.channel(name)
            while True:
                future = c.submit(random.random, pure=False)
@@ -92,7 +92,7 @@ environment similar to other python task queues such as Celery_.
                sleep(1)
 
     def combine():
-        with local_client() as c:
+        with worker_client() as c:
             a_chan = c.channel('a')
             b_chan = c.channel('b')
             out_chan = c.channel('adds')

--- a/docs/source/task-launch.rst
+++ b/docs/source/task-launch.rst
@@ -86,15 +86,15 @@ on worker nodes.
 To submit new tasks from a worker that worker must first create a new client
 object that connects to the scheduler.  There is a convenience function to do
 this for you so that you don't have to pass around connection information.
-However you must use this function ``local_client`` as a context manager to
+However you must use this function ``worker_client`` as a context manager to
 ensure proper cleanup on the worker.
 
 .. code-block:: python
 
-   from distributed import local_client
+   from distributed import worker_client
 
    def process_all(data):
-       with local_client() as e:
+       with worker_client() as e:
            elements = e.scatter(data)
            futures = e.map(process_element, elements)
            analysis = e.submit(aggregate, futures)
@@ -115,7 +115,7 @@ that submit tasks that submit other tasks, etc..
 
 .. code-block:: python
 
-   In [1]: from distributed import Client, local_client
+   In [1]: from distributed import Client, worker_client
 
    In [2]: client = Client()
 
@@ -123,7 +123,7 @@ that submit tasks that submit other tasks, etc..
       ...:     if n < 2:
       ...:         return n
       ...:     else:
-      ...:         with local_client() as c
+      ...:         with worker_client() as c
       ...:             a = c.submit(fib, n - 1)
       ...:             b = c.submit(fib, n - 2)
       ...:             a, b = c.gather([a, b])
@@ -146,11 +146,11 @@ that even pathological cases function robustly.
 Technical details
 ~~~~~~~~~~~~~~~~~
 
-Tasks that invoke ``local_client`` are conservatively assumed to be *long
+Tasks that invoke ``worker_client`` are conservatively assumed to be *long
 running*.  They can take a long time blocking, waiting for other tasks to
 finish, gathering results, etc..  In order to avoid having them take up
 processing slots the following actions occur whenever a task invokes
-``local_client``.
+``worker_client``.
 
 1.  The thread on the worker running this function *secedes* from the thread
     pool and goes off on its own.  This allows the thread pool to populate that


### PR DESCRIPTION
This retains the local_client alias for backwards compatibility.

Fixes #885