### PR TITLE
remove blosc threading from protocol.numpy

### DIFF
--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -4,12 +4,6 @@ import fractions
 
 import numpy as np
 
-try:
-    import blosc
-    n = blosc.set_nthreads(2)
-except ImportError:
-    blosc = False
-
 from .utils import frame_split_size, merge_frames
 from .serialize import dask_serialize, dask_deserialize
 from . import pickle

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from distributed.protocol import (serialize, deserialize, decompress, dumps,
-                                  loads, to_serialize, msgpack)
+                                  loads, to_serialize, )
 from distributed.protocol.utils import BIG_BYTES_SHARD_SIZE
 from distributed.utils import tmpfile, nbytes
 from distributed.utils_test import slow, gen_cluster

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -138,24 +138,6 @@ def test_itemsize(dt, size):
     assert itemsize(np.dtype(dt)) == size
 
 
-@pytest.mark.skipif(sys.version_info[0] < 3,
-                    reason='numpy doesnt use memoryviews')
-def test_compress_numpy():
-    pytest.importorskip('lz4')
-    x = np.ones(10000000, dtype='i4')
-    frames = dumps({'x': to_serialize(x)})
-    assert sum(map(nbytes, frames)) < x.nbytes
-
-    header = msgpack.loads(frames[2], encoding='utf8', use_list=False)
-    try:
-        import blosc  # noqa: F401
-    except ImportError:
-        pass
-    else:
-        assert all(c == 'blosc' for c in
-                   header['headers'][('x',)]['compression'])
-
-
 def test_compress_memoryview():
     mv = memoryview(b'0' * 1000000)
     compression, compressed = maybe_compress(mv)

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -174,6 +174,7 @@ def test_dumps_large_blosc(c, s, a, b):
 @pytest.mark.skipif(sys.version_info[0] < 3,
                     reason='numpy doesnt use memoryviews')
 def test_compression_takes_advantage_of_itemsize():
+    pytest.importorskip('lz4')
     blosc = pytest.importorskip('blosc')
     x = np.arange(1000000, dtype='i8')
 


### PR DESCRIPTION
* removed test_compress_numpy, as it was failing if blosc & python3
  was installed, and not run otherwise