### PR TITLE
Added parameters to dask-ssh command

### DIFF
--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -37,9 +37,21 @@ from distributed.cli.utils import check_python_3
                     "dask-scheduler and dask-worker commands."))
 @click.option('--remote-python', default=None, type=str,
               help="Path to Python on remote nodes.")
+@click.option('--memory-limit', default='auto',
+              help="Bytes of memory that the worker can use. "
+                   "This can be an integer (bytes), "
+                   "float (fraction of total system memory), "
+                   "string (like 5GB or 5000M), "
+                   "'auto', or zero for no memory management")
+@click.option('--worker-port', type=int, default=0,
+              help="Serving computation port, defaults to random")
+@click.option('--nanny-port', type=int, default=0,
+              help="Serving nanny port, defaults to random")
+
 @click.pass_context
 def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
-         ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python):
+         ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python,
+         memory_limit, worker_port, nanny_port):
     try:
         hostnames = list(hostnames)
         if hostfile:
@@ -54,8 +66,11 @@ def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
         print(ctx.get_help())
         exit(1)
 
+    
+    
     c = SSHCluster(scheduler, scheduler_port, hostnames, nthreads, nprocs,
-                   ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python)
+                   ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python,
+                   memory_limit, worker_port, nanny_port)
 
     import distributed
     print('\n---------------------------------------------------------------')

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -47,7 +47,6 @@ from distributed.cli.utils import check_python_3
               help="Serving computation port, defaults to random")
 @click.option('--nanny-port', type=int, default=0,
               help="Serving nanny port, defaults to random")
-
 @click.pass_context
 def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
          ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python,
@@ -66,8 +65,6 @@ def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
         print(ctx.get_help())
         exit(1)
 
-    
-    
     c = SSHCluster(scheduler, scheduler_port, hostnames, nthreads, nprocs,
                    ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python,
                    memory_limit, worker_port, nanny_port)

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -210,20 +210,43 @@ def start_scheduler(logdir, addr, port, ssh_username, ssh_port, ssh_private_key,
 
 
 def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, nprocs,
-                 ssh_username, ssh_port, ssh_private_key, nohost, remote_python=None):
+                 ssh_username, ssh_port, ssh_private_key, nohost,
+                 memory_limit,
+                 worker_port,
+                 nanny_port,
+                 remote_python=None):
 
     cmd = ('{python} -m distributed.cli.dask_worker '
            '{scheduler_addr}:{scheduler_port} '
-           '--nthreads {nthreads} --nprocs {nprocs}')
+           '--nthreads {nthreads} --nprocs {nprocs} ')
+    
     if not nohost:
-        cmd += ' --host {worker_addr}'
+        cmd += ' --host {worker_addr} '
+        
+    if memory_limit:
+        cmd += '--memory-limit {memory_limit} '
+        
+    if worker_port:
+        cmd += '--worker-port {worker_port} '
+        
+    if nanny_port:
+        cmd += '--nanny-port {nanny_port} '
+    
+    
+        
+        
     cmd = cmd.format(
         python=remote_python or sys.executable,
         scheduler_addr=scheduler_addr,
         scheduler_port=scheduler_port,
         worker_addr=worker_addr,
         nthreads=nthreads,
-        nprocs=nprocs)
+        nprocs=nprocs,
+        memory_limit=memory_limit,
+        worker_port=worker_port,
+        nanny_port=nanny_port)
+    
+    print(cmd)
 
     # Optionally redirect stdout and stderr to a logfile
     if logdir is not None:
@@ -254,7 +277,8 @@ class SSHCluster(object):
 
     def __init__(self, scheduler_addr, scheduler_port, worker_addrs, nthreads=0, nprocs=1,
                  ssh_username=None, ssh_port=22, ssh_private_key=None,
-                 nohost=False, logdir=None, remote_python=None):
+                 nohost=False, logdir=None, remote_python=None,
+                 memory_limit=None, worker_port = None, nanny_port = None):
 
         self.scheduler_addr = scheduler_addr
         self.scheduler_port = scheduler_port
@@ -268,6 +292,13 @@ class SSHCluster(object):
         self.nohost = nohost
 
         self.remote_python = remote_python
+        
+        self.memory_limit = memory_limit
+        self.worker_port = worker_port
+        self.nanny_port = nanny_port
+        
+        
+    
 
         # Generate a universal timestamp to use for log files
         import datetime
@@ -325,6 +356,9 @@ class SSHCluster(object):
                                          self.nthreads, self.nprocs,
                                          self.ssh_username, self.ssh_port,
                                          self.ssh_private_key, self.nohost,
+                                         self.memory_limit,
+                                         self.worker_port,
+                                         self.nanny_port,
                                          self.remote_python))
 
     def shutdown(self):

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -219,22 +219,19 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
     cmd = ('{python} -m distributed.cli.dask_worker '
            '{scheduler_addr}:{scheduler_port} '
            '--nthreads {nthreads} --nprocs {nprocs} ')
-    
+
     if not nohost:
         cmd += ' --host {worker_addr} '
-        
+
     if memory_limit:
         cmd += '--memory-limit {memory_limit} '
-        
+
     if worker_port:
         cmd += '--worker-port {worker_port} '
-        
+
     if nanny_port:
         cmd += '--nanny-port {nanny_port} '
-    
-    
-        
-        
+
     cmd = cmd.format(
         python=remote_python or sys.executable,
         scheduler_addr=scheduler_addr,
@@ -245,7 +242,6 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
         memory_limit=memory_limit,
         worker_port=worker_port,
         nanny_port=nanny_port)
-    
 
     # Optionally redirect stdout and stderr to a logfile
     if logdir is not None:
@@ -277,7 +273,7 @@ class SSHCluster(object):
     def __init__(self, scheduler_addr, scheduler_port, worker_addrs, nthreads=0, nprocs=1,
                  ssh_username=None, ssh_port=22, ssh_private_key=None,
                  nohost=False, logdir=None, remote_python=None,
-                 memory_limit=None, worker_port = None, nanny_port = None):
+                 memory_limit=None, worker_port=None, nanny_port=None):
 
         self.scheduler_addr = scheduler_addr
         self.scheduler_port = scheduler_port
@@ -291,13 +287,10 @@ class SSHCluster(object):
         self.nohost = nohost
 
         self.remote_python = remote_python
-        
+
         self.memory_limit = memory_limit
         self.worker_port = worker_port
         self.nanny_port = nanny_port
-        
-        
-    
 
         # Generate a universal timestamp to use for log files
         import datetime

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -246,7 +246,6 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
         worker_port=worker_port,
         nanny_port=nanny_port)
     
-    print(cmd)
 
     # Optionally redirect stdout and stderr to a logfile
     if logdir is not None:


### PR DESCRIPTION
I have added parameters memory-limit, nanny-port and worker-port to the dask-ssh command in order to be able to launch dask on enviroments with ports or memory restrictions.

This PR solve the open issue: #1354 