### PR TITLE
Revert addition of terminate to joblib backend

### DIFF
--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -73,7 +73,7 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             raise TypeError("scatter must be a list/tuple, got "
                             "`%s`" % type(scatter).__name__)
 
-        self.client = Client(scheduler_host, loop=loop)
+        self.client = Client(scheduler_host, loop=loop, set_as_default=False)
         if scatter is not None:
             # Keep a reference to the scattered data to keep the ids the same
             self._scatter = list(scatter)
@@ -135,15 +135,11 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
         future.get = future.result  # monkey patch to achieve AsyncResult API
         return future
 
-    def terminate(self):
-        self.client.shutdown()
-
     def abort_everything(self, ensure_ready=True):
         # Tell the client to cancel any task submitted via this instance
         # as joblib.Parallel will never access those results.
         self.client.cancel(self.futures)
         self.futures.clear()
-        self.terminate()
 
 
 for base in _bases:

--- a/distributed/tests/test_joblib.py
+++ b/distributed/tests/test_joblib.py
@@ -38,7 +38,7 @@ def test_simple(loop, joblib):
             seq = Parallel()(delayed(inc)(i) for i in range(10))
             assert seq == [inc(i) for i in range(10)]
 
-            ba.terminate()
+            ba.client.shutdown()
 
 
 def random2():
@@ -58,7 +58,7 @@ def test_dont_assume_function_purity(loop, joblib):
             x, y = Parallel()(delayed(random2)() for i in range(2))
             assert x != y
 
-            ba.terminate()
+            ba.client.shutdown()
 
 
 @pytest.mark.parametrize('joblib', joblibs)
@@ -123,7 +123,7 @@ def test_joblib_scatter(loop, joblib):
             sols = [func(*args, **kwargs) for func, args, kwargs in tasks]
             results = Parallel()(tasks)
 
-            ba.terminate()
+            ba.client.shutdown()
 
         # Scatter must take a list/tuple
         with pytest.raises(TypeError):


### PR DESCRIPTION
Due to how joblib calls terminate, this can fail if you ever call
`Parallel` twice inside the `parallel_backend` contextmanager. Until
this is fixed in joblib, we'll need to let the gc cleanup handle
shutdown.