### PR TITLE
Display system graphs nicely on different screen sizes

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -1053,12 +1053,13 @@ class WorkerTable(DashboardComponent):
 
 def systemmonitor_doc(scheduler, extra, doc):
     with log_errors():
-        sysmon = SystemMonitor(scheduler, sizing_mode='scale_width')
+        sysmon = SystemMonitor(scheduler, sizing_mode='stretch_both')
         doc.title = "Dask: Scheduler System Monitor"
         doc.add_periodic_callback(sysmon.update, 500)
 
-        doc.add_root(column(sysmon.root, sizing_mode='scale_width'))
-        doc.template = env.get_template('simple.html')
+        for subdoc in sysmon.root.children:
+            doc.add_root(subdoc)
+        doc.template = env.get_template('system.html')
         doc.template_variables.update(extra)
         doc.theme = BOKEH_THEME
 

--- a/distributed/bokeh/static/css/system.css
+++ b/distributed/bokeh/static/css/system.css
@@ -1,0 +1,26 @@
+#system-fluid {
+    display: flex;
+    flex-wrap: wrap;
+    height: 100%;
+}
+
+/* Small layout: stack all graphs on top of each other, space split equally */
+@media (min-width: 0px) {
+    #system-fluid {
+        flex-direction: column;
+    }
+    #system-fluid .system-item {
+        flex: 1;
+    }
+}
+
+/* Large layout: as many rows as necessary, each item consuming at least
+ * half of the width */
+@media (min-width: 992px) {
+    #system-fluid {
+        flex-direction: row;
+    }
+    #system-fluid .system-item {
+        flex: 1 50%;
+    }
+}

--- a/distributed/bokeh/templates/system.html
+++ b/distributed/bokeh/templates/system.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block extra_resources %}
+<link rel="stylesheet" href="statics/css/system.css">
+{% endblock %}
+
+{% block content %}
+{% from macros import embed %}
+<div id="system-fluid">
+  {% for plot in roots %}
+    <div class="system-item">
+      {{ embed(plot) }}
+    </div>
+  {% endfor %}
+</div>
+{{ plot_script }}
+{% endblock %}
+

--- a/distributed/bokeh/templates/system.html
+++ b/distributed/bokeh/templates/system.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block extra_resources %}
-<link rel="stylesheet" href="statics/css/system.css">
+<link rel="stylesheet" href="statics/css/system.css"/>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
A followup to #2213 - this makes the system graph page scale nicely.

<img width="1360" alt="screen shot 2018-09-05 at 6 03 13 pm" src="https://user-images.githubusercontent.com/787031/45129021-054bbc80-b136-11e8-92a5-27e95443f9b4.png">
<img width="684" alt="screen shot 2018-09-05 at 6 03 23 pm" src="https://user-images.githubusercontent.com/787031/45129023-0aa90700-b136-11e8-8e3c-f3b27a431ac9.png">

This one is more amenable to flexbox, especially since there can be variable numbers of graphs here (well, 3 on Windows, 4 otherwise).

Thanks @canavandl for cleaning up the CSS into separate files!