### PR TITLE
Scatter update

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1147,44 +1147,38 @@ class Client(Node):
             d = yield self._scatter(keymap(tokey, data), workers, broadcast)
             raise gen.Return({k: d[tokey(k)] for k in data})
 
+        if isinstance(data, type(range(0))):
+            data = list(data)
+        input_type = type(data)
+        names = False
         unpack = False
-        if isinstance(data, dict):
-            data2 = valmap(to_serialize, data)
-            types = valmap(type, data)
-        elif isinstance(data, (list, tuple, set, frozenset)):
-            data2 = list(map(to_serialize, data))
-            types = list(map(type, data))
-        elif isinstance(data, (Iterable, Iterator)):
-            data2 = list(map(to_serialize, data))
-            types = list(map(type, data))
-        else:
-            data2 = [to_serialize(data)]
-            types = [type(data)]
+        if not isinstance(data, dict) and  isinstance(data, (Iterable, Iterator)):
+            data = list(data)
+        if not isinstance(data, (dict, list, tuple, set, frozenset)):
             unpack = True
+            data = [data]
+        if isinstance(data, list):
+            names = list(map(tokenize, data))
+            data = dict(zip(names, data))
+
+        assert isinstance(data, dict)
+
+        data2 = valmap(to_serialize, data)
+        types = valmap(type, data)
+
         keys = yield self.scheduler.scatter(data=data2, workers=workers,
                                             client=self.id,
                                             broadcast=broadcast)
-        if isinstance(data, dict):
-            out = {k: self._Future(k, self) for k in keys}
-        elif isinstance(data, (tuple, list, set, frozenset)):
-            out = type(data)([self._Future(k, self) for k in keys])
-        elif isinstance(data, (Iterable, Iterator)):
-            out = [self._Future(k, self) for k in keys]
-        else:
-            out = [self._Future(k, self) for k in keys]
+        out = {k: self._Future(k, self) for k in keys}
+        for key, typ in types.items():
+            self.futures[key].finish(type=typ)
 
-        for key in keys:
-            self.futures[key].finish(type=None)
-
-        if isinstance(types, list):
-            for key, typ in zip(keys, types):
-                self.futures[key].type = typ
-        elif isinstance(types, dict):
-            for key in keys:
-                self.futures[key].type = types[key]
+        if issubclass(input_type, (list, tuple, set, frozenset)):
+            out = input_type(out[k] for k in names)
 
         if unpack:
-            out = out[0]
+            assert len(out) == 1
+            out = list(out.values())[0]
 
         raise gen.Return(out)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1219,7 +1219,7 @@ class Client(Node):
             for future in futures:
                 qout.put(future)
 
