### PR TITLE
Deprecate Executor

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2777,10 +2777,11 @@ class Client(Node):
         return collections_to_dsk(collections, *args, **kwargs)
 
 
-def Executor(*args, **kwargs):
+class Executor(Client):
     """ Deprecated: see Client """
-    warnings.warn("Executor has been renamed to Client")
-    return Client(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        warnings.warn("Executor has been renamed to Client")
+        super(Executor, self).__init__(*args, **kwargs)
 
 
 def CompatibleExecutor(*args, **kwargs):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -20,6 +20,7 @@ import uuid
 import threading
 import six
 import socket
+import warnings
 import weakref
 
 import dask
@@ -2776,7 +2777,10 @@ class Client(Node):
         return collections_to_dsk(collections, *args, **kwargs)
 
 
-Executor = Client
+def Executor(*args, **kwargs):
+    """ Deprecated: see Client """
+    warnings.warn("Executor has been renamed to Client")
+    return Client(*args, **kwargs)
 
 
 def CompatibleExecutor(*args, **kwargs):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -15,6 +15,7 @@ import threading
 from threading import Thread, Semaphore
 from time import sleep
 import traceback
+import warnings
 import weakref
 import zipfile
 
@@ -29,7 +30,7 @@ import dask
 from dask import delayed
 from dask.context import _globals
 from distributed import (Worker, Nanny, recreate_exceptions, fire_and_forget,
-        get_client, secede, get_worker)
+        get_client, secede, get_worker, Executor)
 from distributed.comm import CommClosedError
 from distributed.utils_comm import WrappedKey
 from distributed.client import (Client, Future, _wait,
@@ -4563,6 +4564,15 @@ def test_quiet_quit_when_cluster_leaves(loop):
 
     loop.add_callback(loop.stop)
     thread.join(timeout=1)
+
+
+def test_warn_executor(loop):
+    with cluster() as (s, [a, b]):
+        with warnings.catch_warnings(record=True) as record:
+            with Executor(s['address'], loop=loop) as c:
+                pass
+
+        assert any('Client' in str(r.message) for r in record)
 
 
 if sys.version_info >= (3, 5):


### PR DESCRIPTION
This adds a warning.

It is also a bit unclean because Executor is now a function rather than
the class itself, so isinstance checks and the like will stop working
immediately.

https://stackoverflow.com/questions/45449038/what-is-the-difference-between-calling-dask-distrubuted-executor-and-dask-distri/45449190#45449190