### PR TITLE
Fix test_stress.py::test_close_connections

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2397,8 +2397,9 @@ class Worker(WorkerBase):
                 self.validate_key_executing(key)
         except Exception as e:
             logger.exception(e)
-            import pdb
-            pdb.set_trace()
+            if LOG_PDB:
+                import pdb
+                pdb.set_trace()
             raise
 
     def validate_dep_waiting(self, dep):
@@ -2434,8 +2435,9 @@ class Worker(WorkerBase):
                 raise ValueError("Unknown dependent state", state)
         except Exception as e:
             logger.exception(e)
-            import pdb
-            pdb.set_trace()
+            if LOG_PDB:
+                import pdb
+                pdb.set_trace()
             raise
 
     def validate_state(self):


### PR DESCRIPTION
The loop which closes communications at random wasn't even entered (here at least) as the "processing" check occurred before the scheduler had actually started to spawn tasks (thus s.processing was empty).

Note that the test passes nominally, but it dumps some validation warnings in the Worker. @mrocklin 