### PR TITLE
Always create worker's local directory

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -79,8 +79,6 @@ def handle_signal(sig, frame):
               help="File to write the process PID")
 @click.option('--local-directory', default='', type=str,
               help="Directory to place worker files")
-@click.option('--temp-filename', default=None,
-              help="Internal use only")
 @click.option('--resources', type=str, default='',
               help='Resources for task constraints like "GPU=2 MEM=10e9"')
 @click.option('--scheduler-file', type=str, default='',
@@ -94,7 +92,7 @@ def handle_signal(sig, frame):
               help='Module that should be loaded by each worker process '
                    'like "foo.bar" or "/path/to/foo.py"')
 def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
-         nanny, name, memory_limit, pid_file, temp_filename, reconnect,
+         nanny, name, memory_limit, pid_file, reconnect,
          resources, bokeh, bokeh_port, local_directory, scheduler_file,
          interface, death_timeout, preload, bokeh_prefix):
     if nanny:
@@ -188,18 +186,6 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
             n.start(port)
         if t is Nanny:
             global_nannies.append(n)
-
-    if temp_filename:
-        @gen.coroutine
-        def f():
-            while nannies[0].status != 'running':
-                yield gen.sleep(0.01)
-            import json
-            msg = {'port': nannies[0].port,
-                   'local_directory': nannies[0].local_dir}
-            with open(temp_filename, 'w') as f:
-                json.dump(msg, f)
-        loop.add_callback(f)
 
     @gen.coroutine
     def run():

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -89,11 +89,13 @@ def test_local_directory(loop, nanny):
             with popen(['dask-worker', '127.0.0.1:8786', nanny,
                         '--no-bokeh', '--local-directory', fn]) as worker:
                 with Client('127.0.0.1:8786', loop=loop, timeout=10) as c:
+                    start = time()
                     while not c.scheduler_info()['workers']:
                         sleep(0.1)
+                        assert time() < start + 8
                     info = c.scheduler_info()
                     worker = list(info['workers'].values())[0]
-                    assert worker['local_directory'] == fn
+                    assert worker['local_directory'].startswith(fn)
 
 
 @pytest.mark.parametrize('nanny', ['--nanny', '--no-nanny'])

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -46,17 +46,8 @@ class Nanny(Server):
         self.resources = resources
         self.death_timeout = death_timeout
         self.preload = preload
-        if not local_dir:
-            local_dir = tempfile.mkdtemp(prefix='nanny-')
-            self._should_cleanup_local_dir = True
-
-            @atexit.register
-            def _cleanup_local_dir():
-                if os.path.exists(local_dir):
-                    shutil.rmtree(local_dir)
-        else:
-            self._should_cleanup_local_dir = False
         self.local_dir = local_dir
+
         self.worker_dir = ''
         self.status = None
         self.process = None
@@ -264,8 +255,6 @@ class Nanny(Server):
                         self.process.terminate()
 
     def __del__(self):
-        if self._should_cleanup_local_dir and os.path.exists(self.local_dir):
-            shutil.rmtree(self.local_dir)
         self.cleanup()
 
     @gen.coroutine

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -6,7 +6,6 @@ import logging
 from multiprocessing.queues import Empty
 import os
 import shutil
-import tempfile
 from time import sleep
 import weakref
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -76,15 +76,18 @@ class WorkerBase(Server):
             scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))
         self._port = 0
         self.ncores = ncores or _ncores
-        self.local_dir = local_dir or tempfile.mkdtemp(prefix='worker-')
         self.total_resources = resources or {}
         self.available_resources = (resources or {}).copy()
         self.death_timeout = death_timeout
         self.preload = preload
         if silence_logs:
             logger.setLevel(silence_logs)
-        if not os.path.exists(self.local_dir):
-            os.mkdir(self.local_dir)
+
+        if local_dir:
+            local_dir = os.path.abspath(local_dir)
+            if not os.path.exists(local_dir):
+                os.mkdir(local_dir)
+        self.local_dir = tempfile.mkdtemp(prefix='worker-', dir=local_dir)
 
         if memory_limit == 'auto':
             memory_limit = int(TOTAL_MEMORY * 0.6 * min(1, self.ncores / _ncores))


### PR DESCRIPTION
Previously if given a directory we put files directly into that
directory.  This caused problems because users gave us large spaces like
/tmp or /local.  It also required us to track if we wanted to delete the
directory afterwards or not.

Now we *always* create a new directory and we always delete it when
finished.  This removes the ability to specify a particular space, but
it's not clear that this was being used.  This seems to be more
predictable and less error prone.

Also, we remove the temp_filename keyword, which is no longer needed.

cc @rabernat 

Fixes #1066 