### PR TITLE
Handle failures in gen_cluster when start_cluster fails

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -154,11 +154,11 @@ class Server(object):
         diff = now - self._last_tick
         self._last_tick = now
         if diff > config.get('tick-maximum-delay', 1000) / 1000:
-            logger.warning("Event loop was unresponsive for %.2fs.  "
+            logger.warning("Event loop was unresponsive in %s for %.2fs.  "
                            "This is often caused by long-running GIL-holding "
                            "functions or moving large chunks of data. "
                            "This can cause timeouts and instability.",
-                           diff)
+                           type(self).__name__, diff)
         if self.digests is not None:
             self.digests['tick-duration'].add(diff)
 

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -107,7 +107,8 @@ def test_simple():
 
     del proc
     gc.collect()
-    if wr1() is not None:
+    start = time()
+    while wr1() is not None and time() < start + 1:
         # Perhaps the GIL switched before _watch_process() exit,
         # help it a little
         sleep(0.001)

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -567,3 +567,4 @@ def test_tick_logging(s, a, b):
 
     text = sio.getvalue()
     assert "unresponsive" in text
+    assert 'Scheduler' in text or 'Worker' in text

--- a/distributed/tests/test_worker_failure.py
+++ b/distributed/tests/test_worker_failure.py
@@ -48,7 +48,7 @@ def test_submit_after_failed_worker_async(c, s, a, b):
     yield n._close()
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, timeout=60)
 def test_submit_after_failed_worker(c, s, a, b):
     L = c.map(inc, range(10))
     yield wait(L)
@@ -127,7 +127,7 @@ def test_failed_worker_without_warning(c, s, a, b):
     assert not (set(ncores2) & set(s.ncores))  # no overlap
 
 
-@gen_cluster(Worker=Nanny, client=True)
+@gen_cluster(Worker=Nanny, client=True, timeout=60)
 def test_restart(c, s, a, b):
     assert s.ncores == {a.worker_address: 1, b.worker_address: 2}
 
@@ -155,7 +155,7 @@ def test_restart(c, s, a, b):
     assert not any(cs.wants_what for cs in s.clients.values())
 
 
-@gen_cluster(Worker=Nanny, client=True)
+@gen_cluster(Worker=Nanny, client=True, timeout=60)
 def test_restart_cleared(c, s, a, b):
     x = 2 * delayed(1) + 1
     f = c.compute(x)
@@ -197,7 +197,7 @@ def test_restart_sync(loop):
             assert y.result() == 1 / 3
 
 
-@gen_cluster(Worker=Nanny, client=True, timeout=20)
+@gen_cluster(Worker=Nanny, client=True, timeout=60)
 def test_restart_fast(c, s, a, b):
     L = c.map(sleep, range(10))
 
@@ -240,7 +240,7 @@ def test_restart_fast_sync(loop):
             assert x.result() == 2
 
 
-@gen_cluster(Worker=Nanny, client=True, timeout=20)
+@gen_cluster(Worker=Nanny, client=True, timeout=60)
 def test_fast_kill(c, s, a, b):
     L = c.map(sleep, range(10))
 
@@ -255,7 +255,7 @@ def test_fast_kill(c, s, a, b):
     assert result == 2
 
 
-@gen_cluster(Worker=Nanny)
+@gen_cluster(Worker=Nanny, timeout=60)
 def test_multiple_clients_restart(s, a, b):
     e1 = yield Client((s.ip, s.port), asynchronous=True)
     e2 = yield Client((s.ip, s.port), asynchronous=True)
@@ -276,7 +276,7 @@ def test_multiple_clients_restart(s, a, b):
     yield e2._close(fast=True)
 
 
-@gen_cluster(Worker=Nanny)
+@gen_cluster(Worker=Nanny, timeout=60)
 def test_restart_scheduler(s, a, b):
     import gc
     gc.collect()
@@ -288,7 +288,7 @@ def test_restart_scheduler(s, a, b):
     assert addrs != addrs2
 
 
-@gen_cluster(Worker=Nanny, client=True)
+@gen_cluster(Worker=Nanny, client=True, timeout=60)
 def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
     x = c.submit(inc, 1)
     yield c._restart()
@@ -339,7 +339,7 @@ def test_broken_worker_during_computation(c, s, a, b):
     yield n._close()
 
 
