### PR TITLE
Add serializer for masked arrays

### DIFF
--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -102,3 +102,37 @@ def deserialize_numpy_ndarray(header, frames):
                        strides=header['strides'])
 
         return x
+
+
+@dask_serialize.register(np.ma.core.MaskedArray)
+def serialize_numpy_maskedarray(x):
+    # Separate elements of the masked array that we need to deal with discretely.
+    data = x.data
+    mask = x.mask
+    fill_value = x.fill_value
+
+    # Make use of existing numpy serialization for the two ndarray elements of
+    # the masked array.
+    data_header, data_frames = serialize_numpy_ndarray(data)
+    mask_header, mask_frames = serialize_numpy_ndarray(mask)
+
+    header = {"data-header": data_header,
+              "mask-header": mask_header,
+              "fill_value": fill_value,
+              "nframes": [len(data_frames), len(mask_frames)]}
+    return header, data_frames + mask_frames
+
+
+@dask_deserialize.register(np.ma.core.MaskedArray)
+def deserialize_numpy_maskedarray(header, frames):
+    data_frames = frames[:header["nframes"][0]]
+    mask_frames = frames[header["nframes"][1]:]
+    data_header = header["data-header"]
+    mask_header = header["mask-header"]
+
+    # Get the individual elements of the masked array in order to reconstruct.
+    data = deserialize_numpy_ndarray(data_header, data_frames)
+    mask = deserialize_numpy_ndarray(mask_header, mask_frames)
+    fill_value = header["fill_value"]
+
+    return np.ma.masked_array(data, mask=mask, fill_value=fill_value)

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -27,51 +27,71 @@ def test_serialize():
     assert (result == x).all()
 
 
