### PR TITLE
Add base_url parameter to Bokeh handling

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -19,7 +19,7 @@ from bokeh.models.widgets import DataTable, TableColumn
 from bokeh.plotting import figure
 from bokeh.palettes import Viridis11
 from bokeh.io import curdoc
-from toolz import pipe
+from toolz import pipe, merge
 try:
     import numpy as np
 except ImportError:
@@ -980,46 +980,42 @@ def profile_doc(scheduler, extra, doc):
 
 
 class BokehScheduler(BokehServer):
-    def __init__(self, scheduler, io_loop=None, prefix='', base_url='/', **kwargs):
+    def __init__(self, scheduler, io_loop=None, prefix='', **kwargs):
         self.scheduler = scheduler
         self.server_kwargs = kwargs
         self.server_kwargs['prefix'] = prefix or None
-        if not base_url.startswith('/'):
-            base_url = '/' + base_url
-        if not base_url.endswith('/'):
-            base_url = base_url + '/'
-        self.base_url = base_url
         prefix = prefix or ''
         prefix = prefix.rstrip('/')
         if prefix and not prefix.startswith('/'):
             prefix = '/' + prefix
+        self.prefix = prefix
 
-        self.extra = extra = {'prefix': prefix, 'base_url': base_url}
-        extra.update(template_variables)
-
-        systemmonitor = Application(FunctionHandler(partial(systemmonitor_doc, scheduler, extra)))
-        workers = Application(FunctionHandler(partial(workers_doc, scheduler, extra)))
-        stealing = Application(FunctionHandler(partial(stealing_doc, scheduler, extra)))
-        counters = Application(FunctionHandler(partial(counters_doc, scheduler, extra)))
-        events = Application(FunctionHandler(partial(events_doc, scheduler, extra)))
-        tasks = Application(FunctionHandler(partial(tasks_doc, scheduler, extra)))
-        status = Application(FunctionHandler(partial(status_doc, scheduler, extra)))
-        profile = Application(FunctionHandler(partial(profile_doc, scheduler, extra)))
+        systemmonitor = Application(FunctionHandler(partial(systemmonitor_doc, scheduler, self.extra)))
+        workers = Application(FunctionHandler(partial(workers_doc, scheduler, self.extra)))
+        stealing = Application(FunctionHandler(partial(stealing_doc, scheduler, self.extra)))
+        counters = Application(FunctionHandler(partial(counters_doc, scheduler, self.extra)))
+        events = Application(FunctionHandler(partial(events_doc, scheduler, self.extra)))
+        tasks = Application(FunctionHandler(partial(tasks_doc, scheduler, self.extra)))
+        status = Application(FunctionHandler(partial(status_doc, scheduler, self.extra)))
+        profile = Application(FunctionHandler(partial(profile_doc, scheduler, self.extra)))
 
         self.apps = {
-            'system': systemmonitor,
-            'stealing': stealing,
-            'workers': workers,
-            'events': events,
-            'counters': counters,
-            'tasks': tasks,
-            'status': status,
-            'profile': profile,
+            '/system': systemmonitor,
+            '/stealing': stealing,
+            '/workers': workers,
+            '/events': events,
+            '/counters': counters,
+            '/tasks': tasks,
+            '/status': status,
+            '/profile': profile,
         }
-        self.apps = {self.base_url + k: v for k, v in self.apps.items()}
 
         self.loop = io_loop or scheduler.loop
         self.server = None
+
+    @property
+    def extra(self):
+        return merge({'prefix': self.prefix}, template_variables)
 
     @property
     def my_server(self):
@@ -1029,6 +1025,6 @@ class BokehScheduler(BokehServer):
         super(BokehScheduler, self).listen(*args, **kwargs)
 
         from .scheduler_html import routes
