### PR TITLE
Clean up IOLoop handling in PeriodicCallbacks

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -518,11 +518,13 @@ class Client(Node):
 
         self._periodic_callbacks = dict()
         self._periodic_callbacks['scheduler-info'] = PeriodicCallback(
-                self._update_scheduler_info, 2000, io_loop=self.loop)
+                self._update_scheduler_info, 2000, io_loop=self.loop
+        )
         self._periodic_callbacks['heartbeat'] = PeriodicCallback(
                 self._heartbeat,
                 heartbeat_interval or config.get('client-heartbeat-interval', 5000),
-                io_loop=self.loop)
+                io_loop=self.loop
+        )
 
         if address is None and 'scheduler-address' in config:
             address = config['scheduler-address']

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1023,11 +1023,11 @@ class Client(Node):
                 future = gen.with_timeout(timedelta(seconds=timeout), future)
             return future
 
-        sync(self.loop, self._close, fast=True)
-
         if self._start_arg is None:
             with ignoring(AttributeError):
                 self.cluster.close()
+
+        sync(self.loop, self._close, fast=True)
 
         assert self.status == 'closed'
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1021,11 +1021,12 @@ class Client(Node):
                 future = gen.with_timeout(timedelta(seconds=timeout), future)
             return future
 
+        sync(self.loop, self._close, fast=True)
+
         if self._start_arg is None:
             with ignoring(AttributeError):
                 self.cluster.close()
 
-        sync(self.loop, self._close, fast=True)
         assert self.status == 'closed'
 
         if self._should_close_loop:
@@ -1048,8 +1049,8 @@ class Client(Node):
         return self.close(*args, **kwargs)
 
     def get_executor(self, **kwargs):
-        """ Return a concurrent.futures Executor for submitting tasks
-        on this Client.
+        """
+        Return a concurrent.futures Executor for submitting tasks on this Client
 
         Parameters
         ----------

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -102,6 +102,7 @@ class Server(object):
 
         self.listener = None
         self.io_loop = io_loop or IOLoop.current()
+        self.loop = io_loop
 
         # Statistics counters for various events
         with ignoring(ImportError):
@@ -122,7 +123,6 @@ class Server(object):
         pc = PeriodicCallback(self._measure_tick, config.get('tick-time', 20),
                               io_loop=self.io_loop)
         self.periodic_callbacks['tick'] = pc
-        self.start_periodic_callbacks()
 
         self.__stopped = False
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -115,16 +115,14 @@ class Server(object):
 
         self.periodic_callbacks = dict()
 
-        def _():
-            pc = PeriodicCallback(self.monitor.update, 500)
-            self.periodic_callbacks['monitor'] = pc
+        pc = PeriodicCallback(self.monitor.update, 500, io_loop=self.io_loop)
+        self.periodic_callbacks['monitor'] = pc
 
-            self._last_tick = time()
-            pc = PeriodicCallback(self._measure_tick, config.get('tick-time', 20))
-            self.periodic_callbacks['tick'] = pc
-            self.start_periodic_callbacks()
-
-        self.loop.add_callback(_)
+        self._last_tick = time()
+        pc = PeriodicCallback(self._measure_tick, config.get('tick-time', 20),
+                              io_loop=self.io_loop)
+        self.periodic_callbacks['tick'] = pc
+        self.start_periodic_callbacks()
 
         self.__stopped = False
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -115,12 +115,16 @@ class Server(object):
 
         self.periodic_callbacks = dict()
 
-        pc = PeriodicCallback(self.monitor.update, 500)
-        self.periodic_callbacks['monitor'] = pc
+        def _():
+            pc = PeriodicCallback(self.monitor.update, 500)
+            self.periodic_callbacks['monitor'] = pc
 
-        self._last_tick = time()
-        pc = PeriodicCallback(self._measure_tick, config.get('tick-time', 20))
-        self.periodic_callbacks['tick'] = pc
+            self._last_tick = time()
+            pc = PeriodicCallback(self._measure_tick, config.get('tick-time', 20))
+            self.periodic_callbacks['tick'] = pc
+            self.start_periodic_callbacks()
+
+        self.loop.add_callback(_)
 
         self.__stopped = False
 

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -334,3 +334,13 @@ def test_bokeh_kwargs(loop):
 
         bs = c.scheduler.services['bokeh']
         assert bs.prefix == '/foo'
