### PR TITLE
Add nanny's process to processes_to_close

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -203,6 +203,7 @@ class Nanny(Server):
                         'validate': self.validate,
                         'silence_logs': self.silence_logs})
             self.process.daemon = True
+            processes_to_close.add(self.process)
             self.process.start()
             while True:
                 try:


### PR DESCRIPTION
I've noticed that dask-workers hang around for a while if I create a
LocalCluster in a notebook and then restart the kernel.  This may help.

cc @pitrou for review