### PR TITLE
Remove Python 3.4 run from Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ services:
 env:
   matrix:
     - PYTHON=2.7 PACKAGES="blosc futures faulthandler"
-    - PYTHON=3.4 COVERAGE=true DASK_EXPERIMENTAL_ZMQ=1
-    - PYTHON=3.5 CRICK=true ASYNCIO=true
-    - PYTHON=3.6 PACKAGES=blosc ASYNCIO=true
+    - PYTHON=3.5 COVERAGE=true PACKAGES=blosc CRICK=true DASK_EXPERIMENTAL_ZMQ=1
+    - PYTHON=3.6
     - HDFS=true PYTHON=2.7
     - HDFS=true PYTHON=3.5 PACKAGES=blosc
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,19 @@ setup(name='distributed',
                 'distributed.http'],
       long_description=(open('README.rst').read() if os.path.exists('README.rst')
                         else ''),
+      classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering",
+        "Topic :: System :: Distributed Computing",
+      ],
       entry_points='''
         [console_scripts]
         dask-ssh=distributed.cli.dask_ssh:go


### PR DESCRIPTION
This may help speed up builds a bit.
Also remove the ASYNCIO environment variable which doesn't seem examined anywhere.
Also taking the liberty of adding `setup.py` classifiers.