### PR TITLE
Task stream cleanup

### DIFF
--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -64,7 +64,7 @@ class TaskStream(DashboardComponent):
             worker=[], y=[], worker_thread=[], alpha=[])
         )
 
-        x_range = DataRange1d()
+        x_range = DataRange1d(range_padding=0)
         y_range = DataRange1d(range_padding=0)
 
         self.root = Plot(

--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -42,7 +42,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-PROFILING = True
+PROFILING = False
 
 import jinja2
 
@@ -477,6 +477,7 @@ class Events(DashboardComponent):
 class TaskStream(components.TaskStream):
     def __init__(self, scheduler, n_rectangles=1000, clear_interval=20000, **kwargs):
         self.scheduler = scheduler
+        self.offset = 0
         es = [p for p in self.scheduler.plugins if isinstance(p, TaskStreamPlugin)]
         if not es:
             self.plugin = TaskStreamPlugin(self.scheduler)
@@ -490,26 +491,38 @@ class TaskStream(components.TaskStream):
 
     def update(self):
         with log_errors():
+            if self.index:
+                start = min(self.source.data['start'])
+                duration = max(self.source.data['duration'])
+                boundary = (self.offset + start - duration) / 1000
+            else:
+                boundary = self.offset
             rectangles = self.plugin.rectangles(istart=self.index,
-                                                workers=self.workers)
+                                                workers=self.workers,
+                                                start_boundary=boundary)
             n = len(rectangles['name'])
             self.index += n
 
-            # If there has been a significant delay then clear old rectangles
-            if rectangles['start']:
-                m = min(map(add, rectangles['start'], rectangles['duration']))
-                if m > self.last:
-                    self.last, last = m, self.last
-                    if m > last + self.clear_interval:
-                        update(self.source, rectangles)
-                        return
-
-            if len(set(map(len, rectangles.values()))) != 1:
-                import pdb; pdb.set_trace()
-            if not n:
+            if not rectangles['start']:
                 return
-            if n > 10 and np:
-                rectangles = valmap(np.array, rectangles)
+
+            # If there has been a significant delay then clear old rectangles
+            first_end = min(map(add, rectangles['start'], rectangles['duration']))
+            if first_end > self.last:
+                last = self.last
+                self.last = first_end
+                if first_end > last + self.clear_interval:
+                    self.offset = min(rectangles['start'])
+                    self.source.data.update({k: [] for k in rectangles})
+
+            rectangles['start'] = [x - self.offset for x in rectangles['start']]
+
+            # Convert to numpy for serialization speed
+            if n >= 10 and np:
+                for k, v in rectangles.items():
+                    if isinstance(v[0], Number):
+                        rectangles[k] = np.array(v)
+
             if PROFILING:
                 curdoc().add_next_tick_callback(lambda:
                         self.source.stream(rectangles, self.n_rectangles))

--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -490,6 +490,8 @@ class TaskStream(components.TaskStream):
                                        clear_interval=clear_interval, **kwargs)
 
     def update(self):
+        if self.index == self.plugin.index:
+            return
         with log_errors():
             if self.index:
                 start = min(self.source.data['start'])
@@ -501,7 +503,7 @@ class TaskStream(components.TaskStream):
                                                 workers=self.workers,
                                                 start_boundary=boundary)
             n = len(rectangles['name'])
-            self.index += n
+            self.index = self.plugin.index
 
             if not rectangles['start']:
                 return
@@ -532,7 +534,6 @@ class TaskStream(components.TaskStream):
 
 class TaskProgress(DashboardComponent):
     """ Progress bars per task type """
-
     def __init__(self, scheduler, **kwargs):
         self.scheduler = scheduler
         ps = [p for p in scheduler.plugins if isinstance(p, AllProgress)]

--- a/distributed/bokeh/task_stream.py
+++ b/distributed/bokeh/task_stream.py
@@ -26,7 +26,7 @@ class TaskStreamPlugin(SchedulerPlugin):
                 if len(self.buffer) > self.maxlen:
                     self.buffer = self.buffer[len(self.buffer):]
 
-    def rectangles(self, istart, istop=None, workers=None):
+    def rectangles(self, istart, istop=None, workers=None, start_boundary=0):
         L_start = []
         L_duration = []
         L_key = []
@@ -54,6 +54,8 @@ class TaskStreamPlugin(SchedulerPlugin):
                 workers[worker_thread] = len(workers) / 2
 
             for action, start, stop in startstops:
