### PR TITLE
Bump up connect sleep time from 10ms to 50ms

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -193,7 +193,7 @@ def connect(addr, timeout=None, deserialize=True, connection_args=None):
         except EnvironmentError as e:
             error = str(e)
             if time() < deadline:
-                yield gen.sleep(0.01)
+                yield gen.sleep(0.050)
                 logger.debug("sleeping on connect")
             else:
                 _raise(error)


### PR DESCRIPTION
We used to try to connect to the scheduler every 10ms if it wasn't around.  This might be a bit too busy?  Bumping up to 50ms to see if it makes a difference for #2398 