### PR TITLE
Use dispatch for dask serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   matrix:
     - PYTHON=2.7 TESTS=true PACKAGES="python-blosc futures faulthandler"
     - PYTHON=3.5.4 TESTS=true COVERAGE=true PACKAGES=python-blosc CRICK=true
-    - PYTHON=3.6 TESTS=true
+    - PYTHON=3.6 TESTS=true PACKAGES="scikit-learn"
 
 matrix:
   fast_finish: true

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -8,7 +8,7 @@ from .serialize import (
     serialize, deserialize, nested_deserialize, Serialize, Serialized,
     to_serialize, register_serialization, dask_serialize, dask_deserialize,
     serialize_bytes, deserialize_bytes, serialize_bytelist,
-    register_serialization_family, register_attributes,
+    register_serialization_family, register_generic,
 )
 
 from ..utils import ignoring
@@ -54,7 +54,7 @@ def _register_arrow():
 @dask_deserialize.register_lazy("sklearn")
 def _register_sklearn():
     import sklearn.base
-    register_attributes(sklearn.base.BaseEstimator)
+    register_generic(sklearn.base.BaseEstimator)
 
 
 @dask_serialize.register_lazy("torch")

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -55,3 +55,11 @@ def _register_arrow():
 def _register_sklearn():
     import sklearn.base
     register_attributes(sklearn.base.BaseEstimator)
+
+
+@dask_serialize.register_lazy("torch")
+@dask_deserialize.register_lazy("torch")
+@dask_serialize.register_lazy("torchvision")
+@dask_deserialize.register_lazy("torchvision")
+def _register_torch():
+    from . import torch

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -6,7 +6,7 @@ from .compression import compressions, default_compression
 from .core import (dumps, loads, maybe_compress, decompress, msgpack)
 from .serialize import (
     serialize, deserialize, nested_deserialize, Serialize, Serialized,
-    to_serialize, register_serialization, register_serialization_lazy,
+    to_serialize, register_serialization, dask_serialize, dask_deserialize,
     serialize_bytes, deserialize_bytes, serialize_bytelist,
     register_serialization_family,
 )
