### PR TITLE
Add concurrent.futures-compatible Executor

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -4,8 +4,7 @@ from .config import config
 from .core import connect, rpc
 from .deploy import LocalCluster
 from .diagnostics import progress
-from .client import (Client, Executor, CompatibleExecutor, wait, as_completed,
-        default_client)
+from .client import Client, Executor, wait, as_completed, default_client
 from .nanny import Nanny
 from .scheduler import Scheduler
 from .utils import sync

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -4,7 +4,8 @@ from .config import config
 from .core import connect, rpc
 from .deploy import LocalCluster
 from .diagnostics import progress
-from .client import Client, Executor, wait, as_completed, default_client
+from .client import (Client, Executor, CompatibleExecutor,
+                     wait, as_completed, default_client)
 from .nanny import Nanny
 from .scheduler import Scheduler
 from .utils import sync

--- a/distributed/cfexecutor.py
+++ b/distributed/cfexecutor.py
@@ -1,0 +1,151 @@
+from __future__ import print_function, division, absolute_import
+
+from functools import partial
+import weakref
+
+import six
+
+from toolz import merge
+
+from tornado import gen
+
+from concurrent.futures import Future, Executor
+
+from .utils import sync
+
+
+@gen.coroutine
+def _cascade_future(future, cf_future):
+    """
+    Coroutine that waits on future, then transmits its outcome to cf_future.
+    """
+    result = yield future._result(raiseit=False)
+    status = future.status
+    if status == 'finished':
+        cf_future.set_running_or_notify_cancel()
+        cf_future.set_result(result)
+    elif status == 'cancelled':
+        cf_future.cancel()
+        cf_future.set_running_or_notify_cancel()
+    else:
+        cf_future.set_running_or_notify_cancel()
+        try:
+            six.reraise(*result)
+        except BaseException as exc:
+            cf_future.set_exception(exc)
+
+
+@gen.coroutine
+def _wait_on_futures(futures):
+    try:
+        yield [futures]
+    except Exception:
+        # One future errored, ignore
+        pass
+
+
+class ClientExecutor(Executor):
+    """
+    A concurrent.futures Executor that executes tasks on a distributed Client.
+    """
+
+    _allowed_kwargs = frozenset(['pure', 'workers', 'resources', 'allow_other_workers'])
+
+    def __init__(self, client, **kwargs):
+        assert set(kwargs) <= self._allowed_kwargs, "unsupported kwargs to ClientExecutor"
+        self._client = client
+        self._futures = weakref.WeakSet()
+        self._shutdown = False
+        self._kwargs = kwargs
+
+    def _wrap_future(self, future):
+        """
+        Wrap a distributed Future in a concurrent.futures Future.
+        """
+        cf_future = Future()
+        # Support cancelling task through .cancel() on c.f.Future
+        def cf_callback(cf_future):
+            if cf_future.cancelled() and future.status != 'cancelled':
+                future.cancel()
+
+        cf_future.add_done_callback(cf_callback)
+
+        self._client.loop.add_callback(_cascade_future, future, cf_future)
+        return cf_future
+
+    def submit(self, fn, *args, **kwargs):
+        """Submits a callable to be executed with the given arguments.
+
+        Schedules the callable to be executed as fn(*args, **kwargs) and returns
+        a Future instance representing the execution of the callable.
+
+        Returns:
+            A Future representing the given call.
+        """
+        if self._shutdown:
+            raise RuntimeError('cannot schedule new futures after shutdown')
+        future = self._client.submit(fn, *args, **merge(self._kwargs, kwargs))
+        self._futures.add(future)
+        return self._wrap_future(future)
+
+    def map(self, fn, *iterables, timeout=None, chunksize=1):
+        """Returns an iterator equivalent to map(fn, iter).
+
+        Args:
+            fn: A callable that will take as many arguments as there are
+                passed iterables.
+            timeout: The maximum number of seconds to wait. If None, then there
+                is no limit on the wait time.
+            chunksize: The size of the chunks the iterable will be broken into
+                before being passed to a child process. This argument is only
+                used by ProcessPoolExecutor; it is ignored by
+                ThreadPoolExecutor.
+
+        Returns:
+            An iterator equivalent to: map(func, *iterables) but the calls may
+            be evaluated out-of-order.
+
+        Raises:
+            TimeoutError: If the entire result iterator could not be generated
+                before the given timeout.
+            Exception: If fn(*args) raises for any values.
+        """
+        if timeout is not None:
+            # TODO
+            raise NotImplementedError("timeout argument not support on CompatibleExecutor")
+
+        fs = self._client.map(fn, *iterables, **self._kwargs)
+
+        # Yield must be hidden in closure so that the tasks are submitted
+        # before the first iterator value is required.
+        def result_iterator():
+            try:
+                for future in fs:
+                    self._futures.add(future)
+                    yield future.result()
+            finally:
+                remaining = list(fs)
+                for future in remaining:
+                    self._futures.add(future)
+                self._client.cancel(remaining)
+
+        return result_iterator()
+
+    def shutdown(self, wait=True):
+        """Clean-up the resources associated with the Executor.
+
+        It is safe to call this method several times. Otherwise, no other
+        methods can be called after this one.
+
+        Args:
+            wait: If True then shutdown will not return until all running
+                futures have finished executing and the resources used by the
+                executor have been reclaimed.
+        """
+        if not self._shutdown:
+            self._shutdown = True
+            fs = list(self._futures)
+            if wait:
+                sync(self._client.loop, _wait_on_futures, fs)
+            else:
+                self._client.cancel(fs)

