### PR TITLE
lz4: first try passing memoryview before fallback

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -158,7 +158,7 @@ def maybe_compress(payload, min_size=1e4, sample_size=1e4, nsamples=5):
     else:
         nbytes = len(payload)
 
-    if blosc and type(payload) is memoryview and payload.itemsize > 1:
+    if blosc and type(payload) is memoryview:
         # Blosc does itemsize-aware shuffling, resulting in better compression
         compressed = blosc.compress(payload, typesize=payload.itemsize,
                                     cname='lz4', clevel=5)

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -158,7 +158,8 @@ def maybe_compress(payload, min_size=1e4, sample_size=1e4, nsamples=5):
     else:
         nbytes = len(payload)
 
-    if blosc and type(payload) is memoryview:
+    if blosc and type(payload) is memoryview and payload.itemsize > 1:
+        # Blosc does itemsize-aware shuffling, resulting in better compression
         compressed = blosc.compress(payload, typesize=payload.itemsize,
                                     cname='lz4', clevel=5)
         compression = 'blosc'


### PR DESCRIPTION
Current versions of the lz4 binding don't support memoryview inputs, but later versions should (see https://github.com/python-lz4/python-lz4/pull/38/).