### PR TITLE
Fix deserialization of queues on main ioloop thread

### DIFF
--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -273,3 +273,19 @@ def test_timeout(c, s, a, b):
         yield q.put(2, timeout=0.3)
     stop = time()
     assert 0.1 < stop - start < 2.0
+
+
+@gen_cluster(client=True)
+def test_2220(c, s, a, b):
+    q = Queue()
+
+    def put():
+        q.put(55)
+
+    def get():
+        print(q.get())
+
+    fut = c.submit(put)
+    res = c.submit(get)
+
+    yield [res, fut]

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -49,7 +49,8 @@ from .process import _cleanup_dangling
 from .proctitle import enable_proctitle_on_children
 from .security import Security
 from .utils import (ignoring, log_errors, mp_context, get_ip, get_ipv6,
-                    DequeHandler, reset_logger_locks, sync, iscoroutinefunction)
+                    DequeHandler, reset_logger_locks, sync,
+                    iscoroutinefunction, thread_state)
 from .worker import Worker, TOTAL_MEMORY, _global_workers
 
 try:
@@ -863,6 +864,8 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)],
                         call_stacks = profile.call_stack(sys._current_frames()[tid])
                         assert False, (thread, call_stacks)
             _cleanup_dangling()
+            with ignoring(AttributeError):
+                del thread_state.on_event_loop_thread
             return result
 
         return test_func

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -207,7 +207,7 @@ class Variable(object):
         name, address = state
         try:
             client = get_client(address)
-            assert client.address == address
+            assert client.scheduler.address == address
         except (AttributeError, AssertionError):
             client = Client(address, set_as_default=False)
         self.__init__(name=name, client=client)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -402,6 +402,7 @@ class WorkerBase(ServerNode):
         assert self.status is None
 
         enable_gc_diagnosis()
+        thread_state.on_event_loop_thread = True
 
         # XXX Factor this out
         if not addr_or_port:


### PR DESCRIPTION
Previously we had a difficult time determining that we were on the IOLoop
thread and should act asynchronously.  This adds a new thread local,
`on_event_loop_thread` to verify this explicitly

Fixes https://github.com/dask/distributed/issues/2220