### PR TITLE
Use self.sync so Client.processing works in asynchronous context

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2749,8 +2749,7 @@ class Client(Node):
             workers = list(workers)
         if workers is not None and not isinstance(workers, (list, set)):
             workers = [workers]
-        return valmap(set, sync(self.loop, self.scheduler.processing,
-                                workers=workers))
+        return self.sync(self.scheduler.processing, workers=workers)
 
     def nbytes(self, keys=None, summary=True, **kwargs):
         """ The bytes taken up by each key on the cluster

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2691,36 +2691,6 @@ class Client(Node):
             workers = [workers]
         return self.sync(self.scheduler.has_what, workers=workers, **kwargs)
 
-    def stacks(self, workers=None):
-        """ The task queues on each worker
-
-        Parameters
-        ----------
-        workers: list (optional)
-            A list of worker addresses, defaults to all
-
-        Examples
-        --------
-        >>> x, y, z = c.map(inc, [1, 2, 3])  # doctest: +SKIP
-        >>> c.stacks()  # doctest: +SKIP
-        {'192.168.1.141:46784': ['inc-1c8dd6be1c21646c71f76c16d09304ea',
-                                 'inc-fd65c238a7ea60f6a01bf4c8a5fcf44b',
-                                 'inc-1e297fc27658d7b67b3a758f16bcf47a']}
-
-        See Also
-        --------
-        Client.processing
-        Client.who_has
-        Client.has_what
-        Client.ncores
-        """
-        if (isinstance(workers, tuple)
-                and all(isinstance(i, (str, tuple)) for i in workers)):
-            workers = list(workers)
-        if workers is not None and not isinstance(workers, (list, set)):
-            workers = [workers]
-        return sync(self.loop, self.scheduler.stacks, workers=workers)
-
     def processing(self, workers=None):
         """ The tasks currently running on each worker
 
@@ -2739,7 +2709,6 @@ class Client(Node):
 
         See Also
         --------
-        Client.stacks
         Client.who_has
         Client.has_what
         Client.ncores

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3354,6 +3354,12 @@ def test_get_processing(c, s, a, b):
     x = yield c.scheduler.processing(workers=[a.address])
     assert isinstance(x[a.address], list)
 
+    x = yield c.processing()
+    assert set(x) == {a.address, b.address}
+
+    x = yield c.processing(workers=[a.address])
+    assert isinstance(x[a.address], list)
+
 
 @gen_cluster(client=True)
 def test_get_foo(c, s, a, b):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3340,19 +3340,13 @@ def test_default_get():
 
 @gen_cluster(client=True)
 def test_get_processing(c, s, a, b):
-    processing = yield c.scheduler.processing()
+    processing = yield c.processing()
     assert processing == valmap(list, s.processing)
 
     futures = c.map(slowinc, range(10), delay=0.1, workers=[a.address],
                     allow_other_workers=True)
 
     yield gen.sleep(0.2)
-
-    x = yield c.scheduler.processing()
-    assert set(x) == {a.address, b.address}
-
-    x = yield c.scheduler.processing(workers=[a.address])
-    assert isinstance(x[a.address], list)
 
     x = yield c.processing()
     assert set(x) == {a.address, b.address}


### PR DESCRIPTION
This PR attempts to close issue #1952 using the fix suggested by @mrocklin in this [comment](https://github.com/dask/distributed/issues/1952#issuecomment-386140014).

I also added a couple test cases that hang without this fix. Please let me know if there is a better way to include these tests or if there are other tests that should be added.

Also, `Client.stacks` does not use the `Client.sync` method either. Should I go ahead and use `self.sync` there, too?