### PR TITLE
[WIP] Rewrite batched communications

### DIFF
--- a/distributed/channels.py
+++ b/distributed/channels.py
@@ -49,14 +49,14 @@ class ChannelScheduler(object):
 
         comm = self.scheduler.comms[client]
         for type, value in self.deques[channel]:
-            comm.send({'op': 'channel-append',
-                       'type': type,
-                       'value': value,
-                       'channel': channel})
+            comm.write({'op': 'channel-append',
+                        'type': type,
+                        'value': value,
+                        'channel': channel})
 
         if self.stopped[channel]:
-            comm.send({'op': 'channel-stop',
-                       'channel': channel})
+            comm.write({'op': 'channel-stop',
+                        'channel': channel})
 
     def unsubscribe(self, channel=None, client=None):
         logger.info("Remove client from channel, %s, %s", client, channel)
@@ -92,8 +92,8 @@ class ChannelScheduler(object):
         for client in list(self.clients[channel]):
             try:
                 comm = self.scheduler.comms[client]
-                comm.send({'op': 'channel-stop',
-                           'channel': channel})
+                comm.write({'op': 'channel-stop',
+                            'channel': channel})
             except (KeyError, CommClosedError):
                 self.unsubscribe(channel, client)
 
@@ -101,10 +101,10 @@ class ChannelScheduler(object):
         for client in list(self.clients[channel]):
             try:
                 comm = self.scheduler.comms[client]
-                comm.send({'op': 'channel-append',
-                           'type': type,
-                           'value': value,
-                           'channel': channel})
+                comm.write({'op': 'channel-append',
+                            'type': type,
+                            'value': value,
+                            'channel': channel})
             except (KeyError, CommClosedError):
                 self.unsubscribe(channel, client)
 

--- a/distributed/comm/__init__.py
+++ b/distributed/comm/__init__.py
@@ -7,6 +7,7 @@ from .addressing import (parse_address, unparse_address,
                          get_local_address_for,
                          )
 from .core import connect, listen, Comm, CommClosedError
+from .batched import BatchedComm
 
 
 def _register_transports():

--- a/distributed/comm/batched.py
+++ b/distributed/comm/batched.py
@@ -1,0 +1,134 @@
+from __future__ import print_function, division, absolute_import
+
+from collections import deque
+import logging
+
+from tornado import gen, locks
+from tornado.ioloop import IOLoop
+
+from .core import Comm, CommClosedError
+
+
+logger = logging.getLogger(__name__)
+
+
+class BatchedComm(Comm):
+    """
+    This takes a comm and an interval and ensures that we send no
+    more than one message every interval seconds.  We send lists of
+    messages.
+    """
+
+    def __init__(self, comm, interval):
+        self.interval = interval
+        self.comm = comm
+        self.loop = IOLoop.current(instance=False)
+
+        self._please_stop = False
+        self._buffer = []
+        self.message_count = 0
+        self.batch_count = 0
+        self.byte_count = 0
+        self._last_write = None
+        self._next_deadline = None
+        self._timeout = None
+
+    def __str__(self):
+        return '<BatchedComm: %d messages pending>' % len(self._buffer)
+
+    __repr__ = __str__
+
+    def _schedule_iteration(self):
+        assert self._timeout is None
+        self._timeout = self.loop.add_timeout(self._next_deadline, self._iterate)
+
+    def _cancel_iteration(self):
+        timeout, self._timeout = self._timeout, None
+        if timeout is not None:
+            self.loop.remove_timeout(timeout)
+
+    @gen.coroutine
+    def _iterate(self):
+        self._timeout = None
+
+        if self._please_stop:
+            return
+        assert self._next_deadline is not None
+        if self.loop.time() < self._next_deadline:
+            # Spurious wakeup?  Send interval not expired yet
+            logger.warning("Got spurious wakeup")
+            self._schedule_iteration()
+            return
+        payload, self._buffer = self._buffer, []
+        self._next_deadline = None
+        if not payload:
+            # Nothing to send
+            return
+        self.batch_count += 1
+        try:
+            nbytes = yield self.comm.write(payload)
+            self.byte_count += nbytes
+        except CommClosedError as e:
+            if not self._please_stop:
+                logger.info("BatchedComm Closed: %s", e)
+        except Exception:
+            if not self._please_stop:
+                logger.exception("Error in batched write")
+        else:
+            self._last_write = self.loop.time()
+
+    def write(self, msg):
+        """
+        Schedule a message for sending to the other side.
+
+        This completes quickly and synchronously.
+        """
+        if self.comm.closed():
+            raise CommClosedError
+
+        self.message_count += 1
+        self._buffer.append(msg)
+        if self._timeout is None:
+            if self._last_write is None:
+                self._next_deadline = self.loop.time() + self.interval
+            else:
+                self._next_deadline = self._last_write + self.interval
+            self._schedule_iteration()
+        return gen.moment
+
+    @gen.coroutine
+    def close(self):
+        """
+        Flush existing messages and then close comm.
+        """
+        self._cancel_iteration()
+        self._buffer, payload = [], self._buffer
+        self._please_stop = True
+        if not self.comm.closed():
+            try:
+                if payload:
+                    yield self.comm.write(payload)
+            except CommClosedError:
+                pass
+            yield self.comm.close()
+
+    def abort(self):
+        self._cancel_iteration()
+        self._buffer = []
+        self._please_stop = True
+        if not self.comm.closed():
+            self.comm.abort()
+
+    def closed(self):
+        return self.comm.closed()
+
+    def peer_address(self):
+        return self.comm.peer_address()
+
+    def read(self):
+        # XXX Should read() first try to send pending messages?
+        return self.comm.read()
+
+    @property
+    def extra_info(self):
+        return self.comm.extra_info

