### PR TITLE
Distributed Queues

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -8,6 +8,7 @@ from .client import (Client, Executor, CompatibleExecutor,
                      wait, as_completed, default_client)
 from .tornado_client import TornadoClient
 from .nanny import Nanny
+from .queues import Queue
 from .scheduler import Scheduler
 from .utils import sync
 from .worker import Worker, get_worker

--- a/distributed/channels.py
+++ b/distributed/channels.py
@@ -236,13 +236,10 @@ class Channel(object):
         with self._lock:
             self.count += 1
             if type == 'Future':
-                self.data.append(Future(value, self.client))
+                self.data.append(Future(value, self.client, inform=True))
             else:
                 self.data.append(value)
         if type == 'Future':
-            self.client._send_to_scheduler({'op': 'client-desires-keys',
-                                            'keys': [value],
-                                            'client': self.client.id})
             if value in self._pending:
                 del self._pending[value]
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -92,11 +92,11 @@ class Future(WrappedKey):
     _cb_executor = None
     _cb_executor_pid = None
 
-    def __init__(self, key, client):
+    def __init__(self, key, client, inform=False):
         self.key = key
         self._cleared = False
         tkey = tokey(key)
-        self.client = client
+        self.client = client or _get_global_client()
         self.client._inc_ref(tkey)
         self._generation = self.client.generation
 
@@ -104,6 +104,11 @@ class Future(WrappedKey):
             self._state = client.futures[tkey]
         else:
             self._state = client.futures[tkey] = FutureState(Event())
+
+        if inform:
+            self.client._send_to_scheduler({'op': 'client-desires-keys',
+                                            'keys': [tokey(key)],
+                                            'client': self.client.id})
 
     @property
     def executor(self):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -397,6 +397,7 @@ class Client(Node):
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args('client')
         self._connecting_to_scheduler = False
+        self._asynchronous = asynchronous
 
         if loop is None:
             self._should_close_loop = None

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -1,18 +1,14 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import deque, defaultdict
+from collections import defaultdict
 import logging
-from time import sleep
-import threading
 import uuid
-import warnings
 
 from tornado import gen
 import tornado.queues
 
 from .client import Future, _get_global_client, in_ioloop
-from .core import CommClosedError
-from .utils import tokey, log_errors, sync
+from .utils import tokey, sync
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +117,7 @@ class Queue(object):
             yield self.client.scheduler.queue_put(data=value,
                                                   timeout=timeout,
                                                   name=self.name)
+
     def put(self, value, timeout=None):
         return sync(self.client.loop, self._put, value, timeout=timeout)
 

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -121,6 +121,14 @@ class Queue(object):
             yield self.client.scheduler.queue_put(data=value,
                                                   timeout=timeout,
                                                   name=self.name)
