### PR TITLE
Allow service ports to be specified as a (host, port) instead

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -38,6 +38,11 @@ class LocalCluster(object):
         Use a falsey value like False or None for no change.
     ip: string
         IP address on which the scheduler will listen, defaults to only localhost
+    diagnostics_port: int
+        Port on which the :doc:`web` will be provided.  8787 by default, use 0
+        to choose a random port, ``None`` to disable it, or an
+        :samp:`({ip}:{port})` tuple to listen on a different IP address than
+        the scheduler.
     kwargs: dict
         Extra worker arguments, will be passed to the Worker constructor.
     service_kwargs: Dict[str, Dict]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -975,7 +975,10 @@ class Scheduler(ServerNode):
 
             try:
                 service = v(self, io_loop=self.loop, **kwargs)
-                service.listen((listen_ip, port))
+                if isinstance(port, tuple):
+                    service.listen(port)
+                else:
+                    service.listen((listen_ip, port))
                 self.services[k] = service
             except Exception as e:
                 logger.info("Could not launch service: %r", (k, port),

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1045,51 +1045,29 @@ def test_correct_bad_time_estimate(c, s, *workers):
 
 
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
-                    reason="Need 127.0.0.2 to mean localhost")
-@gen_test(timeout=None)
-def test_service_hosts_match_scheduler():
-    pytest.importorskip('bokeh')
-    from distributed.bokeh.scheduler import BokehScheduler
-    services = {('bokeh', 0): BokehScheduler}
-
-    s = Scheduler(services=services)
-    yield s.start('tcp://0.0.0.0')
-
-    sock = first(s.services['bokeh'].server._http._sockets.values())
-    assert sock.getsockname()[0] in ('::', '0.0.0.0')
-    yield s.close()
-
-    for host in ['tcp://127.0.0.2', 'tcp://127.0.0.2:38275']:
-        s = Scheduler(services=services)
-        yield s.start(host)
-
-        sock = first(s.services['bokeh'].server._http._sockets.values())
-        assert sock.getsockname()[0] == '127.0.0.2'
-        yield s.close()
-
-
-@pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason="Need 127.0.0.* to mean localhost")
-@gen_test(timeout=None)
-def test_service_custom_host():
+@gen_test()
+def test_service_hosts():
     pytest.importorskip('bokeh')
     from distributed.bokeh.scheduler import BokehScheduler
-    services = {('bokeh', ('127.0.0.3', 0)): BokehScheduler}
 
-    s = Scheduler(services=services)
-    yield s.start('tcp://0.0.0.0')
+    for port in [0, ('127.0.0.3', 0)]:
+        for url, expected in [('tcp://0.0.0.0', ('::', '0.0.0.0')),
+                              ('tcp://127.0.0.2', '127.0.0.2'),
+                              ('tcp://127.0.0.2:38275', '127.0.0.2')]:
+            services = {('bokeh', port): BokehScheduler}
 
-    sock = first(s.services['bokeh'].server._http._sockets.values())
-    assert sock.getsockname()[0] == '127.0.0.3'
-    yield s.close()
+            s = Scheduler(services=services)
+            yield s.start(url)
 
-    for host in ['tcp://127.0.0.2', 'tcp://127.0.0.2:38275']:
-        s = Scheduler(services=services)
-        yield s.start(host)
-
-        sock = first(s.services['bokeh'].server._http._sockets.values())
-        assert sock.getsockname()[0] == '127.0.0.3'
-        yield s.close()
+            sock = first(s.services['bokeh'].server._http._sockets.values())
+            if isinstance(port, tuple):    # host explicitly overridden
+                assert sock.getsockname()[0] == port[0]
+            elif isinstance(expected, tuple):
+                assert sock.getsockname()[0] in expected
+            else:
+                assert sock.getsockname()[0] == expected
+            yield s.close()
 
 
 @gen_cluster(client=True, worker_kwargs={'profile_cycle_interval': 100})

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1080,7 +1080,7 @@ def test_service_custom_host():
     yield s.start('tcp://0.0.0.0')
 
     sock = first(s.services['bokeh'].server._http._sockets.values())
-    assert sock.getsockname()[0] in ('::', '0.0.0.0')
+    assert sock.getsockname()[0] == '127.0.0.3'
     yield s.close()
 
     for host in ['tcp://127.0.0.2', 'tcp://127.0.0.2:38275']:


### PR DESCRIPTION
My main use case is to pass `diagnostics_port=(host, port)` to
LocalCluster to run a world-accessible Bokeh server even when the
scheduler uses inproc://. However, the design should be more general
e.g. it is a step towards dask/distributed#1687.

I haven't written any tests or documented it yet - I'd like to get
feedback on whether this is the right approach before investing in
those.