### PR TITLE
Additional flexibility for Adpative

### DIFF
--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -11,6 +11,21 @@ from distributed.utils_test import loop, slowinc, gen_test
 from distributed.metrics import time
 
 
+def test_get_scale_up_kwargs(loop):
+    with LocalCluster(0, scheduler_port=0, silence_logs=False,
+                      diagnostics_port=None, loop=loop) as cluster:
+
+        alc = Adaptive(cluster.scheduler, cluster, interval=100,
+                       scale_factor=3)
+        assert alc.get_scale_up_kwargs() == {'n': 1}
+
+        with Client(cluster, loop=loop) as c:
+            future = c.submit(lambda x: x + 1, 1)
+            assert future.result() == 2
+            assert c.ncores()
+            assert alc.get_scale_up_kwargs() == {'n': 3}
+
+
 def test_adaptive_local_cluster(loop):
     with LocalCluster(0, scheduler_port=0, silence_logs=False,
                       diagnostics_port=None, loop=loop) as cluster:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -157,3 +157,11 @@ Asyncio Client
 .. currentmodule:: distributed.asyncio
 .. autoclass:: AioClient
    :members:
+
+
+Adaptive
+--------
+
+.. currentmodule:: distributed.deploy
+.. autoclass:: Adaptive
+   :members:


### PR DESCRIPTION
This starts to make `deploy.Adaptive` more reusable by subclasses like `dask_drmaa.Adaptive` by giving the subclass more places to override the default behavior. Currently the extra points are

- Whether to scale down (e.g. a subclass can choose not to change the cluster size if it's been less than `n` seconds since the last task finished)
- How to scale up (a subclass may have tasks with some resource constraints)
- Why we should scale up (currently are we cpu-bound? or are we memory-bound?).

I'll add additional tests and docs tomorrow, but everything should be backwards compatible.