### PR TITLE
Handler blocking

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -102,7 +102,9 @@ class Server(object):
             'connection_stream': self.handle_stream,
         }
         self.handlers.update(handlers)
-        self.blocked_handlers = blocked_handlers or []
+        if blocked_handlers is None:
+            blocked_handlers = dask.config.get('distributed.%s.blocked-handlers' % type(self).lower(), [])
+        self.blocked_handlers = blocked_handlers
         self.stream_handlers = {}
         self.stream_handlers.update(stream_handlers or {})
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -43,6 +43,12 @@ def get_total_physical_memory():
         return 2e9
 
 
+def raise_later(exc):
+    def _raise(*args, **kwargs):
+        raise exc
+    return _raise
+
+
 MAX_BUFFER_SIZE = get_total_physical_memory()
 
 tick_maximum_delay = parse_timedelta(dask.config.get('distributed.admin.tick.limit'), default='ms')
@@ -313,9 +319,6 @@ class Server(object):
 
                 try:
                     op = msg.pop('op')
-                    if op in self.blocked_handlers:
-                        msg = "The '{op}' handler has been explicitly disallowed in {obj}, possibly due to security concerns."
-                        raise ValueError(msg.format(op=op, obj=type(self).__name__))
                 except KeyError:
                     raise ValueError(
                         "Received unexpected message without 'op' key: " %
@@ -334,7 +337,12 @@ class Server(object):
 
                 result = None
                 try:
-                    handler = self.handlers[op]
+                    if op in self.blocked_handlers:
+                        _msg = "The '{op}' handler has been explicitly disallowed in {obj}, possibly due to security concerns."
+                        exc = ValueError(_msg.format(op=op, obj=type(self).__name__))
+                        handler = raise_later(exc)
+                    else:
+                        handler = self.handlers[op]
                 except KeyError:
                     logger.warning("No handler %s found in %s", op,
                                    type(self).__name__, exc_info=True)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -103,7 +103,7 @@ class Server(object):
         }
         self.handlers.update(handlers)
         if blocked_handlers is None:
-            blocked_handlers = dask.config.get('distributed.%s.blocked-handlers' % type(self).lower(), [])
+            blocked_handlers = dask.config.get('distributed.%s.blocked-handlers' % type(self).__name__.lower(), [])
         self.blocked_handlers = blocked_handlers
         self.stream_handlers = {}
         self.stream_handlers.update(stream_handlers or {})

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -314,7 +314,7 @@ class Server(object):
                 try:
                     op = msg.pop('op')
                     if op in self.blocked_handlers:
-                        msg = "The {op} handler has been explicitly disallowed in {obj}, possibly due to security concerns."
+                        msg = "The '{op}' handler has been explicitly disallowed in {obj}, possibly due to security concerns."
                         raise ValueError(msg.format(op=op, obj=type(self).__name__))
                 except KeyError:
                     raise ValueError(

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -338,7 +338,8 @@ class Server(object):
                 result = None
                 try:
                     if op in self.blocked_handlers:
-                        _msg = "The '{op}' handler has been explicitly disallowed in {obj}, possibly due to security concerns."
+                        _msg = ("The '{op}' handler has been explicitly disallowed "
+                                "in {obj}, possibly due to security concerns.")
                         exc = ValueError(_msg.format(op=op, obj=type(self).__name__))
                         handler = raise_later(exc)
                     else:

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -54,6 +54,9 @@ class LocalCluster(Cluster):
         Tornado gen.coroutines.  This should remain False for normal use.
     kwargs: dict
         Extra worker arguments, will be passed to the Worker constructor.
+    blocked_handlers: List[str]
+        A list of strings specifying a blacklist of handlers to disallow on the Scheduler,
+        e.g., ``['feed', 'run_function']``
     service_kwargs: Dict[str, Dict]
         Extra keywords to hand to the running services
     security : Security
@@ -82,7 +85,7 @@ class LocalCluster(Cluster):
                  loop=None, start=None, ip=None, scheduler_port=0,
                  silence_logs=logging.WARN, diagnostics_port=8787,
                  services=None, worker_services=None, service_kwargs=None,
-                 asynchronous=False, security=None, **worker_kwargs):
+                 asynchronous=False, security=None, blocked_handlers=None, **worker_kwargs):
         if start is not None:
             msg = ("The start= parameter is deprecated. "
                    "LocalCluster always starts. "
@@ -133,7 +136,8 @@ class LocalCluster(Cluster):
 
         self.scheduler = Scheduler(loop=self.loop,
                                    services=services,
-                                   security=security)
+                                   security=security,
+                                   blocked_handlers=blocked_handlers)
         self.scheduler_port = scheduler_port
 
         self.workers = []

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -56,7 +56,7 @@ class LocalCluster(Cluster):
         Extra worker arguments, will be passed to the Worker constructor.
     blocked_handlers: List[str]
         A list of strings specifying a blacklist of handlers to disallow on the Scheduler,
-        e.g., ``['feed', 'run_function']``
+        like ``['feed', 'run_function']``
     service_kwargs: Dict[str, Dict]
         Extra keywords to hand to the running services
     security : Security

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -14,7 +14,6 @@ from tornado import gen
 import pytest
 
 from distributed import Client, Worker, Nanny
