### PR TITLE
Remove explicit pycodestyle checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ install:
 script:
   - source continuous_integration/travis/run_tests.sh
   - flake8 distributed
-  - pycodestyle --select=E722 distributed  # check for bare `except:` blocks
 
 after_success:
   - if [[ $COVERAGE == true ]]; then coverage report; pip install -q coveralls ; coveralls ; fi

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -45,7 +45,6 @@ conda install -q -c conda-forge \
     netcdf4 \
     paramiko \
     psutil \
-    pycodestyle \
     pytest=3.1 \
     pytest-faulthandler \
     pytest-timeout \


### PR DESCRIPTION
As of the most recent release of flake8, pycodestyle is now called
directly by flake8. Remove explicit install and check call from ci.