### PR TITLE
Add Global Variable coordination object

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -11,6 +11,7 @@ from .nanny import Nanny
 from .queues import Queue
 from .scheduler import Scheduler
 from .utils import sync
+from .variable import Variable
 from .worker import Worker, get_worker
 from .worker_client import local_client, worker_client
 

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -18,11 +18,11 @@ class QueueExtension(object):
 
     This adds the following routes to the scheduler
 
-    *  queue-create
-    *  queue-release
-    *  queue-put
-    *  queue-get
-    *  queue-size
+    *  queue_create
+    *  queue_release
+    *  queue_put
+    *  queue_get
+    *  queue_size
     """
     def __init__(self, scheduler):
         self.scheduler = scheduler
@@ -80,9 +80,14 @@ class QueueExtension(object):
 class Queue(object):
     """ Distributed Queue
 
-    This allows multiple clients to share futures between each other with a
-    multi-producer/multi-consumer queue.  All metadata is sequentialized
-    through the scheduler.
+    This allows multiple clients to share futures or small bits of data between
+    each other with a multi-producer/multi-consumer queue.  All metadata is
+    sequentialized through the scheduler.
+
+    Elements of the Queue must be either Futures or msgpack-encodable data
+    (ints, strings, lists, dicts).  All data is sent through the scheduler so
+    it is wise not to send large objects.  To share large objects scatter the
+    data and share the future instead.
 
     Examples
     --------
@@ -91,6 +96,10 @@ class Queue(object):
     >>> queue = Queue('x')  # doctest: +SKIP
     >>> future = client.submit(f, x)  # doctest: +SKIP
     >>> queue.put(future)  # doctest: +SKIP
