### PR TITLE
Silently pass on cancelled futures in as_completed

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2939,7 +2939,10 @@ class as_completed(object):
 
     @gen.coroutine
     def track_future(self, future):
-        yield _wait(future)
+        try:
+            yield _wait(future)
+        except CancelledError:
+            return
         if self.with_results:
             result = yield future._result()
         with self.lock:

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -1,11 +1,14 @@
 from collections import Iterator
 from operator import add
 import random
+from time import sleep
 
 import pytest
+from tornado import gen
 
 from distributed import Client
 from distributed.client import _as_completed, as_completed, _first_completed
+from distributed.compatibility import Empty
 from distributed.utils_test import cluster, gen_cluster, inc
 from distributed.utils_test import loop # flake8: noqa
 from distributed.compatibility import Queue
@@ -109,3 +112,18 @@ def test_as_completed_is_empty(loop):
             assert not ac.is_empty()
             assert next(ac) is x
             assert ac.is_empty()
+
+
+def test_as_completed_cancel(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            x = c.submit(sleep, 1)
+            y = c.submit(inc, 1)
+
+            ac = as_completed([x, y])
+            x.cancel()
+
+            assert next(ac) is y
+
+            with pytest.raises(Empty):
+                ac.queue.get(timeout=0.1)


### PR DESCRIPTION
This matches concurrent.futures behavior

See #1364 
cc @adamklein