### PR TITLE
Close nannies gracefully

### DIFF
--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -474,6 +474,7 @@ def test_death_timeout_raises(loop):
             loop=loop,
         ) as cluster:
             pass
+    LocalCluster._instances.clear()  # ignore test hygiene checks
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="Unknown")

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -131,6 +131,7 @@ class Nanny(ServerNode):
             "restart": self.restart,
             # cannot call it 'close' on the rpc side for naming conflict
             "terminate": self.close,
+            "close_gracefully": self.close_gracefully,
             "run": self.run,
         }
 
@@ -355,7 +356,7 @@ class Nanny(ServerNode):
                     return
 
             try:
-                if self.status not in ("closing", "closed"):
+                if self.status not in ("closing", "closed", "closing-gracefully"):
                     if self.auto_restart:
                         logger.warning("Restarting worker")
                         yield self.instantiate()
@@ -371,6 +372,14 @@ class Nanny(ServerNode):
     def _close(self, *args, **kwargs):
         warnings.warn("Worker._close has moved to Worker.close", stacklevel=2)
         return self.close(*args, **kwargs)
+
+    def close_gracefully(self, comm=None):
+        """
+        A signal that we shouldn't try to restart workers if they go away
+
+        This is used as part of the cluster shutdown process.
+        """
+        self.status = "closing-gracefully"
 
     @gen.coroutine
     def close(self, comm=None, timeout=5, report=None):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1265,6 +1265,7 @@ class Scheduler(ServerNode):
         setproctitle("dask-scheduler [closing]")
 
         if close_workers:
+            self.broadcast(msg={"op": "close_gracefully"}, nanny=True)
             for worker in self.workers:
                 self.worker_send(worker, {"op": "close"})
             for i in range(20):  # wait a second for send signals to clear

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -44,6 +44,7 @@ from .comm import Comm
 from .comm.utils import offload
 from .config import initialize_logging
 from .core import connect, rpc, CommClosedError
+from .deploy import SpecCluster
 from .metrics import time
 from .process import _cleanup_dangling
 from .proctitle import enable_proctitle_on_children
@@ -1477,6 +1478,7 @@ def check_instances():
     Client._instances.clear()
     Worker._instances.clear()
     Scheduler._instances.clear()
+    SpecCluster._instances.clear()
     # assert all(n.status == "closed" for n in Nanny._instances), {
     #     n: n.status for n in Nanny._instances
     # }
@@ -1513,6 +1515,10 @@ def check_instances():
     assert all(n.status == "closed" or n.status == "init" for n in Nanny._instances), {
         n: n.status for n in Nanny._instances
     }
+
+    # assert not list(SpecCluster._instances)  # TODO
+    assert all(c.status == "closed" for c in SpecCluster._instances)
+    SpecCluster._instances.clear()
 
     Nanny._instances.clear()
     DequeHandler.clear_all_instances()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1047,6 +1047,10 @@ class Worker(ServerNode):
             if self.batched_stream:
                 self.batched_stream.close()
 
+            if nanny and self.nanny:
+                with self.rpc(self.nanny) as r:
+                    yield r.terminate()
+
             self.stop()
             self.rpc.close()
             self._closed.set()


### PR DESCRIPTION
Previously a worker process could be stopped before it told its nanny
that it was going away.  Now we intentionally tell the nanny ahead of
time from the scheduler (and the worker for good measure) before we
start the shutdown procedure.