-from distributed.core import CommClosedError
 from distributed.deploy.local import LocalCluster, nprocesses_nthreads
 from distributed.metrics import time
 from distributed.utils_test import (inc, gen_test, slowinc,
@@ -45,8 +44,10 @@ def test_simple(loop):
 def test_local_cluster_supports_blocked_handlers(loop):
     with LocalCluster(blocked_handlers=['run_function'], loop=loop) as c:
         with Client(c) as client:
-            with pytest.raises(CommClosedError):
+            with pytest.raises(ValueError) as exc:
                 client.run_on_scheduler(lambda x: x, 42)
+
+    assert "'run_function' handler has been explicitly disallowed in Scheduler" in str(exc.value)
 
 
 @pytest.mark.skipif('sys.version_info[0] == 2', reason='fork issues')

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -11,6 +11,7 @@ distributed:
   scheduler:
     allowed-failures: 3     # number of retries before a task is considered bad
     bandwidth: 100000000    # 100 MB/s estimated worker-worker bandwidth
+    blocked-handlers: []
     default-data-size: 1000
     # Number of seconds to wait until workers or clients are removed from the events log
     # after they have been removed from the scheduler
@@ -22,6 +23,7 @@ distributed:
     preload-argv: []
 
   worker:
+    blocked-handlers: []
     multiprocessing-method: forkserver
     use-file-locking: True
     connections:            # Maximum concurrent connections for data

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -31,7 +31,7 @@ class ServerNode(Node, Server):
     # XXX avoid inheriting from Server? there is some large potential for confusion
     # between base and derived attribute namespaces...
 
-    def __init__(self, handlers=None, stream_handlers=None,
+    def __init__(self, handlers=None, blocked_handlers=None, stream_handlers=None,
                  connection_limit=512, deserialize=True,
                  connection_args=None, io_loop=None, serializers=None,
                  deserializers=None):
@@ -42,6 +42,7 @@ class ServerNode(Node, Server):
                       serializers=serializers,
                       deserializers=deserializers)
         Server.__init__(self, handlers=handlers,
+                        blocked_handlers=blocked_handlers,
                         stream_handlers=stream_handlers,
                         connection_limit=connection_limit,
                         deserialize=deserialize, io_loop=self.io_loop)

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -104,9 +104,13 @@ def test_server_raises_on_blocked_handlers(loop):
 
         comm = yield connect(server.address)
         yield comm.write({'op': 'ping'})
-        with pytest.raises(CommClosedError):
-            msg = yield comm.read()
+        msg = yield comm.read()
 
+        assert 'exception' in msg
+        assert isinstance(msg['exception'], ValueError)
+        assert "'ping' handler has been explicitly disallowed" in repr(msg['exception'])
+
+        comm.close()
         server.stop()
 
     res = loop.run_sync(f)

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -11,7 +11,7 @@ import pytest
 import dask
 from distributed.compatibility import finalize, get_thread_identity
 from distributed.core import (pingpong, Server, rpc, connect, send_recv,
-                               coerce_to_address, ConnectionPool, CommClosedError)
+                               coerce_to_address, ConnectionPool)
 from distributed.protocol.compression import compressions
 
 from distributed.metrics import time

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -16,7 +16,7 @@ from tornado import gen
 import pytest
 
 from distributed import Nanny, Worker, Client, wait, fire_and_forget
-from distributed.core import connect, rpc, CommClosedError
+from distributed.core import connect, rpc
 from distributed.scheduler import Scheduler, BANDWIDTH
 from distributed.client import wait
 from distributed.metrics import time

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -271,6 +271,12 @@ def test_blocked_handlers_are_respected(s, a, b):
     yield comm.close()
 
 
+def test_scheduler_init_pulls_blocked_handlers_from_config():
+    with dask.config.set({'distributed.scheduler.blocked-handlers': ['test-handler']}):
+        s = Scheduler()
+    assert s.blocked_handlers == ['test-handler']
+
+
 @gen_cluster()
 def test_feed(s, a, b):
     def func(scheduler):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -253,7 +253,7 @@ def test_add_worker(s, a, b):
 
 
 @gen_cluster(scheduler_kwargs={'blocked_handlers': ['feed']})
-def test_blocked_handlers_is_respected(s, a, b):
+def test_blocked_handlers_are_respected(s, a, b):
     def func(scheduler):
         return dumps(dict(scheduler.worker_info))
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -262,8 +262,11 @@ def test_blocked_handlers_are_respected(s, a, b):
                       'function': dumps(func),
                       'interval': 0.01})
 
-    with pytest.raises(CommClosedError):
-        response = yield comm.read()
+    response = yield comm.read()
+
+    assert 'exception' in response
+    assert isinstance(response['exception'], ValueError)
+    assert "'feed' handler has been explicitly disallowed" in repr(response['exception'])
 
     yield comm.close()
 


### PR DESCRIPTION
Closes #2550 by surfacing a `blocked_handlers` kwarg on a few different classes, which serves the purpose of ultimately preventing certain routes on the Scheduler from being called by workers.