### PR TITLE
Localcluster cleanup

### DIFF
--- a/distributed/bokeh/tests/test_application.py
+++ b/distributed/bokeh/tests/test_application.py
@@ -32,18 +32,3 @@ def test_BokehWebInterface(loop):
                 sleep(0.01)
     with pytest.raises(Exception):
         response = requests.get('http://127.0.0.1:8787/status/')
-
-
-def test_bokeh_shutsdown_without_cluster___del__(loop):
-    c = LocalCluster(2, loop=loop, scheduler_port=0,
-                     services={('http', 0): HTTPScheduler})
-    proc = c.diagnostics.process
-    # don't run the del, as it isn't ever run in python < 3.5 due to cycles
-    c.__del__ = lambda self: None
-    del c
-    start = time()
-    while True:
-        if proc.poll() is not None:
-            break
-        assert time() < start + 5
-        sleep(0.01)

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -4,6 +4,7 @@ import logging
 import math
 from threading import Thread
 from time import sleep
+import warnings
 
 from tornado import gen
 from tornado.ioloop import IOLoop

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -163,6 +163,16 @@ class LocalCluster(object):
             kwargs['quiet'] = True
         else:
             W = Worker
+
+        try:
+            from distributed.bokeh.worker import BokehWorker
+        except ImportError:
+            pass
+        else:
+            if 'services' not in kwargs:
+                kwargs['services'] = {}
+            kwargs['services'][('bokeh', 0)] = BokehWorker
+
         w = W(self.scheduler.address, loop=self.loop,
               death_timeout=death_timeout,
               silence_logs=self.silence_logs, **kwargs)

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -37,7 +37,7 @@ def test_adaptive_local_cluster(loop):
 @gen_test(timeout=30)
 def test_adaptive_local_cluster_multi_workers():
     loop = IOLoop.current()
