### PR TITLE
Workers inform scheduler when they can't gather data

### DIFF
--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -109,7 +109,7 @@ def test_stress_scatter_death(c, s, *workers):
     import random
     s.allowed_failures = 1000
     np = pytest.importorskip('numpy')
-    L = yield c._scatter([np.random.random(10000) for i in range(len(workers))])
+    L = yield c.scatter([np.random.random(10000) for i in range(len(workers))])
     yield c._replicate(L, n=2)
 
     adds = [delayed(slowadd, pure=True)(random.choice(L),

--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -318,7 +318,7 @@ def test_broken_worker_during_computation(c, s, a, b):
     with ignoring(CommClosedError, EnvironmentError):  # perhaps new worker can't be contacted yet
         yield c._run(os._exit, 1, workers=[n.worker_address])
 
-    result = yield c._gather(L)
+    result = yield c.gather(L)
     assert isinstance(result[0], int)
 
     yield n._close()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1749,8 +1749,11 @@ class Worker(WorkerBase):
             else:
                 raise
         finally:
-            for dep in original_deps:
-                self._missing_dep_flight.remove(dep)
+            try:
+                for dep in original_deps:
+                    self._missing_dep_flight.remove(dep)
+            except KeyError:
+                pass
 
             self.ensure_communicating()
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1684,6 +1684,9 @@ class Worker(WorkerBase):
 
                     if d not in response and d in self.dependents:
                         self.log.append(('missing-dep', d))
+                        self.batched_stream.send({'op': 'missing-data',
+                                                  'errant_worker': worker,
+                                                  'key': d})
 
                 if self.validate:
                     self.validate_state()
@@ -1785,7 +1788,7 @@ class Worker(WorkerBase):
                 self.task_state[key] = state
                 return
             if cause:
-                self.log.append((key, 'release-key', cause))
+                self.log.append((key, 'release-key', {'cause': cause}))
             else:
                 self.log.append((key, 'release-key'))
             del self.tasks[key]
@@ -1854,7 +1857,8 @@ class Worker(WorkerBase):
                 del self.nbytes[dep]
 
             if dep in self.in_flight_tasks:
-                del self.in_flight_tasks[dep]
+                worker = self.in_flight_tasks.pop(dep)
+                self.in_flight_workers[worker].remove(dep)
 
             for key in self.dependents.pop(dep, ()):
                 self.dependencies[key].remove(dep)


### PR DESCRIPTION
In odd cases a scheduler and worker's understanding of their own data
may go out of sync.  When a worker tries and fails to gather data from a
peer they inform the scheduler of the missing data.

This resolves two intermittent failures:

1.  distributed/tests/test_worker_failure.py::test_broken_worker_during_computation
2.  distributed/tests/test_worker_failure.py::test_submit_after_failed_worker_async