### PR TITLE
Add versions routes to avoid the use of run in Client.get_versions

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2889,7 +2889,7 @@ class Client(Node):
         except KeyError:
             scheduler = None
 
-        workers = sync(self.loop, self._run, get_versions)
+        workers = sync(self.loop, self.scheduler.broadcast, msg={'op': 'versions'})
         result = {'scheduler': scheduler, 'workers': workers, 'client': client}
 
         if check:

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division, absolute_import
 from tornado.ioloop import IOLoop
 
 from .core import Server, ConnectionPool
+from .versions import get_versions
 
 
 class Node(object):
@@ -35,3 +36,6 @@ class ServerNode(Node, Server):
                       io_loop=io_loop)
         Server.__init__(self, handlers, connection_limit=connection_limit,
                         deserialize=deserialize, io_loop=self.io_loop)
+
+    def versions(self, comm=None):
+        return get_versions()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -41,7 +41,6 @@ from .utils import (All, ignoring, get_ip, get_fileno_limit, log_errors,
                     key_split, validate_key, no_default, DequeHandler)
 from .utils_comm import (scatter_to_workers, gather_from_workers)
 from .utils_perf import enable_gc_diagnosis, disable_gc_diagnosis
-from .versions import get_versions
 
 from .publish import PublishExtension
 from .queues import QueueExtension
@@ -881,7 +880,7 @@ class Scheduler(ServerNode):
                          'logs': self.get_logs,
                          'worker_logs': self.get_worker_logs,
                          'nbytes': self.get_nbytes,
-                         'versions': self.get_versions,
+                         'versions': self.versions,
                          'add_keys': self.add_keys,
                          'rebalance': self.rebalance,
                          'replicate': self.replicate,
@@ -954,10 +953,6 @@ class Scheduler(ServerNode):
             return None
         else:
             return ws.info['host'], port
-
-    def get_versions(self, comm):
-        """ Basic information about ourselves and our cluster """
-        return get_versions()
 
     def start_services(self, listen_ip):
         for k, v in self.service_specs.items():

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -187,6 +187,7 @@ class WorkerBase(ServerNode):
             'profile_metadata': self.get_profile_metadata,
             'get_logs': self.get_logs,
             'keys': self.keys,
+            'versions': self.versions,
         }
 
         super(WorkerBase, self).__init__(handlers, io_loop=self.loop,


### PR DESCRIPTION
This sometimes fails if, for example, cloudpickle is the wrong version