### PR TITLE
Aggressively GC on high memory usage in worker

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1013,7 +1013,7 @@ def test_pause_executor(c, s, a):
         assert a.paused
         out = logger.getvalue()
         assert 'memory' in out.lower()
-        assert 'stop' in out.lower()
+        assert 'pausing' in out.lower()
 
     assert sum(f.status == 'finished' for f in futures) < 4
 


### PR DESCRIPTION
This is a possible fix for some of the spurious worker restarts reported in the discussion of dask/dask#2470.

I ran the test script of https://github.com/dask/dask/issues/2470#issuecomment-338117445 with additional logs before and after the call to `gc.collect()` and I confirm that many unnecessary restarts can be avoided this way when memory is tight.