+
+
+def test_io_loop_periodic_callbacks(loop):
+    with LocalCluster(loop=loop) as cluster:
+        assert cluster.scheduler.loop is loop
+        for pc in cluster.scheduler.periodic_callbacks.values():
+            assert pc.io_loop is loop
+        for worker in cluster.workers:
+            for pc in worker.periodic_callbacks.values():
+                assert pc.io_loop is loop

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -95,8 +95,11 @@ class Nanny(ServerNode):
                                     **kwargs)
 
         if self.memory_limit:
-            pc = PeriodicCallback(self.memory_monitor, 100)
-            self.periodic_callbacks['memory'] = pc
+            def _():
+                pc = PeriodicCallback(self.memory_monitor, 100)
+                self.periodic_callbacks['memory'] = pc
+                self.start_periodic_callbacks()
+            self.loop.add_callback(_)
 
         self._listen_address = listen_address
         self.status = 'init'

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -329,9 +329,12 @@ class WorkerProcess(object):
             yield self.running.wait()
             return
 
-        self.init_result_q = mp_context.Queue()
-        self.child_stop_q = mp_context.Queue()
-        for i in range(5):
+        while True:
+            # FIXME: this sometimes stalls in _wait_until_running
+            # our temporary solution is to retry a few times if the process
+            # doesn't start up in five seconds
+            self.init_result_q = mp_context.Queue()
+            self.child_stop_q = mp_context.Queue()
             try:
                 self.process = AsyncProcess(
                     target=self._run,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -95,11 +95,8 @@ class Nanny(ServerNode):
                                     **kwargs)
 
         if self.memory_limit:
-            def _():
-                pc = PeriodicCallback(self.memory_monitor, 100)
-                self.periodic_callbacks['memory'] = pc
-                self.start_periodic_callbacks()
-            self.loop.add_callback(_)
+            pc = PeriodicCallback(self.memory_monitor, 100, io_loop=self.loop)
+            self.periodic_callbacks['memory'] = pc
 
         self._listen_address = listen_address
         self.status = 'init'

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -21,7 +21,7 @@ from .process import AsyncProcess
 from .proctitle import enable_proctitle_on_children
 from .security import Security
 from .utils import (get_ip, mp_context, silence_logging, json_load_robust,
-        PeriodicCallback, reset_logger_locks)
+        PeriodicCallback)
 from .worker import _ncores, run, parse_memory_limit
 
 

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import weakref
 
