### PR TITLE
Add pass-through arguments for scheduler/worker `--preload` modules.

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -25,6 +25,7 @@ logger = logging.getLogger('distributed.scheduler')
 
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
+
 @click.command(context_settings=dict(ignore_unknown_options=True))
 @click.option('--host', type=str, default='',
               help="URI, IP or hostname of this server")

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -16,7 +16,7 @@ from distributed.security import Security
 from distributed.utils import get_ip_interface, ignoring
 from distributed.cli.utils import (check_python_3, install_signal_handlers,
                                    uri_from_host_port)
-from distributed.preloading import preload_modules
+from distributed.preloading import preload_modules, validate_preload_argv
 from distributed.proctitle import (enable_proctitle_on_children,
                                    enable_proctitle_on_current)
 
@@ -25,8 +25,7 @@ logger = logging.getLogger('distributed.scheduler')
 
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
-
-@click.command()
+@click.command(context_settings=dict(ignore_unknown_options=True))
 @click.option('--host', type=str, default='',
               help="URI, IP or hostname of this server")
 @click.option('--port', type=int, default=None, help="Serving port")
@@ -58,10 +57,10 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
               "cluster is on a shared network file system.")
 @click.option('--local-directory', default='', type=str,
               help="Directory to place scheduler files")
-@click.option('--preload', type=str, multiple=True,
+@click.option('--preload', type=str, multiple=True, is_eager=True,
               help='Module that should be loaded by each worker process like "foo.bar" or "/path/to/foo.py"')
-@click.option('--preload_argv', type=str, multiple=True,
-              help='Command line arguments passed through to preload modules via `argv`.')
+@click.argument('preload_argv', nargs=-1,
+                type=click.UNPROCESSED, callback=validate_preload_argv)
 def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,
         use_xheaders, pid_file, scheduler_file, interface,
         local_directory, preload, preload_argv, tls_ca_file, tls_cert, tls_key):

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -60,9 +60,11 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
               help="Directory to place scheduler files")
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process like "foo.bar" or "/path/to/foo.py"')
+@click.option('--preload_argv', type=str, multiple=True,
+              help='Command line arguments passed through to preload modules via `argv`.')
 def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,
-         use_xheaders, pid_file, scheduler_file, interface,
-         local_directory, preload, tls_ca_file, tls_cert, tls_key):
+        use_xheaders, pid_file, scheduler_file, interface,
+        local_directory, preload, preload_argv, tls_ca_file, tls_cert, tls_key):
 
     enable_proctitle_on_current()
     enable_proctitle_on_children()
@@ -119,7 +121,7 @@ def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,
                           scheduler_file=scheduler_file,
                           security=sec)
     scheduler.start(addr)
-    preload_modules(preload, parameter=scheduler, file_dir=local_directory)
+    preload_modules(preload, parameter=scheduler, file_dir=local_directory, argv=preload_argv)
 
     logger.info('Local Directory: %26s', local_directory)
     logger.info('-' * 47)

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -58,7 +58,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option('--local-directory', default='', type=str,
               help="Directory to place scheduler files")
 @click.option('--preload', type=str, multiple=True, is_eager=True,
-              help='Module that should be loaded by each worker process like "foo.bar" or "/path/to/foo.py"')
+              help='Module that should be loaded by each worker process '
+                   'like "foo.bar" or "/path/to/foo.py"')
 @click.argument('preload_argv', nargs=-1,
                 type=click.UNPROCESSED, callback=validate_preload_argv)
 def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -92,11 +92,13 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process '
                    'like "foo.bar" or "/path/to/foo.py"')
+@click.option('--preload_argv', type=str, multiple=True,
+              help='Command line arguments passed through to preload modules via `argv`.')
 def main(scheduler, host, worker_port, listen_address, contact_address,
          nanny_port, nthreads, nprocs, nanny, name,
          memory_limit, pid_file, reconnect, resources, bokeh,
          bokeh_port, local_directory, scheduler_file, interface,
-         death_timeout, preload, bokeh_prefix, tls_ca_file,
+         death_timeout, preload, preload_argv, bokeh_prefix, tls_ca_file,
          tls_cert, tls_key):
     enable_proctitle_on_current()
     enable_proctitle_on_children()
