### PR TITLE
Default host to tls:// if tls information provided

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -75,6 +75,9 @@ def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,
                    tls_scheduler_key=tls_key,
                    )
 
+    if not host and (tls_ca_file or tls_cert or tls_key):
+        host = 'tls://'
+
     if pid_file:
         with open(pid_file, 'w') as f:
             f.write(str(os.getpid()))

--- a/distributed/cli/tests/test_tls_cli.py
+++ b/distributed/cli/tests/test_tls_cli.py
@@ -28,7 +28,7 @@ def wait_for_cores(c, ncores=1):
 
 
 def test_basic(loop):
-    with popen(['dask-scheduler', '--no-bokeh', '--host', 'tls://'] + tls_args) as s:
+    with popen(['dask-scheduler', '--no-bokeh'] + tls_args) as s:
         with popen(['dask-worker', '--no-bokeh', 'tls://127.0.0.1:8786'] + tls_args) as w:
             with Client('tls://127.0.0.1:8786', loop=loop,
                         security=tls_security()) as c:
@@ -36,7 +36,7 @@ def test_basic(loop):
 
 
 def test_nanny(loop):
-    with popen(['dask-scheduler', '--no-bokeh', '--host', 'tls://'] + tls_args) as s:
+    with popen(['dask-scheduler', '--no-bokeh'] + tls_args) as s:
         with popen(['dask-worker', '--no-bokeh', '--nanny', 'tls://127.0.0.1:8786'] + tls_args) as w:
             with Client('tls://127.0.0.1:8786', loop=loop,
                         security=tls_security()) as c:
@@ -44,7 +44,7 @@ def test_nanny(loop):
 
 
 def test_separate_key_cert(loop):
-    with popen(['dask-scheduler', '--no-bokeh', '--host', 'tls://'] + tls_args_2) as s:
+    with popen(['dask-scheduler', '--no-bokeh'] + tls_args_2) as s:
         with popen(['dask-worker', '--no-bokeh', 'tls://127.0.0.1:8786'] + tls_args_2) as w:
             with Client('tls://127.0.0.1:8786', loop=loop,
                         security=tls_security()) as c:


### PR DESCRIPTION
Fixes #1696 

This defaults `host` to `tls://` if no host is provided and any of the `--tls-*` keywords is provided.

@pitrou any objection or concerns to this change?