### PR TITLE
Quiet logs if terminating on a closed loop

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -135,7 +135,9 @@ class Nanny(Server):
             except CommClosedError:
                 pass
             except BaseException as e:
-                logger.exception(e)
+                if (not self.loop._closing and self.loop._running and not
+                        self.loop._stopped):
+                    logger.exception(e)
 
             allowed_errors = (gen.TimeoutError, CommClosedError, EnvironmentError, RPCClosed)
             try:


### PR DESCRIPTION
This was causing annoying and needless logging messages.

It's possible that we should be doing something more mature here and figure out why we're calling terminate when the loop is closed.

cc @pitrou in case he has any thoughts here