### PR TITLE
Handle errant workers when another worker has data

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2038,11 +2038,12 @@ class Scheduler(ServerNode):
         ts = self.tasks.get(key)
         if ts is None or not ts.who_has:
             return
-        ws = self.workers[errant_worker]
-        if ws in ts.who_has:
-            ts.who_has.remove(ws)
-            ws.has_what.remove(ts)
-            ws.nbytes -= ts.get_nbytes()
+        if errant_worker in self.workers:
+            ws = self.workers[errant_worker]
+            if ws in ts.who_has:
+                ts.who_has.remove(ws)
+                ws.has_what.remove(ts)
+                ws.nbytes -= ts.get_nbytes()
         if not ts.who_has:
             if ts.run_spec:
                 self.transitions({key: 'released'})
@@ -3320,9 +3321,9 @@ class Scheduler(ServerNode):
                 return {key: 'released'}
 
             if ws is not ts.processing_on:  # someone else has this task
-                logger.warning("Unexpected worker completed task, likely due to"
-                               " work stealing.  Expected: %s, Got: %s, Key: %s",
-                               ts.processing_on, ws, key)
+                logger.info("Unexpected worker completed task, likely due to"
+                            " work stealing.  Expected: %s, Got: %s, Key: %s",
+                            ts.processing_on, ws, key)
                 return {}
 
             if startstops:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -534,7 +534,8 @@ class WorkerBase(ServerNode):
         try:
             compressed = yield comm.write(msg)
         except EnvironmentError:
-            logger.exception('failed during get data', exc_info=True)
+            logger.exception('failed during get data with %s -> %s',
+                             self.address, who, exc_info=True)
             comm.abort()
             raise
         stop = time()


### PR DESCRIPTION
Previously we would fail in the following situation:

1.  A and B both have data
2.  C tries to get data from A
3.  A fails during this transfer
4.  The scheduler goes to clean things up and gets confused because
    someone (B) still has the data

The fix for this wasn't hard, but the test is a bit odd.  It seems
that the subsequent communication from C to B fails, which I don't
yet understand.

Related to #1836