@@ -14,31 +14,37 @@ from .serialize import (
 from ..utils import ignoring
 
 
-@partial(register_serialization_lazy, "numpy")
+@dask_serialize.register_lazy("numpy")
+@dask_deserialize.register_lazy("numpy")
 def _register_numpy():
     from . import numpy
 
 
-@partial(register_serialization_lazy, "h5py")
+@dask_serialize.register_lazy("h5py")
+@dask_deserialize.register_lazy("h5py")
 def _register_h5py():
     from . import h5py
 
 
-@partial(register_serialization_lazy, "netCDF4")
+@dask_serialize.register_lazy("netCDF4")
+@dask_deserialize.register_lazy("netCDF4")
 def _register_netcdf4():
     from . import netcdf4
 
 
-@partial(register_serialization_lazy, "keras")
+@dask_serialize.register_lazy("keras")
+@dask_deserialize.register_lazy("keras")
 def _register_keras():
     from . import keras
 
 
-@partial(register_serialization_lazy, "sparse")
+@dask_serialize.register_lazy("sparse")
+@dask_deserialize.register_lazy("sparse")
 def _register_sparse():
     from . import sparse
 
 
-@partial(register_serialization_lazy, "pyarrow")
+@dask_serialize.register_lazy("pyarrow")
+@dask_deserialize.register_lazy("pyarrow")
 def _register_arrow():
     from . import arrow

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -8,7 +8,7 @@ from .serialize import (
     serialize, deserialize, nested_deserialize, Serialize, Serialized,
     to_serialize, register_serialization, dask_serialize, dask_deserialize,
     serialize_bytes, deserialize_bytes, serialize_bytelist,
-    register_serialization_family,
+    register_serialization_family, register_attributes,
 )
 
 from ..utils import ignoring
@@ -48,3 +48,10 @@ def _register_sparse():
 @dask_deserialize.register_lazy("pyarrow")
 def _register_arrow():
     from . import arrow
+
+
+@dask_serialize.register_lazy("sklearn")
+@dask_deserialize.register_lazy("sklearn")
+def _register_sklearn():
+    import sklearn.base
+    register_attributes(sklearn.base.BaseEstimator)

--- a/distributed/protocol/arrow.py
+++ b/distributed/protocol/arrow.py
@@ -1,12 +1,14 @@
 from __future__ import print_function, division, absolute_import
 
-from .serialize import register_serialization
+from .serialize import dask_serialize, dask_deserialize
+
+import pyarrow
 
 
+@dask_serialize.register(pyarrow.RecordBatch)
 def serialize_batch(batch):
-    import pyarrow as pa
-    sink = pa.BufferOutputStream()
-    writer = pa.RecordBatchStreamWriter(sink, batch.schema)
+    sink = pyarrow.BufferOutputStream()
+    writer = pyarrow.RecordBatchStreamWriter(sink, batch.schema)
     writer.write_batch(batch)
     writer.close()
     buf = sink.get_result()
@@ -15,17 +17,17 @@ def serialize_batch(batch):
     return header, frames
 
 
+@dask_deserialize.register(pyarrow.RecordBatch)
 def deserialize_batch(header, frames):
-    import pyarrow as pa
     blob = frames[0]
-    reader = pa.RecordBatchStreamReader(pa.BufferReader(blob))
+    reader = pyarrow.RecordBatchStreamReader(pyarrow.BufferReader(blob))
     return reader.read_next_batch()
 
 
+@dask_serialize.register(pyarrow.Table)
 def serialize_table(tbl):
-    import pyarrow as pa
-    sink = pa.BufferOutputStream()
-    writer = pa.RecordBatchStreamWriter(sink, tbl.schema)
+    sink = pyarrow.BufferOutputStream()
+    writer = pyarrow.RecordBatchStreamWriter(sink, tbl.schema)
     writer.write_table(tbl)
     writer.close()
     buf = sink.get_result()
@@ -34,20 +36,8 @@ def serialize_table(tbl):
     return header, frames
 
 
+@dask_deserialize.register(pyarrow.Table)
 def deserialize_table(header, frames):
-    import pyarrow as pa
     blob = frames[0]
-    reader = pa.RecordBatchStreamReader(pa.BufferReader(blob))
+    reader = pyarrow.RecordBatchStreamReader(pyarrow.BufferReader(blob))
     return reader.read_all()
-
-
-register_serialization(
-    'pyarrow.lib.RecordBatch',
-    serialize_batch,
-    deserialize_batch
-)
-register_serialization(
-    'pyarrow.lib.Table',
-    serialize_table,
-    deserialize_table
-)

--- a/distributed/protocol/h5py.py
+++ b/distributed/protocol/h5py.py
@@ -1,39 +1,31 @@
 from __future__ import print_function, division, absolute_import
 
-from .serialize import register_serialization
+from .serialize import dask_serialize, dask_deserialize
+
+import h5py
 
 
+@dask_serialize.register(h5py.File)
 def serialize_h5py_file(f):
     if f.mode != 'r':
         raise ValueError("Can only serialize read-only h5py files")
     return {'filename': f.filename}, []
 
 
+@dask_deserialize.register(h5py.File)
 def deserialize_h5py_file(header, frames):
     import h5py
     return h5py.File(header['filename'], mode='r')
 
 
-register_serialization('h5py._hl.files.File',
-                       serialize_h5py_file,
-                       deserialize_h5py_file)
-
-
+@dask_serialize.register((h5py.Group, h5py.Dataset))
 def serialize_h5py_dataset(x):
     header, _ = serialize_h5py_file(x.file)
     header['name'] = x.name
     return header, []
 
 
+@dask_deserialize.register((h5py.Group, h5py.Dataset))
 def deserialize_h5py_dataset(header, frames):
     file = deserialize_h5py_file(header, frames)
     return file[header['name']]
-
-
-register_serialization('h5py._hl.dataset.Dataset',
-                       serialize_h5py_dataset,
-                       deserialize_h5py_dataset)
-
-register_serialization('h5py._hl.group.Group',
-                       serialize_h5py_dataset,
-                       deserialize_h5py_dataset)

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -11,7 +11,7 @@ except ImportError:
     blosc = False
 
 from .utils import frame_split_size, merge_frames
-from .serialize import register_serialization
+from .serialize import dask_serialize, dask_deserialize
 from . import pickle
 
 from ..utils import log_errors
@@ -28,6 +28,7 @@ def itemsize(dt):
     return result
 
 
+@dask_serialize.register(np.ndarray)
 def serialize_numpy_ndarray(x):
     if x.dtype.hasobject:
         header = {'pickle': True}
@@ -88,6 +89,7 @@ def serialize_numpy_ndarray(x):
     return header, frames
 
 
+@dask_deserialize.register(np.ndarray)
 def deserialize_numpy_ndarray(header, frames):
     with log_errors():
         if len(frames) > 1:
@@ -106,6 +108,3 @@ def deserialize_numpy_ndarray(header, frames):
                        strides=header['strides'])
 
         return x
