### PR TITLE
Replace msgpack-python by msgpack

### DIFF
--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -30,7 +30,6 @@ call deactivate
     joblib ^
     jupyter_client ^
     mock ^
-    msgpack-python ^
     psutil ^
     pytest=3.1 ^
     python=%PYTHON% ^
@@ -49,6 +48,7 @@ call activate %CONDA_ENV%
 %PIP_INSTALL% git+https://github.com/dask/zict --upgrade
 
 %PIP_INSTALL% pytest-repeat pytest-timeout pytest-faulthandler sortedcollections
+%PIP_INSTALL% msgpack
 
 @rem Display final environment (for reproducing)
 %CONDA% list

--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -30,7 +30,7 @@ call deactivate
     joblib ^
     jupyter_client ^
     mock ^
-    msgpack ^
+    msgpack-python ^
     psutil ^
     pytest=3.1 ^
     python=%PYTHON% ^

--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -30,7 +30,7 @@ call deactivate
     joblib ^
     jupyter_client ^
     mock ^
-    msgpack-python ^
+    msgpack ^
     psutil ^
     pytest=3.1 ^
     python=%PYTHON% ^

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -60,7 +60,7 @@ pip install -q git+https://github.com/dask/dask.git --upgrade --no-deps
 pip install -q git+https://github.com/joblib/joblib.git --upgrade --no-deps
 pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
 pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
-pip install -q sortedcollections msgpack-python --no-deps
+pip install -q sortedcollections msgpack --no-deps
 pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click >= 6.6
 cloudpickle >= 0.2.2
 dask >= 0.17.0
-msgpack-python
+msgpack
 psutil
 six
 sortedcontainers


### PR DESCRIPTION
This is the new name of the package on PyPI. The [msgpack-python PyPI page](https://pypi.org/project/msgpack-python/) says "This package is deprecated. Install msgpack instead."

This may just fix #1913 as mentioned in https://github.com/dask/distributed/issues/1913#issuecomment-382798935.

Close #1794.