### PR TITLE
WIP: DOC: adds note about client.compute in get_client

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2584,6 +2584,12 @@ def get_client(address=None, timeout=3):
 
     This client connects to the same scheduler to which the worker is connected
 
+    Submitting new jobs with the client returned by this function will likely
+    work best with ``client.compute``, especially if no computation can proceed
+    until task completion and the tasks take a significant amount of time.
+    However, calls to ``secede`` and ``rejoin`` `may` be more adventageous for
+    particular use cases.
+
     Examples
     --------
     >>> def f():
@@ -2601,6 +2607,7 @@ def get_client(address=None, timeout=3):
     get_worker
     worker_client
     secede
+    compute
     """
     try:
         worker = get_worker()


### PR DESCRIPTION
This is documentation of https://github.com/dask/distributed/issues/465#issuecomment-346450238.

Is `dask.delayed` responsible for `client.compute` doing "everything correctly" in https://github.com/dask/distributed/issues/465#issuecomment-346450238? That is, would `client.map(delayed(f), X)` do the same thing as `[client.compute(delayed(f)(x)) for x in X]` in terms of freeing up scheduling slots when `client = get_client()`? Clarifying this could help simply the docs.