### PR TITLE
Stateful Actors

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from . import config
 from dask.config import config
+from .actor import Actor, ActorFuture
 from .core import connect, rpc
 from .deploy import LocalCluster, Adaptive
 from .diagnostics import progress

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -1,0 +1,209 @@
+from tornado import gen
+import functools
+
+from .client import Future, default_client
+from .compatibility import get_thread_identity, Queue
+from .protocol import to_serialize
+from .utils import sync
+from .utils_comm import WrappedKey
+from .worker import get_worker
+
+
+class Actor(WrappedKey):
+    """ Controls an object on a remote worker
+
+    An actor allows remote control of a stateful object living on a remote
+    worker.  Method calls on this object trigger operations on the remote
+    object and return ActorFutures on which we can block to get results.
+
+    Examples
+    --------
+    >>> class Counter:
+    ...    def __init__(self):
+    ...        self.n = 0
+    ...    def increment(self):
+    ...        self.n += 1
+    ...        return self.n
+
+    >>> from dask.distributed import Client
+    >>> client = Client()
+
+    You can create an actor by submitting a class with the keyword
+    ``actor=True``.
+
+    >>> future = client.submit(Counter, actor=True)
+    >>> counter = future.result()
+    >>> counter
+    <Actor: Counter, key=Counter-1234abcd>
+
+    Calling methods on this object immediately returns deferred ``ActorFuture``
+    objects.  You can call ``.result()`` on these objects to block and get the
+    result of the function call.
+
+    >>> future = counter.increment()
+    >>> future.result()
+    1
+    >>> future = counter.increment()
+    >>> future.result()
+    2
+    """
+    def __init__(self, cls, address, key, worker=None):
+        self._cls = cls
+        self._address = address
+        self.key = key
+        self._future = None
+        if worker:
+            self._worker = worker
+            self._client = None
+        else:
+            try:
+                self._worker = get_worker()
+            except ValueError:
+                self._worker = None
+            try:
+                self._client = default_client()
+                self._future = Future(key)
+            except ValueError:
+                self._client = None
+
+    def __repr__(self):
+        return '<Actor: %s, key=%s>' % (self._cls.__name__, self.key)
+
+    def __reduce__(self):
+        return (Actor, (self._cls, self._address, self.key))
+
+    @property
+    def _io_loop(self):
+        if self._worker:
+            return self._worker.io_loop
+        else:
+            return self._client.io_loop
+
+    @property
+    def _scheduler_rpc(self):
+        if self._worker:
+            return self._worker.scheduler
+        else:
+            return self._client.scheduler
+
+    @property
+    def _worker_rpc(self):
+        if self._worker:
+            return self._worker.rpc(self._address)
+        else:
+            if self._client.direct_to_workers:
+                return self._client.rpc(self._address)
+            else:
+                return ProxyRPC(self._client.scheduler, self._address)
+
+    @property
+    def _asynchronous(self):
+        if self._client:
+            return self._client.asynchronous
+        else:
+            return get_thread_identity() == self._worker.thread_id
+
+    def _sync(self, func, *args, **kwargs):
+        if self._client:
+            return self._client.sync(func, *args, **kwargs)
+        else:
+            # TODO support sync operation by checking against thread ident of loop
+            return sync(self._worker.loop, func, *args, **kwargs)
+
+    def __dir__(self):
+        o = set(dir(type(self)))
+        o.update(attr for attr in dir(self._cls) if not attr.startswith('_'))
+        return sorted(o)
+
+    def __getattr__(self, key):
+        attr = getattr(self._cls, key)
+
+        if self._future and not self._future.status == 'finished':
+            raise ValueError("Worker holding Actor was lost")
+
+        if callable(attr):
+            @functools.wraps(attr)
+            def func(*args, **kwargs):
+                @gen.coroutine
+                def run_actor_function_on_worker():
+                    try:
+                        result = yield self._worker_rpc.actor_execute(
+                            function=key,
+                            actor=self.key,
+                            args=[to_serialize(arg) for arg in args],
+                            kwargs={k: to_serialize(v) for k, v in kwargs.items()},
+                        )
+                    except OSError:
+                        if self._future:
+                            yield self._future
+                        else:
+                            raise OSError("Unable to contact Actor's worker")
+                    raise gen.Return(result['result'])
+
+                if self._asynchronous:
+                    return run_actor_function_on_worker()
+                else:
+                    # TODO: this mechanism is error prone
+                    # we should endeavor to make dask's standard code work here
+                    q = Queue()
+
+                    @gen.coroutine
+                    def wait_then_add_to_queue():
+                        x = yield run_actor_function_on_worker()
+                        q.put(x)
+                    self._io_loop.add_callback(wait_then_add_to_queue)
+
+                    return ActorFuture(q, self._io_loop)
+            return func
+
+        else:
+            @gen.coroutine
+            def get_actor_attribute_from_worker():
+                x = yield self._worker_rpc.actor_attribute(attribute=key, actor=self.key)
+                raise gen.Return(x['result'])
+
+            return self._sync(get_actor_attribute_from_worker)
+
+
+class ProxyRPC(object):
+    """
+    An rpc-like object that uses the scheduler's rpc to connect to a worker
+    """
+    def __init__(self, rpc, address):
+        self.rpc = rpc
+        self._address = address
+
+    def __getattr__(self, key):
+        @gen.coroutine
+        def func(**msg):
+            msg['op'] = key
+            result = yield self.rpc.proxy(worker=self._address, msg=msg)
+            raise gen.Return(result)
+
+        return func
+
+
+class ActorFuture(object):
+    """ Future to an actor's method call
+
+    Whenever you call a method on an Actor you get an ActorFuture immediately
+    while the computation happens in the background.  You can call ``.result``
+    to block and collect the full result
+
+    See Also
+    --------
+    Actor
+    """
+    def __init__(self, q, io_loop):
+        self.q = q
+        self.io_loop = io_loop
+
+    def result(self, timeout=None):
+        try:
+            return self._cached_result
+        except AttributeError:
+            self._cached_result = self.q.get(timeout=timeout)
+            return self._cached_result
+
+    def __repr__(self):
+        return '<ActorFuture>'

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -233,7 +233,7 @@ class Server(object):
             _, self._port = get_address_host_port(self.address)
         return self._port
 
