### PR TITLE
Share scheduler RPC between worker and client

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5007,7 +5007,8 @@ def test_client_async_before_loop_starts():
 
 
 @slow
-@gen_cluster(client=True, Worker=Nanny if PY3 else Worker, timeout=60)
+@gen_cluster(client=True, Worker=Nanny if PY3 else Worker, timeout=60,
+             ncores=[('127.0.0.1', 3)] * 2)
 def test_nested_compute(c, s, a, b):
     def fib(x):
         assert get_worker().get_current_task()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1013,7 +1013,7 @@ def test_statistical_profiling_cycle(c, s, a, b):
     assert x['count'] == sum(p['count'] for _, p in a.profile_history) + a.profile_recent['count']
 
     y = a.get_profile(start=end - 0.300, stop=time())
-    assert 0 < y['count'] < x['count']
+    assert 0 < y['count'] <= x['count']
 
 
 @gen_cluster(client=True)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2512,7 +2512,7 @@ class Worker(WorkerBase):
         if not self._client:
             from .client import Client
             asynchronous = self.loop is IOLoop.current()
-            self._client = Client(self.scheduler.address, loop=self.loop,
+            self._client = Client(self.scheduler, loop=self.loop,
                                   security=self.security,
                                   set_as_default=True,
                                   asynchronous=asynchronous,


### PR DESCRIPTION
This reduces connection pressure and avoids a race condition when two threads
of the same worker start the same client at the same time.  This caused an
intermittent failure in test_nested_compute