### PR TITLE
Fix #1158: Make socket backlog configurable

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -37,6 +37,8 @@ def get_total_physical_memory():
 
 MAX_BUFFER_SIZE = get_total_physical_memory()
 
+DEFAULT_BACKLOG = 2048
+
 
 def set_tcp_timeout(stream):
     """
@@ -321,6 +323,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         self.tcp_server = TCPServer(max_buffer_size=MAX_BUFFER_SIZE,
                                     **self.server_args)
         self.tcp_server.handle_stream = self.handle_stream
+        backlog = int(config.get('socket-backlog', DEFAULT_BACKLOG))
         for i in range(5):
             try:
                 # When shuffling data between workers, there can
@@ -328,7 +331,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
                 # on a single worker socket, make sure the backlog
                 # is large enough not to lose any.
                 sockets = netutil.bind_sockets(self.port, address=self.ip,
-                                               backlog=2048)
+                                               backlog=backlog)
             except EnvironmentError as e:
                 # EADDRINUSE can happen sporadically when trying to bind
                 # to an ephemeral port

--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -21,6 +21,7 @@ multiprocessing-method: forkserver
 tcp-timeout: 30         # seconds delay before calling an unresponsive connection dead
 default-scheme: tcp
 require-encryption: False   # whether to require encryption on non-local comms
+socket-backlog: 2048
 #tls:
     #ca-file: xxx.pem
     #scheduler:

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -4,8 +4,11 @@ from concurrent.futures import CancelledError
 from datetime import timedelta
 from operator import add
 import random
+import re
 import sys
 from time import sleep
+import threading
+import traceback
 
 from dask import delayed
 import pytest
@@ -16,7 +19,7 @@ from distributed.config import config
 from distributed.metrics import time
 from distributed.utils import All
 from distributed.utils_test import (gen_cluster, cluster, inc, slowinc, loop,
-        slowadd, slow, slowsum)
+        slowadd, slow, slowsum, new_config, bump_rlimit)
 from distributed.client import _wait
 from tornado import gen
 
@@ -170,14 +173,7 @@ def test_stress_communication(c, s, *workers):
     da = pytest.importorskip('dask.array')
     # Test consumes many file descriptors and can hang if the limit is too low
     resource = pytest.importorskip('resource')
-    try:
-        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-        lim = 8192
-        if soft < lim:
-            resource.setrlimit(resource.RLIMIT_NOFILE, (lim, max(hard, lim)))
-    except Exception as e:
-        pytest.skip("file descriptor limit too low and can't be increased :"
-                    + str(e))
+    bump_rlimit(resource.RLIMIT_NOFILE, 8192)
 
     n = 20
     xs = [da.random.random((100, 100), chunks=(5, 5)) for i in range(n)]
@@ -188,6 +184,70 @@ def test_stress_communication(c, s, *workers):
 
     result = yield future
     assert isinstance(result, float)
+
+
+monopolize_gil_evt = threading.Event()
+
+def monopolize_gil():
+    """
+    Start a background thread that will periodically monopolize the GIL
+    for multiple seconds.
+    """
+    def run():
+        try:
+            while not monopolize_gil_evt.is_set():
+                sleep(2.0 + random.random())
+                print("monopolizing GIL...")
+                t1 = time()
+                # GIL-holding time waster
+                # (see https://bugs.python.org/issue1662581)
+                re.compile(r'(\w+)*=.*').match("a" * 27)
+                dt = time() - t1
+                print("done monopolizing GIL for %.1f s." % (dt,))
+        except Exception:
+            traceback.print_exc()
+
+    t = threading.Thread(target=run)
+    t.daemon = True
+    t.start()
+
+
+def build_highly_connected_delayed(depth, fanout):
+    r = random.Random(42)
+    nodes = [delayed(1) for i in range(fanout)]
+    for d in range(depth - 1):
+        nodes = [delayed(sum)
+                 ([nodes[r.randrange(0, fanout)] for i in range(fanout)])
+                 for j in range(fanout)]
+    return delayed(sum)(nodes)
+
+
+@slow
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 60, timeout=100)
+def test_stress_communication_failure(c, s, *workers):
+    monopolize_gil_evt.clear()
+
+    da = pytest.importorskip('dask.array')
+    resource = pytest.importorskip('resource')
+    # Test may consume many file descriptors
+    bump_rlimit(resource.RLIMIT_NOFILE, 8192)
+
+    try:
+        with new_config({'socket-backlog': 1}):
+            c.run(monopolize_gil, workers=[workers[0].address])
+
+            depth = 2
+            fanout = 70
+            x = build_highly_connected_delayed(depth, fanout)
+            d = dict(x.dask)
+            print("compute ...", len(x.dask))
+            fut = yield c.compute(x)
+            result, = yield c.gather([fut])
+            print("result =", result)
+            assert result == fanout ** depth
+
+    finally:
+        monopolize_gil_evt.set()
 
 
 @pytest.mark.skip

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -923,3 +923,15 @@ def tls_only_security():
         sec = Security()
     assert sec.require_encryption
     return sec
+
+
+def bump_rlimit(limit, desired):
+    resource = pytest.importorskip('resource')
+    try:
+        soft, hard = resource.getrlimit(limit)
+        if soft < desired:
+            resource.setrlimit(limit,
+                               (desired, max(hard, desired)))
+    except Exception as e:
+        pytest.skip("rlimit too low (%s) and can't be increased: %s"
+                    % (soft, e))


### PR DESCRIPTION
Like PR #1199, but without the additional stress test.