### PR TITLE
Add interface= keyword to LocalCluster

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -15,6 +15,7 @@ from .cluster import Cluster
 from ..compatibility import get_thread_identity
 from ..core import CommClosedError
 from ..utils import (
+    get_ip_interface,
     sync,
     ignoring,
     All,
@@ -74,6 +75,8 @@ class LocalCluster(Cluster):
         Protocol to use like ``tcp://``, ``tls://``, ``inproc://``
         This defaults to sensible choice given other keyword arguments like
         ``processes`` and ``security``
+    interface: str (optional)
+        Network interface to use.  Defaults to lo/localhost
 
     Examples
     --------
@@ -115,6 +118,7 @@ class LocalCluster(Cluster):
         security=None,
         protocol=None,
         blocked_handlers=None,
+        interface=None,
         **worker_kwargs
     ):
         if start is not None:
@@ -152,6 +156,7 @@ class LocalCluster(Cluster):
         self.silence_logs = silence_logs
         self._asynchronous = asynchronous
         self.security = security
+        self.interface = interface
         services = services or {}
         worker_services = worker_services or {}
         if silence_logs:
@@ -255,7 +260,10 @@ class LocalCluster(Cluster):
             address = self.protocol
         else:
             if ip is None:
-                ip = "127.0.0.1"
+                if self.interface:
+                    ip = get_ip_interface(self.interface)
+                else:
+                    ip = "127.0.0.1"
 
             if "://" in ip:
                 address = ip

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5061,8 +5061,9 @@ def test_call_stack_future(c, s, a, b):
 
 @gen_cluster([("127.0.0.1", 4)] * 2, client=True)
 def test_call_stack_all(c, s, a, b):
-    future = c.submit(slowinc, 1, delay=0.5)
-    yield gen.sleep(0.1)
+    future = c.submit(slowinc, 1, delay=0.8)
+    while not a.executing and not b.executing:
+        yield gen.sleep(0.01)
     result = yield c.call_stack()
     w = a if a.executing else b
     assert list(result) == [w.address]


### PR DESCRIPTION
This is useful when you want to use a particular network interface, like
infiniband.

Fixes https://github.com/dask/distributed/issues/2618