### PR TITLE
Allow tasks with restrictions to be stolen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ continuous_integration/hdfs-initialized
 .pytest_cache/
 dask-worker-space/
 .vscode/
+*.swp
+.ycm_extra_conf.py
+tags

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -44,7 +44,7 @@ conda install -q \
     paramiko \
     prometheus_client \
     psutil \
-    pytest \
+    pytest>=4 \
     pytest-timeout \
     python=$PYTHON \
     requests \

--- a/distributed/cli/dask_mpi.py
+++ b/distributed/cli/dask_mpi.py
@@ -105,7 +105,7 @@ def main(
             scheduler_file=scheduler_file,
             loop=loop,
             name=rank if scheduler else None,
-            ncores=nthreads,
+            nthreads=nthreads,
             local_dir=local_directory,
             services={("dashboard", bokeh_worker_port): BokehWorker},
             memory_limit=memory_limit,

--- a/distributed/cli/dask_mpi.py
+++ b/distributed/cli/dask_mpi.py
@@ -63,6 +63,7 @@ loop = IOLoop()
     help="Worker's Bokeh port for visual diagnostics",
 )
 @click.option("--bokeh-prefix", type=str, default=None, help="Prefix for the bokeh app")
+@click.version_option()
 def main(
     scheduler_file,
     interface,

--- a/distributed/cli/dask_remote.py
+++ b/distributed/cli/dask_remote.py
@@ -8,6 +8,7 @@ from distributed.submit import _remote
 @click.command()
 @click.option("--host", type=str, default=None, help="IP or hostname of this server")
 @click.option("--port", type=int, default=8788, help="Remote Client Port")
+@click.version_option()
 def main(host, port):
     _remote(host, port)
 

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -113,6 +113,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.argument(
     "preload_argv", nargs=-1, type=click.UNPROCESSED, callback=validate_preload_argv
 )
+@click.version_option()
 def main(
     host,
     port,

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -101,6 +101,7 @@ from distributed.cli.utils import check_python_3
     help="Worker to run. Defaults to distributed.cli.dask_worker",
 )
 @click.pass_context
+@click.version_option()
 def main(
     ctx,
     scheduler,

--- a/distributed/cli/dask_submit.py
+++ b/distributed/cli/dask_submit.py
@@ -9,6 +9,7 @@ from distributed.submit import _submit
 @click.command()
 @click.argument("remote_client_address", type=str, required=True)
 @click.argument("filepath", type=str, required=True)
+@click.version_option()
 def main(remote_client_address, filepath):
     @gen.coroutine
     def f():

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -180,6 +180,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.argument(
     "preload_argv", nargs=-1, type=click.UNPROCESSED, callback=validate_preload_argv
 )
+@click.version_option()
 def main(
     scheduler,
     host,

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import atexit
 import logging
+import multiprocessing
 import gc
 import os
 from sys import exit
@@ -11,7 +12,6 @@ import click
 import dask
 from distributed import Nanny, Worker
 from distributed.utils import parse_timedelta
-from distributed.worker import _ncores
 from distributed.security import Security
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.comm import get_address_host_port
@@ -280,7 +280,7 @@ def main(
         port = worker_port
 
     if not nthreads:
-        nthreads = _ncores // nprocs
+        nthreads = multiprocessing.cpu_count() // nprocs
 
     if pid_file:
         with open(pid_file, "w") as f:
@@ -329,7 +329,7 @@ def main(
         t(
             scheduler,
             scheduler_file=scheduler_file,
-            ncores=nthreads,
+            nthreads=nthreads,
             services=services,
             loop=loop,
             resources=resources,

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -347,7 +347,7 @@ def main(
             host=host,
             port=port,
             dashboard_address=dashboard_address if dashboard else None,
-            service_kwargs={"bokhe": {"prefix": dashboard_prefix}},
+            service_kwargs={"dashboard": {"prefix": dashboard_prefix}},
             name=name if nprocs == 1 or not name else name + "-" + str(i),
             **kwargs
         )

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -373,7 +373,10 @@ def main(
 
     try:
         loop.run_sync(run)
-    except (KeyboardInterrupt, TimeoutError):
+    except TimeoutError:
+        # We already log the exception in nanny / worker. Don't do it again.
+        raise TimeoutError("Timed out starting worker.") from None
+    except KeyboardInterrupt:
         pass
     finally:
         logger.info("End worker")

--- a/distributed/cli/tests/test_dask_mpi.py
+++ b/distributed/cli/tests/test_dask_mpi.py
@@ -8,12 +8,14 @@ import pytest
 pytest.importorskip("mpi4py")
 
 import requests
+from click.testing import CliRunner
 
 from distributed import Client
 from distributed.utils import tmpfile
 from distributed.metrics import time
 from distributed.utils_test import popen
 from distributed.utils_test import loop  # noqa: F401
+from distributed.cli.dask_remote import main
 
 
 @pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
@@ -96,3 +98,9 @@ def test_bokeh(loop):
 
     with pytest.raises(Exception):
         requests.get("http://localhost:59583/status/")
+
+
+def test_version_option():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0

--- a/distributed/cli/tests/test_dask_remote.py
+++ b/distributed/cli/tests/test_dask_remote.py
@@ -7,3 +7,9 @@ def test_dask_remote():
     result = runner.invoke(main, ["--help"])
     assert "--host TEXT     IP or hostname of this server" in result.output
     assert result.exit_code == 0
+
+
+def test_version_option():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -53,7 +53,7 @@ def test_hostport(loop):
             ]
 
         with Client("127.0.0.1:8978", loop=loop) as c:
-            assert len(c.ncores()) == 0
+            assert len(c.nthreads()) == 0
             c.sync(f)
 
 
@@ -150,7 +150,7 @@ def test_multiple_workers(loop):
             with popen(["dask-worker", "localhost:8786", "--no-dashboard"]) as b:
                 with Client("127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
                     start = time()
-                    while len(c.ncores()) < 2:
+                    while len(c.nthreads()) < 2:
                         sleep(0.1)
                         assert time() < start + 10
 
@@ -178,7 +178,7 @@ def test_interface(loop):
         ) as a:
             with Client("tcp://127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
                 start = time()
-                while not len(c.ncores()):
+                while not len(c.nthreads()):
                     sleep(0.1)
                     assert time() - start < 5
                 info = c.scheduler_info()

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -13,7 +13,9 @@ import tempfile
 from time import sleep
 
 from tornado import gen
+from click.testing import CliRunner
 
+import distributed
 from distributed import Scheduler, Client
 from distributed.utils import get_ip, get_ip_interface, tmpfile
 from distributed.utils_test import (
@@ -23,6 +25,7 @@ from distributed.utils_test import (
 )
 from distributed.utils_test import loop  # noqa: F401
 from distributed.metrics import time
+import distributed.cli.dask_scheduler
 
 
 def test_defaults(loop):
@@ -374,3 +377,9 @@ def test_preload_command_default(loop):
 
     finally:
         shutil.rmtree(tmpdir)
+
+
+def test_version_option():
+    runner = CliRunner()
+    result = runner.invoke(distributed.cli.dask_scheduler.main, ["--version"])
+    assert result.exit_code == 0

--- a/distributed/cli/tests/test_dask_ssh.py
+++ b/distributed/cli/tests/test_dask_ssh.py
@@ -1,0 +1,8 @@
+from click.testing import CliRunner
+from distributed.cli.dask_ssh import main
+
+
+def test_version_option():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0

--- a/distributed/cli/tests/test_dask_submit.py
+++ b/distributed/cli/tests/test_dask_submit.py
@@ -7,3 +7,9 @@ def test_submit_runs_as_a_cli():
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "Usage: main [OPTIONS] REMOTE_CLIENT_ADDRESS FILEPATH" in result.output
+
+
+def test_version_option():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -58,7 +58,7 @@ def test_memory_limit(loop):
             ]
         ) as worker:
             with Client("127.0.0.1:8786", loop=loop) as c:
-                while not c.ncores():
+                while not c.nthreads():
                     sleep(0.1)
                 info = c.scheduler_info()
                 [d] = info["workers"].values()
@@ -218,7 +218,7 @@ def test_contact_listen_address(loop, nanny, listen_address):
             ]
         ) as worker:
             with Client("127.0.0.1:8786") as client:
-                while not client.ncores():
+                while not client.nthreads():
                     sleep(0.1)
                 info = client.scheduler_info()
                 assert "tcp://127.0.0.2:39837" in info["workers"]
@@ -243,7 +243,7 @@ def test_respect_host_listen_address(loop, nanny, host):
             ["dask-worker", "127.0.0.1:8786", nanny, "--no-dashboard", "--host", host]
         ) as worker:
             with Client("127.0.0.1:8786") as client:
-                while not client.ncores():
+                while not client.nthreads():
                     sleep(0.1)
                 info = client.scheduler_info()
 

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -296,6 +296,12 @@ def test_dashboard_non_standard_ports(loop):
             requests.get("http://localhost:4833/status/")
 
 
+def test_version_option():
+    runner = CliRunner()
+    result = runner.invoke(distributed.cli.dask_worker.main, ["--version"])
+    assert result.exit_code == 0
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("no_nanny", [True, False])
 def test_worker_timeout(no_nanny):

--- a/distributed/cli/tests/test_tls_cli.py
+++ b/distributed/cli/tests/test_tls_cli.py
@@ -25,9 +25,9 @@ tls_args = ["--tls-ca-file", ca_file, "--tls-cert", keycert]
 tls_args_2 = ["--tls-ca-file", ca_file, "--tls-cert", cert, "--tls-key", key]
 
 
-def wait_for_cores(c, ncores=1):
+def wait_for_cores(c, nthreads=1):
     start = time()
-    while len(c.ncores()) < 1:
+    while len(c.nthreads()) < 1:
         sleep(0.1)
         assert time() < start + 10
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2270,6 +2270,10 @@ class Client(Node):
         wait: boolean (optional)
             If the function is asynchronous whether or not to wait until that
             function finishes.
+        nanny : bool, defualt False
+            Whether to run ``function`` on the nanny. By default, the function
+            is run on the worker process.  If specified, the addresses in
+            ``workers`` should still be the worker addresses, not the nanny addresses.
 
         Examples
         --------
@@ -3354,7 +3358,7 @@ class Client(Node):
 
         Parameters
         ----------
-        n: int
+        n : int
             Number of logs to retrive.  Maxes out at 10000 by default,
             confiruable in config.yaml::log-length
 
@@ -3364,23 +3368,27 @@ class Client(Node):
         """
         return self.sync(self.scheduler.logs, n=n)
 
-    def get_worker_logs(self, n=None, workers=None):
+    def get_worker_logs(self, n=None, workers=None, nanny=False):
         """ Get logs from workers
 
         Parameters
         ----------
-        n: int
+        n : int
             Number of logs to retrive.  Maxes out at 10000 by default,
             confiruable in config.yaml::log-length
-        workers: iterable
-            List of worker addresses to retrive.  Gets all workers by default.
+        workers : iterable
+            List of worker addresses to retrieve.  Gets all workers by default.
+        nanny : bool, default False
+            Whether to get the logs from the workers (False) or the nannies (True). If
+            specified, the addresses in `workers` should still be the worker addresses,
+            not the nanny addresses.
 
         Returns
         -------
         Dictionary mapping worker address to logs.
         Logs are returned in reversed order (newest first)
         """
-        return self.sync(self.scheduler.worker_logs, n=n, workers=workers)
+        return self.sync(self.scheduler.worker_logs, n=n, workers=workers, nanny=nanny)
 
     def retire_workers(self, workers=None, close_workers=True, **kwargs):
         """ Retire certain workers on the scheduler

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2351,6 +2351,7 @@ class Client(Node):
                 resources = self._expand_resources(
                     resources, all_keys=itertools.chain(dsk, keys)
                 )
+                resources = {tokey(k): v for k, v in resources.items()}
 
             if retries:
                 retries = self._expand_retries(

--- a/distributed/dashboard/components.py
+++ b/distributed/dashboard/components.py
@@ -276,7 +276,7 @@ class Processing(DashboardComponent):
     """
 
     def __init__(self, **kwargs):
-        data = self.processing_update({"processing": {}, "ncores": {}})
+        data = self.processing_update({"processing": {}, "nthreads": {}})
         self.source = ColumnDataSource(data)
 
         x_range = Range1d(-1, 1)
@@ -321,12 +321,12 @@ class Processing(DashboardComponent):
     def update(self, messages):
         with log_errors():
             msg = messages["processing"]
-            if not msg.get("ncores"):
+            if not msg.get("nthreads"):
                 return
             data = self.processing_update(msg)
             x_range = self.root.x_range
             max_right = max(data["right"])
-            cores = max(data["ncores"])
+            cores = max(data["nthreads"])
             if x_range.end < max_right:
                 x_range.end = max_right + 2
             elif x_range.end > 2 * max_right + cores:  # way out there, walk back
@@ -341,8 +341,8 @@ class Processing(DashboardComponent):
             names = sorted(names)
             processing = msg["processing"]
             processing = [processing[name] for name in names]
-            ncores = msg["ncores"]
-            ncores = [ncores[name] for name in names]
+            nthreads = msg["nthreads"]
+            nthreads = [nthreads[name] for name in names]
             n = len(names)
             d = {
                 "name": list(names),
@@ -350,7 +350,7 @@ class Processing(DashboardComponent):
                 "right": list(processing),
                 "top": list(range(n, 0, -1)),
                 "bottom": list(range(n - 1, -1, -1)),
-                "ncores": ncores,
+                "nthreads": nthreads,
             }
 
             d["alpha"] = [0.7] * n

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -189,7 +189,7 @@ class Occupancy(DashboardComponent):
             if total:
                 self.root.title.text = "Occupancy -- total time: %s  wall time: %s" % (
                     format_time(total),
-                    format_time(total / self.scheduler.total_ncores),
+                    format_time(total / self.scheduler.total_nthreads),
                 )
             else:
                 self.root.title.text = "Occupancy"
@@ -1179,7 +1179,7 @@ class WorkerTable(DashboardComponent):
         self.names = [
             "name",
             "address",
-            "ncores",
+            "nthreads",
             "cpu",
             "memory",
             "memory_limit",
@@ -1198,7 +1198,7 @@ class WorkerTable(DashboardComponent):
         table_names = [
             "name",
             "address",
-            "ncores",
+            "nthreads",
             "cpu",
             "memory",
             "memory_limit",
@@ -1223,7 +1223,7 @@ class WorkerTable(DashboardComponent):
             "read_bytes": NumberFormatter(format="0 b"),
             "write_bytes": NumberFormatter(format="0 b"),
             "num_fds": NumberFormatter(format="0"),
-            "ncores": NumberFormatter(format="0"),
+            "nthreads": NumberFormatter(format="0"),
         }
 
         if BOKEH_VERSION < "0.12.15":
@@ -1345,8 +1345,8 @@ class WorkerTable(DashboardComponent):
                 data["memory_percent"][-1] = ""
             data["memory_limit"][-1] = ws.memory_limit
             data["cpu"][-1] = ws.metrics["cpu"] / 100.0
-            data["cpu_fraction"][-1] = ws.metrics["cpu"] / 100.0 / ws.ncores
-            data["ncores"][-1] = ws.ncores
+            data["cpu_fraction"][-1] = ws.metrics["cpu"] / 100.0 / ws.nthreads
+            data["nthreads"][-1] = ws.nthreads
 
         self.source.data.update(data)
 

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -449,7 +449,7 @@ class CurrentLoad(DashboardComponent):
                     "nbytes_text": nbytes_text,
                     "dashboard_host": dashboard_host,
                     "dashboard_port": dashboard_port,
-                    "address": [ws.address for ws in workers],
+                    "worker": [ws.address for ws in workers],
                     "y": y,
                 }
 

--- a/distributed/dashboard/scheduler_html.py
+++ b/distributed/dashboard/scheduler_html.py
@@ -107,7 +107,7 @@ class CountsJSON(RequestHandler):
         scheduler = self.server
         erred = 0
         nbytes = 0
-        ncores = 0
+        nthreads = 0
         memory = 0
         processing = 0
         released = 0
@@ -124,7 +124,7 @@ class CountsJSON(RequestHandler):
             if ts.waiters:
                 waiting_data += 1
         for ws in scheduler.workers.values():
-            ncores += ws.ncores
+            nthreads += ws.nthreads
             memory += len(ws.has_what)
             nbytes += ws.nbytes
             processing += len(ws.processing)
@@ -132,7 +132,7 @@ class CountsJSON(RequestHandler):
         response = {
             "bytes": nbytes,
             "clients": len(scheduler.clients),
-            "cores": ncores,
+            "cores": nthreads,
             "erred": erred,
             "hosts": len(scheduler.host_info),
             "idle": len(scheduler.idle),

--- a/distributed/dashboard/scheduler_html.py
+++ b/distributed/dashboard/scheduler_html.py
@@ -1,28 +1,16 @@
 from datetime import datetime
-import os
 
 import toolz
 from tornado import escape
 from tornado import gen
-from tornado import web
 
 from ..utils import log_errors, format_bytes, format_time
 from .proxy import GlobalProxyHandler
-
-dirname = os.path.dirname(__file__)
+from .utils import RequestHandler, redirect
 
 ns = {
     func.__name__: func for func in [format_bytes, format_time, datetime.fromtimestamp]
 }
-
-
-class RequestHandler(web.RequestHandler):
-    def initialize(self, server=None, extra=None):
-        self.server = server
-        self.extra = extra or {}
-
-    def get_template_path(self):
-        return os.path.join(dirname, "templates")
 
 
 class Workers(RequestHandler):
@@ -238,6 +226,7 @@ class HealthHandler(RequestHandler):
 
 
 routes = [
+    (r"info", redirect("info/main/workers.html")),
     (r"info/main/workers.html", Workers),
     (r"info/worker/(.*).html", Worker),
     (r"info/task/(.*).html", Task),

--- a/distributed/dashboard/templates/base.html
+++ b/distributed/dashboard/templates/base.html
@@ -29,9 +29,6 @@
           <a href="{{ page }}">{{ page|title }}</a>
         </li>
         {% endfor %}
-        <li>
-          <a href="info/main/workers.html">Info</a>
-        </li>
         <li id="navbar-toggle-icon">
           <a href="javascript:void(0);" onclick="myFunction()">
             <img src="statics/images/fa-bars.svg"></img>

--- a/distributed/dashboard/templates/worker-table.html
+++ b/distributed/dashboard/templates/worker-table.html
@@ -15,7 +15,7 @@
     <tr>
         <td><a href="../worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
         <td> {{ ws.name if ws.name is not None else "" }} </td>
-        <td> {{ ws.ncores }} </td>
+        <td> {{ ws.nthreads }} </td>
         <td> {{ format_bytes(ws.memory_limit) }} </td>
         <td> <progress class="progress" value="{{ ws.metrics['memory'] }}" max="{{ ws.memory_limit }}"></progress> </td>
         <td> {{ format_time(ws.occupancy) }} </td>

--- a/distributed/dashboard/templates/worker-table.html
+++ b/distributed/dashboard/templates/worker-table.html
@@ -1,6 +1,7 @@
    <table class="table is-striped is-hoverable">
     <tr>
         <th> Worker </th>
+        <th> Name </th>
         <th> Cores </th>
         <th> Memory </th>
         <th> Memory use </th>
@@ -13,14 +14,15 @@
     {% for ws in worker_list %}
     <tr>
         <td><a href="../worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
+        <td> {{ ws.name if ws.name is not None else "" }} </td>
         <td> {{ ws.ncores }} </td>
         <td> {{ format_bytes(ws.memory_limit) }} </td>
         <td> <progress class="progress" value="{{ ws.metrics['memory'] }}" max="{{ ws.memory_limit }}"></progress> </td>
         <td> {{ format_time(ws.occupancy) }} </td>
         <td> {{ len(ws.processing) }} </td>
         <td> {{ len(ws.has_what) }} </td>
-        {% if 'bokeh' in ws.services %}
-        <td> <a href="../../proxy/{{ ws.services['bokeh'] }}/{{ ws.host }}/status">bokeh</a> </td>
+        {% if 'dashboard' in ws.services %}
+        <td> <a href="../../proxy/{{ ws.services['dashboard'] }}/{{ ws.host }}/status">dashboard</a> </td>
         {% else %}
         <td> </td>
         {% end %}

--- a/distributed/dashboard/templates/worker.html
+++ b/distributed/dashboard/templates/worker.html
@@ -1,8 +1,8 @@
 {% extends main.html %}
 {% block content %}
-    <h1 class="title"> Worker: {{Worker}} </h1>
-      {% set ws = workers[Worker] %}
-      {% set worker_list = [ws] %}
+{% set ws = workers[Worker] %}
+{% set worker_list = [ws] %}
+    <h1 class="title"> Worker: {{ ws.address }} </h1>
       {% include "worker-table.html" %}
 
     <div class="columns">

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -321,8 +321,8 @@ def test_WorkerTable(c, s, a, b):
     assert all(wt.source.data.values())
     assert all(len(v) == 2 for v in wt.source.data.values())
 
-    ncores = wt.source.data["ncores"]
-    assert all(ncores)
+    nthreads = wt.source.data["nthreads"]
+    assert all(nthreads)
 
 
 @gen_cluster(client=True)

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -354,7 +354,7 @@ def test_WorkerTable_custom_metrics(c, s, a, b):
 
     assert all(data.values())
     assert all(len(v) == 2 for v in data.values())
-    my_index = data["worker"].index(a.address), data["worker"].index(b.address)
+    my_index = data["address"].index(a.address), data["address"].index(b.address)
     assert [data["metric_port"][i] for i in my_index] == [a.port, b.port]
     assert [data["metric_address"][i] for i in my_index] == [a.address, b.address]
 
@@ -379,7 +379,7 @@ def test_WorkerTable_different_metrics(c, s, a, b):
     assert "metric_b" in data
     assert all(data.values())
     assert all(len(v) == 2 for v in data.values())
-    my_index = data["worker"].index(a.address), data["worker"].index(b.address)
+    my_index = data["address"].index(a.address), data["address"].index(b.address)
     assert [data["metric_a"][i] for i in my_index] == [a.port, None]
     assert [data["metric_b"][i] for i in my_index] == [None, b.port]
 
@@ -399,7 +399,7 @@ def test_WorkerTable_metrics_with_different_metric_2(c, s, a, b):
     assert "metric_a" in data
     assert all(data.values())
     assert all(len(v) == 2 for v in data.values())
-    my_index = data["worker"].index(a.address), data["worker"].index(b.address)
+    my_index = data["address"].index(a.address), data["address"].index(b.address)
     assert [data["metric_a"][i] for i in my_index] == [a.port, None]
 
 

--- a/distributed/dashboard/utils.py
+++ b/distributed/dashboard/utils.py
@@ -1,13 +1,16 @@
 from __future__ import print_function, division, absolute_import
 
 from distutils.version import LooseVersion
+import os
 
 import bokeh
+from tornado import web
 from toolz import partition
 
 from ..compatibility import PY2
 
 BOKEH_VERSION = LooseVersion(bokeh.__version__)
+dirname = os.path.dirname(__file__)
 
 
 if BOKEH_VERSION >= "1.0.0" and not PY2:
@@ -32,3 +35,20 @@ def parse_args(args):
 def transpose(lod):
     keys = list(lod[0].keys())
     return {k: [d[k] for d in lod] for k in keys}
+
+
+class RequestHandler(web.RequestHandler):
+    def initialize(self, server=None, extra=None):
+        self.server = server
+        self.extra = extra or {}
+
+    def get_template_path(self):
+        return os.path.join(dirname, "templates")
+
+
+def redirect(path):
+    class Redirect(RequestHandler):
+        def get(self):
+            self.redirect(path)
+
+    return Redirect

--- a/distributed/dashboard/worker.py
+++ b/distributed/dashboard/worker.py
@@ -76,7 +76,7 @@ class StateTable(DashboardComponent):
             w = self.worker
             d = {
                 "Stored": [len(w.data)],
-                "Executing": ["%d / %d" % (len(w.executing), w.ncores)],
+                "Executing": ["%d / %d" % (len(w.executing), w.nthreads)],
                 "Ready": [len(w.ready)],
                 "Waiting": [len(w.waiting_for_data)],
                 "Connections": [len(w.in_flight_workers)],
@@ -251,7 +251,7 @@ class ExecutingTimeSeries(DashboardComponent):
         fig = figure(
             title="Executing History",
             x_axis_type="datetime",
-            y_range=[-0.1, worker.ncores + 0.1],
+            y_range=[-0.1, worker.nthreads + 0.1],
             height=150,
             tools="",
             x_range=x_range,

--- a/distributed/dashboard/worker.py
+++ b/distributed/dashboard/worker.py
@@ -735,7 +735,7 @@ def counters_doc(server, extra, doc):
 def profile_doc(server, extra, doc):
     with log_errors():
         doc.title = "Dask Worker Profile"
-        profile = ProfileTimePlot(server, sizing_mode="scale_width")
+        profile = ProfileTimePlot(server, sizing_mode="scale_width", doc=doc)
         profile.trigger_update()
 
         doc.add_root(profile.root)

--- a/distributed/dashboard/worker_html.py
+++ b/distributed/dashboard/worker_html.py
@@ -1,17 +1,4 @@
-import os
-
-from tornado import web
-
-dirname = os.path.dirname(__file__)
-
-
-class RequestHandler(web.RequestHandler):
-    def initialize(self, server=None, extra=None):
-        self.server = server
-        self.extra = extra or {}
-
-    def get_template_path(self):
-        return os.path.join(dirname, "templates")
+from .utils import RequestHandler, redirect
 
 
 class _PrometheusCollector(object):
@@ -67,15 +54,10 @@ class HealthHandler(RequestHandler):
         self.set_header("Content-Type", "text/plain")
 
 
-class OldRoute(RequestHandler):
-    def get(self):
-        self.redirect("/status")
-
-
 routes = [
     (r"metrics", PrometheusHandler),
     (r"health", HealthHandler),
-    (r"main", OldRoute),
+    (r"main", redirect("/status")),
 ]
 
 

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -123,7 +123,7 @@ class Cluster(object):
 
     def _widget_status(self):
         workers = len(self.scheduler.workers)
-        cores = sum(ws.ncores for ws in self.scheduler.workers.values())
+        cores = sum(ws.nthreads for ws in self.scheduler.workers.values())
         memory = sum(ws.memory_limit for ws in self.scheduler.workers.values())
         memory = format_bytes(memory)
         text = """

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -197,14 +197,8 @@ class LocalCluster(SpecCluster):
         )
 
     def __repr__(self):
-        return "LocalCluster(%r, workers=%d, ncores=%d)" % (
-            self.scheduler_address,
-            len(self.workers),
-            sum(w.ncores for w in self.workers.values()),
-        )
-
-    def __repr__(self):
-        return "LocalCluster(%r, workers=%d, ncores=%d)" % (
+        return "%s(%r, workers=%d, ncores=%d)" % (
+            type(self).__name__,
             self.scheduler_address,
             len(self.workers),
             sum(w.ncores for w in self.workers.values()),

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -44,8 +44,8 @@ class SpecCluster(Cluster):
     >>> from dask.distributed import Scheduler, Worker, Nanny
     >>> scheduler = {'cls': Scheduler, 'options': {"dashboard_address": ':8787'}}
     >>> workers = {
-    ...     'my-worker': {"cls": Worker, "options": {"ncores": 1}},
-    ...     'my-nanny': {"cls": Nanny, "options": {"ncores": 2}},
+    ...     'my-worker': {"cls": Worker, "options": {"nthreads": 1}},
+    ...     'my-nanny': {"cls": Nanny, "options": {"nthreads": 2}},
     ... }
     >>> cluster = SpecCluster(scheduler=scheduler, workers=workers)
 
@@ -53,8 +53,8 @@ class SpecCluster(Cluster):
 
     >>> cluster.worker_spec
     {
-       'my-worker': {"cls": Worker, "options": {"ncores": 1}},
-       'my-nanny': {"cls": Nanny, "options": {"ncores": 2}},
+       'my-worker': {"cls": Worker, "options": {"nthreads": 1}},
+       'my-nanny': {"cls": Nanny, "options": {"nthreads": 2}},
     }
 
     While the instantiation of this spec is stored in the ``.workers``

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -274,6 +274,10 @@ class SpecCluster(Cluster):
         while len(self.worker_spec) > n:
             self.worker_spec.popitem()
 
+        if self.status in ("closing", "closed"):
+            self.loop.add_callback(self._correct_state)
+            return
+
         while len(self.worker_spec) < n:
             k, spec = self.new_worker_spec()
             self.worker_spec[k] = spec
@@ -321,4 +325,5 @@ class SpecCluster(Cluster):
 def close_clusters():
     for cluster in list(SpecCluster._instances):
         with ignoring(gen.TimeoutError):
-            cluster.close(timeout=10)
+            if cluster.status != "closed":
+                cluster.close(timeout=10)

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -275,11 +275,27 @@ class SpecCluster(Cluster):
             self.worker_spec.popitem()
 
         while len(self.worker_spec) < n:
-            while self._i in self.worker_spec:
-                self._i += 1
-            self.worker_spec[self._i] = self.new_spec
+            k, spec = self.new_worker_spec()
+            self.worker_spec[k] = spec
 
         self.loop.add_callback(self._correct_state)
+
+    def new_worker_spec(self):
+        """ Return name and spec for the next worker
+
+        Returns
+        -------
+        name: identifier for worker
+        spec: dict
+
+        See Also
+        --------
+        scale
+        """
+        while self._i in self.worker_spec:
+            self._i += 1
+
+        return self._i, self.new_spec
 
     async def scale_down(self, workers):
         workers = set(workers)

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -23,11 +23,11 @@ def test_get_scale_up_kwargs(loop):
         with Client(cluster, loop=loop) as c:
             future = c.submit(lambda x: x + 1, 1)
             assert future.result() == 2
-            assert c.ncores()
+            assert c.nthreads()
             assert alc.get_scale_up_kwargs() == {"n": 3}
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 4)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
 def test_simultaneous_scale_up_and_down(c, s, *workers):
     class TestAdaptive(Adaptive):
         def get_scale_up_kwargs(self):
@@ -65,22 +65,22 @@ def test_adaptive_local_cluster(loop):
     ) as cluster:
         alc = Adaptive(cluster.scheduler, cluster, interval=100)
         with Client(cluster, loop=loop) as c:
-            assert not c.ncores()
+            assert not c.nthreads()
             future = c.submit(lambda x: x + 1, 1)
             assert future.result() == 2
-            assert c.ncores()
+            assert c.nthreads()
 
             sleep(0.1)
-            assert c.ncores()  # still there after some time
+            assert c.nthreads()  # still there after some time
 
             del future
 
             start = time()
-            while cluster.scheduler.ncores:
+            while cluster.scheduler.nthreads:
                 sleep(0.01)
                 assert time() < start + 5
 
-            assert not c.ncores()
+            assert not c.nthreads()
 
 
 @nodebug
@@ -128,7 +128,7 @@ def test_adaptive_local_cluster_multi_workers():
         yield cluster.close()
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10, active_rpc_timeout=10)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10, active_rpc_timeout=10)
 def test_adaptive_scale_down_override(c, s, *workers):
     class TestAdaptive(Adaptive):
         def __init__(self, *args, **kwargs):

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -17,9 +17,9 @@ class BrokenWorker(Worker):
 
 
 worker_spec = {
-    0: {"cls": Worker, "options": {"ncores": 1}},
-    1: {"cls": Worker, "options": {"ncores": 2}},
-    "my-worker": {"cls": MyWorker, "options": {"ncores": 3}},
+    0: {"cls": Worker, "options": {"nthreads": 1}},
+    1: {"cls": Worker, "options": {"nthreads": 2}},
+    "my-worker": {"cls": MyWorker, "options": {"nthreads": 3}},
 }
 scheduler = {"cls": Scheduler, "options": {"port": 0}}
 
@@ -37,9 +37,9 @@ async def test_specification():
         assert isinstance(cluster.workers[1], Worker)
         assert isinstance(cluster.workers["my-worker"], MyWorker)
 
-        assert cluster.workers[0].ncores == 1
-        assert cluster.workers[1].ncores == 2
-        assert cluster.workers["my-worker"].ncores == 3
+        assert cluster.workers[0].nthreads == 1
+        assert cluster.workers[1].nthreads == 2
+        assert cluster.workers["my-worker"].nthreads == 3
 
         async with Client(cluster, asynchronous=True) as client:
             result = await client.submit(lambda x: x + 1, 10)
@@ -51,9 +51,9 @@ async def test_specification():
 
 def test_spec_sync(loop):
     worker_spec = {
-        0: {"cls": Worker, "options": {"ncores": 1}},
-        1: {"cls": Worker, "options": {"ncores": 2}},
-        "my-worker": {"cls": MyWorker, "options": {"ncores": 3}},
+        0: {"cls": Worker, "options": {"nthreads": 1}},
+        1: {"cls": Worker, "options": {"nthreads": 2}},
+        "my-worker": {"cls": MyWorker, "options": {"nthreads": 3}},
     }
     with SpecCluster(workers=worker_spec, scheduler=scheduler, loop=loop) as cluster:
         assert cluster.worker_spec is worker_spec
@@ -64,9 +64,9 @@ def test_spec_sync(loop):
         assert isinstance(cluster.workers[1], Worker)
         assert isinstance(cluster.workers["my-worker"], MyWorker)
 
-        assert cluster.workers[0].ncores == 1
-        assert cluster.workers[1].ncores == 2
-        assert cluster.workers["my-worker"].ncores == 3
+        assert cluster.workers[0].nthreads == 1
+        assert cluster.workers[1].nthreads == 2
+        assert cluster.workers["my-worker"].nthreads == 3
 
         with Client(cluster, loop=loop) as client:
             assert cluster.loop is cluster.scheduler.loop
@@ -83,7 +83,7 @@ def test_loop_started():
 
 @pytest.mark.asyncio
 async def test_scale():
-    worker = {"cls": Worker, "options": {"ncores": 1}}
+    worker = {"cls": Worker, "options": {"nthreads": 1}}
     async with SpecCluster(
         asynchronous=True, scheduler=scheduler, worker=worker
     ) as cluster:
@@ -134,9 +134,9 @@ async def test_new_worker_spec():
     class MyCluster(SpecCluster):
         def new_worker_spec(self):
             i = len(self.worker_spec)
-            return i, {"cls": Worker, "options": {"ncores": i + 1}}
+            return i, {"cls": Worker, "options": {"nthreads": i + 1}}
 
     async with MyCluster(asynchronous=True, scheduler=scheduler) as cluster:
         cluster.scale(3)
         for i in range(3):
-            assert cluster.worker_spec[i]["options"]["ncores"] == i + 1
+            assert cluster.worker_spec[i]["options"]["nthreads"] == i + 1

--- a/distributed/deploy/utils_test.py
+++ b/distributed/deploy/utils_test.py
@@ -18,7 +18,7 @@ class ClusterTest(object):
     @pytest.mark.xfail()
     def test_cores(self):
         info = self.client.scheduler_info()
-        assert len(self.client.ncores()) == 2
+        assert len(self.client.nthreads()) == 2
 
     def test_submit(self):
         future = self.client.submit(lambda x: x + 1, 1)
@@ -27,7 +27,7 @@ class ClusterTest(object):
     def test_context_manager(self):
         with self.Cluster(**self.kwargs) as c:
             with Client(c) as e:
-                assert e.ncores()
+                assert e.nthreads()
 
     def test_no_workers(self):
         with self.Cluster(0, scheduler_port=0, **self.kwargs):

--- a/distributed/diagnostics/tests/test_eventstream.py
+++ b/distributed/diagnostics/tests/test_eventstream.py
@@ -11,7 +11,7 @@ from distributed.metrics import time
 from distributed.utils_test import div, gen_cluster
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 3)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
 def test_eventstream(c, s, *workers):
     pytest.importorskip("bokeh")
 

