### PR TITLE
1258: Added option to specify different listen and contact IPs for workers

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -49,14 +49,12 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option('--bokeh/--no-bokeh', 'bokeh', default=True, show_default=True,
               required=False, help="Launch Bokeh Web UI")
 @click.option('--listen-address', type=str, default=None,
-        help="The <protocol>://<address>:<port> on which the worker binds to. "
-                   "The options --worker-port and --host are not compatible "
-                   "with this option. Cannot be used with --nprocs>1")
+        help="The address to which the worker binds. "
+             "Example: tcp://0.0.0.0:9000")
 @click.option('--contact-address', type=str, default=None,
-        help="The <protocol>://<address>:<port> the worker advertises to the scheduler "
-                   "for communication with it and other workers. If specified "
-                   "must also specify --listen-address. "
-                   "If not specified uses the --listen-address")
+        help="The address the worker advertises to the scheduler for "
+             "communication with it and other workers. "
+             "Example: tcp://127.0.0.1:9000")
 @click.option('--host', type=str, default=None,
               help="Serving host. Should be an ip address that is"
                    " visible to the scheduler and other workers. "
@@ -96,7 +94,6 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process '
                    'like "foo.bar" or "/path/to/foo.py"')
-
 def main(scheduler, host, worker_port, listen_address, contact_address,
          http_port, nanny_port, nthreads, nprocs, nanny, name,
          memory_limit, pid_file, reconnect, resources, bokeh,
@@ -190,7 +187,7 @@ def main(scheduler, host, worker_port, listen_address, contact_address,
     loop = IOLoop.current()
 
     if nanny:
-        kwargs = {'worker_port': worker_port}
+        kwargs = {'worker_port': worker_port, 'listen_address': listen_address}
         t = Nanny
     else:
         kwargs = {}
@@ -230,7 +227,7 @@ def main(scheduler, host, worker_port, listen_address, contact_address,
                  services=services, name=name, loop=loop, resources=resources,
                  memory_limit=memory_limit, reconnect=reconnect,
                  local_dir=local_directory, death_timeout=death_timeout,
-                 preload=preload, security=sec, contact_addr = contact_address,
+                 preload=preload, security=sec, contact_address=contact_address,
                  **kwargs)
                for i in range(nprocs)]
 

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -19,6 +19,7 @@ from distributed.http import HTTPWorker
 from distributed.metrics import time
 from distributed.security import Security
 from distributed.cli.utils import check_python_3, uri_from_host_port
+from distributed.comm import get_address_host_port
 
 from toolz import valmap
 from tornado.ioloop import IOLoop, TimeoutError
@@ -47,9 +48,20 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
               help="Bokeh port, defaults to 8789")
 @click.option('--bokeh/--no-bokeh', 'bokeh', default=True, show_default=True,
               required=False, help="Launch Bokeh Web UI")
+@click.option('--listen-address', type=str, default=None,
+        help="The <protocol>://<address>:<port> on which the worker binds to. "
+                   "The options --worker-port and --host are not compatible "
+                   "with this option. Cannot be used with --nprocs>1")
+@click.option('--contact-address', type=str, default=None,
+        help="The <protocol>://<address>:<port> the worker advertises to the scheduler "
+                   "for communication with it and other workers. If specified "
+                   "must also specify --listen-address. "
+                   "If not specified uses the --listen-address")
 @click.option('--host', type=str, default=None,
               help="Serving host. Should be an ip address that is"
                    " visible to the scheduler and other workers. "
+                   "See --listen-address and --contact-address if you "
+                   "need different listen and contact addresses. "
                    "See --interface.")
 @click.option('--interface', type=str, default=None,
               help="Network interface like 'eth0' or 'ib0'")
@@ -84,20 +96,17 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process '
                    'like "foo.bar" or "/path/to/foo.py"')
