### PR TITLE
Add support for "grouped" adaptive scaling and adaptive behavior overrides.

### DIFF
--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -140,20 +140,41 @@ class Adaptive(object):
 
         Notes
         -----
-        ``Adaptive.should_scale_down`` always returns True, so we will always
-        attempt to remove workers as determined by
-        ``Scheduler.workers_to_close``.
+        ``Adaptive.should_scale_down`` defaults to dispatching to
+        ``Adaptive.workers_to_close``, returning True if any workers to close
+        are specified.
 
         See Also
         --------
         Scheduler.workers_to_close
         """
-        return len(self.scheduler.workers_to_close()) > 0
+        return len(self.workers_to_close()) > 0
+
+    def workers_to_close(self):
+        """
+        Determine which, if any, workers should potentially be removed from
+        the cluster.
+
+        Returns
+        -------
+        workers: [worker_name]
+
+        Notes
+        -----
+        ``Adaptive.workers_to_close`` dispatches to Scheduler.workers_to_close(),
+        but may be overridden in subclasses.
+
+        See Also
+        --------
+        Scheduler.workers_to_close
+        """
+        return self.scheduler.workers_to_close()
 
     @gen.coroutine
     def _retire_workers(self):
         with log_errors():
-            workers = yield self.scheduler.retire_workers(remove=True,
+            workers = yield self.scheduler.retire_workers(workers=self.workers_to_close(),
+                                                          remove=True,
                                                           close_workers=True)
 
             if workers:

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -26,6 +26,7 @@ def test_get_scale_up_kwargs(loop):
             assert c.ncores()
             assert alc.get_scale_up_kwargs() == {'n': 3}
 
+
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 4)
 def test_simultaneous_scale_up_and_down(c, s, *workers):
     class TestAdaptive(Adaptive):

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -120,3 +120,34 @@ def test_adaptive_local_cluster_multi_workers():
         yield c._close()
         yield cluster._close()
 
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 10)
+def test_adaptive_scale_down_override(c, s, *workers):
+    class TestAdaptive(Adaptive):
+        def __init__(self, *args, **kwargs):
+            self.min_size = kwargs.pop("min_size", 0)
+            Adaptive.__init__(self, *args, **kwargs)
+
+        def workers_to_close(self):
+            num_workers = len(self.scheduler.workers)
+            to_close = self.scheduler.workers_to_close()
+            if num_workers - len(to_close) < self.min_size:
+                to_close = to_close[:num_workers - self.min_size]
+
+            return to_close
+
+    class TestCluster(object):
+        def scale_up(self, n, **kwargs):
+            assert False
+
+        def scale_down(self, workers):
+            assert False
+
+    assert len(s.workers) == 10
+
+    # Assert that adaptive cycle does not reduce cluster below minimum size
+    # as determined via override.
+    cluster = TestCluster()
+    ta = TestAdaptive(s, cluster, min_size=2, interval=.1, scale_factor=2)
+    yield gen.sleep(0.3)
+
+    assert len(s.workers) == 2

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -17,7 +17,7 @@ try:
     from cytoolz import frequencies, merge, pluck, merge_sorted, first
 except ImportError:
     from toolz import frequencies, merge, pluck, merge_sorted, first
-from toolz import memoize, valmap, first, second, concat, compose
+from toolz import memoize, valmap, first, second, concat, compose, groupby
 from tornado import gen
 from tornado.gen import Return
 from tornado.ioloop import IOLoop
@@ -2548,7 +2548,7 @@ class Scheduler(ServerNode):
                                'key-count': len(keys),
                                'branching-factor': branching_factor})
 
-    def workers_to_close(self, memory_ratio=2):
+    def workers_to_close(self, memory_ratio=2, key=None):
         """
         Find workers that we can close with low cost
 
@@ -2566,10 +2566,24 @@ class Scheduler(ServerNode):
             Amount of extra space we want to have for our stored data.
             Defaults two 2, or that we want to have twice as much memory as we
             currently have data.
