### PR TITLE
More as completed methods

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2649,6 +2649,11 @@ class AsCompleted(object):
             self.futures[future] += 1
         self.loop.add_callback(self.track_future, future)
 
+    def is_empty(self):
+        """Return True if there no waiting futures, False otherwise"""
+        with self.lock:
+            return not self.futures and self.queue.empty()
+
     def __iter__(self):
         return self
 
@@ -2656,9 +2661,8 @@ class AsCompleted(object):
         return self
 
     def __next__(self):
-        with self.lock:
-            if not self.futures and self.queue.empty():
-                raise StopIteration()
+        if self.is_empty():
+            raise StopIteration()
         return self.queue.get()
 
     @gen.coroutine

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2620,8 +2620,7 @@ class AsCompleted(object):
         self.with_results = with_results
 
         if futures:
-            for future in futures:
-                self.add(future)
+            self.update(futures)
 
     @gen.coroutine
     def track_future(self, future):
@@ -2642,8 +2641,8 @@ class AsCompleted(object):
         """ Add multiple futures to the collection.
 
         The added futures will emit from the iterator once they finish"""
-        for f in futures:
-            with self.lock:
+        with self.lock:
+            for f in futures:
                 if not isinstance(f, Future):
                     raise TypeError("Input must be a future, got %s" % f)
                 self.futures[f] += 1

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -5,8 +5,7 @@ import random
 import pytest
 
 from distributed import Client
-from distributed.client import (_as_completed, as_completed, _first_completed,
-        AsCompleted)
+from distributed.client import _as_completed, as_completed, _first_completed
 from distributed.utils_test import gen_cluster, inc, loop, cluster
 from distributed.compatibility import Queue
 
@@ -43,7 +42,7 @@ def test_as_completed(loop):
 
 def test_as_completed_with_non_futures(loop):
     with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
+        with Client(s['address'], loop=loop):
             with pytest.raises(TypeError):
                 list(as_completed([1, 2, 3]))
 
@@ -54,7 +53,7 @@ def test_as_completed_add(loop):
             total = 0
             expected = sum(map(inc, range(10)))
             futures = c.map(inc, range(10))
-            ac = AsCompleted(futures)
+            ac = as_completed(futures)
             for future in ac:
                 result = future.result()
                 total += result
@@ -71,7 +70,7 @@ def test_as_completed_update(loop):
             total = 0
             todo = list(range(10))
             expected = sum(map(inc, todo))
-            ac = AsCompleted([])
+            ac = as_completed([])
             while todo or not ac.is_empty():
                 if todo:
                     work, todo = todo[:4], todo[4:]
@@ -84,7 +83,7 @@ def test_as_completed_update(loop):
 def test_as_completed_repeats(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
-            ac = AsCompleted()
+            ac = as_completed()
             x = c.submit(inc, 1)
             ac.add(x)
             ac.add(x)
@@ -102,7 +101,7 @@ def test_as_completed_repeats(loop):
 def test_as_completed_is_empty(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
-            ac = AsCompleted()
+            ac = as_completed()
             assert ac.is_empty()
             x = c.submit(inc, 1)
             ac.add(x)

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -81,3 +81,15 @@ def test_as_completed_repeats(loop):
 
             ac.add(x)
             assert next(ac) is x
+
+
+def test_as_completed_is_empty(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            ac = AsCompleted()
+            assert ac.is_empty()
+            x = c.submit(inc, 1)
+            ac.add(x)
+            assert not ac.is_empty()
+            assert next(ac) is x
+            assert ac.is_empty()


### PR DESCRIPTION
Add two new methods to `AsCompleted`:

- `is_empty`: returns True if there no waiting futures, False otherwise
- `update`: a bulk version of `add`

I'm not set on the names. Since we have `add`, I used `update` instead of `extend` to better mirror a `set`. For `is_empty`, the `Queue` class has an `empty` method, but I don't like that name as it could be confused with `clear`.

I also thought about implementing `__bool__` as `not self.is_empty()`, but didn't yet. Could go either way on that.