### PR TITLE
Add pytest fixture for cluster tests

### DIFF
--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -6,8 +6,8 @@ import pytest
 
 import dask
 from distributed import Actor, ActorFuture, Client, Future, wait, Nanny
-from distributed.utils_test import gen_cluster, cluster
-from distributed.utils_test import loop  # noqa: F401
+from distributed.utils_test import gen_cluster
+from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
 from distributed.metrics import time
 
 
@@ -237,23 +237,21 @@ def test_future_dependencies(c, s, a, b):
     assert {ts.key for ts in s.tasks[counter.key].dependents} == {x.key, y.key}
 
 
-def test_sync(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            counter = c.submit(Counter, actor=True)
-            counter = counter.result()
+def test_sync(client):
+    counter = client.submit(Counter, actor=True)
+    counter = counter.result()
 
-            assert counter.n == 0
+    assert counter.n == 0
 
-            future = counter.increment()
-            n = future.result()
-            assert n == 1
-            assert counter.n == 1
+    future = counter.increment()
+    n = future.result()
+    assert n == 1
+    assert counter.n == 1
 
-            assert future.result() == future.result()
+    assert future.result() == future.result()
 
-            assert 'ActorFuture' in repr(future)
-            assert 'distributed.actor' not in repr(future)
+    assert 'ActorFuture' in repr(future)
+    assert 'distributed.actor' not in repr(future)
 
 
 @gen_cluster(client=True, config={'distributed.comm.timeouts.connect': '1s'})

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -7,11 +7,10 @@ from time import sleep
 import pytest
 from tornado import gen
 
-from distributed import Client
 from distributed.client import _as_completed, as_completed, _first_completed
 from distributed.compatibility import Empty, StopAsyncIteration, Queue
-from distributed.utils_test import cluster, gen_cluster, inc, throws
-from distributed.utils_test import loop  # noqa: F401
+from distributed.utils_test import gen_cluster, inc, throws
+from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
 
 
 @gen_cluster(client=True)
@@ -30,132 +29,116 @@ def test__as_completed(c, s, a, b):
     assert result in [x, y, z]
 
 
-def test_as_completed(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            x = c.submit(inc, 1)
-            y = c.submit(inc, 2)
-            z = c.submit(inc, 1)
+def test_as_completed(client):
+    x = client.submit(inc, 1)
+    y = client.submit(inc, 2)
+    z = client.submit(inc, 1)
 
-            seq = as_completed([x, y, z])
-            assert seq.count() == 3
-            assert isinstance(seq, Iterator)
-            assert set(seq) == {x, y, z}
-            assert seq.count() == 0
+    seq = as_completed([x, y, z])
+    assert seq.count() == 3
+    assert isinstance(seq, Iterator)
+    assert set(seq) == {x, y, z}
+    assert seq.count() == 0
 
-            assert list(as_completed([])) == []
+    assert list(as_completed([])) == []
 
 
-def test_as_completed_with_non_futures(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop):
-            with pytest.raises(TypeError):
-                list(as_completed([1, 2, 3]))
+def test_as_completed_with_non_futures(client):
+    with pytest.raises(TypeError):
+        list(as_completed([1, 2, 3]))
 
 
-def test_as_completed_add(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            total = 0
-            expected = sum(map(inc, range(10)))
-            futures = c.map(inc, range(10))
-            ac = as_completed(futures)
-            for future in ac:
-                result = future.result()
-                total += result
-                if random.random() < 0.5:
-                    future = c.submit(add, future, 10)
-                    ac.add(future)
-                    expected += result + 10
-            assert total == expected
+def test_as_completed_add(client):
+    total = 0
+    expected = sum(map(inc, range(10)))
+    futures = client.map(inc, range(10))
+    ac = as_completed(futures)
+    for future in ac:
+        result = future.result()
+        total += result
+        if random.random() < 0.5:
+            future = client.submit(add, future, 10)
+            ac.add(future)
+            expected += result + 10
+    assert total == expected
 
 
-def test_as_completed_update(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            total = 0
-            todo = list(range(10))
-            expected = sum(map(inc, todo))
-            ac = as_completed([])
-            while todo or not ac.is_empty():
-                if todo:
-                    work, todo = todo[:4], todo[4:]
-                    ac.update(c.map(inc, work))
-                batch = ac.next_batch(block=True)
-                total += sum(r.result() for r in batch)
-            assert total == expected
+def test_as_completed_update(client):
+    total = 0
+    todo = list(range(10))
+    expected = sum(map(inc, todo))
+    ac = as_completed([])
+    while todo or not ac.is_empty():
+        if todo:
+            work, todo = todo[:4], todo[4:]
+            ac.update(client.map(inc, work))
+        batch = ac.next_batch(block=True)
+        total += sum(r.result() for r in batch)
+    assert total == expected
 
 
-def test_as_completed_repeats(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            ac = as_completed()
-            x = c.submit(inc, 1)
-            ac.add(x)
-            ac.add(x)
+def test_as_completed_repeats(client):
+    ac = as_completed()
+    x = client.submit(inc, 1)
+    ac.add(x)
+    ac.add(x)
 
-            assert next(ac) is x
-            assert next(ac) is x
+    assert next(ac) is x
+    assert next(ac) is x
 
-            with pytest.raises(StopIteration):
-                next(ac)
+    with pytest.raises(StopIteration):
+        next(ac)
 
-            ac.add(x)
-            assert next(ac) is x
+    ac.add(x)
+    assert next(ac) is x
 
 
-def test_as_completed_is_empty(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            ac = as_completed()
-            assert ac.is_empty()
-            x = c.submit(inc, 1)
-            ac.add(x)
-            assert not ac.is_empty()
-            assert next(ac) is x
-            assert ac.is_empty()
+def test_as_completed_is_empty(client):
+    ac = as_completed()
+    assert ac.is_empty()
+    x = client.submit(inc, 1)
+    ac.add(x)
+    assert not ac.is_empty()
+    assert next(ac) is x
+    assert ac.is_empty()
 
 
-def test_as_completed_cancel(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            x = c.submit(inc, 1)
-            y = c.submit(inc, 1)
+def test_as_completed_cancel(client):
+    x = client.submit(inc, 1)
+    y = client.submit(inc, 1)
 
-            ac = as_completed([x, y])
-            x.cancel()
+    ac = as_completed([x, y])
+    x.cancel()
 
-            assert next(ac) is x or y
-            assert next(ac) is y or x
+    assert next(ac) is x or y
+    assert next(ac) is y or x
 
-            with pytest.raises(Empty):
-                ac.queue.get(timeout=0.1)
+    with pytest.raises(Empty):
+        ac.queue.get(timeout=0.1)
 
-            res = list(as_completed([x, y, x]))
-            assert len(res) == 3
-            assert set(res) == {x, y}
-            assert res.count(x) == 2
+    res = list(as_completed([x, y, x]))
+    assert len(res) == 3
+    assert set(res) == {x, y}
+    assert res.count(x) == 2
 
 
-def test_as_completed_cancel_last(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            w = c.submit(inc, 0.3)
-            x = c.submit(inc, 1)
-            y = c.submit(inc, 0.3)
+def test_as_completed_cancel_last(client):
+    w = client.submit(inc, 0.3)
+    x = client.submit(inc, 1)
+    y = client.submit(inc, 0.3)
 
-            @gen.coroutine
-            def _():
-                yield gen.sleep(0.1)
-                yield w.cancel(asynchronous=True)
-                yield y.cancel(asynchronous=True)
+    @gen.coroutine
+    def _():
+        yield gen.sleep(0.1)
+        yield w.cancel(asynchronous=True)
+        yield y.cancel(asynchronous=True)
 
-            loop.add_callback(_)
+    client.loop.add_callback(_)
 
-            ac = as_completed([x, y])
-            result = set(ac)
+    ac = as_completed([x, y])
+    result = set(ac)
 
-            assert result == {x, y}
+    assert result == {x, y}
 
 
 @gen_cluster(client=True)
@@ -190,32 +173,28 @@ def test_as_completed_error_async(c, s, a, b):
     assert y.status == 'finished'
 
 
-def test_as_completed_error(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            x = c.submit(throws, 1)
-            y = c.submit(inc, 1)
+def test_as_completed_error(client):
+    x = client.submit(throws, 1)
+    y = client.submit(inc, 1)
 
-            ac = as_completed([x, y])
-            result = set(ac)
+    ac = as_completed([x, y])
+    result = set(ac)
 
-            assert result == {x, y}
-            assert x.status == 'error'
-            assert y.status == 'finished'
+    assert result == {x, y}
+    assert x.status == 'error'
+    assert y.status == 'finished'
 
 
-def test_as_completed_with_results(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            x = c.submit(throws, 1)
-            y = c.submit(inc, 5)
-            z = c.submit(inc, 1)
+def test_as_completed_with_results(client):
+    x = client.submit(throws, 1)
+    y = client.submit(inc, 5)
+    z = client.submit(inc, 1)
 
-            ac = as_completed([x, y, z], with_results=True)
-            y.cancel()
-            with pytest.raises(RuntimeError) as exc:
-                res = list(ac)
-            assert str(exc.value) == 'hello!'
+    ac = as_completed([x, y, z], with_results=True)
+    y.cancel()
+    with pytest.raises(RuntimeError) as exc:
+        res = list(ac)
+    assert str(exc.value) == 'hello!'
 
 
 @gen_cluster(client=True)
@@ -233,26 +212,24 @@ def test_as_completed_with_results_async(c, s, a, b):
     assert str(exc.value) == 'hello!'
 
 
-def test_as_completed_with_results_no_raise(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            x = c.submit(throws, 1)
-            y = c.submit(inc, 5)
-            z = c.submit(inc, 1)
+def test_as_completed_with_results_no_raise(client):
+    x = client.submit(throws, 1)
+    y = client.submit(inc, 5)
+    z = client.submit(inc, 1)
 
-            ac = as_completed([x, y, z], with_results=True, raise_errors=False)
-            y.cancel()
-            res = list(ac)
+    ac = as_completed([x, y, z], with_results=True, raise_errors=False)
+    y.cancel()
+    res = list(ac)
 
-            dd = {r[0]: r[1:] for r in res}
-            assert set(dd.keys()) == {y, x, z}
-            assert x.status == 'error'
-            assert y.status == 'cancelled'
-            assert z.status == 'finished'
+    dd = {r[0]: r[1:] for r in res}
+    assert set(dd.keys()) == {y, x, z}
+    assert x.status == 'error'
+    assert y.status == 'cancelled'
+    assert z.status == 'finished'
 
-            assert isinstance(dd[y][0], CancelledError)
-            assert isinstance(dd[x][0][1], RuntimeError)
-            assert dd[z][0] == 2
+    assert isinstance(dd[y][0], CancelledError)
+    assert isinstance(dd[x][0][1], RuntimeError)
+    assert dd[z][0] == 2
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -10,255 +10,234 @@ from concurrent.futures import (
 import pytest
 from toolz import take
 
-from distributed.client import Client
 from distributed.utils_test import (slowinc, slowadd, slowdec,
-                                    inc, throws, cluster, varying)
-from distributed.utils_test import loop  # noqa: F401
+                                    inc, throws, varying)
+from distributed.utils_test import client, cluster_fixture, loop, s, a, b  # noqa: F401
 
 
 def number_of_processing_tasks(client):
     return sum(len(v) for k, v in client.processing().items())
 
 
-def test_submit(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            with c.get_executor() as e:
-                f1 = e.submit(slowadd, 1, 2)
-                assert isinstance(f1, Future)
-                f2 = e.submit(slowadd, 3, y=4)
-                f3 = e.submit(throws, "foo")
-                f4 = e.submit(slowadd, x=5, y=6)
-                assert f1.result() == 3
-                assert f2.result() == 7
-                with pytest.raises(RuntimeError):
-                    f3.result()
-                assert f4.result() == 11
+def test_submit(client):
+    with client.get_executor() as e:
+        f1 = e.submit(slowadd, 1, 2)
+        assert isinstance(f1, Future)
+        f2 = e.submit(slowadd, 3, y=4)
+        f3 = e.submit(throws, "foo")
+        f4 = e.submit(slowadd, x=5, y=6)
+        assert f1.result() == 3
+        assert f2.result() == 7
+        with pytest.raises(RuntimeError):
+            f3.result()
+        assert f4.result() == 11
 
 
-def test_as_completed(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            with c.get_executor() as e:
-                N = 10
-                fs = [e.submit(slowinc, i, delay=0.02) for i in range(N)]
-                expected = set(range(1, N + 1))
+def test_as_completed(client):
+    with client.get_executor() as e:
+        N = 10
+        fs = [e.submit(slowinc, i, delay=0.02) for i in range(N)]
+        expected = set(range(1, N + 1))
 
-                for f in as_completed(fs):
-                    res = f.result()
-                    assert res in expected
-                    expected.remove(res)
+        for f in as_completed(fs):
+            res = f.result()
+            assert res in expected
+            expected.remove(res)
 
-                assert not expected
+        assert not expected
 
 
-def test_wait(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            with c.get_executor(pure=False) as e:
-                N = 10
-                fs = [e.submit(slowinc, i, delay=0.05) for i in range(N)]
-                res = wait(fs, timeout=0.01)
-                assert len(res.not_done) > 0
-                res = wait(fs)
-                assert len(res.not_done) == 0
-                assert res.done == set(fs)
+def test_wait(client):
+    with client.get_executor(pure=False) as e:
+        N = 10
+        fs = [e.submit(slowinc, i, delay=0.05) for i in range(N)]
+        res = wait(fs, timeout=0.01)
+        assert len(res.not_done) > 0
+        res = wait(fs)
+        assert len(res.not_done) == 0
+        assert res.done == set(fs)
 
-                fs = [e.submit(slowinc, i, delay=0.05) for i in range(N)]
-                res = wait(fs, return_when=FIRST_COMPLETED)
-                assert len(res.not_done) > 0
-                assert len(res.done) >= 1
-                res = wait(fs)
-                assert len(res.not_done) == 0
-                assert res.done == set(fs)
+        fs = [e.submit(slowinc, i, delay=0.05) for i in range(N)]
+        res = wait(fs, return_when=FIRST_COMPLETED)
+        assert len(res.not_done) > 0
+        assert len(res.done) >= 1
+        res = wait(fs)
+        assert len(res.not_done) == 0
+        assert res.done == set(fs)
 
-                fs = [e.submit(slowinc, i, delay=0.05) for i in range(N)]
-                fs += [e.submit(throws, None)]
-                fs += [e.submit(slowdec, i, delay=0.05) for i in range(N)]
-                res = wait(fs, return_when=FIRST_EXCEPTION)
-                assert any(f.exception() for f in res.done)
-                assert res.not_done
+        fs = [e.submit(slowinc, i, delay=0.05) for i in range(N)]
+        fs += [e.submit(throws, None)]
+        fs += [e.submit(slowdec, i, delay=0.05) for i in range(N)]
+        res = wait(fs, return_when=FIRST_EXCEPTION)
+        assert any(f.exception() for f in res.done)
+        assert res.not_done
 
-                errors = []
-                for fs in res.done:
-                    try:
-                        fs.result()
-                    except RuntimeError as e:
-                        errors.append(e)
+        errors = []
+        for fs in res.done:
+            try:
+                fs.result()
+            except RuntimeError as e:
+                errors.append(e)
 
-                assert len(errors) == 1
-                assert "hello" in str(errors[0])
+        assert len(errors) == 1
+        assert "hello" in str(errors[0])
 
 
-def test_cancellation(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            with c.get_executor(pure=False) as e:
-                fut = e.submit(time.sleep, 2.0)
-                start = time.time()
-                while number_of_processing_tasks(c) == 0:
-                    assert time.time() < start + 1
-                    time.sleep(0.01)
-                assert not fut.done()
+def test_cancellation(client):
+    with client.get_executor(pure=False) as e:
+        fut = e.submit(time.sleep, 2.0)
+        start = time.time()
+        while number_of_processing_tasks(client) == 0:
+            assert time.time() < start + 1
+            time.sleep(0.01)
+        assert not fut.done()
 
-                fut.cancel()
-                assert fut.cancelled()
-                start = time.time()
-                while number_of_processing_tasks(c) != 0:
-                    assert time.time() < start + 1
-                    time.sleep(0.01)
+        fut.cancel()
+        assert fut.cancelled()
+        start = time.time()
+        while number_of_processing_tasks(client) != 0:
+            assert time.time() < start + 1
+            time.sleep(0.01)
 
-                with pytest.raises(CancelledError):
-                    fut.result()
+        with pytest.raises(CancelledError):
+            fut.result()
 
-            # With wait()
-            with c.get_executor(pure=False) as e:
-                N = 10
-                fs = [e.submit(slowinc, i, delay=0.02) for i in range(N)]
-                fs[3].cancel()
-                res = wait(fs, return_when=FIRST_COMPLETED)
-                assert len(res.not_done) > 0
-                assert len(res.done) >= 1
+    # With wait()
+    with client.get_executor(pure=False) as e:
+        N = 10
+        fs = [e.submit(slowinc, i, delay=0.02) for i in range(N)]
+        fs[3].cancel()
+        res = wait(fs, return_when=FIRST_COMPLETED)
+        assert len(res.not_done) > 0
+        assert len(res.done) >= 1
 
-                assert fs[3] in res.done
-                assert fs[3].cancelled()
+        assert fs[3] in res.done
+        assert fs[3].cancelled()
 
-            # With as_completed()
-            with c.get_executor(pure=False) as e:
-                N = 10
-                fs = [e.submit(slowinc, i, delay=0.02) for i in range(N)]
-                fs[3].cancel()
-                fs[8].cancel()
+    # With as_completed()
+    with client.get_executor(pure=False) as e:
+        N = 10
+        fs = [e.submit(slowinc, i, delay=0.02) for i in range(N)]
+        fs[3].cancel()
+        fs[8].cancel()
 
-                n_cancelled = sum(f.cancelled() for f in as_completed(fs))
-                assert n_cancelled == 2
+        n_cancelled = sum(f.cancelled() for f in as_completed(fs))
+        assert n_cancelled == 2
 
 
-def test_map(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            with c.get_executor() as e:
-                N = 10
-                it = e.map(inc, range(N))
-                expected = set(range(1, N + 1))
-                for x in it:
-                    expected.remove(x)
-                assert not expected
+def test_map(client):
+    with client.get_executor() as e:
+        N = 10
+        it = e.map(inc, range(N))
+        expected = set(range(1, N + 1))
+        for x in it:
+            expected.remove(x)
+        assert not expected
 
-            with c.get_executor(pure=False) as e:
-                N = 10
-                it = e.map(slowinc, range(N), [0.1] * N, timeout=0.4)
-                results = []
-                with pytest.raises(TimeoutError):
-                    for x in it:
-                        results.append(x)
-                assert 2 <= len(results) < 7
+    with client.get_executor(pure=False) as e:
+        N = 10
+        it = e.map(slowinc, range(N), [0.1] * N, timeout=0.4)
+        results = []
+        with pytest.raises(TimeoutError):
+            for x in it:
+                results.append(x)
+        assert 2 <= len(results) < 7
 
-            with c.get_executor(pure=False) as e:
-                N = 10
-                # Not consuming the iterator will cancel remaining tasks
-                it = e.map(slowinc, range(N), [0.1] * N)
-                for x in take(2, it):
-                    pass
-                # Some tasks still processing
-                assert number_of_processing_tasks(c) > 0
-                # Garbage collect the iterator => remaining tasks are cancelled
-                del it
-                assert number_of_processing_tasks(c) == 0
+    with client.get_executor(pure=False) as e:
+        N = 10
+        # Not consuming the iterator will cancel remaining tasks
+        it = e.map(slowinc, range(N), [0.1] * N)
+        for x in take(2, it):
+            pass
+        # Some tasks still processing
+        assert number_of_processing_tasks(client) > 0
+        # Garbage collect the iterator => remaining tasks are cancelled
+        del it
+        assert number_of_processing_tasks(client) == 0
 
 
 def get_random():
     return random.random()
 
 
-def test_pure(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            N = 10
-            with c.get_executor() as e:
-                fs = [e.submit(get_random) for i in range(N)]
-                res = [fut.result() for fut in as_completed(fs)]
-                assert len(set(res)) < len(res)
-            with c.get_executor(pure=False) as e:
-                fs = [e.submit(get_random) for i in range(N)]
-                res = [fut.result() for fut in as_completed(fs)]
-                assert len(set(res)) == len(res)
+def test_pure(client):
+    N = 10
+    with client.get_executor() as e:
+        fs = [e.submit(get_random) for i in range(N)]
+        res = [fut.result() for fut in as_completed(fs)]
+        assert len(set(res)) < len(res)
+    with client.get_executor(pure=False) as e:
+        fs = [e.submit(get_random) for i in range(N)]
+        res = [fut.result() for fut in as_completed(fs)]
+        assert len(set(res)) == len(res)
 
 
-def test_workers(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            N = 10
-            with c.get_executor(workers=[b['address']]) as e:
-                fs = [e.submit(slowinc, i) for i in range(N)]
-                wait(fs)
-                has_what = c.has_what()
-                assert not has_what.get(a['address'])
-                assert len(has_what[b['address']]) == N
+def test_workers(client, s, a, b):
+    N = 10
+    with client.get_executor(workers=[b['address']]) as e:
+        fs = [e.submit(slowinc, i) for i in range(N)]
+        wait(fs)
+        has_what = client.has_what()
+        assert not has_what.get(a['address'])
+        assert len(has_what[b['address']]) == N
 
 
-def test_unsupported_arguments(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            with pytest.raises(TypeError) as excinfo:
-                c.get_executor(workers=[b['address']], foo=1, bar=2)
-            assert ("unsupported arguments to ClientExecutor: ['bar', 'foo']"
-                    in str(excinfo.value))
+def test_unsupported_arguments(client, s, a, b):
+    with pytest.raises(TypeError) as excinfo:
+        client.get_executor(workers=[b['address']], foo=1, bar=2)
+    assert ("unsupported arguments to ClientExecutor: ['bar', 'foo']"
+            in str(excinfo.value))
 
 
-def test_retries(loop):
+def test_retries(client):
     args = [ZeroDivisionError("one"), ZeroDivisionError("two"), 42]
 
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            with c.get_executor(retries=3, pure=False) as e:
-                future = e.submit(varying(args))
-                assert future.result() == 42
+    with client.get_executor(retries=3, pure=False) as e:
+        future = e.submit(varying(args))
+        assert future.result() == 42
 
-            with c.get_executor(retries=2) as e:
-                future = e.submit(varying(args))
-                result = future.result()
-                assert result == 42
+    with client.get_executor(retries=2) as e:
+        future = e.submit(varying(args))
+        result = future.result()
+        assert result == 42
 
-            with c.get_executor(retries=1) as e:
-                future = e.submit(varying(args))
-                with pytest.raises(ZeroDivisionError) as exc_info:
-                    res = future.result()
-                exc_info.match("two")
+    with client.get_executor(retries=1) as e:
+        future = e.submit(varying(args))
+        with pytest.raises(ZeroDivisionError) as exc_info:
+            res = future.result()
+        exc_info.match("two")
 
-            with c.get_executor(retries=0) as e:
-                future = e.submit(varying(args))
-                with pytest.raises(ZeroDivisionError) as exc_info:
-                    res = future.result()
-                exc_info.match("one")
+    with client.get_executor(retries=0) as e:
+        future = e.submit(varying(args))
+        with pytest.raises(ZeroDivisionError) as exc_info:
+            res = future.result()
+        exc_info.match("one")
 
 
-def test_shutdown(loop):
-    with cluster(active_rpc_timeout=10) as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            # shutdown(wait=True) waits for pending tasks to finish
-            e = c.get_executor()
-            fut = e.submit(time.sleep, 1.0)
-            t1 = time.time()
-            e.shutdown()
-            dt = time.time() - t1
-            assert 0.5 <= dt <= 2.0
-            time.sleep(0.1)  # wait for future outcome to propagate
-            assert fut.done()
-            fut.result()  # doesn't raise
+def test_shutdown(client):
+    # shutdown(wait=True) waits for pending tasks to finish
+    e = client.get_executor()
+    fut = e.submit(time.sleep, 1.0)
+    t1 = time.time()
+    e.shutdown()
+    dt = time.time() - t1
+    assert 0.5 <= dt <= 2.0
+    time.sleep(0.1)  # wait for future outcome to propagate
+    assert fut.done()
+    fut.result()  # doesn't raise
 
-            with pytest.raises(RuntimeError):
-                e.submit(time.sleep, 1.0)
+    with pytest.raises(RuntimeError):
+        e.submit(time.sleep, 1.0)
 
-            # shutdown(wait=False) cancels pending tasks
-            e = c.get_executor()
-            fut = e.submit(time.sleep, 2.0)
-            t1 = time.time()
-            e.shutdown(wait=False)
-            dt = time.time() - t1
-            assert dt < 0.5
-            time.sleep(0.1)  # wait for future outcome to propagate
-            assert fut.cancelled()
+    # shutdown(wait=False) cancels pending tasks
+    e = client.get_executor()
+    fut = e.submit(time.sleep, 2.0)
+    t1 = time.time()
+    e.shutdown(wait=False)
+    dt = time.time() - t1
+    assert dt < 0.5
+    time.sleep(0.1)  # wait for future outcome to propagate
+    assert fut.cancelled()
 
-            with pytest.raises(RuntimeError):
-                e.submit(time.sleep, 1.0)
+    with pytest.raises(RuntimeError):
+        e.submit(time.sleep, 1.0)

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -5,10 +5,10 @@ from time import sleep
 
 import pytest
 
-from distributed import Client, Lock, get_client
+from distributed import Lock, get_client
 from distributed.metrics import time
-from distributed.utils_test import gen_cluster, cluster
-from distributed.utils_test import loop  # noqa F401
+from distributed.utils_test import gen_cluster
+from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
 
 
 @gen_cluster(client=True, ncores=[('127.0.0.1', 8)] * 2)
@@ -65,11 +65,9 @@ def test_acquires_with_zero_timeout(c, s, a, b):
     yield lock.release()
 
 
-def test_timeout_sync(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            with Lock('x') as lock:
-                assert Lock('x').acquire(timeout=0.1) is False
+def test_timeout_sync(client):
+    with Lock('x') as lock:
+        assert Lock('x').acquire(timeout=0.1) is False
 
 
 @gen_cluster(client=True)
@@ -79,7 +77,7 @@ def test_errors(c, s, a, b):
         yield lock.release()
 
 
-def test_lock_sync(loop):
+def test_lock_sync(client):
     def f(x):
         with Lock('x') as lock:
             client = get_client()
@@ -88,11 +86,10 @@ def test_lock_sync(loop):
             sleep(0.05)
             assert client.get_metadata('locked') is True
             client.set_metadata('locked', False)
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            c.set_metadata('locked', False)
-            futures = c.map(f, range(10))
-            c.gather(futures)
+
+    client.set_metadata('locked', False)
+    futures = client.map(f, range(10))
+    client.gather(futures)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -30,6 +30,7 @@ def test_worker_preload_file(loop):
         path = os.path.join(tmpdir, 'worker_info.py')
         with open(path, 'w') as f:
             f.write(PRELOAD_TEXT)
+
         with cluster(worker_kwargs={'preload': [path]}) as (s, workers), \
                 Client(s['address'], loop=loop) as c:
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -728,9 +728,11 @@ def test_priorities(c, s, w):
 @gen_cluster(client=True)
 def test_heartbeats(c, s, a, b):
     x = s.workers[a.address].last_seen
+    start = time()
     yield gen.sleep(a.periodic_callbacks['heartbeat'].callback_time / 1000 + 0.1)
-    y = s.workers[a.address].last_seen
-    assert x != y
+    while s.workers[a.address].last_seen == x:
+        yield gen.sleep(0.01)
+        assert time() < start + 2
     assert a.periodic_callbacks['heartbeat'].callback_time < 1000
 
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -19,7 +19,7 @@ import tornado
 from tornado import gen
 from tornado.ioloop import TimeoutError
 
-from distributed import (Nanny, Client, get_client, wait, default_client,
+from distributed import (Nanny, get_client, wait, default_client,
         get_worker, Reschedule)
 from distributed.compatibility import WINDOWS, cache_from_source
 from distributed.core import rpc
@@ -29,9 +29,8 @@ from distributed.metrics import time
 from distributed.worker import Worker, error_message, logger, TOTAL_MEMORY
 from distributed.utils import tmpfile, format_bytes
 from distributed.utils_test import (inc, mul, gen_cluster, div, dec,
-                                    slow, slowinc, gen_test, cluster,
-                                    captured_logger)
-from distributed.utils_test import loop, nodebug # noqa: F401
+                                    slow, slowinc, gen_test, captured_logger)
+from distributed.utils_test import client, loop, nodebug, cluster_fixture, s, a, b  # noqa: F401
 
 
 def test_worker_ncores():
@@ -846,16 +845,14 @@ def test_get_client(c, s, a, b):
     assert a._client is a_client
 
 
-def test_get_client_sync(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            def f(x):
-                cc = get_client()
-                future = cc.submit(inc, x)
-                return future.result()
+def test_get_client_sync(client):
+    def f(x):
+        cc = get_client()
+        future = cc.submit(inc, x)
+        return future.result()
 
-            future = c.submit(f, 10)
-            assert future.result() == 11
+    future = client.submit(f, 10)
+    assert future.result() == 11
 
 
 @gen_cluster(client=True)
@@ -872,19 +869,17 @@ def test_get_client_coroutine(c, s, a, b):
                        b.address: 11}
 
 
-def test_get_client_coroutine_sync(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            @gen.coroutine
-            def f():
-                client = yield get_client()
-                future = client.submit(inc, 10)
-                result = yield future
-                raise gen.Return(result)
+def test_get_client_coroutine_sync(client, s, a, b):
+    @gen.coroutine
+    def f():
+        client = yield get_client()
+        future = client.submit(inc, 10)
+        result = yield future
+        raise gen.Return(result)
 
-            results = c.run_coroutine(f)
-            assert results == {a['address']: 11,
-                               b['address']: 11}
+    results = client.run_coroutine(f)
+    assert results == {a['address']: 11,
+                       b['address']: 11}
 
 
 @gen_cluster()
@@ -1116,21 +1111,19 @@ def test_dict_data_if_no_spill_to_disk(s, w):
     assert type(w.data) is dict
 
 
-def test_get_worker_name(loop):
-    with cluster() as (s, [a, b]):
-        with Client(s['address'], loop=loop) as c:
-            def f():
-                get_client().submit(inc, 1).result()
+def test_get_worker_name(client):
+    def f():
+        get_client().submit(inc, 1).result()
 
-            c.run(f)
+    client.run(f)
 
-            def func(dask_scheduler):
-                return list(dask_scheduler.clients)
+    def func(dask_scheduler):
+        return list(dask_scheduler.clients)
 
-            start = time()
-            while not any('worker' in n for n in c.run_on_scheduler(func)):
-                sleep(0.1)
-                assert time() < start + 10
+    start = time()
+    while not any('worker' in n for n in client.run_on_scheduler(func)):
+        sleep(0.1)
+        assert time() < start + 10
 
 
 @gen_cluster(ncores=[('127.0.0.1', 1)],


### PR DESCRIPTION
This replaces the ``with cluster(...)`` style tests for syncrhonous API
with a pytest fixture.  This reduces the nesting and boiler plate for
many of our tests.

The old system is still available for backwards compatibility.

Fixes https://github.com/dask/distributed/issues/1966