### PR TITLE
Support async for protocol in as_completed

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2573,10 +2573,6 @@ class AsCompleted(object):
             yield self.event.wait()
         return self.queue.get()
 
-
-
-
-
     next = __next__
 
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2571,6 +2571,7 @@ class AsCompleted(object):
             raise StopAsyncIteration  # flake8: noqa
         while self.queue.empty():
             yield self.event.wait()
+        sleep(0.0000000001)
         raise gen.Return(self.queue.get())
 
     next = __next__

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2568,7 +2568,7 @@ class AsCompleted(object):
     @gen.coroutine
     def __anext__(self):
         if not self.futures and self.queue.empty():
-            raise StopAsyncIteration
+            raise StopAsyncIteration  # flake8: noqa
         while self.queue.empty():
             yield self.event.wait()
         raise gen.Return(self.queue.get())

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2571,7 +2571,7 @@ class AsCompleted(object):
             raise StopAsyncIteration
         while self.queue.empty():
             yield self.event.wait()
-        return self.queue.get()
+        raise gen.Return(self.queue.get())
 
     next = __next__
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -27,7 +27,7 @@ from dask.context import _globals
 from toolz import first, groupby, merge, valmap, keymap
 from tornado import gen
 from tornado.gen import Return, TimeoutError
-from tornado.locks import Event
+from tornado.locks import Event, Condition
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.queues import Queue
 
@@ -2526,7 +2526,7 @@ class AsCompleted(object):
         self.queue = pyQueue()
         self.lock = Lock()
         self.loop = loop or default_client().loop
-        self.event = Event()
+        self.condition = Condition()
 
         if futures:
             for future in futures:
@@ -2540,7 +2540,7 @@ class AsCompleted(object):
             if not self.futures[future]:
                 del self.futures[future]
             self.queue.put_nowait(future)
-            self.event.set()
+            self.condition.notify()
 
     def add(self, future):
         """ Add a future to the collection
@@ -2570,8 +2570,7 @@ class AsCompleted(object):
         if not self.futures and self.queue.empty():
             raise StopAsyncIteration  # flake8: noqa
         while self.queue.empty():
-            yield self.event.wait()
-        sleep(0.0000000001)
+            yield self.condition.wait()
         raise gen.Return(self.queue.get())
 
     next = __next__

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -246,6 +246,9 @@ class Future(WrappedKey):
 
     __repr__ = __str__
 
+    def __await__(self):
+        return self._result().__await__()
+
 
 class FutureState(object):
     """A Future's internal state.

--- a/distributed/tests/py3_test_client.py
+++ b/distributed/tests/py3_test_client.py
@@ -3,21 +3,6 @@ import pytest
 from distributed.utils_test import gen_cluster, inc, div
 from distributed import as_completed
 
-@gen_cluster(client=True)
-def test_as_completed_async_for(c, s, a, b):
-    futures = c.map(inc, range(10))
-    ac = as_completed(futures)
-    results = []
-
-    async def f():
-        async for future in ac:
-            result = await future._result()
-            results.append(result)
-
-    yield f()
-
-    assert set(results) == set(range(1, 11))
-
 
 @gen_cluster(client=True)
 def test_await_future(c, s, a, b):
@@ -37,3 +22,18 @@ def test_await_future(c, s, a, b):
 
     yield f()
 
+
+@gen_cluster(client=True)
+def test_as_completed_async_for(c, s, a, b):
+    futures = c.map(inc, range(10))
+    ac = as_completed(futures)
+    results = []
+
+    async def f():
+        async for future in ac:
+            result = await future
+            results.append(result)
+
+    yield f()
+
+    assert set(results) == set(range(1, 11))

--- a/distributed/tests/py3_test_client.py
+++ b/distributed/tests/py3_test_client.py
@@ -1,0 +1,39 @@
+import pytest
+
+from distributed.utils_test import gen_cluster, inc, div
+from distributed import as_completed
+
+@gen_cluster(client=True)
+def test_as_completed_async_for(c, s, a, b):
+    futures = c.map(inc, range(10))
+    ac = as_completed(futures)
+    results = []
+
+    async def f():
+        async for future in ac:
+            result = await future._result()
+            results.append(result)
+
+    yield f()
+
+    assert set(results) == set(range(1, 11))
+
+
+@gen_cluster(client=True)
+def test_await_future(c, s, a, b):
+    future = c.submit(inc, 1)
+
+    async def f():
+        result = await future
+        assert result == 2
+
+    yield f()
+
+    future = c.submit(div, 1, 0)
+
+    async def f():
+        with pytest.raises(ZeroDivisionError):
+            await future
+
+    yield f()
+

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3017,6 +3017,22 @@ def test_as_completed_list(loop):
             assert set(c.gather(seq2)) == {1, 2, 3, 4, 5}
 
 
+@gen_cluster(client=True)
+def test_as_completed_async_for(c, s, a, b):
+    futures = c.map(inc, range(10))
+    ac = as_completed(futures)
+    results = []
+
+    async def f():
+        async for future in ac:
+            result = await future._result()
+            results.append(result)
+
+    yield f()
+
+    assert set(results) == set(range(1, 11))
+
+
 @gen_test()
 def test_status():
     s = Scheduler()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3033,6 +3033,25 @@ def test_as_completed_async_for(c, s, a, b):
     assert set(results) == set(range(1, 11))
 
 
+@gen_cluster(client=True)
+def test_await_future(c, s, a, b):
+    future = c.submit(inc, 1)
+
+    async def f():
+        result = await future
+        assert result == 2
+
+    yield f()
+
+    future = c.submit(div, 1, 0)
+
+    async def f():
+        with pytest.raises(ZeroDivisionError):
+            await future
+
+    yield f()
+
+
 @gen_test()
 def test_status():
     s = Scheduler()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -14,7 +14,7 @@ import sys
 from threading import Thread, Semaphore
 from time import sleep
 import traceback
-import zipfile, sys
+import zipfile
 
 import mock
 import pytest
@@ -3017,41 +3017,6 @@ def test_as_completed_list(loop):
             assert set(c.gather(seq2)) == {1, 2, 3, 4, 5}
 
 
-@gen_cluster(client=True)
-def test_as_completed_async_for(c, s, a, b):
-    futures = c.map(inc, range(10))
-    ac = as_completed(futures)
-    results = []
-
-    async def f():
-        async for future in ac:
-            result = await future._result()
-            results.append(result)
-
-    yield f()
-
-    assert set(results) == set(range(1, 11))
-
-
-@gen_cluster(client=True)
-def test_await_future(c, s, a, b):
-    future = c.submit(inc, 1)
-
-    async def f():
-        result = await future
-        assert result == 2
-
-    yield f()
-
-    future = c.submit(div, 1, 0)
-
-    async def f():
-        with pytest.raises(ZeroDivisionError):
-            await future
-
-    yield f()
-
-
 @gen_test()
 def test_status():
     s = Scheduler()
@@ -4003,3 +3968,7 @@ def test_robust_undeserializable_function(c, s, a, b):
 
     assert results == list(map(inc, range(10)))
     assert a.data and b.data
+
+
+if sys.version_info > (3, 5):
+    from distributed.tests.py3_test_client import *


### PR DESCRIPTION
This just defines `__aiter__` and `__anext__` protocols for `as_completed`.  

What is the right way to test Python-3 only code?  Can we put these in separate files that are ignored by pytest in Python 2?  I imagine that this is tricky because just parsing things will raise syntax errors.  cc @pitrou 