### PR TITLE
Serialize worker exceptions through normal channels

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2499,7 +2499,7 @@ class Client(Node):
                                                 'data': to_serialize(data)})
 
         if any(v['status'] == 'error' for v in d.values()):
-            exceptions = [loads(v['exception']) for v in d.values()
+            exceptions = [v['exception'] for v in d.values()
                           if v['status'] == 'error']
             if raise_on_error:
                 raise exceptions[0]

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -819,18 +819,19 @@ def error_message(e, status='error'):
         e3 = protocol.pickle.dumps(e2)
         protocol.pickle.loads(e3)
     except Exception:
-        e3 = Exception(str(e2))
-        e3 = protocol.pickle.dumps(e3)
+        e2 = Exception(str(e2))
+    e4 = protocol.to_serialize(e2)
     try:
         tb2 = protocol.pickle.dumps(tb)
     except Exception:
-        tb2 = ''.join(traceback.format_tb(tb))
-        tb2 = protocol.pickle.dumps(tb2)
+        tb = tb2 = ''.join(traceback.format_tb(tb))
 
     if len(tb2) > 10000:
-        tb2 = None
+        tb_result = None
+    else:
+        tb_result = protocol.to_serialize(tb)
 
-    return {'status': status, 'exception': e3, 'traceback': tb2}
+    return {'status': status, 'exception': e4, 'traceback': tb_result}
 
 
 def clean_exception(exception, traceback, **kwargs):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -685,7 +685,7 @@ class WorkerBase(ServerNode):
             except Exception as e:
                 logger.exception(e)
                 raise gen.Return({'status': 'error',
-                                  'exception': pickle.dumps(e)})
+                                  'exception': to_serialize(e)})
 
         raise gen.Return({'status': 'OK', 'nbytes': len(data)})
 
@@ -2162,7 +2162,7 @@ class Worker(WorkerBase):
                                    str(funcname(function))[:1000],
                                    convert_args_to_str(args2, max_len=1000),
                                    convert_kwargs_to_str(kwargs2, max_len=1000),
-                                   repr(pickle.loads(result['exception'])))
+                                   repr(result['exception'].data))
                     self.transition(key, 'error')
 
             logger.debug("Send compute response to scheduler: %s, %s", key,


### PR DESCRIPTION
Previously the client called pickle.loads on exceptions raised by workers