--- a/distributed/diagnostics/tests/test_plugin.py
+++ b/distributed/diagnostics/tests/test_plugin.py
@@ -34,7 +34,7 @@ def test_simple(c, s, a, b):
     assert counter not in s.plugins
 
 
-@gen_cluster(ncores=[], client=False)
+@gen_cluster(nthreads=[], client=False)
 def test_add_remove_worker(s):
     events = []
 

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -44,7 +44,7 @@ def test_TextProgressBar_empty(capsys):
     @gen_test()
     def f():
         s = yield Scheduler(port=0)
-        a, b = yield [Worker(s.address, ncores=1), Worker(s.address, ncores=1)]
+        a, b = yield [Worker(s.address, nthreads=1), Worker(s.address, nthreads=1)]
 
         progress = TextProgressBar([], scheduler=s.address, start=False, interval=0.01)
         yield progress.listen()

--- a/distributed/diagnostics/tests/test_task_stream.py
+++ b/distributed/diagnostics/tests/test_task_stream.py
@@ -14,7 +14,7 @@ from distributed.diagnostics.task_stream import TaskStreamPlugin
 from distributed.metrics import time
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 3)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
 def test_TaskStreamPlugin(c, s, *workers):
     es = TaskStreamPlugin(s)
     assert not es.buffer

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -32,6 +32,7 @@ distributed:
       incoming: 10
     preload: []
     preload-argv: []
