### PR TITLE
Use Connection Pool for Inter-worker communication

### DIFF
--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -175,21 +175,18 @@ def color_of_message(msg):
 
 
 colors = {'transfer': 'red',
-          'connect': 'purple',
           'disk': 'orange',
           'deserialize': 'gray',
           'compute': color_of_message}
 
 
 alphas = {'transfer': 0.4,
-          'connect': '0.3',
           'compute': 1,
           'deserialize': 0.4,
           'disk': 0.4}
 
 
 prefix = {'transfer': 'transfer-',
-          'connect': 'connect-',
           'disk': 'load-',
           'deserialize': 'deserialize-',
           'compute': ''}

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -175,18 +175,21 @@ def color_of_message(msg):
 
 
 colors = {'transfer': 'red',
+          'connect': 'red',
           'disk': 'orange',
           'deserialize': 'gray',
           'compute': color_of_message}
 
 
 alphas = {'transfer': 0.4,
+          'connect': '0.8',
           'compute': 1,
           'deserialize': 0.4,
           'disk': 0.4}
 
 
 prefix = {'transfer': 'transfer-',
+          'connect': 'connect-',
           'disk': 'load-',
           'deserialize': 'deserialize-',
           'compute': ''}

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1545,11 +1545,11 @@ class Worker(WorkerBase):
                 if self.validate:
                     self.validate_state()
 
+                self.log.append(('request-dep', dep, worker, deps))
+                logger.debug("Request %d keys", len(deps))
                 start = time()
                 response = yield self.rpc(worker).get_data(keys=list(deps),
                                                            who=self.address)
-                self.log.append(('request-dep', dep, worker, deps))
-                logger.debug("Request %d keys", len(deps))
                 stop = time()
 
                 if cause:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -27,7 +27,7 @@ from .batched import BatchedSend
 from .comm import get_address_host
 from .config import config
 from .compatibility import reload, unicode, invalidate_caches, cache_from_source
-from .core import (connect, send_recv, error_message, CommClosedError,
+from .core import (error_message, CommClosedError,
                    rpc, Server, pingpong, coerce_to_address)
 from .metrics import time
 from .protocol.pickle import dumps, loads

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1551,6 +1551,8 @@ class Worker(WorkerBase):
                 stop = time()
                 if self.digests is not None:
                     self.digests['gather-connect-duration'].add(stop - start)
+                if stop - start > 0.020:  # 20ms connect time is longish
+                    self.startstops[cause].append(('connect', start, stop))
 
                 self.log.append(('request-dep', dep, worker, deps))
                 logger.debug("Request %d keys", len(deps))


### PR DESCRIPTION
Previously we made new connections any time any worker wanted to request data
from another worker.  Now we use the pre-existing connection pool for this
purpose.  This lets us avoid reconnection costs.

We had this feature before but removed it due to errors that we couldn't track
down.  Given how much has changed since them I'm comfortable adding this back
in, but we should be aware of the potential problem.
