### PR TITLE
Add fifo timeout to control priority generation 

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -810,6 +810,7 @@ class Scheduler(ServerNode):
                     _StateLegacySet(self.tasks, func))
 
         self.generation = 0
+        self._last_client = None
         self.unrunnable = set()
 
         self.n_tasks = 0
@@ -1361,9 +1362,13 @@ class Scheduler(ServerNode):
                 generation = ts.priority[0] - 0.01
             else:  # super-task already cleaned up
                 generation = self.generation
-        else:
+        elif client != self._last_client:
             self.generation += 1  # older graph generations take precedence
             generation = self.generation
+            self._last_client = client
+        else:
+            generation = self.generation
+
         for key in set(priority) & touched_keys:
             ts = self.tasks[key]
             if ts.priority is None:

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -1,11 +1,13 @@
+import pytest
+from tornado import gen
+
 from dask.core import flatten
+import dask
 from dask import delayed, persist
 
-from distributed.utils_test import gen_cluster, inc, slowinc
+from distributed.utils_test import gen_cluster, inc, slowinc, slowdec
 from distributed import wait
 from distributed.utils import tokey
-
-import pytest
 
 
 @gen_cluster(client=True)
@@ -77,3 +79,31 @@ def test_expand_persist(c, s, a, b):
     low, high, x, y, z, w = persist(low, high, *many, priority={low: -1, high: 1})
     yield wait(high)
     assert s.tasks[low.key].state == 'processing'
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)])
+def test_repeated_persists_same_priority(c, s, w):
+    xs = [delayed(slowinc)(i, delay=0.05) for i in range(10)]
+    ys = [delayed(slowinc)(x, delay=0.05) for x in xs]
+    zs = [delayed(slowdec)(x, delay=0.05) for x in xs]
+
+    ys = dask.persist(*ys)
+    zs = dask.persist(*zs)
+
+    while sum(t.state == 'memory' for t in s.tasks.values()) < 6:
+        yield gen.sleep(0.01)
+
+    assert any(s.tasks[y.key].state == 'memory' for y in ys)
+    assert any(s.tasks[z.key].state == 'memory' for z in zs)
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)])
+def test_last_in_first_out(c, s, w):
+    xs = [c.submit(slowinc, i, delay=0.05) for i in range(5)]
+    ys = [c.submit(slowinc, x, delay=0.05) for x in xs]
+    zs = [c.submit(slowinc, y, delay=0.05) for y in ys]
+
+    while len(s.tasks) < 15 or not any(s.tasks[z.key].state == 'memory' for z in zs):
+        yield gen.sleep(0.01)
+
+    assert not all(s.tasks[x.key].state == 'memory' for x in xs)

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -90,7 +90,7 @@ def test_repeated_persists_same_priority(c, s, w):
     ys = dask.persist(*ys)
     zs = dask.persist(*zs)
 
-    while sum(t.state == 'memory' for t in s.tasks.values()) < 10:  # TODO: reduce this number
+    while sum(t.state == 'memory' for t in s.tasks.values()) < 5:  # TODO: reduce this number
         yield gen.sleep(0.01)
 
     assert any(s.tasks[y.key].state == 'memory' for y in ys)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1015,9 +1015,10 @@ def test_retire_nannies_close(c, s, a, b):
 def test_fifo_submission(c, s, w):
     futures = []
     for i in range(20):
-        future = c.submit(slowinc, i, delay=0.1, key='inc-%02d' % i)
+        future = c.submit(slowinc, i, delay=0.1, key='inc-%02d' % i,
+                          fifo_timeout=0.01)
         futures.append(future)
-        yield gen.sleep(0.01)
+        yield gen.sleep(0.02)
     yield wait(futures[-1])
     assert futures[10].status == 'finished'
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1087,6 +1087,7 @@ class Worker(WorkerBase):
         self.profile_history = deque(maxlen=3600)
 
         self.priorities = dict()
+        self.generation = 0
         self.durations = dict()
         self.startstops = defaultdict(list)
         self.resource_restrictions = dict()
@@ -1245,6 +1246,10 @@ class Worker(WorkerBase):
                     return
                 if state in IN_PLAY:
                     return
+
+            if priority is not None:
+                priority = tuple(priority) + (self.generation,)
+                self.generation -= 1
 
             if self.dep_state.get(key) == 'memory':
                 self.task_state[key] = 'memory'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -92,6 +92,7 @@ Contents
    locality
    manage-computation
    memory
+   priority
    related-work
    resilience
    scheduling-policies

--- a/docs/source/priority.rst
+++ b/docs/source/priority.rst
@@ -1,0 +1,59 @@
+Prioritizing Work
+=================
+
+When there is more work than workers, Dask has to decide which tasks to
+prioritize over others.  Dask can determine these priorities automatically to
+optimize performance, or a user can specify priorities manually according to
+their needs.
+
+Dask uses the following priorities, in order:
+
+1.  **User priorities**: A user defined priority, provided by the ``priority=`` keyword argument
+    to functions like ``compute()``, ``persist()``, ``submit()``, or ``map()``.
+    Tasks with higher priorities run before tasks with lower priorities with
+    the default priority being zero.
+
+    .. code-block:: python
+
+       future = client.submit(func, *args, priority=10)  # high priority task
+       future = client.submit(func, *args, priority=-10)  # low priority task
+
+       df = df.persist(priority=10)  # high priority computation
+
+2.  **First in first out chronologically**: Dask prefers computations that were
+    submitted early.  Because users can submit computations asynchronously it
+    may be that several different computations are running on the workers at
+    the same time.  Generally Dask prefers those groups of tasks that were
+    submitted first.
+
+    As a nuance, tasks that are submitted within a close window are often
+    considered to be submitted at the same time.
+
+    .. code-block:: python
+
+       x = x.persist()  # submitted first and so has higher priority
+       # wait a while
+       x = x.persist()  # submitted second and so has lower priority
+
+    In this case "a while" depends on the kind of computation. Operations
+    that are often used in bulk processing, like ``compute`` and ``persist``
+    consider any two computations submitted in the same sixty seconds
+    to have the same priority.  Operations that are often used in real-time
+    processing, like ``submit`` or ``map`` are considered the same priority if
+    they are submitted within the 100 milliseconds of each other.  This
+    behavior can be controlled with the ``fifo_timeout=`` keyword:
+
+    .. code-block:: python
+
+       x = x.persist()
+       # wait one minute
+       x = x.persist(fifo_timeout='10 minutes')  # has the same priority
+
+       a = client.submit(func, *args)
+       # wait no time at all
+       b = client.submit(func, *args, fifo_timeout='0ms')  # is lower priority
+
+3.  **Graph Structure**: Within any given computation (a compute or persist
+    call) Dask orders tasks in such a way as to minimize the memory-footprint
+    of the computation.  This is discussed in more depth in the
+    `task ordering documentation <https://github.com/dask/dask/blob/master/dask/order.py>`_.


### PR DESCRIPTION
Previously every call to update_graph would decrement the priority of
those tasks.  This resulted in a first-in-first-out behavior.
This was good both for multi-client workloads, and for consistent
ordering.

However, this got in the way of common workflows where people would
call persist rapidly in sucession:

    x = x.persist()
    y = y.persist()  # <-- these are all lower priority

Now we only decrement priority when enough time has passed.  
This time is different for realtime apis (map/submit) and dask collections
(compute/persist)

-  submit/map: 100ms
-  compute/persist: 60s

These are controllable with the `fifo_timeout=` keyword

Additionally we re-institute a last-in-first-out policy on workers
that serves only as a tie breaker, such as when using client.submit.