### PR TITLE
Temp default client

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3459,6 +3459,24 @@ def test_temp_client(s, a, b):
     yield f._shutdown()
 
 
+@gen_cluster(client=False)
+def test_temp_client_no_default(s, a, b):
+    c = yield Client((s.ip, s.port), asynchronous=True, set_as_default=False)
+
+    with temp_default_client(c):
+        assert default_client() is c
+
+    yield c._shutdown()
+
+
+@gen_cluster(client=False)
+def test_no_default_client(s, a, b):
+    assert not _get_global_client()
+    c = yield Client((s.ip, s.port), asynchronous=True, set_as_default=False)
+    assert not _get_global_client()
+    yield c._shutdown()
+
+
 @gen_cluster(ncores=[('127.0.0.1', 1)] * 3, client=True)
 def test_persist_workers(e, s, a, b, c):
     L1 = [delayed(inc)(i) for i in range(4)]

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -844,7 +844,8 @@ def test_global_clients(loop):
                 assert default_client(c) is c
                 assert default_client(f) is f
 
-    assert _get_global_client() is None
+            assert _get_global_client() is c
+        assert _get_global_client() is None
 
 
 @gen_cluster(client=True)

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 from contextlib import contextmanager
-from datetime import timedelta
 from toolz import keymap, valmap, merge
 import uuid
 
@@ -9,15 +8,14 @@ from dask.base import tokenize
 from tornado import gen
 
 from .client import AllExit, Client, Future, pack_data, unpack_remotedata
-from dask.compatibility import apply
 from .sizeof import sizeof
 from .threadpoolexecutor import secede
-from .utils import All, log_errors, sync, tokey, ignoring
+from .utils import All, log_errors, tokey, ignoring
 from .worker import thread_state, get_worker
 
 
 @contextmanager
-def worker_client(timeout=3, separate_thread=True):
+def worker_client(timeout=3, separate_thread=True, **kwargs):
     """ Get client for this thread
 
     This context manager is intended to be called within functions that we run
@@ -54,9 +52,7 @@ def worker_client(timeout=3, separate_thread=True):
         worker.loop.add_callback(worker.transition, thread_state.key, 'long-running')
 
     with WorkerClient(address, loop=worker.loop, security=worker.security,
-                      asynchronous=True) as wc:
-        # Make sure connection errors are bubbled to the caller
-        sync(wc.loop, gen.with_timeout, timedelta(seconds=timeout), wc._started)
+                      **kwargs) as wc:
         assert wc.status == 'running'
         yield wc
 
@@ -72,11 +68,9 @@ class WorkerClient(Client):
     look to the local data dictionary rather than sending data over the network
     """
     def __init__(self, *args, **kwargs):
-        loop = kwargs.get('loop')
         self.worker = get_worker()
-        kwargs['start'] = False
-        kwargs['set_as_default'] = False
-        sync(loop, apply, Client.__init__, (self,) + args, kwargs)
+        kwargs['loop'] = self.worker.loop
+        super(WorkerClient, self).__init__(*args, **kwargs)
 
     @gen.coroutine
     def _scatter(self, data, workers=None, broadcast=False):


### PR DESCRIPTION
Fixes `temp_default_client` to operate even when there is no global client.

We also fix Client to not register itself if `set_as_default=False`

This is currently based off of #1124 