### PR TITLE
Yield on Tornado IOStream.write futures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tornado >= 4.4
+tornado >= 4.4.3
 toolz >= 0.7.4
 msgpack-python
 cloudpickle >= 0.2.2


### PR DESCRIPTION
Previously this failed if the single write_future was overwritten.
Tornado has since been fixed to track all write futures.

Currently we pile on writes until we reach a set limit
(currently hard-coded to 128MB) and then we wait.