### PR TITLE
Offload (de)serialization to a separate thread

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -166,7 +166,7 @@ class TCP(Comm):
             convert_stream_closed_error(e)
 
         try:
-            msg = from_frames(frames, deserialize=self.deserialize)
+            msg = yield from_frames(frames, deserialize=self.deserialize)
         except EOFError:
             # Frames possibly garbled or truncated by communication error
             self.abort()
@@ -179,10 +179,9 @@ class TCP(Comm):
         if stream is None:
             raise CommClosedError
 
-        if self._iostream_allows_memoryview:
-            frames = to_frames(msg)
-        else:
-            frames = [ensure_bytes(f) for f in to_frames(msg)]
+        frames = yield to_frames(msg)
+        if not self._iostream_allows_memoryview:
+            frames = [ensure_bytes(f) for f in frames]
 
         try:
             lengths = ([struct.pack('Q', len(frames))] +

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -868,7 +868,7 @@ def check_deserialize(addr):
 
     msg = {'op': 'update',
            'x': b'abc',
-           'y': b'def\n' * (2 ** 20),
+           'y': b'def\n' * (3 * 1024 ** 2),  # end size: 12 MB
            }
     msg_orig = msg.copy()
 

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -1,43 +1,88 @@
 from __future__ import print_function, division, absolute_import
 
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import socket
 
+from tornado import gen
+
 from .. import protocol
-from ..utils import get_ip, get_ipv6
+from ..compatibility import finalize
+from ..sizeof import sizeof
+from ..utils import get_ip, get_ipv6, nbytes
 
 
 logger = logging.getLogger(__name__)
 
 
+# Offload (de)serializing large frames to improve event loop responsiveness
+FRAME_OFFLOAD_THRESHOLD = 10 * 1024 ** 2   # 10 MB
+
+
+class Offloader(object):
+
+    def __init__(self):
+        self.executor = ThreadPoolExecutor(max_workers=1)
+        self._finalizer = finalize(self, self.executor.shutdown)
+
+    def submit(self, fn, *args, **kwargs):
+        return self.executor.submit(fn, *args, **kwargs)
+
+
+_offloader = Offloader()
+
+
+def offload(fn, *args, **kwargs):
+    return _offloader.submit(fn, *args, **kwargs)
+
+
+@gen.coroutine
 def to_frames(msg):
     """
     Serialize a message into a list of Distributed protocol frames.
     """
-    try:
-        return list(protocol.dumps(msg))
-    except Exception as e:
-        logger.info("Unserializable Message: %s", msg)
-        logger.exception(e)
-        raise
+    def _to_frames():
+        try:
+            return list(protocol.dumps(msg))
+        except Exception as e:
+            logger.info("Unserializable Message: %s", msg)
+            logger.exception(e)
+            raise
+
+    if sizeof(msg) > FRAME_OFFLOAD_THRESHOLD:
+        res = yield offload(_to_frames)
+    else:
+        res = _to_frames()
+
+    raise gen.Return(res)
 
 
+@gen.coroutine
 def from_frames(frames, deserialize=True):
     """
     Unserialize a list of Distributed protocol frames.
     """
-    try:
-        return protocol.loads(frames, deserialize=deserialize)
-    except EOFError:
-        size = sum(map(len, frames))
-        if size > 1000:
-            datastr = "[too large to display]"
-        else:
-            datastr = frames
-        # Aid diagnosing
-        logger.error("truncated data stream (%d bytes): %s", size,
-                     datastr)
-        raise
+    size = sum(map(nbytes, frames))
+
+    def _from_frames():
+        try:
+            return protocol.loads(frames, deserialize=deserialize)
+        except EOFError:
+            if size > 1000:
+                datastr = "[too large to display]"
+            else:
+                datastr = frames
+            # Aid diagnosing
+            logger.error("truncated data stream (%d bytes): %s", size,
+                         datastr)
+            raise
+
+    if deserialize and size > FRAME_OFFLOAD_THRESHOLD:
+        res = yield offload(_from_frames)
+    else:
+        res = _from_frames()
+
+    raise gen.Return(res)
 
 
 def get_tcp_server_address(tcp_server):


### PR DESCRIPTION
This is conditioned on the input size, to avoid increasing the overhead of processing
small administrative messages.