### PR TITLE
Improve documentation for scheduler states

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j4
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build

--- a/docs/source/scheduling-policies.rst
+++ b/docs/source/scheduling-policies.rst
@@ -7,6 +7,8 @@ more information on how this these policies are enacted efficiently see
 :doc:`Scheduling State<scheduling-state>`.
 
 
+.. _decide-worker:
+
 Choosing Workers
 ----------------
 

--- a/docs/source/scheduling-state.rst
+++ b/docs/source/scheduling-state.rst
@@ -34,30 +34,36 @@ State Variables
 ---------------
 
 We start with a description of the state that the scheduler keeps on each task.
-Each of the following is a dictionary keyed by task name (described below):
+Each of the following is a dictionary keyed by task name (described below).
+
+Task description variables
+''''''''''''''''''''''''''
+
+These containers keep task information accross a task's whole lifetime.
 
 * **tasks:** ``{key: task}``:
 
-    Dictionary mapping key to a serialized task.
+   Dictionary mapping key to a serialized task.
 
-    A key is the name of a task,
-    generally formed from the name of the function, followed by a hash of the
-    function and arguments, like ``'inc-ab31c010444977004d656610d2d421ec'``.
+   A key is the name of a task, generally formed from the name of the
+   function, followed by a hash of the function and arguments, like
+   ``'inc-ab31c010444977004d656610d2d421ec'``.
 
-    The value of this dictionary is the task, which is an unevaluated function
-    and arguments.  This is stored in one of two forms:
+   The value of this dictionary is the task, which is an unevaluated function
+   and arguments.  This is stored in one of two forms:
 
-    * ``{'function': inc, 'args': (1,), 'kwargs': {}}``; a dictionary with the
-      function, arguments, and keyword arguments (kwargs).  However in the
-      scheduler these are stored serialized, as they were sent from the client,
-      so it looks more like ``{'function': b'\x80\x04\x95\xcb\...', 'args':
-      b'...', }``
+   * ``{'function': inc, 'args': (1,), 'kwargs': {}}``; a dictionary with the
+     function, arguments, and keyword arguments (kwargs).  However in the
+     scheduler these are stored serialized, as they were sent from the client,
+     so it looks more like ``{'function': b'\x80\x04\x95\xcb\...', 'args':
+     b'...', }``
 
-    * ``{'task': (inc, 1)}``: a tuple satisfying the dask graph protocol.  This
-      again is stored serialized.
+   * ``(inc, 1)``: a tuple satisfying the `dask graph protocol
+     <http://dask.pydata.org/en/latest/graphs.html>`_.  This
+     again is stored serialized.
 
-    These are the values that will eventually be sent to a worker when the task
-    is ready to run.
+   These are the values that will eventually be sent to a worker when the task
+   is ready to run.
 
 * **dependencies and dependents:** ``{key: {keys}}``:
 
@@ -70,153 +76,197 @@ Each of the following is a dictionary keyed by task name (described below):
    for constant-time access for either direction of query, so we can both look
    up a task's out-edges or in-edges efficiently.
 
-* **waiting and waiting_data:** ``{key: {keys}}``:
-
-   These are dictionaries very similar to dependencies and dependents, but they
-   only track keys that are still in play.  For example ``waiting`` looks like
-   ``dependencies``, tracking all of the tasks that a certain task requires
-   before it can run.  However as tasks are completed and arrive in memory they
-   are removed from their dependents sets in ``waiting``, so that when a set
-   becomes empty we know that a key is ready to run and ready to be allocated
-   to a worker.
-
-   The ``waiting_data`` dictionary on the other hand holds all of the
-   dependents of a key that have yet to run and still require that this task
-   stay in memory in services of tasks that may depend on it (its
-   ``dependents``).  When a value set in this dictionary becomes empty its task
-   may be garbage collected (unless some client actively desires that this task
-   stay in memory).
-
-* **task_state:** ``{key: string}``:
-
-    The ``task_state`` dictionary holds the current state of every key.
-    Current valid states include released, waiting, no-worker, processing,
-    memory, and erred.  These states are explained further below.
-
 * **priority:** ``{key: tuple}``:
 
