### PR TITLE
Don't forget released keys

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3590,7 +3590,7 @@ class Scheduler(ServerNode):
             dts.dependents.remove(ts)
             s = dts.waiters
             s.discard(ts)
-            if not s and not dts.who_wants:
+            if not dts.dependents and not dts.who_wants:
                 # Task not needed anymore
                 assert dts is not ts
                 recommendations[dts.key] = 'forgotten'
@@ -3621,7 +3621,7 @@ class Scheduler(ServerNode):
                 elif ts.has_lost_dependencies:
                     # It's ok to forget a task with forgotten dependencies
                     pass
-                elif not ts.who_wants and not ts.waiters:
+                elif not ts.who_wants and not ts.waiters and not ts.dependents:
                     # It's ok to forget a task that nobody needs
                     pass
                 else:
@@ -3656,7 +3656,7 @@ class Scheduler(ServerNode):
                 elif ts.has_lost_dependencies:
                     # It's ok to forget a task with forgotten dependencies
                     pass
-                elif not ts.who_wants and not ts.waiters:
+                elif not ts.who_wants and not ts.waiters and not ts.dependents:
                     # It's ok to forget a task that nobody needs
                     pass
                 else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3456,7 +3456,8 @@ class Scheduler(ServerNode):
                 recommendations[key] = 'forgotten'
             elif ts.waiters or ts.who_wants:
                 recommendations[key] = 'waiting'
-            else:
+
+            if recommendations.get(key) != 'waiting':
                 for dts in ts.dependencies:
                     if dts.state != 'released':
                         s = dts.waiters

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1301,6 +1301,21 @@ def test_dont_recompute_if_persisted_4(c, s, a, b):
 
 
 @gen_cluster(client=True)
+def test_dont_forget_released_keys(c, s, a, b):
+    x = c.submit(inc, 1, key='x')
+    y = c.submit(inc, x, key='y')
+    z = c.submit(dec, x, key='z')
+    del x
+    yield wait([y, z])
+    del z
+
+    while 'z' in s.tasks:
+        yield gen.sleep(0.01)
+
+    assert 'x' in s.tasks
+
+
+@gen_cluster(client=True)
 def test_dont_recompute_if_erred(c, s, a, b):
     x = delayed(inc)(1, dask_key_name='x')
     y = delayed(div)(x, 0, dask_key_name='y')


### PR DESCRIPTION
Previously we would allow forgetting keys if a dependency of a forgotten
key had no active waiting tasks.  Now we properly check dependents, not
active waiters.