### PR TITLE
Extend default timeout to 10s

### DIFF
--- a/distributed/bokeh/tests/test_scheduler_bokeh.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh.py
@@ -349,7 +349,7 @@ def test_GraphPlot_clear(c, s, a, b):
         assert time() < start + 5
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, timeout=30)
 def test_GraphPlot_complex(c, s, a, b):
     da = pytest.importorskip('dask.array')
     gp = GraphPlot(s)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -489,7 +489,7 @@ class Client(Node):
                  security=None, asynchronous=False,
                  name=None, heartbeat_interval=None, **kwargs):
         if timeout == no_default:
-            timeout = config.get('connect-timeout', '5s')
+            timeout = config.get('connect-timeout', '10s')
         if timeout is not None:
             timeout = parse_timedelta(timeout, 's')
         self._timeout = timeout
@@ -716,7 +716,7 @@ class Client(Node):
     @gen.coroutine
     def _start(self, timeout=no_default, **kwargs):
         if timeout == no_default:
-            timeout = config.get('connect-timeout', '5s')
+            timeout = self._timeout
         if timeout is not None:
             timeout = parse_timedelta(timeout, 's')
 
@@ -2399,7 +2399,7 @@ class Client(Node):
     @gen.coroutine
     def _restart(self, timeout=no_default):
         if timeout == no_default:
-            timeout = self._timeout
+            timeout = self._timeout * 2
         self._send_to_scheduler({'op': 'restart', 'timeout': timeout})
         self._restart_event = Event()
         try:

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -161,7 +161,7 @@ def connect(addr, timeout=None, deserialize=True, connection_args=None):
     retried until the *timeout* is expired.
     """
     if timeout is None:
-        timeout = config.get('connect-timeout', '3s')
+        timeout = config.get('connect-timeout', '10s')
     timeout = parse_timedelta(timeout, default='seconds')
 
     scheme, loc = parse_address(addr)

--- a/distributed/config.yaml
+++ b/distributed/config.yaml
@@ -51,7 +51,7 @@ version: 1
 #########################
 #
 # compression: auto
-# connect-timeout: 5s     # seconds delay before connecting fails
+# connect-timeout: 10s    # seconds delay before connecting fails
 # tcp-timeout: 30s        # seconds delay before calling an unresponsive connection dead
 # default-scheme: tcp
 # require-encryption: False   # whether to require encryption on non-local comms

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -478,36 +478,37 @@ def test_worker_name():
 
 @gen_test()
 def test_coerce_address():
-    s = Scheduler(validate=True)
-    s.start(0)
-    print("scheduler:", s.address, s.listen_address)
-    a = Worker(s.ip, s.port, name='alice')
-    b = Worker(s.ip, s.port, name=123)
-    c = Worker('127.0.0.1', s.port, name='charlie')
-    yield [a._start(), b._start(), c._start()]
+    with set_config({'connect-timeout': '100ms'}):
+        s = Scheduler(validate=True)
+        s.start(0)
+        print("scheduler:", s.address, s.listen_address)
+        a = Worker(s.ip, s.port, name='alice')
+        b = Worker(s.ip, s.port, name=123)
+        c = Worker('127.0.0.1', s.port, name='charlie')
+        yield [a._start(), b._start(), c._start()]
 
-    assert s.coerce_address('127.0.0.1:8000') == 'tcp://127.0.0.1:8000'
-    assert s.coerce_address('[::1]:8000') == 'tcp://[::1]:8000'
-    assert s.coerce_address('tcp://127.0.0.1:8000') == 'tcp://127.0.0.1:8000'
-    assert s.coerce_address('tcp://[::1]:8000') == 'tcp://[::1]:8000'
-    assert s.coerce_address('localhost:8000') in ('tcp://127.0.0.1:8000', 'tcp://[::1]:8000')
-    assert s.coerce_address(u'localhost:8000') in ('tcp://127.0.0.1:8000', 'tcp://[::1]:8000')
-    assert s.coerce_address(a.address) == a.address
-    # Aliases
-    assert s.coerce_address('alice') == a.address
-    assert s.coerce_address(123) == b.address
-    assert s.coerce_address('charlie') == c.address
+        assert s.coerce_address('127.0.0.1:8000') == 'tcp://127.0.0.1:8000'
+        assert s.coerce_address('[::1]:8000') == 'tcp://[::1]:8000'
+        assert s.coerce_address('tcp://127.0.0.1:8000') == 'tcp://127.0.0.1:8000'
+        assert s.coerce_address('tcp://[::1]:8000') == 'tcp://[::1]:8000'
+        assert s.coerce_address('localhost:8000') in ('tcp://127.0.0.1:8000', 'tcp://[::1]:8000')
+        assert s.coerce_address(u'localhost:8000') in ('tcp://127.0.0.1:8000', 'tcp://[::1]:8000')
+        assert s.coerce_address(a.address) == a.address
+        # Aliases
+        assert s.coerce_address('alice') == a.address
+        assert s.coerce_address(123) == b.address
+        assert s.coerce_address('charlie') == c.address
 
-    assert s.coerce_hostname('127.0.0.1') == '127.0.0.1'
-    assert s.coerce_hostname('alice') == a.ip
-    assert s.coerce_hostname(123) == b.ip
-    assert s.coerce_hostname('charlie') == c.ip
-    assert s.coerce_hostname('jimmy') == 'jimmy'
+        assert s.coerce_hostname('127.0.0.1') == '127.0.0.1'
+        assert s.coerce_hostname('alice') == a.ip
+        assert s.coerce_hostname(123) == b.ip
+        assert s.coerce_hostname('charlie') == c.ip
+        assert s.coerce_hostname('jimmy') == 'jimmy'
 
-    assert s.coerce_address('zzzt:8000', resolve=False) == 'tcp://zzzt:8000'
+        assert s.coerce_address('zzzt:8000', resolve=False) == 'tcp://zzzt:8000'
 
-    yield s.close()
-    yield [w._close() for w in [a, b, c]]
+        yield s.close()
+        yield [w._close() for w in [a, b, c]]
 
 
 @pytest.mark.skipif(sys.platform.startswith('win'),

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -704,6 +704,7 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
         end
     """
     config['nanny-start-timeout'] = '5s'
+    config['connect-timeout'] = '5s'
     worker_kwargs = merge({'memory_limit': TOTAL_MEMORY, 'death_timeout': 5},
                           worker_kwargs)
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -742,7 +742,11 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                                              asynchronous=True)
                             args = [c] + args
                         try:
-                            result = yield func(*args)
+                            future = func(*args)
+                            if timeout:
+                                future = gen.with_timeout(timedelta(seconds=timeout),
+                                                          future)
+                            result = yield future
                             if s.validate:
                                 s.validate_state()
                         finally:
@@ -754,7 +758,7 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
 
                         raise gen.Return(result)
 
-                    result = loop.run_sync(coro, timeout=timeout)
+                    result = loop.run_sync(coro, timeout=timeout * 2 if timeout else timeout)
 
             for w in workers:
                 if getattr(w, 'data', None):


### PR DESCRIPTION
As we see people operate in more extreme situations (larger clusters,
larger graphs, weirder codebases) we experience longer periods of
non-communication.  It seems sensible to extend the default timeout to
10s.  We also double the default timeout for restarts, which are
particularly problematic.