### PR TITLE
Make restart more robust

### DIFF
--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -277,8 +277,12 @@ def test_multiple_clients_restart(s, a, b):
 @gen_cluster(Worker=Nanny)
 def test_restart_scheduler(s, a, b):
     import gc; gc.collect()
+    addrs = (a.worker_address, b.worker_address)
     yield s.restart()
     assert len(s.ncores) == 2
+    addrs2 = (a.worker_address, b.worker_address)
+
+    assert addrs != addrs2
 
 
 @gen_cluster(Worker=Nanny, client=True)


### PR DESCRIPTION
Previously race conditions could occur which would make client.restart hang.
Now we explicitly try to remove all workers cleanly, but if this fails we
bluntly clear out all state.