### PR TITLE
added missing whitespace to start_worker cmd

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -220,19 +220,19 @@ def start_worker(logdir, scheduler_addr, scheduler_port, worker_addr, nthreads, 
     cmd = ('{python} -m {remote_dask_worker} '
            '{scheduler_addr}:{scheduler_port} '
            '--nthreads {nthreads}'
-           + ('--nprocs {nprocs}' if nprocs != 1 else ''))
+           + (' --nprocs {nprocs}' if nprocs != 1 else ''))
 
     if not nohost:
-        cmd += ' --host {worker_addr} '
+        cmd += ' --host {worker_addr}'
 
     if memory_limit:
-        cmd += '--memory-limit {memory_limit} '
+        cmd += ' --memory-limit {memory_limit}'
 
     if worker_port:
-        cmd += '--worker-port {worker_port} '
+        cmd += ' --worker-port {worker_port}'
 
     if nanny_port:
-        cmd += '--nanny-port {nanny_port} '
+        cmd += ' --nanny-port {nanny_port}'
 
     cmd = cmd.format(
         python=remote_python or sys.executable,


### PR DESCRIPTION
A whitespace was missing in front of the optional "nprocs" option. Aditionally changed the following optional options to a more readable way, where the separating whitespace is always in front of the additional command.