### PR TITLE
Add profile page for event loop thread

### DIFF
--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -37,7 +37,7 @@ call deactivate
     requests ^
     toolz ^
     tblib ^
-    tornado=4.5 ^
+    tornado=5 ^
     zict ^
     -c conda-forge
 

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -119,7 +119,7 @@ class Actor(WrappedKey):
         attr = getattr(self._cls, key)
 
         if self._future and not self._future.status == 'finished':
-            raise ValueError("Worker holding Actor was lost")
+            raise ValueError("Worker holding Actor was lost.  Status: " + self._future.status)
 
         if callable(attr):
             @functools.wraps(attr)

--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -30,7 +30,7 @@ except ImportError:
     np = False
 
 from . import components
-from .components import DashboardComponent, ProfileTimePlot
+from .components import (DashboardComponent, ProfileTimePlot, ProfileServer)
 from .core import BokehServer
 from .worker import SystemMonitor, counters_doc
 from .utils import transpose
@@ -1164,6 +1164,18 @@ def profile_doc(scheduler, extra, doc):
         prof.trigger_update()
 
 
+def profile_server_doc(scheduler, extra, doc):
+    with log_errors():
+        doc.title = "Dask: Profile of Event Loop"
+        prof = ProfileServer(scheduler, sizing_mode='scale_width', doc=doc)
+        doc.add_root(prof.root)
+        doc.template = template
+        # doc.template_variables['active_page'] = 'profile'
+        doc.template_variables.update(extra)
+
+        prof.trigger_update()
+
+
 class BokehScheduler(BokehServer):
     def __init__(self, scheduler, io_loop=None, prefix='', **kwargs):
         self.scheduler = scheduler
@@ -1184,6 +1196,7 @@ class BokehScheduler(BokehServer):
         tasks = Application(FunctionHandler(partial(tasks_doc, scheduler, self.extra)))
         status = Application(FunctionHandler(partial(status_doc, scheduler, self.extra)))
         profile = Application(FunctionHandler(partial(profile_doc, scheduler, self.extra)))
+        profile_server = Application(FunctionHandler(partial(profile_server_doc, scheduler, self.extra)))
         graph = Application(FunctionHandler(partial(graph_doc, scheduler, self.extra)))
 
         self.apps = {
@@ -1195,6 +1208,7 @@ class BokehScheduler(BokehServer):
             '/tasks': tasks,
             '/status': status,
             '/profile': profile,
+            '/profile-server': profile_server,
             '/graph': graph,
         }
 

--- a/distributed/bokeh/tests/test_scheduler_bokeh.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh.py
@@ -22,7 +22,7 @@ from distributed.bokeh.scheduler import (BokehScheduler, SystemMonitor,
                                          MemoryUse, CurrentLoad,
                                          ProcessingHistogram,
                                          NBytesHistogram, WorkerTable,
-                                         GraphPlot)
+                                         GraphPlot, ProfileServer)
 
 from distributed.bokeh import scheduler
 
@@ -389,3 +389,14 @@ def test_GraphPlot_order(c, s, a, b):
     gp.update()
 
     assert gp.node_source.data['state'][gp.layout.index[y.key]] == 'erred'
+
+
+@gen_cluster(client=True,
+             config={'distributed.worker.profile.interval': '10ms',
+                     'distributed.worker.profile.cycle': '50ms'})
+def test_profile_server(c, s, a, b):
+    ptp = ProfileServer(s)
+    ptp.trigger_update()
+    yield gen.sleep(0.200)
+    ptp.trigger_update()
+    assert 2 < len(ptp.ts_source.data['time']) < 20

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -50,7 +50,7 @@ def test_hostport(loop):
         def f():
             yield [
                 # The scheduler's main port can't be contacted from the outside
-                assert_can_connect_locally_4(8978, 2.0),
+                assert_can_connect_locally_4(8978, 5.0),
             ]
 
         loop.run_sync(f)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1478,7 +1478,10 @@ class Client(Node):
                     self._send_to_scheduler({'op': 'report-key',
                                              'key': key})
                 for key in response['keys']:
-                    self.futures[key].reset()
+                    try:
+                        self.futures[key].reset()
+                    except KeyError:  # TODO: verify that this is safe
+                        pass
             else:
                 break
 

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -733,8 +733,11 @@ def test_inproc_comm_closed_explicit_2():
 
     comm = yield connect(contact_addr)
     comm.write("foo")
-    yield gen.sleep(0.01)
-    assert comm.closed()
+
+    start = time()
+    while not comm.closed():
+        yield gen.sleep(0.01)
+        assert time() < start + 2
 
     comm.close()
     comm.close()

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -16,11 +16,12 @@ from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.locks import Event
 
