### PR TITLE
Use nbytes more consistently throughout protocol code

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -213,7 +213,7 @@ class TCP(Comm):
             stream = None
             convert_stream_closed_error(self, e)
 
-        raise gen.Return(sum(map(len, frames)))
+        raise gen.Return(sum(map(nbytes, frames)))
 
     @gen.coroutine
     def close(self):

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -16,6 +16,7 @@ from .compression import compressions, maybe_compress, decompress
 from .serialize import (serialize, deserialize, Serialize, Serialized,
         extract_serialize)
 from .utils import frame_split_size, merge_frames
+from ..utils import nbytes
 
 _deserialize = deserialize
 
@@ -51,7 +52,7 @@ def dumps(msg):
 
         for key, (head, frames) in data.items():
             if 'lengths' not in head:
-                head['lengths'] = tuple(map(len, frames))
+                head['lengths'] = tuple(map(nbytes, frames))
             if 'compression' not in head:
                 frames = frame_split_size(frames)
                 if frames:
@@ -66,7 +67,7 @@ def dumps(msg):
 
         for key, (head, frames) in pre.items():
             if 'lengths' not in head:
-                head['lengths'] = tuple(map(len, frames))
+                head['lengths'] = tuple(map(nbytes, frames))
             head['count'] = len(frames)
             header['headers'][key] = head
             header['keys'].append(key)

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -10,6 +10,7 @@ from distributed.protocol import (loads, dumps, msgpack, maybe_compress,
 from distributed.protocol.compression import compressions
 from distributed.protocol.serialize import (Serialize, Serialized,
                                             serialize, deserialize)
+from distributed.utils import nbytes
 from distributed.utils_test import slow
 
 
@@ -23,7 +24,7 @@ def test_compression_1():
     np = pytest.importorskip('numpy')
     x = np.ones(1000000)
     frames = dumps({'x': Serialize(x.tobytes())})
-    assert sum(map(len, frames)) < x.nbytes
+    assert sum(map(nbytes, frames)) < x.nbytes
     y = loads(frames)
     assert {'x': x.tobytes()} == y
 
@@ -50,8 +51,8 @@ def test_compression_without_deserialization():
 
 
 def test_small():
-    assert sum(map(len, dumps(b''))) < 10
-    assert sum(map(len, dumps(1))) < 10
+    assert sum(map(nbytes, dumps(b''))) < 10
+    assert sum(map(nbytes, dumps(1))) < 10
 
 
 def test_small_and_big():
@@ -154,10 +155,10 @@ def test_loads_without_deserialization_avoids_compression():
     msg = {'x': 1, 'data': to_serialize(b)}
     frames = dumps(msg)
 
-    assert sum(map(len, frames)) < 10000
+    assert sum(map(nbytes, frames)) < 10000
 
     msg2 = loads(frames, deserialize=False)
-    assert sum(map(len, msg2['data'].frames)) < 10000
+    assert sum(map(nbytes, msg2['data'].frames)) < 10000
 
     msg3 = dumps(msg2)
     msg4 = loads(msg3)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -9,8 +9,9 @@ from toolz import identity
 
 from distributed.protocol import (register_serialization, serialize,
         deserialize, nested_deserialize, Serialize, Serialized,
-        to_serialize, serialize_bytes, deserialize_bytes, serialize_bytelist)
-from distributed.protocol import decompress
+        to_serialize, serialize_bytes, deserialize_bytes, serialize_bytelist,
+        decompress)
+from distributed.utils import nbytes
 
 
 class MyObj(object):
@@ -175,7 +176,7 @@ def test_serialize_list_compress():
     pytest.importorskip('lz4')
     x = np.ones(1000000)
     L = serialize_bytelist(x)
-    assert sum(map(len, L)) < x.nbytes / 2
+    assert sum(map(nbytes, L)) < x.nbytes / 2
 
     b = b''.join(L)
     y = deserialize_bytes(b)

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -21,7 +21,7 @@ def frame_split_size(frames, n=BIG_BYTES_SHARD_SIZE):
     if not frames:
         return frames
 
-    if max(map(len, frames)) <= n:
+    if max(map(nbytes, frames)) <= n:
         return frames
 
     out = []
@@ -33,8 +33,8 @@ def frame_split_size(frames, n=BIG_BYTES_SHARD_SIZE):
                 itemsize = frame.itemsize
             except AttributeError:
                 itemsize = 1
-            for i in range(0, nbytes(frame), n // itemsize):
-                out.append(frame[i: i + n])
+            for i in range(0, nbytes(frame) // itemsize, n // itemsize):
+                out.append(frame[i: i + n // itemsize])
         else:
             out.append(frame)
     return out
@@ -55,7 +55,7 @@ def merge_frames(header, frames):
     if not frames:
         return frames
 
-    assert sum(lengths) == sum(map(len, frames))
+    assert sum(lengths) == sum(map(nbytes, frames))
 
     if all(len(f) == l for f, l in zip(frames, lengths)):
         return frames
@@ -69,9 +69,9 @@ def merge_frames(header, frames):
         L = []
         while l:
             frame = frames.pop()
-            if len(frame) <= l:
+            if nbytes(frame) <= l:
                 L.append(frame)
-                l -= len(frame)
+                l -= nbytes(frame)
             else:
                 mv = memoryview(frame)
                 L.append(mv[:l])

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -179,3 +179,16 @@ def test_dataframe_groupby_tasks(loop):
                 b = ddf.groupby(['A', 'B']).apply(len)
 
                 assert_equal(a, b.compute(get=dask.get).sort_index())
+
+
+@gen_cluster(client=True)
+def test_sparse_arrays(c, s, a, b):
+    sparse = pytest.importorskip('sparse')
+    da = pytest.importorskip('dask.array')
+
+    x = da.random.random((100, 10), chunks=(10, 10))
+    x[x < 0.95] = 0
+    s = x.map_blocks(sparse.COO)
+    future = c.compute(s.sum(axis=0)[:10])
+
+    yield future


### PR DESCRIPTION
Historically we always moved bytestrings around and so used the `len`
function to determine how many bytes there were.  In the last release we
started supporting memoryviews with itemsizes greater than one.  These
itemsizes were used as hints for the compression code.  We started using
a new function, `nbytes`, which provided the bytes of an object
regardless of type (for bytestrings, buffers, and memoryviews).

However we didn't smoothly transition all uses of `len` to `nbytes`.  In
particular some of the sparse array code wasn't transitioned over.  This
commit goes through the protocol more thoroughly replacing uses of `len`
with `nbytes`.

Fixes https://github.com/dask/distributed/issues/1223

cc @ogrisel 