### PR TITLE
[WIP] Investigate worker-scheduler latency

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -40,7 +40,8 @@ from .proctitle import setproctitle
 from .security import Security
 from .utils import (All, ignoring, get_ip, get_fileno_limit, log_errors,
                     key_split, validate_key, no_default, DequeHandler,
-                    parse_timedelta, PeriodicCallback, shutting_down)
+                    parse_timedelta, PeriodicCallback, shutting_down, tictoc,
+                    format_time)
 from .utils_comm import (scatter_to_workers, gather_from_workers)
 from .utils_perf import enable_gc_diagnosis, disable_gc_diagnosis
 
@@ -1313,7 +1314,7 @@ class Scheduler(ServerNode):
             # for key in keys:  # TODO
             #     self.mark_key_in_memory(key, [address])
 
-            self.stream_comms[address] = BatchedSend(interval='5ms', loop=self.loop)
+            self.stream_comms[address] = BatchedSend(interval='0ms', loop=self.loop)
 
             if ws.ncores > len(ws.processing):
                 self.idle.add(ws)
@@ -2076,6 +2077,7 @@ class Scheduler(ServerNode):
             else:
                 msg['task'] = task
 
+            print('scheduler send task to worker', format_time(tictoc()))
             self.worker_send(worker, msg)
         except Exception as e:
             logger.exception(e)
@@ -2091,6 +2093,8 @@ class Scheduler(ServerNode):
         if worker not in self.workers:
             return
         validate_key(key)
+        print('scheduler task finished', format_time(tictoc()))
+        print('')
         r = self.stimulus_task_finished(key=key, worker=worker, **msg)
         self.transitions(r)
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1412,3 +1412,14 @@ def iscoroutinefunction(f):
     if sys.version_info >= (3, 5) and inspect.iscoroutinefunction(f):
         return True
     return False
+
+
+_tictoc_last = time()
+
+
+def tictoc():
+    global _tictoc_last
+    now = time()
+    duration = now - _tictoc_last
+    _tictoc_last = now
+    return duration

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -47,7 +47,8 @@ from .utils import (funcname, get_ip, has_arg, _maybe_complex, log_errors,
                     ignoring, mp_context, import_file,
                     silence_logging, thread_state, json_load_robust, key_split,
                     format_bytes, DequeHandler, PeriodicCallback,
-                    parse_bytes, parse_timedelta, iscoroutinefunction)
+                    parse_bytes, parse_timedelta, iscoroutinefunction, tictoc,
+                    format_time)
 from .utils_comm import pack_data, gather_from_workers
 from .utils_perf import ThrottledGC, enable_gc_diagnosis, disable_gc_diagnosis
 
@@ -271,7 +272,7 @@ class WorkerBase(ServerNode):
                 if response['status'] == 'missing':
                     yield self._register_with_scheduler()
                     return
-                self.scheduler_delay = response['time'] - middle
+                self.scheduler_delay = 0 # response['time'] - middle
                 self.periodic_callbacks['heartbeat'].callback_time = response['heartbeat-interval'] * 1000
             except CommClosedError:
                 logger.warn("Heartbeat to scheduler failed")
@@ -354,7 +355,7 @@ class WorkerBase(ServerNode):
             logger.info('        Registered to: %26s', self.scheduler.address)
             logger.info('-' * 49)
 
-        self.batched_stream = BatchedSend(interval='2ms', loop=self.loop)
+        self.batched_stream = BatchedSend(interval='0ms', loop=self.loop)
         self.batched_stream.start(comm)
         self.periodic_callbacks['heartbeat'].start()
         self.loop.add_callback(self.handle_scheduler, comm)
@@ -391,7 +392,7 @@ class WorkerBase(ServerNode):
 
     def send_to_worker(self, address, msg):
         if address not in self.stream_comms:
-            bcomm = BatchedSend(interval='1ms', loop=self.loop)
+            bcomm = BatchedSend(interval='2ms', loop=self.loop)
             self.stream_comms[address] = bcomm
 
             @gen.coroutine
@@ -910,6 +911,7 @@ def apply_function(function, args, kwargs, execution_state, key,
     -------
     msg: dictionary with status, result/error, timings, etc..
     """
+    print('worker starts computing', format_time(tictoc()))
     ident = get_thread_identity()
     with active_threads_lock:
         active_threads[ident] = key
@@ -1353,6 +1355,7 @@ class Worker(WorkerBase):
     def add_task(self, key, function=None, args=None, kwargs=None, task=None,
                  who_has=None, nbytes=None, priority=None, duration=None,
                  resource_restrictions=None, actor=False, **kwargs2):
+        print('worker accepts task', format_time(tictoc()))
         try:
             if key in self.tasks:
                 state = self.task_state[key]
@@ -1443,6 +1446,7 @@ class Worker(WorkerBase):
             if self.waiting_for_data[key]:
                 self.data_needed.append(key)
             else:
+                print('worker transitions key', format_time(tictoc()))
                 self.transition(key, 'ready')
             if self.validate:
                 if who_has:
@@ -1837,6 +1841,7 @@ class Worker(WorkerBase):
 
         if key in self.startstops:
             d['startstops'] = self.startstops[key]
+        print('worker reports done scheduler', format_time(tictoc()))
         self.batched_stream.send(d)
 
     def put_key_in_memory(self, key, value, transition=True):
@@ -2301,6 +2306,7 @@ class Worker(WorkerBase):
 
             logger.debug("Execute key: %s worker: %s", key, self.address)  # TODO: comment out?
             try:
+                print('worker submits task to threadpool', format_time(tictoc()))
                 result = yield self.executor_submit(key, apply_function,
                                                     args=(function, args2, kwargs2,
                                                           self.execution_state, key,

--- a/inproc-bench.py
+++ b/inproc-bench.py
@@ -1,0 +1,20 @@
+from time import time
+import operator
+
+from dask.distributed import Client, wait, get_task_stream
+
+client = Client(processes=False, n_workers=2, threads_per_worker=1)
+a, b = client.cluster.scheduler.workers
+
+start = time()
+with get_task_stream(plot='save', filename='latency.html') as ts:
+    x = 0
+    for i in range(10):
+        x = client.submit(operator.add, x, 1, workers=[a])
+        # x = client.submit(operator.add, x, 1, workers=[b])
+    wait(x)
+
+from distributed.utils import format_time
+
+stop = time()
+print(format_time(stop - start))


### PR DESCRIPTION
This branch does a few things to help investigate latency between the
scheduler and workers:

1.  Includes a benchmark script that uses the inproc:// protocol and
    computes a sequential computation
2.  Turns off all BatchedSend throttles, allowing communications to be
    sent rapidly one after the other
3.  Adds print statements throughout key sections of the code to
    highlight what parts of code take what durations

We find that fully sequential computations have milliseconds of latency,
and then when we look at the /profile-server dashboard we don't see much
activity.  It's not clear what's taking up all of our time.

Here is some sample output.  Each duration value corresponds to the amount of time spent since the last reported step (see the `tictoc` function defined in this PR).

```
scheduler send task to worker 123.50 us
worker accepts task 276.80 us
worker transitions key 61.27 us
worker submits task to threadpool 89.88 us
worker starts computing 134.47 us
worker reports done scheduler 200.27 us
scheduler task finished 214.58 us

scheduler send task to worker 123.26 us
worker accepts task 265.60 us
worker transitions key 32.66 us
worker submits task to threadpool 109.67 us
worker starts computing 162.60 us
worker reports done scheduler 213.38 us
scheduler task finished 323.06 us
```