--- a/distributed/comm/batched.py
+++ b/distributed/comm/batched.py
@@ -1,9 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import deque
 import logging
 
-from tornado import gen, locks
+from tornado import gen
 from tornado.ioloop import IOLoop
 
 from .core import Comm, CommClosedError

--- a/distributed/comm/batched.py
+++ b/distributed/comm/batched.py
@@ -14,12 +14,14 @@ logger = logging.getLogger(__name__)
 
 class BatchedComm(Comm):
     """
-    This takes a comm and an interval and ensures that we send no
-    more than one message every interval seconds.  We send lists of
-    messages.
+    This takes an interval and ensures that we send no more than one
+    message every interval seconds.  We send lists of messages.
+
+    The comm can be passed later on (through start()) to allow for
+    buffering early sends.
     """
 
-    def __init__(self, comm, interval):
+    def __init__(self, interval, comm=None):
         self.interval = interval
         self.comm = comm
         self.loop = IOLoop.current(instance=False)
@@ -38,13 +40,21 @@ class BatchedComm(Comm):
 
     __repr__ = __str__
 
+    def _check_comm(self):
+        if self.comm is None:
+            raise ValueError("please call BatchedComm.start() first")
+
     def _schedule_iteration(self):
+        logger.debug("Scheduling iteration at %s (%.3f s. from now)",
+                     self._next_deadline,
+                     self._next_deadline - self.loop.time())
         assert self._timeout is None
         self._timeout = self.loop.add_timeout(self._next_deadline, self._iterate)
 
     def _cancel_iteration(self):
         timeout, self._timeout = self._timeout, None
         if timeout is not None:
+            logger.debug("Cancelling iteration")
             self.loop.remove_timeout(timeout)
 
     @gen.coroutine
@@ -56,26 +66,41 @@ class BatchedComm(Comm):
         assert self._next_deadline is not None
         if self.loop.time() < self._next_deadline:
             # Spurious wakeup?  Send interval not expired yet
-            logger.warning("Got spurious wakeup")
+            logger.info("Iterate: Got spurious wakeup")
             self._schedule_iteration()
             return
         payload, self._buffer = self._buffer, []
         self._next_deadline = None
         if not payload:
             # Nothing to send
+            logger.debug("Iterate: Nothing to send")
             return
         self.batch_count += 1
+        logger.debug("Iterate: Sending %d messages at once to %r",
+                     len(payload), self.peer_address)
         try:
             nbytes = yield self.comm.write(payload)
             self.byte_count += nbytes
         except CommClosedError as e:
