### PR TITLE
Fix key_split for tuple keys

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -481,6 +481,8 @@ def key_split(s):
     'x'
     >>> key_split("('x-2', 1)")
     'x'
+    >>> key_split("('x', 1)")
+    'x'
     >>> key_split('hello-world-1')
     'hello-world'
     >>> key_split(b'hello-world-1')
@@ -501,7 +503,7 @@ def key_split(s):
     try:
         words = s.split('-')
         if not words[0][0].isalpha():
-            result = words[0].lstrip("'(\"")
+            result = words[0].split(",")[0].strip("'(\"")
         else:
             result = words[0]
         for word in words[1:]:


### PR DESCRIPTION
We use tuples as keys in our computations, but we don't use hyphens. This causes the bokeh web interface to display weird names. I believe it's because the bokeh messages are all of type `str`, so it's doing `key_split(key)` on a `key` that looks like a `tuple` but is really a `str`.