### PR TITLE
Prioritize tasks with their true keys, before stringifying

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2049,27 +2049,31 @@ class Client(Node):
             if loose_restrictions is not None:
                 loose_restrictions = list(map(tokey, loose_restrictions))
 
-            dependencies = {tokey(k): set(map(tokey, v[1])) for k, v in d.items()}
+            future_dependencies = {tokey(k): set(map(tokey, v[1])) for k, v in d.items()}
 
-            for s in dependencies.values():
+            for s in future_dependencies.values():
                 for v in s:
                     if v not in self.futures:
                         raise CancelledError(v)
 
-            for k, v in dsk3.items():
-                dependencies[k] |= get_dependencies(dsk3, task=v)
+            dependencies = {k: get_dependencies(dsk, k) for k in dsk}
 
             if priority is None:
-                dependencies2 = {key: {dep for dep in deps if dep in dependencies}
-                                 for key, deps in dependencies.items()}
-                priority = dask.order.order(dsk3, dependencies2)
+                priority = dask.order.order(dsk, dependencies=dependencies)
+                priority = keymap(tokey, priority)
+
+            dependencies = {tokey(k): [tokey(dep) for dep in deps]
+                            for k, deps in dependencies.items()}
+            for k, deps in future_dependencies.items():
+                if deps:
+                    dependencies[k] = list(set(dependencies.get(k, ())) | deps)
 
             if isinstance(retries, Number) and retries > 0:
                 retries = {k: retries for k in dsk3}
 
             self._send_to_scheduler({'op': 'update-graph',
                                      'tasks': valmap(dumps_task, dsk3),
-                                     'dependencies': valmap(list, dependencies),
+                                     'dependencies': dependencies,
                                      'keys': list(flatkeys),
                                      'restrictions': restrictions or {},
                                      'loose_restrictions': loose_restrictions,

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -21,7 +21,7 @@ import zipfile
 
 import pytest
 from toolz import (identity, isdistinct, concat, pluck, valmap,
-                   partial, first)
+                   partial, first, merge)
 from tornado import gen
 from tornado.ioloop import IOLoop
 
@@ -5369,6 +5369,21 @@ def test_client_repr_closed_sync(loop):
     with Client(loop=loop, processes=False) as c:
         c.close()
         c._repr_html_()
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)])
+def test_nested_prioritization(c, s, w):
+    x = delayed(inc)(1, dask_key_name=('a', 2))
+    y = delayed(inc)(2, dask_key_name=('a', 10))
+
+    o = dask.order.order(merge(x.__dask_graph__(), y.__dask_graph__()))
+
+    fx, fy = c.compute([x, y])
+
+    yield wait([fx, fy])
+
+    assert ((o[x.key] < o[y.key]) ==
+            (s.tasks[tokey(fx.key)].priority < s.tasks[tokey(fy.key)].priority))
 
 
 if sys.version_info >= (3, 5):


### PR DESCRIPTION
Previously we would call dask.order after calling tokey on all of the
keys.  This would result in incorrect prioritiziations when we depend
on the keyname as a hint.