### PR TITLE
Use ensure_dict in _optimize_insert_futures

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -28,6 +28,7 @@ from dask.base import tokenize, normalize_token, collections_to_dsk
 from dask.core import flatten, get_dependencies
 from dask.optimization import SubgraphCallable
 from dask.compatibility import apply, unicode
+from dask.utils import ensure_dict
 try:
     from cytoolz import first, groupby, merge, valmap, keymap
 except ImportError:
@@ -2354,7 +2355,7 @@ class Client(Node):
                 if tokey(key) in self.futures:
                     if not changed:
                         changed = True
-                        dsk = dict(dsk)
+                        dsk = ensure_dict(dsk)
                     dsk[key] = Future(key, self, inform=False)
 
         if changed:


### PR DESCRIPTION
This PR updates `_optimize_insert_futures` to use `dask.utils.ensure_dict` instead of the built-in `dict` constructor when converting a dask graph to a dictionary.

Both `dask.utils.ensure_dict` and `dict` will produce the same output, but `dask.utils.ensure_dict` is faster when dealing with large `HighLevelGraph`s for dask collections with lots of chunks / partitions. 

For example:

```python
In [1]: import dask

In [2]: import dask.array as da

In [3]: a = da.random.randint(0, 100, size=200_000, chunks=1)

In [4]: # Add additional layers to the underlying HighLevelGraph
   ...: a = a + 1
   ...: a = a * 2

In [5]: len(a.dask)
Out[5]: 600000

In [6]: %timeit -n 1 dict(a.dask)
1.43 s ± 60.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [7]: %timeit -n 1 dask.utils.ensure_dict(a.dask)
272 ms ± 11.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [8]: dict(a.dask) == dask.utils.ensure_dict(a.dask)
Out[8]: True
```