### PR TITLE
Remove flake8: noqa marks from tests

### DIFF
--- a/distributed/cli/tests/test_dask_mpi.py
+++ b/distributed/cli/tests/test_dask_mpi.py
@@ -12,7 +12,7 @@ from distributed import Client
 from distributed.utils import tmpfile
 from distributed.metrics import time
 from distributed.utils_test import popen
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 
 
 @pytest.mark.parametrize('nanny', ['--nanny', '--no-nanny'])

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -19,7 +19,7 @@ from distributed.utils_test import (popen,
                                     assert_can_connect_from_everywhere_4_6,
                                     assert_can_connect_locally_4,
                                     )
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 from distributed.metrics import time
 
 
@@ -51,7 +51,7 @@ def test_hostport(loop):
             yield [
                 # The scheduler's main port can't be contacted from the outside
                 assert_can_connect_locally_4(8978, 2.0),
-                ]
+            ]
 
         loop.run_sync(f)
 

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -12,7 +12,7 @@ from distributed.metrics import time
 from distributed.utils import sync, tmpfile
 from distributed.utils_test import (popen, slow, terminate_process,
                                     wait_for_port)
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 
 
 def test_nanny_worker_ports(loop):

--- a/distributed/cli/tests/test_tls_cli.py
+++ b/distributed/cli/tests/test_tls_cli.py
@@ -6,7 +6,7 @@ from time import sleep
 from distributed import Client
 from distributed.utils_test import (popen, get_cert, new_config_file,
                                     tls_security, tls_only_config)
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 from distributed.metrics import time
 
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import atexit
-from collections import Iterator, Mapping, defaultdict
+from collections import Iterator, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import DoneAndNotDoneFutures, CancelledError
 from contextlib import contextmanager
@@ -16,7 +16,6 @@ import logging
 from numbers import Number, Integral
 import os
 import sys
-from time import sleep
 import uuid
 import threading
 import six
@@ -47,8 +46,7 @@ from .batched import BatchedSend
 from .utils_comm import (WrappedKey, unpack_remotedata, pack_data,
                          scatter_to_workers, gather_from_workers)
 from .cfexecutor import ClientExecutor
-from .compatibility import (Queue as pyQueue, Empty, isqueue,
-                            get_thread_identity, html_escape)
+from .compatibility import Queue as pyQueue, Empty, isqueue, html_escape
 from .config import config
 from .core import connect, rpc, clean_exception, CommClosedError
 from .metrics import time
@@ -3083,8 +3081,8 @@ class Client(Node):
         # such as {'x': {'GPU': 1}, 'y': {'SSD': 4}} indicating
         # per-key requirements
         if not isinstance(resources, dict):
-            raise TypeError("`retries` should be a dict, got %r"
-                            % (type(retries,)))
+            raise TypeError("`resources` should be a dict, got %r"
+                            % (type(resources,)))
 
         per_key_reqs = {}
         global_reqs = {}
@@ -3101,7 +3099,6 @@ class Client(Node):
             raise ValueError("cannot have both per-key and all-key requirements "
                              "in resources dict %r" % (resources,))
         return global_reqs or per_key_reqs
-
 
     @classmethod
     def get_restrictions(cls, collections, workers, allow_other_workers):
@@ -3348,10 +3345,10 @@ class as_completed(object):
     @gen.coroutine
     def __anext__(self):
         if not self.futures and self.queue.empty():
-            raise StopAsyncIteration  # flake8: noqa
+            raise StopAsyncIteration
         while self.queue.empty():
             if not self.futures:
-                raise StopAsyncIteration  # flake8: noqa
+                raise StopAsyncIteration
             yield self.condition.wait()
 
         raise gen.Return(self.queue.get())

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -15,7 +15,7 @@ from distributed.utils import get_ip, get_ipv6
 from distributed.utils_test import (gen_test, requires_ipv6, has_ipv6,
                                     get_cert, get_server_ssl_context,
                                     get_client_ssl_context)
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 
 from distributed.protocol import (to_serialize, Serialized, serialize,
                                   deserialize)
