### PR TITLE
Add min and max worker flags to adaptive cluster

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -61,10 +61,14 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
               help="Directory to place scheduler files")
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process like "foo.bar" or "/path/to/foo.py"')
+@click.option('--min-workers', type=int, default=0,
+              help="Minimum number of workers required in an adaptive cluster")
+@click.option('--max-workers', type=int, default=1e100,
+              help="Maximum number of workers required in an adaptive cluster")
 def main(host, port, bokeh_port, show, _bokeh,
          bokeh_whitelist, bokeh_prefix, use_xheaders, pid_file, scheduler_file,
          interface, local_directory, preload, tls_ca_file, tls_cert,
-         tls_key):
+         tls_key, min_workers, max_workers):
     enable_proctitle_on_current()
     enable_proctitle_on_children()
 
@@ -118,7 +122,8 @@ def main(host, port, bokeh_port, show, _bokeh,
                                                       prefix=bokeh_prefix)
     scheduler = Scheduler(loop=loop, services=services,
                           scheduler_file=scheduler_file,
-                          security=sec)
+                          security=sec, min_workers=min_workers,
+                          max_workers=max_workers)
     scheduler.start(addr)
     preload_modules(preload, parameter=scheduler, file_dir=local_directory)
 

--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -118,7 +118,8 @@ class Adaptive(object):
         needs_memory
         """
         with log_errors():
-            if self.scheduler.unrunnable and not self.scheduler.ncores:
+            if len(self.scheduler.ncores) < self.scheduler.min_workers or \
+                    (self.scheduler.unrunnable and not self.scheduler.ncores):
                 return True
 
             needs_cpu = self.needs_cpu()
@@ -177,7 +178,9 @@ class Adaptive(object):
         --------
         LocalCluster.scale_up
         """
-        instances = max(1, len(self.scheduler.ncores) * self.scale_factor)
+        instances = max(1, self.scheduler.min_workers,
+                        len(self.scheduler.ncores) * self.scale_factor)
+        instances = min(instances, self.scheduler.max_workers)
         logger.info("Scaling up to %d workers", instances)
         return {'n': instances}
 


### PR DESCRIPTION
### Description
Add min and max worker flags to adaptive cluster.

We've been using adaptive clusters on Kubernetes (over EC2) and have found an initial spin up time before tasks start calculating due to the first couple of scale up calls taking time to complete.

This PR adds a minimum number of workers to keep alive in the adaptive cluster meaning that tasks start processing immediately.

We've also added a maximum number of workers while we were at it.

#### Example usage
```
dask-scheduler --port 8786 --bokeh-port 8787 --min-workers 10 --max-workers 100 --preload /opt/scheduler/adaptive.py
```