### PR TITLE
Rename client.shutdown to client.close

### DIFF
--- a/distributed/asyncio.py
+++ b/distributed/asyncio.py
@@ -69,7 +69,7 @@ class AioClient(Client):
 
             # Use the client....
 
-            await client.shutdown()
+            await client.close()
 
     An ``async with`` statement is a more convenient way to start and shut down
     the client::
@@ -117,17 +117,17 @@ class AioClient(Client):
         return self
 
     async def __aexit__(self, type, value, traceback):
-        await self.shutdown()
+        await self.close()
 
     def __await__(self):
         return to_asyncio_future(self._started).__await__()
 
-    async def shutdown(self, fast=False):
+    async def close(self, fast=False):
         if self.status == 'closed':
             return
 
         try:
-            future = self._shutdown(fast=fast)
+            future = self._close(fast=fast)
             await to_asyncio_future(future)
 
             with ignoring(AttributeError):
@@ -138,7 +138,7 @@ class AioClient(Client):
             BaseAsyncIOLoop.clear_current()
 
     def __del__(self):
-        # Override Client.__del__ to avoid running self.shutdown()
+        # Override Client.__del__ to avoid running self.close()
         assert self.status != 'running'
 
     gather = to_asyncio(Client._gather)

--- a/distributed/asyncio.py
+++ b/distributed/asyncio.py
@@ -157,6 +157,7 @@ class AioClient(Client):
     rebalance = to_asyncio(Client._rebalance)
     replicate = to_asyncio(Client._replicate)
     start_ipython_workers = to_asyncio(Client._start_ipython_workers)
+    shutdown = close
 
     def __enter__(self):
         raise RuntimeError("Use AioClient in an 'async with' block, not 'with'")

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -886,7 +886,8 @@ class Client(Node):
                 self._release_key(key=key)
             if self.status == 'running':
                 self._send_to_scheduler({'op': 'close-stream'})
-            yield self.scheduler_comm.close()
+            if self.scheduler_comm:
+                yield self.scheduler_comm.close()
             if self._start_arg is None:
                 with ignoring(AttributeError):
                     yield self.cluster._close()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -623,12 +623,13 @@ class Client(Node):
         return self._started.__await__()
 
     def _send_to_scheduler(self, msg):
-        if self.status is 'running':
+        if self.status in ('running', 'closing'):
             self.loop.add_callback(self.scheduler_comm.send, msg)
         elif self.status is 'connecting':
             self.loop.add_callback(self._pending_msg_buffer.append, msg)
         else:
-            raise Exception("Client not running.  Status: %s" % self.status)
+            raise Exception("Tried sending message after closing.  Status: %s\n"
+                            "Message: %s" % (self.status, msg))
 
     @gen.coroutine
     def _start(self, timeout=5, **kwargs):
@@ -752,13 +753,13 @@ class Client(Node):
 
     @gen.coroutine
     def __aexit__(self, typ, value, traceback):
-        yield self._shutdown()
+        yield self._close()
 
     def __exit__(self, type, value, traceback):
-        self.shutdown()
+        self.close()
 
     def __del__(self):
-        self.shutdown()
+        self.close()
 
     def _inc_ref(self, key):
         with self._refcount_lock:
@@ -871,31 +872,21 @@ class Client(Node):
         logger.warning("Scheduler exception:")
         logger.exception(exception)
 
-    @gen.coroutine
-    def _close(self):
-        with log_errors():
-            if self.status == 'closed':
-                raise gen.Return()
-            if self.status == 'running':
-                self._send_to_scheduler({'op': 'close-stream'})
-            with ignoring(AttributeError):
-                yield self.scheduler_comm.close()
-            with ignoring(AttributeError):
-                self.scheduler.close_rpc()
-            self.status = 'closed'
-
     def close(self, **kwargs):
         """ Close this client and its connection to the scheduler """
         return self.sync(self._close, **kwargs)
 
     @gen.coroutine
-    def _shutdown(self, fast=False):
-        """ Send shutdown signal and wait until scheduler completes """
+    def _close(self, fast=False):
+        """ Send close signal and wait until scheduler completes """
         with log_errors():
             if self.status == 'closed':
                 raise gen.Return()
