### PR TITLE
[py.test] Hunt for process leaks

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -117,9 +117,10 @@ def test_is_kernel():
 
 #@pytest.mark.leaking('fds')
 #def test_zzz_leaks(l=[]):
-    #import os
+    #import os, subprocess
     #l.append(b"x" * (17 * 1024**2))
     #os.open(__file__, os.O_RDONLY)
+    #subprocess.Popen('sleep 100', shell=True, stdin=subprocess.DEVNULL)
 
 
 def test_ensure_ip():


### PR DESCRIPTION
Add a leak checker option to look for child process leaks after each test.
Note the check is slightly expensive due to psutil.Process.children() being slow.