### PR TITLE
Ensure that default `remote_dask_worker` is used

### DIFF
--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -47,13 +47,12 @@ from distributed.cli.utils import check_python_3
               help="Serving computation port, defaults to random")
 @click.option('--nanny-port', type=int, default=0,
               help="Serving nanny port, defaults to random")
-@click.option('--remote-dask-worker', default=None, type=str,
+@click.option('--remote-dask-worker', type=str,
+              default="distributed.cli.dask_worker",
               help="Worker to run. Defaults to distributed.cli.dask_worker")
 @click.pass_context
-def main(ctx, scheduler, scheduler_port, hostnames, hostfile, log_directory, **kwargs):
-
-    if kwargs.get("remote_dask_worker") is None:
-        kwargs.pop("remote_dask_worker")
+def main(ctx, scheduler, scheduler_port, hostnames, hostfile, log_directory,
+         **kwargs):
 
     try:
         hostnames = list(hostnames)
@@ -69,7 +68,8 @@ def main(ctx, scheduler, scheduler_port, hostnames, hostfile, log_directory, **k
         print(ctx.get_help())
         exit(1)
 
-    c = SSHCluster(scheduler, scheduler_port, hostnames, logdir=log_directory, **kwargs)
+    c = SSHCluster(scheduler, scheduler_port, hostnames, logdir=log_directory,
+                   **kwargs)
 
     import distributed
     print('\n---------------------------------------------------------------')

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -52,6 +52,9 @@ from distributed.cli.utils import check_python_3
 @click.pass_context
 def main(ctx, scheduler, scheduler_port, hostnames, hostfile, log_directory, **kwargs):
 
+    if kwargs.get("remote_dask_worker") is None:
+        kwargs.pop("remote_dask_worker")
+
     try:
         hostnames = list(hostnames)
         if hostfile:

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -50,9 +50,8 @@ from distributed.cli.utils import check_python_3
 @click.option('--remote-dask-worker', default=None, type=str,
               help="Worker to run. Defaults to distributed.cli.dask_worker")
 @click.pass_context
-def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
-         ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python,
-         memory_limit, worker_port, nanny_port, remote_dask_worker):
+def main(ctx, scheduler, scheduler_port, hostnames, hostfile, **kwargs):
+
     try:
         hostnames = list(hostnames)
         if hostfile:
@@ -67,9 +66,7 @@ def main(ctx, scheduler, scheduler_port, hostnames, hostfile, nthreads, nprocs,
         print(ctx.get_help())
         exit(1)
 
-    c = SSHCluster(scheduler, scheduler_port, hostnames, nthreads, nprocs,
-                   ssh_username, ssh_port, ssh_private_key, nohost, log_directory, remote_python,
-                   memory_limit, worker_port, nanny_port, remote_dask_worker)
+    c = SSHCluster(scheduler, scheduler_port, hostnames, **kwargs)
 
     import distributed
     print('\n---------------------------------------------------------------')

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -50,7 +50,7 @@ from distributed.cli.utils import check_python_3
 @click.option('--remote-dask-worker', default=None, type=str,
               help="Worker to run. Defaults to distributed.cli.dask_worker")
 @click.pass_context
-def main(ctx, scheduler, scheduler_port, hostnames, hostfile, **kwargs):
+def main(ctx, scheduler, scheduler_port, hostnames, hostfile, log_directory, **kwargs):
 
     try:
         hostnames = list(hostnames)
@@ -66,7 +66,7 @@ def main(ctx, scheduler, scheduler_port, hostnames, hostfile, **kwargs):
         print(ctx.get_help())
         exit(1)
 
-    c = SSHCluster(scheduler, scheduler_port, hostnames, **kwargs)
+    c = SSHCluster(scheduler, scheduler_port, hostnames, logdir=log_directory, **kwargs)
 
     import distributed
     print('\n---------------------------------------------------------------')

--- a/distributed/cli/tests/test_dask_ssh.py
+++ b/distributed/cli/tests/test_dask_ssh.py
@@ -1,0 +1,25 @@
+from __future__ import print_function, division, absolute_import
+
+import subprocess
+from time import sleep
+
+import pytest
+pytest.importorskip('paramiko')
+
+from distributed import Client
+from distributed.metrics import time
+from distributed.utils_test import popen
+from distributed.utils_test import loop  # noqa: F401
+
+
+def test_basic(loop):
+    with popen(['dask-ssh', '--scheduler-port', '54321',
+                '127.0.0.1', '127.0.0.1'],
+               stdin=subprocess.DEVNULL):
+        with Client("tcp://127.0.0.1:54321") as c:
+            start = time()
+            while len(c.scheduler_info()['workers']) != 2:
+                assert time() < start + 10
+                sleep(0.2)
+
+            assert c.submit(lambda x: x + 1, 10, workers=1).result() == 11

--- a/distributed/cli/tests/test_dask_ssh.py
+++ b/distributed/cli/tests/test_dask_ssh.py
@@ -16,10 +16,9 @@ def test_basic(loop):
     with popen(['dask-ssh', '--scheduler-port', '54321',
                 '127.0.0.1', '127.0.0.1'],
                stdin=subprocess.DEVNULL):
-        with Client("tcp://127.0.0.1:54321") as c:
+        with Client("tcp://127.0.0.1:54321", loop=loop) as c:
+
             start = time()
             while len(c.scheduler_info()['workers']) != 2:
                 assert time() < start + 10
                 sleep(0.2)
-
-            assert c.submit(lambda x: x + 1, 10, workers=1).result() == 11

--- a/distributed/cli/tests/test_dask_ssh.py
+++ b/distributed/cli/tests/test_dask_ssh.py
@@ -12,11 +12,11 @@ from distributed.utils_test import popen
 from distributed.utils_test import loop  # noqa: F401
 
 
-def test_basic(loop):
+def test_dask_ssh_cluster_creation(loop):
     with popen(['dask-ssh', '--scheduler-port', '54321',
                 '127.0.0.1', '127.0.0.1'],
                stdin=subprocess.DEVNULL):
-        with Client("tcp://127.0.0.1:54321", loop=loop) as c:
+        with Client("tcp://127.0.0.1:54321", loop=loop, timeout=20) as c:
 
             start = time()
             while len(c.scheduler_info()['workers']) != 2:

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -297,8 +297,6 @@ class SSHCluster(object):
         self.nanny_port = nanny_port
         if remote_dask_worker is None:
             self.remote_dask_worker = 'distributed.cli.dask_worker'
-        else:
-            self.remote_dask_worker = remote_dask_worker
 
         # Generate a universal timestamp to use for log files
         import datetime

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -295,7 +295,8 @@ class SSHCluster(object):
         self.memory_limit = memory_limit
         self.worker_port = worker_port
         self.nanny_port = nanny_port
-        self.remote_dask_worker = remote_dask_worker
+        if remote_dask_worker is None:
+            self.remote_dask_worker = 'distributed.cli.dask_worker'
 
         # Generate a universal timestamp to use for log files
         import datetime

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -295,8 +295,7 @@ class SSHCluster(object):
         self.memory_limit = memory_limit
         self.worker_port = worker_port
         self.nanny_port = nanny_port
-        if remote_dask_worker is None:
-            self.remote_dask_worker = 'distributed.cli.dask_worker'
+        self.remote_dask_worker = remote_dask_worker
 
         # Generate a universal timestamp to use for log files
         import datetime

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -297,6 +297,8 @@ class SSHCluster(object):
         self.nanny_port = nanny_port
         if remote_dask_worker is None:
             self.remote_dask_worker = 'distributed.cli.dask_worker'
+        else:
+            self.remote_dask_worker = remote_dask_worker
 
         # Generate a universal timestamp to use for log files
         import datetime


### PR DESCRIPTION
Currently, the cli will pass `remote_dask_worker=None` to the `SSHCluster` and hence override the default kwarg resulting in `dask-ssh` without the `--remote-dask-worker` flag being broken.

- [x] Add test for `distributed.cli.dask_ssh`?
- [ ] Anything else?