-@pytest.mark.parametrize('x',
-                         [np.ones(5),
-                          np.array(5),
-                             np.random.random((5, 5)),
-                             np.random.random((5, 5))[::2, :],
-                             np.random.random((5, 5))[:, ::2],
-                             np.asfortranarray(np.random.random((5, 5))),
-                             np.asfortranarray(np.random.random((5, 5)))[::2, :],
-                             np.asfortranarray(np.random.random((5, 5)))[:, ::2],
-                             np.random.random(5).astype('f4'),
-                             np.random.random(5).astype('>i8'),
-                             np.random.random(5).astype('<i8'),
-                             np.arange(5).astype('M8[us]'),
-                             np.arange(5).astype('M8[ms]'),
-                             np.arange(5).astype('m8'),
-                             np.arange(5).astype('m8[s]'),
-                             np.arange(5).astype('c16'),
-                             np.arange(5).astype('c8'),
-                             np.array([True, False, True]),
-                             np.ones(shape=5, dtype=[('a', 'i4'), ('b', 'M8[us]')]),
-                             np.array(['abc'], dtype='S3'),
-                             np.array(['abc'], dtype='U3'),
-                             np.array(['abc'], dtype=object),
-                             np.ones(shape=(5,), dtype=('f8', 32)),
-                             np.ones(shape=(5,), dtype=[('x', 'f8', 32)]),
-                             np.ones(shape=(5,), dtype=np.dtype([('a', 'i1'), ('b', 'f8')], align=False)),
-                             np.ones(shape=(5,), dtype=np.dtype([('a', 'i1'), ('b', 'f8')], align=True)),
-                             np.ones(shape=(5,), dtype=np.dtype([('a', 'm8[us]')], align=False)),
-                             # this dtype fails unpickling
-                             np.ones(shape=(5,), dtype=np.dtype([('a', 'm8')], align=False)),
-                             np.array([(1, 'abc')], dtype=[('x', 'i4'), ('s', object)]),
-                             np.zeros(5000, dtype=[('x%d' % i, '<f8') for i in range(4)]),
-                             np.zeros(5000, dtype='S32'),
-                             np.zeros((1, 1000, 1000)),
-                             np.arange(12)[::2],  # non-contiguous array
-                             np.ones(shape=(5, 6)).astype(dtype=[('total', '<f8'), ('n', '<f8')])])
+@pytest.mark.parametrize('x', [
+    np.ones(5),
+    np.array(5),
+    np.random.random((5, 5)),
+    np.random.random((5, 5))[::2, :],
+    np.random.random((5, 5))[:, ::2],
+    np.asfortranarray(np.random.random((5, 5))),
+    np.asfortranarray(np.random.random((5, 5)))[::2, :],
+    np.asfortranarray(np.random.random((5, 5)))[:, ::2],
+    np.random.random(5).astype('f4'),
+    np.random.random(5).astype('>i8'),
+    np.random.random(5).astype('<i8'),
+    np.arange(5).astype('M8[us]'),
+    np.arange(5).astype('M8[ms]'),
+    np.arange(5).astype('m8'),
+    np.arange(5).astype('m8[s]'),
+    np.arange(5).astype('c16'),
+    np.arange(5).astype('c8'),
+    np.array([True, False, True]),
+    np.ones(shape=5, dtype=[('a', 'i4'), ('b', 'M8[us]')]),
+    np.array(['abc'], dtype='S3'),
+    np.array(['abc'], dtype='U3'),
+    np.array(['abc'], dtype=object),
+    np.ones(shape=(5,), dtype=('f8', 32)),
+    np.ones(shape=(5,), dtype=[('x', 'f8', 32)]),
+    np.ones(shape=(5,), dtype=np.dtype([('a', 'i1'), ('b', 'f8')], align=False)),
+    np.ones(shape=(5,), dtype=np.dtype([('a', 'i1'), ('b', 'f8')], align=True)),
+    np.ones(shape=(5,), dtype=np.dtype([('a', 'm8[us]')], align=False)),
+    # this dtype fails unpickling
+    np.ones(shape=(5,), dtype=np.dtype([('a', 'm8')], align=False)),
+    np.array([(1, 'abc')], dtype=[('x', 'i4'), ('s', object)]),
+    np.zeros(5000, dtype=[('x%d' % i, '<f8') for i in range(4)]),
+    np.zeros(5000, dtype='S32'),
+    np.zeros((1, 1000, 1000)),
+    np.arange(12)[::2],  # non-contiguous array
+    np.ones(shape=(5, 6)).astype(dtype=[('total', '<f8'), ('n', '<f8')]),
+    np.ma.masked_array((5, 6), mask=[True, False]),  # int array
+    np.ma.masked_array((5., 6.), mask=[True, False]),  # float array (different default fill_value)
+    np.ma.masked_array((5., 6.), mask=[True, False], fill_value=np.nan),
+])
 def test_dumps_serialize_numpy(x):
     header, frames = serialize(x)
     if 'compression' in header:
         frames = decompress(header, frames)
+    for frame in frames:
+        assert isinstance(frame, (bytes, memoryview))
     y = deserialize(header, frames)
 
     np.testing.assert_equal(x, y)
     if x.flags.c_contiguous or x.flags.f_contiguous:
         assert x.strides == y.strides
+
+
+def test_masked_array_serialize():
+    data = (5, 6)
+    mask = [True, False]
+    fill_value = 999
+    x = np.ma.masked_array(data, mask=mask, fill_value=fill_value)
+    header, frames = serialize(x)
+    y = deserialize(header, frames)
+
+    # Explicitly test the particular elements of the masked array.
+    np.testing.assert_equal(data, y.data)
+    np.testing.assert_equal(mask, y.mask)
+    assert fill_value == y.fill_value
 
 
 def test_dumps_serialize_numpy_custom_dtype():


### PR DESCRIPTION
Currently masked array objects are serialized and deserialized by the NumPy serializer/deserializer, which can fall afoul of this peculiarity of the NumPy API:

```python
import numpy as np
x = np.arange(8)
mx = np.ma.masked_less(x, 5)

x.data
<memory at 0x7f1d3c72d048>

mx.data
array([0, 1, 2, 3, 4, 5, 6, 7])
```

This means that if a masked array gets passed to the NumPy serializer, not all of the frames are serialized properly to bytes, causing the error reported in https://github.com/dask/dask/issues/4163.

This adds a serializer and deserializer specifically for masked arrays, which splits masked arrays up to separately handle `data`, `mask` and `fill_value`.

Fixes https://github.com/dask/dask/issues/4163.