### PR TITLE
Handle nested parallelism in distributed.joblib

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -514,6 +514,7 @@ class Client(Node):
         self.connection_args = self.security.get_connection_args('client')
         self._connecting_to_scheduler = False
         self._asynchronous = asynchronous
+        self._should_close_loop = not loop
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
         self.loop = self._loop_runner.loop
 
@@ -618,7 +619,7 @@ class Client(Node):
             return '<%s: not connected>' % (self.__class__.__name__,)
 
     def _repr_html_(self):
-        if self._loop_runner.is_started():
+        if self._loop_runner.is_started() and self.scheduler:
             info = sync(self.loop, self.scheduler.identity)
         else:
             info = False
@@ -1021,7 +1022,8 @@ class Client(Node):
         sync(self.loop, self._close, fast=True)
         assert self.status == 'closed'
 
-        self._loop_runner.stop()
+        if self._should_close_loop:
+            self._loop_runner.stop()
 
         with ignoring(AttributeError):
             dask.set_options(get=self._previous_get)

--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -9,7 +9,7 @@ from tornado import gen
 
 from .client import Client, _wait
 from .utils import ignoring, funcname, itemgetter
-from . import get_client, secede
+from . import get_client, secede, rejoin
 
 # A user could have installed joblib, sklearn, both, or neither. Further, only
 # joblib >= 0.10.0 supports backends, so we also need to check for that. This
@@ -186,7 +186,11 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             pass
 
         yield
-        # No need to rejoin here
+
+        try:
+            rejoin()
+        except AttributeError:
+            pass
 
 
 for base in _bases:

--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -104,6 +104,9 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             self.data_to_future = {}
         self.futures = set()
 
+    def __reduce__(self):
+        return (DaskDistributedBackend, ())
+
     def get_nested_backend(self):
         return DaskDistributedBackend()
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5166,5 +5166,13 @@ def test_client_name(s, a, b):
     yield c._close()
 
 
+def test_client_doesnt_close_given_loop(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            assert c.submit(inc, 1).result() == 2
+        with Client(s['address'], loop=loop) as c:
+            assert c.submit(inc, 2).result() == 3
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # flake8: noqa

--- a/distributed/tests/test_joblib.py
+++ b/distributed/tests/test_joblib.py
@@ -147,7 +147,6 @@ def test_nested_backend_context_manager(loop, joblib):
     def get_nested_pids():
         return Parallel(n_jobs=2)(delayed(os.getpid)() for _ in range(2))
 
-
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:
             with joblib.parallel_backend('dask') as (ba, _):
@@ -158,8 +157,7 @@ def test_nested_backend_context_manager(loop, joblib):
                 for pid_group in pid_groups:
                     assert len(set(pid_group)) <= 2
 
-    # No deadlocks
-    with cluster(nworkers=1) as (s, [a]):
+        # No deadlocks
         with Client(s['address'], loop=loop) as client:
             with joblib.parallel_backend('dask') as (ba, _):
                 pid_groups = Parallel(n_jobs=2)(
@@ -172,6 +170,9 @@ def test_nested_backend_context_manager(loop, joblib):
 
 @pytest.mark.parametrize('joblib', joblibs)
 def test_errors(loop, joblib):
+    if joblib is None:
+        pytest.skip()
+
     with pytest.raises(ValueError) as info:
         with joblib.parallel_backend('dask'):
             pass

--- a/distributed/tests/test_joblib.py
+++ b/distributed/tests/test_joblib.py
@@ -145,7 +145,9 @@ def test_nested_backend_context_manager(loop, joblib):
     delayed = joblib.delayed
 
     def get_nested_pids():
-        return Parallel(n_jobs=2)(delayed(os.getpid)() for _ in range(2))
+        pids = set(Parallel(n_jobs=2)(delayed(os.getpid)() for _ in range(2)))
+        pids |= set(Parallel(n_jobs=2)(delayed(os.getpid)() for _ in range(2)))
+        return pids
 
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as client:


### PR DESCRIPTION
This implements the new API introduced in
https://github.com/joblib/joblib/pull/538 for to ensure nested parallelism works
correctly.

This breaks our API as previously `DaskDistributedBackend` had a `client` attribute
with the `Client` that was used. I believe (though I may be wrong) that the backend object gets serialized in nested calls, and clients are not serializable.

Nested parallelism will be workers creating a `DaskDistributedBackend`, with no
'scheduler_host'. To avoid deadlocks, worker threads will secede and rejoin.

cc @ogrisel.