### PR TITLE
Add asynchronous= keyword to blocking client methods

### DIFF
--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -176,11 +176,11 @@ class Queue(object):
                                                   timeout=timeout,
                                                   name=self.name)
 
-    def put(self, value, timeout=None):
+    def put(self, value, timeout=None, **kwargs):
         """ Put data into the queue """
-        return self.client.sync(self._put, value, timeout=timeout)
+        return self.client.sync(self._put, value, timeout=timeout, **kwargs)
 
-    def get(self, timeout=None, batch=False):
+    def get(self, timeout=None, batch=False, **kwargs):
         """ Get data from the queue
 
         Parameters
@@ -192,11 +192,12 @@ class Queue(object):
             If an integer than return that many elements from the queue
             If False (default) then return one item at a time
          """
-        return self.client.sync(self._get, timeout=timeout, batch=batch)
+        return self.client.sync(self._get, timeout=timeout, batch=batch,
+                                **kwargs)
 
-    def qsize(self):
+    def qsize(self, **kwargs):
         """ Current number of elements in the queue """
-        return self.client.sync(self._qsize)
+        return self.client.sync(self._qsize, **kwargs)
 
     @gen.coroutine
     def _get(self, timeout=None, batch=False):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4507,5 +4507,19 @@ def test_bytes_keys(c, s, a, b):
     assert result == 2
 
 
+def test_use_synchronous_scheduler_in_async_context(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            @gen.coroutine
+            def f():
+                x = yield c.scatter(123, asynchronous=True)
+                y = c.submit(inc, x)
+                z = yield c.gather(y, asynchronous=True)
+                raise gen.Return(z)
+
+            z = sync(loop, f)
+            assert z == 124
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -156,7 +156,7 @@ class Variable(object):
             yield self.client.scheduler.variable_set(data=value,
                                                      name=self.name)
 
-    def set(self, value):
+    def set(self, value, **kwargs):
         """ Set the value of this variable
 
         Parameters
@@ -164,7 +164,7 @@ class Variable(object):
         value: Future or object
             Must be either a Future or a msgpack-encodable value
         """
-        return self.client.sync(self._set, value)
+        return self.client.sync(self._set, value, **kwargs)
 
     @gen.coroutine
     def _get(self, timeout=None):
@@ -181,9 +181,9 @@ class Variable(object):
             value = d['value']
         raise gen.Return(value)
 
-    def get(self, timeout=None):
+    def get(self, timeout=None, **kwargs):
         """ Get the value of this variable """
-        return self.client.sync(self._get, timeout=timeout)
+        return self.client.sync(self._get, timeout=timeout, **kwargs)
 
     def delete(self):
         """ Delete this variable

--- a/docs/source/asynchronous.rst
+++ b/docs/source/asynchronous.rst
@@ -43,6 +43,19 @@ received information from the scheduler should now be ``await``'ed.
 
    result = await client.gather(future)
 
+If you want to reuse the same client in asynchronous and synchronous
+environments you can apply the ``asynchronous=True`` keyword at each method
+call.
+
+.. code-block:: python
+
+   client = Client()  # normal blocking client
+
+   async def f():
+       futures = client.map(func, L)
+       results = await client.gather(futures, asynchronous=True)
+       return results
+
 AsyncIO
 -------
 

--- a/docs/source/client.rst
+++ b/docs/source/client.rst
@@ -166,6 +166,20 @@ functions.
        result = yield future
        return result
 
+If you want to reuse the same client in asynchronous and synchronous
+environments you can apply the ``asynchronous=True`` keyword at each method
+call.
+
+.. code-block:: python
+
+   client = Client()  # normal blocking client
+
+   @gen.corotuine
+   def f():
+       futures = client.map(func, L)
+       results = yield client.gather(futures, asynchronous=True)
+       return results
+
 See the :doc:`Asynchronous <asynchronous>` documentation for more information.
 
 


### PR DESCRIPTION
This provides more control on a method-call-by-method-call basis for
users to operate in asynchronous mode, even if a client's default
operation is synchronous.