### PR TITLE
Correctly empty progressbars when no tasks

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -600,7 +600,7 @@ class TaskProgress(DashboardComponent):
                      'nbytes': self.plugin.nbytes}
             for k in ['memory', 'erred', 'released']:
                 state[k] = valmap(len, self.plugin.state[k])
-            if not state['all']:
+            if not state['all'] and not self.source.data['all']:
                 return
 
             d = progress_quads(state)

--- a/distributed/bokeh/tests/test_scheduler_bokeh.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh.py
@@ -145,6 +145,14 @@ def test_TaskProgress(c, s, a, b):
     assert all(len(L) == 2 for L in d.values())
     assert d['name'] == ['slowinc', 'dec']
 
+    del futures, futures2
+
+    while s.task_state:
+        yield gen.sleep(0.01)
+
+    tp.update()
+    assert not tp.source.data['all']
+
 
 @gen_cluster(client=True)
 def test_MemoryUse(c, s, a, b):


### PR DESCRIPTION
Previously we avoided this due to a misplaced optimization