### PR TITLE
Add mytestegg to manifest.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include LICENSE.txt
 include MANIFEST.in
 include requirements.txt
 include distributed/config.yaml
+include distributed/tests/mytestegg-1.0.0-py3.4.egg
 
 prune docs/_build
 include versioneer.py


### PR DESCRIPTION
Not including this file means tests break when installed from PyPI.