### PR TITLE
Move import of `infer_storage_options`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1700,10 +1700,10 @@ class Client(Node):
 
         Examples
         --------
-        >>> from dask import do, value
+        >>> from dask import delayed
         >>> from operator import add
-        >>> x = dask.do(add)(1, 2)
-        >>> y = dask.do(add)(x, x)
+        >>> x = delayed(add)(1, 2)
+        >>> y = delayed(add)(x, x)
         >>> xx, yy = client.compute([x, y])  # doctest: +SKIP
         >>> xx  # doctest: +SKIP
         <Future: status: finished, key: add-8f6e709446674bad78ea8aeecfee188e>

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -6,7 +6,7 @@ import pytest
 pytest.importorskip('bokeh')
 from tornado import gen
 
-from dask import do
+from dask import delayed
 from distributed.client import _wait
 from distributed.diagnostics.progress_stream import (progress_quads,
         nbytes_bar, progress_stream, _incrementing_index_cache)
@@ -58,7 +58,7 @@ def test_progress_stream(c, s, a, b):
 
     x = 1
     for i in range(5):
-        x = do(inc)(x)
+        x = delayed(inc)(x)
     future = c.compute(x)
 
     yield _wait(futures + [future])

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -1,17 +1,17 @@
 """ This file is experimental and may disappear without warning """
 from __future__ import print_function, division, absolute_import
 
-import logging
-
 from dask.base import tokenize
 from dask.bytes import core
-from dask.utils import infer_storage_options
 from hdfs3 import HDFileSystem
 
+# infer_storage_options moved after dask 0.14.3 release
+try:
+    from dask.bytes.utils import infer_storage_options
+except ImportError:
+    from dask.utils import infer_storage_options
+
 from .utils import PY3
-
-
-logger = logging.getLogger(__name__)
 
 
 class DaskHDFileSystem(HDFileSystem):


### PR DESCRIPTION
`dask.utils.infer_storage_options` moved to `dask.bytes.utils.infer_storage_options`. We use a try/except block to remain compatible with older dask releases. See https://github.com/dask/dask/pull/2346.

Also deleted unused logger in `hdfs.py`.