### PR TITLE
Handling repeated signals in cli

### DIFF
--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -36,7 +36,7 @@ def install_signal_handlers():
     import signal
 
     def handle_signal(sig, frame):
-        IOLoop.instance().add_callback(IOLoop.instance().stop)
+        IOLoop.instance().add_callback_from_signal(IOLoop.instance().stop)
 
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
+import sys
+
 py3_err_msg = """
 Your terminal does not properly support unicode text required by command line
 utilities running Python 3.  This is commonly solved by specifying encoding
@@ -23,7 +25,6 @@ def check_python_3():
         from click import _unicodefun
         _unicodefun._verify_python3_env()
     except (TypeError, RuntimeError) as e:
-        import sys
         import click
         click.echo(py3_err_msg, err=True)
         sys.exit(1)
@@ -35,8 +36,14 @@ def install_signal_handlers():
     from tornado.ioloop import IOLoop
     import signal
 
+    signal_count = [0]
+
     def handle_signal(sig, frame):
-        IOLoop.instance().add_callback_from_signal(IOLoop.instance().stop)
+        if signal_count[0]:
+            sys.exit(0)
+        else:
+            IOLoop.instance().add_callback_from_signal(IOLoop.instance().stop)
+            signal_count[0] += 1
 
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -42,10 +42,6 @@ def get_total_physical_memory():
 MAX_BUFFER_SIZE = get_total_physical_memory()
 
 
-def handle_signal(sig, frame):
-    IOLoop.instance().add_callback(IOLoop.instance().stop)
-
-
 class Server(object):
     """ Distributed TCP Server
 


### PR DESCRIPTION
This uses the `IOLoop.add_callback_from_signal` method rather than `IOLoop.add_callback` method when running from a signal handler.  

This also simply exits when calling a signal handler twice.

However I'm not sure how best to test this.  Playing around interactively I wasn't able to convince myself that the `sys.exit` branch was ever taken.

cc @pitrou for advice