### PR TITLE
WIP: Add option to ignore error in get_dataset

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1827,8 +1827,10 @@ class Client(Node):
         return self.sync(self.scheduler.publish_list, **kwargs)
 
     @gen.coroutine
-    def _get_dataset(self, name):
-        out = yield self.scheduler.publish_get(name=name, client=self.id)
+    def _get_dataset(self, name, **kwargs):
+        out = yield self.scheduler.publish_get(
+            name=name, client=self.id, **kwargs
+        )
 
         with temp_default_client(self):
             data = loads(out['data'])

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -40,11 +40,11 @@ class PublishExtension(object):
         with log_errors():
             return list(sorted(self.datasets.keys()))
 
-    def get(self, stream, name=None, client=None):
+    def get(self, stream, name=None, client=None, error=True):
         with log_errors():
             if name in self.datasets:
                 return self.datasets[name]
-            else:
+            elif error:
                 raise KeyError("Dataset '%s' not found" % name)
 
 

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -53,6 +53,11 @@ def test_publish_roundtrip(s, a, b):
     with pytest.raises(KeyError) as exc_info:
         result = yield f.get_dataset(name='nonexistent')
 
+    try:
+        result = yield f.get_dataset(name='nonexistent', error=False)
+    except KeyError:
+        pytest.fail("`get_dataset` raised `KeyError` when it shouldn't.")
+
     assert "not found" in str(exc_info.value)
     assert "nonexistent" in str(exc_info.value)
 


### PR DESCRIPTION
When calling `get_dataset` with a non-existent name, the resulting exceptions (including logging thereof) is a bit loud. This remains the case when catching and handling the `KeyError` that propagates upward. To make this a little nicer, add an `error` keyword argument to `get` and `get_dataset` to ensure that the `KeyError` can be optionally suppressed. This silences the logging while allowing users to easily check if they got what they expected.