### PR TITLE
DOC: adds CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ code conforms with these styles, run
 ``` shell
 $ pip install black flake8
 $ cd path/to/distributed
-$ black .
-$ flake8 .
+$ black distributed
+$ flake8 distributed
 ```
 
 [flake8]:http://flake8.pycqa.org/en/latest/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+For more information, see https://docs.dask.org/en/latest/develop.html#contributing-to-code
+
+
+## Style
+Distributed conforms with the [flake8] and [black] styles. To make sure your
+code conforms with these styles, run
+
+``` shell
+$ pip install black flake8
+$ cd path/to/distributed
+$ black .
+$ flake8 .
+```
+
+[flake8]:http://flake8.pycqa.org/en/latest/
+[black]:https://github.com/python/black
+
+## Docstrings
+
+Dask Distributed roughly follows the [numpydoc] standard. More information is
+available at https://docs.dask.org/en/latest/develop.html#docstrings.
+
+[numpydoc]:https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+
+## Tests
+
+Dask employs extensive unit tests to ensure correctness of code both for today
+and for the future. Test coverage is expected for all code contributions. More
+detail is at https://docs.dask.org/en/latest/develop.html#test


### PR DESCRIPTION
In https://github.com/dask/distributed/pull/2619#issuecomment-491020372 I had to tell the new contributor @muammar that `black` and `flake8` needed to be run. This PR would eliminate that need adding a CONTRIBUTING.md file which shows up when a PR is made (https://github.blog/2012-09-17-contributing-guidelines/).