### PR TITLE
Allow `name` to be explicitly passed in publish_dataset

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1806,7 +1806,7 @@ class Client(Node):
             def add_coro(name, data):
                 keys = [tokey(f.key) for f in futures_of(data)]
                 coroutines.append(self.scheduler.publish_put(keys=keys,
-                                                             name=dumps(name),
+                                                             name=name,
                                                              data=to_serialize(data),
                                                              client=self.id))
 
@@ -1890,7 +1890,7 @@ class Client(Node):
         --------
         Client.publish_dataset
         """
-        return self.sync(self.scheduler.publish_delete, name=dumps(name), **kwargs)
+        return self.sync(self.scheduler.publish_delete, name=name, **kwargs)
 
     def list_datasets(self, **kwargs):
         """
@@ -1905,7 +1905,7 @@ class Client(Node):
 
     @gen.coroutine
     def _get_dataset(self, name):
-        out = yield self.scheduler.publish_get(name=dumps(name), client=self.id)
+        out = yield self.scheduler.publish_get(name=name, client=self.id)
         if out is None:
             raise KeyError("Dataset '%s' not found" % name)
 

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -1,8 +1,6 @@
 from collections import MutableMapping
 from distributed.utils import log_errors, tokey
 
-from .protocol.pickle import dumps, loads
-
 
 class PublishExtension(object):
     """ An extension for the scheduler to manage collections

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -27,7 +27,6 @@ class PublishExtension(object):
 
     def put(self, stream=None, keys=None, data=None, name=None, client=None):
         with log_errors():
-            name = loads(name)
             if name in self.datasets:
                 raise KeyError("Dataset %s already exists" % name)
             self.scheduler.client_desires_keys(keys, 'published-%s' % tokey(name))
@@ -36,17 +35,15 @@ class PublishExtension(object):
 
     def delete(self, stream=None, name=None):
         with log_errors():
-            name = loads(name)
             out = self.datasets.pop(name, {'keys': []})
             self.scheduler.client_releases_keys(out['keys'], 'published-%s' % tokey(name))
 
     def list(self, *args):
         with log_errors():
-            return list(sorted(self.datasets.keys()))
+            return list(sorted(self.datasets.keys(), key=str))
 
     def get(self, stream, name=None, client=None):
         with log_errors():
-            name = loads(name)
             return self.datasets.get(name, None)
 
 

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -60,7 +60,7 @@ class Datasets(MutableMapping):
         return self.__client.get_dataset(key)
 
     def __setitem__(self, key, value):
-        self.__client.publish_dataset(**{key: value})
+        self.__client.publish_dataset(value, name=key)
 
     def __delitem__(self, key):
         self.__client.unpublish_dataset(key)

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -43,14 +43,13 @@ def test_publish_non_string_key(s, a, b):
     c = yield Client((s.ip, s.port), asynchronous=True)
     f = yield Client((s.ip, s.port), asynchronous=True)
 
-    for name in [('a', 'b'), frozenset([1, 2]), datetime.datetime.now()]:
+    for name in [('a', 'b'), 9.0, 8]:
         data = yield c.scatter(range(3))
         out = yield c.publish_dataset(data, name=name)
         assert name in s.extensions['publish'].datasets
         assert isinstance(s.extensions['publish'].datasets[name]['data'], Serialized)
 
-        datasets = yield c.list_datasets()
-        #datasets = yield c.scheduler.publish_list()
+        datasets = yield c.scheduler.publish_list()
         assert name in datasets
 
     yield c.close()

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -190,7 +190,7 @@ def test_datasets_setitem(loop):
             for key in ['key', ('key', 'key'), 1]:
                 value = 'value'
                 client.datasets[key] = value
-                assert client.get_dataset('key') == value
+                assert client.get_dataset(key) == value
 
 
 def test_datasets_getitem(loop):

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -1,6 +1,5 @@
 
 import pytest
-import datetime
 
 from dask import delayed
 from distributed import Client


### PR DESCRIPTION
We can now make datasets that don't have string names