-    The ``priority`` dictionary provides each key with a relative ranking.
-    This ranking is generally a tuple of two parts.  The first (and dominant)
-    part corresponds to when it was submitted.  Generally earlier tasks take
-    precedence.  The second part is determined by the client, and is a way to
-    prioritize tasks within a large graph that may be important, such as if
-    they are on the critical path, or good to run in order to release many
-    dependencies.  This is explained further in :doc:`Scheduling Policy
-    <scheduling-policies>`
+   The ``priority`` dictionary provides each key with a relative ranking
+   which is used to break ties when many keys are being
+   considered for execution.
 
-    A key's priority is only used to break ties, when many keys are being
-    considered for execution.  The priority does *not* determine running order,
-    but does exert some subtle influence that does significantly shape the long
-    term performance of the cluster.
-
-* **processing:** ``{worker: {key: cost}}``:
-
-    Keys that are currently allocated to a worker.  This is keyed by worker
-    address and contains the expected cost in seconds of running that task.
-
-* **rprocessing:** ``{key: worker}``:
-
-    The reverse of the ``processing`` dictionary.  This is all keys that are
-    currently running with the workers that is currently running them.  This is
-    redundant with ``processing`` and just here for faster indexed querying.
-
-* **who_has:** ``{key: {worker}}``:
-
-    For keys that are in memory this shows on which workers they currently
-    reside.
-
-* **has_what:** ``{worker: {key}}``:
-
-    This is the transpose of ``who_has``, showing all keys that currently
-    reside on each worker.
-
-* **released:** ``{keys}``
-
-    The set of keys that are known, but released from memory.  These have
-    typically run to completion and are no longer necessary.
-
-* **unrunnable:** ``{key}``
-
-    The set ``unrunnable`` contains keys that are not currently able to run,
-    probably because they have a user defined restriction (described below)
-    that is not met by any available worker.  These keys are waiting for an
-    appropriate worker to join the network before computing.
+   This ranking is generally a tuple of two parts.  The first (and dominant)
+   part corresponds to when it was submitted.  Generally earlier tasks take
+   precedence.  The second part is determined by the client, and is a way to
+   prioritize tasks within a large graph that may be important, such as if
+   they are on the critical path, or good to run in order to release many
+   dependencies.  This is explained further in :doc:`Scheduling Policy
+   <scheduling-policies>`.
 
 * **host_restrictions:** ``{key: {hostnames}}``:
 
-    A set of hostnames per key of where that key can be run.  Usually this
-    is empty unless a key has been specifically restricted to only run on
-    certain hosts.  These restrictions don't include a worker port.  Any
-    worker on that hostname is deemed valid.
+   A set of hostnames per key of where that key can be run.  Usually this
+   is empty unless a key has been specifically restricted to only run on
+   certain hosts.  A hostname may correspond to one or several connected
+   workers.
 
 * **worker_restrictions:** ``{key: {worker addresses}}``:
 
-    A set of complete host:port worker addresses per key of where that key can
-    be run.  Usually this is empty unless a key has been specifically
-    restricted to only run on certain workers.
-
-* **loose_restrictions:** ``{key}``:
-
-    Set of keys for which we are allowed to violate restrictions (see above) if
-    not valid workers are present and the task would otherwise go into the
-    ``unrunnable`` set.
+   A set of complete worker addresses per key of where that key can
+   be run.  Usually this is empty unless a key has been specifically
+   restricted to only run on certain workers.
 
 * **resource_restrictions:** ``{key: {resource: quantity}}``:
 
-    Resources required by a task, such as ``{'GPU': 1}`` or ``{'memory': 1e9}``.
-    These names must match resources specified when creating workers.
+   Resources required by a task, such as ``{'gpu': 1}`` or ``{'memory': 1e9}``.
+   These are user-defined names and are matched against the contents
+   of the ``worker_resources`` dictionary.
 
-* **worker_resources:** ``{worker: {str: Number}}``:
+* **loose_restrictions:** ``{key}``:
 
