### PR TITLE
compute resources handle multi-dimensional collections

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3036,14 +3036,17 @@ class Client(Node):
         Expand a user-provided task key specification, e.g. in a resources
         or retries dictionary.
         """
-        if not isinstance(k, tuple):
-            k = (k,)
-        for kk in k:
-            if dask.is_dask_collection(kk):
-                for kkk in flatten(kk.__dask_keys__()):
-                    yield tokey(kkk)
-            else:
-                yield tokey(kk)
+        if isinstance(k, tuple) or isinstance(k, str) or dask.is_dask_collection(k):
+            if not isinstance(k, tuple):
+                k = (k,)
+            for kk in k:
+                if dask.is_dask_collection(kk):
+                    for kkk in flatten(kk.__dask_keys__()):
+                        yield tokey(kkk)
+                else:
+                    yield tokey(kk)
+        else:
+            raise TypeError("key should be tuple, string, or dask collection")
 
     @classmethod
     def _expand_retries(cls, retries, all_keys):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3040,7 +3040,7 @@ class Client(Node):
             k = (k,)
         for kk in k:
             if dask.is_dask_collection(kk):
-                for kkk in list(flatten([kk])):
+                for kkk in flatten(kk.__dask_keys__()):
                     yield tokey(kkk)
             else:
                 yield tokey(kk)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3037,18 +3037,10 @@ class Client(Node):
         or retries dictionary.
         """
         if not isinstance(k, tuple):
-            if not dask.is_dask_collection(k):
-                raise TypeError("key should be a tuple of dask collection")
             k = (k,)
         for kk in k:
             if dask.is_dask_collection(kk):
-
-                # flatten nested lists for multi-dim data
-                keys = kk.__dask_keys__()
-                while isinstance(keys[0], list):
-                    keys = keys[0]
-
-                for kkk in keys:
+                for kkk in list(flatten([kk])):
                     yield tokey(kkk)
             else:
                 yield tokey(kk)

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -268,13 +268,10 @@ def test_dont_optimize_out(c, s, a, b):
 def test_compute_multidim(c, s, a, b):
     da = pytest.importorskip('dask.array')
     np = pytest.importorskip('numpy')
-    x = delayed(np.random.randint)(0, 1, (5,5))
-    y = da.from_delayed(x, (5,5), int)
+    x = delayed(np.random.randint)(0, 10, (5,5))
 
     xx = c.compute(x, resources={x: {'A': 1}},)
-    yy = c.compute(y, resources={y: {'A': 1}},)
 
-    yield wait([xx, yy])
+    yield wait([xx])
     
     assert all(tokey(key) in a.data for key in x.__dask_keys__())
-    assert all(tokey(key) in a.data for key in y.__dask_keys__())

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -261,3 +261,20 @@ def test_dont_optimize_out(c, s, a, b):
 
     for key in map(tokey, y.__dask_keys__()):
         assert 'executing' in str(a.story(key))
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1, {'resources': {'A': 1}}),
+                                  ('127.0.0.1', 1, {'resources': {'B': 1}})])
+def test_compute_multidim(c, s, a, b):
+    da = pytest.importorskip('dask.array')
+    np = pytest.importorskip('numpy')
+    x = delayed(np.random.randint)(0, 1, (5,5))
+    y = da.from_delayed(x, (5,5), int)
+
+    xx = c.compute(x, resources={x: {'A': 1}},)
+    yy = c.compute(y, resources={y: {'A': 1}},)
+
+    yield wait([xx, yy])
+    
+    assert all(tokey(key) in a.data for key in x.__dask_keys__())
+    assert all(tokey(key) in a.data for key in y.__dask_keys__())

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -269,9 +269,12 @@ def test_compute_multidim(c, s, a, b):
     da = pytest.importorskip('dask.array')
     np = pytest.importorskip('numpy')
     x = delayed(np.random.randint)(0, 10, (5,5))
+    y = da.from_delayed(x, (5,5), int)
 
     xx = c.compute(x, resources={x: {'A': 1}},)
+    yy = c.compute(tupl(y.__dask_keys__()), resources={x: {'A': 1}},)
 
-    yield wait([xx])
+    yield wait([xx, yy])
     
     assert all(tokey(key) in a.data for key in x.__dask_keys__())
+    assert all(tokey(key) in a.data for key in y.__dask_keys__())

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -79,7 +79,6 @@ In some cases (such as the case above) the keys for ``y`` may be optimized away
 before execution.  You can avoid that either by requiring them as an explicit
 output, or by passing the ``optimize_graph=False`` keyword.
 
-
 .. code-block:: python
 
     z.compute(resources={tuple(y.__dask_keys__()): {'GPU': 1}, optimize_graph=False)

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -64,8 +64,8 @@ Resources with collections
 --------------------------
 
 You can also use resources with Dask collections, like arrays, dataframes, and
-delayed objects.  You can pass a dictionary mapping keys of the collection to
-resource requirements during compute or persist calls.
+delayed objects.  You can either pass the collection or a dictionary mapping keys 
+of the collection to resource requirements during compute or persist calls.
 
 .. code-block:: python
 

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -64,7 +64,7 @@ Resources with collections
 --------------------------
 
 You can also use resources with Dask collections, like arrays, dataframes, and
-delayed objects.  You can either pass the collection or a dictionary mapping keys 
+delayed objects.  You can either pass the a delayed function or a tuple of dictionary mapping keys 
 of the collection to resource requirements during compute or persist calls.
 
 .. code-block:: python


### PR DESCRIPTION
Adds a check for bad input and also flattens the dask_keys list to properly handle multi-dimensional collections.
See also #1702.