### PR TITLE
Add basic health endpoints to scheduler and worker bokeh.

### DIFF
--- a/distributed/bokeh/scheduler_html.py
+++ b/distributed/bokeh/scheduler_html.py
@@ -210,6 +210,12 @@ class PrometheusHandler(RequestHandler):
         self.set_header('Content-Type', 'text/plain; version=0.0.4')
 
 
+class HealthHandler(RequestHandler):
+    def get(self):
+        self.write('ok')
+        self.set_header('Content-Type', 'text/plain')
+
+
 routes = [
         (r'info/main/workers.html', Workers),
         (r'info/worker/(.*).html', Worker),
@@ -223,6 +229,7 @@ routes = [
         (r'json/index.html', IndexJSON),
         (r'individual-plots.json', IndividualPlots),
         (r'metrics', PrometheusHandler),
+        (r'health', HealthHandler),
 ]
 
 

--- a/distributed/bokeh/tests/test_scheduler_bokeh_html.py
+++ b/distributed/bokeh/tests/test_scheduler_bokeh_html.py
@@ -85,3 +85,18 @@ def test_prometheus(c, s, a, b):
             for familiy in text_string_to_metric_families(txt)
         }
         assert 'dask_scheduler_workers' in families
+
+
+@gen_cluster(client=True,
+    check_new_threads=False,
+    scheduler_kwargs={'services': {('bokeh', 0):  BokehScheduler}})
+def test_health(c, s, a, b):
+    http_client = AsyncHTTPClient()
+
+    response = yield http_client.fetch('http://localhost:%d/health'
+                                       % s.services['bokeh'].port)
+    assert response.code == 200
+    assert response.headers['Content-Type'] == 'text/plain'
+
+    txt = response.body.decode('utf8')
+    assert txt == 'ok'

--- a/distributed/bokeh/tests/test_worker_bokeh_html.py
+++ b/distributed/bokeh/tests/test_worker_bokeh_html.py
@@ -28,3 +28,17 @@ def test_prometheus(c, s, a, b):
             for familiy in text_string_to_metric_families(txt)
         }
         assert len(families) > 0
+
+
+@gen_cluster(client=True,
+    worker_kwargs={'services': {('bokeh', 0):  BokehWorker}})
+def test_health(c, s, a, b):
+    http_client = AsyncHTTPClient()
+
+    response = yield http_client.fetch('http://localhost:%d/health'
+                                       % a.services['bokeh'].port)
+    assert response.code == 200
+    assert response.headers['Content-Type'] == 'text/plain'
+
+    txt = response.body.decode('utf8')
+    assert txt == 'ok'

--- a/distributed/bokeh/worker_html.py
+++ b/distributed/bokeh/worker_html.py
@@ -63,8 +63,15 @@ class PrometheusHandler(RequestHandler):
         self.set_header('Content-Type', 'text/plain; version=0.0.4')
 
 
+class HealthHandler(RequestHandler):
+    def get(self):
+        self.write('ok')
+        self.set_header('Content-Type', 'text/plain')
+
+
 routes = [
         (r'metrics', PrometheusHandler),
+        (r'health', HealthHandler),
 ]
 
 

--- a/docs/source/web.rst
+++ b/docs/source/web.rst
@@ -50,6 +50,7 @@ The available pages are ``http://scheduler-address:8787/<page>/`` where ``<page>
 - ``status``: a stream of recently run tasks, progress bars, resource use
 - ``tasks``: a larger stream of the last 100k tasks
 - ``workers``: basic information about workers and their current load
+- ``health``: basic health check, returns ``ok`` if service is running
 
 .. _Bokeh: http://bokeh.pydata.org/en/latest/
 


### PR DESCRIPTION
This adds a basic `/health` endpoint as used by many microservices/frameworks.

For now, this is just a basic check whether the service is up. This is intended as a starting point, more sophisticated checks whether the components are really healthy could be added on top of this later.