-    The available resources on each worker like ``{'gpu': 2, 'mem': 1e9}``.
-    These are abstract quantities that constrain certain tasks from running at
-    the same time.
-
-* **used_resources:** ``{worker: {str: Number}}``:
-
-    The sum of each resource used by all tasks allocated to a particular
-    worker.
-
-*  **exceptions and tracebacks:** ``{key: Exception/Traceback}``:
-
-    Dictionaries mapping keys to remote exceptions and tracebacks.  When tasks
-    fail we store their exceptions and tracebacks (serialized from the worker)
-    here so that users may gather the exceptions to see the error.
-
-*  **exceptions_blame:** ``{key: key}``:
-
-    If a task fails then we mark all of its dependent tasks as failed as well.
-    This dictionary lets any failed task see which task was the origin of its
-    failure.
-
-* **suspicious_tasks:** ``{key: int}``
-
-    Number of times a task has been involved in a worker failure.  Some tasks
-    may cause workers to fail (such as ``sys.exit(0)``).  When a worker fails
-    all of the tasks on that worker are reassigned to others.  This combination
-    of behaviors can cause a bad task to catastrophically destroy all workers
-    on the cluster, one after another.  Whenever a worker fails we mark each
-    task currently running on that worker as suspicious.  If a task is involved
-    in three failures (or some other fixed constant) then we mark the task as
-    failed.
+   Set of keys for which we are allowed to violate restrictions (see above)
+   if no valid workers are present and the task would otherwise go into the
+   ``unrunnable`` set.  In other words, if a key is in ``loose_restrictions``,
+   then its restrictions become mere preferences, otherwise they are mandatory.
 
 * **who_wants:** ``{key: {client}}``:
 
-    When a client submits a graph to the scheduler it also specifies which
-    output keys it desires.  Those keys are tracked here where each desired key
-    knows which clients want it.  These keys will not be released from memory
-    and, when they complete, messages will be sent to all of these clients that
-    the task is ready.
+   When a client submits a graph to the scheduler it also specifies which
+   output keys it desires.  Those keys are tracked here where each desired key
+   knows which clients want it.  These keys will not be released from memory
+   and, when they complete, messages will be sent to all of these clients that
+   the task is ready.
 
 * **wants_what:** ``{client: {key}}``:
 
