### PR TITLE
Change memory-limit keyword to refer to maximum number of bytes

### DIFF
--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -30,7 +30,7 @@ else:
     ExportTool = None
 
 
-profile_interval = config.get('profile-interval')
+profile_interval = config.get('profile-interval', 0.010)
 
 
 class DashboardComponent(object):

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -65,9 +65,9 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option('--name', type=str, default='',
               help="A unique name for this worker like 'worker-1'")
 @click.option('--memory-limit', default='auto',
-              help="Number of bytes before spilling data to disk. "
-                   "This can be an integer (nbytes) "
-                   "float (fraction of total memory) "
+              help="Bytes of memory that the worker can use. "
+                   "This can be an integer (bytes) "
+                   "float (fraction of total system memory) "
                    "or 'auto'")
 @click.option('--reconnect/--no-reconnect', default=True,
               help="Reconnect to scheduler if disconnected")

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -303,7 +303,7 @@ def test_remote_access(loop):
 def test_memory(loop):
     with LocalCluster(scheduler_port=0, processes=False, silence_logs=False,
                       diagnostics_port=None, loop=loop) as cluster:
-        assert sum(w.memory_limit for w in cluster.workers) < TOTAL_MEMORY * 0.8
+        assert sum(w.memory_limit for w in cluster.workers) <= TOTAL_MEMORY
 
 
 def test_memory_nanny(loop):
@@ -312,7 +312,7 @@ def test_memory_nanny(loop):
         with Client(cluster.scheduler_address, loop=loop) as c:
             info = c.scheduler_info()
             assert (sum(w['memory_limit'] for w in info['workers'].values())
-                    < TOTAL_MEMORY * 0.9)
+                    <= TOTAL_MEMORY)
 
 
 def test_death_timeout_raises(loop):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -73,7 +73,7 @@ class Nanny(ServerNode):
         self.auto_restart = True
 
         if memory_limit == 'auto':
-            memory_limit = int(TOTAL_MEMORY * 0.6 * min(1, self.ncores / _ncores))
+            memory_limit = int(TOTAL_MEMORY * min(1, self.ncores / _ncores))
         with ignoring(TypeError):
             memory_limit = float(memory_limit)
         if isinstance(memory_limit, float) and memory_limit <= 1:

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -319,7 +319,7 @@ def test_io_loop(loop):
 @gen_cluster(client=True, ncores=[])
 def test_spill_to_disk(e, s):
     np = pytest.importorskip('numpy')
-    w = Worker(s.address, loop=s.loop, memory_limit=1200)
+    w = Worker(s.address, loop=s.loop, memory_limit=1200 / 0.6)
     yield w._start()
 
     x = e.submit(np.random.randint, 0, 255, size=500, dtype='u1', key='x')
@@ -986,8 +986,7 @@ def test_robust_to_bad_sizeof_estimates(c, s, a):
     start = time()
     while not a.data.slow:
         yield gen.sleep(0.1)
-        if time() > start + 5:
-            import pdb; pdb.set_trace()
+        assert time() < start + 5
 
 
 @pytest.mark.slow

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -111,7 +111,7 @@ class WorkerBase(ServerNode):
         self.listen_args = self.security.get_listen_args('worker')
 
         if memory_limit == 'auto':
-            memory_limit = int(TOTAL_MEMORY * 0.6 * min(1, self.ncores / _ncores))
+            memory_limit = int(TOTAL_MEMORY * min(1, self.ncores / _ncores))
         with ignoring(TypeError):
             memory_limit = float(memory_limit)
         if isinstance(memory_limit, float) and memory_limit <= 1:
@@ -126,7 +126,7 @@ class WorkerBase(ServerNode):
                 raise ImportError("Please `pip install zict` for spill-to-disk workers")
             path = os.path.join(self.local_dir, 'storage')
             storage = Func(serialize_bytelist, deserialize_bytes, File(path))
-            self.data = Buffer({}, storage, int(float(self.memory_limit)), weight)
+            self.data = Buffer({}, storage, int(float(self.memory_limit) * 0.6), weight)
         else:
             self.data = dict()
         self.loop = loop or IOLoop.current()
@@ -342,7 +342,7 @@ class WorkerBase(ServerNode):
         logger.info('-' * 49)
         logger.info('              Threads: %26d', self.ncores)
         if self.memory_limit:
-            logger.info('               Memory: %23.2f GB', self.memory_limit / 1e9)
+            logger.info('               Memory: %s', format_bytes(self.memory_limit))
         logger.info('      Local Directory: %26s', self.local_dir)
         logger.info('-' * 49)
 
@@ -1003,7 +1003,7 @@ class Worker(WorkerBase):
     heartbeat_interval: int
         Milliseconds between heartbeats to scheduler
     memory_limit: int
-        Number of bytes of data to keep in memory before using disk
+        Number of bytes of memory that this worker should use
     executor: concurrent.futures.Executor
     resources: dict
         Resources that thiw worker has like ``{'GPU': 2}``
@@ -2196,6 +2196,7 @@ class Worker(WorkerBase):
             if count:
                 logger.debug("Moved %d pieces of data data and %s to disk",
                              count, format_bytes(total))
+
         self._memory_monitoring = False
         raise gen.Return(total)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -342,7 +342,7 @@ class WorkerBase(ServerNode):
         logger.info('-' * 49)
         logger.info('              Threads: %26d', self.ncores)
         if self.memory_limit:
-            logger.info('               Memory: %s', format_bytes(self.memory_limit))
+            logger.info('               Memory: %26s', format_bytes(self.memory_limit))
         logger.info('      Local Directory: %26s', self.local_dir)
         logger.info('-' * 49)
 


### PR DESCRIPTION
Previously this was the 60% limit imposed on the `.data` dict.  Now that we have multiple levels of memory management we pin this to the total expected quantity.