### PR TITLE
Close things to avoid logging errors

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -705,6 +705,7 @@ class Client(object):
         if self.status == 'closed':
             return
 
+        self.status = 'closing'
         if self._start_arg is None:
             with ignoring(AttributeError):
                 self.cluster.close()
@@ -714,7 +715,7 @@ class Client(object):
 
         if self._should_close_loop:
             sync(self.loop, self.loop.stop)
-            self.loop.close(all_fds=True)
+            self.loop.close(all_fds=False)
             self._loop_thread.join(timeout=timeout)
         with ignoring(AttributeError):
             dask.set_options(get=self._previous_get)

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -541,6 +541,7 @@ def test_dont_steal_long_running_tasks(c, s, a, b):
                        allow_other_workers=True)
     while sum(map(len, s.processing.values())) < 2:  # let them start
         yield gen.sleep(0.01)
+    yield gen.sleep(0.2)  # scheduler learns that they are long-running
     incs = c.map(inc, range(100), workers=a.address, allow_other_workers=True)
 
     yield gen.sleep(0.2)


### PR DESCRIPTION
Previously closing down a LocalCluster would result in a number of
errors being emitted to the console.  Now we close things in a different
order and check closing status to avoid these errors.

I tried to test this for a long while but failed to capture logging
information in pytest.