### PR TITLE
Comment out likely assertion in test_nanny_process_failure

### DIFF
--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -96,7 +96,7 @@ def test_nanny_process_failure(c, s):
         yield gen.sleep(0.01)
         assert time() - start < 5
 
-    assert n.worker_address != original_address  # most likely
+    # assert n.worker_address != original_address  # most likely
 
     start = time()
     while n.worker_address not in s.ncores or n.worker_dir is None:


### PR DESCRIPTION
This was causing intermittent errors.  The cost to development for this
test is high and this assertion seems suspect anyway.