@@ -954,8 +954,8 @@ def check_deserialize_roundtrip(addr):
            'ser': Serialized(*serialize(_uncompressible)),
            }
 
-    for deserialize in (True, False):
-        a, b = yield get_comm_pair(addr, deserialize=deserialize)
+    for should_deserialize in (True, False):
+        a, b = yield get_comm_pair(addr, deserialize=should_deserialize)
         yield a.write(msg)
         got = yield b.read()
         yield b.write(got)
@@ -964,7 +964,7 @@ def check_deserialize_roundtrip(addr):
         assert sorted(got) == sorted(msg)
         for k in ('op', 'x'):
             assert got[k] == msg[k]
-        if deserialize:
+        if should_deserialize:
             assert isinstance(got['to_ser'][0], (bytes, bytearray))
             assert isinstance(got['ser'], (bytes, bytearray))
         else:

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -3,6 +3,8 @@ from __future__ import print_function, division, absolute_import
 import logging
 import sys
 
+# flake8: noqa
+
 if sys.version_info[0] == 2:
     from Queue import Queue, Empty
     from io import BytesIO
@@ -10,8 +12,8 @@ if sys.version_info[0] == 2:
     from inspect import getargspec
     from cgi import escape as html_escape
 
-    reload = reload  # flake8: noqa
-    unicode = unicode  # flake8: noqa
+    reload = reload
+    unicode = unicode
     PY2 = True
     PY3 = False
     ConnectionRefusedError = OSError
@@ -50,7 +52,7 @@ if sys.version_info[0] == 2:
     logging_names = logging._levelNames
 
 if sys.version_info[0] == 3:
-    from queue import Queue, Empty  # flake8: noqa
+    from queue import Queue, Empty
     from importlib import reload
     from threading import get_ident as get_thread_identity
     from importlib import invalidate_caches

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -8,7 +8,7 @@ from tornado.ioloop import IOLoop
 from distributed import Client
 from distributed.deploy import Adaptive, LocalCluster
 from distributed.utils_test import gen_cluster, gen_test, slowinc
-from distributed.utils_test import loop, nodebug  # flake8: noqa
+from distributed.utils_test import loop, nodebug  # noqa: F401
 from distributed.metrics import time
 
 
@@ -120,6 +120,7 @@ def test_adaptive_local_cluster_multi_workers():
     finally:
         yield c._close()
         yield cluster._close()
+
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 10)
 def test_adaptive_scale_down_override(c, s, *workers):

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -18,7 +18,7 @@ from distributed.utils_test import (inc, gen_test,
                                     assert_can_connect_locally_4,
                                     assert_can_connect_from_everywhere_4_6,
                                     captured_logger)
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 from distributed.utils import sync
 from distributed.worker import TOTAL_MEMORY
 

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -8,7 +8,7 @@ pytest.importorskip('paramiko')
 from distributed import Client
 from distributed.deploy.ssh import SSHCluster
 from distributed.metrics import time
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 
 
 @pytest.mark.avoid_travis

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -8,7 +8,7 @@ from distributed import Client, Scheduler, Worker
 from distributed.diagnostics.progressbar import TextProgressBar, progress
 from distributed.metrics import time
 from distributed.utils_test import (cluster, inc, div, gen_cluster)
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 
 
 def test_text_progressbar(capsys, loop):

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -79,7 +79,7 @@ from toolz import valmap
 from distributed.client import Client, wait
 from distributed.worker import dumps_task
 from distributed.utils_test import (cluster, inc, dec, throws, gen_cluster)
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 from distributed.utils import sync
 from distributed.diagnostics.progressbar import (ProgressWidget,
                                                  MultiProgressWidget, progress)

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -148,7 +148,7 @@ def test_compress_numpy():
 
     header = msgpack.loads(frames[2], encoding='utf8', use_list=False)
     try:
-        import blosc  # flake8: noqa
+        import blosc  # noqa: F401
     except ImportError:
         pass
     else:

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -223,7 +223,7 @@ def test_maybe_compress_memoryviews():
     x = np.arange(1000000, dtype='int64')
     compression, payload = maybe_compress(x.data)
     try:
