### PR TITLE
Use connect-timeout throughout client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -482,10 +482,15 @@ class Client(Node):
     --------
     distributed.scheduler.Scheduler: Internal scheduler
     """
-    def __init__(self, address=None, loop=None, timeout=5,
+    def __init__(self, address=None, loop=None, timeout=no_default,
                  set_as_default=True, scheduler_file=None,
                  security=None, asynchronous=False,
                  name=None, heartbeat_interval=None, **kwargs):
+        if timeout == no_default:
+            timeout = config.get('connect-timeout', '5s')
+        if timeout is not None:
+            timeout = parse_timedelta(timeout, 's')
+        self._timeout = timeout
 
         self.futures = dict()
         self.refcount = defaultdict(lambda: 0)
@@ -707,7 +712,12 @@ class Client(Node):
                             "Message: %s" % (self.status, msg))
 
     @gen.coroutine
-    def _start(self, timeout=5, **kwargs):
+    def _start(self, timeout=no_default, **kwargs):
+        if timeout == no_default:
+            timeout = config.get('connect-timeout', '5s')
+        if timeout is not None:
+            timeout = parse_timedelta(timeout, 's')
+
         address = self._start_arg
         if self.cluster is not None:
             # Ensure the cluster is started (no-op if already running)
@@ -1009,7 +1019,7 @@ class Client(Node):
 
     _shutdown = _close
 
-    def close(self, timeout=10):
+    def close(self, timeout=no_default):
         """ Close this client
 
         Clients will also close automatically when your Python session ends
@@ -1021,6 +1031,8 @@ class Client(Node):
         --------
         Client.restart
         """
+        if timeout == no_default:
+            timeout = self._timeout * 2
         # XXX handling of self.status here is not thread-safe
         if self.status == 'closed':
             return
@@ -1487,7 +1499,9 @@ class Client(Node):
 
     @gen.coroutine
     def _scatter(self, data, workers=None, broadcast=False, direct=None,
-                 local_worker=None, timeout=3, hash=True):
+                 local_worker=None, timeout=no_default, hash=True):
+        if timeout == no_default:
+            timeout = self._timeout
         if isinstance(workers, six.string_types + (Number,)):
             workers = [workers]
         if isinstance(data, dict) and not all(isinstance(k, (bytes, unicode))
@@ -1599,7 +1613,7 @@ class Client(Node):
                 qout.put(future)
 
     def scatter(self, data, workers=None, broadcast=False, direct=None,
-                hash=True, maxsize=0, timeout=3, asynchronous=None):
+                hash=True, maxsize=0, timeout=no_default, asynchronous=None):
         """ Scatter data into distributed memory
 
         This moves data from the local client process into the workers of the
@@ -1665,6 +1679,8 @@ class Client(Node):
         --------
         Client.gather: Gather data back to local process
         """
+        if timeout == no_default:
+            timeout = self._timeout
         if isqueue(data) or isinstance(data, Iterator):
             logger.debug("Starting thread for streaming data")
             qout = pyQueue(maxsize=maxsize)
@@ -2359,7 +2375,9 @@ class Client(Node):
         return self.sync(self._upload_environment, name, zipfile)
 
     @gen.coroutine
-    def _restart(self, timeout=5):
+    def _restart(self, timeout=no_default):
+        if timeout == no_default:
+            timeout = self._timeout
         self._send_to_scheduler({'op': 'restart', 'timeout': timeout})
         self._restart_event = Event()
         try:

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -161,8 +161,8 @@ def connect(addr, timeout=None, deserialize=True, connection_args=None):
     retried until the *timeout* is expired.
     """
     if timeout is None:
-        timeout = config.get('connect-timeout', 3)
-        timeout = float(parse_timedelta(timeout, default='seconds'))
+        timeout = config.get('connect-timeout', '3s')
+    timeout = parse_timedelta(timeout, default='seconds')
 
     scheme, loc = parse_address(addr)
     backend = registry.get_backend(scheme)

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -131,7 +131,9 @@ def initialize_logging(config):
 
 
 @contextmanager
-def set_config(**kwargs):
+def set_config(arg=None, **kwargs):
+    if arg and not kwargs:
+        kwargs = arg
     old = {}
     for key in kwargs:
         if key in config:

--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -21,7 +21,7 @@ multiprocessing-method: forkserver
 use-file-locking: True
 
 # Communication options
-connect-timeout: 3s     # seconds delay before connecting fails
+connect-timeout: 5s     # seconds delay before connecting fails
 tcp-timeout: 30s        # seconds delay before calling an unresponsive connection dead
 default-scheme: tcp
 require-encryption: False   # whether to require encryption on non-local comms

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5234,11 +5234,11 @@ def test_diagnostics_link_env_variable(loop):
 
 
 @gen_test()
-def test_client_timeout():
+def test_client_timeout_2():
     with set_config({'connect-timeout': '10ms'}):
         start = time()
         c = Client('127.0.0.1:3755', asynchronous=True)
-        with pytest.raises((TimeoutError, OSError)):
+        with pytest.raises((TimeoutError, IOError)):
             yield c
         stop = time()
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -29,7 +29,9 @@ import dask
 from dask import delayed
 from dask.context import _globals
 from distributed import (Worker, Nanny, fire_and_forget, config,
-                         get_client, secede, get_worker, Executor, profile)
+                         get_client, secede, get_worker, Executor, profile,
+                         TimeoutError)
+from distributed.config import set_config
 from distributed.comm import CommClosedError
 from distributed.client import (Client, Future, wait, as_completed, tokenize,
                                 _get_global_client, default_client,
@@ -5229,6 +5231,20 @@ def test_diagnostics_link_env_variable(loop):
                 assert link in text
             finally:
                 del config['diagnostics-link']
+
+
+@gen_test()
+def test_client_timeout():
+    with set_config({'connect-timeout': '10ms'}):
+        start = time()
+        c = Client('127.0.0.1:3755', asynchronous=True)
+        with pytest.raises((TimeoutError, OSError)):
+            yield c
+        stop = time()
+
+        yield c.close()
+
+        assert stop - start < 1
 
 
 if sys.version_info >= (3, 5):


### PR DESCRIPTION
Previously we had a number of hard-coded timeouts in the client that
roughly corresponded to "how quickly we expect to be able to make
connections".  Now we refer these to the `connect-timeout` entry in the
configuration.