### PR TITLE
[WIP] - Restart if nanny's checks fail

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -361,7 +361,7 @@ class WorkerProcess(object):
                 if self.status == 'starting':
                     yield gen.with_timeout(timedelta(seconds=5),
                                            self._wait_until_started())
-            except gen.TimeoutError:
+            except (gen.TimeoutError, AssertionError):
                 logger.info("Failed to start worker process.  Restarting")
                 yield gen.with_timeout(timedelta(seconds=1),
                                        self.process.terminate())


### PR DESCRIPTION
This is an attempt to track down the following error:

```
  File "/home/b.weinstein/miniconda3/envs/pangeo/lib/python3.6/site-packages/distributed/nanny.py", line 471, in _wait_until_started
    assert msg == 'started', msg
AssertionError: {'address': 'tcp://172.16.194.178:37068', 'dir': '/home/b.weinstein/dask-worker-space/worker-5ipv17oi'}
```