### PR TITLE
Fix bokeh error for `memory_limit=None`

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -330,12 +330,7 @@ class CurrentLoad(DashboardComponent):
             nbytes_color = []
             max_limit = 0
             for ws, nb in zip(workers, nbytes):
-                try:
-                    limit = self.scheduler.workers[ws.address].memory_limit
-                except KeyError:
-                    limit = None
-                if limit is None:
-                    limit = 16e9
+                limit = getattr(self.scheduler.workers[ws.address], 'memory_limit', math.inf) or math.inf
 
                 if limit > max_limit:
                     max_limit = limit

--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -4,7 +4,6 @@ from distutils.version import LooseVersion
 from functools import partial
 import logging
 import math
-from math import sqrt
 from numbers import Number
 from operator import add
 import os
@@ -58,6 +57,7 @@ template_variables = {'pages': ['status', 'workers', 'tasks', 'system', 'profile
 BOKEH_THEME = Theme(os.path.join(os.path.dirname(__file__), 'theme.yaml'))
 
 nan = float('nan')
+inf = float('inf')
 
 
 def update(source, data):
@@ -330,7 +330,7 @@ class CurrentLoad(DashboardComponent):
             nbytes_color = []
             max_limit = 0
             for ws, nb in zip(workers, nbytes):
-                limit = getattr(self.scheduler.workers[ws.address], 'memory_limit', math.inf) or math.inf
+                limit = getattr(self.scheduler.workers[ws.address], 'memory_limit', inf) or inf
 
                 if limit > max_limit:
                     max_limit = limit
@@ -442,7 +442,7 @@ class StealingEvents(DashboardComponent):
         except (KeyError, IndexError):
             color = 'black'
 
-        radius = sqrt(min(total_duration, 10)) * 30 + 2
+        radius = math.sqrt(min(total_duration, 10)) * 30 + 2
 
         d = {'time': time * 1000, 'level': level, 'count': len(msgs),
              'color': color, 'duration': total_duration, 'radius': radius,

--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -333,7 +333,10 @@ class CurrentLoad(DashboardComponent):
                 try:
                     limit = self.scheduler.workers[ws.address].memory_limit
                 except KeyError:
+                    limit = None
+                if limit is None:
                     limit = 16e9
+
                 if limit > max_limit:
                     max_limit = limit
 


### PR DESCRIPTION
Diagnostics page currently breaks if `memory_limit` is set to `None`.
```
distributed.utils - ERROR - '>' not supported between instances of 'NoneType' and 'int'
Traceback (most recent call last):
  File "/Users/brettnaul/venvs/model37/lib/python3.7/site-packages/distributed/utils.py", line 646, in log_errors
    yield
  File "/Users/brettnaul/venvs/model37/lib/python3.7/site-packages/distributed/bokeh/scheduler.py", line 337, in update
    if limit > max_limit:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```
Maybe there's a more elegant way to do this? I'm not sure how to check if the `memory_limit` attr exists, I assume that's why it's currently done using a try/except