### PR TITLE
Clarifying couldn't gather keys warning

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1415,7 +1415,7 @@ class Client(Node):
 
             if response['status'] == 'error':
                 log = logger.warning if errors == 'raise' else logger.debug
-                log("Couldn't gather keys %s", response['keys'])
+                log("Couldn't gather %s keys, rescheduling %s", (len(response['keys']), response['keys']))
                 for key in response['keys']:
                     self._send_to_scheduler({'op': 'report-key',
                                              'key': key})


### PR DESCRIPTION
Fixes #1933 

Unfortunately (fortunately?) I couldn't reproduce the issue that prompted #1933 with master, but if this pops up again in the future, it should hopefully be a bit less mystifying. The pipenv entry for the version that prompted #1933:

```
"distributed": {
    "hashes": [
        "sha256:caf224b8ff994713f9c04967f91c2b6564e3387b9065d3365576f3f83f839a04",
        "sha256:0fa6057c9b7aa0235ba240e7eb66ffbf5fc9d25a5c4b5cf1169d93bc582b8687"
    ],
    "version": "==1.21.6"
},
```