### PR TITLE
Remove bare `except:` blocks and test that none exist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ install:
 script:
   - source continuous_integration/travis/run_tests.sh
   - flake8 distributed/*.py distributed/{bokeh,comm,deploy,protocol}/*.py # no tests yet
+  - pycodestyle --select=E722 distributed  # check for bare `except:` blocks
 
 after_success:
   - if [[ $COVERAGE == true ]]; then coverage report; pip install -q coveralls ; coveralls ; fi

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -45,6 +45,7 @@ conda install -q -c conda-forge \
     netcdf4 \
     paramiko \
     psutil \
+    pycodestyle \
     pytest=3.1 \
     pytest-faulthandler \
     pytest-timeout \

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -122,7 +122,7 @@ def test_bokeh_non_standard_ports(loop):
                 response = requests.get('http://localhost:4832/status/')
                 assert response.ok
                 break
-            except:
+            except Exception:
                 sleep(0.1)
                 assert time() < start + 20
     with pytest.raises(Exception):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1196,7 +1196,7 @@ class Client(Node):
         if direct is None:
             try:
                 w = get_worker()
-            except:
+            except Exception:
                 direct = False
             else:
                 if w.scheduler.address == self.scheduler.address:
@@ -1396,7 +1396,7 @@ class Client(Node):
         if direct is None:
             try:
                 w = get_worker()
-            except:
+            except Exception:
                 direct = False
             else:
                 if w.scheduler.address == self.scheduler.address:

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -350,7 +350,7 @@ def run_coro_in_thread(func, *args, **kwargs):
         try:
             res = thread_loop.run_sync(partial(func, *args, **kwargs),
                                        timeout=10)
-        except:
+        except Exception:
             main_loop.add_callback(fut.set_exc_info, sys.exc_info())
         else:
             main_loop.add_callback(fut.set_result, res)

--- a/distributed/hdfs.py
+++ b/distributed/hdfs.py
@@ -40,7 +40,7 @@ class DaskHDFileSystem(HDFileSystem):
             part.append(parts)
             try:
                 self.mkdir('/'.join(part))
-            except:
+            except Exception:
                 pass
 
     def glob(self, path):

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 def _call_and_set_future(loop, future, func, *args, **kwargs):
     try:
         res = func(*args, **kwargs)
-    except:
+    except Exception:
         # Tornado futures are not thread-safe, need to
         # set_result() / set_exc_info() from the loop's thread
         loop.add_callback(future.set_exc_info, sys.exc_info())

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -46,7 +46,7 @@ def dumps(x):
                 return result
             else:
                 return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
-    except:
+    except Exception:
         try:
             return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
         except Exception as e:

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -149,7 +149,7 @@ def test_stress_scatter_death(c, s, *workers):
         print(futures)
         try:
             worker = [w for w in ws.values() if w.waiting_for_data][0]
-        except:
+        except Exception:
             pass
         if config.get('log-on-err'):
             import pdb; pdb.set_trace()

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -67,7 +67,7 @@ def funcname(func):
         func = func.func
     try:
         return func.__name__
-    except:
+    except AttributeError:
         return str(func)
 
 
@@ -345,7 +345,7 @@ def key_split(s):
             if result[0] == '<':
                 result = result.strip('<>').split()[0].split('.')[-1]
             return result
-    except:
+    except Exception:
         return 'Other'
 
 
@@ -477,7 +477,7 @@ def truncate_exception(e, n=10000):
         try:
             return type(e)("Long error message",
                            str(e)[:n])
-        except:
+        except Exception:
             return Exception("Long error message",
                               type(e),
                               str(e)[:n])

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -62,7 +62,7 @@ def get_package_info(pkgs):
             mod = importlib.import_module(modname)
             ver = ver_f(mod)
             pversions.append((modname, ver))
-        except:
+        except Exception:
             pversions.append((modname, None))
 
     return pversions

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -724,7 +724,7 @@ def convert_args_to_str(args, max_len=None):
     for i, arg in enumerate(args):
         try:
             sarg = repr(arg)
-        except:
+        except Exception:
             sarg = "< could not convert arg to str >"
         strs[i] = sarg
         length += len(sarg) + 2
@@ -743,7 +743,7 @@ def convert_kwargs_to_str(kwargs, max_len=None):
     for i, (argname, arg) in enumerate(kwargs.items()):
         try:
             sarg = repr(arg)
-        except:
+        except Exception:
             sarg = "< could not convert arg to str >"
         skwarg = repr(argname) + ": " + sarg
         strs[i] = skwarg


### PR DESCRIPTION
If a bare except is desired, do `except: # noqa: E722`.

`pycodestyle` is used, because this is a recent feature not yet available in `pep8` or `flake8` utilities.

I was mostly lazy and used `Exception` rather than more specific exceptions, but this is still better than bare `except:`.