@@ -212,7 +214,8 @@ def main(scheduler, host, worker_port, listen_address, contact_address,
                  services=services, loop=loop, resources=resources,
                  memory_limit=memory_limit, reconnect=reconnect,
                  local_dir=local_directory, death_timeout=death_timeout,
-                 preload=preload, security=sec, contact_address=contact_address,
+                 preload=preload, preload_argv=preload_argv,
+                 security=sec, contact_address=contact_address,
                  name=name if nprocs == 1 else name + '-' + str(i),
                  **kwargs)
                for i in range(nprocs)]

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -14,6 +14,7 @@ from distributed.security import Security
 from distributed.cli.utils import (check_python_3, uri_from_host_port,
                                    install_signal_handlers)
 from distributed.comm import get_address_host_port
+from distributed.preloading import validate_preload_argv
 from distributed.proctitle import (enable_proctitle_on_children,
                                    enable_proctitle_on_current)
 
@@ -27,7 +28,7 @@ logger = logging.getLogger('distributed.dask_worker')
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 
-@click.command()
+@click.command(context_settings=dict(ignore_unknown_options=True))
 @click.argument('scheduler', type=str, required=False)
 @click.option('--tls-ca-file', type=pem_file_option_type, default=None,
               help="CA cert(s) file for TLS (in PEM format)")
@@ -92,8 +93,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process '
                    'like "foo.bar" or "/path/to/foo.py"')
-@click.option('--preload_argv', type=str, multiple=True,
-              help='Command line arguments passed through to preload modules via `argv`.')
+@click.argument('preload_argv', nargs=-1,
+                type=click.UNPROCESSED, callback=validate_preload_argv)
 def main(scheduler, host, worker_port, listen_address, contact_address,
          nanny_port, nthreads, nprocs, nanny, name,
          memory_limit, pid_file, reconnect, resources, bokeh,

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -90,7 +90,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
               help="Seconds to wait for a scheduler before closing")
 @click.option('--bokeh-prefix', type=str, default=None,
               help="Prefix for the bokeh app")
-@click.option('--preload', type=str, multiple=True,
+@click.option('--preload', type=str, multiple=True, is_eager=True,
               help='Module that should be loaded by each worker process '
                    'like "foo.bar" or "/path/to/foo.py"')
 @click.argument('preload_argv', nargs=-1,

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -297,6 +297,7 @@ def test_preload_module(loop):
     finally:
         shutil.rmtree(tmpdir)
 
+
 PRELOAD_COMMAND_TEXT = """
 import click
 _config = {}
@@ -309,6 +310,7 @@ def dask_setup(scheduler, passthrough):
 def get_passthrough():
     return _config["passthrough"]
 """
+
 
 def test_preload_command(loop):
 
@@ -331,6 +333,7 @@ def test_preload_command(loop):
                         "foobar"
     finally:
         shutil.rmtree(tmpdir)
+
 
 def test_preload_command_default(loop):
 

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -296,3 +296,64 @@ def test_preload_module(loop):
                         c.scheduler.address
     finally:
         shutil.rmtree(tmpdir)
+
+PRELOAD_COMMAND_TEXT = """
+import click
+_config = {}
+
+@click.command()
+@click.option("--passthrough", type=str, default="default")
+def dask_command(passthrough):
+    _config["passthrough"] = passthrough
+
+def dask_setup(scheduler):
+    pass
+
+def get_passthrough():
+    return _config["passthrough"]
+"""
+
+def test_preload_command(loop):
+
+    def check_passthrough():
+        import passthrough_info
+        return passthrough_info.get_passthrough()
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, 'passthrough_info.py')
+        with open(path, 'w') as f:
+            f.write(PRELOAD_COMMAND_TEXT)
+
+        with tmpfile() as fn:
+            print(fn)
+            with popen(['dask-scheduler', '--scheduler-file', fn,
+                        '--preload', path, "--passthrough", "foobar"]):
+                with Client(scheduler_file=fn, loop=loop) as c:
+                    assert c.run_on_scheduler(check_passthrough) == \
+                        "foobar"
+    finally:
+        shutil.rmtree(tmpdir)
+
+def test_preload_command_default(loop):
+
+    def check_passthrough():
+        import passthrough_info
+        return passthrough_info.get_passthrough()
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, 'passthrough_info.py')
+        with open(path, 'w') as f:
+            f.write(PRELOAD_COMMAND_TEXT)
+
+        with tmpfile() as fn2:
+            print(fn2)
+            with popen(['dask-scheduler', '--scheduler-file', fn2,
+                        '--preload', path], stdout=sys.stdout, stderr=sys.stderr):
+                with Client(scheduler_file=fn2, loop=loop) as c:
+                    assert c.run_on_scheduler(check_passthrough) == \
+                        "default"
+
+    finally:
+        shutil.rmtree(tmpdir)

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -303,11 +303,8 @@ _config = {}
 
 @click.command()
 @click.option("--passthrough", type=str, default="default")
