### PR TITLE
Specify data storage explicitly from Worker constructor

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -244,10 +244,9 @@ class LocalCluster(Cluster):
         else:
             W = Worker
 
-        w = W(self.scheduler.address, loop=self.loop,
+        w = yield W(self.scheduler.address, loop=self.loop,
               death_timeout=death_timeout,
               silence_logs=self.silence_logs, **kwargs)
-        yield w._start()
 
         self.workers.append(w)
 

--- a/distributed/diagnostics/tests/test_plugin.py
+++ b/distributed/diagnostics/tests/test_plugin.py
@@ -54,8 +54,8 @@ def test_add_remove_worker(s):
 
     a = Worker(s.address)
     b = Worker(s.address)
-    yield a._start()
-    yield b._start()
+    yield a
+    yield b
     yield a._close()
     yield b._close()
 
@@ -67,7 +67,6 @@ def test_add_remove_worker(s):
 
     events[:] = []
     s.remove_plugin(plugin)
-    a = Worker(s.address)
-    yield a._start()
+    a = yield Worker(s.address)
     yield a._close()
     assert events == []

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -164,6 +164,11 @@ class Nanny(ServerNode):
 
         self.start_periodic_callbacks()
 
+        raise gen.Return(self)
+
+    def __await__(self):
+        return self._start().__await__()
+
     def start(self, addr_or_port=0):
         self.loop.add_callback(self._start, addr_or_port)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2751,7 +2751,7 @@ def test_worker_aliases():
     a = Worker(s.ip, s.port, name='alice')
     b = Worker(s.ip, s.port, name='bob')
     w = Worker(s.ip, s.port, name=3)
-    yield [a._start(), b._start(), w._start()]
+    yield [a, b, w]
 
     c = yield Client((s.ip, s.port), asynchronous=True)
 
@@ -2965,8 +2965,7 @@ def test_unrunnable_task_runs(c, s, a, b):
     assert s.tasks[x.key] in s.unrunnable
     assert s.get_task_status(keys=[x.key]) == {x.key: 'no-worker'}
 
-    w = Worker(s.ip, s.port, loop=s.loop)
-    yield w._start()
+    w = yield Worker(s.ip, s.port, loop=s.loop)
 
     start = time()
     while x.status != 'finished':
@@ -3634,7 +3633,7 @@ def test_open_close_many_workers(loop, worker, count, repeat):
                 yield gen.sleep(sleep)
                 w = worker(s['address'], loop=loop)
                 running[w] = None
-                yield w._start()
+                yield w
                 addr = w.worker_address
                 running[w] = addr
                 yield gen.sleep(duration)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -333,3 +333,11 @@ def test_environment_variable(c, s):
     results = yield c.run(lambda: os.environ['FOO'])
     assert results == {a.worker_address: "123", b.worker_address: "456"}
     yield [a._close(), b._close()]
+
+
+@gen_cluster(ncores=[], client=True)
+def test_data_types(c, s):
+    w = yield Nanny(s.address, data=dict)
+    r = yield c.run(lambda dask_worker: type(dask_worker.data))
+    assert r[w.worker_address] == dict
+    yield w._close()

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -24,9 +24,8 @@ from distributed.utils_test import (gen_cluster, gen_test, slow, inc,
 
 @gen_cluster(ncores=[])
 def test_nanny(s):
-    n = Nanny(s.ip, s.port, ncores=2, loop=s.loop)
+    n = yield Nanny(s.ip, s.port, ncores=2, loop=s.loop)
 
-    yield n._start(0)
     with rpc(n.address) as nn:
         assert n.is_alive()
         assert s.ncores[n.worker_address] == 2
@@ -55,8 +54,7 @@ def test_nanny(s):
 
 @gen_cluster(ncores=[])
 def test_many_kills(s):
-    n = Nanny(s.address, ncores=2, loop=s.loop)
-    yield n._start(0)
+    n = yield Nanny(s.address, ncores=2, loop=s.loop)
     assert n.is_alive()
     yield [n.kill() for i in range(5)]
     yield [n.kill() for i in range(5)]
@@ -73,8 +71,7 @@ def test_str(s, a, b):
 
 @gen_cluster(ncores=[], timeout=20, client=True)
 def test_nanny_process_failure(c, s):
-    n = Nanny(s.ip, s.port, ncores=2, loop=s.loop)
-    yield n._start()
+    n = yield Nanny(s.ip, s.port, ncores=2, loop=s.loop)
     first_dir = n.worker_dir
 
     assert os.path.exists(first_dir)
@@ -121,8 +118,7 @@ def test_nanny_no_port():
 @gen_cluster(ncores=[])
 def test_run(s):
     pytest.importorskip('psutil')
-    n = Nanny(s.ip, s.port, ncores=2, loop=s.loop)
-    yield n._start()
+    n = yield Nanny(s.ip, s.port, ncores=2, loop=s.loop)
 
     with rpc(n.address) as nn:
         response = yield nn.run(function=dumps(lambda: 1))
@@ -169,8 +165,7 @@ def test_nanny_alt_worker_class(c, s, w1, w2):
 @gen_cluster(client=False, ncores=[])
 def test_nanny_death_timeout(s):
     yield s.close()
-    w = Nanny(s.address, death_timeout=1)
-    yield w._start()
+    w = yield Nanny(s.address, death_timeout=1)
 
     yield gen.sleep(3)
     assert w.status == 'closed'
@@ -199,8 +194,7 @@ def test_num_fds(s):
     proc = psutil.Process()
 
     # Warm up
-    w = Nanny(s.address)
-    yield w._start()
+    w = yield Nanny(s.address)
     yield w._close()
     del w
     gc.collect()
@@ -208,8 +202,7 @@ def test_num_fds(s):
     before = proc.num_fds()
 
     for i in range(3):
-        w = Nanny(s.address)
-        yield w._start()
+        w = yield Nanny(s.address)
         yield gen.sleep(0.1)
         yield w._close()
 
@@ -241,8 +234,7 @@ def test_scheduler_file():
     with tmpfile() as fn:
         s = Scheduler(scheduler_file=fn)
         s.start(8008)
-        w = Nanny(scheduler_file=fn)
-        yield w._start()
+        w = yield Nanny(scheduler_file=fn)
         assert set(s.workers) == {w.worker_address}
         yield w._close()
         s.stop()
@@ -290,8 +282,7 @@ def test_nanny_terminate(c, s, a):
 
 @gen_cluster(ncores=[], client=True)
 def test_avoid_memory_monitor_if_zero_limit(c, s):
-    nanny = Nanny(s.address, loop=s.loop, memory_limit=0)
-    yield nanny._start()
+    nanny = yield Nanny(s.address, loop=s.loop, memory_limit=0)
     typ = yield c.run(lambda dask_worker: type(dask_worker.data))
     assert typ == {nanny.worker_address: dict}
     pcs = yield c.run(lambda dask_worker: list(dask_worker.periodic_callbacks))
@@ -310,8 +301,7 @@ def test_avoid_memory_monitor_if_zero_limit(c, s):
 @gen_cluster(ncores=[], client=True)
 def test_scheduler_address_config(c, s):
     with dask.config.set({'scheduler-address': s.address}):
-        nanny = Nanny(loop=s.loop)
-        yield nanny._start()
+        nanny = yield Nanny(loop=s.loop)
         assert nanny.scheduler.address == s.address
 
         start = time()
@@ -339,7 +329,7 @@ def test_wait_for_scheduler():
 def test_environment_variable(c, s):
     a = Nanny(s.address, loop=s.loop, memory_limit=0, env={"FOO": "123"})
     b = Nanny(s.address, loop=s.loop, memory_limit=0, env={"FOO": "456"})
-    yield [a._start(), b._start()]
+    yield [a, b]
     results = yield c.run(lambda: os.environ['FOO'])
     assert results == {a.worker_address: "123", b.worker_address: "456"}
     yield [a._close(), b._close()]

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -22,7 +22,7 @@ def test_resources(c, s):
     a = Worker(s.ip, s.port, loop=s.loop, resources={'GPU': 2})
     b = Worker(s.ip, s.port, loop=s.loop, resources={'GPU': 1, 'DB': 1})
 
-    yield [a._start(), b._start()]
+    yield [a, b]
 
     assert s.resources == {'GPU': {a.address: 2, b.address: 1},
                            'DB': {b.address: 1}}
@@ -52,8 +52,7 @@ def test_resource_submit(c, s, a, b):
 
     assert s.get_task_status(keys=[z.key]) == {z.key: 'no-worker'}
 
-    d = Worker(s.ip, s.port, loop=s.loop, resources={'C': 10})
-    yield d._start()
+    d = yield Worker(s.ip, s.port, loop=s.loop, resources={'C': 10})
 
     yield wait(z)
     assert z.key in d.data

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -162,8 +162,7 @@ def test_new_worker_steals(c, s, a):
     while len(a.task_state) < 10:
         yield gen.sleep(0.01)
 
-    b = Worker(s.ip, s.port, loop=s.loop, ncores=1, memory_limit=TOTAL_MEMORY)
-    yield b._start()
+    b = yield Worker(s.ip, s.port, loop=s.loop, ncores=1, memory_limit=TOTAL_MEMORY)
 
     result = yield total
     assert result == sum(map(inc, range(100)))
@@ -266,8 +265,7 @@ def test_steal_resource_restrictions(c, s, a):
         yield gen.sleep(0.01)
     assert len(a.task_state) == 101
 
-    b = Worker(s.ip, s.port, loop=s.loop, ncores=1, resources={'A': 4})
-    yield b._start()
+    b = yield Worker(s.ip, s.port, loop=s.loop, ncores=1, resources={'A': 4})
 
     start = time()
     while not b.task_state or len(a.task_state) == 101:
@@ -527,8 +525,8 @@ def test_steal_twice(c, s, a, b):
     while len(s.tasks) < 100:  # tasks are all allocated
         yield gen.sleep(0.01)
 
-    workers = [Worker(s.ip, s.port, loop=s.loop) for _ in range(20)]
-    yield [w._start() for w in workers]  # army of new workers arrives to help
+    # Army of new workers arrives to help
+    workers = yield [Worker(s.ip, s.port, loop=s.loop) for _ in range(20)]
 
     yield wait(futures)
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -21,8 +21,7 @@ from tornado.ioloop import TimeoutError
 
 from distributed import (Nanny, get_client, wait, default_client,
         get_worker, Reschedule)
-from distributed.compatibility import (WINDOWS, cache_from_source,
-        MutableMapping)
+from distributed.compatibility import WINDOWS, cache_from_source
 from distributed.core import rpc
 from distributed.client import wait
 from distributed.scheduler import Scheduler

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -29,7 +29,8 @@ from . import profile, comm
 from .batched import BatchedSend
 from .comm import get_address_host, get_local_address_for, connect
 from .comm.utils import offload
-from .compatibility import unicode, get_thread_identity, finalize
+from .compatibility import (unicode, get_thread_identity, finalize,
+        MutableMapping)
 from .core import (error_message, CommClosedError, send_recv,
                    pingpong, coerce_to_address)
 from .diskutils import WorkSpace
@@ -216,6 +217,8 @@ class Worker(ServerNode):
     scheduler_ip: str
     scheduler_port: int
     ip: str, optional
+    data: MutableMapping, type, None
+        The object to use for storage, builds a disk-backed LRU dict by default
     ncores: int, optional
     loop: tornado.ioloop.IOLoop
     local_dir: str, optional
@@ -260,7 +263,7 @@ class Worker(ServerNode):
                  executor=None, resources=None, silence_logs=None,
                  death_timeout=None, preload=None, preload_argv=None, security=None,
                  contact_address=None, memory_monitor_interval='200ms',
-                 extensions=None, metrics=None, **kwargs):
+                 extensions=None, metrics=None, data=None, **kwargs):
         self.tasks = dict()
         self.task_state = dict()
         self.dep_state = dict()
