### PR TITLE
Implement manual timeout for popen wait

### DIFF
--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -249,6 +249,7 @@ def test_bokeh_port_zero(loop):
             while count < 1:
                 line = proc.stderr.readline()
                 if b'bokeh' in line.lower() or b'web' in line.lower():
+                    sleep(0.01)
                     count += 1
                     assert b':0' not in line
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -565,7 +565,9 @@ def terminate_process(proc):
             if sys.version_info[0] == 3:
                 proc.wait(10)
             else:
-                proc.wait()
+                start = time()
+                while proc.poll() is None and time() < start + 10:
+                    sleep(0.02)
         finally:
             # Make sure we don't leave the process lingering around
             with ignoring(OSError):
@@ -595,12 +597,12 @@ def popen(*args, **kwargs):
             if dump_stdout:
                 line = '\n\nPrint from stderr\n=================\n'
                 while line:
-                    print(line)
+                    print(line, end='')
                     line = proc.stderr.readline()
 
                 line = '\n\nPrint from stdout\n=================\n'
                 while line:
-                    print(line)
+                    print(line, end='')
                     line = proc.stdout.readline()
 
 


### PR DESCRIPTION
This resolves the test_bokeh_zero_port intermittent error.  In Python
2.7 we Process.wait() lacks a timeout= keyword argument.  We implement
this manually with Process.poll and a sleep-while loop.

Additionally we add a small sleep in the bokeh-zero-port test to
minimize the frequency of the process hang (the original cause of which
remains unknown).