### PR TITLE
Joblib scatter

### DIFF
--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -23,13 +23,16 @@ with ignoring(ImportError):
     if LooseVersion(sk_joblib.__version__) < '0.10.2':
         sk_joblib = None
 
+_bases = []
 if joblib:
     from joblib.parallel import (ParallelBackendBase,
         AutoBatchingMixin)
-elif sk_joblib:
+    _bases.append(ParallelBackendBase)
+if sk_joblib:
     from sklearn.externals.joblib.parallel import (
         ParallelBackendBase, AutoBatchingMixin)
-else:
+    _bases.append(ParallelBackendBase)
+if not _bases:
     raise RuntimeError("Joblib backend requires either `joblib` >= '0.10.2' "
                        " or `sklearn` > '0.17.1'. Please install or upgrade")
 
@@ -45,31 +48,98 @@ def joblib_funcname(x):
     return funcname(x)
 
 
-class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
-    MIN_IDEAL_BATCH_DURATION = 0.2
-    MAX_IDEAL_BATCH_DURATION = 1.0
+class itemgetter(object):
+    __slots__ = ('index',)
 
-    def __init__(self, scheduler_host='127.0.0.1:8786', loop=None):
+    def __init__(self, index):
+        self.index = index
+
+    def __call__(self, x):
+        return x[self.index]
+
+    def __reduce__(self):
+        return (itemgetter, (self.index,))
+
+
+class Batch(object):
+    def __init__(self, tasks):
+        self.tasks = tasks
+
+    def __call__(self, *data):
+        results = []
+        for func, args, kwargs in self.tasks:
+            args = [a(data) if isinstance(a, itemgetter) else a
+                    for a in args]
+            kwargs = {k: v(data) if isinstance(v, itemgetter) else v
+                      for (k, v) in kwargs.items()}
+            results.append(func(*args, **kwargs))
+        return results
+
+    def __reduce__(self):
+        return (Batch, (self.tasks,))
+
+
+class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
+    MIN_IDEAL_BATCH_DURATION = 0.5
+    MAX_IDEAL_BATCH_DURATION = 5.0
+
+    def __init__(self, scheduler_host='127.0.0.1:8786', scatter=None, loop=None):
         self.client = Client(scheduler_host, loop=loop)
+        if scatter is not None:
+            # Keep a reference to the scattered data to keep the ids the same
+            self._scatter = list(scatter)
+            scattered = self.client.scatter(scatter, broadcast=True)
+            self.data_to_future = {id(x): f for (x, f) in zip(scatter, scattered)}
+        else:
+            self._scatter = []
+            self.data_to_future = {}
         self.futures = set()
 
     def configure(self, n_jobs=1, parallel=None, **backend_args):
         return self.effective_n_jobs(n_jobs)
 
-    def effective_n_jobs(self, n_jobs=1):
+    def effective_n_jobs(self, n_jobs):
         return sum(self.client.ncores().values())
 
-    def apply_async(self, func, *args, **kwargs):
-        callback = kwargs.pop('callback', None)
-        kwargs['key'] = '%s-%s' % (joblib_funcname(func), uuid4().hex)
-        future = self.client.submit(func, *args, **kwargs)
+    def _to_func_args(self, func):
+        if not self.data_to_future:
+            return func, ()
+        args2 = []
+        lookup = dict(self.data_to_future)
+
+        def maybe_to_futures(args):
+            for x in args:
+                id_x = id(x)
+                if id_x in lookup:
+                    x = lookup[id_x]
+                    if type(x) is not itemgetter:
+                        x = itemgetter(len(args2))
+                        args2.append(lookup[id_x])
+                        lookup[id_x] = x
+                yield x
+
+        tasks = []
+        for f, args, kwargs in func.items:
+            args = list(maybe_to_futures(args))
+            kwargs = dict(zip(kwargs.keys(), maybe_to_futures(kwargs.values())))
+            tasks.append((f, args, kwargs))
+
+        if not args2:
+            return func, ()
+        return Batch(tasks), args2
+
+    def apply_async(self, func, callback=None):
+        key = '%s-%s' % (joblib_funcname(func), uuid4().hex)
+        func, args = self._to_func_args(func)
+        future = self.client.submit(func, *args, key=key)
         self.futures.add(future)
 
         @gen.coroutine
         def callback_wrapper():
             result = yield _wait([future])
             self.futures.remove(future)
-            callback(result)  # gets called in separate thread
+            if callback is not None:
+                callback(result)  # gets called in separate thread
 
         self.client.loop.add_callback(callback_wrapper)
 
@@ -81,6 +151,10 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
         # as joblib.Parallel will never access those results.
         self.client.cancel(self.futures)
         self.futures.clear()
+
+
+for base in _bases:
+    base.register(DaskDistributedBackend)
 
 
 DistributedBackend = DaskDistributedBackend

--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -6,8 +6,7 @@ from uuid import uuid4
 from tornado import gen
 
 from .client import Client, _wait
-from .utils import ignoring, funcname
-
+from .utils import ignoring, funcname, itemgetter
 
 # A user could have installed joblib, sklearn, both, or neither. Further, only
 # joblib >= 0.10.0 supports backends, so we also need to check for that. This
