### PR TITLE
Add failing test for coro_test on OSX

### DIFF
--- a/distributed/tests/py3_test_asyncio.py
+++ b/distributed/tests/py3_test_asyncio.py
@@ -27,6 +27,7 @@ def coro_test(fn):
         try:
             IOLoop.clear_current()
             loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
             loop.run_until_complete(fn(*args, **kwargs))
         finally:
             if loop is not None:

--- a/distributed/tests/py3_test_asyncio.py
+++ b/distributed/tests/py3_test_asyncio.py
@@ -39,6 +39,11 @@ def coro_test(fn):
 
 
 @coro_test
+async def test_coro_test():
+    assert asyncio.get_event_loop().is_running()
+
+
+@coro_test
 async def test_asyncio_start_shutdown():
     c = await AioClient(processes=False)
 


### PR DESCRIPTION
This works fine on my Linux machine, but fails on my OSX machine.

cc @kszucs 