### PR TITLE
Allow recreate on persisted collections

### DIFF
--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 import logging
 from tornado import gen
 from .client import futures_of, _wait
-from .utils import sync
+from .utils import sync, tokey
 from .utils_comm import pack_data
 from .worker import _deserialize
 
@@ -42,6 +42,7 @@ class ReplayExceptionScheduler(object):
         for key in keys:
             if isinstance(key, list):
                 key = tuple(key)  # ensure not a list from msgpack
+            key = tokey(key)
             if key in self.scheduler.exceptions_blame:
                 cause = self.scheduler.exceptions_blame[key]
                 # cannot serialize sets

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4100,6 +4100,13 @@ def test_recreate_error_collection(c, s, a, b):
     with pytest.raises(ValueError):
         function(*args, **kwargs)
 
+    # with persist
+    df3 = c.persist(df2)
+    function, args, kwargs = yield c._recreate_error_locally(df3)
+    with pytest.raises(ValueError):
+        function(*args, **kwargs)
+
+
 
 def test_recreate_error_sync(loop):
     with cluster() as (s, [a, b]):


### PR DESCRIPTION
Previously only worked for single futures (which could have been pointing
to a compute of a collection), now works for persisted collections.

Suggestions for how to test for a non-persisted collection and improve
the error message?

Suggestions on whether there should be an action taken if local recreation
doesn't raise anything (this has happened to me over credentials).

(thanks, @jcrist )