### PR TITLE
Properly reset dask.config scheduler and shuffle when closing the client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -606,11 +606,8 @@ class Client(Node):
 
         self._start_arg = address
         if set_as_default:
-            self._previous_scheduler = dask.config.get('scheduler', None)
-            dask.config.set(scheduler='dask.distributed')
-
-            self._previous_shuffle = dask.config.get('shuffle', None)
-            dask.config.set(shuffle='tasks')
+            self._set_config = dask.config.set(scheduler='dask.distributed',
+                                               shuffle='tasks')
 
         self._stream_handlers = {
             'key-in-memory': self._handle_key_in_memory,
@@ -1074,9 +1071,9 @@ class Client(Node):
                 pc.stop()
             self._scheduler_identity = {}
             with ignoring(AttributeError):
-                dask.config.set(scheduler=self._previous_scheduler)
-            with ignoring(AttributeError):
-                dask.config.set(shuffle=self._previous_shuffle)
+                # clear the dask.config set keys
+                with self._set_config:
+                    pass
             if self.get == dask.config.get('get', None):
                 del dask.config.config['get']
             if self.status == 'closed':
@@ -1158,13 +1155,6 @@ class Client(Node):
 
         if self._should_close_loop and not shutting_down():
             self._loop_runner.stop()
-
-        with ignoring(AttributeError):
-            dask.config.set(scheduler=self._previous_scheduler)
-        with ignoring(AttributeError):
-            dask.config.set(shuffle=self._previous_shuffle)
-        if self.get == dask.config.get('get', None):
-            del dask.config.config['get']
 
     def shutdown(self, *args, **kwargs):
         """ Deprecated, see close instead

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3243,17 +3243,17 @@ def test_cancel_clears_processing(c, s, *workers):
 def test_default_get():
     with cluster() as (s, [a, b]):
         pre_get = dask.base.get_scheduler()
-        pre_shuffle = dask.config.get('shuffle', None)
+        pytest.raises(KeyError, dask.config.get, 'shuffle')
         with Client(s['address'], set_as_default=True) as c:
             assert dask.base.get_scheduler() == c.get
             assert dask.config.get('shuffle') == 'tasks'
 
         assert dask.base.get_scheduler() == pre_get
-        assert dask.config.get('shuffle') == pre_shuffle
+        pytest.raises(KeyError, dask.config.get, 'shuffle')
 
         c = Client(s['address'], set_as_default=False)
         assert dask.base.get_scheduler() == pre_get
-        assert dask.config.get('shuffle') == pre_shuffle
+        pytest.raises(KeyError, dask.config.get, 'shuffle')
         c.close()
 
         c = Client(s['address'], set_as_default=True)
@@ -3261,7 +3261,7 @@ def test_default_get():
         assert dask.base.get_scheduler() == c.get
         c.close()
         assert dask.base.get_scheduler() == pre_get
-        assert dask.config.get('shuffle') == pre_shuffle
+        pytest.raises(KeyError, dask.config.get, 'shuffle')
 
         with Client(s['address']) as c:
             assert dask.base.get_scheduler() == c.get


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/2473