### PR TITLE
Add idle timeout to scheduler

### DIFF
--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -52,7 +52,7 @@ def test_simple(loop):
 
 
 def test_local_cluster_supports_blocked_handlers(loop):
-    with LocalCluster(blocked_handlers=["run_function"], loop=loop) as c:
+    with LocalCluster(blocked_handlers=["run_function"], n_workers=0, loop=loop) as c:
         with Client(c) as client:
             with pytest.raises(ValueError) as exc:
                 client.run_on_scheduler(lambda x: x, 42)
@@ -309,11 +309,11 @@ def test_cleanup():
 
 def test_repeated():
     with LocalCluster(
-        scheduler_port=8448, silence_logs=False, dashboard_address=None
+        0, scheduler_port=8448, silence_logs=False, dashboard_address=None
     ) as c:
         pass
     with LocalCluster(
-        scheduler_port=8448, silence_logs=False, dashboard_address=None
+        0, scheduler_port=8448, silence_logs=False, dashboard_address=None
     ) as c:
         pass
 
@@ -323,6 +323,7 @@ def test_bokeh(loop, processes):
     pytest.importorskip("bokeh")
     requests = pytest.importorskip("requests")
     with LocalCluster(
+        n_workers=0,
         scheduler_port=0,
         silence_logs=False,
         loop=loop,
@@ -405,14 +406,19 @@ def test_silent_startup():
 
 def test_only_local_access(loop):
     with LocalCluster(
-        scheduler_port=0, silence_logs=False, dashboard_address=None, loop=loop
+        0, scheduler_port=0, silence_logs=False, dashboard_address=None, loop=loop
     ) as c:
         sync(loop, assert_can_connect_locally_4, c.scheduler.port)
 
 
 def test_remote_access(loop):
     with LocalCluster(
-        scheduler_port=0, silence_logs=False, dashboard_address=None, ip="", loop=loop
+        0,
+        scheduler_port=0,
+        silence_logs=False,
+        dashboard_address=None,
+        ip="",
+        loop=loop,
     ) as c:
         sync(loop, assert_can_connect_from_everywhere_4_6, c.scheduler.port)
 
@@ -463,6 +469,7 @@ def test_death_timeout_raises(loop):
 def test_bokeh_kwargs(loop):
     pytest.importorskip("bokeh")
     with LocalCluster(
+        n_workers=0,
         scheduler_port=0,
         silence_logs=False,
         loop=loop,
@@ -496,6 +503,7 @@ def test_logging():
 def test_ipywidgets(loop):
     ipywidgets = pytest.importorskip("ipywidgets")
     with LocalCluster(
+        n_workers=0,
         scheduler_port=0,
         silence_logs=False,
         loop=loop,
@@ -607,6 +615,7 @@ def test_local_tls(loop):
 
     security = tls_only_security()
     with LocalCluster(
+        n_workers=0,
         scheduler_port=8786,
         silence_logs=False,
         security=security,
@@ -730,7 +739,9 @@ def test_protocol_inproc(loop):
 
 
 def test_protocol_tcp(loop):
-    with LocalCluster(protocol="tcp", loop=loop, processes=False) as cluster:
+    with LocalCluster(
+        protocol="tcp", loop=loop, n_workers=0, processes=False
+    ) as cluster:
         assert cluster.scheduler.address.startswith("tcp://")
 
 
@@ -738,7 +749,9 @@ def test_protocol_tcp(loop):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 def test_protocol_ip(loop):
-    with LocalCluster(ip="tcp://127.0.0.2", loop=loop, processes=False) as cluster:
+    with LocalCluster(
+        ip="tcp://127.0.0.2", loop=loop, n_workers=0, processes=False
+    ) as cluster:
         assert cluster.scheduler.address.startswith("tcp://127.0.0.2")
 
 

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -16,6 +16,7 @@ distributed:
     # Number of seconds to wait until workers or clients are removed from the events log
     # after they have been removed from the scheduler
     events-cleanup-delay: 1h
+    idle-timeout: null      # Shut down after this duration, like "1h" or "30 minutes"
     transition-log-length: 100000
     work-stealing: True     # workers should steal tasks from each other
     worker-ttl: null        # like '60s'. Time to live for workers.  They must heartbeat faster than this

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -837,13 +837,13 @@ class Scheduler(ServerNode):
         self.scheduler_file = scheduler_file
         worker_ttl = worker_ttl or dask.config.get("distributed.scheduler.worker-ttl")
         self.worker_ttl = parse_timedelta(worker_ttl) if worker_ttl else None
-        self.idle_timeout = (
-            parse_timedelta(
-                idle_timeout or dask.config.get("distributed.scheduler.idle-timeout")
-            )
-            if idle_timeout
-            else None
+        idle_timeout = idle_timeout or dask.config.get(
+            "distributed.scheduler.idle-timeout"
         )
+        if idle_timeout:
+            self.idle_timeout = parse_timedelta(idle_timeout)
+        else:
+            self.idle_timeout = None
         self.time_started = time()
 
         self.security = security or Security()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -816,6 +816,7 @@ class Scheduler(ServerNode):
         scheduler_file=None,
         security=None,
         worker_ttl=None,
+        idle_timeout=None,
         **kwargs
     ):
 
@@ -836,6 +837,14 @@ class Scheduler(ServerNode):
         self.scheduler_file = scheduler_file
         worker_ttl = worker_ttl or dask.config.get("distributed.scheduler.worker-ttl")
         self.worker_ttl = parse_timedelta(worker_ttl) if worker_ttl else None
+        self.idle_timeout = (
+            parse_timedelta(
+                idle_timeout or dask.config.get("distributed.scheduler.idle-timeout")
+            )
+            if idle_timeout
+            else None
+        )
+        self.time_started = time()
 
         self.security = security or Security()
         assert isinstance(self.security, Security)
@@ -1053,6 +1062,10 @@ class Scheduler(ServerNode):
         if self.worker_ttl:
             pc = PeriodicCallback(self.check_worker_ttl, self.worker_ttl, io_loop=loop)
             self.periodic_callbacks["worker-ttl"] = pc
+
+        if self.idle_timeout:
+            pc = PeriodicCallback(self.check_idle, self.idle_timeout / 4, io_loop=loop)
+            self.periodic_callbacks["idle-timeout"] = pc
 
         if extensions is None:
             extensions = DEFAULT_EXTENSIONS
@@ -4650,6 +4663,21 @@ class Scheduler(ServerNode):
                     ws,
                 )
                 self.remove_worker(address=ws.address)
+
+    def check_idle(self):
+        if any(ws.processing for ws in self.workers.values()):
+            return
+        if self.unrunnable:
+            return
+
+        if not self.transition_log:
+            close = time() > self.time_started + self.idle_timeout
+        else:
+            last_task = self.transition_log[-1][-1]
+            close = time() > last_task + self.idle_timeout
+
+        if close:
+            self.loop.add_callback(self.close)
 
 
 def decide_worker(ts, all_workers, valid_workers, objective):


### PR DESCRIPTION
Schedulers that haven't been touched in a while can choose to shut
themselves down.  This is useful as a stop-gap to clean up costly
forgotten resources.

cc @jacobtomlinson I think you asked for this at one point