### PR TITLE
Add disclaimer to Queue/Variable docstrings for Python 2

### DIFF
--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -94,6 +94,10 @@ class Queue(object):
     it is wise not to send large objects.  To share large objects scatter the
     data and share the future instead.
 
+    .. warning::
+
+       This object is experimental and has known issues in Python 2
+
     Examples
     --------
     >>> from dask.distributed import Client, Queue  # doctest: +SKIP

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from operator import add
 from time import sleep
+import sys
 
 import pytest
 from toolz import take
@@ -117,6 +118,7 @@ def test_picklability_sync(loop):
             assert q.get() == 11
 
 
+@pytest.mark.skipif(sys.version_info[0] == 2, reason='Multi-client issues')
 @slow
 @gen_cluster(client=True, ncores=[('127.0.0.1', 2)] * 5, Worker=Nanny,
              timeout=None)

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from operator import add
 from time import sleep
+import sys
 
 import pytest
 from toolz import take
@@ -140,6 +141,7 @@ def test_timeout_get(c, s, a, b):
     assert result == 1
 
 
+@pytest.mark.skipif(sys.version_info[0] == 2, reason='Multi-client issues')
 @slow
 @gen_cluster(client=True, ncores=[('127.0.0.1', 2)] * 5, Worker=Nanny,
              timeout=None)

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -113,6 +113,10 @@ class Variable(object):
     it is wise not to send too much.  If you want to share a large amount of
     data then ``scatter`` it and share the future instead.
 
+    .. warning::
+
+       This object is experimental and has known issues in Python 2
+
     Examples
     --------
     >>> from dask.distributed import Client, Variable # doctest: +SKIP


### PR DESCRIPTION
This also skips race-condition tests in Python 2