### PR TITLE
Automatically scatter large arguments in joblib connector

### DIFF
--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -12,6 +12,7 @@ from .client import Client, _wait
 from .utils import ignoring, funcname, itemgetter
 from . import get_client, secede, rejoin
 from .worker import thread_state
+from .sizeof import sizeof
 
 # A user could have installed joblib, sklearn, both, or neither. Further, only
 # joblib >= 0.10.0 supports backends, so we also need to check for that. This
@@ -38,6 +39,63 @@ if sk_joblib:
 if not _bases:
     raise RuntimeError("Joblib backend requires either `joblib` >= '0.10.2' "
                        " or `sklearn` > '0.17.1'. Please install or upgrade")
+
+
+def is_weakrefable(obj):
+    try:
+        weakref.ref(obj)
+        return True
+    except TypeError:
+        return False
+
+
+class _WeakKeyDictionary:
+    """A variant of weakref.WeakKeyDictionary for unhashable objects.
+
+    This datastructure is used to store futures for broadcasted data objects
+    such as large numpy arrays or pandas dataframes that are not hashable and
+    therefore cannot be used as keys of traditional python dicts.
+
+    Futhermore using a dict with id(array) as key is not safe because the
+    Python is likely to reuse id of recently collected arrays.
+    """
+
+    def __init__(self):
+        self._data = {}
+
+    def __getitem__(self, obj):
+        ref, val = self._data[id(obj)]
+        if ref() is not obj:
+            # In case of a race condition with on_destroy.
+            raise KeyError(obj)
+        return val
+
+    def __setitem__(self, obj, value):
+        key = id(obj)
+        try:
+            ref, _ = self._data[key]
+            if ref() is not obj:
+                # In case of race condition with on_destroy.
+                raise KeyError(obj)
+        except KeyError:
+            # Insert the new entry in the mapping along with a weakref
+            # callback to automatically delete the entry from the mapping
+            # as soon as the object used as key is garbage collected.
+            def on_destroy(_):
+                del self._data[key]
+            try:
+                ref = weakref.ref(obj, on_destroy)
+            except TypeError:
+                # Some interned objects such as str cannot have a weakref:
+                # store the object directly
+                ref = obj
+        self._data[key] = ref, value
+
+    def __len__(self):
+        return len(self._data)
+
+    def clear(self):
+        self._data.clear()
 
 
 def joblib_funcname(x):
@@ -96,15 +154,15 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             raise TypeError("scatter must be a list/tuple, got "
                             "`%s`" % type(scatter).__name__)
 
-        if scatter is not None:
+        if scatter is not None and len(scatter) > 0:
             # Keep a reference to the scattered data to keep the ids the same
             self._scatter = list(scatter)
             scattered = self.client.scatter(scatter, broadcast=True)
-            self.data_to_future = {id(x): f for (x, f) in zip(scatter, scattered)}
+            self.data_futures = {id(x): f for x, f in zip(scatter, scattered)}
         else:
             self._scatter = []
-            self.data_to_future = {}
-        self.futures = set()
+            self.data_futures = {}
+        self.task_futures = set()
         self.submit_kwargs = submit_kwargs
 
     def __reduce__(self):
@@ -116,25 +174,58 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
     def configure(self, n_jobs=1, parallel=None, **backend_args):
         return self.effective_n_jobs(n_jobs)
 
+    def start_call(self):
+        self.call_data_futures = _WeakKeyDictionary()
+
+    def stop_call(self):
+        # The explicit call to clear is required to break a cycling reference
+        # to the futures.
+        self.call_data_futures.clear()
+        self.call_data_futures = None
+
     def effective_n_jobs(self, n_jobs):
         return sum(self.client.ncores().values())
 
     def _to_func_args(self, func):
-        if not self.data_to_future:
-            return func, ()
-        args2 = []
-        lookup = dict(self.data_to_future)
+        collected_futures = []
+        itemgetters = dict()
+
+        # Futures that are dynamically generated during a single call to
+        # Parallel.__call__.
+        call_data_futures = getattr(self, 'call_data_futures', None)
 
         def maybe_to_futures(args):
-            for x in args:
-                id_x = id(x)
-                if id_x in lookup:
-                    x = lookup[id_x]
-                    if type(x) is not itemgetter:
-                        x = itemgetter(len(args2))
-                        args2.append(lookup[id_x])
-                        lookup[id_x] = x
-                yield x
+            for arg in args:
+                arg_id = id(arg)
+                if arg_id in itemgetters:
+                    yield itemgetters[arg_id]
+                    continue
+
+                f = None
+                if f is None and arg_id in self.data_futures:
+                    f = self.data_futures[arg_id]
+
+                if f is None and call_data_futures is not None:
+                    try:
+                        f = call_data_futures[arg]
+                    except KeyError:
+                        if (call_data_futures is not None
+                                and is_weakrefable(arg)
+                                and sizeof(arg) > 1e6):
+                            # Automatically scatter large objects to some of
+                            # the workers to avoid duplicated data transfers.
+                            # Rely on automated inter-worker data stealing if
+                            # more workers need to reuse this data concurrently
+                            # beyond the initial broadcast arity.
+                            [f] = self.client.scatter([arg], broadcast=3)
+                            call_data_futures[arg] = f
+
+                if f is not None:
+                    getter = itemgetter(len(collected_futures))
+                    collected_futures.append(f)
+                    itemgetters[arg_id] = getter
+                    arg = getter
+                yield arg
 
         tasks = []
         for f, args, kwargs in func.items:
@@ -142,21 +233,21 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
             kwargs = dict(zip(kwargs.keys(), maybe_to_futures(kwargs.values())))
             tasks.append((f, args, kwargs))
 
-        if not args2:
+        if not collected_futures:
             return func, ()
-        return Batch(tasks), args2
+        return Batch(tasks), collected_futures
 
     def apply_async(self, func, callback=None):
         key = '%s-batch-%s' % (joblib_funcname(func), uuid4().hex)
         func, args = self._to_func_args(func)
 
         future = self.client.submit(func, *args, key=key, **self.submit_kwargs)
-        self.futures.add(future)
+        self.task_futures.add(future)
 
         @gen.coroutine
         def callback_wrapper():
             result = yield _wait([future])
-            self.futures.remove(future)
+            self.task_futures.remove(future)
             if callback is not None:
                 callback(result)  # gets called in separate thread
 
@@ -175,8 +266,8 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
 
         joblib.Parallel will never access those results
         """
-        self.client.cancel(self.futures)
-        self.futures.clear()
+        self.client.cancel(self.task_futures)
+        self.task_futures.clear()
 
     @contextlib.contextmanager
     def retrieval_context(self):


### PR DESCRIPTION
This requires: https://github.com/joblib/joblib/pull/689 to work efficiently but should not crash or degrade performance when used with an older joblib.