### PR TITLE
Find Futures inside SubgraphCallable

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -26,6 +26,7 @@ import weakref
 import dask
 from dask.base import tokenize, normalize_token, collections_to_dsk
 from dask.core import flatten, get_dependencies
+from dask.optimization import SubgraphCallable
 from dask.compatibility import apply, unicode
 try:
     from cytoolz import first, groupby, merge, valmap, keymap
@@ -3964,11 +3965,13 @@ def futures_of(o, client=None):
         x = stack.pop()
         if type(x) in (tuple, set, list):
             stack.extend(x)
-        if type(x) is dict:
+        elif type(x) is dict:
             stack.extend(x.values())
-        if isinstance(x, Future):
+        elif type(x) is SubgraphCallable:
+            stack.extend(x.dsk.values())
+        elif isinstance(x, Future):
             futures.add(x)
-        if dask.is_dask_collection(x):
+        elif dask.is_dask_collection(x):
             stack.extend(x.__dask_graph__().values())
 
     if client is not None:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2494,7 +2494,7 @@ def test_wait_on_collections(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_futures_of(c, s, a, b):
+def test_futures_of_get(c, s, a, b):
     x, y, z = c.map(inc, [1, 2, 3])
 
     assert set(futures_of(0)) == set()
@@ -2505,6 +2505,11 @@ def test_futures_of(c, s, a, b):
 
     b = db.Bag({('b', i): f for i, f in enumerate([x, y, z])}, 'b', 3)
     assert set(futures_of(b)) == {x, y, z}
+
+    sg = SubgraphCallable({'x': x, 'y': y, 'z': z,
+                           'out': (add, (add, (add, x, y), z), 'in')},
+                          'out', ('in',))
+    assert set(futures_of(sg)) == {x, y, z}
 
 
 def test_futures_of_class():

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5527,5 +5527,19 @@ def test_get_mix_futures_and_SubgraphCallable(c, s, a, b):
     assert result == 22
 
 
+@gen_cluster(client=True)
+def test_get_mix_futures_and_SubgraphCallable_dask_dataframe(c, s, a, b):
+    dd = pytest.importorskip('dask.dataframe')
+    import pandas as pd
+    df = pd.DataFrame({'x': range(1, 11)})
+    ddf = dd.from_pandas(df, npartitions=2).persist()
+    ddf = ddf.map_partitions(lambda x: x)
+    ddf['x'] = ddf['x'].astype('f8')
+    ddf = ddf.map_partitions(lambda x: x)
+    ddf['x'] = ddf['x'].astype('f8')
+    result = yield c.compute(ddf)
+    assert result.equals(df.astype('f8'))
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # noqa F401

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -27,6 +27,7 @@ from tornado.ioloop import IOLoop
 
 import dask
 from dask import delayed
+from dask.optimization import SubgraphCallable
 import dask.bag as db
 from distributed import (Worker, Nanny, fire_and_forget, LocalCluster,
                          get_client, secede, get_worker, Executor, profile,
@@ -5496,6 +5497,34 @@ def test_profile_bokeh(c, s, a, b):
     with tmpfile('html') as fn:
         yield c.profile(filename=fn)
         assert os.path.exists(fn)
+
+
+@gen_cluster(client=True)
+def test_get_mix_futures_and_SubgraphCallable(c, s, a, b):
+    future = c.submit(add, 1, 2)
+
+    subgraph = SubgraphCallable({'_2': (add, '_0', '_1'),
+                                 '_3': (add, future, '_2')},
+                                '_3', ('_0', '_1'))
+    dsk = {'a': 1,
+           'b': 2,
+           'c': (subgraph, 'a', 'b'),
+           'd': (subgraph, 'c', 'b')}
+
+    future2 = c.get(dsk, 'd', sync=False)
+    result = yield future2
+    assert result == 11
+
+    # Nested subgraphs
+    subgraph2 = SubgraphCallable({'_2': (subgraph, '_0', '_1'),
+                                  '_3': (subgraph, '_2', '_1'),
+                                  '_4': (add, '_3', future2)},
+                                 '_4', ('_0', '_1'))
+
+    dsk2 = {'e': 1, 'f': 2, 'g': (subgraph2, 'e', 'f')}
+
+    result = yield c.get(dsk2, 'g', sync=False)
+    assert result == 22
 
 
 if sys.version_info >= (3, 5):


### PR DESCRIPTION
New releases of `dask` contain a `SubgraphCallable`, which is an opaque
object that contains a subgraph to be computed as a single task. This
worked fine in many cases, but would fail if that graph contained any
Futures, as distributed wouldn't find them and convert them to data
before computing. We now traverse inside `SubgraphCallable` objects,
pulling out any found futures.

This feels like a bit of a hack to me, but I can't think of a better way
to do this without making more major changes to both codebases.

Fixes #2460, dask/dask#4361