### PR TITLE
TST: Fetch executables from build root.

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -992,7 +992,7 @@ def popen(args, **kwargs):
     if sys.platform.startswith('win'):
         args[0] = os.path.join(sys.prefix, 'Scripts', args[0])
     else:
-        args[0] = os.path.join(sys.prefix, 'bin', args[0])
+        args[0] = os.path.join(os.environ.get('DESTDIR', '') + sys.prefix, 'bin', args[0])
     proc = subprocess.Popen(args, **kwargs)
     try:
         yield proc


### PR DESCRIPTION
When building a package, nothing is installed in the prefix, but to a build root. This means any tests that use the `popen` wrapper cannot find the executables (or find old ones if distributed is installed already).

This looks in the build root instead, if the `DESTDIR` environment variable is set. 