### PR TITLE
fix double init of prometheus metrics

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,4 @@ ipython >= 5.0.0
 jupyter_client >= 4.4.0
 ipykernel >= 4.5.2
 pytest >= 3.0.5
+prometheus_client >= 0.6.0

--- a/distributed/bokeh/scheduler_html.py
+++ b/distributed/bokeh/scheduler_html.py
@@ -170,13 +170,13 @@ class _PrometheusCollector(object):
 
     def collect(self):
         yield self.prometheus_client.core.GaugeMetricFamily(
-            'scheduler_workers_total',
-            'Total number of workers.',
+            'dask_scheduler_workers',
+            'Number of workers.',
             value=len(self.server.workers),
         )
         yield self.prometheus_client.core.GaugeMetricFamily(
-            'scheduler_clients_total',
-            'Total number of clients.',
+            'dask_scheduler_clients',
+            'Number of clients.',
             value=len(self.server.clients),
         )
 

--- a/distributed/bokeh/scheduler_html.py
+++ b/distributed/bokeh/scheduler_html.py
@@ -207,6 +207,7 @@ class PrometheusHandler(RequestHandler):
 
     def get(self):
         self.write(self.prometheus_client.generate_latest())
+        self.set_header('Content-Type', 'text/plain; version=0.0.4')
 
 
 routes = [

--- a/distributed/bokeh/tests/test_scheduler_bokeh_html.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh_html.py
@@ -67,6 +67,8 @@ def test_prefix(c, s, a, b):
              scheduler_kwargs={'services': {('bokeh', 0):  BokehScheduler}})
 def test_prometheus(c, s, a, b):
     pytest.importorskip('prometheus_client')
+    from prometheus_client.parser import text_string_to_metric_families
+
     http_client = AsyncHTTPClient()
 
     # request data twice since there once was a case where metrics got registered multiple times resulting in
@@ -75,3 +77,11 @@ def test_prometheus(c, s, a, b):
         response = yield http_client.fetch('http://localhost:%d/metrics'
                                            % s.services['bokeh'].port)
         assert response.code == 200
+        assert response.headers['Content-Type'] == 'text/plain; version=0.0.4'
+
+        txt = response.body.decode('utf8')
+        families = {
+            familiy.name
+            for familiy in text_string_to_metric_families(txt)
+        }
+        assert 'dask_scheduler_workers' in families

--- a/distributed/bokeh/tests/test_scheduler_bokeh_html.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh_html.py
@@ -68,6 +68,10 @@ def test_prefix(c, s, a, b):
 def test_prometheus(c, s, a, b):
     pytest.importorskip('prometheus_client')
     http_client = AsyncHTTPClient()
-    response = yield http_client.fetch('http://localhost:%d/metrics'
-                                       % s.services['bokeh'].port)
-    assert response.code == 200
+
+    # request data twice since there once was a case where metrics got registered multiple times resulting in
+    # prometheus_client errors
+    for _ in range(2):
+        response = yield http_client.fetch('http://localhost:%d/metrics'
+                                           % s.services['bokeh'].port)
+        assert response.code == 200

--- a/distributed/bokeh/tests/test_worker_bokeh_html.py
+++ b/distributed/bokeh/tests/test_worker_bokeh_html.py
@@ -1,0 +1,20 @@
+import pytest
+pytest.importorskip('bokeh')
+
+from tornado.httpclient import AsyncHTTPClient
+from distributed.utils_test import gen_cluster
+from distributed.bokeh.worker import BokehWorker
+
+
+@gen_cluster(client=True,
+             worker_kwargs={'services': {('bokeh', 0):  BokehWorker}})
+def test_prometheus(c, s, a, b):
+    pytest.importorskip('prometheus_client')
+    http_client = AsyncHTTPClient()
+
+    # request data twice since there once was a case where metrics got registered multiple times resulting in
+    # prometheus_client errors
+    for _ in range(2):
+        response = yield http_client.fetch('http://localhost:%d/metrics'
+                                           % a.services['bokeh'].port)
+        assert response.code == 200