-
-
-register_serialization(np.ndarray, serialize_numpy_ndarray, deserialize_numpy_ndarray)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -471,10 +471,11 @@ def serialize_object_with_dict(est):
         d = est.__dict__
 
     for k, v in d.items():
-        if (isinstance(v, basic) or
-                isinstance(v, dict) and all(isinstance(x, basic) for x in v.values())
-                                    and all(isinstance(x, basic) for x in v.keys()) or
-                isinstance(v, (list, tuple)) and all(isinstance(x, basic) for x in v)):
+        typ = type(v)
+        if (typ is str or typ is int or typ is float or
+                isinstance(v, dict) and all(typ is str or typ is int or typ is float for x in v.values())
+                                    and all(typ is str for x in v.keys()) or
+                isinstance(v, (list, tuple)) and all(typ is str or typ is int or typ is float for x in v)):
             header['simple'][k] = v
         else:
             if isinstance(v, dict):

--- a/distributed/protocol/sparse.py
+++ b/distributed/protocol/sparse.py
@@ -1,8 +1,11 @@
 from __future__ import print_function, division, absolute_import
 
-from .serialize import register_serialization, serialize, deserialize
+from .serialize import dask_serialize, dask_deserialize, serialize, deserialize
+
+import sparse
 
 
+@dask_serialize.register(sparse.COO)
 def serialize_sparse(x):
     coords_header, coords_frames = serialize(x.coords)
     data_header, data_frames = serialize(x.data)
@@ -14,8 +17,8 @@ def serialize_sparse(x):
     return header, coords_frames + data_frames
 
 
+@dask_deserialize.register(sparse.COO)
 def deserialize_sparse(header, frames):
-    import sparse
 
     coords_frames = frames[:header['nframes'][0]]
     data_frames = frames[header['nframes'][0]:]
@@ -26,7 +29,3 @@ def deserialize_sparse(header, frames):
     shape = header['shape']
 
     return sparse.COO(coords, data, shape=shape)
-
-
-register_serialization('sparse.core.COO', serialize_sparse, deserialize_sparse)  # version 0.1
-register_serialization('sparse.coo.COO', serialize_sparse, deserialize_sparse)  # version 0.2

--- a/distributed/protocol/tests/test_arrow.py
+++ b/distributed/protocol/tests/test_arrow.py
@@ -5,7 +5,6 @@ pa = pytest.importorskip('pyarrow')
 
 from distributed.utils_test import gen_cluster
 from distributed.protocol import deserialize, serialize
-from distributed.protocol.serialize import class_serializers, typename
 
 
 df = pd.DataFrame({'A': list('abc'), 'B': [1,2,3]})
