### PR TITLE
Fix excess threading on missing connections

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -181,10 +181,11 @@ def connect(addr, timeout=None, deserialize=True, connection_args=None):
                % (addr, timeout, error))
         raise IOError(msg)
 
+    # This starts a thread
+    future = connector.connect(loc, deserialize=deserialize,
+                               **(connection_args or {}))
     while True:
         try:
-            future = connector.connect(loc, deserialize=deserialize,
-                                       **(connection_args or {}))
             comm = yield gen.with_timeout(timedelta(seconds=deadline - time()),
                                           future,
                                           quiet_exceptions=EnvironmentError)

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -182,10 +182,10 @@ def connect(addr, timeout=None, deserialize=True, connection_args=None):
         raise IOError(msg)
 
     # This starts a thread
-    future = connector.connect(loc, deserialize=deserialize,
-                               **(connection_args or {}))
     while True:
         try:
+            future = connector.connect(loc, deserialize=deserialize,
+                                       **(connection_args or {}))
             comm = yield gen.with_timeout(timedelta(seconds=deadline - time()),
                                           future,
                                           quiet_exceptions=EnvironmentError)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -322,9 +322,13 @@ class RequireEncryptionMixin(object):
 
 
 class BaseTCPConnector(Connector, RequireEncryptionMixin):
-    executor = ThreadPoolExecutor(3)
-    t_executor = netutil.ExecutorResolver(close_executor=False, executor=executor)
-    client = TCPClient(t_executor)
+    if PY3:  # see github PR #2403 discussion for more info
+        _executor = ThreadPoolExecutor(2)
+        _resolver = netutil.ExecutorResolver(close_executor=False,
+                                             executor=_executor)
+    else:
+        _resolver = None
+    client = TCPClient(resolver=_resolver)
 
     @gen.coroutine
     def connect(self, address, deserialize=True, **connection_args):

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -323,7 +323,7 @@ class RequireEncryptionMixin(object):
 
 class BaseTCPConnector(Connector, RequireEncryptionMixin):
     executor = ThreadPoolExecutor(2)
-    t_executor = netutil.ExecutorResolver(close_executor=False, executor=executor)
+    t_executor = netutil.ExecutorResolver(executor=executor)
     client = TCPClient(t_executor)
 
     @gen.coroutine

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -322,7 +322,7 @@ class RequireEncryptionMixin(object):
 
 
 class BaseTCPConnector(Connector, RequireEncryptionMixin):
-    executor = ThreadPoolExecutor(2)
+    executor = ThreadPoolExecutor(3)
     t_executor = netutil.ExecutorResolver(close_executor=False, executor=executor)
     client = TCPClient(t_executor)
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -327,7 +327,7 @@ class BaseTCPConnector(Connector, RequireEncryptionMixin):
     client = TCPClient(t_executor)
 
     @gen.coroutine
-    def connect(self, address, deserialize=True, executor=None, **connection_args):
+    def connect(self, address, deserialize=True, **connection_args):
         self._check_encryption(address, connection_args)
         ip, port = parse_host_port(address)
         kwargs = self._get_connect_args(**connection_args)
@@ -336,6 +336,14 @@ class BaseTCPConnector(Connector, RequireEncryptionMixin):
             stream = yield BaseTCPConnector.client.connect(ip, port,
                                           max_buffer_size=MAX_BUFFER_SIZE,
                                           **kwargs)
+
+            # Under certain circumstances tornado will have a closed connnection with an error and not raise
+            # a StreamClosedError.
+            #
+            # This occurs with tornado 5.x and openssl 1.1+
+            if stream.closed() and stream.error:
+                raise StreamClosedError(stream.error)
+
         except StreamClosedError as e:
             # The socket connect() call failed
             convert_stream_closed_error(self, e)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -323,7 +323,7 @@ class RequireEncryptionMixin(object):
 
 class BaseTCPConnector(Connector, RequireEncryptionMixin):
     executor = ThreadPoolExecutor(2)
-    t_executor = netutil.ExecutorResolver(executor=executor)
+    t_executor = netutil.ExecutorResolver(close_executor=False, executor=executor)
     client = TCPClient(t_executor)
 
     @gen.coroutine

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -304,7 +304,7 @@ def test_comm_failure_threading():
             thread_count = threading.active_count()
             if thread_count > max_thread_count:
                 max_thread_count = thread_count
-        return max_thread_count
+        raise gen.Return(max_thread_count)
     original_thread_count = threading.active_count()
 
     # tcp.TCPConnector()

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -312,8 +312,8 @@ def test_comm_failure_threading():
     with pytest.raises(IOError):
         yield connect("tcp://localhost:28400", 0.052)
     max_thread_count = yield sleep_future
-    # 3 is the number set by BaseTCPConnector.executor (ThreadPoolExecutor)
-    assert max_thread_count <= 3 + original_thread_count
+    # 2 is the number set by BaseTCPConnector.executor (ThreadPoolExecutor)
+    assert max_thread_count <= 2 + original_thread_count
 
     # tcp.TLSConnector()
     sleep_future = sleep_for_60ms()
