### PR TITLE
Set `gen_cluster`s `Client` as the default one

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -779,7 +779,8 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                             args = [s] + workers
                             if client:
                                 c = yield Client(s.address, loop=loop, security=security,
-                                                 asynchronous=True, **client_kwargs)
+                                                 set_as_default=True, asynchronous=True,
+                                                 **client_kwargs)
                                 args = [c] + args
                             try:
                                 future = func(*args)


### PR DESCRIPTION
Needed for PR ( https://github.com/dask/dask/pull/3561 ).