### PR TITLE
Minor typo in documentation

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -113,7 +113,7 @@ Using the Python API
 
 Alternatively you can start up the ``distributed.scheduler.Scheduler`` and
 ``distributed.worker.Worker`` objects within a Python session manually.  Both
-are ``torando.tcpserver.TCPServer`` objects.
+are ``tornado.tcpserver.TCPServer`` objects.
 
 Start the Scheduler, provide the listening port (defaults to 8786) and Tornado
 IOLoop (defaults to ``IOLoop.current()``)


### PR DESCRIPTION
It said 'torando.tcpserver.TCPServer' somewhere instead of 'tornado.tcpserver.TCPServer'.