+    daemon: True
 
     profile:
       interval: 10ms        # Time between statistical profiling queries

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -304,7 +304,13 @@ class Nanny(ServerNode):
                 )
             except gen.TimeoutError:
                 yield self.close(timeout=self.death_timeout)
-                raise gen.Return("timed out")
+                logger.exception(
+                    "Timed out connecting Nanny '%s' to scheduler '%s'",
+                    self,
+                    self.scheduler_addr,
+                )
+                raise
+
         else:
             result = yield self.process.start()
         raise gen.Return(result)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division, absolute_import
 from datetime import timedelta
 import logging
 from multiprocessing.queues import Empty
+import multiprocessing
 import os
 import psutil
 import shutil
@@ -32,7 +33,7 @@ from .utils import (
     PeriodicCallback,
     parse_timedelta,
 )
-from .worker import _ncores, run, parse_memory_limit, Worker
+from .worker import run, parse_memory_limit, Worker
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ class Nanny(ServerNode):
         scheduler_port=None,
         scheduler_file=None,
         worker_port=0,
+        nthreads=None,
         ncores=None,
         loop=None,
         local_dir="dask-worker-space",
@@ -96,8 +98,12 @@ class Nanny(ServerNode):
         else:
             self.scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))
 
+        if ncores is not None:
+            warnings.warn("the ncores= parameter has moved to nthreads=")
+            nthreads = ncores
+
         self._given_worker_port = worker_port
