### PR TITLE
Add Scheduler method to compute target cores and memory

### DIFF
--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -263,11 +263,10 @@ class Adaptive(object):
         --------
         LocalCluster.scale_up
         """
-        target = math.ceil(self.scheduler.total_occupancy /
-                           self.target_duration)
+        target = self.scheduler.target_workers(target_duration=self.target_duration)
         instances = max(1,
                         len(self.scheduler.workers) * self.scale_factor,
-                        target,
+                        target['cores'],
                         self.minimum)
 
         if self.maximum:


### PR DESCRIPTION
This moves logic from Adaptive onto the main Scheduler and is a small
tentative step towards restructuring deployment.

cc @jcrist 