-    cluster = LocalCluster(0, scheduler_port=0, silence_logs=False, nanny=False,
+    cluster = LocalCluster(0, scheduler_port=0, silence_logs=False, processes=False,
                            diagnostics_port=None, loop=loop, start=False)
     cluster.scheduler.allowed_failures = 1000
     alc = Adaptive(cluster.scheduler, cluster, interval=100)

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -22,7 +22,7 @@ from distributed.deploy.utils_test import ClusterTest
 
 
 def test_simple(loop):
-    with LocalCluster(4, scheduler_port=0, nanny=False, silence_logs=False,
+    with LocalCluster(4, scheduler_port=0, processes=False, silence_logs=False,
                       diagnostics_port=None, loop=loop) as c:
         with Client(c.scheduler_address, loop=loop) as e:
             x = e.submit(inc, 1)
@@ -33,7 +33,7 @@ def test_simple(loop):
 
 @pytest.mark.skipif('sys.version_info[0] == 2', reason='multi-loop')
 def test_procs(loop):
-    with LocalCluster(2, scheduler_port=0, nanny=False, threads_per_worker=3,
+    with LocalCluster(2, scheduler_port=0, processes=False, threads_per_worker=3,
             diagnostics_port=None, silence_logs=False) as c:
         assert len(c.workers) == 2
         assert all(isinstance(w, Worker) for w in c.workers)
@@ -42,7 +42,7 @@ def test_procs(loop):
             assert all(isinstance(w, Worker) for w in c.workers)
         repr(c)
 
-    with LocalCluster(2, scheduler_port=0, nanny=True, threads_per_worker=3,
+    with LocalCluster(2, scheduler_port=0, processes=True, threads_per_worker=3,
             diagnostics_port=None, silence_logs=False) as c:
         assert len(c.workers) == 2
         assert all(isinstance(w, Nanny) for w in c.workers)
@@ -59,7 +59,7 @@ def test_move_unserializable_data():
     Test that unserializable data is still fine to transfer over inproc
     transports.
     """
-    with LocalCluster(nanny=False, silence_logs=False,
+    with LocalCluster(processes=False, silence_logs=False,
                       diagnostics_port=None) as cluster:
         assert cluster.scheduler_address.startswith('inproc://')
         assert cluster.workers[0].address.startswith('inproc://')
@@ -74,7 +74,7 @@ def test_transports():
     """
     Test the transport chosen by LocalCluster depending on arguments.
     """
-    with LocalCluster(1, nanny=False, silence_logs=False,
+    with LocalCluster(1, processes=False, silence_logs=False,
             diagnostics_port=None) as c:
         assert c.scheduler_address.startswith('inproc://')
         assert c.workers[0].address.startswith('inproc://')
@@ -82,7 +82,7 @@ def test_transports():
             assert e.submit(inc, 4).result() == 5
 
     # Have nannies => need TCP
-    with LocalCluster(1, nanny=True, silence_logs=False,
+    with LocalCluster(1, processes=True, silence_logs=False,
                       diagnostics_port=None) as c:
         assert c.scheduler_address.startswith('tcp://')
         assert c.workers[0].address.startswith('tcp://')
@@ -90,7 +90,7 @@ def test_transports():
             assert e.submit(inc, 4).result() == 5
 
     # Scheduler port specified => need TCP
-    with LocalCluster(1, nanny=False, scheduler_port=8786, silence_logs=False,
+    with LocalCluster(1, processes=False, scheduler_port=8786, silence_logs=False,
                       diagnostics_port=None) as c:
 
         assert c.scheduler_address == 'tcp://127.0.0.1:8786'
@@ -133,7 +133,7 @@ def test_defaults():
         assert all(isinstance(w, Nanny) for w in c.workers)
         assert all(w.ncores == 1 for w in c.workers)
 
-    with LocalCluster(nanny=False, scheduler_port=0, silence_logs=False,
+    with LocalCluster(processes=False, scheduler_port=0, silence_logs=False,
             diagnostics_port=None) as c:
         assert sum(w.ncores for w in c.workers) == _ncores
         assert all(isinstance(w, Worker) for w in c.workers)
@@ -246,7 +246,7 @@ def test_blocks_until_full(loop):
 @gen_test()
 def test_scale_up_and_down():
     loop = IOLoop.current()
-    cluster = LocalCluster(0, scheduler_port=0, nanny=False, silence_logs=False,
+    cluster = LocalCluster(0, scheduler_port=0, processes=False, silence_logs=False,
                            diagnostics_port=None, loop=loop, start=False)
     c = Client(cluster, start=False, loop=loop)
     yield c._start()
@@ -290,13 +290,13 @@ def test_remote_access(loop):
 
 
 def test_memory(loop):
-    with LocalCluster(scheduler_port=0, nanny=False, silence_logs=False,
+    with LocalCluster(scheduler_port=0, processes=False, silence_logs=False,
                       diagnostics_port=None, loop=loop) as cluster:
         assert sum(w.memory_limit for w in cluster.workers) < TOTAL_MEMORY * 0.8
 
 
 def test_memory_nanny(loop):
-    with LocalCluster(scheduler_port=0, nanny=True, silence_logs=False,
+    with LocalCluster(scheduler_port=0, processes=True, silence_logs=False,
                       diagnostics_port=None, loop=loop) as cluster:
         with Client(cluster.scheduler_address, loop=loop) as c:
             info = c.scheduler_info()

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -118,6 +118,13 @@ def test_Client_solo(loop):
     assert c.cluster.status == 'closed'
 
 
+def test_Client_kwargs(loop):
+    with Client(loop=loop, processes=False, n_workers=2) as c:
+        assert len(c.cluster.workers) == 2
+        assert all(isinstance(w, Worker) for w in c.cluster.workers)
+    assert c.cluster.status == 'closed'
+
+
 def test_Client_twice(loop):
     with Client(loop=loop) as c:
         with Client(loop=loop) as f:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import atexit
 from datetime import datetime, timedelta
 import logging
 from multiprocessing.queues import Empty
@@ -376,8 +377,6 @@ def join(proc, timeout):
     if proc is not None:
         proc.join(timeout)
 
-
-import atexit
 
 closing = [False]
 

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -153,7 +153,7 @@ You can do the work above easily using :doc:`LocalCluster<local-cluster>`.
 .. code-block:: python
 
    from distributed import LocalCluster
-   c = LocalCluster(nanny=False)
+   c = LocalCluster(processes=False)
 
 A scheduler will be available under ``c.scheduler`` and a list of workers under
 ``c.workers``.  There is an IOLoop running in a background thread.


### PR DESCRIPTION
This does four things:

1.  Replace the nanny= keyword with processes= keyword
2.  Pass keywords from the Client down the LocalCluster if started with `Client(**kwargs)`  (cc @pelson)
3.  Replace the separate process Bokeh server with the in-process one.  I want to start with this before changing it out on dask-scheduler
4.  Adds bokeh servers to all of the workers by default

Everything seems fine so far.  However I'm now seeing this (cc @pitrou):

```python
In [1]: from dask.distributed import Client

In [2]: client = Client()

In [3]:                                                                         
Do you really want to exit ([y]/n)? 
/home/mrocklin/Software/anaconda/lib/python3.6/multiprocessing/semaphore_tracker.py:129: UserWarning: semaphore_tracker: There appear to be 20 leaked semaphores to clean up at shutdown
  len(cache))
```