### PR TITLE
Remove some uses of IOLoop._running

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -136,6 +136,9 @@ def main(host, port, http_port, bokeh_port, bokeh_internal_port, show, _bokeh,
 
     logger.info('Local Directory: %26s', local_directory)
     logger.info('-' * 47)
+
+    install_signal_handlers(loop)
+
     try:
         loop.start()
         loop.close()
@@ -148,7 +151,6 @@ def main(host, port, http_port, bokeh_port, bokeh_internal_port, show, _bokeh,
 
 
 def go():
-    install_signal_handlers()
     check_python_3()
     main()
 

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -1,5 +1,11 @@
 from __future__ import print_function, division, absolute_import
 
+from tornado import gen
+
+from distributed.comm import (parse_address, unparse_address,
+                              parse_host_port, unparse_host_port)
+
+
 py3_err_msg = """
 Your terminal does not properly support unicode text required by command line
 utilities running Python 3.  This is commonly solved by specifying encoding
@@ -10,10 +16,6 @@ environment variables, though exact solutions may depend on your system:
 
 For more information see: http://click.pocoo.org/5/python3/
 """.strip()
-
-
-from distributed.comm import (parse_address, unparse_address,
-                              parse_host_port, unparse_host_port)
 
 
 def check_python_3():
@@ -29,21 +31,27 @@ def check_python_3():
 
 
 def install_signal_handlers(loop, cleanup=None):
-    """Install global signal handlers to halt the Tornado IOLoop in case of
-    a SIGINT or SIGTERM."""
+    """
+    Install global signal handlers to halt the Tornado IOLoop in case of
+    a SIGINT or SIGTERM.  *cleanup* is an optional callback called,
+    before the loop stops, with a single signal number argument.
+    """
     import signal
 
     old_handlers = {}
 
     def handle_signal(sig, frame):
+        @gen.coroutine
         def cleanup_and_stop():
             try:
                 if cleanup is not None:
-                    cleanup(sig)
+                    yield cleanup(sig)
             finally:
                 loop.stop()
 
         loop.add_callback_from_signal(cleanup_and_stop)
+        # Restore old signal handler to allow for a quicker exit
+        # if the user sends the signal again.
         signal.signal(sig, old_handlers[sig])
 
     for sig in [signal.SIGINT, signal.SIGTERM]:

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -35,7 +35,7 @@ def test_simple(loop):
             assert any(w.data == {x.key: 2} for w in c.workers)
 
 
-def test_close_twice(loop):
+def test_close_twice():
     cluster = LocalCluster()
     with Client(cluster.scheduler_address) as client:
         f = client.map(inc, range(100))
@@ -50,12 +50,12 @@ def test_close_twice(loop):
 
 
 @pytest.mark.skipif('sys.version_info[0] == 2', reason='multi-loop')
-def test_procs(loop):
+def test_procs():
     with LocalCluster(2, scheduler_port=0, processes=False, threads_per_worker=3,
                       diagnostics_port=None, silence_logs=False) as c:
         assert len(c.workers) == 2
         assert all(isinstance(w, Worker) for w in c.workers)
-        with Client(c.scheduler.address, loop=loop) as e:
+        with Client(c.scheduler.address) as e:
             assert all(w.ncores == 3 for w in c.workers)
             assert all(isinstance(w, Worker) for w in c.workers)
         repr(c)
@@ -64,7 +64,7 @@ def test_procs(loop):
                       diagnostics_port=None, silence_logs=False) as c:
         assert len(c.workers) == 2
         assert all(isinstance(w, Nanny) for w in c.workers)
-        with Client(c.scheduler.address, loop=loop) as e:
+        with Client(c.scheduler.address) as e:
             assert all(v == 3 for v in e.ncores().values())
 
             c.start_worker()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -933,11 +933,11 @@ def test_get_releases_data(c, s, a, b):
 def test_Current(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
-            Client.current() is c
+            assert Client.current() is c
         with pytest.raises(ValueError):
             Client.current()
         with Client(s['address'], loop=loop) as c:
-            Client.current() is c
+            assert Client.current() is c
 
 
 def test_global_clients(loop):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -45,7 +45,7 @@ from distributed.utils_test import (cluster, slow, slowinc, slowadd, slowdec,
                                     randominc, inc, dec, div, throws, geninc, asyncinc,
                                     gen_cluster, gen_test, double, deep, popen,
                                     captured_logger)
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop, loop_in_thread  # flake8: noqa
 
 
 @gen_cluster(client=True, timeout=None)
@@ -4633,15 +4633,10 @@ def test_use_synchronous_client_in_async_context(loop):
             assert z == 124
 
 
-def test_quiet_quit_when_cluster_leaves(loop):
+def test_quiet_quit_when_cluster_leaves(loop_in_thread):
     from distributed import LocalCluster
-    thread = Thread(target=loop.start,
-                    name="LocalCluster loop")
-    thread.daemon = True
-    thread.start()
-    while not loop._running:
-        sleep(0.001)
 
+    loop = loop_in_thread
     cluster = LocalCluster(loop=loop, scheduler_port=0, diagnostics_port=None,
                            silence_logs=False)
     with captured_logger('distributed.comm') as sio:
@@ -4653,9 +4648,6 @@ def test_quiet_quit_when_cluster_leaves(loop):
 
     text = sio.getvalue()
     assert not text
-
-    loop.add_callback(loop.stop)
-    thread.join(timeout=1)
 
 
 def test_warn_executor(loop):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -930,13 +930,13 @@ def test_get_releases_data(c, s, a, b):
     assert c.refcount['x'] == 0
 
 
-def test_Current(loop):
+def test_Current():
     with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
+        with Client(s['address']) as c:
             assert Client.current() is c
         with pytest.raises(ValueError):
             Client.current()
-        with Client(s['address'], loop=loop) as c:
+        with Client(s['address']) as c:
             assert Client.current() is c
 
 
@@ -2674,7 +2674,7 @@ def test_startup_close_startup_sync(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
             sleep(0.1)
-        with Client(s['address'], loop=loop) as c:
+        with Client(s['address']) as c:
             pass
         with Client(s['address']) as c:
             pass
@@ -3088,33 +3088,33 @@ def test_cancel_clears_processing(c, s, *workers):
     s.validate_state()
 
 
-def test_default_get(loop):
+def test_default_get():
     with cluster() as (s, [a, b]):
         pre_get = _globals.get('get')
         pre_shuffle = _globals.get('shuffle')
-        with Client(s['address'], loop=loop, set_as_default=True) as c:
+        with Client(s['address'], set_as_default=True) as c:
             assert _globals['get'] == c.get
             assert _globals['shuffle'] == 'tasks'
 
         assert _globals['get'] is pre_get
         assert _globals['shuffle'] == pre_shuffle
 
-        c = Client(s['address'], loop=loop, set_as_default=False)
+        c = Client(s['address'], set_as_default=False)
         assert _globals['get'] is pre_get
         assert _globals['shuffle'] == pre_shuffle
         c.close()
 
-        c = Client(s['address'], loop=loop, set_as_default=True)
+        c = Client(s['address'], set_as_default=True)
         assert _globals['shuffle'] == 'tasks'
         assert _globals['get'] == c.get
         c.close()
         assert _globals['get'] is pre_get
         assert _globals['shuffle'] == pre_shuffle
 
-        with Client(s['address'], loop=loop) as c:
+        with Client(s['address']) as c:
             assert _globals['get'] == c.get
 
-        with Client(s['address'], loop=loop, set_as_default=False) as c:
+        with Client(s['address'], set_as_default=False) as c:
             assert _globals['get'] != c.get
             dask.set_options(get=c.get)
             assert _globals['get'] == c.get

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3404,8 +3404,8 @@ def test_reconnect(loop):
         assert time() < start + 5
         sleep(0.1)
 
-    c.close()
     sync(loop, w._close)
+    c.close()
 
 
 # On Python 2, heavy process spawning can deadlock (e.g. on a logging IO lock)

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -372,8 +372,7 @@ def test_loop_runner(loop_in_thread):
     assert_running(loop)
     runner.stop()
     assert not runner.is_started()
-    # Explicit loop is still running
-    assert_running(loop)
+    assert_not_running(loop)
 
     # Explicit loop, already started
     runner = LoopRunner(loop=loop_in_thread)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -256,6 +256,112 @@ def sync(loop, func, *args, **kwargs):
         return result[0]
 
 
+class LoopRunner(object):
+    """
+    A helper to start and stop an IO loop.
+
+    Parameters
+    ----------
+    loop: IOLoop (optional)
+        If given, this loop will be re-used, otherwise an appropriate one
+        will be looked up or created.
+    asynchronous: boolean (optional, default False)
+        If false (the default), the loop is meant to run in a separate
+        thread and will be started if necessary.
+        If true, the loop is meant to run in the thread this
+        object is instantiated from, and will not be started automatically.
+    """
+    def __init__(self, loop=None, asynchronous=False):
+        if loop is None:
+            if asynchronous:
+                self._loop = IOLoop.current()
+            else:
+                # We're expectinf the loop to run in another thread,
+                # avoid re-using this thread's assigned loop
+                self._loop = IOLoop()
+            self._should_close_loop = True
+        else:
+            self._loop = loop
+            self._should_close_loop = False
+        self._asynchronous = asynchronous
+        self._loop_thread = None
+        self._started = False
+
+    def start(self):
+        """
+        Start the IO loop if required.  The loop is run in a dedicated
+        thread.
+
+        If the loop is already running, this method does nothing.
+        """
+        if self._asynchronous or self._loop_thread is not None:
+            self._started = True
+            return
+
+        loop_evt = threading.Event()
+        done_evt = threading.Event()
+        in_thread = [None]
+        start_exc = [None]
+
+        def loop_cb():
+            in_thread[0] = threading.current_thread()
+            loop_evt.set()
+
+        def run_loop(loop=self._loop):
+            loop.add_callback(loop_cb)
+            try:
+                loop.start()
+            except Exception as e:
+                start_exc[0] = e
+            finally:
+                done_evt.set()
+
+        thread = threading.Thread(target=run_loop,
+                                  name="IO loop")
+        thread.daemon = True
+        thread.start()
+
+        loop_evt.wait(timeout=1000)
+        self._started = True
+
+        actual_thread = in_thread[0]
+        if actual_thread is not thread:
+            # Loop already running in other thread (user-launched)
+            done_evt.wait(5)
+            if not isinstance(start_exc[0], RuntimeError):
+                raise start_exc[0]
+        else:
+            assert start_exc[0] is None, start_exc
+            self._loop_thread = thread
+
+    def stop(self, timeout=10):
+        """
+        Stop and close the loop if it was created by us.
+        Otherwise, just mark this object "stopped".
+        """
+        # XXX it would be more logical to stop an user-created loop
+        # if we started it, but that would break the current distributed API
+        self._started = False
+        if self._loop_thread is not None:
+            try:
+                if self._should_close_loop:
+                    self._loop.add_callback(self._loop.stop)
+                    self._loop_thread.join(timeout=timeout)
+                    self._loop.close()
+            finally:
+                self._loop_thread = None
+
+    def is_started(self):
+        """
+        Return True between start() and stop() calls, False otherwise.
+        """
+        return self._started
+
+    @property
+    def loop(self):
+        return self._loop
+
+
 @contextmanager
 def set_thread_state(**kwargs):
     old = {}

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -276,7 +276,7 @@ class LoopRunner(object):
             if asynchronous:
                 self._loop = IOLoop.current()
             else:
-                # We're expectinf the loop to run in another thread,
+                # We're expecting the loop to run in another thread,
                 # avoid re-using this thread's assigned loop
                 self._loop = IOLoop()
             self._should_close_loop = True

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -339,15 +339,12 @@ class LoopRunner(object):
         Stop and close the loop if it was created by us.
         Otherwise, just mark this object "stopped".
         """
-        # XXX it would be more logical to stop an user-created loop
-        # if we started it, but that would break the current distributed API
         self._started = False
         if self._loop_thread is not None:
             try:
-                if self._should_close_loop:
-                    self._loop.add_callback(self._loop.stop)
-                    self._loop_thread.join(timeout=timeout)
-                    self._loop.close()
+                self._loop.add_callback(self._loop.stop)
+                self._loop_thread.join(timeout=timeout)
+                self._loop.close()
             finally:
                 self._loop_thread = None
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -220,6 +220,9 @@ def sync(loop, func, *args, **kwargs):
             return loop.run_sync(make_coro)
         except RuntimeError:  # loop already running
             pass
+        except TypeError:
+            # TypeError: object of type 'NoneType' has no len()
+            raise RuntimeError("IO loop is closed")
 
     e = threading.Event()
     main_tid = get_thread_identity()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import threading
 from time import sleep
 import uuid
 import warnings
@@ -73,24 +74,27 @@ def invalid_python_script(tmpdir_factory):
 
 @pytest.fixture
 def loop():
-    IOLoop.clear_instance()
-    IOLoop.clear_current()
-    loop = IOLoop()
-    loop.make_current()
-    yield loop
-    if loop._running:
-        sync(loop, loop.stop)
-    for i in range(5):
-        try:
-            loop.close(all_fds=True)
-            IOLoop.clear_instance()
-            break
-        except Exception as e:
-            f = e
-    else:
-        print(f)
-    IOLoop.clear_instance()
-    IOLoop.clear_current()
+    with pristine_loop() as loop:
+        yield loop
+        if getattr(loop, '_running', False):
+            # XXX should warn?
+            pass
+        sync(loop, loop.stop)  # just in case
+
+
+@pytest.fixture
+def loop_in_thread():
+    with pristine_loop() as loop:
+        thread = threading.Thread(target=loop.start,
+                                  name="test IOLoop")
+        thread.daemon = True
+        thread.start()
+        loop_started = threading.Event()
+        loop.add_callback(loop_started.set)
+        loop_started.wait()
+        yield loop
+        loop.add_callback(loop.stop)
+        thread.join(timeout=5)
 
 
 @pytest.fixture

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -79,7 +79,12 @@ def loop():
         if getattr(loop, '_running', False):
             # XXX should warn?
             pass
-        sync(loop, loop.stop)  # just in case
+        # Stop the loop in case it's still running
+        try:
+            sync(loop, loop.stop)
+        except RuntimeError as e:
+            if not "IO loop is closed" in str(e):
+                raise
 
 
 @pytest.fixture


### PR DESCRIPTION
Also some small cleanups.

One question revolves around the `loop` fixture. It asks the loop to stop at the end in case the test didn't stop already... and it turns out some tests don't seem to stop the loop indeed. Is it an error for a test not to do so?