### PR TITLE
fix scale /  avoid returning coroutines

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -96,7 +96,7 @@ class Cluster(object):
                 to_close = self.scheduler.workers_to_close(
                     n=len(self.scheduler.workers) - n)
                 print("Closing workers: %s", to_close)
-                self.scheduler.loop.add_callback(self.scheduler.retire_workers, to_close)
+                self.scheduler.loop.add_callback(self.scheduler.retire_workers, workers=to_close)
                 self.scheduler.loop.add_callback(self.scale_down, to_close)
 
     def _widget_status(self):

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -95,7 +95,7 @@ class Cluster(object):
             else:
                 to_close = self.scheduler.workers_to_close(
                     n=len(self.scheduler.workers) - n)
-                print("Closing workers: %s", to_close)
+                logger.debug("Closing workers: %s", to_close)
                 self.scheduler.loop.add_callback(self.scheduler.retire_workers, workers=to_close)
                 self.scheduler.loop.add_callback(self.scale_down, to_close)
 

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -93,12 +93,10 @@ class Cluster(object):
             if n >= len(self.scheduler.workers):
                 self.scheduler.loop.add_callback(self.scale_up, n)
             else:
-                to_close = self.scheduler.retire_workers(
-                    remove=False,
-                    close_workers=True,
-                    n=len(self.scheduler.workers) - n
-                )
-                logger.debug("Closing workers: %s", to_close)
+                to_close = self.scheduler.workers_to_close(
+                    n=len(self.scheduler.workers) - n)
+                print("Closing workers: %s", to_close)
+                self.scheduler.loop.add_callback(self.scheduler.retire_workers, to_close)
                 self.scheduler.loop.add_callback(self.scale_down, to_close)
 
     def _widget_status(self):


### PR DESCRIPTION
This reworks the scale down block of `Cluster.scale()` to avoid calling coroutines. 

xref: https://github.com/dask/dask-jobqueue/pull/97#discussion_r208428234