-        import blosc  # flake8: noqa
+        import blosc  # noqa: F401
     except ImportError:
         assert compression == 'lz4'
         assert len(payload) < x.nbytes * 0.75

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -17,12 +17,11 @@ try:
     from cytoolz import frequencies, merge, pluck, merge_sorted, first
 except ImportError:
     from toolz import frequencies, merge, pluck, merge_sorted, first
-from toolz import memoize, valmap, first, second, concat, compose, groupby
+from toolz import valmap, first, second, compose, groupby
 from tornado import gen
 from tornado.gen import Return
 from tornado.ioloop import IOLoop
 
-from dask.core import reverse_dict
 from dask.order import order
 
 from .batched import BatchedSend
@@ -30,7 +29,7 @@ from .comm import (normalize_address, resolve_address,
                    get_address_host, unparse_host_port)
 from .compatibility import finalize, unicode
 from .config import config, log_format
-from .core import (rpc, connect, Server, send_recv,
+from .core import (rpc, connect, send_recv,
                    error_message, clean_exception, CommClosedError)
 from . import profile
 from .metrics import time
@@ -99,7 +98,7 @@ class ClientState(object):
         'client_key',
         'wants_what',
         'last_seen',
-        )
+    )
 
     def __init__(self, client):
         self.client_key = client
@@ -480,7 +479,7 @@ class TaskState(object):
         'suspicious',
         'retries',
         'nbytes',
-        )
+    )
 
     def __init__(self, key, run_spec):
         self.key = key
@@ -753,8 +752,7 @@ class Scheduler(ServerNode):
                 ('priority', 'priority', None),
                 ('dependencies', 'dependencies', _legacy_task_key_set),
                 ('dependents', 'dependents', _legacy_task_key_set),
-                ('retries', 'retries', None),
-                ]:
+                ('retries', 'retries', None)]:
             func = operator.attrgetter(new_attr)
             if wrap is not None:
                 func = compose(wrap, func)
@@ -774,17 +772,14 @@ class Scheduler(ServerNode):
                 ('suspicious_tasks', 'suspicious', None),
                 ('exceptions', 'exception', None),
                 ('tracebacks', 'traceback', None),
-                ('exceptions_blame', 'exception_blame', _task_key_or_none),
-                ]:
+                ('exceptions_blame', 'exception_blame', _task_key_or_none)]:
             func = operator.attrgetter(new_attr)
             if wrap is not None:
                 func = compose(wrap, func)
             setattr(self, old_attr,
                     _OptionalStateLegacyMapping(self.tasks, func))
 
-        for old_attr, new_attr, wrap in [
-                ('loose_restrictions', 'loose_restrictions', None),
-                ]:
+        for old_attr, new_attr, wrap in [('loose_restrictions', 'loose_restrictions', None)]:
             func = operator.attrgetter(new_attr)
             if wrap is not None:
                 func = compose(wrap, func)
@@ -804,9 +799,7 @@ class Scheduler(ServerNode):
 
         # Client state
         self.clients = dict()
-        for old_attr, new_attr, wrap in [
-                ('wants_what', 'wants_what', _legacy_task_key_set),
-                ]:
+        for old_attr, new_attr, wrap in [('wants_what', 'wants_what', _legacy_task_key_set)]:
             func = operator.attrgetter(new_attr)
             if wrap is not None:
                 func = compose(wrap, func)
@@ -824,8 +817,7 @@ class Scheduler(ServerNode):
                 ('occupancy', 'occupancy', None),
                 ('worker_info', 'info', None),
                 ('processing', 'processing', _legacy_task_key_dict),
-                ('has_what', 'has_what', _legacy_task_key_set),
-                ]:
+                ('has_what', 'has_what', _legacy_task_key_set)]:
             func = operator.attrgetter(new_attr)
             if wrap is not None:
                 func = compose(wrap, func)
