### PR TITLE
[WIP] Fix dask.config dict usage in favor of config object interface

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 from . import config
-from dask.config import config
 from .actor import Actor, ActorFuture
 from .core import connect, rpc
 from .deploy import LocalCluster, Adaptive


### PR DESCRIPTION
This PR goes along with https://github.com/dask/dask/pull/4328 (or its predecessor https://github.com/dask/dask/pull/4099).

It was discussed in related issues that it would be best if dask used a configuration object instead of the global config module in `dask/config.py`. I started doing this in 4099 and then ended up creating a separate config package named `donfig` which is what 4328 uses. The only failing tests remaining for me locally were related to the `distributed` package and its use of `dask/config.py:config`; the internal dictionary representing the configuration.

This PR shows one way of working around the transition from internal dict to public config object. I couldn't really think of a better solution. New versions of `donfig` support the `x in config` usage, but old dask config doesn't so it just makes the code ugly.

TODO: Need to fix up tests and find the easiest way to present these changes for the dask devs.