### PR TITLE
Add warning if creating scratch directories takes a long time

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -5,6 +5,7 @@ from functools import partial
 import io
 import socket
 import sys
+from time import sleep
 import traceback
 
 import numpy as np
@@ -20,7 +21,7 @@ from distributed.utils import (All, sync, is_kernel, ensure_ip, str_graph,
                                iterator_to_queue, _maybe_complex, read_block, seek_delimiter,
                                funcname, ensure_bytes, open_port, get_ip_interface, nbytes,
                                set_thread_state, thread_state, LoopRunner,
-                               parse_bytes, parse_timedelta)
+                               parse_bytes, parse_timedelta, warn_on_duration)
 from distributed.utils_test import loop, loop_in_thread  # noqa: F401
 from distributed.utils_test import (div, has_ipv6, inc, throws, gen_test,
         captured_logger)
@@ -526,3 +527,17 @@ def test_all_exceptions_logging():
         yield gen.sleep(0.1)
 
     assert 'foo1234' not in sio.getvalue()
+
+
+def test_warn_on_duration():
+    with pytest.warns(None) as record:
+        with warn_on_duration('10s', 'foo'):
+            pass
+    assert not record
+
+    with pytest.warns(None) as record:
+        with warn_on_duration('1ms', 'foo'):
+            sleep(0.100)
+
+    assert len(record) == 1
+    assert 'foo' in str(record[0].message)

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -539,5 +539,5 @@ def test_warn_on_duration():
         with warn_on_duration('1ms', 'foo'):
             sleep(0.100)
 
-    assert len(record) == 1
+    assert len(record) == 1, record
     assert 'foo' in str(record[0].message)

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -539,5 +539,5 @@ def test_warn_on_duration():
         with warn_on_duration('1ms', 'foo'):
             sleep(0.100)
 
-    assert len(record) == 1, record
+    assert len(record) == 1, [str(r.message) for r in record]
     assert 'foo' in str(record[0].message)

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -539,5 +539,5 @@ def test_warn_on_duration():
         with warn_on_duration('1ms', 'foo'):
             sleep(0.100)
 
-    assert len(record) == 1, [str(r.message) for r in record]
-    assert 'foo' in str(record[0].message)
+    assert record
+    assert any('foo' in str(rec.message) for rec in record)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1425,3 +1425,12 @@ def iscoroutinefunction(f):
     if sys.version_info >= (3, 5) and inspect.iscoroutinefunction(f):
         return True
     return False
+
+
+@contextmanager
+def warn_on_duration(duration, msg):
+    start = time()
+    yield
+    stop = time()
+    if stop - start > parse_timedelta(duration):
+        warnings.warn(msg, stacklevel=2)


### PR DESCRIPTION
This adds a context manager `warn_on_duration` which warns if an action
takes a surprisingly long time.

We then use the context manager when creating a worker's local
directory.

Fixes https://github.com/rapidsai/dask-cuda/issues/11
See also https://github.com/dask/dask-jobqueue/issues/193