### PR TITLE
Iterate over full list of plugins in transition

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3954,7 +3954,7 @@ class Scheduler(ServerNode):
                     except KeyError:
                         pass
                     self.tasks[ts.key] = ts
-                for plugin in self.plugins:
+                for plugin in list(self.plugins):
                     try:
                         plugin.transition(key, start, finish2, *args, **kwargs)
                     except Exception:

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1040,7 +1040,7 @@ def test_pause_executor(c, s, a):
     yield wait(futures)
 
 
-@gen_cluster(client=True, worker_kwargs={'profile_cycle_interval': 100})
+@gen_cluster(client=True, worker_kwargs={'profile_cycle_interval': '10 ms'})
 def test_statistical_profiling_cycle(c, s, a, b):
     futures = c.map(slowinc, range(20), delay=0.05)
     yield wait(futures)


### PR DESCRIPTION
The progress plugin removes itself, which can screw with iteration semantics
This was causing a a failure in test_many_Progress