### PR TITLE
Add entry for export tool in config.yaml

### DIFF
--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -16,10 +16,14 @@ from bokeh.palettes import Spectral9
 from bokeh.plotting import figure
 from toolz import valmap
 
+from distributed.config import config
 from distributed.diagnostics.progress_stream import progress_quads, nbytes_bar
 from distributed.utils import log_errors
 
-# from .export_tool import ExportTool
+if config.get('bokeh-export-tool', False):
+    from .export_tool import ExportTool
+else:
+    ExportTool = None
 
 
 class DashboardComponent(object):
@@ -94,17 +98,17 @@ class TaskStream(DashboardComponent):
                 """
         )
 
-        # export = ExportTool()
-        # export.register_plot(self.root)
-
         self.root.add_tools(
             hover,
-            # export,
             BoxZoomTool(),
             ResetTool(reset_size=False),
             PanTool(dimensions="width"),
             WheelZoomTool(dimensions="width")
         )
+        if ExportTool:
+            export = ExportTool()
+            export.register_plot(self.root)
+            self.root.add_tools(export)
 
         # Required for update callback
         self.task_stream_index = [0]

--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -15,5 +15,8 @@ transition-log-length: 100000
 multiprocessing-method: forkserver
 
 # Communication options
-tcp-timeout: 30         # delay (in s.) before considering an unresponsive connection dead
+tcp-timeout: 30         # seconds delay before calling an unresponsive connection dead
 default-scheme: tcp
+
+# Bokeh web dashboard
+bokeh-export-tool: False


### PR DESCRIPTION
This tool is useful, but requires that a recent version of NPM is installed.
Rather than try to determine the npm version we just leave this as a config
parameter and let users (mostly just me) handle it.