### PR TITLE
Worker death timeout

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -80,9 +80,12 @@ def handle_signal(sig, frame):
 @click.option('--scheduler-file', type=str, default='',
               help='Filename to JSON encoded scheduler information. '
                    'Use with dask-scheduler --scheduler-file')
+@click.option('--death-timeout', type=float, default=None,
+              help="Seconds to wait for a scheduler before closing")
 def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
          nanny, name, memory_limit, pid_file, temp_filename, reconnect,
-         resources, bokeh, bokeh_port, local_directory, scheduler_file):
+         resources, bokeh, bokeh_port, local_directory, scheduler_file,
+         death_timeout):
     if nanny:
         port = nanny_port
     else:
@@ -155,7 +158,8 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
     nannies = [t(scheduler, ncores=nthreads,
                  services=services, name=name, loop=loop, resources=resources,
                  memory_limit=memory_limit, reconnect=reconnect,
-                 local_dir=local_directory, **kwargs)
+                 local_dir=local_directory, death_timeout=death_timeout,
+                 **kwargs)
                for i in range(nprocs)]
 
     for n in nannies:

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -197,12 +197,13 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
 
     @gen.coroutine
     def f():
-        scheduler = rpc(nannies[0].scheduler.address)
-        if nanny:
-            yield gen.with_timeout(timedelta(seconds=2),
-                    All([scheduler.unregister(address=n.worker_address, close=True)
-                         for n in nannies if n.process and n.worker_address]),
-                    io_loop=loop2)
+        with rpc(nannies[0].scheduler.address) as scheduler:
+            if nanny:
+                yield gen.with_timeout(
+                        timeout=timedelta(seconds=2),
+                        future=All([scheduler.unregister(address=n.worker_address, close=True)
+                                   for n in nannies if n.process and n.worker_address]),
+                        io_loop=loop2)
 
     loop2.run_sync(f)
 

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -144,7 +144,7 @@ class LocalCluster(object):
         yield [self._start_worker(**kwargs) for i in range(n_workers)]
 
     @gen.coroutine
-    def _start_worker(self, port=0, nanny=None, **kwargs):
+    def _start_worker(self, port=0, nanny=None, death_timeout=60, **kwargs):
         if nanny is None:
             nanny = self.nanny
         if nanny:
@@ -154,7 +154,8 @@ class LocalCluster(object):
             W = Worker
         try:
             w = W(self.scheduler.address, loop=self.loop,
-                  silence_logs=self.silence_logs, **kwargs)
+                  silence_logs=self.silence_logs, death_timeout=death_timeout,
+                  **kwargs)
             yield w._start(port)
         except Exception:
             raise

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -32,7 +32,7 @@ class Nanny(Server):
                  ncores=None, loop=None, local_dir=None, services=None,
                  name=None, memory_limit='auto', reconnect=True,
                  validate=False, quiet=False, resources=None, silence_logs=None,
-                 **kwargs):
+                 death_timeout=None, **kwargs):
         if scheduler_port is None:
             scheduler_addr = coerce_to_address(scheduler_ip)
         else:
@@ -43,6 +43,7 @@ class Nanny(Server):
         self.reconnect = reconnect
         self.validate = validate
         self.resources = resources
+        self.death_timeout = death_timeout
         if not local_dir:
             local_dir = tempfile.mkdtemp(prefix='nanny-')
             self._should_cleanup_local_dir = True
@@ -98,10 +99,11 @@ class Nanny(Server):
             self.ip = get_address_host(self.address)
 
         logger.info('        Start Nanny at: %r', self.address)
-        yield self.instantiate()
-        self.loop.add_callback(self._watch)
-        assert self.worker_address
-        self.status = 'running'
+        response = yield self.instantiate()
+        if response == 'OK':
+            self.loop.add_callback(self._watch)
+            assert self.worker_address
+            self.status = 'running'
 
     def start(self, addr_or_port=0):
         self.loop.add_callback(self._start, addr_or_port)
