### PR TITLE
Start fewer but larger workers with LocalCluster

### DIFF
--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -14,7 +14,7 @@ from tornado import gen
 import pytest
 
 from distributed import Client, Worker, Nanny
-from distributed.deploy.local import LocalCluster
+from distributed.deploy.local import LocalCluster, nprocesses_nthreads
 from distributed.metrics import time
 from distributed.utils_test import (inc, gen_test, slowinc,
                                     assert_cannot_connect,
@@ -527,6 +527,19 @@ def test_local_tls_restart(loop):
             workers_after = set(client.scheduler_info()['workers'])
             assert client.submit(inc, 2).result() == 3
             assert workers_before != workers_after
+
+
+def test_default_process_thread_breakdown():
+    assert nprocesses_nthreads(1) == (1, 1)
+    assert nprocesses_nthreads(4) == (4, 1)
+    assert nprocesses_nthreads(5) == (5, 1)
+    assert nprocesses_nthreads(8) == (4, 2)
+    assert nprocesses_nthreads(12) in ((6, 2), (4, 3))
+    assert nprocesses_nthreads(20) == (5, 4)
+    assert nprocesses_nthreads(24) in ((6, 4), (8, 3))
+    assert nprocesses_nthreads(32) == (8, 4)
+    assert nprocesses_nthreads(40) in ((8, 5), (10, 4))
+    assert nprocesses_nthreads(80) in ((10, 8), (16, 5))
 
 
 if sys.version_info >= (3, 5):


### PR DESCRIPTION
When we have a large number of available cores we should set the default number
of threads per process to be higher than one.

This implements a policy that aims for a number of processes equal to the
square root of the number of cores, at least above a certain amount of cores.

Partially addresses https://github.com/dask/distributed/issues/2450