+            raise
             if not self._please_stop:
                 logger.info("BatchedComm Closed: %s", e)
         except Exception:
+            raise
             if not self._please_stop:
                 logger.exception("Error in batched write")
         else:
             self._last_write = self.loop.time()
+
+    def start(self, comm):
+        """
+        """
+        assert self.comm is None, "cannot be called twice"
+        assert self._timeout is None
+        self.comm = comm
+        if self._buffer:
+            self._next_deadline = self.loop.time() + self.interval
+            self._schedule_iteration()
 
     def write(self, msg):
         """
@@ -83,12 +108,13 @@ class BatchedComm(Comm):
 
         This completes quickly and synchronously.
         """
-        if self.comm.closed():
+        if self.comm is not None and self.comm.closed():
             raise CommClosedError
 
         self.message_count += 1
         self._buffer.append(msg)
-        if self._timeout is None:
+        logger.debug("Queue one message for sending")
+        if self.comm is not None and self._timeout is None:
             if self._last_write is None:
                 self._next_deadline = self.loop.time() + self.interval
             else:
@@ -104,7 +130,7 @@ class BatchedComm(Comm):
         self._cancel_iteration()
         self._buffer, payload = [], self._buffer
         self._please_stop = True
-        if not self.comm.closed():
+        if self.comm is not None and not self.comm.closed():
             try:
                 if payload:
                     yield self.comm.write(payload)
@@ -116,19 +142,25 @@ class BatchedComm(Comm):
         self._cancel_iteration()
         self._buffer = []
         self._please_stop = True
-        if not self.comm.closed():
+        if self.comm is not None and not self.comm.closed():
             self.comm.abort()
 
     def closed(self):
+        self._check_comm()
         return self.comm.closed()
 
+    @property
     def peer_address(self):
-        return self.comm.peer_address()
+        self._check_comm()
+        return self.comm.peer_address
 
+    @gen.coroutine
     def read(self):
-        # XXX Should read() first try to send pending messages?
-        return self.comm.read()
+        self._check_comm()
+        msg = yield self.comm.read()
+        raise gen.Return(msg)
 
     @property
     def extra_info(self):
+        self._check_comm()
         return self.comm.extra_info

--- a/distributed/comm/tests/test_batched_comm.py
+++ b/distributed/comm/tests/test_batched_comm.py
@@ -35,7 +35,7 @@ def get_comm_pair(listen_addr, listen_args=None, connect_args=None):
     comm = yield connect(listener.contact_address,
                          connection_args=connect_args)
     serv_comm = yield q.get()
-    return comm, serv_comm
+    raise gen.Return((comm, serv_comm))
 
 
 @gen.coroutine

