### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -26,7 +26,7 @@ import weakref
 import dask
 from dask.base import tokenize, normalize_token, collections_to_dsk
 from dask.core import flatten, get_dependencies
-from dask.compatibility import apply, unicode, Iterator
+from dask.compatibility import apply, unicode
 try:
     from cytoolz import first, groupby, merge, valmap, keymap
 except ImportError:
@@ -46,7 +46,7 @@ from .utils_comm import (WrappedKey, unpack_remotedata, pack_data,
                          scatter_to_workers, gather_from_workers)
 from .cfexecutor import ClientExecutor
 from .compatibility import (Queue as pyQueue, Empty, isqueue, html_escape,
-        StopAsyncIteration)
+        StopAsyncIteration, Iterator)
 from .core import connect, rpc, clean_exception, CommClosedError, PooledRPCCall
 from .metrics import time
 from .node import Node

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1,12 +1,13 @@
 from __future__ import print_function, division, absolute_import
 
 import atexit
+from collections import defaultdict
 try:
     # Python 3
-    from collections.abc import Iterator, defaultdict
+    from collections.abc import Iterator
 except ImportError:
     # Python 2.7
-    from collections import Iterator, defaultdict
+    from collections import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import DoneAndNotDoneFutures, CancelledError
 from contextlib import contextmanager

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1,7 +1,12 @@
 from __future__ import print_function, division, absolute_import
 
 import atexit
-from collections import Iterator, defaultdict
+try:
+    # Python 3
+    from collections.abc import Iterator, defaultdict
+except ImportError:
+    # Python 2.7
+    from collections import Iterator, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import DoneAndNotDoneFutures, CancelledError
 from contextlib import contextmanager

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2,12 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 import atexit
 from collections import defaultdict
-try:
-    # Python 3
-    from collections.abc import Iterator
-except ImportError:
-    # Python 2.7
-    from collections import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import DoneAndNotDoneFutures, CancelledError
 from contextlib import contextmanager
@@ -32,7 +26,7 @@ import weakref
 import dask
 from dask.base import tokenize, normalize_token, collections_to_dsk
 from dask.core import flatten, get_dependencies
-from dask.compatibility import apply, unicode
+from dask.compatibility import apply, unicode, Iterator
 try:
     from cytoolz import first, groupby, merge, valmap, keymap
 except ImportError:

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -11,7 +11,7 @@ if sys.version_info[0] == 2:
     from thread import get_ident as get_thread_identity
     from inspect import getargspec
     from cgi import escape as html_escape
-    from collections import Iterator, Mapping, Set
+    from collections import Iterator, Mapping, Set, MutableMapping
 
     reload = reload
     unicode = unicode
@@ -59,7 +59,7 @@ if sys.version_info[0] == 2:
 
 if sys.version_info[0] == 3:
     from asyncio import iscoroutinefunction
-    from collections.abc import Iterator, Mapping, Set
+    from collections.abc import Iterator, Mapping, Set, MutableMapping
     from queue import Queue, Empty
     from importlib import reload
     from threading import get_ident as get_thread_identity

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -11,6 +11,7 @@ if sys.version_info[0] == 2:
     from thread import get_ident as get_thread_identity
     from inspect import getargspec
     from cgi import escape as html_escape
+    from collections import Iterator, Mapping, Set
 
     reload = reload
     unicode = unicode
@@ -58,6 +59,7 @@ if sys.version_info[0] == 2:
 
 if sys.version_info[0] == 3:
     from asyncio import iscoroutinefunction
+    from collections.abc import Iterator, Mapping, Set
     from queue import Queue, Empty
     from importlib import reload
     from threading import get_ident as get_thread_identity

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from distributed.compatibility import MutableMapping
 from distributed.utils import log_errors, tokey
 
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,10 +1,11 @@
 from __future__ import print_function, division, absolute_import
+from collections import defaultdict, deque, OrderedDict
 try:
     # Python 3
-    from collections.abc import defaultdict, deque, OrderedDict, Mapping, Set
+    from collections.abc import Mapping, Set
 except ImportError:
     # Python 2.7
-    from collections import defaultdict, deque, OrderedDict, Mapping, Set
+    from collections import Mapping, Set
 from datetime import timedelta
 from functools import partial
 import itertools

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,11 +1,5 @@
 from __future__ import print_function, division, absolute_import
 from collections import defaultdict, deque, OrderedDict
-try:
-    # Python 3
-    from collections.abc import Mapping, Set
-except ImportError:
-    # Python 2.7
-    from collections import Mapping, Set
 from datetime import timedelta
 from functools import partial
 import itertools
@@ -35,7 +29,7 @@ import dask
 from .batched import BatchedSend
 from .comm import (normalize_address, resolve_address,
                    get_address_host, unparse_host_port)
-from .compatibility import finalize, unicode
+from .compatibility import finalize, unicode, Mapping, Set
 from .core import (rpc, connect, send_recv,
                    clean_exception, CommClosedError)
 from . import profile

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division, absolute_import
+
 from collections import defaultdict, deque, OrderedDict
 from datetime import timedelta
 from functools import partial

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,6 +1,10 @@
 from __future__ import print_function, division, absolute_import
-
-from collections import defaultdict, deque, OrderedDict, Mapping, Set
+try:
+    # Python 3
+    from collections.abc import defaultdict, deque, OrderedDict, Mapping, Set
+except ImportError:
+    # Python 2.7
+    from collections import defaultdict, deque, OrderedDict, Mapping, Set
 from datetime import timedelta
 from functools import partial
 import itertools

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -19,7 +19,7 @@ try:
     from cytoolz import frequencies, merge, pluck, merge_sorted, first
 except ImportError:
     from toolz import frequencies, merge, pluck, merge_sorted, first
-from toolz import valmap, first, second, compose, groupby
+from toolz import valmap, second, compose, groupby
 from tornado import gen
 from tornado.gen import Return
 from tornado.ioloop import IOLoop

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -1,4 +1,3 @@
-from collections import Iterator
 from concurrent.futures._base import CancelledError
 from operator import add
 import random
@@ -8,7 +7,7 @@ import pytest
 from tornado import gen
 
 from distributed.client import _as_completed, as_completed, _first_completed
-from distributed.compatibility import Empty, StopAsyncIteration, Queue
+from distributed.compatibility import Empty, StopAsyncIteration, Queue, Iterator
 from distributed.utils_test import gen_cluster, inc, throws
 from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from operator import add
 
-from collections import Iterator, deque
+from collections import deque
 from concurrent.futures import CancelledError
 import gc
 import itertools
@@ -36,7 +36,7 @@ from distributed.client import (Client, Future, wait, as_completed, tokenize,
                                 _get_global_client, default_client,
                                 futures_of,
                                 temp_default_client)
-from distributed.compatibility import PY3
+from distributed.compatibility import PY3, Iterator
 
 from distributed.metrics import time
 from distributed.scheduler import Scheduler, KilledWorker

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import Iterator
 import datetime
 from functools import partial
 import io
@@ -14,7 +13,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop
 
 import dask
-from distributed.compatibility import Queue, Empty, isqueue, PY2
+from distributed.compatibility import Queue, Empty, isqueue, PY2, Iterator
 from distributed.metrics import time
 from distributed.utils import (All, sync, is_kernel, ensure_ip, str_graph,
                                truncate_exception, get_traceback, queue_to_iterator,


### PR DESCRIPTION
- There is multiple `DepricationWarnings` with python 3.7. 
> 
> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
- This pull request fixes these import warnings but maintain backwards compatibility. 