### PR TITLE
Move blosc compression to mainline codebase

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -129,18 +129,18 @@ def maybe_compress(payload, min_size=1e4, sample_size=1e4, nsamples=5):
     if len(compress(sample)) > 0.9 * len(sample):  # sample not very compressible
         return None, payload
 
-    compressed = None
     if type(payload) is memoryview:
         nbytes = payload.itemsize * len(payload)
-        if blosc:
-            compressed = blosc.compress(payload, typesize=payload.itemsize,
-                                        cname='lz4', clevel=5)
-            compression = 'blosc'
     else:
         nbytes = len(payload)
 
-    if compressed is None:
+    if blosc and type(payload) is memoryview:
+        compressed = blosc.compress(payload, typesize=payload.itemsize,
+                                    cname='lz4', clevel=5)
+        compression = 'blosc'
+    else:
         compressed = compress(ensure_bytes(payload))
+
     if len(compressed) > 0.9 * nbytes:  # full data not very compressible
         return None, payload
     else:

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -131,9 +131,10 @@ def maybe_compress(payload, min_size=1e4, sample_size=1e4, nsamples=5):
 
     compressed = None
     if type(payload) is memoryview:
-        nbytes = payload.nbytes
+        nbytes = payload.itemsize * len(payload)
         if blosc:
-            compressed = blosc.compress(payload, typesize=payload.itemsize, cname='lz4', clevel=5)
+            compressed = blosc.compress(payload, typesize=payload.itemsize,
+                                        cname='lz4', clevel=5)
             compression = 'blosc'
     else:
         nbytes = len(payload)

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -194,3 +194,18 @@ def test_dumps_loads_Serialized():
 
     result3 = loads(frames2)
     assert result == result3
+
+
+def test_maybe_compress_memoryviews():
+    np = pytest.importorskip('numpy')
+    pytest.importorskip('lz4')
+    x = np.arange(1000000)
+    compression, payload = maybe_compress(x.data)
+    try:
+        import blosc
+    except ImportError:
+        assert compression == 'lz4'
+        assert len(payload) < x.nbytes * 0.75
+    else:
+        assert compression == 'blosc'
+        assert len(payload) < x.nbytes / 10

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import sys
 
+import dask
 import pytest
 
 from distributed.protocol import (loads, dumps, msgpack, maybe_compress,
@@ -63,20 +64,22 @@ def test_small_and_big():
 def test_maybe_compress():
     import zlib
     payload = b'123'
-    assert maybe_compress(payload, None) == (None, payload)
-    assert maybe_compress(payload, 'zlib') == (None, payload)
+    with dask.set_options(compression=None):
+        assert maybe_compress(payload) == (None, payload)
 
-    assert maybe_compress(b'111', 'zlib') == (None, b'111')
+    with dask.set_options(compression='zlib'):
+        assert maybe_compress(payload) == (None, payload)
+        assert maybe_compress(b'111') == (None, b'111')
 
-    payload = b'0' * 10000
-    assert maybe_compress(payload, 'zlib') == ('zlib', zlib.compress(payload))
+        payload = b'0' * 10000
+        assert maybe_compress(payload) == ('zlib', zlib.compress(payload))
 
 
 def test_maybe_compress_sample():
     np = pytest.importorskip('numpy')
     lz4 = pytest.importorskip('lz4')
     payload = np.random.randint(0, 255, size=10000).astype('u1').tobytes()
-    fmt, compressed = maybe_compress(payload, 'lz4')
+    fmt, compressed = maybe_compress(payload)
     assert fmt == None
     assert compressed == payload
 

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -199,7 +199,7 @@ def test_dumps_loads_Serialized():
 def test_maybe_compress_memoryviews():
     np = pytest.importorskip('numpy')
     pytest.importorskip('lz4')
-    x = np.arange(1000000)
+    x = np.arange(1000000, dtype='int64')
     compression, payload = maybe_compress(x.data)
     try:
         import blosc


### PR DESCRIPTION
Previously we special cased and used blosc within numpy serialization.

Now we optionally use blosc on any memoryview object that passes through the protocol