-        self.ncores = ncores or _ncores
+        self.nthreads = nthreads or multiprocessing.cpu_count()
         self.reconnect = reconnect
         self.validate = validate
         self.resources = resources
@@ -120,7 +126,7 @@ class Nanny(ServerNode):
         self.quiet = quiet
         self.auto_restart = True
 
-        self.memory_limit = parse_memory_limit(memory_limit, self.ncores)
+        self.memory_limit = parse_memory_limit(memory_limit, self.nthreads)
 
         if silence_logs:
             silence_logging(level=silence_logs)
@@ -160,7 +166,7 @@ class Nanny(ServerNode):
         self.status = "init"
 
     def __repr__(self):
-        return "<Nanny: %s, threads: %d>" % (self.worker_address, self.ncores)
+        return "<Nanny: %s, threads: %d>" % (self.worker_address, self.nthreads)
 
     @gen.coroutine
     def _unregister(self, timeout=10):
@@ -263,7 +269,7 @@ class Nanny(ServerNode):
         if self.process is None:
             worker_kwargs = dict(
                 scheduler_ip=self.scheduler_addr,
-                ncores=self.ncores,
+                nthreads=self.nthreads,
                 local_dir=self.local_dir,
                 services=self.services,
                 nanny=self.address,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -464,7 +464,7 @@ class WorkerProcess(object):
                 env=self.env,
             ),
         )
-        self.process.daemon = True
+        self.process.daemon = dask.config.get("distributed.worker.daemon", default=True)
         self.process.set_exit_callback(self._on_exit)
         self.running = Event()
         self.stopped = Event()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -79,6 +79,7 @@ class Nanny(ServerNode):
         protocol=None,
         **worker_kwargs
     ):
+        self._setup_logging(logger)
         self.loop = loop or IOLoop.current()
         self.security = security or Security()
         assert isinstance(self.security, Security)
@@ -130,6 +131,7 @@ class Nanny(ServerNode):
             "kill": self.kill,
             "restart": self.restart,
             # cannot call it 'close' on the rpc side for naming conflict
+            "get_logs": self.get_logs,
             "terminate": self.close,
             "close_gracefully": self.close_gracefully,
             "run": self.run,

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -130,3 +130,10 @@ class ServerNode(Node, Server):
     @property
     def service_ports(self):
         return {k: v.port for k, v in self.services.items()}
+
+    async def __aenter__(self):
+        await self
+        return self
+
+    async def __aexit__(self, typ, value, traceback):
+        await self.close()

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -330,7 +330,7 @@ _dangling = weakref.WeakSet()
 @atexit.register
 def _cleanup_dangling():
     for proc in list(_dangling):
-        if proc.daemon and proc.is_alive():
+        if proc.is_alive():
             try:
                 logger.warning("reaping stray process %s" % (proc,))
                 proc.terminate()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -13,6 +13,7 @@ import os
 import pickle
 import random
 import six
+import warnings
 import weakref
 
 import psutil
@@ -306,6 +307,11 @@ class WorkerState(object):
             "metrics": self.metrics,
             "nanny": self.nanny,
         }
+
+    @property
+    def ncores(self):
+        warnings.warn("WorkerState.ncores has moved to WorkerState.nthreads")
+        return self.nthreads
 
 
 class TaskState(object):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -73,8 +73,6 @@ from .variable import VariableExtension
 logger = logging.getLogger(__name__)
 
 
-ALLOWED_FAILURES = dask.config.get("distributed.scheduler.allowed-failures")
-
 LOG_PDB = dask.config.get("distributed.admin.pdb-on-err")
 DEFAULT_DATA_SIZE = dask.config.get("distributed.scheduler.default-data-size")
 
@@ -829,7 +827,7 @@ class Scheduler(ServerNode):
         synchronize_worker_interval="60s",
         services=None,
         service_kwargs=None,
-        allowed_failures=ALLOWED_FAILURES,
+        allowed_failures=None,
         extensions=None,
         validate=False,
         scheduler_file=None,
@@ -846,6 +844,8 @@ class Scheduler(ServerNode):
         self._setup_logging(logger)
 
         # Attributes
+        if allowed_failures is None:
+            allowed_failures = dask.config.get("distributed.scheduler.allowed-failures")
         self.allowed_failures = allowed_failures
         self.validate = validate
         self.status = None

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -333,7 +333,7 @@ class WorkStealing(SchedulerPlugin):
                 saturated = [
                     ws
                     for ws in saturated
-                    if combined_occupancy(ws) > 0.2 and len(ws.processing) > ws.ncores
+                    if combined_occupancy(ws) > 0.2 and len(ws.processing) > ws.nthreads
                 ]
             elif len(s.saturated) < 20:
                 saturated = sorted(saturated, key=combined_occupancy, reverse=True)
@@ -379,7 +379,7 @@ class WorkStealing(SchedulerPlugin):
                             continue
                         if combined_occupancy(sat) < 0.2:
                             continue
