### PR TITLE
Support bytestrings as keys

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4292,5 +4292,16 @@ def test_identity(c, s, a, b):
     assert s.id.lower().startswith('scheduler')
 
 
+@gen_cluster(client=True)
+def test_bytes_keys(c, s, a, b):
+    key = b'inc-123'
+    future = c.submit(inc, 1, key=key)
+    result = yield future
+    assert type(future.key) is bytes
+    assert list(s.task_state)[0] == key
+    assert key in a.data or key in b.data
+    assert result == 2
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -506,10 +506,8 @@ def tokey(o):
     '1'
     """
     t = type(o)
-    if t is str:
+    if t is str or t is bytes:
         return o
-    elif t is bytes:
-        return o.decode('latin1')
     else:
         return str(o)
 
@@ -517,7 +515,8 @@ def tokey(o):
 def validate_key(k):
     """Validate a key as received on a stream.
     """
-    if type(k) is not str:
+    typ = type(k)
+    if typ is not str and typ is not bytes:
         raise TypeError("Unexpected key type %s (value: %r)"
                         % (type(k), k))
 


### PR DESCRIPTION
This is useful to other languages where msgpack may interpret text as
bytes.

Fixes https://github.com/dask/distributed/issues/1230

cc @nicoleepp