-from .compatibility import get_thread_identity
+from .compatibility import get_thread_identity, finalize
 from .comm import (connect, listen, CommClosedError,
                    normalize_address,
                    unparse_host_port, get_address_host_port)
 from .metrics import time
+from . import profile
 from .system_monitor import SystemMonitor
 from .utils import (get_traceback, truncate_exception, ignoring, shutting_down,
                     PeriodicCallback, parse_timedelta, has_keyword)
@@ -114,6 +115,15 @@ class Server(object):
         self.listener = None
         self.io_loop = io_loop or IOLoop.current()
         self.loop = self.io_loop
+
+        if not hasattr(self.io_loop, 'profile'):
+            self.io_loop.profile, stop = profile.watch(
+                    omit=('profile.py', 'selectors.py'),
+                    interval=dask.config.get('distributed.worker.profile.interval'),
+                    cycle=dask.config.get('distributed.worker.profile.cycle')
+            )
+            self.io_loop._profile_stop = stop
+            finalize(self.io_loop, stop)
 
         # Statistics counters for various events
         with ignoring(ImportError):

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -119,9 +119,14 @@ class Server(object):
         if not hasattr(self.io_loop, 'profile'):
             ref = weakref.ref(self.io_loop)
 
-            def stop():
-                loop = ref()
-                return loop is None or loop.closing
+            if hasattr(self.io_loop, 'closing'):
+                def stop():
+                    loop = ref()
+                    return loop is None or loop.closing
+            else:
+                def stop():
+                    loop = ref()
+                    return loop is None or loop._closing
 
             self.io_loop.profile = profile.watch(
                     omit=('profile.py', 'selectors.py'),

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -285,7 +285,10 @@ class LocalCluster(Cluster):
                 else:
                     sleep(0.01)
             del self.workers[:]
-            self._loop_runner.run_sync(self._close, callback_timeout=timeout)
+            try:
+                self._loop_runner.run_sync(self._close, callback_timeout=timeout)
+            except RuntimeError:  # IOLoop is closed
+                pass
             self._loop_runner.stop()
         finally:
             self.status = 'closed'

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -34,10 +34,10 @@ def _loop_add_callback(loop, func, *args):
 def _call_and_set_future(loop, future, func, *args, **kwargs):
     try:
         res = func(*args, **kwargs)
-    except Exception:
+    except Exception as exc:
         # Tornado futures are not thread-safe, need to
         # set_result() / set_exc_info() from the loop's thread
-        _loop_add_callback(loop, future.set_exc_info, sys.exc_info())
+        _loop_add_callback(loop, future.set_exception, exc)
     else:
         _loop_add_callback(loop, future.set_result, res)
 

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import logging
 import os
 import re
-import sys
 import threading
 import weakref
 

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -24,12 +24,18 @@ We represent this tree as a nested dictionary with the following form:
                    'children': {...}}}
     }
 """
-
-
-from collections import defaultdict
+import bisect
+from collections import defaultdict, deque
 import linecache
+import sys
+import threading
+from time import sleep
 
-from .utils import format_time, color_of
+import toolz
+
+from .metrics import time
+from .utils import format_time, color_of, parse_timedelta
+from .compatibility import get_thread_identity
 
 
 def identifier(frame):
@@ -64,7 +70,7 @@ def info_frame(frame):
             'line': line}
 
 
-def process(frame, child, state, stop=None):
+def process(frame, child, state, stop=None, omit=None):
     """ Add counts from a frame stack onto existing state
 
     This recursively adds counts to the existing state dictionary and creates
