### PR TITLE
Ensure that client remains asynchronous before an ioloop starts

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -537,7 +537,7 @@ class Client(Node):
         """
         result = self._asynchronous
         try:
-            if get_thread_identity() != self.loop._thread_ident:
+            if self.loop._thread_ident and get_thread_identity() != self.loop._thread_ident:
                 result = False
         except AttributeError:  # AsyncIOLoop doesn't have _thread_ident
             pass

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4757,5 +4757,11 @@ def test_future_auto_inform(c, s, a, b):
     yield client.close()
 
 
+def test_client_async_before_loop_starts():
+    loop = IOLoop()
+    client = Client(asynchronous=True, loop=loop)
+    assert client.asynchronous
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # flake8: noqa


### PR DESCRIPTION
cc @seibert, you may have been running into this yesterday