### PR TITLE
Limit concurrency when gathering many times

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -532,7 +532,6 @@ def test_limit_concurrent_gathering(c, s, a, b):
     futures = c.map(inc, range(100))
     results = yield futures
     assert len(a.outgoing_transfer_log) + len(b.outgoing_transfer_log) < 100
-    assert len(a.outgoing_transfer_log) + len(b.outgoing_transfer_log) < 30
 
 
 @gen_cluster(client=True, timeout=None)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -527,6 +527,14 @@ def test_gather_skip(c, s, a):
     assert not sched.getvalue()
 
 
+@gen_cluster(client=True)
+def test_limit_concurrent_gathering(c, s, a, b):
+    futures = c.map(inc, range(100))
+    results = yield futures
+    assert len(a.outgoing_transfer_log) + len(b.outgoing_transfer_log) < 100
+    assert len(a.outgoing_transfer_log) + len(b.outgoing_transfer_log) < 30
+
+
 @gen_cluster(client=True, timeout=None)
 def test_get(c, s, a, b):
     future = c.get({'x': (inc, 1)}, 'x', sync=False)


### PR DESCRIPTION
Previously requests like the following would generate many independent
requests to the scheduler or workers

    results = [future.result() for future in futures]

We would try to push people away from this and recommend that they use
gather, but this didn't always happen, especially when they were using
as_completed

    for future, result in as_completed(futures, with_results=True)

So now we just impose a bit of flow control around the `Client.gather`
method (which all of these use) to allow only five concurrent
outgoing communications at once.

Fixes https://github.com/dask/distributed/issues/1858
Fixes https://github.com/dask/dask/issues/4011