-def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
-         nanny, name, memory_limit, pid_file, reconnect,
-         resources, bokeh, bokeh_port, local_directory, scheduler_file,
-         interface, death_timeout, preload, bokeh_prefix,
-         tls_ca_file, tls_cert, tls_key):
+
+def main(scheduler, host, worker_port, listen_address, contact_address,
+         http_port, nanny_port, nthreads, nprocs, nanny, name,
+         memory_limit, pid_file, reconnect, resources, bokeh,
+         bokeh_port, local_directory, scheduler_file, interface,
+         death_timeout, preload, bokeh_prefix, tls_ca_file,
+         tls_cert, tls_key):
     sec = Security(tls_ca_file=tls_ca_file,
                    tls_worker_cert=tls_cert,
                    tls_worker_key=tls_key,
                    )
-
-    if nanny:
-        port = nanny_port
-    else:
-        port = worker_port
 
     if nprocs > 1 and worker_port != 0:
         logger.error("Failed to launch worker.  You cannot use the --port argument when nprocs > 1.")
@@ -110,6 +119,40 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
     if nprocs > 1 and not nanny:
         logger.error("Failed to launch worker.  You cannot use the --no-nanny argument when nprocs > 1.")
         exit(1)
+
+    if contact_address and not listen_address:
+        logger.error("Failed to launch worker. "
+                     "Must specify --listen-address when --contact-address is given")
+        exit(1)
+
+    if nprocs > 1 and listen_address:
+        logger.error("Failed to launch worker. "
+                     "You cannot specify --listen-address when nprocs > 1.")
+        exit(1)
+
+    if  (worker_port or host) and listen_address:
+        logger.error("Failed to launch worker. "
+                     "You cannot specify --listen-address when --worker-port or --host is given.")
+        exit(1)
+
+    try:
+        if listen_address:
+            (host, worker_port) = get_address_host_port(listen_address, strict=True)
+
+        if contact_address:
+            # we only need this to verify it is getting parsed
+            (_, _) = get_address_host_port(contact_address, strict=True)
+        else:
+            # if contact address is not present we use the listen_address for contact
+            contact_address = listen_address
+    except ValueError as e:
+        logger.error("Failed to launch worker. " + str(e))
+        exit(1)
+
+    if nanny:
+        port = nanny_port
+    else:
+        port = worker_port
 
     if not nthreads:
         nthreads = _ncores // nprocs
@@ -187,7 +230,7 @@ def main(scheduler, host, worker_port, http_port, nanny_port, nthreads, nprocs,
                  services=services, name=name, loop=loop, resources=resources,
                  memory_limit=memory_limit, reconnect=reconnect,
                  local_dir=local_directory, death_timeout=death_timeout,
-                 preload=preload, security=sec,
+                 preload=preload, security=sec, contact_addr = contact_address,
                  **kwargs)
                for i in range(nprocs)]
 

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -38,14 +38,16 @@ def test_defaults(loop):
         loop.run_sync(f)
 
         with Client('127.0.0.1:%d' % Scheduler.default_port, loop=loop) as c:
-            response = requests.get('http://127.0.0.1:9786/info.json')
-            assert response.ok
-            assert response.json()['status'] == 'running'
+            pass
+
+        response = requests.get('http://127.0.0.1:9786/info.json')
+        assert response.ok
+        assert response.json()['status'] == 'running'
 
     with pytest.raises(Exception):
-        response = requests.get('http://127.0.0.1:9786/info.json')
-    with pytest.raises(Exception):
         requests.get('http://127.0.0.1:8787/status/')
+    with pytest.raises(Exception):
+        response = requests.get('http://127.0.0.1:9786/info.json')
 
 
 def test_hostport(loop):
@@ -56,8 +58,7 @@ def test_hostport(loop):
             yield [
                 # The scheduler's main port can't be contacted from the outside
                 assert_can_connect_locally_4(8978, 2.0),
-                # ... but its HTTP port can
-                assert_can_connect_from_everywhere_4_6(8979, 2.0),
+                assert_can_connect_locally_4(8979, 2.0),
                 ]
 
         loop.run_sync(f)

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -6,6 +6,7 @@ pytest.importorskip('requests')
 import os
 import requests
 import signal
