### PR TITLE
Accept KeyError when closing tornado IOLoop in tests

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -56,11 +56,11 @@ conda install -q \
 
 pip install -q pytest-repeat pytest-faulthandler
 
-pip install -q git+https://github.com/dask/dask.git --upgrade
-pip install -q git+https://github.com/joblib/joblib.git --upgrade
-pip install -q git+https://github.com/dask/s3fs.git --upgrade
-pip install -q git+https://github.com/dask/zict.git --upgrade
-pip install -q sortedcollections msgpack-python
+pip install -q git+https://github.com/dask/dask.git --upgrade --no-deps
+pip install -q git+https://github.com/joblib/joblib.git --upgrade --no-deps
+pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
+pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
+pip install -q sortedcollections msgpack-python --no-deps
 pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -142,7 +142,7 @@ def pristine_loop():
     finally:
         try:
             loop.close(all_fds=True)
-        except ValueError:
+        except (KeyError, ValueError):
             pass
         IOLoop.clear_instance()
         IOLoop.clear_current()


### PR DESCRIPTION
Previously this would raise a confusing KeyError.

See https://github.com/tornadoweb/tornado/issues/2367

We ignore this for now, which *seems* innocuous.