### PR TITLE
Monitor worker children processes 

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2393,7 +2393,7 @@ class Worker(ServerNode):
         total = 0
 
         proc = self.monitor.proc
-        memory = proc.memory_info().rss
+        memory = proc.memory_info().rss + sum([child.memory_info().rss for child in proc.children(True)])
         frac = memory / self.memory_limit
 
         # Pause worker threads if above 80% memory use


### PR DESCRIPTION
add proc.children() memory info to proc memory info. #2568 

This pull request is an effort to gather more profiling data on all processes running on a worker node. I am not sure where the cpu monitoring takes place, and if this is also only monitoring cpu usage by the worker process and not the children processes.

p.s. this is my first ever pull request. Apologies for any obvious mistakes.