### PR TITLE
Avoid reference cycle in str_graph

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -46,7 +46,7 @@ from .utils_comm import (WrappedKey, unpack_remotedata, pack_data,
                          scatter_to_workers, gather_from_workers)
 from .cfexecutor import ClientExecutor
 from .compatibility import Queue as pyQueue, Empty, isqueue, html_escape
-from .core import connect, rpc, clean_exception, CommClosedError
+from .core import connect, rpc, clean_exception, CommClosedError, PooledRPCCall
 from .metrics import time
 from .node import Node
 from .protocol import to_serialize
@@ -575,7 +575,7 @@ class Client(Node):
                 logger.info("Config value `scheduler-address` found: %s",
                             address)
 
-        if isinstance(address, rpc):
+        if isinstance(address, (rpc, PooledRPCCall)):
             self.scheduler = address
         elif hasattr(address, "scheduler_address"):
             # It's a LocalCluster or LocalCluster-compatible object

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -598,6 +598,10 @@ class PooledRPCCall(object):
         self.serializers = serializers
         self.deserializers = deserializers if deserializers is not None else serializers
 
+    @property
+    def address(self):
+        return self.addr
+
     def __getattr__(self, key):
         @gen.coroutine
         def send_recv_from_rpc(**kwargs):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3706,7 +3706,7 @@ def test_open_close_many_workers(loop, worker, count, repeat):
             sleep(1)
 
             for i in range(count):
-                done.acquire(timeout=20)
+                done.acquire()
                 gc.collect()
                 if not running:
                     break

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3706,7 +3706,7 @@ def test_open_close_many_workers(loop, worker, count, repeat):
             sleep(1)
 
             for i in range(count):
-                done.acquire()
+                done.acquire(timeout=20)
                 gc.collect()
                 if not running:
                     break


### PR DESCRIPTION
This caused an intermittent failure in

    distributed/tests/test_batched.py::test_dont_hold_on_to_large_messages