### PR TITLE
Return dictionary of worker info in retire_workers

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2587,6 +2587,26 @@ class Scheduler(ServerNode):
     @gen.coroutine
     def retire_workers(self, comm=None, workers=None, remove=True, close=False,
                        close_workers=False):
+        """ Gracefully retire workers from cluster
+
+        Parameters
+        ----------
+        workers: list (optional)
+            List of worker IDs to retire.
+            If not provided we call ``workers_to_close`` which finds a good set
+        remove: bool (defaults to True)
+            Whether or not to remove the worker metadata immediately or else
+            wait for the worker to contact us
+        close_workers: bool (defaults to False)
+            Whether or not to actually close the worker explicitly from here.
+            Otherwise we expect some external job scheduler to finish off the
+            worker.
+
+        Returns
+        -------
+        Dictionary mapping worker ID/address to dictionary of information about
+        that worker for each retired worker.
+        """
         if close:
             logger.warning("The keyword close= has been deprecated. "
                            "Use close_workers= instead")
@@ -2597,9 +2617,10 @@ class Scheduler(ServerNode):
                     try:
                         workers = self.workers_to_close()
                         if workers:
-                            yield self.retire_workers(workers=workers,
-                                                      remove=remove, close_workers=close_workers)
-                        raise gen.Return(list(workers))
+                            workers = yield self.retire_workers(workers=workers,
+                                                                remove=remove,
+                                                                close_workers=close_workers)
+                        raise gen.Return(workers)
                     except KeyError:  # keys left during replicate
                         pass
 
@@ -2620,7 +2641,8 @@ class Scheduler(ServerNode):
                 else:
                     raise gen.Return([])
 
-            worker_keys = [ws.worker_key for ws in workers]
+            worker_keys = {ws.worker_key: self.worker_info[ws.worker_key]
+                           for ws in workers}
             if close_workers and worker_keys:
                 yield [self.close_worker(worker=w, safe=True)
                        for w in worker_keys]
@@ -2631,7 +2653,7 @@ class Scheduler(ServerNode):
             self.log_event('all', {'action': 'retire-workers',
                                    'workers': worker_keys,
                                    'moved-keys': len(keys)})
-            self.log_event(worker_keys, {'action': 'retired'})
+            self.log_event(list(worker_keys), {'action': 'retired'})
 
             raise gen.Return(worker_keys)
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -603,7 +603,8 @@ def test_retire_workers(c, s, a, b):
     assert s.workers_to_close() == [a.address]
 
     workers = yield s.retire_workers()
-    assert workers == [a.address]
+    assert list(workers) == [a.address]
+    assert workers[a.address]['ncores'] == a.ncores
     assert list(s.ncores) == [b.address]
 
     assert s.workers_to_close() == []


### PR DESCRIPTION
This can be useful for cluster managers when cleaning up workers

It is decently backwards compatible assuming people are only iterating
over the result