### PR TITLE
Avoid race condition in Actor's Future

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -118,7 +118,7 @@ class Actor(WrappedKey):
     def __getattr__(self, key):
         attr = getattr(self._cls, key)
 
-        if self._future and not self._future.status == 'finished':
+        if self._future and self._future.status not in ('finished', 'pending'):
             raise ValueError("Worker holding Actor was lost.  Status: " + self._future.status)
 
         if callable(attr):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2262,7 +2262,8 @@ class Client(Node):
 
     def get(self, dsk, keys, restrictions=None, loose_restrictions=None,
             resources=None, sync=True, asynchronous=None, direct=None,
-            retries=None, priority=0, fifo_timeout='60s', **kwargs):
+            retries=None, priority=0, fifo_timeout='60s', actors=None,
+            **kwargs):
         """ Compute dask graph
 
         Parameters
@@ -2293,13 +2294,17 @@ class Client(Node):
         --------
         Client.compute: Compute asynchronous collections
         """
-        futures = self._graph_to_futures(dsk, set(flatten([keys])),
-                                         restrictions, loose_restrictions,
-                                         resources=resources,
-                                         fifo_timeout=fifo_timeout,
-                                         retries=retries,
-                                         user_priority=priority,
-                                         )
+        futures = self._graph_to_futures(
+            dsk,
+            keys=set(flatten([keys])),
+            restrictions=restrictions,
+            loose_restrictions=loose_restrictions,
+            resources=resources,
+            fifo_timeout=fifo_timeout,
+            retries=retries,
+            user_priority=priority,
+            actors=actors,
+        )
         packed = pack_data(keys, futures)
         if sync:
             if getattr(thread_state, 'key', False):


### PR DESCRIPTION
Previously we would err if an actor's future had been created, and the
task finished, but the worker holding the ActorFuture hadn't yet been
informed that the task had finished.  Now we allow the status to be
"pending".

We also move logic from an async test to a sync test because previously
the worker-client would be the same as the main client, which created a
reference cycle and so the future wouldn't get cleaned up.