### PR TITLE
Centralize more state into WorkerState

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -128,7 +128,7 @@ class Occupancy(DashboardComponent):
 
             bokeh_addresses = []
             for ws in workers:
-                addr = self.scheduler.get_worker_service_addr(ws.worker_key, 'bokeh')
+                addr = self.scheduler.get_worker_service_addr(ws.address, 'bokeh')
                 bokeh_addresses.append('%s:%d' % addr if addr is not None else '')
 
             y = list(range(len(workers)))
@@ -154,7 +154,7 @@ class Occupancy(DashboardComponent):
 
             if occupancy:
                 result = {'occupancy': occupancy,
-                          'worker': [ws.worker_key for ws in workers],
+                          'worker': [ws.address for ws in workers],
                           'ms': ms,
                           'color': color,
                           'bokeh_address': bokeh_addresses,
@@ -307,7 +307,7 @@ class CurrentLoad(DashboardComponent):
 
             bokeh_addresses = []
             for ws in workers:
-                addr = self.scheduler.get_worker_service_addr(ws.worker_key, 'bokeh')
+                addr = self.scheduler.get_worker_service_addr(ws.address, 'bokeh')
                 bokeh_addresses.append('%s:%d' % addr if addr is not None else '')
 
             y = list(range(len(workers)))
@@ -327,7 +327,7 @@ class CurrentLoad(DashboardComponent):
             max_limit = 0
             for ws, nb in zip(workers, nbytes):
                 try:
-                    limit = self.scheduler.worker_info[ws.worker_key]['memory_limit']
+                    limit = self.scheduler.worker_info[ws.address]['memory_limit']
                 except KeyError:
                     limit = 16e9
                 if limit > max_limit:
@@ -351,7 +351,7 @@ class CurrentLoad(DashboardComponent):
                           'nbytes-color': nbytes_color,
                           'nbytes_text': nbytes_text,
                           'bokeh_address': bokeh_addresses,
-                          'worker': [ws.worker_key for ws in workers],
+                          'worker': [ws.address for ws in workers],
                           'y': y}
 
                 self.nbytes_figure.title.text = 'Bytes stored: ' + format_bytes(sum(nbytes))

--- a/distributed/bokeh/templates/task.html
+++ b/distributed/bokeh/templates/task.html
@@ -12,7 +12,7 @@
           {% if ts.processing_on %}
           <tr>
               <th> processing on </th>
-              <td> {{ ts.processing_on.worker_key }} </td>
+              <td> {{ ts.processing_on.address }} </td>
           </tr>
           <tr>
               <th> call stack </th>

--- a/distributed/bokeh/templates/worker-table.html
+++ b/distributed/bokeh/templates/worker-table.html
@@ -11,9 +11,9 @@
         <th> Logs </th>
     </tr>
     {% for ws in worker_list %}
-    {% set wi = worker_info[ws.worker_key] %}
+    {% set wi = worker_info[ws.address] %}
     <tr>
-        <td><a href="/info/worker/{{ url_escape(ws.worker_key) }}.html">{{ws.worker_key}}</a></td>
+        <td><a href="/info/worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
         <td> {{ ws.ncores }} </td>
         <td> {{ format_bytes(wi['memory_limit']) }} </td>
         <td> <progress class="progress" value="{{ wi.get('memory-rss') }}" max="{{ wi['memory_limit'] }}"></progress> </td>
@@ -25,7 +25,7 @@
         {% else %}
         <td> </td>
         {% end %}
-        <td> <a href="/info/logs/{{ url_escape(ws.worker_key) }}.html">logs</a></td>
+        <td> <a href="/info/logs/{{ url_escape(ws.address) }}.html">logs</a></td>
     </tr>
     {% end %}
   </table>

--- a/distributed/bokeh/templates/worker.html
+++ b/distributed/bokeh/templates/worker.html
@@ -20,7 +20,7 @@
       <div class="column">
         <div class="content">
           <h2 class="subtitle"> Processing </h2>
-          <a class="button is-primary" href="/info/call-stacks/{{ url_escape(ws.worker_key) }}.html">Call Stacks</a>
+          <a class="button is-primary" href="/info/call-stacks/{{ url_escape(ws.address) }}.html">Call Stacks</a>
           <ul>
             {% for ts in ws.processing %}
             <li> <a href="/info/task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></li>


### PR DESCRIPTION
This moves information like `Scheduler.worker_info` into `WorkerState.info` and other attributes on WorkerState.  

We also rename `worker_key` to `address`.