### PR TITLE
Catch the RuntimeError caused if the _loop_runner is already shutdown

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -243,6 +243,8 @@ class LocalCluster(object):
             del self.workers[:]
             self._loop_runner.run_sync(self._close, callback_timeout=timeout)
             self._loop_runner.stop()
+        except RuntimeError as e:
+            logger.error("%s", e)
         finally:
             self.status = 'closed'
 


### PR DESCRIPTION
This is a fix for https://github.com/dask/distributed/issues/1620