### PR TITLE
Avoid setting event loop policy if within Jupyter notebook server

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1373,9 +1373,21 @@ def reset_logger_locks():
 
 # Only bother if asyncio has been loaded by Tornado
 if 'asyncio' in sys.modules:
-    import asyncio
-    import tornado.platform.asyncio
-    asyncio.set_event_loop_policy(tornado.platform.asyncio.AnyThreadEventLoopPolicy())
+
+    jupyter_event_loop_initialized = False
+
+    if 'notebook' in sys.modules:
+        import traitlets
+        from notebook.notebookapp import NotebookApp
+        jupyter_event_loop_initialized = (
+            traitlets.config.Application.initialized() and
+            isinstance(traitlets.config.Application.instance(), NotebookApp)
+        )
+
+    if not jupyter_event_loop_initialized:
+        import asyncio
+        import tornado.platform.asyncio
+        asyncio.set_event_loop_policy(tornado.platform.asyncio.AnyThreadEventLoopPolicy())
 
 
 def has_keyword(func, keyword):


### PR DESCRIPTION
This is a hack.

If Dask is imported within the Jupyter notebook server it can cause the
server to hang.  This occurs because Dask sets an asyncio event loop
policy useful when starting multiple event loops in multiple threads.
Unfortunately setting this policy after Jupyter has already created an
event loop causes Jupyter to have two different event loops, which
understandably causes difficulties.

In the future we should investigate avoiding setting global asyncio
policies, possibly through managing event loops ourselves without using
`asyncio.get_event_loop` but until then this special-cased hack should
relieve some pressure.

Note that this means that some advanced functionality, like
`get_client`, `as_completed` and so forth won't work.  Fortunately these
are unlikely to be relevant within the Jupyter server process, which is
more likely to run scheduler rather than client code.

See https://github.com/jupyter/notebook/issues/4183