+
+    See Also
+    --------
+    Variable: shared variable between clients
     """
     def __init__(self, name=None, client=None, maxsize=0):
         self.client = client or _get_global_client()
@@ -122,12 +131,15 @@ class Queue(object):
                                                   name=self.name)
 
     def put(self, value, timeout=None):
+        """ Put data into the queue """
         return sync(self.client.loop, self._put, value, timeout=timeout)
 
     def get(self, timeout=None):
+        """ Get data from the queue """
         return sync(self.client.loop, self._get, timeout=timeout)
 
     def qsize(self):
+        """ Current number of elements in the queue """
         return sync(self.client.loop, self._qsize)
 
     @gen.coroutine

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -32,16 +32,18 @@ from .core import (rpc, connect, Server, send_recv,
                    error_message, clean_exception, CommClosedError)
 from .metrics import time
 from .node import ServerNode
-from .publish import PublishExtension
-from .channels import ChannelScheduler
-from .queues import QueueExtension
-from .stealing import WorkStealing
-from .recreate_exceptions import ReplayExceptionScheduler
 from .security import Security
 from .utils import (All, ignoring, get_ip, get_fileno_limit, log_errors,
         key_split, validate_key)
 from .utils_comm import (scatter_to_workers, gather_from_workers)
 from .versions import get_versions
+
+from .channels import ChannelScheduler
+from .publish import PublishExtension
+from .queues import QueueExtension
+from .recreate_exceptions import ReplayExceptionScheduler
+from .stealing import WorkStealing
+from .variable import VariableExtension
 
 
 logger = logging.getLogger(__name__)
@@ -190,7 +192,8 @@ class Scheduler(ServerNode):
                  delete_interval=500, synchronize_worker_interval=60000,
                  services=None, allowed_failures=ALLOWED_FAILURES,
                  extensions=[ChannelScheduler, PublishExtension, WorkStealing,
-                             ReplayExceptionScheduler, QueueExtension],
+                             ReplayExceptionScheduler, QueueExtension,
+                             VariableExtension],
                  validate=False, scheduler_file=None, security=None,
                  **kwargs):
 

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -29,7 +29,7 @@ def test_variable(c, s, a, b):
     yield gen.sleep(0.1)
     assert s.task_state  # future still present
 
-    yield x.delete()
+    x.delete()
 
     start = time()
     while s.task_state:

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -7,33 +7,29 @@ import pytest
 from toolz import take
 from tornado import gen
 
-from distributed import Client, Queue
+from distributed import Client, Variable
 from distributed.metrics import time
 from distributed.utils_test import gen_cluster, inc, loop, cluster, slowinc
 
 
 @gen_cluster(client=True)
-def test_queue(c, s, a, b):
-    x = yield Queue('x')
-    y = yield Queue('y')
-    xx = yield Queue('x')
+def test_variable(c, s, a, b):
+    x = Variable('x')
+    xx = Variable('x')
     assert x.client is c
 
     future = c.submit(inc, 1)
 
-    yield x._put(future)
-    yield y._put(future)
+    yield x._set(future)
     future2 = yield xx._get()
     assert future.key == future2.key
-
-    with pytest.raises(gen.TimeoutError):
-        yield x._get(timeout=0.1)
 
     del future, future2
 
     yield gen.sleep(0.1)
-    assert s.task_state  # future still present in y's queue
-    yield y._get()  # burn future
+    assert s.task_state  # future still present
+
+    yield x.delete()
 
     start = time()
     while s.task_state:
@@ -43,28 +39,23 @@ def test_queue(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_queue_with_data(c, s, a, b):
-    x = yield Queue('x')
-    xx = yield Queue('x')
+    x = Variable('x')
+    xx = Variable('x')
     assert x.client is c
 
-    yield x._put([1, 'hello'])
+    yield x._set([1, 'hello'])
     data = yield xx._get()
 
     assert data == [1, 'hello']
-
-    with pytest.raises(gen.TimeoutError):
-        yield x._get(timeout=0.1)
 
 
 def test_sync(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address']) as c:
             future = c.submit(lambda x: x + 1, 10)
-            x = Queue('x')
-            xx = Queue('x')
-            x.put(future)
-            assert x.qsize() == 1
-            assert xx.qsize() == 1
+            x = Variable('x')
+            xx = Variable('x')
+            x.set(future)
             future2 = xx.get()
 
             assert future2.result() == 11
@@ -74,17 +65,50 @@ def test_sync(loop):
 def test_hold_futures(s, a, b):
     c1 = yield Client(s.address, asynchronous=True)
     future = c1.submit(lambda x: x + 1, 10)
-    q1 = yield Queue('q')
-    yield q1._put(future)
-    del q1
+    x1 = Variable('x')
+    yield x1._set(future)
+    del x1
     yield c1._shutdown()
 
     yield gen.sleep(0.1)
 
     c2 = yield Client(s.address, asynchronous=True)
-    q2 = yield Queue('q')
-    future2 = yield q2._get()
+    x2 = Variable('x')
+    future2 = yield x2._get()
     result = yield future2
 
     assert result == 11
     yield c2._shutdown()
+
+
+@gen_cluster(client=True)
+def test_timeout(c, s, a, b):
+    v = Variable('v')
+
+    start = time()
+    with pytest.raises(gen.TimeoutError):
+        yield v._get(timeout=0.1)
+    assert time() - start < 0.5
+
+
+@gen_cluster(client=True)
+def test_cleanup(c, s, a, b):
+    v = Variable('v')
+    vv = Variable('v')
+
+    x = c.submit(lambda x: x + 1, 10)
+    y = c.submit(lambda x: x + 1, 20)
+    x_key = x.key
+
+    yield v._set(x)
+    del x
+    yield gen.sleep(0.1)
+
+    t_future = xx = vv._get()
+    yield gen.moment
+    v._set(y)
+
+    future = yield t_future
+    assert future.key == x_key
+    result = yield future
+    assert result == 11

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -112,3 +112,15 @@ def test_cleanup(c, s, a, b):
     assert future.key == x_key
     result = yield future
     assert result == 11
+
+
+def test_pickleable(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address']) as c:
+            v = Variable('v')
+
+            def f(x):
+                v.set(x + 1)
+
+            c.submit(f, 10).result()
+            assert v.get() == 11

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -38,7 +38,7 @@ class VariableExtension(object):
 
         self.scheduler.extensions['queues'] = self
 
-    def set(self, stream=None, name=None, key=None, data=None, client=None, timeout=None):
+    def set(self, stream=None, name=None, key=None, data=None, client=None):
         if key is not None:
             record = {'type': 'Future', 'value': key}
             self.scheduler.client_desires_keys(keys=[key], client='variable-%s' % name)
@@ -134,7 +134,7 @@ class Variable(object):
             yield self.client.scheduler.variable_set(data=value,
                                                      name=self.name)
 
-    def set(self, value, timeout=None):
+    def set(self, value):
         """ Set the value of this variable
 
         Parameters

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -1,0 +1,156 @@
+from __future__ import print_function, division, absolute_import
+
+from collections import defaultdict
+import logging
+import uuid
+
+from tornado import gen
+import tornado.locks
+
+from .client import Future, _get_global_client
+from .metrics import time
+from .utils import tokey, sync, log_errors
+
+logger = logging.getLogger(__name__)
+
+
+class VariableExtension(object):
+    """ An extension for the scheduler to manage queues
+
+    This adds the following routes to the scheduler
+
+    *  variable-set
+    *  variable-get
+    *  variable-delete
+    """
+    def __init__(self, scheduler):
+        self.scheduler = scheduler
+        self.variables = dict()
+        self.lingering = defaultdict(set)
+        self.events = defaultdict(tornado.locks.Event)
+        self.started = tornado.locks.Condition()
+
+        self.scheduler.handlers.update({'variable_set': self.set,
+                                        'variable_get': self.get})
+
+        self.scheduler.client_handlers['variable-future-release'] = self.future_release
+        self.scheduler.client_handlers['variable_delete'] = self.delete
+
+        self.scheduler.extensions['queues'] = self
+
+    def set(self, stream=None, name=None, key=None, data=None, client=None, timeout=None):
+        if key is not None:
+            record = {'type': 'Future', 'value': key}
+            self.scheduler.client_desires_keys(keys=[key], client='variable-%s' % name)
+        else:
+            record = {'type': 'msgpack', 'value': data}
+        try:
+            old = self.variables[name]
+        except KeyError:
+            pass
+        else:
+            if old['type'] == 'Future':
+                self.release(old['value'], name)
+        if name not in self.variables:
+            self.started.notify_all()
+        self.variables[name] = record
+
+    @gen.coroutine
+    def release(self, key, name):
+        while self.lingering[key, name]:
+            yield self.events[name].wait()
+
+        self.scheduler.client_releases_keys(keys=[key],
+                                            client='variable-%s' % name)
+        del self.lingering[key, name]
+
+    def future_release(self, name=None, key=None, client=None):
+        self.lingering[key, name].remove(client)
+        self.events[name].set()
+
+    @gen.coroutine
+    def get(self, stream=None, name=None, client=None, timeout=None):
+        start = time()
+        while name not in self.variables:
+            if timeout is not None:
+                timeout2 = timeout - (time() - start)
+            else:
+                timeout2 = None
+            if timeout2 < 0:
+                raise gen.TimeoutError()
+            yield self.started.wait(timeout=timeout2)
+        record = self.variables[name]
+        if record['type'] == 'Future':
+            self.lingering[record['value'], name].add(client)
+        raise gen.Return(record)
+
+    @gen.coroutine
+    def delete(self, stream=None, name=None, client=None):
+        with log_errors():
+            try:
+                old = self.variables[name]
+            except KeyError:
+                pass
+            else:
+                if old['type'] == 'Future':
+                    yield self.release(old['value'], name)
+            del self.events[name]
+            del self.variables[name]
+
+
+class Variable(object):
+    """ Distributed Global Variable
+
+    This allows multiple clients to share futures and data between each other
+    with a single mutable variable.  All metadata is sequentialized through the
+    scheduler.  Race conditions can occur.
+
+    Examples
+    --------
+    >>> from dask.distributed import Client, Variable # doctest: +SKIP
+    >>> client = Client()  # doctest: +SKIP
+    >>> x = Variable('x')  # doctest: +SKIP
+    >>> x.set(123)  # docttest: +SKIP
+    >>> x.get()  # docttest: +SKIP
+    123
+    >>> future = client.submit(f, x)  # doctest: +SKIP
+    >>> x.set(future)  # doctest: +SKIP
+    """
+    def __init__(self, name=None, client=None, maxsize=0):
+        self.client = client or _get_global_client()
+        self.name = name or 'variable-' + uuid.uuid4().hex
+
+    @gen.coroutine
+    def _set(self, value):
+        if isinstance(value, Future):
+            yield self.client.scheduler.variable_set(key=tokey(value.key),
+                                                     name=self.name)
+        else:
+            yield self.client.scheduler.variable_set(data=value,
+                                                     name=self.name)
+
+    def set(self, value, timeout=None):
+        return sync(self.client.loop, self._set, value)
+
+    @gen.coroutine
+    def _get(self, timeout=None):
+        d = yield self.client.scheduler.variable_get(timeout=timeout,
+                                                     name=self.name,
+                                                     client=self.client.id)
+        if d['type'] == 'Future':
+            value = Future(d['value'], self.client, inform=True)
+            self.client._send_to_scheduler({'op': 'variable-future-release',
+                                            'name': self.name,
+                                            'key': d['value'],
+                                            'client': self.client.id})
+        else:
+            value = d['value']
+        raise gen.Return(value)
+
+    def get(self, timeout=None):
+        return sync(self.client.loop, self._get, timeout=timeout)
+
+    def delete(self):
+        if self.client.status == 'running':  # TODO: can leave zombie futures
+            self.client._send_to_scheduler({'op': 'variable_delete',
+                                            'name': self.name})


### PR DESCRIPTION
This creates a global `Variable` object to which clients can set and get
values.  Coordination happens through the central scheduler.

```python
In [1]: from distributed import Client, Variable
In [2]: client = Client()

In [3]: v = Variable('var-1')
In [4]: v.set(1)
In [5]: v.get()
Out[5]: 1

In [6]: client.scheduler.address
Out[6]: 'tcp://127.0.0.1:36535'
```

```python
In [1]: from distributed import Client, Variable
In [2]: client = Client('tcp://127.0.0.1:36535')
In [3]: v = Variable('var-1')  # same name

In [4]: v.get()
Out[4]: 1
```

This can send msgpack values or futures

cc @MLnick this might be a better way to publish your betas rather than with channels.