-def dask_command(passthrough):
+def dask_setup(scheduler, passthrough):
     _config["passthrough"] = passthrough
-
-def dask_setup(scheduler):
-    pass
 
 def get_passthrough():
     return _config["passthrough"]

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -42,7 +42,7 @@ class Nanny(ServerNode):
                  ncores=None, loop=None, local_dir=None, services=None,
                  name=None, memory_limit='auto', reconnect=True,
                  validate=False, quiet=False, resources=None, silence_logs=None,
-                 death_timeout=None, preload=(), security=None,
+                 death_timeout=None, preload=(), preload_argv=[], security=None,
                  contact_address=None, listen_address=None, **kwargs):
         if scheduler_file:
             cfg = json_load_robust(scheduler_file)
@@ -60,6 +60,8 @@ class Nanny(ServerNode):
         self.resources = resources
         self.death_timeout = death_timeout
         self.preload = preload
+        self.preload_arv = preload_argv
+
         self.contact_address = contact_address
         self.memory_terminate_fraction = config.get('worker-memory-terminate', 0.95)
 
@@ -203,6 +205,7 @@ class Nanny(ServerNode):
                                    silence_logs=self.silence_logs,
                                    death_timeout=self.death_timeout,
                                    preload=self.preload,
+                                   preload_argv=self.preload_argv,
                                    security=self.security,
                                    contact_address=self.contact_address),
                 worker_start_args=(start_arg,),

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -60,7 +60,7 @@ class Nanny(ServerNode):
         self.resources = resources
         self.death_timeout = death_timeout
         self.preload = preload
-        self.preload_arv = preload_argv
+        self.preload_argv = preload_argv
 
         self.contact_address = contact_address
         self.memory_terminate_fraction = config.get('worker-memory-terminate', 0.95)

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -13,6 +13,10 @@ logger = logging.getLogger(__name__)
 
 def validate_preload_argv(ctx, param, value):
     """Click option callback providing validation of preload subcommand arguments."""
+    if not value and not ctx.params.get("preload", None):
+        # No preload argv provided and no preload modules specified.
+        return value
+
     if value and not ctx.params.get("preload", None):
         raise click.UsageError("Additional preload arguments specified without --preload target.")
 
@@ -109,7 +113,7 @@ def preload_modules(names, parameter=None, file_dir=None, argv=None):
         # handle special functions
         if interface["dask_command"]:
             ctx = click.Context(interface["dask_command"], allow_extra_args=False)
-            interface["dask_command"].main(argv)
+            interface["dask_command"].main(argv, standalone_mode=False)
 
         if interface["dask_setup"]:
             interface["dask_setup"](parameter)

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -28,10 +28,12 @@ def validate_preload_argv(ctx, param, value):
     ]
 
     if len(preload_commands) > 1:
-        raise click.UsageError("Multiple --preload modules with command-line parsing specified.")
+        raise click.UsageError(
+            "Multiple --preload modules with 'dask_command': %s" % preload_commands)
 
     if value and not preload_commands:
-        raise click.UsageError("Additional preload arguments specified, but --preload target did not expose command.")
+        raise click.UsageError(
+            "Additional preload arguments specified, but --preload target did not expose 'dask_command'.")
     if not preload_commands:
         return value
     else:

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -5,25 +5,61 @@ import shutil
 import sys
 from importlib import import_module
 
+import click
+
 from .utils import import_file
 
 logger = logging.getLogger(__name__)
 
+def validate_preload_argv(ctx, param, value):
+    """Click option callback providing validation of preload subcommand arguments."""
+    if value and not ctx.params.get("preload", None):
+        raise click.UsageError("Additional preload arguments specified without --preload target.")
 
-def preload_modules(names, parameter=None, file_dir=None, argv=None):
-    """ Imports modules, handles `dask_setup` and `dask_teardown` functions.
+    preload_modules = _import_modules(ctx.params.get("preload"))
+
+    preload_commands = [
+        m["dask_command"] for m in preload_modules.values()
+        if m["dask_command"] is not None
+    ]
+
+    if len(preload_commands) > 1:
+        raise click.UsageError("Multiple --preload modules with command-line parsing specified.")
+
+    if value and not preload_commands:
+        raise click.UsageError("Additional preload arguments specified, but --preload target did not expose command.")
+    if not preload_commands:
+        return value
+    else:
+        preload_command = preload_commands[0]
+
+    ctx = click.Context(preload_command, allow_extra_args=False)
+    preload_command.parse_args(ctx, list(value))
+
+    return value
+
+
+def _import_modules(names, file_dir=None):
+    """ Imports modules and extracts preload interface functions.
+    
+    Imports modules specified by names and extracts 'dask_command', 
+    'dask_setup' and 'dask_teardown' if present.
+
 
     Parameters
     ----------
     names: list of strings
         Module names or file paths