-from .compatibility import finalize, Queue as PyQueue, PY2
+from .compatibility import finalize, Queue as PyQueue
 from .utils import mp_context
 
 from tornado import gen

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -153,10 +153,9 @@ class AsyncProcess(object):
 
         https://github.com/dask/distributed/issues/1491
         """
-        if PY2:
-            for name in logging.Logger.manager.loggerDict.keys():
-                for handler in logging.getLogger(name).handlers:
-                    handler.createLock()
+        for name in logging.Logger.manager.loggerDict.keys():
+            for handler in logging.getLogger(name).handlers:
+                handler.createLock()
 
     @classmethod
     def _run(cls, target, args, kwargs, parent_alive_pipe, _keep_child_alive):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1070,6 +1070,10 @@ class Scheduler(ServerNode):
         logger.info("Scheduler closing...")
         setproctitle("dask-scheduler [closing]")
 
+        for pc in self.periodic_callbacks.values():
+            pc.stop()
+        self.periodic_callbacks.clear()
+
         self.stop_services()
         for ext in self.extensions:
             with ignoring(AttributeError):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1277,6 +1277,16 @@ def fix_asyncio_event_loop_policy(asyncio):
     asyncio.set_event_loop_policy(PatchedDefaultEventLoopPolicy())
 
 
+def reset_logger_locks():
+    """ Python 2's logger's locks don't survive a fork event
+
+    https://github.com/dask/distributed/issues/1491
+    """
+    for name in logging.Logger.manager.loggerDict.keys():
+        for handler in logging.getLogger(name).handlers:
+            handler.createLock()
+
+
 # Only bother if asyncio has been loaded by Tornado
 if 'asyncio' in sys.modules:
     fix_asyncio_event_loop_policy(sys.modules['asyncio'])

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -275,9 +275,10 @@ class LoopRunner(object):
     _lock = threading.Lock()
 
     def __init__(self, loop=None, asynchronous=False):
+        current = IOLoop.current()
         if loop is None:
             if asynchronous:
-                self._loop = IOLoop.current()
+                self._loop = current
             else:
                 # We're expecting the loop to run in another thread,
                 # avoid re-using this thread's assigned loop

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -45,7 +45,7 @@ from .metrics import time
 from .proctitle import enable_proctitle_on_children
 from .security import Security
 from .utils import (ignoring, log_errors, mp_context, get_ip, get_ipv6,
-                    DequeHandler)
+                    DequeHandler, reset_logger_locks)
 from .worker import Worker, TOTAL_MEMORY
 
 
@@ -420,6 +420,7 @@ def run_scheduler(q, nputs, **kwargs):
 def run_worker(q, scheduler_q, **kwargs):
     from distributed import Worker
 
+    reset_logger_locks()
     with log_errors():
         with pristine_loop() as loop:
             scheduler_addr = scheduler_q.get()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -192,15 +192,19 @@ class WorkerBase(ServerNode):
                                          connection_args=self.connection_args,
                                          **kwargs)
 
-        pc = PeriodicCallback(self.heartbeat, 1000)
-        self.periodic_callbacks['heartbeat'] = pc
-        self._address = contact_address
+        def _():
+            pc = PeriodicCallback(self.heartbeat, 1000)
+            self.periodic_callbacks['heartbeat'] = pc
+            self._address = contact_address
 
-        if self.memory_limit:
-            self._memory_monitoring = False
-            pc = PeriodicCallback(self.memory_monitor,
-                                  self.memory_monitor_interval)
-            self.periodic_callbacks['memory'] = pc
+            if self.memory_limit:
+                self._memory_monitoring = False
+                pc = PeriodicCallback(self.memory_monitor,
+                                      self.memory_monitor_interval)
+                self.periodic_callbacks['memory'] = pc
+
+        self.loop.add_callback(_)
+
         self._throttled_gc = ThrottledGC(logger=logger)
 
         setproctitle("dask-worker [not started]")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -192,18 +192,16 @@ class WorkerBase(ServerNode):
                                          connection_args=self.connection_args,
                                          **kwargs)
 
-        def _():
-            pc = PeriodicCallback(self.heartbeat, 1000)
-            self.periodic_callbacks['heartbeat'] = pc
-            self._address = contact_address
+        pc = PeriodicCallback(self.heartbeat, 1000, io_loop=self.io_loop)
+        self.periodic_callbacks['heartbeat'] = pc
+        self._address = contact_address
 
-            if self.memory_limit:
-                self._memory_monitoring = False
-                pc = PeriodicCallback(self.memory_monitor,
-                                      self.memory_monitor_interval)
-                self.periodic_callbacks['memory'] = pc
-
-        self.loop.add_callback(_)
+        if self.memory_limit:
+            self._memory_monitoring = False
+            pc = PeriodicCallback(self.memory_monitor,
+                                  self.memory_monitor_interval,
+                                  io_loop=self.io_loop)
+            self.periodic_callbacks['memory'] = pc
 
         self._throttled_gc = ThrottledGC(logger=logger)
 
@@ -1139,11 +1137,13 @@ class Worker(WorkerBase):
         WorkerBase.__init__(self, *args, **kwargs)
 
         pc = PeriodicCallback(self.trigger_profile,
-                              config.get('profile-interval', 10))
+                              config.get('profile-interval', 10),
+                              io_loop=self.io_loop)
         self.periodic_callbacks['profile'] = pc
 
         pc = PeriodicCallback(self.cycle_profile,
-                              profile_cycle_interval)
+                              profile_cycle_interval,
+                              io_loop=self.io_loop)
         self.periodic_callbacks['profile-cycle'] = pc
 
         _global_workers.append(weakref.ref(self))


### PR DESCRIPTION
In Tornado 4 the IOLoop is specified at creation time.
This gave PeriodicCallbacks the wrong IOLoop when running in the console.