### PR TITLE
Add waiting tasks to progress title bar

### DIFF
--- a/distributed/bokeh/scheduler.py
+++ b/distributed/bokeh/scheduler.py
@@ -1049,7 +1049,7 @@ class TaskProgress(DashboardComponent):
     def update(self):
         with log_errors():
             state = {"all": valmap(len, self.plugin.all), "nbytes": self.plugin.nbytes}
-            for k in ["memory", "erred", "released", "processing"]:
+            for k in ["memory", "erred", "released", "processing", "waiting"]:
                 state[k] = valmap(len, self.plugin.state[k])
             if not state["all"] and not len(self.source.data["all"]):
                 return
@@ -1060,7 +1060,7 @@ class TaskProgress(DashboardComponent):
 
             totals = {
                 k: sum(state[k].values())
-                for k in ["all", "memory", "erred", "released"]
+                for k in ["all", "memory", "erred", "released", "waiting"]
             }
             totals["processing"] = totals["all"] - sum(
                 v for k, v in totals.items() if k != "all"
@@ -1069,6 +1069,7 @@ class TaskProgress(DashboardComponent):
             self.root.title.text = (
                 "Progress -- total: %(all)s, "
                 "in-memory: %(memory)s, processing: %(processing)s, "
+                "waiting: %(waiting)s, "
                 "erred: %(erred)s" % totals
             )
 


### PR DESCRIPTION
It was brought to my attention that the progress bar examples in http://distributed.dask.org/en/latest/web.html#progress have the number of tasks waiting for dependencies in the title bar, but when using the distributed `master` branch, this doesn't seem to be the case. For instance, running the [example computation](http://distributed.dask.org/en/latest/web.html#example-computation) in the Web Interface docs gives

<img width="679" alt="Screen Shot 2019-05-06 at 3 07 44 PM" src="https://user-images.githubusercontent.com/11656932/57255080-871f1d00-7018-11e9-97af-3b76350115fc.png">

As best I can tell, the number of waiting tasks was removed from the title bar in #1729. Not sure if this was removed intentionally and the gifs in the docs are just outdated, or if it was an unintentional change. As the number of waiting tasks can be useful when charting the overall progress of a computation, this PR adds waiting tasks back to the `TaskProgress` title text.