+    def put(self, value, timeout=None):
+        return sync(self.client.loop, self._put, value, timeout=timeout)
+
+    def get(self, timeout=None):
+        return sync(self.client.loop, self._get, timeout=timeout)
+
+    def qsize(self):
+        return sync(self.client.loop, self._qsize)
 
     @gen.coroutine
     def _get(self, timeout=None):

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -1,0 +1,127 @@
+from __future__ import print_function, division, absolute_import
+
+from collections import deque, defaultdict
+import logging
+from time import sleep
+import threading
+import uuid
+import warnings
+
+from tornado import gen
+import tornado.queues
+
+from .client import Future, _get_global_client
+from .core import CommClosedError
+from .utils import tokey, log_errors, sync
+
+logger = logging.getLogger(__name__)
+
+
+class QueueExtension(object):
+    """ An extension for the scheduler to manage queues
+
+    This adds the following routes to the scheduler
+
+    *  queue-create
+    *  queue-release
+    *  queue-put
+    *  queue-get
+    *  queue-size
+    """
+    def __init__(self, scheduler):
+        self.scheduler = scheduler
+        self.queues = dict()
+        self.refcount = defaultdict(lambda: 0)
+
+        self.scheduler.handlers.update({'queue_create': self.create,
+                                        'queue_release': self.release,
+                                        'queue_put': self.put,
+                                        'queue_get': self.get,
+                                        'queue_qsize': self.qsize})
+
+        self.scheduler.extensions['queues'] = self
+
+    def create(self, stream=None, name=None, client=None, maxsize=0):
+        if name not in self.queues:
+            self.queues[name] = tornado.queues.Queue(maxsize=maxsize)
+            self.refcount[name] = 1
+        else:
+            self.refcount[name] += 1
+
+    def release(self, stream=None, name=None, client=None):
+        self.refcount[name] -= 1
+        if self.refcount[name] == 0:
+            del self.refcount[name]
+            futures = self.queues[name].queue
+            del self.queues[name]
+            self.scheduler.client_releases_keys(keys=[f.key for f in futures],
+                                                client='queue-plugin')
+
+    @gen.coroutine
+    def put(self, stream=None, name=None, key=None, client=None, timeout=None):
+        yield self.queues[name].put(key, timeout=timeout)
+        self.scheduler.client_desires_keys(keys=[key], client='queue-plugin')
+
+    @gen.coroutine
+    def get(self, stream=None, name=None, client=None, timeout=None):
+        key = yield self.queues[name].get(timeout=timeout)
+        raise gen.Return(key)
+
+    def qsize(self, stream=None, name=None, client=None):
+        return self.queues[name].qsize()
+
+
+class Queue(object):
+    """ Distributed Queue
+
+    This allows multiple clients to share futures between each other with a
+    multi-producer/multi-consumer queue.  All metadata is sequentialized
+    through the scheduler.
+
+    Examples
+    --------
+    >>> from dask.distributed import Client, Queue  # doctest: +SKIP
+    >>> client = Client()  # doctest: +SKIP
+    >>> queue = Queue('x')  # doctest: +SKIP
+    >>> future = client.submit(f, x)  # doctest: +SKIP
+    >>> queue.put(future)  # doctest: +SKIP
+    """
+    def __init__(self, name=None, client=None, maxsize=0):
+        self.client = client or _get_global_client()
+        self.name = name or 'queue-' + uuid.uuid4().hex
+        self._started = self.client.scheduler.queue_create(name=name,
+                                                           maxsize=maxsize)
+        if self.client.loop._thread_ident != threading.get_ident():
+            sync(self.client.loop, gen.coroutine(lambda: self._started))
+
+    def __await__(self):
+        @gen.coroutine
+        def _():
+            yield self._started
+            raise gen.Return(self)
+        return _().__await__()
+
+    @gen.coroutine
+    def _put(self, future, timeout=None):
+        yield self.client.scheduler.queue_put(key=tokey(future.key),
+                                              timeout=timeout,
+                                              name=self.name)
+
+    @gen.coroutine
+    def _get(self, timeout=None):
+        key = yield self.client.scheduler.queue_get(timeout=timeout, name=self.name)
+        future = Future(key, self.client)
+        raise gen.Return(future)
+
+    @gen.coroutine
+    def _qsize(self):
+        result = yield self.client.scheduler.queue_qsize(name=self.name)
+        raise gen.Return(result)
+
+    def _release(self):
+        if self.client.status == 'running':  # TODO: can leave zombie futures
+            self.client._send_to_scheduler({'op': 'queue_release',
+                                            'name': self.name})
+
+    def __del__(self):
+        self._release()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -34,6 +34,7 @@ from .metrics import time
 from .node import ServerNode
 from .publish import PublishExtension
 from .channels import ChannelScheduler
+from .queues import QueueExtension
 from .stealing import WorkStealing
 from .recreate_exceptions import ReplayExceptionScheduler
 from .security import Security
@@ -189,7 +190,7 @@ class Scheduler(ServerNode):
                  delete_interval=500, synchronize_worker_interval=60000,
                  services=None, allowed_failures=ALLOWED_FAILURES,
                  extensions=[ChannelScheduler, PublishExtension, WorkStealing,
-                             ReplayExceptionScheduler],
+                             ReplayExceptionScheduler, QueueExtension],
                  validate=False, scheduler_file=None, security=None,
                  **kwargs):
 

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -27,3 +27,18 @@ def test_queue(c, s, a, b):
 
     with pytest.raises(gen.TimeoutError):
         yield x._get(timeout=0.1)
