### PR TITLE
Allow worker to refuse data requests with busy signal

### DIFF
--- a/distributed/bokeh/worker.py
+++ b/distributed/bokeh/worker.py
@@ -159,7 +159,7 @@ class CommunicatingTimeSeries(DashboardComponent):
 
         fig = figure(title="Communication History",
                      x_axis_type='datetime',
-                     y_range=[-0.1, worker.total_connections + 0.5],
+                     y_range=[-0.1, worker.total_out_connections + 0.5],
                      height=150, tools='', x_range=x_range, **kwargs)
         fig.line(source=self.source, x='x', y='in', color='red')
         fig.line(source=self.source, x='x', y='out', color='blue')

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -19,7 +19,9 @@ distributed:
   worker:
     multiprocessing-method: forkserver
     use-file-locking: True
-    max-connections: 10     # maximum simultaneous outgoing connections
+    connections:            # Maximum concurrent connections for data
+      outgoing: 50          # This helps to control network saturation
+      incoming: 10
 
     profile:
       interval: 10ms        # Time between statistical profiling queries

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -19,6 +19,7 @@ distributed:
   worker:
     multiprocessing-method: forkserver
     use-file-locking: True
+    max-connections: 10     # maximum simultaneous outgoing connections
 
     profile:
       interval: 10ms        # Time between statistical profiling queries

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -564,7 +564,7 @@ def test_clean_nbytes(c, s, a, b):
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 20)
 def test_gather_many_small(c, s, a, *workers):
-    a.total_connections = 2
+    a.total_out_connections = 2
     futures = yield c._scatter(list(range(100)))
 
     assert all(w.data for w in workers)
@@ -1194,17 +1194,17 @@ def test_prefer_gather_from_local_address(c, s, w1, w2, w3):
     assert not any(d['who'] == w2.address for d in w3.outgoing_transfer_log)
 
 
-@gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 20, timeout=30)
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 20, timeout=30,
+             config={'distributed.worker.connections.incoming': 1})
 def test_avoid_oversubscription(c, s, *workers):
     np = pytest.importorskip('numpy')
     x = c.submit(np.random.random, 1000000, workers=[workers[0].address])
     yield wait(x)
 
-    with dask.config.set({'distributed.worker.max-connections': 1}):
-        futures = [c.submit(len, x, pure=False, workers=[w.address])
-                   for w in workers[1:]]
+    futures = [c.submit(len, x, pure=False, workers=[w.address])
+               for w in workers[1:]]
 
-        yield wait(futures)
+    yield wait(futures)
 
     # Original worker not responsible for all transfers
     assert len(workers[0].outgoing_transfer_log) < len(workers) - 2

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1206,5 +1206,8 @@ def test_avoid_oversubscription(c, s, *workers):
 
         yield wait(futures)
 
-    assert len(workers[0].outgoing_transfer_log) < 18
-    assert sum(not not w.outgoing_transfer_log for w in workers) >= 3
+    # Original worker not responsible for all transfers
+    assert len(workers[0].outgoing_transfer_log) < len(workers) - 2
+
+    # Some other workers did some work
+    assert len([w for w in workers if len(w.outgoing_transfer_log) > 0]) >= 3

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -57,7 +57,8 @@ def gather_from_workers(who_has, rpc, close=True, serializers=None, who=None):
         rpcs = {addr: rpc(addr) for addr in d}
         try:
             coroutines = {address: get_data_from_worker(rpc, keys, address,
-                                                        who=who)
+                                                        who=who,
+                                                        max_connections=False)
                           for address, keys in d.items()}
             response = {}
             for worker, c in coroutines.items():
@@ -66,7 +67,7 @@ def gather_from_workers(who_has, rpc, close=True, serializers=None, who=None):
                 except EnvironmentError:
                     missing_workers.add(worker)
                 else:
-                    response.update(r)
+                    response.update(r['data'])
         finally:
             for r in rpcs.values():
                 r.close_rpc()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2786,7 +2786,7 @@ def get_data_from_worker(rpc, keys, worker, who=None, max_connections=None):
                                    serializers=rpc.serializers,
                                    deserializers=rpc.deserializers,
                                    op='get_data', keys=keys, who=who,
-                                   max_connections=None)
+                                   max_connections=max_connections)
         if response['status'] == 'OK':
             yield comm.write('OK')
     finally:


### PR DESCRIPTION
This allows workers to say "I'm too busy right now" when presented with
a request for data from another worker.  That worker then waits a bit,
queries the scheduler to see if anyone else has that data, and then
tries again.  The wait time is an exponential backoff.

Pragmatically this means that when single pieces of data are in high
demand that the cluster will informally do a tree scattering.  Some workers
will get the data directly while others wait on the busy signal.  Then other
workers will get from them, etc..  We used to ask users to do this explicitly
with the following:

    client.replicate(future)
    or
    client.scatter(data, broadcast=True)

And now the replicate/broadcast step is no longer strictly necessary. (though
some scattering of local data still is).

Machines on the same host are given some preference, and so should be able to
sneak in more easily.

Currently this has two issues:

1.  We need to unify the configuration with the total_connections parameter
    (which does the same thing, but in the opposite direction)
2.  We don't test the same-host behavior (this is hard because we're currently
    getting host information from the socket.)