### PR TITLE
add ConnectionPool.remove method

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -724,14 +724,18 @@ class ConnectionPool(object):
         """
         Reuse an open communication to the given address.  For internal use.
         """
-        self.occupied[addr].remove(comm)
-        self.active -= 1
-        if comm.closed():
-            self.open -= 1
-            if self.open < self.limit:
-                self.event.set()
+        try:
+            self.occupied[addr].remove(comm)
+        except KeyError:
+            pass
         else:
-            self.available[addr].add(comm)
+            self.active -= 1
+            if comm.closed():
+                self.open -= 1
+                if self.open < self.limit:
+                    self.event.set()
+            else:
+                self.available[addr].add(comm)
 
     def collect(self):
         """

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -747,6 +747,25 @@ class ConnectionPool(object):
         if self.open < self.limit:
             self.event.set()
 
+    def remove(self, addr):
+        """
+        Remove all Comms to a given address.
+        """
+        logger.info("Removing comms to %s", addr)
+        if addr in self.available:
+            comms = self.available.pop(addr)
+            for comm in comms:
+                comm.close()
+                self.open -= 1
+        if addr in self.occupied:
+            comms = self.occupied.pop(addr)
+            for comm in comms:
+                comm.close()
+                self.open -= 1
+                self.active -= 1
+        if self.open < self.limit:
+            self.event.set()
+
     def close(self):
         """
         Close all communications abruptly.

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1620,6 +1620,7 @@ class Scheduler(ServerNode):
                 del self.host_info[host]
 
             del self.worker_comms[address]
+            self.rpc.remove(address)
             del self.aliases[ws.name]
             self.idle.discard(ws)
             self.saturated.discard(ws)

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -540,6 +540,39 @@ def test_connection_pool_tls():
 
 
 @gen_test()
+def test_connection_pool_remove():
+
+    @gen.coroutine
+    def ping(comm, delay=0.01):
+        yield gen.sleep(delay)
+        raise gen.Return('pong')
+
+    servers = [Server({'ping': ping}) for i in range(5)]
+    for server in servers:
+        server.listen(0)
+
+    rpc = ConnectionPool(limit=10)
+    s = servers.pop()
+    yield [rpc(s.address).ping() for s in servers]
+    yield [rpc(s.address).ping(delay=0.1) for i in range(3)]
+    yield rpc.connect(s.address)
+    assert sum(map(len, rpc.available.values())) == 6
+    assert sum(map(len, rpc.occupied.values())) == 1
+    assert rpc.active == 1
+    assert rpc.open == 7
+
+    rpc.remove(s.address)
+    assert s.address not in rpc.available
+    assert s.address not in rpc.occupied
+    assert sum(map(len, rpc.available.values())) == 4
+    assert sum(map(len, rpc.occupied.values())) == 0
+    assert rpc.active == 0
+    assert rpc.open == 4
+
+    rpc.close()
+
+
+@gen_test()
 def test_counters():
     server = Server({'div': stream_div})
     server.listen('tcp://')

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -554,7 +554,7 @@ def test_connection_pool_remove():
     rpc = ConnectionPool(limit=10)
     s = servers.pop()
     yield [rpc(s.address).ping() for s in servers]
-    yield [rpc(s.address).ping(delay=0.1) for i in range(3)]
+    yield [rpc(s.address).ping() for i in range(3)]
     yield rpc.connect(s.address)
     assert sum(map(len, rpc.available.values())) == 6
     assert sum(map(len, rpc.occupied.values())) == 1
@@ -568,6 +568,11 @@ def test_connection_pool_remove():
     assert sum(map(len, rpc.occupied.values())) == 0
     assert rpc.active == 0
     assert rpc.open == 4
+
+    rpc.collect()
+    comm = yield rpc.connect(s.address)
+    rpc.remove(s.address)
+    rpc.reuse(s.address, comm)
 
     rpc.close()
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -552,27 +552,27 @@ def test_connection_pool_remove():
         server.listen(0)
 
     rpc = ConnectionPool(limit=10)
-    s = servers.pop()
+    serv = servers.pop()
     yield [rpc(s.address).ping() for s in servers]
-    yield [rpc(s.address).ping() for i in range(3)]
-    yield rpc.connect(s.address)
+    yield [rpc(serv.address).ping() for i in range(3)]
+    yield rpc.connect(serv.address)
     assert sum(map(len, rpc.available.values())) == 6
     assert sum(map(len, rpc.occupied.values())) == 1
     assert rpc.active == 1
     assert rpc.open == 7
 
-    rpc.remove(s.address)
-    assert s.address not in rpc.available
-    assert s.address not in rpc.occupied
+    rpc.remove(serv.address)
+    assert serv.address not in rpc.available
+    assert serv.address not in rpc.occupied
     assert sum(map(len, rpc.available.values())) == 4
     assert sum(map(len, rpc.occupied.values())) == 0
     assert rpc.active == 0
     assert rpc.open == 4
 
     rpc.collect()
-    comm = yield rpc.connect(s.address)
-    rpc.remove(s.address)
-    rpc.reuse(s.address, comm)
+    comm = yield rpc.connect(serv.address)
+    rpc.remove(serv.address)
+    rpc.reuse(serv.address, comm)
 
     rpc.close()
 


### PR DESCRIPTION
fixes #1946 

Adds a ``ConnectionPool.remove`` method to remove all connections to a given address. Then call ``ConnectionPool.remove`` from ``Scheduler.remove_worker`` to make sure connections to removed workers are cleaned up.