### PR TITLE
Bump Tornado requirement to 4.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tornado >= 4.2
+tornado >= 4.4
 toolz >= 0.7.4
 msgpack-python
 cloudpickle >= 0.2.2


### PR DESCRIPTION
This seems to be the minimum required version to get the test suite passing.