--- a/distributed/cfexecutor.py
+++ b/distributed/cfexecutor.py
@@ -89,7 +89,7 @@ class ClientExecutor(Executor):
         self._futures.add(future)
         return self._wrap_future(future)
 
-    def map(self, fn, *iterables, timeout=None, chunksize=1):
+    def map(self, fn, *iterables, **kwargs):
         """Returns an iterator equivalent to ``map(fn, *iterables)``.
 
         Parameters
@@ -112,8 +112,14 @@ class ClientExecutor(Executor):
             before the given timeout.
         Exception: If ``fn(*args)`` raises for any values.
         """
+        timeout = kwargs.pop('timeout', None)
         if timeout is not None:
             end_time = timeout + time()
+        if 'chunksize' in kwargs:
+            del kwargs['chunksize']
+        if kwargs:
+            raise TypeError("unexpected arguments to map(): %s"
+                            % sorted(kwargs))
 
         fs = self._client.map(fn, *iterables, **self._kwargs)
 

--- a/distributed/cfexecutor.py
+++ b/distributed/cfexecutor.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-from functools import partial
 import weakref
 
 import six
@@ -63,6 +62,7 @@ class ClientExecutor(Executor):
         Wrap a distributed Future in a concurrent.futures Future.
         """
         cf_future = Future()
+
         # Support cancelling task through .cancel() on c.f.Future
         def cf_callback(cf_future):
             if cf_future.cancelled() and future.status != 'cancelled':

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2425,6 +2425,10 @@ class Client(object):
 Executor = Client
 
 
+def CompatibleExecutor(*args, **kwargs):
+    raise Exception("This has been moved to the Client.get_executor() method")
+
+
 @gen.coroutine
 def _wait(fs, timeout=None, return_when='ALL_COMPLETED'):
     if timeout is not None and not isinstance(timeout, Number):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -120,7 +120,7 @@ class Future(WrappedKey):
     def result(self, timeout=None):
         """ Wait until computation completes. Gather result to local process.
 
-        If `timeout` seconds are elapsed before returning, a TimeoutError
+        If *timeout* seconds are elapsed before returning, a TimeoutError
         is raised.
         """
         result = sync(self.client.loop,
@@ -163,7 +163,7 @@ class Future(WrappedKey):
     def exception(self, timeout=None):
         """ Return the exception of a failed task
 
-        If `timeout` seconds are elapsed before returning, a TimeoutError
+        If *timeout* seconds are elapsed before returning, a TimeoutError
         is raised.
 
         See Also
@@ -219,7 +219,7 @@ class Future(WrappedKey):
         ``traceback`` module.  Alternatively if you call ``future.result()``
         this traceback will accompany the raised exception.
 
-        If `timeout` seconds are elapsed before returning, a TimeoutError
+        If *timeout* seconds are elapsed before returning, a TimeoutError
         is raised.
 
         Examples

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -723,6 +723,11 @@ class Client(object):
         **kwargs:
             Any submit()- or map()- compatible arguments, such as
             `workers` or `resources`.
