### PR TITLE
Fix count tracking in system monitor

### DIFF
--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -69,3 +69,15 @@ class SystemMonitor(object):
                 -1 if WINDOWS else self.num_fds[-1])
 
     __repr__ = __str__
+
+    def range_query(self, start):
+        if start == self.count:
+            return {k: [] for k in self.quantities}
+
+        istart = start - (self.count - len(self.cpu))
+        istart = max(0, istart)
+
+        seq = [i for i in range(istart, len(self.cpu))]
+
+        d = {k: [v[i] for i in seq] for k, v in self.quantities.items()}
+        return d

--- a/distributed/tests/test_system_monitor.py
+++ b/distributed/tests/test_system_monitor.py
@@ -4,6 +4,7 @@ from time import sleep
 
 from distributed.system_monitor import SystemMonitor
 
+
 def test_SystemMonitor():
     sm = SystemMonitor()
     a = sm.update()
@@ -18,3 +19,37 @@ def test_SystemMonitor():
     assert all(len(q) == 2 for q in sm.quantities.values())
 
     assert 'cpu' in repr(sm)
+
+
+def test_count():
+    sm = SystemMonitor(n=5)
+    assert sm.count == 0
+    sm.update()
+    assert sm.count == 1
+
+    for i in range(10):
+        sm.update()
+
+    assert sm.count == 11
+    for v in sm.quantities.values():
+        assert len(v) == 5
+
+
+def test_range_query():
+    sm = SystemMonitor(n=5)
+
+    assert all(len(v) == 0 for v in sm.range_query(0).values())
+    assert all(len(v) == 0 for v in sm.range_query(123).values())
+
+    sm.update()
+    sm.update()
+    sm.update()
+
+    assert all(len(v) == 3 for v in sm.range_query(0).values())
+    assert all(len(v) == 2 for v in sm.range_query(1).values())
+
+    for i in range(10):
+        sm.update()
+
+    assert all(len(v) == 3 for v in sm.range_query(10).values())
+    assert all(len(v) == 5 for v in sm.range_query(0).values())


### PR DESCRIPTION
Previously the system monitor diagnostic would fail if you started it well
after the server was started because it would index off of the end of a deque.

Now we more properly track ends and improve testing.

cc @rabernat