### PR TITLE
Use normal serialization mechanisms to serialize published datasets

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1770,7 +1770,9 @@ class Client(Node):
             for name, data in kwargs.items():
                 keys = [tokey(f.key) for f in futures_of(data)]
                 coroutines.append(self.scheduler.publish_put(keys=keys,
-                                                             name=tokey(name), data=dumps(data), client=self.id))
+                                                             name=tokey(name),
+                                                             data=to_serialize(data),
+                                                             client=self.id))
 
             yield coroutines
 
@@ -1853,7 +1855,7 @@ class Client(Node):
             raise KeyError("Dataset '%s' not found" % name)
 
         with temp_default_client(self):
-            data = loads(out['data'])
+            data = out['data']
         raise gen.Return(data)
 
     def get_dataset(self, name, **kwargs):

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -125,6 +125,7 @@ class LocalTest(ClusterTest, unittest.TestCase):
     Cluster = partial(LocalCluster, silence_logs=False, diagnostics_port=None)
 
 
+@pytest.mark.skipif('sys.version_info[0] == 2', reason='')
 def test_Client_with_local(loop):
     with LocalCluster(1, scheduler_port=0, silence_logs=False,
                       diagnostics_port=None, loop=loop) as c:


### PR DESCRIPTION
This unifies serialization with the standard comm system, reducing extra logic, and removing a custom (and potentially unsafe) use of pickle.