### PR TITLE
DOC/API: Signature for base class write / read

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -40,19 +40,32 @@ class Comm(with_metaclass(ABCMeta)):
     # XXX add set_close_callback()?
 
     @abstractmethod
-    def read(self):
+    def read(self, deserializers=None):
         """
         Read and return a message (a Python object).
 
         This method is a coroutine.
+
+        Parameters
+        ----------
+        deserializers : Optional[Dict[str, Tuple[Callable, Callable, bool]]]
+            An optional dict appropriate for distributed.protocol.deserialize.
+            See :ref:`serialization` for more.
         """
 
     @abstractmethod
-    def write(self, msg):
+    def write(self, msg, on_error=None):
         """
         Write a message (a Python object).
 
         This method is a coroutine.
+
+        Parameters
+        ----------
+        msg :
+        on_error : Optional[str]
+            The behavior when serialization fails. See
+            ``distributed.protocol.core.dumps`` for valid values.
         """
 
     @abstractmethod

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -171,6 +171,9 @@ def deserialize(header, frames, deserializers=None):
     ----------
     header: dict
     frames: list of bytes
+    deserializers : Optional[Dict[str, Tuple[Callable, Callable, bool]]]
+        An optional dict mapping a name to a (de)serializer.
+        See `dask_serialize` and `dask_deserialize` for more.
 
     See Also
     --------

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -1,3 +1,5 @@
+.. _serialization:
+
 Serialization
 =============
 


### PR DESCRIPTION
https://github.com/dask/distributed/blob/b818d788deea53b9d6a5fff332d92dcda3084b76/distributed/core.py#L455-L459
will unconditionally pass these arguments, so they should likely be
present in the base class's signature. I think they're generally good to
support if possible.