### PR TITLE
DOC: note about when secede useful

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2625,7 +2625,10 @@ def secede():
     """
     Have this task secede from the worker's thread pool
 
-    This opens up a new scheduling slot and a new thread for a new task.
+    This opens up a new scheduling slot and a new thread for a new task. This
+    enables the client to schedule tasks on this node, which is
+    especially useful while waiting for other jobs to finish (e.g., with
+    ``client.gather``).
 
     Examples
     --------


### PR DESCRIPTION
It took me a while to parse the docstring for `secede`, and this helps resolve that (also, `get_client` is super useful!).

It looks like a function that has called `secede` may be moved to another compute node. I think that's adequately covered by the docstring.