+            for key in list(self.futures):
+                self._release_key(key=key)
             if self.status == 'running':
                 self._send_to_scheduler({'op': 'close-stream'})
+            yield self.scheduler_comm.close()
             if self._start_arg is None:
                 with ignoring(AttributeError):
                     yield self.cluster._close()
@@ -907,13 +898,13 @@ class Client(Node):
                     yield [gen.with_timeout(timedelta(seconds=2), f)
                             for f in self.coroutines]
             with ignoring(AttributeError):
-                yield self.scheduler_comm.close()
-            with ignoring(AttributeError):
                 self.scheduler.close_rpc()
             self.scheduler = None
 
-    def shutdown(self, timeout=10):
-        """ Send shutdown signal and wait until scheduler terminates
+    _shutdown = _close
+
+    def close(self, timeout=10):
+        """ Send close signal and wait until scheduler terminates
 
         This cancels all currently running tasks, clears the state of the
         scheduler, and shuts down all workers and scheduler.
@@ -926,7 +917,7 @@ class Client(Node):
         Client.restart
         """
         if self.asynchronous:
-            future = self._shutdown()
+            future = self._close()
             if timeout:
                 future = gen.with_timeout(timedelta(seconds=timeout), future)
             return future
@@ -939,7 +930,7 @@ class Client(Node):
             with ignoring(AttributeError):
                 self.cluster.close()
 
-        sync(self.loop, self._shutdown, fast=True)
+        sync(self.loop, self._close, fast=True)
         assert self.status == 'closed'
 
         if self._should_close_loop:
@@ -953,6 +944,8 @@ class Client(Node):
             dask.set_options(shuffle=self._previous_shuffle)
         if self.get == _globals.get('get'):
             del _globals['get']
+
+    shutdown = close
 
     def get_executor(self, **kwargs):
         """ Return a concurrent.futures Executor for submitting tasks
@@ -3134,14 +3127,14 @@ def temp_default_client(c):
         _set_global_client(old_exec)
 
 
-def _shutdown_global_client():
+def _close_global_client():
     """
-    Force shutdown of global client.  This cleans up when a client
-    wasn't shutdown explicitly, e.g. interactive sessions.
+    Force close of global client.  This cleans up when a client
+    wasn't close explicitly, e.g. interactive sessions.
     """
     c = _get_global_client()
     if c is not None:
-        c.shutdown(timeout=2)
+        c.close(timeout=2)
 
 
-atexit.register(_shutdown_global_client)
+atexit.register(_close_global_client)

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -67,5 +67,5 @@ def test_adaptive_local_cluster_multi_workers():
     futures = c.map(slowinc, range(100), delay=0.01)
     yield c._gather(futures)
 
-    yield c._shutdown()
+    yield c._close()
     yield cluster._close()

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -262,7 +262,7 @@ def test_scale_up_and_down():
     assert len(cluster.workers) == 1
     assert addr not in cluster.scheduler.ncores
 
-    yield c._shutdown()
+    yield c._close()
     yield cluster._close()
 
 

--- a/distributed/deploy/utils_test.py
+++ b/distributed/deploy/utils_test.py
@@ -9,7 +9,7 @@ class ClusterTest(object):
         self.client = Client(self.cluster.scheduler_address)
 
     def tearDown(self):
-        self.client.shutdown()
+        self.client.close()
         self.cluster.close()
 
     def test_cores(self):

--- a/distributed/tests/py3_test_asyncio.py
+++ b/distributed/tests/py3_test_asyncio.py
@@ -45,7 +45,7 @@ async def test_coro_test():
 
 
 @coro_test
-async def test_asyncio_start_shutdown():
+async def test_asyncio_start_close():
     c = await AioClient(processes=False)
 
     assert c.status == 'running'
@@ -55,7 +55,7 @@ async def test_asyncio_start_shutdown():
     result = await c.submit(inc, 10)
     assert result == 11
 
