### PR TITLE
let nannied processes inherit stdin

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -343,6 +343,7 @@ class WorkerProcess(object):
                         silence_logs=self.silence_logs,
                         init_result_q=self.init_result_q,
                         child_stop_q=self.child_stop_q),
+            inherit_stdin=True,
         )
         self.process.daemon = True
         self.process.set_exit_callback(self._on_exit)


### PR DESCRIPTION
enables things like `IPython.embed()` in workers to access the terminal.

Adds `inherit_stdin` arg to AsyncProcess. Default is False to preserve default behavior, but nannies specify inherit_stdin=True.

If no fileno for sys.stdin can be found (e.g. sys.stdin is None, which can happen, or sys.stdin has already been redirected and is not the original FD), inheriting stdin is disabled.

closes #1505