### PR TITLE
Add __aenter__ and __aexit__ methods to Client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -544,6 +544,15 @@ class Client(object):
             self.start()
         return self
 
+    @gen.coroutine
+    def __aenter__(self):
+        yield self._start()
+        raise gen.Return(self)
+
+    @gen.coroutine
+    def __aexit__(self, typ, value, traceback):
+        yield self._shutdown()
+
     def __exit__(self, type, value, traceback):
         self.shutdown()
 
@@ -665,8 +674,7 @@ class Client(object):
             if self.status == 'running':
                 self._send_to_scheduler({'op': 'close-stream'})
             if self._start_arg is None:
-                with ignoring(AttributeError):
-                    yield self.cluster._close()
+                yield self.cluster._close()
             self.status = 'closed'
             if _global_client[0] is self:
                 _global_client[0] = None

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -674,7 +674,8 @@ class Client(object):
             if self.status == 'running':
                 self._send_to_scheduler({'op': 'close-stream'})
             if self._start_arg is None:
-                yield self.cluster._close()
+                with ignoring(AttributeError):
+                    yield self.cluster._close()
             self.status = 'closed'
             if _global_client[0] is self:
                 _global_client[0] = None

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -664,6 +664,9 @@ class Client(object):
                 raise gen.Return()
             if self.status == 'running':
                 self._send_to_scheduler({'op': 'close-stream'})
+            if self._start_arg is None:
+                with ignoring(AttributeError):
+                    yield self.cluster._close()
             self.status = 'closed'
             if _global_client[0] is self:
                 _global_client[0] = None

--- a/distributed/tests/py3_test_client.py
+++ b/distributed/tests/py3_test_client.py
@@ -40,18 +40,19 @@ def test_as_completed_async_for(c, s, a, b):
 
 
 def test_async_with(loop):
-    results = []
-    ns = {}
+    result = None
+    client = None
+    cluster = None
     async def f():
         async with Client(processes=False, start=False) as c:
+            nonlocal result, client, cluster
             result = await c.submit(lambda x: x + 1, 10)
-            results.append(result)
 
-            ns['client'] = c
-            ns['cluster'] = c.cluster
+            client = c
+            cluster = c.cluster
 
     loop.run_sync(f)
 
-    assert results == [11]
-    assert ns['client'].status == 'closed'
-    assert ns['cluster'].status == 'closed'
+    assert result == 11
+    assert client.status == 'closed'
+    assert cluster.status == 'closed'


### PR DESCRIPTION
Companion to #1029 

cc @kszucs I'm trying to see if I can trigger the errors you get with a normal tornado solution.  Also, stealing some of your logic back into the main client codebase.