### PR TITLE
Extend nanny started timeout to 30s

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -21,7 +21,7 @@ from .process import AsyncProcess
 from .proctitle import enable_proctitle_on_children
 from .security import Security
 from .utils import (get_ip, mp_context, silence_logging, json_load_robust,
-        PeriodicCallback)
+        PeriodicCallback, parse_timedelta)
 from .worker import _ncores, run, parse_memory_limit
 
 
@@ -359,7 +359,8 @@ class WorkerProcess(object):
                 self.status = 'starting'
                 yield self.process.start()
                 if self.status == 'starting':
-                    yield gen.with_timeout(timedelta(seconds=5),
+                    timeout = parse_timedelta(config.get('nanny-start-timeout', '30s'))
+                    yield gen.with_timeout(timedelta(seconds=timeout),
                                            self._wait_until_started())
             except gen.TimeoutError:
                 logger.info("Failed to start worker process.  Restarting")
@@ -468,7 +469,10 @@ class WorkerProcess(object):
                 return
             try:
                 msg = self.init_result_q.get_nowait()
-                assert msg == 'started', msg
+                if msg != 'started':
+                    logger.warn("Nanny got unexpected message %s. "
+                                "Starting worker again", msg)
+                    raise gen.TimeoutError()
                 return
             except Empty:
                 yield gen.sleep(delay)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -700,6 +700,7 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
         start
         end
     """
+    config['nanny-start-timeout'] = '5s'
     worker_kwargs = merge({'memory_limit': TOTAL_MEMORY, 'death_timeout': 5},
                           worker_kwargs)
 


### PR DESCRIPTION
Sometimes worker processes just don't start.  We don't know why.
Previously we set up a timeout of five seconds such that if a worker
process does not at least start in that time we restart the process
and try again.  This timeout is slow on some systems, notably HPC
clusters with slow network file systems, and also windows machines when
they try to start many workers simultaneously.

This commit extends that timeout to thirty seconds and makes it
configurable with the ``nanny-started-timeout`` config option.

Additionally, sometimes wires seem to get crossed and we get messages
from previous attempts.  We now restart cleanly in these cases.