### PR TITLE
Provide communication context to serialization functions

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -216,7 +216,9 @@ class TCP(Comm):
 
         frames = yield to_frames(msg,
                                  serializers=serializers,
-                                 on_error=on_error)
+                                 on_error=on_error,
+                                 context={'sender': self._local_addr,
+                                          'recipient': self._peer_addr})
 
         try:
             lengths = ([struct.pack('Q', len(frames))] +

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -29,7 +29,7 @@ def offload(fn, *args, **kwargs):
 
 
 @gen.coroutine
-def to_frames(msg, serializers=None, on_error='message'):
+def to_frames(msg, serializers=None, on_error='message', context=None):
     """
     Serialize a message into a list of Distributed protocol frames.
     """
@@ -37,7 +37,8 @@ def to_frames(msg, serializers=None, on_error='message'):
         try:
             return list(protocol.dumps(msg,
                                        serializers=serializers,
-                                       on_error=on_error))
+                                       on_error=on_error,
+                                       context=context))
         except Exception as e:
             logger.info("Unserializable Message: %s", msg)
             logger.exception(e)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division, absolute_import
 from collections import defaultdict, deque
 from concurrent.futures import CancelledError
 from functools import partial
-import inspect
 import logging
 import six
 import traceback
@@ -17,7 +16,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.locks import Event
 
-from .compatibility import PY3, get_thread_identity
+from .compatibility import get_thread_identity
 from .comm import (connect, listen, CommClosedError,
                    normalize_address,
                    unparse_host_port, get_address_host_port)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -24,7 +24,7 @@ from .comm import (connect, listen, CommClosedError,
 from .metrics import time
 from .system_monitor import SystemMonitor
 from .utils import (get_traceback, truncate_exception, ignoring, shutting_down,
-                    PeriodicCallback, parse_timedelta)
+                    PeriodicCallback, parse_timedelta, has_keyword)
 from . import protocol
 
 
@@ -310,7 +310,7 @@ class Server(object):
                     logger.warning("No handler %s found in %s", op,
                                    type(self).__name__, exc_info=True)
                 else:
-                    if serializers is not None and has_serializers_keyword(handler):
+                    if serializers is not None and has_keyword(handler, 'serializers'):
                         msg['serializers'] = serializers  # add back in
 
                     logger.debug("Calling into handler %s", handler.__name__)
@@ -852,13 +852,3 @@ def clean_exception(exception, traceback, **kwargs):
     elif isinstance(traceback, string_types):
         traceback = None  # happens if the traceback failed serializing
     return type(exception), exception, traceback
-
-
-def has_serializers_keyword(func):
-    if PY3:
-        return 'serializers' in inspect.signature(func).parameters
-    else:
-        # https://stackoverflow.com/questions/50100498/determine-keywords-of-a-tornado-coroutine
-        if gen.is_coroutine_function(func):
-            func = func.__wrapped__
-        return 'serializers' in inspect.getargspec(func).args

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -33,11 +33,14 @@ class ServerNode(Node, Server):
 
     def __init__(self, handlers=None, stream_handlers=None,
                  connection_limit=512, deserialize=True,
-                 connection_args=None, io_loop=None):
+                 connection_args=None, io_loop=None, serializers=None,
+                 deserializers=None):
         Node.__init__(self, deserialize=deserialize,
                       connection_limit=connection_limit,
                       connection_args=connection_args,
-                      io_loop=io_loop)
+                      io_loop=io_loop,
+                      serializers=serializers,
+                      deserializers=deserializers)
         Server.__init__(self, handlers=handlers,
                         stream_handlers=stream_handlers,
                         connection_limit=connection_limit,

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -8,6 +8,7 @@ from .serialize import (
     serialize, deserialize, nested_deserialize, Serialize, Serialized,
     to_serialize, register_serialization, register_serialization_lazy,
     serialize_bytes, deserialize_bytes, serialize_bytelist,
+    register_serialization_family,
 )
 
 from ..utils import ignoring

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -22,7 +22,7 @@ _deserialize = deserialize
 logger = logging.getLogger(__name__)
 
 
-def dumps(msg, serializers=None, on_error='message'):
+def dumps(msg, serializers=None, on_error='message', context=None):
     """ Transform Python message to bytestream suitable for communication """
     try:
         data = {}
@@ -40,7 +40,8 @@ def dumps(msg, serializers=None, on_error='message'):
 
         data = {key: serialize(value.data,
                                serializers=serializers,
-                               on_error=on_error)
+                               on_error=on_error,
+                               context=context)
                 for key, value in data.items()
                 if type(value) is Serialize}
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -3,14 +3,17 @@ from __future__ import print_function, division, absolute_import
 import copy
 import pickle
 
