### PR TITLE
Update Tornado version on CI runs

### DIFF
--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -17,7 +17,7 @@ call deactivate
 
 @rem Create test environment
 @rem (note: no cytoolz as it seems to prevent faulthandler tracebacks on crash)
-%CONDA% create -n %CONDA_ENV% -q -y python=%PYTHON% pytest toolz dill futures dask ipywidgets psutil bokeh requests joblib mock ipykernel jupyter_client tblib msgpack-python cloudpickle click zict lz4 tornado=4.4 -c conda-forge
+%CONDA% create -n %CONDA_ENV% -q -y python=%PYTHON% pytest toolz dill futures dask ipywidgets psutil bokeh requests joblib mock ipykernel jupyter_client tblib msgpack-python cloudpickle click zict lz4 tornado=4.5 -c conda-forge
 
 call activate %CONDA_ENV%
 

--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -17,7 +17,29 @@ call deactivate
 
 @rem Create test environment
 @rem (note: no cytoolz as it seems to prevent faulthandler tracebacks on crash)
-%CONDA% create -n %CONDA_ENV% -q -y python=%PYTHON% pytest toolz dill futures dask ipywidgets psutil bokeh requests joblib mock ipykernel jupyter_client tblib msgpack-python cloudpickle click zict lz4 tornado=4.5 -c conda-forge
+%CONDA% create -n %CONDA_ENV% -q -y ^
+    bokeh ^
+    click ^
+    cloudpickle ^
+    dask ^
+    dill ^
+    futures ^
+    lz4 ^
+    ipykernel ^
+    ipywidgets ^
+    joblib ^
+    jupyter_client ^
+    mock ^
+    msgpack-python ^
+    psutil ^
+    pytest ^
+    python=%PYTHON% ^
+    requests ^
+    toolz ^
+    tblib ^
+    tornado=4.5 ^
+    zict ^
+    -c conda-forge
 
 call activate %CONDA_ENV%
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -27,7 +27,7 @@ conda create -q -n test-environment python=$PYTHON
 source activate test-environment
 
 # Install dependencies
-# (Tornado pinned to 4.4 until a new Bokeh is released)
+# (Tornado pinned to 4.5 until we fix our compatibility with Tornado 5.0)
 conda install -q -c conda-forge \
     bokeh \
     click \
@@ -51,7 +51,7 @@ conda install -q -c conda-forge \
     requests \
     tblib \
     toolz \
-    tornado=4.4 \
+    tornado=4.5 \
     $PACKAGES
 
 if [[ $HDFS == true ]]; then


### PR DESCRIPTION
Bokeh 0.12.6 is now released which fixes compatibility with Tornado 4.5+.