### PR TITLE
Don't log errors in sync

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -237,7 +237,6 @@ def sync(loop, func, *args, **kwargs):
             thread_state.asynchronous = True
             result[0] = yield make_coro()
         except Exception as exc:
-            logger.exception(exc)
             error[0] = sys.exc_info()
         finally:
             thread_state.asynchronous = False


### PR DESCRIPTION
We raise anyway, so lets let that process be enough.