### PR TITLE
Use string timedeltas everywhere

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -8,6 +8,7 @@ from tornado.ioloop import IOLoop
 
 from .config import config
 from .core import CommClosedError
+from .utils import parse_timedelta
 
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ class BatchedSend(object):
     Example
     -------
     >>> stream = yield connect(ip, port)
-    >>> bstream = BatchedSend(interval=10)  # 10 ms
+    >>> bstream = BatchedSend(interval='10 ms')
     >>> bstream.start(stream)
     >>> bstream.send('Hello,')
     >>> bstream.send('world!')
@@ -40,8 +41,7 @@ class BatchedSend(object):
     def __init__(self, interval, loop=None):
         # XXX is the loop arg useful?
         self.loop = loop or IOLoop.current()
-        self.interval = interval / 1000.
-
+        self.interval = parse_timedelta(interval, default='ms')
         self.waker = locks.Event()
         self.stopped = locks.Event()
         self.please_stop = False

--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -16,7 +16,7 @@ from tornado import gen
 from ..config import config
 from ..diagnostics.progress_stream import nbytes_bar
 from .. import profile
-from ..utils import log_errors
+from ..utils import log_errors, parse_timedelta
 
 if config.get('bokeh-export-tool', False):
     from .export_tool import ExportTool
@@ -24,7 +24,8 @@ else:
     ExportTool = None
 
 
-profile_interval = config.get('profile-interval', 10) / 1000
+profile_interval = config.get('profile-interval', 10)
+profile_interval = parse_timedelta(profile_interval, default='ms')
 
 
 class DashboardComponent(object):
@@ -53,10 +54,11 @@ class TaskStream(DashboardComponent):
     The start and stop time of tasks as they occur on each core of the cluster.
     """
 
-    def __init__(self, n_rectangles=1000, clear_interval=20000, **kwargs):
+    def __init__(self, n_rectangles=1000, clear_interval='20s', **kwargs):
         """
         kwargs are applied to the bokeh.models.plots.Plot constructor
         """
+        clear_interval = parse_timedelta(clear_interval, default='ms')
         self.n_rectangles = n_rectangles
         self.clear_interval = clear_interval
         self.last = 0

--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -541,7 +541,7 @@ class Events(DashboardComponent):
 
 
 class TaskStream(components.TaskStream):
-    def __init__(self, scheduler, n_rectangles=1000, clear_interval=20000, **kwargs):
+    def __init__(self, scheduler, n_rectangles=1000, clear_interval='20s', **kwargs):
         self.scheduler = scheduler
         self.offset = 0
         es = [p for p in self.scheduler.plugins if isinstance(p, TaskStreamPlugin)]
@@ -579,7 +579,7 @@ class TaskStream(components.TaskStream):
             if first_end > self.last:
                 last = self.last
                 self.last = first_end
-                if first_end > last + self.clear_interval:
+                if first_end > last + self.clear_interval * 1000:
                     self.offset = min(rectangles['start'])
                     self.source.data.update({k: [] for k in rectangles})
 
@@ -1084,7 +1084,7 @@ def workers_doc(scheduler, extra, doc):
 
 def tasks_doc(scheduler, extra, doc):
     with log_errors():
-        ts = TaskStream(scheduler, n_rectangles=100000, clear_interval=60000,
+        ts = TaskStream(scheduler, n_rectangles=100000, clear_interval='60s',
                         sizing_mode='stretch_both')
         ts.update()
         doc.add_periodic_callback(ts.update, 5000)
@@ -1109,7 +1109,8 @@ def graph_doc(scheduler, extra, doc):
 
 def status_doc(scheduler, extra, doc):
     with log_errors():
-        task_stream = TaskStream(scheduler, n_rectangles=1000, clear_interval=10000, height=350)
+        task_stream = TaskStream(scheduler, n_rectangles=1000,
+                                 clear_interval='10s', height=350)
         task_stream.update()
         doc.add_periodic_callback(task_stream.update, 100)
 

--- a/distributed/bokeh/worker.py
+++ b/distributed/bokeh/worker.py
@@ -21,7 +21,7 @@ from .utils import transpose
 from ..compatibility import WINDOWS
 from ..diagnostics.progress_stream import color_of
 from ..metrics import time
-from ..utils import log_errors, key_split, format_bytes, format_time
+from ..utils import (log_errors, key_split, format_bytes, format_time)
 
 
 logger = logging.getLogger(__name__)

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -10,6 +10,7 @@ from tornado import gen
 
 from ..config import config
 from ..metrics import time
+from ..utils import parse_timedelta
 from . import registry
 from .addressing import parse_address
 
@@ -160,7 +161,8 @@ def connect(addr, timeout=None, deserialize=True, connection_args=None):
     retried until the *timeout* is expired.
     """
     if timeout is None:
