### PR TITLE
Add retire_workers API to Client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2886,6 +2886,26 @@ class Client(Node):
         """
         return self.sync(self.scheduler.worker_logs, n=n, workers=workers)
 
+    def retire_workers(self, workers=None, close_workers=True, **kwargs):
+        """ Retire certain workers on the scheduler
+
+        See dask.distributed.Scheduler.retire_workers for the full docstring.
+
+        Examples
+        --------
+        You can get information about active workers using the following:
+        >>> workers = client.scheduler_info()['workers']
+
+        From that list you may want to select some workers to close
+        >>> client.retire_workers(workers=['tcp://address:port', ...])
+
+        See Also
+        --------
+        dask.distributed.Scheduler.retire_workers
+        """
+        return self.sync(self.scheduler.retire_workers, workers=workers,
+                         close_workers=close_workers, **kwargs)
+
     def set_metadata(self, key, value):
         """ Set arbitrary metadata in the scheduler
 

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -137,7 +137,6 @@ class AsyncProcess(object):
                 # later might be needed to restore normal system function.
                 # If this is in appropriate for your use case, please file a
                 # bug.
-                parent_alive_pipe.close()
                 os._exit(-1)
             else:
                 # If we get here, something odd is going on. File descriptors

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2698,7 +2698,7 @@ class Scheduler(ServerNode):
             return result
 
     @gen.coroutine
-    def retire_workers(self, comm=None, workers=None, remove=True, close=False,
+    def retire_workers(self, comm=None, workers=None, remove=True,
                        close_workers=False, **kwargs):
         """ Gracefully retire workers from cluster
 
@@ -2727,10 +2727,6 @@ class Scheduler(ServerNode):
         --------
         Scheduler.workers_to_close
         """
-        if close:
-            logger.warning("The keyword close= has been deprecated. "
-                           "Use close_workers= instead")
-        close_workers = close_workers or close
         with log_errors():
             if workers is None:
                 while True:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4007,7 +4007,7 @@ def test_scatter_type(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_retire_workers(c, s, a, b):
+def test_retire_workers_2(c, s, a, b):
     [x] = yield c.scatter([1], workers=a.address)
 
     yield s.retire_workers(workers=[a.address])
@@ -4460,7 +4460,7 @@ def test_recreate_error_not_error(loop):
 @gen_cluster(client=True)
 def test_retire_workers(c, s, a, b):
     assert set(s.workers) == {a.address, b.address}
-    yield c.scheduler.retire_workers(workers=[a.address], close_workers=True)
+    yield c.retire_workers(workers=[a.address], close_workers=True)
     assert set(s.workers) == {b.address}
 
     start = time()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -991,14 +991,14 @@ def test_close_nanny(c, s, a, b):
 
 @gen_cluster(client=True, timeout=20)
 def test_retire_workers_close(c, s, a, b):
-    yield s.retire_workers(close=True)
+    yield s.retire_workers(close_workers=True)
     assert not s.workers
 
 
 @gen_cluster(client=True, timeout=20, Worker=Nanny)
 def test_retire_nannies_close(c, s, a, b):
     nannies = [a, b]
-    yield s.retire_workers(close=True, remove=True)
+    yield s.retire_workers(close_workers=True, remove=True)
     assert not s.workers
 
     start = time()


### PR DESCRIPTION
This just defers to the Scheduler route, but is more accessible for users

Fixes https://github.com/dask/distributed/issues/1823

