### PR TITLE
Forward kwargs through Nanny to Worker

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -233,17 +233,16 @@ class LocalCluster(Cluster):
         raise gen.Return(self)
 
     @gen.coroutine
-    def _start_worker(self, death_timeout=60, **worker_kwargs):
+    def _start_worker(self, death_timeout=60, **kwargs):
         if self.status and self.status.startswith('clos'):
             warnings.warn("Tried to start a worker while status=='%s'" % self.status)
             return
 
         if self.processes:
             W = Nanny
-            kwargs = dict(quiet=True, worker_kwargs=worker_kwargs)
+            kwargs['quiet'] = True
         else:
             W = Worker
-            kwargs = worker_kwargs
 
         w = W(self.scheduler.address, loop=self.loop,
               death_timeout=death_timeout,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -242,8 +242,8 @@ class LocalCluster(Cluster):
             W = Nanny
             kwargs = dict(quiet=True, worker_kwargs=worker_kwargs)
         else:
-            kwargs = worker_kwargs
             W = Worker
+            kwargs = worker_kwargs
 
         w = W(self.scheduler.address, loop=self.loop,
               death_timeout=death_timeout,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -233,15 +233,16 @@ class LocalCluster(Cluster):
         raise gen.Return(self)
 
     @gen.coroutine
-    def _start_worker(self, death_timeout=60, **kwargs):
+    def _start_worker(self, death_timeout=60, **worker_kwargs):
         if self.status and self.status.startswith('clos'):
             warnings.warn("Tried to start a worker while status=='%s'" % self.status)
             return
 
         if self.processes:
             W = Nanny
-            kwargs['quiet'] = True
+            kwargs = dict(quiet=True, worker_kwargs=worker_kwargs)
         else:
+            kwargs = worker_kwargs
             W = Worker
 
         w = W(self.scheduler.address, loop=self.loop,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -43,7 +43,7 @@ class Nanny(ServerNode):
             memory_limit='auto', reconnect=True, validate=False, quiet=False,
             resources=None, silence_logs=None, death_timeout=None, preload=(),
             preload_argv=[], security=None, contact_address=None,
-            listen_address=None, worker_class=None, env=None, worker_kwargs={}, **kwargs):
+            listen_address=None, worker_class=None, env=None, **worker_kwargs):
 
         if scheduler_file:
             cfg = json_load_robust(scheduler_file)
@@ -97,8 +97,7 @@ class Nanny(ServerNode):
                     'run': self.run}
 
         super(Nanny, self).__init__(handlers, io_loop=self.loop,
-                                    connection_args=self.connection_args,
-                                    **kwargs)
+                                    connection_args=self.connection_args)
 
         if self.memory_limit:
             pc = PeriodicCallback(self.memory_monitor, 100, io_loop=self.loop)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -197,7 +197,8 @@ class Nanny(ServerNode):
                     self._given_worker_port)
 
         if self.process is None:
-            worker_kwargs = dict(ncores=self.ncores,
+            worker_kwargs = dict(scheduler_ip=self.scheduler_addr,
+                                 ncores=self.ncores,
                                  local_dir=self.local_dir,
                                  services=self.services,
                                  service_ports={'nanny': self.port},
@@ -214,7 +215,7 @@ class Nanny(ServerNode):
                                  contact_address=self.contact_address)
             worker_kwargs.update(self.worker_kwargs)
             self.process = WorkerProcess(
-                worker_args=(self.scheduler_addr,),
+                worker_args=tuple(),
                 worker_kwargs=worker_kwargs,
                 worker_start_args=(start_arg,),
                 silence_logs=self.silence_logs,


### PR DESCRIPTION
Ensure `Nanny` forwards kwargs to `Worker`. kwargs are no longer forwarded to `ServerNode`.

kwargs `scheduler_port`, `scheduler_file`, and `loop` are still "intercepted" by `Nanny.__init__` (and are not forwarded to Worker). I'm assuming this is okay for now.

For readability I've also moved `scheduler_ip` to the kwargs object (instead of in the `worker_args`).

This would resolve part of https://github.com/dask/distributed/issues/2456

Let me know if I should add a test (?)