### PR TITLE
Add percentage to profile plot

### DIFF
--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -322,6 +322,10 @@ class ProfilePlot(DashboardComponent):
                     <span style="font-size: 14px; font-weight: bold;">Time:</span>&nbsp;
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@time</span>
                 </div>
+                <div>
+                    <span style="font-size: 14px; font-weight: bold;">Percentage:</span>&nbsp;
+                    <span style="font-size: 10px; font-family: Monaco, monospace;">@width</span>
+                </div>
                 """
         )
         self.root.add_tools(hover)
@@ -409,6 +413,10 @@ class ProfileTimePlot(DashboardComponent):
                 <div>
                     <span style="font-size: 14px; font-weight: bold;">Time:</span>&nbsp;
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@time</span>
+                </div>
+                <div>
+                    <span style="font-size: 14px; font-weight: bold;">Percentage:</span>&nbsp;
+                    <span style="font-size: 10px; font-family: Monaco, monospace;">@percentage</span>
                 </div>
                 """
         )

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -202,6 +202,7 @@ def plot_data(state, profile_interval=0.010):
             x += width
 
     traverse(state, 0, 1, 0)
+    percentages = ["{:.2f}%".format(100 * w) for w in widths]
     return {'left': starts,
             'right': stops,
             'bottom': heights,
@@ -213,7 +214,8 @@ def plot_data(state, profile_interval=0.010):
             'line': lines,
             'line_number': line_numbers,
             'name': names,
-            'time': times}
+            'time': times,
+            'percentage': percentages}
 
 
 try:


### PR DESCRIPTION
Percentage of total runtime seems like a very useful metric (I always end up computing it by hand) so why not add it to the tooltip?

![image](https://user-images.githubusercontent.com/903655/37071638-49905b8e-2172-11e8-8771-cb2ca5425efb.png)