@@ -321,7 +321,7 @@ def test_comm_failure_threading():
         yield connect("tls://localhost:28400", 0.052,
                                  connection_args={'ssl_context': get_client_ssl_context()})
     max_thread_count = yield sleep_future
-    assert max_thread_count <= 3 + original_thread_count
+    assert max_thread_count <= 2 + original_thread_count
 
 
 @gen.coroutine

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -305,23 +305,22 @@ def test_comm_failure_threading():
             if thread_count > max_thread_count:
                 max_thread_count = thread_count
         return max_thread_count
+    original_thread_count = threading.active_count()
 
     # tcp.TCPConnector()
-    sleep_future = gen.convert_yielded(sleep_for_500ms())
+    sleep_future = sleep_for_500ms()
     with pytest.raises(IOError):
-        future_connect = gen.convert_yielded(connect("tcp://localhost:28400", 0.6))
-        yield future_connect
+        yield connect("tcp://localhost:28400", 0.6)
     max_thread_count = yield sleep_future
-    assert max_thread_count == 4
+    assert max_thread_count - original_thread_count == 2
 
     # tcp.TLSConnector()
-    sleep_future = gen.convert_yielded(sleep_for_500ms())
+    sleep_future = sleep_for_500ms()
     with pytest.raises(IOError):
-        future_connect = gen.convert_yielded(
-                connect("tls://localhost:28400", 0.6, connection_args={'ssl_context': get_client_ssl_context()}))
-        yield future_connect
+        yield connect("tls://localhost:28400", 0.6,
+                                 connection_args={'ssl_context': get_client_ssl_context()})
     max_thread_count = yield sleep_future
-    assert max_thread_count == 4
+    assert max_thread_count - original_thread_count == 2
 
 
 @gen.coroutine

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -312,8 +312,8 @@ def test_comm_failure_threading():
     with pytest.raises(IOError):
         yield connect("tcp://localhost:28400", 0.052)
     max_thread_count = yield sleep_future
-    # 2 is the number set by BaseTCPConnector.executor (ThreadPoolExecutor)
-    assert max_thread_count <= 2 + original_thread_count
+    # 3 is the number set by BaseTCPConnector.executor (ThreadPoolExecutor)
+    assert max_thread_count <= 3 + original_thread_count
 
     # tcp.TLSConnector()
     sleep_future = sleep_for_60ms()
@@ -321,7 +321,7 @@ def test_comm_failure_threading():
         yield connect("tls://localhost:28400", 0.052,
                                  connection_args={'ssl_context': get_client_ssl_context()})
     max_thread_count = yield sleep_future
-    assert max_thread_count <= 2 + original_thread_count
+    assert max_thread_count <= 3 + original_thread_count
 
 
 @gen.coroutine

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -297,9 +297,9 @@ def test_comm_failure_threading():
     """
 
     @gen.coroutine
-    def sleep_for_120ms():
+    def sleep_for_60ms():
         max_thread_count = 0
-        for x in range(120):
+        for x in range(60):
             yield gen.sleep(0.001)
             thread_count = threading.active_count()
             if thread_count > max_thread_count:
@@ -308,17 +308,17 @@ def test_comm_failure_threading():
     original_thread_count = threading.active_count()
 
     # tcp.TCPConnector()
-    sleep_future = sleep_for_120ms()
+    sleep_future = sleep_for_60ms()
     with pytest.raises(IOError):
-        yield connect("tcp://localhost:28400", 0.1)
+        yield connect("tcp://localhost:28400", 0.052)
     max_thread_count = yield sleep_future
     # 2 is the number set by BaseTCPConnector.executor (ThreadPoolExecutor)
     assert max_thread_count <= 2 + original_thread_count
 
     # tcp.TLSConnector()
-    sleep_future = sleep_for_120ms()
+    sleep_future = sleep_for_60ms()
     with pytest.raises(IOError):
-        yield connect("tls://localhost:28400", 0.1,
+        yield connect("tls://localhost:28400", 0.052,
                                  connection_args={'ssl_context': get_client_ssl_context()})
     max_thread_count = yield sleep_future
     assert max_thread_count <= 2 + original_thread_count

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -312,7 +312,7 @@ def test_comm_failure_threading():
         future_connect = gen.convert_yielded(connect("tcp://localhost:28400", 0.6))
         yield future_connect
     max_thread_count = yield sleep_future
-    assert max_thread_count == 4, f"Max thread count found to be: {max_thread_count}"
+    assert max_thread_count == 4
 
     # tcp.TLSConnector()
     sleep_future = gen.convert_yielded(sleep_for_500ms())
@@ -321,7 +321,7 @@ def test_comm_failure_threading():
                 connect("tls://localhost:28400", 0.6, connection_args={'ssl_context': get_client_ssl_context()}))
         yield future_connect
     max_thread_count = yield sleep_future
-    assert max_thread_count == 4, f"Max thread count found to be: {max_thread_count}"
+    assert max_thread_count == 4
 
 
 @gen.coroutine

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -11,7 +11,7 @@ import pytest
 from tornado import gen, ioloop, locks, queues
 from tornado.concurrent import Future
 
-from distributed.compatibility import finalize, PY3
+from distributed.compatibility import PY3
 from distributed.metrics import time
 from distributed.utils import get_ip, get_ipv6
 from distributed.utils_test import (gen_test, requires_ipv6, has_ipv6,

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -11,6 +11,7 @@ import pytest
 from tornado import gen, ioloop, locks, queues
 from tornado.concurrent import Future
 
+from distributed.compatibility import finalize, PY3
 from distributed.metrics import time
 from distributed.utils import get_ip, get_ipv6
 from distributed.utils_test import (gen_test, requires_ipv6, has_ipv6,
@@ -294,6 +295,9 @@ def test_comm_failure_threading():
     """
     When we fail to connect, make sure we don't make a lot
     of threads.
