### PR TITLE
Replace yield _foo with yield foo in tests

### DIFF
--- a/distributed/bokeh/tests/test_task_stream.py
+++ b/distributed/bokeh/tests/test_task_stream.py
@@ -6,7 +6,7 @@ pytest.importorskip('bokeh')
 from toolz import frequencies
 
 from distributed.utils_test import gen_cluster, div
-from distributed.client import _wait
+from distributed.client import wait
 from distributed.bokeh.task_stream import TaskStreamPlugin
 
 
@@ -17,7 +17,7 @@ def test_TaskStreamPlugin(c, s, *workers):
 
     futures = c.map(div, [1] * 10, range(10))
     total = c.submit(sum, futures[1:])
-    yield _wait(total)
+    yield wait(total)
 
     assert len(es.buffer) == 11
 

--- a/distributed/bokeh/tests/test_worker_bokeh.py
+++ b/distributed/bokeh/tests/test_worker_bokeh.py
@@ -10,7 +10,7 @@ from toolz import first
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient
 
-from distributed.client import _wait
+from distributed.client import wait
 from distributed.metrics import time
 from distributed.utils_test import gen_cluster, inc, dec
 from distributed.bokeh.worker import (BokehWorker, StateTable, CrossFilter,
@@ -109,7 +109,7 @@ def test_CommunicatingStream(c, s, a, b):
     adds = c.map(add, xs, ys, workers=a.address)
     subs = c.map(sub, xs, ys, workers=b.address)
 
-    yield _wait([adds, subs])
+    yield wait([adds, subs])
 
     aa.update()
     bb.update()

--- a/distributed/diagnostics/tests/test_eventstream.py
+++ b/distributed/diagnostics/tests/test_eventstream.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 import pytest
 from tornado import gen
 
-from distributed.client import _wait
+from distributed.client import wait
 from distributed.diagnostics.eventstream import EventStream, eventstream
 from distributed.metrics import time
 from distributed.utils_test import div, gen_cluster
@@ -21,8 +21,8 @@ def test_eventstream(c, s, *workers):
 
     futures = c.map(div, [1] * 10, range(10))
     total = c.submit(sum, futures[1:])
-    yield _wait(total)
-    yield _wait(futures)
+    yield wait(total)
+    yield wait(futures)
 
     assert len(es.buffer) == 11
 

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -5,7 +5,7 @@ import pytest
 pytest.importorskip('bokeh')
 
 from dask import delayed
-from distributed.client import _wait
+from distributed.client import wait
 from distributed.diagnostics.progress_stream import (progress_quads,
                                                      nbytes_bar, progress_stream, _incrementing_index_cache)
 from distributed.utils_test import div, gen_cluster, inc
@@ -58,7 +58,7 @@ def test_progress_stream(c, s, a, b):
         x = delayed(inc)(x)
     future = c.compute(x)
 
-    yield _wait(futures + [future])
+    yield wait(futures + [future])
 
     comm = yield progress_stream(s.address, interval=0.010)
     msg = yield comm.read()

--- a/distributed/diagnostics/tests/test_scheduler_diagnostics.py
+++ b/distributed/diagnostics/tests/test_scheduler_diagnostics.py
@@ -4,7 +4,7 @@ import pytest
 
 from distributed.utils_test import gen_cluster, div
 from distributed.diagnostics.scheduler import tasks, workers
-from distributed.client import _wait
+from distributed.client import wait
 
 
 @gen_cluster(client=True)
@@ -17,7 +17,7 @@ def test_tasks(c, s, a, b):
     assert d['waiting'] == 0
 
     L = c.map(div, range(10), range(10))
-    yield _wait(L)
+    yield wait(L)
 
     d = tasks(s)
     assert d['failed'] == 1
@@ -40,7 +40,7 @@ def test_workers(c, s, a, b):
     # assert d[a.ip]['last-seen'] > 0
 
     L = c.map(div, range(10), range(10))
-    yield _wait(L)
+    yield wait(L)
 
     assert 0 <= d[a.ip]['cpu'] <= 100
     assert 0 <= d[a.ip]['memory']

--- a/distributed/http/tests/test_scheduler_http.py
+++ b/distributed/http/tests/test_scheduler_http.py
@@ -6,7 +6,7 @@ from tornado.httpclient import AsyncHTTPClient
 from tornado.httpserver import HTTPServer
 
 from distributed import Scheduler
-from distributed.client import _wait
+from distributed.client import wait
 from distributed.sizeof import getsizeof
 from distributed.utils_test import gen_cluster, gen_test, inc, div
 from distributed.http.scheduler import HTTPScheduler
@@ -120,7 +120,7 @@ def test_with_data(e, s, a, b):
 
     L = e.map(inc, [1, 2, 3])
     L2 = yield e._scatter(['Hello', 'world!'])
-    yield _wait(L)
+    yield wait(L)
 
     client = AsyncHTTPClient()
     response = yield client.fetch('http://localhost:%d/memory-load.json' %
@@ -162,7 +162,7 @@ def test_with_status(e, s, a, b):
     assert out['waiting'] == 0
 
     L = e.map(div, range(10), range(10))
-    yield _wait(L)
+    yield wait(L)
 
     client = AsyncHTTPClient()
     response = yield client.fetch('http://localhost:%d/tasks.json' %

--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from tornado import gen
 
-from .client import Client, wait
+from .client import Client, _wait
 from .utils import ignoring, funcname, itemgetter
 
 # A user could have installed joblib, sklearn, both, or neither. Further, only

--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from tornado import gen
 
-from .client import Client, _wait
+from .client import Client, wait
 from .utils import ignoring, funcname, itemgetter
 
 # A user could have installed joblib, sklearn, both, or neither. Further, only

--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 from tornado import gen
-from .client import futures_of, _wait
+from .client import futures_of, wait
 from .utils import sync, tokey
 from .utils_comm import pack_data
 from .worker import _deserialize
@@ -124,7 +124,7 @@ class ReplayExceptionClient(object):
 
     @gen.coroutine
     def _recreate_error_locally(self, future):
-        yield _wait(future)
+        yield wait(future)
         out = yield self._get_futures_error(future)
         function, args, kwargs, deps = out
         futures = self.client._graph_to_futures({}, deps)

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -188,7 +188,7 @@ def test_stress():
 
 
 @gen.coroutine
-def _run_traffic_jam(nsends, nbytes):
+def run_traffic_jam(nsends, nbytes):
     # This test eats `nsends * nbytes` bytes in RAM
     np = pytest.importorskip('numpy')
     from distributed.protocol import to_serialize
@@ -226,13 +226,13 @@ def _run_traffic_jam(nsends, nbytes):
 
 @gen_test()
 def test_sending_traffic_jam():
-    yield _run_traffic_jam(50, 300000)
+    yield run_traffic_jam(50, 300000)
 
 
 @slow
 @gen_test()
 def test_large_traffic_jam():
-    yield _run_traffic_jam(500, 1500000)
+    yield run_traffic_jam(500, 1500000)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_hdfs.py
+++ b/distributed/tests/test_hdfs.py
@@ -18,7 +18,7 @@ from distributed.utils_test import cluster, gen_cluster, make_hdfs
 from distributed.utils_test import loop # flake8: noqa
 from distributed.utils import get_ip
 from distributed import Client
-from distributed.client import _wait, Future
+from distributed.client import wait, Future
 
 hdfs3 = pytest.importorskip('hdfs3')
 _orig_cluster = cluster
@@ -228,7 +228,7 @@ def test_write_bytes(c, s, a, b):
 
         futures = c.compute(write_bytes(remote_data,
                                         'hdfs://%s/data/file.*.dat' % basedir))
-        yield _wait(futures)
+        yield wait(futures)
 
         yield futures[0]
 
@@ -239,7 +239,7 @@ def test_write_bytes(c, s, a, b):
         hdfs.mkdir('%s/data2/' % basedir)
         futures = c.compute(write_bytes(remote_data,
                                         'hdfs://%s/data2/' % basedir))
-        yield _wait(futures)
+        yield wait(futures)
 
         assert len(hdfs.ls('%s/data2/' % basedir)) == 3
 

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -18,7 +18,7 @@ from distributed.utils import All
 from distributed.utils_test import (gen_cluster, cluster, inc, slowinc,
                                     slowadd, slow, slowsum, bump_rlimit)
 from distributed.utils_test import loop # flake8: noqa
-from distributed.client import _wait
+from distributed.client import wait
 from tornado import gen
 
 
@@ -54,7 +54,7 @@ def test_cancel_stress(c, s, *workers):
     da = pytest.importorskip('dask.array')
     x = da.random.random((40, 40), chunks=(1, 1))
     x = c.persist(x)
-    yield _wait([x])
+    yield wait([x])
     y = (x.sum(axis=0) + x.sum(axis=1) + 1).std()
     for i in range(5):
         f = c.compute(y)
@@ -233,7 +233,7 @@ def test_close_connections(c, s, *workers):
         # for w in workers:
         #     print(w)
 
-    yield _wait(future)
+    yield wait(future)
 
 
 @pytest.mark.xfail(reason="IOStream._handle_write blocks on large write_buffer"

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -9,7 +9,7 @@ from __future__ import print_function, division, absolute_import
 from tornado import gen
 
 from distributed import Nanny, worker_client, Queue
-from distributed.client import _wait
+from distributed.client import wait
 from distributed.utils_test import (gen_cluster, tls_only_security,
                                     inc, double, slowinc, slowadd)
 
@@ -110,7 +110,7 @@ def test_work_stealing(c, s, a, b):
     [x] = yield c._scatter([1], workers=a.address)
     futures = c.map(slowadd, range(50), [x] * 50)
     yield gen.sleep(0.1)
-    yield _wait(futures)
+    yield wait(futures)
     assert len(a.data) > 10
     assert len(b.data) > 10
     assert len(a.data) > len(b.data) - 5


### PR DESCRIPTION
This is mostly a stylistic change.  Other developers were taking up and
propagating this old way of doing things so I decided to remove it.