### PR TITLE
Improve handle_signal for worker

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -36,7 +36,7 @@ def handle_signal(sig, frame):
         except (OSError, IOError, TypeError):
             pass
     if loop._running:
-        loop.add_callback(loop.stop)
+        loop.add_callback_from_signal(loop.stop)
     else:
         exit(1)
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -366,6 +366,8 @@ def run_worker_fork(q, scheduler_addr, ncores, nanny_port,
         loop.run_sync(run)
     except TimeoutError:
         logger.info("Worker timed out")
+    except KeyboardInterrupt:
+        pass
     finally:
         loop.stop()
         loop.close(all_fds=True)


### PR DESCRIPTION
In https://github.com/dask/distributed/commit/8ad0971c31039da868bace66501375169f9c3753 I neglected to use `IOLoop.add_callback_from_signal` in `cli/dask_worker.py`.  This resolves that.

Additionally I'm looking at the output that comes when interrupting the worker process.

```python
(dev) mrocklin@workstation:~/workspace/distributed$ dask-worker localhost:8786
distributed.nanny - INFO -         Start Nanny at: 'tcp://127.0.0.1:48671'
distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:33935
distributed.worker - INFO -              nanny at:            127.0.0.1:48671
distributed.worker - INFO -               http at:            127.0.0.1:45485
distributed.worker - INFO -              bokeh at:            127.0.0.1:8789
distributed.worker - INFO - Waiting to connect to:       tcp://localhost:8786
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -               Threads:                          8
distributed.worker - INFO -                Memory:                   10.02 GB
distributed.worker - INFO -       Local Directory:        /tmp/nanny-uwfkhsuo
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -         Registered to:             tcp://localhost:8786
distributed.worker - INFO - -------------------------------------------------
distributed.nanny - INFO - Nanny 'tcp://127.0.0.1:48671' starts worker process 'tcp://127.0.0.1:33935'

^CTraceback (most recent call last):
  File "<string>", line 1, in <module>
distributed.dask_worker - INFO - End worker
  File "/home/mrocklin/anaconda/envs/dev/lib/python3.6/multiprocessing/forkserver.py", line 164, in main
    rfds = [key.fileobj for (key, events) in selector.select()]
  File "/home/mrocklin/anaconda/envs/dev/lib/python3.6/selectors.py", line 445, in select
    fd_event_list = self._epoll.poll(timeout, max_ev)
KeyboardInterrupt
```

Is this traceback something that we should be aware of or addressing?  If not then is there a convenient way to avoid showing it to the user?  cc @pitrou 