### PR TITLE
Fix uri_from_host_port import in dask-mpi

### DIFF
--- a/distributed/cli/dask_mpi.py
+++ b/distributed/cli/dask_mpi.py
@@ -8,7 +8,8 @@ from warnings import warn
 
 from distributed import Scheduler, Nanny, Worker
 from distributed.bokeh.worker import BokehWorker
-from distributed.cli.utils import check_python_3, uri_from_host_port
+from distributed.cli.utils import check_python_3
+from distributed.comm.addressing import uri_from_host_port
 from distributed.utils import get_ip_interface
 
 


### PR DESCRIPTION
There is an `ImportError` for `uri_from_host_port` in the `dask-mpi` cli command:

```console
$ dask-mpi --help
Traceback (most recent call last):
  File "/Users/jbourbeau/miniconda/envs/dask-dev/bin/dask-mpi", line 6, in <module>
    from distributed.cli.dask_mpi import go
  File "/Users/jbourbeau/miniconda/envs/dask-dev/lib/python3.6/site-packages/distributed/cli/dask_mpi.py", line 11, in <module>
    from distributed.cli.utils import check_python_3, uri_from_host_port
ImportError: cannot import name 'uri_from_host_port'
```

This PR fixes the import issue (`uri_from_host_port` lives in `distributed.comm.addressing`).