-                        if len(sat.processing) <= sat.ncores:
+                        if len(sat.processing) <= sat.nthreads:
                             continue
 
                         i += 1

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -430,12 +430,12 @@ def _can_steal(ws, what, from_):
     ``from_``.
     """
     if what.loose_restrictions:
-        logger.debug("Task {} has loose restrictions".format(what.key))
+        logger.debug("Task %s has loose restrictions", what.key)
         return True
     elif not (
         what.host_restrictions or what.worker_restrictions or what.resource_restrictions
     ):
-        logger.debug("Task {} has no restrictions".format(what.key))
+        logger.debug("Task %s has no restrictions", what.key)
         return True
 
     if (
@@ -443,16 +443,16 @@ def _can_steal(ws, what, from_):
         and get_address_host(ws.address) not in what.host_restrictions
     ):
         logger.debug(
-            "Candidate thief {} does not satisfy host restrictions {}".format(
-                ws.address, what.host_restrictions
-            )
+            "Candidate thief %s does not satisfy host restrictions %s",
+            ws.address,
+            what.host_restrictions,
         )
         return False
     elif what.worker_restrictions and ws.address not in what.worker_restrictions:
         logger.debug(
-            "Candidate thief {} does not satisfy worker restrictions {}".format(
-                ws.address, what.worker_restrictions
-            )
+            "Candidate thief %s does not satisfy worker restrictions %s",
+            ws.address,
+            what.worker_restrictions,
         )
         return False
 
@@ -468,16 +468,15 @@ def _has_resources(ws, required_resources):
         try:
             supplied = ws.resources[resource]
         except KeyError:
-            logger.debug(
-                'Worker {} does not have resource "{}"'.format(ws.address, resource)
-            )
+            logger.debug('Worker %s does not have resource "%s"', ws.address, resource)
             return False
         else:
             if supplied < value:
                 logger.debug(
-                    "Worker {} has fewer resources ({}) than required ({})".format(
-                        ws.address, supplied, value
-                    )
+                    "Worker %s has fewer resources (%s) than required (%s)",
+                    ws.address,
+                    supplied,
+                    value,
                 )
                 return False
     return True

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -349,9 +349,12 @@ class WorkStealing(SchedulerPlugin):
                             stealable.discard(ts)
                             continue
                         i += 1
-                        thieves = [
-                            ws for ws in idle if _can_steal(ws, what=ts, from_=sat)
-                        ]
+                        if _has_restrictions(ts):
+                            thieves = [
+                                ws for ws in idle if _can_steal(ws, what=ts, from_=sat)
+                            ]
+                        else:
+                            thieves = idle
                         if not thieves:
                             break
                         thief = thieves[i % len(thieves)]
@@ -384,9 +387,12 @@ class WorkStealing(SchedulerPlugin):
                             continue
 
                         i += 1
-                        thieves = [
-                            ws for ws in idle if _can_steal(ws, what=ts, from_=sat)
-                        ]
+                        if _has_restrictions(ts):
+                            thieves = [
+                                ws for ws in idle if _can_steal(ws, what=ts, from_=sat)
+                            ]
+                        else:
+                            thieves = idle
                         if not thieves:
                             continue
                         thief = thieves[i % len(thieves)]
@@ -425,17 +431,23 @@ class WorkStealing(SchedulerPlugin):
         return out
 
 
+def _has_restrictions(ts):
+    """Determine whether the given task has restrictions and whether these
+    restrictions are strict.
+    """
+    return not ts.loose_restrictions and (
+        ts.host_restrictions or ts.worker_restrictions or ts.resource_restrictions
+    )
+
+
 def _can_steal(ws, what, from_):
     """Determine whether worker ``ws`` can steal task ``what`` from worker
     ``from_``.
     """
-    if what.loose_restrictions:
-        logger.debug("Task %s has loose restrictions", what.key)
-        return True
-    elif not (
-        what.host_restrictions or what.worker_restrictions or what.resource_restrictions
-    ):
-        logger.debug("Task %s has no restrictions", what.key)
+    if not _has_restrictions(what):
+        logger.debug(
+            "Task %s has loose restrictions or no restrictions at all", what.key
+        )
         return True
 
     if (

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -341,13 +341,13 @@ def test_many_computations(c, s, a, b):
     done = c.submit(lambda x: None, futures)
 
     while not done.done():
-        assert len(s.processing) <= a.ncores + b.ncores
+        assert len(s.processing) <= a.nthreads + b.nthreads
         yield gen.sleep(0.01)
 
     yield done
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 5)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 5)] * 2)
 def test_thread_safety(c, s, a, b):
     class Unsafe(object):
         def __init__(self):
@@ -394,7 +394,7 @@ def test_load_balance(c, s, a, b):
     assert s.tasks[x.key].who_has != s.tasks[y.key].who_has  # second load balanced
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 5)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 5)
 def test_load_balance_map(c, s, *workers):
     class Foo(object):
         def __init__(self, x, y=None):
@@ -409,7 +409,7 @@ def test_load_balance_map(c, s, *workers):
     assert all(len(w.actors) == 2 for w in workers)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 4, Worker=Nanny)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4, Worker=Nanny)
 def bench_param_server(c, s, *workers):
     import dask.array as da
     import numpy as np
@@ -506,7 +506,7 @@ def test_compute_sync(client):
 
 @gen_cluster(
     client=True,
-    ncores=[("127.0.0.1", 1)],
+    nthreads=[("127.0.0.1", 1)],
     config={"distributed.worker.profile.interval": "1ms"},
 )
 def test_actors_in_profile(c, s, a):

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -188,7 +188,7 @@ def test_sparse_arrays(c, s, a, b):
     yield future
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 def test_delayed_none(c, s, w):
     x = dask.delayed(None)
     y = dask.delayed(123)

--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -276,6 +276,8 @@ def _test_workspace_concurrency(tmpdir, timeout, max_procs):
 def test_workspace_concurrency(tmpdir):
     if WINDOWS:
         raise pytest.xfail.Exception("TODO: unknown failure on windows")
+    if sys.version_info < (3, 6):
+        raise pytest.xfail.Exception("TODO: unknown failure on Python 3.5")
     _test_workspace_concurrency(tmpdir, 2.0, 6)
 
 

--- a/distributed/tests/test_ipython.py
+++ b/distributed/tests/test_ipython.py
@@ -88,7 +88,7 @@ def test_start_ipython_workers_magic(loop, zmq_ctx):
     with cluster(2) as (s, [a, b]):
 
         with Client(s["address"], loop=loop) as e, mock_ipython() as ip:
-            workers = list(e.ncores())[:2]
+            workers = list(e.nthreads())[:2]
             names = ["magic%i" % i for i in range(len(workers))]
             info_dict = e.start_ipython_workers(workers, magic_names=names)
 
@@ -116,7 +116,7 @@ def test_start_ipython_workers_magic_asterix(loop, zmq_ctx):
     with cluster(2) as (s, [a, b]):
 
         with Client(s["address"], loop=loop) as e, mock_ipython() as ip:
-            workers = list(e.ncores())[:2]
+            workers = list(e.nthreads())[:2]
             info_dict = e.start_ipython_workers(workers, magic_names="magic_*")
 
         expected = [
@@ -144,7 +144,7 @@ def test_start_ipython_remote(loop, zmq_ctx):
 
     with cluster(1) as (s, [a]):
         with Client(s["address"], loop=loop) as e, mock_ipython() as ip:
-            worker = first(e.ncores())
+            worker = first(e.nthreads())
             ip.user_ns["info"] = e.start_ipython_workers(worker)[worker]
             remote_magic("info 1")  # line magic
             remote_magic("info", "worker")  # cell magic
@@ -165,7 +165,7 @@ def test_start_ipython_qtconsole(loop):
         with mock.patch("distributed._ipython_utils.Popen", Popen), Client(
             s["address"], loop=loop
         ) as e:
-            worker = first(e.ncores())
+            worker = first(e.nthreads())
             e.start_ipython_workers(worker, qtconsole=True)
             e.start_ipython_workers(worker, qtconsole=True, qtconsole_args=["--debug"])
     assert Popen.call_count == 2

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -11,7 +11,7 @@ from distributed.utils_test import gen_cluster
 from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 8)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)
 def test_lock(c, s, a, b):
     c.set_metadata("locked", False)
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -160,9 +160,10 @@ def test_nanny_alt_worker_class(c, s, w1, w2):
 @gen_cluster(client=False, nthreads=[])
 def test_nanny_death_timeout(s):
     yield s.close()
-    w = yield Nanny(s.address, death_timeout=1)
+    w = Nanny(s.address, death_timeout=1)
+    with pytest.raises(gen.TimeoutError):
+        yield w
 
-    yield gen.sleep(3)
     assert w.status == "closed"
 
 

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -83,7 +83,7 @@ def test_expand_persist(c, s, a, b):
     assert s.tasks[low.key].state == "processing"
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 def test_repeated_persists_same_priority(c, s, w):
     xs = [delayed(slowinc)(i, delay=0.05, dask_key_name="x-%d" % i) for i in range(10)]
     ys = [
@@ -107,7 +107,7 @@ def test_repeated_persists_same_priority(c, s, w):
     assert any(s.tasks[z.key].state == "memory" for z in zs)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 def test_last_in_first_out(c, s, w):
     xs = [c.submit(slowinc, i, delay=0.05) for i in range(5)]
     ys = [c.submit(slowinc, x, delay=0.05) for x in xs]

--- a/distributed/tests/test_pubsub.py
+++ b/distributed/tests/test_pubsub.py
@@ -49,7 +49,7 @@ def test_speed(c, s, a, b):
     # print('duration', stop - start)  # I get around 3ms/roundtrip on my laptop
 
 
-@gen_cluster(client=True, ncores=[])
+@gen_cluster(client=True, nthreads=[])
 def test_client(c, s):
     with pytest.raises(Exception):
         get_worker()

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 from datetime import timedelta
 from time import sleep
-import sys
 
 import pytest
 from tornado import gen
@@ -113,9 +112,8 @@ def test_picklability_sync(client):
     assert q.get() == 11
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="Multi-client issues")
 @pytest.mark.slow
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
 def test_race(c, s, *workers):
     def f(i):
         with worker_client() as c:

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -14,7 +14,7 @@ from distributed.utils_test import inc, gen_cluster, slowinc, slowadd
 from distributed.utils_test import client, cluster_fixture, loop, s, a, b  # noqa: F401
 
 
-@gen_cluster(client=True, ncores=[])
+@gen_cluster(client=True, nthreads=[])
 def test_resources(c, s):
     assert not s.worker_resources
     assert not s.resources
@@ -37,7 +37,7 @@ def test_resources(c, s):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 5}}),
         ("127.0.0.1", 1, {"resources": {"A": 1, "B": 1}}),
     ],
@@ -65,7 +65,7 @@ def test_resource_submit(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -80,7 +80,7 @@ def test_submit_many_non_overlapping(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -96,7 +96,7 @@ def test_move(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -114,7 +114,7 @@ def test_dont_work_steal(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -128,7 +128,7 @@ def test_map(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -147,7 +147,7 @@ def test_persist(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 11}}),
     ],
@@ -170,7 +170,7 @@ def test_compute(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -184,7 +184,7 @@ def test_get(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -222,7 +222,7 @@ def test_resources_str(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 4, {"resources": {"A": 2}}),
         ("127.0.0.1", 4, {"resources": {"A": 1}}),
     ],
@@ -240,7 +240,7 @@ def test_submit_many_non_overlapping(c, s, a, b):
     assert b.total_resources == b.available_resources
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 4, {"resources": {"A": 2, "B": 1}})])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 4, {"resources": {"A": 2, "B": 1}})])
 def test_minimum_resource(c, s, a):
     futures = c.map(slowinc, range(30), resources={"A": 1, "B": 1}, delay=0.02)
 
@@ -252,7 +252,7 @@ def test_minimum_resource(c, s, a):
     assert a.total_resources == a.available_resources
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2, {"resources": {"A": 1}})])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2, {"resources": {"A": 1}})])
 def test_prefer_constrained(c, s, a):
     futures = c.map(slowinc, range(1000), delay=0.1)
     constrained = c.map(inc, range(10), resources={"A": 1})
@@ -270,7 +270,7 @@ def test_prefer_constrained(c, s, a):
 @pytest.mark.skip(reason="")
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 2, {"resources": {"A": 1}}),
         ("127.0.0.1", 2, {"resources": {"A": 1}}),
     ],
@@ -284,7 +284,7 @@ def test_balance_resources(c, s, a, b):
     assert any(f.key in b.data for f in constrained)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2)])
 def test_set_resources(c, s, a):
     yield a.set_resources(A=2)
     assert a.total_resources["A"] == 2
@@ -303,7 +303,7 @@ def test_set_resources(c, s, a):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -325,7 +325,7 @@ def test_persist_collections(c, s, a, b):
 @pytest.mark.skip(reason="Should protect resource keys from optimization")
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -346,7 +346,7 @@ def test_dont_optimize_out(c, s, a, b):
 @pytest.mark.xfail(reason="atop fusion seemed to break this")
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1607,3 +1607,17 @@ async def test_async_context_manager():
             assert w.status == "running"
             assert s.workers
         assert not s.workers
+
+
+@pytest.mark.asyncio
+async def test_allowed_failures_config():
+    async with Scheduler(port=0, allowed_failures=10) as s:
+        assert s.allowed_failures == 10
+
+    with dask.config.set({"distributed.scheduler.allowed_failures": 100}):
+        async with Scheduler(port=0) as s:
+            assert s.allowed_failures == 100
+
+    with dask.config.set({"distributed.scheduler.allowed_failures": 0}):
+        async with Scheduler(port=0) as s:
+            assert s.allowed_failures == 0

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1574,6 +1574,31 @@ def test_dashboard_address():
     yield s.close()
 
 
+@gen_cluster(client=True)
+async def test_adaptive_target(c, s, a, b):
+    assert s.adaptive_target() == 0
+    x = c.submit(inc, 1)
+    await x
+    assert s.adaptive_target() == 1
+
+    # Long task
+    s.task_duration["slowinc"] = 10
+    x = c.submit(slowinc, 1, delay=0.5)
+    while x.key not in s.tasks:
+        await gen.sleep(0.01)
+    assert s.adaptive_target(target_duration=".1s") == 1  # still one
+
+    s.task_duration["slowinc"] = 10
+    L = c.map(slowinc, range(100), delay=0.5)
+    while len(s.tasks) < 100:
+        await gen.sleep(0.01)
+    assert 10 < s.adaptive_target(target_duration=".1s") <= 100
+    del x, L
+    while s.tasks:
+        await gen.sleep(0.01)
+    assert s.adaptive_target(target_duration=".1s") == 0
+
+
 @pytest.mark.asyncio
 async def test_async_context_manager():
     async with Scheduler(port=0) as s:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1572,3 +1572,13 @@ def test_dashboard_address():
     s = yield Scheduler(dashboard_address="127.0.0.1", port=0)
     assert s.services["dashboard"].port
     yield s.close()
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager():
+    async with Scheduler(port=0) as s:
+        assert s.status == "running"
+        async with Worker(s.address) as w:
+            assert w.status == "running"
+            assert s.workers
+        assert not s.workers

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -37,7 +37,7 @@ teardown_module = nodebug_teardown_module
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2), ("127.0.0.2", 2)], timeout=20)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2), ("127.0.0.2", 2)], timeout=20)
 def test_work_stealing(c, s, a, b):
     [x] = yield c._scatter([1], workers=a.address)
     futures = c.map(slowadd, range(50), [x] * 50)
@@ -46,7 +46,7 @@ def test_work_stealing(c, s, a, b):
     assert len(b.data) > 10
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_dont_steal_expensive_data_fast_computation(c, s, a, b):
     np = pytest.importorskip("numpy")
     x = c.submit(np.arange, 1000000, workers=a.address)
@@ -64,7 +64,7 @@ def test_dont_steal_expensive_data_fast_computation(c, s, a, b):
     assert len(a.data) == 12
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_steal_cheap_data_slow_computation(c, s, a, b):
     x = c.submit(slowinc, 100, delay=0.1)  # learn that slowinc is slow
     yield wait(x)
@@ -77,7 +77,7 @@ def test_steal_cheap_data_slow_computation(c, s, a, b):
 
 
 @pytest.mark.avoid_travis
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_steal_expensive_data_slow_computation(c, s, a, b):
     np = pytest.importorskip("numpy")
 
@@ -94,7 +94,7 @@ def test_steal_expensive_data_slow_computation(c, s, a, b):
     assert b.data  # not empty
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
 def test_worksteal_many_thieves(c, s, *workers):
     x = c.submit(slowinc, -1, delay=0.1)
     yield x
@@ -110,7 +110,7 @@ def test_worksteal_many_thieves(c, s, *workers):
     assert sum(map(len, s.has_what.values())) < 150
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_dont_steal_unknown_functions(c, s, a, b):
     futures = c.map(inc, [1, 2], workers=a.address, allow_other_workers=True)
     yield wait(futures)
@@ -118,7 +118,7 @@ def test_dont_steal_unknown_functions(c, s, a, b):
     assert len(b.data) == 0
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_eventually_steal_unknown_functions(c, s, a, b):
     futures = c.map(
         slowinc, range(10), delay=0.1, workers=a.address, allow_other_workers=True
@@ -129,7 +129,7 @@ def test_eventually_steal_unknown_functions(c, s, a, b):
 
 
 @pytest.mark.skip(reason="")
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 3)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
 def test_steal_related_tasks(e, s, a, b, c):
     futures = e.map(
         slowinc, range(20), delay=0.05, workers=a.address, allow_other_workers=True
@@ -145,7 +145,7 @@ def test_steal_related_tasks(e, s, a, b, c):
     assert nearby > 10
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10, timeout=1000)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10, timeout=1000)
 def test_dont_steal_fast_tasks(c, s, *workers):
     np = pytest.importorskip("numpy")
     x = c.submit(np.random.random, 10000000, workers=workers[0].address)
@@ -163,7 +163,7 @@ def test_dont_steal_fast_tasks(c, s, *workers):
     assert len(s.has_what[workers[0].address]) == 1001
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)], timeout=20)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)], timeout=20)
 def test_new_worker_steals(c, s, a):
     yield wait(c.submit(slowinc, 1, delay=0.01))
 
@@ -172,7 +172,7 @@ def test_new_worker_steals(c, s, a):
     while len(a.task_state) < 10:
         yield gen.sleep(0.01)
 
-    b = yield Worker(s.address, loop=s.loop, ncores=1, memory_limit=TOTAL_MEMORY)
+    b = yield Worker(s.address, loop=s.loop, nthreads=1, memory_limit=TOTAL_MEMORY)
 
     result = yield total
     assert result == sum(map(inc, range(100)))
@@ -204,7 +204,7 @@ def test_work_steal_no_kwargs(c, s, a, b):
     assert result == sum(map(inc, range(100)))
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1), ("127.0.0.1", 2)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1), ("127.0.0.1", 2)])
 def test_dont_steal_worker_restrictions(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
     yield future
@@ -228,7 +228,7 @@ def test_dont_steal_worker_restrictions(c, s, a, b):
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1), ("127.0.0.2", 1)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1), ("127.0.0.2", 1)])
 def test_dont_steal_host_restrictions(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
     yield future
@@ -247,7 +247,7 @@ def test_dont_steal_host_restrictions(c, s, a, b):
 
 
 @gen_cluster(
-    client=True, ncores=[("127.0.0.1", 1, {"resources": {"A": 2}}), ("127.0.0.1", 1)]
+    client=True, nthreads=[("127.0.0.1", 1, {"resources": {"A": 2}}), ("127.0.0.1", 1)]
 )
 def test_dont_steal_resource_restrictions(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
@@ -267,7 +267,9 @@ def test_dont_steal_resource_restrictions(c, s, a, b):
 
 
 @pytest.mark.skip(reason="no stealing of resources")
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1, {"resources": {"A": 2}})], timeout=3)
+@gen_cluster(
+    client=True, nthreads=[("127.0.0.1", 1, {"resources": {"A": 2}})], timeout=3
+)
 def test_steal_resource_restrictions(c, s, a):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
     yield future
@@ -277,7 +279,7 @@ def test_steal_resource_restrictions(c, s, a):
         yield gen.sleep(0.01)
     assert len(a.task_state) == 101
 
-    b = yield Worker(s.address, loop=s.loop, ncores=1, resources={"A": 4})
+    b = yield Worker(s.address, loop=s.loop, nthreads=1, resources={"A": 4})
 
     start = time()
     while not b.task_state or len(a.task_state) == 101:
@@ -290,7 +292,7 @@ def test_steal_resource_restrictions(c, s, a):
     yield b.close()
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 5, timeout=20)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 5, timeout=20)
 def test_balance_without_dependencies(c, s, *workers):
     s.extensions["stealing"]._pc.callback_time = 20
 
@@ -306,7 +308,7 @@ def test_balance_without_dependencies(c, s, *workers):
     assert max(durations) / min(durations) < 3
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 4)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 4)] * 2)
 def test_dont_steal_executing_tasks(c, s, a, b):
     futures = c.map(
         slowinc, range(4), delay=0.1, workers=a.address, allow_other_workers=True
@@ -317,7 +319,7 @@ def test_dont_steal_executing_tasks(c, s, a, b):
     assert len(b.data) == 0
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
 def test_dont_steal_few_saturated_tasks_many_workers(c, s, a, *rest):
     s.extensions["stealing"]._pc.callback_time = 20
     x = c.submit(mul, b"0", 100000000, workers=a.address)  # 100 MB
@@ -334,7 +336,7 @@ def test_dont_steal_few_saturated_tasks_many_workers(c, s, a, *rest):
 
 @gen_cluster(
     client=True,
-    ncores=[("127.0.0.1", 1)] * 10,
+    nthreads=[("127.0.0.1", 1)] * 10,
     worker_kwargs={"memory_limit": TOTAL_MEMORY},
 )
 def test_steal_when_more_tasks(c, s, a, *rest):
@@ -351,7 +353,7 @@ def test_steal_when_more_tasks(c, s, a, *rest):
         assert time() < start + 1
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
 def test_steal_more_attractive_tasks(c, s, a, *rest):
     def slow2(x):
         sleep(1)
@@ -473,11 +475,11 @@ def assert_balanced(inp, expected, c, s, *workers):
 )
 def test_balance(inp, expected):
     test = lambda *args, **kwargs: assert_balanced(inp, expected, *args, **kwargs)
-    test = gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * len(inp))(test)
+    test = gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * len(inp))(test)
     test()
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2, Worker=Nanny, timeout=20)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2, Worker=Nanny, timeout=20)
 def test_restart(c, s, a, b):
     futures = c.map(
         slowinc, range(100), delay=0.1, workers=a.address, allow_other_workers=True
@@ -569,7 +571,7 @@ def test_dont_steal_executing_tasks(c, s, a, b):
     assert not b.executing
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_dont_steal_long_running_tasks(c, s, a, b):
     def long(delay):
         with worker_client() as c:
@@ -603,7 +605,7 @@ def test_dont_steal_long_running_tasks(c, s, a, b):
         ) <= 1
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 5)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 5)] * 2)
 def test_cleanup_repeated_tasks(c, s, a, b):
     class Foo(object):
         pass
@@ -635,7 +637,7 @@ def test_cleanup_repeated_tasks(c, s, a, b):
     assert not list(ws)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_lose_task(c, s, a, b):
     with captured_logger("distributed.stealing") as log:
         s.periodic_callbacks["stealing"].interval = 1

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -285,8 +285,7 @@ def test_steal_host_restrictions(c, s, wa, wb):
     assert len(wa.task_state) == ntasks
     assert len(wb.task_state) == 0
 
-    wc = yield Worker(s.address, loop=s.loop, ncores=1)
-    print(s.workers)
+    wc = yield Worker(s.address, ncores=1)
 
     start = time()
     while not wc.task_state or len(wa.task_state) == ntasks:

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -225,6 +225,30 @@ def test_dont_steal_worker_restrictions(c, s, a, b):
     assert len(b.task_state) == 0
 
 
+@gen_cluster(client=True, ncores=[("127.0.0.1", 1), ("127.0.0.1", 2), ("127.0.0.1", 2)])
+def test_steal_worker_restrictions(c, s, wa, wb, wc):
+    future = c.submit(slowinc, 1, delay=0.1, workers={wa.address, wb.address})
+    yield future
+
+    ntasks = 100
+    futures = c.map(slowinc, range(ntasks), delay=0.1, workers={wa.address, wb.address})
+
+    while sum(len(w.task_state) for w in [wa, wb, wc]) < ntasks:
+        yield gen.sleep(0.01)
+
+    assert 0 < len(wa.task_state) < ntasks
+    assert 0 < len(wb.task_state) < ntasks
+    assert len(wc.task_state) == 0
+
+    s.extensions["stealing"].balance()
+
+    yield gen.sleep(0.1)
+
+    assert 0 < len(wa.task_state) < ntasks
+    assert 0 < len(wb.task_state) < ntasks
+    assert len(wc.task_state) == 0
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
@@ -244,6 +268,35 @@ def test_dont_steal_host_restrictions(c, s, a, b):
     yield gen.sleep(0.1)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
+)
+@gen_cluster(client=True, ncores=[("127.0.0.1", 1), ("127.0.0.2", 2)])
+def test_steal_host_restrictions(c, s, wa, wb):
+    future = c.submit(slowinc, 1, delay=0.10, workers=wa.address)
+    yield future
+
+    ntasks = 100
+    futures = c.map(slowinc, range(ntasks), delay=0.1, workers="127.0.0.1")
+    while len(wa.task_state) < ntasks:
+        yield gen.sleep(0.01)
+    assert len(wa.task_state) == ntasks
+    assert len(wb.task_state) == 0
+
+    wc = yield Worker(s.address, loop=s.loop, ncores=1)
+    print(s.workers)
+
+    start = time()
+    while not wc.task_state or len(wa.task_state) == ntasks:
+        yield gen.sleep(0.01)
+        assert time() < start + 3
+
+    yield gen.sleep(0.1)
+    assert 0 < len(wa.task_state) < ntasks
+    assert len(wb.task_state) == 0
+    assert 0 < len(wc.task_state) < ntasks
 
 
 @gen_cluster(
@@ -266,10 +319,7 @@ def test_dont_steal_resource_restrictions(c, s, a, b):
     assert len(b.task_state) == 0
 
 
-@pytest.mark.skip(reason="no stealing of resources")
-@gen_cluster(
-    client=True, nthreads=[("127.0.0.1", 1, {"resources": {"A": 2}})], timeout=3
-)
+@gen_cluster(client=True, ncores=[("127.0.0.1", 1, {"resources": {"A": 2}})], timeout=3)
 def test_steal_resource_restrictions(c, s, a):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
     yield future

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -64,7 +64,7 @@ def test_stress_gc(loop, func, n):
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="test can leave dangling RPC objects"
 )
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 8, timeout=None)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 8, timeout=None)
 def test_cancel_stress(c, s, *workers):
     da = pytest.importorskip("dask.array")
     x = da.random.random((50, 50), chunks=(2, 2))
@@ -93,7 +93,7 @@ def test_cancel_stress_sync(loop):
                 c.cancel(f)
 
 
-@gen_cluster(ncores=[], client=True, timeout=None)
+@gen_cluster(nthreads=[], client=True, timeout=None)
 def test_stress_creation_and_deletion(c, s):
     # Assertions are handled by the validate mechanism in the scheduler
     s.allowed_failures = 100000
@@ -108,7 +108,7 @@ def test_stress_creation_and_deletion(c, s):
     def create_and_destroy_worker(delay):
         start = time()
         while time() < start + 5:
-            n = Nanny(s.address, ncores=2, loop=s.loop)
+            n = Nanny(s.address, nthreads=2, loop=s.loop)
             n.start(0)
 
             yield gen.sleep(delay)
@@ -122,7 +122,7 @@ def test_stress_creation_and_deletion(c, s):
     )
 
 
-@gen_cluster(ncores=[("127.0.0.1", 1)] * 10, client=True, timeout=60)
+@gen_cluster(nthreads=[("127.0.0.1", 1)] * 10, client=True, timeout=60)
 def test_stress_scatter_death(c, s, *workers):
     import random
 
@@ -198,7 +198,7 @@ def vsum(*args):
 
 @pytest.mark.avoid_travis
 @pytest.mark.slow
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 80, timeout=1000)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 80, timeout=1000)
 def test_stress_communication(c, s, *workers):
     s.validate = False  # very slow otherwise
     da = pytest.importorskip("dask.array")
@@ -218,7 +218,7 @@ def test_stress_communication(c, s, *workers):
 
 
 @pytest.mark.skip
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10, timeout=60)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10, timeout=60)
 def test_stress_steal(c, s, *workers):
     s.validate = False
     for w in workers:
@@ -244,7 +244,7 @@ def test_stress_steal(c, s, *workers):
 
 
 @pytest.mark.slow
-@gen_cluster(ncores=[("127.0.0.1", 1)] * 10, client=True, timeout=120)
+@gen_cluster(nthreads=[("127.0.0.1", 1)] * 10, client=True, timeout=120)
 def test_close_connections(c, s, *workers):
     da = pytest.importorskip("dask.array")
     x = da.random.random(size=(1000, 1000), chunks=(1000, 1))
@@ -269,7 +269,7 @@ def test_close_connections(c, s, *workers):
     reason="IOStream._handle_write blocks on large write_buffer"
     " https://github.com/tornadoweb/tornado/issues/2110"
 )
-@gen_cluster(client=True, timeout=20, ncores=[("127.0.0.1", 1)])
+@gen_cluster(client=True, timeout=20, nthreads=[("127.0.0.1", 1)])
 def test_no_delay_during_large_transfer(c, s, w):
     pytest.importorskip("crick")
     np = pytest.importorskip("numpy")

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -82,7 +82,7 @@ def test_nanny(c, s, a, b):
         assert isinstance(n, Nanny)
         assert n.address.startswith("tls://")
         assert n.worker_address.startswith("tls://")
-    assert s.ncores == {n.worker_address: n.ncores for n in [a, b]}
+    assert s.nthreads == {n.worker_address: n.nthreads for n in [a, b]}
 
     x = c.submit(inc, 10)
     result = yield x
@@ -101,7 +101,7 @@ def test_rebalance(c, s, a, b):
     assert len(b.data) == 1
 
 
-@gen_tls_cluster(client=True, ncores=[("tls://127.0.0.1", 2)] * 2)
+@gen_tls_cluster(client=True, nthreads=[("tls://127.0.0.1", 2)] * 2)
 def test_work_stealing(c, s, a, b):
     [x] = yield c._scatter([1], workers=a.address)
     futures = c.map(slowadd, range(50), [x] * 50, delay=0.1)
@@ -127,7 +127,7 @@ def test_worker_client(c, s, a, b):
     assert yy == 20 + 1 + (20 + 1) * 2
 
 
-@gen_tls_cluster(client=True, ncores=[("tls://127.0.0.1", 1)] * 2)
+@gen_tls_cluster(client=True, nthreads=[("tls://127.0.0.1", 1)] * 2)
 def test_worker_client_gather(c, s, a, b):
     a_address = a.address
     b_address = b.address

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -50,7 +50,7 @@ def test_gen_cluster(c, s, a, b):
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
-    assert s.ncores == {w.address: w.ncores for w in [a, b]}
+    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
 
 
 @pytest.mark.skip(reason="This hangs on travis")
@@ -74,13 +74,13 @@ def test_gen_cluster_without_client(s, a, b):
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
-    assert s.ncores == {w.address: w.ncores for w in [a, b]}
+    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
 
 
 @gen_cluster(
     client=True,
     scheduler="tls://127.0.0.1",
-    ncores=[("tls://127.0.0.1", 1), ("tls://127.0.0.1", 2)],
+    nthreads=[("tls://127.0.0.1", 1), ("tls://127.0.0.1", 2)],
     security=tls_only_security(),
 )
 def test_gen_cluster_tls(e, s, a, b):
@@ -90,7 +90,7 @@ def test_gen_cluster_tls(e, s, a, b):
     for w in [a, b]:
         assert isinstance(w, Worker)
         assert w.address.startswith("tls://")
-    assert s.ncores == {w.address: w.ncores for w in [a, b]}
+    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
 
 
 @gen_test()

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -148,7 +148,7 @@ def test_timeout_get(c, s, a, b):
 
 @pytest.mark.skipif(sys.version_info[0] == 2, reason="Multi-client issues")
 @pytest.mark.slow
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
 def test_race(c, s, *workers):
     NITERS = 50
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -736,9 +736,11 @@ def test_hold_onto_dependents(c, s, a, b):
 def test_worker_death_timeout(s):
     with dask.config.set({"distributed.comm.timeouts.connect": "1s"}):
         yield s.close()
-        w = yield Worker(s.address, death_timeout=1)
+        w = Worker(s.address, death_timeout=1)
 
-    yield gen.sleep(2)
+    with pytest.raises(gen.TimeoutError):
+        yield w
+
     assert w.status == "closed"
 
 

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -42,7 +42,7 @@ def test_submit_from_worker(c, s, a, b):
     assert len([id for id in s.wants_what if id.lower().startswith("client")]) == 1
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_scatter_from_worker(c, s, a, b):
     def func():
         with worker_client() as c:
@@ -78,12 +78,12 @@ def test_scatter_from_worker(c, s, a, b):
     assert result is True
 
     start = time()
-    while not all(v == 1 for v in s.ncores.values()):
+    while not all(v == 1 for v in s.nthreads.values()):
         yield gen.sleep(0.1)
         assert time() < start + 5
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_scatter_singleton(c, s, a, b):
     np = pytest.importorskip("numpy")
 
@@ -96,7 +96,7 @@ def test_scatter_singleton(c, s, a, b):
     yield c.submit(func)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_gather_multi_machine(c, s, a, b):
     a_address = a.address
     b_address = b.address
@@ -162,7 +162,7 @@ def test_async(c, s, a, b):
         assert time() < start + 3
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 3)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 3)])
 def test_separate_thread_false(c, s, a):
     a.count = 0
 

--- a/distributed/tests/test_worker_plugins.py
+++ b/distributed/tests/test_worker_plugins.py
@@ -19,7 +19,7 @@ class MyPlugin:
         self.worker._my_plugin_status = "teardown"
 
 
-@gen_cluster(client=True, ncores=[])
+@gen_cluster(client=True, nthreads=[])
 def test_create_with_client(c, s):
     yield c.register_worker_plugin(MyPlugin(123))
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -950,13 +950,13 @@ def tmpfile(extension=""):
     yield filename
 
     if os.path.exists(filename):
-        if os.path.isdir(filename):
-            shutil.rmtree(filename)
-        else:
-            try:
+        try:
+            if os.path.isdir(filename):
+                shutil.rmtree(filename)
+            else:
                 os.remove(filename)
-            except OSError:  # sometimes we can't remove a generated temp file
-                pass
+        except OSError:  # sometimes we can't remove a generated temp file
+            pass
 
 
 def ensure_bytes(s):

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -110,19 +110,19 @@ _round_robin_counter = [0]
 
 
 @gen.coroutine
-def scatter_to_workers(ncores, data, rpc=rpc, report=True, serializers=None):
+def scatter_to_workers(nthreads, data, rpc=rpc, report=True, serializers=None):
     """ Scatter data directly to workers
 
     This distributes data in a round-robin fashion to a set of workers based on
