### PR TITLE
Disable OS X build on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,16 @@ matrix:
     # Using Travis-CI's python makes job faster by not downloading miniconda
     python: 3.6
     env: LINT=true
-  - os: osx
-    env: PYTHON=3.6 RUNSLOW=false
+  #- os: osx
+    #env: PYTHON=3.6 RUNSLOW=false
   # Tornado dev builds disabled, as Bokeh and IPython choke on it
   #- env: PYTHON=3.6 TORNADO=dev
   #- env: PYTHON=2.7 TORNADO=dev RUNSLOW=false PACKAGES="futures faulthandler"
   # Together with fast_finish, allow build to be marked successful before the OS X job finishes
-  allow_failures:
-  - os: osx
-    # This needs to be the exact same line as above
-    env: PYTHON=3.6 RUNSLOW=false
+  #allow_failures:
+  #- os: osx
+    ## This needs to be the exact same line as above
+    #env: PYTHON=3.6 RUNSLOW=false
 
 install:
   - if [[ $TESTS == true ]]; then source continuous_integration/travis/install.sh ; fi


### PR DESCRIPTION
It has been broken for quite some time ("language: python" is not supported on OS X builds) and I don't think there's any motivation among us to fix it.