### PR TITLE
Support connections between Python 2/3 client/scheduler

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from .config import config
 from .core import connect, rpc

--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -4,7 +4,7 @@ These functions should probably reside in Jupyter and IPython repositories,
 after which we can import them instead of having our own definitions.
 """
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import atexit
 import os

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import deque
 import logging
@@ -6,6 +6,7 @@ import logging
 from tornado import gen, locks
 from tornado.ioloop import IOLoop
 
+from .compatibility import unicode as str
 from .core import CommClosedError
 from .utils import ignoring
 

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -6,7 +6,7 @@ import logging
 from tornado import gen, locks
 from tornado.ioloop import IOLoop
 
-from .compatibility import unicode as str
+from .compatibility import unicode as str  # flake8: noqa
 from .core import CommClosedError
 from .utils import ignoring
 

--- a/distributed/bokeh/application.py
+++ b/distributed/bokeh/application.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import atexit
 import logging

--- a/distributed/bokeh/background/server_lifecycle.py
+++ b/distributed/bokeh/background/server_lifecycle.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import json
 import logging

--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from bisect import bisect
 from operator import add

--- a/distributed/bokeh/core.py
+++ b/distributed/bokeh/core.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import bokeh
 from bokeh.server.server import Server

--- a/distributed/bokeh/export_tool.py
+++ b/distributed/bokeh/export_tool.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import os
 

--- a/distributed/bokeh/memory-usage.py
+++ b/distributed/bokeh/memory-usage.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from bokeh.io import curdoc
 

--- a/distributed/bokeh/processing-stacks.py
+++ b/distributed/bokeh/processing-stacks.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from bokeh.io import curdoc
 

--- a/distributed/bokeh/resource-profiles.py
+++ b/distributed/bokeh/resource-profiles.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from bokeh.io import curdoc
 

--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from functools import partial
 import logging

--- a/distributed/bokeh/task-progress.py
+++ b/distributed/bokeh/task-progress.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from bokeh.io import curdoc
 

--- a/distributed/bokeh/task-stream.py
+++ b/distributed/bokeh/task-stream.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from bokeh.io import curdoc
 

--- a/distributed/bokeh/task_stream.py
+++ b/distributed/bokeh/task_stream.py
@@ -1,7 +1,8 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 
+from ..compatibility import unicode as str
 from ..diagnostics.progress_stream import color_of
 from ..diagnostics.plugin import SchedulerPlugin
 from ..utils import key_split

--- a/distributed/bokeh/utils.py
+++ b/distributed/bokeh/utils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from toolz import partition
 

--- a/distributed/bokeh/worker-table.py
+++ b/distributed/bokeh/worker-table.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from bokeh.io import curdoc
 

--- a/distributed/bokeh/worker.py
+++ b/distributed/bokeh/worker.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from functools import partial
 import logging

--- a/distributed/bokeh/worker_monitor.py
+++ b/distributed/bokeh/worker_monitor.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 

--- a/distributed/channels.py
+++ b/distributed/channels.py
@@ -7,7 +7,7 @@ import threading
 import warnings
 
 from .client import Future
-from .compatibility import unicode as str
+from .compatibility import unicode as str  # flake8: noqa
 from .core import CommClosedError
 from .utils import tokey, log_errors
 

--- a/distributed/channels.py
+++ b/distributed/channels.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import deque
 import logging
@@ -7,6 +7,7 @@ import threading
 import warnings
 
 from .client import Future
+from .compatibility import unicode as str
 from .core import CommClosedError
 from .utils import tokey, log_errors
 

--- a/distributed/cli/__init__.py
+++ b/distributed/cli/__init__.py
@@ -1,0 +1,2 @@
+import click
+click.disable_unicode_literals_warning = True

--- a/distributed/cli/dask_remote.py
+++ b/distributed/cli/dask_remote.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import click
 from distributed.cli.utils import check_python_3, install_signal_handlers

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import atexit
 import json

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from distributed.deploy.ssh import SSHCluster
 import click

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import atexit
 from datetime import timedelta

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 py3_err_msg = """
 Your terminal does not properly support unicode text required by command line

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import defaultdict, Iterator, Iterable
 from concurrent.futures import ThreadPoolExecutor
