### PR TITLE
Only add reevaluate_occupancy callback once

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1056,6 +1056,8 @@ class Scheduler(ServerNode):
             for k, v in self.services.items():
                 logger.info("%11s at: %25s", k, '%s:%d' % (listen_ip, v.port))
 
+            self.loop.add_callback(self.reevaluate_occupancy)
+
         if self.scheduler_file:
             with open(self.scheduler_file, 'w') as f:
                 json.dump(self.identity(), f, indent=2)
@@ -1068,7 +1070,6 @@ class Scheduler(ServerNode):
 
             finalize(self, del_scheduler_file)
 
-        self.loop.add_callback(self.reevaluate_occupancy)
         self.start_periodic_callbacks()
 
         setproctitle("dask-scheduler [%s]" % (self.address,))

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4141,10 +4141,6 @@ class Scheduler(ServerNode):
             last = time()
             next_time = timedelta(seconds=DELAY)
 
-            # scheduler was somehow moved to another PID
-            if self.proc.pid != os.getpid():
-                self.proc = psutil.Process()
-
             if self.proc.cpu_percent() < 50:
                 workers = list(self.workers.values())
                 for i in range(len(workers)):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4137,11 +4137,10 @@ class Scheduler(ServerNode):
                 return
 
             import psutil
-            proc = psutil.Process()
             last = time()
             next_time = timedelta(seconds=DELAY)
 
-            if proc.cpu_percent() < 50:
+            if psutil.cpu_percent() < 50:
                 workers = list(self.workers.values())
                 for i in range(len(workers)):
                     ws = workers[worker_index % len(workers)]

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -27,7 +27,7 @@ from distributed.client import wait
 from distributed.scheduler import Scheduler
 from distributed.metrics import time
 from distributed.worker import Worker, error_message, logger, TOTAL_MEMORY
-from distributed.utils import tmpfile
+from distributed.utils import tmpfile, format_bytes
 from distributed.utils_test import (inc, mul, gen_cluster, div, dec,
                                     slow, slowinc, gen_test, cluster,
                                     captured_logger)
@@ -1016,7 +1016,8 @@ def test_pause_executor(c, s, a):
         futures = c.map(slowinc, range(10), delay=0.1)
 
         yield gen.sleep(0.3)
-        assert a.paused
+        assert a.paused, (format_bytes(psutil.Process().memory_info().rss),
+                          format_bytes(a.memory_limit))
         out = logger.getvalue()
         assert 'memory' in out.lower()
         assert 'pausing' in out.lower()


### PR DESCRIPTION
``Scheduler.reevaluate_occupancy`` is currently added as a callback every time ``Scheduler.start()`` is called. Since ``Scheduler.start()`` is called every time ``Scheduler.restart()``is called, long running schedulers that have restarted many times eventually consume most of a CPU trying to reevaluate occupancy. To add to the problem, the cpu percent check in ``reevaluate_occupancy`` always returns 0.0, at least on linux with psutil 5.4.3, since a new ``psutil.Process``object is made for each check (see https://psutil.readthedocs.io/en/latest/#psutil.cpu_percent).

I've moved where the ``reevaluate_occupancy``callback is added to the IOLoop so that it is not re-added on a restart. I've also switched to using ``psutil.cpu_percent()`` instead of ``psutil.Process().cpu_percent()``.

I'm not sure if this needs testing or how to go about adding this to the test suite.