### PR TITLE
Update `keras` serializer for `tensorflow.contrib` version

### DIFF
--- a/distributed/protocol/keras.py
+++ b/distributed/protocol/keras.py
@@ -31,9 +31,7 @@ def deserialize_keras_model(header, frames):
     return model
 
 
-register_serialization('keras.engine.training.Model', serialize_keras_model,
-                       deserialize_keras_model)
-register_serialization('keras.models.Model', serialize_keras_model,
-                       deserialize_keras_model)
-register_serialization('keras.models.Sequential', serialize_keras_model,
-                       deserialize_keras_model)
+for module in ['keras', 'tensorflow.contrib.keras.python.keras']:
+    for name in ['engine.training.Model', 'models.Model', 'models.Sequential']:
+        register_serialization('.'.join([module, name]), serialize_keras_model,
+                               deserialize_keras_model)


### PR DESCRIPTION
`keras` now comes bundled as part of the default `tensorflow` install via `tf.contrib.keras`: models instantiated that way look like `tensorflow.contrib.keras.python.keras.models.Sequential`.

Perhaps there's a better way to handle this? All six of the calls to `register_serialization` here are for classes that have basically the same API.