### PR TITLE
gather_dep: don't request dependencies we already found out we don't need

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1594,8 +1594,10 @@ class Worker(ServerNode):
                 if self.validate:
                     self.validate_state()
 
+                # dep states may have changed before gather_dep runs
+                # if a dep is no longer in-flight then don't fetch it
                 deps = tuple(dep for dep in deps
-                                 if self.dep_state.get(dep) in ('waiting', 'flight'))
+                                 if self.dep_state.get(dep) == 'flight')
 
                 self.log.append(('request-dep', dep, worker, deps))
                 logger.debug("Request %d keys", len(deps))


### PR DESCRIPTION
Came across this while diagnosing another problem.  A dependency is set as in-flight before adding the callback to `gather_dep`, but the state can change in that window if e.g. the task that depended on it was stolen.