### PR TITLE
Release tasks on worker when released from scheduler

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2500,6 +2500,7 @@ class Scheduler(Server):
                 self.total_occupancy -= duration
                 self.check_idle_saturated(w)
                 self.release_resources(key, w)
+                self.worker_comms[w].send({'op': 'release-task', 'key': key})
 
             self.released.add(key)
             self.task_state[key] = 'released'

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -661,3 +661,16 @@ def test_worker_death_timeout():
 
     yield gen.sleep(3)
     assert w.status == 'closed'
+
+
+@gen_cluster(client=True)
+def test_stop_doing_unnecessary_work(c, s, a, b):
+    futures = c.map(slowinc, range(1000), delay=0.01)
+    yield gen.sleep(0.1)
+
+    del futures
+
+    start = time()
+    while a.executing:
+        yield gen.sleep(0.01)
+        assert time() - start < 0.5


### PR DESCRIPTION
Previously workers would remain busy even if we cancelled work