### PR TITLE
Except EnvironmentError when writing config file

### DIFF
--- a/distributed/config.py
+++ b/distributed/config.py
@@ -47,7 +47,7 @@ else:
     try:
         ensure_config_file()
         load_config_file(config)
-    except OSError as e:
+    except EnvironmentError as e:
         logger.warn("Could not write default config file to %s. Received error %s",
                     default_path, e)
 


### PR DESCRIPTION
We except errors when writing our config file to ~/.dask in case we
don't have permission, such as occurs in YARN settings.  Previously we
excepted OSErrors, however this didn't cover Python 2 situations.  Now
we cover the more broad EnvironmentError

See https://github.com/dask/dask-yarn/issues/10