### PR TITLE
Clean up two cases of forgotten keys

### DIFF
--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -283,9 +283,9 @@ class AllProgress(SchedulerPlugin):
                         pass
 
         if start == 'memory':
-            self.nbytes[k] -= self.scheduler.nbytes[key]
+            self.nbytes[k] -= self.scheduler.nbytes.get(key, 0)
         if finish == 'memory':
-            self.nbytes[k] += self.scheduler.nbytes[key]
+            self.nbytes[k] += self.scheduler.nbytes.get(key, 0)
 
     def restart(self, scheduler):
         self.all.clear()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -781,7 +781,7 @@ class Scheduler(ServerNode):
             recommendations = self.transition(key, 'memory', worker=worker,
                                               **kwargs)
 
-            if self.task_state[key] == 'memory':
+            if self.task_state.get(key) == 'memory':
                 if key not in self.has_what[worker]:
                     self.worker_bytes[worker] += self.nbytes.get(key,
                                                                  DEFAULT_DATA_SIZE)


### PR DESCRIPTION
In fire-and-forget workloads we frequently forget keys just after
computing them.  This has exposed two cases in the scheduler that we
needed to clean up.