-        timeout = float(config.get('connect-timeout', 3))  # default 3 s.
+        timeout = config.get('connect-timeout', 3)
+        timeout = float(parse_timedelta(timeout, default='seconds'))
 
     scheme, loc = parse_address(addr)
     backend = registry.get_backend(scheme)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -19,7 +19,8 @@ from tornado.tcpserver import TCPServer
 
 from .. import config
 from ..compatibility import finalize
-from ..utils import (ensure_bytes, ensure_ip, get_ip, get_ipv6, nbytes)
+from ..utils import (ensure_bytes, ensure_ip, get_ip, get_ipv6, nbytes,
+                    parse_timedelta)
 
 from .registry import Backend, backends
 from .addressing import parse_host_port, unparse_host_port
@@ -51,7 +52,8 @@ def set_tcp_timeout(stream):
     if stream.closed():
         return
 
-    timeout = int(config.get('tcp-timeout', 30))
+    timeout = config.get('tcp-timeout', 30)
+    timeout = int(parse_timedelta(timeout, default='seconds'))
 
     sock = stream.socket
 

--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -20,8 +20,8 @@ multiprocessing-method: forkserver
 use-file-locking: True
 
 # Communication options
-connect-timeout: 3      # seconds delay before connecting fails
-tcp-timeout: 30         # seconds delay before calling an unresponsive connection dead
+connect-timeout: 3s     # seconds delay before connecting fails
+tcp-timeout: 30s        # seconds delay before calling an unresponsive connection dead
 default-scheme: tcp
 require-encryption: False   # whether to require encryption on non-local comms
 socket-backlog: 2048
@@ -44,11 +44,11 @@ recent-messages-log-length: 0  # number of messages to keep for debugging
 # Bokeh web dashboard
 bokeh-export-tool: False
 
-tick-time: 20             # milliseconds between event loop health checks
+tick-time: 20ms           # milliseconds between event loop health checks
 tick-maximum-delay: 1000  # milliseconds allowed before triggering a warning
 
-profile-interval: 10  # milliseconds in between statistical profiling queries
-profile-cycle-interval: 1000  # milliseconds between starting new profile
+profile-interval: 10ms          # milliseconds in between statistical profiling queries
+profile-cycle-interval: 1000ms  # milliseconds between starting new profile
 
 # Fractions of worker memory at which we take action to avoid memory blowup
 # Set any of the lower three values to False to turn off the behavior entirely
@@ -61,4 +61,4 @@ worker-memory-terminate: 0.95  # fraction at which we terminate the worker
 log-length: 10000  # default length of logs to keep in memory
 log-format: '%(name)s - %(levelname)s - %(message)s'
 
-client-heartbeat-interval: 5000  # milliseconds between client heartbeats
+client-heartbeat-interval: 5000ms  # milliseconds between client heartbeats

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -86,7 +86,6 @@ def test_adaptive_local_cluster(loop):
 @nodebug
 @gen_test(timeout=30)
 def test_adaptive_local_cluster_multi_workers():
-    loop = IOLoop.current()
     cluster = yield LocalCluster(0, scheduler_port=0, silence_logs=False,
                                  processes=False, diagnostics_port=None,
                                  asynchronous=True)
@@ -102,13 +101,13 @@ def test_adaptive_local_cluster_multi_workers():
             yield gen.sleep(0.01)
             assert time() < start + 15
 
-        yield c._gather(futures)
+        yield c.gather(futures)
         del futures
 
         start = time()
         while cluster.workers:
             yield gen.sleep(0.01)
-            assert time() < start + 5
+            assert time() < start + 15
 
         assert not cluster.workers
         assert not cluster.scheduler.workers
@@ -117,7 +116,7 @@ def test_adaptive_local_cluster_multi_workers():
         assert not cluster.scheduler.workers
 
         futures = c.map(slowinc, range(100), delay=0.01)
-        yield c._gather(futures)
+        yield c.gather(futures)
 
     finally:
         yield c._close()

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -14,7 +14,8 @@ from ..compatibility import html_escape
 from ..core import connect, coerce_to_address, CommClosedError
 from ..client import default_client, futures_of
 from ..protocol.pickle import dumps
-from ..utils import ignoring, key_split, is_kernel, LoopRunner
+from ..utils import (ignoring, key_split, is_kernel, LoopRunner,
+        parse_timedelta)
 
 
 logger = logging.getLogger(__name__)
