### PR TITLE
Make it more explict that resources are per worker.

### DIFF
--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -48,6 +48,34 @@ When we submit tasks to the cluster we specify constraints per task
    final = client.submit(aggregate, processed, resources={'MEMORY': 70e9})
 
 
+Resources are per worker process
+--------------------------------
+
+If you are using ``dask-worker --nprocs <nprocs>`` the resource will be applied
+to each of the ``nprocs`` workers. Suppose you have 2 GPUs on your machine, if
+you want to use two worker processes, you have 1 GPU per worker process so you
+need to do something like this::
+
+   dask-worker scheduler:8786 --nprocs 2 --resources "GPU=1"
+
+Here is an example that illustrates how to use resources to ensure each task is
+run inside a separate process, which is useful to execute non thread-safe tasks
+or tasks that uses manages multithreading internally::
+
+   dask-worker scheduler:8786 --nprocs 3 --nthreads 2 --resources "process=1"
+
+With the code below, there will be at most 3 tasks running concurrently and
+each task will run in a separate process::
+
+.. code-block:: python
+
+   from distributed import Client
+   client = Client('scheduler:8786')
+
+   futures = [client.submit(non_thread_safe_function, arg,
+                            resources={'process': 1}) for arg in args]
+
+
 Resources are Abstract
 ----------------------
 


### PR DESCRIPTION
Although it is mentioned in the text already, I was confused between the `dask-worker` command (that can create multiple workers) vs "worker".

I think that adding a simple example with `dask-worker --nprocs` helps clearing the suggestion. Suggestions on how to improve it more than welcome!

For more context, some (long) discussion happened in https://github.co
For more context, some discussion happened in https://github.com/dask/dask-jobqueue/issues/181 about how to execute tasks that managed threading internally (in the OP python bindings on top of C++ code that does multi-threading) and some concerns about running non thread-safe tasks in combination with resource. I have to say it took me a while to figure m/dask/dask-jobqueue/issues/181 about how to execute tasks that managed threading internally (in the OP python bindings on top of C++ code that does multi-threading) and some concerns about running non thread-safe tasks in combination with resource. I have to say it took me a while to figure out that resources could be used to solve the problem. 

