### PR TITLE
.detach_() pytorch tensor to serialize data as numpy array.

### DIFF
--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -36,4 +36,10 @@ def test_resnet():
 def test_deserialize_grad():
     a = np.random.rand(8, 1)
     t = torch.tensor(a, requires_grad=True, dtype=torch.float)
-    deserialize(*serialize(t))
+    t2 = deserialize(*serialize(t))
+
+    assert t2.requires_grad
+
+    a = np.around(a, decimals=6)
+    t2 = np.around(t2.detach_().numpy(), decimals=6)
+    assert a.all() == t2.all()

--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -31,3 +31,10 @@ def test_resnet():
     header, frames = serialize(model)
     model2 = deserialize(header, frames)
     assert str(model) == str(model2)
+
+
+def test_deserialize_grad():
+    torch.set_printoptions(precision=10)
+    a = np.random.rand(8, 1)
+    t = torch.tensor(a, requires_grad=True, dtype=torch.float)
+    deserialize(*serialize(t))

--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -34,7 +34,6 @@ def test_resnet():
 
 
 def test_deserialize_grad():
-    torch.set_printoptions(precision=10)
     a = np.random.rand(8, 1)
     t = torch.tensor(a, requires_grad=True, dtype=torch.float)
     deserialize(*serialize(t))

--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -38,7 +38,4 @@ def test_deserialize_grad():
     t = torch.tensor(a, requires_grad=True, dtype=torch.float)
     t2 = deserialize(*serialize(t))
     assert t2.requires_grad
-
-    a = np.around(a, decimals=6)
-    t2 = np.around(t2.detach_().numpy(), decimals=6)
-    assert a.all() == t2.all()
+    assert np.allclose(a, t2.detach_().numpy())

--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -37,7 +37,6 @@ def test_deserialize_grad():
     a = np.random.rand(8, 1)
     t = torch.tensor(a, requires_grad=True, dtype=torch.float)
     t2 = deserialize(*serialize(t))
-
     assert t2.requires_grad
 
     a = np.around(a, decimals=6)

--- a/distributed/protocol/torch.py
+++ b/distributed/protocol/torch.py
@@ -7,7 +7,7 @@ import numpy as np
 
 @dask_serialize.register(torch.Tensor)
 def serialize_torch_Tensor(t):
-    header, frames = serialize(t.detach_().numpy())
+    header, frames = serialize(t.detach().numpy())
     if t.grad is not None:
         grad_header, grad_frames = serialize(t.grad.numpy())
         header['grad'] = {'header': grad_header, 'start': len(frames)}

--- a/distributed/protocol/torch.py
+++ b/distributed/protocol/torch.py
@@ -7,12 +7,13 @@ import numpy as np
 
 @dask_serialize.register(torch.Tensor)
 def serialize_torch_Tensor(t):
-    header, frames = serialize(t.detach().numpy())
+    requires_grad_ = t.requires_grad
+    header, frames = serialize(t.detach_().numpy())
     if t.grad is not None:
         grad_header, grad_frames = serialize(t.grad.numpy())
         header['grad'] = {'header': grad_header, 'start': len(frames)}
         frames += grad_frames
-    header['requires_grad'] = t.requires_grad
+    header['requires_grad'] = requires_grad_
     header['device'] = t.device.type
     return header, frames
 

--- a/distributed/protocol/torch.py
+++ b/distributed/protocol/torch.py
@@ -1,5 +1,5 @@
 from .serialize import (serialize, dask_serialize, dask_deserialize,
-        register_generic)
+                        register_generic)
 
 import torch
 import numpy as np
@@ -7,7 +7,7 @@ import numpy as np
 
 @dask_serialize.register(torch.Tensor)
 def serialize_torch_Tensor(t):
-    header, frames = serialize(t.numpy())
+    header, frames = serialize(t.detach_().numpy())
     if t.grad is not None:
         grad_header, grad_frames = serialize(t.grad.numpy())
         header['grad'] = {'header': grad_header, 'start': len(frames)}
@@ -22,7 +22,8 @@ def deserialize_torch_Tensor(header, frames):
     if header.get('grad', False):
         i = header['grad']['start']
         frames, grad_frames = frames[:i], frames[i:]
-        grad = dask_deserialize.dispatch(np.ndarray)(header['grad']['header'], grad_frames)
+        grad = dask_deserialize.dispatch(np.ndarray)(header['grad']['header'],
+                                                     grad_frames)
     else:
         grad = None
 


### PR DESCRIPTION
This commit is related to #2581. Tensors with requires_grad=True cannot
be converted to numpy unless they are detached from the computational
graph first. To fix that, the tensor has to be detached as a leaf using
the .detach_() method. For more information see:

https://pytorch.org/docs/stable/autograd.html#torch.Tensor.detach_