### PR TITLE
Async cleanup

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -6,6 +6,7 @@ from .deploy import LocalCluster
 from .diagnostics import progress
 from .client import (Client, Executor, CompatibleExecutor,
                      wait, as_completed, default_client)
+from .tornado_client import TornadoClient
 from .nanny import Nanny
 from .scheduler import Scheduler
 from .utils import sync

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -328,10 +328,6 @@ def done_callback(future, callback):
 def normalize_future(f):
     return [f.key, type(f)]
 
-def in_ioloop():
-    """ Are we running within the current IOLoop? """
-    return IOLoop.current()._running and IOLoop.current()._thread_ident == get_thread_identity()
-
 
 class AllExit(Exception):
     """Custom exception class to exit All(...) early.

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -41,8 +41,7 @@ def test_adaptive_local_cluster_multi_workers():
                            diagnostics_port=None, loop=loop, start=False)
     cluster.scheduler.allowed_failures = 1000
     alc = Adaptive(cluster.scheduler, cluster, interval=100)
-    c = Client(cluster, start=False, loop=loop)
-    yield c
+    c = yield Client(cluster, asynchronous=True, loop=loop)
 
     futures = c.map(slowinc, range(100), delay=0.01)
 

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -232,8 +232,7 @@ def test_scale_up_and_down():
     loop = IOLoop.current()
     cluster = LocalCluster(0, scheduler_port=0, processes=False, silence_logs=False,
                            diagnostics_port=None, loop=loop, start=False)
-    c = Client(cluster, start=False, loop=loop)
-    yield c
+    c = yield Client(cluster, loop=loop, asynchronous=True)
 
     assert not cluster.workers
 

--- a/distributed/tests/py3_test_asyncio.py
+++ b/distributed/tests/py3_test_asyncio.py
@@ -40,10 +40,8 @@ def coro_test(fn):
 
 @coro_test
 async def test_asyncio_start_shutdown():
-    c = AioClient(processes=False)
-    assert c.status is None
+    c = await AioClient(processes=False)
 
-    await c.start()
     assert c.status == 'running'
     # AioClient has installed its AioLoop shim.
     assert isinstance(IOLoop.current(instance=False), BaseAsyncIOLoop)
@@ -349,8 +347,7 @@ async def test_asyncio_run_coroutine():
 @slow
 @coro_test
 async def test_asyncio_restart():
-    c = AioClient(processes=False)
-    await c.start()
+    c = await AioClient(processes=False)
 
     assert c.status == 'running'
     x = c.submit(inc, 1)

--- a/distributed/tests/py3_test_client.py
+++ b/distributed/tests/py3_test_client.py
@@ -44,7 +44,7 @@ def test_async_with(loop):
     client = None
     cluster = None
     async def f():
-        async with Client(processes=False) as c:
+        async with Client(processes=False, asynchronous=True) as c:
             nonlocal result, client, cluster
             result = await c.submit(lambda x: x + 1, 10)
 

--- a/distributed/tests/py3_test_utils_tst.py
+++ b/distributed/tests/py3_test_utils_tst.py
@@ -3,8 +3,8 @@ from distributed import Client
 
 
 @gen_cluster()
-async def test_gen_cluster(s, a, b):
-    async with Client(s.address) as c:
+async def test_gen_cluster_async(s, a, b):
+    async with Client(s.address, asynchronous=True) as c:
         future = c.submit(lambda x: x + 1, 1)
         result = await future
         assert result == 2

--- a/distributed/tests/test_channels.py
+++ b/distributed/tests/test_channels.py
@@ -127,8 +127,7 @@ def test_channel_scheduler(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_multiple_maxlen(c, s, a, b):
-    c2 = Client((s.ip, s.port), start=False)
-    yield c2
+    c2 = yield Client((s.ip, s.port), asynchronous=True)
 
     x = c.channel('x', maxlen=10)
     assert x.data.maxlen == 10
@@ -186,8 +185,7 @@ def test_stop(loop):
 
 @gen_cluster(client=True)
 def test_values(c, s, a, b):
-    c2 = Client((s.ip, s.port), start=False)
-    yield c2
+    c2 = yield Client((s.ip, s.port), asynchronous=True)
 
     x = c.channel('x')
     x2 = c2.channel('x')

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -201,7 +201,7 @@ def test_exceptions(c, s, a, b):
 
 @gen_cluster()
 def test_gc(s, a, b):
-    c = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
 
     x = c.submit(inc, 10)
     yield x
@@ -501,7 +501,7 @@ def test_missing_worker(s, a, b):
     s.who_has['b'] = {bad}
     s.has_what[bad] = {'b'}
 
-    c = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
 
     dsk = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b')}
 
@@ -714,13 +714,12 @@ def test_map_quotes(c, s, a, b):
 @gen_cluster()
 def test_two_consecutive_clients_share_results(s, a, b):
     from random import randint
-    c = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
 
     x = c.submit(randint, 0, 1000, pure=True)
     xx = yield x
 
-    f = Client((s.ip, s.port))
-    yield f
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     y = f.submit(randint, 0, 1000, pure=True)
     yy = yield y
@@ -1222,10 +1221,8 @@ def test_upload_file_exception_sync(loop):
 @pytest.mark.xfail
 @gen_cluster()
 def test_multiple_clients(s, a, b):
-    a = Client((s.ip, s.port))
-    yield a
-    b = Client((s.ip, s.port))
-    yield b
+    a = yield Client((s.ip, s.port), asynchronous=True)
+    b = yield Client((s.ip, s.port), asynchronous=True)
 
     x = a.submit(inc, 1)
     y = b.submit(inc, 2)
@@ -1634,9 +1631,9 @@ def test_waiting_data(c, s, a, b):
 
 @gen_cluster()
 def test_multi_client(s, a, b):
-    c = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
 
-    f = yield Client((s.ip, s.port))
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     assert set(s.comms) == {c.id, f.id}
 
@@ -1698,9 +1695,9 @@ def test_cleanup_after_broken_client_connection(s, a, b):
 
 @gen_cluster()
 def test_multi_garbage_collection(s, a, b):
-    c = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
 
-    f = yield Client((s.ip, s.port))
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     x = c.submit(inc, 1)
     y = f.submit(inc, 2)
@@ -1817,8 +1814,8 @@ def test__cancel_tuple_key(c, s, a, b):
 
 @gen_cluster()
 def test__cancel_multi_client(s, a, b):
-    c = yield Client((s.ip, s.port))
-    f = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     x = c.submit(slowinc, 1)
     y = f.submit(slowinc, 1)
@@ -2363,7 +2360,7 @@ def test_worker_aliases():
     b = Worker(s.ip, s.port, name='bob')
     yield [a._start(), b._start()]
 
-    c = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
 
     L = c.map(inc, range(10), workers='alice')
     yield _wait(L)
@@ -2431,10 +2428,10 @@ def test_client_num_fds(loop):
 
 @gen_cluster()
 def test_startup_shutdown_startup(s, a, b):
-    c = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
     yield c._shutdown()
 
-    c = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
     yield c._shutdown()
 
 
@@ -3086,7 +3083,7 @@ def test_status():
     s = Scheduler()
     s.start(0)
 
-    c = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
     assert c.status == 'running'
     x = c.submit(inc, 1)
 
@@ -3231,8 +3228,8 @@ def test_open_close_many_workers(loop, worker, count, repeat):
 
 @gen_cluster(client=False, timeout=None)
 def test_idempotence(s, a, b):
-    c = yield Client((s.ip, s.port))
-    f = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     # Submit
     x = c.submit(inc, 1)
@@ -3428,8 +3425,8 @@ def test_scatter_compute_store_lose_processing(c, s, a, b):
 
 @gen_cluster(client=False)
 def test_serialize_future(s, a, b):
-    c = yield Client((s.ip, s.port))
-    f = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     future = c.submit(lambda: 1)
     result = yield future
@@ -3447,8 +3444,8 @@ def test_serialize_future(s, a, b):
 
 @gen_cluster(client=False)
 def test_temp_client(s, a, b):
-    c = yield Client((s.ip, s.port))
-    f = yield Client((s.ip, s.port))
+    c = yield Client((s.ip, s.port), asynchronous=True)
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     with temp_default_client(c):
         assert default_client() is c
@@ -3776,7 +3773,7 @@ def test_scatter_dict_workers(c, s, a, b):
 @gen_test()
 def test_client_timeout():
     loop = IOLoop.current()
-    c = Client('127.0.0.1:57484', loop=loop)
+    c = Client('127.0.0.1:57484', asynchronous=True)
 
     s = Scheduler(loop=loop)
     yield gen.sleep(4)

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -10,10 +10,8 @@ from distributed.utils_test import cluster, loop
 
 @gen_cluster(client=False)
 def test_publish_simple(s, a, b):
-    c = Client((s.ip, s.port), start=False)
-    yield c
-    f = Client((s.ip, s.port), start=False)
-    yield f
+    c = yield Client((s.ip, s.port), asynchronous=True)
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     data = yield c._scatter(range(3))
     out = yield c._publish_dataset(data=data)
@@ -37,10 +35,8 @@ def test_publish_simple(s, a, b):
 
 @gen_cluster(client=False)
 def test_publish_roundtrip(s, a, b):
-    c = Client((s.ip, s.port), start=False)
-    yield c
-    f = Client((s.ip, s.port), start=False)
-    yield f
+    c = yield Client((s.ip, s.port), asynchronous=True)
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     data = yield c._scatter([0, 1, 2])
     yield c._publish_dataset(data=data)
@@ -138,10 +134,8 @@ def test_unpublish_multiple_datasets_sync(loop):
 @gen_cluster(client=False)
 def test_publish_bag(s, a, b):
     db = pytest.importorskip('dask.bag')
-    c = Client((s.ip, s.port), start=False)
-    yield c
-    f = Client((s.ip, s.port), start=False)
-    yield f
+    c = yield Client((s.ip, s.port), asynchronous=True)
+    f = yield Client((s.ip, s.port), asynchronous=True)
 
     bag = db.from_sequence([0, 1, 2])
     bagp = c.persist(bag)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1093,8 +1093,7 @@ def test_scheduler_file():
             data = json.load(f)
         assert data['address'] == s.address
 
-        c = Client(scheduler_file=fn, loop=s.loop, start=False)
-        yield c
+        c = yield Client(scheduler_file=fn, loop=s.loop, asynchronous=True)
     yield s.close()
 
 

--- a/distributed/tests/test_tornado_client.py
+++ b/distributed/tests/test_tornado_client.py
@@ -1,0 +1,11 @@
+from distributed.tornado_client import TornadoClient
+from distributed.utils_test import gen_cluster
+
+
+@gen_cluster()
+def test_tornado_client(s, a, b):
+    c = yield TornadoClient(s.address)
+    future = yield c.scatter(1)
+    result = yield c.gather(future)
+    assert result == 1
+    yield c.shutdown()

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -25,12 +25,13 @@ def test_cluster(loop):
 
 
 @gen_cluster(client=True)
-def test_gen_cluster(e, s, a, b):
-    assert isinstance(e, Client)
+def test_gen_cluster(c, s, a, b):
+    assert isinstance(c, Client)
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
     assert s.ncores == {w.address: w.ncores for w in [a, b]}
+
 
 @gen_cluster(client=False)
 def test_gen_cluster_without_client(s, a, b):
@@ -38,6 +39,7 @@ def test_gen_cluster_without_client(s, a, b):
     for w in [a, b]:
         assert isinstance(w, Worker)
     assert s.ncores == {w.address: w.ncores for w in [a, b]}
+
 
 @gen_cluster(client=True, scheduler='tls://127.0.0.1',
              ncores=[('tls://127.0.0.1', 1), ('tls://127.0.0.1', 2)],

--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -253,9 +253,8 @@ def test_fast_kill(c, s, a, b):
 
 @gen_cluster(Worker=Nanny)
 def test_multiple_clients_restart(s, a, b):
-    e1 = yield Client((s.ip, s.port), start=False)
-    yield e1
-    e2 = yield Client((s.ip, s.port), start=False)
+    e1 = yield Client((s.ip, s.port), asynchronous=True)
+    e2 = yield Client((s.ip, s.port), asynchronous=True)
 
     x = e1.submit(inc, 1)
     y = e2.submit(inc, 2)

--- a/distributed/tornado_client.py
+++ b/distributed/tornado_client.py
@@ -1,0 +1,42 @@
+from .client import Client
+
+
+class TornadoClient(Client):
+    """ An Asynchronous Dask Client that uses Tornado coroutines
+
+    This copies the normal interface of the dask.distributed Client but
+    operates asynchronously within a Tornado IOLoop.
+
+    Examples
+    --------
+    >>> @tornado.gen.coroutine  # doctest: +SKIP
+    ... def f():
+    ...     c = yield TornadoClient('scheduler:8786')
+    ...     futures = yield c.scatter([1, 2, 3])
+    ...     future = c.submit(sum, futures)
+    ...     result = yield c.gather(future)
+
+    >>> IOLoop.current().add_callback(f)  # doctest: +SKIP
+
+    See Also
+    --------
+    distributed.Client: Synchronous version
+    distributed.AioClient: AsyncIO Client
+    """
+    def __init__(self, *args, **kwargs):
+        kwargs['asynchronous'] = True
+        super(TornadoClient, self).__init__(*args, **kwargs)
+
+    gather = Client._gather
+    get_dataset = Client._get_dataset
+    publish_dataset = Client._publish_dataset
+    replicate = Client._replicate
+    rebalance = Client._rebalance
+    restart = Client._restart
+    run = Client._run
+    run_coroutine = Client._run_coroutine
+    run_on_scheduler = Client._run_on_scheduler
+    scatter = Client._scatter
+    shutdown = Client._shutdown
+    start_ipython_workers = Client._start_ipython_workers
+    upload_file = Client._upload_file

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -538,8 +538,8 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                         c = []
                         @gen.coroutine
                         def f():
-                            c2 = Client(s.address, loop=loop, security=security)
-                            yield c2._started
+                            c2 = yield Client(s.address, loop=loop, security=security,
+                                              asynchronous=True)
                             c.append(c2)
                         loop.run_sync(f)
                         args = c + args

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -53,11 +53,9 @@ def worker_client(timeout=3, separate_thread=True):
         secede()  # have this thread secede from the thread pool
         worker.loop.add_callback(worker.transition, thread_state.key, 'long-running')
 
-    with WorkerClient(address, loop=worker.loop, security=worker.security) as wc:
+    with WorkerClient(address, loop=worker.loop, security=worker.security,
+                      asynchronous=True) as wc:
         # Make sure connection errors are bubbled to the caller
-        @gen.coroutine
-        def f():
-            yield wc
         sync(wc.loop, gen.with_timeout, timedelta(seconds=timeout), wc._started)
         assert wc.status == 'running'
         yield wc

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -116,6 +116,12 @@ Other
 .. autofunction:: distributed.get_worker
 
 
+Tornado Client
+--------------
+
+.. currentmodule:: distributed.tornado_client
+.. autoclass:: TornadoClient
+
 Asyncio Client
 --------------
 


### PR DESCRIPTION
Follows on https://github.com/dask/distributed/pull/1115

- This adds a TornadoClient (cc @ajdavis who requested this)
- This adds an explicit `asynchronous=` keyword to Client for use in async situations
- This slightly changes the behavior and startup of the AioClient (cc @kszucs) 

I would also like to rename `AioClient` to `AsyncIOClient`.  Any objections?