@@ -1771,9 +1763,6 @@ class Scheduler(ServerNode):
 
         actual_total_occupancy = 0
         for worker, ws in self.workers.items():
-        #     for d in self.extensions['stealing'].in_flight.values():
-        #         if worker in (d['thief'], d['victim']):
-        #             continue
             assert abs(sum(ws.processing.values()) - ws.occupancy) < 1e-8
             actual_total_occupancy += ws.occupancy
 
@@ -2189,7 +2178,7 @@ class Scheduler(ServerNode):
         self.update_data(who_has=who_has, nbytes=nbytes, client=client)
 
         if broadcast:
-            if broadcast == True:  # flake8: noqa
+            if broadcast == True:  # noqa: E712
                 n = len(ncores)
             else:
                 n = broadcast
@@ -3146,9 +3135,7 @@ class Scheduler(ServerNode):
                 worker = min(self.workers.values(),
                              key=operator.attrgetter('occupancy'))
             else:  # dumb but fast in large case
-                worker = self.workers[
-                    self.workers.iloc[self.n_tasks % len(self.workers)]
-                    ]
+                worker = self.workers[self.workers.iloc[self.n_tasks % len(self.workers)]]
 
         assert worker is None or isinstance(worker, WorkerState), (type(worker), worker)
         return worker
@@ -4019,7 +4006,6 @@ class Scheduler(ServerNode):
             L = deque_handler.deque
             L = [L[-i] for i in range(min(n, len(L)))]
         return [(msg.levelname, deque_handler.format(msg)) for msg in L]
-
 
     @gen.coroutine
     def get_worker_logs(self, comm=None, n=None, workers=None):

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -10,7 +10,7 @@ from distributed import Client
 from distributed.client import _as_completed, as_completed, _first_completed
 from distributed.compatibility import Empty
 from distributed.utils_test import cluster, gen_cluster, inc
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 from distributed.compatibility import Queue
 
 

--- a/distributed/tests/test_asyncio.py
+++ b/distributed/tests/test_asyncio.py
@@ -2,4 +2,4 @@ import sys
 
 
 if sys.version_info >= (3, 5):
-    from distributed.tests.py3_test_asyncio import *  # flake8: noqa
+    from distributed.tests.py3_test_asyncio import *  # noqa: F401, F403

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -12,7 +12,7 @@ import pickle
 import random
 import sys
 import threading
-from threading import Thread, Semaphore
+from threading import Semaphore
 from time import sleep
 import traceback
 import warnings
@@ -46,7 +46,7 @@ from distributed.utils_test import (cluster, slow, slowinc, slowadd, slowdec,
                                     gen_cluster, gen_test, double, deep, popen,
                                     captured_logger, varying, map_varying,
                                     wait_for, async_wait_for)
-from distributed.utils_test import loop, loop_in_thread, nodebug  # flake8: noqa
+from distributed.utils_test import loop, loop_in_thread, nodebug  # noqa F401
 
 
 @gen_cluster(client=True, timeout=None)
@@ -370,7 +370,7 @@ def test_short_tracebacks(loop):
             tb = tblib.Traceback(tb).to_dict()
             n = 0
 
-            while tb != None:
+            while tb is not None:
                 n += 1
                 tb = tb['tb_next']
 
@@ -4691,6 +4691,7 @@ def test_secede_simple(c, s, a):
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 2, timeout=60)
 def test_secede_balances(c, s, a, b):
     count = threading.active_count()
+
     def f(x):
         client = get_client()
         sleep(0.01)  # do some work
@@ -4990,6 +4991,7 @@ def test_future_defaults_to_default_client(c, s, a, b):
     future = Future(x.key)
     assert future.client is c
 
+
 @gen_cluster(client=True)
 def test_future_auto_inform(c, s, a, b):
     x = c.submit(inc, 1)
@@ -5175,4 +5177,4 @@ def test_client_doesnt_close_given_loop(loop):
 
 
 if sys.version_info >= (3, 5):
