### PR TITLE
Avoid formatting traceback on dask serialization

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -33,7 +33,7 @@ def dask_dumps(x):
     elif _find_lazy_registration(typ):
         return dask_dumps(x)  # recurse
     else:
-        raise TypeError(typ)
+        raise NotImplementedError(typ)
 
 
 def dask_loads(header, frames):
@@ -196,6 +196,8 @@ def serialize(x, serializers=None, on_error='message'):
             header, frames = dumps(x)
             header['serializer'] = name
             return header, frames
+        except NotImplementedError:
+            continue
         except Exception:
             tb = traceback.format_exc()
             continue


### PR DESCRIPTION
When we pass through serialization families we often check Dask's
type-based serialization first.  Often this fails quickly because we can
tell that we don't support the type.

Previously we would record the traceback whenever this happened (which
was all the time) and this would add a non-trivial amount of latency to
frequent small messages.

Now we avoid recording the tracebacks when the serialization family
raises a NotImplementedError.