### PR TITLE
Track scheduler delay times in workers

### DIFF
--- a/distributed/diagnostics/profile.py
+++ b/distributed/diagnostics/profile.py
@@ -73,7 +73,7 @@ def process(frame, child, state, stop=None):
      'children': {'...'}}
     """
     ident = identifier(frame)
-    if frame.f_back is not None and (stop is None or stop != frame.f_back.f_code.co_name):
+    if frame.f_back is not None and (stop is None or frame.f_back.f_code.co_filename.endswith(stop)):
         state = process(frame.f_back, frame, state, stop=stop)
 
     try:

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -946,7 +946,7 @@ def test_statistical_profiling(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_statistical_profiling(c, s, a, b):
+def test_statistical_profiling_2(c, s, a, b):
     da = pytest.importorskip('dask.array')
     for i in range(5):
         x = da.random.random(1000000, chunks=(10000,))

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -925,6 +925,16 @@ def test_scheduler_file():
         s.stop()
 
 
+@gen_cluster(client=True, worker_kwargs={'heartbeat_interval': 50})
+def test_scheduler_delay(c, s, a, b):
+    old = a.scheduler_delay
+    assert abs(a.scheduler_delay) < 0.01
+    assert abs(b.scheduler_delay) < 0.01
+
+    yield gen.sleep(0.100)
+    assert a.scheduler_delay != old
+
+
 @gen_cluster(client=True)
 def test_statistical_profiling(c, s, a, b):
     futures = c.map(slowinc, range(10), delay=0.1)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -196,7 +196,8 @@ class WorkerBase(ServerNode):
                 else:
                     kwargs = {}
 
-                yield self.scheduler.register(
+                start = time()
+                response = yield self.scheduler.register(
                     address=self.contact_address,
                     name=self.name,
                     ncores=self.ncores,
@@ -209,6 +210,9 @@ class WorkerBase(ServerNode):
                     ready=len(self.ready),
                     in_flight=len(self.in_flight_tasks),
                     **kwargs)
+                end = time()
+                middle = (start + end) / 2
+                self.scheduler_delay = response['time'] - middle
             finally:
                 self.heartbeat_active = False
         else:
@@ -227,6 +231,7 @@ class WorkerBase(ServerNode):
             if self.status in ('closed', 'closing'):
                 raise gen.Return
             try:
+                _start = time()
                 future = self.scheduler.register(
                         ncores=self.ncores,
                         address=self.contact_address,
@@ -244,7 +249,10 @@ class WorkerBase(ServerNode):
                     diff = self.death_timeout - (time() - start)
                     future = gen.with_timeout(timedelta(seconds=diff), future,
                                               io_loop=self.loop)
-                resp = yield future
+                response = yield future
+                _end = time()
+                middle = (_start + _end) / 2
+                self.scheduler_delay = response['time'] - middle
                 self.status = 'running'
                 break
             except EnvironmentError:
@@ -253,8 +261,9 @@ class WorkerBase(ServerNode):
                 yield gen.sleep(0.1)
             except gen.TimeoutError:
                 pass
-        if resp != 'OK':
-            raise ValueError("Unexpected response from register: %r" % (resp,))
+        if response['status'] != 'OK':
+            raise ValueError("Unexpected response from register: %r" %
+                             (response,))
         self.periodic_callbacks['heartbeat'].start()
 
     def start_services(self, listen_ip=''):
@@ -496,8 +505,8 @@ class WorkerBase(ServerNode):
         self.outgoing_count += 1
         duration = (stop - start) or 0.5  # windows
         self.outgoing_transfer_log.append({
-            'start': start,
-            'stop': stop,
+            'start': start + self.scheduler_delay,
+            'stop': stop + self.scheduler_delay,
             'middle': (start + stop) / 2,
             'duration': duration,
             'who': who,
@@ -705,7 +714,7 @@ def dumps_task(task):
 
 
 def apply_function(function, args, kwargs, execution_state, key,
-                   active_threads, active_threads_lock):
+                   active_threads, active_threads_lock, time_delay):
     """ Run a function, collect information
 
     Returns
@@ -732,8 +741,8 @@ def apply_function(function, args, kwargs, execution_state, key,
                'type': type(result) if result is not None else None}
     finally:
         end = time()
-    msg['start'] = start
-    msg['stop'] = end
+    msg['start'] = start + time_delay
+    msg['stop'] = end + time_delay
     msg['thread'] = ident
     with active_threads_lock:
         del active_threads[ident]
@@ -1700,10 +1709,11 @@ class Worker(WorkerBase):
 
                 self.log.append(('request-dep', dep, worker, deps))
                 logger.debug("Request %d keys", len(deps))
-                start = time()
+
+                start = time() + self.scheduler_delay
                 response = yield self.rpc(worker).get_data(keys=deps,
                                                            who=self.address)
-                stop = time()
+                stop = time() + self.scheduler_delay
 
                 if cause:
                     self.startstops[cause].append(('transfer', start, stop))
@@ -2045,7 +2055,8 @@ class Worker(WorkerBase):
                                                     args2, kwargs2,
                                                     self.execution_state, key,
                                                     self.active_threads,
-                                                    self.active_threads_lock)
+                                                    self.active_threads_lock,
+                                                    self.scheduler_delay)
             except RuntimeError as e:
                 executor_error = e
                 raise

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2132,8 +2132,8 @@ class Worker(WorkerBase):
         frames = {ident: frames[ident] for ident in active_threads}
         for ident, frame in frames.items():
             key = key_split(active_threads[ident])
-            profile.process(frame, None, self.profile_recent, stop='apply_function')
-            profile.process(frame, None, self.profile_keys[key], stop='apply_function')
+            profile.process(frame, None, self.profile_recent, stop='_concurrent_futures_thread.py')
+            profile.process(frame, None, self.profile_keys[key], stop='_concurrent_futures_thread.py')
         stop = time()
         if self.digests is not None:
             self.digests['profile-duration'].add(stop - start)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1091,6 +1091,8 @@ class Worker(WorkerBase):
         self.outgoing_count = 0
         self._client = None
 
+        self.scheduler_delay = 0
+
         WorkerBase.__init__(self, *args, **kwargs)
 
         pc = PeriodicCallback(self.trigger_profile,


### PR DESCRIPTION
Previously we modified times when they arrived at the scheduler.
Now when the worker sends a heartbeat to the scheduler it receives back
the scheduler's time.  Workers now send all times pre-modified against
this value.