### PR TITLE
Protect against new sklearn API

### DIFF
--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -33,8 +33,12 @@ if joblib:
     from joblib.parallel import AutoBatchingMixin, ParallelBackendBase
     _bases.append(ParallelBackendBase)
 if sk_joblib:
-    from sklearn.externals.joblib.parallel import (AutoBatchingMixin,  # noqa
-            ParallelBackendBase)
+    try:
+        from sklearn.externals._joblib.parallel import (AutoBatchingMixin,  # noqa
+                ParallelBackendBase)
+    except ImportError:
+        from sklearn.externals.joblib.parallel import (AutoBatchingMixin,  # noqa
+                ParallelBackendBase)
     _bases.append(ParallelBackendBase)
 if not _bases:
     raise RuntimeError("Joblib backend requires either `joblib` >= '0.10.2' "


### PR DESCRIPTION
The new sklearn API does not allow importing subpackages from `externals.joblib`. 
Those Imports should be done from `externals._joblib`.

See [here](https://github.com/scikit-learn/scikit-learn/pull/11166) for more details on the API changes.