### PR TITLE
Add timeout to Client._reconnect

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -954,9 +954,10 @@ class Client(Node):
         raise gen.Return(self)
 
     @gen.coroutine
-    def _reconnect(self, timeout=0.1):
+    def _reconnect(self):
         with log_errors():
             assert self.scheduler_comm.comm.closed()
+
             self.status = "connecting"
             self.scheduler_comm = None
 
@@ -964,12 +965,20 @@ class Client(Node):
                 st.cancel()
             self.futures.clear()
 
-            while self.status == "connecting":
+            timeout = self._timeout
+            deadline = self.loop.time() + timeout
+            while timeout > 0 and self.status == "connecting":
                 try:
-                    yield self._ensure_connected()
+                    yield self._ensure_connected(timeout=timeout)
                     break
                 except EnvironmentError:
-                    yield gen.sleep(timeout)
+                    # Wait a bit before retrying
+                    yield gen.sleep(0.1)
+                    timeout = deadline - self.loop.time()
+            else:
+                logger.error("Failed to reconnect to scheduler after %.2f "
+                             "seconds, closing client", self._timeout)
+                yield self._close()
 
     @gen.coroutine
     def _ensure_connected(self, timeout=None):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -976,8 +976,11 @@ class Client(Node):
                     yield gen.sleep(0.1)
                     timeout = deadline - self.loop.time()
             else:
-                logger.error("Failed to reconnect to scheduler after %.2f "
-                             "seconds, closing client", self._timeout)
+                logger.error(
+                    "Failed to reconnect to scheduler after %.2f "
+                    "seconds, closing client",
+                    self._timeout,
+                )
                 yield self._close()
 
     @gen.coroutine

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3711,6 +3711,7 @@ def test_reconnect_timeout(c, s):
         start = time()
         while c.status != "closed":
             yield c._update_scheduler_info()
+            yield gen.sleep(0.05)
             assert time() < start + 5, "Timeout waiting for reconnect to fail"
     text = logger.getvalue()
     assert "Failed to reconnect" in text

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3704,6 +3704,18 @@ def test_reconnect(loop):
     c.close()
 
 
+@gen_cluster(client=True, ncores=[], client_kwargs={'timeout': 0.5})
+def test_reconnect_timeout(c, s):
+    with captured_logger(logging.getLogger("distributed.client")) as logger:
+        yield s.close()
+        start = time()
+        while c.status != 'closed':
+            yield c._update_scheduler_info()
+            assert time() < start + 5, "Timeout waiting for reconnect to fail"
+    text = logger.getvalue()
+    assert "Failed to reconnect" in text
+
+
 @slow
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="num_fds not supported on windows"

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3704,12 +3704,12 @@ def test_reconnect(loop):
     c.close()
 
 
-@gen_cluster(client=True, ncores=[], client_kwargs={'timeout': 0.5})
+@gen_cluster(client=True, ncores=[], client_kwargs={"timeout": 0.5})
 def test_reconnect_timeout(c, s):
     with captured_logger(logging.getLogger("distributed.client")) as logger:
         yield s.close()
         start = time()
-        while c.status != 'closed':
+        while c.status != "closed":
             yield c._update_scheduler_info()
             assert time() < start + 5, "Timeout waiting for reconnect to fail"
     text = logger.getvalue()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -974,7 +974,7 @@ def gen_cluster(
                                 if s.validate:
                                     s.validate_state()
                             finally:
-                                if client and c.status != "closed":
+                                if client and c.status not in ("closing", "closed"):
                                     yield c._close(fast=s.status == "closed")
                                 yield end_cluster(s, workers)
                                 yield gen.with_timeout(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -974,7 +974,7 @@ def gen_cluster(
                                 if s.validate:
                                     s.validate_state()
                             finally:
-                                if client:
+                                if client and c.status != 'closed':
                                     yield c._close(fast=s.status == "closed")
                                 yield end_cluster(s, workers)
                                 yield gen.with_timeout(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -974,7 +974,7 @@ def gen_cluster(
                                 if s.validate:
                                     s.validate_state()
                             finally:
-                                if client and c.status != 'closed':
+                                if client and c.status != "closed":
                                     yield c._close(fast=s.status == "closed")
                                 yield end_cluster(s, workers)
                                 yield gen.with_timeout(


### PR DESCRIPTION
Previously if a client lost connection to the scheduler, it would try to
reconnect forever. We now use the same timeout as the initial connect.
On failure a nice message is logged and the client is shutdown.

Fixes #2582.