+                if start < start_boundary:
+                    continue
                 color = colors[action]
                 if type(color) is not str:
                     color = color(msg)
@@ -69,14 +71,14 @@ class TaskStreamPlugin(SchedulerPlugin):
                 L_y.append(workers[worker_thread])
 
         return {'start': L_start,
-                 'duration': L_duration,
-                 'key': L_key,
-                 'name': L_name,
-                 'color': L_color,
-                 'alpha': L_alpha,
-                 'worker': L_worker,
-                 'worker_thread': L_worker_thread,
-                 'y': L_y}
+                'duration': L_duration,
+                'key': L_key,
+                'name': L_name,
+                'color': L_color,
+                'alpha': L_alpha,
+                'worker': L_worker,
+                'worker_thread': L_worker_thread,
+                'y': L_y}
 
 
 def color_of_message(msg):

--- a/distributed/bokeh/task_stream.py
+++ b/distributed/bokeh/task_stream.py
@@ -13,12 +13,15 @@ logger = logging.getLogger(__name__)
 class TaskStreamPlugin(SchedulerPlugin):
     def __init__(self, scheduler):
         self.buffer = []
+        self.scheduler = scheduler
         scheduler.add_plugin(self)
         self.index = 0
         self.maxlen = 100000
 
     def transition(self, key, start, finish, *args, **kwargs):
         if start == 'processing':
+            if key not in self.scheduler.task_state:
+                return
             kwargs['key'] = key
             if finish == 'memory' or finish == 'erred':
                 self.buffer.append(kwargs)

--- a/distributed/bokeh/tests/test_scheduler_bokeh.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh.py
@@ -112,6 +112,7 @@ def test_task_stream(c, s, a, b):
     d = dict(ts.source.data)
 
     assert all(len(L) == 10 for L in d.values())
+    assert min(d['start']) == 0  # zero based
 
     ts.update()
     d = dict(ts.source.data)

--- a/distributed/bokeh/tests/test_scheduler_bokeh.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh.py
@@ -127,6 +127,35 @@ def test_task_stream(c, s, a, b):
 
 
 @gen_cluster(client=True)
+def test_task_stream_n_rectangles(c, s, a, b):
+    ts = TaskStream(s, n_rectangles=10)
+    futures = c.map(slowinc, range(10), delay=0.001)
+    yield _wait(futures)
+    ts.update()
+
+    assert len(ts.source.data['start']) == 10
+
+
+@gen_cluster(client=True)
+def test_task_stream_clear_interval(c, s, a, b):
+    ts = TaskStream(s, clear_interval=100)
+
+    yield _wait(c.map(inc, range(10)))
+    ts.update()
+    yield gen.sleep(0.010)
+    yield _wait(c.map(dec, range(10)))
+    ts.update()
+
+    assert len(ts.source.data['start']) == 20
+
+    yield gen.sleep(0.150)
+    yield _wait(c.map(inc, range(10, 20)))
+    ts.update()
+
+    assert len(ts.source.data['start']) == 10
+
+
+@gen_cluster(client=True)
 def test_TaskProgress(c, s, a, b):
     tp = TaskProgress(s)
 

--- a/distributed/bokeh/tests/test_task_stream.py
+++ b/distributed/bokeh/tests/test_task_stream.py
@@ -29,3 +29,8 @@ def test_TaskStreamPlugin(c, s, *workers):
 
     rects = es.rectangles(2, 5, workers)
     assert all(len(L) == 3 for L in rects.values())
+
+    starts = sorted(rects['start'])
+    rects = es.rectangles(2, 5, workers=workers,
+                          start_boundary=(starts[0] + starts[1]) / 2000)
+    assert rects['start'] == starts[1:]

--- a/distributed/bokeh/tests/test_task_stream.py
+++ b/distributed/bokeh/tests/test_task_stream.py
@@ -33,4 +33,4 @@ def test_TaskStreamPlugin(c, s, *workers):
     starts = sorted(rects['start'])
     rects = es.rectangles(2, 5, workers=workers,
                           start_boundary=(starts[0] + starts[1]) / 2000)
-    assert rects['start'] == starts[1:]
+    assert set(rects['start']) == set(starts[1:])


### PR DESCRIPTION
This changes the task stream diagnostic in two ways:

1.  Whenever it restarts it starts at time zero (Fixes https://github.com/dask/dask/issues/2106 cc @jbednar)
2.  Avoids jumping backwards in time, which occurred before if a task had been previously computed long ago.  This was visually jarring