-    from distributed.tests.py3_test_client import *  # flake8: noqa
+    from distributed.tests.py3_test_client import *  # noqa F401

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -13,7 +13,7 @@ from toolz import take
 from distributed.client import Client
 from distributed.utils_test import (slowinc, slowadd, slowdec,
                                     inc, throws, cluster, varying)
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa: F401
 
 
 def number_of_processing_tasks(client):

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -11,7 +11,7 @@ import dask.bag as db
 from distributed import Client
 from distributed.client import wait
 from distributed.utils_test import cluster, gen_cluster
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop # noqa F401
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -23,7 +23,7 @@ from distributed.utils_test import (
     assert_can_connect_from_everywhere_4_6, assert_can_connect_from_everywhere_6,
     assert_can_connect_locally_4, assert_can_connect_locally_6,
     tls_security, captured_logger)
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop  # noqa F401
 
 
 EXTERNAL_IP4 = get_ip()

--- a/distributed/tests/test_counter.py
+++ b/distributed/tests/test_counter.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 import pytest
 
 from distributed.counter import Counter
-from distributed.utils_test import loop  # flake8: noqa
+from distributed.utils_test import loop  # noqa F401
 
 try:
     from distributed.counter import Digest

--- a/distributed/tests/test_ipython.py
+++ b/distributed/tests/test_ipython.py
@@ -8,13 +8,13 @@ import tornado
 
 from distributed import Client
 from distributed.utils_test import cluster, mock_ipython
-from distributed.utils_test import loop, zmq_ctx  # flake8: noqa
+from distributed.utils_test import loop, zmq_ctx  # noqa F401
 
 
 def need_functional_ipython(func):
     try:
-        import ipykernel
-        import jupyter_client
+        import ipykernel  # noqa: F401
+        import jupyter_client  # noqa: F401
     except ImportError:
         return pytest.mark.skip("need ipykernel and jupyter_client installed")(func)
     if tornado.version_info >= (5,):

--- a/distributed/tests/test_joblib.py
+++ b/distributed/tests/test_joblib.py
@@ -8,7 +8,7 @@ from time import sleep
 
 from distributed import Client
 from distributed.utils_test import cluster, inc
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop # noqa F401
 
 distributed_joblib = pytest.importorskip('distributed.joblib')
 joblibs = [distributed_joblib.joblib, distributed_joblib.sk_joblib]

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -1,27 +1,26 @@
 from __future__ import print_function, division, absolute_import
 
 from time import sleep
-import sys
 
 import pytest
-from tornado import gen
 
-from distributed import Client, Lock, wait, get_client
+from distributed import Client, Lock, get_client
 from distributed.metrics import time
-from distributed.utils_test import (gen_cluster, inc, cluster, slow, div)
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import gen_cluster, cluster
+from distributed.utils_test import loop  # noqa F401
 
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 8)] * 2)
 def test_lock(c, s, a, b):
     c.set_metadata('locked', False)
+
     def f(x):
         client = get_client()
         with Lock('x') as lock:
-            assert client.get_metadata('locked') == False
+            assert client.get_metadata('locked') is False
             client.set_metadata('locked', True)
             sleep(0.05)
-            assert client.get_metadata('locked') == True
+            assert client.get_metadata('locked') is True
             client.set_metadata('locked', False)
 
     futures = c.map(f, range(20))
@@ -83,10 +82,10 @@ def test_lock_sync(loop):
     def f(x):
         with Lock('x') as lock:
             client = get_client()
-            assert client.get_metadata('locked') == False
+            assert client.get_metadata('locked') is False
             client.set_metadata('locked', True)
             sleep(0.05)
-            assert client.get_metadata('locked') == True
+            assert client.get_metadata('locked') is True
             client.set_metadata('locked', False)
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
@@ -103,4 +102,5 @@ def test_lock_types(c, s, a, b):
 
         yield lock.acquire()
         yield lock.release()
