### PR TITLE
Add nanny logs

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2270,6 +2270,10 @@ class Client(Node):
         wait: boolean (optional)
             If the function is asynchronous whether or not to wait until that
             function finishes.
+        nanny : bool, defualt False
+            Whether to run ``function`` on the nanny. By default, the function
+            is run on the worker process.  If specified, the addresses in
+            ``workers`` should still be the worker addresses, not the nanny addresses.
 
         Examples
         --------
@@ -3364,7 +3368,7 @@ class Client(Node):
         """
         return self.sync(self.scheduler.logs, n=n)
 
-    def get_worker_logs(self, n=None, workers=None):
+    def get_worker_logs(self, n=None, workers=None, nanny=False):
         """ Get logs from workers
 
         Parameters
@@ -3374,32 +3378,17 @@ class Client(Node):
             confiruable in config.yaml::log-length
         workers : iterable
             List of worker addresses to retrieve.  Gets all workers by default.
+        nanny : bool, default False
+            Whether to get the logs from the workers (False) or the nannies (True). If
+            specified, the addresses in `workers` should still be the worker addresses,
+            not the nanny addresses.
 
         Returns
         -------
         Dictionary mapping worker address to logs.
         Logs are returned in reversed order (newest first)
         """
-        return self.sync(self.scheduler.worker_logs, n=n, workers=workers)
-
-    def get_nanny_logs(self, n=None, workers=None):
-        """Get logs from nannies.
-
-        Parameters
-        ----------
-        n: int
-            Number of logs to retrive.  Maxes out at 10000 by default,
-            confiruable in config.yaml::log-length
-        workers: iterable
-            List of worker addresses to retrieve.  Gets all workers by default.
-            Note that this is the address of the worker, not the nanny.
-
-        Returns
-        -------
-        Dictionary mapping worker address to logs.
-        Logs are returned in reversed order (newest first)
-        """
-        return self.sync(self.scheduler.nanny_logs, n=n, workers=workers)
+        return self.sync(self.scheduler.worker_logs, n=n, workers=workers, nanny=nanny)
 
     def retire_workers(self, workers=None, close_workers=True, **kwargs):
         """ Retire certain workers on the scheduler

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3354,7 +3354,7 @@ class Client(Node):
 
         Parameters
         ----------
-        n: int
+        n : int
             Number of logs to retrive.  Maxes out at 10000 by default,
             confiruable in config.yaml::log-length
 
@@ -3369,11 +3369,11 @@ class Client(Node):
 
         Parameters
         ----------
-        n: int
+        n : int
             Number of logs to retrive.  Maxes out at 10000 by default,
             confiruable in config.yaml::log-length
-        workers: iterable
-            List of worker addresses to retrive.  Gets all workers by default.
+        workers : iterable
+            List of worker addresses to retrieve.  Gets all workers by default.
 
         Returns
         -------
@@ -3381,6 +3381,25 @@ class Client(Node):
         Logs are returned in reversed order (newest first)
         """
         return self.sync(self.scheduler.worker_logs, n=n, workers=workers)
+
+    def get_nanny_logs(self, n=None, workers=None):
+        """Get logs from nannies.
+
+        Parameters
+        ----------
+        n: int
+            Number of logs to retrive.  Maxes out at 10000 by default,
+            confiruable in config.yaml::log-length
+        workers: iterable
+            List of worker addresses to retrieve.  Gets all workers by default.
+            Note that this is the address of the worker, not the nanny.
+
+        Returns
+        -------
+        Dictionary mapping worker address to logs.
+        Logs are returned in reversed order (newest first)
+        """
+        return self.sync(self.scheduler.nanny_logs, n=n, workers=workers)
 
     def retire_workers(self, workers=None, close_workers=True, **kwargs):
         """ Retire certain workers on the scheduler

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -79,6 +79,7 @@ class Nanny(ServerNode):
         protocol=None,
         **worker_kwargs
     ):
+        self._setup_logging(logger)
         self.loop = loop or IOLoop.current()
         self.security = security or Security()
         assert isinstance(self.security, Security)
@@ -130,6 +131,7 @@ class Nanny(ServerNode):
             "kill": self.kill,
             "restart": self.restart,
             # cannot call it 'close' on the rpc side for naming conflict
+            "get_logs": self.get_logs,
             "terminate": self.close,
             "close_gracefully": self.close_gracefully,
             "run": self.run,

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -1,12 +1,15 @@
 from __future__ import print_function, division, absolute_import
 
 import warnings
+import logging
 
 from tornado.ioloop import IOLoop
+import dask
 
-from .compatibility import unicode
+from .compatibility import unicode, finalize
 from .core import Server, ConnectionPool
 from .versions import get_versions
+from .utils import DequeHandler
 
 
 class Node(object):
