### PR TITLE
Move thread_state in dask

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -44,7 +44,7 @@ from .metrics import time
 
 
 try:
-    from dask import thread_state
+    from dask.context import thread_state
 except ImportError:
     thread_state = threading.local()
 


### PR DESCRIPTION
Previously this was in the top namespace. In https://github.com/dask/dask/pull/2858 this is moved  to `dask.context`, adjust the import accordingly.