### PR TITLE
Improved description accuracy of --memory-limit option.

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -223,7 +223,8 @@ class Worker(ServerNode):
     name: str, optional
     memory_limit: int, float, string
         Number of bytes of memory that this worker should use.
-        Set to zero for no limit.  Set to 'auto' for 60% of memory use.
+        Set to zero for no limit.  Set to 'auto' to calculate
+        as TOTAL_MEMORY * min(1, ncores / total_cores)
         Use strings or numbers like 5GB or 5e9
     memory_target_fraction: float
         Fraction of memory to try to stay beneath

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -70,7 +70,7 @@ thread per process::
    $ dask-worker scheduler:8786 --nprocs 8 --nthreads 1
 
 This will launch 8 worker processes each of which has its own
-ThreadPoolExecutor of size 1. 
+ThreadPoolExecutor of size 1.
 
 If your computations are external to Python and long-running and don't release
 the GIL then beware that while the computation is running the worker process
@@ -99,7 +99,7 @@ are the available options::
      --nprocs INTEGER       Number of worker processes to launch.  Defaults to one.
      --name TEXT            Alias
      --memory-limit TEXT    Maximum bytes of memory that this worker should use.
-                            Use None for unlimited, or 'auto' for
+                            Use 0 for unlimited, or 'auto' for
                             TOTAL_MEMORY * min(1, ncores / total_cores)
      --no-nanny
      --help                 Show this message and exit.

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -98,7 +98,9 @@ are the available options::
                             cores
      --nprocs INTEGER       Number of worker processes to launch.  Defaults to one.
      --name TEXT            Alias
-     --memory-limit TEXT    Number of bytes (per worker process) before spilling data to disk
+     --memory-limit TEXT    Maximum bytes of memory that this worker should use.
+                            Use None for unlimited, or 'auto' for
+                            TOTAL_MEMORY * min(1, ncores / total_cores)
      --no-nanny
      --help                 Show this message and exit.
 
@@ -149,7 +151,7 @@ command line ``--memory-limit`` keyword or the ``memory_limit=`` Python
 keyword argument, which sets the memory limit per worker processes launched
 by dask-worker ::
 
-    $ dask-worker tcp://scheduler:port --memory-limit=auto  # total available RAM on the machine
+    $ dask-worker tcp://scheduler:port --memory-limit=auto  # TOTAL_MEMORY * min(1, ncores / total_cores)
     $ dask-worker tcp://scheduler:port --memory-limit=4e9  # four gigabytes per worker process.
 
 Workers use a few different heuristics to keep memory use beneath this limit:


### PR DESCRIPTION
Kicking-off some changes to try and make the memory limit options more accurate.  The 60% factor has not been around since ca6beed95b82618386c7d566099b3b82429d9b56 and there are other inaccuracies.

Changes likely imperfect, feedback welcome.