+
+        Returns
+        -------
+        An Executor object that's fully compatible with the concurrent.futures
+        API.
         """
         return ClientExecutor(self, **kwargs)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -29,7 +29,7 @@ from dask.context import _globals
 from distributed import Worker, Nanny, recreate_exceptions
 from distributed.comm import CommClosedError
 from distributed.utils_comm import WrappedKey
-from distributed.client import (Client, Future, CompatibleExecutor, _wait,
+from distributed.client import (Client, Future, _wait,
         wait, _as_completed, as_completed, tokenize, _global_client,
         default_client, _first_completed, ensure_default_get, futures_of,
         temp_default_client)
@@ -128,30 +128,6 @@ def test_map_keynames(c, s, a, b):
     keys = ['inc-1', 'inc-2', 'inc-3', 'inc-4']
     futures = c.map(inc, range(4), key=keys)
     assert [f.key for f in futures] == keys
-
-
-@gen_cluster()
-def test_compatible_map(s, a, b):
-    e = CompatibleExecutor((s.ip, s.port), start=False)
-    yield e._start()
-
-    results = e.map(inc, range(5))
-    assert not isinstance(results, list)
-    # Since this map blocks as it waits for results,
-    # waiting here will block the current IOLoop,
-    # which happens to also be running the test Workers.
-    # So wait on the results in a background thread to avoid blocking.
-    f = gen.Future()
-    def wait_on_results():
-        f.set_result(list(results))
-    t = Thread(target=wait_on_results)
-    t.daemon = True
-    t.start()
-    result_list = yield f
-    # getting map results blocks
-    assert result_list == list(map(inc, range(5)))
-
-    yield e._shutdown()
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -222,6 +222,11 @@ def test_thread(loop):
             x = c.submit(inc, 1)
             assert x.result() == 2
 
+            x = c.submit(slowinc, 1, delay=0.3)
+            with pytest.raises(gen.TimeoutError):
+                x.result(timeout=0.01)
+            assert x.result() == 2
+
 
 def test_sync_exceptions(loop):
     with cluster() as (s, [a, b]):

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -202,6 +202,7 @@ def test_shutdown(loop):
             e.shutdown()
             dt = time.time() - t1
             assert 0.5 <= dt <= 2.0
+            time.sleep(0.1)  # wait for future outcome to propagate
             assert fut.done()
             fut.result()  # doesn't raise
 
@@ -215,7 +216,7 @@ def test_shutdown(loop):
             e.shutdown(wait=False)
             dt = time.time() - t1
             assert dt < 0.3
-            time.sleep(0.1)  # wait for cancellation to propagate
+            time.sleep(0.1)  # wait for future outcome to propagate
             assert fut.cancelled()
 
             with pytest.raises(RuntimeError):

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -1,0 +1,189 @@
+from __future__ import print_function, division, absolute_import
+
+from operator import add
+import random
+import time
+
+from concurrent.futures import (
+    CancelledError, Future, wait, as_completed,
+    FIRST_COMPLETED, FIRST_EXCEPTION, ALL_COMPLETED)
+
+import pytest
+from toolz import take
+from tornado import gen
+
+from distributed.client import Client
+from distributed.scheduler import Scheduler, KilledWorker
+from distributed.sizeof import sizeof
+from distributed.utils_test import (slow, slowinc, slowadd, slowdec,
+        loop, inc, dec, div, throws, gen_cluster, cluster)
+
+
+def number_of_processing_tasks(client):
+    return sum(len(v) for k, v in client.processing().items())
+
+
+def test_submit(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            with c.get_executor() as e:
+                f1 = e.submit(slowadd, 1, 2)
+                assert isinstance(f1, Future)
+                f2 = e.submit(slowadd, 3, y=4)
+                f3 = e.submit(throws, "foo")
+                f4 = e.submit(slowadd, x=5, y=6)
+                assert f1.result() == 3
+                assert f2.result() == 7
+                with pytest.raises(RuntimeError):
+                    f3.result()
+                assert f4.result() == 11
+
+
+def test_as_completed(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            with c.get_executor() as e:
+                N = 10
+                fs = [e.submit(slowinc, i, delay=0.02) for i in range(N)]
+                expected = set(range(1, N + 1))
+
+                for f in as_completed(fs):
+                    res = f.result()
+                    assert res in expected
+                    expected.remove(res)
+
+                assert not expected
+
+
+def test_wait(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            with c.get_executor(pure=False) as e:
+                N = 10
+                fs = [e.submit(slowinc, i, delay=0.05) for i in range(N)]
+                res = wait(fs, timeout=0.01)
+                assert len(res.not_done) > 0
+                res = wait(fs)
+                assert len(res.not_done) == 0
+                assert res.done == set(fs)
+
+                fs = [e.submit(slowinc, i, delay=0.05) for i in range(N)]
+                res = wait(fs, return_when=FIRST_COMPLETED)
+                assert len(res.not_done) > 0
+                assert len(res.done) >= 1
+                res = wait(fs)
+                assert len(res.not_done) == 0
+                assert res.done == set(fs)
+
+                fs = [e.submit(slowinc, i, delay=0.05) for i in range(N)]
+                fs += [e.submit(throws, None)]
+                fs += [e.submit(slowdec, i, delay=0.05) for i in range(N)]
+                res = wait(fs, return_when=FIRST_EXCEPTION)
+                assert len(res.not_done) > 0
+                assert len(res.done) > N - 2  # likely, unless tasks get reordered
+
+                errors = []
+                for fs in res.done:
+                    try:
+                        fs.result()
+                    except RuntimeError as e:
+                        errors.append(e)
+
+                assert len(errors) == 1
+                assert "hello" in str(errors[0])
+
+
+def test_cancellation(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            with c.get_executor() as e:
+                fut = e.submit(time.sleep, 5.0)
+                assert number_of_processing_tasks(c) > 0
+                assert not fut.done()
+                fut.cancel()
+                assert fut.cancelled()
+                assert number_of_processing_tasks(c) == 0
+                with pytest.raises(CancelledError):
+                    fut.result()
+
+
+def test_map(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            with c.get_executor() as e:
+                N = 10
+                it = e.map(inc, range(N))
+                expected = set(range(1, N + 1))
+                for x in it:
+                    expected.remove(x)
+                assert not expected
+
+            with c.get_executor(pure=False) as e:
+                N = 10
+                # Not consuming the iterator will cancel remaining tasks
+                it = e.map(slowinc, range(N), [0.1] * N)
+                for x in take(2, it):
+                    pass
+                # Some tasks still processing
+                assert number_of_processing_tasks(c) > 0
+                # Garbage collect the iterator => remaining tasks are cancelled
+                del it
+                assert number_of_processing_tasks(c) == 0
+
+def get_random():
+    return random.random()
+
+
+def test_pure(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            N = 10
+            with c.get_executor() as e:
+                fs = [e.submit(get_random) for i in range(N)]
+                res = [fut.result() for fut in as_completed(fs)]
+                assert len(set(res)) < len(res)
+            with c.get_executor(pure=False) as e:
+                fs = [e.submit(get_random) for i in range(N)]
+                res = [fut.result() for fut in as_completed(fs)]
+                assert len(set(res)) == len(res)
+
+def test_workers(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            N = 10
+            with c.get_executor(workers=[b['address']]) as e:
+                fs = [e.submit(slowinc, i) for i in range(N)]
+                wait(fs)
+                has_what = c.has_what()
+                assert not has_what.get(a['address'])
+                assert len(has_what[b['address']]) == N
+
+
+def test_shutdown(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            # shutdown(wait=True) waits for pending tasks to finish
+            e = c.get_executor()
+            fut = e.submit(time.sleep, 1.0)
+            t1 = time.time()
+            e.shutdown()
+            dt = time.time() - t1
+            assert 0.5 <= dt <= 2.0
+            assert fut.done()
+            fut.result()  # doesn't raise
+
+            with pytest.raises(RuntimeError):
+                e.submit(time.sleep, 1.0)
+
+            # shutdown(wait=False) cancels pending tasks
+            e = c.get_executor()
+            fut = e.submit(time.sleep, 5.0)
+            t1 = time.time()
+            e.shutdown(wait=False)
+            dt = time.time() - t1
+            assert dt < 0.3
+            time.sleep(0.1)  # wait for cancellation to propagate
+            assert fut.cancelled()
+
+            with pytest.raises(RuntimeError):
+                e.submit(time.sleep, 1.0)

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -192,6 +192,15 @@ def test_workers(loop):
                 assert len(has_what[b['address']]) == N
 
 
+def test_unsupported_arguments(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            with pytest.raises(TypeError) as excinfo:
+                c.get_executor(workers=[b['address']], foo=1, bar=2)
+            assert ("unsupported arguments to ClientExecutor: ['bar', 'foo']"
+                    in str(excinfo.value))
+
+
 def test_shutdown(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -135,3 +135,15 @@ def test_async(c, s, a, b):
     while len(a.data) + len(b.data) > 1:
         yield gen.sleep(0.1)
         assert time() < start + 3
+
+
+@gen_cluster(client=True)
+def test_client_executor(c, s, a, b):
+    def mysum():
+        with worker_client() as c:
+            with c.get_executor() as e:
+                return sum(e.map(double, range(30)))
+
+    future = c.submit(mysum)
+    result = yield future._result()
+    assert result == 30 * 29

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -12,6 +12,7 @@ API
    Client.gather
    Client.get
    Client.get_dataset
+   Client.get_executor
    Client.has_what
    Client.list_datasets
    Client.map

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -86,11 +86,6 @@ Client
 .. autoclass:: distributed.recreate_exceptions.ReplayExceptionClient
    :members:
 
-CompatibleExecutor
-------------------
-
-.. autoclass:: CompatibleExecutor
-    :members: map
 
 Future
 ------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
     'sphinx.ext.extlinks',
+    'sphinx.ext.intersphinx',
     'numpydoc',
 ]
 
@@ -375,3 +376,10 @@ extlinks = {
     'issue': ('https://github.com/dask/distributed/issues/%s', 'GH#'),
     'pr': ('https://github.com/dask/distributed/pull/%s', 'GH#')
 }
+
+# Configuration for intersphinx: refer to the Python standard library
+# and the Numpy documentation.
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy', None),
+    }

--- a/docs/source/related-work.rst
+++ b/docs/source/related-work.rst
@@ -197,15 +197,23 @@ IPython Parallel has the following advantages over ``distributed``
 concurrent.futures
 ~~~~~~~~~~~~~~~~~~
 
-The ``distributed.Client`` API is modeled after ``concurrent.futures`` and
-PEP-3184_.  It has a few notable differences:
+The :class:`distributed.Client` API is modeled after :mod:`concurrent.futures`
+and :pep:`3184`.  It has a few notable differences:
 
-*  ``distributed`` accepts ``Future`` objects within calls to ``submit/map``.
-   It is preferable to submit Future objects directly rather than wait on them
-   before submission.
-*  The ``map`` function returns ``Future`` objects, not concrete results.  The
-   ``map`` function returns immediately.
-*  Distributed generally does not support timeouts or callbacks
+*  ``distributed`` accepts :class:`~distributed.client.Future` objects within
+   calls to ``submit/map``. When chaining computations, it is preferable to
+   submit Future objects directly rather than wait on them before submission.
+*  The :meth:`~distributed.client.Client.map` method returns
+   :class:`~distributed.client.Future` objects, not concrete results.
+   The :meth:`~distributed.client.Client.map` method returns immediately.
+*  Despite sharing a similar API, ``distributed`` :class:`~distributed.client.Future`
+   objects cannot always be substituted for :class:`concurrent.futures.Future`
+   objects, especially when using ``wait()`` or ``as_completed()``.
+*  Distributed generally does not support callbacks.
+
+If you need full compatibility with the :class:`concurrent.futures.Executor`
+API, use the object returned by the
+:meth:`~distributed.client.Client.get_executor` method.
 
 
 .. _PEP-3184: https://www.python.org/dev/peps/pep-3148/

--- a/docs/source/related-work.rst
+++ b/docs/source/related-work.rst
@@ -205,12 +205,7 @@ PEP-3184_.  It has a few notable differences:
    before submission.
 *  The ``map`` function returns ``Future`` objects, not concrete results.  The
    ``map`` function returns immediately.
-*  It is not yet possible to cancel a ``Future`` (though this is theoretically
-   possible please raise an issue if this is of concrete importance to you.)
 *  Distributed generally does not support timeouts or callbacks
 
-``distributed.CompatibleExecutor`` is a subclass of ``distributed.Client`` that
-does conform to the ``concurrent.futures`` API, allowing it to be used as a
-drop-in replacement for other Executors using the common API.
 
 .. _PEP-3184: https://www.python.org/dev/peps/pep-3148/


### PR DESCRIPTION
The CompatibleExecutor added in #94 isn't compatible with wait() or as_completed() functions from the concurrent.futures package.

We replace it with a better implementation that returns concurrent.futures Futures.