+
     assert not s.extensions['locks'].events

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -5,7 +5,7 @@ import tempfile
 
 from distributed import Client
 from distributed.utils_test import cluster
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop  # noqa F401
 
 
 PRELOAD_TEXT = """

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -6,7 +6,7 @@ from distributed import Client
 from distributed.client import futures_of
 from distributed.metrics import time
 from distributed.utils_test import gen_cluster, inc, cluster
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop  # noqa F401
 from tornado import gen
 
 

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -10,7 +10,7 @@ from tornado import gen
 from distributed import Client, Queue, Nanny, worker_client, wait
 from distributed.metrics import time
 from distributed.utils_test import (gen_cluster, inc, cluster, slow, div)
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop # noqa: F401
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -11,7 +11,7 @@ from distributed.client import wait
 from distributed.utils import tokey
 from distributed.utils_test import (inc, gen_cluster,
                                     slowinc, slowadd)
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop # noqa: F401
 
 
 @gen_cluster(client=True, ncores=[])
@@ -191,7 +191,6 @@ def test_prefer_constrained(c, s, a):
     futures = c.map(slowinc, range(1000), delay=0.1)
     constrained = c.map(inc, range(10), resources={'A': 1})
 
-    import traceback, sys
     start = time()
     yield wait(constrained)
     end = time()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1,14 +1,14 @@
 from __future__ import print_function, division, absolute_import
 
 import cloudpickle
-from collections import defaultdict, deque
+from collections import defaultdict
 from datetime import timedelta
 import json
 from operator import add, mul
 import sys
 
 from dask import delayed
-from toolz import merge, concat, valmap, first, frequencies, pluck
+from toolz import merge, concat, valmap, first, frequencies
 from tornado import gen
 
 import pytest
@@ -24,7 +24,7 @@ from distributed.utils import tmpfile
 from distributed.utils_test import (inc, dec, gen_cluster, gen_test, readone,
                                     slowinc, slowadd, slowdec, cluster, div,
                                     varying, slow)
-from distributed.utils_test import loop, nodebug  # flake8: noqa
+from distributed.utils_test import loop, nodebug  # noqa: F401
 from dask.compatibility import apply
 
 
@@ -48,7 +48,6 @@ def test_respect_data_in_memory(c, s, a):
     y = delayed(inc)(x)
     f = c.persist(y)
     yield wait([f])
-
 
     assert s.tasks[y.key].who_has == {s.workers[a.address]}
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -17,8 +17,8 @@ from distributed.metrics import time
 from distributed.scheduler import BANDWIDTH, key_split
 from distributed.utils_test import (slowinc, slowadd, inc, gen_cluster,
                                     slowidentity)
-from distributed.utils_test import (loop, nodebug_setup_module,
-                                    nodebug_teardown_module)  # flake8: noqa
+from distributed.utils_test import (nodebug_setup_module,
+                                    nodebug_teardown_module)
 from distributed.worker import TOTAL_MEMORY
 
 import pytest
@@ -393,7 +393,6 @@ def assert_balanced(inp, expected, c, s, *workers):
 
     while len(s.rprocessing) < len(futures):
         yield gen.sleep(0.001)
-
 
     for i in range(10):
         steal.balance()

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -17,8 +17,7 @@ from distributed.metrics import time
 from distributed.utils import All
 from distributed.utils_test import (gen_cluster, cluster, inc, slowinc,
                                     slowadd, slow, slowsum, bump_rlimit)
-from distributed.utils_test import (loop, nodebug_setup_module,
-                                    nodebug_teardown_module)  # flake8: noqa
+from distributed.utils_test import (loop, nodebug_setup_module, nodebug_teardown_module)  # noqa: F401
 from distributed.client import wait
 from tornado import gen
 

--- a/distributed/tests/test_submit_cli.py
+++ b/distributed/tests/test_submit_cli.py
@@ -4,8 +4,7 @@ from mock import Mock
 from tornado import gen
 from tornado.ioloop import IOLoop
 from distributed.submit import RemoteClient, _submit, _remote
-from distributed.utils_test import (valid_python_script, invalid_python_script,
-                                    loop)  # flake8: noqa
+from distributed.utils_test import (valid_python_script, invalid_python_script, loop)  # noqa: F401
 
 
 def test_dask_submit_cli_writes_result_to_stdout(loop, tmpdir,

--- a/distributed/tests/test_submit_remote_client.py
+++ b/distributed/tests/test_submit_remote_client.py
@@ -4,8 +4,7 @@ from tornado import gen
 
 from distributed import rpc
 from distributed.submit import RemoteClient
-from distributed.utils_test import (loop, valid_python_script,
-                                    invalid_python_script)  # flake8: noqa
+from distributed.utils_test import (loop, valid_python_script, invalid_python_script)  # noqa: F401
 
 
 def test_remote_client_uploads_a_file(loop, tmpdir):

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -5,16 +5,12 @@ from functools import partial
 import io
 import socket
 import sys
-from time import sleep
-from threading import Thread
-import threading
 import traceback
 
 import numpy as np
 import pytest
 from tornado import gen
 from tornado.ioloop import IOLoop
-from tornado.locks import Event
 
 import dask
 from distributed.compatibility import Queue, Empty, isqueue, PY2
@@ -25,7 +21,7 @@ from distributed.utils import (All, sync, is_kernel, ensure_ip, str_graph,
                                funcname, ensure_bytes, open_port, get_ip_interface, nbytes,
                                set_thread_state, thread_state, LoopRunner,
                                parse_bytes)
-from distributed.utils_test import loop, loop_in_thread  # flake8: noqa
+from distributed.utils_test import loop, loop_in_thread  # noqa: F401
 from distributed.utils_test import div, has_ipv6, inc, throws, gen_test
 
 
@@ -285,7 +281,7 @@ def test_funcname():
 def test_ensure_bytes():
     data = [b'1', '1', memoryview(b'1'), bytearray(b'1')]
     if PY2:
-        data.append(buffer(b'1'))  # flake8: noqa
+        data.append(buffer(b'1'))  # noqa: F821
     for d in data:
         result = ensure_bytes(d)
         assert isinstance(result, bytes)
@@ -328,6 +324,7 @@ def assert_running(loop):
     q = Queue()
     loop.add_callback(q.put, 42)
     assert q.get(timeout=1) == 42
+
 
 def assert_not_running(loop):
     """

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -15,7 +15,7 @@ from distributed.metrics import time
 from distributed.utils_test import (cluster, gen_cluster, inc,
                                     gen_test, wait_for_port, new_config,
                                     tls_only_security)
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop # noqa: F401
 from distributed.utils import get_ip
 
 
