### PR TITLE
Fix test teardown when skipping because of bokeh missing

### DIFF
--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -325,6 +325,7 @@ def test_death_timeout_raises(loop):
 
 @pytest.mark.parametrize('processes', [True, False])
 def test_diagnostics_available_at_localhost(loop, processes):
+    pytest.importorskip('bokeh')
     import requests
     import random
     for i in range(3):


### PR DESCRIPTION
Symptom:
```
$ py.test -vx --tb=native distributed/diagnostics/
========================================================================= test session starts =========================================================================
platform linux -- Python 3.6.3, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/antoine/miniconda3/envs/dask36/bin/python
cachedir: .cache
rootdir: /home/antoine/distributed, inifile:
plugins: xdist-1.20.1, timeout-1.2.0, repeat-0.4.1, forked-0.2, faulthandler-1.3.1
collected 17 items / 2 skipped                                                                                                                                         

distributed/diagnostics/tests/test_eventstream.py::test_eventstream <- distributed/utils_test.py FAILED

============================================================================== FAILURES ===============================================================================
__________________________________________________________________________ test_eventstream ___________________________________________________________________________
Traceback (most recent call last):
  File "/home/antoine/distributed/distributed/utils_test.py", line 656, in test_func
    result = loop.run_sync(lambda: cor(*args), timeout=timeout)
  File "/home/antoine/tornado/tornado/ioloop.py", line 453, in run_sync
    self.start()
  File "/home/antoine/tornado/tornado/ioloop.py", line 832, in start
    self._run_callback(self._callbacks.popleft())
  File "/home/antoine/tornado/tornado/ioloop.py", line 605, in _run_callback
    ret = callback()
  File "/home/antoine/tornado/tornado/stack_context.py", line 277, in null_wrapper
    return fn(*args, **kwargs)
  File "/home/antoine/tornado/tornado/ioloop.py", line 436, in run
    result = func()
  File "/home/antoine/distributed/distributed/utils_test.py", line 656, in <lambda>
    result = loop.run_sync(lambda: cor(*args), timeout=timeout)
  File "/home/antoine/tornado/tornado/gen.py", line 307, in wrapper
    yielded = next(result)
  File "/home/antoine/distributed/distributed/diagnostics/tests/test_eventstream.py", line 16, in test_eventstream
    pytest.importorskip('bokeh')
  File "/home/antoine/miniconda3/envs/dask36/lib/python3.6/site-packages/_pytest/outcomes.py", line 125, in importorskip
    raise Skipped("could not import %r" % (modname,), allow_module_level=True)
Skipped: could not import 'bokeh'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/antoine/distributed/distributed/utils_test.py", line 659, in test_func
    loop.run_sync(c[0]._close)
  File "/home/antoine/tornado/tornado/ioloop.py", line 453, in run_sync
    self.start()
  File "/home/antoine/tornado/tornado/ioloop.py", line 755, in start
    raise RuntimeError("IOLoop is already running")
RuntimeError: IOLoop is already running
```