@@ -27,11 +28,11 @@ def get_scheduler(scheduler):
 
 
 class ProgressBar(object):
-    def __init__(self, keys, scheduler=None, interval=0.1, complete=True):
+    def __init__(self, keys, scheduler=None, interval='100ms', complete=True):
         self.scheduler = get_scheduler(scheduler)
 
         self.keys = {k.key if hasattr(k, 'key') else k for k in keys}
-        self.interval = interval
+        self.interval = parse_timedelta(interval, default='s')
         self.complete = complete
         self._start_time = default_timer()
 
@@ -87,7 +88,7 @@ class ProgressBar(object):
 
 
 class TextProgressBar(ProgressBar):
-    def __init__(self, keys, scheduler=None, interval=0.1, width=40,
+    def __init__(self, keys, scheduler=None, interval='100ms', width=40,
                  loop=None, complete=True, start=True):
         super(TextProgressBar, self).__init__(keys, scheduler, interval,
                                               complete)
@@ -119,7 +120,7 @@ class ProgressWidget(ProgressBar):
     TextProgressBar: Text version suitable for the console
     """
 
-    def __init__(self, keys, scheduler=None, interval=0.1,
+    def __init__(self, keys, scheduler=None, interval='100ms',
                  complete=False, loop=None):
         super(ProgressWidget, self).__init__(keys, scheduler, interval,
                                              complete)
@@ -155,7 +156,7 @@ class ProgressWidget(ProgressBar):
 
 
 class MultiProgressBar(object):
-    def __init__(self, keys, scheduler=None, func=key_split, interval=0.1, complete=False):
+    def __init__(self, keys, scheduler=None, func=key_split, interval='100ms', complete=False):
         self.scheduler = get_scheduler(scheduler)
 
         self.keys = {k.key if hasattr(k, 'key') else k for k in keys}

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -8,6 +8,7 @@ import functools
 import json
 import logging
 import multiprocessing
+from numbers import Number
 import operator
 import os
 import re
@@ -1128,6 +1129,70 @@ def parse_bytes(s):
 
     result = n * multiplier
     return int(result)
+
+
+timedelta_sizes = {
+        's': 1,
+        'ms': 1e-3,
+        'us': 1e-6,
+        'ns': 1e-9,
+        'm': 60,
+        'h': 3600,
+        'd': 3600 * 24,
+}
+
+tds2 = {
+        'second': 1,
+        'minute': 60,
+        'hour': 60 * 60,
+        'day': 60 * 60 * 24,
+        'millisecond': 1e-3,
+        'microsecond': 1e-6,
+        'nanosecond': 1e-9,
+}
+tds2.update({k + 's': v for k, v in tds2.items()})
+timedelta_sizes.update(tds2)
+timedelta_sizes.update({k.upper(): v for k, v in timedelta_sizes.items()})
+
+
+def parse_timedelta(s, default='seconds'):
+    """ Parse timedelta string to number of seconds
+
+    Examples
+    --------
+    >>> parse_timedelta('3s')
+    3
+    >>> parse_timedelta('3.5 seconds')
+    3.5
+    >>> parse_timedelta('300ms')
+    0.3
+    >>> parse_timedelta(timedelta(seconds=3))  # also supports timedeltas
+    3
+    """
+    if isinstance(s, timedelta):
+        return s.total_seconds()
+    if isinstance(s, Number):
+        s = str(s)
+    s = s.replace(' ', '')
+    if not s[0].isdigit():
+        s = '1' + s
+
+    for i in range(len(s) - 1, -1, -1):
+        if not s[i].isalpha():
+            break
+    index = i + 1
+
+    prefix = s[:index]
+    suffix = s[index:] or default
+
+    n = float(prefix)
+
+    multiplier = timedelta_sizes[suffix.lower()]
+
+    result = n * multiplier
+    if int(result) == result:
+        result = int(result)
+    return result
 
 
 def asciitable(columns, rows):


### PR DESCRIPTION
Previously when taking time-delta inputs we usually took numbers that
represented either seconds or milliseconds, depending on if we were
using system python or tornado/bokeh commands. 

```python
>>> Adaptive(..., interval=1000, startup_cost=1)
```

Now we normalize everything to strings or timedelta objects and parse them.

```python
>>> Adaptive(..., interval='1000 ms', startup_cost='1s')
```

This is clearer and more explicit.

We maintain backwards compatibility by supporting a default= keyword
to parse_timedelta that lets us choose a default unit.
