### PR TITLE
DOC: Use of local cluster in script

### DIFF
--- a/docs/source/local-cluster.rst
+++ b/docs/source/local-cluster.rst
@@ -37,7 +37,7 @@ an ``Client`` with no arguments:
 
       if __name__ == '__main__':
           cluster = LocalCluster()
-          client = client(cluster)
+          client = Client(cluster)
           main(client)
 
 API

--- a/docs/source/local-cluster.rst
+++ b/docs/source/local-cluster.rst
@@ -38,7 +38,7 @@ an ``Client`` with no arguments:
       if __name__ == '__main__':
           cluster = LocalCluster()
           client = Client(cluster)
-          main(client)
+          # Your code follows here
 
 API
 ---

--- a/docs/source/local-cluster.rst
+++ b/docs/source/local-cluster.rst
@@ -28,6 +28,18 @@ an ``Client`` with no arguments:
    >>> client
    <Client: scheduler=127.0.0.1:8786 processes=8 cores=8>
 
+.. note::
+
+   Within a Python script you need to start a local cluster in the
+   ``if __name__ == '__main__'`` block:
+
+   .. code-block:: python
+
+      if __name__ == '__main__':
+          cluster = LocalCluster()
+          client = client(cluster)
+          main(client)
+
 API
 ---
 


### PR DESCRIPTION
Add a note to the Local Cluster docs on how to use `LocalCluster` in a Python script – that is, within the `if __name__ == '__main__'` block. Closes #2422 (by clarifying the docs relating to such usage).