### PR TITLE
Avoid recursively calling bokeh callback

### DIFF
--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -373,7 +373,11 @@ class ProfileTimePlot(DashboardComponent):
         self.states = data.pop('states')
         self.source = ColumnDataSource(data=data)
 
+        changing = [False]  # avoid repeated changes from within callback
+
         def cb(attr, old, new):
+            if changing[0]:
+                return
             with log_errors():
                 try:
                     ind = new['1d']['indices'][0]
@@ -382,8 +386,10 @@ class ProfileTimePlot(DashboardComponent):
                 data = profile.plot_data(self.states[ind], profile_interval)
                 del self.states[:]
                 self.states.extend(data.pop('states'))
+                changing[0] = True  # don't recursively trigger callback
                 self.source.data.update(data)
                 self.source.selected = old
+                changing[0] = False
 
         self.source.on_change('selected', cb)
 

--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -394,8 +394,10 @@ class ProfileTimePlot(DashboardComponent):
         self.source.on_change('selected', cb)
 
         self.profile_plot = figure(tools='tap', height=400, **kwargs)
-        self.profile_plot.quad('left', 'right', 'top', 'bottom', color='color',
-                               line_color='black', source=self.source)
+        r = self.profile_plot.quad('left', 'right', 'top', 'bottom', color='color',
+                                   line_color='black', source=self.source)
+        r.selection_glyph = None
+        r.nonselection_glyph = None
 
         hover = HoverTool(
             point_policy="follow_mouse",


### PR DESCRIPTION
Previously we would trigger the callback again when we changed the CDS
from within the callback function.  Now we set up a signal to avoid
this.

Fixes #2040 

Unfortunately I don't have good testing practices for interaction with the bokeh pages.