### PR TITLE
Delete cached file safely in upload file

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2480,13 +2480,13 @@ class Client(Node):
         """ Upload local package to workers
 
         This sends a local file up to all worker nodes.  This file is placed
-        into a temporary directory on Python's system path so any .py, .pyc, .egg
+        into a temporary directory on Python's system path so any .py,  .egg
         or .zip  files will be importable.
 
         Parameters
         ----------
         filename: string
-            Filename of .py, .pyc, .egg or .zip file to send to workers
+            Filename of .py, .egg or .zip file to send to workers
 
         Examples
         --------

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -20,7 +20,7 @@ from tornado.ioloop import TimeoutError
 
 from distributed import (Nanny, Client, get_client, wait, default_client,
         get_worker, Reschedule)
-from distributed.compatibility import WINDOWS
+from distributed.compatibility import WINDOWS, cache_from_source
 from distributed.config import config
 from distributed.core import rpc
 from distributed.client import wait
@@ -179,6 +179,33 @@ def test_upload_file(c, s, a, b):
     aa.close_rpc()
     bb.close_rpc()
     assert not os.path.exists(os.path.join(a.local_dir, 'foobar.py'))
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)])
+def test_upload_file_pyc(c, s, w):
+    with tmpfile() as dirname:
+        os.mkdir(dirname)
+        with open(os.path.join(dirname, 'foo.py'), mode='w') as f:
+            f.write('def f():\n    return 123')
+
+        sys.path.append(dirname)
+        try:
+            import foo
+            assert foo.f() == 123
+            pyc = cache_from_source(os.path.join(dirname, 'foo.py'))
+            assert os.path.exists(pyc)
+            yield c.upload_file(pyc)
+
+            def g():
+                import foo
+                return foo.x
+
+            future = c.submit(g)
+            result = yield future
+            assert result == 123
+        finally:
+            sys.path.remove(dirname)
+
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -181,6 +181,7 @@ def test_upload_file(c, s, a, b):
     assert not os.path.exists(os.path.join(a.local_dir, 'foobar.py'))
 
 
+@pytest.mark.xfail(reason="don't yet support uploading pyc files")
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)])
 def test_upload_file_pyc(c, s, w):
     with tmpfile() as dirname:
@@ -205,7 +206,6 @@ def test_upload_file_pyc(c, s, w):
             assert result == 123
         finally:
             sys.path.remove(dirname)
-
 
 
 @gen_cluster(client=True)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -987,13 +987,13 @@ def open_port(host=''):
 
 
 def import_file(path):
-    """ Loads modules for a file (.py, .pyc, .zip, .egg) """
+    """ Loads modules for a file (.py, .zip, .egg) """
     directory, filename = os.path.split(path)
     name, ext = os.path.splitext(filename)
     names_to_import = []
     tmp_python_path = None
 
-    if ext in ('.py', '.pyc'):
+    if ext in ('.py'):  # , '.pyc'):
         if directory not in sys.path:
             tmp_python_path = directory
         names_to_import.append(name)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -997,9 +997,9 @@ def import_file(path):
         if directory not in sys.path:
             tmp_python_path = directory
         names_to_import.append(name)
-        # Ensures that no pyc file will be reused
+    if ext == '.py':  # Ensure that no pyc file will be reused
         cache_file = cache_from_source(path)
-        if os.path.exists(cache_file):
+        with ignoring(OSError):
             os.remove(cache_file)
     if ext in ('.egg', '.zip'):
         if path not in sys.path:


### PR DESCRIPTION
Also don't delete pyc files when uploading

Fixes #1915 

This also tries to fix the pyc deletion situation.  The test doesn't pass yet, but I thought I'd push anyway so that I don't lose track of this.