### PR TITLE
Bump version of tornado dependency to >= 4.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tornado >= 4.2
+tornado >= 4.5
 toolz >= 0.7.4
 msgpack-python
 cloudpickle >= 0.2.2


### PR DESCRIPTION
The [`requirements.txt`](https://github.com/dask/distributed/blob/master/requirements.txt#L1) for this project specifies the following dependency:
```
tornado >= 4.2
```

The current code appears to be incompatible with version 4.2 of tornado. Given the the following `requirements.txt`:
```
tornado==4.2
pandas==0.20.2
dask==0.15.0
distributed==1.17.1
## The following requirements were added by pip freeze:
click==6.7
cloudpickle==0.3.1
HeapDict==1.0.0
msgpack-python==0.4.8
numpy==1.13.0
psutil==5.2.2
python-dateutil==2.6.0
pytz==2017.2
six==1.10.0
sortedcontainers==1.5.7
tblib==1.3.2
toolz==0.8.2
zict==0.1.2
```

and this sample code:
```python
from dask.distributed import Client

client = Client('dask_scheduler:8786')
```

the following errors are produced on both the "worker" and "scheduler" when the python script exits:
```
distributed.utils - ERROR - 'StreamClosedError' object has no attribute 'real_error'
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/distributed/comm/tcp.py", line 152, in read
    n_frames = yield stream.read_bytes(8)
  File "/usr/local/lib/python3.5/site-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python3.5/site-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
tornado.iostream.StreamClosedError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/distributed/utils.py", line 381, in log_errors
    yield
  File "/usr/local/lib/python3.5/site-packages/distributed/client.py", line 742, in _handle_report
    msgs = yield self.scheduler_comm.comm.read()
  File "/usr/local/lib/python3.5/site-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python3.5/site-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
  File "/usr/local/lib/python3.5/site-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python3.5/site-packages/distributed/comm/tcp.py", line 166, in read
    convert_stream_closed_error(e)
  File "/usr/local/lib/python3.5/site-packages/distributed/comm/tcp.py", line 101, in convert_stream_closed_error
    if exc.real_error is not None:
AttributeError: 'StreamClosedError' object has no attribute 'real_error'
tornado.application - ERROR - Future <tornado.concurrent.Future object at 0x7f5c80fc07f0> exception was never retrieved: Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/distributed/comm/tcp.py", line 152, in read
    n_frames = yield stream.read_bytes(8)
  File "/usr/local/lib/python3.5/site-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python3.5/site-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
tornado.iostream.StreamClosedError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python3.5/site-packages/distributed/client.py", line 742, in _handle_report
    msgs = yield self.scheduler_comm.comm.read()
  File "/usr/local/lib/python3.5/site-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python3.5/site-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
  File "/usr/local/lib/python3.5/site-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python3.5/site-packages/distributed/comm/tcp.py", line 166, in read
    convert_stream_closed_error(e)
  File "/usr/local/lib/python3.5/site-packages/distributed/comm/tcp.py", line 101, in convert_stream_closed_error
    if exc.real_error is not None:
AttributeError: 'StreamClosedError' object has no attribute 'real_error'
```

When using to tornado v4.5.2 this error is not present. 

I also noticed that the the tests specify v4.5 for tornado:
https://github.com/dask/distributed/blob/21d59d89a9637705923e813dc1dac432f10039ec/continuous_integration/travis/install.sh#L54
https://github.com/dask/distributed/blob/21d59d89a9637705923e813dc1dac432f10039ec/continuous_integration/setup_conda_environment.cmd#L40