### PR TITLE
Avoid storing large messages in message log

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -81,8 +81,11 @@ class BatchedSend(object):
             self.batch_count += 1
             self.next_deadline = self.loop.time() + self.interval
             try:
-                self.recent_message_log.append(payload)
                 nbytes = yield self.comm.write(payload)
+                if nbytes < 1e6:
+                    self.recent_message_log.append(payload)
+                else:
+                    self.recent_message_log.append('large-message')
                 self.byte_count += nbytes
             except CommClosedError as e:
                 logger.info("Batched Comm Closed: %s", e)

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -246,6 +246,8 @@ def test_dont_hold_on_to_large_messages(c, s, a, b):
     d = d.persist()
     del x
 
+    c.submit(lambda: 1)  # push one more message down the comm
+
     start = time()
     while xr() is not None:
         yield gen.sleep(0.05)

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -2,6 +2,7 @@
 from contextlib import contextmanager
 from datetime import timedelta
 import random
+import weakref
 
 import pytest
 from toolz import assoc
@@ -11,7 +12,7 @@ from distributed.batched import BatchedSend
 from distributed.core import listen, connect, CommClosedError
 from distributed.metrics import time
 from distributed.utils import All
-from distributed.utils_test import gen_test, slow
+from distributed.utils_test import gen_test, slow, gen_cluster
 
 
 class EchoServer(object):
@@ -232,3 +233,20 @@ def test_sending_traffic_jam():
 @gen_test()
 def test_large_traffic_jam():
     yield _run_traffic_jam(500, 1500000)
+
+
+@gen_cluster(client=True)
+def test_dont_hold_on_to_large_messages(c, s, a, b):
+    np = pytest.importorskip('numpy')
+    da = pytest.importorskip('dask.array')
+    x = np.random.random(1000000)
+    xr = weakref.ref(x)
+
+    d = da.from_array(x, chunks=(100000,))
+    d = d.persist()
+    del x
+
+    start = time()
+    while xr() is not None:
+        yield gen.sleep(0.05)
+        assert time() < start + 1


### PR DESCRIPTION
The test here still fails.  I'm not yet sure why.

#2625