### PR TITLE
Add logging when the worker fails to read messages

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1065,6 +1065,11 @@ class Worker(WorkerBase):
                     break
                 except EnvironmentError as e:
                     break
+                except Exception as e:
+                    logger.error("Worker failed to read message. "
+                                 "This will likely cause the cluster to fail.",
+                                 exc_info=True)
+                    raise
 
                 start = time()
 


### PR DESCRIPTION
Currently this just logs a stark warning and then raises.
This is not yet tested and does not make any attempt to recover.