+import msgpack
 import numpy as np
 import pytest
 from toolz import identity
 
+from distributed import wait
 from distributed.protocol import (register_serialization, serialize,
                                   deserialize, nested_deserialize, Serialize,
                                   Serialized, to_serialize, serialize_bytes,
-                                  deserialize_bytes, serialize_bytelist,)
+                                  deserialize_bytes, serialize_bytelist,
+                                  register_serialization_family)
 from distributed.utils import nbytes
 from distributed.utils_test import inc, gen_test
 from distributed.comm.utils import to_frames, from_frames
@@ -245,3 +248,58 @@ def test_err_on_bad_deserializer():
 
     with pytest.raises(TypeError) as info:
         yield from_frames(frames, deserializers=['msgpack'])
+
+
+@gen_cluster(client=True,
+             client_kwargs={'serializers': ['my-ser', 'pickle']},
+             worker_kwargs={'serializers': ['my-ser', 'pickle']})
+def test_context_specific_serialization(c, s, a, b):
+    class MyObject(object):
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    def my_dumps(obj, context=None):
+        if type(obj).__name__ == 'MyObject':
+            header = {'serializer': 'my-ser'}
+            frames = [msgpack.dumps(obj.__dict__, use_bin_type=True),
+                      msgpack.dumps(context, use_bin_type=True)]
+            return header, frames
+        else:
+            raise NotImplementedError()
+
+    def my_loads(header, frames):
+        assert header['serializer'] == 'my-ser'
+        obj = MyObject(**msgpack.loads(frames[0], encoding='utf8'))
+
+        # to provide something to test against, lets just attach the context to
+        # the object itself
+        obj.context = msgpack.loads(frames[1], encoding='utf8')
+        return obj
+
+    register_serialization_family('my-ser', my_dumps, my_loads)
+
+    try:
+        # Create the object on A, force communication to B
+        x = c.submit(MyObject, x=1, y=2, workers=a.address)
+        y = c.submit(lambda x: x, x, workers=b.address)
+
+        yield wait(y)
+
+        key = y.key
+
+        def check(dask_worker):
+            # Get the context from the object stored on B
+            my_obj = dask_worker.data[key]
+            return my_obj.context
+
+        result = yield c.run(check, workers=[b.address])
+        expected = {'sender': a.address, 'recipient': b.address}
+        assert result[b.address]['sender'] == a.address  # see origin worker
+
+        z = yield y  # bring object to local process
+
+        assert z.x == 1 and z.y == 2
+        assert z.context['sender'] == b.address
+    finally:
+        from distributed.protocol.serialize import families
+        del families['my-ser']

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -250,32 +250,34 @@ def test_err_on_bad_deserializer():
         yield from_frames(frames, deserializers=['msgpack'])
 
 