-    await c.shutdown()
+    await c.close()
     assert c.status == 'closed'
     assert IOLoop.current(instance=False) is None
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -215,7 +215,7 @@ def test_gc(s, a, b):
     x.__del__()
     yield gen.moment
 
-    yield c.shutdown()
+    yield c.close()
 
     assert x.key not in s.who_has
 
@@ -249,7 +249,7 @@ def test_sync_exceptions(loop):
         z = c.submit(div, 10, 5)
         assert z.result() == 2
 
-        c.shutdown()
+        c.close()
 
 
 @gen_cluster(client=True)
@@ -520,7 +520,7 @@ def test_missing_worker(s, a, b):
     assert result == 3
     assert bad not in s.ncores
 
-    yield c.shutdown()
+    yield c.close()
 
 
 @pytest.mark.skip
@@ -738,8 +738,8 @@ def test_two_consecutive_clients_share_results(s, a, b):
 
     assert xx == yy
 
-    yield c.shutdown()
-    yield f.shutdown()
+    yield c.close()
+    yield f.close()
 
 
 @gen_cluster(client=True)
@@ -1373,8 +1373,8 @@ def test_multiple_clients(s, a, b):
     zz = yield z
     assert zz == 5
 
-    yield a.shutdown()
-    yield b.shutdown()
+    yield a.close()
+    yield b.close()
 
 
 @gen_cluster(client=True)
@@ -1794,7 +1794,7 @@ def test_multi_client(s, a, b):
                             'fire-and-forget': set()}
     assert s.who_wants == {x.key: {c.id}, y.key: {c.id, f.id}}
 
-    yield c.shutdown()
+    yield c.close()
 
     start = time()
     while c.id in s.wants_what:
@@ -1805,7 +1805,7 @@ def test_multi_client(s, a, b):
     assert c.id not in s.who_wants[y.key]
     assert x.key not in s.who_wants
 
-    yield f.shutdown()
+    yield f.close()
 
     assert not s.tasks
 
@@ -1886,8 +1886,8 @@ def test_multi_garbage_collection(s, a, b):
     assert not any(v for v in s.wants_what.values())
     assert not s.who_wants
 
-    yield c.shutdown()
-    yield f.shutdown()
+    yield c.close()
+    yield f.close()
 
 
 @gen_cluster(client=True)
@@ -1988,8 +1988,8 @@ def test__cancel_multi_client(s, a, b):
     with pytest.raises(CancelledError):
         yield x
 
-    yield c.shutdown()
-    yield f.shutdown()
+    yield c.close()
+    yield f.close()
 
 
 @gen_cluster(client=True)
@@ -2523,7 +2523,7 @@ def test_worker_aliases():
     assert len(a.data) == 10
     assert len(b.data) == 0
 
-    yield c.shutdown()
+    yield c.close()
     yield [a._close(), b._close()]
     yield s.close()
 
@@ -2583,15 +2583,15 @@ def test_client_num_fds(loop):
 
 
 @gen_cluster()
-def test_startup_shutdown_startup(s, a, b):
+def test_startup_close_startup(s, a, b):
     c = yield Client((s.ip, s.port), asynchronous=True)
-    yield c.shutdown()
+    yield c.close()
 
     c = yield Client((s.ip, s.port), asynchronous=True)
