### PR TITLE
TST: Skip more bokeh-requiring tests if unavailable.

### DIFF
--- a/distributed/bokeh/tests/test_application.py
+++ b/distributed/bokeh/tests/test_application.py
@@ -3,6 +3,7 @@ from time import sleep
 import sys
 
 import pytest
+pytest.importorskip('bokeh')
 
 from distributed.bokeh.application import BokehWebInterface
 from distributed import LocalCluster

--- a/distributed/bokeh/tests/test_components.py
+++ b/distributed/bokeh/tests/test_components.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import pytest
+pytest.importorskip('bokeh')
 
 from bokeh.models import ColumnDataSource, Model
 

--- a/distributed/bokeh/tests/test_scheduler_bokeh.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh.py
@@ -4,6 +4,7 @@ from operator import add, sub
 from time import sleep
 
 import pytest
+pytest.importorskip('bokeh')
 import sys
 from toolz import first
 from tornado import gen

--- a/distributed/bokeh/tests/test_worker_bokeh.py
+++ b/distributed/bokeh/tests/test_worker_bokeh.py
@@ -4,6 +4,7 @@ from operator import add, sub
 from time import sleep
 
 import pytest
+pytest.importorskip('bokeh')
 import sys
 from toolz import first
 from tornado import gen

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -228,6 +228,7 @@ def test_scheduler_port_zero(loop):
 
 
 def test_bokeh_port_zero(loop):
+    pytest.importorskip('bokeh')
     with tmpfile() as fn:
         with popen(['dask-scheduler',
                     '--bokeh-port', '0',

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -148,6 +148,7 @@ def test_http(loop):
 
 
 def test_bokeh(loop):
+    pytest.importorskip('bokeh')
     from distributed.http import HTTPScheduler
     import requests
     with LocalCluster(scheduler_port=0, silence_logs=False, loop=loop,
@@ -170,6 +171,7 @@ def test_bokeh(loop):
 
 
 def test_start_diagnostics(loop):
+    pytest.importorskip('bokeh')
     from distributed.http import HTTPScheduler
     import requests
     with LocalCluster(scheduler_port=0, silence_logs=False, loop=loop,

--- a/distributed/diagnostics/tests/test_eventstream.py
+++ b/distributed/diagnostics/tests/test_eventstream.py
@@ -9,7 +9,6 @@ from tornado import gen
 from distributed import Client, Scheduler, Worker
 from distributed.client import _wait
 from distributed.diagnostics.eventstream import EventStream, eventstream
-from distributed.diagnostics.progress_stream import task_stream_append
 from distributed.metrics import time
 from distributed.utils_test import inc, div, dec, gen_cluster
 from distributed.worker import dumps_task
@@ -17,6 +16,8 @@ from distributed.worker import dumps_task
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 3)
 def test_eventstream(c, s, *workers):
+    pytest.importorskip('bokeh')
+
     es = EventStream()
     s.add_plugin(es)
     assert es.buffer == []
@@ -29,6 +30,7 @@ def test_eventstream(c, s, *workers):
     assert len(es.buffer) == 11
 
     from distributed.bokeh import messages
+    from distributed.diagnostics.progress_stream import task_stream_append
     lists = deepcopy(messages['task-events']['rectangles'])
     workers = dict()
     for msg in es.buffer:

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -3,12 +3,13 @@ from __future__ import print_function, division, absolute_import
 from time import sleep
 
 import pytest
+pytest.importorskip('bokeh')
 from tornado import gen
 
 from dask import do
 from distributed.client import _wait
 from distributed.diagnostics.progress_stream import (progress_quads,
-        nbytes_bar, progress_stream, task_stream_append)
+        nbytes_bar, progress_stream)
 from distributed.metrics import time
 from distributed.utils_test import inc, div, dec, gen_cluster
 from distributed.worker import dumps_task


### PR DESCRIPTION
Tests are currently a bit divided on this; some parts skip if bokeh is not available and some don't. Sometimes this is even inconsistent within the same file. With this change, bokeh is now completely optional for tests. It would be nice if CI checked this though, but I don't know if that change should be made here.