-    def scatter(self, data, workers=None, broadcast=False, maxsize=0):
+    def scatter(self, data, workers=None, broadcast=False, direct=False, maxsize=0):
         """ Scatter data into distributed memory
 
         This moves data from the local client process into the workers of the
@@ -1237,6 +1237,10 @@ class Client(Node):
         broadcast: bool (defaults to False)
             Whether to send each data element to all workers.
             By default we round-robin based on number of cores.
+        direct: bool (defaults to False)
+            Send data directly to workers, bypassing the central scheduler
+            This avoids burdening the scheduler but assumes that the client is
+            able to talk directly with the workers.
         maxsize: int (optional)
             Maximum size of queue if using queues, 0 implies infinite
 
@@ -1294,7 +1298,7 @@ class Client(Node):
                 return queue_to_iterator(qout)
         else:
             return sync(self.loop, self._scatter, data, workers=workers,
-                        broadcast=broadcast)
+                        broadcast=broadcast, direct=direct)
 
     @gen.coroutine
     def _cancel(self, futures):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1153,12 +1153,14 @@ class Client(Node):
         input_type = type(data)
         names = False
         unpack = False
-        if not isinstance(data, dict) and  isinstance(data, (Iterable, Iterator)):
+        if isinstance(data, Iterator):
+            data = list(data)
+        if isinstance(data, (set, frozenset)):
             data = list(data)
         if not isinstance(data, (dict, list, tuple, set, frozenset)):
             unpack = True
             data = [data]
-        if isinstance(data, list):
+        if isinstance(data, (list, tuple)):
             names = list(map(tokenize, data))
             data = dict(zip(names, data))
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1173,9 +1173,8 @@ class Client(Node):
             if not ncores:
                 raise ValueError("No valid workers")
 
-            _, who_has, nbytes = yield scatter_to_workers(ncores, data,
-                                                          report=False,
-                                                          serialize=False)
+            _, who_has, nbytes = yield scatter_to_workers(ncores, data2,
+                                                          report=False)
 
             yield self.scheduler.update_data(who_has=who_has, nbytes=nbytes)
         else:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1174,7 +1174,8 @@ class Client(Node):
                 raise ValueError("No valid workers")
 
             _, who_has, nbytes = yield scatter_to_workers(ncores, data2,
-                                                          report=False)
+                                                          report=False,
+                                                          rpc=self.rpc)
 
             yield self.scheduler.update_data(who_has=who_has, nbytes=nbytes)
         else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1403,7 +1403,7 @@ class Scheduler(ServerNode):
 
     @gen.coroutine
     def scatter(self, comm=None, data=None, workers=None, client=None,
-            broadcast=False, timeout=2):
+                broadcast=False, timeout=2):
         """ Send data out to workers
 
         See also

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1426,8 +1426,7 @@ class Scheduler(ServerNode):
 
         keys, who_has, nbytes = yield scatter_to_workers(ncores, data,
                                                          rpc=self.rpc,
-                                                         report=False,
-                                                         serialize=False)
+                                                         report=False)
 
         self.update_data(who_has=who_has, nbytes=nbytes, client=client)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1422,6 +1422,8 @@ class Scheduler(ServerNode):
             workers = [self.coerce_address(w) for w in workers]
             ncores = {w: self.ncores[w] for w in workers}
 
+        assert isinstance(data, dict)
+
         keys, who_has, nbytes = yield scatter_to_workers(ncores, data,
                                                          rpc=self.rpc,
                                                          report=False,

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1164,10 +1164,20 @@ def test_scatter_direct_spread_evenly(c, s, *workers):
 
 @pytest.mark.parametrize('direct', [True, False])
 @pytest.mark.parametrize('broadcast', [True, False])
-def test_scatter_sync(loop, direct, broadcast):
+def test_scatter_gather_sync(loop, direct, broadcast):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
             futures = c.scatter([1, 2, 3], direct=direct, broadcast=broadcast)
+            results = c.gather(futures, direct=direct)
+            assert results == [1, 2, 3]
+
+
+@gen_cluster(client=True)
+def test_gather_direct(c, s, a, b):
+    futures = yield c._scatter([1, 2, 3])
+
+    data = yield c._gather(futures, direct=True)
+    assert data == [1, 2, 3]
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -985,7 +985,7 @@ def test_iterator_scatter(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
             aa = c.scatter([1,2,3])
-            assert [1,2,3] == c.gather(aa)
+            assert [1, 2, 3] == c.gather(aa)
 
             g = (i for i in range(10))
             futures = c.scatter(g)
@@ -1085,6 +1085,60 @@ def test_iterator_gather(loop):
             assert isinstance(i_out[3], StopIteration)
             assert i_out[3].args == i_in[3].args
             assert i_out[4:] == i_in[4:]
+
+
+@gen_cluster(client=True)
+def test_scatter_direct(c, s, a, b):
+    future = yield c._scatter(123, direct=True)
+    assert future.key in a.data or future.key in b.data
+    assert s.who_has[future.key]
+    assert future.status == 'finished'
+    result = yield future
+    assert result == 123
+
+
+@gen_cluster(client=True)
+def test_scatter_direct_broadcast(c, s, a, b):
+    future2 = yield c._scatter(456, direct=True, broadcast=True)
+    assert future2.key in a.data
+    assert future2.key in b.data
+    assert s.who_has[future2.key] == {a.address, b.address}
+    result = yield future2
+    assert result == 456
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 4)
+def test_scatter_direct_balanced(c, s, *workers):
+    futures = yield c._scatter([1, 2, 3], direct=True)
+    assert sorted([len(w.data) for w in workers]) == [0, 1, 1, 1]
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 4)
+def test_scatter_direct_broadcast_target(c, s, *workers):
+    futures = yield c._scatter([123, 456], direct=True,
+                                workers=workers[0].address)
+    assert futures[0].key in workers[0].data
+    assert futures[1].key in workers[0].data
+
+    futures = yield c._scatter([123, 456], direct=True, broadcast=True,
+                                workers=[w.address for w in workers[:3]])
+    assert (f.key in w.data and w.address in s.who_has[f.key]
+            for f in futures
+            for w in workers[:3])
+
+
+@gen_cluster(client=True, ncores=[])
+def test_scatter_direct_empty(c, s):
+    with pytest.raises(ValueError):
+        yield c._scatter(123, direct=True)
+
+
+@gen_cluster(client=True)
+def test_scatter_direct_spread_evenly(c, s, a, b):
+    x = yield c._scatter(123, direct=True)
+    y = yield c._scatter(456, direct=True)
+    assert a.data and b.data
+
 
 @gen_cluster(client=True)
 def test_many_submits_spread_evenly(c, s, a, b):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1150,6 +1150,14 @@ def test_scatter_direct_spread_evenly(c, s, a, b):
     assert a.data and b.data
 
 
