### PR TITLE
Updated runtime requirements and changes in using the lz4 compression api

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -52,12 +52,12 @@ with ignoring(ImportError):
     import lz4
 
     def _fixed_lz4_decompress(data):
-        # lz4.LZ4_uncompress() doesn't accept memoryviews
+        # lz4.block.decompress() doesn't accept memoryviews
         if isinstance(data, memoryview):
             data = data.tobytes()
-        return lz4.LZ4_uncompress(data)
+        return lz4.block.decompress(data)
 
-    compressions['lz4'] = {'compress': lz4.LZ4_compress,
+    compressions['lz4'] = {'compress': lz4.block.compress,
                            'decompress': _fixed_lz4_decompress}
     default_compression = 'lz4'
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -53,12 +53,12 @@ with ignoring(ImportError):
 
     try:
         # try using the new lz4 API
-        lz4_compress=lz4.block.compress
-        lz4_decompress=lz4.block.decompress
+        lz4_compress = lz4.block.compress
+        lz4_decompress = lz4.block.decompress
     except AttributeError as err:
         # fall back to old one
-        lz4_compress=lz4.LZ4_compress
-        lz4_decompress=lz4.LZ4_uncompress
+        lz4_compress = lz4.LZ4_compress
+        lz4_decompress = lz4.LZ4_uncompress
 
     def _fixed_lz4_decompress(data):
         # helper to bypass missing memoryview support in lz4

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -68,7 +68,7 @@ with ignoring(ImportError):
 
     compressions['lz4'] = {'compress': lz4_compress,
                            'decompress': _fixed_lz4_decompress}
-     default_compression = 'lz4'
+    default_compression = 'lz4'
 
 with ignoring(ImportError):
     import blosc

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -51,15 +51,24 @@ with ignoring(ImportError):
 with ignoring(ImportError):
     import lz4
 
+    try:
+        # try using the new lz4 API
+        lz4_compress=lz4.block.compress
+        lz4_decompress=lz4.block.decompress
+    except AttributeError as err:
+        # fall back to old one
+        lz4_compress=lz4.LZ4_compress
+        lz4_decompress=lz4.LZ4_uncompress
+
     def _fixed_lz4_decompress(data):
-        # lz4.block.decompress() doesn't accept memoryviews
+        # helper to bypass missing memoryview support in lz4
         if isinstance(data, memoryview):
             data = data.tobytes()
-        return lz4.block.decompress(data)
+        return lz4_decompress(data)
 
-    compressions['lz4'] = {'compress': lz4.block.compress,
+    compressions['lz4'] = {'compress': lz4_compress,
                            'decompress': _fixed_lz4_decompress}
-    default_compression = 'lz4'
+     default_compression = 'lz4'
 
 with ignoring(ImportError):
     import blosc

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,3 @@ zict >= 0.1.1
 sortedcollections
 futures; python_version < '3.0'
 singledispatch; python_version < '3.4'
-bokeh
-paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ zict >= 0.1.1
 sortedcollections
 futures; python_version < '3.0'
 singledispatch; python_version < '3.4'
+bokeh
+paramiko


### PR DESCRIPTION
I've had a lot of DeprecationWarnings regarding lz4 in my jupyter notebook environment and noticed that dask distributed was the source of these. Instead of simply suppressing these I thought that updating distributed to use the new api would be more sufficient.

When testing  the updated version in a new conda based environment I noticed that paramiko and bokeh were missing as necessary runtime requirements for dask-ssh and the bokeh based status pages, so I updated these requirements as well.

Hope these changes are useful.