### PR TITLE
Issue #1477: Use IOStream.read_into() when available

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -254,7 +254,7 @@ def extract_serialize(x):
 
     bytestrings = set()
     for k, v in ser.items():
-        if type(v) is bytes:
+        if type(v) in (bytes, bytearray):
             ser[k] = to_serialize(v)
             bytestrings.add(k)
     return x, ser, bytestrings
@@ -267,7 +267,7 @@ def _extract_serialize(x, ser, path=()):
             if typ is list or typ is dict:
                 _extract_serialize(v, ser, path + (k,))
             elif (typ is Serialize or typ is Serialized
-                  or typ is bytes and len(v) > 2**16):
+                  or typ in (bytes, bytearray) and len(v) > 2**16):
                 ser[path + (k,)] = v
     elif type(x) is list:
         for k, v in enumerate(x):
@@ -275,7 +275,7 @@ def _extract_serialize(x, ser, path=()):
             if typ is list or typ is dict:
                 _extract_serialize(v, ser, path + (k,))
             elif (typ is Serialize or typ is Serialized
-                  or typ is bytes and len(v) > 2**16):
+                  or typ in (bytes, bytearray) and len(v) > 2**16):
                 ser[path + (k,)] = v
 
 
@@ -333,6 +333,7 @@ def _deserialize_bytes(header, frames):
 
 
 register_serialization(bytes, _serialize_bytes, _deserialize_bytes)
+register_serialization(bytearray, _serialize_bytes, _deserialize_bytes)
 
 
 def serialize_bytelist(x):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -332,6 +332,9 @@ def _deserialize_bytes(header, frames):
     return frames[0]
 
 
+# NOTE: using the same exact serialization means a bytes object may be
+# deserialized as bytearray or vice-versa...  Not sure this is a problem
+# in practice.
 register_serialization(bytes, _serialize_bytes, _deserialize_bytes)
 register_serialization(bytearray, _serialize_bytes, _deserialize_bytes)
 

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -103,13 +103,14 @@ def test_maybe_compress_sample():
 
 
 def test_large_bytes():
-    msg = {'x': b'0' * 1000000, 'y': 1}
-    frames = dumps(msg)
-    assert loads(frames) == msg
-    assert len(frames[0]) < 1000
-    assert len(frames[1]) < 1000
+    for tp in (bytes, bytearray):
+        msg = {'x': tp(b'0' * 1000000), 'y': 1}
+        frames = dumps(msg)
+        assert loads(frames) == msg
+        assert len(frames[0]) < 1000
+        assert len(frames[1]) < 1000
 
-    assert loads(frames, deserialize=False) == msg
+        assert loads(frames, deserialize=False) == msg
 
 
 @slow

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -52,9 +52,11 @@ def test_dumps_serialize():
 
 
 def test_serialize_bytestrings():
-    b = b'123'
-    header, frames = serialize(b)
-    assert frames[0] is b
+    for b in (b'123', bytearray(b'4567')):
+        header, frames = serialize(b)
+        assert frames[0] is b
+        bb = deserialize(header, frames)
+        assert bb == b
 
 
 def test_Serialize():
@@ -88,14 +90,14 @@ def test_nested_deserialize():
     x = {'op': 'update',
          'x': [to_serialize(123), to_serialize(456), 789],
          'y': {'a': ['abc', Serialized(*serialize('def'))],
-               'b': 'ghi'}
+               'b': b'ghi'}
          }
     x_orig = copy.deepcopy(x)
 
     assert nested_deserialize(x) == {'op': 'update',
                                      'x': [123, 456, 789],
                                      'y': {'a': ['abc', 'def'],
-                                           'b': 'ghi'}
+                                           'b': b'ghi'}
                                      }
     assert x == x_orig  # x wasn't mutated
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -27,7 +27,7 @@ def frame_split_size(frames, n=BIG_BYTES_SHARD_SIZE):
     out = []
     for frame in frames:
         if nbytes(frame) > n:
-            if isinstance(frame, bytes):
+            if isinstance(frame, (bytes, bytearray)):
                 frame = memoryview(frame)
             try:
                 itemsize = frame.itemsize


### PR DESCRIPTION
The API is proposed in https://github.com/tornadoweb/tornado/pull/2193 and allows zero-copy reads of distributed protocol frames.