### PR TITLE
Make sizeof test work with 32-bit 2.7 as well.

### DIFF
--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -41,13 +41,14 @@ def test_pandas():
 def test_sparse_matrix():
     sparse = pytest.importorskip('scipy.sparse')
     sp = sparse.eye(10)
-    assert sizeof(sp.todia()) >= 152  # these are the 32 bit values
+    # These are the 32-bit Python 2.7 values.
+    assert sizeof(sp.todia()) >= 152
     assert sizeof(sp.tobsr()) >= 232
-    assert sizeof(sp.tocoo()) >= 248
+    assert sizeof(sp.tocoo()) >= 240
     assert sizeof(sp.tocsc()) >= 232
-    assert sizeof(sp.tocsr()) >= 238
+    assert sizeof(sp.tocsr()) >= 232
     assert sizeof(sp.todok()) >= 192
-    assert sizeof(sp.tolil()) >= 210
+    assert sizeof(sp.tolil()) >= 204
 
 
 def test_serires_object_dtype():


### PR DESCRIPTION
A slight tweak over #948. Fixes #923.

The results for each type that I get are:

type | 3.5.2 64bit | 2.7.13 64bit | 3.5.3 32bit | 2.7.13 32bit
---- | ----------- | ------------ | ----------- | ------------
sparse | 232 | 228 | 158 | 152
dia | 232 | 228 | 158 | 152
bsr | 312 | 308 | 238 | 232
coo | 336 | 328 | 248 | 240
csc | 312 | 308 | 238 | 232
csr | 312 | 308 | 238 | 232
dok | 472 | 1032 | 236 | 516
lil | 404 | 400 | 210 | 204

I don't know why `dok` has such variance or why the test has it all the way down to 192, but it works as it is, so...