### PR TITLE
BUG: fix spelling error

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -76,7 +76,7 @@ PermissionError [Errno 13] Permission Denied: \`/root/.dask\`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This error can be seen when starting distributed through the standard process
-control tool ``supervisor`` and running as a non-root suer. This is caused
+control tool ``supervisor`` and running as a non-root user. This is caused
 by ``supervisor`` not passing the shell environment variables through to the
 subprocess, head to `this section`_ of the supervisor documentation to see
 how to pass the ``$HOME`` and ``$USER`` variables through.


### PR DESCRIPTION
I had to think for a few minutes whether `suer` was referring to something to do with the linux command `su`. Fix spelling error so others do not get confused.