### PR TITLE
Short error message if bokeh cannot be imported

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -123,8 +123,11 @@ def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,
             services[('bokeh', bokeh_port)] = (BokehScheduler,
                                                {'prefix': bokeh_prefix})
         except ImportError as error:
-            logger.info('bokeh import error: %s' % error)
-            
+            if str(error).startswith('No module named'):
+                logger.info('Web dashboard not loaded.  Unable to import bokeh')
+            else:
+                logger.info('Unable to import bokeh: %s' % str(error))
+
     scheduler = Scheduler(loop=loop, services=services,
                           scheduler_file=scheduler_file,
                           security=sec)

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -118,10 +118,13 @@ def main(host, port, bokeh_port, show, _bokeh, bokeh_whitelist, bokeh_prefix,
 
     services = {}
     if _bokeh:
-        with ignoring(ImportError):
+        try:
             from distributed.bokeh.scheduler import BokehScheduler
             services[('bokeh', bokeh_port)] = (BokehScheduler,
                                                {'prefix': bokeh_prefix})
+        except ImportError as error:
+            logger.info('bokeh import error: %s' % error)
+            
     scheduler = Scheduler(loop=loop, services=services,
                           scheduler_file=scheduler_file,
                           security=sec)

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -14,7 +14,7 @@ from tornado.ioloop import IOLoop
 
 from distributed import Scheduler
 from distributed.security import Security
-from distributed.utils import get_ip_interface, ignoring
+from distributed.utils import get_ip_interface
 from distributed.cli.utils import (check_python_3, install_signal_handlers,
                                    uri_from_host_port)
 from distributed.preloading import preload_modules, validate_preload_argv


### PR DESCRIPTION
see https://github.com/dask/distributed/issues/2443

for example 
```
$ dask-scheduler --port 12121 --bokeh-port 21122 --show --host $SLURMD_NODENAME --pid-file dask-scheduler.pid
distributed.scheduler - INFO - -----------------------------------------------
distributed.scheduler - INFO - bokeh import error: libtiff.so.5: cannot open shared object file: No such file or directory
distributed.scheduler - INFO - Clear task state
distributed.scheduler - INFO -   Scheduler at:  tcp://172.30.1.100:12121
distributed.scheduler - INFO - Local Directory: /loc/scratch/27074830/scheduler-ovibbh3q
distributed.scheduler - INFO - -----------------------------------------------
```