### PR TITLE
Support coroutines and async-def functions in run/run_scheduler

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2048,9 +2048,11 @@ class Client(Node):
 
     @gen.coroutine
     def _run_on_scheduler(self, function, *args, **kwargs):
+        wait = kwargs.pop('wait', True)
         response = yield self.scheduler.run_function(function=dumps(function),
                                                      args=dumps(args),
-                                                     kwargs=dumps(kwargs))
+                                                     kwargs=dumps(kwargs),
+                                                     wait=wait)
         if response['status'] == 'error':
             six.reraise(*clean_exception(**response))
         else:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2084,9 +2084,11 @@ class Client(Node):
     def _run(self, function, *args, **kwargs):
         nanny = kwargs.pop('nanny', False)
         workers = kwargs.pop('workers', None)
+        wait = kwargs.pop('wait', True)
         responses = yield self.scheduler.broadcast(msg=dict(op='run',
                                                             function=dumps(function),
                                                             args=dumps(args),
+                                                            wait=wait,
                                                             kwargs=dumps(kwargs)),
                                                    workers=workers, nanny=nanny)
         results = {}
@@ -2095,7 +2097,10 @@ class Client(Node):
                 results[key] = resp['result']
             elif resp['status'] == 'error':
                 six.reraise(*clean_exception(**resp))
-        raise gen.Return(results)
+        if wait:
+            raise gen.Return(results)
+        else:
+            return None
 
     def run(self, function, *args, **kwargs):
         """
@@ -2142,27 +2147,6 @@ class Client(Node):
         """
         return self.sync(self._run, function, *args, **kwargs)
 
-    @gen.coroutine
-    def _run_coroutine(self, function, *args, **kwargs):
-        workers = kwargs.pop('workers', None)
-        wait = kwargs.pop('wait', True)
-        responses = yield self.scheduler.broadcast(msg=dict(op='run_coroutine',
-                                                            function=dumps(function),
-                                                            args=dumps(args),
-                                                            kwargs=dumps(kwargs),
-                                                            wait=wait),
-                                                   workers=workers)
-        if not wait:
-            raise gen.Return(None)
-        else:
-            results = {}
-            for key, resp in responses.items():
-                if resp['status'] == 'OK':
-                    results[key] = resp['result']
-                elif resp['status'] == 'error':
-                    six.reraise(*clean_exception(**resp))
-            raise gen.Return(results)
-
     def run_coroutine(self, function, *args, **kwargs):
         """
         Spawn a coroutine on all workers.
@@ -2184,7 +2168,10 @@ class Client(Node):
             Workers on which to run the function. Defaults to all known workers.
 
         """