+import sys
 from time import sleep
 from toolz import first
 
@@ -116,3 +117,30 @@ def test_nprocs_requires_nanny(loop):
                     '--no-nanny']) as worker:
             assert any(b'Failed to launch worker' in worker.stderr.readline()
                        for i in range(15))
+
+
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="Need 127.0.0.2 to mean localhost")
+@pytest.mark.parametrize('nanny', ['--nanny', '--no-nanny'])
+@pytest.mark.parametrize('listen_address', [
+    'tcp://0.0.0.0:39837',
+    'tcp://127.0.0.2:39837'])
+def test_contact_listen_address(loop, nanny, listen_address):
+    with popen(['dask-scheduler', '--no-bokeh']) as sched:
+        with popen(['dask-worker', '127.0.0.1:8786',
+                    nanny, '--no-bokeh',
+                    '--contact-address', 'tcp://127.0.0.2:39837',
+                    '--listen-address', listen_address]) as worker:
+            with Client('127.0.0.1:8786') as client:
+                while not client.ncores():
+                    sleep(0.1)
+                info = client.scheduler_info()
+                assert 'tcp://127.0.0.2:39837' in info['workers']
+
+                # roundtrip works
+                assert client.submit(lambda x: x + 1, 10).result() == 11
+
+                def func(dask_worker):
+                    return dask_worker.listener.listen_address
+
+                assert client.run(func) == {'tcp://127.0.0.2:39837': listen_address}

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -144,3 +144,27 @@ def test_contact_listen_address(loop, nanny, listen_address):
                     return dask_worker.listener.listen_address
 
                 assert client.run(func) == {'tcp://127.0.0.2:39837': listen_address}
+
+
+@pytest.mark.skipif(not sys.platform.startswith('linux'),
+                    reason="Need 127.0.0.2 to mean localhost")
+@pytest.mark.parametrize('nanny', ['--nanny', '--no-nanny'])
+@pytest.mark.parametrize('host', ['127.0.0.2', '0.0.0.0'])
+def test_respect_host_listen_address(loop, nanny, host):
+    with popen(['dask-scheduler', '--no-bokeh']) as sched:
+        with popen(['dask-worker', '127.0.0.1:8786',
+                    nanny, '--no-bokeh',
+                    '--host', host]) as worker:
+            with Client('127.0.0.1:8786') as client:
+                while not client.ncores():
+                    sleep(0.1)
+                info = client.scheduler_info()
+
+                # roundtrip works
+                assert client.submit(lambda x: x + 1, 10).result() == 11
+
+                def func(dask_worker):
+                    return dask_worker.listener.listen_address
+
+                listen_addresses = client.run(func)
+                assert all(host in v for v in listen_addresses.values())

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -22,8 +22,10 @@ def parse_address(addr, strict=False):
         raise TypeError("expected str, got %r" % addr.__class__.__name__)
     scheme, sep, loc = addr.rpartition('://')
     if strict and not sep:
-        raise ValueError("Invalid url scheme. Must be of the form <protocol>://<host>:<port>. "
-                        "Got %s" % addr)
+        msg = ("Invalid url scheme. "
+               "Must include protocol like tcp://localhost:8000. "
+               "Got %s" % addr)
+        raise ValueError(msg)
     if not sep:
         scheme = DEFAULT_SCHEME
     return scheme, loc

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -9,16 +9,21 @@ from . import registry
 DEFAULT_SCHEME = config.get('default-scheme', 'tcp')
 
 
