### PR TITLE
Support missing packages keyword in Client.get_versions

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3175,6 +3175,8 @@ class Client(Node):
                              packages=packages)
         except KeyError:
             scheduler = None
+        except TypeError:  # packages keyword not supported
+            scheduler = sync(self.loop, self.scheduler.versions)  # this raises
 
         workers = sync(self.loop, self.scheduler.broadcast,
                        msg={'op': 'versions', 'packages': packages})


### PR DESCRIPTION
Previously users would get a non-informative error if their scheduler
was too old to support the packages= keyword.  Now we try again without
the keyword.  This is unfortunate because it drops the packages=
keyword, but is good because it will give a more informative error.