### PR TITLE
Improve `Client.get_versions`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -49,7 +49,7 @@ from .security import Security
 from .sizeof import sizeof
 from .worker import dumps_task, thread_state, get_client, get_worker
 from .utils import (All, sync, funcname, ignoring, queue_to_iterator,
-        tokey, log_errors, str_graph, key_split, format_bytes)
+        tokey, log_errors, str_graph, key_split, format_bytes, asciitable)
 from .versions import get_versions
 
 
@@ -2543,30 +2543,29 @@ class Client(Node):
 
         if check:
             # we care about the required & optional packages matching
-            extract = lambda x: merge(result[x]['packages'].values())
-            client_versions = extract('client')
-            scheduler_versions = extract('scheduler')
+            to_packages = lambda d: merge(d['packages'].values())
+            client_versions = to_packages(result['client'])
+            versions = [('scheduler', to_packages(result['scheduler']))]
+            versions.extend((w, to_packages(d))
+                            for w, d in sorted(workers.items()))
 
-            for pkg, cv in client_versions.items():
-                sv = scheduler_versions[pkg]
-                if sv != cv:
-                    raise ValueError("package [{package}] is version [{client}] "
-                                     "on client and [{scheduler}] on scheduler!".format(
-                                         package=pkg,
-                                         client=cv,
-                                         scheduler=sv))
-
-            for w, d in workers.items():
-                worker_versions = merge(d['packages'].values())
+            mismatched = defaultdict(list)
+            for name, vers in versions:
                 for pkg, cv in client_versions.items():
-                    wv = worker_versions[pkg]
-                    if wv != cv:
-                        raise ValueError("package [{package}] is version [{client}] "
-                                         "on client and [{worker}] on worker [{w}]!".format(
-                                             package=pkg,
-                                             client=cv,
-                                             worker=wv,
-                                             w=w))
+                    v = vers.get(pkg, 'MISSING')
+                    if cv != v:
+                        mismatched[pkg].append((name, v))
+
+            if mismatched:
+                errs = []
+                for pkg, versions in sorted(mismatched.items()):
+                    rows = [('client', client_versions[pkg])] 
+                    rows.extend(versions)
+                    errs.append("%s\n%s" % (pkg, asciitable(['', 'version'], rows)))
+
+                raise ValueError("Mismatched versions found\n"
+                                 "\n"
+                                 "%s" % ('\n\n'.join(errs)))
 
         return result
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2538,16 +2538,7 @@ class Client(Node):
         except KeyError:
             scheduler = None
 
-        def f(worker=None):
-
-            # use our local version
-            try:
-                from distributed.versions import get_versions
-                return get_versions()
-            except ImportError:
-                return None
-
-        workers = sync(self.loop, self._run, f)
+        workers = sync(self.loop, self._run, get_versions)
         result = {'scheduler': scheduler, 'workers': workers, 'client': client}
 
         if check:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -825,6 +825,28 @@ def format_bytes(n):
     return '%d B' % n
 
 
+def asciitable(columns, rows):
+    """Formats an ascii table for given columns and rows.
+
+    Parameters
+    ----------
+    columns : list
+        The column names
+    rows : list of tuples
+        The rows in the table. Each tuple must be the same length as
+        ``columns``.
+    """
+    rows = [tuple(str(i) for i in r) for r in rows]
+    columns = tuple(str(i) for i in columns)
+    widths = tuple(max(max(map(len, x)), len(c))
+                   for x, c in zip(zip(*rows), columns))
+    row_template = ('|' + (' %%-%ds |' * len(columns))) % widths
+    header = row_template % tuple(columns)
+    bar = '+%s+' % '+'.join('-' * (w + 2) for w in widths)
+    data = '\n'.join(row_template % r for r in rows)
+    return '\n'.join([bar, header, bar, data, bar])
+
+
 if PY2:
     def nbytes(frame):
         """ Number of bytes of a frame or memoryview """


### PR DESCRIPTION
This fixes two issues:

- `get_versions` now works even if `cloudpickle` versions mismatch. This was caused by applying a function in a closure, which required cloudpickle to serialize. We now just use `get_versions` directly.

- Fully describe all mismatched versions. Previously we only errored on the first found mismatch, which led to playing whack-a-mole with getting version compatibility. We now provide a nicely formatted error message describing all version incompatibilities with the client. Only workers/scheduler that mismatch the client are reported.

**Example:**

```
In [3]: client.get_versions(check=True)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-13767d2792b6> in <module>()
----> 1 client.get_versions(check=True)

~/Code/distributed/distributed/client.py in get_versions(self, check)
   2566                 raise ValueError("Mismatched versions found\n"
   2567                                  "\n"
-> 2568                                  "%s" % ('\n\n'.join(errs)))
   2569
   2570         return result

ValueError: Mismatched versions found

cloudpickle
+-------------------------+---------+
|                         | version |
+-------------------------+---------+
| client                  | 0.3.1   |
| tcp://10.10.20.47:52687 | 0.2.2   |
+-------------------------+---------+

distributed
+-----------+--------------------------+
|           | version                  |
+-----------+--------------------------+
| client    | 1.18.0+15.gafbd453       |
| scheduler | 1.18.0+14.gef90d9e.dirty |
+-----------+--------------------------+

pandas
+-------------------------+---------+
|                         | version |
+-------------------------+---------+
| client                  | 0.20.3  |
| tcp://10.10.20.47:52687 | 0.19.2  |
+-------------------------+---------+
```

Note that there currently aren't any tests, as I wasn't sure how to test this. Could break the error formatting code out into a function and test that, but not sure if it's worth it.