### PR TITLE
Santize get_dataset trace

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1829,6 +1829,8 @@ class Client(Node):
     @gen.coroutine
     def _get_dataset(self, name):
         out = yield self.scheduler.publish_get(name=name, client=self.id)
+        if out is None:
+            raise KeyError("Dataset '%s' not found" % name)
 
         with temp_default_client(self):
             data = loads(out['data'])

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -42,10 +42,7 @@ class PublishExtension(object):
 
     def get(self, stream, name=None, client=None):
         with log_errors():
-            if name in self.datasets:
-                return self.datasets[name]
-            else:
-                raise KeyError("Dataset '%s' not found" % name)
+            return self.datasets.get(name, None)
 
 
 class Datasets(MutableMapping):


### PR DESCRIPTION
Closes https://github.com/dask/distributed/pull/1887

Bump up where `KeyError` is raised in the `get_dataset` stack to cutdown on noise in the logs while preserving the expected behavior in the user facing API.

cc @martindurant