+@pytest.mark.parametrize('direct', [True, False])
+@pytest.mark.parametrize('broadcast', [True, False])
+def test_scatter_sync(loop, direct, broadcast):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            futures = c.scatter([1, 2, 3], direct=direct, broadcast=broadcast)
+
+
 @gen_cluster(client=True)
 def test_many_submits_spread_evenly(c, s, a, b):
     L = [c.submit(inc, i) for i in range(10)]

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1108,6 +1108,15 @@ def test_scatter_direct(c, s, a, b):
 
 
 @gen_cluster(client=True)
+def test_scatter_direct_numpy(c, s, a, b):
+    np = pytest.importorskip('numpy')
+    x = np.ones(5)
+    future = yield c._scatter(x, direct=True)
+    result = yield future
+    assert np.allclose(x, result)
+
+
+@gen_cluster(client=True)
 def test_scatter_direct_broadcast(c, s, a, b):
     future2 = yield c._scatter(456, direct=True, broadcast=True)
     assert future2.key in a.data

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1152,11 +1152,14 @@ def test_scatter_direct_empty(c, s):
         yield c._scatter(123, direct=True)
 
 
-@gen_cluster(client=True)
-def test_scatter_direct_spread_evenly(c, s, a, b):
-    x = yield c._scatter(123, direct=True)
-    y = yield c._scatter(456, direct=True)
-    assert a.data and b.data
+@gen_cluster(client=True, timeout=None, ncores=[('127.0.0.1', 1)] * 5)
+def test_scatter_direct_spread_evenly(c, s, *workers):
+    futures = []
+    for i in range(10):
+        future = yield c._scatter(i, direct=True)
+        futures.append(future)
+
+    assert all(w.data for w in workers)
 
 
 @pytest.mark.parametrize('direct', [True, False])

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -843,6 +843,16 @@ def test_scatter_tokenize_local(c, s, a, b):
 
 
 @gen_cluster(client=True)
+def test_scatter_singletons(c, s, a, b):
+    np = pytest.importorskip('numpy')
+    pd = pytest.importorskip('pandas')
+    for x in [1, np.ones(5), pd.DataFrame({'x': [1, 2, 3]})]:
+        future = yield c._scatter(x)
+        result = yield future
+        assert str(result) == str(x)
+
+
+@gen_cluster(client=True)
 def test_get_releases_data(c, s, a, b):
     [x] = yield c.get({'x': (inc, 1)}, ['x'], sync=False)
     import gc; gc.collect()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -824,6 +824,25 @@ def test_scatter_hash(c, s, a, b):
 
 
 @gen_cluster(client=True)
+def test_scatter_tokenize_local(c, s, a, b):
+    from dask.base import normalize_token
+    class MyObj(object):
+        pass
+
+    L = []
+
+    @normalize_token.register(MyObj)
+    def f(x):
+        L.append(x)
+        return 'x'
+
+    obj = MyObj()
+
+    future = yield c._scatter(obj)
+    assert L and L[0] is obj
+
+
+@gen_cluster(client=True)
 def test_get_releases_data(c, s, a, b):
     [x] = yield c.get({'x': (inc, 1)}, ['x'], sync=False)
     import gc; gc.collect()

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -100,7 +100,7 @@ _round_robin_counter = [0]
 
 
 @gen.coroutine