@@ -34,6 +34,7 @@ from tornado.queues import Queue
 
 from .batched import BatchedSend
 from .utils_comm import WrappedKey, unpack_remotedata, pack_data
+from .compatibility import unicode as str
 from .compatibility import Queue as pyQueue, Empty, isqueue
 from .core import connect, rpc, clean_exception, CommClosedError
 from .protocol import to_serialize
@@ -421,11 +422,12 @@ class Client(object):
         self.status = 'running'
 
     def _send_to_scheduler(self, msg):
-        if self.status is 'running':
+        if self.status == 'running':
             self.loop.add_callback(self.scheduler_comm.send, msg)
-        elif self.status is 'connecting':
+        elif self.status == 'connecting':
             self._pending_msg_buffer.append(msg)
         else:
+            print(type(self.status))
             raise Exception("Client not running.  Status: %s" % self.status)
 
     @gen.coroutine

--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -1,5 +1,5 @@
 """ This file is experimental and may disappear without warning """
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from itertools import product
 
@@ -8,6 +8,7 @@ from tornado import gen
 
 from .client import (default_client, Future, _first_completed,
         ensure_default_get)
+from .compatibility import unicode as str
 from .utils import sync
 
 

--- a/distributed/comm/__init__.py
+++ b/distributed/comm/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from .addressing import (parse_address, unparse_address,
                          normalize_address, parse_host_port,

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import six
 

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 from datetime import timedelta

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import deque, namedtuple
 import itertools

--- a/distributed/comm/registry.py
+++ b/distributed/comm/registry.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from datetime import timedelta
 import errno
@@ -124,7 +124,10 @@ class TCP(Comm):
         def finalize(stream=self.stream, r=repr(self)):
             if not stream.closed():
                 logger.warn("Closing dangling stream in %s" % (r,))
-                stream.close()
+                try:
+                    stream.close()
+                except socket.error:
+                    pass
 
         return finalize
 
@@ -166,6 +169,9 @@ class TCP(Comm):
         stream = self.stream
         if stream is None:
             raise CommClosedError
+
+        if isinstance(msg, dict) and any(isinstance(k, bytes) for k in msg):
+            print(msg)
 
         # IOStream.write() only takes bytes objects, not memoryviews
         frames = [ensure_bytes(f) for f in to_frames(msg)]

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 import socket

--- a/distributed/comm/zmq.py
+++ b/distributed/comm/zmq.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from datetime import timedelta
 import logging

--- a/distributed/comm/zmqimpl.py
+++ b/distributed/comm/zmqimpl.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import deque, namedtuple
 from itertools import chain

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 import sys

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 
-from .compatibility import unicode as str
+from .compatibility import unicode as str  # flake8: noqa
 from .compatibility import FileExistsError, logging_names
 
 logger = logging.getLogger(__name__)

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -1,9 +1,10 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 import os
 import sys
 
+from .compatibility import unicode as str
 from .compatibility import FileExistsError, logging_names
 
 logger = logging.getLogger(__name__)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -15,7 +15,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.locks import Event
 
-from .compatibility import unicode as str, unicode, PY2
+from .compatibility import unicode as str, PY2
 from .comm import (connect, listen, CommClosedError,
                    normalize_address,
                    unparse_host_port, get_address_host_port)
@@ -237,7 +237,6 @@ class Server(object):
                     op = msg.pop('op')
                 except Exception as e:
                     logger.info("couldn't pop op: %s", msg, exc_info=True)
-                    import pdb; pdb.set_trace()
                     raise
                 if self.counters is not None:
                     self.counters['op'].add(op)
@@ -306,7 +305,7 @@ def send_recv(comm=None, addr=None, reply=True, deserialize=True, **kwargs):
     msg['reply'] = reply
     please_close = kwargs.get('close')
     if PY2:
-        msg = keymap(unicode, msg)
+        msg = keymap(str, msg)
 
     if comm is None:
         comm = yield connect(addr_from_args(addr), deserialize=deserialize)
@@ -425,7 +424,7 @@ class rpc(object):
 
     def __getattr__(self, key):
         if PY2:
-            key = unicode(key)
+            key = str(key)
         @gen.coroutine
         def send_recv_from_rpc(**kwargs):
             try:
@@ -478,7 +477,7 @@ class PooledRPCCall(object):
 
     def __getattr__(self, key):
         if PY2:
-            key = unicode(key)
+            key = str(key)
         @gen.coroutine
         def send_recv_from_rpc(**kwargs):
             comm = yield self.pool.connect(self.addr)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -15,7 +15,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.locks import Event
 
-from .compatibility import unicode as str, PY2
+from .compatibility import unicode as str, PY2  # flake8: noqa
 from .comm import (connect, listen, CommClosedError,
                    normalize_address,
                    unparse_host_port, get_address_host_port)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import defaultdict, deque
 from functools import partial
@@ -9,12 +9,13 @@ import uuid
 
 from six import string_types
 
-from toolz import assoc
+from toolz import assoc, keymap
 
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.locks import Event
 
+from .compatibility import unicode as str, unicode, PY2
 from .comm import (connect, listen, CommClosedError,
                    normalize_address,
                    unparse_host_port, get_address_host_port)
@@ -232,7 +233,12 @@ class Server(object):
                 if not isinstance(msg, dict):
                     raise TypeError("Bad message type.  Expected dict, got\n  "
                                     + str(msg))
-                op = msg.pop('op')
+                try:
+                    op = msg.pop('op')
+                except Exception as e:
+                    logger.info("couldn't pop op: %s", msg, exc_info=True)
+                    import pdb; pdb.set_trace()
+                    raise
                 if self.counters is not None:
                     self.counters['op'].add(op)
                 self._comms[comm] = op
@@ -299,6 +305,8 @@ def send_recv(comm=None, addr=None, reply=True, deserialize=True, **kwargs):
     msg = kwargs
     msg['reply'] = reply
     please_close = kwargs.get('close')
+    if PY2:
+        msg = keymap(unicode, msg)
 
     if comm is None:
         comm = yield connect(addr_from_args(addr), deserialize=deserialize)
@@ -416,6 +424,8 @@ class rpc(object):
         self.comms.clear()
 
     def __getattr__(self, key):
+        if PY2:
+            key = unicode(key)
         @gen.coroutine
         def send_recv_from_rpc(**kwargs):
             try:
@@ -467,6 +477,8 @@ class PooledRPCCall(object):
         self.pool = pool
 
     def __getattr__(self, key):
+        if PY2:
+            key = unicode(key)
         @gen.coroutine
         def send_recv_from_rpc(**kwargs):
             comm = yield self.pool.connect(self.addr)

--- a/distributed/counter.py
+++ b/distributed/counter.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import defaultdict
 

--- a/distributed/deploy/__init__.py
+++ b/distributed/deploy/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from ..utils import ignoring
 

--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 from ..utils import log_errors

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 import math

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from time import sleep
 import socket

--- a/distributed/diagnostics/__init__.py
+++ b/distributed/diagnostics/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from ..utils import ignoring
 with ignoring(ImportError):

--- a/distributed/diagnostics/eventstream.py
+++ b/distributed/diagnostics/eventstream.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 
@@ -6,6 +6,7 @@ from tornado import gen
 
 from .plugin import SchedulerPlugin
 
+from ..compatibility import unicode as str
 from ..core import connect, coerce_to_address
 from ..worker import dumps_function
 

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import defaultdict
 import logging

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import itertools
 import logging
@@ -10,6 +10,7 @@ from tornado import gen
 
 from .progress import AllProgress
 
+from ..compatibility import unicode as str
 from ..core import connect, coerce_to_address
 from ..scheduler import Scheduler
 from ..utils import key_split

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 from timeit import default_timer

--- a/distributed/diagnostics/scheduler.py
+++ b/distributed/diagnostics/scheduler.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import os
 

--- a/distributed/diagnostics/tests/test_eventstream.py
+++ b/distributed/diagnostics/tests/test_eventstream.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from copy import deepcopy
 from time import sleep

--- a/distributed/diagnostics/tests/test_plugin.py
+++ b/distributed/diagnostics/tests/test_plugin.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from distributed.utils_test import inc, gen_cluster
 from distributed.diagnostics.plugin import SchedulerPlugin

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from operator import add
 import pytest

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from time import sleep
 

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from time import sleep
 

--- a/distributed/diagnostics/tests/test_scheduler_diagnostics.py
+++ b/distributed/diagnostics/tests/test_scheduler_diagnostics.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+
 import json
 import pytest
 

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import pytest
 pytest.importorskip('ipywidgets')

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -1,5 +1,5 @@
 """ This file is experimental and may disappear without warning """
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 

--- a/distributed/http/__init__.py
+++ b/distributed/http/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from .worker import HTTPWorker
 from .scheduler import HTTPScheduler

--- a/distributed/http/core.py
+++ b/distributed/http/core.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import json
 import logging

--- a/distributed/http/scheduler.py
+++ b/distributed/http/scheduler.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import defaultdict
 import json

--- a/distributed/http/worker.py
+++ b/distributed/http/worker.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import defaultdict
 import logging

--- a/distributed/metrics.py
+++ b/distributed/metrics.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import collections
 from functools import wraps

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from datetime import datetime, timedelta
 import logging
@@ -12,6 +12,7 @@ import weakref
 from tornado.ioloop import IOLoop, TimeoutError
 from tornado import gen
 
+from .compatibility import unicode as str
 from .comm import get_address_host
 from .core import Server, rpc, RPCClosed, CommClosedError, coerce_to_address
 from .metrics import disk_io_counters, net_io_counters, time

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -12,7 +12,7 @@ import weakref
 from tornado.ioloop import IOLoop, TimeoutError
 from tornado import gen
 
-from .compatibility import unicode as str
+from .compatibility import unicode as str  # flake8: noqa
 from .comm import get_address_host
 from .core import Server, rpc, RPCClosed, CommClosedError, coerce_to_address
 from .metrics import disk_io_counters, net_io_counters, time

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from functools import partial
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -3,7 +3,7 @@ Record known compressors
 
 Includes utilities for determining whether or not to compress
 """
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 import random

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 

--- a/distributed/protocol/h5py.py
+++ b/distributed/protocol/h5py.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from .serialize import register_serialization
 

--- a/distributed/protocol/keras.py
+++ b/distributed/protocol/keras.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from .serialize import register_serialization, serialize, deserialize
 

--- a/distributed/protocol/netcdf4.py
+++ b/distributed/protocol/netcdf4.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from .serialize import register_serialization, serialize, deserialize
 

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import sys
 

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 import sys

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from functools import partial
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from ..utils import ensure_bytes
 

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -1,4 +1,6 @@
-from distributed.utils import log_errors
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+from .utils import log_errors
 
 
 class PublishExtension(object):

--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 from tornado import gen

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import defaultdict, deque, OrderedDict
 from functools import partial
@@ -26,6 +26,7 @@ from .batched import BatchedSend
 from .comm import (normalize_address, resolve_address,
                    get_address_host, unparse_host_port)
 from .compatibility import finalize
+from .compatibility import unicode as str
 from .config import config
 from .core import (rpc, connect, Server, send_recv,
                    error_message, clean_exception, CommClosedError)

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import sys
 

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -8,7 +8,7 @@ from time import time
 
 from tornado.ioloop import PeriodicCallback
 
-from .compatibility import unicode as str
+from .compatibility import unicode as str  # flake8: noqa
 from .config import config
 from .core import CommClosedError
 from .diagnostics.plugin import SchedulerPlugin

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import defaultdict, deque
 import logging
@@ -8,6 +8,7 @@ from time import time
 
 from tornado.ioloop import PeriodicCallback
 
+from .compatibility import unicode as str
 from .config import config
 from .core import CommClosedError
 from .diagnostics.plugin import SchedulerPlugin

--- a/distributed/submit.py
+++ b/distributed/submit.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
 import os

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -1,8 +1,9 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import deque
 import psutil
 
+from .compatibility import unicode as str
 from .compatibility import WINDOWS
 from .metrics import time
 

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 from collections import deque
 import psutil
 
-from .compatibility import unicode as str
+from .compatibility import unicode as str  # flake8: noqa
 from .compatibility import WINDOWS
 from .metrics import time
 

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+
 from collections import Iterator
 from operator import add
 import random

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from contextlib import contextmanager
 from datetime import timedelta

--- a/distributed/tests/test_channels.py
+++ b/distributed/tests/test_channels.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from operator import add
 from time import sleep

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from operator import add
 

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from datetime import timedelta
 import sys

--- a/distributed/tests/test_compatibility.py
+++ b/distributed/tests/test_compatibility.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from distributed.compatibility import (
     gzip_compress, gzip_decompress, finalize)

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from contextlib import contextmanager
 from functools import partial

--- a/distributed/tests/test_counter.py
+++ b/distributed/tests/test_counter.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import pytest
 

--- a/distributed/tests/test_hdfs.py
+++ b/distributed/tests/test_hdfs.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import socket
 import sys

--- a/distributed/tests/test_ipython.py
+++ b/distributed/tests/test_ipython.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import mock
 

--- a/distributed/tests/test_joblib.py
+++ b/distributed/tests/test_joblib.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import pytest
 from random import random

--- a/distributed/tests/test_metrics.py
+++ b/distributed/tests/test_metrics.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import time
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from datetime import datetime
 import os

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import pytest
 

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from time import time
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import cloudpickle
 from collections import defaultdict, deque
@@ -19,6 +19,7 @@ from tornado import gen
 
 import pytest
 
+from distributed.compatibility import unicode as str
 from distributed import Nanny, Worker, Client
 from distributed.core import connect, rpc, CommClosedError
 from distributed.scheduler import validate_state, Scheduler, BANDWIDTH

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import sys
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import itertools
 from functools import partial

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from concurrent.futures import CancelledError
 from datetime import timedelta

--- a/distributed/tests/test_submit_cli.py
+++ b/distributed/tests/test_submit_cli.py
@@ -1,4 +1,5 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
+
 from mock import Mock
 
 from tornado import gen

--- a/distributed/tests/test_submit_remote_client.py
+++ b/distributed/tests/test_submit_remote_client.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+
 import os
 
 from tornado import gen

--- a/distributed/tests/test_system_monitor.py
+++ b/distributed/tests/test_system_monitor.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from time import sleep
 

--- a/distributed/tests/test_threadpoolexecutor.py
+++ b/distributed/tests/test_threadpoolexecutor.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import, unicode_literals
+
 from time import sleep
 
 from distributed.metrics import time

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import Iterator
 from functools import partial
@@ -16,7 +16,7 @@ from tornado.ioloop import IOLoop
 from tornado.locks import Event
 
 import dask
-from distributed.compatibility import Queue, isqueue, PY2
+from distributed.compatibility import Queue, isqueue, PY2, unicode as str
 from distributed.metrics import time
 from distributed.utils import (All, sync, is_kernel, ensure_ip, str_graph,
         truncate_exception, get_traceback, queue_to_iterator,

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import pytest
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from contextlib import contextmanager
 import socket

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from concurrent.futures import ThreadPoolExecutor
 import logging
@@ -296,7 +296,7 @@ def test_error_message():
             return "MyException(%s)" % self.args
 
     msg = error_message(MyException('Hello', 'World!'))
-    assert 'Hello' in str(msg['exception'])
+    assert b'Hello' in msg['exception']
 
 
 @gen_cluster()

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from datetime import timedelta
 

--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from concurrent.futures import CancelledError
 from datetime import timedelta

--- a/distributed/threadpoolexecutor.py
+++ b/distributed/threadpoolexecutor.py
@@ -26,7 +26,7 @@ from concurrent.futures import thread
 import logging
 from threading import local, Thread
 
-from .compatibility import unicode as str
+from .compatibility import unicode as str  # flake8: noqa
 from .compatibility import get_thread_identity
 
 logger = logging.getLogger(__name__)

--- a/distributed/threadpoolexecutor.py
+++ b/distributed/threadpoolexecutor.py
@@ -20,12 +20,13 @@ which is included as a comment at the end of this file:
 
    Copyright 2001-2016 Python Software Foundation; All Rights Reserved
 """
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from concurrent.futures import thread
 import logging
 from threading import local, Thread
 
+from .compatibility import unicode as str
 from .compatibility import get_thread_identity
 
 logger = logging.getLogger(__name__)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import atexit
 from collections import Iterable
@@ -26,7 +26,7 @@ from dask import istask
 from toolz import memoize, valmap
 from tornado import gen
 
-from .compatibility import Queue, PY3, PY2, get_thread_identity
+from .compatibility import Queue, PY3, PY2, get_thread_identity, unicode as str
 from .config import config
 
 

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import Iterable, defaultdict
 from itertools import cycle
@@ -12,6 +12,7 @@ from dask.base import tokenize
 from toolz import merge, concat, groupby, drop
 
 from .core import rpc, coerce_to_address
+from .compatibility import unicode as str
 from .utils import All, tokey
 from .protocol.pickle import dumps
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from contextlib import contextmanager
 from datetime import timedelta
@@ -22,6 +22,7 @@ from tornado import gen, queues
 from tornado.gen import TimeoutError
 from tornado.ioloop import IOLoop
 
+from .compatibility import unicode as str
 from .core import connect, rpc, CommClosedError
 from .metrics import time
 from .utils import ignoring, log_errors, sync, mp_context, get_ip, get_ipv6
@@ -513,14 +514,14 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)], timeout=10,
                     args = [s] + workers
 
                     if client:
