### PR TITLE
use worker SSL context when getting client from worker.

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -543,7 +543,12 @@ class Client(Node):
         self.security = security or Security()
         self.scheduler_comm = None
         assert isinstance(self.security, Security)
-        self.connection_args = self.security.get_connection_args('client')
+
+        if name == 'worker':
+            self.connection_args = self.security.get_connection_args('worker')
+        else:
+            self.connection_args = self.security.get_connection_args('client')
+
         self._connecting_to_scheduler = False
         self._asynchronous = asynchronous
         self._should_close_loop = not loop


### PR DESCRIPTION
This fixes #2288 for me. I have no easy test for this yet. -- I wasn't able to reproduce #2288 in the reduced TLS setup used for the TLS unit tests so far. #2288 describes in more detail how to test the fix. Locally unit tests ran through successfully with python.