### PR TITLE
Install msgpack-python with conda on AppVeyor

### DIFF
--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -30,6 +30,7 @@ call deactivate
     joblib ^
     jupyter_client ^
     mock ^
+    msgpack-python ^
     psutil ^
     pytest ^
     python=%PYTHON% ^
@@ -48,7 +49,6 @@ call activate %CONDA_ENV%
 %PIP_INSTALL% git+https://github.com/dask/zict --upgrade
 
 %PIP_INSTALL% pytest-repeat pytest-timeout pytest-faulthandler sortedcollections
-%PIP_INSTALL% msgpack
 
 @rem Display final environment (for reproducing)
 %CONDA% list


### PR DESCRIPTION
Follow up on https://github.com/dask/distributed/pull/1927#issuecomment-386337526.

This is a cleanup of the work-around because of the mspack-python to msgpack renaming on PyPI.