### PR TITLE
Fix `UnboundLocalError` for `key`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1439,7 +1439,7 @@ class Scheduler(ServerNode):
             for dts in ts.dependencies:
                 if dts.exception_blame:
                     ts.exception_blame = dts.exception_blame
-                    recommendations[key] = 'erred'
+                    recommendations[ts.key] = 'erred'
                     break
 
         for plugin in self.plugins[:]:


### PR DESCRIPTION
Appears `key` in this context was not necessarily defined, which caused some errors to bubble up from the scheduler. From context, it seems like this should be `ts.key`. So this changes it to `ts.key`.