### PR TITLE
Fix error from get_client() with no global client

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4612,6 +4612,17 @@ def test_get_client(c, s, a, b):
         del distributed.tmp_client
 
 
+def test_get_client_no_cluster():
+    # Clean up any global workers added by other tests. This test requires that
+    # there are no global workers.
+    from distributed.worker import _global_workers
+    del _global_workers[:]
+
+    msg = 'No global client found and no address provided'
+    with pytest.raises(ValueError, match=r'^{}$'.format(msg)):
+        get_client()
+
+
 @gen_cluster(client=True)
 def test_serialize_collections(c, s, a, b):
     da = pytest.importorskip('dask.array')

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2619,7 +2619,7 @@ def get_client(address=None, timeout=3):
 
     from .client import _get_global_client
     client = _get_global_client()  # TODO: assumes the same scheduler
-    if client and not address or client.scheduler.address == address:
+    if client and (not address or client.scheduler.address == address):
         return client
     elif address:
         from .client import Client


### PR DESCRIPTION
Fix TypeError from get_client() with no global client. This is supposed
to raise a ValueError.