### PR TITLE
WIP - Add tests for UCX and cuDF serialization

### DIFF
--- a/distributed/protocol/cudf.py
+++ b/distributed/protocol/cudf.py
@@ -34,7 +34,6 @@ def serialize_cudf_dataframe(x):
     arrays.extend(null_masks)
 
     header = {
-        "is_cuda": len(arrays),
         "subheaders": sub_headers,
         # TODO: the header must be msgpack (de)serializable.
         # See if we can avoid names, and just use integer positions.

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -24,7 +24,6 @@ def serialize_cupy_ndarray(x):
     # used in the ucx comms for gpu/cpu message passing
     # 'lengths' set by dask
     header = x.__cuda_array_interface__.copy()
-    header["is_cuda"] = 1
     header["dtype"] = dtype
     return header, [data]
 

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -29,7 +29,6 @@ def serialize_numba_ndarray(x):
     # used in the ucx comms for gpu/cpu message passing
     # 'lengths' set by dask
     header = x.__cuda_array_interface__.copy()
-    header["is_cuda"] = 1
     header["dtype"] = dtype
     return header, [data]
 

--- a/distributed/protocol/tests/test_cudf.py
+++ b/distributed/protocol/tests/test_cudf.py
@@ -1,0 +1,29 @@
+import pytest
+
+cudf = pytest.importorskip("cudf")
+
+from distributed.protocol import serialize, deserialize
+import dask.dataframe as dd
+
+
+@pytest.mark.parametrize(
+    "df",
+    [
+        cudf.Series([1, 2, 3]),
+        cudf.Series([1, 2, None]),
+        cudf.DataFrame({"x": [1, 2, 3], "y": [1.0, 2.0, 3.0]}),
+        cudf.DataFrame({"x": [1, 2, 3], "s": ["a", "bb", "ccc"]}),
+        cudf.DataFrame(
+            {"x": [1, 2, None], "y": [1.0, 2.0, None], "s": ["a", "bb", None]}
+        ),
+    ],
+)
+def test_basic(df):
+    header, frames = serialize(
+        df, serializers=("cuda", "dask", "pickle"), on_error="raise"
+    )
+    assert header["serializer"] == "cuda"
+    assert not any(isinstance(frame, (bytes, memoryview)) for frame in frames)
+
+    df2 = deserialize(header, frames, deserializers=("cuda", "dask", "pickle"))
+    dd.assert_eq(df, df2)


### PR DESCRIPTION
Currently we don't robustly serialize cudf dataframes or series.  This causes issues when trying to communciate them in dask workloads.  So far this PR adds a few failing tests around cudf serialization and a larger full dask + cudf workload