### PR TITLE
minimal fix for Python 2.7.6 compatibility

### DIFF
--- a/distributed/security.py
+++ b/distributed/security.py
@@ -126,6 +126,7 @@ class Security(object):
         """
         d = {}
         tls = self.get_tls_config_for_role(role)
+        # Ensure backwards compatibility (ssl.Purpose is Python 2.7.9+ only)
         purpose = ssl.Purpose.SERVER_AUTH if hasattr(ssl, "Purpose") else None
         d['ssl_context'] = self._get_tls_context(tls, purpose)
         d['require_encryption'] = self.require_encryption
@@ -138,6 +139,7 @@ class Security(object):
         """
         d = {}
         tls = self.get_tls_config_for_role(role)
+        # Ensure backwards compatibility (ssl.Purpose is Python 2.7.9+ only)
         purpose = ssl.Purpose.CLIENT_AUTH if hasattr(ssl, "Purpose") else None
         d['ssl_context'] = self._get_tls_context(tls, purpose)
         d['require_encryption'] = self.require_encryption

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -123,7 +123,8 @@ class Security(object):
         """
         d = {}
         tls = self.get_tls_config_for_role(role)
-        d['ssl_context'] = self._get_tls_context(tls, ssl.Purpose.SERVER_AUTH)
+        purpose = ssl.Purpose.SERVER_AUTH if hasattr(ssl, "Purpose") else None
+        d['ssl_context'] = self._get_tls_context(tls, purpose)
         d['require_encryption'] = self.require_encryption
         return d
 
@@ -134,6 +135,7 @@ class Security(object):
         """
         d = {}
         tls = self.get_tls_config_for_role(role)
-        d['ssl_context'] = self._get_tls_context(tls, ssl.Purpose.CLIENT_AUTH)
+        purpose = ssl.Purpose.CLIENT_AUTH if hasattr(ssl, "Purpose") else None
+        d['ssl_context'] = self._get_tls_context(tls, purpose)
         d['require_encryption'] = self.require_encryption
         return d

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -105,8 +105,11 @@ class Security(object):
 
     def _get_tls_context(self, tls, purpose):
         if tls.get('ca_file') and tls.get('cert'):
-            ctx = ssl.create_default_context(purpose=purpose,
-                                             cafile=tls['ca_file'])
+            try:
+                ctx = ssl.create_default_context(purpose=purpose,
+                                                 cafile=tls['ca_file'])
+            except AssertionError:
+                raise RuntimeError("TLS functionality requires Python 2.7.9+")
             ctx.verify_mode = ssl.CERT_REQUIRED
             # We expect a dedicated CA for the cluster and people using
             # IP addresses rather than hostnames

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -108,7 +108,7 @@ class Security(object):
             try:
                 ctx = ssl.create_default_context(purpose=purpose,
                                                  cafile=tls['ca_file'])
-            except AssertionError:
+            except AttributeError:
                 raise RuntimeError("TLS functionality requires Python 2.7.9+")
             ctx.verify_mode = ssl.CERT_REQUIRED
             # We expect a dedicated CA for the cluster and people using


### PR DESCRIPTION
This is the minimal code change that works around issue #1122.

I have no experience with SSL, so this need review from maybe @pitrou.

Note that this is only a partial fix, because `ssl.create_default_context` is also not available in Python 2.7.6, but without specifying a `ca_file` and `cert`, it is at least possible to get distributed running again.