### PR TITLE
Add HDFS wrapper for pyarrow compat

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -64,7 +64,8 @@ if [[ $HDFS == true ]]; then
     pip install -q git+https://github.com/dask/hdfs3 --upgrade
 fi;
 
-pip install -q git+https://github.com/dask/dask.git --upgrade
+# TODO: revert to install from dask after this PR is merged
+pip install -q git+https://github.com/jcrist/dask.git@arrow-hdfs-works --upgrade
 pip install -q git+https://github.com/joblib/joblib.git --upgrade
 pip install -q git+https://github.com/dask/s3fs.git --upgrade
 pip install -q git+https://github.com/dask/zict.git --upgrade

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -60,7 +60,7 @@ pip install -q pytest-repeat
 
 if [[ $HDFS == true ]]; then
     conda install -q libxml2 krb5 boost
-    conda install -q -c conda-forge libhdfs3 libgsasl libntlm
+    conda install -q -c conda-forge libhdfs3 libgsasl libntlm pyarrow
     pip install -q git+https://github.com/dask/hdfs3 --upgrade
 fi;
 


### PR DESCRIPTION
Add a wrapper for `DaskHDFileSystem` to provide an arrow compatible
interface to our hdfs filesystem. Adds a test using parquet to ensure
compatibility. Depends on https://github.com/dask/dask/pull/2881.