### PR TITLE
Serialize more dtypes

### DIFF
--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from numpy.lib import stride_tricks
 
 try:
     import blosc
@@ -52,16 +51,17 @@ def serialize_numpy_ndarray(x):
         dt = (0, x.dtype.str)
 
     if not x.shape:
+        # 0d array
         strides = x.strides
         data = x.ravel().view('u1').data
-    elif np.isfortran(x):
+    elif x.flags.c_contiguous or x.flags.f_contiguous:
+        # Avoid a copy and respect order when unserializing
         strides = x.strides
-        data = stride_tricks.as_strided(x, shape=(np.prod(x.shape),),
-                                           strides=(x.dtype.itemsize,)).view('u1').data
+        data = x.ravel(order='K').view('u1').data
     else:
         x = np.ascontiguousarray(x)
         strides = x.strides
-        data = x.ravel().view('u1').data
+        data = x.view('u1').data
 
     header = {'dtype': dt,
               'shape': x.shape,
@@ -88,18 +88,13 @@ def deserialize_numpy_ndarray(header, frames):
         is_custom, dt = header['dtype']
         if is_custom:
             dt = pickle.loads(dt)
-        elif isinstance(dt, tuple):
-            dt = list(dt)
+        else:
+            dt = np.dtype(dt)
 
         x = np.ndarray(header['shape'], dtype=dt, buffer=frames[0],
                        strides=header['strides'])
 
-        new_x = stride_tricks.as_strided(x, strides=header['strides'])
-        if new_x.dtype != x.dtype:
-            assert new_x.dtype.kind == x.dtype.kind
-            new_x = new_x.view(x.dtype)
-
-        return new_x
+        return x
 
 
 register_serialization(np.ndarray, serialize_numpy_ndarray, deserialize_numpy_ndarray)

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -38,7 +38,7 @@ def serialize_numpy_ndarray(x):
         # Preserving all the information works best when pickling
         try:
             # Only use stdlib pickle as cloudpickle is slow when failing
-            # (milliseconds instead of microseconds)
+            # (microseconds instead of nanoseconds)
             dt = (1, pickle.pickle.dumps(x.dtype))
             pickle.loads(dt[1])  # does it unpickle fine?
         except Exception:

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -31,6 +31,9 @@ def test_serialize():
 @pytest.mark.parametrize('x',
         [np.ones(5),
          np.array(5),
+         np.random.random((5, 5)),
+         np.random.random((5, 5))[::2, :],
+         np.random.random((5, 5))[:, ::2],
          np.asfortranarray(np.random.random((5, 5))),
          np.asfortranarray(np.random.random((5, 5)))[::2, :],
          np.asfortranarray(np.random.random((5, 5)))[:, ::2],
@@ -67,7 +70,7 @@ def test_dumps_serialize_numpy(x):
     y = deserialize(header, frames)
 
     np.testing.assert_equal(x, y)
-    if np.isfortran(x):
+    if x.flags.c_contiguous or x.flags.f_contiguous:
         assert x.strides == y.strides
 
 


### PR DESCRIPTION
Structured dtypes (kind 'V') can have additional complication which require more care than is currently done.

Also remove unnecessary `stride_tricks` calls.