@@ -130,3 +133,22 @@ class ServerNode(Node, Server):
     @property
     def service_ports(self):
         return {k: v.port for k, v in self.services.items()}
+
+    def _setup_logging(self, logger):
+        self._deque_handler = DequeHandler(
+            n=dask.config.get("distributed.admin.log-length")
+        )
+        self._deque_handler.setFormatter(
+            logging.Formatter(dask.config.get("distributed.admin.log-format"))
+        )
+        logger.addHandler(self._deque_handler)
+        finalize(self, logger.removeHandler, self._deque_handler)
+
+    def get_logs(self, comm=None, n=None):
+        deque_handler = self._deque_handler
+        if n is None:
+            L = list(deque_handler.deque)
+        else:
+            L = deque_handler.deque
+            L = [L[-i] for i in range(min(n, len(L)))]
+        return [(msg.levelname, deque_handler.format(msg)) for msg in L]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1046,7 +1046,6 @@ class Scheduler(ServerNode):
             "profile": self.get_profile,
             "logs": self.get_logs,
             "worker_logs": self.get_worker_logs,
-            "nanny_logs": self.get_nanny_logs,
             "nbytes": self.get_nbytes,
             "versions": self.versions,
             "add_keys": self.add_keys,
@@ -4616,14 +4615,9 @@ class Scheduler(ServerNode):
         raise gen.Return({"counts": counts, "keys": keys})
 
     @gen.coroutine
-    def get_worker_logs(self, comm=None, n=None, workers=None):
-        results = yield self.broadcast(msg={"op": "get_logs", "n": n}, workers=workers)
-        raise gen.Return(results)
-
-    @gen.coroutine
-    def get_nanny_logs(self, comm=None, n=None, workers=None):
+    def get_worker_logs(self, comm=None, n=None, workers=None, nanny=False):
         results = yield self.broadcast(
-            msg={"op": "get_logs", "n": n}, workers=workers, nanny=True
+            msg={"op": "get_logs", "n": n}, workers=workers, nanny=nanny
         )
         raise gen.Return(results)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5111,7 +5111,7 @@ def test_task_metadata(c, s, a, b):
     assert result == {"a": {"c": {"d": 1}}, "b": 2}
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, Worker=Nanny)
 def test_logs(c, s, a, b):
     yield wait(c.map(inc, range(5)))
     logs = yield c.get_scheduler_logs(n=5)
@@ -5121,10 +5121,16 @@ def test_logs(c, s, a, b):
         assert "distributed.scheduler" in msg
 
     w_logs = yield c.get_worker_logs(n=5)
-    assert set(w_logs.keys()) == {a.address, b.address}
+    assert set(w_logs.keys()) == {a.worker_address, b.worker_address}
     for log in w_logs.values():
         for _, msg in log:
             assert "distributed.worker" in msg
+
+    n_logs = yield c.get_nanny_logs()
+    assert set(n_logs.keys()) == {a.worker_address, b.worker_address}
+    for log in n_logs.values():
+        for _, msg in log:
+            assert "distributed.nanny" in msg
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5126,8 +5126,14 @@ def test_logs(c, s, a, b):
         for _, msg in log:
             assert "distributed.worker" in msg
 
-    n_logs = yield c.get_nanny_logs()
+    n_logs = yield c.get_worker_logs(nanny=True)
     assert set(n_logs.keys()) == {a.worker_address, b.worker_address}
+    for log in n_logs.values():
+        for _, msg in log:
+            assert "distributed.nanny" in msg
+
+    n_logs = yield c.get_worker_logs(nanny=True, workers=[a.worker_address])
+    assert set(n_logs.keys()) == {a.worker_address}
     for log in n_logs.values():
         for _, msg in log:
             assert "distributed.nanny" in msg

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -20,7 +20,6 @@ API
    Client.get_metadata
    Client.get_scheduler_logs
    Client.get_worker_logs
-   Client.get_nanny_logs
    Client.get_task_stream
    Client.has_what
    Client.list_datasets

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,8 +19,9 @@ API
    Client.get_executor
    Client.get_metadata
    Client.get_scheduler_logs
-   Client.get_task_stream
    Client.get_worker_logs
+   Client.get_nanny_logs
+   Client.get_task_stream
    Client.has_what
    Client.list_datasets
    Client.map


### PR DESCRIPTION
I had a need to collate logs from the cluster, and would like to include logs from the Nanny. This adds a method to get logs from the nanny as well. 

This isn't quite ready.

1. The keys in the returned dict are the address of the workers, not the nannies. Do we have a convention here? I assume we want the address of the nannies.
2. I may be adding the handler to the `distribted.nanny.logger` multiple times, resulting in duplicate logs. Need to verify what's going on.