### PR TITLE
Fix bug with queue timeouts

### DIFF
--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from collections import defaultdict
+import datetime
 import logging
 import uuid
 
@@ -75,6 +76,8 @@ class QueueExtension(object):
             self.scheduler.client_desires_keys(keys=[key], client='queue-%s' % name)
         else:
             record = {'type': 'msgpack', 'value': data}
+        if timeout is not None:
+            timeout = datetime.timedelta(seconds=(timeout))
         yield self.queues[name].put(record, timeout=timeout)
 
     def future_release(self, name=None, key=None, client=None):
@@ -120,6 +123,8 @@ class QueueExtension(object):
             out = [process(o) for o in out]
             raise gen.Return(out)
         else:
+            if timeout is not None:
+                timeout = datetime.timedelta(seconds=timeout)
             record = yield self.queues[name].get(timeout=timeout)
             record = process(record)
             raise gen.Return(record)

--- a/distributed/tests/test_joblib.py
+++ b/distributed/tests/test_joblib.py
@@ -10,6 +10,7 @@ from time import sleep
 from distributed import Client
 from distributed.utils_test import cluster, inc
 from distributed.utils_test import loop # noqa F401
+from toolz import identity
 
 distributed_joblib = pytest.importorskip('distributed.joblib')
 joblib_funcname = distributed_joblib.joblib_funcname
@@ -179,12 +180,9 @@ def test_errors(loop, joblib):
 def test_secede_with_no_processes(loop, joblib):
     # https://github.com/dask/distributed/issues/1775
 
-    def f(x):
-        return x
-
     with Client(loop=loop, processes=False, set_as_default=True):
         with joblib.parallel_backend('dask'):
-            joblib.Parallel(n_jobs=4)(joblib.delayed(f)(i) for i in range(2))
+            joblib.Parallel(n_jobs=4)(joblib.delayed(identity)(i) for i in range(2))
 
 
 def _test_keywords_f(_):

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -254,3 +254,22 @@ def test_close(c, s, a, b):
 
     while q.name in s.extensions['queues'].queues:
         yield gen.sleep(0.01)
+
+
+@gen_cluster(client=True)
+def test_timeout(c, s, a, b):
+    q = Queue('v', maxsize=1)
+
+    start = time()
+    with pytest.raises(gen.TimeoutError):
+        yield q.get(timeout=0.1)
+    stop = time()
+    assert 0.1 < stop - start < 2.0
+
+    yield q.put(1)
+
+    start = time()
+    with pytest.raises(gen.TimeoutError):
+        yield q.put(2, timeout=0.1)
+    stop = time()
+    assert 0.1 < stop - start < 2.0

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -89,7 +89,19 @@ def test_timeout(c, s, a, b):
     start = time()
     with pytest.raises(gen.TimeoutError):
         yield v.get(timeout=0.1)
-    assert 0.05 < time() - start < 2.0
+    stop = time()
+    assert 0.1 < stop - start < 2.0
+
+
+def test_timeout_sync(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address']) as c:
+            v = Variable('v')
+            start = time()
+            with pytest.raises(gen.TimeoutError):
+                v.get(timeout=0.1)
+            stop = time()
+            assert 0.1 < stop - start < 2.0
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
It turns out that tornado queues interpret timeout parameters as absolute times
rather than intervals.  See https://github.com/tornadoweb/tornado/issues/2370

We now explicitly use timedeltas to avoid the ambiguity.

Fixes https://github.com/dask/distributed/issues/1911