### PR TITLE
Support tuple-keys in retries

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3045,15 +3045,16 @@ class Client(Node):
         to a {task key: Integral} dictionary.
         """
         if retries and isinstance(retries, dict):
-            return {name: value
-                    for key, value in retries.items()
-                    for name in cls._expand_key(key)}
+            result = {name: value
+                      for key, value in retries.items()
+                      for name in cls._expand_key(key)}
         elif isinstance(retries, Integral):
             # Each task unit may potentially fail, allow retrying all of them
-            return {name: retries for name in all_keys}
+            result = {name: retries for name in all_keys}
         else:
             raise TypeError("`retries` should be an integer or dict, got %r"
                             % (type(retries,)))
+        return keymap(tokey, result)
 
     def _expand_resources(cls, resources, all_keys):
         """

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -270,6 +270,15 @@ def test_persist_retries(c, s, a, b):
 
 
 @gen_cluster(client=True)
+def test_retries_dask_array(c, s, a, b):
+    da = pytest.importorskip('dask.array')
+    x = da.ones((10, 10), chunks=(3, 3))
+    future = c.compute(x.sum(), retries=2)
+    y = yield future
+    assert y == 100
+
+
+@gen_cluster(client=True)
 def test_future_repr(c, s, a, b):
     x = c.submit(inc, 10)
     for func in [repr, lambda x: x._repr_html_()]:


### PR DESCRIPTION
Previously the retries dict passed to the scheduler contained the keys
of the dask collection.  This could be problematic when those keys were
tuples, such as is the case in dask.array and dask.dataframe.  We now
sanitize the keys with the ``tokey`` function.

In the future we might consider cleaning this up ahead of time.
Currently we do it both in retires and in `_graph_to_futures`.