### PR TITLE
DOC: Clean up reference to cluster object

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -82,19 +82,19 @@ class LocalCluster(Cluster):
 
     Examples
     --------
-    >>> c = LocalCluster()  # Create a local cluster with as many workers as cores  # doctest: +SKIP
-    >>> c  # doctest: +SKIP
+    >>> cluster = LocalCluster()  # Create a local cluster with as many workers as cores  # doctest: +SKIP
+    >>> cluster  # doctest: +SKIP
     LocalCluster("127.0.0.1:8786", workers=8, ncores=8)
 
-    >>> c = Client(c)  # connect to local cluster  # doctest: +SKIP
+    >>> c = Client(cluster)  # connect to local cluster  # doctest: +SKIP
 
     Add a new worker to the cluster
 
-    >>> w = c.start_worker(ncores=2)  # doctest: +SKIP
+    >>> w = cluster.start_worker(ncores=2)  # doctest: +SKIP
 
     Shut down the extra worker
 
-    >>> c.stop_worker(w)  # doctest: +SKIP
+    >>> cluster.stop_worker(w)  # doctest: +SKIP
 
     Pass extra keyword arguments to Bokeh
 


### PR DESCRIPTION
The current docs would overwrite the cluster objects, so it needs to get its own variable name.
As the Client is usually named `c`, I changed the cluster object to the name `cluster`

Solves #4779