### PR TITLE
Test all compressions against serialization

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -47,6 +47,8 @@ with ignoring(ImportError):
         # snappy.decompress() doesn't accept memoryviews
         if isinstance(data, memoryview):
             data = data.tobytes()
+        elif isinstance(data, bytearray):
+            data = bytes(data)
         return snappy.decompress(data)
 
     compressions['snappy'] = {'compress': snappy.compress,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3769,7 +3769,7 @@ class Scheduler(ServerNode):
             if start == finish:
                 return {}
 
-            if self.plugins and finish == 'forgotten':
+            if self.plugins:
                 dependents = set(ts.dependents)
                 dependencies = set(ts.dependencies)
 


### PR DESCRIPTION
Fixes #1830

Snappy doesn't accept the bytearrays produced by Tornado.
Now we convert explicitly to bytes if necessary.

This also includes parametrized tests for all comressions.