--- a/distributed/bokeh/tests/test_worker_bokeh_html.py
+++ b/distributed/bokeh/tests/test_worker_bokeh_html.py
@@ -10,6 +10,8 @@ from distributed.bokeh.worker import BokehWorker
              worker_kwargs={'services': {('bokeh', 0):  BokehWorker}})
 def test_prometheus(c, s, a, b):
     pytest.importorskip('prometheus_client')
+    from prometheus_client.parser import text_string_to_metric_families
+
     http_client = AsyncHTTPClient()
 
     # request data twice since there once was a case where metrics got registered multiple times resulting in
@@ -18,3 +20,11 @@ def test_prometheus(c, s, a, b):
         response = yield http_client.fetch('http://localhost:%d/metrics'
                                            % a.services['bokeh'].port)
         assert response.code == 200
+        assert response.headers['Content-Type'] == 'text/plain; version=0.0.4'
+
+        txt = response.body.decode('utf8')
+        families = {
+            familiy.name
+            for familiy in text_string_to_metric_families(txt)
+        }
+        assert len(families) > 0

--- a/distributed/bokeh/worker_html.py
+++ b/distributed/bokeh/worker_html.py
@@ -14,21 +14,51 @@ class RequestHandler(web.RequestHandler):
         return os.path.join(dirname, 'templates')
 
 
+class _PrometheusCollector(object):
+    def __init__(self, server, prometheus_client):
+        self.server = server
+        self.prometheus_client = prometheus_client
+
+    def collect(self):
+        # add your metrics here:
+        #
+        # 1. remove the following lines
+        while False:
+            yield None
+        #
+        # 2. yield your metrics
+        #     yield self.prometheus_client.core.GaugeMetricFamily(
+        #         'worker_connections_total',
+        #         'Total number of connections currently open.',
+        #         value=???,
+        #     )
+
+
 class PrometheusHandler(RequestHandler):
+    _initialized = False
+
     def __init__(self, *args, **kwargs):
-        import prometheus_client # keep out of global namespace
+        import prometheus_client  # keep out of global namespace
         self.prometheus_client = prometheus_client
 
         super(PrometheusHandler, self).__init__(*args, **kwargs)
-        # Add metrics like this:
-        # self.workers = self.prometheus_client.Gauge('memory_bytes',
-        #    'Total memory.',
-        #    namespace='worker')
+
+        self._init()
+
+    def _init(self):
+        if PrometheusHandler._initialized:
+            return
+
+        self.prometheus_client.REGISTRY.register(
+            _PrometheusCollector(
+                self.server,
+                self.prometheus_client,
+            )
+        )
+
+        PrometheusHandler._initialized = True
 
     def get(self):
-        # Example metric update
-        # self.workers.set(0.)
-
         self.write(self.prometheus_client.generate_latest())
 
 

--- a/distributed/bokeh/worker_html.py
+++ b/distributed/bokeh/worker_html.py
@@ -60,6 +60,7 @@ class PrometheusHandler(RequestHandler):
 
     def get(self):
         self.write(self.prometheus_client.generate_latest())
+        self.set_header('Content-Type', 'text/plain; version=0.0.4')
 
 
 routes = [

--- a/distributed/bokeh/worker_html.py
+++ b/distributed/bokeh/worker_html.py
@@ -28,8 +28,8 @@ class _PrometheusCollector(object):
         #
         # 2. yield your metrics
         #     yield self.prometheus_client.core.GaugeMetricFamily(
-        #         'worker_connections_total',
-        #         'Total number of connections currently open.',
+        #         'dask_worker_connections',
+        #         'Number of connections currently open.',
         #         value=???,
         #     )
 


### PR DESCRIPTION
Tornado handlers might be initaliazed multiple times within the same
python interpreter process. Adding new prometheus gauges/counters
every time leads to `ValueError: Duplicated timeseries` errors because
`prometheus_client` has one single, global registry to track all known
metrics. Instead, use a class-level singelton instead.