### PR TITLE
Move dashboard_address logic into Scheduler/Worker

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -188,29 +188,15 @@ def main(
     loop = IOLoop.current()
     logger.info("-" * 47)
 
-    services = {}
-    if _bokeh:
-        try:
-            from distributed.bokeh.scheduler import BokehScheduler
-
-            services[("bokeh", dashboard_address)] = (
-                BokehScheduler,
-                {"prefix": bokeh_prefix},
-            )
-        except ImportError as error:
-            if str(error).startswith("No module named"):
-                logger.info("Web dashboard not loaded.  Unable to import bokeh")
-            else:
-                logger.info("Unable to import bokeh: %s" % str(error))
-
     scheduler = Scheduler(
         loop=loop,
-        services=services,
         scheduler_file=scheduler_file,
         security=sec,
         host=host,
         port=port,
         interface=interface,
+        dashboard_address=dashboard_address if _bokeh else None,
+        service_kwargs={"bokeh": {"prefix": bokeh_prefix}},
     )
     scheduler.start()
     if not preload:

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -163,7 +163,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     default=None,
     help="Seconds to wait for a scheduler before closing",
 )
-@click.option("--bokeh-prefix", type=str, default=None, help="Prefix for the bokeh app")
+@click.option("--bokeh-prefix", type=str, default="", help="Prefix for the bokeh app")
 @click.option(
     "--preload",
     type=str,
@@ -288,18 +288,6 @@ def main(
 
     services = {}
 
-    if bokeh:
-        try:
-            from distributed.bokeh.worker import BokehWorker
-        except ImportError:
-            pass
-        else:
-            if bokeh_prefix:
-                result = (BokehWorker, {"prefix": bokeh_prefix})
-            else:
-                result = BokehWorker
-            services[("bokeh", dashboard_address)] = result
-
     if resources:
         resources = resources.replace(",", " ").split()
         resources = dict(pair.split("=") for pair in resources)
@@ -350,6 +338,8 @@ def main(
             interface=interface,
             host=host,
             port=port,
+            dashboard_address=dashboard_address if bokeh else None,
+            service_kwargs={"bokhe": {"prefix": bokeh_prefix}},
             name=name if nprocs == 1 or not name else name + "-" + str(i),
             **kwargs
         )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -818,6 +818,7 @@ class Scheduler(ServerNode):
         delete_interval="500ms",
         synchronize_worker_interval="60s",
         services=None,
+        service_kwargs=None,
         allowed_failures=ALLOWED_FAILURES,
         extensions=None,
         validate=False,
@@ -829,6 +830,7 @@ class Scheduler(ServerNode):
         host=None,
         port=8786,
         protocol=None,
+        dashboard_address=None,
         **kwargs
     ):
         self._setup_logging()
@@ -861,6 +863,17 @@ class Scheduler(ServerNode):
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args("scheduler")
         self.listen_args = self.security.get_listen_args("scheduler")
+
+        if dashboard_address is not None:
+            try:
+                from distributed.bokeh.scheduler import BokehScheduler
+            except ImportError:
+                logger.debug("To start diagnostics web server please install Bokeh")
+            else:
+                self.service_specs[("bokeh", dashboard_address)] = (
+                    BokehScheduler,
+                    (service_kwargs or {}).get("bokeh", {}),
+                )
 
         # Communication state
         self.loop = loop or IOLoop.current()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -822,7 +822,7 @@ def test_file_descriptors(c, s):
     yield [n.close() for n in nannies]
 
     assert not s.rpc.open
-    assert not c.rpc.active, list(c.rpc._created)
+    assert not any(occ for addr, occ in c.rpc.occupied.items() if occ != s.address)
     assert not s.stream_comms
 
     start = time()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -290,6 +290,7 @@ class Worker(ServerNode):
         local_dir="dask-worker-space",
         services=None,
         service_ports=None,
+        service_kwargs=None,
         name=None,
         reconnect=True,
         memory_limit="auto",
@@ -309,6 +310,7 @@ class Worker(ServerNode):
         host=None,
         port=None,
         protocol=None,
+        dashboard_address=None,
         low_level_profiler=dask.config.get("distributed.worker.profile.low-level"),
         **kwargs
     ):
@@ -535,6 +537,18 @@ class Worker(ServerNode):
         self.services = {}
         self.service_ports = service_ports or {}
         self.service_specs = services or {}
+
+        if dashboard_address is not None:
+            try:
+                from distributed.bokeh.worker import BokehWorker
+            except ImportError:
+                logger.debug("To start diagnostics web server please install Bokeh")
+            else:
+                self.service_specs[("bokeh", dashboard_address)] = (
+                    BokehWorker,
+                    (service_kwargs or {}).get("bokeh", {}),
+                )
+
         self.metrics = dict(metrics) if metrics else {}
 
         self.low_level_profiler = low_level_profiler


### PR DESCRIPTION
This removes repetitive logic from the LocalCluster and
dask-scheduler/dask-worker CLI and moves it into the classes.
This also makes it easier to make other Cluster objects without
depending on LocalCluster