### PR TITLE
Make test_silent_startup more robust

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -126,6 +126,8 @@ class BatchedSend(object):
     def abort(self):
         if self.comm is None:
             return
+        self.please_stop = True
+        self.buffer = []
         self.waker.set()
         if not self.comm.closed():
             self.comm.abort()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -749,7 +749,7 @@ class Client(Node):
 
         if self._should_close_loop:
             sync(self.loop, self.loop.stop)
-            self.loop.close(all_fds=False)
+            self.loop.close()
             self._loop_thread.join(timeout=timeout)
         with ignoring(AttributeError):
             dask.set_options(get=self._previous_get)

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -68,23 +68,42 @@ def load_env_vars(config):
             config[varname] = value
 
 
-def initialize_logging(config):
+def _get_logging_config(config):
     loggers = config.get('logging', {})
     loggers.setdefault('distributed', 'info')
-    # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
+    # We could remove those lines and let the default config.yaml handle it
     loggers.setdefault('tornado', 'critical')
     loggers.setdefault('tornado.application', 'error')
+    return loggers
+
+
+def initialize_logging(config):
+    loggers = _get_logging_config(config)
 
     fmt = '%(name)s - %(levelname)s - %(message)s'
 
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(logging.Formatter(fmt))
     for name, level in loggers.items():
-        LEVEL = logging_names[level.upper()]
+        if isinstance(level, str):
+            level = logging_names[level.upper()]
         logger = logging.getLogger(name)
-        logger.setLevel(LEVEL)
+        logger.setLevel(level)
         logger.addHandler(handler)
         logger.propagate = False
+
+
+def silence_logging(level, root='distributed'):
+    loggers = _get_logging_config(config)
+
+    if isinstance(level, str):
+        level = logging_names[level.upper()]
+    for name in loggers:
+        if name.startswith(root + '.'):
+            logger = logging.getLogger(name)
+            logger.setLevel(level)
+
+    logging.getLogger(root).setLevel(level)
 
 
 try:

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -68,17 +68,12 @@ def load_env_vars(config):
             config[varname] = value
 
 
-def _get_logging_config(config):
+def initialize_logging(config):
     loggers = config.get('logging', {})
     loggers.setdefault('distributed', 'info')
     # We could remove those lines and let the default config.yaml handle it
     loggers.setdefault('tornado', 'critical')
     loggers.setdefault('tornado.application', 'error')
-    return loggers
-
-
-def initialize_logging(config):
-    loggers = _get_logging_config(config)
 
     fmt = '%(name)s - %(levelname)s - %(message)s'
 
@@ -91,19 +86,6 @@ def initialize_logging(config):
         logger.setLevel(level)
         logger.addHandler(handler)
         logger.propagate = False
-
-
-def silence_logging(level, root='distributed'):
-    loggers = _get_logging_config(config)
-
-    if isinstance(level, str):
-        level = logging_names[level.upper()]
-    for name in loggers:
-        if name.startswith(root + '.'):
-            logger = logging.getLogger(name)
-            logger.setLevel(level)
-
-    logging.getLogger(root).setLevel(level)
 
 
 try:

--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -2,6 +2,9 @@ logging:
   distributed: info
   distributed.client: warning
   bokeh: critical
+  # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
+  tornado: critical
+  tornado.application: error
 
 compression: auto
 

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -98,10 +98,12 @@ class LocalCluster(object):
         if diagnostics_port is not None:
             try:
                 from distributed.bokeh.scheduler import BokehScheduler
+                from distributed.bokeh.worker import BokehWorker
             except ImportError:
                 logger.debug("To start diagnostics web server please install Bokeh")
             else:
                 services[('bokeh', diagnostics_port)] = BokehScheduler
+                worker_services[('bokeh', 0)] = BokehWorker
 
         self.scheduler = Scheduler(loop=self.loop,
                                    services=services)
@@ -167,15 +169,6 @@ class LocalCluster(object):
             kwargs['quiet'] = True
         else:
             W = Worker