-    how many cores they have.  ncores should be a dictionary mapping worker
+    how many cores they have.  nthreads should be a dictionary mapping worker
     identities to numbers of cores.
 
     See scatter for parameter docstring
     """
-    assert isinstance(ncores, dict)
+    assert isinstance(nthreads, dict)
     assert isinstance(data, dict)
 
-    workers = list(concat([w] * nc for w, nc in ncores.items()))
+    workers = list(concat([w] * nc for w, nc in nthreads.items()))
     names, data = list(zip(*data.items()))
 
     worker_iter = drop(_round_robin_counter[0] % len(workers), cycle(workers))

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -22,6 +22,7 @@ import textwrap
 import threading
 from time import sleep
 import uuid
+import warnings
 import weakref
 
 try:
@@ -841,6 +842,7 @@ def end_cluster(s, workers):
 
 def gen_cluster(
     nthreads=[("127.0.0.1", 1), ("127.0.0.1", 2)],
+    ncores=None,
     scheduler="127.0.0.1",
     timeout=10,
     security=None,
@@ -865,6 +867,10 @@ def gen_cluster(
         start
         end
     """
+    if ncores is not None:
+        warnings.warn("ncores= has moved to nthreads=")
+        nthreads = ncores
+
     worker_kwargs = merge(
         {"memory_limit": TOTAL_MEMORY, "death_timeout": 5}, worker_kwargs
     )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -708,8 +708,14 @@ class Worker(ServerNode):
         logger.info("-" * 49)
         while True:
             if self.death_timeout and time() > start + self.death_timeout:
+                logger.exception(
+                    "Timed out when connecting to scheduler '%s'",
+                    self.scheduler.address,
+                )
                 yield self.close(timeout=1)
-                return
+                raise gen.TimeoutError(
+                    "Timed out connecting to scheduler '%s'" % self.scheduler.address
+                )
             if self.status in ("closed", "closing"):
                 raise gen.Return
             try:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -5,6 +5,7 @@ from collections import defaultdict, deque
 from datetime import timedelta
 import heapq
 import logging
+import multiprocessing
 import os
 from pickle import PicklingError
 import random
@@ -53,7 +54,6 @@ from .utils import (
     _maybe_complex,
     log_errors,
     ignoring,
-    mp_context,
     import_file,
     silence_logging,
     thread_state,
@@ -68,8 +68,6 @@ from .utils import (
 )
 from .utils_comm import pack_data, gather_from_workers
 from .utils_perf import ThrottledGC, enable_gc_diagnosis, disable_gc_diagnosis
-
-_ncores = mp_context.cpu_count()
 
 logger = logging.getLogger(__name__)
 
@@ -116,8 +114,8 @@ class Worker(ServerNode):
 
     These attributes don't change significantly during execution.
 
-    * **ncores:** ``int``:
-        Number of cores used by this worker process
+    * **nthreads:** ``int``:
+        Number of nthreads used by this worker process
     * **executor:** ``concurrent.futures.ThreadPoolExecutor``:
         Executor used to perform computation
     * **local_dir:** ``path``:
@@ -233,7 +231,7 @@ class Worker(ServerNode):
     ip: str, optional
     data: MutableMapping, type, None
         The object to use for storage, builds a disk-backed LRU dict by default
-    ncores: int, optional
+    nthreads: int, optional
     loop: tornado.ioloop.IOLoop
     local_dir: str, optional
         Directory where we place local resources
@@ -241,7 +239,7 @@ class Worker(ServerNode):
     memory_limit: int, float, string
         Number of bytes of memory that this worker should use.
         Set to zero for no limit.  Set to 'auto' to calculate
-        as TOTAL_MEMORY * min(1, ncores / total_cores)
+        as TOTAL_MEMORY * min(1, nthreads / total_cores)
         Use strings or numbers like 5GB or 5e9
     memory_target_fraction: float
         Fraction of memory to try to stay beneath
@@ -281,6 +279,7 @@ class Worker(ServerNode):
         scheduler_port=None,
         scheduler_file=None,
         ncores=None,
+        nthreads=None,
         loop=None,
         local_dir=None,
         services=None,
@@ -432,7 +431,11 @@ class Worker(ServerNode):
             security=security,
         )
 
-        self.ncores = ncores or _ncores
+        if ncores is not None:
+            warnings.warn("the ncores= parameter has moved to nthreads=")
+            nthreads = ncores
+
+        self.nthreads = nthreads or multiprocessing.cpu_count()
         self.total_resources = resources or {}
         self.available_resources = (resources or {}).copy()
         self.death_timeout = parse_timedelta(death_timeout)
@@ -471,7 +474,7 @@ class Worker(ServerNode):
         self.connection_args = self.security.get_connection_args("worker")
         self.listen_args = self.security.get_listen_args("worker")
 
-        self.memory_limit = parse_memory_limit(memory_limit, self.ncores)
+        self.memory_limit = parse_memory_limit(memory_limit, self.nthreads)
 
         self.paused = False
 
@@ -526,7 +529,7 @@ class Worker(ServerNode):
         self._closed = Event()
         self.reconnect = reconnect
         self.executor = executor or ThreadPoolExecutor(
-            self.ncores, thread_name_prefix="Dask-Worker-Threads'"
+            self.nthreads, thread_name_prefix="Dask-Worker-Threads'"
         )
         self.actor_executor = ThreadPoolExecutor(
             1, thread_name_prefix="Dask-Actor-Threads"
@@ -658,7 +661,7 @@ class Worker(ServerNode):
                 self.status,
                 len(self.data),
                 len(self.executing),
-                self.ncores,
+                self.nthreads,
                 len(self.ready),
                 len(self.in_flight_tasks),
                 len(self.waiting_for_data),
@@ -687,7 +690,8 @@ class Worker(ServerNode):
             "type": type(self).__name__,
             "id": self.id,
             "scheduler": self.scheduler.address,
-            "ncores": self.ncores,
+            "nthreads": self.nthreads,
+            "ncores": self.nthreads,  # backwards compatibility
             "memory_limit": self.memory_limit,
         }
 
@@ -722,7 +726,7 @@ class Worker(ServerNode):
                         reply=False,
                         address=self.contact_address,
                         keys=list(self.data),
-                        ncores=self.ncores,
+                        nthreads=self.nthreads,
                         name=self.name,
                         nbytes=self.nbytes,
                         types=types,
@@ -941,7 +945,7 @@ class Worker(ServerNode):
             logger.info("  %16s at: %26s" % (k, listen_host + ":" + str(v)))
         logger.info("Waiting to connect to: %26s", self.scheduler.address)
         logger.info("-" * 49)
-        logger.info("              Threads: %26d", self.ncores)
+        logger.info("              Threads: %26d", self.nthreads)
         if self.memory_limit:
             logger.info("               Memory: %26s", format_bytes(self.memory_limit))
         logger.info("      Local Directory: %26s", self.local_dir)
@@ -2283,7 +2287,7 @@ class Worker(ServerNode):
         if self.paused:
             return
         try:
-            while self.constrained and len(self.executing) < self.ncores:
+            while self.constrained and len(self.executing) < self.nthreads:
                 key = self.constrained[0]
                 if self.task_state.get(key) != "constrained":
                     self.constrained.popleft()
@@ -2293,7 +2297,7 @@ class Worker(ServerNode):
                     self.transition(key, "executing")
                 else:
                     break
-            while self.ready and len(self.executing) < self.ncores:
+            while self.ready and len(self.executing) < self.nthreads:
                 _, key = heapq.heappop(self.ready)
                 if self.task_state.get(key) in READY:
                     self.transition(key, "executing")
@@ -2955,12 +2959,12 @@ class Reschedule(Exception):
     pass
 
 
-def parse_memory_limit(memory_limit, ncores, total_cores=_ncores):
+def parse_memory_limit(memory_limit, nthreads, total_cores=multiprocessing.cpu_count()):
     if memory_limit is None:
         return None
 
     if memory_limit == "auto":
-        memory_limit = int(TOTAL_MEMORY * min(1, ncores / total_cores))
+        memory_limit = int(TOTAL_MEMORY * min(1, nthreads / total_cores))
     with ignoring(ValueError, TypeError):
         memory_limit = float(memory_limit)
         if isinstance(memory_limit, float) and memory_limit <= 1:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2038,7 +2038,7 @@ class Worker(ServerNode):
         response = {"op": "steal-response", "key": key, "state": state}
         self.batched_stream.send(response)
 
