### PR TITLE
Danpf/track subprocess resources

### DIFF
--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -10,7 +10,7 @@ from .metrics import time
 class SystemMonitor(object):
     def __init__(self, n=10000):
         self.proc = psutil.Process()
-        self.proc_children = psutil.children(recursive=True)
+        self.proc_children = self.proc.children(recursive=True)
 
         self.time = deque(maxlen=n)
         self.cpu = deque(maxlen=n)

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -10,6 +10,7 @@ from .metrics import time
 class SystemMonitor(object):
     def __init__(self, n=10000):
         self.proc = psutil.Process()
+        self.proc_children = psutil.children(recursive=True)
 
         self.time = deque(maxlen=n)
         self.cpu = deque(maxlen=n)
@@ -49,6 +50,14 @@ class SystemMonitor(object):
         with self.proc.oneshot():
             cpu = self.proc.cpu_percent()
             memory = self.proc.memory_info().rss
+        updated_children = self.proc.children(recursive=True)
+        self.proc_children = [child for child in self.proc_children if child in updated_children]
+        self.proc_children += [child for child in updated_children if child not in self.proc_children]
+        for child in self.proc_children:
+            with child.oneshot():
+                cpu += child.cpu_percent()
+                memory += child.memory_info().rss
+
         now = time()
 
         self.cpu.append(cpu)

--- a/distributed/tests/test_system_monitor.py
+++ b/distributed/tests/test_system_monitor.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from time import sleep
+import subprocess
 
 from distributed.system_monitor import SystemMonitor
 
@@ -19,6 +20,19 @@ def test_SystemMonitor():
     assert all(len(q) == 3 for q in sm.quantities.values())
 
     assert 'cpu' in repr(sm)
+
+    # Test subprocess usage
+    sm.update()
+    sub = subprocess.Popen(["bash", "-c", "while true; do true; done"])
+    sleep(0.3)
+    sm.update()
+    sleep(0.3)
+    ret = sm.update()
+    assert ret['cpu'] > 90
+    sub.terminate()
+    sleep(0.3)
+    ret = sm.update()
+    assert ret['cpu'] < 90
 
 
 def test_count():


### PR DESCRIPTION
I'm not sure of the performance implications of this, but I've been using this to track my resource usage.

fix for https://github.com/dask/distributed/issues/1949

description:
Currently, Dask can only track the worker's cpu usage and memory usage. If you make another process via `subprocess` that process's resources will not be tracked.   This makes us track the resource usage of all process children instead of just the python process.

I'm not sure if this is everything that needs to be changed, but it appears to work for me. I'm guessing this is slightly slower since tests are failing. 