@@ -20,13 +19,6 @@ def test_roundtrip(obj):
     header, frames = serialize(obj)
     new_obj = deserialize(header, frames)
     assert obj.equals(new_obj)
-
-
-@pytest.mark.parametrize('obj', [batch, tbl], ids=["RecordBatch", "Table"])
-def test_typename(obj):
-    # The typename used to register the custom serialization is hardcoded
-    # ensure that the typename hasn't changed
-    assert typename(type(obj)) in class_serializers
 
 
 def echo(arg):

--- a/distributed/protocol/tests/test_sklearn.py
+++ b/distributed/protocol/tests/test_sklearn.py
@@ -1,0 +1,16 @@
+import sklearn.linear_model
+
+from distributed.protocol import serialize, deserialize
+
+
+def test_basic():
+    est = sklearn.linear_model.LinearRegression()
+    est.fit([[0, 0], [1, 1], [2, 2]], [0, 1, 2])
+
+    header, frames = serialize(est)
+    assert header['serializer'] == 'dask'
+
+    est2 = deserialize(header, frames)
+
+    inp = [[2, 3], [-1, 3]]
+    assert (est.predict(inp) == est2.predict(inp)).all()

--- a/distributed/protocol/tests/test_sklearn.py
+++ b/distributed/protocol/tests/test_sklearn.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('sklearn')
+
 import sklearn.linear_model
 
 from distributed.protocol import serialize, deserialize

--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -14,11 +14,20 @@ def test_tensor():
     assert (x == t2.numpy()).all()
 
 
+def test_grad():
+    x = np.arange(10)
+    t = torch.Tensor(x)
+    t.grad = torch.zeros_like(t) + 1
+
+    t2 = deserialize(*serialize(t))
+    assert (t2.numpy() == x).all()
+    assert (t2.grad.numpy() == 1).all()
+
+
 def test_resnet():
     torchvision = pytest.importorskip('torchvision')
     model = torchvision.models.resnet.resnet18()
 
     header, frames = serialize(model)
-    import pdb; pdb.set_trace()
     model2 = deserialize(header, frames)
     assert str(model) == str(model2)

--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -1,0 +1,24 @@
+from distributed.protocol import serialize, deserialize
+import pytest
+
+np = pytest.importorskip('numpy')
+torch = pytest.importorskip('torch')
+
+
+def test_tensor():
+    x = np.arange(10)
+    t = torch.Tensor(x)
+    header, frames = serialize(t)
+    assert header['serializer'] == 'dask'
+    t2 = deserialize(header, frames)
+    assert (x == t2.numpy()).all()
+
+
+def test_resnet():
+    torchvision = pytest.importorskip('torchvision')
+    model = torchvision.models.resnet.resnet18()
+
+    header, frames = serialize(model)
+    import pdb; pdb.set_trace()
+    model2 = deserialize(header, frames)
+    assert str(model) == str(model2)

--- a/distributed/protocol/torch.py
+++ b/distributed/protocol/torch.py
@@ -1,5 +1,5 @@
 from .serialize import (serialize, dask_serialize, dask_deserialize,
-        register_attributes)
+        register_generic)
 
 import torch
 import numpy as np
@@ -53,4 +53,4 @@ def deserialize_torch_Parameters(header, frames):
     return torch.nn.Parameter(data=t, requires_grad=header['requires_grad'])
 
 
-register_attributes(torch.nn.Module)
+register_generic(torch.nn.Module)

--- a/distributed/protocol/torch.py
+++ b/distributed/protocol/torch.py
@@ -8,6 +8,10 @@ import numpy as np
 @dask_serialize.register(torch.Tensor)
 def serialize_torch_Tensor(t):
     header, frames = serialize(t.numpy())
+    if t.grad is not None:
+        grad_header, grad_frames = serialize(t.grad.numpy())
+        header['grad'] = {'header': grad_header, 'start': len(frames)}
+        frames += grad_frames
     header['requires_grad'] = t.requires_grad
     header['device'] = t.device.type
     return header, frames
