### PR TITLE
specify IOLoop for stealing PeriodicCallback

### DIFF
--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -45,7 +45,8 @@ class WorkStealing(SchedulerPlugin):
             self.add_worker(worker=worker)
 
         pc = PeriodicCallback(callback=self.balance,
-                              callback_time=100)
+                              callback_time=100,
+                              io_loop=self.scheduler.loop)
         self._pc = pc
         self.scheduler.periodic_callbacks['stealing'] = pc
         self.scheduler.plugins.append(self)


### PR DESCRIPTION
Previously this would use IOLoop.current, which, when deploying from a Jupyter notebook, was the notebooks IOLoop.  This would turn off work stealing during `compute` calls.

Fixes https://github.com/pangeo-data/pangeo/issues/118