### PR TITLE
Handle exception deserialization in FutureState.set_error

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -376,6 +376,20 @@ class FutureState(object):
         self._get_event().clear()
 
     def set_error(self, exception, traceback):
+        if isinstance(exception, bytes):
+            try:
+                exception = loads(exception)
+            except TypeError:
+                exception = Exception("Undeserializable exception", exception)
+        if traceback:
+            if isinstance(traceback, bytes):
+                try:
+                    traceback = loads(traceback)
+                except (TypeError, AttributeError):
+                    traceback = None
+        else:
+            traceback = None
+
         self.status = 'error'
         self.exception = exception
         self.traceback = traceback
@@ -896,17 +910,6 @@ class Client(Node):
     def _handle_task_erred(self, key=None, exception=None, traceback=None):
         state = self.futures.get(key)
         if state is not None:
-            try:
-                exception = loads(exception)
-            except TypeError:
-                exception = Exception("Undeserializable exception", exception)
-            if traceback:
-                try:
-                    traceback = loads(traceback)
-                except AttributeError:
-                    traceback = None
-            else:
-                traceback = None
             state.set_error(exception, traceback)
 
     def _handle_restart(self):

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -236,3 +236,6 @@ def test_erred_future(c, s, a, b):
     future2 = yield q.get()
     with pytest.raises(ZeroDivisionError):
         yield future2.result()
+
+    exc = yield future2.exception()
+    assert isinstance(exc, ZeroDivisionError)

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -216,3 +216,21 @@ def test_erred_future(c, s, a, b):
     future2 = yield var.get()
     with pytest.raises(ZeroDivisionError):
         yield future2.result()
+
+    exc = yield future2.exception()
+    assert isinstance(exc, ZeroDivisionError)
+
+
+def test_future_erred_sync(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address']) as c:
+            future = c.submit(div, 1, 0)
+            var = Variable()
+            var.set(future)
+
+            sleep(0.1)
+
+            future2 = var.get()
+
+            with pytest.raises(ZeroDivisionError):
+                future2.result()


### PR DESCRIPTION
This centralizes deserialization logic

Fixes https://github.com/dask/distributed/issues/1588