+        key: Callable(WorkerState)
+            An optional callable mapping a WorkerState object to a group
+            affiliation.  Groups will be closed together.  This is useful when
+            closing workers must be done collectively, such as by hostname.
+
+        Examples
+        --------
+        >>> scheduler.workers_to_close()
+        ['tcp://192.168.0.1:1234', 'tcp://192.168.0.2:1234']
+
+        Group workers by hostname prior to closing
+
+        >>> scheduler.workers_to_close(key=lambda ws: ws.host)
+        ['tcp://192.168.0.1:1234', 'tcp://192.168.0.1:4567']
 
         Returns
         -------
-        to_close: list of workers that are OK to close
+        to_close: list of worker addresses that are OK to close
         """
         with log_errors():
             # XXX processing isn't used is the heuristics below
@@ -2584,17 +2598,34 @@ class Scheduler(ServerNode):
             idle = sorted([ws for ws in self.idle if not ws.processing],
                           key=operator.attrgetter('nbytes'), reverse=True)
 
+            if key is None:
+                key = lambda ws: ws.address
+
+            groups = groupby(key, self.workers.values())
+
+            logger.info("workers_by_group: %s", groups)
+
+            limit_bytes = {k: sum(ws.memory_limit for ws in v)
+                           for k, v in groups.items()}
+            group_bytes = {k: sum(ws.nbytes for ws in v)
+                           for k, v in groups.items()}
+
+            limit = sum(limit_bytes.values())
+            total = sum(group_bytes.values())
+            idle = sorted([group for group, workers in groups.items()
+                           if not any(ws.processing for ws in workers)],
+                          key=group_bytes.get, reverse=True)
             to_close = []
 
             while idle:
-                w = idle.pop().address
+                w = idle.pop()
                 limit -= limit_bytes[w]
                 if limit >= memory_ratio * total:  # still plenty of space
                     to_close.append(w)
                 else:
                     break
 
-            return to_close
+            return [ws.address for g in to_close for ws in groups[g]]
 
     @gen.coroutine
     def retire_workers(self, comm=None, workers=None, remove=True, close=False,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2603,8 +2603,6 @@ class Scheduler(ServerNode):
 
             groups = groupby(key, self.workers.values())
 
-            logger.info("workers_by_group: %s", groups)
-
             limit_bytes = {k: sum(ws.memory_limit for ws in v)
                            for k, v in groups.items()}
             group_bytes = {k: sum(ws.nbytes for ws in v)
@@ -2625,7 +2623,11 @@ class Scheduler(ServerNode):
                 else:
                     break
 
-            return [ws.address for g in to_close for ws in groups[g]]
+            result = [ws.address for g in to_close for ws in groups[g]]
+            if result:
+                logger.info("Suggest closing workers: %s", result)
+
+            return result
 
     @gen.coroutine
     def retire_workers(self, comm=None, workers=None, remove=True, close=False,


### PR DESCRIPTION
_This is a vaguely strawman proposal. I'm *certainly* happy to hear implementation feedback from maintainers, and admit that this conflicts with the open PR #1618, but believe these changes may offer a minimally invasive approach to support custom adaptive logic without further changes to score scheduler class._

- [x] Determine if additional test coverage is required.
- [x] Maybe extended out-of-the-box implementation with "min size" and "max size" logic and hostname-based grouping via command-line flag.
- [ ] Update documentation.

This pull intended to improve support for adaptive scaling on clusters in which there is not a 1-to-1 mapping between workers and underlying cluster resources (a "node"). This may occur in which a resource restriction, such as node startup time, fixed node resource cost or node count limitation, require that multiple workers are hosted on a single node. In these contexts adaptive scaling should logically occur on a per-node basis, rather than a per worker basis, as closing a single worker on a node does not allow removal of the underlying cluster resource. 

This patch attempts to provide the minimal required extension of the core scheduler "workers_to_close" logic required to perform scale-down analysis in a grouped context. Worker activity and memory use are considered on a grouped basis, and groups are selected on an all-or-none basis for retirement. Identification of a worker "group" is deferred to a user-specified grouping function, as the desired behavior is *challenging to anticipate*. A simple example of hostname-based grouping is provided in documentation.

Extends the `Adaptive` base class with an overridable hook for `workers_to_close`, allowing optional specification of a grouping key as well as post-facto analysis of the candidate retirement list. This hook may be used to provide support for minimum cluster size logic, which is demonstrated via a test. This implementation *may* be relevant for #1618.