@@ -84,9 +90,14 @@ def process(frame, child, state, stop=None):
      'description': 'root',
      'children': {'...'}}
     """
+    if omit is not None and any(frame.f_code.co_filename.endswith(o) for o in omit):
+        return False
+
     prev = frame.f_back
     if prev is not None and (stop is None or not prev.f_code.co_filename.endswith(stop)):
         state = process(prev, frame, state, stop=stop)
+        if state is False:
+            return False
 
     ident = identifier(frame)
 
@@ -214,3 +225,79 @@ def plot_data(state, profile_interval=0.010):
             'name': names,
             'time': times,
             'percentage': percentages}
+
+
+def _watch(thread_id, log, interval='20ms', cycle='2s', omit=None, stop=None):
+    interval = parse_timedelta(interval)
+    cycle = parse_timedelta(cycle)
+
+    recent = create()
+    last = time()
+
+    while not stop:
+        if time() > last + cycle:
+            log.append((time(), recent))
+            recent = create()
+            last = time()
+        try:
+            frame = sys._current_frames()[thread_id]
+        except KeyError:
+            return
+
+        process(frame, None, recent, omit=omit)
+        sleep(interval)
+
+
+def watch(thread_id=None, interval='20ms', cycle='2s', maxlen=1000, omit=None):
+    if thread_id is None:
+        thread_id = get_thread_identity()
+
+    log = deque(maxlen=maxlen)
+
+    _stop = []
+
+    thread = threading.Thread(target=_watch,
+                              kwargs={'thread_id': thread_id,
+                                      'interval': interval,
+                                      'cycle': cycle,
+                                      'log': log,
+                                      'omit': omit,
+                                      'stop': _stop})
+    thread.daemon = True
+    thread.start()
+
+    def stop():
+        _stop.append(True)
+
+    return log, stop
+
+
+def get_profile(history, recent=None, start=None, stop=None, key=None):
+    now = time()
+    if start is None:
+        istart = 0
+    else:
+        istart = bisect.bisect_left(history, (start,))
+
+    if stop is None:
+        istop = None
+    else:
+        istop = bisect.bisect_right(history, (stop,)) + 1
+        if istop >= len(history):
+            istop = None  # include end
+
+    if istart == 0 and istop is None:
+        history = list(history)
+    else:
+        iistop = len(history) if istop is None else istop
+        history = [history[i] for i in range(istart, iistop)]
+
+    prof = merge(*toolz.pluck(1, history))
+
+    if not history:
+        return create()
+
+    if recent:
+        prof = merge(prof, recent)
+
+    return prof

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -257,6 +257,7 @@ def watch(thread_id=None, interval='20ms', cycle='2s', maxlen=1000, omit=None):
     _stop = []
 
     thread = threading.Thread(target=_watch,
+                              name='Profile',
                               kwargs={'thread_id': thread_id,
                                       'interval': interval,
                                       'cycle': cycle,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1376,7 +1376,7 @@ class Scheduler(ServerNode):
                             stack.append(dep)
 
             for d in done:
-                del tasks[d]
+                tasks.pop(d, None)
                 del dependencies[d]
 
         # Get or create task states

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2802,7 +2802,13 @@ class Scheduler(ServerNode):
     def report_on_key(self, key=None, ts=None, client=None):
         assert (key is None) + (ts is None) == 1, (key, ts)
         if ts is None:
-            ts = self.tasks[key]
+            try:
+                ts = self.tasks[key]
+            except KeyError:
+                self.report({'op': 'cancelled-key',
+                             'key': key},
+                            client=client)
+                return
         else:
             key = ts.key
         if ts.state == 'forgotten':

--- a/distributed/tests/py3_test_pubsub.py
+++ b/distributed/tests/py3_test_pubsub.py
@@ -13,7 +13,7 @@ def test_basic(c, s, a, b):
         i = 0
         while True:
             await gen.sleep(0.01)
-            pub.put(i)
+            pub._put(i)
             i += 1
 
     def f(_):

--- a/distributed/tests/py3_test_pubsub.py
+++ b/distributed/tests/py3_test_pubsub.py
@@ -32,4 +32,4 @@ def test_basic(c, s, a, b):
         # assert r == [x, x + 1, x + 2, x + 3, x + 4]
 
         assert len(r) == 5
-        assert all(r[i] < r[i + 1] for i in range(0, 4))
+        assert all(r[i] < r[i + 1] for i in range(0, 4)), r

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2049,7 +2049,6 @@ def test_waiting_data(c, s, a, b):
 @gen_cluster()
 def test_multi_client(s, a, b):
     c = yield Client((s.ip, s.port), asynchronous=True)
-
     f = yield Client((s.ip, s.port), asynchronous=True)
 
     assert set(s.client_comms) == {c.id, f.id}
@@ -2080,7 +2079,10 @@ def test_multi_client(s, a, b):
 
     yield f.close()
 
-    assert not s.tasks
+    start = time()
+    while s.tasks:
+        yield gen.sleep(0.01)
+        assert time() < start + 2, s.tasks
 
 
 def long_running_client_connection(address):

--- a/distributed/tests/test_metrics.py
+++ b/distributed/tests/test_metrics.py
@@ -35,7 +35,7 @@ def test_process_time():
     t.start()
     t.join()
     dt = metrics.process_time() - start
-    assert dt >= 0.08
+    assert dt >= 0.05
 
     if PY3:
         # Sleep time not counted

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -4,7 +4,7 @@ from toolz import first
 from threading import Thread
 
 from distributed.profile import (process, merge, create, call_stack,
-        identifier)
+        identifier, watch)
 from distributed.compatibility import get_thread_identity
 
 
@@ -113,3 +113,10 @@ def test_identifier():
     frame = sys._current_frames()[get_thread_identity()]
     assert identifier(frame) == identifier(frame)
     assert identifier(None) == identifier(None)
+
+
+def test_watch():
+    log, stop = watch(interval='10ms', cycle='50ms')
+    time.sleep(0.5)
+    assert 1 < len(log) < 10
+    stop()

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -262,14 +262,14 @@ def test_timeout(c, s, a, b):
 
     start = time()
     with pytest.raises(gen.TimeoutError):
-        yield q.get(timeout=0.1)
+        yield q.get(timeout=0.3)
     stop = time()
-    assert 0.1 < stop - start < 2.0
+    assert 0.2 < stop - start < 2.0
 
     yield q.put(1)
 
     start = time()
     with pytest.raises(gen.TimeoutError):
-        yield q.put(2, timeout=0.1)
+        yield q.put(2, timeout=0.3)
     stop = time()
-    assert 0.05 < stop - start < 2.0
+    assert 0.1 < stop - start < 2.0

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -732,26 +732,28 @@ def test_file_descriptors(c, s):
         assert time() < start + 3
 
 
+@slow
 @nodebug
 @gen_cluster(client=True)
 def test_learn_occupancy(c, s, a, b):
-    futures = c.map(slowinc, range(1000), delay=0.01)
+    futures = c.map(slowinc, range(1000), delay=0.2)
     while sum(len(ts.who_has) for ts in s.tasks.values()) < 10:
         yield gen.sleep(0.01)
 
-    assert 1 < s.total_occupancy < 40
+    assert 100 < s.total_occupancy < 1000
     for w in [a, b]:
-        assert 1 < s.workers[w.address].occupancy < 20
+        assert 50 < s.workers[w.address].occupancy < 700
 
 
+@slow
 @nodebug
 @gen_cluster(client=True)
 def test_learn_occupancy_2(c, s, a, b):
-    future = c.map(slowinc, range(1000), delay=0.1)
+    future = c.map(slowinc, range(1000), delay=0.2)
     while not any(ts.who_has for ts in s.tasks.values()):
         yield gen.sleep(0.01)
 
-    assert 50 < s.total_occupancy < 200
+    assert 100 < s.total_occupancy < 1000
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -514,16 +514,16 @@ def test_parse_timedelta():
 def test_all_exceptions_logging():
     @gen.coroutine
     def throws():
-        raise Exception('foo')
+        raise Exception('foo1234')
 
     with captured_logger('') as sio:
         try:
             yield All([throws() for _ in range(5)],
-                    quiet_exceptions=Exception)
+                      quiet_exceptions=Exception)
         except Exception:
             pass
 
         import gc; gc.collect()
         yield gen.sleep(0.1)
 
-    assert not sio.getvalue()
+    assert 'foo1234' not in sio.getvalue()

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -358,12 +358,11 @@ class LoopRunner(object):
             finally:
                 done_evt.set()
 
-        thread = threading.Thread(target=run_loop,
-                                  name="IO loop")
+        thread = threading.Thread(target=run_loop, name="IO loop")
         thread.daemon = True
         thread.start()
 
-        loop_evt.wait(timeout=1000)
+        loop_evt.wait(timeout=10)
         self._started = True
 
         actual_thread = in_thread[0]

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -172,9 +172,6 @@ def pristine_loop():
         IOLoop.clear_instance()
         IOLoop.clear_current()
 
-        with ignoring(AttributeError):
-            loop._profile_stop()
-
 
 @contextmanager
 def mock_ipython():
@@ -816,8 +813,6 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                             raise gen.Return(result)
 
                     result = loop.run_sync(coro, timeout=timeout * 2 if timeout else timeout)
-                    with ignoring(AttributeError):
-                        loop._profile_stop()
 
                 for w in workers:
                     if getattr(w, 'data', None):


### PR DESCRIPTION
We have nice statistical profiling for the worker threads of each worker that is visible from the bokeh diagnostic pages.  However it would be nice to also get this same kind of information about the main administrative thread within the scheduler and workers themselves.  This will help us to understand performance costs generally and tune the scheduler and worker codes.  

This PR copies and modifies the profile code to operate on each event loop and provides a new route (currently not advertised) on the dashboard.  This helps us to understand the costs of things like asyncio and how they affect our general performance.

![image](https://user-images.githubusercontent.com/306380/43368136-4574f46c-930d-11e8-9d5b-6f4b4f6aeffe.png)
