### PR TITLE
Relax pytest constraint in appveyor tests

### DIFF
--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -31,7 +31,7 @@ call deactivate
     jupyter_client ^
     mock ^
     psutil ^
-    pytest=3.1 ^
+    pytest ^
     python=%PYTHON% ^
     requests ^
     toolz ^


### PR DESCRIPTION
Previously appveyor was failing because pytest was pinned to a version that
made the pytest.timeout package unhappy.  Lets relax this constraint for now.