### PR TITLE
Use proper address in worker -> nanny comms

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -996,7 +996,12 @@ class Worker(ServerNode):
             self.status = "closed"
 
             if nanny and "nanny" in self.service_ports:
-                with self.rpc((self.ip, self.service_ports["nanny"])) as r:
+                nanny_address = "%s%s:%d" % (
+                    self.listener.prefix,
+                    self.ip,
+                    self.service_ports["nanny"],
+                )
+                with self.rpc(nanny_address) as r:
                     yield r.terminate()
 
             if self.batched_stream and not self.batched_stream.comm.closed():


### PR DESCRIPTION
When a worker is shutdown explicitly it notifies the nanny that it
should also shutdown. Previously the address it used for this assumed
tcp in all cases, this changes that to use the same protocol as the
worker (which is currently always the same as the nanny's). This allows
`retire_workers` to properly work over TLS.

Fixes #2584.