### PR TITLE
Don't remove dep from Worker.dependencies

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2197,8 +2197,7 @@ class Scheduler(ServerNode):
                     if not workers:
                         continue
                     ts = self.tasks[key]
-                    logger.exception("Workers don't have promised key. "
-                                     "This should never occur: %s, %s",
+                    logger.exception("Workers don't have promised key: %s, %s",
                                      str(workers), str(key))
                     for worker in workers:
                         ws = self.workers.get(worker)

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -79,15 +79,12 @@ def test_gather_then_submit_after_failed_workers(c, s, w, x, y, z):
     total = c.submit(sum, L)
 
     for i in range(3):
-        print(i)
         yield wait(total)
         addr = first(s.tasks[total.key].who_has).address
         for worker in [x, y, z]:
             if worker.worker_address == addr:
                 worker.process.process._process.terminate()
                 break
-        else:
-            assert 0, "Could not find worker %r" % (addr,)
 
         result = yield c.gather([total])
         assert result == [sum(map(inc, range(20)))]

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -6,7 +6,7 @@ import random
 from time import sleep
 
 import pytest
-from toolz import partition_all
+from toolz import partition_all, first
 from tornado import gen
 
 from dask import delayed
@@ -69,26 +69,28 @@ def test_gather_after_failed_worker(loop):
             assert result == list(map(inc, range(10)))
 
 
-@slow
-def test_gather_then_submit_after_failed_workers(loop):
-    with cluster(nworkers=4, active_rpc_timeout=10) as (s, [w, x, y, z]):
-        with Client(s['address'], loop=loop) as c:
-            L = c.map(inc, range(20))
-            wait(L)
-            w['proc']().terminate()
-            total = c.submit(sum, L)
-            wait([total])
+@gen_cluster(client=True, Worker=Nanny, ncores=[('127.0.0.1', 1)] * 4,
+             config={'distributed.comm.timeouts.connect': '1s'})
+def test_gather_then_submit_after_failed_workers(c, s, w, x, y, z):
+    L = c.map(inc, range(20))
+    yield wait(L)
 
-            addr = c.who_has()[total.key][0]
-            for d in [x, y, z]:
-                if d['address'] == addr:
-                    d['proc']().terminate()
-                    break
-            else:
-                assert 0, "Could not find worker %r" % (addr,)
+    w.process.process._process.terminate()
+    total = c.submit(sum, L)
 
-            result = c.gather([total])
-            assert result == [sum(map(inc, range(20)))]
+    for i in range(3):
+        print(i)
+        yield wait(total)
+        addr = first(s.tasks[total.key].who_has).address
+        for worker in [x, y, z]:
+            if worker.worker_address == addr:
+                worker.process.process._process.terminate()
+                break
+        else:
+            assert 0, "Could not find worker %r" % (addr,)
+
+        result = yield c.gather([total])
+        assert result == [sum(map(inc, range(20)))]
 
 
 @gen_cluster(Worker=Nanny, timeout=60, client=True)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -183,7 +183,7 @@ def test_upload_file(c, s, a, b):
 
 @pytest.mark.xfail(reason="don't yet support uploading pyc files")
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)])
-def dont_test_upload_file_pyc(c, s, w):
+def test_upload_file_pyc(c, s, w):
     with tmpfile() as dirname:
         os.mkdir(dirname)
         with open(os.path.join(dirname, 'foo.py'), mode='w') as f:

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -183,7 +183,7 @@ def test_upload_file(c, s, a, b):
 
 @pytest.mark.xfail(reason="don't yet support uploading pyc files")
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)])
-def test_upload_file_pyc(c, s, w):
+def dont_test_upload_file_pyc(c, s, w):
     with tmpfile() as dirname:
         os.mkdir(dirname)
         with open(os.path.join(dirname, 'foo.py'), mode='w') as f:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1955,9 +1955,10 @@ class Worker(WorkerBase):
                 del self.waiting_for_data[key]
 
             for dep in self.dependencies.pop(key, ()):
-                self.dependents[dep].remove(key)
-                if not self.dependents[dep] and self.dep_state[dep] in ('waiting', 'flight'):
-                    self.release_dep(dep)
+                if dep in self.dependents:
+                    self.dependents[dep].remove(key)
+                    if not self.dependents[dep] and self.dep_state[dep] in ('waiting', 'flight'):
+                        self.release_dep(dep)
 
             if key in self.threads:
                 del self.threads[key]
@@ -2016,7 +2017,7 @@ class Worker(WorkerBase):
                 self.in_flight_workers[worker].remove(dep)
 
             for key in self.dependents.pop(dep, ()):
-                self.dependencies[key].remove(dep)
+                # self.dependencies[key].remove(dep)
                 if self.task_state[key] != 'memory':
                     self.release_key(key, cause=dep)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2017,7 +2017,6 @@ class Worker(WorkerBase):
                 self.in_flight_workers[worker].remove(dep)
 
             for key in self.dependents.pop(dep, ()):
-                # self.dependencies[key].remove(dep)
                 if self.task_state[key] != 'memory':
                     self.release_key(key, cause=dep)
 


### PR DESCRIPTION
Previously when releasing dependencies from workers we would also
remove mention of that dependence on all dependents.  This would sometimes
cause issues when later, that dependency wasn't included in computations.

This would manifest, infrequently in the following test::

    distributed/tests/test_failed_workers.py::test_gather_then_submit_after_failed_workers