### PR TITLE
Respect timeouts when restarting

### DIFF
--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -32,7 +32,7 @@ call deactivate
     mock ^
     msgpack-python ^
     psutil ^
-    pytest ^
+    pytest=3.1 ^
     python=%PYTHON% ^
     requests ^
     toolz ^

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -45,7 +45,7 @@ conda install -q -c conda-forge \
     netcdf4 \
     paramiko \
     psutil \
-    pytest \
+    pytest=3.1 \
     pytest-faulthandler \
     pytest-timeout \
     requests \

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1574,7 +1574,8 @@ class Scheduler(ServerNode):
                        if nanny_address is not None]
 
             try:
-                resps = All([nanny.restart(close=True) for nanny in nannies])
+                resps = All([nanny.restart(close=True, timeout=timeout * 0.8)
+                             for nanny in nannies])
                 resps = yield gen.with_timeout(timedelta(seconds=timeout), resps)
                 assert all(resp == 'OK' for resp in resps)
             except gen.TimeoutError:

--- a/distributed/threadpoolexecutor.py
+++ b/distributed/threadpoolexecutor.py
@@ -64,9 +64,9 @@ class ThreadPoolExecutor(thread.ThreadPoolExecutor):
             self._threads.add(t)
             t.start()
 
-    def shutdown(self):
+    def shutdown(self, wait=True):
         with threads_lock:
-            thread.ThreadPoolExecutor.shutdown(self)
+            thread.ThreadPoolExecutor.shutdown(self, wait=wait)
 
 
 def secede():

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -329,7 +329,7 @@ class WorkerBase(ServerNode):
                         self.scheduler.unregister(address=self.address),
                         io_loop=self.loop)
         self.scheduler.close_rpc()
-        self.executor.shutdown()
+        self.executor.shutdown(wait=False)
         if os.path.exists(self.local_dir):
             shutil.rmtree(self.local_dir)
 


### PR DESCRIPTION
Previously restarting a cluster that had long-running tasks would sometimes
hang.  This was because of two reasons:

1.  The nanny's restart timeout was longer than the scheduler's restart
    timeout
    Now we pass a fraction of the scheduler's timeout down to the nanny

2.  The workers used to wait for the executor to finish all currently
    running tasks.
    Now we don't

Fixes #1303 .  Either of these changes are enough to fix the issue independently.

@eferreira