### PR TITLE
Check if worker is available to trigger direct scatter

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1389,7 +1389,7 @@ class Client(Node):
             except:
                 direct = False
             else:
-                if w.address.address == self.scheduler.address:
+                if w.scheduler.address == self.scheduler.address:
                     direct = True
 
         if local_worker:  # running within task
@@ -1411,7 +1411,9 @@ class Client(Node):
                                                               report=False,
                                                               rpc=self.rpc)
 
-                yield self.scheduler.update_data(who_has=who_has, nbytes=nbytes)
+                yield self.scheduler.update_data(who_has=who_has,
+                                                 nbytes=nbytes,
+                                                 client=self.id)
             else:
                 yield self.scheduler.scatter(data=data2, workers=workers,
                                                 client=self.id,
@@ -1422,7 +1424,8 @@ class Client(Node):
             self.futures[key].finish(type=typ)
 
         if direct and broadcast:
-            yield self._replicate(list(out.values()), workers=workers)
+            n = None if broadcast is True else broadcast
+            yield self._replicate(list(out.values()), workers=workers, n=n)
 
         if issubclass(input_type, (list, tuple, set, frozenset)):
             out = input_type(out[k] for k in names)

--- a/distributed/tests/py3_test_client.py
+++ b/distributed/tests/py3_test_client.py
@@ -39,6 +39,22 @@ def test_as_completed_async_for(c, s, a, b):
     assert set(results) == set(range(1, 11))
 
 
+@gen_cluster(client=True)
+def test_as_completed_async_for_results(c, s, a, b):
+    futures = c.map(inc, range(10))
+    ac = as_completed(futures, with_results=True)
+    results = []
+
+    async def f():
+        async for future, result in ac:
+            results.append(result)
+
+    yield f()
+
+    assert set(results) == set(range(1, 11))
+    assert not s.counters['op'].components[0]['gather']
+
+
 def test_async_with(loop):
     result = None
     client = None

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1119,6 +1119,13 @@ def test_scatter_direct(c, s, a, b):
     assert future.status == 'finished'
     result = yield future
     assert result == 123
+    assert not s.counters['op'].components[0]['scatter']
+
+    result = yield future
+    assert not s.counters['op'].components[0]['gather']
+
+    result = yield c.gather(future)
+    assert not s.counters['op'].components[0]['gather']
 
 
 @gen_cluster(client=True)
@@ -1128,6 +1135,7 @@ def test_scatter_direct_numpy(c, s, a, b):
     future = yield c.scatter(x, direct=True)
     result = yield future
     assert np.allclose(x, result)
+    assert not s.counters['op'].components[0]['scatter']
 
 
 @gen_cluster(client=True)
@@ -1138,6 +1146,7 @@ def test_scatter_direct_broadcast(c, s, a, b):
     assert s.who_has[future2.key] == {a.address, b.address}
     result = yield future2
     assert result == 456
+    assert not s.counters['op'].components[0]['scatter']
 
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 4)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1171,8 +1171,8 @@ def test_scatter_direct_broadcast_target(c, s, *workers):
 
 @gen_cluster(client=True, ncores=[])
 def test_scatter_direct_empty(c, s):
-    with pytest.raises(ValueError):
-        yield c.scatter(123, direct=True)
+    with pytest.raises((ValueError, gen.TimeoutError)):
+        yield c.scatter(123, direct=True, timeout=0.1)
 
 
 @gen_cluster(client=True, timeout=None, ncores=[('127.0.0.1', 1)] * 5)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -429,20 +429,20 @@ def test_garbage_collection(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_garbage_collection_with_scatter(c, s, a, b):
-    [a] = yield c.scatter([1])
-    assert a.key in c.futures
-    assert a.status == 'finished'
-    assert a.event.is_set()
-    assert s.who_wants[a.key] == {c.id}
+    [future] = yield c.scatter([1])
+    assert future.key in c.futures
+    assert future.status == 'finished'
+    assert future.event.is_set()
+    assert s.who_wants[future.key] == {c.id}
 
-    assert c.refcount[a.key] == 1
-    a.__del__()
+    assert c.refcount[future.key] == 1
+    future.__del__()
     yield gen.moment
-    assert c.refcount[a.key] == 0
+    assert c.refcount[future.key] == 0
 
     start = time()
     while True:
-        if a.key not in s.who_has:
+        if future.key not in s.who_has:
             break
         else:
             assert time() < start + 3

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -738,8 +738,7 @@ def test_launch_without_blocked_services():
 @gen_cluster(ncores=[], client=True)
 def test_scatter_no_workers(c, s):
     with pytest.raises(gen.TimeoutError):
-        yield gen.with_timeout(timedelta(seconds=0.1),
-                               s.scatter(data={'x': 1}, client='alice'))
+        yield s.scatter(data={'x': 1}, client='alice', timeout=0.1)
 
     w = Worker(s.ip, s.port, ncores=3)
     yield [c._scatter(data={'x': 1}),

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -352,12 +352,11 @@ class WorkerBase(ServerNode):
         self._remove_from_global_workers()
 
     def _remove_from_global_workers(self):
-        with log_errors():
-            for ref in list(_global_workers):
-                if ref() is self:
-                    _global_workers.remove(ref)
-                if ref() is None:
-                    _global_workers.remove(ref)
+        for ref in list(_global_workers):
+            if ref() is self:
+                _global_workers.remove(ref)
+            if ref() is None:
+                _global_workers.remove(ref)
 
     @gen.coroutine
     def terminate(self, comm, report=True):


### PR DESCRIPTION
Previously functions like as_completed and Future.result did not
participate in direct gather/scattering.  Now we check for the presence
of any local worker that matches our scheduler address.  If so then we
try direct gather/scattering.

cc @adamklein