### PR TITLE
Avoid using nprocs keyword in dask-ssh if set to one

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -219,7 +219,8 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
 
     cmd = ('{python} -m {remote_dask_worker} '
            '{scheduler_addr}:{scheduler_port} '
-           '--nthreads {nthreads} --nprocs {nprocs} ')
+           '--nthreads {nthreads}'
+           + ('--nprocs {nprocs}' if nprocs != 1 else ''))
 
     if not nohost:
         cmd += ' --host {worker_addr} '


### PR DESCRIPTION
It's complex and gets in the way.  It also assumes that the underlying
dask-worker command supports it (which may not be universally true as we allow
more dask-worker commands).

Concretely my motivation for this is for dask-cuda-worker