### PR TITLE
Expand client clearing timeout to 10s in testing

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -136,7 +136,7 @@ def loop():
     start = time()
     while set(_global_clients):
         sleep(0.1)
-        assert time() < start + 5
+        assert time() < start + 10
 
     _cleanup_dangling()
 


### PR DESCRIPTION
Appveyor can be very very slow sometimes