### PR TITLE
Fix deprecation warning from logger.warn()

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -154,11 +154,11 @@ class Server(object):
         diff = now - self._last_tick
         self._last_tick = now
         if diff > config.get('tick-maximum-delay', 1000) / 1000:
-            logger.warn("Event loop was unresponsive for %.2fs.  "
-                        "This is often caused by long-running GIL-holding "
-                        "functions or moving large chunks of data. "
-                        "This can cause timeouts and instability.",
-                        diff)
+            logger.warning("Event loop was unresponsive for %.2fs.  "
+                           "This is often caused by long-running GIL-holding "
+                           "functions or moving large chunks of data. "
+                           "This can cause timeouts and instability.",
+                           diff)
         if self.digests is not None:
             self.digests['tick-duration'].add(diff)
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -245,7 +245,7 @@ class Nanny(ServerNode):
         memory = psutil.Process(self.process.pid).memory_info().rss
         frac = memory / self.memory_limit
         if self.memory_terminate_fraction and frac > self.memory_terminate_fraction:
-            logger.warn("Worker exceeded 95% memory budget.  Restarting")
+            logger.warning("Worker exceeded 95% memory budget.  Restarting")
             self.process.process.terminate()
 
     def is_alive(self):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2164,18 +2164,18 @@ class Worker(WorkerBase):
             # Try to free some memory while in paused state
             self._throttled_gc.collect()
             if not self.paused:
-                logger.warn("Worker is at %d%% memory usage. Pausing worker.  "
-                            "Process memory: %s -- Worker memory limit: %s",
-                            int(frac * 100),
-                            format_bytes(proc.memory_info().rss),
-                            format_bytes(self.memory_limit))
+                logger.warning("Worker is at %d%% memory usage. Pausing worker.  "
+                               "Process memory: %s -- Worker memory limit: %s",
+                               int(frac * 100),
+                               format_bytes(proc.memory_info().rss),
+                               format_bytes(self.memory_limit))
                 self.paused = True
         elif self.paused:
-            logger.warn("Worker is at %d%% memory usage. Resuming worker. "
-                        "Process memory: %s -- Worker memory limit: %s",
-                        int(frac * 100),
-                        format_bytes(proc.memory_info().rss),
-                        format_bytes(self.memory_limit))
+            logger.warning("Worker is at %d%% memory usage. Resuming worker. "
+                           "Process memory: %s -- Worker memory limit: %s",
+                           int(frac * 100),
+                           format_bytes(proc.memory_info().rss),
+                           format_bytes(self.memory_limit))
             self.paused = False
             self.ensure_computing()
 
@@ -2186,12 +2186,12 @@ class Worker(WorkerBase):
             need = memory - target
             while memory > target:
                 if not self.data.fast:
-                    logger.warn("Memory use is high but worker has no data "
-                                "to store to disk.  Perhaps some other process "
-                                "is leaking memory?  Process memory: %s -- "
-                                "Worker memory limit: %s",
-                                format_bytes(proc.memory_info().rss),
-                                format_bytes(self.memory_limit))
+                    logger.warning("Memory use is high but worker has no data "
+                                   "to store to disk.  Perhaps some other process "
+                                   "is leaking memory?  Process memory: %s -- "
+                                   "Worker memory limit: %s",
+                                   format_bytes(proc.memory_info().rss),
+                                   format_bytes(self.memory_limit))
                     break
                 k, v, weight = self.data.fast.evict()
                 del k, v


### PR DESCRIPTION
Had to cancel a job because I was getting inundated with:
```
/home/brettnaul/miniconda3/lib/python3.6/site-packages/distributed/worker.py:2232: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
  format_bytes(self.memory_limit))
```
Think this should be fine but feel free to close if it isn't backwards compatible for some reason.