### PR TITLE
Ensure the client is quiet if scheduler leaves

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -822,7 +822,7 @@ class Client(Node):
         try:
             self._scheduler_identity = yield self.scheduler.identity()
         except EnvironmentError:
-            if self.status not in ('running', 'connecting'):
+            if self.status != 'running':
                 return
             else:
                 raise

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5195,5 +5195,15 @@ def test_client_doesnt_close_given_loop(loop):
             assert c.submit(inc, 2).result() == 3
 
 
+@gen_cluster(client=True, ncores=[])
+def test_quiet_scheduler_loss(c, s):
+    c._periodic_callbacks['scheduler-info'].interval = 10
+    with captured_logger(logging.getLogger('distributed.client')) as logger:
+        yield s.close()
+        yield c._update_scheduler_info()
+    text = logger.getvalue()
+    assert "BrokenPipeError" not in text
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # noqa F401

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -742,7 +742,7 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                                 s.validate_state()
                         finally:
                             if client:
-                                yield c._close()
+                                yield c._close(fast=s.status == 'closed')
                             yield end_cluster(s, workers)
                             _globals.clear()
                             _globals.update(old_globals)


### PR DESCRIPTION
We still print out a basic warning, but previously we were dumping
large stack traces every few seconds.