### PR TITLE
Add try-except to scheduler when logging worker errors (Resolves #1396)

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1426,11 +1426,16 @@ class Scheduler(ServerNode):
                     for msg in msgs:
                         if msg == 'OK':  # from close
                             break
-
                         if 'status' in msg and 'error' in msg['status']:
-                            logger.error("error from worker %s: %s",
+                            try:
+                                logger.error("error from worker %s: %s",
                                          worker, clean_exception(**msg)[1])
-
+                            except ImportError:
+                                # clean_exception may try to unpickle an object that requires a package that does not
+                                # exist on the scheduler but does exist on the worker – this attempt would generate an
+                                # ImportError
+                                logger.error("error from worker %s",
+                                         worker)
                         op = msg.pop('op')
                         if op:
                             self.correct_time_delay(worker, msg)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1431,11 +1431,7 @@ class Scheduler(ServerNode):
                                 logger.error("error from worker %s: %s",
                                          worker, clean_exception(**msg)[1])
                             except Exception:
-                                # clean_exception may raise an Exception whilst trying to unpickle an object (e.g. if
-                                # it requires a package that does not exist on the scheduler but does exist on the
-                                # worker)
-                                logger.error("error from worker %s",
-                                         worker)
+                                logger.error("error from worker %s", worker)
                         op = msg.pop('op')
                         if op:
                             self.correct_time_delay(worker, msg)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1432,7 +1432,7 @@ class Scheduler(ServerNode):
                                          worker, clean_exception(**msg)[1])
                             except ImportError:
                                 # clean_exception may try to unpickle an object that requires a package that does not
-                                # exist on the scheduler but does exist on the worker – this attempt would generate an
+                                # exist on the scheduler but does exist on the worker - this attempt would generate an
                                 # ImportError
                                 logger.error("error from worker %s",
                                          worker)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1430,10 +1430,10 @@ class Scheduler(ServerNode):
                             try:
                                 logger.error("error from worker %s: %s",
                                          worker, clean_exception(**msg)[1])
-                            except ImportError:
-                                # clean_exception may try to unpickle an object that requires a package that does not
-                                # exist on the scheduler but does exist on the worker - this attempt would generate an
-                                # ImportError
+                            except Exception:
+                                # clean_exception may raise an Exception whilst trying to unpickle an object (e.g. if
+                                # it requires a package that does not exist on the scheduler but does exist on the
+                                # worker)
                                 logger.error("error from worker %s",
                                          worker)
                         op = msg.pop('op')


### PR DESCRIPTION
Worker errors may involve classes loaded from packages which do not exist on the scheduler. Currently, the scheduler tries to parse these exceptions, which may (in an unpickle) try to import a module that doesn't exist on the scheduler.

The alternative would be to send the pre-rendered error from the worker to the scheduler, but as it can be useful for the client to receive the actual Exception object (e.g. for viewing the traceback), this would involve sending both the original Exception and the rendered version.