### PR TITLE
Fix deserialization of bytes chunks larger than 64MB

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -473,7 +473,7 @@ def _serialize_bytes(obj):
 
 @dask_deserialize.register((bytes, bytearray))
 def _deserialize_bytes(header, frames):
-    return frames[0]
+    return b"".join(frames)
 
 
 #########################

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -192,7 +192,7 @@ def test_empty_loads_deep():
 
 
 def test_serialize_bytes():
-    for x in [1, "abc", np.arange(5)]:
+    for x in [1, "abc", np.arange(5), b"ab" * int(100e6)]:
         b = serialize_bytes(x)
         assert isinstance(b, bytes)
         y = deserialize_bytes(b)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -192,7 +192,7 @@ def test_empty_loads_deep():
 
 
 def test_serialize_bytes():
-    for x in [1, "abc", np.arange(5), b"ab" * int(100e6)]:
+    for x in [1, "abc", np.arange(5), b"ab" * int(40e6)]:
         b = serialize_bytes(x)
         assert isinstance(b, bytes)
         y = deserialize_bytes(b)


### PR DESCRIPTION
When chunks of `bytes` are larger than 64MB they get split into multiple 64MB frames within the serializer. When `_deserialize_bytes()` returns only the first frame, it truncates the object and it's unable to deserialize it. The solution is simply to join all the frames.