### PR TITLE
fix StopIteration behaviour in AsCompleted.batches

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2693,7 +2693,10 @@ class AsCompleted(object):
         [6]
         """
         while True:
-            yield self.next_batch(block=True)
+            try:
+                yield self.next_batch(block=True)
+            except StopIteration:
+                return
 
 
 as_completed = AsCompleted


### PR DESCRIPTION
PEP 479: generators should `return` instead of `raise StopIteration`

Fixes #1069