-    parameter: object
-        Parameter passed to `dask_setup` and `dask_teardown`
-    argv: [string]
-        List of string arguments from the preload command line specification.
     file_dir: string
         Path of a directory where files should be copied
+    
+    Returns
+    -------
+    Nest dict of names to extracted module interface components if present
+    in imported module.
     """
+    result_modules =  {}
+
     for name in names:
         # import
         if name.endswith(".py"):
@@ -32,7 +68,8 @@ def preload_modules(names, parameter=None, file_dir=None, argv=None):
                 basename = os.path.basename(name)
                 copy_dst = os.path.join(file_dir, basename)
                 if os.path.exists(copy_dst):
-                    logger.error("File name collision: %s", basename)
+                    if not filecmp.cmp(name, copy_dst):
+                        logger.error("File name collision: %s", basename)
                 shutil.copy(name, copy_dst)
                 module = import_file(copy_dst)[0]
             else:
@@ -44,13 +81,38 @@ def preload_modules(names, parameter=None, file_dir=None, argv=None):
                 import_module(name)
             module = sys.modules[name]
 
+        result_modules[name] = {
+            attrname : getattr(module, attrname, None)
+            for attrname in ("dask_setup", "dask_teardown", "dask_command")
+        }
+
+    return result_modules
+
+def preload_modules(names, parameter=None, file_dir=None, argv=None):
+    """ Imports modules, handles `dask_command`, `dask_setup` and `dask_teardown`.
+
+    Parameters
+    ----------
+    names: list of strings
+        Module names or file paths
+    parameter: object
+        Parameter passed to `dask_setup` and `dask_teardown`
+    argv: [string]
+        List of string arguments passed to `dask_command`.
+    file_dir: string
+        Path of a directory where files should be copied
+    """
+
+    imported_modules = _import_modules(names, file_dir=file_dir)
+
+    for name, interface in imported_modules.items():
         # handle special functions
-        dask_setup = getattr(module, 'dask_setup', None)
-        dask_teardown = getattr(module, 'dask_teardown', None)
-        if dask_setup is not None:
-            if argv:
-                dask_setup(parameter, argv=argv)
-            else:
-                dask_setup(parameter)
-        if dask_teardown is not None:
-            atexit.register(dask_teardown, parameter)
+        if interface["dask_command"]:
+            ctx = click.Context(interface["dask_command"], allow_extra_args=False)
+            interface["dask_command"].main(argv)
+
+        if interface["dask_setup"]:
+            interface["dask_setup"](parameter)
+
+        if interface["dask_teardown"]:
+            atexit.register(interface["dask_teardown"], parameter)

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import sys
+import filecmp
 from importlib import import_module
 
 import click
@@ -10,6 +11,7 @@ import click
 from .utils import import_file
 
 logger = logging.getLogger(__name__)
+
 
 def validate_preload_argv(ctx, param, value):
     """Click option callback providing validation of preload subcommand arguments."""
@@ -47,8 +49,8 @@ def validate_preload_argv(ctx, param, value):
 
 def _import_modules(names, file_dir=None):
     """ Imports modules and extracts preload interface functions.
-    
-    Imports modules specified by names and extracts 'dask_command', 
+
+    Imports modules specified by names and extracts 'dask_command',
     'dask_setup' and 'dask_teardown' if present.
 
 
@@ -58,13 +60,13 @@ def _import_modules(names, file_dir=None):
         Module names or file paths
     file_dir: string
         Path of a directory where files should be copied
-    
+
     Returns
     -------
     Nest dict of names to extracted module interface components if present
     in imported module.
     """
-    result_modules =  {}
+    result_modules = {}
 
     for name in names:
         # import
@@ -93,6 +95,7 @@ def _import_modules(names, file_dir=None):
         }
 
     return result_modules
+
 
 def preload_modules(names, parameter=None, file_dir=None, argv=None):
     """ Imports modules, handles `dask_command`, `dask_setup` and `dask_teardown`.

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -10,8 +10,8 @@ from .utils import import_file
 logger = logging.getLogger(__name__)
 
 
