### PR TITLE
as_completed touchups

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3610,10 +3610,7 @@ class as_completed(object):
         try:
             yield _wait(future)
         except CancelledError:
-            del self.futures[future]
-            if not self.futures:
-                self._notify()
-            return
+            pass
         if self.with_results:
             result = yield future._result()
         with self.lock:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3631,7 +3631,7 @@ class as_completed(object):
             if not self.futures[future]:
                 del self.futures[future]
             if self.with_results:
-                self.queue.put_nowait((future, result, future.status == 'error'))
+                self.queue.put_nowait((future, result))
             else:
                 self.queue.put_nowait(future)
             self._notify()
@@ -3675,13 +3675,12 @@ class as_completed(object):
         return self
 
     def _get_and_raise(self):
+        res = self.queue.get()
         if self.with_results:
-            future, result, erred = self.queue.get()
-            if self.raise_errors and erred:
+            future, result = res
+            if self.raise_errors and future.status == 'error':
                 six.reraise(*result)
-            else:
-                return future, result
-        return self.queue.get()
+        return res
 
     def __next__(self):
         while self.queue.empty():

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3560,9 +3560,8 @@ class as_completed(object):
         Whether to wait and include results of futures as well;
         in this case `as_completed` yields a tuple of (future, result)
     raise_errors: bool (True)
-        Whether we should raise when the result of a future raises an exception
-        (and break from iteration), or return the exception as the result of
-        the future.  Only affects behavior when `with_results=True`.
+        Whether we should raise when the result of a future raises an exception;
+        only affects behavior when `with_results=True`.
 
     Examples
     --------
@@ -3638,7 +3637,6 @@ class as_completed(object):
             self._notify()
         if all([self.with_results, self.raise_errors,
                 future.status == 'error']):
-            self.futures.clear()
             six.reraise(*result)
 
     def update(self, futures):

--- a/distributed/tests/py3_test_client.py
+++ b/distributed/tests/py3_test_client.py
@@ -79,7 +79,7 @@ def test_as_completed_async_for_cancel(c, s, a, b):
 
     yield f()
 
-    assert L == [x]
+    assert L == [x, y]
 
 
 def test_async_with(loop):

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -124,12 +124,13 @@ def test_as_completed_cancel(loop):
             ac = as_completed([x, y])
             x.cancel()
 
+            assert next(ac) is x
             assert next(ac) is y
 
             with pytest.raises(Empty):
                 ac.queue.get(timeout=0.1)
 
-            assert list(as_completed([x, y, x])) == [y]
+            assert list(as_completed([x, y, x])) == [x, y, x]
 
 
 def test_as_completed_cancel_last(loop):
@@ -150,7 +151,7 @@ def test_as_completed_cancel_last(loop):
             ac = as_completed([x, y])
             result = list(ac)
 
-            assert result == [x]
+            assert result == [x, y]
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -242,7 +242,7 @@ def test_as_completed_with_results_no_raise(loop):
             res = list(ac)
 
             dd = {r[0]: r[1:] for r in res}
-            assert dd.keys() == {y, x, z}
+            assert set(dd.keys()) == {y, x, z}
             assert x.status == 'error'
             assert y.status == 'cancelled'
             assert z.status == 'finished'
@@ -266,7 +266,7 @@ def test_as_completed_with_results_no_raise_async(c, s, a, b):
         res = [first, second, third]
 
         dd = {r[0]: r[1:] for r in res}
-        assert dd.keys() == {y, x, z}
+        assert set(dd.keys()) == {y, x, z}
         assert x.status == 'error'
         assert y.status == 'cancelled'
         assert z.status == 'finished'


### PR DESCRIPTION
Attempting to get my feet wet contributing

- Closes #2089 
- Closes #2065

Not sure if this is issue worthy or not, but the following tests fail for me locally (and are unrelated to my changes):
- `distributed/cli/tests/test_dask_scheduler.py::test_pid_file` (times out)
- `distributed/deploy/tests/test_local.py::test_duplicate_clients` (doesn't warn)
- `distributed/cli/tests/test_dask_worker.py::test_nprocs_requires_nanny` (intermittently times out)