### PR TITLE
Notify waiting threads/coroutines on cancellation

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1156,7 +1156,7 @@ def test_profile_metadata(c, s, a, b):
     now = time()
     assert meta
     assert all(start < t < now for t, count in meta['counts'])
-    assert all(0 < count < 11 for t, count in meta['counts'][:4])
+    assert all(0 < count < 13 for t, count in meta['counts'][:4])
     assert not meta['counts'][-1][1]
 
 


### PR DESCRIPTION
Previously as_completed would hang if the last future to be waited on was
cancelled.  Now we use conditions to alert us of this case in both async
and sync situations.