### PR TITLE
Support calling compute within worker_client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2043,13 +2043,17 @@ class Client(Node):
         packed = pack_data(keys, futures)
         if sync:
             if getattr(thread_state, 'key', False):
-                secede()
+                try:
+                    secede()
+                    should_rejoin = True
+                except Exception:
+                    should_rejoin = False
             try:
                 results = self.gather(packed, asynchronous=asynchronous)
             finally:
                 for f in futures.values():
                     f.release()
-                if getattr(thread_state, 'key', False):
+                if getattr(thread_state, 'key', False) and should_rejoin:
                     rejoin()
             return results
         return packed

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -272,3 +272,15 @@ def test_secede_without_stealing_issue_1262():
     assert f == 2
     # ensure no workers had errors
     assert all([f.exception() is None for f in s._worker_coroutines])
+
+
+@gen_cluster(client=True)
+def test_compute_within_worker_client(c, s, a, b):
+
+    @dask.delayed
+    def f():
+        with worker_client():
+            return dask.delayed(lambda x: x)(1).compute()
+
+    result = yield c.compute(f())
+    assert result == 1


### PR DESCRIPTION
Previously we failed when calling secede twice.