### PR TITLE
Add env vars

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import atexit
+from distutils.util import strtobool
 from functools import partial
 import logging
 import os
@@ -111,11 +112,73 @@ def main(host, port, http_port, bokeh_port, bokeh_internal_port, show, _bokeh,
         limit = max(soft, hard // 2)
         resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
 
-    # check in env vars if DASK_SCHEDULER_IP and DASK_SCHEDULER_PORT are defined
+    # check for env vars
+
+    # DASK_SCHEDULER_IP / DASK_SCHEDULER_PORT
     if not host:
         if 'scheduler-ip' in config and 'scheduler-port' in config:
             host = config['scheduler-ip']
             port = int(config['scheduler-port'])
+
+    # DASK_INTERFACE
+    if not interface:
+        if 'interface' in config:
+            interface = config['interface']
+
+    # DASK_HTTP_PORT
+    if not http_port:
+        if 'http-port' in config:
+            http_port = int(config['http-port'])
+
+    # DASK_BOKEH_PORT
+    if not bokeh_port:
+        if 'bokeh-port' in config:
+            bokeh_port = int(config['bokeh-port'])
+
+    # DASK_BOKEH
+    if not _bokeh:
+        if 'bokeh' in config:
+            _bokeh = config['bokeh']
+
+    # DASK_SHOW
+    if not show:
+        if 'show' in config:
+            show = config['show']
+
+    # DASK_BOKEH_WHITELIST
+    if not bokeh_whitelist:
+        if 'bokeh-whitelist' in config:
+            bokeh_whitelist = config['bokeh-whitelist']
+
+    # DASK_BOKEH_PREFIX
+    if not bokeh_prefix:
+        if 'bokeh-prefix' in config:
+            bokeh_prefix = config['bokeh-prefix']
+
+    # DASK_USE_XHEADERS
+    if not use_xheaders:
+        if 'use-xheaders' in config:
+            use_xheaders = strtobool(config['use-xheaders'])
+
+    # DASK_PID_FILE
+    if not pid_file:
+        if 'pid-file' in config:
+            pid_file = config['pid-file']
+
+    # DASK_SCHEDULER_FILE
+    if not scheduler_file:
+        if 'scheduler-file' in config:
+            scheduler_file = config['scheduler-file']
+
+    # DASK_LOCAL_DIRECTORY
+    if not local_directory:
+        if 'local-directory' in config:
+            local_directory = config['local-directory']
+
+    # DASK_PRELOAD
+    if not preload:
+        if 'preload' in config:
+            preload = config['preload']
 
     if interface:
         if host:

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -11,7 +11,6 @@ import tempfile
 import click
 
 from distributed import Scheduler, config
-from distributed.compatibility import PY2
 from distributed.security import Security
 from distributed.utils import get_ip_interface, ignoring
 from distributed.http import HTTPScheduler
@@ -112,12 +111,9 @@ def main(host, port, http_port, bokeh_port, bokeh_internal_port, show, _bokeh,
         limit = max(soft, hard // 2)
         resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
 
-    # check if DASK_SCHEDULER_IP and DASK_SCHEDULER_PORT are defined
+    # check in env vars if DASK_SCHEDULER_IP and DASK_SCHEDULER_PORT are defined
     if not host:
-        dict_view = config.keys
-        if PY2:
-            dict_view = config.viewkeys
-        if {'scheduler-ip', 'scheduler-port'} <= dict_view():
+        if 'scheduler-ip' in config and 'scheduler-port' in config:
             host = config['scheduler-ip']
             port = int(config['scheduler-port'])
 

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -10,7 +10,8 @@ import tempfile
 
 import click
 
-from distributed import Scheduler
+from distributed import Scheduler, config
+from distributed.compatibility import PY2
 from distributed.security import Security
 from distributed.utils import get_ip_interface, ignoring
 from distributed.http import HTTPScheduler
@@ -110,6 +111,15 @@ def main(host, port, http_port, bokeh_port, bokeh_internal_port, show, _bokeh,
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
         limit = max(soft, hard // 2)
         resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
+
+    # check if DASK_SCHEDULER_IP and DASK_SCHEDULER_PORT are defined
+    if not host:
+        dict_view = config.keys
+        if PY2:
+            dict_view = config.viewkeys
+        if {'scheduler-ip', 'scheduler-port'} <= dict_view():
+            host = config['scheduler-ip']
+            port = int(config['scheduler-port'])
 
     if interface:
         if host:

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -7,7 +7,7 @@ import signal
 from sys import exit
 
 import click
-from distributed import Nanny, Worker
+from distributed import Nanny, Worker, config
 from distributed.utils import get_ip_interface
 from distributed.worker import _ncores
 from distributed.http import HTTPWorker
@@ -191,8 +191,11 @@ def main(scheduler, host, worker_port, listen_address, contact_address,
         t = Worker
 
     if not scheduler and not scheduler_file:
-        raise ValueError("Need to provide scheduler address like\n"
-                         "dask-worker SCHEDULER_ADDRESS:8786")
+        try:
+            scheduler = ":".join((config['scheduler-ip'], config['scheduler-port']))
+        except KeyError:
+            raise ValueError("Need to provide scheduler address like\n"
+            "dask-worker SCHEDULER_ADDRESS:8786 or with environment variables")
 
     if interface:
         if host:

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -195,7 +195,7 @@ def main(scheduler, host, worker_port, listen_address, contact_address,
             scheduler = ":".join((config['scheduler-ip'], config['scheduler-port']))
         except KeyError:
             raise ValueError("Need to provide scheduler address like\n"
-            "dask-worker SCHEDULER_ADDRESS:8786 or with environment variables")
+            "dask-worker SCHEDULER_ADDRESS:8786")
 
     if interface:
         if host:

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -174,7 +174,5 @@ def test_scheduler_with_env_vars(loop):
     port = envs['DASK_SCHEDULER_PORT'] = '8786'
     address = "tcp://{}:{}".format(ip, port).encode('utf-8')
     with popen(['dask-scheduler', '--no-bokeh']) as sched:
-        with popen(['dask-worker',
-                    '--no-bokeh'], env=envs) as worker:
-                    assert any(address in worker.stderr.readline()
-                       for i in range(15))
+        with popen(['dask-worker', '--no-bokeh'], env=envs) as worker:
+            assert any(address in worker.stderr.readline() for i in range(15))

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -64,6 +64,12 @@ def load_config_file(config, path):
 
 
 def load_env_vars(config):
+    """
+    Scan environment variables for `DASK_`.
+    Names of the vars become:
+    - DASK_NAME -> name
+    - DASK_NAME_NAME -> name-name
+    """
     for name, value in os.environ.items():
         if name.startswith('DASK_'):
             varname = name[5:].lower().replace('_', '-')

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -64,11 +64,20 @@ def load_config_file(config, path):
 
 
 def load_env_vars(config):
-    """
-    Scan environment variables for `DASK_`.
-    Names of the vars become:
-    - DASK_NAME -> name
-    - DASK_NAME_NAME -> name-name
+    """ Scan environment variables for `DASK_*` and add those values to config.
+
+    Parameters
+    ----------
+    config: dict
+
+    Examples
+    --------
+    >>> import os
+    >>> config = {}
+    >>> os.environ['DASK_WORKER_IP'] = '127.0.0.1'
+    >>> load_env_vars(config)
+    >>> config['worker-ip']
+    '127.0.0.1'
     """
     for name, value in os.environ.items():
         if name.startswith('DASK_'):

--- a/distributed/tests/test_config.py
+++ b/distributed/tests/test_config.py
@@ -10,7 +10,7 @@ import pytest
 
 from distributed.utils_test import (captured_handler, captured_logger,
                                     new_config, new_config_file)
-from distributed.config import initialize_logging, set_config, config
+from distributed.config import initialize_logging, set_config, config, load_env_vars
 
 
 def dump_logger_list():
@@ -276,3 +276,15 @@ def test_set_config():
     with set_config(foo=1):
         assert config['foo'] == 1
     assert 'foo' not in config
+
+
+def test_load_env_vars():
+    os.environ['DASK_CONFIG_IP'] = '127.0.0.1'
+    load_env_vars(config)
+    assert 'config-ip' in config
+
+
+def test_fail_load_env_vars():
+    os.environ['DASK_CONFIG_IP'] = '127.0.0.1'
+    load_env_vars(config)
+    assert 'config_ip' not in config


### PR DESCRIPTION
With this PR you can specify for both workers and scheduler an IP:PORT using env vars `DASK_SCHEDULER_IP` and `DASK_SCHEDULER_PORT`.

https://github.com/dask/distributed/issues/1391