### PR TITLE
Fix #1064: Avoid warnings when client still running at exit

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -121,7 +121,7 @@ class TCP(Comm):
         set_tcp_timeout(stream)
 
     def _get_finalizer(self):
-        def finalize(stream=self.stream, r=repr(self), p=print):
+        def finalize(stream=self.stream, r=repr(self)):
             if not stream.closed():
                 logger.warn("Closing dangling stream in %s" % (r,))
                 stream.close()

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -121,7 +121,7 @@ class TCP(Comm):
         set_tcp_timeout(stream)
 
     def _get_finalizer(self):
-        def finalize(stream=self.stream, r=repr(self)):
+        def finalize(stream=self.stream, r=repr(self), p=print):
             if not stream.closed():
                 logger.warn("Closing dangling stream in %s" % (r,))
                 stream.close()

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -87,7 +87,7 @@ except ImportError:
     import itertools
     from weakref import ref
 
-    class finalize:
+    class finalize(object):
         """Class for finalization of weakrefable objects
 
         finalize(obj, func, *args, **kwargs) returns a callable finalizer

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -30,7 +30,7 @@ from distributed import Worker, Nanny, recreate_exceptions
 from distributed.comm import CommClosedError
 from distributed.utils_comm import WrappedKey
 from distributed.client import (Client, Future, _wait,
-        wait, _as_completed, as_completed, tokenize, _global_client,
+        wait, _as_completed, as_completed, tokenize, _get_global_client,
         default_client, _first_completed, ensure_default_get, futures_of,
         temp_default_client)
 from distributed.metrics import time
@@ -842,20 +842,20 @@ def test_get_releases_data(c, s, a, b):
 
 
 def test_global_clients(loop):
-    assert not _global_client[0]
+    assert _get_global_client() is None
     with pytest.raises(ValueError):
         default_client()
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
-            assert _global_client == [c]
+            assert _get_global_client() is c
             assert default_client() is c
             with Client(s['address'], loop=loop) as f:
-                assert _global_client == [f]
+                assert _get_global_client() is f
                 assert default_client() is f
                 assert default_client(c) is c
                 assert default_client(f) is f
 
-    assert not _global_client[0]
+    assert _get_global_client() is None
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_compatibility.py
+++ b/distributed/tests/test_compatibility.py
@@ -20,7 +20,10 @@ def test_finalize():
         l.append(value)
 
     o = C()
-    finalize(o, cb, 1)
+    f = finalize(o, cb, 1)
+    assert f in f._select_for_exit()
+    f.atexit = False
+    assert f not in f._select_for_exit()
     assert not l
     del o
     assert l.pop() == 1


### PR DESCRIPTION
This fixes two bugs:
- explicitly shutdown global client at process exit
- fix setting the "atexit" property on finalize objects on Python 2

Also, it makes the global client a weak reference to avoid risking keeping it alive longer than necessary.