### PR TITLE
Fix warning when garbage collecting AioClient

### DIFF
--- a/distributed/asyncio.py
+++ b/distributed/asyncio.py
@@ -152,6 +152,10 @@ class AioClient(Client):
         finally:
             BaseAsyncIOLoop.clear_current()
 
+    def __del__(self):
+        # Override Client.__del__ to avoid running self.shutdown()
+        assert self.status != 'running'
+
     gather = to_asyncio(Client._gather)
     scatter = to_asyncio(Client._scatter)
     cancel = to_asyncio(Client._cancel)


### PR DESCRIPTION
AioClient would inherit `Client.__del__` and print out such warnings:
```
  /home/antoine/distributed/distributed/client.py:594: RuntimeWarning: coroutine 'AioClient.shutdown' was never awaited
    self.shutdown()
```