-        return self.sync(self._run_coroutine, function, *args, **kwargs)
+        warnings.warn("This method has been deprecated. "
+                      "Instead use Client.run which detects async functions "
+                      "automatically")
+        return self.run(function, *args, **kwargs)
 
     def _graph_to_futures(self, dsk, keys, restrictions=None,
                           loose_restrictions=None, priority=None,

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2101,8 +2101,6 @@ class Client(Node):
                 six.reraise(*clean_exception(**resp))
         if wait:
             raise gen.Return(results)
-        else:
-            return None
 
     def run(self, function, *args, **kwargs):
         """

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3068,7 +3068,7 @@ class Scheduler(ServerNode):
             self.unknown_durations[prefix].add(ts)
             return default
 
-    def run_function(self, stream, function, args=(), kwargs={}):
+    def run_function(self, stream, function, args=(), kwargs={}, wait=True):
         """ Run a function within this process
 
         See Also
@@ -3077,7 +3077,7 @@ class Scheduler(ServerNode):
         """
         from .worker import run
         self.log_event('all', {'action': 'run-function', 'function': function})
-        return run(self, stream, function=function, args=args, kwargs=kwargs)
+        return run(self, stream, function=function, args=args, kwargs=kwargs, wait=wait)
 
     def set_metadata(self, stream=None, keys=None, value=None):
         try:

--- a/distributed/tests/py3_test_client.py
+++ b/distributed/tests/py3_test_client.py
@@ -158,3 +158,22 @@ async def test_dont_hold_on_to_large_messages(c, s, a, b):
             pytest.fail("array should have been destroyed")
 
         await gen.sleep(0.200)
+
+
+@gen_cluster(client=True)
+async def test_run_scheduler_async_def(c, s, a, b):
+    async def f(dask_scheduler):
+        await gen.sleep(0.01)
+        dask_scheduler.foo = 'bar'
+
+    await c.run_on_scheduler(f)
+
+    assert s.foo == 'bar'
+
+    async def f(dask_worker):
+        await gen.sleep(0.01)
+        dask_worker.foo = 'bar'
+
+    await c.run(f)
+    assert a.foo == 'bar'
+    assert b.foo == 'bar'

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2616,35 +2616,34 @@ def test_run_sync(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_run_coroutine(c, s, a, b):
-    results = yield c.run_coroutine(geninc, 1, delay=0.05)
+    results = yield c.run(geninc, 1, delay=0.05)
     assert results == {a.address: 2, b.address: 2}
 
-    results = yield c.run_coroutine(geninc, 1, delay=0.05, workers=[a.address])
+    results = yield c.run(geninc, 1, delay=0.05, workers=[a.address])
     assert results == {a.address: 2}
 
-    results = yield c.run_coroutine(geninc, 1, workers=[])
+    results = yield c.run(geninc, 1, workers=[])
     assert results == {}
 
     with pytest.raises(RuntimeError) as exc_info:
-        yield c.run_coroutine(throws, 1)
+        yield c.run(throws, 1)
     assert "hello" in str(exc_info)
 
     if sys.version_info >= (3, 5):
-        results = yield c.run_coroutine(asyncinc, 2, delay=0.01)
+        results = yield c.run(asyncinc, 2, delay=0.01)
         assert results == {a.address: 3, b.address: 3}
 
 
 def test_run_coroutine_sync(c, s, a, b):
-    result = c.run_coroutine(geninc, 2, delay=0.01)
+    result = c.run(geninc, 2, delay=0.01)
     assert result == {a['address']: 3,
                       b['address']: 3}
 
-    result = c.run_coroutine(geninc, 2,
-                             workers=[a['address']])
+    result = c.run(geninc, 2, workers=[a['address']])
     assert result == {a['address']: 3}
 
     t1 = time()
-    result = c.run_coroutine(geninc, 2, delay=10, wait=False)
+    result = c.run(geninc, 2, delay=10, wait=False)
     t2 = time()
     assert result is None
     assert t2 - t1 <= 1.0

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -399,7 +399,7 @@ def test_run_coroutine_dask_worker(c, s, a, b):
         yield gen.sleep(0.001)
         raise gen.Return(dask_worker.id)
 
-    response = yield c._run_coroutine(f)
+    response = yield c.run(f)
     assert response == {a.address: a.id, b.address: b.id}
 
 
@@ -866,7 +866,7 @@ def test_get_client_coroutine(c, s, a, b):
         result = yield future
         raise gen.Return(result)
 
-    results = yield c.run_coroutine(f)
+    results = yield c.run(f)
     assert results == {a.address: 11,
                        b.address: 11}
 
@@ -879,7 +879,7 @@ def test_get_client_coroutine_sync(client, s, a, b):
         result = yield future
         raise gen.Return(result)
 
-    results = client.run_coroutine(f)
+    results = client.run(f)
     assert results == {a['address']: 11,
                        b['address']: 11}
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1960,13 +1960,14 @@ class Worker(ServerNode):
         # logger.info("Finish job %d, %s", i, key)
         raise gen.Return(result)
 
-    def run(self, comm, function, args=(), kwargs=None):
+    def run(self, comm, function, args=(), wait=True, kwargs=None):
         kwargs = kwargs or {}
-        return run(self, comm, function=function, args=args, kwargs=kwargs)
+        return run(self, comm, function=function, args=args, kwargs=kwargs,
+                   wait=wait)
 
     def run_coroutine(self, comm, function, args=(), kwargs=None, wait=True):
         return run(self, comm, function=function, args=args, kwargs=kwargs,
-                   is_coro=True, wait=wait)
+                   wait=wait)
 
     @gen.coroutine
     def actor_execute(self, comm=None, actor=None, function=None, args=(), kwargs={}):
@@ -2915,9 +2916,14 @@ def weight(k, v):
 
 
 @gen.coroutine
-def run(server, comm, function, args=(), kwargs={}, is_coro=False, wait=True):
-    assert wait or is_coro, "Combination not supported"
+def run(server, comm, function, args=(), kwargs={}, is_coro=None, wait=True):
     function = pickle.loads(function)
+    if is_coro is None:
+        is_coro = iscoroutinefunction(function)
+    else:
+        warnings.warn("The is_coro= parameter is deprecated. "
+                      "We now automatically detect coroutines/async functions")
+    assert wait or is_coro, "Combination not supported"
     if args:
         args = pickle.loads(args)
     if kwargs:


### PR DESCRIPTION
Previously we asked users to explicitly provide a keyword argument.  Now we auto-detect this for them.