--- a/distributed/comm/tests/test_batched_comm.py
+++ b/distributed/comm/tests/test_batched_comm.py
@@ -1,0 +1,142 @@
+from __future__ import print_function, division, absolute_import
+
+from functools import partial
+import os
+import ssl
+import sys
+import threading
+
+import pytest
+
+from tornado import gen, queues
+from tornado.ioloop import IOLoop
+
+from distributed.utils_test import (gen_test, get_server_ssl_context,
+                                    get_client_ssl_context)
+from distributed.comm import connect, listen, CommClosedError
+from distributed.comm.batched import BatchedComm
+
+
+tls_kwargs = dict(listen_args={'ssl_context': get_server_ssl_context()},
+                  connect_args={'ssl_context': get_client_ssl_context()})
+
+
+@gen.coroutine
+def get_comm_pair(listen_addr, listen_args=None, connect_args=None):
+    q = queues.Queue()
+
+    def handle_comm(comm):
+        q.put(comm)
+
+    listener = listen(listen_addr, handle_comm,
+                      connection_args=listen_args)
+    listener.start()
+
+    comm = yield connect(listener.contact_address,
+                         connection_args=connect_args)
+    serv_comm = yield q.get()
+    return comm, serv_comm
+
+
+@gen.coroutine
+def check_write(addr, **kwargs):
+    loop = IOLoop.current(instance=False)
+
+    a, b = yield get_comm_pair(addr, **kwargs)
+    b = BatchedComm(b, interval=0.2)
+
+    t1 = loop.time()
+    for i in range(3):
+        b.write(i)
+
+    msg = yield a.read()
+    t2 = loop.time()
+    assert t2 - t1 >= 0.2
+    # Hopefully CI machines are fast enough for the 0.2s interval?
+    assert msg == list(range(3))
+
+    N = 100
+    for i in range(N):
+        yield b.write(i)
+        yield gen.sleep(5e-3)  # wait for more than batched interval / N
+
+    got = []
+    while len(got) < N:
+        got += (yield a.read())
+
+    assert got == list(range(N))
+
+    a.abort()
+    b.abort()
+
+
+@gen_test()
+def test_write_tcp():
+    yield check_write('tcp://')
+
+@gen_test()
+def test_write_inproc():
+    yield check_write('inproc://')
+
+@gen_test()
+def test_write_tls():
+    yield check_write('inproc://', **tls_kwargs)
+
+
+@gen_test()
+def test_read():
+    a, b = yield get_comm_pair('tcp://')
+    a = BatchedComm(a, interval=0.2)
+    b = BatchedComm(b, interval=0.2)
+
+    for i in range(3):
+        b.write(i)
+    msg = yield a.read()
+    assert msg == list(range(3))
+
+    a.abort()
+    b.abort()
+
+
+@gen_test()
+def test_close():
+    a, b = yield get_comm_pair('tcp://')
+    b = BatchedComm(b, interval=0.2)
+
+    assert not b.closed()
+    assert not b.comm.closed()
+    yield b.close()
+    assert b.closed()
+    assert b.comm.closed()
+    a.abort()
+
+
+@gen_test()
+def test_abort():
+    a, b = yield get_comm_pair('tcp://')
+    b = BatchedComm(b, interval=0.2)
+
+    assert not b.closed()
+    assert not b.comm.closed()
+    b.abort()
+    assert b.closed()
+    assert b.comm.closed()
+    a.abort()
+
+
+@gen.coroutine
+def check_extra_info(addr, **kwargs):
+    a, b = yield get_comm_pair(addr, **kwargs)
+    b = BatchedComm(b, interval=0.2)
+    assert b.extra_info == b.comm.extra_info
+
+    a.abort()
+    b.abort()
+
+@gen_test()
+def test_extra_info_tcp():
+    yield check_extra_info('tcp://')
+
+@gen_test()
+def test_extra_info_tls():
+    yield check_extra_info('tls://', **tls_kwargs)

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -15,7 +15,8 @@ from distributed.core import pingpong
 from distributed.metrics import time
 from distributed.utils import get_ip, get_ipv6
 from distributed.utils_test import (slow, loop, gen_test, gen_cluster,
-                                    requires_ipv6, has_ipv6, get_cert)
+                                    requires_ipv6, has_ipv6, get_cert,
+                                    get_server_ssl_context, get_client_ssl_context)
 
 from distributed.protocol import (loads, dumps,
                                   to_serialize, Serialized, serialize, deserialize)
@@ -50,22 +51,6 @@ def check_tls_extra(info):
     assert 'AES' in cipher_name
     assert 'TLS' in proto_name
     assert secret_bits >= 128
-
-
-def get_server_ssl_context(certfile='tls-cert.pem', keyfile='tls-key.pem'):
-    ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=ca_file)
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_REQUIRED
-    ctx.load_cert_chain(get_cert(certfile), get_cert(keyfile))
-    return ctx
-
-def get_client_ssl_context(certfile='tls-cert.pem', keyfile='tls-key.pem'):
-    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=ca_file)
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_REQUIRED
-    ctx.load_cert_chain(get_cert(certfile), get_cert(keyfile))
-    return ctx
-
 
 
 @gen.coroutine

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -23,7 +23,6 @@ from tornado.ioloop import IOLoop
 from dask.core import reverse_dict
 from dask.order import order
 
