### PR TITLE
Gather information from running frames

### DIFF
--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -580,8 +580,9 @@ class ProfilePlot(DashboardComponent):
         self.root = figure(tools='tap', **kwargs)
         self.root.quad('left', 'right', 'top', 'bottom', color='color',
                       line_color='black', line_width=2, source=self.source)
-        self.root.text(x='left', y='bottom', text='short_text', y_offset=-5,
-                      x_offset=10, source=self.source)
+        self.root.text(x='left', y='bottom', text='short_text',
+                       x_offset=5, text_font_size=value('10pt'),
+                       source=self.source)
 
         hover = HoverTool()
         hover.tooltips = "@long_text{safe}"  # this is unsafe

--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -580,14 +580,14 @@ class ProfilePlot(DashboardComponent):
 
         self.source.on_change('selected', cb)
 
-        self.root = figure(tools='tap')
+        self.root = figure(tools='tap', **kwargs)
         self.root.quad('left', 'right', 'top', 'bottom', color='color',
                       line_color='black', line_width=2, source=self.source)
         self.root.text(x='left', y='bottom', text='short_text', y_offset=-5,
                       x_offset=10, source=self.source)
 
         hover = HoverTool()
-        hover.tooltips = "@long_text"
+        hover.tooltips = "@long_text{safe}"  # this is unsafe
         hover.point_policy = 'follow_mouse'
         self.root.add_tools(hover)
 

--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -564,7 +564,6 @@ class ProfilePlot(DashboardComponent):
         self.source = ColumnDataSource(data=data)
 
         def cb(attr, old, new):
-            print(attr, old, new)
             with log_errors():
                 try:
                     ind = new['1d']['indices'][0]
@@ -574,9 +573,7 @@ class ProfilePlot(DashboardComponent):
                 del self.states[:]
                 self.states.extend(data.pop('states'))
                 self.source.data.update(data)
-                print('updated')
                 self.source.selected = old
-                print('deselected')
 
         self.source.on_change('selected', cb)
 

--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -567,7 +567,7 @@ class ProfilePlot(DashboardComponent):
             print(attr, old, new)
             with log_errors():
                 try:
-                   ind = new['1d']['indices'][0]
+                    ind = new['1d']['indices'][0]
                 except IndexError:
                     return
                 data = profile.plot_data(self.states[ind])

--- a/distributed/bokeh/tests/test_components.py
+++ b/distributed/bokeh/tests/test_components.py
@@ -6,10 +6,11 @@ pytest.importorskip('bokeh')
 from bokeh.models import ColumnDataSource, Model
 
 from distributed.bokeh import messages
+from distributed.utils_test import slowinc
 
 from distributed.bokeh.components import (
     TaskStream, TaskProgress, MemoryUsage, ResourceProfiles, WorkerTable,
-    Processing
+    Processing, ProfilePlot
 )
 
 
@@ -42,3 +43,12 @@ def test_worker_table(s, a, b):
     c = WorkerTable()
     c.update(messages)
     assert c.source.data['host'] == ['127.0.0.1']
+
+
+@gen_cluster(client=True)
+def test_profile_plot(c, s, a, b):
+    p = ProfilePlot()
+    assert len(p.source.data['left']) <= 1
+    yield c.map(slowinc, range(10), delay=0.05)
+    p.update(a.profile_recent)
+    assert len(p.source.data['left']) > 1

--- a/distributed/bokeh/worker.py
+++ b/distributed/bokeh/worker.py
@@ -32,7 +32,7 @@ with open(os.path.join(os.path.dirname(__file__), 'template.html')) as f:
     template_source = f.read()
 
 template = jinja2.Template(template_source)
-template_variables = {'pages': ['main', 'system', 'crossfilter', 'counters']}
+template_variables = {'pages': ['main', 'system', 'profile', 'crossfilter', 'counters']}
 
 
 class StateTable(DashboardComponent):
