### PR TITLE
check for len(workers) in Scheduler.retire_workers

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1791,8 +1791,11 @@ class Scheduler(Server):
                         pass
 
             workers = set(workers)
-            keys = set.union(*[self.has_what[w] for w in workers])
-            keys = {k for k in keys if self.who_has[k].issubset(workers)}
+            if len(workers) > 0:
+                keys = set.union(*[self.has_what[w] for w in workers])
+                keys = {k for k in keys if self.who_has[k].issubset(workers)}
+            else:
+                keys = set()
 
             other_workers = set(self.worker_info) - workers
             if keys:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -155,6 +155,15 @@ def test_no_workers(client, s):
         yield gen.with_timeout(timedelta(milliseconds=50), x._result())
 
 
+@gen_cluster(ncores=[])
+def test_retire_workers_empty(s):
+	x = s.retire_workers(workers=[])
+	while not x.done():
+		yield gen.sleep(0.01)
+
+	assert x.exception() is None
+
+
 @pytest.mark.skip
 def test_validate_state():
     dsk = {'x': 1, 'y': (inc, 'x')}

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -157,11 +157,7 @@ def test_no_workers(client, s):
 
 @gen_cluster(ncores=[])
 def test_retire_workers_empty(s):
-	x = s.retire_workers(workers=[])
-	while not x.done():
-		yield gen.sleep(0.01)
-
-	assert x.exception() is None
+    yield s.retire_workers(workers=[])
 
 
 @pytest.mark.skip


### PR DESCRIPTION
    In some scenarios workers set in retire_workers function gets empty,
    which then causes an exception in set.union, which gets no
    arguments. This commit adds check for number of workers in that
    place.