### PR TITLE
Serialize numpy.ma.masked objects properly

### DIFF
--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -103,6 +103,16 @@ def deserialize_numpy_ndarray(header, frames):
         return x
 
 
+@dask_serialize.register(np.ma.core.MaskedConstant)
+def serialize_numpy_ma_masked(x):
+    return {}, []
+
+
+@dask_deserialize.register(np.ma.core.MaskedConstant)
+def deserialize_numpy_ma_masked(header, frames):
+    return np.ma.masked
+
+
 @dask_serialize.register(np.ma.core.MaskedArray)
 def serialize_numpy_maskedarray(x):
     data_header, frames = serialize_numpy_ndarray(x.data)

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -87,12 +87,17 @@ def test_dumps_serialize_numpy(x):
     np.ma.masked_array([True, False], mask=np.ma.nomask, fill_value=True, dtype='bool'),
     np.ma.masked_array(['a', 'b'], mask=[True, False], fill_value='c', dtype='O')
 ])
-def test_masked_array_serialize(x):
+def test_serialize_numpy_ma_masked_array(x):
     y, = loads(dumps([to_serialize(x)]))
     assert x.data.dtype == y.data.dtype
     np.testing.assert_equal(x.data, y.data)
     np.testing.assert_equal(x.mask, y.mask)
     np.testing.assert_equal(x.fill_value, y.fill_value)
+
+
+def test_serialize_numpy_ma_masked():
+    y, = loads(dumps([to_serialize(np.ma.masked)]))
+    assert y is np.ma.masked
 
 
 def test_dumps_serialize_numpy_custom_dtype():


### PR DESCRIPTION
`numpy.ma.masked` is a singleton of type `np.ma.core.MaskedConstant`. Since this singleton is a subclass of `np.ma.core.MaskedArray`, it was erroneously being picked up by the serializer for `MaskedArray`s, leading to errors. We now register a serializer/deserializer for `MaskedConstant` directly, fixing the issue.

Fixes https://github.com/dask/dask/issues/4225#issuecomment-443035031