### PR TITLE
support directory change after starting new worker processes

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -81,6 +81,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
               help="File to write the process PID")
 @click.option('--local-directory', default='', type=str,
               help="Directory to place worker files")
+@click.option('--change-directory/--keep-directory', default=False,
+              help="Change working directory to local directory")
 @click.option('--resources', type=str, default='',
               help='Resources for task constraints like "GPU=2 MEM=10e9"')
 @click.option('--scheduler-file', type=str, default='',
@@ -98,7 +100,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 def main(scheduler, host, worker_port, listen_address, contact_address,
          nanny_port, nthreads, nprocs, nanny, name,
          memory_limit, pid_file, reconnect, resources, bokeh,
-         bokeh_port, local_directory, scheduler_file, interface,
+         bokeh_port, local_directory, change_directory, scheduler_file, interface,
          death_timeout, preload, preload_argv, bokeh_prefix, tls_ca_file,
          tls_cert, tls_key):
     enable_proctitle_on_current()
@@ -217,7 +219,7 @@ def main(scheduler, host, worker_port, listen_address, contact_address,
     nannies = [t(scheduler, scheduler_file=scheduler_file, ncores=nthreads,
                  services=services, loop=loop, resources=resources,
                  memory_limit=memory_limit, reconnect=reconnect,
-                 local_dir=local_directory, death_timeout=death_timeout,
+                 local_dir=local_directory, change_dir=change_directory, death_timeout=death_timeout,
                  preload=preload, preload_argv=preload_argv,
                  security=sec, contact_address=contact_address,
                  name=name if nprocs == 1 or not name else name + '-' + str(i),

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -39,7 +39,7 @@ class Nanny(ServerNode):
 
     def __init__(self, scheduler_ip=None, scheduler_port=None,
                  scheduler_file=None, worker_port=0,
-                 ncores=None, loop=None, local_dir=None, services=None,
+                 ncores=None, loop=None, local_dir=None, change_dir=False, services=None,
                  name=None, memory_limit='auto', reconnect=True,
                  validate=False, quiet=False, resources=None, silence_logs=None,
                  death_timeout=None, preload=(), preload_argv=[], security=None,
@@ -73,6 +73,7 @@ class Nanny(ServerNode):
         self.listen_args = self.security.get_listen_args('worker')
 
         self.local_dir = local_dir
+        self.change_dir = change_dir
 
         self.loop = loop or IOLoop.current()
         self.scheduler = rpc(self.scheduler_addr, connection_args=self.connection_args)
@@ -199,6 +200,7 @@ class Nanny(ServerNode):
                 worker_args=(self.scheduler_addr,),
                 worker_kwargs=dict(ncores=self.ncores,
                                    local_dir=self.local_dir,
+                                   change_dir=self.change_dir,
                                    services=self.services,
                                    service_ports={'nanny': self.port},
                                    name=self.name,

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1018,24 +1018,25 @@ def import_file(path):
     names_to_import = []
     tmp_python_path = None
 
-    if ext in ('.py'):  # , '.pyc'):
-        if directory not in sys.path:
-            tmp_python_path = directory
-        names_to_import.append(name)
-    if ext == '.py':  # Ensure that no pyc file will be reused
-        cache_file = cache_from_source(path)
-        with ignoring(OSError):
-            os.remove(cache_file)
-    if ext in ('.egg', '.zip', '.pyz'):
-        if path not in sys.path:
-            sys.path.insert(0, path)
-        if ext == '.egg':
-            import pkg_resources
-            pkgs = pkg_resources.find_distributions(path)
-            for pkg in pkgs:
-                names_to_import.append(pkg.project_name)
-        elif ext in ('.zip', '.pyz'):
+    if ext.strip() != '':
+        if ext in ('.py'):  # , '.pyc'):
+            if directory not in sys.path:
+                tmp_python_path = directory
             names_to_import.append(name)
+        if ext == '.py':  # Ensure that no pyc file will be reused
+            cache_file = cache_from_source(path)
+            with ignoring(OSError):
+                os.remove(cache_file)
+        if ext in ('.egg', '.zip', '.pyz'):
+            if path not in sys.path:
+                sys.path.insert(0, path)
+            if ext == '.egg':
+                import pkg_resources
+                pkgs = pkg_resources.find_distributions(path)
+                for pkg in pkgs:
+                    names_to_import.append(pkg.project_name)
+            elif ext in ('.zip', '.pyz'):
+                names_to_import.append(name)
 
     loaded = []
     if not names_to_import:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -83,14 +83,13 @@ _global_workers = []
 
 class WorkerBase(ServerNode):
     def __init__(self, scheduler_ip=None, scheduler_port=None,
-                 scheduler_file=None, ncores=None, loop=None, local_dir=None,
+                 scheduler_file=None, ncores=None, loop=None, local_dir=None, change_dir=False,
                  services=None, service_ports=None, name=None,
                  reconnect=True, memory_limit='auto',
                  executor=None, resources=None, silence_logs=None,
                  death_timeout=None, preload=(), preload_argv=[], security=None,
                  contact_address=None, memory_monitor_interval='200ms',
                  extensions=None, metrics=None, **kwargs):
-
         self._setup_logging()
 
         if scheduler_file:
@@ -122,6 +121,8 @@ class WorkerBase(ServerNode):
         self._workspace = WorkSpace(local_dir)
         self._workdir = self._workspace.new_work_dir(prefix='worker-')
         self.local_dir = self._workdir.dir_path
+        if change_dir:
+            os.chdir(self.local_dir)
 
         self.security = security or Security()
         assert isinstance(self.security, Security)


### PR DESCRIPTION
When a new worker process starts, current working directory (cwd) will change to it.

#2274 