### PR TITLE
Fix large-messages test

### DIFF
--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -250,7 +250,7 @@ def test_dont_hold_on_to_large_messages(c, s, a, b):
 
     start = time()
     while xr() is not None:
-        if time() > start + 1:
+        if s.tasks and not any(s.processing.values()):
             # Help diagnosing
             from types import FrameType
             x = xr()


### PR DESCRIPTION
This possibly fixes an intermittent failure described here
https://github.com/dask/distributed/issues/966#issuecomment-346228536

I was unable t reproduce the failure locally, so this is a blind shot.