-#from .batched import BatchedSend
 from .comm import (normalize_address, resolve_address,
                    get_address_host, unparse_host_port, BatchedComm)
 from .compatibility import finalize

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -172,9 +172,9 @@ class WorkStealing(SchedulerPlugin):
             self.scheduler.total_occupancy += duration
             self.put_key_in_stealable(key)
 
-            self.scheduler.worker_comms[victim].send({'op': 'release-task',
-                                                      'reason': 'stolen',
-                                                      'key': key})
+            self.scheduler.worker_comms[victim].write({'op': 'release-task',
+                                                       'reason': 'stolen',
+                                                       'key': key})
 
             try:
                 self.scheduler.send_task_to_worker(thief, key)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -543,11 +543,11 @@ def test_broadcast(s, a, b):
     result = yield s.broadcast(msg={'op': 'ping'})
     assert result == {a.address: b'pong', b.address: b'pong'}
 
-    #result = yield s.broadcast(msg={'op': 'ping'}, workers=[a.address])
-    #assert result == {a.address: b'pong'}
+    result = yield s.broadcast(msg={'op': 'ping'}, workers=[a.address])
+    assert result == {a.address: b'pong'}
 
-    #result = yield s.broadcast(msg={'op': 'ping'}, hosts=[a.ip])
-    #assert result == {a.address: b'pong', b.address: b'pong'}
+    result = yield s.broadcast(msg={'op': 'ping'}, hosts=[a.ip])
+    assert result == {a.address: b'pong', b.address: b'pong'}
 
 
 @gen_cluster(Worker=Nanny)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -543,11 +543,11 @@ def test_broadcast(s, a, b):
     result = yield s.broadcast(msg={'op': 'ping'})
     assert result == {a.address: b'pong', b.address: b'pong'}
 
-    result = yield s.broadcast(msg={'op': 'ping'}, workers=[a.address])
-    assert result == {a.address: b'pong'}
+    #result = yield s.broadcast(msg={'op': 'ping'}, workers=[a.address])
+    #assert result == {a.address: b'pong'}
 
-    result = yield s.broadcast(msg={'op': 'ping'}, hosts=[a.ip])
-    assert result == {a.address: b'pong', b.address: b'pong'}
+    #result = yield s.broadcast(msg={'op': 'ping'}, hosts=[a.ip])
+    #assert result == {a.address: b'pong', b.address: b'pong'}
 
 
 @gen_cluster(Worker=Nanny)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -924,7 +924,7 @@ def test_worker_breaks_and_returns(c, s, a):
 
     yield _wait(future)
 
-    a.batched_stream.comm.close()
+    a.batched_comm.abort()
 
     yield gen.sleep(0.1)
     start = time()

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -17,7 +17,7 @@ def test_pack_data():
 
 @gen_cluster()
 def test_gather_from_workers_permissive(s, a, b):
-    while not a.batched_stream:
+    while a.batched_comm is None:
         yield gen.sleep(0.01)
     a.update_data(data={'x': 1})
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import signal
 import socket
+import ssl
 import subprocess
 import sys
 import tempfile
@@ -926,3 +927,22 @@ def tls_only_security():
         sec = Security()
     assert sec.require_encryption
     return sec
+
+
+def get_server_ssl_context(certfile='tls-cert.pem', keyfile='tls-key.pem',
+                           ca_file='tls-ca-cert.pem'):
+    ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH,
+                                     cafile=get_cert(ca_file))
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.load_cert_chain(get_cert(certfile), get_cert(keyfile))
+    return ctx
+
+def get_client_ssl_context(certfile='tls-cert.pem', keyfile='tls-key.pem',
+                           ca_file='tls-ca-cert.pem'):
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH,
+                                     cafile=get_cert(ca_file))
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.load_cert_chain(get_cert(certfile), get_cert(keyfile))
+    return ctx


### PR DESCRIPTION
This was prompted by the BatchedSend-induced memory leak. The new design doesn't have a background-running loop but only schedules a callback when required, which should remove the core issue.

Also the new "batched" object is an actual Comm, which would ideally simplify and streamline things. Unfortunately the requirement to instantiate a "batched" before having an underlying Comm reintroduces some of the complication I hoped to dispose of.