### PR TITLE
Capture logs

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2649,6 +2649,39 @@ class Client(Node):
         return self.sync(self.scheduler.get_metadata, keys=keys,
                          default=default)
 
+    def get_scheduler_logs(self, n=None):
+        """ Get logs from scheduler
+
+        Parameters
+        ----------
+        n: int
+            Number of logs to retrive.  Maxes out at 10000 by default,
+            confiruable in config.yaml::log-length
+
+        Returns
+        -------
+        Logs in reversed order (newest first)
+        """
+        return self.sync(self.scheduler.logs, n=n)
+
+    def get_worker_logs(self, n=None, workers=None):
+        """ Get logs from workers
+
+        Parameters
+        ----------
+        n: int
+            Number of logs to retrive.  Maxes out at 10000 by default,
+            confiruable in config.yaml::log-length
+        workers: iterable
+            List of worker addresses to retrive.  Gets all workers by default.
+
+        Returns
+        -------
+        Dictionary mapping worker address to logs.
+        Logs are returned in reversed order (newest first)
+        """
+        return self.sync(self.scheduler.worker_logs, n=n, workers=workers)
+
     def set_metadata(self, key, value):
         """ Set arbitrary metadata in the scheduler
 

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -87,10 +87,8 @@ def _initialize_logging_old_style(config):
     loggers.setdefault('tornado', 'critical')
     loggers.setdefault('tornado.application', 'error')
 
-    fmt = '%(name)s - %(levelname)s - %(message)s'
-
     handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(logging.Formatter(fmt))
+    handler.setFormatter(logging.Formatter(log_format))
     for name, level in loggers.items():
         if isinstance(level, str):
             level = logging_names[level.upper()]
@@ -161,5 +159,7 @@ else:
     load_config_file(config, path)
 
 load_env_vars(config)
+
+log_format = config.get('log-format', '%(name)s - %(levelname)s - %(message)s')
 
 initialize_logging(config)

--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -53,3 +53,7 @@ worker-memory-target: 0.60  # target fraction to stay below
 worker-memory-spill: 0.70  # fraction at which we spill to disk
 worker-memory-pause: 0.80  # fraction at which we pause worker threads
 worker-memory-terminate: 0.95  # fraction at which we terminate the worker
+
+
+log-length: 10000  # default length of logs to keep in memory
+log-format: '%(name)s - %(levelname)s - %(message)s'

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4850,5 +4850,21 @@ def test_task_metadata(c, s, a, b):
     assert result == {'a': {'c': {'d': 1}}, 'b': 2}
 
 
+@gen_cluster(client=True)
+def test_logs(c, s, a, b):
+    yield wait(c.map(inc, range(5)))
+    logs = yield c.get_scheduler_logs(n=5)
+    assert logs
+
+    for _, msg in logs:
+        assert 'distributed.scheduler' in msg
+
+    w_logs = yield c.get_worker_logs(n=5)
+    assert set(w_logs.keys()) == {a.address, b.address}
+    for log in w_logs.values():
+        for _, msg in log:
+            assert 'distributed.worker' in msg
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # flake8: noqa

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4645,12 +4645,11 @@ def test_quiet_quit_when_cluster_leaves(loop):
     cluster = LocalCluster(loop=loop, scheduler_port=0, diagnostics_port=None,
                            silence_logs=False)
     with captured_logger('distributed.comm') as sio:
-        client = Client(cluster, loop=loop)
-        futures = client.map(lambda x: x + 1, range(10))
-        sleep(0.05)
-        cluster.close()
-        sleep(0.05)
-        client.close()
+        with Client(cluster, loop=loop) as client:
+            futures = client.map(lambda x: x + 1, range(10))
+            sleep(0.05)
+            cluster.close()
+            sleep(0.05)
 
     text = sio.getvalue()
     assert not text
@@ -4756,7 +4755,8 @@ def test_profile_keys(c, s, a, b):
 @gen_cluster()
 def test_client_with_name(s, a, b):
     with captured_logger('distributed.scheduler') as sio:
-        client = yield Client(s.address, asynchronous=True, name='foo')
+        client = yield Client(s.address, asynchronous=True, name='foo',
+                              silence_logs=False)
         assert 'foo' in client.id
         yield client.close()
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1221,3 +1221,12 @@ def test_get_task_status(c, s, a, b):
 
     result = yield a.scheduler.get_task_status(keys=[future.key])
     assert result == {future.key: 'memory'}
+
+
+def test_deque_handler():
+    from distributed.scheduler import deque_handler, logger
+    logger.info('foo123')
+    assert deque_handler.deque
+    msg = deque_handler.deque[-1]
+    assert 'distributed.scheduler' in deque_handler.format(msg)
+    assert any(msg.msg == 'foo123' for msg in deque_handler.deque)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1061,3 +1061,12 @@ def test_reschedule(c, s, a, b):
     yield wait(futures)
 
     assert all(f.key in b.data for f in futures)
+
+
+def test_deque_handler():
+    from distributed.worker import deque_handler, logger
+    logger.info('foo456')
+    assert deque_handler.deque
+    msg = deque_handler.deque[-1]
+    assert 'distributed.worker' in deque_handler.format(msg)
+    assert any(msg.msg == 'foo456' for msg in deque_handler.deque)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import atexit
-from collections import Iterable
+from collections import Iterable, deque
 from contextlib import contextmanager
 from datetime import timedelta
 import functools
@@ -989,3 +989,14 @@ def format_time(n):
     if n >= 1e-3:
         return '%.2f ms' % (n * 1e3)
     return '%.2f us' % (n * 1e6)
+
+
+class DequeHandler(logging.Handler):
+    """ A logging.Handler that records records into a deque """
+    def __init__(self, *args, **kwargs):
+        n = kwargs.pop('n', 10000)
+        self.deque = deque(maxlen=n)
+        super(DequeHandler, self).__init__(*args, **kwargs)
+
+    def emit(self, record):
+        self.deque.append(record)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -43,6 +43,11 @@ import psutil
 logger = logging.getLogger(__name__)
 
 
+logging_levels = {name: logger.level for name, logger in
+                  logging.root.manager.loggerDict.items()
+                  if isinstance(logger, logging.Logger)}
+
+
 @pytest.fixture(scope='session')
 def valid_python_script(tmpdir_factory):
     local_file = tmpdir_factory.mktemp('data').join('file.py')
@@ -351,6 +356,9 @@ def cluster(nworkers=2, nanny=False, worker_kwargs={}, active_rpc_timeout=1,
             scheduler_kwargs={}, should_check_state=True):
     ws = weakref.WeakSet()
     before = process_state()
+    for name, level in logging_levels.items():
+        logging.getLogger(name).setLevel(level)
+
     with pristine_loop() as loop:
         with check_active_rpc(loop, active_rpc_timeout):
             if nanny:
@@ -612,7 +620,11 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
         start
         end
     """
+    for name, level in logging_levels.items():
+        logging.getLogger(name).setLevel(level)
+
     worker_kwargs = merge({'memory_limit': TOTAL_MEMORY}, worker_kwargs)
+
     def _(func):
         cor = func
         if not iscoroutinefunction(func):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,6 +18,8 @@ API
    Client.get_dataset
    Client.get_executor
    Client.get_metadata
+   Client.get_scheduler_logs
+   Client.get_worker_logs
    Client.has_what
    Client.list_datasets
    Client.map


### PR DESCRIPTION
We now track the last 10000 logged records for both the scheduler and
worker modules.  These are accessible through normal routes on the
workers, scheduler, and client.