### PR TITLE
Check idle/saturated in extra cases

### DIFF
--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -712,7 +712,10 @@ def test_inproc_comm_closed_explicit_2():
     comm = yield connect(contact_addr)
     comm.close()
     assert comm.closed()
-    yield gen.sleep(0.01)
+    start = time()
+    while len(listener_errors) < 1:
+        assert time() < start + 1
+        yield gen.sleep(0.01)
     assert len(listener_errors) == 1
 
     with pytest.raises(CommClosedError):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -331,10 +331,10 @@ class WorkerProcess(object):
         """
         enable_proctitle_on_children()
         if self.status == 'running':
-            return self.status
+            raise gen.Return(self.status)
         if self.status == 'starting':
             yield self.running.wait()
-            return self.status
+            raise gen.Return(self.status)
 
         while True:
             # FIXME: this sometimes stalls in _wait_until_connected
@@ -371,14 +371,14 @@ class WorkerProcess(object):
         if self.status == 'starting':
             msg = yield self._wait_until_connected()
             if not msg:
-                return self.status
+                raise gen.Return(self.status)
             self.worker_address = msg['address']
             self.worker_dir = msg['dir']
             assert self.worker_address
             self.status = 'running'
             self.running.set()
 
-        return self.status
+        raise gen.Return(self.status)
 
     def _on_exit(self, proc):
         if proc is not self.process:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -153,9 +153,11 @@ class Nanny(ServerNode):
 
         logger.info('        Start Nanny at: %r', self.address)
         response = yield self.instantiate()
-        if response == 'OK':
+        if response == 'running':
             assert self.worker_address
             self.status = 'running'
+        else:
+            yield self._close()
 
         self.start_periodic_callbacks()
 
@@ -216,14 +218,16 @@ class Nanny(ServerNode):
         self.auto_restart = True
         if self.death_timeout:
             try:
-                yield gen.with_timeout(timedelta(seconds=self.death_timeout),
-                                       self.process.start())
+                result = yield gen.with_timeout(
+                        timedelta(seconds=self.death_timeout),
+                        self.process.start()
+                )
             except gen.TimeoutError:
                 yield self._close(timeout=self.death_timeout)
                 raise gen.Return('timed out')
         else:
-            yield self.process.start()
-        raise gen.Return('OK')
+            result = yield self.process.start()
+        raise gen.Return(result)
 
     @gen.coroutine
     def restart(self, comm=None, timeout=2, executor_wait=True):
@@ -327,10 +331,10 @@ class WorkerProcess(object):
         """
         enable_proctitle_on_children()
         if self.status == 'running':
-            return
+            return self.status
         if self.status == 'starting':
             yield self.running.wait()
-            return
+            return self.status
 
         while True:
             # FIXME: this sometimes stalls in _wait_until_connected
@@ -365,7 +369,16 @@ class WorkerProcess(object):
                 break
 
         if self.status == 'starting':
-            yield self._wait_until_connected()
+            msg = yield self._wait_until_connected()
+            if not msg:
+                return self.status
+            self.worker_address = msg['address']
+            self.worker_dir = msg['dir']
+            assert self.worker_address
+            self.status = 'running'
+            self.running.set()
+
+        return self.status
 
     def _on_exit(self, proc):
         if proc is not self.process:
@@ -474,14 +487,11 @@ class WorkerProcess(object):
                 continue
 
             if isinstance(msg, Exception):
+                logger.error("Failed while trying to start worker process",
+                             exc_info=True)
                 yield self.process.join()
                 raise msg
             else:
-                self.worker_address = msg['address']
-                self.worker_dir = msg['dir']
-                assert self.worker_address
-                self.status = 'running'
-                self.running.set()
                 raise gen.Return(msg)
 
     @classmethod

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -519,15 +519,21 @@ class TaskState(object):
         return "<Task %r %s>" % (self.key, self.state)
 
     def validate(self):
