### PR TITLE
Fix numeric environment variable configuration

### DIFF
--- a/distributed/config.py
+++ b/distributed/config.py
@@ -67,7 +67,24 @@ def load_env_vars(config):
     for name, value in os.environ.items():
         if name.startswith('DASK_'):
             varname = name[5:].lower().replace('_', '-')
-            config[varname] = value
+            config[varname] = _parse_env_value(value)
+
+
+def _parse_env_value(value):
+    """ Convert a string to an integer, float or boolean (in that order) if possible. """
+    bools = {
+        'true': True,
+        'false': False
+    }
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return bools.get(value.lower(), value)
 
 
 def _initialize_logging_old_style(config):

--- a/distributed/tests/test_config.py
+++ b/distributed/tests/test_config.py
@@ -9,8 +9,8 @@ import os
 import pytest
 
 from distributed.utils_test import (captured_handler, captured_logger,
-                                    new_config, new_config_file)
-from distributed.config import initialize_logging, set_config, config
+                                    new_config, new_config_file, new_environment)
+from distributed.config import initialize_logging, set_config, config, load_env_vars
 
 
 def dump_logger_list():
@@ -279,3 +279,28 @@ def test_set_config():
     with set_config(foo=1):
         assert config['foo'] == 1
     assert 'foo' not in config
+
+
+def test_load_env_vars():
+    environment = dict(
+        DASK_STRING='test',
+        DASK_INT='20',
+        DASK_TRUE='True',
+        DASK_FALSE='false',
+        DASK_FLOAT='1.5',
+        NOT_FOR_DASK='__variable not used__'
+    )
+    conf = {}
+    with new_environment(environment):
+        load_env_vars(conf)
+        assert conf['string'] == 'test'
+        assert conf['int'] == 20
+        assert conf['true'] is True
+        assert conf['false'] is False
+        assert conf['float'] == 1.5
+        assert isinstance(conf['string'], str)
+        assert isinstance(conf['int'], int)
+        assert isinstance(conf['float'], float)
+        assert isinstance(conf['true'], bool)
+        assert isinstance(conf['false'], bool)
+        assert '__variable not used__' not in conf.values()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1067,6 +1067,17 @@ def new_config(new_config):
 
 
 @contextmanager
+def new_environment(changes):
+    saved_environ = os.environ.copy()
+    os.environ.update(changes)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved_environ)
+
+
+@contextmanager
 def new_config_file(c):
     """
     Temporarily change configuration file to match dictionary *c*.


### PR DESCRIPTION
This fixes #1884 by trying to parse environment variables as integers, floats or booleans if possible. I allow booleans to be represented with any case to stay consistent with PyYAML.

I've also added a test of `load_env_vars()`, and a helper to temporarily set environment variables.

(A small note: this will actually make environment variables more compatible with YAML than PyYAML is, since `yaml.load('1e+10')` incorrectly returns the string '1e+10'.)