### PR TITLE
Turn off bokeh property validation in dashboard

### DIFF
--- a/distributed/bokeh/components.py
+++ b/distributed/bokeh/components.py
@@ -5,7 +5,6 @@ from operator import add
 from time import time
 import weakref
 
-import bokeh
 from bokeh.layouts import row, column
 from bokeh.models import ( ColumnDataSource, Plot, DataRange1d, LinearAxis,
         HoverTool, BoxZoomTool, ResetTool, PanTool, WheelZoomTool, Range1d,
@@ -16,6 +15,7 @@ import dask
 from tornado import gen
 import toolz
 
+from .utils import without_property_validation, BOKEH_VERSION
 from ..diagnostics.progress_stream import nbytes_bar
 from .. import profile
 from ..utils import log_errors, parse_timedelta
@@ -70,6 +70,7 @@ class TaskStream(DashboardComponent):
         # Required for update callback
         self.task_stream_index = [0]
 
+    @without_property_validation
     def update(self, messages):
         with log_errors():
             index = messages['task-events']['index']
@@ -211,6 +212,7 @@ class MemoryUsage(DashboardComponent):
         )
         self.root.add_tools(hover)
 
+    @without_property_validation
     def update(self, messages):
         with log_errors():
             msg = messages['progress']
@@ -260,6 +262,7 @@ class Processing(DashboardComponent):
 
         self.root = fig
 
+    @without_property_validation
     def update(self, messages):
         with log_errors():
             msg = messages['processing']
@@ -310,6 +313,7 @@ class ProfilePlot(DashboardComponent):
         self.states = data.pop('states')
         self.source = ColumnDataSource(data=data)
 
+        @without_property_validation
         def cb(attr, old, new):
             with log_errors():
                 try:
@@ -326,7 +330,7 @@ class ProfilePlot(DashboardComponent):
                 self.source.data.update(data)
                 self.source.selected = old
 
-        if bokeh.__version__ >= '1.0':
+        if BOKEH_VERSION >= '1.0.0':
             self.source.selected.on_change('indices', cb)
         else:
             self.source.on_change('selected', cb)
@@ -370,6 +374,7 @@ class ProfilePlot(DashboardComponent):
         self.root.yaxis.visible = False
         self.root.grid.visible = False
 
+    @without_property_validation
     def update(self, state):
         with log_errors():
             self.state = state
@@ -411,6 +416,7 @@ class ProfileTimePlot(DashboardComponent):
 
         changing = [False]  # avoid repeated changes from within callback
 
+        @without_property_validation
         def cb(attr, old, new):
             if changing[0]:
                 return
@@ -434,7 +440,7 @@ class ProfileTimePlot(DashboardComponent):
                     self.source.selected = old
                 changing[0] = False
 
-        if bokeh.__version__ >= '1.0':
+        if BOKEH_VERSION >= '1.0.0':
             self.source.selected.on_change('indices', cb)
         else:
             self.source.on_change('selected', cb)
@@ -506,7 +512,7 @@ class ProfileTimePlot(DashboardComponent):
                     self.start = self.stop = None
                 self.trigger_update(update_metadata=False)
 
-        if bokeh.__version__ >= '1.0':
+        if BOKEH_VERSION >= '1.0.0':
             self.ts_source.selected.on_change('indices', ts_change)
         else:
             self.ts_source.on_change('selected', ts_change)
@@ -531,6 +537,7 @@ class ProfileTimePlot(DashboardComponent):
                                self.update_button, sizing_mode='scale_width'),
                            self.profile_plot, self.ts_plot, **kwargs)
 
+    @without_property_validation
     def update(self, state, metadata=None):
         with log_errors():
             self.state = state
@@ -550,6 +557,7 @@ class ProfileTimePlot(DashboardComponent):
 
                 self.ts_source.data.update(self.ts)
 
+    @without_property_validation
     def trigger_update(self, update_metadata=True):
         @gen.coroutine
         def cb():
@@ -587,6 +595,7 @@ class ProfileServer(DashboardComponent):
 
         changing = [False]  # avoid repeated changes from within callback
 
+        @without_property_validation
         def cb(attr, old, new):
             if changing[0]:
                 return
@@ -610,7 +619,7 @@ class ProfileServer(DashboardComponent):
                     self.source.selected = old
                 changing[0] = False
 
