### PR TITLE
WIP: Allow selective de-serialization

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -487,7 +487,8 @@ class Client(Node):
     def __init__(self, address=None, loop=None, timeout=no_default,
                  set_as_default=True, scheduler_file=None,
                  security=None, asynchronous=False,
-                 name=None, heartbeat_interval=None, **kwargs):
+                 name=None, heartbeat_interval=None,
+                 serializers=None, **kwargs):
         if timeout == no_default:
             timeout = config.get('connect-timeout', '10s')
         if timeout is not None:
@@ -512,6 +513,7 @@ class Client(Node):
         self._lock = threading.Lock()
         self._refcount_lock = threading.Lock()
         self.datasets = Datasets(self)
+        self._serializers = serializers
 
         # Communication
         self.security = security or Security()

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -11,6 +11,7 @@ from tornado import gen
 from ..config import config
 from ..metrics import time
 from ..utils import parse_timedelta
+from ..protocol.serialize import deser
 from . import registry
 from .addressing import parse_address
 

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -7,7 +7,7 @@ from .core import (dumps, loads, maybe_compress, decompress, msgpack)
 from .serialize import (
     serialize, deserialize, nested_deserialize, Serialize, Serialized,
     to_serialize, register_serialization, register_serialization_lazy,
-    serialize_bytes, deserialize_bytes, serialize_bytelist)
+    serialize_bytes, deserialize_bytes, serialize_bytelist, deser)
 
 from ..utils import ignoring
 


### PR DESCRIPTION
Now have a "fallback" entry is serialize, which is the pair of functions
to call when the "dask" method (i.e., custom class serializers) fails;
the name of this fallback is saved.