### PR TITLE
Restrict arbitrary panning in bokeh plots

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -827,7 +827,7 @@ class WorkerTable(DashboardComponent):
 
         mem_plot = figure(title='Memory Use (%)', toolbar_location=None,
                           x_range=(0, 1), y_range=(-0.1, 0.1), height=80,
-                          **kwargs)
+                          tools='', **kwargs)
         mem_plot.circle(source=self.source, x='memory_percent', y=0,
                         size=10, fill_alpha=0.5)
         mem_plot.ygrid.visible = False
@@ -847,7 +847,7 @@ class WorkerTable(DashboardComponent):
 
         cpu_plot = figure(title='CPU Use (%)', toolbar_location=None,
                           x_range=(0, 1), y_range=(-0.1, 0.1), height=80,
-                          **kwargs)
+                          tools='', **kwargs)
         cpu_plot.circle(source=self.source, x='cpu', y=0,
                         size=10, fill_alpha=0.5)
         cpu_plot.ygrid.visible = False

--- a/distributed/bokeh/worker.py
+++ b/distributed/bokeh/worker.py
@@ -359,7 +359,7 @@ class SystemMonitor(DashboardComponent):
         x_range = DataRange1d(follow='end', follow_interval=20000,
                               range_padding=0)
 
-        tools = 'reset,pan,wheel_zoom'
+        tools = 'reset,xpan,xwheel_zoom'
 
         self.cpu = figure(title="CPU", x_axis_type='datetime',
                           height=height, tools=tools, x_range=x_range, **kwargs)


### PR DESCRIPTION
Previously you could pan and zoom in all directions.  Now we restrict
this in two cases.