### PR TITLE
Publish temp_default_client

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -4,7 +4,7 @@ from .config import config
 from .core import connect, rpc
 from .deploy import LocalCluster, Adaptive
 from .diagnostics import progress
-from .client import (Client, Executor, CompatibleExecutor,
+from .client import (Client, Executor, CompatibleExecutor, temp_default_client,
                      wait, as_completed, default_client, fire_and_forget,
                      Future, futures_of)
 from .lock import Lock

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,6 +46,7 @@ API
 .. currentmodule:: distributed
 
 .. autosummary::
+   temp_default_client
    worker_client
    get_worker
    get_client
@@ -156,6 +157,7 @@ Other
 
 .. currentmodule:: distributed
 
+.. autofunction:: distributed.temp_default_client
 .. autofunction:: distributed.worker_client
 .. autofunction:: distributed.get_worker
 .. autofunction:: distributed.get_client


### PR DESCRIPTION
Adds the `temp_default_client` function as part of the public API. Can be useful in cases where a user wants to guarantee what `Client` is used for submission, but does not want to alter what the default `Client` may be set as elsewhere.