@@ -25,12 +24,11 @@ with ignoring(ImportError):
 
 _bases = []
 if joblib:
-    from joblib.parallel import (ParallelBackendBase,
-        AutoBatchingMixin)
+    from joblib.parallel import AutoBatchingMixin, ParallelBackendBase
     _bases.append(ParallelBackendBase)
 if sk_joblib:
-    from sklearn.externals.joblib.parallel import (
-        ParallelBackendBase, AutoBatchingMixin)
+    from sklearn.externals.joblib.parallel import (AutoBatchingMixin,  # noqa
+            ParallelBackendBase)
     _bases.append(ParallelBackendBase)
 if not _bases:
     raise RuntimeError("Joblib backend requires either `joblib` >= '0.10.2' "
@@ -46,19 +44,6 @@ def joblib_funcname(x):
     except Exception:
         pass
     return funcname(x)
-
-
-class itemgetter(object):
-    __slots__ = ('index',)
-
-    def __init__(self, index):
-        self.index = index
-
-    def __call__(self, x):
-        return x[self.index]
-
-    def __reduce__(self):
-        return (itemgetter, (self.index,))
 
 
 class Batch(object):

--- a/distributed/tests/test_joblib.py
+++ b/distributed/tests/test_joblib.py
@@ -71,3 +71,67 @@ def test_joblib_funcname(joblib):
     func = BatchedCalls([(random2,), (random2,)])
     assert joblib_funcname(func) == 'random2'
     assert joblib_funcname(random2) == 'random2'
+
+
+@pytest.mark.parametrize('joblib', joblibs)
+def test_joblib_backend_subclass(joblib):
+    if joblib is None:
+        pytest.skip()
+
+    assert issubclass(distributed_joblib.DaskDistributedBackend,
+                      joblib.parallel.ParallelBackendBase)
+
+
+def add5(a, b, c, d=0, e=0):
+    return a + b + c + d + e
+
+
+class CountSerialized(object):
+    def __init__(self, x):
+        self.x = x
+        self.count = 0
+
+    def __add__(self, other):
+        return self.x + getattr(other, 'x', other)
+
+    __radd__ = __add__
+
+    def __reduce__(self):
+        self.count += 1
+        return (CountSerialized, (self.x,))
+
+
+@pytest.mark.parametrize('joblib', joblibs)
+def test_joblib_scatter(loop, joblib):
+    if joblib is None:
+        pytest.skip()
+
+    Parallel = joblib.Parallel
+    delayed = joblib.delayed
+
+    x = CountSerialized(1)
+    y = CountSerialized(2)
+    z = CountSerialized(3)
+
+    with cluster() as (s, [a, b]):
+        with joblib.parallel_backend('dask.distributed', loop=loop,
+                                     scheduler_host=s['address'],
+                                     scatter=[x, y]):
+            f = delayed(add5)
+            tasks = [f(x, y, z, d=4, e=5),
+                     f(x, z, y, d=5, e=4),
+                     f(y, x, z, d=x, e=5),
+                     f(z, z, x, d=z, e=y)]
+            sols = [func(*args, **kwargs) for func, args, kwargs in tasks]
+            results = Parallel()(tasks)
+
+            ba, _ = joblib.parallel.get_active_backend()
+            ba.client.shutdown()
+
+    for l, r in zip(sols, results):
+        assert l == r
+
+    # Scattered variables only serialized once
+    assert x.count == 1
+    assert y.count == 1
+    assert z.count == 4

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -743,3 +743,25 @@ def import_file(path):
             if tmp_python_path is not None:
                 sys.path.remove(tmp_python_path)
     return loaded
+
+
+class itemgetter(object):
+    """A picklable itemgetter.
+
+    Examples
+    --------
+    >>> data = [0, 1, 2]
+    >>> get_1 = itemgetter(1)
+    >>> get_1(data)
+    1
+    """
+    __slots__ = ('index',)
+
+    def __init__(self, index):
+        self.index = index
+
+    def __call__(self, x):
+        return x[self.index]
+
+    def __reduce__(self):
+        return (itemgetter, (self.index,))

--- a/docs/source/joblib.rst
+++ b/docs/source/joblib.rst
@@ -52,4 +52,18 @@ validated parameter search as follows.
    with parallel_backend('dask.distributed', scheduler_host='localhost:8786'):
        search.fit(digits.data, digits.target)
 
+
+For large arguments that are used by multiple tasks, it may be more efficient
+to pre-scatter the data to every worker, rather than serializing it once for
+every task. This can be done using the ``scatter`` keyword argument, which
+takes an iterable of objects to send to each worker.
+
+.. code-block:: python
+
+   # Serialize the training data only once to each worker
+   with parallel_backend('dask.distributed', scheduler_host='localhost:8786',
+                         scatter=[digits.data, digits.target]):
+       search.fit(digits.data, digits.target)
+
+
 .. _Joblib: https://pythonhosted.org/joblib/


### PR DESCRIPTION
Allows to prescatter data to the cluster. For large arguments (big arrays, etc...) that are used in more than one task, this can be more efficient as it avoids serializing the data for every task.

Also fix to ensure distributed backend is an instance of the `ParallelBackendBase` for both scikit-learn and joblib modules.
