### PR TITLE
Don't assume cluster has _start method

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -448,7 +448,13 @@ class Client(object):
         address = self._start_arg
         if self.cluster is not None:
             # Ensure the cluster is started (no-op if already running)
-            yield self.cluster._start()
+            try:
+                yield self.cluster._start()
+            except AttributeError:  # Some clusters don't have this method
+                pass
+            except Exception:
+                logger.info("Tried to start cluster and received an error. "
+                            "Proceeding.", exc_info=True)
             address = self.cluster.scheduler_address
         elif self.scheduler_file is not None:
             while not os.path.exists(self.scheduler_file):


### PR DESCRIPTION
When given a cluster don't assume that it wants to be started.
Fail gracefully.