-                        e = Client(s.address, loop=loop, start=False)
-                        loop.run_sync(e._start)
-                        args = [e] + args
+                        c = Client(s.address, loop=loop, start=False)
+                        loop.run_sync(c._start)
+                        args = [c] + args
                     try:
                         return loop.run_sync(lambda: cor(*args), timeout=timeout)
                     finally:
                         if client:
-                            loop.run_sync(e._shutdown)
+                            loop.run_sync(c._shutdown)
                         loop.run_sync(lambda: end_cluster(s, workers))
 
                     for w in workers:

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -1,6 +1,6 @@
 """ utilities for package version introspection """
 
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 import platform
 import struct

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from collections import defaultdict, deque
 from datetime import timedelta
@@ -28,6 +28,7 @@ from .batched import BatchedSend
 from .comm import get_address_host, get_local_address_for
 from .config import config
 from .compatibility import reload, unicode, invalidate_caches, cache_from_source
+from .compatibility import unicode as str
 from .core import (error_message, CommClosedError,
                    rpc, Server, pingpong, coerce_to_address)
 from .metrics import time

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import print_function, division, absolute_import, unicode_literals
 
 from contextlib import contextmanager
 from toolz import keymap, valmap, merge, assoc
@@ -7,6 +7,7 @@ import uuid
 from dask.base import tokenize
 from tornado import gen
 
+from .compatibility import unicode as str
 from .client import AllExit, Client, Future, pack_data, unpack_remotedata
 from dask.compatibility import apply
 from .sizeof import sizeof


### PR DESCRIPTION
This changes the Python 2 implementation to always use unicode.
This allows a Python 2 scheduler to support Python 3 client/workers and
the reverse.

This required the following changes:

1. from __future__ import unicode_literals everywhere
2. from .compatibility import unicode as str in many files

cc @pitrou @jcrist for thoughts