### PR TITLE
BUG: yield for coroutine handlers

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -21,7 +21,7 @@ from tornado.tcpserver import TCPServer
 from ..compatibility import finalize, PY3
 from ..threadpoolexecutor import ThreadPoolExecutor
 from ..utils import (ensure_bytes, ensure_ip, get_ip, get_ipv6, nbytes,
-                     parse_timedelta, shutting_down, iscoroutinefunction)
+                     parse_timedelta, shutting_down)
 
 from .registry import Backend, backends
 from .addressing import parse_host_port, unparse_host_port
@@ -433,9 +433,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
                      address, self.contact_address)
         local_address = self.prefix + get_stream_address(stream)
         comm = self.comm_class(stream, local_address, address, self.deserialize)
-        maybe_coro = self.comm_handler(comm)
-        if iscoroutinefunction(self.comm_handler):
-            yield maybe_coro
+        yield self.comm_handler(comm)
 
     def get_host_port(self):
         """


### PR DESCRIPTION
Without this change, I see the following when running [this](https://github.com/TomAugspurger/dask-perf/blob/master/bench_comm.py)
comm benchmark.

```
(ucx-dev) an.taugspurger@dgx05:~/ucx-dev-env/dask-perf$ python bench_comm.py
/home/nfs/an.taugspurger/ucx-dev-env/distributed/distributed/comm/tcp.py:436: RuntimeWarning: coroutine 'server_handle_comm' was never awaited
  self.comm_handler(comm)
```

In Antoine's original benchmark, tornado was used throughout (for the handlers). Perhaps tornado does something special in that case. But I believe that to handle `async def` functions, we'll need something like this patch.