### PR TITLE
Make log length configurable, default to zero

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -6,6 +6,7 @@ import logging
 from tornado import gen, locks
 from tornado.ioloop import IOLoop
 
+from .config import config
 from .core import CommClosedError
 
 
@@ -50,7 +51,7 @@ class BatchedSend(object):
         self.batch_count = 0
         self.byte_count = 0
         self.next_deadline = None
-        self.recent_message_log = deque(maxlen=100)
+        self.recent_message_log = deque(maxlen=config.get('recent-messages-log-length', 0))
 
     def start(self, comm):
         self.comm = comm

--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -855,7 +855,10 @@ class WorkerTable(DashboardComponent):
             for name in self.names:
                 data[name].append(info.get(name, None))
             data['worker'][-1] = worker
-            data['memory_percent'][-1] = info['memory'] / info['memory_limit']
+            if info['memory_limit']:
+                data['memory_percent'][-1] = info['memory'] / info['memory_limit']
+            else:
+                data['memory_percent'][-1] = ''
             data['cpu'][-1] = info['cpu'] / 100.0
             data['cpu_fraction'][-1] = info['cpu'] / 100.0 / info['ncores']
 

--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -25,6 +25,8 @@ tcp-timeout: 30         # seconds delay before calling an unresponsive connectio
 default-scheme: tcp
 require-encryption: False   # whether to require encryption on non-local comms
 socket-backlog: 2048
+recent-messages-log-length: 0  # number of messages to keep for debugging
+
 #tls:
     #ca-file: xxx.pem
     #scheduler:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1094,7 +1094,7 @@ class Worker(WorkerBase):
         self.long_running = set()
 
         self.batched_stream = None
-        self.recent_messages_log = deque(maxlen=10000)
+        self.recent_messages_log = deque(maxlen=config.get('recent-messages-log-length', 0))
         self.target_message_size = 50e6  # 50 MB
 
         self.log = deque(maxlen=100000)


### PR DESCRIPTION
This adds an entry to the config.yaml file for BatchedSend's recent
message log length.  This log is purely for debugging purposes.  We now
set it to zero by default.

Supercedes #1630 @pitrou 