### PR TITLE
option to choose remote Python

### DIFF
--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -35,9 +35,11 @@ from distributed.cli.utils import check_python_3
 @click.option('--log-directory', default=None, type=click.Path(exists=True),
               help=("Directory to use on all cluster nodes for the output of "
                     "dask-scheduler and dask-worker commands."))
+@click.option('--remote-python', default=None, type=str,
+              help="Path to Python on remote nodes.")
 @click.pass_context
 def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
-         ssh_username, ssh_port, ssh_private_key, nohost, log_directory):
+         ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python):
     try:
         hostnames = list(hostnames)
         if hostfile:
@@ -53,7 +55,7 @@ def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
         exit(1)
 
     c = SSHCluster(scheduler, scheduler_port, hostnames, nthreads, nprocs,
-                   ssh_username, ssh_port, ssh_private_key, nohost, log_directory)
+                   ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python)
 
     import distributed
     print('\n---------------------------------------------------------------')

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -176,9 +176,9 @@ def async_ssh(cmd_dict):
     ssh.close()
 
 
-def start_scheduler(logdir, addr, port, ssh_username, ssh_port, ssh_private_key):
+def start_scheduler(logdir, addr, port, ssh_username, ssh_port, ssh_private_key, remote_python=None):
     cmd = '{python} -m distributed.cli.dask_scheduler --port {port}'.format(
-        python=sys.executable, port=port, logdir=logdir)
+        python=remote_python or sys.executable, port=port, logdir=logdir)
 
     # Optionally re-direct stdout and stderr to a logfile
     if logdir is not None:
@@ -210,7 +210,7 @@ def start_scheduler(logdir, addr, port, ssh_username, ssh_port, ssh_private_key)
 
 
 def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, nprocs,
-                 ssh_username, ssh_port, ssh_private_key, nohost):
+                 ssh_username, ssh_port, ssh_private_key, nohost, remote_python=None):
 
     cmd = ('{python} -m distributed.cli.dask_worker '
            '{scheduler_addr}:{scheduler_port} '
@@ -218,7 +218,7 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
     if not nohost:
         cmd += ' --host {worker_addr}'
     cmd = cmd.format(
-        python=sys.executable,
+        python=remote_python or sys.executable,
         scheduler_addr=scheduler_addr,
         scheduler_port=scheduler_port,
         worker_addr=worker_addr,
@@ -254,7 +254,7 @@ class SSHCluster(object):
 
     def __init__(self, scheduler_addr, scheduler_port, worker_addrs, nthreads=0, nprocs=1,
                  ssh_username=None, ssh_port=22, ssh_private_key=None,
-                 nohost=False, logdir=None):
+                 nohost=False, logdir=None, remote_python=None):
 
         self.scheduler_addr = scheduler_addr
         self.scheduler_port = scheduler_port
@@ -266,6 +266,8 @@ class SSHCluster(object):
         self.ssh_private_key = ssh_private_key
 
         self.nohost = nohost
+
+        self.remote_python = remote_python
 
         # Generate a universal timestamp to use for log files
         import datetime
@@ -282,7 +284,7 @@ class SSHCluster(object):
         # Start the scheduler node
         self.scheduler = start_scheduler(logdir, scheduler_addr,
                                          scheduler_port, ssh_username, ssh_port,
-                                         ssh_private_key)
+                                         ssh_private_key, remote_python)
 
         # Start worker nodes
         self.workers = []
@@ -322,7 +324,8 @@ class SSHCluster(object):
                                          self.scheduler_port, address,
                                          self.nthreads, self.nprocs,
                                          self.ssh_username, self.ssh_port,
-                                         self.ssh_private_key, self.nohost))
+                                         self.ssh_private_key, self.nohost,
+                                         self.remote_python))
 
     def shutdown(self):
         all_processes = [self.scheduler] + self.workers


### PR DESCRIPTION
The default continuous to be `sys.executable`. For remote systems with a different file layout, this can now be set to `python` or `python3` or `some/other/path/python3`.