### PR TITLE
Drop `__contains__` from `Datasets`

### DIFF
--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -68,9 +68,6 @@ class Datasets(MutableMapping):
     def __delitem__(self, key):
         self.__client.unpublish_dataset(key)
 
-    def __contains__(self, key):
-        return key in self.__client.list_datasets()
-
     def __iter__(self):
         for key in self.__client.list_datasets():
             yield key


### PR DESCRIPTION
By default, the `Mapping` interface provides a method for `__contains__`,  which `MutableMapping` inherits. So there is no need for this method to be included explicitly on `Datasets`.