-@gen_cluster(client=True, Worker=Nanny)
+@gen_cluster(client=True, Worker=Nanny, timeout=60)
 def test_restart_during_computation(c, s, a, b):
     xs = [delayed(slowinc)(i, delay=0.01) for i in range(50)]
     ys = [delayed(slowinc)(i, delay=0.01) for i in xs]
@@ -356,7 +356,7 @@ def test_restart_during_computation(c, s, a, b):
     assert not s.tasks
 
 
-@gen_cluster(client=True, timeout=None)
+@gen_cluster(client=True, timeout=60)
 def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
     n = Nanny(s.ip, s.port, ncores=2, loop=s.loop)
     n.start(0)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -250,6 +250,7 @@ class WorkerBase(ServerNode):
         start = time()
         if self.contact_address is None:
             self.contact_address = self.address
+        logger.info('-' * 49)
         while True:
             if self.death_timeout and time() > start + self.death_timeout:
                 yield self._close(timeout=1)
@@ -273,8 +274,8 @@ class WorkerBase(ServerNode):
                         **self.monitor.recent())
                 if self.death_timeout:
                     diff = self.death_timeout - (time() - start)
-                    if diff <= 0:
-                        raise Exception("Timeout when trying to register")
+                    if diff < 0:
+                        continue
                     future = gen.with_timeout(timedelta(seconds=diff), future)
                 response = yield future
                 _end = time()
@@ -283,14 +284,16 @@ class WorkerBase(ServerNode):
                 self.status = 'running'
                 break
             except EnvironmentError:
-                logger.info("Trying to connect to scheduler: %s" %
-                            str(self.scheduler.address))
+                logger.info('Waiting to connect to: %26s', self.scheduler.address)
                 yield gen.sleep(0.1)
             except gen.TimeoutError:
                 logger.info("Timed out when connecting to scheduler")
         if response['status'] != 'OK':
             raise ValueError("Unexpected response from register: %r" %
                              (response,))
+        else:
+            logger.info('        Registered to: %26s', self.scheduler.address)
+            logger.info('-' * 49)
         self.periodic_callbacks['heartbeat'].start()
 
     def start_services(self, listen_ip=''):
@@ -361,15 +364,10 @@ class WorkerBase(ServerNode):
         if self.memory_limit:
             logger.info('               Memory: %26s', format_bytes(self.memory_limit))
         logger.info('      Local Directory: %26s', self.local_dir)
-        logger.info('-' * 49)
 
         setproctitle("dask-worker [%s]" % self.address)
 
         yield self._register_with_scheduler()
-
-        if self.status == 'running':
-            logger.info('        Registered to: %26s', self.scheduler.address)
-            logger.info('-' * 49)
 
         self.start_periodic_callbacks()
 
@@ -1163,14 +1161,6 @@ class Worker(WorkerBase):
             self.batched_stream = BatchedSend(interval=2, loop=self.loop)
             self.batched_stream.start(comm)
 
-            @gen.coroutine
-            def on_closed():
-                if self.reconnect and self.status not in ('closed', 'closing'):
-                    logger.info("Connection to scheduler broken. Reregistering")
-                    yield self._register_with_scheduler()
-                else:
-                    yield self._close(report=False)
-
             closed = False
 
             while not closed:
@@ -1178,10 +1168,13 @@ class Worker(WorkerBase):
                     msgs = yield comm.read()
                 except CommClosedError as e:
                     logger.error("Failed while reading from scheduler. "
-                                 "Number of messages received: %d",
-                                 self.batched_stream.message_count,
-                                 exc_info=True)
-                    yield on_closed()
+                                 "Exception: %s", e)
+                    if self.reconnect and self.status not in ('closed', 'closing'):
+                        logger.info("Connection to scheduler broken. Reregistering")
+                        yield self._register_with_scheduler()
+                        return
+                    else:
+                        yield self._close(report=False)
                     break
                 except EnvironmentError as e:
                     break
@@ -1223,12 +1216,13 @@ class Worker(WorkerBase):
                 if self.digests is not None:
                     self.digests['handle-messages-duration'].add(end - start)
 
-            yield self.batched_stream.close()
             logger.info('Close compute stream')
         except Exception as e:
             logger.exception(e)
             yield self._close()
             raise
+        finally:
+            yield self.batched_stream.close()
 
     def add_task(self, key, function=None, args=None, kwargs=None, task=None,
                  who_has=None, nbytes=None, priority=None, duration=None,


### PR DESCRIPTION
We try to start the cluster a few times.  This error arose when running
many tests in test_worker_failures back-to-back