### PR TITLE
Allow failures in deserialization of type

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -839,7 +839,10 @@ class Client(Node):
         state = self.futures.get(key)
         if state is not None:
             if type and not state.type:  # Type exists and not yet set
-                type = loads(type)
+                try:
+                    type = loads(type)
+                except Exception:
+                    type = None
                 # Here, `type` may be a str if actual type failed
                 # serializing in Worker
             else:

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -81,7 +81,7 @@ def test_move_unserializable_data():
         assert cluster.workers[0].address.startswith('inproc://')
         with Client(cluster) as client:
             lock = Lock()
-            [x] = client.scatter([lock])
+            x = client.scatter(lock)
             y = client.submit(lambda x: x, x)
             assert y.result() is lock
 


### PR DESCRIPTION
When a type is serializable but not deserializable we degrade gracefully.

Fixes #1347 