### PR TITLE
Fix slow marker when conftest is missing.

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -423,8 +423,7 @@ try:
                 not pytest.config.getoption("--runslow"),
                 reason="need --runslow option to run")
 except (AttributeError, ValueError):
-    def slow(*args):
-        pass
+    slow = pytest.mark.slow
 
 
 from tornado import gen


### PR DESCRIPTION
The old fallback does not return anything, breaking anything that might be using the return value, like a marked parametrization.

An example is `test_dynamic_workloads_sync` in `distributed/tests/test_client.py`.