+class MyObject(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def my_dumps(obj, context=None):
+    if type(obj).__name__ == 'MyObject':
+        header = {'serializer': 'my-ser'}
+        frames = [msgpack.dumps(obj.__dict__, use_bin_type=True),
+                  msgpack.dumps(context, use_bin_type=True)]
+        return header, frames
+    else:
+        raise NotImplementedError()
+
+
+def my_loads(header, frames):
+    obj = MyObject(**msgpack.loads(frames[0], encoding='utf8'))
+
+    # to provide something to test against, lets just attach the context to
+    # the object itself
+    obj.context = msgpack.loads(frames[1], encoding='utf8')
+    return obj
+
+
 @gen_cluster(client=True,
              client_kwargs={'serializers': ['my-ser', 'pickle']},
              worker_kwargs={'serializers': ['my-ser', 'pickle']})
 def test_context_specific_serialization(c, s, a, b):
-    class MyObject(object):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    def my_dumps(obj, context=None):
-        if type(obj).__name__ == 'MyObject':
-            header = {'serializer': 'my-ser'}
-            frames = [msgpack.dumps(obj.__dict__, use_bin_type=True),
-                      msgpack.dumps(context, use_bin_type=True)]
-            return header, frames
-        else:
-            raise NotImplementedError()
-
-    def my_loads(header, frames):
-        assert header['serializer'] == 'my-ser'
-        obj = MyObject(**msgpack.loads(frames[0], encoding='utf8'))
-
-        # to provide something to test against, lets just attach the context to
-        # the object itself
-        obj.context = msgpack.loads(frames[1], encoding='utf8')
-        return obj
-
     register_serialization_family('my-ser', my_dumps, my_loads)
 
     try:
@@ -303,3 +305,34 @@ def test_context_specific_serialization(c, s, a, b):
     finally:
         from distributed.protocol.serialize import families
         del families['my-ser']
+
+
+@gen_cluster(client=True)
+def test_context_specific_serialization_class(c, s, a, b):
+    register_serialization(MyObject, my_dumps, my_loads)
+
+    try:
+        # Create the object on A, force communication to B
+        x = c.submit(MyObject, x=1, y=2, workers=a.address)
+        y = c.submit(lambda x: x, x, workers=b.address)
+
+        yield wait(y)
+
+        key = y.key
+
+        def check(dask_worker):
+            # Get the context from the object stored on B
+            my_obj = dask_worker.data[key]
+            return my_obj.context
+
+        result = yield c.run(check, workers=[b.address])
+        expected = {'sender': a.address, 'recipient': b.address}
+        assert result[b.address]['sender'] == a.address  # see origin worker
+
+        z = yield y  # bring object to local process
+
+        assert z.x == 1 and z.y == 2
+        assert z.context['sender'] == b.address
+    finally:
+        from distributed.protocol.serialize import class_serializers, typename
+        del class_serializers[typename(MyObject)]

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -5,6 +5,7 @@ from collections import deque
 from contextlib import contextmanager
 from datetime import timedelta
 import functools
+import inspect
 import json
 import logging
 import multiprocessing
@@ -1385,3 +1386,13 @@ def reset_logger_locks():
 # Only bother if asyncio has been loaded by Tornado
 if 'asyncio' in sys.modules:
     fix_asyncio_event_loop_policy(sys.modules['asyncio'])
+
+
+def has_keyword(func, keyword):
+    if PY3:
+        return keyword in inspect.signature(func).parameters
+    else:
+        # https://stackoverflow.com/questions/50100498/determine-keywords-of-a-tornado-coroutine
+        if gen.is_coroutine_function(func):
+            func = func.__wrapped__
+        return keyword in inspect.getargspec(func).args

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -86,11 +86,37 @@ dictionary with an appropriate name.  Here is the definition of
            frame = frames[0]
        return pickle.loads(frame)
 
-   from distributed.protocol.serialize import families
-   families['pickle'] = (pickle_dumps, pickle_loads)
+   from distributed.protocol.serialize import register_serialization_family
+   register_serialization_family('pickle', pickle_dumps, pickle_loads)
 
 After this the name ``'pickle'`` can be used in the ``serializers=`` and
 ``deserializers=`` keywords in ``Client`` and other parts of Dask.
+
+
+Communication Context
++++++++++++++++++++++
+
+Dask :doc:`Comms <communications>` can provide additional context to
+serialization family functions if they provide a ``context=`` keyword.
+This allows serialization to behave differently according to how it is being
+used.
+
+.. code-block:: python
+
+   def my_dumps(x, context=None):
+       if context and 'recipient' in context:
+           # check if we're sending to the same host or not
+
+The context depends on the kind of communication.  For example when sending
+over TCP, the address of the sender (us) and the recipient are available in a
+dictionary.
+
+.. code-block:: python
+
+   >>> context
+   {'sender': 'tcp://127.0.0.1:1234', 'recipient': 'tcp://127.0.0.1:5678'}
+
+Other comms may provide other information.
 
 
 Dask Serialization Family

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -96,6 +96,8 @@ After this the name ``'pickle'`` can be used in the ``serializers=`` and
 Communication Context
 +++++++++++++++++++++
 
+.. note:: This is an experimental feature and may change without notice
+
 Dask :doc:`Comms <communications>` can provide additional context to
 serialization family functions if they provide a ``context=`` keyword.
 This allows serialization to behave differently according to how it is being


### PR DESCRIPTION
This allows comms to provide information about the communication, for example the address of the receiving end, to serialization functions.

This is primarily motivated by the support of side-channel communication for GPUs, but has also come up when we've wanted to know if we're writing to disk or sending along a comm.