### PR TITLE
Handle corner cases with busy signal

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1542,6 +1542,8 @@ class Worker(WorkerBase):
                 import pdb
                 pdb.set_trace()
             raise
+        if value is not no_value and dep not in self.data:
+            self.put_key_in_memory(dep, value, transition=False)
 
     def transition(self, key, finish, **kwargs):
         start = self.task_state[key]
@@ -1890,7 +1892,8 @@ class Worker(WorkerBase):
                 if response['status'] == 'busy':
                     self.log.append(('busy-gather', worker, deps))
                     for dep in deps:
-                        self.transition_dep(dep, 'waiting')
+                        if self.dep_state[dep] == 'flight':
+                            self.transition_dep(dep, 'waiting')
                     return
 
                 if cause:


### PR DESCRIPTION
There are a couple cases where in-flight dependencies can come in in atypical
ways:

1.  A request can be made and in-flight, for some reason the dependency state
    changes (it gets cancelled and then re-requested) then when the request
    comes in we try to transition to a memory state, buy may not have an
    established route to do so
2.  A request can be made and in-flight, for some reason the dependency state
    changes, then the request comes in with a busy signal and we try to
    transition down to waiting, but may not have an established route to do so

This currently doesn't have any tests, and transition_dep_waiting_memory is
entirely uncovered.