### PR TITLE
Guard against None values in Scheduler.comms when cleaning up

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1164,8 +1164,9 @@ class Scheduler(ServerNode):
         finally:
             if not comm.closed():
                 self.comms[client].send({'op': 'stream-closed'})
-            yield self.comms[client].close()
-            del self.comms[client]
+            if self.comms[client] is not None:
+                yield self.comms[client].close()
+                del self.comms[client]
             logger.info("Close client connection: %s", client)
 
     def remove_client(self, client=None):


### PR DESCRIPTION
This sometimes results in spurious warnings on shutdown.

Fixes https://github.com/dask/distributed/issues/1283