### PR TITLE
Wait for n workers before continuing

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1061,6 +1061,7 @@ class Client(Node):
             info = yield self.scheduler.identity()
 
     def wait_for_workers(self, n_workers=0):
+        """Blocking call to wait for n workers before continuing"""
         return self.sync(self._wait_for_workers, n_workers)
 
     def _heartbeat(self):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1053,6 +1053,14 @@ class Client(Node):
         except EnvironmentError:
             logger.debug("Not able to query scheduler for identity")
 
+    @gen.coroutine
+    def _wait_until_n_workers(self, n):
+        while n and len(self.cluster.scheduler.workers) < n:
+            yield gen.sleep(0.01)
+
+    def wait_until_n_workers(self, n):
+        return self.sync(self._wait_until_n_workers, n)
+
     def _heartbeat(self):
         if self.scheduler_comm:
             self.scheduler_comm.send({"op": "heartbeat-client"})

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1056,7 +1056,7 @@ class Client(Node):
     @gen.coroutine
     def _wait_for_workers(self, n_workers=0):
         info = yield self.scheduler.identity()
-        while n_workers and len(info['workers']) < n_workers:
+        while n_workers and len(info["workers"]) < n_workers:
             yield gen.sleep(0.1)
             info = yield self.scheduler.identity()
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1056,7 +1056,7 @@ class Client(Node):
     @gen.coroutine
     def _wait_for_workers(self, func, n):
         while n and (yield func()) < n:
-            yield gen.sleep(0.2)
+            yield gen.sleep(0.1)
 
     def wait_for_workers(self, n_workers=0):
         """

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1055,8 +1055,10 @@ class Client(Node):
 
     @gen.coroutine
     def _wait_until_n_workers(self, n):
-        while n and len(self.cluster.scheduler.workers) < n:
-            yield gen.sleep(0.01)
+        info = yield self.scheduler.identity()
+        while n and len(info['workers']) < n:
+            yield gen.sleep(0.200)
+            info = yield self.scheduler.identity()
 
     def wait_until_n_workers(self, n):
         return self.sync(self._wait_until_n_workers, n)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5715,7 +5715,7 @@ def test_instances(c, s, a, b):
 @gen_cluster(client=True)
 def test_wait_for_workers(c, s, a, b):
     future = c.wait_for_workers(n_workers=3)
-    yield gen.sleep(0.22) # 2 chances
+    yield gen.sleep(0.22)  # 2 chances
     assert not future.done()
 
     w = yield Worker(s.address)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5715,7 +5715,7 @@ def test_instances(c, s, a, b):
 @gen_cluster(client=True)
 def test_wait_for_workers(c, s, a, b):
     future = c.wait_for_workers(n_workers=3)
-    yield gen.sleep(0.1)
+    yield gen.sleep(0.22) # 2 chances
     assert not future.done()
 
     w = yield Worker(s.address)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5712,5 +5712,18 @@ def test_instances(c, s, a, b):
     assert set(Worker._instances) == {a, b}
 
 
+@gen_cluster(client=True)
+def test_wait_for_workers(c, s, a, b):
+    future = c.wait_for_workers(n_workers=3)
+    yield gen.sleep(0.1)
+    assert not future.done()
+
+    w = yield Worker(s.address)
+    start = time()
+    yield future
+    assert time() < start + 1
+    yield w.close()
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # noqa F401


### PR DESCRIPTION
This is the easiest and I think most well supported implementation of waiting for n workers.

Initially I thought it was wrong to be in `Client`, but considering the implementation of `Cluster` -- (the bulk of which is in `LocalCluster`) this is the solution which is most immediately compatible with jobqueue and kubernetes.

The alternative would be to move `asynchronous` and `loop` from `LocalCluster` to `Cluster`,  and then make this a top level member of Cluster.  In addition, jobqueue would need to inherit from `Cluster` instead of `ClusterManager`.  This is currently tested and working on `SLURMCluster`, I will think of a way to test it without jobqueue though once we settle on the correct path.

I'm okay with both ways, but figured I would start with this since it's so low effort.
@mrocklin @guillaumeeb 

fix #2138