### PR TITLE
Skip unhashable functions test

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5136,6 +5136,7 @@ def test_scatter_direct(s, a, b):
     yield c._close()
 
 
+@pytest.mark.skipif(sys.version_info[0] < 3, reason="cloudpickle Py27 issue")
 @gen_cluster(client=True)
 def test_unhashable_function(c, s, a, b):
     d = {'a': 1}


### PR DESCRIPTION
This fails with the new cloudpickle release on Python 2.7

I have no desire to identify and fix the problem on Python 2.7.  This is non-critical functionality.  Skipping the test.  