### PR TITLE
Concatenate all bytes of small messages in TCP comms

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -221,21 +221,26 @@ class TCP(Comm):
                                           'recipient': self._peer_addr})
 
         try:
-            lengths = ([struct.pack('Q', len(frames))] +
-                       [struct.pack('Q', nbytes(frame)) for frame in frames])
-            stream.write(b''.join(lengths))
+            lengths = [nbytes(frame) for frame in frames]
+            length_bytes = ([struct.pack('Q', len(frames))] +
+                            [struct.pack('Q', x) for x in lengths])
+            if sum(lengths) < 2**17:  # 128kiB
+                b = b''.join(length_bytes + frames)  # small enough, send in one go
+                stream.write(b)
+            else:
+                stream.write(b''.join(length_bytes))  # avoid large memcpy, send in many
 
-            for frame in frames:
-                # Can't wait for the write() Future as it may be lost
-                # ("If write is called again before that Future has resolved,
-                #   the previous future will be orphaned and will never resolve")
-                if not self._iostream_allows_memoryview:
-                    frame = ensure_bytes(frame)
-                future = stream.write(frame)
-                bytes_since_last_yield += nbytes(frame)
-                if bytes_since_last_yield > 32e6:
-                    yield future
-                    bytes_since_last_yield = 0
+                for frame in frames:
+                    # Can't wait for the write() Future as it may be lost
+                    # ("If write is called again before that Future has resolved,
+                    #   the previous future will be orphaned and will never resolve")
+                    if not self._iostream_allows_memoryview:
+                        frame = ensure_bytes(frame)
+                    future = stream.write(frame)
+                    bytes_since_last_yield += nbytes(frame)
+                    if bytes_since_last_yield > 32e6:
+                        yield future
+                        bytes_since_last_yield = 0
         except StreamClosedError as e:
             stream = None
             convert_stream_closed_error(self, e)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -224,7 +224,7 @@ class TCP(Comm):
             lengths = [nbytes(frame) for frame in frames]
             length_bytes = ([struct.pack('Q', len(frames))] +
                             [struct.pack('Q', x) for x in lengths])
-            if sum(lengths) < 2**17:  # 128kiB
+            if PY3 and sum(lengths) < 2**17:  # 128kiB
                 b = b''.join(length_bytes + frames)  # small enough, send in one go
                 stream.write(b)
             else:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -985,7 +985,7 @@ def assert_can_connect(addr, timeout=None, connection_args=None):
     within the given *timeout*.
     """
     if timeout is None:
-        timeout = 0.2
+        timeout = 0.5
     comm = yield connect(addr, timeout=timeout,
                          connection_args=connection_args)
     comm.abort()
@@ -998,7 +998,7 @@ def assert_cannot_connect(addr, timeout=None, connection_args=None, exception_cl
     within the given *timeout*.
     """
     if timeout is None:
-        timeout = 0.2
+        timeout = 0.5
     with pytest.raises(exception_class):
         comm = yield connect(addr, timeout=timeout,
                              connection_args=connection_args)


### PR DESCRIPTION
Previously we would write lengths to a socket, and then follow up with
frames.  This causes additional socket.send calls, which can be costly.

Now for small messages we just bundle everything together and suffer a
memory copy, but avoid the extra socket.send calls.