### PR TITLE
add to_scheduler_file to Client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2767,8 +2767,25 @@ class Client(Node):
         self.sync(self._update_scheduler_info)
         return self._scheduler_identity
 
-    def to_scheduler_file(self, scheduler_file):
-        """Dump the info in this file to a scheduler file"""
+    def write_scheduler_file(self, scheduler_file):
+        """ Write the scheduler information to a json file.
+
+        This facilitates easy sharing of scheduler information using a file
+        system. The scheduler file can be used to instantiate a second Client
+        using the same scheduler.
+
+        Parameter
+        ---------
+        scheduler_file: str
+            Path to a write the scheduler file.
+
+        Examples
+        --------
+        >>> client = Client()
+        >>> client.to_scheduler_file('scheduler.json')
+        # connect to previous client's scheduler
+        >>> client2 = Client(scheduler_file='scheduler.json')
+        """
 
         if self.scheduler_file:
             raise ValueError('Scheduler file already set')

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2782,11 +2782,10 @@ class Client(Node):
         Examples
         --------
         >>> client = Client()
-        >>> client.to_scheduler_file('scheduler.json')
+        >>> client.write_scheduler_file('scheduler.json')
         # connect to previous client's scheduler
         >>> client2 = Client(scheduler_file='scheduler.json')
         """
-
         if self.scheduler_file:
             raise ValueError('Scheduler file already set')
         else:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2767,6 +2767,17 @@ class Client(Node):
         self.sync(self._update_scheduler_info)
         return self._scheduler_identity
 
+    def to_scheduler_file(self, scheduler_file):
+        """Dump the info in this file to a scheduler file"""
+
+        if self.scheduler_file:
+            raise ValueError('Scheduler file already set')
+        else:
+            self.scheduler_file = scheduler_file
+
+        with open(self.scheduler_file, 'w') as f:
+            json.dump(self.scheduler_info(), f, indent=2)
+
     def get_metadata(self, keys, default=no_default):
         """ Get arbitrary metadata from scheduler
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3727,6 +3727,11 @@ def test_to_scheduler_file(loop):
                     info2 = c2.scheduler_info()
                     assert info['address'] == info2['address']
 
+                # test that a ValueError is raised if the scheduler_file
+                # attribute is already set
+                with pytest.raises(ValueError):
+                    c.to_scheduler_file(scheduler_file)
+
 
 def test_get_versions(loop):
     with cluster() as (s, [a, b]):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3717,20 +3717,20 @@ def test_scheduler_info(loop):
             assert len(info['workers']) == 2
 
 
-def test_to_scheduler_file(loop):
+def test_write_scheduler_file(loop):
     with cluster() as (s, [a, b]):
         with Client(s['address'], loop=loop) as c:
             info = c.scheduler_info()
             with tmpfile('json') as scheduler_file:
-                c.to_scheduler_file(scheduler_file)
+                c.write_scheduler_file(scheduler_file)
                 with Client(scheduler_file=scheduler_file) as c2:
                     info2 = c2.scheduler_info()
-                    assert info['address'] == info2['address']
+                    assert c.scheduler.address == c2.scheduler.address
 
                 # test that a ValueError is raised if the scheduler_file
                 # attribute is already set
                 with pytest.raises(ValueError):
-                    c.to_scheduler_file(scheduler_file)
+                    c.write_scheduler_file(scheduler_file)
 
 
 def test_get_versions(loop):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -40,7 +40,8 @@ from distributed.compatibility import PY3
 from distributed.metrics import time
 from distributed.scheduler import Scheduler, KilledWorker
 from distributed.sizeof import sizeof
-from distributed.utils import ignoring, mp_context, sync, tmp_text, tokey
+from distributed.utils import (ignoring, mp_context, sync, tmp_text, tokey,
+                               tmpfile)
 from distributed.utils_test import (cluster, slow, slowinc, slowadd, slowdec,
                                     randominc, inc, dec, div, throws, geninc, asyncinc,
                                     gen_cluster, gen_test, double, deep, popen,
@@ -3714,6 +3715,17 @@ def test_scheduler_info(loop):
             info = c.scheduler_info()
             assert isinstance(info, dict)
             assert len(info['workers']) == 2
+
+
+def test_to_scheduler_file(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            info = c.scheduler_info()
+            with tmpfile('json') as scheduler_file:
+                c.to_scheduler_file(scheduler_file)
+                with Client(scheduler_file=scheduler_file) as c2:
+                    info2 = c2.scheduler_info()
+                    assert info['address'] == info2['address']
 
 
 def test_get_versions(loop):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -34,6 +34,7 @@ API
    Client.run_on_scheduler
    Client.scatter
    Client.scheduler_info
+   Client.write_scheduler_file
    Client.set_metadata
    Client.start_ipython_workers
    Client.start_ipython_scheduler


### PR DESCRIPTION
This adds a new method to `Client` that writes a "scheduler_file". This file can be used when instantiating new Clients using the `scheduler_file` keyword argument.  This is purely a convenience method that facilitates sharing scheduler information via a filesystem. Example usage:

In one python session:
```Python
from distributed import Client
client = Client()
client.to_scheduler_file('test.json')
```

In a second session:
```Python
from distributed import Client
client = Client(scheduler_file='test.json')
```

closes #1741 
