### PR TITLE
Joblib backend improvements

### DIFF
--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -196,7 +196,7 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
                     continue
 
                 f = None
-                if f is None and arg_id in self.data_futures:
+                if arg_id in self.data_futures:
                     f = self.data_futures[arg_id]
 
                 elif f is None and call_data_futures is not None:

--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -204,12 +204,13 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
                         f = call_data_futures[arg]
                     except KeyError:
                         if is_weakrefable(arg) and sizeof(arg) > 1e3:
-                            # Automatically scatter large objects to some of
-                            # the workers to avoid duplicated data transfers.
-                            # Rely on automated inter-worker data stealing if
-                            # more workers need to reuse this data concurrently
-                            # beyond the initial broadcast arity.
-                            [f] = self.client.scatter([arg], broadcast=3)
+                            # Automatically scatter large objects to one of the
+                            # workers to avoid duplicated data transfers. Rely
+                            # on automated inter-worker data stealing if more
+                            # workers need to reuse this data concurrently as
+                            # well as the ability of a worker to refuse data
+                            # requests with busy signal.
+                            [f] = self.client.scatter([arg], broadcast=1)
                             call_data_futures[arg] = f
 
                 if f is not None:

--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -210,7 +210,7 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
                             # workers need to reuse this data concurrently as
                             # well as the ability of a worker to refuse data
                             # requests with busy signal.
-                            [f] = self.client.scatter([arg], broadcast=1)
+                            [f] = self.client.scatter([arg])
                             call_data_futures[arg] = f
 
                 if f is not None:

--- a/distributed/joblib.py
+++ b/distributed/joblib.py
@@ -203,7 +203,7 @@ class DaskDistributedBackend(ParallelBackendBase, AutoBatchingMixin):
                     try:
                         f = call_data_futures[arg]
                     except KeyError:
-                        if is_weakrefable(arg) and sizeof(arg) > 1e6:
+                        if is_weakrefable(arg) and sizeof(arg) > 1e3:
                             # Automatically scatter large objects to some of
                             # the workers to avoid duplicated data transfers.
                             # Rely on automated inter-worker data stealing if


### PR DESCRIPTION
@TomAugspurger I wonder if the change in the threshold of the size to trigger the auto-scattering could fix the case we observed together at scipy.

If so I would love to get your confirmation that using 1 kB instead of 1 MB as the threshold is a good idea.