### PR TITLE
Rename transition_story to story

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3056,11 +3056,13 @@ class Scheduler(ServerNode):
             for key in keys:
                 self.validate_key(key)
 
-    def transition_story(self, *keys):
+    def story(self, *keys):
         """ Get all transitions that touch one of the input keys """
         keys = set(keys)
         return [t for t in self.transition_log
                 if t[0] in keys or keys.intersection(t[3])]
+
+    transition_story = story
 
     ##############################
     # Assigning Tasks to Workers #

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -700,7 +700,7 @@ def test_io_loop(loop):
 
 
 @gen_cluster(client=True)
-def test_transition_story(c, s, a, b):
+def test_story(c, s, a, b):
     x = delayed(inc)(1)
     y = delayed(inc)(x)
     f = c.persist(y)
@@ -708,12 +708,12 @@ def test_transition_story(c, s, a, b):
 
     assert s.transition_log
 
-    story = s.transition_story(x.key)
+    story = s.story(x.key)
     assert all(line in s.transition_log for line in story)
     assert len(story) < len(s.transition_log)
     assert all(x.key == line[0] or x.key in line[-2] for line in story)
 
-    assert len(s.transition_story(x.key, y.key)) > len(story)
+    assert len(s.story(x.key, y.key)) > len(story)
 
 
 @gen_test()


### PR DESCRIPTION
This is more consistent with the worker and also is shorter.

I chose not to deprecate transition_story.  At some point stories might
get a bit more complex and it might make sense to keep the name.