@@ -15,10 +19,25 @@ def serialize_torch_Tensor(t):
 
 @dask_deserialize.register(torch.Tensor)
 def deserialize_torch_Tensor(header, frames):
+    if header.get('grad', False):
+        i = header['grad']['start']
+        frames, grad_frames = frames[:i], frames[i:]
+        grad = dask_deserialize.dispatch(np.ndarray)(header['grad']['header'], grad_frames)
+    else:
+        grad = None
+
     x = dask_deserialize.dispatch(np.ndarray)(header, frames)
-    return torch.tensor(data=x,
-                        device=header['device'],
-                        requires_grad=header['requires_grad'])
+    if header['device'] == 'cpu':
+        t = torch.from_numpy(x)
+        if header['requires_grad']:
+            t = t.requires_grad_(True)
+    else:
+        t = torch.tensor(data=x,
+                         device=header['device'],
+                         requires_grad=header['requires_grad'])
+    if grad is not None:
+        t.grad = torch.from_numpy(grad)
+    return t
 
 
 @dask_serialize.register(torch.nn.Parameter)

--- a/distributed/protocol/torch.py
+++ b/distributed/protocol/torch.py
@@ -1,0 +1,37 @@
+from .serialize import (serialize, dask_serialize, dask_deserialize,
+        register_attributes)
+
+import torch
+import numpy as np
+
+
+@dask_serialize.register(torch.Tensor)
+def serialize_torch_Tensor(t):
+    header, frames = serialize(t.numpy())
+    header['requires_grad'] = t.requires_grad
+    header['device'] = t.device.type
+    return header, frames
+
+
+@dask_deserialize.register(torch.Tensor)
+def deserialize_torch_Tensor(header, frames):
+    x = dask_deserialize.dispatch(np.ndarray)(header, frames)
+    return torch.tensor(data=x,
+                        device=header['device'],
+                        requires_grad=header['requires_grad'])
+
+
+@dask_serialize.register(torch.nn.Parameter)
+def serialize_torch_Parameters(p):
+    header, frames = serialize(p.detach())
+    header['requires_grad'] = p.requires_grad
+    return header, frames
+
+
+@dask_deserialize.register(torch.nn.Parameter)
+def deserialize_torch_Parameters(header, frames):
+    t = dask_deserialize.dispatch(torch.Tensor)(header, frames)
+    return torch.nn.Parameter(data=t, requires_grad=header['requires_grad'])
+
+
+register_attributes(torch.nn.Module)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3858,12 +3858,12 @@ def test_scatter_compute_lose(c, s, a, b):
 
     yield a._close()
 
+    with pytest.raises(CancelledError):
+        yield wait(z)
+
     assert x.status == 'cancelled'
     assert y.status == 'finished'
     assert z.status == 'cancelled'
-
-    with pytest.raises(CancelledError):
-        yield wait(z)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -265,7 +265,8 @@ def test_nanny_timeout(c, s, a):
 
 
 @gen_cluster(ncores=[('127.0.0.1', 1)], client=True, Worker=Nanny,
-             worker_kwargs={'memory_limit': 1e8}, timeout=20)
+             worker_kwargs={'memory_limit': 1e8}, timeout=20,
+             check_new_threads=False)
 def test_nanny_terminate(c, s, a):
     from time import sleep
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -549,6 +549,7 @@ def key_split(s):
 try:
     from functools import lru_cache
 except ImportError:
+    lru_cache = False
     pass
 else:
     key_split = lru_cache(100000)(key_split)
@@ -1404,6 +1405,10 @@ def has_keyword(func, keyword):
         if gen.is_coroutine_function(func):
             func = func.__wrapped__
         return keyword in inspect.getargspec(func).args
+
+
+if lru_cache:
+    has_keyword = lru_cache(1000)(has_keyword)
 
 
 # from bokeh.palettes import viridis

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -853,7 +853,7 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                         break
                     else:
                         sleep(0.01)
