### PR TITLE
DOC: get_client and dask.compute example

### DIFF
--- a/docs/source/task-launch.rst
+++ b/docs/source/task-launch.rst
@@ -116,9 +116,9 @@ object that connects to the scheduler. There are three options for this:
 dask.delayed
 ~~~~~~~~~~~~
 
-`dask.delayed`_ behaves as normal: it submits the functions to the graph,
-optimizes for less bandwidth/computation and gathers the results.
-For more detail, see `dask.delayed`_.
+The Dask delayed behaves as normal: it submits the functions to the graph,
+optimizes for less bandwidth/computation and gathers the results.  For more
+detail, see `dask.delayed`_.
 
 .. code-block:: python
 
@@ -149,9 +149,9 @@ For more detail, see `dask.delayed`_.
 Getting the client on a worker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :py:func:`distributed.get_client` function provides a normal Client object that gives full
-access to the dask cluster, including the ability to submit, scatter, and
-gather results.
+The :py:func:`get_client <distributed.get_client>` function provides a normal
+Client object that gives full access to the dask cluster, including the ability
+to submit, scatter, and gather results.
 
 .. code-block:: python
 
@@ -177,9 +177,10 @@ once. Each task does not communicate to the scheduler that they are waiting on
 results and are free to compute other tasks. This can deadlock the cluster if
 every scheduling slot is running a task and they all request more tasks.
 
-To avoid this deadlocking issue we can use :py:func:`distributed.secede` and
-:py:func:`distributed.rejoin`. These functions will remove and rejoin the
-current task from the cluster respectively.
+To avoid this deadlocking issue we can use :py:func:`secede
+<distributed.secede>` and :py:func:`rejoin <distributed.rejoin>`. These
+functions will remove and rejoin the current task from the cluster
+respectively.
 
 .. code-block:: python
 
@@ -197,9 +198,10 @@ current task from the cluster respectively.
 Connection with context manager
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :py:func:`distributed.worker_client` function performs the same task as
-:py:func:`distributed.get_client`, but is implemented as a context manager.
-Using ``worker_client`` as a context manager ensures proper cleanup on the
+The :py:func:`worker_client <distributed.worker_client>` function performs the
+same task as :py:func:`get_client <distributed.get_client>`, but is implemented
+as a context manager.  Using :py:func:`worker_client
+<distributed.worker_client>` as a context manager ensures proper cleanup on the
 worker.
 
 .. code-block:: python
@@ -222,11 +224,11 @@ worker.
         result = future.result()
         print(result)  # prints "55"
 
-Tasks that invoke ``worker_client`` are conservatively assumed to be *long
+Tasks that invoke :py:func:`worker_client <distributed.worker_client>` are conservatively assumed to be *long
 running*.  They can take a long time blocking, waiting for other tasks to
 finish, gathering results, etc. In order to avoid having them take up
 processing slots the following actions occur whenever a task invokes
-``worker_client``.
+:py:func:`worker_client <distributed.worker_client>`.
 
 1.  The thread on the worker running this function *secedes* from the thread
     pool and goes off on its own.  This allows the thread pool to populate that

--- a/docs/source/task-launch.rst
+++ b/docs/source/task-launch.rst
@@ -90,9 +90,7 @@ submitting tasks from tasks.
        b = fib(n - 2)
        return a + b
 
-   if __name__ == "__main__":
-       result = fib(10)
-       print(result)  # prints "55"
+   print(fib(10))  # prints "55"
 
 We will use this example to show the different interfaces.
 
@@ -138,11 +136,11 @@ detail, see `dask.delayed`_.
         return a + b
 
     if __name__ == "__main__":
-        # these features require the newer dask.distributed scheduler
+        # these features require the dask.distributed scheduler
         client = Client()
 
         result = fib(10).compute()
-        print(result)  # print "55"
+        print(result)  # prints "55"
 
 .. _dask.delayed: https://dask.pydata.org/en/latest/delayed.html
 
@@ -206,7 +204,7 @@ worker.
 
 .. code-block:: python
 
-    from distributed import worker_client
+    from dask.distributed import worker_client
 
 
     def fib(n):
@@ -224,11 +222,11 @@ worker.
         result = future.result()
         print(result)  # prints "55"
 
-Tasks that invoke :py:func:`worker_client <distributed.worker_client>` are conservatively assumed to be *long
-running*.  They can take a long time blocking, waiting for other tasks to
-finish, gathering results, etc. In order to avoid having them take up
-processing slots the following actions occur whenever a task invokes
-:py:func:`worker_client <distributed.worker_client>`.
+Tasks that invoke :py:func:`worker_client <distributed.worker_client>` are
+conservatively assumed to be *long running*.  They can take a long time,
+waiting for other tasks to finish, gathering results, etc. In order to avoid
+having them take up processing slots the following actions occur whenever a
+task invokes :py:func:`worker_client <distributed.worker_client>`.
 
 1.  The thread on the worker running this function *secedes* from the thread
     pool and goes off on its own.  This allows the thread pool to populate that
@@ -238,6 +236,6 @@ processing slots the following actions occur whenever a task invokes
     allowed number of tasks by one.  This likewise lets the scheduler allocate
     more tasks to this worker, not counting this long running task against it.
 
-Establishing a connection to the scheduler takes on the order of 10—20 ms and
-so it is wise for computations that use this feature to be at least a few times
+Establishing a connection to the scheduler takes a few milliseconds and so it
+is wise for computations that use this feature to be at least a few times
 longer in duration than this.

--- a/docs/source/task-launch.rst
+++ b/docs/source/task-launch.rst
@@ -179,8 +179,7 @@ optimizes for less bandwidth/computation and gathers the results.
     client = Client()  # to change default dask scheduler
     assert fib(4).compute() == 3
 
-Computation of this function will continue on this node after completion of
-``dask.gather``.
+Look at the documentation of ``dask.compute`` for more detail.
 
 ``get_client``
 ~~~~~~~~~~~~~~
@@ -199,15 +198,16 @@ a node.
         client = get_client()
         jobs = client.map(fib, [n-1, n-2])
         secede()  # so we don't take up a scheduling slot
-        out = client.gather(jobs)
-        rejoin()
-        return sum(out)
+        return sum(client.gather(jobs))
 
     client = Client()
     assert fib(4) == 3
 
 Note that if all nodes submit jobs but none call ``secede`` this will lock the
 cluster and no computation will be performed.
+
+``rejoin`` is also available, and may be more advantageous if more work is done
+(and not just a ``return`` statement).
 
 ``dask.worker_client``
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The page on launching tasks from workers was stale and only mentioned `worker_client`. This refreshes that and mentions `dask.compute` and `get_client`. It also tries to mention why one might choose a particular method.

I am unsure if I am missing any important points, and I feel the descriptions of `dask.compute` and `get_client` are too terse. Could someone look it over and suggest changes?