### PR TITLE
insert newline by default after TextProgressBar

### DIFF
--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -103,12 +103,11 @@ class ProgressBar(object):
 
 class TextProgressBar(ProgressBar):
     def __init__(self, keys, scheduler=None, interval='100ms', width=40,
-                 loop=None, complete=True, start=True, newline=True):
+                 loop=None, complete=True, start=True):
         super(TextProgressBar, self).__init__(keys, scheduler, interval,
                                               complete)
         self.width = width
         self.loop = loop or IOLoop()
-        self.newline = newline
 
         if start:
             loop_runner = LoopRunner(self.loop)
@@ -126,9 +125,8 @@ class TextProgressBar(ProgressBar):
             sys.stdout.flush()
 
     def _draw_stop(self):
-        if self.newline:
-            sys.stdout.write('\n')
-            sys.stdout.flush()
+        sys.stdout.write('\n')
+        sys.stdout.flush()
 
 
 class ProgressWidget(ProgressBar):
@@ -350,9 +348,6 @@ def progress(*futures, **kwargs):
     complete: bool (optional)
         Track all keys (True) or only keys that have not yet run (False)
         (defaults to True)
-    newline: bool (optional)
-        Insert a newline after the progress bar. Ignored in notebooks.
-        (defaults to True)
 
     Notes
     -----
@@ -368,7 +363,6 @@ def progress(*futures, **kwargs):
     notebook = kwargs.pop('notebook', None)
     multi = kwargs.pop('multi', True)
     complete = kwargs.pop('complete', True)
-    newline = kwargs.pop('newline', True)
     assert not kwargs
 
     futures = futures_of(futures)
@@ -383,4 +377,4 @@ def progress(*futures, **kwargs):
             bar = ProgressWidget(futures, complete=complete)
         return bar
     else:
-        TextProgressBar(futures, complete=complete, newline=newline)
+        TextProgressBar(futures, complete=complete)

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -124,7 +124,7 @@ class TextProgressBar(ProgressBar):
             sys.stdout.write(msg)
             sys.stdout.flush()
 
-    def _draw_stop(self):
+    def _draw_stop(self, **kwargs):
         sys.stdout.write('\n')
         sys.stdout.flush()
 

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -103,12 +103,12 @@ class ProgressBar(object):
 
 class TextProgressBar(ProgressBar):
     def __init__(self, keys, scheduler=None, interval='100ms', width=40,
-                 loop=None, complete=True, start=True, no_newline=False):
+                 loop=None, complete=True, start=True, newline=True):
         super(TextProgressBar, self).__init__(keys, scheduler, interval,
                                               complete)
         self.width = width
         self.loop = loop or IOLoop()
-        self.no_newline = no_newline
+        self.newline = newline
 
         if start:
             loop_runner = LoopRunner(self.loop)
@@ -126,10 +126,9 @@ class TextProgressBar(ProgressBar):
             sys.stdout.flush()
 
     def _draw_stop(self):
-        if self.no_newline:
-            return
-        sys.stdout.write('\n')
-        sys.stdout.flush()
+        if self.newline:
+            sys.stdout.write('\n')
+            sys.stdout.flush()
 
 
 class ProgressWidget(ProgressBar):
@@ -351,9 +350,9 @@ def progress(*futures, **kwargs):
     complete: bool (optional)
         Track all keys (True) or only keys that have not yet run (False)
         (defaults to True)
-    no_newline: bool (optional)
-        Do not insert a newline after the progress bar. Ignored in notebooks.
-        (defaults to False)
+    newline: bool (optional)
+        Insert a newline after the progress bar. Ignored in notebooks.
+        (defaults to True)
 
     Notes
     -----
@@ -369,7 +368,7 @@ def progress(*futures, **kwargs):
     notebook = kwargs.pop('notebook', None)
     multi = kwargs.pop('multi', True)
     complete = kwargs.pop('complete', True)
-    no_newline = kwargs.pop('no_newline', False)
+    newline = kwargs.pop('newline', True)
     assert not kwargs
 
     futures = futures_of(futures)
@@ -384,4 +383,4 @@ def progress(*futures, **kwargs):
             bar = ProgressWidget(futures, complete=complete)
         return bar
     else:
-        TextProgressBar(futures, complete=complete, no_newline=no_newline)
+        TextProgressBar(futures, complete=complete, newline=newline)

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -125,7 +125,7 @@ class TextProgressBar(ProgressBar):
             sys.stdout.flush()
 
     def _draw_stop(self, **kwargs):
-        sys.stdout.write('\n')
+        sys.stdout.write('\r')
         sys.stdout.flush()
 
 

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -103,11 +103,12 @@ class ProgressBar(object):
 
 class TextProgressBar(ProgressBar):
     def __init__(self, keys, scheduler=None, interval='100ms', width=40,
-                 loop=None, complete=True, start=True):
+                 loop=None, complete=True, start=True, no_newline=False):
         super(TextProgressBar, self).__init__(keys, scheduler, interval,
                                               complete)
         self.width = width
         self.loop = loop or IOLoop()
+        self.no_newline = no_newline
 
         if start:
             loop_runner = LoopRunner(self.loop)
@@ -123,6 +124,12 @@ class TextProgressBar(ProgressBar):
         with ignoring(ValueError):
             sys.stdout.write(msg)
             sys.stdout.flush()
+
+    def _draw_stop(self):
+        if self.no_newline:
+            return
+        sys.stdout.write('\n')
+        sys.stdout.flush()
 
 
 class ProgressWidget(ProgressBar):
@@ -344,6 +351,9 @@ def progress(*futures, **kwargs):
     complete: bool (optional)
         Track all keys (True) or only keys that have not yet run (False)
         (defaults to True)
+    no_newline: bool (optional)
+        Do not insert a newline after the progress bar. Ignored in notebooks.
+        (defaults to False)
 
     Notes
     -----
@@ -359,6 +369,7 @@ def progress(*futures, **kwargs):
     notebook = kwargs.pop('notebook', None)
     multi = kwargs.pop('multi', True)
     complete = kwargs.pop('complete', True)
+    no_newline = kwargs.pop('no_newline', False)
     assert not kwargs
 
     futures = futures_of(futures)
@@ -373,4 +384,4 @@ def progress(*futures, **kwargs):
             bar = ProgressWidget(futures, complete=complete)
         return bar
     else:
-        TextProgressBar(futures, complete=complete)
+        TextProgressBar(futures, complete=complete, no_newline=no_newline)

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -73,7 +73,8 @@ def test_TextProgressBar_empty(loop, capsys):
 
 def check_bar_completed(capsys, width=40):
     out, err = capsys.readouterr()
-    bar, percent, time = [i.strip() for i in out.split('\r')[-1].split('|')]
+    # trailing newline so grab next to last line for final state of bar
+    bar, percent, time = [i.strip() for i in out.split('\r')[-2].split('|')]
     assert bar == '[' + '#' * width + ']'
     assert percent == '100% Completed'
 


### PR DESCRIPTION
PR to add functionality requested in issue #1487.

New option to progress() allows the old behaviour to be reproduced but default to adding a newline as that seems to be more likely what most people will want.