### PR TITLE
Fix LocalCluster to not overallocate memory when overcommitting threads per worker

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -18,7 +18,7 @@ from ..utils import (sync, ignoring, All, silence_logging, LoopRunner,
         log_errors, thread_state, parse_timedelta)
 from ..nanny import Nanny
 from ..scheduler import Scheduler
-from ..worker import Worker, _ncores
+from ..worker import Worker, parse_memory_limit, _ncores
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +110,8 @@ class LocalCluster(Cluster):
         if n_workers and threads_per_worker is None:
             # Overcommit threads per worker, rather than undercommit
             threads_per_worker = max(1, int(math.ceil(_ncores / n_workers)))
+        if n_workers and 'memory_limit' not in worker_kwargs:
+            worker_kwargs['memory_limit'] = parse_memory_limit('auto', 1, n_workers)
 
         worker_kwargs.update({
             'ncores': threads_per_worker,

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -328,15 +328,17 @@ def test_remote_access(loop):
         sync(loop, assert_can_connect_from_everywhere_4_6, c.scheduler.port)
 
 
-def test_memory(loop):
-    with LocalCluster(scheduler_port=0, processes=False, silence_logs=False,
-                      diagnostics_port=None, loop=loop) as cluster:
+@pytest.mark.parametrize('n_workers', [None, 3])
+def test_memory(loop, n_workers):
+    with LocalCluster(n_workers=n_workers, scheduler_port=0, processes=False,
+                      silence_logs=False, diagnostics_port=None, loop=loop) as cluster:
         assert sum(w.memory_limit for w in cluster.workers) <= TOTAL_MEMORY
 
 
-def test_memory_nanny(loop):
-    with LocalCluster(scheduler_port=0, processes=True, silence_logs=False,
-                      diagnostics_port=None, loop=loop) as cluster:
+@pytest.mark.parametrize('n_workers', [None, 3])
+def test_memory_nanny(loop, n_workers):
+    with LocalCluster(n_workers=n_workers, scheduler_port=0, processes=True,
+                      silence_logs=False, diagnostics_port=None, loop=loop) as cluster:
         with Client(cluster.scheduler_address, loop=loop) as c:
             info = c.scheduler_info()
             assert (sum(w['memory_limit'] for w in info['workers'].values())

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2627,11 +2627,11 @@ class Reschedule(Exception):
     pass
 
 
-def parse_memory_limit(memory_limit, ncores):
+def parse_memory_limit(memory_limit, ncores, total_cores=_ncores):
     if memory_limit is None:
         return None
     if memory_limit == 'auto':
-        memory_limit = int(TOTAL_MEMORY * min(1, ncores / _ncores))
+        memory_limit = int(TOTAL_MEMORY * min(1, ncores / total_cores))
     with ignoring(ValueError, TypeError):
         x = float(memory_limit)
         if isinstance(x, float) and x <= 1:


### PR DESCRIPTION
Fixes #2536 