### PR TITLE
Catch RuntimeError to avoid serialization fail when using pytorch

### DIFF
--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -13,6 +13,7 @@ def test_tensor():
     t2 = deserialize(header, frames)
     assert (x == t2.numpy()).all()
 
+
 @pytest.mark.parametrize("requires_grad", [True, False])
 def test_grad(requires_grad):
     x = np.arange(10)
@@ -23,12 +24,13 @@ def test_grad(requires_grad):
 
     t2 = deserialize(*serialize(t))
 
-    assert (t2.requires_grad is requires_grad)
-    assert (t.requires_grad is requires_grad)
+    assert t2.requires_grad is requires_grad
+    assert t.requires_grad is requires_grad
     assert np.allclose(t2.detach().numpy(), x)
 
     if requires_grad:
         assert np.allclose(t2.grad.numpy(), 1)
+
 
 def test_resnet():
     torchvision = pytest.importorskip("torchvision")

--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -14,15 +14,17 @@ def test_tensor():
     assert (x == t2.numpy()).all()
 
 
-def test_grad():
+@pytest.mark.parametrize("requires_grad", [True, False])
+def test_grad(requires_grad):
     x = np.arange(10)
-    t = torch.Tensor(x)
+    t = torch.tensor(x, dtype=torch.float, requires_grad=requires_grad)
     t.grad = torch.zeros_like(t) + 1
 
     t2 = deserialize(*serialize(t))
-    assert (t2.numpy() == x).all()
-    assert (t2.grad.numpy() == 1).all()
 
+    assert (t2.detach().numpy() == x).all()
+    assert (t2.grad.numpy() == 1).all()
+    assert (t2.requires_grad is requires_grad)
 
 def test_resnet():
     torchvision = pytest.importorskip("torchvision")

--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -13,18 +13,22 @@ def test_tensor():
     t2 = deserialize(header, frames)
     assert (x == t2.numpy()).all()
 
-
 @pytest.mark.parametrize("requires_grad", [True, False])
 def test_grad(requires_grad):
     x = np.arange(10)
     t = torch.tensor(x, dtype=torch.float, requires_grad=requires_grad)
-    t.grad = torch.zeros_like(t) + 1
+
+    if requires_grad:
+        t.grad = torch.zeros_like(t) + 1
 
     t2 = deserialize(*serialize(t))
 
-    assert (t2.detach().numpy() == x).all()
-    assert (t2.grad.numpy() == 1).all()
     assert (t2.requires_grad is requires_grad)
+    assert (t.requires_grad is requires_grad)
+    assert np.allclose(t2.detach().numpy(), x)
+
+    if requires_grad:
+        assert np.allclose(t2.grad.numpy(), 1)
 
 def test_resnet():
     torchvision = pytest.importorskip("torchvision")

--- a/distributed/protocol/torch.py
+++ b/distributed/protocol/torch.py
@@ -7,7 +7,12 @@ import numpy as np
 @dask_serialize.register(torch.Tensor)
 def serialize_torch_Tensor(t):
     requires_grad_ = t.requires_grad
-    header, frames = serialize(t.detach_().numpy())
+
+    if requires_grad_:
+        header, frames = serialize(t.detach().numpy())
+    else:
+        header, frames = serialize(t.numpy())
+
     if t.grad is not None:
         grad_header, grad_frames = serialize(t.grad.numpy())
         header["grad"] = {"header": grad_header, "start": len(frames)}


### PR DESCRIPTION
After updating one of my systems I realized that there was a problem in `distributed/protocol/torch.py` that made serialization to fail. In this PR, the problem is fixed by adding a try/except statement to fix the problem. 