### PR TITLE
Fix sporadic failure in test_asyncprocess

### DIFF
--- a/distributed/process.py
+++ b/distributed/process.py
@@ -82,6 +82,7 @@ class AsyncProcess(object):
         self._process.terminate()
 
     def _on_exit(self):
+        print("_on_exit")
         self._process = None
         if self._exit_callback is not None:
             self._exit_callback(self)
@@ -138,6 +139,7 @@ class AsyncProcess(object):
                 # User hooks
                 _maybe_call_exit_callback()
                 exit_future.set_result(r)
+                print("_watch: done joining")
                 # No need to examine process result again
                 break
 
@@ -163,6 +165,7 @@ class AsyncProcess(object):
         assert self._state.pid is not None, 'can only join a started process'
         if self._state.exitcode is not None:
             return
+        print("join...")
         if timeout is None:
             yield self._exit_future
         else:
@@ -170,6 +173,7 @@ class AsyncProcess(object):
                 yield gen.with_timeout(timedelta(seconds=timeout), self._exit_future)
             except gen.TimeoutError:
                 pass
+        print("/join...")
 
     def set_exit_callback(self, func):
         """

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -136,8 +136,8 @@ class AsyncProcess(object):
                 # (see _children in multiprocessing/process.py)
                 process.join(timeout=0)
                 # User hooks
-                exit_future.set_result(r)
                 _maybe_call_exit_callback()
+                exit_future.set_result(r)
                 # No need to examine process result again
                 break
 

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -92,11 +92,25 @@ def test_simple():
     t1 = time()
     yield proc.join()
     dt = time() - t1
-    assert dt <= 0.2
+    assert dt <= 0.6
 
+    #yield gen.sleep(0.1)
+    #sys.exc_clear()
     del proc
     gc.collect()
-    assert wr1() is None
+    if wr1() is not None:
+        from types import FrameType
+        p = wr1()
+        if p is not None:
+            rc = sys.getrefcount(p)
+            refs = gc.get_referrers(p)
+            del p
+            print("refs to proc:", rc, refs)
+            frames = [r for r in refs if isinstance(r, FrameType)]
+            for i, f in enumerate(frames):
+                print("frames #%d:" % i,
+                      f.f_code.co_name, f.f_code.co_filename, sorted(f.f_locals))
+        pytest.fail("AsyncProcess should have been destroyed")
     t1 = time()
     while wr2() is not None:
         yield gen.sleep(0.01)

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -94,11 +94,10 @@ def test_simple():
     dt = time() - t1
     assert dt <= 0.6
 
-    #yield gen.sleep(0.1)
-    #sys.exc_clear()
     del proc
     gc.collect()
     if wr1() is not None:
+        # Help diagnosing
         from types import FrameType
         p = wr1()
         if p is not None:

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -95,9 +95,9 @@ def test_simple():
     assert dt <= 0.2
 
     del proc
-    t1 = time()
     gc.collect()
     assert wr1() is None
+    t1 = time()
     while wr2() is not None:
         yield gen.sleep(0.01)
         gc.collect()


### PR DESCRIPTION
On Python 2, test_asyncprocess.py::test_simple would sometimes fail on Travis-CI:
https://travis-ci.org/dask/distributed/jobs/242713974#L1669