-
-        try:
-            from distributed.bokeh.worker import BokehWorker
-        except ImportError:
-            pass
-        else:
-            if 'services' not in kwargs:
-                kwargs['services'] = {}
-            kwargs['services'][('bokeh', 0)] = BokehWorker
 
         w = W(self.scheduler.address, loop=self.loop,
               death_timeout=death_timeout,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -11,9 +11,8 @@ import weakref
 from tornado import gen
 from tornado.ioloop import IOLoop
 
-from ..config import silence_logging
 from ..core import CommClosedError
-from ..utils import sync, ignoring, All
+from ..utils import sync, ignoring, All, silence_logging
 from ..nanny import Nanny
 from ..scheduler import Scheduler
 from ..worker import Worker, _ncores

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -11,6 +11,7 @@ import weakref
 from tornado import gen
 from tornado.ioloop import IOLoop
 
+from ..config import silence_logging
 from ..core import CommClosedError
 from ..utils import sync, ignoring, All
 from ..nanny import Nanny
@@ -69,11 +70,7 @@ class LocalCluster(object):
         self.processes = processes
         self.silence_logs = silence_logs
         if silence_logs:
-            for l in ['distributed.scheduler',
-                      'distributed.worker',
-                      'distributed.core',
-                      'distributed.nanny']:
-                logging.getLogger(l).setLevel(silence_logs)
+            silence_logging(level=silence_logs)
         if n_workers is None and threads_per_worker is None:
             if processes:
                 n_workers = _ncores

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from functools import partial
+import subprocess
 import sys
 from time import sleep
 from threading import Lock
@@ -251,19 +252,22 @@ def test_scale_up_and_down():
     yield cluster._close()
 
 
-def test_silent_startup(capsys, loop):
-    with LocalCluster(1, diagnostics_port=None, loop=loop, scheduler_port=0):
-        sleep(0.5)
+def test_silent_startup():
+    code = """if 1:
+        from time import sleep
+        from distributed import LocalCluster
 
-    out, err = capsys.readouterr()
+        with LocalCluster(1, diagnostics_port=None, scheduler_port=0):
+            sleep(1.5)
+        """
+
+    out = subprocess.check_output([sys.executable, "-Wi", "-c", code],
+                                  stderr=subprocess.STDOUT)
     try:
         assert not out
-        assert not err
     except AssertionError:
-        print("=== Cluster stdout ===")
-        print(out)
-        print("=== Cluster stderr ===")
-        print(err)
+        print("=== Cluster stdout / stderr ===")
+        print(out.decode())
         raise
 
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -13,6 +13,7 @@ from tornado.ioloop import IOLoop, TimeoutError
 from tornado import gen
 
 from .comm import get_address_host, get_local_address_for
+from .config import silence_logging
 from .core import rpc, RPCClosed, CommClosedError, coerce_to_address
 from .metrics import disk_io_counters, net_io_counters, time
 from .node import ServerNode
@@ -68,7 +69,7 @@ class Nanny(ServerNode):
         self.should_watch = True
 
         if silence_logs:
-            logger.setLevel(silence_logs)
+            silence_logging(level=silence_logs)
         self.silence_logs = silence_logs
 
         handlers = {'instantiate': self.instantiate,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -335,7 +335,8 @@ class Nanny(ServerNode):
 
 
 def run_worker_fork(q, scheduler_addr, ncores, nanny_port,
-                    worker_ip, worker_port, local_dir, **kwargs):
+                    worker_ip, worker_port, local_dir, silence_logs,
+                    **kwargs):
     """
     Create a worker in a forked child.
     """
@@ -349,11 +350,15 @@ def run_worker_fork(q, scheduler_addr, ncores, nanny_port,
     else:
         initialize_worker_process()
 
+    if silence_logs:
+        logger.setLevel(silence_logs)
+
     IOLoop.clear_instance()  # pragma: no cover
     loop = IOLoop()  # pragma: no cover
     loop.make_current()  # pragma: no cover
     worker = Worker(scheduler_addr, ncores=ncores,
-                    service_ports={'nanny': nanny_port}, local_dir=local_dir,
+                    service_ports={'nanny': nanny_port},
+                    local_dir=local_dir, silence_logs=silence_logs,
                     **kwargs)  # pragma: no cover
 
     @gen.coroutine  # pragma: no cover

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -13,12 +13,11 @@ from tornado.ioloop import IOLoop, TimeoutError
 from tornado import gen
 
 from .comm import get_address_host, get_local_address_for
-from .config import silence_logging
 from .core import rpc, RPCClosed, CommClosedError, coerce_to_address
 from .metrics import disk_io_counters, net_io_counters, time
 from .node import ServerNode
 from .security import Security
-from .utils import get_ip, ignoring, mp_context, log_errors
+from .utils import get_ip, ignoring, mp_context, log_errors, silence_logging
 from .worker import _ncores, run
 
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -383,7 +383,7 @@ def run_worker_fork(q, scheduler_addr, ncores, nanny_port,
         pass
     finally:
         loop.stop()
-        loop.close(all_fds=True)
+        loop.close()
 
 
 def isalive(proc):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1296,7 +1296,8 @@ class Scheduler(ServerNode):
             self.remove_worker(address=worker)
             return
         yield comm.write({'op': 'compute-stream', 'reply': False})
-        self.worker_comms[worker].start(comm)
+        worker_comm = self.worker_comms[worker]
+        worker_comm.start(comm)
         logger.info("Starting worker compute stream, %s", worker)
 
         io_error = None
@@ -1341,10 +1342,11 @@ class Scheduler(ServerNode):
                 if io_error:
                     logger.info("Worker %r failed from closed comm: %s",
                                 worker, io_error)
-                yield comm.close()
+                worker_comm.abort()
                 self.remove_worker(address=worker)
             else:
                 assert comm.closed()
+                worker_comm.abort()
 
     def correct_time_delay(self, worker, msg):
         """

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -111,8 +111,8 @@ def test_server_listen():
 
     # Note server.address is the concrete, contactable address
 
-    with listen_on(Server, 8882) as server:
-        assert server.port == 8882
+    with listen_on(Server, 7800) as server:
+        assert server.port == 7800
         assert server.address == 'tcp://%s:%d' % (EXTERNAL_IP4, server.port)
         yield assert_can_connect(server.address)
         yield assert_can_connect_from_everywhere_4_6(server.port)
@@ -129,34 +129,34 @@ def test_server_listen():
         yield assert_can_connect(server.address)
         yield assert_can_connect_from_everywhere_4_6(server.port)
 
-    with listen_on(Server, ('', 2468)) as server:
-        assert server.port == 2468
+    with listen_on(Server, ('', 7801)) as server:
+        assert server.port == 7801
         assert server.address == 'tcp://%s:%d' % (EXTERNAL_IP4, server.port)
         yield assert_can_connect(server.address)
         yield assert_can_connect_from_everywhere_4_6(server.port)
 
-    with listen_on(Server, 'tcp://:2468') as server:
-        assert server.port == 2468
+    with listen_on(Server, 'tcp://:7802') as server:
+        assert server.port == 7802
         assert server.address == 'tcp://%s:%d' % (EXTERNAL_IP4, server.port)
         yield assert_can_connect(server.address)
         yield assert_can_connect_from_everywhere_4_6(server.port)
 
     # Only IPv4
 
-    with listen_on(Server, ('0.0.0.0', 2468)) as server:
-        assert server.port == 2468
+    with listen_on(Server, ('0.0.0.0', 7810)) as server:
+        assert server.port == 7810
         assert server.address == 'tcp://%s:%d' % (EXTERNAL_IP4, server.port)
         yield assert_can_connect(server.address)
         yield assert_can_connect_from_everywhere_4(server.port)
 
-    with listen_on(Server, ('127.0.0.1', 2468)) as server:
-        assert server.port == 2468
+    with listen_on(Server, ('127.0.0.1', 7811)) as server:
+        assert server.port == 7811
         assert server.address == 'tcp://127.0.0.1:%d' % server.port
         yield assert_can_connect(server.address)
         yield assert_can_connect_locally_4(server.port)
 
-    with listen_on(Server, 'tcp://127.0.0.1:2468') as server:
-        assert server.port == 2468
+    with listen_on(Server, 'tcp://127.0.0.1:7812') as server:
+        assert server.port == 7812
         assert server.address == 'tcp://127.0.0.1:%d' % server.port
         yield assert_can_connect(server.address)
         yield assert_can_connect_locally_4(server.port)
@@ -164,20 +164,20 @@ def test_server_listen():
     # Only IPv6
 
     if has_ipv6():
-        with listen_on(Server, ('::', 2468)) as server:
-            assert server.port == 2468
+        with listen_on(Server, ('::', 7813)) as server:
+            assert server.port == 7813
             assert server.address == 'tcp://[%s]:%d' % (EXTERNAL_IP6, server.port)
             yield assert_can_connect(server.address)
             yield assert_can_connect_from_everywhere_6(server.port)
 
-        with listen_on(Server, ('::1', 2468)) as server:
-            assert server.port == 2468
+        with listen_on(Server, ('::1', 7814)) as server:
+            assert server.port == 7814
             assert server.address == 'tcp://[::1]:%d' % server.port
             yield assert_can_connect(server.address)
             yield assert_can_connect_locally_6(server.port)
 
-        with listen_on(Server, 'tcp://[::1]:2468') as server:
-            assert server.port == 2468
+        with listen_on(Server, 'tcp://[::1]:7815') as server:
+            assert server.port == 7815
             assert server.address == 'tcp://[::1]:%d' % server.port
             yield assert_can_connect(server.address)
             yield assert_can_connect_locally_6(server.port)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -377,6 +377,21 @@ def log_errors(pdb=False):
         raise
 
 
+def silence_logging(level, root='distributed'):
+    """
+    Force all existing loggers below *root* to the given level at least
+    (or keep the existing level if less verbose).
+    """
+    if isinstance(level, str):
+        level = logging_names[level.upper()]
+
+    for name, logger in logging.root.manager.loggerDict.items():
+        if (isinstance(logger, logging.Logger)
+            and logger.name.startswith(root + '.')
+            and logger.level < level):
+            logger.setLevel(level)
+
+
 @memoize
 def ensure_ip(hostname):
     """ Ensure that address is an IP address

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -25,7 +25,7 @@ from tornado.locks import Event
 
 from .batched import BatchedSend
 from .comm import get_address_host, get_local_address_for
-from .config import config, silence_logging
+from .config import config
 from .compatibility import unicode
 from .core import (error_message, CommClosedError,
                    rpc, pingpong, coerce_to_address)
@@ -38,7 +38,8 @@ from .security import Security
 from .sizeof import safe_sizeof as sizeof
 from .threadpoolexecutor import ThreadPoolExecutor
 from .utils import (funcname, get_ip, has_arg, _maybe_complex, log_errors,
-                    ignoring, validate_key, mp_context, import_file)
+                    ignoring, validate_key, mp_context, import_file,
+                    silence_logging)
 from .utils_comm import pack_data, gather_from_workers
 
 _ncores = mp_context.cpu_count()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -25,7 +25,7 @@ from tornado.locks import Event
 
 from .batched import BatchedSend
 from .comm import get_address_host, get_local_address_for
-from .config import config
+from .config import config, silence_logging
 from .compatibility import unicode
 from .core import (error_message, CommClosedError,
                    rpc, pingpong, coerce_to_address)
@@ -84,7 +84,7 @@ class WorkerBase(ServerNode):
         self.death_timeout = death_timeout
         self.preload = preload
         if silence_logs:
-            logger.setLevel(silence_logs)
+            silence_logging(level=silence_logs)
 
         if local_dir:
             local_dir = os.path.abspath(local_dir)


### PR DESCRIPTION
Launch code in a subprocess to avoid cleanup logs from dangling coroutines or GC runs.