### PR TITLE
Use environment variable for scheduler address if present

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -449,9 +449,6 @@ class Client(Node):
         Claim this scheduler as the global dask scheduler
     scheduler_file: string (optional)
         Path to a file with scheduler information if available
-    scheduler_env_variable: bool (optional)
-        If True then use DASK_SCHEDULER_ADDRESS for scheduler address if it
-        exists.  True by default.
     security: (optional)
         Optional security information
     asynchronous: bool (False by default)
@@ -487,7 +484,7 @@ class Client(Node):
     def __init__(self, address=None, loop=None, timeout=5,
                  set_as_default=True, scheduler_file=None,
                  security=None, asynchronous=False,
-                 name=None, scheduler_env_variable=True, **kwargs):
+                 name=None, **kwargs):
 
         self.futures = dict()
         self.refcount = defaultdict(lambda: 0)
@@ -519,7 +516,7 @@ class Client(Node):
         pc = PeriodicCallback(self._update_scheduler_info, 2000, io_loop=self.loop)
         self._periodic_callbacks.append(pc)
 
-        if address is None and scheduler_env_variable and 'scheduler-address' in config:
+        if address is None and 'scheduler-address' in config:
             address = config['scheduler-address']
 
         if hasattr(address, "scheduler_address"):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -518,6 +518,9 @@ class Client(Node):
 
         if address is None and 'scheduler-address' in config:
             address = config['scheduler-address']
+            if address:
+                logger.info("Config value `scheduler-address` found: %s",
+                            address)
 
         if hasattr(address, "scheduler_address"):
             # It's a LocalCluster or LocalCluster-compatible object

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5059,5 +5059,15 @@ def test_avoid_delayed_finalize(c, s, a, b):
     assert list(s.tasks) == [future.key] == [x.key]
 
 
+@gen_cluster()
+def test_config_scheduler_address(s, a, b):
+    from distributed import config
+    config['scheduler-address'] = s.address
+    c = yield Client(asynchronous=True)
+    assert c.scheduler.address == s.address
+    del config['scheduler-address']
+    yield c.close()
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # flake8: noqa

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5063,8 +5063,13 @@ def test_avoid_delayed_finalize(c, s, a, b):
 def test_config_scheduler_address(s, a, b):
     from distributed import config
     config['scheduler-address'] = s.address
-    c = yield Client(asynchronous=True)
-    assert c.scheduler.address == s.address
+    with captured_logger('distributed.client') as sio:
+        c = yield Client(asynchronous=True)
+        assert c.scheduler.address == s.address
+
+    text = sio.getvalue()
+    assert s.address in text
+
     del config['scheduler-address']
     yield c.close()
 


### PR DESCRIPTION
This makes `Client()` use the `DASK_SCHEDULER_ADDRESS` if available.  Set
`Client(scheduler_env_variable=False)` to retain original behavior.

This ends up being useful when deploying on distributed systems.