-def parse_address(addr):
+def parse_address(addr, strict=False):
     """
     Split address into its scheme and scheme-dependent location string.
 
     >>> parse_address('tcp://127.0.0.1')
     ('tcp', '127.0.0.1')
+
+    If strict is set to true the address must have a scheme.
     """
     if not isinstance(addr, six.string_types):
         raise TypeError("expected str, got %r" % addr.__class__.__name__)
     scheme, sep, loc = addr.rpartition('://')
+    if strict and not sep:
+        raise ValueError("Invalid url scheme. Must be of the form <protocol>://<host>:<port>. "
+                        "Got %s" % addr)
     if not sep:
         scheme = DEFAULT_SCHEME
     return scheme, loc
@@ -96,17 +101,17 @@ def unparse_host_port(host, port=None):
         return host
 
 
-def get_address_host_port(addr):
+def get_address_host_port(addr, strict=False):
     """
     Get a (host, port) tuple out of the given address.
-
+    For definition of strict check parse_address
     ValueError is raised if the address scheme doesn't allow extracting
     the requested information.
 
     >>> get_address_host_port('tcp://1.2.3.4:80')
     ('1.2.3.4', 80)
     """
-    scheme, loc = parse_address(addr)
+    scheme, loc = parse_address(addr, strict=strict)
     backend = registry.get_backend(scheme)
     try:
         return backend.get_address_host_port(loc)

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -232,6 +232,7 @@ class InProc(Comm):
 
 
 class InProcListener(Listener):
+    prefix = 'inproc'
 
     def __init__(self, address, comm_handler, deserialize=True):
         self.manager = global_manager

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -36,7 +36,7 @@ class Nanny(ServerNode):
                  ncores=None, loop=None, local_dir=None, services=None,
                  name=None, memory_limit='auto', reconnect=True,
                  validate=False, quiet=False, resources=None, silence_logs=None,
-                 death_timeout=None, preload=(), security=None, **kwargs):
+                 death_timeout=None, preload=(), security=None, contact_addr=None, **kwargs):
         if scheduler_port is None:
             self.scheduler_addr = coerce_to_address(scheduler_ip)
         else:
@@ -48,6 +48,7 @@ class Nanny(ServerNode):
         self.resources = resources
         self.death_timeout = death_timeout
         self.preload = preload
+        self.contact_addr = contact_addr
 
         self.security = security or Security()
         assert isinstance(self.security, Security)
@@ -176,7 +177,9 @@ class Nanny(ServerNode):
                                    silence_logs=self.silence_logs,
                                    death_timeout=self.death_timeout,
                                    preload=self.preload,
-                                   security=self.security),
+                                   security=self.security,
+                                   contact_addr=self.contact_addr),
+                # worker_start_args=(self._given_worker_port,),
                 worker_start_args=(self._given_worker_port,),
                 silence_logs=self.silence_logs,
                 on_exit=self._on_exit,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -36,7 +36,8 @@ class Nanny(ServerNode):
                  ncores=None, loop=None, local_dir=None, services=None,
                  name=None, memory_limit='auto', reconnect=True,
                  validate=False, quiet=False, resources=None, silence_logs=None,
-                 death_timeout=None, preload=(), security=None, contact_addr=None, **kwargs):
+                 death_timeout=None, preload=(), security=None,
+                 contact_address=None, listen_address=None, **kwargs):
         if scheduler_port is None:
             self.scheduler_addr = coerce_to_address(scheduler_ip)
         else:
@@ -48,7 +49,7 @@ class Nanny(ServerNode):
         self.resources = resources
         self.death_timeout = death_timeout
         self.preload = preload
-        self.contact_addr = contact_addr
+        self.contact_address = contact_address
 
         self.security = security or Security()
         assert isinstance(self.security, Security)
@@ -80,6 +81,7 @@ class Nanny(ServerNode):
                                     connection_args=self.connection_args,
                                     **kwargs)
 
+        self._listen_address = listen_address
         self.status = 'init'
 
     def __str__(self):
@@ -178,9 +180,9 @@ class Nanny(ServerNode):
                                    death_timeout=self.death_timeout,
                                    preload=self.preload,
                                    security=self.security,
