### PR TITLE
Incorrect sizeof() result for dicts and memoryviews

### DIFF
--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -28,8 +28,13 @@ def sizeof_default(o):
 @sizeof.register(tuple)
 @sizeof.register(set)
 @sizeof.register(frozenset)
-def sizeof_python_collection(seq):
+def sizeof_python_container(seq):
     return getsizeof(seq) + sum(map(sizeof, seq))
+
+
+@sizeof.register(dict)
+def sizeof_python_mapping(dct):
+    return getsizeof(dct) + sum(map(sizeof, dct)) + sum(map(sizeof, dct.values()))
 
 
 @sizeof.register_lazy("numpy")

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
+from functools import reduce
 import logging
+import operator
 import sys
 
 from dask.utils import Dispatch
@@ -35,6 +37,15 @@ def sizeof_python_container(seq):
 @sizeof.register(dict)
 def sizeof_python_mapping(dct):
     return getsizeof(dct) + sum(map(sizeof, dct)) + sum(map(sizeof, dct.values()))
+
+
+@sizeof.register(memoryview)
+def sizeof_memoryview(mem):
+    try:
+        return getsizeof(mem) + mem.nbytes
+    except AttributeError:
+        # Python 2
+        return getsizeof(mem) + reduce(operator.mul, mem.shape, mem.itemsize)
 
 
 @sizeof.register_lazy("numpy")

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -13,6 +13,9 @@ def test_base():
 
 def test_containers():
     assert sizeof([1, 2, [3]]) > (getsizeof(3) * 3 + getsizeof([]))
+    b = b"x" * 100
+    assert sizeof({b}) >= (getsizeof(b) + getsizeof(set()))
+    assert sizeof({b: b + b'z'}) >= (2 * getsizeof(b) + getsizeof({}))
 
 
 def test_numpy():

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -18,6 +18,12 @@ def test_containers():
     assert sizeof({b: b + b'z'}) >= (2 * getsizeof(b) + getsizeof({}))
 
 
+def test_memoryview():
+    b = b"x" * 1000
+    m = memoryview(b)
+    assert 1000 < sizeof(m) <= 1500
+
+
 def test_numpy():
     np = pytest.importorskip('numpy')
     assert 8000 <= sizeof(np.empty(1000, dtype='f8')) <= 9000


### PR DESCRIPTION
Note that unfortunately `sizeof()` is quite slow, and I'm not sure it's a good idea to call it in `distributed.comm`.