-    def identity(self, comm):
+    def identity(self, comm=None):
         return {'type': type(self).__name__, 'id': self.id}
 
     def listen(self, port_or_addr=None, listen_args=None):

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -851,9 +851,17 @@ def clean_exception(exception, traceback, **kwargs):
     error_message: create and serialize errors into message
     """
     if isinstance(exception, bytes):
-        exception = protocol.pickle.loads(exception)
+        try:
+            exception = protocol.pickle.loads(exception)
+        except Exception:
+            exception = Exception(exception)
+    elif isinstance(exception, str):
+        exception = Exception(exception)
     if isinstance(traceback, bytes):
-        traceback = protocol.pickle.loads(traceback)
+        try:
+            traceback = protocol.pickle.loads(traceback)
+        except (TypeError, AttributeError):
+            traceback = None
     elif isinstance(traceback, string_types):
         traceback = None  # happens if the traceback failed serializing
     return type(exception), exception, traceback

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -903,6 +903,7 @@ class Scheduler(ServerNode):
             'feed': self.feed,
             'terminate': self.close,
             'broadcast': self.broadcast,
+            'proxy': self.proxy,
             'ncores': self.get_ncores,
             'has_what': self.get_has_what,
             'who_has': self.get_who_has,
@@ -2322,6 +2323,13 @@ class Scheduler(ServerNode):
                              if address is not None])
 
         raise Return(dict(zip(workers, results)))
+
+    @gen.coroutine
+    def proxy(self, comm=None, msg=None, worker=None, serializers=None):
+        """ Proxy a communication through the scheduler to some other worker """
+        d = yield self.broadcast(comm=comm, msg=msg, workers=[worker],
+                                 serializers=serializers)
+        raise gen.Return(d[worker])
 
     @gen.coroutine
     def rebalance(self, comm=None, keys=None, workers=None):

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -1,0 +1,521 @@
+import operator
+from time import sleep
+from tornado import gen
+
+import pytest
+
+import dask
+from distributed import Actor, ActorFuture, Client, Future, wait, Nanny
+from distributed.utils_test import gen_cluster, cluster
+from distributed.utils_test import loop  # noqa: F401
+from distributed.metrics import time
+
+
+class Counter(object):
+    n = 0
+
+    def __init__(self):
+        self.n = 0
+
+    def increment(self):
+        self.n += 1
+        return self.n
+
+    def add(self, x):
+        self.n += x
+        return self.n
+
+
+class List(object):
+    L = []
+
+    def __init__(self, dummy=None):
+        self.L = []
+
+    def append(self, x):
+        self.L.append(x)
+
+
+class ParameterServer(object):
+    def __init__(self):
+        self.data = {}
+
+    def put(self, key, value):
+        self.data[key] = value
+
+    def get(self, key):
+        return self.data[key]
+
+
+@pytest.mark.parametrize('direct_to_workers', [True, False])
+def test_client_actions(direct_to_workers):
+
+    @gen_cluster(client=True)
+    def test(c, s, a, b):
+        c = yield Client(s.address, asynchronous=True,
+                         direct_to_workers=direct_to_workers)
+
+        counter = c.submit(Counter, workers=[a.address], actor=True)
+        assert isinstance(counter, Future)
+        counter = yield counter
+        assert counter._address
+        assert hasattr(counter, 'increment')
+        assert hasattr(counter, 'add')
+        assert hasattr(counter, 'n')
+
+        n = yield counter.n
+        assert n == 0
+
+        assert counter._address == a.address
+
+        assert isinstance(a.actors[counter.key], Counter)
+        assert s.tasks[counter.key].actor
+
+        yield [counter.increment(), counter.increment()]
+
+        n = yield counter.n
+        assert n == 2
+
+        counter.add(10)
+        while (yield counter.n) != 10 + 2:
+            n = yield counter.n
+            yield gen.sleep(0.01)
+
+        yield c.close()
+
+    test()
+
+
+@pytest.mark.parametrize('separate_thread', [False, True])
+def test_worker_actions(separate_thread):
+
+    @gen_cluster(client=True)
+    def test(c, s, a, b):
+        counter = c.submit(Counter, workers=[a.address], actor=True)
+        a_address = a.address
+
+        def f(counter):
+            start = counter.n
+
+            assert type(counter) is Actor
+            assert counter._address == a_address
+
+            future = counter.increment(separate_thread=separate_thread)
+            assert isinstance(future, ActorFuture)
+            assert "Future" in type(future).__name__
+            end = future.result(timeout=1)
+            assert end > start
+
+        futures = [c.submit(f, counter, pure=False) for _ in range(10)]
+        yield futures
+
+        counter = yield counter
+        assert (yield counter.n) == 10
+
+    test()
+
+
+@gen_cluster(client=True)
+def test_Actor(c, s, a, b):
+    counter = yield c.submit(Counter, actor=True)
+
+    assert counter._cls == Counter
+
+    assert hasattr(counter, 'n')
+    assert hasattr(counter, 'increment')
+    assert hasattr(counter, 'add')
+
+    assert not hasattr(counter, 'abc')
+
+
+@pytest.mark.xfail(reason="Tornado can pass things out of order" +
+        "Should rely on sending small messages rather than rpc")
+@gen_cluster(client=True)
+def test_linear_access(c, s, a, b):
+    start = time()
+    future = c.submit(sleep, 0.2)
+    actor = c.submit(List, actor=True, dummy=future)
+    actor = yield actor
+
+    for i in range(100):
+        actor.append(i)
+
+    while True:
+        yield gen.sleep(0.1)
+        L = yield actor.L
+        if len(L) == 100:
+            break
+
+    L = yield actor.L
+    stop = time()
+    assert L == tuple(range(100))
+
+    assert stop - start > 0.2
+
+
+@gen_cluster(client=True)
+def test_exceptions_create(c, s, a, b):
+    class Foo(object):
+        x = 0
+
+        def __init__(self):
+            raise ValueError('bar')
+
+    with pytest.raises(ValueError) as info:
+        future = yield c.submit(Foo, actor=True)
+
+    assert "bar" in str(info.value)
+
+
+@gen_cluster(client=True)
+def test_exceptions_method(c, s, a, b):
+    class Foo(object):
+        def throw(self):
+            1 / 0
+
+    foo = yield c.submit(Foo, actor=True)
+    with pytest.raises(ZeroDivisionError):
+        yield foo.throw()
+
+
+@gen_cluster(client=True)
+def test_gc(c, s, a, b):
+    actor = c.submit(Counter, actor=True)
+    yield wait(actor)
+    del actor
+
+    while a.actors or b.actors:
+        yield gen.sleep(0.01)
+
+
+@gen_cluster(client=True)
+def test_track_dependencies(c, s, a, b):
+    actor = c.submit(Counter, actor=True)
+    yield wait(actor)
+    x = c.submit(sleep, 0.5)
+    y = c.submit(lambda x, y: x, x, actor)
+    del actor
+
+    yield gen.sleep(0.3)
+
+    assert a.actors or b.actors
+
+
+@gen_cluster(client=True)
+def test_future(c, s, a, b):
+    counter = c.submit(Counter, actor=True, workers=[a.address])
+    assert isinstance(counter, Future)
+    yield wait(counter)
+    assert isinstance(a.actors[counter.key], Counter)
+
+    counter = yield counter
+    assert isinstance(counter, Actor)
+    assert counter._address
+
+    yield gen.sleep(0.1)
+    assert counter.key in c.futures  # don't lose future
+
+
+@gen_cluster(client=True)
+def test_future_dependencies(c, s, a, b):
+    counter = c.submit(Counter, actor=True, workers=[a.address])
+
+    def f(a):
+        assert isinstance(a, Actor)
+        assert a._cls == Counter
+
+    x = c.submit(f, counter, workers=[b.address])
+    yield x
+
+    assert {ts.key for ts in s.tasks[x.key].dependencies} == {counter.key}
+    assert {ts.key for ts in s.tasks[counter.key].dependents} == {x.key}
+
+    y = c.submit(f, counter, workers=[a.address], pure=False)
+    yield y
+
+    assert {ts.key for ts in s.tasks[y.key].dependencies} == {counter.key}
+    assert {ts.key for ts in s.tasks[counter.key].dependents} == {x.key, y.key}
+
+
+def test_sync(loop):
+    with cluster() as (s, [a, b]):
+        with Client(s['address'], loop=loop) as c:
+            counter = c.submit(Counter, actor=True)
+            counter = counter.result()
+
+            assert counter.n == 0
+
+            future = counter.increment()
+            n = future.result()
+            assert n == 1
+            assert counter.n == 1
+
+            assert future.result() == future.result()
+
+            assert 'ActorFuture' in repr(future)
+            assert 'distributed.actor' not in repr(future)
+
+
+@gen_cluster(client=True, config={'distributed.comm.timeouts.connect': '1s'})
+def test_failed_worker(c, s, a, b):
+    future = c.submit(Counter, actor=True, workers=[a.address])
+    yield wait(future)
+    counter = yield future
+
+    yield a._close()
+
+    with pytest.raises(Exception) as info:
+        yield counter.increment()
+
+    assert "actor" in str(info.value).lower()
+    assert "worker" in str(info.value).lower()
+    assert "lost" in str(info.value).lower()
+
+
+@gen_cluster(client=True)
+def bench(c, s, a, b):
+    counter = yield c.submit(Counter, actor=True)
+
+    for i in range(1000):
+        yield counter.increment()
+
+
+@gen_cluster(client=True)
+def test_numpy_roundtrip(c, s, a, b):
+    np = pytest.importorskip('numpy')
+
+    server = yield c.submit(ParameterServer, actor=True)
+
+    x = np.random.random(1000)
+    yield server.put('x', x)
+
+    y = yield server.get('x')
+
+    assert (x == y).all()
+
+
+@gen_cluster(client=True)
+def test_numpy_roundtrip_getattr(c, s, a, b):
+    np = pytest.importorskip('numpy')
+
+    counter = yield c.submit(Counter, actor=True)
+
+    x = np.random.random(1000)
+
+    yield counter.add(x)
+
+    y = yield counter.n
+
+    assert (x == y).all()
+
+
+@gen_cluster(client=True)
+def test_repr(c, s, a, b):
+    counter = yield c.submit(Counter, actor=True)
+
+    assert 'Counter' in repr(counter)
+    assert 'Actor' in repr(counter)
+    assert counter.key in repr(counter)
+    assert 'distributed.actor' not in repr(counter)
+
+
+@gen_cluster(client=True)
+def test_dir(c, s, a, b):
+    counter = yield c.submit(Counter, actor=True)
+
+    d = set(dir(counter))
+
+    for attr in dir(Counter):
+        if not attr.startswith('_'):
+            assert attr in d
+
+
+@gen_cluster(client=True)
+def test_many_computations(c, s, a, b):
+    counter = yield c.submit(Counter, actor=True)
+
+    def add(n, counter):
+        for i in range(n):
+            counter.increment().result()
+
+    futures = c.map(add, range(10), counter=counter)
+    done = c.submit(lambda x: None, futures)
+
+    while not done.done():
+        assert len(s.processing) <= a.ncores + b.ncores
+        yield gen.sleep(0.01)
+
+    yield done
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 5)] * 2)
+def test_thread_safety(c, s, a, b):
+    class Unsafe(object):
+        def __init__(self):
+            self.n = 0
+
+        def f(self):
+            assert self.n == 0
+            self.n += 1
+
+            for i in range(20):
+                sleep(0.002)
+                assert self.n == 1
+            self.n = 0
+
+    unsafe = yield c.submit(Unsafe, actor=True)
+
+    futures = [unsafe.f() for i in range(10)]
+    yield futures
+
+
+@gen_cluster(client=True)
+def test_Actors_create_dependencies(c, s, a, b):
+    counter = yield c.submit(Counter, actor=True)
+    future = c.submit(lambda x: None, counter)
+    yield wait(future)
+    assert s.tasks[future.key].dependencies == {s.tasks[counter.key]}
+
+
+@gen_cluster(client=True)
+def test_load_balance(c, s, a, b):
+    class Foo(object):
+        def __init__(self, x):
+            pass
+
+    b = c.submit(operator.mul, 'b', 1000000)
+    yield wait(b)
+    [ws] = s.tasks[b.key].who_has
+
+    x = yield c.submit(Foo, b, actor=True)
+    y = yield c.submit(Foo, b, actor=True)
+    assert x.key != y.key  # actors assumed not pure
+
+    assert s.tasks[x.key].who_has == {ws}  # first went to best match
+    assert s.tasks[x.key].who_has != s.tasks[y.key].who_has  # second load balanced
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 5)
+def test_load_balance_map(c, s, *workers):
+    class Foo(object):
+        def __init__(self, x, y=None):
+            pass
+
+    b = c.submit(operator.mul, 'b', 1000000)
+    yield wait(b)
+
+    actors = c.map(Foo, range(10), y=b, actor=True)
+    yield wait(actors)
+
+    assert all(len(w.actors) == 2 for w in workers)
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)] * 4, Worker=Nanny)
+def bench_param_server(c, s, *workers):
+    import dask.array as da
+    import numpy as np
+    x = da.random.random((500000, 1000), chunks=(1000, 1000))
+    x = x.persist()
+    yield wait(x)
+
+    class ParameterServer:
+        data = None
+
+        def __init__(self, n):
+            self.data = np.random.random(n)
+
+        def update(self, x):
+            self.data += x
+            self.data /= 2
+
+        def get_data(self):
+            return self.data
+
+    def f(block, ps=None):
+        start = time()
+        params = ps.get_data(separate_thread=False).result()
+        stop = time()
+        update = (block - params).mean(axis=0)
+        ps.update(update, separate_thread=False)
+        print(format_time(stop - start))
+        return np.array([[stop - start]])
+
+    from distributed.utils import format_time
+    start = time()
+    ps = yield c.submit(ParameterServer, x.shape[1], actor=True)
+    y = x.map_blocks(f, ps=ps, dtype=x.dtype)
+    # result = yield c.compute(y.mean())
+    yield wait(y.persist())
+    end = time()
+    print(format_time(end - start))
+
+
+@gen_cluster(client=True)
+def test_compute(c, s, a, b):
+
+    @dask.delayed
+    def f(n, counter):
+        assert isinstance(counter, Actor)
+        for i in range(n):
+            counter.increment().result()
+
+    @dask.delayed
+    def check(counter, blanks):
+        return counter.n
+
+    counter = dask.delayed(Counter)()
+    values = [f(i, counter) for i in range(5)]
+    final = check(counter, values)
+
+    result = yield c.compute(final, actors=counter)
+    assert result == 0 + 1 + 2 + 3 + 4
+
+    start = time()
+    while a.data or b.data or a.actors or b.actors:
+        yield gen.sleep(0.01)
+        assert time() < start + 2
+
+
+@gen_cluster(client=True, ncores=[('127.0.0.1', 1)],
+             config={'distributed.worker.profile.interval': '1ms'})
+def test_actors_in_profile(c, s, a):
+    class Sleeper(object):
+        def sleep(self, time):
+            sleep(time)
+
+    sleeper = yield c.submit(Sleeper, actor=True)
+
+    for i in range(5):
+        yield sleeper.sleep(0.200)
+        if (list(a.profile_recent['children'])[0].startswith('sleep') or
+                'Sleeper.sleep' in a.profile_keys):
+            return
+    assert False, list(a.profile_keys)
+
+
+@gen_cluster(client=True)
+def test_waiter(c, s, a, b):
+    from tornado.locks import Event
+
+    class Waiter(object):
+        def __init__(self):
+            self.event = Event()
+
+        @gen.coroutine
+        def set(self):
+            self.event.set()
+
+        @gen.coroutine
+        def wait(self):
+            yield self.event.wait()
+
+    waiter = yield c.submit(Waiter, actor=True)
+
+    futures = [waiter.wait() for i in range(5)]  # way more than we have actor threads
+
+    yield gen.sleep(0.1)
+    assert not any(future.done() for future in futures)
+
+    yield waiter.set()
+
+    yield futures

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2201,6 +2201,12 @@ def test_broadcast(loop):
 
 
 @gen_cluster(client=True)
+def test_proxy(c, s, a, b):
+    msg = yield c.scheduler.proxy(msg={'op': 'identity'}, worker=a.address)
+    assert msg['id'] == a.identity()['id']
+
+
+@gen_cluster(client=True)
 def test__cancel(c, s, a, b):
     x = c.submit(slowinc, 1)
     y = c.submit(slowinc, x)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -705,21 +705,6 @@ def test_stop_doing_unnecessary_work(c, s, a, b):
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 1)])
 def test_priorities(c, s, w):
-    a = delayed(slowinc)(1, dask_key_name='a', delay=0.05)
-    b = delayed(slowinc)(2, dask_key_name='b', delay=0.05)
-    a1 = delayed(slowinc)(a, dask_key_name='a1', delay=0.05)
-    a2 = delayed(slowinc)(a1, dask_key_name='a2', delay=0.05)
-    b1 = delayed(slowinc)(b, dask_key_name='b1', delay=0.05)
-
-    z = delayed(add)(a2, b1)
-    future = yield c.compute(z)
-
-    log = [t for t in w.log if t[1] == 'executing' and t[2] == 'memory']
-    assert [t[0] for t in log[:5]] == ['a', 'b', 'a1', 'b1', 'a2']
-
-
-@gen_cluster(client=True, ncores=[('127.0.0.1', 1)])
-def test_priorities_2(c, s, w):
     values = []
     for i in range(10):
         a = delayed(slowinc)(i, dask_key_name='a-%d' % i, delay=0.01)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1418,3 +1418,11 @@ def color_of(x, palette=palette):
     h = md5(str(x).encode())
     n = int(h.hexdigest()[:8], 16)
     return palette[n % len(palette)]
+
+
+def iscoroutinefunction(f):
+    if gen.is_coroutine_function(f):
+        return True
+    if sys.version_info >= (3, 5) and inspect.iscoroutinefunction(f):
+        return True
+    return False

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -8,7 +8,6 @@ import functools
 import gc
 from glob import glob
 import itertools
-import inspect
 import logging
 import logging.config
 import os
@@ -40,14 +39,14 @@ from tornado.gen import TimeoutError
 from tornado.ioloop import IOLoop
 
 from .client import default_client, _global_clients
-from .compatibility import PY3, iscoroutinefunction, Empty, WINDOWS
+from .compatibility import PY3, Empty, WINDOWS
 from .config import initialize_logging
 from .core import connect, rpc, CommClosedError
 from .metrics import time
 from .proctitle import enable_proctitle_on_children
 from .security import Security
 from .utils import (ignoring, log_errors, mp_context, get_ip, get_ipv6,
-                    DequeHandler, reset_logger_locks, sync)
+                    DequeHandler, reset_logger_locks, sync, iscoroutinefunction)
 from .worker import Worker, TOTAL_MEMORY, _global_workers
 
 try:
@@ -717,12 +716,6 @@ def end_cluster(s, workers):
     yield [end_worker(w) for w in workers]
     yield s.close()  # wait until scheduler stops completely
     s.stop()
-
-
-def iscoroutinefunction(f):
-    if sys.version_info >= (3, 5) and inspect.iscoroutinefunction(f):
-        return True
-    return False
 
 
 def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -450,7 +450,7 @@ class WorkerBase(ServerNode):
     def start(self, port=0):
         self.loop.add_callback(self._start, port)
 
-    def identity(self, comm):
+    def identity(self, comm=None):
         return {'type': type(self).__name__,
                 'id': self.id,
                 'scheduler': self.scheduler.address,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2605,6 +2605,7 @@ class Worker(WorkerBase):
                                   security=self.security,
                                   set_as_default=True,
                                   asynchronous=asynchronous,
+                                  direct_to_workers=True,
                                   name='worker',
                                   timeout=timeout)
             if not asynchronous:

--- a/docs/source/actors.rst
+++ b/docs/source/actors.rst
@@ -1,0 +1,235 @@
+Actors
+======
+
+.. note:: This is an experimental feature and is subject to change without notice
+.. note:: This is an advanced feature and may not be suitable for beginning users.
+   It is rarely necessary for common workloads.
+
+Actors enable stateful computations within a Dask workflow.  They are useful
+for some rare algorithms that require additional performance and are willing to
+sacrifice resilience.
+
+An actor is a pointer to a user-defined-object living on a remote worker.
+Anyone with that actor can call methods on that remote object.
+
+Example
+-------
+
+Here we create a simple ``Counter`` class, instantiate that class on one worker,
+and then call methods on that class remotely.
+
+.. code-block:: python
+
+   class Counter:
+       """ A simple class to manage an incrementing counter """
+       n = 0
+
+       def __init__(self):
+           self.n = 0
+
+       def increment(self):
+           self.n += 1
+           return self.n
+
+       def add(self, x):
+           self.n += x
+           return self.n
+
+   from dask.distributed import Client          # Start a Dask Client
+   client = Client()
+
+   future = client.submit(Counter, actor=True)  # Create a Counter on a worker
+   counter = future.result()                    # Get back a pointer to that object
+
+   counter
+   # <Actor: Counter, key=Counter-1234abcd>
+
+   future = counter.increment()                 # Call remote method
+   future.result()                              # Get back result
+   # 1
+
+   future = counter.add(10)                     # Call remote method
+   future.result()                              # Get back result
+   # 11
+
+Motivation
+----------
+
+Actors are motivated by some of the challenges of using pure task graphs.
+
+Normal Dask computations are composed of a graph of functions.
+This approach has a few limitations that are good for resilience, but can
+negatively affect performance:
+
+1.  **State**: The functions should not mutate their inputs in-place or rely on
+    global state.  They  should instead operate in a pure-functional manner,
+    consuming inputs and producing separate outputs.
+2.  **Central Overhead**: The execution location and order is determined by the
+    centralized scheduler.  Because the scheduler is involved in every decision
+    it can sometimes create a central bottleneck.
+
+Some workloads may need to update state directly, or may involve more tiny
+tasks than the scheduler can handle (the scheduler can coordinate about 4000
+tasks per second).
+
+Actors side-step both of these limitations:
+
+1.  **State**: Actors can hold on to and mutate state.  They are allowed to
+    update their state in-place.
+2.  **Overhead**: Operations on actors do not inform the central scheduler, and
+    so do not contribute to the 4000 task/second overhead.  They also avoid an
+    extra network hop and so have lower latencies.
+
+Create an Actor
+---------------
+
+You create an actor by submitting a Class to run on a worker using normal Dask
+computation functions like ``submit``, ``map``, ``compute``, or ``persist``,
+and using the ``actors=`` keyword (or ``actor=`` on ``submit``).
+
+.. code-block:: python
+
+   future = client.submit(Counter, actors=True)
+
+You can use all other keywords to these functions like ``workers=``,
+``resources=``, and so on to control where this actor ends up.
+
+This creates a normal Dask future on which you can call ``.result()`` to get
+the Actor once it has successfully run on a worker.
+
+.. code-block:: python
+
+   >>> counter = future.result()
+   >>> counter
+   <Actor: Counter, key=...>
+
+A ``Counter`` object has been instantiated on one of the workers, and this
+``Actor`` object serves as our proxy to that remote object.  It has the same
+methods and attributes.
+
+.. code-block:: python
+
+   >>> dir(counter)
+   ['add', 'increment', 'n']
+
+Call Remote Methods
+-------------------
+
+However accessing an attribute or calling a method will trigger a communication
+to the remote worker, run the method on the remote worker in a separate thread
+pool, and then communicate the result back to the calling side.  For attribute
+access these operations block and return when finished, for method calls they
+return an ``ActorFuture`` immediately.
+
+.. code-block:: python
+
+   >>> future = counter.increment()  # Immediately returns an ActorFuture
+   >>> future.result()               # Block until finished and result arrives
+   1
+
+``ActorFuture`` are similar to normal Dask ``Future`` objects, but not as fully
+featured.  They curently *only* support the ``result`` method and nothing else.
+They don't currently work with any other Dask functions that expect futures,
+like ``as_completed``, ``wait``, or ``client.gather``.  They can't be placed
+into additional submit or map calls to form dependencies.  They communicate
+their results immediately (rather than waiting for result to be called) and
+cache the result on the future itself.
+
+Access Attributes
+-----------------
+
+If you define an attribute at the class level then that attribute will be
+accessible to the actor.
+
+.. code-block:: python
+
+   class Counter:
+       n = 0   # Recall that we defined our class with `n` as a class variable
+
+       ...
+
+   >>> counter.n                     # Blocks until finished
+   1
+
+Attribute access blocks automatically.  It's as though you called ``.result()``.
+
+
+Execution on the Worker
+-----------------------
+
+When you call a method on an actor, your arguments get serialized and sent
+to the worker that owns the actor's object.  If you do this from a worker this
+communication is direct.  If you do this from a Client then this will be direct
+if the Client has direct access to the workers (create a client with
+``Client(..., direct_to_workers=True)`` if direct connections are possible) or
+by proxying through the scheduler if direct connections from the client to the
+workers are not possible.
+
+The appropriate method of the Actor's object is then called in a separate
+thread, the result captured, and then sent back to the calling side.  Currently
+workers have only a single thread for actors, but this may change in the
+future.
+
+The result is sent back immediately to the calling side, and is not stored on
+the worker with the actor.  It is cached on the ``ActorFuture`` object.
+
+
+Calling from coroutines and async/await
+--------------------------
+
+If you use actors within a coroutine or async/await function then actor methods
+and attrbute access will return Tornado futures
+
+.. code-block:: python
+
+   async def f():
+       counter = await client.submit(Counter, actor=True)
+
+       await counter.increment()
+       n = await counter.n
+
+
+Coroutines and async/await on the Actor
+---------------------------------------
+
+If you define an ``async def`` function on the actor class then that method
+will run on the Worker's event loop thread rather than a separate thread.
+
+.. code-block:: python
+
+   def Waiter(object):
+       def __init__(self):
+           self.event = tornado.locks.Event()
+
+       async def set(self):
+           self.event.set()
+
+       async def wait(self):
+           await self.event.wait()
+
+   waiter = client.submit(Waiter, actor=True).result()
+   waiter.wait().result()  # waits until set, without consuming a worker thread
+
+
+Performance
+-----------
+
+Worker operations currently have about 1ms of latency, on top of any network
+latency that may exist.  However other activity in a worker may easily increase
+these latencies if enough other activities are present.
+
+
+Limitations
+-----------
+
+Actors offer advanced capabilities, but with some cost:
+
+1.  **No Resilience:** No effort is made to make actor workloads resilient to
+    worker failure.  If the worker dies while holding an actor that actor is
+    lost forever.
+2.  **No Diagnostics:** Because the scheduler is not informed about actor
+    computations no diagnostics are available about these computations.
+3.  **No Load balancing:** Actors are allocated onto workers evenly, without
+    serious consideration given to avoiding communication.
+4.  **Experimental:** Actors are a new feature and subject to change without
+    warning

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,6 +104,7 @@ Contents
    :maxdepth: 1
    :caption: Additional Features
 
+   actors
    adaptive
    asynchronous
    configuration


### PR DESCRIPTION
This allows Dask to manage remote stateful classes.  This has a few advantages:

1.  We can update state quickly without having to engage pure tasks
2.  Actor operations happen between workers without the scheduler, and so have lower latency and don't suffer the same bottlenecks

And a few drawbacks

1.  Makes no attempt at resilience to worker failure
2.  Not fully integrated with the task scheduling framework (passing actor futures to won't give the same semantics as with normal futures, for example)

Fixes #2109 

### Example

```python
In [1]: from dask.distributed import Client

In [2]: client = Client(processes=False)

In [3]: class Counter:
   ...:     n = 0
   ...:     def __init__(self):
   ...:         self.n = 0
   ...:     def increment(self):
   ...:         self.n += 1
   ...:         return self.n
   ...:     

In [4]: counter = client.submit(Counter, actors=True)

In [5]: counter = counter.result()

In [6]: counter.n
Out[6]: 0

In [7]: counter.increment()
Out[7]: <distributed.actor.ActorFuture at 0x7f31b44d5d68>

In [8]: _.result()
Out[8]: 1

In [9]: counter.n
Out[9]: 1

In [10]: %time counter.increment().result()
CPU times: user 4.06 ms, sys: 21 µs, total: 4.08 ms
Wall time: 3.91 ms
Out[10]: 2

In [11]: %%time
    ...: for i in range(1000):
    ...:     counter.increment()
    ...: 
CPU times: user 566 ms, sys: 40.1 ms, total: 606 ms
Wall time: 585 ms

In [12]: %time counter.n
CPU times: user 5.65 ms, sys: 125 µs, total: 5.77 ms
Wall time: 4.25 ms
Out[12]: 1002
```

### Performance

Current roundtrip latency is around a millisecond

```python
In [14]: %timeit counter.n
3.57 ms ± 727 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [15]: client = Client(direct_to_workers=True)

In [16]: counter = client.submit(Counter, actor=True)

In [17]: %timeit counter.n
1.25 ms ± 30.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```