@@ -411,7 +414,13 @@ class Worker(ServerNode):
         else:
             self.memory_pause_fraction = dask.config.get('distributed.worker.memory.pause')
 
-        if (self.memory_limit and
+        if isinstance(data, MutableMapping):
+            self.data = data
+        elif callable(data):
+            self.data = data()
+        elif isinstance(data, tuple):
+            self.data = data[0](**data[1])
+        elif (self.memory_limit and
                 (self.memory_target_fraction or
                  self.memory_spill_fraction)):
             try:
@@ -825,6 +834,10 @@ class Worker(ServerNode):
         yield self._register_with_scheduler()
 
         self.start_periodic_callbacks()
+        raise gen.Return(self)
+
+    def __await__(self):
+        return self._start().__await__()
 
     def start(self, port=0):
         self.loop.add_callback(self._start, port)


### PR DESCRIPTION
This allows users to provide storage explicitly to the Worker and Nanny constructors as any of the following options:

1.  An explicit MutableMapping, like `Worker(data={})`
2.  A type, like `Worker(data=dict)`
3.  A type and keywords, like `Worker(data=(MyDict, {'option': 123}))`

Additionally, in testing I used `w = yield Worker(...)` and was surprised that this didn't work, so I fixed that everywhere as well.

This PR is working towards supporting a fancier spill-to-disk dictionary for device and host memory.  See https://github.com/rapidsai/dask-cuda/issues/30