### PR TITLE
Revert reference cycle fix in bokeh plots

### DIFF
--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -44,6 +44,7 @@ call deactivate
 call activate %CONDA_ENV%
 
 %CONDA% uninstall -q -y --force dask joblib zict
+%PIP_INSTALL% pip --upgrade
 %PIP_INSTALL% git+https://github.com/dask/dask --upgrade
 %PIP_INSTALL% git+https://github.com/joblib/joblib.git --upgrade
 %PIP_INSTALL% git+https://github.com/dask/zict --upgrade

--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -681,12 +681,24 @@ def add_periodic_callback(doc, component, interval):
     the component stays in memory as a reference cycle because its method is
     still around.  This way we avoid that and let things clean up a bit more
     nicely.
+
+    TODO: we still have reference cycles.  Docs seem to be referred to by their
+    add_periodic_callback methods.
     """
     ref = weakref.ref(component)
 
-    def update():
-        component = ref()
-        if component is not None:
-            component.update()
+    doc.add_periodic_callback(lambda: update(ref), interval)
+    _attach(doc, component)
 
-    doc.add_periodic_callback(update, interval)
+
+def update(ref):
+    comp = ref()
+    if comp is not None:
+        comp.update()
+
+
+def _attach(doc, component):
+    if not hasattr(doc, 'components'):
+        doc.components = set()
+
+    doc.components.add(component)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -370,6 +370,8 @@ class LoopRunner(object):
             # Loop already running in other thread (user-launched)
             done_evt.wait(5)
             if not isinstance(start_exc[0], RuntimeError):
+                if not isinstance(start_exc[0]):  # track down infrequent error
+                    raise TypeError("not an exception", start_exc[0])
                 raise start_exc[0]
             self._all_loops[self._loop] = count + 1, None
         else:


### PR DESCRIPTION
in https://github.com/dask/distributed/pull/2261 we used weakrefs to avoid
reference cycles that kept around Bokeh documents forever, causing increased
load from plugins.

Unfortunately we needed some reference from the Doc to the Plot Component,
otherwise the component would disappear.  We add that back in, but
unfortunately this causes a reference cycle.  Attempts to avoid this reference
cycle have proved difficult.