### PR TITLE
Check self.dependencies when looking at tasks in memory

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1369,7 +1369,11 @@ class Scheduler(ServerNode):
             while stack:  # remove unnecessary dependencies
                 key = stack.pop()
                 ts = self.tasks[key]
-                for dep in dependencies[key]:
+                try:
+                    deps = dependencies[key]
+                except KeyError:
+                    deps = self.dependencies[key]
+                for dep in deps:
                     if all(d in done for d in dependents[dep]):
                         if dep in self.tasks:
                             done.add(dep)
@@ -1377,7 +1381,7 @@ class Scheduler(ServerNode):
 
             for d in done:
                 tasks.pop(d, None)
-                del dependencies[d]
+                dependencies.pop(d, None)
 
         # Get or create task states
         stack = list(keys)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1362,3 +1362,25 @@ def test_resources_reset_after_cancelled_task(c, s, w):
     assert w.available_resources == {'A': 1}
 
     yield c.submit(inc, 1, resources={'A': 1})
+
+
+@gen_cluster(client=True)
+def test_gh2187(c, s, a, b):
+    def foo():
+        return 'foo'
+
+    def bar(x):
+        return x + 'bar'
+
+    def baz(x):
+        sleep(0.1)
+        return x + 'baz'
+
+    x = c.submit(foo, key='x')
+    y = c.submit(bar, x, key='y')
+    yield y
+    z = c.submit(baz, y, key='z')
+    del y
+    yield gen.sleep(0.1)
+    f = c.submit(bar, x, key='y')
+    yield f


### PR DESCRIPTION
Previously during a check to see if tasks and their dependencies were already
in memory we assumed that the dependencies were known to the client when it
sent in the computation.  However if the inputs were futures then this was not
the case, and a KeyError was raised because only the scheduler knew where
things were.

Now we properly check both the input dependencies and self.dependencies and are
robust to the information being in either place.

Fixes #2187