### PR TITLE
Fixes small typo in quickstart documentation

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -20,7 +20,7 @@ scheduler and worker for you.
 .. code-block:: python
 
    >>> from dask.distributed import Client
-   >>> client = Client()  # set up local cluster on your lapotp
+   >>> client = Client()  # set up local cluster on your laptop
    >>> client
    <Client: scheduler="127.0.0.1:8786" processes=8 cores=8>
 


### PR DESCRIPTION
This PR fixes a super small typo I ran across on the quickstart documentation page