### PR TITLE
Added gc on mem usage warning

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2209,6 +2209,7 @@ class Worker(WorkerBase):
                                 "Worker memory limit: %s",
                                 format_bytes(proc.memory_info().rss),
                                 format_bytes(self.memory_limit))
+                    self.gc.collect()
                     break
                 k, v, weight = self.data.fast.evict()
                 del k, v


### PR DESCRIPTION
We were re-running our standard workflows with the latest master and noticed that our computations will no longer run through, because the workers go into an idling mode as a result of exceeding the 80% memory barrier threshold. This results in a situation where GC never triggers, and there is no visible progress at all (and worker logs flooded by "Memory use is high ..." message).

We found this very simple solution to the problem: Triggering GC when `break`ing out of the loop. This is how our workflow behaves with and without this change:

![2017-10-26_runwithgconwarning](https://user-images.githubusercontent.com/3620703/32064030-059047f6-ba79-11e7-9cca-be006ccea09e.png)

The first run around 09:00 is using the change and runs fine in <1h. The run started at ~09:30 is plain master and stalls due to not releasing memory appropriately.

I discussed this topic yesterday with @mrocklin at pycon.de and he wasn't sure if @pitrou would be happy with the change. His suggestion was to open a PR and discuss how what's the best solution to this.

cc @ogrisel