-    yield c.shutdown()
+    yield c.close()
 
 
-def test_startup_shutdown_startup_sync(loop):
+def test_startup_close_startup_sync(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
             sleep(0.1)
@@ -3022,12 +3022,12 @@ def test_default_get(loop):
         c = Client(s['address'], loop=loop, set_as_default=False)
         assert _globals['get'] is pre_get
         assert _globals['shuffle'] == pre_shuffle
-        c.shutdown()
+        c.close()
 
         c = Client(s['address'], loop=loop, set_as_default=True)
         assert _globals['shuffle'] == 'tasks'
         assert _globals['get'] == c.get
-        c.shutdown()
+        c.close()
         assert _globals['get'] is pre_get
         assert _globals['shuffle'] == pre_shuffle
 
@@ -3131,12 +3131,12 @@ def dont_test_scheduler_falldown(loop):
             s2.close()
 
 
-def test_shutdown_idempotent(loop):
+def test_close_idempotent(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
-            c.shutdown()
-            c.shutdown()
-            c.shutdown()
+            c.close()
+            c.close()
+            c.close()
 
 
 def test_get_returns_early(loop):
@@ -3244,7 +3244,7 @@ def test_status():
     assert c.status == 'running'
     x = c.submit(inc, 1)
 
-    yield c.shutdown()
+    yield c.close()
     assert c.status == 'closed'
 
     yield s.close()
@@ -3334,7 +3334,7 @@ def test_reconnect(loop):
         assert time() < start + 5
         sleep(0.1)
 
-    c.shutdown()
+    c.close()
     sync(loop, w._close)
 
 
@@ -3438,8 +3438,8 @@ def test_idempotence(s, a, b):
 
     assert len(s.transition_log) == len_single_submit
 
-    yield c.shutdown()
-    yield f.shutdown()
+    yield c.close()
+    yield f.close()
 
 
 def test_scheduler_info(loop):
@@ -3610,8 +3610,8 @@ def test_serialize_future(s, a, b):
         result2 = yield future2
         assert result == result2
 
-    yield c.shutdown()
-    yield f.shutdown()
+    yield c.close()
+    yield f.close()
 
 
 @gen_cluster(client=False)
@@ -3627,8 +3627,8 @@ def test_temp_client(s, a, b):
         assert default_client() is f
         assert default_client(c) is c
 
-    yield c.shutdown()
-    yield f.shutdown()
+    yield c.close()
+    yield f.close()
 
 
 @gen_cluster(ncores=[('127.0.0.1', 1)] * 3, client=True)
@@ -3973,7 +3973,7 @@ def test_client_timeout():
         yield gen.sleep(0.1)
         assert time() < start + 2
 
-    yield c.shutdown()
+    yield c.close()
     yield s.close()
 
 
@@ -4251,7 +4251,7 @@ def test_fire_and_forget_err(c, s, a, b):
         assert time() < start + 1
 
 
-def test_quiet_client_shutdown(loop):
+def test_quiet_client_close(loop):
     import logging
     with captured_logger(logging.getLogger('distributed')) as logger:
         with Client(loop=loop, processes=False, threads_per_worker=4) as c:

--- a/distributed/tests/test_joblib.py
+++ b/distributed/tests/test_joblib.py
@@ -38,7 +38,7 @@ def test_simple(loop, joblib):
             seq = Parallel()(delayed(inc)(i) for i in range(10))
             assert seq == [inc(i) for i in range(10)]
 
-            ba.client.shutdown()
+            ba.client.close()
 
 
 def random2():
@@ -58,7 +58,7 @@ def test_dont_assume_function_purity(loop, joblib):
             x, y = Parallel()(delayed(random2)() for i in range(2))
             assert x != y
 
-            ba.client.shutdown()
+            ba.client.close()
 
 
 @pytest.mark.parametrize('joblib', joblibs)
@@ -123,7 +123,7 @@ def test_joblib_scatter(loop, joblib):
             sols = [func(*args, **kwargs) for func, args, kwargs in tasks]
             results = Parallel()(tasks)
 
-            ba.client.shutdown()
+            ba.client.close()
 
         # Scatter must take a list/tuple
         with pytest.raises(TypeError):

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -29,8 +29,8 @@ def test_publish_simple(s, a, b):
     result = yield f.scheduler.publish_list()
     assert result == ['data']
 
-    yield c.shutdown()
-    yield f.shutdown()
+    yield c.close()
+    yield f.close()
 
 
 @gen_cluster(client=False)
@@ -54,8 +54,8 @@ def test_publish_roundtrip(s, a, b):
     assert "not found" in str(exc_info.value)
     assert "nonexistent" in str(exc_info.value)
 
-    yield c.shutdown()
-    yield f.shutdown()
+    yield c.close()
+    yield f.close()
 
 
 @gen_cluster(client=True)
@@ -155,5 +155,5 @@ def test_publish_bag(s, a, b):
 
     out = yield f.compute(result)
     assert out == [0, 1, 2]
-    yield c.shutdown()
-    yield f.shutdown()
+    yield c.close()
+    yield f.close()

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -80,7 +80,7 @@ def test_hold_futures(s, a, b):
     q1 = yield Queue('q')
     yield q1.put(future)
     del q1
-    yield c1.shutdown()
+    yield c1.close()
 
     yield gen.sleep(0.1)
 
@@ -90,7 +90,7 @@ def test_hold_futures(s, a, b):
     result = yield future2
 
     assert result == 11
-    yield c2.shutdown()
+    yield c2.close()
 
 
 @pytest.mark.skip(reason='getting same client from main thread')
@@ -226,4 +226,4 @@ def test_Future_knows_status_immediately(c, s, a, b):
             assert time() < start + 5
             yield gen.sleep(0.05)
 
-    yield c2.shutdown()
+    yield c2.close()

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -70,7 +70,7 @@ def test_hold_futures(s, a, b):
     x1 = Variable('x')
     yield x1.set(future)
     del x1
-    yield c1.shutdown()
+    yield c1.close()
 
     yield gen.sleep(0.1)
 
@@ -80,7 +80,7 @@ def test_hold_futures(s, a, b):
     result = yield future2
 
     assert result == 11
-    yield c2.shutdown()
+    yield c2.close()
 
 
 @gen_cluster(client=True)
@@ -204,4 +204,4 @@ def test_Future_knows_status_immediately(c, s, a, b):
             assert time() < start + 5
             yield gen.sleep(0.05)
 
-    yield c2.shutdown()
+    yield c2.close()

--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -269,8 +269,8 @@ def test_multiple_clients_restart(s, a, b):
     assert x.cancelled()
     assert y.cancelled()
 
-    yield e1._shutdown(fast=True)
-    yield e2._shutdown(fast=True)
+    yield e1._close(fast=True)
+    yield e2._close(fast=True)
 
 
 @gen_cluster(Worker=Nanny)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -549,7 +549,7 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                         return loop.run_sync(lambda: cor(*args), timeout=timeout)
                     finally:
                         if client:
-                            loop.run_sync(c[0]._shutdown)
+                            loop.run_sync(c[0]._close)
                         loop.run_sync(lambda: end_cluster(s, workers))
 
                     for w in workers:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -320,8 +320,6 @@ class WorkerBase(ServerNode):
         if self.status in ('closed', 'closing'):
             return
         logger.info("Stopping worker at %s", self.address)
-        if self._client:
-            yield self._client._close()
         self.status = 'closing'
         self.stop()
         self.heartbeat_callback.stop()

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,6 +10,7 @@ API
 .. autosummary::
    Client
    Client.cancel
+   Client.close
    Client.compute
    Client.gather
    Client.get
@@ -27,9 +28,7 @@ API
    Client.run
    Client.run_on_scheduler
    Client.scatter
-   Client.shutdown
    Client.scheduler_info
-   Client.shutdown
    Client.start_ipython_workers
    Client.start_ipython_scheduler
    Client.submit

--- a/docs/source/asynchronous.rst
+++ b/docs/source/asynchronous.rst
@@ -100,7 +100,7 @@ Python 3 with Tornado
        client = await Client(asynchronous=True)
        future = client.submit(lambda x: x + 1, 10)
        result = await future
-       await client.shutdown()
+       await client.close()
        return result
 
    from tornado.ioloop import IOLoop
@@ -119,7 +119,7 @@ Python 2/3 with Tornado
        client = yield Client(asynchronous=True)
        future = client.submit(lambda x: x + 1, 10)
        result = yield future
-       yield client.shutdown()
+       yield client.close()
        raise gen.Result(result)
 
    from tornado.ioloop import IOLoop
@@ -136,7 +136,7 @@ Python 3 with Asyncio
        client = await AioClient()
        future = client.submit(lambda x: x + 1, 10)
        result = await future
-       await client.shutdown()
+       await client.close()
        return result
 
    from asyncio import get_event_loop


### PR DESCRIPTION
This also cleanly sends release-key messages for all active futures