### PR TITLE
Join event loop then close event loop

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -935,7 +935,7 @@ class Client(Node):
         assert self.status == 'closed'
 
         if self._should_close_loop:
-            sync(self.loop, self.loop.stop)
+            self.loop.add_callback(self.loop.stop)
             try:
                 self._loop_thread.join(timeout=timeout)
             finally:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -936,8 +936,10 @@ class Client(Node):
 
         if self._should_close_loop:
             sync(self.loop, self.loop.stop)
-            self.loop.close()
-            self._loop_thread.join(timeout=timeout)
+            try:
+                self._loop_thread.join(timeout=timeout)
+            finally:
+                self.loop.close()
         self._loop_thread = None
         with ignoring(AttributeError):
             dask.set_options(get=self._previous_get)
@@ -2559,7 +2561,7 @@ class Client(Node):
             if mismatched:
                 errs = []
                 for pkg, versions in sorted(mismatched.items()):
-                    rows = [('client', client_versions[pkg])] 
+                    rows = [('client', client_versions[pkg])]
                     rows.extend(versions)
                     errs.append("%s\n%s" % (pkg, asciitable(['', 'version'], rows)))
 

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -245,8 +245,10 @@ class LocalCluster(object):
             sync(self.loop, self._close)
         if hasattr(self, '_thread'):
             sync(self.loop, self.loop.stop)
-            self._thread.join(timeout=1)
-            self.loop.close()
+            try:
+                self._thread.join(timeout=1)
+            finally:
+                self.loop.close()
             del self._thread
 
     @gen.coroutine

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -244,7 +244,7 @@ class LocalCluster(object):
         if self.loop._running:
             sync(self.loop, self._close)
         if hasattr(self, '_thread'):
-            sync(self.loop, self.loop.stop)
+            self.loop.add_callback(self.loop.stop)
             try:
                 self._thread.join(timeout=1)
             finally:


### PR DESCRIPTION
This *may* resolve errors on closing such as the following:

```
Traceback (most recent call last):
  File ".../python2.7/threading.py", line 804, in __bootstrap_inner
    self.run()
  File ".../python2.7/threading.py", line 757, in run
    self.__target(*self.__args, **self.__kwargs)
  File ".../tornado/ioloop.py", line 832, in start
    self._run_callback(self._callbacks.popleft())
AttributeError: 'NoneType' object has no attribute 'popleft'
```