### PR TITLE
Skip task stream test when bokeh is unavailable.

### DIFF
--- a/distributed/bokeh/tests/test_task_stream.py
+++ b/distributed/bokeh/tests/test_task_stream.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+pytest.importorskip('bokeh')
+
 from toolz import frequencies
 
 from distributed.utils_test import gen_cluster, div


### PR DESCRIPTION
Also, add missing `__future__` imports.