### PR TITLE
Make closing resilient to lacking an address

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -829,7 +829,10 @@ class Worker(ServerNode):
 
             disable_gc_diagnosis()
 
-            logger.info("Stopping worker at %s", self.address)
+            try:
+                logger.info("Stopping worker at %s", self.address)
+            except ValueError:  # address not available if already closed
+                logger.info("Stopping worker")
             self.status = 'closing'
             setproctitle("dask-worker [closing]")
 


### PR DESCRIPTION
Previously we were getting this intermittent error

    File "/home/travis/build/dask/distributed/distributed/worker.py", line 832, in _close
        logger.info("Stopping worker at %s", self.address)
    File "/home/travis/build/dask/distributed/distributed/core.py", line 228, in address
        raise ValueError("cannot get address of non-running Server")