@@ -608,6 +608,7 @@ def profile_doc(server, extra, doc):
     with log_errors():
         doc.title = "Dask Worker Profile"
         profile = ProfilePlot(sizing_mode='stretch_both')
+        print(server.profile_recent['count'])
         profile.update(server.profile_recent)
 
         doc.add_root(profile.root)

--- a/distributed/bokeh/worker.py
+++ b/distributed/bokeh/worker.py
@@ -641,8 +641,7 @@ class BokehWorker(BokehServer):
                      '/counters': counters,
                      '/crossfilter': crossfilter,
                      '/system': systemmonitor,
-                     '/profile': profile
-                    }
+                     '/profile': profile}
 
         self.loop = io_loop or worker.loop
         self.server = None

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2399,7 +2399,7 @@ class Client(Node):
         """
         if futures is not None:
             futures = self.futures_of(futures)
-            keys = list({f.key for f in futures})
+            keys = list(map(tokey, {f.key for f in futures}))
         else:
             keys = None
         return self.sync(self.scheduler.who_has, keys=keys, **kwargs)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2525,6 +2525,28 @@ class Client(Node):
         return self.sync(self.scheduler.nbytes, keys=keys,
                          summary=summary, **kwargs)
 
+    def call_stack(self, futures=None):
+        """ The actively running call stack of all relevant keys
+
+        Parameters
+        ----------
+        futures: list (optional)
+            A list of futures, defaults to all data
+
+        Examples
+        --------
+        >>> df = dd.read_parquet(...).persist()  # doctest: +SKIP
+        >>> client.call_stack(df)  # call on collections
+
+        >>> client.call_stack()  # Or call with no arguments for all activity  # doctest: +SKIP
+        """
+        if futures is not None:
+            futures = self.futures_of(futures)
+            keys = list(map(tokey, {f.key for f in futures}))
+        else:
+            keys = None
+        return self.sync(self.scheduler.call_stack, keys=keys)
+
     def scheduler_info(self, **kwargs):
         """ Basic information about the workers in the cluster
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2547,6 +2547,33 @@ class Client(Node):
             keys = None
         return self.sync(self.scheduler.call_stack, keys=keys)
 
+    def profile(self, keys=None, workers=None, merge_keys=True,
+                merge_workers=True):
+        """ The actively running call stack of all relevant keys
+
+        Parameters
+        ----------
+        futures: list (optional)
+            A list of futures, defaults to all data
+        workers: list
+            A list of workers to restrict the profile to
+        merge_keys: boolean
+            Whether or not to group the profiles or keep them separated by key
+        merge_workers: boolean
+            Whether or not to group the profiles or keep them separated by worker
+
+        Examples
+        --------
+        >>> client.profile()  # call on collections
+        """
+        if isinstance(workers, six.string_types + (Number,)):
+            workers = [workers]
+        if isinstance(keys, six.string_types):
+            keys = [keys]
+
+        return self.sync(self.scheduler.profile, keys=keys, workers=workers,
+                         merge_keys=merge_keys, merge_workers=merge_workers)
+
     def scheduler_info(self, **kwargs):
         """ Basic information about the workers in the cluster
 

--- a/distributed/diagnostics/profile.py
+++ b/distributed/diagnostics/profile.py
@@ -71,7 +71,8 @@ def process(frame, child, state, stop=None):
     except KeyError:
         d = {'count': 0,
              'description': repr_frame(frame),
-             'children': {}}
+             'children': {},
+             'identifier': ident}
         state['children'][ident] = d
 
     state['count'] += 1
@@ -84,7 +85,11 @@ def process(frame, child, state, stop=None):
 
 def merge(*args):
     """ Merge multiple frame states together """
-    assert len({arg['description'] for arg in args}) == 1
+    if not args:
+        return create()
+    s = {arg['identifier'] for arg in args}
+    if len(s) != 1:
+        raise ValueError("Expected identifiers, got %s" % str(s))
     children = defaultdict(list)
     for arg in args:
         for child in arg['children']:
@@ -94,11 +99,12 @@ def merge(*args):
     count = sum(arg['count'] for arg in args)
     return {'description': args[0]['description'],
             'children': dict(children),
-            'count': count}
+            'count': count,
+            'identifier': args[0]['identifier']}
 
 
 def create():
-    return {'description': 'root', 'count': 0, 'children': {}}
+    return {'description': 'root', 'count': 0, 'children': {}, 'identifier': 'root'}
 
 
 def call_stack(frame):

--- a/distributed/diagnostics/profile.py
+++ b/distributed/diagnostics/profile.py
@@ -117,6 +117,7 @@ def plot_data(state):
     short_texts = []
     long_texts = []
     colors = []
+    states = []
 
     def traverse(state, start, stop, height, ident):
         starts.append(start)
@@ -124,8 +125,11 @@ def plot_data(state):
         heights.append(height)
         width = stop - start
         widths.append(width)
+        states.append(state)
         if width > 0.1:
             short_texts.append(ident.split(';')[0])
+        else:
+            short_texts.append('')
         try:
             colors.append(color_of(ident.split(';')[1]))
         except IndexError:
@@ -151,7 +155,9 @@ def plot_data(state):
             'top': [x + 1 for x in heights],
             'short_text': short_texts,
             'long_text': long_texts,
-            'color': colors}
+            'color': colors,
+            'states': states}
+
 
 try:
     from bokeh.palettes import viridis

--- a/distributed/diagnostics/profile.py
+++ b/distributed/diagnostics/profile.py
@@ -42,7 +42,7 @@ def repr_frame(frame):
     return text + '\n\t' + line
 
 
-def process(frame, child, state):
+def process(frame, child, state, stop=None):
     """ Add counts from a frame stack onto existing state
 
     This recursively adds counts to the existing state dictionary and creates