@@ -113,8 +115,12 @@ class Nanny(Server):
         Blocks until both the process is down and the scheduler is properly
         informed
         """
+        timeout_time = time() + timeout
+
         while not self.worker_address:
             yield gen.sleep(0.1)
+            if time() > timeout_time:
+                raise gen.TimeoutError()
 
         if self.process is None:
             raise gen.Return('OK')
@@ -201,10 +207,14 @@ class Nanny(Server):
                         'reconnect': self.reconnect,
                         'resources': self.resources,
                         'validate': self.validate,
-                        'silence_logs': self.silence_logs})
+                        'silence_logs': self.silence_logs,
+                        'death_timeout': self.death_timeout})
             self.process.daemon = True
             self.process.start()
+            start = time()
             while True:
+                if self.death_timeout and time() > start + self.death_timeout:
+                    yield self._close(timeout=1)
                 try:
                     msg = q.get_nowait()
                     if isinstance(msg, Exception):
@@ -218,6 +228,8 @@ class Nanny(Server):
 
             logger.info("Nanny %r starts worker process %r",
                         self.address, self.worker_address)
+        except gen.Return:
+            raise
         except Exception as e:
             logger.exception(e)
             raise
@@ -281,7 +293,8 @@ class Nanny(Server):
             raise gen.Return('OK')
         logger.info("Closing Nanny at %r", self.address)
         self.status = 'closed'
-        yield self._kill(timeout=timeout)
+        with ignoring(gen.TimeoutError):
+            yield self._kill(timeout=timeout)
         self.rpc.close()
         self.scheduler.close_rpc()
         self.stop()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -9,7 +9,7 @@ import tempfile
 from time import sleep
 import weakref
 
-from tornado.ioloop import IOLoop
+from tornado.ioloop import IOLoop, TimeoutError
 from tornado import gen
 
 from .comm import get_address_host
@@ -352,6 +352,8 @@ def run_worker_fork(q, scheduler_addr, ncores, nanny_port,
         logger.info("Worker closed")
     try:
         loop.run_sync(run)
+    except TimeoutError:
+        logger.info("Worker timed out")
     finally:
         loop.stop()
         loop.close(all_fds=True)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -14,7 +14,7 @@ from distributed.core import connect, CommClosedError
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps, loads
 from distributed.utils import ignoring
-from distributed.utils_test import gen_cluster
+from distributed.utils_test import gen_cluster, gen_test
 from distributed.nanny import isalive
 
 
@@ -151,3 +151,12 @@ def test_close_on_disconnect(s, w):
     while w.status != 'closed':
         yield gen.sleep(0.01)
         assert time() < start + 9
+
+
+@gen_test()
+def test_nanny_death_timeout():
+    w = Nanny('127.0.0.1', 38848, death_timeout=1)
+    yield w._start()
+
+    yield gen.sleep(3)
+    assert w.status == 'closed'

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -651,3 +651,13 @@ def test_hold_onto_dependents(c, s, a, b):
     yield gen.sleep(0.1)
 
     assert x.key in b.data
+
+
+@slow
+@gen_test()
+def test_worker_with_port_zero():
+    w = Worker('127.0.0.1', 38848, death_timeout=1)
+    yield w._start()
+
+    yield gen.sleep(3)
+    assert w.status == 'closed'

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -655,7 +655,7 @@ def test_hold_onto_dependents(c, s, a, b):
 
 @slow
 @gen_test()
-def test_worker_with_port_zero():
+def test_worker_death_timeout():
     w = Worker('127.0.0.1', 38848, death_timeout=1)
     yield w._start()
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -69,7 +69,7 @@ class WorkerBase(Server):
                  loop=None, local_dir=None, services=None, service_ports=None,
                  name=None, heartbeat_interval=5000, reconnect=True,
                  memory_limit='auto', executor=None, resources=None,
-                 silence_logs=None, **kwargs):
+                 silence_logs=None, death_timeout=None, **kwargs):
         if scheduler_port is None:
             scheduler_addr = coerce_to_address(scheduler_ip)
         else:
@@ -79,6 +79,7 @@ class WorkerBase(Server):
         self.local_dir = local_dir or tempfile.mkdtemp(prefix='worker-')
         self.total_resources = resources or {}
         self.available_resources = (resources or {}).copy()
+        self.death_timeout = death_timeout
         if silence_logs:
             logger.setLevel(silence_logs)
         if not os.path.exists(self.local_dir):
@@ -180,11 +181,15 @@ class WorkerBase(Server):
     @gen.coroutine
     def _register_with_scheduler(self):
         self.heartbeat_callback.stop()
+        start = time()
         while True:
+            if self.death_timeout and time() > start + self.death_timeout:
+                yield self._close(timeout=1)
+                return
             if self.status in ('closed', 'closing'):
                 raise gen.Return
             try:
-                resp = yield self.scheduler.register(
+                future = self.scheduler.register(
                         ncores=self.ncores, address=self.address,
                         keys=list(self.data),
                         name=self.name,
@@ -195,10 +200,18 @@ class WorkerBase(Server):
                         memory_limit=self.memory_limit,
                         local_directory=self.local_dir,
                         resources=self.total_resources)
+                if self.death_timeout:
+                    diff = self.death_timeout - (time() - start)
+                    future = gen.with_timeout(timedelta(seconds=diff), future,
+                                              io_loop=self.loop)
+                resp = yield future
+                self.status = 'running'
                 break
             except EnvironmentError:
                 logger.debug("Unable to register with scheduler.  Waiting")
                 yield gen.sleep(0.1)
+            except gen.TimeoutError:
+                pass
         if resp != 'OK':
             raise ValueError(resp)
         self.heartbeat_callback.start()
@@ -250,9 +263,9 @@ class WorkerBase(Server):
 
         yield self._register_with_scheduler()
 
-        logger.info('        Registered to: %32s', self.scheduler.address)
-        logger.info('-' * 49)
-        self.status = 'running'
+        if self.status == 'running':
+            logger.info('        Registered to: %32s', self.scheduler.address)
+            logger.info('-' * 49)
 
     def start(self, port=0):
         self.loop.add_callback(self._start, port)
@@ -272,7 +285,7 @@ class WorkerBase(Server):
         self.status = 'closing'
         self.stop()
         self.heartbeat_callback.stop()
-        with ignoring(EnvironmentError):
+        with ignoring(EnvironmentError, gen.TimeoutError):
             if report:
                 yield gen.with_timeout(timedelta(seconds=timeout),
                         self.scheduler.unregister(address=self.address),


### PR DESCRIPTION
Workers can terminate gracefully if they haven't seen a scheduler in a certain amount of time

    dask-worker scheduler:8786 --death-timeout 60

Fixes https://github.com/dask/distributed/issues/786