### PR TITLE
Make nanny tell worker to GC itself on high memory usage

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -7,6 +7,8 @@ import os
 import psutil
 import shutil
 import threading
+import signal
+import gc
 
 from tornado import gen
 from tornado.ioloop import IOLoop, TimeoutError, PeriodicCallback
@@ -245,6 +247,7 @@ class Nanny(ServerNode):
         else:
             raise gen.Return('OK')
 
+    @gen.coroutine
     def memory_monitor(self):
         """ Track worker's memory.  Restart if it goes above 95% """
         if self.status != 'running':
@@ -252,8 +255,20 @@ class Nanny(ServerNode):
         memory = psutil.Process(self.process.pid).memory_info().rss
         frac = memory / self.memory_limit
         if self.memory_terminate_fraction and frac > self.memory_terminate_fraction:
-            logger.warn("Worker exceeded 95% memory budget.  Restarting")
-            self.process.process.terminate()
+            if hasattr(signal, 'SIGUSR1'):
+                # Try to be nice and tell the worker to free some memory.
+                logger.warn("Worker exceeded 95% memory budget.  Forcing GC")
+                os.kill(self.process.process.pid, signal.SIGUSR1)
+
+                # Give some time to the worker to GC.
+                yield gen.sleep(0.2)
+                memory = psutil.Process(self.process.pid).memory_info().rss
+                frac = memory / self.memory_limit
+
+            if frac > self.memory_terminate_fraction:
+                # The worker has not been nice enough.
+                logger.warn("Worker exceeded 95% memory budget.  Restarting")
+                self.process.process.terminate()
 
     def is_alive(self):
         return self.process is not None and self.process.status == 'running'
@@ -304,6 +319,10 @@ class Nanny(ServerNode):
         self.scheduler.close_rpc()
         self.status = 'closed'
         raise gen.Return('OK')
+
+
+def _handle_gc_signal(signum, frame):
+    gc.collect()
 
 
 class WorkerProcess(object):
@@ -474,6 +493,11 @@ class WorkerProcess(object):
         loop = IOLoop()
         loop.make_current()
         worker = Worker(*worker_args, **worker_kwargs)
+
+        # Register a handler to let the nanny force a GC in case of memory
+        # high memory limit
+        if hasattr(signal, 'SIGUSR1'):
+            signal.signal(signal.SIGUSR1, _handle_gc_signal)
 
         @gen.coroutine
         def do_stop(timeout):


### PR DESCRIPTION
This PR is built on top of #1488.

#1488 should make worker free memory on a regular basis when reaching the 70% limit using an unthrottled GC and without any warning in the logs.

However, sometimes the nanny monitor might detect the 95% limit before the worker gets the opportunity to use its throttled GC. In this case, the nanny would restart the worker directly.

Instead, this PR sends a USR1 signal (POSIX only) to make the worker process do a non-throttled GC. If the memory usage of the worker has not decreased in the following 200ms, then the worker is restarted.

On Windows, this PR does nothing.