### PR TITLE
Cull in graph_to_futures

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2094,6 +2094,7 @@ class Client(Node):
                       and k not in keyset}
             if values:
                 dsk = dask.optimization.inline(dsk, keys=values,
+                                               inline_constants=False,
                                                dependencies=dependencies)
 
             d = {k: unpack_remotedata(v) for k, v in dsk.items()}

--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -128,7 +128,8 @@ class ReplayExceptionClient(object):
         yield wait(future)
         out = yield self._get_futures_error(future)
         function, args, kwargs, deps = out
-        futures = self.client._graph_to_futures({}, deps)
+        futures = self.client._graph_to_futures({dep: dep for dep in deps},
+                                                list(deps))
         data = yield self.client._gather(futures)
         args = pack_data(args, data)
         kwargs = pack_data(kwargs, data)


### PR DESCRIPTION
Currently dask.delayed objects aren't culled prior to sending up to the
scheduler.  This can result in too much communication.

This adds a cull step in the Client, but this should maybe be handled instead
by the collections.