### PR TITLE
Fix code in adaptive docs.

### DIFF
--- a/docs/source/adaptive.rst
+++ b/docs/source/adaptive.rst
@@ -60,7 +60,7 @@ class will call these methods with the correct values at the correct times.
 
    class MyCluster(object):
        @gen.coroutine
-       def scale_up(n):
+       def scale_up(self, n):
            """
            Bring the total count of workers up to ``n``
 
@@ -69,7 +69,7 @@ class will call these methods with the correct values at the correct times.
 
            This can be implemented either as a function or as a Tornado coroutine.
            """
-       raise NotImplementedError()
+           raise NotImplementedError()
 
        @gen.coroutine
        def scale_down(self, workers):
@@ -88,6 +88,7 @@ class will call these methods with the correct values at the correct times.
    scheduler = Scheduler()
    cluster = MyCluster()
    adapative_cluster = Adaptive(scheduler, cluster)
+   scheduler.start()
 
 Implementing these ``scale_up`` and ``scale_down`` functions depends strongly
 on the cluster management system.  See :doc:`LocalCluster <local-cluster>` for


### PR DESCRIPTION
Also, I wanted to check that it is expected behaviour that the ```scale_down``` method is called each iteration of the PeriodicCallback with an empty list of workers? The following log is therefore emitted every 1 second:

```
distributed.deploy.adaptive - INFO - Retiring workers []
```

As a result, my ```scale_down``` method needs to check whether workers is empty.