### PR TITLE
Discard dependent rather than remove

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2121,7 +2121,7 @@ class Worker(WorkerBase):
 
             for dep in self.dependencies.pop(key, ()):
                 if dep in self.dependents:
-                    self.dependents[dep].remove(key)
+                    self.dependents[dep].discard(key)
                     if not self.dependents[dep] and self.dep_state[dep] in ('waiting', 'flight'):
                         self.release_dep(dep)
 


### PR DESCRIPTION
There are some cases where Worker dependencies and dependents can get out of
sync, especially when we lose dependencies but the dependents are still around.

To reflect this we replace a set.remove with set.discard

Fixes https://github.com/dask/distributed/issues/2126

There is a test in #2126 but I was unable to turn it into something that could run happily in small time.