-    The transpose of ``who_wants``.
+   The transpose of ``who_wants``.
+
+Task state flow
+'''''''''''''''
+
+These state variables reflect the current status of a task and may
+get updated at each state transition.
+
+* **task_state:** ``{key: string}``:
+
+   The ``task_state`` dictionary holds the current state of every key.
+   Current valid states include ``released``, ``waiting``, ``no-worker``,
+   ``processing``, ``memory``, and ``erred``.  These states are explained
+   :ref:`further below <task-states>`.
+
+* **waiting and waiting_data:** ``{key: {keys}}``:
+
+   These dictionaries are a subset of ``dependencies`` and ``dependents``
+   respectively, as they only track keys that are still in play.
+
+   For example ``waiting`` looks like ``dependencies``, tracking all of the
+   tasks that a certain task requires before it can run.  However, as tasks
+   are completed and arrive in memory they are removed from their dependents
+   sets in ``waiting``, so that when a set becomes empty we know that a
+   key is ready to run and ready to be allocated to a worker.
+
+   Similarly, the ``waiting_data`` dictionary holds all of the dependents
+   of a key that have yet to run and still require that this task
+   stay in memory in services of tasks that may depend on it (its
+   ``dependents``).  When a value set in this dictionary becomes empty
+   its task may be garbage-collected (unless some client actively desires
+   that this task stay in memory, as tracked in ``who_wants``).
+
+* **processing:** ``{worker: {key: cost}}``:
+
+   Keys that are currently allocated to a worker.  This is keyed by worker
+   address and contains the expected cost in seconds of running that task.
+
+   Multiple tasks can typically be submitted to a worker in advance and the
+   worker will run them eventually, depending on its execution resources
+   (but see :doc:`work-stealing`).
+
+* **rprocessing:** ``{key: worker}``:
+
+   The reverse of the ``processing`` dictionary.  This tracks the worker
+   processing each task that is currently running.  This is redundant
+   with ``processing`` and just here for faster indexed querying.
+
+* **who_has:** ``{key: {worker}}``:
+
+   For keys that are in memory this shows on which workers they currently
+   reside.
+
+* **has_what:** ``{worker: {key}}``:
+
+   This is the transpose of ``who_has``, showing all keys that currently
+   reside on each worker.
+
+* **released:** ``{keys}``
+
+   The set of keys that are neither waiting to be processed, nor in memory.
+   These typically are just-initialized tasks, or tasks that have already
+   been computed but which it is not necessary to keep in memory.
+
+* **unrunnable:** ``{key}``
+
+   The set of keys that are not currently able to run, either because they
+   have a user-defined restriction (described in ``host_restrictions``,
+   ``worker_restrictions`` and ``resource_restrictions``) that is not met
+   by any connected worker, or because no worker is connected at all.
+
+   These keys already have all their ``dependencies`` satisfied (their
+   ``waiting`` set is empty), and are waiting for an appropriate worker
+   to join the network before computing.
+
+* **exceptions and tracebacks:** ``{key: Exception/Traceback}``:
+
+   Dictionaries mapping keys to remote exceptions and tracebacks.  When tasks
+   fail we store their exceptions and tracebacks (serialized from the worker)
+   here so that users may gather the exceptions to see the error.
+
+* **exceptions_blame:** ``{key: key}``:
+
+   If a task fails then we mark all of its dependent tasks as failed as well.
+   This dictionary lets any failed task see which task was the origin of its
+   failure.
+
+* **suspicious_tasks:** ``{key: int}``
+
+   Number of times a task has been involved in a worker failure.  Some tasks
+   may cause workers to fail (such as ``sys.exit(0)``).  When a worker fails
+   all of the tasks on that worker are reassigned to others.  This combination
+   of behaviors can cause a bad task to catastrophically destroy all workers
+   on the cluster, one after another.  Whenever a worker fails we mark each
+   task currently running on that worker as suspicious.  If a task is involved
+   in three failures (or some other fixed constant) then we mark the task as
+   ``erred``.
 
 * **nbytes:** ``{key: int}``:
 
-    The number of bytes, as determined by ``sizeof``, of the result of each
-    finished task.  This number is used for diagnostics and to help prioritize
-    work.
+   The number of bytes, as determined by ``sizeof``, of the result of each
+   finished task.  This number is used for diagnostics and to help prioritize
+   work.
+
+Worker state variables
+''''''''''''''''''''''
+
+These state variables track the current state of each worker.
+
+* **ncores:** ``{worker: int}``
+
+   The number of CPU cores made available on each worker.
+
+* **worker_resources:** ``{worker: {str: Number}}``:
+
+   The available resources on each worker like ``{'gpu': 2, 'mem': 1e9}``.
+   These are abstract quantities that constrain certain tasks from running at
+   the same time on a given worker.
+
+* **used_resources:** ``{worker: {str: Number}}``:
+
+   The sum of each resource used by all tasks allocated to a particular
+   worker.  The numbers in this dictionary can only be less or equal than
+   those in ``worker_resources``.
+
+* **worker_bytes:** ``{worker: int}``:
+
+   The total memory size, in bytes, used by the keys currently held in memory
+   on each given worker.
+
+* **idle:** ``{worker}``:
+
+   A set of workers considered "idle", meaning we expect them to be able
+   to start processing a new task in a relatively short timespan
+   (for example because they are processing fewer tasks than their
+   number of CPU cores).
+
+.. XXX list invariants somewhere?
+
+   For every worker ``w``,
+   ``worker_bytes[w] == sum(nbytes[k] for k in has_what[w])``
 
 
 Example Event and Response
@@ -245,15 +295,17 @@ following:
        send_done_message_to_clients(who_wants[key])
 
    for dep in dependencies[key]:
-      waiting_data[dep].remove(key)
+       waiting_data[dep].remove(key)
 
    for dep in dependents[key]:
-      waiting[dep].remove(key)
+       waiting[dep].remove(key)
 
    for task in ready_tasks():