-        handlers = [(self.base_url + url, cls, {'server': self.my_server, 'extra': self.extra})
+        handlers = [(self.prefix + '/' + url, cls, {'server': self.my_server, 'extra': self.extra})
                     for url, cls in routes]
         self.server._tornado.add_handlers(r'.*', handlers)

--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -982,13 +982,14 @@ def profile_doc(scheduler, extra, doc):
 class BokehScheduler(BokehServer):
     def __init__(self, scheduler, io_loop=None, prefix='', **kwargs):
         self.scheduler = scheduler
-        self.server_kwargs = kwargs
-        self.server_kwargs['prefix'] = prefix or None
         prefix = prefix or ''
         prefix = prefix.rstrip('/')
         if prefix and not prefix.startswith('/'):
             prefix = '/' + prefix
         self.prefix = prefix
+
+        self.server_kwargs = kwargs
+        self.server_kwargs['prefix'] = prefix or None
 
         systemmonitor = Application(FunctionHandler(partial(systemmonitor_doc, scheduler, self.extra)))
         workers = Application(FunctionHandler(partial(workers_doc, scheduler, self.extra)))

--- a/distributed/bokeh/template.html
+++ b/distributed/bokeh/template.html
@@ -103,9 +103,9 @@
       <ul>
           <li><a href="http://dask.pydata.org/en/latest/" style="padding:0px 0px;"><img src="https://dask.readthedocs.io/en/latest/_images/dask_horizontal.svg"></a></li>
           {% for page in pages %}
-          <li{% if page == active_page %} class="active"{% endif %}><a href="{{ prefix }}/{{ page }}">{{ page|title }}</a></li>
+          <li{% if page == active_page %} class="active"{% endif %}><a href="{{ base_url }}{{ page }}">{{ page|title }}</a></li>
           {% endfor %}
-          <li><a href="/info/workers.html">Info</a></li>
+          <li><a href="{{ base_url }}info/workers.html">Info</a></li>
       </ul>
     </div>
     <div class="dashboard">

--- a/distributed/bokeh/template.html
+++ b/distributed/bokeh/template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
+      <meta charset="utf-8"></meta>
     <title>Dask - Status dashboard</title>
     {{ bokeh_css }}
     {{ bokeh_js }}
@@ -101,11 +101,11 @@
   <body>
     <div class="navbar">
       <ul>
-          <li><a href="http://dask.pydata.org/en/latest/" style="padding:0px 0px;"><img src="https://dask.readthedocs.io/en/latest/_images/dask_horizontal.svg"></a></li>
+          <li><a href="http://dask.pydata.org/en/latest/" style="padding:0px 0px;"><img src="https://dask.readthedocs.io/en/latest/_images/dask_horizontal.svg"></img></a></li>
           {% for page in pages %}
-          <li{% if page == active_page %} class="active"{% endif %}><a href="{{ base_url }}{{ page }}">{{ page|title }}</a></li>
+          <li{% if page == active_page %} class="active"{% endif %}><a href="{{ prefix }}/{{ page }}">{{ page|title }}</a></li>
           {% endfor %}
-          <li><a href="{{ base_url }}info/workers.html">Info</a></li>
+          <li><a href="{{ prefix }}/info/workers.html">Info</a></li>
       </ul>
     </div>
     <div class="dashboard">

--- a/distributed/bokeh/templates/json-index.html
+++ b/distributed/bokeh/templates/json-index.html
@@ -4,7 +4,7 @@
     <p> These are typically used by automated services to query the state of the scheduler </p>
     <ul>
       {% for url in routes %}
-      <li><a href="{{base_url}}{{url}}">{{url}}</a></li>
+      <li><a href="{{prefix}}/{{url}}">{{url}}</a></li>
       {% end %}
     </ul>
   </body>

--- a/distributed/bokeh/templates/json-index.html
+++ b/distributed/bokeh/templates/json-index.html
@@ -4,7 +4,7 @@
     <p> These are typically used by automated services to query the state of the scheduler </p>
     <ul>
       {% for url in routes %}
-      <li><a href="{{url}}">{{url}}</a></li>
+      <li><a href="{{base_url}}{{url}}">{{url}}</a></li>
       {% end %}
     </ul>
   </body>

--- a/distributed/bokeh/templates/task.html
+++ b/distributed/bokeh/templates/task.html
@@ -16,7 +16,7 @@
           </tr>
           <tr>
               <th> call stack </th>
-              <td><a class="button is-primary" href="/info/call-stack/{{ url_escape(Task) }}.html">Call Stack</a></td>
+              <td><a class="button is-primary" href="{{base_url}}info/call-stack/{{ url_escape(Task) }}.html">Call Stack</a></td>
           </tr>
           {% end %}
           {% if ts.nbytes %}
@@ -29,7 +29,7 @@
           {% for dts in ts.waiting_on %}
           <tr>
               <td> waiting on </td>
-              <td><a href="/info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
+              <td><a href="{{base_url}}info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
           </tr>
           {% end %}
           {% end %}
@@ -45,7 +45,7 @@
           </thead>
           {% for dts in ts.dependencies %}
           <tr>
-            <td> <a href="/info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
+            <td> <a href="{{base_url}}info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
             <td> {{ dts.state }} </td>
           </tr>
           {% end %}
@@ -61,7 +61,7 @@
           </thead>
           {% for dts in ts.dependents %}
           <tr>
-            <td> <a href="/info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
+            <td> <a href="{{base_url}}info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
             <td> {{ dts.state }} </td>
           </tr>
           {% end %}
@@ -84,7 +84,7 @@
         <div class="content">
           <ul>
             {% for cs in ts.who_wants %}
-            <li> <a href="/info/client/{{ url_escape(cs.client_key) }}.html">{{cs.client_key}}</a></li>
+            <li> <a href="{{base_url}}info/client/{{ url_escape(cs.client_key) }}.html">{{cs.client_key}}</a></li>
             {% end %}
           </ul>
         </div>
@@ -107,7 +107,7 @@
               {% for key, start, finish, recommendations, time in server.story(Task) %}
               <tr>
                   <td> {{ fromtimestamp(time) }} </td>
-                  <td> <a href="/info/task/{{ url_escape(key) }}.html">{{key}}</a> </td>
+                  <td> <a href="{{base_url}}info/task/{{ url_escape(key) }}.html">{{key}}</a> </td>
                   <td> {{ start }} </td>
                   <td> {{ finish }} </td>
                   <td> </td>
@@ -119,7 +119,7 @@
                   <td> </td>
                   <td> </td>
                   <td> </td>
-                  <td> <a href="/info/task/{{ url_escape(key2) }}.html">{{key2}}</a> </td>
+                  <td> <a href="{{base_url}}info/task/{{ url_escape(key2) }}.html">{{key2}}</a> </td>
                   <td> {{ rec }} </td>
               </tr>
                 {% end %}

--- a/distributed/bokeh/templates/task.html
+++ b/distributed/bokeh/templates/task.html
@@ -16,7 +16,7 @@
           </tr>
           <tr>
               <th> call stack </th>
-              <td><a class="button is-primary" href="{{base_url}}info/call-stack/{{ url_escape(Task) }}.html">Call Stack</a></td>
+              <td><a class="button is-primary" href="{{prefix}}/info/call-stack/{{ url_escape(Task) }}.html">Call Stack</a></td>
           </tr>
           {% end %}
           {% if ts.nbytes %}
@@ -29,7 +29,7 @@
           {% for dts in ts.waiting_on %}
           <tr>
               <td> waiting on </td>
-              <td><a href="{{base_url}}info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
+              <td><a href="{{prefix}}/info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
           </tr>
           {% end %}
           {% end %}
@@ -45,7 +45,7 @@
           </thead>
           {% for dts in ts.dependencies %}
           <tr>
-            <td> <a href="{{base_url}}info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
+            <td> <a href="{{prefix}}/info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
             <td> {{ dts.state }} </td>
           </tr>
           {% end %}
@@ -61,7 +61,7 @@
           </thead>
           {% for dts in ts.dependents %}
           <tr>
-            <td> <a href="{{base_url}}info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
+            <td> <a href="{{prefix}}/info/task/{{ url_escape(dts.key) }}.html">{{dts.key}}</a> </td>
             <td> {{ dts.state }} </td>
           </tr>
           {% end %}
@@ -84,7 +84,7 @@
         <div class="content">
           <ul>
             {% for cs in ts.who_wants %}
-            <li> <a href="{{base_url}}info/client/{{ url_escape(cs.client_key) }}.html">{{cs.client_key}}</a></li>
+            <li> <a href="{{prefix}}/info/client/{{ url_escape(cs.client_key) }}.html">{{cs.client_key}}</a></li>
             {% end %}
           </ul>
         </div>
@@ -107,7 +107,7 @@
               {% for key, start, finish, recommendations, time in server.story(Task) %}
               <tr>
                   <td> {{ fromtimestamp(time) }} </td>
-                  <td> <a href="{{base_url}}info/task/{{ url_escape(key) }}.html">{{key}}</a> </td>
+                  <td> <a href="{{prefix}}/info/task/{{ url_escape(key) }}.html">{{key}}</a> </td>
                   <td> {{ start }} </td>
                   <td> {{ finish }} </td>
                   <td> </td>
@@ -119,7 +119,7 @@
                   <td> </td>
                   <td> </td>
                   <td> </td>
-                  <td> <a href="{{base_url}}info/task/{{ url_escape(key2) }}.html">{{key2}}</a> </td>
+                  <td> <a href="{{prefix}}/info/task/{{ url_escape(key2) }}.html">{{key2}}</a> </td>
                   <td> {{ rec }} </td>
               </tr>
                 {% end %}

--- a/distributed/bokeh/templates/worker-table.html
+++ b/distributed/bokeh/templates/worker-table.html
@@ -13,7 +13,7 @@
     {% for ws in worker_list %}
     {% set wi = worker_info[ws.address] %}
     <tr>
-        <td><a href="/info/worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
+        <td><a href="{{base_url}}info/worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
         <td> {{ ws.ncores }} </td>
         <td> {{ format_bytes(wi['memory_limit']) }} </td>
         <td> <progress class="progress" value="{{ wi.get('memory-rss') }}" max="{{ wi['memory_limit'] }}"></progress> </td>
@@ -25,7 +25,7 @@
         {% else %}
         <td> </td>
         {% end %}
-        <td> <a href="/info/logs/{{ url_escape(ws.address) }}.html">logs</a></td>
+        <td> <a href="{{base_url}}info/logs/{{ url_escape(ws.address) }}.html">logs</a></td>
     </tr>
     {% end %}
   </table>

--- a/distributed/bokeh/templates/worker-table.html
+++ b/distributed/bokeh/templates/worker-table.html
@@ -13,7 +13,7 @@
     {% for ws in worker_list %}
     {% set wi = worker_info[ws.address] %}
     <tr>
-        <td><a href="{{base_url}}info/worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
+        <td><a href="{{prefix}}/info/worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
         <td> {{ ws.ncores }} </td>
         <td> {{ format_bytes(wi['memory_limit']) }} </td>
         <td> <progress class="progress" value="{{ wi.get('memory-rss') }}" max="{{ wi['memory_limit'] }}"></progress> </td>
@@ -25,7 +25,7 @@
         {% else %}
         <td> </td>
         {% end %}
-        <td> <a href="{{base_url}}info/logs/{{ url_escape(ws.address) }}.html">logs</a></td>
+        <td> <a href="{{prefix}}/info/logs/{{ url_escape(ws.address) }}.html">logs</a></td>
     </tr>
     {% end %}
   </table>

--- a/distributed/bokeh/templates/worker.html
+++ b/distributed/bokeh/templates/worker.html
@@ -11,7 +11,7 @@
           <h2 class="subtitle"> In Memory </h2>
           <ul>
             {% for ts in ws.has_what %}
-            <li> <a href="/info/task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></li>
+            <li> <a href="{{base_url}}info/task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></li>
             {% end %}
           </ul>
         </div>
@@ -20,10 +20,10 @@
       <div class="column">
         <div class="content">
           <h2 class="subtitle"> Processing </h2>
-          <a class="button is-primary" href="/info/call-stacks/{{ url_escape(ws.address) }}.html">Call Stacks</a>
+          <a class="button is-primary" href="{{base_url}}info/call-stacks/{{ url_escape(ws.address) }}.html">Call Stacks</a>
           <ul>
             {% for ts in ws.processing %}
-            <li> <a href="/info/task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></li>
+            <li> <a href="{{base_url}}info/task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></li>
             {% end %}
           </ul>
         </div>

--- a/distributed/bokeh/templates/worker.html
+++ b/distributed/bokeh/templates/worker.html
@@ -11,7 +11,7 @@
           <h2 class="subtitle"> In Memory </h2>
           <ul>
             {% for ts in ws.has_what %}
-            <li> <a href="{{base_url}}info/task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></li>
+            <li> <a href="{{prefix}}/info/task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></li>
             {% end %}
           </ul>
         </div>
@@ -20,10 +20,10 @@
       <div class="column">
         <div class="content">
           <h2 class="subtitle"> Processing </h2>
-          <a class="button is-primary" href="{{base_url}}info/call-stacks/{{ url_escape(ws.address) }}.html">Call Stacks</a>
+          <a class="button is-primary" href="{{prefix}}/info/call-stacks/{{ url_escape(ws.address) }}.html">Call Stacks</a>
           <ul>
             {% for ts in ws.processing %}
-            <li> <a href="{{base_url}}info/task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></li>
+            <li> <a href="{{prefix}}/info/task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></li>
             {% end %}
           </ul>
         </div>

--- a/distributed/bokeh/templates/workers.html
+++ b/distributed/bokeh/templates/workers.html
@@ -1,8 +1,8 @@
 {% extends main.html %}
 {% block content %}
 
-  <a class="button is-primary" href="{{base_url}}info/logs.html">Logs</a>
-  <a class="button is-primary" href="{{base_url}}status">Bokeh</a>
+  <a class="button is-primary" href="{{prefix}}/info/logs.html">Logs</a>
+  <a class="button is-primary" href="{{prefix}}/status">Bokeh</a>
 
   {% set worker_list = list(workers.values()) %}
   {% include "worker-table.html" %}

--- a/distributed/bokeh/templates/workers.html
+++ b/distributed/bokeh/templates/workers.html
@@ -1,8 +1,8 @@
 {% extends main.html %}
 {% block content %}
 
-  <a class="button is-primary" href="/info/logs.html">Logs</a>
-  <a class="button is-primary" href="/status">Bokeh</a>
+  <a class="button is-primary" href="{{base_url}}info/logs.html">Logs</a>
+  <a class="button is-primary" href="{{base_url}}status">Bokeh</a>
 
   {% set worker_list = list(workers.values()) %}
   {% include "worker-table.html" %}

--- a/distributed/bokeh/tests/test_scheduler_bokeh_html.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh_html.py
@@ -43,8 +43,8 @@ def test_connect(c, s, a, b):
 
 @gen_cluster(client=True,
              scheduler_kwargs={'services': {('bokeh', 0):  (BokehScheduler,
-                 {'base_url': '/foo'})}})
-def test_base_url(c, s, a, b):
+                 {'prefix': '/foo'})}})
+def test_prefix(c, s, a, b):
     http_client = AsyncHTTPClient()
     for suffix in ['foo/info/workers.html',
                    'foo/json/index.html',

--- a/distributed/bokeh/tests/test_scheduler_bokeh_html.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh_html.py
@@ -39,3 +39,21 @@ def test_connect(c, s, a, b):
             json.loads(body)
         else:
             assert xml.etree.ElementTree.fromstring(body) is not None
+
+
+@gen_cluster(client=True,
+             scheduler_kwargs={'services': {('bokeh', 0):  (BokehScheduler,
+                 {'base_url': '/foo'})}})
+def test_base_url(c, s, a, b):
+    http_client = AsyncHTTPClient()
+    for suffix in ['foo/info/workers.html',
+                   'foo/json/index.html',
+                   'foo/system']:
+        response = yield http_client.fetch('http://localhost:%d/%s'
+                                           % (s.services['bokeh'].port, suffix))
+        assert response.code == 200
+        body = response.body.decode()
+        if suffix.endswith('.json'):
+            json.loads(body)
+        else:
+            assert xml.etree.ElementTree.fromstring(body) is not None

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -48,8 +48,6 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
               help="IP addresses to whitelist for bokeh.")
 @click.option('--bokeh-prefix', type=str, default=None,
               help="Prefix for the bokeh app")