+
+    We only assert for PY3, because the thread limit only is
+    set for python 3.  See github PR #2403 discussion for info.
     """
 
     @gen.coroutine
@@ -313,7 +317,8 @@ def test_comm_failure_threading():
         yield connect("tcp://localhost:28400", 0.052)
     max_thread_count = yield sleep_future
     # 2 is the number set by BaseTCPConnector.executor (ThreadPoolExecutor)
-    assert max_thread_count <= 2 + original_thread_count
+    if PY3:
+        assert max_thread_count <= 2 + original_thread_count
 
     # tcp.TLSConnector()
     sleep_future = sleep_for_60ms()
@@ -321,7 +326,8 @@ def test_comm_failure_threading():
         yield connect("tls://localhost:28400", 0.052,
                                  connection_args={'ssl_context': get_client_ssl_context()})
     max_thread_count = yield sleep_future
-    assert max_thread_count <= 2 + original_thread_count
+    if PY3:
+        assert max_thread_count <= 2 + original_thread_count
 
 
 @gen.coroutine

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -297,9 +297,9 @@ def test_comm_failure_threading():
     """
 
     @gen.coroutine
-    def sleep_for_500ms():
+    def sleep_for_120ms():
         max_thread_count = 0
-        for x in range(500):
+        for x in range(120):
             yield gen.sleep(0.001)
             thread_count = threading.active_count()
             if thread_count > max_thread_count:
@@ -308,17 +308,17 @@ def test_comm_failure_threading():
     original_thread_count = threading.active_count()
 
     # tcp.TCPConnector()
-    sleep_future = sleep_for_500ms()
+    sleep_future = sleep_for_120ms()
     with pytest.raises(IOError):
-        yield connect("tcp://localhost:28400", 0.6)
+        yield connect("tcp://localhost:28400", 0.1)
     max_thread_count = yield sleep_future
     # 2 is the number set by BaseTCPConnector.executor (ThreadPoolExecutor)
     assert max_thread_count <= 2 + original_thread_count
 
     # tcp.TLSConnector()
-    sleep_future = sleep_for_500ms()
+    sleep_future = sleep_for_120ms()
     with pytest.raises(IOError):
-        yield connect("tls://localhost:28400", 0.6,
+        yield connect("tls://localhost:28400", 0.1,
                                  connection_args={'ssl_context': get_client_ssl_context()})
     max_thread_count = yield sleep_future
     assert max_thread_count <= 2 + original_thread_count

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -312,7 +312,8 @@ def test_comm_failure_threading():
     with pytest.raises(IOError):
         yield connect("tcp://localhost:28400", 0.6)
     max_thread_count = yield sleep_future
-    assert max_thread_count - original_thread_count == 2
+    # 2 is the number set by BaseTCPConnector.executor (ThreadPoolExecutor)
+    assert max_thread_count <= 2 + original_thread_count
 
     # tcp.TLSConnector()
     sleep_future = sleep_for_500ms()
@@ -320,7 +321,7 @@ def test_comm_failure_threading():
         yield connect("tls://localhost:28400", 0.6,
                                  connection_args={'ssl_context': get_client_ssl_context()})
     max_thread_count = yield sleep_future
-    assert max_thread_count - original_thread_count == 2
+    assert max_thread_count <= 2 + original_thread_count
 
 
 @gen.coroutine


### PR DESCRIPTION
When you start a worker, and there is no scheduler at the location you expect it to be, it continuously generates threads until it hits some limit (~300 for me) and then fails.
The problem is this `while True` loop.

we can solve this by making the future outside the loop, and then tracking that one instead of all of the ones from each `while` loop.

I  - think - this is an okay way to do this, but maybe someone that knows tornado more can say otherwise.

possible fix for https://github.com/dask/distributed/issues/2398