### PR TITLE
add get_task_status handler to scheduler

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -354,7 +354,8 @@ class Scheduler(ServerNode):
                          'set_resources': self.add_resources,
                          'retire_workers': self.retire_workers,
                          'get_metadata': self.get_metadata,
-                         'set_metadata': self.set_metadata}
+                         'set_metadata': self.set_metadata,
+                         'get_task_status': self.get_task_status}
 
         self._transitions = {
             ('released', 'waiting'): self.transition_released_waiting,
@@ -2180,6 +2181,8 @@ class Scheduler(ServerNode):
             metadata = metadata[key]
         return metadata[keys[-1]]
 
+    def get_task_status(self, stream=None, keys=None):
+        return {key: self.task_state.get(key) for key in keys}
 
     #####################
     # State Transitions #

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1212,3 +1212,12 @@ def test_reschedule(c, s, a, b):
     yield wait(x)
     assert sum(future.key in b.data for future in x) >= 3
     assert sum(future.key in a.data for future in x) <= 1
+
+
+@gen_cluster(client=True)
+def test_get_task_status(c, s, a, b):
+    future = c.submit(inc, 1)
+    yield wait(future)
+
+    result = yield a.scheduler.get_task_status(keys=[future.key])
+    assert result == {future.key: 'memory'}


### PR DESCRIPTION
This is useful for some experiments on avoiding task stealing.