### PR TITLE
Add as_completed methods to docs

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4110,7 +4110,7 @@ class as_completed(object):
             self.thread_condition.notify()
 
     @gen.coroutine
-    def track_future(self, future):
+    def _track_future(self, future):
         try:
             yield _wait(future)
         except CancelledError:
@@ -4136,7 +4136,7 @@ class as_completed(object):
                 if not isinstance(f, Future):
                     raise TypeError("Input must be a future, got %s" % f)
                 self.futures[f] += 1
-                self.loop.add_callback(self.track_future, f)
+                self.loop.add_callback(self._track_future, f)
 
     def add(self, future):
         """ Add a future to the collection
@@ -4146,8 +4146,12 @@ class as_completed(object):
         self.update((future,))
 
     def is_empty(self):
-        """Return True if there no waiting futures, False otherwise"""
+        """Returns True if there no completed or computing futures"""
         return not self.count()
+
+    def has_ready(self):
+        """Returns True if there are completed futures available."""
+        return not self.queue.empty()
 
     def count(self):
         """ Return the number of futures yet to be returned
@@ -4195,7 +4199,7 @@ class as_completed(object):
     next = __next__
 
     def next_batch(self, block=True):
-        """ Get next batch of futures from as_completed iterator
+        """ Get the next batch of completed futures.
 
         Parameters
         ----------

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3590,8 +3590,13 @@ def test_as_completed_batches(c, with_results):
 def test_as_completed_next_batch(c):
     futures = c.map(slowinc, range(2), delay=0.1)
     ac = as_completed(futures)
+    assert not ac.is_empty()
     assert ac.next_batch(block=False) == []
     assert set(ac.next_batch(block=True)).issubset(futures)
+    while not ac.is_empty():
+        assert set(ac.next_batch(block=True)).issubset(futures)
+    assert ac.is_empty()
+    assert not ac.has_ready()
 
 
 @gen_test()

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -152,7 +152,9 @@ Future
 Other
 -----
 
-.. autofunction:: as_completed
+.. autoclass:: as_completed
+   :members:
+
 .. autofunction:: distributed.diagnostics.progress
 .. autofunction:: wait
 .. autofunction:: fire_and_forget


### PR DESCRIPTION
Adds ``as_completed`` methods to the docs, and cleans up the existing
docstrings slightly. Also adds a new method ``has_ready`` for checking
if there are any completed futures ready for processing.

Fixes https://github.com/dask/dask/issues/4729.