### PR TITLE
Handle exceptions in futures in Variables and Queues

### DIFF
--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -225,3 +225,14 @@ def test_Future_knows_status_immediately(c, s, a, b):
             yield gen.sleep(0.05)
 
     yield c2.close()
+
+
+@gen_cluster(client=True)
+def test_erred_future(c, s, a, b):
+    future = c.submit(div, 1, 0)
+    q = Queue()
+    yield q.put(future)
+    yield gen.sleep(0.1)
+    future2 = yield q.get()
+    with pytest.raises(ZeroDivisionError):
+        yield future2.result()

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -205,3 +205,14 @@ def test_Future_knows_status_immediately(c, s, a, b):
             yield gen.sleep(0.05)
 
     yield c2.close()
+
+
+@gen_cluster(client=True)
+def test_erred_future(c, s, a, b):
+    future = c.submit(div, 1, 0)
+    var = Variable()
+    yield var.set(future)
+    yield gen.sleep(0.1)
+    future2 = yield var.get()
+    with pytest.raises(ZeroDivisionError):
+        yield future2.result()


### PR DESCRIPTION
We now send back exceptions and tracebacks when reconstituting futures in
variables and queues.

Fixes #1578