-        if state in ("ready", "waiting"):
+        if state in ("ready", "waiting", "constrained"):
             self.release_key(key)
 
     def release_key(self, key, cause=None, reason=None, report=True):

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ dask
 numpydoc
 sphinx
 dask_sphinx_theme
+sphinx-click

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -24,7 +24,7 @@ API
    Client.has_what
    Client.list_datasets
    Client.map
-   Client.ncores
+   Client.nthreads
    Client.persist
    Client.publish_dataset
    Client.profile

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,8 +19,8 @@ API
    Client.get_executor
    Client.get_metadata
    Client.get_scheduler_logs
-   Client.get_task_stream
    Client.get_worker_logs
+   Client.get_task_stream
    Client.has_what
    Client.list_datasets
    Client.map

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,54 +12,51 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-import shlex
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.todo',
-    'sphinx.ext.ifconfig',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.extlinks',
-    'sphinx.ext.intersphinx',
-    'numpydoc',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.todo",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
+    "numpydoc",
+    "sphinx_click.ext",
 ]
 
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'Dask.distributed'
-copyright = u'2016, Anaconda, Inc.'
-author = u'Anaconda, Inc.'
+project = u"Dask.distributed"
+copyright = u"2016, Anaconda, Inc."
+author = u"Anaconda, Inc."
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -67,6 +64,7 @@ author = u'Anaconda, Inc.'
 #
 # The short X.Y version.
 import distributed
+
 version = distributed.__version__
 # The full version, including alpha/beta/rc tags.
 release = distributed.__version__
@@ -80,9 +78,9 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -90,27 +88,27 @@ exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'default'
+pygments_style = "default"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
@@ -119,144 +117,147 @@ todo_include_todos = True
 # -- Options for HTML output ----------------------------------------------
 
 import dask_sphinx_theme
-html_theme = 'dask_sphinx_theme'
+
+html_theme = "dask_sphinx_theme"
 html_theme_path = [dask_sphinx_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'distributeddoc'
+htmlhelp_basename = "distributeddoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'distributed.tex', u'Dask.distributed Documentation',
-   u'Matthew Rocklin', 'manual'),
+    (
+        master_doc,
+        "distributed.tex",
+        u"Dask.distributed Documentation",
+        u"Matthew Rocklin",
+        "manual",
+    )
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
@@ -264,12 +265,11 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'Dask.distributed', u'Dask.distributed Documentation',
-     [author], 1)
+    (master_doc, "Dask.distributed", u"Dask.distributed Documentation", [author], 1)
 ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -278,22 +278,28 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'Dask.distributed', u'Dask.distributed Documentation',
-   author, 'Dask.distributed', 'One line description of project.',
-   'Miscellaneous'),
+    (
+        master_doc,
+        "Dask.distributed",
+        u"Dask.distributed Documentation",
+        author,
+        "Dask.distributed",
+        "One line description of project.",
+        "Miscellaneous",
+    )
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 
 # -- Options for Epub output ----------------------------------------------
@@ -305,85 +311,85 @@ epub_publisher = author
 epub_copyright = copyright
 
 # The basename for the epub file. It defaults to the project name.
-#epub_basename = project
+# epub_basename = project
 
 # The HTML theme for the epub output. Since the default themes are not optimized
 # for small screen space, using the same theme for HTML and epub output is
 # usually not wise. This defaults to 'epub', a theme designed to save visual
 # space.
-#epub_theme = 'epub'
+# epub_theme = 'epub'
 
 # The language of the text. It defaults to the language option
 # or 'en' if the language is not set.
-#epub_language = ''
+# epub_language = ''
 
 # The scheme of the identifier. Typical schemes are ISBN or URL.
-#epub_scheme = ''
+# epub_scheme = ''
 
 # The unique identifier of the text. This can be a ISBN number
 # or the project homepage.
-#epub_identifier = ''
+# epub_identifier = ''
 
 # A unique identification for the text.
-#epub_uid = ''
+# epub_uid = ''
 
 # A tuple containing the cover image and cover page html template filenames.
-#epub_cover = ()
+# epub_cover = ()
 
 # A sequence of (type, uri, title) tuples for the guide element of content.opf.
-#epub_guide = ()
+# epub_guide = ()
 
 # HTML files that should be inserted before the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
-#epub_pre_files = []
+# epub_pre_files = []
 
 # HTML files shat should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
-#epub_post_files = []
+# epub_post_files = []
 
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
+epub_exclude_files = ["search.html"]
 
 # The depth of the table of contents in toc.ncx.
-#epub_tocdepth = 3
+# epub_tocdepth = 3
 
 # Allow duplicate toc entries.
-#epub_tocdup = True
+# epub_tocdup = True
 
 # Choose between 'default' and 'includehidden'.
-#epub_tocscope = 'default'
+# epub_tocscope = 'default'
 
 # Fix unsupported image types using the Pillow.
-#epub_fix_images = False
+# epub_fix_images = False
 
 # Scale large images.
-#epub_max_image_width = 0
+# epub_max_image_width = 0
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#epub_show_urls = 'inline'
+# epub_show_urls = 'inline'
 
 # If false, no index is generated.
-#epub_use_index = True
+# epub_use_index = True
 
 # Link to GitHub issues and pull requests using :pr:`1234` and :issue:`1234`
 # syntax
 extlinks = {
-    'issue': ('https://github.com/dask/distributed/issues/%s', 'GH#'),
-    'pr': ('https://github.com/dask/distributed/pull/%s', 'GH#')
+    "issue": ("https://github.com/dask/distributed/issues/%s", "GH#"),
+    "pr": ("https://github.com/dask/distributed/pull/%s", "GH#"),
 }
 
 # Configuration for intersphinx: refer to the Python standard library
 # and the Numpy documentation.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy', None),
-    }
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("http://docs.scipy.org/doc/numpy", None),
+}
 
 # Redirects
 # https://tech.signavio.com/2017/managing-sphinx-redirects
 redirect_files = [
     # old html, new html
-    ('joblib.html', 'https://ml.dask.org/joblib.html'),
+    ("joblib.html", "https://ml.dask.org/joblib.html")
 ]
 
 
@@ -400,13 +406,13 @@ redirect_template = """\
 
 
 def copy_legacy_redirects(app, docname):
-    if app.builder.name == 'html':
+    if app.builder.name == "html":
         for html_src_path, new in redirect_files:
             page = redirect_template.format(new=new)
-            target_path = app.outdir + '/' + html_src_path
-            with open(target_path, 'w') as f:
+            target_path = app.outdir + "/" + html_src_path
+            with open(target_path, "w") as f:
                 f.write(page)
 
 
 def setup(app):
-    app.connect('build-finished', copy_legacy_redirects)
+    app.connect("build-finished", copy_legacy_redirects)

--- a/docs/source/local-cluster.rst
+++ b/docs/source/local-cluster.rst
@@ -7,7 +7,7 @@ For convenience you can start a local cluster from your Python session.
 
    >>> from distributed import Client, LocalCluster
    >>> cluster = LocalCluster()
-   LocalCluster("127.0.0.1:8786", workers=8, ncores=8)
+   LocalCluster("127.0.0.1:8786", workers=8, nthreads=8)
    >>> client = Client(cluster)
    <Client: scheduler=127.0.0.1:8786 processes=8 cores=8>
 

--- a/docs/source/protocol.rst
+++ b/docs/source/protocol.rst
@@ -25,7 +25,7 @@ In practice we represent these messages with dictionaries/mappings::
    {'op': 'register-worker',
     'address': '192.168.1.42',
     'name': 'alice',
-    'ncores': 4}
+    'nthreads': 4}
 
    {'x': b'...',
     'y': b'...'}

--- a/docs/source/scheduling-state.rst
+++ b/docs/source/scheduling-state.rst
@@ -112,7 +112,7 @@ containers to help with scheduling tasks:
 .. attribute:: Scheduler.saturated: {WorkerState}
 
    A set of workers whose computing power (as
-   measured by :attr:`WorkerState.ncores`) is fully exploited by processing
+   measured by :attr:`WorkerState.nthreads`) is fully exploited by processing
    tasks, and whose current :attr:`~WorkerState.occupancy` is a lot greater
    than the average.
 

--- a/docs/source/submitting-applications.rst
+++ b/docs/source/submitting-applications.rst
@@ -10,8 +10,8 @@ For example, S3 buckets could not be visible from your local machine and hence a
 attempt to create a dask graph from local machine may not work.
 
 
-Submitting dask Applications with `dask-submit`
------------------------------------------------
+Submitting dask Applications with ``dask-submit``
+-------------------------------------------------
 
 In order to remotely submit scripts to the cluster from a local machine or a CI/CD
 environment, we need to run a remote client on the same machine as the scheduler::
@@ -20,7 +20,7 @@ environment, we need to run a remote client on the same machine as the scheduler
    dask-remote --port 8788
 
 
-After making sure the `dask-remote` is running, you can submit a script by::
+After making sure the ``dask-remote`` is running, you can submit a script by::
 
    #local machine
    dask-submit <dask-remote-address>:<port> <script.py>
@@ -28,7 +28,7 @@ After making sure the `dask-remote` is running, you can submit a script by::
 
 Some of the commonly used arguments are:
 
--  ``REMOTE_CLIENT_ADDRESS``: host name where dask-remote client is running
+-  ``REMOTE_CLIENT_ADDRESS``: host name where ``dask-remote`` client is running
 -  ``FILEPATH``: Local path to file containing dask application
 
 For example, given the following dask application saved in a file called
@@ -36,6 +36,7 @@ For example, given the following dask application saved in a file called
 
 .. code-block:: python
 
+   # script.py
    from distributed import Client
 
    def inc(x):
@@ -50,3 +51,21 @@ For example, given the following dask application saved in a file called
 We can submit this application from a local machine by running::
 
    dask-submit <remote-client-address>:<port> script.py
+
+
+CLI Options
+-----------
+
+.. note::
+
+   The command line documentation here may differ depending on your installed
+   version. We recommend referring to the output of ``dask-remote --help``
+   and ``dask-submit --help``.
+
+.. click:: distributed.cli.dask_remote:main
+   :prog: dask-remote
+   :show-nested:
+
+.. click:: distributed.cli.dask_submit:main
+   :prog: dask-submit
+   :show-nested:

--- a/docs/source/tls.rst
+++ b/docs/source/tls.rst
@@ -4,9 +4,9 @@
 TLS/SSL
 =======
 
-Currently dask distributed has experimental support for TLS/SSL communication,
+Dask distributed has support for TLS/SSL communication,
 providing mutual authentication and encryption of communications between cluster
-endpoints (Clients, Schedulers and Workers).
+endpoints (Clients, Schedulers, and Workers).
 
 TLS is enabled by using a ``tls`` address such as ``tls://`` (the default
 being ``tcp``, which sends data unauthenticated and unencrypted).  In

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -100,7 +100,7 @@ are the available options::
      --name TEXT            Alias
      --memory-limit TEXT    Maximum bytes of memory that this worker should use.
                             Use 0 for unlimited, or 'auto' for
-                            TOTAL_MEMORY * min(1, ncores / total_cores)
+                            TOTAL_MEMORY * min(1, nthreads / total_nthreads)
      --no-nanny
      --help                 Show this message and exit.
 
@@ -151,7 +151,7 @@ command line ``--memory-limit`` keyword or the ``memory_limit=`` Python
 keyword argument, which sets the memory limit per worker processes launched
 by dask-worker ::
 
-    $ dask-worker tcp://scheduler:port --memory-limit=auto  # TOTAL_MEMORY * min(1, ncores / total_cores)
+    $ dask-worker tcp://scheduler:port --memory-limit=auto  # TOTAL_MEMORY * min(1, nthreads / total_nthreads)
     $ dask-worker tcp://scheduler:port --memory-limit=4e9  # four gigabytes per worker process.
 
 Workers use a few different heuristics to keep memory use beneath this limit:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,11 @@ universal=1
 [tool:pytest]
 addopts = -rsx -v --durations=10
 minversion = 3.2
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    avoid_travis: marks tests as flaky on TravisCI.
+    ipython: mark a test as exercising IPython
+
 # filterwarnings =
 #     error
 #     ignore::UserWarning


### PR DESCRIPTION
Addresses stealing tasks with resource restrictions, as mentioned in #1851.
If a task has hard restrictions, do not just give up on stealing.
Instead, use the restrictions to determine which workers can steal it
before attempting to execute a steal operation.

A follow up PR will be needed to address the issue of long-running tasks
not being stolen because the scheduler has no information about their
runtime.