### PR TITLE
Keep logs in scheduler and worker even if silenced

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -82,7 +82,7 @@ class LocalCluster(object):
         self.silence_logs = silence_logs
         self._asynchronous = asynchronous
         if silence_logs:
-            silence_logging(level=silence_logs)
+            self._old_logging_level = silence_logging(level=silence_logs)
         if n_workers is None and threads_per_worker is None:
             if processes:
                 n_workers = _ncores
@@ -270,6 +270,8 @@ class LocalCluster(object):
             self._loop_runner.stop()
         finally:
             self.status = 'closed'
+        with ignoring(AttributeError):
+            silence_logging(self._old_logging_level)
 
     @gen.coroutine
     def scale_up(self, n, **kwargs):

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -347,5 +347,14 @@ def test_io_loop_periodic_callbacks(loop):
                 assert pc.io_loop is loop
 
 
+def test_logging():
+    """
+    Workers and scheduler have logs even when silenced
+    """
+    with LocalCluster(1, processes=False, diagnostics_port=None) as c:
+        assert c.scheduler._deque_handler.deque
+        assert c.workers[0]._deque_handler.deque
+
+
 if sys.version_info >= (3, 5):
     from distributed.deploy.tests.py3_test_deploy import *  # noqa F401

--- a/distributed/tests/test_config.py
+++ b/distributed/tests/test_config.py
@@ -54,6 +54,9 @@ def test_logging_default():
     old_root_level = root.level
     root.setLevel('WARN')
 
+    for handler in d.handlers:
+        handler.setLevel('INFO')
+
     try:
         dfb = logging.getLogger('distributed.foo.bar')
         f = logging.getLogger('foo')

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -641,11 +641,14 @@ def silence_logging(level, root='distributed'):
     if isinstance(level, str):
         level = getattr(logging, level.upper())
 
-    for name, logger in logging.root.manager.loggerDict.items():
-        if (isinstance(logger, logging.Logger)
-            and logger.name.startswith(root + '.')
-                and logger.level < level):
-            logger.setLevel(level)
+    old = None
+    logger = logging.getLogger(root)
+    for handler in logger.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            old = handler.level
+            handler.setLevel(level)
+
+    return old
 
 
 @memoize


### PR DESCRIPTION
This silences the global StreamHandler rather than the loggers entirely.

Fixes https://github.com/dask/distributed/issues/1771