### PR TITLE
Avoid double-scheduling in work stealing

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -487,7 +487,7 @@ class StealingEvents(DashboardComponent):
         with log_errors():
             log = self.steal.log
             n = self.steal.count - self.last
-            log = [log[-i] for i in range(1, n + 1)]
+            log = [log[-i] for i in range(1, n + 1) if isinstance(log[-i], list)]
             self.last = self.steal.count
 
             if log:

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -239,6 +239,8 @@ class LocalCluster(object):
         if self.status == 'closed':
             return
 
+        self.scheduler.clear_task_state()
+
         for w in self.workers:
             self.loop.add_callback(self._stop_worker, w)
         for i in range(10):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2536,16 +2536,10 @@ class Scheduler(ServerNode):
                 self.occupancy[w] -= duration
             self.check_idle_saturated(w)
             if w != worker:
-                logger.debug("Unexpected worker completed task, likely due to"
+                logger.error("Unexpected worker completed task, likely due to"
                              " work stealing.  Expected: %s, Got: %s, Key: %s",
                              w, worker, key)
-                msg = {'op': 'release-task', 'key': key, 'reason': 'stolen'}
-                try:
-                    self.worker_comms[w].send(msg)
-                except CommClosedError:
-                    # Don't try to resolve this now.  Proceed normally and
-                    # let normal resiliency mechanisms handle it later
-                    logger.info("Worker comm closed unexpectedly")
+                raise Exception()
 
             recommendations = OrderedDict()
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1151,11 +1151,11 @@ class Scheduler(ServerNode):
 
         assert all(self.who_has.values())
 
-        for worker, occ in self.occupancy.items():
-            for d in self.extensions['stealing'].in_flight.values():
-                if worker in (d['thief'], d['victim']):
-                    continue
-            assert abs(sum(self.processing[worker].values()) - occ) < 1e-8
+        # for worker, occ in self.occupancy.items():
+        #     for d in self.extensions['stealing'].in_flight.values():
+        #         if worker in (d['thief'], d['victim']):
+        #             continue
+        #     assert abs(sum(self.processing[worker].values()) - occ) < 1e-8
 
     ###################
     # Manage Messages #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1580,6 +1580,13 @@ class Scheduler(ServerNode):
                                'count': len(keys)})
         raise gen.Return(result)
 
+    def clear_task_state(self):
+        logger.info("Clear task state")
+        for collection in self._task_collections:
+            collection.clear()
+        for collection in self._worker_collections:
+            collection.clear()
+
     @gen.coroutine
     def restart(self, client=None, timeout=3):
         """ Restart all workers.  Reset local state. """
@@ -1603,11 +1610,7 @@ class Scheduler(ServerNode):
                     logger.info("Exception while restarting.  This is normal",
                                 exc_info=True)
 
-            logger.info("Clear task state")
-            for collection in self._task_collections:
-                collection.clear()
-            for collection in self._worker_collections:
-                collection.clear()
+            self.clear_task_state()
 
             for plugin in self.plugins[:]:
                 try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1152,6 +1152,9 @@ class Scheduler(ServerNode):
         assert all(self.who_has.values())
 
         for worker, occ in self.occupancy.items():
+            for d in self.extensions['stealing'].in_flight.values():
+                if worker in (d['thief'], d['victim']):
+                    continue
             assert abs(sum(self.processing[worker].values()) - occ) < 1e-8
 
     ###################

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -192,12 +192,14 @@ class WorkStealing(SchedulerPlugin):
             raise
 
     def move_task_confirm(self, key=None, worker=None, state=None):
-        if self.scheduler.task_state.get(key) != 'processing':
-            return
         try:
             d = self.in_flight.pop(key)
             thief = d['thief']
             victim = d['victim']