@@ -139,4 +139,4 @@ def test_new_config():
 
 
 if sys.version_info >= (3, 5):
-    from distributed.tests.py3_test_utils_tst import *  # flake8: noqa
+    from distributed.tests.py3_test_utils_tst import *  # noqa: F401, F403

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -10,7 +10,7 @@ from tornado import gen
 from distributed import Client, Variable, worker_client, Nanny, wait
 from distributed.metrics import time
 from distributed.utils_test import (gen_cluster, inc, cluster, slow, div)
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop # noqa: F401
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -31,7 +31,7 @@ from distributed.utils import tmpfile
 from distributed.utils_test import (inc, mul, gen_cluster, div, dec,
                                     slow, slowinc, gen_test, cluster,
                                     captured_logger)
-from distributed.utils_test import loop, nodebug # flake8: noqa
+from distributed.utils_test import loop, nodebug # noqa: F401
 
 
 def test_worker_ncores():
@@ -1031,6 +1031,7 @@ def test_get_current_task(c, s, a, b):
 def test_reschedule(c, s, a, b):
     s.extensions['stealing']._pc.stop()
     a_address = a.address
+
     def f(x):
         sleep(0.1)
         if get_worker().address == a_address:

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -13,7 +13,7 @@ from distributed import (worker_client, Client, as_completed, get_worker, wait,
                          get_client)
 from distributed.metrics import time
 from distributed.utils_test import cluster, double, gen_cluster, inc
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop # noqa: F401
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 from concurrent.futures import CancelledError
-from operator import add
 import os
 import random
 from time import sleep
