### PR TITLE
Check client._start_arg if client.scheduler is None

### DIFF
--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -32,7 +32,7 @@ call deactivate
     mock ^
     msgpack-python ^
     psutil ^
-    pytest ^
+    pytest=3.1 ^
     python=%PYTHON% ^
     requests ^
     toolz ^

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -45,7 +45,7 @@ conda install -q -c conda-forge \
     netcdf4 \
     paramiko \
     psutil \
-    pytest \
+    pytest=3.1 \
     pytest-faulthandler \
     pytest-timeout \
     requests \

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2156,7 +2156,8 @@ class Worker(WorkerBase):
         except ValueError:  # no clients found, need to make a new one
             pass
         else:
-            if client.scheduler.address == self.scheduler.address:
+            if (client.scheduler and client.scheduler.address == self.scheduler.address
+                or client._start_arg == self.scheduler.address):
                 self._client = client
 
         if not self._client:


### PR DESCRIPTION
This avoids a race condition where a client has been registered but
has not yet started.