### PR TITLE
Add dask-mpi executable

### DIFF
--- a/distributed/cli/dask_mpi.py
+++ b/distributed/cli/dask_mpi.py
@@ -1,0 +1,89 @@
+
+import click
+from mpi4py import MPI
+from tornado.ioloop import IOLoop
+from tornado import gen
+
+from distributed import Scheduler, Worker
+from distributed.bokeh.scheduler import BokehScheduler
+from distributed.bokeh.worker import BokehWorker
+from distributed.cli.utils import check_python_3, uri_from_host_port
+from distributed.utils import get_ip_interface
+
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+loop = IOLoop()
+
+
+@click.command()
+@click.option('--scheduler-file', type=str, default='scheduler.json',
+              help='Filename to JSON encoded scheduler information. ')
+@click.option('--interface', type=str, default=None,
+              help="Network interface like 'eth0' or 'ib0'")
+@click.option('--nthreads', type=int, default=0,
+              help="Number of threads per worker.")
+@click.option('--memory-limit', default='auto',
+              help="Number of bytes before spilling data to disk. "
+                   "This can be an integer (nbytes) "
+                   "float (fraction of total memory) "
+                   "or 'auto'")
+@click.option('--local-directory', default='', type=str,
+              help="Directory to place worker files")
+@click.option('--scheduler/--no-scheduler', default=True,
+              help=("Whether or not to include a scheduler. "
+                    "Use --no-scheduler to increase an existing dask cluster"))
+def main(scheduler_file, interface, nthreads, local_directory, memory_limit,
+         scheduler):
+    if interface:
+        host = get_ip_interface(interface)
+    else:
+        host = None
+
+    if rank == 0 and scheduler:
+        scheduler = Scheduler(scheduler_file=scheduler_file,
+                              loop=loop,
+                              services={('bokeh',  8787): BokehScheduler})
+        addr = uri_from_host_port(host, None, 8786)
+        scheduler.start(addr)
+        try:
+            loop.start()
+            loop.close()
+        finally:
+            scheduler.stop()
+    else:
+        worker = Worker(scheduler_file=scheduler_file,
+                        loop=loop,
+                        name=rank if scheduler else None,
+                        ncores=nthreads,
+                        local_dir=local_directory,
+                        services={'bokeh': BokehWorker},
+                        memory_limit=memory_limit)
+        addr = uri_from_host_port(host, None, 0)
+
+        @gen.coroutine
+        def run():
+            yield worker._start(addr)
+            while worker.status != 'closed':
+                yield gen.sleep(0.2)
+
+        try:
+            loop.run_sync(run)
+            loop.close()
+        finally:
+            pass
+
+        @gen.coroutine
+        def close():
+            yield worker._close(timeout=2)
+
+        loop.run_sync(close)
+
+
+def go():
+    check_python_3()
+    main()
+
+
+if __name__ == '__main__':
+    go()

--- a/distributed/cli/tests/test_dask_mpi.py
+++ b/distributed/cli/tests/test_dask_mpi.py
@@ -1,0 +1,48 @@
+from __future__ import print_function, division, absolute_import
+
+import subprocess
+from time import sleep
+
+import pytest
+pytest.importorskip('mpi4py')
+
+from distributed import Client
+from distributed.utils import tmpfile
+from distributed.metrics import time
+from distributed.utils_test import popen
+from distributed.utils_test import loop  # flake8: noqa
+
+
+def test_basic(loop):
+    with tmpfile() as fn:
+        with popen(['mpirun', '--np', '4', 'dask-mpi', '--scheduler-file', fn],
+                   stdin=subprocess.DEVNULL):
+            with Client(scheduler_file=fn) as c:
+
+                start = time()
+                while len(c.scheduler_info()['workers']) != 3:
+                    assert time() < start + 10
+                    sleep(0.2)
+
+                assert c.submit(lambda x: x + 1, 10, workers=1).result() == 11
+
+
+def test_no_scheduler(loop):
+    with tmpfile() as fn:
+        with popen(['mpirun', '--np', '2', 'dask-mpi', '--scheduler-file', fn],
+                   stdin=subprocess.DEVNULL):
+            with Client(scheduler_file=fn) as c:
+
+                start = time()
+                while len(c.scheduler_info()['workers']) != 1:
+                    assert time() < start + 10
+                    sleep(0.2)
+
+                assert c.submit(lambda x: x + 1, 10).result() == 11
+                with popen(['mpirun', '--np', '1', 'dask-mpi',
+                            '--scheduler-file', fn, '--no-scheduler']):
+
+                    start = time()
+                    while len(c.scheduler_info()['workers']) != 2:
+                        assert time() < start + 10
+                        sleep(0.2)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1042,7 +1042,7 @@ class Client(Node):
         if allow_other_workers and workers is None:
             raise ValueError("Only use allow_other_workers= if using workers=")
 
