### PR TITLE
Support upload_file on files with no extension

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1509,6 +1509,12 @@ def test_upload_file(c, s, a, b):
 
 
 @gen_cluster(client=True)
+def test_upload_file_no_extension(c, s, a, b):
+    with tmp_text('myfile', '') as fn:
+        yield c.upload_file(fn)
+
+
+@gen_cluster(client=True)
 def test_upload_file_zip(c, s, a, b):
     def g():
         import myfile

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1020,7 +1020,7 @@ def import_file(path):
     names_to_import = []
     tmp_python_path = None
 
-    if ext in ('.py'):  # , '.pyc'):
+    if ext in ('.py',):  # , '.pyc'):
         if directory not in sys.path:
             tmp_python_path = directory
         names_to_import.append(name)


### PR DESCRIPTION
This was due to a typo where we missed the trailing comma from a tuple

Fixes https://github.com/dask/distributed/issues/2276