### PR TITLE
Update example for stopping a worker

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -70,7 +70,7 @@ class LocalCluster(Cluster):
 
     Shut down the extra worker
 
-    >>> c.remove_worker(w)  # doctest: +SKIP
+    >>> c.stop_worker(w)  # doctest: +SKIP
 
     Pass extra keyword arguments to Bokeh
 


### PR DESCRIPTION
The `remove_worker` syntax is outdated. Update it to use `stop_worker`, which is the current syntax.