@@ -61,8 +61,8 @@ def process(frame, child, state):
      'children': {'...'}}
     """
     ident = identifier(frame)
-    if frame.f_back is not None:
-        state = process(frame.f_back, frame, state)
+    if frame.f_back is not None and (stop is None or stop != frame.f_back.f_code.co_name):
+        state = process(frame.f_back, frame, state, stop=stop)
 
     try:
         d = state['children'][ident]

--- a/distributed/diagnostics/profile.py
+++ b/distributed/diagnostics/profile.py
@@ -125,13 +125,14 @@ def plot_data(state):
     colors = []
     states = []
 
-    def traverse(state, start, stop, height, ident):
+    def traverse(state, start, stop, height):
         starts.append(start)
         stops.append(stop)
         heights.append(height)
         width = stop - start
         widths.append(width)
         states.append(state)
+        ident = state['identifier']
         if width > 0.1:
             short_texts.append(ident.split(';')[0])
         else:
@@ -150,10 +151,10 @@ def plot_data(state):
 
         for name, child in state['children'].items():
             width = child['count'] * delta
-            traverse(child, x, x + width, height + 1, name)
+            traverse(child, x, x + width, height + 1)
             x += width
 
-    traverse(state, 0, 1, 0, '')
+    traverse(state, 0, 1, 0)
     return {'left': starts,
             'right': stops,
             'bottom': heights,

--- a/distributed/diagnostics/profile.py
+++ b/distributed/diagnostics/profile.py
@@ -1,0 +1,95 @@
+""" This module contains utility functions to construct and manipulate counting
+data structures for frames.
+
+When performing statistical profiling we obtain many call stacks.  We aggregate
+these call stacks into data structures that maintain counts of how many times
+each function in that call stack has been called.  Because these stacks will
+overlap this aggregation counting structure forms a tree, such as is commonly
+visualized by profiling tools.
+
+We represent this tree as a nested dictionary with the following form:
+
+    {
+     'description': 'A long description of the line of code being run.',
+     'count': 10  # the number of times we have seen this line
+     'children': {  # callers of this line. Recursive dicts
+         'ident': {'description': ...
+                   'count': ...
+                   'children': {...}},
+         'ident': {'description': ...
+                   'count': ...
+                   'children': {...}}}
+    }
+"""
+
+
+from collections import defaultdict
+import linecache
+
+
+def identifier(frame):
+    return ';'.join((frame.f_code.co_name,
+                     frame.f_code.co_filename,
+                     str(frame.f_code.co_firstlineno)))
+
+
+def repr_frame(frame):
+    co = frame.f_code
+    text = '  File "%s", line %s, in %s' % (co.co_filename,
+                                            frame.f_lineno,
+                                            co.co_name)
+    line = linecache.getline(co.co_filename, frame.f_lineno, frame.f_globals).lstrip()
+    return text + '\n\t' + line
+
+
+def process(frame, child, state):
+    """ Add counts from a frame stack onto existing state
+
+    This recursively adds counts to the existing state dictionary and creates
+    new entries for new functions.
+
+    Example
+    -------
+    >>> import sys, threading
+    >>> ident = threading.get_ident()  # replace with your thread of interest
+    >>> frame = sys._current_frames()[ident]
+    >>> state = {'children': {}, 'count': 0, 'description': 'root'}
+    >>> process(frame, None, state)
+    >>> state
+    {'count': 1,
+     'description': 'root',
+     'children': {'...'}}
+    """
+    ident = identifier(frame)
+    if frame.f_back is not None:
+        state = process(frame.f_back, frame, state)
+
+    try:
+        d = state['children'][ident]
+    except KeyError:
+        d = {'count': 0,
+             'description': repr_frame(frame),
+             'children': {}}
+        state['children'][ident] = d
+
+    state['count'] += 1
+
+    if child is not None:
+        return d
+    else:
+        d['count'] += 1
+
+
+def merge(*args):
+    """ Merge multiple frame states together """
+    assert len({arg['description'] for arg in args}) == 1
+    children = defaultdict(list)
+    for arg in args:
+        for child in arg['children']:
+            children[child].append(arg['children'][child])
+
+    children = {k: merge(*v) for k, v in children.items()}
+    count = sum(arg['count'] for arg in args)
+    return {'description': args[0]['description'],
+            'children': dict(children),
+            'count': count}

--- a/distributed/diagnostics/profile.py
+++ b/distributed/diagnostics/profile.py
@@ -93,3 +93,15 @@ def merge(*args):
     return {'description': args[0]['description'],
             'children': dict(children),
             'count': count}
+
+
+def create():
+    return {'description': 'root', 'count': 0, 'children': {}}
+
+
+def call_stack(frame):
+    L = []
+    while frame:
+        L.append(repr_frame(frame))
+        frame = frame.f_back
+    return L[::-1]

--- a/distributed/diagnostics/tests/test_profile.py
+++ b/distributed/diagnostics/tests/test_profile.py
@@ -3,7 +3,8 @@ import time
 from toolz import first
 from threading import Thread
 
-from distributed.diagnostics.profile import process, merge
+from distributed.diagnostics.profile import process, merge, create, call_stack
+from distributed.compatibility import get_thread_identity
 
 
 def test_basic():
@@ -22,7 +23,7 @@ def test_basic():
     thread.daemon = True
     thread.start()
 
-    state = {'count': 0, 'children': {}, 'description': 'root'}
+    state = create()
 
     for i in range(100):
         time.sleep(0.02)

--- a/distributed/diagnostics/tests/test_profile.py
+++ b/distributed/diagnostics/tests/test_profile.py
@@ -83,3 +83,11 @@ def test_merge():
                    'children': {}}}}
 
     assert merge(a1, a2) == expected
+
+
+def test_call_stack():
+    frame = sys._current_frames()[get_thread_identity()]
+    L = call_stack(frame)
+    assert isinstance(L, list)
+    assert all(isinstance(s, str) for s in L)
+    assert 'test_call_stack' in str(L[-1])

--- a/distributed/diagnostics/tests/test_profile.py
+++ b/distributed/diagnostics/tests/test_profile.py
@@ -48,41 +48,57 @@ def test_basic():
 def test_merge():
     a1 = {
          'count': 5,
+         'identifier': 'root',
          'description': 'a',
          'children': {
              'b': {'count': 3,
                    'description': 'b-func',
+                   'identifier': 'b',
                    'children': {}},
              'c': {'count': 2,
                    'description': 'c-func',
+                   'identifier': 'c',
                    'children': {}}}}
 
     a2 = {
          'count': 4,
          'description': 'a',
+         'identifier': 'root',
          'children': {
              'd': {'count': 2,
                    'description': 'd-func',
-                   'children': {}},
+                   'children': {},
+                   'identifier': 'd'},
              'c': {'count': 2,
                    'description': 'c-func',
-                   'children': {}}}}
+                   'children': {},
+                   'identifier': 'c'}}}
 
     expected = {
          'count': 9,
+         'identifier': 'root',
          'description': 'a',
          'children': {
              'b': {'count': 3,
                    'description': 'b-func',
+                   'identifier': 'b',
                    'children': {}},
              'd': {'count': 2,
                    'description': 'd-func',
+                   'identifier': 'd',
                    'children': {}},
              'c': {'count': 4,
                    'description': 'c-func',
+                   'identifier': 'c',
                    'children': {}}}}
 
     assert merge(a1, a2) == expected
+
+
+def test_merge_empty():
+    assert merge() == create()
+    assert merge(create()) == create()
+    assert merge(create(), create()) == create()
 
 
 def test_call_stack():

--- a/distributed/diagnostics/tests/test_profile.py
+++ b/distributed/diagnostics/tests/test_profile.py
@@ -1,0 +1,84 @@
+import sys
+import time
+from toolz import first
+from threading import Thread
+
+from distributed.diagnostics.profile import process, merge
+
+
+def test_basic():
+    def test_g():
+        time.sleep(0.01)
+
+    def test_h():
+        time.sleep(0.02)
+
+    def test_f():
+        for i in range(100):
+            test_g()
+            test_h()
+
+    thread = Thread(target=test_f)
+    thread.daemon = True
+    thread.start()
+
+    state = {'count': 0, 'children': {}, 'description': 'root'}
+
+    for i in range(100):
+        time.sleep(0.02)
+        frame = sys._current_frames()[thread.ident]
+        process(frame, None, state)
+
+    assert state['description'] == 'root'
+    assert state['count'] == 100
+    d = state
+    while len(d['children']) == 1:
+        d = first(d['children'].values())
+
+    assert d['count'] == 100
+    assert 'test_f' in d['description']
+    g = [c for c in d['children'].values() if 'test_g' in c['description']][0]
+    h = [c for c in d['children'].values() if 'test_h' in c['description']][0]
+
+    assert g['count'] < h['count']
+    assert g['count'] + h['count'] == 100
+
+
+def test_merge():
+    a1 = {
+         'count': 5,
+         'description': 'a',
+         'children': {
+             'b': {'count': 3,
+                   'description': 'b-func',
+                   'children': {}},
+             'c': {'count': 2,
+                   'description': 'c-func',
+                   'children': {}}}}
+
+    a2 = {
+         'count': 4,
+         'description': 'a',
+         'children': {
+             'd': {'count': 2,
+                   'description': 'd-func',
+                   'children': {}},
+             'c': {'count': 2,
+                   'description': 'c-func',
+                   'children': {}}}}
+
+    expected = {
+         'count': 9,
+         'description': 'a',
+         'children': {
+             'b': {'count': 3,
+                   'description': 'b-func',
+                   'children': {}},
+             'd': {'count': 2,
+                   'description': 'd-func',
+                   'children': {}},
+             'c': {'count': 4,
+                   'description': 'c-func',
+                   'children': {}}}}
+
+    assert merge(a1, a2) == expected

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2109,13 +2109,13 @@ class Scheduler(ServerNode):
             workers = {w: None for w in self.workers}
 
         if not workers:
-            return {}
+            raise gen.Return({})
 
         else:
             response = yield {w: self.rpc(w).call_stack(keys=v)
                               for w, v in workers.items()}
             response = {k: v for k, v in response.items() if v}
-            return response
+            raise gen.Return(response)
 
     def get_nbytes(self, comm=None, keys=None, summary=True):
         with log_errors():

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2091,8 +2091,18 @@ class Scheduler(ServerNode):
     @gen.coroutine
     def get_call_stack(self, comm=None, keys=None):
         if keys is not None:
+            stack = list(keys)
+            processing = set()
+            while stack:
+                key = stack.pop()
+                state = self.task_state[key]
+                if state == 'waiting':
+                    stack.extend(self.dependencies[key])
+                elif state == 'processing':
+                    processing.add(key)
+
             workers = defaultdict(list)
-            for key in keys:
+            for key in processing:
                 if key in self.rprocessing:
                     workers[self.rprocessing[key]].append(key)
         else:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4637,5 +4637,47 @@ def test_warn_executor(loop):
         assert any('Client' in str(r.message) for r in record)
 
 
+@gen_cluster(client=True)
+def test_call_stack_future(c, s, a, b):
+    future = c.submit(slowinc, 1, delay=0.5)
+    yield gen.sleep(0.1)
+    result = yield c.call_stack(future)
+    w = a if a.executing else b
+    assert list(result) == [w.address]
+    assert list(result[w.address]) == [future.key]
+    assert 'slowinc' in str(result)
+
+
+@gen_cluster(client=True)
+def test_call_stack_all(c, s, a, b):
+    future = c.submit(slowinc, 1, delay=0.5)
+    yield gen.sleep(0.1)
+    result = yield c.call_stack()
+    w = a if a.executing else b
+    assert list(result) == [w.address]
+    assert list(result[w.address]) == [future.key]
+    assert 'slowinc' in str(result)
+
+
+@gen_cluster(client=True)
+def test_call_stack_collections(c, s, a, b):
+    da = pytest.importorskip('dask.array')
+    x = da.random.random(1000, chunks=(10,)).map_blocks(slowinc).persist()
+    while not a.executing and not b.executing:
+        yield gen.sleep(0.001)
+    result = yield c.call_stack(x)
+    assert result
+
+
+@gen_cluster(client=True)
+def test_call_stack_collections_all(c, s, a, b):
+    da = pytest.importorskip('dask.array')
+    x = da.random.random(1000, chunks=(10,)).map_blocks(slowinc).persist()
+    while not a.executing and not b.executing:
+        yield gen.sleep(0.001)
+    result = yield c.call_stack()
+    assert result
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # flake8: noqa

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4637,7 +4637,7 @@ def test_warn_executor(loop):
         assert any('Client' in str(r.message) for r in record)
 
 
-@gen_cluster(client=True)
+@gen_cluster([('127.0.0.1', 4)] * 2, client=True)
 def test_call_stack_future(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.5)
     yield gen.sleep(0.1)
@@ -4648,7 +4648,7 @@ def test_call_stack_future(c, s, a, b):
     assert 'slowinc' in str(result)
 
 
-@gen_cluster(client=True)
+@gen_cluster([('127.0.0.1', 4)] * 2, client=True)
 def test_call_stack_all(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.5)
     yield gen.sleep(0.1)
@@ -4659,7 +4659,7 @@ def test_call_stack_all(c, s, a, b):
     assert 'slowinc' in str(result)
 
 
-@gen_cluster(client=True)
+@gen_cluster([('127.0.0.1', 4)] * 2, client=True)
 def test_call_stack_collections(c, s, a, b):
     da = pytest.importorskip('dask.array')
     x = da.random.random(1000, chunks=(10,)).map_blocks(slowinc).persist()
@@ -4669,7 +4669,7 @@ def test_call_stack_collections(c, s, a, b):
     assert result
 
 
-@gen_cluster(client=True)
+@gen_cluster([('127.0.0.1', 4)] * 2, client=True)
 def test_call_stack_collections_all(c, s, a, b):
     da = pytest.importorskip('dask.array')
     x = da.random.random(1000, chunks=(10,)).map_blocks(slowinc).persist()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1141,3 +1141,19 @@ def test_service_hosts_match_scheduler():
         sock = first(s.services['http']._sockets.values())
         assert sock.getsockname()[0] == '127.0.0.2'
         yield s.close()
+
+
+@gen_cluster(client=True)
+def test_aggregate_profiles(c, s, a, b):
+    x = c.map(slowinc, range(10))
+    y = c.map(slowadd, range(10), range(10))
+
+    yield wait(x + y)
+
+    prof = yield c.profile()
+    xx = yield c.profile('slowinc')
+    yy = yield c.profile('slowadd')
+    assert 'slowinc' in str(xx)
+    assert 'slowadd' not in str(xx)
+
+    assert xx['count'] + yy['count'] == prof['count']

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -912,3 +912,27 @@ def test_scheduler_file():
         assert s.workers == {w.address}
         yield w._close()
         s.stop()
+
+
+@gen_cluster(client=True)
+def test_statistical_profiling(c, s, a, b):
+    futures = c.map(slowinc, range(10), delay=0.1)
+    yield wait(futures)
+
+    profile = a.profile_keys['slowinc']
+    assert profile['count']
+    assert 'threading' not in str(profile)
+
+
+@gen_cluster(client=True)
+def test_statistical_profiling(c, s, a, b):
+    da = pytest.importorskip('dask.array')
+    for i in range(5):
+        x = da.random.random(1000000, chunks=(10000,))
+        y = (x + x * 2) - x.sum().persist()
+        yield wait(y)
+    profile = a.profile_recent
+    assert profile['count']
+    assert 'threading' not in str(profile)
+    assert 'sum' in str(profile)
+    assert 'random' in str(profile)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -161,6 +161,8 @@ class WorkerBase(ServerNode):
             'upload_file': self.upload_file,
             'start_ipython': self.start_ipython,
             'call_stack': self.get_call_stack,
+            'profile': self.get_profile,
+            'get_profile_metadata': self.get_profile_metadata,
             'keys': self.keys,
         }
 
@@ -2112,6 +2114,20 @@ class Worker(WorkerBase):
         stop = time()
         if self.digests is not None:
             self.digests['profile-duration'].add(stop - start)
+
+    def get_profile(self, stream=None, keys=None, merge=False):
+        if keys is None:
+            return self.profile_recent
+        else:
+            print('other profile')
+            result = {k: self.profile_keys[k] for k in keys
+                    if k in self.profile_keys}
+            if merge:
+                result = profile.merge(*result.values())
+            return result
+
+    def get_profile_metadata(self, stream=None):
+        return {'keys': list(self.profile_keys)}
 
     def get_call_stack(self, stream=None, keys=None):
         with self.active_threads_lock:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,7 @@ API
 
 .. autosummary::
    Client
+   Client.call_stack
    Client.cancel
    Client.close
    Client.compute


### PR DESCRIPTION
This adds two features:

1.  Captures statistical profiling over time for all worker threads
2.  Adds a `call_stack` method to the client

### Call stack

```python
In [1]: from dask.distributed import Client
c;
In [2]: client = Client()

In [3]: import dask.array as da

In [4]: x = da.random.random(100000, chunks=(1000,)).persist()

In [5]: def f(x):
   ...:     time.sleep(0.1)
   ...:     

In [6]: def g(x):
   ...:     f(x)
   ...:     return x + 1
   ...: 

In [7]: import time

In [12]: y = x.map_blocks(g).map_blocks(g).persist()

In [13]: L = client.call_stack(y)
In [15]: list(L)
Out[15]: 
['tcp://127.0.0.1:40435',
 'tcp://127.0.0.1:38442',
 'tcp://127.0.0.1:39592',
 'tcp://127.0.0.1:41992']

In [16]: list(L['tcp://127.0.0.1:40435'])
Out[16]: ["('g-e33d515806f427a08fc14397bfb96bb2', 42)"]

In [17]: print(''.join(L['tcp://127.0.0.1:40435']["('g-e33d515806f427a08fc14397bfb96bb2', 42)"]))
  File "/home/mrocklin/Software/anaconda/lib/python3.6/threading.py", line 884, in _bootstrap
	self._bootstrap_inner()
  File "/home/mrocklin/Software/anaconda/lib/python3.6/threading.py", line 916, in _bootstrap_inner
	self.run()
  File "/home/mrocklin/Software/anaconda/lib/python3.6/threading.py", line 864, in run
	self._target(*self._args, **self._kwargs)
  File "/home/mrocklin/workspace/distributed/distributed/threadpoolexecutor.py", line 45, in _worker
	task.run()
  File "/home/mrocklin/workspace/distributed/distributed/_concurrent_futures_thread.py", line 64, in run
	result = self.fn(*self.args, **self.kwargs)
  File "/home/mrocklin/workspace/distributed/distributed/worker.py", line 709, in apply_function
	result = function(*args, **kwargs)
  File "/home/mrocklin/workspace/distributed/distributed/worker.py", line 639, in execute_task
	return func(*map(execute_task, args))
  File "<ipython-input-6-b4c4ee315192>", line 2, in g
	  File "<ipython-input-5-0e89f8acd5c2>", line 2, in f
```

### Profiling

Every 10ms we now check on what all of the worker threads are doing.  We store this information in a tree structure that captures both counts and relations between calls in the stack.

```python
In [18]: d = client.run(lambda dask_worker: dask_worker.profile_recent)

In [19]: list(d)
Out[19]: 
['tcp://127.0.0.1:38442',
 'tcp://127.0.0.1:39592',
 'tcp://127.0.0.1:40435',
 'tcp://127.0.0.1:41992']

In [20]: d['tcp://127.0.0.1:38442']
Out[20]: 
{'children': {'_apply_random;/home/mrocklin/workspace/dask/dask/array/random.py;355': {'children': {},
   'count': 1,
   'description': '  File "/home/mrocklin/workspace/dask/dask/array/random.py", line 357, in _apply_random\n\tstate = np.random.RandomState(state_data)\n'},
  'execute_task;/home/mrocklin/workspace/distributed/distributed/worker.py;628': {'children': {'execute_task;/home/mrocklin/workspace/distributed/distributed/worker.py;628': {'children': {'g;<ipython-input-6-b4c4ee315192>;1': {'children': {'f;<ipython-input-5-0e89f8acd5c2>;1': {'children': {},
         'count': 502,
         'description': '  File "<ipython-input-5-0e89f8acd5c2>", line 2, in f\n\t'}},
       'count': 502,
       'description': '  File "<ipython-input-6-b4c4ee315192>", line 2, in g\n\t'}},
     'count': 502,
     'description': '  File "/home/mrocklin/workspace/distributed/distributed/worker.py", line 639, in execute_task\n\treturn func(*map(execute_task, args))\n'},
    'g;<ipython-input-6-b4c4ee315192>;1': {'children': {'f;<ipython-input-5-0e89f8acd5c2>;1': {'children': {},
       'count': 501,
       'description': '  File "<ipython-input-5-0e89f8acd5c2>", line 2, in f\n\t'}},
     'count': 501,
     'description': '  File "<ipython-input-6-b4c4ee315192>", line 2, in g\n\t'}},
   'count': 1003,
   'description': '  File "/home/mrocklin/workspace/distributed/distributed/worker.py", line 639, in execute_task\n\treturn func(*map(execute_task, args))\n'}},
 'count': 1004,
 'description': 'root'}
```

### Future

We should figure out nice ways to format and expose this information.