### PR TITLE
Fix testing of blosc compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ services:
 
 env:
   matrix:
-    - PYTHON=2.7 PACKAGES="blosc futures faulthandler"
-    - PYTHON=3.5 COVERAGE=true PACKAGES=blosc CRICK=true
+    - PYTHON=2.7 PACKAGES="python-blosc futures faulthandler"
+    - PYTHON=3.5 COVERAGE=true PACKAGES=python-blosc CRICK=true
     - PYTHON=3.6
     - HDFS=true PYTHON=2.7
-    - HDFS=true PYTHON=3.5 PACKAGES=blosc
+    - HDFS=true PYTHON=3.5 PACKAGES=python-blosc
 
 matrix:
   fast_finish: true

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -214,6 +214,8 @@ def test_dumps_loads_Serialized():
     assert result == result3
 
 
+@pytest.mark.skipif(sys.version_info[0] < 3,
+                    reason='NumPy doesnt use memoryviews')
 def test_maybe_compress_memoryviews():
     np = pytest.importorskip('numpy')
     pytest.importorskip('lz4')


### PR DESCRIPTION
~~Based on [`test_compress_numpy`](https://github.com/dask/distributed/blob/master/distributed/protocol/tests/test_numpy.py#L143), [`test_compression_takes_advantage_of_itemsize`](https://github.com/dask/distributed/blob/master/distributed/protocol/tests/test_numpy.py#L196), and [`test_maybe_compress_memoryviews`](https://github.com/dask/distributed/blob/master/distributed/protocol/tests/test_protocol.py#L217), I believe that blosc is expected to be the default when available. However, it appears that the line setting it as default is missing, and is now added by this PR.~~

I'm a bit confused why a) this never failed on Travis, and b) the latest build of master on Travis is 8 months old.

Install the correct package on Travis and skip a test that shouldn't be run on Python 2.