### PR TITLE
Support nested collections in client.compute

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1829,6 +1829,12 @@ class Client(Node):
             collections = [collections]
             singleton = True
 
+        traverse = kwargs.pop('traverse', True)
+        if traverse:
+            collections = tuple(dask.delayed(a)
+                         if isinstance(a, (list, set, tuple, dict, Iterator))
+                         else a for a in collections)
+
         variables = [a for a in collections if isinstance(a, Base)]
 
         dsk = self.collections_to_dsk(variables, optimize_graph, **kwargs)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3618,6 +3618,20 @@ def test_compute_workers(e, s, a, b, c):
     assert s.loose_restrictions == {total.key} | {v.key for v in L1}
 
 
+@gen_cluster(client=True)
+def test_compute_nested_containers(c, s, a, b):
+    da = pytest.importorskip('dask.array')
+    np = pytest.importorskip('numpy')
+    x = da.ones(10, chunks=(5,)) + 1
+
+    future = c.compute({'x': [x], 'y': 123})
+    result = yield future
+
+    assert isinstance(result, dict)
+    assert (result['x'][0] == np.ones(10) + 1).all()
+    assert result['y'] == 123
+
+
 def test_get_restrictions():
     L1 = [delayed(inc)(i) for i in range(4)]
     total = delayed(sum)(L1)


### PR DESCRIPTION
Things like the following now work:

    future = client.compute({'x': my_dask_array})