### PR TITLE
Change default bokeh scheduler to internal

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('distributed.scheduler')
 # XXX default port (or URI) values should be centralized somewhere
 @click.option('--http-port', type=int, default=9786, help="HTTP port")
 @click.option('--bokeh-port', type=int, default=8787, help="Bokeh port")
-@click.option('--bokeh-internal-port', type=int, default=8788,
+@click.option('--bokeh-external-port', type=int, default=None,
               help="Internal Bokeh port")
 @click.option('--bokeh/--no-bokeh', '_bokeh', default=True, show_default=True,
               required=False, help="Launch Bokeh Web UI")
@@ -50,7 +50,7 @@ logger = logging.getLogger('distributed.scheduler')
               help="Directory to place scheduler files")
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process like "foo.bar"')
-def main(host, port, http_port, bokeh_port, bokeh_internal_port, show, _bokeh,
+def main(host, port, http_port, bokeh_port, bokeh_external_port, show, _bokeh,
          bokeh_whitelist, prefix, use_xheaders, pid_file, scheduler_file,
          interface, local_directory, preload):
 
@@ -95,20 +95,21 @@ def main(host, port, http_port, bokeh_port, bokeh_internal_port, show, _bokeh,
     if _bokeh:
         with ignoring(ImportError):
             from distributed.bokeh.scheduler import BokehScheduler
-            services[('bokeh', bokeh_internal_port)] = BokehScheduler
+            services[('bokeh', bokeh_port)] = BokehScheduler
     scheduler = Scheduler(loop=loop, services=services,
                           scheduler_file=scheduler_file)
     scheduler.start(addr)
     preload_modules(preload, parameter=scheduler, file_dir=local_directory)
 
     bokeh_proc = None
-    if _bokeh:
-        if bokeh_port == 0:          # This is a hack and not robust
+    if _bokeh and bokeh_external_port is not None:
+        if bokeh_external_port == 0: # This is a hack and not robust
             bokeh_port = open_port() # This port may be taken by the OS
         try:                         # before we successfully pass it to Bokeh
             from distributed.bokeh.application import BokehWebInterface
             bokeh_proc = BokehWebInterface(http_port=http_port,
-                    scheduler_address=scheduler.address, bokeh_port=bokeh_port,
+                    scheduler_address=scheduler.address,
+                    bokeh_port=bokeh_external_port,
                     bokeh_whitelist=bokeh_whitelist, show=show, prefix=prefix,
                     use_xheaders=use_xheaders, quiet=False)
         except ImportError:

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -27,6 +27,8 @@ logger = logging.getLogger('distributed.scheduler')
 @click.option('--bokeh-port', type=int, default=8787, help="Bokeh port")
 @click.option('--bokeh-external-port', type=int, default=None,
               help="Internal Bokeh port")
+@click.option('--bokeh-internal-port', type=int, default=None,
+             help="Deprecated.")
 @click.option('--bokeh/--no-bokeh', '_bokeh', default=True, show_default=True,
               required=False, help="Launch Bokeh Web UI")
 @click.option('--host', type=str, default='',
@@ -50,9 +52,16 @@ logger = logging.getLogger('distributed.scheduler')
               help="Directory to place scheduler files")
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process like "foo.bar"')
-def main(host, port, http_port, bokeh_port, bokeh_external_port, show, _bokeh,
-         bokeh_whitelist, prefix, use_xheaders, pid_file, scheduler_file,
-         interface, local_directory, preload):
+def main(host, port, http_port, bokeh_port, bokeh_external_port,
+         bokeh_internal_port, show, _bokeh, bokeh_whitelist, prefix,
+         use_xheaders, pid_file, scheduler_file, interface, local_directory,
+         preload):
+
+    if bokeh_internal_port:
+        print("The --bokeh-internal-port keyword has been removed.\n"
+              "The internal bokeh server is now the default bokeh server.\n"
+              "Use --bokeh-port %d instead" % bokeh_internal_port)
+        sys.exit(1)
 
     if pid_file:
         with open(pid_file, 'w') as f:

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -129,13 +129,12 @@ def test_bokeh_non_standard_ports(loop):
         requests.get('http://localhost:4832/status/')
 
 
-def test_bokeh_internal_port(loop):
+def test_bokeh_external_port(loop):
     pytest.importorskip('bokeh')
 
-    with popen(['dask-scheduler', '--bokeh-internal-port', '4833']) as proc:
+    with popen(['dask-scheduler', '--bokeh-external-port', '4833']) as proc:
         with Client('127.0.0.1:8786', loop=loop) as c:
             d = c.scheduler_info()
-            assert d['services']['bokeh'] == 4833
 
         start = time()
         while True:
@@ -246,10 +245,9 @@ def test_bokeh_port_zero(loop):
     pytest.importorskip('bokeh')
     with tmpfile() as fn:
         with popen(['dask-scheduler',
-                    '--bokeh-port', '0',
-                    '--bokeh-internal-port', '0']) as proc:
+                    '--bokeh-port', '0']) as proc:
             count = 0
-            while count < 2:
+            while count < 1:
                 line = proc.stderr.readline()
                 if b'bokeh' in line.lower() or b'web' in line.lower():
                     count += 1


### PR DESCRIPTION
This changes the default bokeh web application to the internal server.
The external server is still around and accessible by the
`--bokeh-external-port` keyword.