-@click.option('--bokeh-base-url', type=str, default='/',
-              help="Base URL for the bokeh app")
 @click.option('--use-xheaders', type=bool, default=False, show_default=True,
               help="User xheaders in bokeh app for ssl termination in header")
 @click.option('--pid-file', type=str, default='',
@@ -63,7 +61,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process like "foo.bar" or "/path/to/foo.py"')
 def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,
-         bokeh_base_url, use_xheaders, pid_file, scheduler_file, interface,
+         use_xheaders, pid_file, scheduler_file, interface,
          local_directory, preload, tls_ca_file, tls_cert, tls_key):
 
     enable_proctitle_on_current()
@@ -116,8 +114,7 @@ def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,
         with ignoring(ImportError):
             from distributed.bokeh.scheduler import BokehScheduler
             services[('bokeh', bokeh_port)] = (BokehScheduler,
-                                               {'prefix': bokeh_prefix,
-                                                'base_url': bokeh_base_url})
+                                               {'prefix': bokeh_prefix})
     scheduler = Scheduler(loop=loop, services=services,
                           scheduler_file=scheduler_file,
                           security=sec)

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 import atexit
-from functools import partial
 import logging
 import os
 import shutil
@@ -49,6 +48,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
               help="IP addresses to whitelist for bokeh.")
 @click.option('--bokeh-prefix', type=str, default=None,
               help="Prefix for the bokeh app")