-                                   contact_addr=self.contact_addr),
+                                   contact_address=self.contact_address),
                 # worker_start_args=(self._given_worker_port,),
-                worker_start_args=(self._given_worker_port,),
+                worker_start_args=(self._listen_address or self._given_worker_port,),
                 silence_logs=self.silence_logs,
                 on_exit=self._on_exit,
             )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -410,19 +410,19 @@ class Scheduler(ServerNode):
         """ Basic information about ourselves and our cluster """
         return get_versions()
 
-    def start_services(self, host):
+    def start_services(self, listen_ip):
         for k, v in self.service_specs.items():
             if isinstance(k, tuple):
                 k, port = k
             else:
                 port = 0
 
-            if host == '0.0.0.0':
-                host = ''  # for IPv6
+            if listen_ip == '0.0.0.0':
+                listen_ip = ''  # for IPv6
 
             try:
                 service = v(self, io_loop=self.loop)
-                service.listen((host, port))
+                service.listen((listen_ip, port))
                 self.services[k] = service
             except Exception as e:
                 logger.info("Could not launch service: %r", (k, port),
@@ -453,22 +453,22 @@ class Scheduler(ServerNode):
                 # as it would prevent connecting via 127.0.0.1.
                 self.listen(('', addr_or_port), listen_args=self.listen_args)
                 self.ip = get_ip()
-                listen_host = ''
+                listen_ip = ''
             else:
                 self.listen(addr_or_port, listen_args=self.listen_args)
                 self.ip = get_address_host(self.listen_address)
-                listen_host = self.ip
+                listen_ip = self.ip
 
-            if self.ip == '0.0.0.0':
-                self.ip = ''
+            if listen_ip == '0.0.0.0':
+                listen_ip = ''
 
             # Services listen on all addresses
-            self.start_services(listen_host)
+            self.start_services(listen_ip)
 
             self.status = 'running'
             logger.info("  Scheduler at: %25s", self.address)
             for k, v in self.services.items():
-                logger.info("%11s at: %25s", k, '%s:%d' % (self.ip, v.port))
+                logger.info("%11s at: %25s", k, '%s:%d' % (listen_ip, v.port))
 
         if self.scheduler_file:
             with open(self.scheduler_file, 'w') as f:

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -12,7 +12,7 @@ import traceback
 
 from dask import delayed
 import pytest
-from toolz import pluck, sliding_window
+from toolz import pluck, sliding_window, first
 import tornado
 from tornado import gen
 from tornado.ioloop import TimeoutError
@@ -906,3 +906,16 @@ def test_worker_fds(s):
     while psutil.Process().num_fds() > start:
         yield gen.sleep(0.01)
         assert time() < start + 0.5
+
+
+@gen_cluster(ncores=[])
+def test_service_hosts_match_worker(s):
+    from distributed.http.worker import HTTPWorker
+    services = {('http', 0): HTTPWorker}
+    for host in ['tcp://0.0.0.0', 'tcp://127.0.0.2']:
+        w = Worker(s.address, services=services)
+        yield w._start(host)
+
+        sock = first(w.services['http']._sockets.values())
+        assert sock.getsockname()[0] == host.split('://')[1]
+        yield w._close()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -726,11 +726,11 @@ def popen(*args, **kwargs):
             # XXX Also dump stdout if return code != 0 ?
             out, err = proc.communicate()
             if dump_stdout:
-                print('\n\nPrint from stderr\n=================\n')
-                print(err)
+                print('\n\nPrint from stderr\n  %s\n=================\n' % args[0][0])
+                print(err.decode())
 
                 print('\n\nPrint from stdout\n=================\n')
-                print(out)
+                print(out.decode())
 
 
 def wait_for_port(address, timeout=5):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -248,7 +248,7 @@ class WorkerBase(ServerNode):
             raise ValueError("Unexpected response from register: %r" % (resp,))
         self.periodic_callbacks['heartbeat'].start()
 
-    def start_services(self, listen_ip=''):
+    def start_services(self, host):
         for k, v in self.service_specs.items():
             if isinstance(k, tuple):
                 k, port = k
@@ -260,7 +260,7 @@ class WorkerBase(ServerNode):
             else:
                 v, kwargs = v, {}
             self.services[k] = v(self, io_loop=self.loop, **kwargs)
-            self.services[k].listen((listen_ip, port))
+            self.services[k].listen((host, port))
             self.service_ports[k] = self.services[k].port
 
     @gen.coroutine
@@ -270,7 +270,8 @@ class WorkerBase(ServerNode):
         # XXX Factor this out
         if not addr_or_port:
             # Default address is the required one to reach the scheduler
-            self.listen(get_local_address_for(self.scheduler.address),
+            listen_host = get_local_address_for(self.scheduler.address)
+            self.listen(listen_host,
                         listen_args=self.listen_args)
             self.ip = get_address_host(self.address)
         elif isinstance(addr_or_port, int):
@@ -278,24 +279,39 @@ class WorkerBase(ServerNode):
             self.ip = get_ip(
                 get_address_host(self.scheduler.address)
             )
-            self.listen((self.ip, addr_or_port),
+            self.listen((listen_host, addr_or_port),
                         listen_args=self.listen_args)
+            listen_host = self.ip
         else:
             self.listen(addr_or_port, listen_args=self.listen_args)
             self.ip = get_address_host(self.address)
+            try:
+                listen_host = get_address_host(addr_or_port)
+            except ValueError:
+                listen_host = addr_or_port
+
+        if '://' in listen_host:
+            protocol, listen_host = listen_host.split('://')
+            if protocol == 'inproc':
+                listen_host = 'localhost'
 
         self.name = self.name or self.address
         preload_modules(self.preload, parameter=self, file_dir=self.local_dir)
         # Services listen on all addresses
         # Note Nanny is not a "real" service, just some metadata
         # passed in service_ports...
-        self.start_services()
+        self.start_services(listen_host)
+
+        try:
+            listening_address = '%s%s:%d' % (self.listener.prefix, listen_host, self.port)
+        except Exception:
+            listening_address = '%s%s' % (self.listener.prefix, listen_host)
 
         logger.info('      Start worker at: %26s', self.address)
+        logger.info('         Listening to: %26s', listening_address)
         for k, v in self.service_ports.items():
-            logger.info('  %16s at: %20s:%d' % (k, self.ip, v))
-        logger.info('Waiting to connect to: %26s',
-                    self.scheduler.address)
+            logger.info('  %16s at: %26s' % (k, listen_host + ':' + str(v)))
+        logger.info('Waiting to connect to: %26s', self.scheduler.address)
         logger.info('-' * 49)
         logger.info('              Threads: %26d', self.ncores)
         if self.memory_limit:
@@ -306,7 +322,7 @@ class WorkerBase(ServerNode):
         yield self._register_with_scheduler()
 
         if self.status == 'running':
-            logger.info('        Registered to: %32s', self.scheduler.address)
+            logger.info('        Registered to: %26s', self.scheduler.address)
             logger.info('-' * 49)
 
     def start(self, port=0):


### PR DESCRIPTION
This issue fixes #1258 

Currently the bind and the advertise ip of dask-workers is the same. In case the dask-worker is running inside a docker container in bridge mode these addresses will not be the same. While the worker binds to some internal address the scheduler needs to communicate to it using some external IP. Currently we only have the option of settings the host address or the interface on which the Dask-worker listens on but nothing about which address is advertised to the scheduler.

After the fix we now have an option `--contact-addr` that helps achieve this. This needs to specified as `<address>:<port>`. In case this is not specified it defaults to the older behaviour. Run  `dask-worker --help` for more details on the new options.