### PR TITLE
Support work stealing for resource restricted tasks (see issue #1389)

### DIFF
--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -231,11 +231,11 @@ class WorkStealing(SchedulerPlugin):
                 del self.scheduler.processing[victim][key]
                 self.scheduler.processing[thief][key] = d['thief_duration']
                 self.put_key_in_stealable(key)
+                self.scheduler.consume_resources(key, thief)
+                self.scheduler.release_resources(key, victim)
 
                 try:
                     self.scheduler.send_task_to_worker(thief, key)
-                    self.scheduler.consume_resources(key, thief)
-                    self.scheduler.release_resources(key, victim)
                 except CommClosedError:
                     self.scheduler.remove_worker(thief)
                 self.log.append(('confirm', key, victim, thief))
@@ -293,7 +293,7 @@ class WorkStealing(SchedulerPlugin):
 
                         # in case the key has resource_restrictions,
                         # set i to next worker providing them
-                        if key in self.scheduler.resource_restrictions.keys():
+                        if key in self.scheduler.resource_restrictions:
                             resource_i = self.next_resource_i(
                                 idle,
                                 self.scheduler.resource_restrictions[key],
@@ -349,7 +349,7 @@ class WorkStealing(SchedulerPlugin):
 
                         # in case the key has resource_restrictions,
                         # set i to next worker providing them
-                        if key in self.scheduler.resource_restrictions.keys():
+                        if key in self.scheduler.resource_restrictions:
                             resource_i = self.next_resource_i(
                                 idle,
                                 self.scheduler.resource_restrictions[key],
@@ -397,7 +397,7 @@ class WorkStealing(SchedulerPlugin):
                     # Note: Since only idle workers are considered, this check
                     # is against the total amount of resources instead of those
                     # available (which for idle workers should be the same).
-                    if resource not in self.scheduler.worker_resources[workers[iworker]].keys() or \
+                    if resource not in self.scheduler.worker_resources[workers[iworker]] or \
                             quantity > self.scheduler.worker_resources[workers[iworker]][resource]:
                         suitable = False
                         break

--- a/docs/source/work-stealing.rst
+++ b/docs/source/work-stealing.rst
@@ -80,7 +80,9 @@ Restrictions
 ~~~~~~~~~~~~
 
 If a task has been specifically restricted to run on particular workers (such
-as is the case when special hardware is required) then we do not steal.
+as is the case when special hardware is required) then we do not steal. However,
+using the resource framework is compatible with work stealing.
+
 
 Choosing tasks to steal
 -----------------------


### PR DESCRIPTION
(Addresses issue #1389)

Idea is to naturally extend the current stealing approach: If a key has resource restrictions, choose the next idle worker providing the required resources rather than simply the next idle worker.

Modifications in stealing.py:
- find next worker providing the necessary resources
- make sure resources are properly consumed and released during stealing

Added tests to verify that
- resource restricted tasks are stolen when workers with sufficient resources are available (and resources are properly consumed and released)
- resource restricted tasks are not stolen when available workers do not possess sufficient resources

Mentioned the support of the resource framework in the documentation.