-        if isinstance(workers, six.string_types):
+        if isinstance(workers, six.string_types + (Number,)):
             workers = [workers]
         if workers is not None:
             restrictions = {skey: workers}
@@ -1160,7 +1160,7 @@ class Client(Node):
             dsk = {key: (apply, func, (tuple, list(args)), kwargs)
                    for key, args in zip(keys, zip(*iterables))}
 
-        if isinstance(workers, six.string_types):
+        if isinstance(workers, six.string_types + (Number,)):
             workers = [workers]
         if isinstance(workers, (list, set)):
             if workers and isinstance(first(workers), (list, set)):
@@ -1370,7 +1370,7 @@ class Client(Node):
     @gen.coroutine
     def _scatter(self, data, workers=None, broadcast=False, direct=None,
                  local_worker=None, timeout=3, hash=True):
-        if isinstance(workers, six.string_types):
+        if isinstance(workers, six.string_types + (Number,)):
             workers = [workers]
         if isinstance(data, dict) and not all(isinstance(k, (bytes, unicode))
                                               for k in data):
@@ -2659,7 +2659,7 @@ class Client(Node):
         --------
         Client.start_ipython_scheduler: start ipython on the scheduler
         """
-        if isinstance(workers, six.string_types):
+        if isinstance(workers, six.string_types + (Number,)):
             workers = [workers]
 
         (workers, info_dict) = sync(self.loop, self._start_ipython_workers, workers)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -16,7 +16,7 @@ from .core import rpc, RPCClosed, CommClosedError, coerce_to_address
 from .node import ServerNode
 from .process import AsyncProcess
 from .security import Security
-from .utils import get_ip, mp_context, silence_logging
+from .utils import get_ip, mp_context, silence_logging, json_load_robust
 from .worker import _ncores, run
 
 
@@ -32,13 +32,17 @@ class Nanny(ServerNode):
     process = None
     status = None
 
-    def __init__(self, scheduler_ip, scheduler_port=None, worker_port=0,
+    def __init__(self, scheduler_ip=None, scheduler_port=None,
+                 scheduler_file=None, worker_port=0,
                  ncores=None, loop=None, local_dir=None, services=None,
                  name=None, memory_limit='auto', reconnect=True,
                  validate=False, quiet=False, resources=None, silence_logs=None,
                  death_timeout=None, preload=(), security=None,
                  contact_address=None, listen_address=None, **kwargs):
-        if scheduler_port is None:
+        if scheduler_file:
+            cfg = json_load_robust(scheduler_file)
+            self.scheduler_addr = cfg['address']
+        elif scheduler_port is None:
             self.scheduler_addr = coerce_to_address(scheduler_ip)
         else:
             self.scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -219,3 +219,5 @@ def test_scheduler_file():
         w = Nanny(scheduler_file=fn)
         yield w._start()
         assert s.workers == {w.worker_address}
+        yield w._close()
+        s.stop()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -906,7 +906,9 @@ def test_service_hosts_match_worker(s):
 def test_scheduler_file():
     with tmpfile() as fn:
         s = Scheduler(scheduler_file=fn)
-        s.start(8008)
+        s.start(8009)
         w = Worker(scheduler_file=fn)
         yield w._start()
         assert s.workers == {w.address}
+        yield w._close()
+        s.stop()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -241,10 +241,12 @@ def test_broadcast(s, a, b):
 def test_worker_with_port_zero():
     s = Scheduler()
     s.start(8007)
-    w = Worker(s.ip, s.port)
+    w = Worker(s.address)
     yield w._start()
     assert isinstance(w.port, int)
     assert w.port > 1024
+
+    yield w._close()
 
 
 @slow
@@ -898,3 +900,13 @@ def test_service_hosts_match_worker(s):
         sock = first(w.services['http']._sockets.values())
         assert sock.getsockname()[0] == host.split('://')[1]
         yield w._close()
+
+
+@gen_test()
+def test_scheduler_file():
+    with tmpfile() as fn:
+        s = Scheduler(scheduler_file=fn)
+        s.start(8008)
+        w = Worker(scheduler_file=fn)
+        yield w._start()
+        assert s.workers == {w.address}

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -40,7 +40,7 @@ from .sizeof import safe_sizeof as sizeof
 from .threadpoolexecutor import ThreadPoolExecutor, secede as tpe_secede
 from .utils import (funcname, get_ip, has_arg, _maybe_complex, log_errors,
                     ignoring, validate_key, mp_context, import_file,
-                    silence_logging, thread_state)
+                    silence_logging, thread_state, json_load_robust)
 from .utils_comm import pack_data, gather_from_workers
 
 _ncores = mp_context.cpu_count()
@@ -70,13 +70,17 @@ _global_workers = []
 
 
 class WorkerBase(ServerNode):
-    def __init__(self, scheduler_ip, scheduler_port=None, ncores=None,
-                 loop=None, local_dir=None, services=None, service_ports=None,
-                 name=None, heartbeat_interval=5000, reconnect=True,
-                 memory_limit='auto', executor=None, resources=None,
-                 silence_logs=None, death_timeout=None, preload=(),
-                 security=None, contact_address=None, **kwargs):
-        if scheduler_port is None:
+    def __init__(self, scheduler_ip=None, scheduler_port=None,
+                 scheduler_file=None, ncores=None, loop=None, local_dir=None,
+                 services=None, service_ports=None, name=None,
+                 heartbeat_interval=5000, reconnect=True, memory_limit='auto',
+                 executor=None, resources=None, silence_logs=None,
+                 death_timeout=None, preload=(), security=None,
+                 contact_address=None, **kwargs):
+        if scheduler_file:
+            cfg = json_load_robust(scheduler_file)
+            scheduler_addr = cfg['address']
+        elif scheduler_port is None:
             scheduler_addr = coerce_to_address(scheduler_ip)
         else:
             scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -108,6 +108,32 @@ Note, the ``--scheduler-file`` option is *only* valuable if your scheduler and
 workers share a standard POSIX file system.
 
 
+Using MPI
+---------
+
+You can launch a Dask network using ``mpirun`` or ``mpiexec`` and the
+``dask-mpi`` command line executable.
+
+.. code-block:: bash
+
+   mpirun --np 4 dask-mpi --scheduler-file /path/to/scheduler.json
+
+.. code-block:: python
+
+   from dask.distributed import Client
+   client = Client(scheduler_file='/path/to/scheduler.json')
+
+This depends on the `mpi4py <http://mpi4py.readthedocs.io/>`_ library.  It only
+uses MPI to start the Dask cluster, and not for inter-node communication.  You
+may want to specify a high-bandwidth network interface like infiniband using
+the ``--interface`` keyword
+
+.. code-block:: bash
+
+   mpirun --np 4 dask-mpi --nthreads 1 \
+                          --interface ib0 \
+                          --scheduler-file /path/to/scheduler.json
+
 Using the Python API
 --------------------
 

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,6 @@ setup(name='distributed',
         dask-remote=distributed.cli.dask_remote:go
         dask-scheduler=distributed.cli.dask_scheduler:go
         dask-worker=distributed.cli.dask_worker:go
+        dask-mpi=distributed.cli.dask_mpi:go
       ''',
       zip_safe=False)


### PR DESCRIPTION
This assists with deployment on MPI-based clusters.  Note that it doesn't actually use MPI for inter-node communication.  That is still handled through TCP.

See updated doc pages in this PR for more information

cc @rabernat @kmpaul @davidedelvento @pwolfram @jhamman

### Minimal Example
    
    conda install -c conda-forge mpi4py
    mpirun --np 4 dask-mpi

### Actual Example

```
mrocklin@carbon:~/workspace/distributed$ mpirun --np 4 dask-mpi --memory-limit 1e9 --nthreads 2 --interface lo
distributed.scheduler - INFO -   Scheduler at:      tcp://127.0.0.1:8786
distributed.scheduler - INFO -       bokeh at:            127.0.0.1:8787
distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:38822
distributed.worker - INFO -          Listening to:      tcp://127.0.0.1:38822
distributed.worker - INFO -              bokeh at:            127.0.0.1:40020
distributed.worker - INFO - Waiting to connect to:       tcp://127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -               Threads:                          2
distributed.worker - INFO -                Memory:                    1.00 GB
distributed.worker - INFO -       Local Directory:            worker-lfrs4ur7
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:34353
distributed.worker - INFO -          Listening to:      tcp://127.0.0.1:34353
distributed.worker - INFO -              bokeh at:            127.0.0.1:41932
distributed.worker - INFO - Waiting to connect to:       tcp://127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -               Threads:                          2
distributed.worker - INFO -                Memory:                    1.00 GB
distributed.scheduler - INFO - Register tcp://127.0.0.1:38822
distributed.worker - INFO -       Local Directory:            worker-niihtiha
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:39166
distributed.worker - INFO -          Listening to:      tcp://127.0.0.1:39166
distributed.worker - INFO -              bokeh at:            127.0.0.1:43457
distributed.worker - INFO - Waiting to connect to:       tcp://127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.scheduler - INFO - Starting worker compute stream, tcp://127.0.0.1:38822
distributed.worker - INFO -               Threads:                          2
distributed.worker - INFO -                Memory:                    1.00 GB
distributed.worker - INFO -       Local Directory:            worker-nw6m4rgt
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -         Registered to:       tcp://127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.scheduler - INFO - Register tcp://127.0.0.1:34353
distributed.worker - INFO -         Registered to:       tcp://127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.scheduler - INFO - Register tcp://127.0.0.1:39166
distributed.scheduler - INFO - Starting worker compute stream, tcp://127.0.0.1:34353
distributed.worker - INFO -         Registered to:       tcp://127.0.0.1:8786
distributed.worker - INFO - -------------------------------------------------
distributed.scheduler - INFO - Starting worker compute stream, tcp://127.0.0.1:39166
```