### PR TITLE
Rejoin worker client on closing context manager

### DIFF
--- a/distributed/tests/test_threadpoolexecutor.py
+++ b/distributed/tests/test_threadpoolexecutor.py
@@ -107,3 +107,15 @@ def test_secede_rejoin_quiet():
 
         future = e.submit(f)
         result = future.result()
+
+
+def test_rejoin_idempotent():
+    with ThreadPoolExecutor(2) as e:
+        def f():
+            secede()
+            for i in range(5):
+                rejoin()
+            return 1
+
+        future = e.submit(f)
+        result = future.result()

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import random
+import threading
 from time import sleep
 import warnings
 
@@ -284,3 +285,15 @@ def test_compute_within_worker_client(c, s, a, b):
 
     result = yield c.compute(f())
     assert result == 1
+
+
+@gen_cluster(client=True)
+def test_worker_client_rejoins(c, s, a, b):
+    def f():
+        with worker_client():
+            pass
+
+        return threading.current_thread() in get_worker().executor._threads
+
+    result = yield c.submit(f)
+    assert result

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 from contextlib import contextmanager
 import warnings
 
-from .threadpoolexecutor import secede
+from .threadpoolexecutor import secede, rejoin
 from .worker import thread_state, get_client, get_worker
 
 
@@ -47,6 +47,9 @@ def worker_client(timeout=3, separate_thread=True):
         worker.loop.add_callback(worker.transition, thread_state.key, 'long-running')
 
     yield client
+
+    if separate_thread:
+        rejoin()
 
 
 def local_client(*args, **kwargs):


### PR DESCRIPTION
Previously we would secede, but not rejoin.  Now we do.

Fixes #2021