### PR TITLE
Reduce logging verbosity for lost connections while sending

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -285,8 +285,8 @@ class Server(object):
                     try:
                         yield comm.write(result)
                     except EnvironmentError as e:
-                        logger.warning("Lost connection to %r while sending result for op %r: %s",
-                                       address, op, e)
+                        logger.debug("Lost connection to %r while sending result for op %r: %s",
+                                     address, op, e)
                         break
                 msg = result = None
                 if close_desired:


### PR DESCRIPTION
In particular this is common for the progress bar and other feed
operations

Fixes #1308

cc @jneuff 