### PR TITLE
Clean up metrics tests

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -179,7 +179,7 @@ class WorkerBase(ServerNode):
         self.services = {}
         self.service_ports = service_ports or {}
         self.service_specs = services or {}
-        self.metrics = metrics or {}
+        self.metrics = dict(metrics) if metrics else {}
 
         handlers = {
             'gather': self.gather,


### PR DESCRIPTION
We were getting intermittent testing failures with the WorkerTable
custom metrics tests.

This makes two changes that will hopefully resolve the situation:

1.  It explicitly calls heartbeat to accelerate the tests
2.  We make a copy of the metrics dict in order to avoid sharing the same
    metrics across multiple workers in tests