+            if self.scheduler.task_state.get(key) != 'processing':
+                self.scheduler.occupancy[thief] = sum(self.scheduler.processing[thief].values())
+                self.scheduler.occupancy[victim] = sum(self.scheduler.processing[victim].values())
+                return
 
             # One of the pair has left, punt and reschedule
             if (thief not in self.scheduler.workers or

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -192,6 +192,8 @@ class WorkStealing(SchedulerPlugin):
             raise
 
     def move_task_confirm(self, key=None, worker=None, state=None):
+        if self.scheduler.task_state.get(key) != 'processing':
+            return
         try:
             d = self.in_flight.pop(key)
             thief = d['thief']

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -51,6 +51,9 @@ class WorkStealing(SchedulerPlugin):
         self.scheduler.extensions['stealing'] = self
         self.scheduler.events['stealing'] = deque(maxlen=100000)
         self.count = 0
+        self.in_flight = dict()
+
+        self.scheduler.worker_handlers['steal-response'] = self.move_task_confirm
 
     @property
     def log(self):
@@ -76,12 +79,15 @@ class WorkStealing(SchedulerPlugin):
                 ks = key_split(key)
                 if ks in self.stealable_unknown_durations:
                     for k in self.stealable_unknown_durations.pop(ks):
+                        if k in self.in_flight:
+                            continue
                         if self.scheduler.task_state[k] == 'processing':
                             self.put_key_in_stealable(k, split=ks)
 
     def put_key_in_stealable(self, key, split=None):
         worker = self.scheduler.rprocessing[key]
         cost_multiplier, level = self.steal_time_ratio(key, split=split)
+        self.log.append([('add-stealable', key, worker, level)])
         if cost_multiplier is not None:
             self.stealable_all[level].add(key)
             self.stealable[worker][level].add(key)
@@ -89,16 +95,19 @@ class WorkStealing(SchedulerPlugin):
 
     def remove_key_from_stealable(self, key):
         result = self.key_stealable.pop(key, None)
-        if result is not None:
-            worker, level = result
-            try:
-                self.stealable[worker][level].remove(key)
-            except KeyError:
-                pass
-            try:
-                self.stealable_all[level].remove(key)
-            except KeyError:
-                pass
+        if result is None:
+            return
+
+        worker, level = result
+        self.log.append([('remove-stealable', key, worker, level)])
+        try:
+            self.stealable[worker][level].remove(key)
+        except KeyError:
+            pass
+        try:
+            self.stealable_all[level].remove(key)
+        except KeyError:
+            pass
 
     def steal_time_ratio(self, key, split=None):
         """ The compute to communication time ratio of a key
@@ -143,7 +152,7 @@ class WorkStealing(SchedulerPlugin):
             level = max(1, level)
             return cost_multiplier, level
 
-    def move_task(self, key, victim, thief):
+    def move_task_request(self, key, victim, thief):
         try:
             if self.scheduler.validate:
                 if victim != self.scheduler.rprocessing[key]:
@@ -151,34 +160,72 @@ class WorkStealing(SchedulerPlugin):
                     pdb.set_trace()
 
             self.remove_key_from_stealable(key)
-            logger.debug("Moved %s, %s: %2f -> %s: %2f", key,
+            logger.info("Request move %s, %s: %2f -> %s: %2f", key,
                          victim, self.scheduler.occupancy[victim],
                          thief, self.scheduler.occupancy[thief])
 
-            duration = self.scheduler.processing[victim].pop(key)
-            self.scheduler.occupancy[victim] -= duration
-            self.scheduler.total_occupancy -= duration
+            victim_duration = self.scheduler.processing[victim][key]
+            self.scheduler.occupancy[victim] -= victim_duration
+            self.scheduler.total_occupancy -= victim_duration
 
-            duration = self.scheduler.task_duration.get(key_split(key), 0.5)
-            duration += sum(self.scheduler.nbytes[key] for key in
-                            self.scheduler.dependencies[key] -
-                            self.scheduler.has_what[thief]) / BANDWIDTH
-            self.scheduler.processing[thief][key] = duration
-            self.scheduler.rprocessing[key] = thief
-            self.scheduler.occupancy[thief] += duration
-            self.scheduler.total_occupancy += duration
-            self.put_key_in_stealable(key)
+            thief_duration = self.scheduler.task_duration.get(key_split(key), 0.5)
+            thief_duration += sum(self.scheduler.nbytes[key] for key in
+                                  self.scheduler.dependencies[key] -
+                                  self.scheduler.has_what[thief]) / BANDWIDTH
+            self.scheduler.occupancy[thief] += thief_duration
+            self.scheduler.total_occupancy += thief_duration
 
-            self.scheduler.worker_comms[victim].send({'op': 'release-task',
-                                                      'reason': 'stolen',
+            self.scheduler.worker_comms[victim].send({'op': 'steal-request',
                                                       'key': key})
 
-            try:
-                self.scheduler.send_task_to_worker(thief, key)
-            except CommClosedError:
-                self.scheduler.remove_worker(thief)
+            self.in_flight[key] = {'victim': victim,
+                                   'thief': thief,
+                                   'victim_duration': victim_duration,
+                                   'thief_duration': thief_duration}
         except CommClosedError:
             logger.info("Worker comm closed while stealing: %s", victim)
+        except Exception as e:
+            logger.exception(e)
+            if LOG_PDB:
+                import pdb
+                pdb.set_trace()
+            raise
+
+    def move_task_confirm(self, key=None, worker=None, state=None):
+        try:
+            d = self.in_flight.pop(key)
+            thief = d['thief']
+            victim = d['victim']
+
+            # One of the pair has left, punt and reschedule
+            if (thief not in self.scheduler.workers or
+                victim not in self.scheduler.workers):
+                self.scheduler.reschedule(key)
+                return
+
+            # Victim had already started execution, reverse stealing
+            if state in ('memory', 'executing', 'long-running'):
+                self.scheduler.occupancy[thief] -= d['thief_duration']
+                self.scheduler.total_occupancy -= d['thief_duration']
+                self.scheduler.occupancy[victim] += d['victim_duration']
+                self.scheduler.total_occupancy += d['victim_duration']
+                self.log.append([('already-computing', key, victim, thief)])
+
+            # Victim was waiting, has given up task, enact steal
+            elif state in ('waiting', 'ready'):
+                self.scheduler.rprocessing[key] = thief
+                del self.scheduler.processing[victim][key]
+                self.scheduler.processing[thief][key] = d['thief_duration']
+                self.remove_key_from_stealable(key)
+                self.put_key_in_stealable(key)
+
+                try:
+                    self.scheduler.send_task_to_worker(thief, key)
+                except CommClosedError:
+                    self.scheduler.remove_worker(thief)
+                self.log.append([('confirm', key, victim, thief)])
+            else:
+                raise ValueError("Unexpected task state: %s" % state)
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -232,7 +279,7 @@ class WorkStealing(SchedulerPlugin):
 
                         if (occupancy[idl] + cost_multiplier * duration
                                 <= occupancy[sat] - duration / 2):
-                            self.move_task(key, sat, idl)
+                            self.move_task_request(key, sat, idl)
                             log.append((start, level, key, duration,
                                         sat, occupancy[sat],
                                         idl, occupancy[idl]))
@@ -260,7 +307,7 @@ class WorkStealing(SchedulerPlugin):
 
                         if (occupancy[idl] + cost_multiplier * duration
                                 <= occupancy[sat] - duration / 2):
-                            self.move_task(key, sat, idl)
+                            self.move_task_request(key, sat, idl)
                             log.append((start, level, key, duration,
                                         sat, occupancy[sat],
                                         idl, occupancy[idl]))

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -87,7 +87,7 @@ class WorkStealing(SchedulerPlugin):
     def put_key_in_stealable(self, key, split=None):
         worker = self.scheduler.rprocessing[key]
         cost_multiplier, level = self.steal_time_ratio(key, split=split)
-        self.log.append([('add-stealable', key, worker, level)])
+        self.log.append(('add-stealable', key, worker, level))
         if cost_multiplier is not None:
             self.stealable_all[level].add(key)
             self.stealable[worker][level].add(key)
@@ -99,7 +99,7 @@ class WorkStealing(SchedulerPlugin):
             return
 
         worker, level = result
-        self.log.append([('remove-stealable', key, worker, level)])
+        self.log.append(('remove-stealable', key, worker, level))
         try:
             self.stealable[worker][level].remove(key)
         except KeyError:
@@ -209,7 +209,9 @@ class WorkStealing(SchedulerPlugin):
                 self.scheduler.total_occupancy -= d['thief_duration']
                 self.scheduler.occupancy[victim] += d['victim_duration']
                 self.scheduler.total_occupancy += d['victim_duration']
-                self.log.append([('already-computing', key, victim, thief)])
+                self.log.append(('already-computing', key, victim, thief))
+                self.scheduler.check_idle_saturated(thief)
+                self.scheduler.check_idle_saturated(victim)
 
             # Victim was waiting, has given up task, enact steal
             elif state in ('waiting', 'ready'):
@@ -223,7 +225,7 @@ class WorkStealing(SchedulerPlugin):
                     self.scheduler.send_task_to_worker(thief, key)
                 except CommClosedError:
                     self.scheduler.remove_worker(thief)
-                self.log.append([('confirm', key, victim, thief)])
+                self.log.append(('confirm', key, victim, thief))
             else:
                 raise ValueError("Unexpected task state: %s" % state)
         except Exception as e:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -219,10 +219,10 @@ class WorkStealing(SchedulerPlugin):
 
             # Victim was waiting, has given up task, enact steal
             elif state in ('waiting', 'ready'):
+                self.remove_key_from_stealable(key)
                 self.scheduler.rprocessing[key] = thief
                 del self.scheduler.processing[victim][key]
                 self.scheduler.processing[thief][key] = d['thief_duration']
-                self.remove_key_from_stealable(key)
                 self.put_key_in_stealable(key)
 
                 try:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -288,7 +288,13 @@ class WorkStealing(SchedulerPlugin):
                         if not idle:
                             break
                         idl = idle[i % len(idle)]
-                        duration = s.processing[sat][key]
+
+                        durations = s.processing[sat]
+                        try:
+                            duration = durations[key]
+                        except KeyError:
+                            stealable.remove(key)
+                            continue
 
                         if (occupancy[idl] + cost_multiplier * duration
                                 <= occupancy[sat] - duration / 2):
@@ -308,7 +314,11 @@ class WorkStealing(SchedulerPlugin):
                         if not idle:
                             break
 
-                        sat = s.rprocessing[key]
+                        try:
+                            sat = s.rprocessing[key]
+                        except KeyError:
+                            stealable.remove(key)
+                            continue
                         if occupancy[sat] < 0.2:
                             continue
                         if len(s.processing[sat]) <= s.ncores[sat]:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -163,7 +163,7 @@ class WorkStealing(SchedulerPlugin):
                     pdb.set_trace()
 
             self.remove_key_from_stealable(key)
-            logger.info("Request move %s, %s: %2f -> %s: %2f", key,
+            logger.debug("Request move %s, %s: %2f -> %s: %2f", key,
                          victim, self.scheduler.occupancy[victim],
                          thief, self.scheduler.occupancy[thief])
 

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -343,7 +343,14 @@ class WorkStealing(SchedulerPlugin):
 
     def story(self, *keys):
         keys = set(keys)
-        return [t for L in self.log for t in L if any(x in keys for x in t)]
+        out = []
+        for L in self.log:
+            if not isinstance(L, list):
+                L = [L]
+            for t in L:
+                if any(x in keys for x in t):
+                    out.append(t)
+        return out
 
 
 fast_tasks = {'shuffle-split'}

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -523,7 +523,7 @@ def test_steal_twice(c, s, a, b):
     yield wait(futures)
 
     assert all(s.has_what.values())
-    assert max(map(len, s.has_what.values())) < 20
+    assert max(map(len, s.has_what.values())) < 30
 
     yield [w._close() for w in workers]
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -34,7 +34,6 @@ def test_work_stealing(c, s, a, b):
     yield wait(futures)
     assert len(a.data) > 10
     assert len(b.data) > 10
-    assert len(a.data) > len(b.data) - 5
 
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 2)

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -331,18 +331,21 @@ def test_steal_when_more_tasks(c, s, a, *rest):
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 10)
 def test_steal_more_attractive_tasks(c, s, a, *rest):
+
     def slow2(x):
         sleep(1)
         return x
+
     s.extensions['stealing']._pc.callback_time = 20
     x = c.submit(mul, b'0', 100000000, workers=a.address)  # 100 MB
     yield wait(x)
+
     s.task_duration['slowidentity'] = 0.2
     s.task_duration['slow2'] = 1
 
-    future = c.submit(slow2, x)
     futures = [c.submit(slowidentity, x, pure=False, delay=0.2)
                for i in range(10)]
+    future = c.submit(slow2, x)
 
     while not any(w.task_state for w in rest):
         yield gen.sleep(0.01)
@@ -381,21 +384,28 @@ def assert_balanced(inp, expected, c, s, *workers):
     while len(s.rprocessing) < len(futures):
         yield gen.sleep(0.001)
 
-    s.extensions['stealing'].balance()
 
-    result = [sorted([int(key_split(k)) for k in s.processing[w.address]],
-                     reverse=True)
-              for w in workers]
+    for i in range(10):
+        steal.balance()
 
-    result2 = sorted(result, reverse=True)
-    expected2 = sorted(expected, reverse=True)
+        while steal.in_flight:
+            yield gen.sleep(0.001)
 
-    if config.get('pdb-on-err'):
-        if result2 != expected2:
-            import pdb
-            pdb.set_trace()
+        result = [sorted([int(key_split(k)) for k in s.processing[w.address]],
+                         reverse=True)
+                  for w in workers]
 
-    assert result2 == expected2
+        result2 = sorted(result, reverse=True)
+        expected2 = sorted(expected, reverse=True)
+
+        if config.get('pdb-on-err'):
+            if result2 != expected2:
+                import pdb
+                pdb.set_trace()
+
+        if result2 == expected2:
+            return
+    raise Exception()
 
 
 @pytest.mark.parametrize('inp,expected', [
@@ -478,6 +488,7 @@ def test_restart(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_steal_communication_heavy_tasks(c, s, a, b):
+    steal = s.extensions['stealing']
     s.task_duration['slowadd'] = 0.001
     x = c.submit(mul, b'0', int(BANDWIDTH), workers=a.address)
     y = c.submit(mul, b'1', int(BANDWIDTH), workers=b.address)
@@ -489,7 +500,9 @@ def test_steal_communication_heavy_tasks(c, s, a, b):
     while not any(f.key in s.rprocessing for f in futures):
         yield gen.sleep(0.01)
 
-    s.extensions['stealing'].balance()
+    steal.balance()
+    while steal.in_flight:
+        yield gen.sleep(0.001)
 
     assert s.processing[b.address]
 
@@ -516,21 +529,16 @@ def test_steal_twice(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_accept_old_result_if_stolen(c, s, a, b):
+def test_dont_steal_executing_tasks(c, s, a, b):
+    steal = s.extensions['stealing']
+
     future = c.submit(slowinc, 1, delay=0.5, workers=a.address)
     while not a.executing:
         yield gen.sleep(0.01)
-    steal = s.extensions['stealing']
 
-    yield gen.sleep(0.25)
-
-    steal.move_task(future.key, a.address, b.address)
-    while not b.executing:
-        yield gen.sleep(0.01)
-
-    yield gen.sleep(0.35)
-
-    assert future.key in s.who_has
+    steal.move_task_request(future.key, a.address, b.address)
+    yield gen.sleep(0.1)
+    assert future.key in b.executing
 
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 2)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1906,7 +1906,7 @@ class Worker(WorkerBase):
             raise
 
     def steal_request(self, key):
-        state = self.task_state[key]
+        state = self.task_state.get(key, None)
 
         response = {'op': 'steal-response',
                     'key': key,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1199,8 +1199,6 @@ class Worker(WorkerBase):
                         self.delete_data(**msg)
                     elif op == 'steal-request':
                         self.steal_request(**msg)
-                    elif op == 'steal-confirm':
-                        self.steal_confirm(**msg)
                     else:
                         logger.warning("Unknown operation %s, %s", op, msg)
 
@@ -1923,9 +1921,6 @@ class Worker(WorkerBase):
             if key not in self.task_state:
                 return
             state = self.task_state.pop(key)
-            if reason == 'stolen' and state in ('executing', 'long-running', 'memory'):
-                self.task_state[key] = state
-                return
             if cause:
                 self.log.append((key, 'release-key', {'cause': cause}))
             else:


### PR DESCRIPTION
This avoids double-scheduling tasks when work stealing by first checking
with the victim worker to verify that it has not yet started execution.
If it has started then we reverse the steal operation, if it has not
started then we cleanly start the new task only after the victim worker
has removed the task.

This passes most tests (those tests within stealing.py that if fails are
reasonable failures) but typically this sort of change triggers some
knock-on effects.