### PR TITLE
Support unicode keys in pack_data

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4572,6 +4572,14 @@ def test_unicode_keys(c, s, a, b):
     assert key in a.data or key in b.data
     assert result == 2
 
+    future2 = c.submit(inc, future)
+    result2 = yield future2
+    assert result2 == 3
+
+    future3 = yield c.scatter({u'data-123': 123})
+    result3 = yield future3[u'data-123']
+    assert result3 == 123
+
 
 def test_use_synchronous_client_in_async_context(loop):
     with cluster() as (s, [a, b]):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1992,8 +1992,8 @@ class Worker(WorkerBase):
 
             start = time()
             data = {k: self.data[k] for k in self.dependencies[key]}
-            args2 = pack_data(args, data, key_types=str)
-            kwargs2 = pack_data(kwargs, data, key_types=str)
+            args2 = pack_data(args, data, key_types=(bytes, unicode))
+            kwargs2 = pack_data(kwargs, data, key_types=(bytes, unicode))
             stop = time()
             if stop - start > 0.005:
                 self.startstops[key].append(('disk-read', start, stop))


### PR DESCRIPTION
In https://github.com/dask/distributed/pull/1328 we started allowing
Python 2 to use unicode keys, mostly to support Julia.  However this
change missed a the pack_data function used in worker.py which still
only checked for string-based keys.  This arose any time whenever
a task depended on a unicode key.

Fixes https://github.com/pydata/xarray/issues/1540

cc @iamed2 