### PR TITLE
ENH: Worker Environments

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -14,6 +14,7 @@ from .utils import sync
 from .variable import Variable
 from .worker import Worker, get_worker, get_client, secede
 from .worker_client import local_client, worker_client
+from .environments import WorkerEnvironment
 
 from ._version import get_versions
 versions = get_versions()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1808,14 +1808,9 @@ class Client(Node):
                             .format(type(environment)))
 
         environment._name = name
-        env = {name: dumps(environment)}
-        responses = yield self.scheduler.environments_register(environments=env)
-        # TODO: A better way of raising all the exceptions, rather than just the first?
-        # perhaps log_errors?
-        if responses is not None:
-            for key, exc_list in responses.items():
-                for exc in exc_list:
-                    six.reraise(*clean_exception(**exc))
+        env = dumps(environment)
+        responses = yield self.scheduler.environment_register(name=name, environment=env)
+        raise gen.Return(responses)
 
     def environment_register(self, name, environment=None, condition=None,
                              setup=None, teardown=None, asynchronous=None,
@@ -1843,7 +1838,7 @@ class Client(Node):
         See Also
         --------
         WorkerEnvironment
-        Scheduler.environments_register
+        Scheduler.environment_register
         """
         return self.sync(self._environment_register, name=name,
                          environment=environment, condition=condition, setup=setup,
@@ -1851,8 +1846,8 @@ class Client(Node):
                          callback_timeout=callback_timeout)
 
     @gen.coroutine
-    def _environnment_deregister(self, name, workers=None):
-        responses = yield self.scheduler.environments_deregister(environments=[name])
+    def _environment_deregister(self, name, workers=None):
+        responses = yield self.scheduler.environment_deregister(name=name)
         if responses is not None:
             pass
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1797,7 +1797,8 @@ class Client(Node):
 
     @gen.coroutine
     def _environment_register(self, name, environment=None, condition=None,
-                              setup=None, teardown=None):
+                              setup=None, teardown=None,
+                              workers=None):
         if environment is None:
             environment = WorkerEnvironment(condition=condition, setup=setup,
                                             teardown=teardown)
@@ -1809,11 +1810,14 @@ class Client(Node):
 
         environment._name = name
         env = dumps(environment)
-        responses = yield self.scheduler.environment_register(name=name, environment=env)
+        responses = yield self.scheduler.environment_register(name=name,
+                                                              environment=env,
+                                                              workers=workers)
         raise gen.Return(responses)
 
     def environment_register(self, name, environment=None, condition=None,
-                             setup=None, teardown=None, asynchronous=None,
+                             setup=None, teardown=None, workers=None,
+                             asynchronous=None,
                              callback_timeout=None):
         """Register a new ``WorkerEnvironment``
 
@@ -1828,12 +1832,9 @@ class Client(Node):
         environment : WorkerEnvironment, optional
         condition, setup, teardown : callable
             Used to create a new WorkerEnvironment when `environment` is None
-
-        Notes
-        -----
-        When the ``condition`` (and possibly ``setup``) methods run cleanly
-        on the workers, there is no return value. If an exception is raised
-        on the worker, it is reraised on the client.
+        workers : str or list of str, optional
+            Candidate workers to limit registration to. All workers are
+            candidates by default.
 
         See Also
         --------
@@ -1842,7 +1843,8 @@ class Client(Node):
         """
         return self.sync(self._environment_register, name=name,
                          environment=environment, condition=condition, setup=setup,
-                         teardown=teardown, asynchronous=asynchronous,
+                         teardown=teardown, workers=workers,
+                         asynchronous=asynchronous,
                          callback_timeout=callback_timeout)
 
     @gen.coroutine

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1796,8 +1796,8 @@ class Client(Node):
         return self.sync(self._run, function, *args, **kwargs)
 
     @gen.coroutine
-    def _register_worker_environment(self, name, environment=None, condition=None,
-                                     setup=None, teardown=None):
+    def _environment_register(self, name, environment=None, condition=None,
+                              setup=None, teardown=None):
         if environment is None:
             environment = WorkerEnvironment(condition=condition, setup=setup,
                                             teardown=teardown)
@@ -1809,7 +1809,7 @@ class Client(Node):
 
         environment._name = name
         env = {name: dumps(environment)}
-        responses = yield self.scheduler.register_worker_environments(environments=env)
+        responses = yield self.scheduler.environments_register(environments=env)
         # TODO: A better way of raising all the exceptions, rather than just the first?
         # perhaps log_errors?
         if responses is not None:
@@ -1817,9 +1817,9 @@ class Client(Node):
                 for exc in exc_list:
                     six.reraise(*clean_exception(**exc))
 
-    def register_worker_environment(self, name, environment=None, condition=None,
-                                    setup=None, teardown=None, asynchronous=None,
-                                    callback_timeout=None):
+    def environment_register(self, name, environment=None, condition=None,
+                             setup=None, teardown=None, asynchronous=None,
+                             callback_timeout=None):
         """Register a new ``WorkerEnvironment``
 
         The ``WorkerEnvironment.condition`` method is executed on each worker
@@ -1843,21 +1843,21 @@ class Client(Node):
         See Also
         --------
         WorkerEnvironment
-        Scheduler.register_worker_environments
+        Scheduler.environments_register
         """
-        return self.sync(self._register_worker_environment, name=name,
+        return self.sync(self._environment_register, name=name,
                          environment=environment, condition=condition, setup=setup,
                          teardown=teardown, asynchronous=asynchronous,
                          callback_timeout=callback_timeout)
 
     @gen.coroutine
-    def _deregister_worker_environment(self, name, workers=None):
-        responses = yield self.scheduler.deregister_worker_environments(environments=[name])
+    def _environnment_deregister(self, name, workers=None):
+        responses = yield self.scheduler.environments_deregister(environments=[name])
         if responses is not None:
             pass
 
-    def deregister_worker_environment(self, name, workers=None, asynchronous=None,
-                                      callback_timeout=None):
+    def environment_deregister(self, name, workers=None, asynchronous=None,
+                               callback_timeout=None):
         """
         Deregister an environment from the scheduler, running the ``teardown``
         method on the workers if applicable.
@@ -1870,7 +1870,7 @@ class Client(Node):
             Set of worker addresses to limit the deregistration to. Other
             workers in the environment will be untouched.
         """
-        return self.sync(self._deregister_worker_environment, name=name,
+        return self.sync(self._environment_deregister, name=name,
                          workers=workers, asynchronous=asynchronous,
                          callback_timeout=callback_timeout)
 

--- a/distributed/environments.py
+++ b/distributed/environments.py
@@ -1,6 +1,3 @@
-from tornado import gen
-
-
 class WorkerEnvironment(object):
     """A worker environment.
 
@@ -21,7 +18,6 @@ class WorkerEnvironment(object):
     def __repr__(self):
         return "<WorkerEnvironment({})>".format(self._name or '')
 
-    @gen.coroutine
     def condition(self):
         """A function be run on a worker determining whether
         it qualifies for this environment.
@@ -36,16 +32,15 @@ class WorkerEnvironment(object):
         in the environment.
         """
         if self._condition:
-            yield gen.maybe_future(self._condition())
+            result = self._condition()
+            return result
         return True
 
-    @gen.coroutine
     def setup(self):
         """Run on the worker when it's added to the environment"""
         if self._setup:
             return self._setup()
 
-    @gen.coroutine
     def teardown(self):
         """Run on the worker when it's removed from the environment"""
         if self._teardown:

--- a/distributed/environments.py
+++ b/distributed/environments.py
@@ -1,0 +1,52 @@
+from tornado import gen
+
+
+class WorkerEnvironment(object):
+    """A worker environment.
+
+    Parameters
+    ----------
+    condition : callable
+    setup : callable
+    teardown : callable
+    """
+
+    _name = None  # Used only for a nicer repr, and nothing else
+
+    def __init__(self, condition=None, setup=None, teardown=None):
+        self._condition = condition
+        self._setup = setup
+        self._teardown = teardown
+
+    def __repr__(self):
+        return "<WorkerEnvironment({})>".format(self._name or '')
+
+    @gen.coroutine
+    def condition(self):
+        """A function be run on a worker determining whether
+        it qualifies for this environment.
+
+        Returns
+        -------
+        qualifies : bool
+
+        Notes
+        -----
+        By default, the just returns True, meaning every worker falls
+        in the environment.
+        """
+        if self._condition:
+            return self._condition()
+        return True
+
+    @gen.coroutine
+    def setup(self):
+        """Run on the worker when it's added to the environment"""
+        if self._setup:
+            return self._setup()
+
+    @gen.coroutine
+    def teardown(self):
+        """Run on the worker when it's removed from the environment"""
+        if self._teardown:
+            return self._teardown()

--- a/distributed/environments.py
+++ b/distributed/environments.py
@@ -36,7 +36,7 @@ class WorkerEnvironment(object):
         in the environment.
         """
         if self._condition:
-            return self._condition()
+            yield gen.maybe_future(self._condition())
         return True
 
     @gen.coroutine

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -504,10 +504,11 @@ class Scheduler(ServerNode):
     def _environments_register(self, environments, workers):
         # When new workers join, we want to go through the environment
         # registration process
-        for name, env in environments.items():
-            yield self.environment_register(None, name=name,
-                                            environment=env,
-                                            workers=workers)
+        results = yield [self.environment_register(None, name=name,
+                                                   environment=env,
+                                                   workers=workers)
+                         for name, env in environments.items()]
+        raise gen.Return(results)
 
     @gen.coroutine
     def environment_register(self, stream, name, environment, workers=None):
@@ -532,6 +533,7 @@ class Scheduler(ServerNode):
         if (name in self.worker_environments and
                 self.worker_environments[name] != environment):
             raise ValueError("{} has already been registered.".format(name))
+        # TODO: clarify behavior around re-registering environmnets
         self.worker_environments[name] = environment
         self.environment_workers[name] = set()
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -353,8 +353,8 @@ class Scheduler(ServerNode):
                          'update_data': self.update_data,
                          'set_resources': self.add_resources,
                          'retire_workers': self.retire_workers,
-                         'register_worker_environments': self.register_worker_environments,
-                         'deregister_worker_environments': self.deregister_worker_environments,
+                         'environments_register': self.environments_register,
+                         'environments_deregister': self.environments_deregister,
                          }
 
         self._transitions = {
@@ -499,7 +499,7 @@ class Scheduler(ServerNode):
         return self.finished()
 
     @gen.coroutine
-    def register_worker_environments(self, stream=None, environments=None, workers=None):
+    def environmnets_register(self, stream=None, environments=None, workers=None):
         """Register worker environments.
 
         Parameters
@@ -536,7 +536,7 @@ class Scheduler(ServerNode):
         elif isinstance(workers, six.string_types):
             workers = [workers]
 
-        results = yield [self.rpc(addr=worker).register_worker_environments(
+        results = yield [self.rpc(addr=worker).environmnets_register(
             environments=environments) for worker in workers]
         exceptions = defaultdict(list)
         # results is a List[Dict[env, result]], one dict per worker
@@ -555,7 +555,7 @@ class Scheduler(ServerNode):
         raise gen.Return(exceptions)
 
     @gen.coroutine
-    def deregister_worker_environments(self, stream=None, environments=None, workers=None):
+    def environmnets_deregister(self, stream=None, environments=None, workers=None):
         for name in environments:
             if name not in self.environment_workers:
                 continue
@@ -567,7 +567,7 @@ class Scheduler(ServerNode):
                 worker_set = set(workers)
 
             worker_set = worker_set & self.environment_workers[name]
-            results = yield [self.rpc(addr=worker).deregister_worker_environments(
+            results = yield [self.rpc(addr=worker).environmnets_deregister(
                 environments=environments) for worker in worker_set]
             self.environment_workers[name] -= worker_set
 
@@ -725,7 +725,7 @@ class Scheduler(ServerNode):
                 self.idle.add(address)
 
             if self.worker_environments:
-                self.loop.add_callback(self.register_worker_environments,
+                self.loop.add_callback(self.environments_register,
                                        environments=self.worker_environments,
                                        workers=[address])
             for plugin in self.plugins[:]:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -34,7 +34,7 @@ from distributed.client import (Client, Future, wait, as_completed, tokenize,
                                 _get_global_client, default_client,
                                 ensure_default_get, futures_of,
                                 temp_default_client)
-
+from distributed.environments import WorkerEnvironment
 from distributed.metrics import time
 from distributed.scheduler import Scheduler, KilledWorker
 from distributed.sizeof import sizeof
@@ -4620,7 +4620,6 @@ def test_warn_executor(loop):
                 pass
 
         assert any('Client' in str(r.message) for r in record)
-
 
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # flake8: noqa

--- a/distributed/tests/test_worker_environments.py
+++ b/distributed/tests/test_worker_environments.py
@@ -6,7 +6,7 @@ from distributed.metrics import time
 from distributed.utils_test import gen_cluster, cluster, loop  # noqa
 
 class MyEnv(WorkerEnvironment):
-    """Test worker environmnet"""
+    """Test worker environment"""
     data = 0
 
     def condition(self):
@@ -20,9 +20,9 @@ class MyEnv(WorkerEnvironment):
 
 
 @gen_cluster(client=True)
-def test_environmnets_register(c, s, a, b):
+def test_environment_register(c, s, a, b):
     # Register environment
-    yield c._environments_register('myenv', MyEnv())
+    yield c._environment_register('myenv', MyEnv())
     assert len(s.worker_environments) == 1 and 'myenv' in s.worker_environments
     assert len(s.environment_workers['myenv']) == 2
     assert 'myenv' in a.environments
@@ -31,7 +31,7 @@ def test_environmnets_register(c, s, a, b):
     assert b.environments['myenv'].data == 1
 
     # Register another
-    yield c._environments_register('never_passes', condition=lambda: False)
+    yield c._environment_register('never_passes', condition=lambda: False)
     assert len(s.worker_environments) == 2 and 'never_passes' in s.worker_environments
     assert len(s.environment_workers['never_passes']) == 0
 
@@ -58,7 +58,7 @@ def test_environmnets_register(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_register_condition_for_worker_raises(c, s, a, b):
-    r = c._environments_register('myenv', lambda: True)
+    r = c._environment_register('myenv', lambda: True)
     with pytest.raises(TypeError) as m:
         r.result()
 
@@ -67,7 +67,7 @@ def test_register_condition_for_worker_raises(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_register_functional(c, s, a, b):
-    yield c._environments_register('myenv', condition=lambda: True)
+    yield c._environment_register('myenv', condition=lambda: True)
     assert len(s.worker_environments) == 1 and 'myenv' in s.worker_environments
     assert len(s.environment_workers['myenv']) == 2
     assert 'myenv' in a.environments
@@ -79,17 +79,31 @@ def test_register_raises(loop):
         with cluster() as (s, [a, b]):
             with Client(s['address'], loop=loop) as c:
 
-                c.environments_register("zero-division",
-                                        condition=lambda: 1 / 0)
+                c.environment_register("zero-division",
+                                       condition=lambda: 1 / 0)
+
+def test_register_twice_raises(loop):
+    e1 = MyEnv()
+    e2 = MyEnv()
+    e2.data = 10  # make the two unequal
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            c.environment_register('env', environment=e1)
+
+            # registering the same one is fine
+            c.environment_register('env', environment=e1)
+
+            with pytest.raises(ValueError):
+                c.environment_register('env', environment=e2)
 
 
 @gen_cluster(client=True)
 def test_deregister_environment(c, s, a, b):
-    yield c._environmnets_register('myenv', MyEnv())
+    yield c._environment_register('myenv', MyEnv())
     # sanity check before real test
     assert len(s.worker_environments) == 1 and 'myenv' in s.worker_environments
 
-    yield c._environmnets_deregister('myenv')
+    yield c._environment_deregister('myenv')
     assert len(s.environment_workers['myenv']) == 0
     # TODO: what all should we clean up when the number of workers drops to zero?
     assert a.environments['myenv'].data == -1

--- a/distributed/tests/test_worker_environments.py
+++ b/distributed/tests/test_worker_environments.py
@@ -1,0 +1,96 @@
+import pytest
+from tornado import gen
+
+from distributed import WorkerEnvironment, Worker, Client
+from distributed.metrics import time
+from distributed.utils_test import gen_cluster, cluster, loop  # noqa
+
+class MyEnv(WorkerEnvironment):
+    """Test worker environmnet"""
+    data = 0
+
+    def condition(self):
+        return True
+
+    def setup(self):
+        self.data = 1
+
+    def teardown(self):
+        self.data = -1
+
+
+@gen_cluster(client=True)
+def test_register_worker_environment(c, s, a, b):
+    # Register environment
+    yield c._register_worker_environment('myenv', MyEnv())
+    assert len(s.worker_environments) == 1 and 'myenv' in s.worker_environments
+    assert len(s.environment_workers['myenv']) == 2
+    assert 'myenv' in a.environments
+    assert a.environments['myenv'].data == 1
+    assert 'myenv' in b.environments
+    assert b.environments['myenv'].data == 1
+
+    # Register another
+    yield c._register_worker_environment('never_passes', condition=lambda: False)
+    assert len(s.worker_environments) == 2 and 'never_passes' in s.worker_environments
+    assert len(s.environment_workers['never_passes']) == 0
+
+    # Add a worker
+    w = Worker(s.ip, s.port, loop=s.loop, ncores=1)
+    yield w._start(0)
+    start = time()
+    while 'myenv' not in w.environments:
+        yield gen.sleep(0.01)
+        assert time() - start < 5
+
+    assert w.address in s.environment_workers['myenv']
+    assert len(s.environment_workers['never_passes']) == 0
+
+    # Remove worker
+    yield w._close()
+    start = time()
+    while not w.status == 'closed':
+        yield gen.sleep(0.01)
+        assert time() - start < 5
+
+    assert w.address not in s.environment_workers['myenv']
+
+
+@gen_cluster(client=True)
+def test_register_condition_for_worker_raises(c, s, a, b):
+    r = c._register_worker_environment('myenv', lambda: True)
+    with pytest.raises(TypeError) as m:
+        r.result()
+
+    assert m.match("Did you mean")
+
+
+@gen_cluster(client=True)
+def test_register_functional(c, s, a, b):
+    yield c._register_worker_environment('myenv', condition=lambda: True)
+    assert len(s.worker_environments) == 1 and 'myenv' in s.worker_environments
+    assert len(s.environment_workers['myenv']) == 2
+    assert 'myenv' in a.environments
+    assert 'myenv' in b.environments
+
+
+def test_register_raises(loop):
+    with pytest.raises(ZeroDivisionError):
+        with cluster() as (s, [a, b]):
+            with Client(s['address'], loop=loop) as c:
+
+                c.register_worker_environment("zero-division",
+                                              condition=lambda: 1 / 0)
+
+
+@gen_cluster(client=True)
+def test_deregister_environment(c, s, a, b):
+    yield c._register_worker_environment('myenv', MyEnv())
+    # sanity check before real test
+    assert len(s.worker_environments) == 1 and 'myenv' in s.worker_environments
+
+    yield c._deregister_worker_environment('myenv')
+    assert len(s.environment_workers['myenv']) == 0
+    # TODO: what all should we clean up when the number of workers drops to zero?
+    assert a.environments['myenv'].data == -1
+    assert b.environments['myenv'].data == -1

--- a/distributed/tests/test_worker_environments.py
+++ b/distributed/tests/test_worker_environments.py
@@ -20,9 +20,9 @@ class MyEnv(WorkerEnvironment):
 
 
 @gen_cluster(client=True)
-def test_register_worker_environment(c, s, a, b):
+def test_environmnets_register(c, s, a, b):
     # Register environment
-    yield c._register_worker_environment('myenv', MyEnv())
+    yield c._environments_register('myenv', MyEnv())
     assert len(s.worker_environments) == 1 and 'myenv' in s.worker_environments
     assert len(s.environment_workers['myenv']) == 2
     assert 'myenv' in a.environments
@@ -31,7 +31,7 @@ def test_register_worker_environment(c, s, a, b):
     assert b.environments['myenv'].data == 1
 
     # Register another
-    yield c._register_worker_environment('never_passes', condition=lambda: False)
+    yield c._environments_register('never_passes', condition=lambda: False)
     assert len(s.worker_environments) == 2 and 'never_passes' in s.worker_environments
     assert len(s.environment_workers['never_passes']) == 0
 
@@ -58,7 +58,7 @@ def test_register_worker_environment(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_register_condition_for_worker_raises(c, s, a, b):
-    r = c._register_worker_environment('myenv', lambda: True)
+    r = c._environments_register('myenv', lambda: True)
     with pytest.raises(TypeError) as m:
         r.result()
 
@@ -67,7 +67,7 @@ def test_register_condition_for_worker_raises(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_register_functional(c, s, a, b):
-    yield c._register_worker_environment('myenv', condition=lambda: True)
+    yield c._environments_register('myenv', condition=lambda: True)
     assert len(s.worker_environments) == 1 and 'myenv' in s.worker_environments
     assert len(s.environment_workers['myenv']) == 2
     assert 'myenv' in a.environments
@@ -79,17 +79,17 @@ def test_register_raises(loop):
         with cluster() as (s, [a, b]):
             with Client(s['address'], loop=loop) as c:
 
-                c.register_worker_environment("zero-division",
-                                              condition=lambda: 1 / 0)
+                c.environments_register("zero-division",
+                                        condition=lambda: 1 / 0)
 
 
 @gen_cluster(client=True)
 def test_deregister_environment(c, s, a, b):
-    yield c._register_worker_environment('myenv', MyEnv())
+    yield c._environmnets_register('myenv', MyEnv())
     # sanity check before real test
     assert len(s.worker_environments) == 1 and 'myenv' in s.worker_environments
 
-    yield c._deregister_worker_environment('myenv')
+    yield c._environmnets_deregister('myenv')
     assert len(s.environment_workers['myenv']) == 0
     # TODO: what all should we clean up when the number of workers drops to zero?
     assert a.environments['myenv'].data == -1

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2262,8 +2262,10 @@ class Worker(WorkerBase):
         if name not in self.environments:
             env = pickle.loads(environment)
             is_member = yield offload(env.condition)
+            print('#' * 40, name, is_member)
             if gen.is_future(is_member):
                 is_member = yield is_member
+            print('*' * 40, name, is_member)
             if is_member:
                 yield self.executor_submit('setup', env.setup)
                 self.environments[name] = env

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -105,6 +105,7 @@ Contents
    adaptive
    asynchronous
    configuration
+   worker-environments
    ec2
    local-cluster
    ipython

--- a/docs/source/worker-environments.rst
+++ b/docs/source/worker-environments.rst
@@ -1,0 +1,84 @@
+Worker Environments
+===================
+
+A "worker environment" can be used to identify and prepare a set of workers for
+certain tasks. For example, you may have some setup logic to connect to a
+database that must be run prior to doing work, but don't want to open a
+connection on every single worker. As another example, you may have certain
+tasks that require a high amount of memory, so you wish to identify workers with
+at least 32GB of RAM.
+
+Components
+----------
+
+An environment consists of
+
+1. A unique name like ``"high-memory"`` or ``"database-access"``
+2. A ``condition``, a function of no arguments to be called on the worker.
+   Determines whether that worker qualifies for the environment.
+3. A ``setup`` a function of no arguments to be run on the worker when they
+   join an environment
+4. A ``teardown`` function of no arguments to be run on the worker when they
+   leave the environment
+5. A ``state`` variable (TODO: what exactly is this? Tentatively, each worker
+   has a dictionary ``environment_state :: name -> Dict``, where you can get and
+   put whatever you want in that nested ``Dict``)
+
+TODO: Can / should the setup or teardown methods take the ``dask_worker`` itself?
+
+Only the name is required.
+
+Registering Environments
+------------------------
+
+Environments can be registered using :meth:`Client.register_worker_environment`.
+You can use either a functional style:
+
+.. code-block:: python
+
+   def has_high_memory(dask_worker):
+       import psutil
+       return psutil.virtual_memory.total > 30e9
+
+   client.register_worker_environment(name='high-memory',
+                                      condition=has_high_memory)
+
+
+Or class-based style by passing an instance of :class:`WorkerEnvironment`:
+
+.. code-block:: python
+
+   client.register_worker_environment(name='high-memory',
+                                      environment=HighMemory)
+
+
+If using the functional style, an instance of ``WorkerEnvironment`` is created
+with the ``condition``, ``setup``, and ``teardown`` functions passed to
+``client.register_worker_environment`` attached as methods.
+
+The ``condition`` function will be scheduled to be run on each worker. Workers
+that pass the condition are added to the environment, and any setup functions
+are run.
+
+The ``teardown`` method is run when workers are closed.
+
+Specifying Environments
+-----------------------
+
+Environments can be created in code by subclassing ``distributed.Environment``
+and overriding the ``condition``, ``setup``, and ``teardown`` methods.
+
+.. code-block:: python
+
+   class HighMemory(WorkerEnvironment):
+       "An environment for workers with at least 30GB of RAM"
+       name = 'high-memory'
+
+       def condition(self):
+           import psutil
+           return psutil.virtual_memory.total > 30e9
+
+
+Using Environmnets
+------------------
+

--- a/docs/source/worker-environments.rst
+++ b/docs/source/worker-environments.rst
@@ -31,7 +31,7 @@ Only the name is required.
 Registering Environments
 ------------------------
 
-Environments can be registered using :meth:`Client.environments_register`.
+Environments can be registered using :meth:`Client.environment_register`.
 You can use either a functional style:
 
 .. code-block:: python
@@ -40,21 +40,21 @@ You can use either a functional style:
        import psutil
        return psutil.virtual_memory.total > 30e9
 
-   client.environments_register(name='high-memory',
-                                condition=has_high_memory)
+   client.environment_register(name='high-memory',
+                               condition=has_high_memory)
 
 
 Or class-based style by passing an instance of :class:`WorkerEnvironment`:
 
 .. code-block:: python
 
-   client.environments_register(name='high-memory',
-                                environment=HighMemory)
+   client.environment_register(name='high-memory',
+                               environment=HighMemory)
 
 
 If using the functional style, an instance of ``WorkerEnvironment`` is created
 with the ``condition``, ``setup``, and ``teardown`` functions passed to
-``client.environments_register`` attached as methods.
+``client.environment_register`` attached as methods.
 
 The ``condition`` function will be scheduled to be run on each worker. Workers
 that pass the condition are added to the environment, and any setup functions

--- a/docs/source/worker-environments.rst
+++ b/docs/source/worker-environments.rst
@@ -31,7 +31,7 @@ Only the name is required.
 Registering Environments
 ------------------------
 
-Environments can be registered using :meth:`Client.register_worker_environment`.
+Environments can be registered using :meth:`Client.environments_register`.
 You can use either a functional style:
 
 .. code-block:: python
@@ -40,21 +40,21 @@ You can use either a functional style:
        import psutil
        return psutil.virtual_memory.total > 30e9
 
-   client.register_worker_environment(name='high-memory',
-                                      condition=has_high_memory)
+   client.environments_register(name='high-memory',
+                                condition=has_high_memory)
 
 
 Or class-based style by passing an instance of :class:`WorkerEnvironment`:
 
 .. code-block:: python
 
-   client.register_worker_environment(name='high-memory',
-                                      environment=HighMemory)
+   client.environments_register(name='high-memory',
+                                environment=HighMemory)
 
 
 If using the functional style, an instance of ``WorkerEnvironment`` is created
 with the ``condition``, ``setup``, and ``teardown`` functions passed to
-``client.register_worker_environment`` attached as methods.
+``client.environments_register`` attached as methods.
 
 The ``condition`` function will be scheduled to be run on each worker. Workers
 that pass the condition are added to the environment, and any setup functions
@@ -79,6 +79,6 @@ and overriding the ``condition``, ``setup``, and ``teardown`` methods.
            return psutil.virtual_memory.total > 30e9
 
 
-Using Environmnets
+Using Environments
 ------------------
 


### PR DESCRIPTION
Adds the notion of worker environments to the client and scheduler.
These allow for specifying certain setup and teardown methods that
should be called when workers enter or exit the pool. In the future
environments could allow for scheduling decisions, e.g. restricting
certain tasks to certain environments.

```python
>>> client.register_worker_environment("my-env",
...                                    condition=lambda: True)
```

This is pretty rough at the moment.