### PR TITLE
Add resources to scheduler update_graph plugin

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1490,7 +1490,8 @@ class Scheduler(ServerNode):
                                     keys=keys, restrictions=restrictions or {},
                                     dependencies=dependencies,
                                     priority=priority,
-                                    loose_restrictions=loose_restrictions)
+                                    loose_restrictions=loose_restrictions,
+                                    resources=resources)
             except Exception as e:
                 logger.exception(e)
 


### PR DESCRIPTION
I would like to know the resources a task is requesting in my scheduler plugin in the update_graph callback. Could it be added as so?

The docs just reference **kwargs so doesn't seem they need to be updated: https://distributed.dask.org/en/latest/plugins.html