### PR TITLE
quiet cancelledError for scheduler shutdown

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1090,7 +1090,8 @@ class Client(Node):
             # This makes the shutdown slightly smoother and quieter
             with ignoring(AttributeError, gen.TimeoutError):
                 yield gen.with_timeout(timedelta(milliseconds=100),
-                                       self._handle_scheduler_coroutine)
+                                       self._handle_scheduler_coroutine,
+                                       CancelledError)
 
             if self.scheduler_comm and self.scheduler_comm.comm and not self.scheduler_comm.comm.closed():
                 yield self.scheduler_comm.close()


### PR DESCRIPTION
`gen.with_timeout` unfortunately permanently adds a callback to futures, and when the timeout is over, it doesn't remove that callback.

with python asyncio futures, if you get the result of them when they are cancelled they raise `CancelledErrors`.....  This isn't caught by `error_callback` in `with_timeout`, and so it is printed.

we cancel the futures a few lines down.

for reference: (the tornado callback)

```
    def error_callback(future):
        try:
            future.result()
        except Exception as e:
            if not isinstance(e, quiet_exceptions):
                app_log.error("Exception in Future %r after timeout",
                              future, exc_info=True)
```

possible fix for https://github.com/dask/distributed/issues/2273
