### PR TITLE
Fix memory tooltip in workers dashboard

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -971,7 +971,7 @@ class WorkerTable(DashboardComponent):
             point_policy="follow_mouse",
             tooltips="""
                 <div>
-                  <span style="font-size: 10px; font-family: Monaco, monospace;">@host: </span>
+                  <span style="font-size: 10px; font-family: Monaco, monospace;">@worker: </span>
                   <span style="font-size: 10px; font-family: Monaco, monospace;">@memory_percent</span>
                 </div>
                 """


### PR DESCRIPTION
![screenshot_20180808_151728](https://user-images.githubusercontent.com/1680079/43839523-97bbca7a-9b1e-11e8-8dd7-26df24ac85b9.png)

I used the same names as the CPU tooltip a few lines below (which works fine):
https://github.com/dask/distributed/blob/b16ee25506fd20ec5daa7d77e338e2725e778562/distributed/bokeh/scheduler.py#L991-L998

I double-checked that it was working too.