-       worker = best_wrker(task):
+       worker = best_worker(task):
        send_task_to_worker(task, worker)
 
+
+.. _task-states:
 
 State Transitions
 -----------------
@@ -261,28 +313,73 @@ State Transitions
 The code presented in the section above is just for demonstration.  In practice
 writing this code for every possible event is highly error prone, resulting in
 hard-to-track-down bugs.  Instead the scheduler moves tasks between a fixed
-set of states, notably ``'released', 'waiting', 'no-worker', 'processing',
-'memory', 'error'``.  Transitions between common pairs of states are well
-defined and, if no path exists between a pair, the graph of transitions can be
-traversed to find a valid sequence of transitions.  Along with these
-transitions come consistent logging and optional runtime checks that are useful
-in testing.
+set of states, notably ``released``, ``waiting``, ``no-worker``, ``processing``,
+``memory``, ``error``.
 
 Tasks fall into the following states with the following allowed transitions
 
 .. image:: images/task-state.svg
     :alt: Dask scheduler task states
 
-*  Released: known but not actively computing or in memory
-*  Waiting: On track to be computed, waiting on dependencies to arrive in
+*  *Released*: Known but not actively computing or in memory
+*  *Waiting*: On track to be computed, waiting on dependencies to arrive in
    memory
-*  No-worker (ready, rare): Ready to be computed, but no appropriate worker
+*  *No-worker* (ready, rare): Ready to be computed, but no appropriate worker
    exists
-*  Processing: Actively being computed by one or more workers
-*  Memory: In memory on one or more workers
-*  Erred: Task has computed and erred
+*  *Processing*: Actively being computed by one or more workers
+*  *Memory*: In memory on one or more workers
+*  *Erred*: Task computation, or one of its dependencies, has encountered an error
 *  Forgotten (not actually a state): Task is no longer needed by any client and
-   so it removed from state
+   so is removed from state
+
+
+Tasks and states
+''''''''''''''''
+
+The table below shows which state variable a task is in, depending on the
+task's state.  Cells with a check mark (`✓`) indicate the task key *must*
+be present in the given state variable; cells with an question mark (`?`)
+indicate the task key *may* be present in the given state variable.
+
+
+======================= ======== ======= ========= ========== ====== =====
+State variable          Released Waiting No-worker Processing Memory Erred
+======================= ======== ======= ========= ========== ====== =====
+tasks                   ✓        ✓       ✓         ✓          ✓      ✓
+priority                ✓        ✓       ✓         ✓          ✓      ✓
+dependencies            ✓        ✓       ✓         ✓          ✓      ✓
+dependents              ✓        ✓       ✓         ✓          ✓      ✓
+----------------------- -------- ------- --------- ---------- ------ -----
+host_restrictions       ?        ?       ?         ?          ?      ?
+worker_restrictions     ?        ?       ?         ?          ?      ?
+resource_restrictions   ?        ?       ?         ?          ?      ?
+loose_restrictions      ?        ?       ?         ?          ?      ?
+----------------------- -------- ------- --------- ---------- ------ -----
+released                ✓
+waiting                          ✓
+waiting_data                     ✓
+unrunnable                               ✓
+processing                                         ✓
+rprocessing                                        ✓
+who_has                                                       ✓
+has_what                                                      ✓
+nbytes *(1)*            ?        ?       ?         ?          ✓      ?
+exceptions                                                           ✓
+tracebacks                                                           ✓
+exceptions_blame                                                     ✓
+suspicious_tasks        ?        ?       ?         ?          ?      ?
+======================= ======== ======= ========= ========== ====== =====
+
+Notes:
+
+1. **nbytes**: a task can be in this collection as long as it was already
+   computed, even if not currently held in a worker's memory.
+
+
+
+Implementation
+--------------
+
 
 Every transition between states is a separate method in the scheduler.  These
 task transition functions are prefixed with ``transition`` and then have the


### PR DESCRIPTION
This categorizes the state variable in three groups, adds a table of where tasks appear depending on their state, another table listing worker state changes in each task transition, and improves some wording choices in my POV :-)