### PR TITLE
Allow explicit close of AsyncProcess

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -333,6 +333,7 @@ class WorkerProcess(object):
             self.status = 'stopped'
             self.stopped.set()
             # Release resources
+            self.process.close()
             self.init_result_q = None
             self.child_stop_q = None
             self.process = None

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -179,6 +179,28 @@ def test_terminate():
 
 
 @gen_test()
+def test_close():
+    proc = AsyncProcess(target=exit_now)
+    proc.close()
+    with pytest.raises(ValueError):
+        yield proc.start()
+
+    proc = AsyncProcess(target=exit_now)
+    yield proc.start()
+    proc.close()
+    with pytest.raises(ValueError):
+        yield proc.terminate()
+
+    proc = AsyncProcess(target=exit_now)
+    yield proc.start()
+    yield proc.join()
+    proc.close()
+    with pytest.raises(ValueError):
+        yield proc.join()
+    proc.close()
+
+
+@gen_test()
 def test_exit_callback():
     to_child = mp_context.Queue()
     from_child = mp_context.Queue()


### PR DESCRIPTION
This will reap the helper thread, regardless of possible reference cycles delaying garbage collection.