### PR TITLE
Fix Torando 6 test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ dist: trusty
 env:
   matrix:
     - PYTHON=2.7 TESTS=true PACKAGES="python-blosc futures faulthandler lz4"
-    - PYTHON=3.5.4 TESTS=true COVERAGE=true PACKAGES="python-blosc lz4" CRICK=true
-    - PYTHON=3.6 TESTS=true PACKAGES="scikit-learn lz4"
-    - PYTHON=3.7 TESTS=true PACKAGES="scikit-learn python-snappy python-blosc"
+    - PYTHON=3.5.4 TESTS=true COVERAGE=true PACKAGES="python-blosc lz4" CRICK=true TORNADO=6
+    - PYTHON=3.6 TESTS=true PACKAGES="scikit-learn lz4" TORNADO=5
+    - PYTHON=3.7 TESTS=true PACKAGES="scikit-learn python-snappy python-blosc" TORNADO=6
 
 matrix:
   fast_finish: true

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -51,7 +51,7 @@ conda install -q \
     scipy \
     tblib \
     toolz \
-    tornado \
+    tornado=${TORNADO:-5}\
     $PACKAGES
 
 pip install -q pytest-repeat pytest-faulthandler
@@ -70,10 +70,6 @@ fi;
 
 # Install distributed
 pip install --no-deps -e .
-
-if [[ ! -z $TORNADO ]]; then
-    pip install -U tornado==$TORNADO
-fi
 
 # For debugging
 echo -e "--\n--Conda Environment\n--"

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -33,10 +33,8 @@ def test_defaults(loop):
                 assert_can_connect_from_everywhere_4_6(8786, 5.0),  # main port
             ]
 
-        loop.run_sync(f)
-
         with Client('127.0.0.1:%d' % Scheduler.default_port, loop=loop) as c:
-            pass
+            c.sync(f)
 
     with pytest.raises(Exception):
         requests.get('http://127.0.0.1:8787/status/')
@@ -53,10 +51,9 @@ def test_hostport(loop):
                 assert_can_connect_locally_4(8978, 5.0),
             ]
 
-        loop.run_sync(f)
-
         with Client('127.0.0.1:8978', loop=loop) as c:
             assert len(c.ncores()) == 0
+            c.sync(f)
 
 
 def test_no_bokeh(loop):

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -624,8 +624,9 @@ def test_tls_reject_certificate():
     listener.start()
 
     with pytest.raises(EnvironmentError) as excinfo:
-        yield connect(listener.contact_address, timeout=0.5,
+        comm = yield connect(listener.contact_address, timeout=0.5,
                       connection_args={'ssl_context': bad_cli_ctx})
+        yield comm.write({'x': 'foo'})  # TODO: why is this necessary in Tornado 6 ?
 
     # The wrong error is reported on Python 2, see https://github.com/tornadoweb/tornado/pull/2028
     if sys.version_info >= (3,) and os.name != 'nt':


### PR DESCRIPTION
These were failing in Tornado 6

They were faulty anyway because the IOLoop had been run before being
used a second time.