### PR TITLE
Support alternative --remote-dask-worker SSHCluster() and dask-ssh CLI

### DIFF
--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -47,10 +47,12 @@ from distributed.cli.utils import check_python_3
               help="Serving computation port, defaults to random")
 @click.option('--nanny-port', type=int, default=0,
               help="Serving nanny port, defaults to random")
+@click.option('--remote-dask-worker', default=None, type=str,
+              help="Worker to run. Defaults to distributed.cli.dask_worker")
 @click.pass_context
 def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
          ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python,
-         memory_limit, worker_port, nanny_port):
+         memory_limit, worker_port, nanny_port, remote_dask_worker):
     try:
         hostnames = list(hostnames)
         if hostfile:
@@ -67,7 +69,7 @@ def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
 
     c = SSHCluster(scheduler, scheduler_port, hostnames, nthreads, nprocs,
                    ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python,
-                   memory_limit, worker_port, nanny_port)
+                   memory_limit, worker_port, nanny_port, remote_dask_worker)
 
     import distributed
     print('\n---------------------------------------------------------------')

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -214,9 +214,10 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
                  memory_limit,
                  worker_port,
                  nanny_port,
-                 remote_python=None):
+                 remote_python=None,
+                 remote_dask_worker=None):
 
-    cmd = ('{python} -m distributed.cli.dask_worker '
+    cmd = ('{python} -m {remote_dask_worker} '
            '{scheduler_addr}:{scheduler_port} '
            '--nthreads {nthreads} --nprocs {nprocs} ')
 
@@ -234,6 +235,7 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
 
     cmd = cmd.format(
         python=remote_python or sys.executable,
+        remote_dask_worker=remote_dask_worker or 'distributed.cli.dask_worker',
         scheduler_addr=scheduler_addr,
         scheduler_port=scheduler_port,
         worker_addr=worker_addr,
@@ -273,7 +275,8 @@ class SSHCluster(object):
     def __init__(self, scheduler_addr, scheduler_port, worker_addrs, nthreads=0, nprocs=1,
                  ssh_username=None, ssh_port=22, ssh_private_key=None,
                  nohost=False, logdir=None, remote_python=None,
-                 memory_limit=None, worker_port=None, nanny_port=None):
+                 memory_limit=None, worker_port=None, nanny_port=None,
+                 remote_dask_worker=None):
 
         self.scheduler_addr = scheduler_addr
         self.scheduler_port = scheduler_port
@@ -291,6 +294,7 @@ class SSHCluster(object):
         self.memory_limit = memory_limit
         self.worker_port = worker_port
         self.nanny_port = nanny_port
+        self.remote_dask_worker = remote_dask_worker
 
         # Generate a universal timestamp to use for log files
         import datetime
@@ -351,7 +355,8 @@ class SSHCluster(object):
                                          self.memory_limit,
                                          self.worker_port,
                                          self.nanny_port,
-                                         self.remote_python))
+                                         self.remote_python,
+                                         self.remote_dask_worker))
 
     def shutdown(self):
         all_processes = [self.scheduler] + self.workers

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -215,7 +215,7 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
                  worker_port,
                  nanny_port,
                  remote_python=None,
-                 remote_dask_worker=None):
+                 remote_dask_worker='distributed.cli.dask_worker'):
 
     cmd = ('{python} -m {remote_dask_worker} '
            '{scheduler_addr}:{scheduler_port} '
@@ -235,7 +235,7 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
 
     cmd = cmd.format(
         python=remote_python or sys.executable,
-        remote_dask_worker=remote_dask_worker or 'distributed.cli.dask_worker',
+        remote_dask_worker=remote_dask_worker,
         scheduler_addr=scheduler_addr,
         scheduler_port=scheduler_port,
         worker_addr=worker_addr,
@@ -276,7 +276,7 @@ class SSHCluster(object):
                  ssh_username=None, ssh_port=22, ssh_private_key=None,
                  nohost=False, logdir=None, remote_python=None,
                  memory_limit=None, worker_port=None, nanny_port=None,
-                 remote_dask_worker=None):
+                 remote_dask_worker='distributed.cli.dask_worker'):
 
         self.scheduler_addr = scheduler_addr
         self.scheduler_port = scheduler_port


### PR DESCRIPTION
Tested with distributed.cli.dask_worker, dask_cuda.dask_cuda_worker, and an invalid worker.

Fixes https://github.com/rapidsai/dask-cuda/issues/2