### PR TITLE
small change to use localhost for services when using ucx

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1112,7 +1112,8 @@ class Scheduler(ServerNode):
             if listen_ip == '0.0.0.0':
                 listen_ip = ''
 
-            if isinstance(addr_or_port, str) and addr_or_port.startswith('inproc://'):
+            if isinstance(addr_or_port, str) and (addr_or_port.startswith('inproc://')
+                                                  or addr_or_port.startswith('ucx://')):
                 listen_ip = 'localhost'
 
             # Services listen on all addresses


### PR DESCRIPTION
This PR resolves https://github.com/dask/distributed/issues/2580.  I decided to not go down the route of adding bokeh-host at the moment.  There is a fair bit of infrastructure in place just above the `inproc` detection which could be overridden if `bokeh_host` is set.  Alternatively, the [BokehServer](https://github.com/dask/distributed/blob/master/distributed/bokeh/core.py#L21-L377) could be set with `bokeh_host` and ignore the incoming addr to listen on.  

With that said, the above change makes UCX-bokeh interactions passable and gets Boken running on localhost rather than a UCX addr