### PR TITLE
Add helper to open dashboard

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -25,6 +25,7 @@ API
    Client.list_datasets
    Client.map
    Client.ncores
+   Client.open_dashboard
    Client.persist
    Client.publish_dataset
    Client.profile


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/2083

This shares all the limitations with the dashboard URL in the `Client._repr_html_`. Additionally, it won't work on things like `examples.dask.org` because the client is running on the remote machine. I still find it useful for local debugging.