### PR TITLE
Check self.dependencies when looking at dependent tasks in memory

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1425,7 +1425,11 @@ class Scheduler(ServerNode):
                 except KeyError:
                     deps = self.dependencies[key]
                 for dep in deps:
-                    if all(d in done for d in dependents[dep]):
+                    if dep in dependents:
+                        child_deps = dependents[dep]
+                    else:
+                        child_deps = self.dependencies[dep]
+                    if all(d in done for d in child_deps):
                         if dep in self.tasks:
                             done.add(dep)
                             stack.append(dep)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1437,13 +1437,17 @@ def test_gh2187(c, s, a, b):
         return x + 'bar'
 
     def baz(x):
-        sleep(0.1)
         return x + 'baz'
 
-    x = c.submit(foo, key='x')
-    y = c.submit(bar, x, key='y')
+    def qux(x):
+        sleep(0.1)
+        return x + 'qux'
+
+    w = c.submit(foo, key='w')
+    x = c.submit(bar, w, key='x')
+    y = c.submit(baz, x, key='y')
     yield y
-    z = c.submit(baz, y, key='z')
+    z = c.submit(qux, y, key='z')
     del y
     yield gen.sleep(0.1)
     f = c.submit(bar, x, key='y')


### PR DESCRIPTION
This is an extension to https://github.com/dask/distributed/pull/2196 which fixes https://github.com/dask/distributed/issues/2187

As explained in https://github.com/dask/distributed/pull/2196,  only the scheduler would know the dependencies if the inputs were futures, and therefore the fix was to check both the input dependencies and self.dependencies.

This PR extends the same logic to handle dependencies of futures which are futures themselves and would be known only to the scheduler.