@@ -18,7 +17,7 @@ from distributed.metrics import time
 from distributed.utils import sync, ignoring
 from distributed.utils_test import (gen_cluster, cluster, inc, slow, div,
                                     slowinc, slowadd, captured_logger)
-from distributed.utils_test import loop # flake8: noqa
+from distributed.utils_test import loop # noqa: F401
 
 
 def test_submit_after_failed_worker_sync(loop):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -5,10 +5,8 @@ from collections import Iterable, deque
 from contextlib import contextmanager
 from datetime import timedelta
 import functools
-import gc
 import json
 import logging
-import math
 import multiprocessing
 import operator
 import os
@@ -639,7 +637,7 @@ def silence_logging(level, root='distributed'):
     (or keep the existing level if less verbose).
     """
     if isinstance(level, str):
-        level = logging_names[level.upper()]
+        level = getattr(logging, level.upper())
 
     for name, logger in logging.root.manager.loggerDict.items():
         if (isinstance(logger, logging.Logger)
@@ -907,7 +905,7 @@ def ensure_bytes(s):
         return s
     if isinstance(s, memoryview):
         return s.tobytes()
-    if isinstance(s, bytearray) or PY2 and isinstance(s, buffer):  # flake8: noqa
+    if isinstance(s, bytearray) or PY2 and isinstance(s, buffer):  # noqa: F821
         return bytes(s)
     if hasattr(s, 'encode'):
         return s.encode()
@@ -1153,7 +1151,7 @@ def asciitable(columns, rows):
 
 
 if PY2:
-    def nbytes(frame, _bytes_like=(bytes, bytearray, buffer)):
+    def nbytes(frame, _bytes_like=(bytes, bytearray, buffer)):  # noqa: F821
         """ Number of bytes of a frame or memoryview """
         if isinstance(frame, _bytes_like):
             return len(frame)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -29,7 +29,6 @@ try:
 except ImportError:
     ssl = None
 
-import psutil
 import pytest
 import six
 
@@ -39,14 +38,13 @@ from tornado import gen, queues
 from tornado.gen import TimeoutError
 from tornado.ioloop import IOLoop
 
-from .compatibility import WINDOWS, PY3
+from .compatibility import PY3
 from .config import config, initialize_logging
 from .core import connect, rpc, CommClosedError
 from .metrics import time
-from .nanny import Nanny
 from .proctitle import enable_proctitle_on_children
 from .security import Security
-from .utils import (ignoring, log_errors, sync, mp_context, get_ip, get_ipv6,
+from .utils import (ignoring, log_errors, mp_context, get_ip, get_ipv6,
                     DequeHandler)
 from .worker import Worker, TOTAL_MEMORY
 
@@ -89,6 +87,7 @@ def loop():
         orig_start = loop.start
         is_stopped = threading.Event()
         is_stopped.set()
+
         def start():
             is_stopped.clear()
             try:
@@ -156,7 +155,9 @@ def mock_ipython():
     ip.user_ns = {}
     ip.kernel = None
 
-    def get_ip(): return ip
+    def get_ip():
+        return ip
+
     with mock.patch('IPython.get_ipython', get_ip), \
             mock.patch('distributed._ipython_utils.get_ipython', get_ip):
         yield ip
@@ -359,7 +360,7 @@ if sys.version_info >= (3, 5):
             await gen.sleep(delay)
             return x + 1
         """)
-    assert asyncinc  # flake8: noqa
+    assert asyncinc  # noqa: F821
 else:
     asyncinc = None
 
@@ -465,6 +466,7 @@ def check_active_rpc(loop, active_rpc_timeout=1):
     # This would happen especially if a non-localhost address is used,
     # as Nanny does.
     # (*) (example: gather_from_workers())
+
     def fail():
         pytest.fail("some RPCs left active by test: %s"
                     % (sorted(set(rpc.active) - active_before)))


### PR DESCRIPTION
Previously we used these thinking that they applied only the the line
on which they were used.  In fact these applied to the entire file.
This allowed many flake8 violations to creep in.

We remove these lines and resolve the flake8 violations.

Fixes https://github.com/dask/distributed/pull/1713