-def preload_modules(names, parameter=None, file_dir=None):
-    """ Imports modules, handles `dask_setup` and `dask_teardown` functions
+def preload_modules(names, parameter=None, file_dir=None, argv=None):
+    """ Imports modules, handles `dask_setup` and `dask_teardown` functions.
 
     Parameters
     ----------
@@ -19,6 +19,8 @@ def preload_modules(names, parameter=None, file_dir=None):
         Module names or file paths
     parameter: object
         Parameter passed to `dask_setup` and `dask_teardown`
+    argv: [string]
+        List of string arguments from the preload command line specification.
     file_dir: string
         Path of a directory where files should be copied
     """
@@ -46,6 +48,9 @@ def preload_modules(names, parameter=None, file_dir=None):
         dask_setup = getattr(module, 'dask_setup', None)
         dask_teardown = getattr(module, 'dask_teardown', None)
         if dask_setup is not None:
-            dask_setup(parameter)
+            if argv:
+                dask_setup(parameter, argv=argv)
+            else:
+                dask_setup(parameter)
         if dask_teardown is not None:
             atexit.register(dask_teardown, parameter)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -82,7 +82,7 @@ class WorkerBase(ServerNode):
                  services=None, service_ports=None, name=None,
                  reconnect=True, memory_limit='auto',
                  executor=None, resources=None, silence_logs=None,
-                 death_timeout=None, preload=(), security=None,
+                 death_timeout=None, preload=(), preload_argv=[], security=None,
                  contact_address=None, memory_monitor_interval=200, **kwargs):
 
         self._setup_logging()
@@ -102,6 +102,7 @@ class WorkerBase(ServerNode):
         self.available_resources = (resources or {}).copy()
         self.death_timeout = death_timeout
         self.preload = preload
+        self.preload_argv = preload_argv,
         self.contact_address = contact_address
         self.memory_monitor_interval = memory_monitor_interval
         if silence_logs:
@@ -338,7 +339,7 @@ class WorkerBase(ServerNode):
             protocol, listen_host = listen_host.split('://')
 
         self.name = self.name or self.address
-        preload_modules(self.preload, parameter=self, file_dir=self.local_dir)
+        preload_modules(self.preload, parameter=self, file_dir=self.local_dir, argv=self.preload_argv)
         # Services listen on all addresses
         # Note Nanny is not a "real" service, just some metadata
         # passed in service_ports...

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -287,10 +287,11 @@ allows custom initialization of each scheduler/worker respectively. A module or
 python file passed as a ``--preload`` value is guaranteed to be imported before
 establishing any connection. A ``dask_setup(service)`` function is called if
 found, with a ``Scheduler`` or ``Worker`` instance as the argument. As the
-service stops, ``dask_teardown(service)`` is called if present. To support
-additional configuration a single ``--preload`` module may register additional
-command-line arguments by exposing ``dask_setup`` as a  Click_ command.
-This command will be used to parse additional arguments provided to
+service stops, ``dask_teardown(service)`` is called if present.
+
+To support additional configuration a single ``--preload`` module may register
+additional command-line arguments by exposing ``dask_setup`` as a  Click_
+command.  This command will be used to parse additional arguments provided to
 ``dask-worker`` or ``dask-scheduler`` and will be called before service
 initialization.
 
@@ -311,12 +312,12 @@ As an example, consider the following file that creates a
        def __init__(self, print_count):
          self.print_count = print_count
          SchedulerPlugin.__init__(self)
-       
+
        def add_worker(self, scheduler=None, worker=None, **kwargs):
            print("Added a new worker at:", worker)
            if self.print_count and scheduler is not None
                print("Total workers:", len(scheduler.workers))
-               
+
    @click.command
    @click.option("--print-count/--no-print-count", default=False)
    def dask_setup(scheduler, print_count):


### PR DESCRIPTION
Adds support for pass-through command line arguments to worker and scheduler preload modules via an `argv` pattern similar to that used for compiler subcommand arguments. Intended to provide support "generic" preload modules with run-time configuration.

- [x] ~~Extension of `dask_setup` interface will likely break existing preload implementations.~~ Extends preload interface with an optional `dask_command` module attribute.
- [x] Preload argument handling is *ambiguous* in the case of multiple modules. Only support a single preload module exposing the `dask_command` interface. Applications requiring multiple preload modules may declare a single "top-level" module chaining the required subcommands.
- [x] Test coverage and test updates.