### PR TITLE
Return both future and result in as_completed

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2528,7 +2528,7 @@ class AsCompleted(object):
     4
     3
     """
-    def __init__(self, futures=None, loop=None, results=False):
+    def __init__(self, futures=None, loop=None, with_results=False):
         if futures is None:
             futures = []
         self.futures = defaultdict(lambda: 0)
@@ -2536,7 +2536,7 @@ class AsCompleted(object):
         self.lock = Lock()
         self.loop = loop or default_client().loop
         self.condition = Condition()
-        self.results = results
+        self.with_results = with_results
 
         if futures:
             for future in futures:
@@ -2545,13 +2545,13 @@ class AsCompleted(object):
     @gen.coroutine
     def track_future(self, future):
         yield _wait(future)
-        if self.results:
+        if self.with_results:
             result = yield future._result()
         with self.lock:
             self.futures[future] -= 1
             if not self.futures[future]:
                 del self.futures[future]
-            if self.results:
+            if self.with_results:
                 self.queue.put_nowait((future, result))
             else:
                 self.queue.put_nowait(future)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2518,8 +2518,17 @@ class AsCompleted(object):
     6
     12
     24
+
+    Optionally wait until the result has been gathered as well
+
+    >>> ac = as_completed([x, y, z], results=True)  # doctest: +SKIP
+    >>> for future, result in ac:  # doctest: +SKIP
+    ...     print(result)  # doctest: +SKIP
+    2
+    4
+    3
     """
-    def __init__(self, futures=None, loop=None):
+    def __init__(self, futures=None, loop=None, results=False):
         if futures is None:
             futures = []
         self.futures = defaultdict(lambda: 0)
@@ -2527,6 +2536,7 @@ class AsCompleted(object):
         self.lock = Lock()
         self.loop = loop or default_client().loop
         self.condition = Condition()
+        self.results = results
 
         if futures:
             for future in futures:
@@ -2535,11 +2545,16 @@ class AsCompleted(object):
     @gen.coroutine
     def track_future(self, future):
         yield _wait(future)
+        if self.results:
+            result = yield future._result()
         with self.lock:
             self.futures[future] -= 1
             if not self.futures[future]:
                 del self.futures[future]
-            self.queue.put_nowait(future)
+            if self.results:
+                self.queue.put_nowait((future, result))
+            else:
+                self.queue.put_nowait(future)
             self.condition.notify()
 
     def add(self, future):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3035,9 +3035,10 @@ def test_as_completed_list(loop):
 def test_as_completed_results(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
-            seq = c.map(inc, iter(range(5)))
-            seq2 = list(as_completed(seq, results=True))
+            seq = c.map(inc, range(5))
+            seq2 = list(as_completed(seq, with_results=True))
             assert set(pluck(1, seq2)) == {1, 2, 3, 4, 5}
+            assert set(pluck(0, seq2)) == set(seq)
 
 
 @gen_test()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3032,6 +3032,14 @@ def test_as_completed_list(loop):
             assert set(c.gather(seq2)) == {1, 2, 3, 4, 5}
 
 
+def test_as_completed_results(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            seq = c.map(inc, iter(range(5)))
+            seq2 = list(as_completed(seq, results=True))
+            assert set(pluck(1, seq2)) == {1, 2, 3, 4, 5}
+
+
 @gen_test()
 def test_status():
     s = Scheduler()


### PR DESCRIPTION
Many as_completed workflows look like this:

```python
ac = as_completed(futures)
for future in ac:
    result = future.result()
    ...
    new_future = client.submit(func, *args, **kwargs)
    ac.add(new_future)
```

Adding the blocking `.result()` call into this loop can significantly impact responsiveness.  It is sometimes useful to gather asynchronously in the background and only yield the result as it is gathered.

```python
ac = as_completed(futures, results=True)
for future, result in ac:
    # result = future.result()
    ...
    new_future = client.submit(func, *args, **kwargs)
    ac.add(new_future)
```

Any thoughts or suggestions?  This is a deviation away from the concurrent.futures API.

This affects @moody-marlin .  @pitrou may have thoughts on whether or not this API is appropriate.