-        for cs in self.who_wants:
-            assert isinstance(cs, ClientState), (repr(cs), self.who_wants)
-        for ws in self.who_has:
-            assert isinstance(ws, WorkerState), (repr(ws), self.who_has)
-        for ts in self.dependencies:
-            assert isinstance(ts, TaskState), (repr(ts), self.dependencies)
-        for ts in self.dependents:
-            assert isinstance(ts, TaskState), (repr(ts), self.dependents)
-        validate_task_state(self)
+        try:
+            for cs in self.who_wants:
+                assert isinstance(cs, ClientState), (repr(cs), self.who_wants)
+            for ws in self.who_has:
+                assert isinstance(ws, WorkerState), (repr(ws), self.who_has)
+            for ts in self.dependencies:
+                assert isinstance(ts, TaskState), (repr(ts), self.dependencies)
+            for ts in self.dependents:
+                assert isinstance(ts, TaskState), (repr(ts), self.dependents)
+            validate_task_state(self)
+        except Exception as e:
+            logger.exception(e)
+            if LOG_PDB:
+                import pdb
+                pdb.set_trace()
 
 
 class _StateLegacyMapping(Mapping):
@@ -1940,6 +1946,8 @@ class Scheduler(ServerNode):
 
     def send_task_to_worker(self, worker, key):
         """ Send a single computational task to a worker """
+        if worker not in self.workers:
+            return
         try:
             ts = self.tasks[key]
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1753,6 +1753,9 @@ class Scheduler(ServerNode):
             assert isinstance(w, (str, unicode)), (type(w), w)
             assert isinstance(ws, WorkerState), (type(ws), ws)
             assert ws.address == w
+            if not ws.processing:
+                assert not ws.occupancy
+                assert ws in self.idle
 
         for k, ts in self.tasks.items():
             assert isinstance(ts, TaskState), (type(ts), ts)
@@ -2057,6 +2060,7 @@ class Scheduler(ServerNode):
         ws.occupancy -= ws.processing[ts]
         self.total_occupancy -= ws.processing[ts]
         ws.processing[ts] = 0
+        self.check_idle_saturated(ws)
 
     @gen.coroutine
     def handle_worker(self, worker):

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -244,11 +244,13 @@ class WorkStealing(SchedulerPlugin):
                 ts.processing_on = thief
                 duration = victim.processing.pop(ts)
                 victim.occupancy -= duration
+                self.scheduler.total_occupancy -= duration
                 if not victim.processing:
+                    self.scheduler.total_occupancy -= victim.occupancy
                     victim.occupancy = 0
                 thief.processing[ts] = d['thief_duration']
                 thief.occupancy += d['thief_duration']
-                self.scheduler.total_occupancy += d['thief_duration'] - duration
+                self.scheduler.total_occupancy += d['thief_duration']
                 self.put_key_in_stealable(ts)
 
                 try:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -244,6 +244,8 @@ class WorkStealing(SchedulerPlugin):
                 ts.processing_on = thief
                 duration = victim.processing.pop(ts)
                 victim.occupancy -= duration
+                if not victim.processing:
+                    victim.occupancy = 0
                 thief.processing[ts] = d['thief_duration']
                 thief.occupancy += d['thief_duration']
                 self.scheduler.total_occupancy += d['thief_duration'] - duration
@@ -263,6 +265,15 @@ class WorkStealing(SchedulerPlugin):
                 import pdb
                 pdb.set_trace()
             raise
+        finally:
+            try:
+                self.scheduler.check_idle_saturated(thief)
+            except Exception:
+                pass
+            try:
+                self.scheduler.check_idle_saturated(victim)
+            except Exception:
+                pass
 
     def balance(self):
         s = self.scheduler

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -721,7 +721,7 @@ def test_file_descriptors(c, s):
 @gen_cluster(client=True)
 def test_learn_occupancy(c, s, a, b):
     futures = c.map(slowinc, range(1000), delay=0.01)
-    while not any(ts.who_has for ts in s.tasks.values()):
+    while sum(len(ts.who_has) for ts in s.tasks.values()) < 10:
         yield gen.sleep(0.01)
 
     assert 1 < s.total_occupancy < 40


### PR DESCRIPTION
Previously there were two cases where we decreased occupancy but didn't
check idle/saturated.

1.  Long running tasks
2.  Stealing

Now we do.