### PR TITLE
Quiet the client and scheduler when gather(..., errors='skip')

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1353,7 +1353,7 @@ class Client(Node):
             """ Want to stop the All(...) early if we find an error """
             st = self.futures[k]
             yield st.wait()
-            if st.status != 'finished':
+            if st.status != 'finished' and errors == 'raise' :
                 raise AllExit()
 
         while True:
@@ -1414,7 +1414,8 @@ class Client(Node):
                 response = yield self.scheduler.gather(keys=keys)
 
             if response['status'] == 'error':
-                logger.warning("Couldn't gather keys %s", response['keys'])
+                log = logger.warning if errors == 'raise' else logger.debug
+                log("Couldn't gather keys %s", response['keys'])
                 for key in response['keys']:
                     self._send_to_scheduler({'op': 'report-key',
                                              'key': key})

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2144,7 +2144,7 @@ class Scheduler(ServerNode):
                     for msg in msgs:
                         if msg == 'OK':  # from close
                             break
-                        if 'status' in msg and 'error' in msg['status']:
+                        if 'status' in msg and 'error' in msg['status'] and msg.get('op') != 'task-erred':
                             try:
                                 logger.error("error from worker %s: %s",
                                          worker, clean_exception(**msg)[1])


### PR DESCRIPTION
Previously we would log loudly when gathering erred futures, even when
the user had explicitly stated errors='skip'

Now we do a couple checks to avoid these loud warnings

Fixes https://github.com/dask/distributed/issues/1932