-                    if time() > start + 2:
+                    if time() > start + 5:
                         from distributed import profile
                         tid = bad[0]
                         thread = threading._active[tid]

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -173,13 +173,13 @@ Traverse attributes
 +++++++++++++++++++
 
 .. autosummary::
-   register_attributes
+   register_generic
 
 A common case is that your object just wraps Numpy arrays or other objects that
 Dask already serializes well.  For example, Scikit-Learn estimators mostly
 surround Numpy arrays with a bit of extra metadata.  In these cases you can
 register your class for custom Dask serialization with the
-``register_attributes``
+``register_generic``
 function.
 
 API
@@ -189,11 +189,10 @@ API
                  deserialize
                  dask_serialize
                  dask_deserialize
-                 register_attributes
+                 register_generic
 
-.. autofunction:: register_serialization
 .. autofunction:: serialize
 .. autofunction:: deserialize
 .. autofunction:: dask_serialize
 .. autofunction:: dask_deserialize
-.. autofunction:: register_attributes
+.. autofunction:: register_generic

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -150,25 +150,28 @@ register them with Dask.
         def __init__(self, name):
             self.name = name
 
+    from distributed.protocol import dask_serialize, dask_deserialize
+
+    @dask_serialize.register(Human)
     def serialize(human: Human) -> Tuple[Dict, List[bytes]]:
         header = {}
         frames = [human.name.encode()]
         return header, frames
 
+    @dask_deserialize.register(Human)
     def deserialize(header: Dict, frames: List[bytes]) -> Human:
         return Human(frames[0].decode())
 
-    from distributed.protocol.serialize import register_serialization
-    register_serialization(Human, serialize, deserialize)
 
 API
 ---
 
 .. currentmodule:: distributed.protocol.serialize
 
-.. autosummary:: register_serialization
-                 serialize
+.. autosummary:: serialize
                  deserialize
+                 dask_serialize
+                 dask_deserialize
 
 .. autofunction:: register_serialization
 .. autofunction:: serialize

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -1,6 +1,8 @@
 Serialization
 =============
 
+.. currentmodule:: distributed.protocol.serialize
+
 When we communicate data between computers we first convert that data into a
 sequence of bytes that can be communicated across the network.  Choices made in
 serialization can affect performance and security.
@@ -138,6 +140,10 @@ pickle internally in some cases.  It should not be considered more secure.
 Extend
 ++++++
 
+.. autosummary::
+   dask_serialize
+   dask_deserialize
+
 As with serialization families in general, the Dask family in particular is
 *also* extensible.  This is a good way to support custom serialization of a
 single type of object.  The method is similar, you create serialize and
@@ -163,16 +169,31 @@ register them with Dask.
         return Human(frames[0].decode())
 
 
+Traverse attributes
++++++++++++++++++++
+
+.. autosummary::
+   register_attributes
+
+A common case is that your object just wraps Numpy arrays or other objects that
+Dask already serializes well.  For example, Scikit-Learn estimators mostly
+surround Numpy arrays with a bit of extra metadata.  In these cases you can
+register your class for custom Dask serialization with the
+``register_attributes``
+function.
+
 API
 ---
-
-.. currentmodule:: distributed.protocol.serialize
 
 .. autosummary:: serialize
                  deserialize
                  dask_serialize
                  dask_deserialize
+                 register_attributes
 
 .. autofunction:: register_serialization
 .. autofunction:: serialize
 .. autofunction:: deserialize
+.. autofunction:: dask_serialize
+.. autofunction:: dask_deserialize
+.. autofunction:: register_attributes


### PR DESCRIPTION
This allows people to register serialization functions using decorator syntax

```python
@dask_serialize.register(np.ndarray)
def serialize_array(x):
    ...

@dask_deserialize.register(np.ndarray)
def serialize_array(header, frames):
    ...
```

This also means that inheritance turns on by default
(which is both good and bad)