### PR TITLE
Don't send closing messages on closed comm

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -7,7 +7,6 @@ from tornado import gen, locks
 from tornado.ioloop import IOLoop
 
 from .core import CommClosedError
-from .utils import ignoring
 
 
 logger = logging.getLogger(__name__)

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -65,9 +65,11 @@ class BatchedSend(object):
     @gen.coroutine
     def _background_send(self):
         while not self.please_stop:
-            with ignoring(gen.TimeoutError):
+            try:
                 yield self.waker.wait(self.next_deadline)
                 self.waker.clear()
+            except gen.TimeoutError:
+                pass
             if not self.buffer:
                 # Nothing to send
                 self.next_deadline = None

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -883,7 +883,7 @@ class Client(Node):
         with log_errors():
             if self.status == 'closed':
                 raise gen.Return()
-            if not self.scheduler_comm.comm.closed():
+            if self.scheduler_comm and self.scheduler_comm.comm and not self.scheduler_comm.comm.closed():
                 for key in list(self.futures):
                     self._release_key(key=key)
                 if self.status == 'running':

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -883,10 +883,11 @@ class Client(Node):
         with log_errors():
             if self.status == 'closed':
                 raise gen.Return()
-            for key in list(self.futures):
-                self._release_key(key=key)
-            if self.status == 'running':
-                self._send_to_scheduler({'op': 'close-stream'})
+            if not self.scheduler_comm.comm.closed():
+                for key in list(self.futures):
+                    self._release_key(key=key)
+                if self.status == 'running':
+                    self._send_to_scheduler({'op': 'close-stream'})
             if self.scheduler_comm:
                 yield self.scheduler_comm.close()
             if self._start_arg is None:

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -244,7 +244,8 @@ class LocalCluster(object):
         if self.loop._running:
             sync(self.loop, self._close)
         if hasattr(self, '_thread'):
-            self.loop.add_callback(self.loop.stop)
+            if self.loop._running:
+                self.loop.add_callback(self.loop.stop)
             try:
                 self._thread.join(timeout=1)
             finally:

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -202,10 +202,10 @@ def test_cleanup():
 
 def test_repeated():
     with LocalCluster(scheduler_port=8448, silence_logs=False,
-            diagnostics_port=None) as c:
+                      diagnostics_port=None) as c:
         pass
     with LocalCluster(scheduler_port=8448, silence_logs=False,
-            diagnostics_port=None) as c:
+                      diagnostics_port=None) as c:
         pass
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4537,5 +4537,32 @@ def test_use_synchronous_client_in_async_context(loop):
             assert z == 124
 
 
+def test_quiet_quit_when_cluster_leaves(loop):
+    from distributed import LocalCluster
+    import logging
+    thread = Thread(target=loop.start,
+                    name="LocalCluster loop")
+    thread.daemon = True
+    thread.start()
+    while not loop._running:
+        sleep(0.001)
+
+    cluster = LocalCluster(loop=loop, scheduler_port=0, diagnostics_port=None,
+                           silence_logs=False)
+    with captured_logger('distributed.comm') as sio:
+        client = Client(cluster, loop=loop)
+        futures = client.map(lambda x: x + 1, range(10))
+        sleep(0.05)
+        cluster.close()
+        sleep(0.05)
+        client.close()
+
+    text = sio.getvalue()
+    assert not text
+
+    loop.add_callback(loop.stop)
+    thread.join(timeout=1)
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *

--- a/distributed/tests/test_config.py
+++ b/distributed/tests/test_config.py
@@ -60,7 +60,7 @@ def test_logging_default():
         fb = logging.getLogger('foo.bar')
 
         with captured_handler(d.handlers[0]) as distributed_log:
-            with captured_logger(root) as foreign_log:
+            with captured_logger(root, level=logging.ERROR) as foreign_log:
                 h = logging.StreamHandler(foreign_log)
                 fmt = '[%(levelname)s in %(name)s] - %(message)s'
                 h.setFormatter(logging.Formatter(fmt))

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -796,18 +796,21 @@ def assert_can_connect_locally_6(port, timeout=None, connection_args=None):
 
 
 @contextmanager
-def captured_logger(logger):
+def captured_logger(logger, level=logging.INFO):
     """Capture output from the given Logger.
     """
     if isinstance(logger, str):
         logger = logging.getLogger(logger)
+    orig_level = logger.level
     orig_handlers = logger.handlers[:]
     sio = six.StringIO()
     logger.handlers[:] = [logging.StreamHandler(sio)]
+    logger.setLevel(level)
     try:
         yield sio
     finally:
         logger.handlers[:] = orig_handlers
+        logger.setLevel(orig_level)
 
 
 @contextmanager


### PR DESCRIPTION
When client closes it sends out a bunch of final messages to the scheduler
cleaning up its various resources.  However if the scheduler connection is
already dead then this generates annoying error messages.  This was a common
occurrence when closing a LocalCluster.

Reported in https://github.com/dask/distributed/issues/1294