### PR TITLE
Sizeof dataframe tweaks

### DIFF
--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -42,6 +42,8 @@ def register_pandas():
     import numpy as np
 
     def object_size(x):
+        if not len(x):
+            return 0
         sample = np.random.choice(x, size=20, replace=True)
         sample = list(map(sizeof, sample))
         return sum(sample) / 20 * len(x)

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -50,12 +50,12 @@ def register_pandas():
 
     @sizeof.register(pd.DataFrame)
     def sizeof_pandas_dataframe(df):
-        p = int(df.memory_usage(index=True).sum())
-        for col, dtype in df.dtypes.iteritems():
-            if dtype == object:
-                p += object_size(df[col]._values)
-        if df.index.dtype == object:
-            p += object_size(df.ind)
+        p = sum(c.memory_usage(index=False) for _, c in df.iteritems())
+        p += sizeof(df.index)
+        for col in df.columns:
+            col = df[col]
+            if col.dtype == object:
+                p += object_size(col._values)
         return int(p) + 1000
 
     @sizeof.register(pd.Series)

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -39,29 +39,38 @@ def register_numpy():
 @sizeof.register_lazy("pandas")
 def register_pandas():
     import pandas as pd
+    import numpy as np
+
+    def object_size(x):
+        sample = np.random.choice(x, size=20, replace=True)
+        sample = list(map(sizeof, sample))
+        return sum(sample) / 20 * len(x)
 
     @sizeof.register(pd.DataFrame)
     def sizeof_pandas_dataframe(df):
         p = int(df.memory_usage(index=True).sum())
-        obj = int((df.dtypes == object).sum() * len(df) * 100)
+        for col, dtype in df.dtypes.iteritems():
+            if dtype == object:
+                p += object_size(df[col]._values)
         if df.index.dtype == object:
-            obj += len(df) * 100
-        return int(p + obj) + 1000
+            p += object_size(df.ind)
+        return int(p) + 1000
 
     @sizeof.register(pd.Series)
     def sizeof_pandas_series(s):
         p = int(s.memory_usage(index=True))
         if s.dtype == object:
-            p += len(s) * 100
+            p += object_size(s._values)
         if s.index.dtype == object:
-            p += len(s) * 100
+            p += object_size(s.index)
         return int(p) + 1000
 
     @sizeof.register(pd.Index)
     def sizeof_pandas_index(i):
         p = int(i.memory_usage())
-        obj = len(i) * 100 if i.dtype == object else 0
-        return int(p + obj) + 1000
+        if i.dtype == object:
+            p += object_size(i)
+        return int(p) + 1000
 
 
 @sizeof.register_lazy("scipy")

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -48,3 +48,21 @@ def test_sparse_matrix():
     assert sizeof(sp.tocsr()) >= 260
     assert sizeof(sp.todok()) >= 260
     assert sizeof(sp.tolil()) >= 324
+
+
+def test_serires_object_dtype():
+    pd = pytest.importorskip('pandas')
+    s = pd.Series(['a'] * 1000)
+    assert sizeof('a') * 1000 < sizeof(s) < 2 * sizeof('a') * 1000
+
+    s = pd.Series(['a' * 1000] * 1000)
+    assert sizeof(s) > 1000000
+
+
+def test_dataframe_object_dtype():
+    pd = pytest.importorskip('pandas')
+    df = pd.DataFrame({'x': ['a'] * 1000})
+    assert sizeof('a') * 1000 < sizeof(df) < 2 * sizeof('a') * 1000
+
+    s = pd.Series(['a' * 1000] * 1000)
+    assert sizeof(s) > 1000000

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -66,3 +66,15 @@ def test_dataframe_object_dtype():
 
     s = pd.Series(['a' * 1000] * 1000)
     assert sizeof(s) > 1000000
+
+
+def test_empty():
+    pd = pytest.importorskip('pandas')
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': ['a'*100, 'b'*100, 'c'*100]},
+                      index=[10, 20, 30])
+    empty = df.head(0)
+
+    assert sizeof(empty) > 0
+    assert sizeof(empty.x) > 0
+    assert sizeof(empty.y) > 0
+    assert sizeof(empty.index) > 0


### PR DESCRIPTION
Two main changes:

1.  Sample the dataframe for objects when receiving an object dtype column.  Previously we assumed that these were text with length 100.  Now we select a sample of twenty elements and call sizeof on those.
2.  Reduce overhead from calling `DataFrame.memory_usage`