### PR TITLE
Handle missing extensions

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -53,6 +53,14 @@ ALLOWED_FAILURES = config.get('allowed-failures', 3)
 LOG_PDB = config.get('pdb-on-err') or os.environ.get('DASK_ERROR_PDB', False)
 DEFAULT_DATA_SIZE = config.get('default-data-size', 1000)
 
+DEFAULT_EXTENSIONS = [
+    PublishExtension,
+    WorkStealing,
+    ReplayExceptionScheduler,
+    QueueExtension,
+    VariableExtension,
+]
+
 
 class Scheduler(ServerNode):
     """ Dynamic distributed task scheduler
@@ -187,14 +195,19 @@ class Scheduler(ServerNode):
     """
     default_port = 8786
 
-    def __init__(self, center=None, loop=None,
-                 delete_interval=500, synchronize_worker_interval=60000,
-                 services=None, allowed_failures=ALLOWED_FAILURES,
-                 extensions=[PublishExtension, WorkStealing,
-                             ReplayExceptionScheduler, QueueExtension,
-                             VariableExtension],
-                 validate=False, scheduler_file=None, security=None,
-                 **kwargs):
+    def __init__(
+            self,
+            center=None,
+            loop=None,
+            delete_interval=500,
+            synchronize_worker_interval=60000,
+            services=None,
+            allowed_failures=ALLOWED_FAILURES,
+            extensions=None,
+            validate=False,
+            scheduler_file=None,
+            security=None,
+            **kwargs):
 
         # Attributes
         self.allowed_failures = allowed_failures
@@ -355,6 +368,8 @@ class Scheduler(ServerNode):
             connection_args=self.connection_args,
             **kwargs)
 
+        if extensions is None:
+            extensions = DEFAULT_EXTENSIONS
         for ext in extensions:
             ext(self)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1323,7 +1323,8 @@ class Scheduler(ServerNode):
         We stop the task from being stolen in the future, and change task
         duration accounting as if the task has stopped.
         """
-        self.extensions['stealing'].remove_key_from_stealable(key)
+        if 'stealing' in self.extensions:
+            self.extensions['stealing'].remove_key_from_stealable(key)
 
         try:
             actual_worker = self.rprocessing[key]
@@ -3217,7 +3218,8 @@ class Scheduler(ServerNode):
         self.total_occupancy += new - old
         self.check_idle_saturated(w)
 
-        if new > old * 1.3:  # significant increase in duration
+        # significant increase in duration
+        if (new > old * 1.3) and ('stealing' in self.extensions):
             steal = self.extensions['stealing']
             for key in processing:
                 steal.remove_key_from_stealable(key)

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -217,3 +217,31 @@ def test_local_client_warning(c, s, a, b):
     future = c.submit(func, 10)
     result = yield future
     assert result == 11
+
+
+def test_secede_without_stealing_issue_1262():
+    """
+    Tests that seceding works with the Stealing extension disabled
+    https://github.com/dask/distributed/issues/1262
+    """
+
+    # turn off all extensions
+    extensions = []
+
+    # run the loop as an inner function so all workers are closed
+    # and exceptions can be examined
+    @gen_cluster(client=True, scheduler_kwargs={'extensions': extensions})
+    def secede_test(c, s, a, b):
+        def func(x):
+            with worker_client() as wc:
+                y = wc.submit(lambda: 1 + x)
+                return wc.gather(y)
+        f = yield c._gather(c.submit(func, 1))
+
+        return c, s, a, b, f
+
+    c, s, a, b, f = secede_test()
+
+    assert f == 2
+    # ensure no workers had errors
+    assert all([f.exception() is None for f in s._worker_coroutines])

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -238,7 +238,7 @@ def test_secede_without_stealing_issue_1262():
                 return wc.gather(y)
         f = yield c._gather(c.submit(func, 1))
 
-        return c, s, a, b, f
+        raise gen.Return((c, s, a, b, f))
 
     c, s, a, b, f = secede_test()
 


### PR DESCRIPTION
Addresses issue #1262 -- guards against direct access of `extensions['stealing']` in the event that the `Stealing` extension was disabled.

Adds a test for the access in `handle_long_running`, but I didn't find a way to trap the error caused by the access in `_reevaluate_occupancy`.