### PR TITLE
Add `futures_of` to API docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -150,6 +150,7 @@ Other
 .. autofunction:: as_completed
 .. autofunction:: distributed.diagnostics.progress
 .. autofunction:: wait
+.. autofunction:: fire_and_forget
 
 .. currentmodule:: distributed
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -91,6 +91,7 @@ API
    distributed.diagnostics.progress
    wait
    fire_and_forget
+   futures_of
 
 
 Asynchronous methods
@@ -151,6 +152,7 @@ Other
 .. autofunction:: distributed.diagnostics.progress
 .. autofunction:: wait
 .. autofunction:: fire_and_forget
+.. autofunction:: futures_of
 
 .. currentmodule:: distributed
 


### PR DESCRIPTION
Includes `futures_of` in the API docs. Also makes sure `fire_and_forget` has its function documented since it is already listed.