### PR TITLE
Propagate key keyword in progressbar

### DIFF
--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -116,7 +116,7 @@ class Progress(SchedulerPlugin):
 
         if key in self.keys and finish == 'forgotten':
             logger.debug("A task was cancelled (%s), stopping progress", key)
-            self.stop(exception=True)
+            self.stop(exception=True, key=key)
 
     def restart(self, scheduler):
         self.stop()


### PR DESCRIPTION
This is coming up in the `test_many_Progress` test in intermittent failures