+@click.option('--bokeh-base-url', type=str, default='/',
+              help="Base URL for the bokeh app")
 @click.option('--use-xheaders', type=bool, default=False, show_default=True,
               help="User xheaders in bokeh app for ssl termination in header")
 @click.option('--pid-file', type=str, default='',
@@ -61,10 +62,10 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
               help="Directory to place scheduler files")
 @click.option('--preload', type=str, multiple=True,
               help='Module that should be loaded by each worker process like "foo.bar" or "/path/to/foo.py"')
-def main(host, port, bokeh_port, show, _bokeh,
-         bokeh_whitelist, bokeh_prefix, use_xheaders, pid_file, scheduler_file,
-         interface, local_directory, preload, tls_ca_file, tls_cert,
-         tls_key):
+def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,
+         bokeh_base_url, use_xheaders, pid_file, scheduler_file, interface,
+         local_directory, preload, tls_ca_file, tls_cert, tls_key):
+
     enable_proctitle_on_current()
     enable_proctitle_on_children()
 
@@ -114,8 +115,9 @@ def main(host, port, bokeh_port, show, _bokeh,
     if _bokeh:
         with ignoring(ImportError):
             from distributed.bokeh.scheduler import BokehScheduler
-            services[('bokeh', bokeh_port)] = partial(BokehScheduler,
-                                                      prefix=bokeh_prefix)
+            services[('bokeh', bokeh_port)] = (BokehScheduler,
+                                               {'prefix': bokeh_prefix,
+                                                'base_url': bokeh_base_url})
     scheduler = Scheduler(loop=loop, services=services,
                           scheduler_file=scheduler_file,
                           security=sec)

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -58,7 +58,7 @@ class LocalCluster(object):
     >>> c.remove_worker(w)  # doctest: +SKIP
 
     Pass extra keyword arguments to Bokeh
-    >>> LocalCluster(service_kwargs={'bokeh': {'base_url': '/foo'}})  # doctest: +SKIP
+    >>> LocalCluster(service_kwargs={'bokeh': {'prefix': '/foo'}})  # doctest: +SKIP
     """
     def __init__(self, n_workers=None, threads_per_worker=None, processes=True,
                  loop=None, start=True, ip=None, scheduler_port=0,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -63,7 +63,7 @@ class LocalCluster(object):
     def __init__(self, n_workers=None, threads_per_worker=None, processes=True,
                  loop=None, start=True, ip=None, scheduler_port=0,
                  silence_logs=logging.CRITICAL, diagnostics_port=8787,
-                 services={}, worker_services={}, service_kwargs={}, **worker_kwargs):
+                 services={}, worker_services={}, service_kwargs=None, **worker_kwargs):
         self.status = None
         self.processes = processes
         self.silence_logs = silence_logs
@@ -94,7 +94,7 @@ class LocalCluster(object):
             except ImportError:
                 logger.debug("To start diagnostics web server please install Bokeh")
             else:
-                services[('bokeh', diagnostics_port)] = (BokehScheduler, service_kwargs.get('bokeh', {}))
+                services[('bokeh', diagnostics_port)] = (BokehScheduler, (service_kwargs or {}).get('bokeh', {}))
                 worker_services[('bokeh', 0)] = BokehWorker
 
         self.scheduler = Scheduler(loop=self.loop,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -40,6 +40,8 @@ class LocalCluster(object):
         IP address on which the scheduler will listen, defaults to only localhost
     kwargs: dict
         Extra worker arguments, will be passed to the Worker constructor.
+    service_kwargs: Dict[str, Dict]
+        Extra keywords to hand to the running services
 
     Examples
     --------
@@ -54,12 +56,14 @@ class LocalCluster(object):
 
     Shut down the extra worker
     >>> c.remove_worker(w)  # doctest: +SKIP
-    """
 
+    Pass extra keyword arguments to Bokeh
+    >>> LocalCluster(service_kwargs={'bokeh': {'base_url': '/foo'}})  # doctest: +SKIP
+    """
     def __init__(self, n_workers=None, threads_per_worker=None, processes=True,
                  loop=None, start=True, ip=None, scheduler_port=0,
                  silence_logs=logging.CRITICAL, diagnostics_port=8787,
-                 services={}, worker_services={}, **worker_kwargs):
+                 services={}, worker_services={}, service_kwargs={}, **worker_kwargs):
         self.status = None
         self.processes = processes
         self.silence_logs = silence_logs
@@ -90,7 +94,7 @@ class LocalCluster(object):
             except ImportError:
                 logger.debug("To start diagnostics web server please install Bokeh")
             else:
-                services[('bokeh', diagnostics_port)] = BokehScheduler
+                services[('bokeh', diagnostics_port)] = (BokehScheduler, service_kwargs.get('bokeh', {}))
                 worker_services[('bokeh', 0)] = BokehWorker
 
         self.scheduler = Scheduler(loop=self.loop,

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -325,9 +325,9 @@ def test_death_timeout_raises(loop):
             pass
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason='Unknown')
 def test_bokeh_kwargs(loop):
     pytest.importorskip('bokeh')
-    import requests
     with LocalCluster(scheduler_port=0, silence_logs=False, loop=loop,
                       diagnostics_port=0,
                       service_kwargs={'bokeh': {'prefix': '/foo'}}) as c:

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -330,7 +330,7 @@ def test_bokeh_kwargs(loop):
     import requests
     with LocalCluster(scheduler_port=0, silence_logs=False, loop=loop,
                       diagnostics_port=0,
-                      service_kwargs={'bokeh': {'base_url': '/foo'}}) as c:
+                      service_kwargs={'bokeh': {'prefix': '/foo'}}) as c:
 
         bs = c.scheduler.services['bokeh']
-        assert bs.base_url == '/foo/'
+        assert bs.prefix == '/foo'

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -323,3 +323,14 @@ def test_death_timeout_raises(loop):
                           death_timeout=1e-10, diagnostics_port=None,
                           loop=loop) as cluster:
             pass
+
+
+def test_bokeh_kwargs(loop):
+    pytest.importorskip('bokeh')
+    import requests
+    with LocalCluster(scheduler_port=0, silence_logs=False, loop=loop,
+                      diagnostics_port=0,
+                      service_kwargs={'bokeh': {'base_url': '/foo'}}) as c:
+
+        bs = c.scheduler.services['bokeh']
+        assert bs.base_url == '/foo/'

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -972,11 +972,16 @@ class Scheduler(ServerNode):
             else:
                 port = 0
 
+            if isinstance(v, tuple):
+                v, kwargs = v
+            else:
+                kwargs = {}
+
             if listen_ip == '0.0.0.0':
                 listen_ip = ''  # for IPv6
 
             try:
-                service = v(self, io_loop=self.loop)
+                service = v(self, io_loop=self.loop, **kwargs)
                 service.listen((listen_ip, port))
                 self.services[k] = service
             except Exception as e:


### PR DESCRIPTION
This adds a `base_url` to all links within the Bokeh dashboard.  So that instead of serving at `/foo` we now serve at `/some_base_url/foo` .  Most links within our application seem to propagate fine, however we seem to have lost the actual Bokeh plots themselves.  The template renders but the plots don't.  

cc @bryevdv if you have thoughts on this I would welcome help here.