### PR TITLE
FIX: load traceback fails task status not set to error

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -706,7 +706,10 @@ class Client(Node):
             except TypeError:
                 exception = Exception("Undeserializable exception", exception)
             if traceback:
-                traceback = loads(traceback)
+                try:
+                    traceback = loads(traceback)
+                except AttributeError:
+                    traceback = None
             else:
                 traceback = None
             state.set_error(exception, traceback)


### PR DESCRIPTION
While taking dask.distributed for a serious spin I noticed that some task status were not set to error despite the job failing.

> distributed.protocol.pickle - INFO - Failed to deserialize

The problem is caused by the tblib raising an AttributeError when loads(traceback) is called - I am calling R from Python in the task which could explain why there is a traceback issue with tasks raising RRuntimeError.

> AttributeError: ("'Traceback' object has no attribute 'tb_next'", ...)

Setting traceback to None when that happens seems to be a better option than having the tasks hang in there as pending despite having erred.

Not sure how to go about writing an automated test for that corner case - happy to give it a shot just need some guidance.