### PR TITLE
DOC: new lines needed for doctest rendering

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -60,12 +60,15 @@ class LocalCluster(Cluster):
     >>> c = Client(c)  # connect to local cluster  # doctest: +SKIP
 
     Add a new worker to the cluster
+
     >>> w = c.start_worker(ncores=2)  # doctest: +SKIP
 
     Shut down the extra worker
+
     >>> c.remove_worker(w)  # doctest: +SKIP
 
     Pass extra keyword arguments to Bokeh
+
     >>> LocalCluster(service_kwargs={'bokeh': {'prefix': '/foo'}})  # doctest: +SKIP
     """
     def __init__(self, n_workers=None, threads_per_worker=None, processes=True,


### PR DESCRIPTION
From https://distributed.readthedocs.io/en/latest/local-cluster.html:
![image](https://user-images.githubusercontent.com/1680079/38744688-c01e7626-3f42-11e8-9b37-fec7a633e38d.png)
From "Add a new worker to the cluster" the rendering is off.

With this change:
![image](https://user-images.githubusercontent.com/1680079/38744724-d884b9a0-3f42-11e8-9229-164f2d4f2fdd.png)
