### PR TITLE
Adds a warning to the local_dir parameter of Worker

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -903,7 +903,7 @@ class Worker(WorkerBase):
     ncores: int, optional
     loop: tornado.ioloop.IOLoop
     local_dir: str, optional
-        Directory where we place local resources
+        Directory where we place local resources. This will be destroyed when the worker exits.
     name: str, optional
     heartbeat_interval: int
         Milliseconds between heartbeats to scheduler


### PR DESCRIPTION
Tiny PR to add a warning to the local_dir parameter of Worker.

Justification: if you run a LocalCluster, the workers' paths don't include the directory that the LocalCluster was launched from, which means the workers can't load modules. The easy/obvious fix is to pass the LocalCluster an extra argument of `local_dir=os.getcwd()`. This does indeed fix the can't-load-modules problem, but it turns out that when it shuts down, the worker destroys it's working dir. Along with all your code and the local repo :(

(Fortunately I only lost an hour's work. Hooray for compulsive pushing) 