### PR TITLE
Make worker memory_monitor collect data with cyclic references

### DIFF
--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -290,8 +290,8 @@ def test_nanny_no_terminate_on_cyclic_ref(tmpdir):
 
     worker_folder = str(tmpdir)
     memory_limit = int(1e9)
-    size = int(5e7)
-    n_tasks = 40
+    size = int(1e7)
+    n_tasks = 200
     w_kwargs = {'memory_limit': memory_limit, 'local_dir': worker_folder}
     with cluster(nworkers=1, nanny=True, worker_kwargs=w_kwargs) as (s, [a]):
         with Client(s['address']) as c:
@@ -302,7 +302,7 @@ def test_nanny_no_terminate_on_cyclic_ref(tmpdir):
 
 
             pids = get_worker_pids()
-            # 40 x 50 MB should yield 2 GB of data on the worker. Because
+            # 200 x 10 MB should yield 2 GB of data on the worker. Because
             # the memory limit is set to 1 GB, the worker should evict data
             # to its disk-based store and use the GC to free the data with
             # cyclic ref so as to complete the task. The nanny memory check

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -20,7 +20,7 @@ Example
 
 Here is how we special case handling raw Python bytes objects.  In this case
 there is no need to call ``pickle.dumps`` on the object.  The object is
-already a sequnce of bytes.
+already a sequence of bytes.
 
 .. code-block:: python
 


### PR DESCRIPTION
This PR:

- calls `collect()` systematically after any eviction without relying on the weight measurements,
- call the memory pause check nested in the eviction loop in case the workers threads grow the memory faster than the eviction mechanism frees the memory,
- adds a quick stress test to check that large number of tasks with cyclic refs are properly evicted with 

Note: the `sizeof` / `weight` measurements are completely blind to nested.

This is a more robust alternative to #1494 (nanny sending signal to trigger GC).

Note that this does not fix the all the memory problems reported by @bluenote10  as the eviction mechanism itself is very memory hungry because it makes in-memory copies of the data before writing to disk. This is very problematic when working with arrays or dataframe blocks that are a couple GB each.