### PR TITLE
Add worker time to live in Scheduler

### DIFF
--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -14,6 +14,7 @@ allowed-failures: 3     # number of retries before a task is considered bad
 pdb-on-err: False       # enter debug mode on scheduling error
 transition-log-length: 100000
 work-stealing: True     # workers should steal tasks from each other
+worker-ttl: null        # like '60s'. Time to live for workers.  They must heartbeat faster than this
 
 # Worker options
 multiprocessing-method: forkserver

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -696,9 +696,9 @@ def test_priorities_2(c, s, w):
 
 @gen_cluster(client=True)
 def test_heartbeats(c, s, a, b):
-    x = s.worker_info[a.address]['last-seen']
+    x = s.workers[a.address].last_seen
     yield gen.sleep(a.periodic_callbacks['heartbeat'].callback_time / 1000 + 0.1)
-    y = s.worker_info[a.address]['last-seen']
+    y = s.workers[a.address].last_seen
     assert x != y
     assert a.periodic_callbacks['heartbeat'].callback_time < 1000
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -726,8 +726,8 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                                     ncores, scheduler, loop, security=security,
                                     Worker=Worker, scheduler_kwargs=scheduler_kwargs,
                                     worker_kwargs=worker_kwargs)
-                            except Exception:
-                                logger.error("Failed to start gen_cluster, retryng")
+                            except Exception as e:
+                                logger.error("Failed to start gen_cluster, retryng", exc_info=True)
                             else:
                                 break
                         workers[:] = ws


### PR DESCRIPTION
This allows the scheduler to define a time period within which a worker
should heartbeat or else it will be removed from the scheduler's
understanding of the cluster.

This is configurable either by passing the parameter directly to the
Scheduler, or by adding an entry like the following to the config.yaml
file

    worker-ttl: 60s