### PR TITLE
Drop the Bokeh index page

### DIFF
--- a/distributed/bokeh/core.py
+++ b/distributed/bokeh/core.py
@@ -32,6 +32,7 @@ class BokehServer(object):
                                      port=port, address=ip,
                                      check_unused_sessions_milliseconds=500,
                                      allow_websocket_origin=["*"],
+                                     use_index=False,
                                      **self.server_kwargs)
                 self.server.start()
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -142,7 +142,8 @@ def loop():
 
     if PY2:  # no forkserver, so no extra procs
         for child in psutil.Process().children(recursive=True):
-            child.terminate()
+            with ignoring(psutil.NoSuchProcess):
+                child.terminate()
 
     _global_clients.clear()
 


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/2081

As the links on the Bokeh index page are usually incorrect, all the other apps are accessible from each other, and conventional wisdom is to direct users to the status page app, the index page is not particularly useful and can be a bit confusing for the reasons cited. So simply disable it.