### PR TITLE
Add default keyword argument to get_metadata

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -52,7 +52,7 @@ from .threadpoolexecutor import rejoin
 from .worker import dumps_task, get_client, get_worker, secede
 from .utils import (All, sync, funcname, ignoring, queue_to_iterator,
                     tokey, log_errors, str_graph, key_split, format_bytes, asciitable,
-                    thread_state)
+                    thread_state, no_default)
 from .versions import get_versions
 
 
@@ -2626,18 +2626,28 @@ class Client(Node):
         """
         return self.sync(self.scheduler.identity, **kwargs)
 
-    def get_metadata(self, key):
+    def get_metadata(self, keys, default=no_default):
         """ Get arbitrary metadata from scheduler
 
         See set_metadata for the full docstring with examples
+
+        Parameter
+        ---------
+        keys: key or list
+            Key to access.  If a list then gets within a nested collection
+        default: optional
+            If the key does not exist then return this value instead.
+            If not provided then this raises a KeyError if the key is not
+            present
 
         See also
         --------
         Client.set_metadata
         """
-        if not isinstance(key, list):
-            key = [key]
-        return self.sync(self.scheduler.get_metadata, keys=key)
+        if not isinstance(keys, list):
+            keys = [keys]
+        return self.sync(self.scheduler.get_metadata, keys=keys,
+                         default=default)
 
     def set_metadata(self, key, value):
         """ Set arbitrary metadata in the scheduler

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -36,7 +36,7 @@ from .metrics import time
 from .node import ServerNode
 from .security import Security
 from .utils import (All, ignoring, get_ip, get_fileno_limit, log_errors,
-                    key_split, validate_key)
+                    key_split, validate_key, no_default)
 from .utils_comm import (scatter_to_workers, gather_from_workers)
 from .versions import get_versions
 
@@ -2175,11 +2175,17 @@ class Scheduler(ServerNode):
         except Exception as e:
             import pdb; pdb.set_trace()
 
-    def get_metadata(self, stream=None, keys=None):
+    def get_metadata(self, stream=None, keys=None, default=no_default):
         metadata = self.task_metadata
         for key in keys[:-1]:
             metadata = metadata[key]
-        return metadata[keys[-1]]
+        try:
+            return metadata[keys[-1]]
+        except KeyError:
+            if default != no_default:
+                return default
+            else:
+                raise
 
     def get_task_status(self, stream=None, keys=None):
         return {key: self.task_state.get(key) for key in keys}

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4833,6 +4833,9 @@ def test_task_metadata(c, s, a, b):
     with pytest.raises(KeyError):
         yield c.get_metadata(key)
 
+    result = yield c.get_metadata(key, None)
+    assert result is None
+
     yield c.set_metadata(['x', 'a'], 1)
     result = yield c.get_metadata('x')
     assert result == {'a': 1}

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -47,6 +47,9 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+no_default = '__no_default__'
+
+
 def _initialize_mp_context():
     if PY3 and not sys.platform.startswith('win'):
         method = config.get('multiprocessing-method', 'forkserver')

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -13,9 +13,6 @@ from .core import rpc
 from .utils import All, tokey
 
 
-no_default = '__no_default__'
-
-
 @gen.coroutine
 def gather_from_workers(who_has, rpc, close=True):
     """ Gather data directly from peers


### PR DESCRIPTION
This allows for semantics similar to `dict.get`

    >>> client.get_metadata('unknown-key', None)
    None