### PR TITLE
Avoid recomputation on partially-complete results

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1326,8 +1326,8 @@ class Scheduler(ServerNode):
 
         # Avoid computation that is already finished
         already_in_memory = set()  # tasks that are already done
-        for k in dependencies:
-            if k in self.tasks and self.tasks[k].state in ('memory', 'erred'):
+        for k, v  in dependencies.items():
+            if v and k in self.tasks and self.tasks[k].state in ('memory', 'erred'):
                 already_in_memory.add(k)
 
         if already_in_memory:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -24,6 +24,7 @@ from tornado import gen
 from tornado.gen import Return
 from tornado.ioloop import IOLoop
 
+from dask.core import reverse_dict
 from dask.order import order
 
 from .batched import BatchedSend
@@ -1303,7 +1304,7 @@ class Scheduler(ServerNode):
         dependencies = dependencies or {}
 
         n = 0
-        while len(tasks) != n:  # walk thorough new tasks, cancel any bad deps
+        while len(tasks) != n:  # walk through new tasks, cancel any bad deps
             n = len(tasks)
             for k, deps in list(dependencies.items()):
                 if any(dep not in self.tasks and dep not in tasks
@@ -1316,13 +1317,34 @@ class Scheduler(ServerNode):
                     self.report({'op': 'cancelled-key', 'key': k}, client=client)
                     self.client_releases_keys(keys=[k], client=client)
 
-        # Remove any self-dependencies (happens on test_publish_bag()
-        # and others)
-        for k in dependencies:
-            deps = set(dependencies[k])
+        # Remove any self-dependencies (happens on test_publish_bag() and others)
+        for k, v in dependencies.items():
+            deps = set(v)
             if k in deps:
                 deps.remove(k)
             dependencies[k] = deps
+
+        # Avoid computation that is already finished
+        already_in_memory = set()  # tasks that are already done
+        for k in dependencies:
+            if k in self.tasks and self.tasks[k].state in ('memory', 'erred'):
+                already_in_memory.add(k)
+
+        if already_in_memory:
+            dependents = reverse_dict(dependencies)
+            stack = list(already_in_memory)
+            done = set(already_in_memory)
+            while stack:  # remove unnecessary dependencies
+                key = stack.pop()
+                ts = self.tasks[key]
+                for dep in dependencies[key]:
+                    if all(d in done for d in dependents[dep]):
+                        done.add(dep)
+                        stack.append(dep)
+
+            for d in done:
+                del tasks[d]
+                del dependencies[d]
 
         # Get or create task states
         stack = list(keys)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1326,7 +1326,7 @@ class Scheduler(ServerNode):
 
         # Avoid computation that is already finished
         already_in_memory = set()  # tasks that are already done
-        for k, v  in dependencies.items():
+        for k, v in dependencies.items():
             if v and k in self.tasks and self.tasks[k].state in ('memory', 'erred'):
                 already_in_memory.add(k)
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -7,6 +7,7 @@ import json
 from operator import add, mul
 import sys
 
+import dask
 from dask import delayed
 from toolz import merge, concat, valmap, first, frequencies
 from tornado import gen
@@ -1219,3 +1220,77 @@ def test_mising_data_errant_worker(c, s, w1, w2, w3):
             yield gen.sleep(0.001)
         w1._close()
         yield wait(y)
+
+
+@gen_cluster(client=True)
+def test_dont_recompute_if_persisted(c, s, a, b):
+    x = delayed(inc)(1, dask_key_name='x')
+    y = delayed(inc)(x, dask_key_name='y')
+
+    yy = y.persist()
+    yield wait(yy)
+
+    old = list(s.transition_log)
+
+    yyy = y.persist()
+    yield wait(yyy)
+
+    yield gen.sleep(0.100)
+    assert list(s.transition_log) == old
+
+
+@gen_cluster(client=True)
+def test_dont_recompute_if_persisted_2(c, s, a, b):
+    x = delayed(inc)(1, dask_key_name='x')
+    y = delayed(inc)(x, dask_key_name='y')
+    z = delayed(inc)(y, dask_key_name='z')
+
+    yy = y.persist()
+    yield wait(yy)
+
+    old = s.story('x', 'y')
+
+    zz = z.persist()
+    yield wait(zz)
+
+    yield gen.sleep(0.100)
+    assert s.story('x', 'y') == old
+
+
+@gen_cluster(client=True)
+def test_dont_recompute_if_persisted_3(c, s, a, b):
+    x = delayed(inc)(1, dask_key_name='x')
+    y = delayed(inc)(2, dask_key_name='y')
+    z = delayed(inc)(y, dask_key_name='z')
+    w = delayed(add)(x, z, dask_key_name='w')
+
+    ww = w.persist()
+    yield wait(ww)
+
+    old = list(s.transition_log)
+
+    www = w.persist()
+    yield wait(www)
+    yield gen.sleep(0.100)
+    assert list(s.transition_log) == old
+
+
+@gen_cluster(client=True)
+def test_dont_recompute_if_persisted_4(c, s, a, b):
+    x = delayed(inc)(1, dask_key_name='x')
+    y = delayed(inc)(x, dask_key_name='y')
+    z = delayed(inc)(x, dask_key_name='z')
+
+    yy = y.persist()
+    yield wait(yy)
+
+    old = s.story('x')
+
+    while s.tasks['x'].state == 'memory':
+        yield gen.sleep(0.01)
+
+    yyy, zzz = dask.persist(y, z)
+    yield wait([yyy, zzz])
+
+    new = s.story('x')
+    assert len(new) > len(old)


### PR DESCRIPTION
This adds a couple tests that demonstrate a flaw where we recompute
tasks that are dependencies of results that are already in memory or
erred.

See https://github.com/dask/distributed/issues/1832

This is not yet resolved.  We should identify tasks in our graph that are already completed (memory or erred) and then cull subtrees if appropriate.  This all happens in `Scheduler.update_graph`.  Unfortunately at this stage the data structures are somewhat different, and so `dask.optimize.cull` won't resolve our problem.  We need to rewrite that logic but using only dependencies.