+
+
+@gen_cluster(client=True)
+def test_queue_with_data(c, s, a, b):
+    x = yield Queue('x')
+    xx = yield Queue('x')
+    assert x.client is c
+
+    yield x._put([1, 'hello'])
+    data = yield xx._get()
+
+    assert data == [1, 'hello']
+
+    with pytest.raises(gen.TimeoutError):
+        yield x._get(timeout=0.1)

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -16,17 +16,30 @@ from distributed.utils_test import gen_cluster, inc, loop, cluster, slowinc
 @gen_cluster(client=True)
 def test_queue(c, s, a, b):
     x = yield Queue('x')
+    y = yield Queue('y')
     xx = yield Queue('x')
     assert x.client is c
 
     future = c.submit(inc, 1)
 
     yield x._put(future)
+    yield y._put(future)
     future2 = yield xx._get()
     assert future.key == future2.key
 
     with pytest.raises(gen.TimeoutError):
         yield x._get(timeout=0.1)
+
+    del future, future2
+
+    yield gen.sleep(0.1)
+    assert s.task_state  # future still present in y's queue
+    yield y._get()  # burn future
+
+    start = time()
+    while s.task_state:
+        yield gen.sleep(0.01)
+        assert time() < start + 5
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -55,3 +55,17 @@ def test_queue_with_data(c, s, a, b):
 
     with pytest.raises(gen.TimeoutError):
         yield x._get(timeout=0.1)
+
+
+def test_sync(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address']) as c:
+            future = c.submit(lambda x: x + 1, 10)
+            x = Queue('x')
+            xx = Queue('x')
+            x.put(future)
+            assert x.qsize() == 1
+            assert xx.qsize() == 1
+            future2 = xx.get()
+
+            assert future2.result() == 11

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -1,0 +1,29 @@
+from __future__ import print_function, division, absolute_import
+
+from operator import add
+from time import sleep
+
+import pytest
+from toolz import take
+from tornado import gen
+
+from distributed import Client, Queue
+from distributed import worker_client
+from distributed.metrics import time
+from distributed.utils_test import gen_cluster, inc, loop, cluster, slowinc
+
+
+@gen_cluster(client=True)
+def test_queue(c, s, a, b):
+    x = yield Queue('x')
+    xx = yield Queue('x')
+    assert x.client is c
+
+    future = c.submit(inc, 1)
+
+    yield x._put(future)
+    future2 = yield xx._get()
+    assert future.key == future2.key
+
+    with pytest.raises(gen.TimeoutError):
+        yield x._get(timeout=0.1)

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -73,7 +73,7 @@ def test_sync(loop):
 
 @gen_cluster()
 def test_hold_futures(s, a, b):
-    c1 = yield Client(s.address)
+    c1 = yield Client(s.address, asynchronous=True)
     future = c1.submit(lambda x: x + 1, 10)
     q1 = yield Queue('q')
     yield q1._put(future)
@@ -82,7 +82,7 @@ def test_hold_futures(s, a, b):
 
     yield gen.sleep(0.1)
 
-    c2 = yield Client(s.address)
+    c2 = yield Client(s.address, asynchronous=True)
     q2 = yield Queue('q')
     future2 = yield q2._get()
     result = yield future2


### PR DESCRIPTION
This adds a multi-consumer multi-producer queue mediated by the scheduler.  

```python
In [1]: from distributed import Client, Queue

In [2]: client = Client()

In [3]: q = Queue('x')

In [4]: future = client.submit(lambda x: x + 1, 10)

In [5]: q.put(future)

In [6]: q.put(['hello', 'world'])

In [7]: client2 = Client(client.scheduler.address)

In [8]: q2 = Queue('x', client=client2)

In [9]: q2.get()
Out[9]: <Future: status: pending, key: <lambda>-7c3d5d0b0f151b79059d85d7dda814b0>

In [10]: _.result()
Out[10]: 11

In [11]: q2.get()
Out[11]: ['hello', 'world']

In [12]: q2.get(timeout=1)
TimeoutError: 
```

This builds on #1115 

cc @MLnick you may prefer these to channels for sending updates from workers to your parameter server.  They will be nicer in that they won't hold on to the updates in memory forever, but will release them quickly.