-def scatter_to_workers(ncores, data, rpc=rpc, report=True, serialize=True):
+def scatter_to_workers(ncores, data, rpc=rpc, report=True):
     """ Scatter data directly to workers
 
     This distributes data in a round-robin fashion to a set of workers based on
@@ -120,9 +120,8 @@ def scatter_to_workers(ncores, data, rpc=rpc, report=True, serialize=True):
 
     L = list(zip(worker_iter, names, data))
     d = groupby(0, L)
-    d = {worker: {key: dumps(value) if serialize else value
-                  for _, key, value in v}
-          for worker, v in d.items()}
+    d = {worker: {key: value for _, key, value in v}
+         for worker, v in d.items()}
 
     rpcs = {addr: rpc(addr) for addr in d}
     try:

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -1,19 +1,16 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import Iterable, defaultdict
+from collections import defaultdict
 from itertools import cycle
 import random
-import uuid
 
 from tornado import gen
 from tornado.gen import Return
 
-from dask.base import tokenize
 from toolz import merge, concat, groupby, drop
 
-from .core import coerce_to_address, rpc
+from .core import rpc
 from .utils import All, tokey
-from .protocol.pickle import dumps
 
 
 no_default = '__no_default__'

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -11,7 +11,7 @@ from tornado.gen import Return
 from dask.base import tokenize
 from toolz import merge, concat, groupby, drop
 
-from .core import coerce_to_address
+from .core import coerce_to_address, rpc
 from .utils import All, tokey
 from .protocol.pickle import dumps
 
@@ -100,7 +100,7 @@ _round_robin_counter = [0]
 
 
 @gen.coroutine
-def scatter_to_workers(ncores, data, rpc, report=True, serialize=True):
+def scatter_to_workers(ncores, data, rpc=rpc, report=True, serialize=True):
     """ Scatter data directly to workers
 
     This distributes data in a round-robin fashion to a set of workers based on

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -136,7 +136,7 @@ class WorkerClient(Client):
             raise gen.Return(out)
 
     @gen.coroutine
-    def _gather(self, futures, errors='raise'):
+    def _gather(self, futures, errors='raise', direct=False):
         """
 
         Exactly like Client._gather, but get data directly from the local
@@ -167,5 +167,6 @@ class WorkerClient(Client):
         if not futures3:
             raise gen.Return(futures4)
 
-        result = yield Client._gather(self, futures4, errors=errors)
+        result = yield Client._gather(self, futures4, errors=errors,
+                                      direct=True)
         raise gen.Return(result)

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -79,7 +79,7 @@ class WorkerClient(Client):
         sync(loop, apply, Client.__init__, (self,) + args, kwargs)
 
     @gen.coroutine
-    def _scatter(self, data, workers=None, broadcast=False):
+    def _scatter(self, data, workers=None, broadcast=False, direct=None):
         """ Scatter data to local data dictionary
 
         Rather than send data out to the cluster we keep data local.  However


### PR DESCRIPTION
This includes a few fixes:

1.  We add a `direct=` keyword to scatter which pushes data directly from the client to the workers without going through the scheduler.  Better names welcome.
2.  We now scatter singleton numpy arrays and pandas dataframes (and all other Iterables that are not the standard builtin list/tuple/set/etc.) as single elements rather than lists
3.  We ensure that tokenization happens on the client side rather than on the scheduler.  This may have been causing undue serialization/CPU costs on the scheduler.

```python
In [1]: from dask.distributed import Client
In [2]: client = Client()
In [3]: futures = client.scatter([1, 2, 3], direct=True)  # this avoids the scheduler

In [4]: import numpy as np
In [5]: x = np.ones(5)
In [6]: future = client.scatter(x)
In [7]: future
Out[7]: <Future: status: finished, type: ndarray, key: 1ec89731b5394a422f6f47679b292d54>
```