### PR TITLE
Avoid testing truthiness of bokeh source, use len instead

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -559,7 +559,7 @@ class TaskStream(components.TaskStream):
         if self.index == self.plugin.index:
             return
         with log_errors():
-            if self.index and self.source.data['start']:
+            if self.index and len(self.source.data['start']):
                 start = min(self.source.data['start'])
                 duration = max(self.source.data['duration'])
                 boundary = (self.offset + start - duration) / 1000


### PR DESCRIPTION
This can be a numpy array in some cases.  We use len to avoid errors like
the following:

    ValueError: The truth value of an array with more than one element is
    ambiguous. Use a.any() or a.all()