### PR TITLE
Add back LocalCluster.__repr__

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -197,6 +197,13 @@ class LocalCluster(SpecCluster):
         )
         self.scale(n_workers)
 
+    def __repr__(self):
+        return "LocalCluster(%r, workers=%d, ncores=%d)" % (
+            self.scheduler_address,
+            len(self.workers),
+            sum(w.ncores for w in self.workers.values()),
+        )
+
 
 def nprocesses_nthreads(n):
     """


### PR DESCRIPTION
`LocalCluster.__repr__` was removed (I would guess inadvertently) in #2675 where `SpecCluster` was added.

Inside an IPython console on master:
```
In [1]: from distributed import LocalCluster 
   ...: cluster = LocalCluster(n_workers=2) 
   ...: cluster                                                                                                                                                                    
Out[1]: SpecCluster('tcp://127.0.0.1:42717', workers=2)
```

On this PR:
```
In [1]: from distributed import LocalCluster 
   ...: cluster = LocalCluster(n_workers=2) 
   ...: cluster                                                                                                                                                                    
Out[1]: LocalCluster('tcp://127.0.0.1:43065', workers=2, ncores=4)
```

Let me know if you'd like me to add a test.

Note: this does not matter at all inside a Jupyter notebook (or Jupyter lab) because the fancy cluster widget is shown rather than `__repr__`.

