### PR TITLE
Clear deque handlers after each test

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -489,6 +489,7 @@ class Client(Node):
 
         # Communication
         self.security = security or Security()
+        self.scheduler_comm = None
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args('client')
         self._connecting_to_scheduler = False

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -1,6 +1,7 @@
 from distributed.protocol.pickle import dumps, loads
 
 import pytest
+import weakref
 
 from operator import add
 from functools import partial
@@ -22,10 +23,22 @@ def test_pickle_numpy():
 
 
 def test_pickle_functions():
-    value = 1
+    def make_closure():
+        value = 1
+        def f(x):  # closure
+            return x + value
+        return f
 
-    def f(x):  # closure
-        return x + value
+    def funcs():
+        yield make_closure()
+        yield (lambda x: x + 1)
+        yield partial(add, 1)
 
-    for func in [f, lambda x: x + 1, partial(add, 1)]:
-        assert loads(dumps(func))(1) == func(1)
+    for func in funcs():
+        wr = weakref.ref(func)
+        func2 = loads(dumps(func))
+        wr2 = weakref.ref(func2)
+        assert func2(1) == func(1)
+        del func, func2
+        assert wr() is None
+        assert wr2() is None

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -25,6 +25,7 @@ def test_pickle_numpy():
 def test_pickle_functions():
     def make_closure():
         value = 1
+
         def f(x):  # closure
             return x + value
         return f

--- a/distributed/pytest_resourceleaks.py
+++ b/distributed/pytest_resourceleaks.py
@@ -194,8 +194,8 @@ class TracemallocMemoryChecker(ResourceChecker):
             if size_diff < min_size_diff:
                 break
             count = stat.count_diff or stat.count
-            lines += [".. leaked %.1f MB in %d calls at:" % (size_diff / 1e6, count)]
-            lines += ["   " + line for line in stat.traceback.format()]
+            lines += ["  - leaked %.1f MB in %d calls at:" % (size_diff / 1e6, count)]
+            lines += ["    " + line for line in stat.traceback.format()]
 
         return "\n".join(lines)
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1230,9 +1230,11 @@ def test_get_task_status(c, s, a, b):
 
 
 def test_deque_handler():
-    from distributed.scheduler import deque_handler, logger
+    from distributed.scheduler import logger
+    s = Scheduler()
+    deque_handler = s._deque_handler
     logger.info('foo123')
-    assert deque_handler.deque
+    assert len(deque_handler.deque) >= 1
     msg = deque_handler.deque[-1]
     assert 'distributed.scheduler' in deque_handler.format(msg)
     assert any(msg.msg == 'foo123' for msg in deque_handler.deque)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1064,7 +1064,9 @@ def test_reschedule(c, s, a, b):
 
 
 def test_deque_handler():
-    from distributed.worker import deque_handler, logger
+    from distributed.worker import logger
+    w = Worker('127.0.0.1', 8019)
+    deque_handler = w._deque_handler
     logger.info('foo456')
     assert deque_handler.deque
     msg = deque_handler.deque[-1]

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1169,13 +1169,30 @@ def format_time(n):
 
 class DequeHandler(logging.Handler):
     """ A logging.Handler that records records into a deque """
+    _instances = weakref.WeakSet()
+
     def __init__(self, *args, **kwargs):
         n = kwargs.pop('n', 10000)
         self.deque = deque(maxlen=n)
         super(DequeHandler, self).__init__(*args, **kwargs)
+        self._instances.add(self)
 
     def emit(self, record):
         self.deque.append(record)
+
+    def clear(self):
+        """
+        Clear internal storage.
+        """
+        self.deque.clear()
+
+    @classmethod
+    def clear_all_instances(cls):
+        """
+        Clear the internal storage of all live DequeHandlers.
+        """
+        for inst in list(cls._instances):
+            inst.clear()
 
 
 class ThrottledGC(object):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -44,8 +44,10 @@ from .config import config, initialize_logging
 from .core import connect, rpc, CommClosedError
 from .metrics import time
 from .nanny import Nanny
+from .scheduler import deque_handler
 from .security import Security
-from .utils import ignoring, log_errors, sync, mp_context, get_ip, get_ipv6
+from .utils import (ignoring, log_errors, sync, mp_context, get_ip, get_ipv6,
+                    DequeHandler)
 from .worker import Worker, TOTAL_MEMORY
 
 
@@ -673,9 +675,6 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
         start
         end
     """
-    for name, level in logging_levels.items():
-        logging.getLogger(name).setLevel(level)
-
     worker_kwargs = merge({'memory_limit': TOTAL_MEMORY}, worker_kwargs)
 
     def _(func):
@@ -683,6 +682,11 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
             func = gen.coroutine(func)
 
         def test_func():
+            # Restore default logging levels
+            # XXX use pytest hooks/fixtures instead?
+            for name, level in logging_levels.items():
+                logging.getLogger(name).setLevel(level)
+
             old_globals = _globals.copy()
             result = None
             workers = []
@@ -725,6 +729,7 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                         # was already removed
                         pass
                     del w.data
+            DequeHandler.clear_all_instances()
             return result
 
         return test_func

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -44,7 +44,6 @@ from .config import config, initialize_logging
 from .core import connect, rpc, CommClosedError
 from .metrics import time
 from .nanny import Nanny
-from .scheduler import deque_handler
 from .security import Security
 from .utils import (ignoring, log_errors, sync, mp_context, get_ip, get_ipv6,
                     DequeHandler)


### PR DESCRIPTION
This eases memory consumption a bit. Ideally we would instead have a new deque handler for each separate Worker or Scheduler instance...