### PR TITLE
Add Type Attribute to TaskState

### DIFF
--- a/distributed/bokeh/templates/task.html
+++ b/distributed/bokeh/templates/task.html
@@ -21,7 +21,7 @@
           {% end %}
           {% if ts.type %}
           <tr>
-              <th> Bytes </th>
+              <th> Type </th>
               <td> {{ ts.type }} </td>
           </tr>
           {% end %}

--- a/distributed/bokeh/templates/task.html
+++ b/distributed/bokeh/templates/task.html
@@ -19,6 +19,12 @@
               <td><a class="button is-primary" href="../call-stack/{{ url_escape(Task) }}.html">Call Stack</a></td>
           </tr>
           {% end %}
+          {% if ts.type %}
+          <tr>
+              <th> Bytes </th>
+              <td> {{ ts.type }} </td>
+          </tr>
+          {% end %}
           {% if ts.nbytes %}
           <tr>
               <th> Bytes </th>

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -14,7 +14,7 @@ import msgpack
 
 from . import pickle
 from ..compatibility import PY2
-from ..utils import has_keyword
+from ..utils import has_keyword, typename
 from .compression import maybe_compress, decompress
 from .utils import (
     unpack_frames,
@@ -443,18 +443,6 @@ def register_serialization_lazy(toplevel, func):
     module is ever loaded.
     """
     raise Exception("Serialization registration has changed. See documentation")
-
-
-def typename(typ):
-    """ Return name of type
-
-    Examples
-    --------
-    >>> from distributed import Scheduler
-    >>> typename(Scheduler)
-    'distributed.scheduler.Scheduler'
-    """
-    return typ.__module__ + "." + typ.__name__
 
 
 @partial(normalize_token.register, Serialized)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -453,6 +453,11 @@ class TaskState(object):
        of a finished task.  This number is used for diagnostics and to
        help prioritize work.
 
+    .. attribute:: type: str
+
+       The type of the object as a string.  Only present for tasks that have
+       been computed.
+
     .. attribute:: exception: object
 
        If this task failed executing, the exception object is stored here.
@@ -566,6 +571,7 @@ class TaskState(object):
         "suspicious",
         "retries",
         "nbytes",
+        "type",
     )
 
     def __init__(self, key, run_spec):
@@ -590,6 +596,7 @@ class TaskState(object):
         self.resource_restrictions = None
         self.loose_restrictions = False
         self.actor = None
+        self.type = None
 
     def get_nbytes(self):
         nbytes = self.nbytes
@@ -1373,6 +1380,7 @@ class Scheduler(ServerNode):
         name=None,
         resolve_address=True,
         nbytes=None,
+        types=None,
         now=None,
         resources=None,
         host_info=None,
@@ -1451,7 +1459,11 @@ class Scheduler(ServerNode):
                     ts = self.tasks.get(key)
                     if ts is not None and ts.state in ("processing", "waiting"):
                         recommendations = self.transition(
-                            key, "memory", worker=address, nbytes=nbytes[key]
+                            key,
+                            "memory",
+                            worker=address,
+                            nbytes=nbytes[key],
+                            typename=types[key],
                         )
                         self.transitions(recommendations)
 
@@ -3409,7 +3421,9 @@ class Scheduler(ServerNode):
             if send_worker_msg:
                 self.worker_send(w, send_worker_msg)
 
-    def _add_to_memory(self, ts, ws, recommendations, type=None, **kwargs):
+    def _add_to_memory(
+        self, ts, ws, recommendations, type=None, typename=None, **kwargs
+    ):
         """
         Add *ts* to the set of in-memory tasks.
         """
@@ -3445,6 +3459,7 @@ class Scheduler(ServerNode):
             self.report(msg)
 
         ts.state = "memory"
+        ts.type = typename
 
         cs = self.clients["fire-and-forget"]
         if ts in cs.wants_what:
@@ -3667,7 +3682,14 @@ class Scheduler(ServerNode):
             raise
 
     def transition_processing_memory(
-        self, key, nbytes=None, type=None, worker=None, startstops=None, **kwargs
+        self,
+        key,
+        nbytes=None,
+        type=None,
+        typename=None,
+        worker=None,
+        startstops=None,
+        **kwargs
     ):
         try:
             ts = self.tasks[key]
@@ -3740,7 +3762,7 @@ class Scheduler(ServerNode):
 
             self._remove_from_processing(ts)
 
-            self._add_to_memory(ts, ws, recommendations, type=type)
+            self._add_to_memory(ts, ws, recommendations, type=type, typename=typename)
 
             if self.validate:
                 assert not ts.processing_on
@@ -4792,6 +4814,9 @@ def validate_task_state(ts):
             str(ts),
             str(ts.who_has),
         )
+        if ts.run_spec:  # was computed
+            assert ts.type
+            assert isinstance(ts.type, str)
         assert not any(ts in dts.waiting_on for dts in ts.dependents)
         for ws in ts.who_has:
             assert ts in ws.has_what, (

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -73,10 +73,11 @@ def test_dataframes(c, s, a, b):
 def test__dask_array_collections(c, s, a, b):
     import dask.array as da
 
+    s.validate = False
     x_dsk = {("x", i, j): np.random.random((3, 3)) for i in range(3) for j in range(2)}
     y_dsk = {("y", i, j): np.random.random((3, 3)) for i in range(2) for j in range(3)}
-    x_futures = yield c._scatter(x_dsk)
-    y_futures = yield c._scatter(y_dsk)
+    x_futures = yield c.scatter(x_dsk)
+    y_futures = yield c.scatter(y_dsk)
 
     dt = np.random.random(0).dtype
     x_local = da.Array(x_dsk, "x", ((3, 3, 3), (3, 3)), dt)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1530,7 +1530,7 @@ def test_result_type(c, s, a, b):
 
     assert "int" in s.tasks[x.key].type
 
-    
+
 @gen_cluster()
 def test_close_workers(s, a, b):
     yield s.close(close_workers=True)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1521,3 +1521,11 @@ def test_workerstate_clean(s, a, b):
     assert ws.address == a.address
     b = pickle.dumps(ws)
     assert len(b) < 1000
+
+
+@gen_cluster(client=True)
+def test_result_type(c, s, a, b):
+    x = c.submit(lambda: 1)
+    yield x
+
+    assert "int" in s.tasks[x.key].type

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1529,3 +1529,18 @@ def warn_on_duration(duration, msg):
     stop = time()
     if stop - start > parse_timedelta(duration):
         warnings.warn(msg, stacklevel=2)
+
+
+def typename(typ):
+    """ Return name of type
+
+    Examples
+    --------
+    >>> from distributed import Scheduler
+    >>> typename(Scheduler)
+    'distributed.scheduler.Scheduler'
+    """
+    try:
+        return typ.__module__ + "." + typ.__name__
+    except AttributeError:
+        return str(typ)


### PR DESCRIPTION
The scheduler now has a reprentation of the type of data objects in the cluster.

I plan to eventually use this for better bandwidth calculations, but it's good to have for other reasons, like diagnostics.