### PR TITLE
Add worker_class argument to LocalCluster

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -206,6 +206,8 @@ class LocalCluster(Cluster):
         if security:
             self.worker_kwargs["security"] = security
 
+        if not worker_class:
+            worker_class = Worker if not processes else Nanny
         self.worker_class = worker_class
 
         self.start(ip=ip, n_workers=n_workers)
@@ -284,13 +286,9 @@ class LocalCluster(Cluster):
             return
 
         if self.processes:
-            W = Nanny
-            kwargs["worker_class"] = self.worker_class
             kwargs["quiet"] = True
-        else:
-            W = self.worker_class or Worker
 
-        w = yield W(
+        w = yield self.worker_class(
             self.scheduler.address,
             loop=self.loop,
             death_timeout=death_timeout,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -74,6 +74,8 @@ class LocalCluster(Cluster):
         Protocol to use like ``tcp://``, ``tls://``, ``inproc://``
         This defaults to sensible choice given other keyword arguments like
         ``processes`` and ``security``
+    worker_class: Worker
+        Worker class used to instantiate workers from.
 
     Examples
     --------
@@ -115,6 +117,7 @@ class LocalCluster(Cluster):
         security=None,
         protocol=None,
         blocked_handlers=None,
+        worker_class=None,
         **worker_kwargs
     ):
         if start is not None:
@@ -203,6 +206,8 @@ class LocalCluster(Cluster):
         if security:
             self.worker_kwargs["security"] = security
 
+        self.worker_class = worker_class
+
         self.start(ip=ip, n_workers=n_workers)
 
         clusters_to_close.add(self)
@@ -280,9 +285,10 @@ class LocalCluster(Cluster):
 
         if self.processes:
             W = Nanny
+            kwargs["worker_class"] = self.worker_class
             kwargs["quiet"] = True
         else:
-            W = Worker
+            W = self.worker_class or Worker
 
         w = yield W(
             self.scheduler.address,

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -742,5 +742,24 @@ def test_protocol_ip(loop):
         assert cluster.scheduler.address.startswith("tcp://127.0.0.2")
 
 
+class MyWorker(Worker):
+    pass
+
+
+def test_worker_class_worker(loop):
+    with LocalCluster(n_workers=2, loop=loop, worker_class=MyWorker, processes=False,
+                      scheduler_port=0, dashboard_address=None) as cluster:
+        assert all(isinstance(w, MyWorker) for w in cluster.workers)
+
+
+def test_worker_class_nanny(loop):
+    class MyNanny(Nanny):
+        pass
+
+    with LocalCluster(n_workers=2, loop=loop, worker_class=MyNanny,
+                      scheduler_port=0, dashboard_address=None) as cluster:
+        assert all(isinstance(w, MyNanny) for w in cluster.workers)
+
+
 if sys.version_info >= (3, 5):
     from distributed.deploy.tests.py3_test_deploy import *  # noqa F401

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -747,8 +747,14 @@ class MyWorker(Worker):
 
 
 def test_worker_class_worker(loop):
-    with LocalCluster(n_workers=2, loop=loop, worker_class=MyWorker, processes=False,
-                      scheduler_port=0, dashboard_address=None) as cluster:
+    with LocalCluster(
+        n_workers=2,
+        loop=loop,
+        worker_class=MyWorker,
+        processes=False,
+        scheduler_port=0,
+        dashboard_address=None,
+    ) as cluster:
         assert all(isinstance(w, MyWorker) for w in cluster.workers)
 
 
@@ -756,8 +762,13 @@ def test_worker_class_nanny(loop):
     class MyNanny(Nanny):
         pass
 
-    with LocalCluster(n_workers=2, loop=loop, worker_class=MyNanny,
-                      scheduler_port=0, dashboard_address=None) as cluster:
+    with LocalCluster(
+        n_workers=2,
+        loop=loop,
+        worker_class=MyNanny,
+        scheduler_port=0,
+        dashboard_address=None,
+    ) as cluster:
         assert all(isinstance(w, MyNanny) for w in cluster.workers)
 
 


### PR DESCRIPTION
Allows instantiating workers subclassed from Worker (e.g., CUDAWorker) in LocalCluster.

@mrocklin 