-        if bokeh.__version__ >= '1.0':
+        if BOKEH_VERSION >= '1.0.0':
             self.source.selected.on_change('indices', cb)
         else:
             self.source.on_change('selected', cb)
@@ -682,7 +691,7 @@ class ProfileServer(DashboardComponent):
                     self.start = self.stop = None
                 self.trigger_update()
 
-        if bokeh.__version__ >= '1.0':
+        if BOKEH_VERSION >= '1.0.0':
             self.ts_source.selected.on_change('indices', ts_change)
         else:
             self.ts_source.on_change('selected', ts_change)
@@ -697,6 +706,7 @@ class ProfileServer(DashboardComponent):
                                sizing_mode='scale_width'),
                            self.profile_plot, self.ts_plot, **kwargs)
 
+    @without_property_validation
     def update(self, state):
         with log_errors():
             self.state = state
@@ -704,6 +714,7 @@ class ProfileServer(DashboardComponent):
             self.states = data.pop('states')
             self.source.data.update(data)
 
+    @without_property_validation
     def trigger_update(self):
         self.state = profile.get_profile(self.log, start=self.start, stop=self.stop)
         data = profile.plot_data(self.state, profile_interval)

--- a/distributed/bokeh/utils.py
+++ b/distributed/bokeh/utils.py
@@ -1,6 +1,19 @@
 from __future__ import print_function, division, absolute_import
 
+from distutils.version import LooseVersion
+
 from toolz import partition
+
+import bokeh
+
+BOKEH_VERSION = LooseVersion(bokeh.__version__)
+
+
+if BOKEH_VERSION >= '1.0.0':
+    from bokeh.core.properties import without_property_validation
+else:
+    def without_property_validation(f):
+        return f
 
 
 def parse_args(args):

--- a/distributed/bokeh/worker.py
+++ b/distributed/bokeh/worker.py
@@ -19,7 +19,7 @@ from toolz import merge, partition_all
 from .components import (DashboardComponent, ProfileTimePlot, ProfileServer,
                          add_periodic_callback)
 from .core import BokehServer
-from .utils import transpose
+from .utils import transpose, without_property_validation
 from ..compatibility import WINDOWS
 from ..diagnostics.progress_stream import color_of
 from ..metrics import time
@@ -57,6 +57,7 @@ class StateTable(DashboardComponent):
         )
         self.root = table
 
+    @without_property_validation
     def update(self):
         with log_errors():
             w = self.worker
@@ -108,6 +109,7 @@ class CommunicatingStream(DashboardComponent):
             self.last_outgoing = 0
             self.who = dict()
 
+    @without_property_validation
     def update(self):
         with log_errors():
             outgoing = self.worker.outgoing_transfer_log
@@ -176,6 +178,7 @@ class CommunicatingTimeSeries(DashboardComponent):
 
         self.root = fig
 
+    @without_property_validation
     def update(self):
         with log_errors():
             self.source.stream({'x': [time() * 1000],
@@ -204,6 +207,7 @@ class ExecutingTimeSeries(DashboardComponent):
 
         self.root = fig
 
+    @without_property_validation
     def update(self):
         with log_errors():
             self.source.stream({'x': [time() * 1000],
@@ -264,6 +268,7 @@ class CrossFilter(DashboardComponent):
 
             self.root = self.layout
 
+    @without_property_validation
     def update(self):
         with log_errors():
             outgoing = self.worker.outgoing_transfer_log
@@ -323,6 +328,7 @@ class CrossFilter(DashboardComponent):
             )
             return fig
 
+    @without_property_validation
     def update_figure(self, attr, old, new):
         with log_errors():
             fig = self.create_figure(**self.kwargs)
@@ -418,6 +424,7 @@ class SystemMonitor(DashboardComponent):
         self.last = self.worker.monitor.count
         return d
 
+    @without_property_validation
     def update(self):
         with log_errors():
             self.source.stream(self.get_data(), 1000)
@@ -505,6 +512,7 @@ class Counters(DashboardComponent):
             self.counter_figures[name] = fig
             return fig
 
+    @without_property_validation
     def update(self):
         with log_errors():
             for name, fig in self.digest_figures.items():


### PR DESCRIPTION
Bokeh 1.0.0 added a method to turn off property validation contextually, improving performance. Here we make use that method to remove validation in the dashboard update methods. For older versions of bokeh this PR is a no-op.

Fixes #2342.