### PR TITLE
Replace ncores with nthreads throughout codebase

### DIFF
--- a/distributed/cli/dask_mpi.py
+++ b/distributed/cli/dask_mpi.py
@@ -105,7 +105,7 @@ def main(
             scheduler_file=scheduler_file,
             loop=loop,
             name=rank if scheduler else None,
-            ncores=nthreads,
+            nthreads=nthreads,
             local_dir=local_directory,
             services={("dashboard", bokeh_worker_port): BokehWorker},
             memory_limit=memory_limit,

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import atexit
 import logging
+import multiprocessing
 import gc
 import os
 from sys import exit
@@ -11,7 +12,6 @@ import click
 import dask
 from distributed import Nanny, Worker
 from distributed.utils import parse_timedelta
-from distributed.worker import _ncores
 from distributed.security import Security
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.comm import get_address_host_port
@@ -280,7 +280,7 @@ def main(
         port = worker_port
 
     if not nthreads:
-        nthreads = _ncores // nprocs
+        nthreads = multiprocessing.cpu_count() // nprocs
 
     if pid_file:
         with open(pid_file, "w") as f:
@@ -329,7 +329,7 @@ def main(
         t(
             scheduler,
             scheduler_file=scheduler_file,
-            ncores=nthreads,
+            nthreads=nthreads,
             services=services,
             loop=loop,
             resources=resources,

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -53,7 +53,7 @@ def test_hostport(loop):
             ]
 
         with Client("127.0.0.1:8978", loop=loop) as c:
-            assert len(c.ncores()) == 0
+            assert len(c.nthreads()) == 0
             c.sync(f)
 
 
@@ -150,7 +150,7 @@ def test_multiple_workers(loop):
             with popen(["dask-worker", "localhost:8786", "--no-dashboard"]) as b:
                 with Client("127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
                     start = time()
-                    while len(c.ncores()) < 2:
+                    while len(c.nthreads()) < 2:
                         sleep(0.1)
                         assert time() < start + 10
 
@@ -178,7 +178,7 @@ def test_interface(loop):
         ) as a:
             with Client("tcp://127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
                 start = time()
-                while not len(c.ncores()):
+                while not len(c.nthreads()):
                     sleep(0.1)
                     assert time() - start < 5
                 info = c.scheduler_info()

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -58,7 +58,7 @@ def test_memory_limit(loop):
             ]
         ) as worker:
             with Client("127.0.0.1:8786", loop=loop) as c:
-                while not c.ncores():
+                while not c.nthreads():
                     sleep(0.1)
                 info = c.scheduler_info()
                 [d] = info["workers"].values()
@@ -218,7 +218,7 @@ def test_contact_listen_address(loop, nanny, listen_address):
             ]
         ) as worker:
             with Client("127.0.0.1:8786") as client:
-                while not client.ncores():
+                while not client.nthreads():
                     sleep(0.1)
                 info = client.scheduler_info()
                 assert "tcp://127.0.0.2:39837" in info["workers"]
@@ -243,7 +243,7 @@ def test_respect_host_listen_address(loop, nanny, host):
             ["dask-worker", "127.0.0.1:8786", nanny, "--no-dashboard", "--host", host]
         ) as worker:
             with Client("127.0.0.1:8786") as client:
-                while not client.ncores():
+                while not client.nthreads():
                     sleep(0.1)
                 info = client.scheduler_info()
 

--- a/distributed/cli/tests/test_tls_cli.py
+++ b/distributed/cli/tests/test_tls_cli.py
@@ -25,9 +25,9 @@ tls_args = ["--tls-ca-file", ca_file, "--tls-cert", keycert]
 tls_args_2 = ["--tls-ca-file", ca_file, "--tls-cert", cert, "--tls-key", key]
 
 
-def wait_for_cores(c, ncores=1):
+def wait_for_cores(c, nthreads=1):
     start = time()
-    while len(c.ncores()) < 1:
+    while len(c.nthreads()) < 1:
         sleep(0.1)
         assert time() < start + 10
 

--- a/distributed/dashboard/components.py
+++ b/distributed/dashboard/components.py
@@ -276,7 +276,7 @@ class Processing(DashboardComponent):
     """
 
     def __init__(self, **kwargs):
-        data = self.processing_update({"processing": {}, "ncores": {}})
+        data = self.processing_update({"processing": {}, "nthreads": {}})
         self.source = ColumnDataSource(data)
 
         x_range = Range1d(-1, 1)
@@ -321,12 +321,12 @@ class Processing(DashboardComponent):
     def update(self, messages):
         with log_errors():
             msg = messages["processing"]
-            if not msg.get("ncores"):
+            if not msg.get("nthreads"):
                 return
             data = self.processing_update(msg)
             x_range = self.root.x_range
             max_right = max(data["right"])
-            cores = max(data["ncores"])
+            cores = max(data["nthreads"])
             if x_range.end < max_right:
                 x_range.end = max_right + 2
             elif x_range.end > 2 * max_right + cores:  # way out there, walk back
@@ -341,8 +341,8 @@ class Processing(DashboardComponent):
             names = sorted(names)
             processing = msg["processing"]
             processing = [processing[name] for name in names]
-            ncores = msg["ncores"]
-            ncores = [ncores[name] for name in names]
+            nthreads = msg["nthreads"]
+            nthreads = [nthreads[name] for name in names]
             n = len(names)
             d = {
                 "name": list(names),
@@ -350,7 +350,7 @@ class Processing(DashboardComponent):
                 "right": list(processing),
                 "top": list(range(n, 0, -1)),
                 "bottom": list(range(n - 1, -1, -1)),
-                "ncores": ncores,
+                "nthreads": nthreads,
             }
 
             d["alpha"] = [0.7] * n

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -189,7 +189,7 @@ class Occupancy(DashboardComponent):
             if total:
                 self.root.title.text = "Occupancy -- total time: %s  wall time: %s" % (
                     format_time(total),
-                    format_time(total / self.scheduler.total_ncores),
+                    format_time(total / self.scheduler.total_nthreads),
                 )
             else:
                 self.root.title.text = "Occupancy"
@@ -1179,7 +1179,7 @@ class WorkerTable(DashboardComponent):
         self.names = [
             "name",
             "address",
-            "ncores",
+            "nthreads",
             "cpu",
             "memory",
             "memory_limit",
@@ -1198,7 +1198,7 @@ class WorkerTable(DashboardComponent):
         table_names = [
             "name",
             "address",
-            "ncores",
+            "nthreads",
             "cpu",
             "memory",
             "memory_limit",
@@ -1223,7 +1223,7 @@ class WorkerTable(DashboardComponent):
             "read_bytes": NumberFormatter(format="0 b"),
             "write_bytes": NumberFormatter(format="0 b"),
             "num_fds": NumberFormatter(format="0"),
-            "ncores": NumberFormatter(format="0"),
+            "nthreads": NumberFormatter(format="0"),
         }
 
         if BOKEH_VERSION < "0.12.15":
@@ -1345,8 +1345,8 @@ class WorkerTable(DashboardComponent):
                 data["memory_percent"][-1] = ""
             data["memory_limit"][-1] = ws.memory_limit
             data["cpu"][-1] = ws.metrics["cpu"] / 100.0
-            data["cpu_fraction"][-1] = ws.metrics["cpu"] / 100.0 / ws.ncores
-            data["ncores"][-1] = ws.ncores
+            data["cpu_fraction"][-1] = ws.metrics["cpu"] / 100.0 / ws.nthreads
+            data["nthreads"][-1] = ws.nthreads
 
         self.source.data.update(data)
 

--- a/distributed/dashboard/scheduler_html.py
+++ b/distributed/dashboard/scheduler_html.py
@@ -107,7 +107,7 @@ class CountsJSON(RequestHandler):
         scheduler = self.server
         erred = 0
         nbytes = 0
-        ncores = 0
+        nthreads = 0
         memory = 0
         processing = 0
         released = 0
@@ -124,7 +124,7 @@ class CountsJSON(RequestHandler):
             if ts.waiters:
                 waiting_data += 1
         for ws in scheduler.workers.values():
-            ncores += ws.ncores
+            nthreads += ws.nthreads
             memory += len(ws.has_what)
             nbytes += ws.nbytes
             processing += len(ws.processing)
@@ -132,7 +132,7 @@ class CountsJSON(RequestHandler):
         response = {
             "bytes": nbytes,
             "clients": len(scheduler.clients),
-            "cores": ncores,
+            "cores": nthreads,
             "erred": erred,
             "hosts": len(scheduler.host_info),
             "idle": len(scheduler.idle),

--- a/distributed/dashboard/templates/worker-table.html
+++ b/distributed/dashboard/templates/worker-table.html
@@ -15,7 +15,7 @@
     <tr>
         <td><a href="../worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
         <td> {{ ws.name if ws.name is not None else "" }} </td>
-        <td> {{ ws.ncores }} </td>
+        <td> {{ ws.nthreads }} </td>
         <td> {{ format_bytes(ws.memory_limit) }} </td>
         <td> <progress class="progress" value="{{ ws.metrics['memory'] }}" max="{{ ws.memory_limit }}"></progress> </td>
         <td> {{ format_time(ws.occupancy) }} </td>

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -321,8 +321,8 @@ def test_WorkerTable(c, s, a, b):
     assert all(wt.source.data.values())
     assert all(len(v) == 2 for v in wt.source.data.values())
 
-    ncores = wt.source.data["ncores"]
-    assert all(ncores)
+    nthreads = wt.source.data["nthreads"]
+    assert all(nthreads)
 
 
 @gen_cluster(client=True)

--- a/distributed/dashboard/worker.py
+++ b/distributed/dashboard/worker.py
@@ -76,7 +76,7 @@ class StateTable(DashboardComponent):
             w = self.worker
             d = {
                 "Stored": [len(w.data)],
-                "Executing": ["%d / %d" % (len(w.executing), w.ncores)],
+                "Executing": ["%d / %d" % (len(w.executing), w.nthreads)],
                 "Ready": [len(w.ready)],
                 "Waiting": [len(w.waiting_for_data)],
                 "Connections": [len(w.in_flight_workers)],
@@ -251,7 +251,7 @@ class ExecutingTimeSeries(DashboardComponent):
         fig = figure(
             title="Executing History",
             x_axis_type="datetime",
-            y_range=[-0.1, worker.ncores + 0.1],
+            y_range=[-0.1, worker.nthreads + 0.1],
             height=150,
             tools="",
             x_range=x_range,

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -44,8 +44,8 @@ class SpecCluster(Cluster):
     >>> from dask.distributed import Scheduler, Worker, Nanny
     >>> scheduler = {'cls': Scheduler, 'options': {"dashboard_address": ':8787'}}
     >>> workers = {
-    ...     'my-worker': {"cls": Worker, "options": {"ncores": 1}},
-    ...     'my-nanny': {"cls": Nanny, "options": {"ncores": 2}},
+    ...     'my-worker': {"cls": Worker, "options": {"nthreads": 1}},
+    ...     'my-nanny': {"cls": Nanny, "options": {"nthreads": 2}},
     ... }
     >>> cluster = SpecCluster(scheduler=scheduler, workers=workers)
 
@@ -53,8 +53,8 @@ class SpecCluster(Cluster):
 
     >>> cluster.worker_spec
     {
-       'my-worker': {"cls": Worker, "options": {"ncores": 1}},
-       'my-nanny': {"cls": Nanny, "options": {"ncores": 2}},
+       'my-worker': {"cls": Worker, "options": {"nthreads": 1}},
+       'my-nanny': {"cls": Nanny, "options": {"nthreads": 2}},
     }
 
     While the instantiation of this spec is stored in the ``.workers``

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -23,11 +23,11 @@ def test_get_scale_up_kwargs(loop):
         with Client(cluster, loop=loop) as c:
             future = c.submit(lambda x: x + 1, 1)
             assert future.result() == 2
-            assert c.ncores()
+            assert c.nthreads()
             assert alc.get_scale_up_kwargs() == {"n": 3}
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 4)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
 def test_simultaneous_scale_up_and_down(c, s, *workers):
     class TestAdaptive(Adaptive):
         def get_scale_up_kwargs(self):
@@ -65,22 +65,22 @@ def test_adaptive_local_cluster(loop):
     ) as cluster:
         alc = Adaptive(cluster.scheduler, cluster, interval=100)
         with Client(cluster, loop=loop) as c:
-            assert not c.ncores()
+            assert not c.nthreads()
             future = c.submit(lambda x: x + 1, 1)
             assert future.result() == 2
-            assert c.ncores()
+            assert c.nthreads()
 
             sleep(0.1)
-            assert c.ncores()  # still there after some time
+            assert c.nthreads()  # still there after some time
 
             del future
 
             start = time()
-            while cluster.scheduler.ncores:
+            while cluster.scheduler.nthreads:
                 sleep(0.01)
                 assert time() < start + 5
 
-            assert not c.ncores()
+            assert not c.nthreads()
 
 
 @nodebug
@@ -128,7 +128,7 @@ def test_adaptive_local_cluster_multi_workers():
         yield cluster.close()
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10, active_rpc_timeout=10)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10, active_rpc_timeout=10)
 def test_adaptive_scale_down_override(c, s, *workers):
     class TestAdaptive(Adaptive):
         def __init__(self, *args, **kwargs):

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -17,9 +17,9 @@ class BrokenWorker(Worker):
 
 
 worker_spec = {
-    0: {"cls": Worker, "options": {"ncores": 1}},
-    1: {"cls": Worker, "options": {"ncores": 2}},
-    "my-worker": {"cls": MyWorker, "options": {"ncores": 3}},
+    0: {"cls": Worker, "options": {"nthreads": 1}},
+    1: {"cls": Worker, "options": {"nthreads": 2}},
+    "my-worker": {"cls": MyWorker, "options": {"nthreads": 3}},
 }
 scheduler = {"cls": Scheduler, "options": {"port": 0}}
 
@@ -37,9 +37,9 @@ async def test_specification():
         assert isinstance(cluster.workers[1], Worker)
         assert isinstance(cluster.workers["my-worker"], MyWorker)
 
-        assert cluster.workers[0].ncores == 1
-        assert cluster.workers[1].ncores == 2
-        assert cluster.workers["my-worker"].ncores == 3
+        assert cluster.workers[0].nthreads == 1
+        assert cluster.workers[1].nthreads == 2
+        assert cluster.workers["my-worker"].nthreads == 3
 
         async with Client(cluster, asynchronous=True) as client:
             result = await client.submit(lambda x: x + 1, 10)
@@ -51,9 +51,9 @@ async def test_specification():
 
 def test_spec_sync(loop):
     worker_spec = {
-        0: {"cls": Worker, "options": {"ncores": 1}},
-        1: {"cls": Worker, "options": {"ncores": 2}},
-        "my-worker": {"cls": MyWorker, "options": {"ncores": 3}},
+        0: {"cls": Worker, "options": {"nthreads": 1}},
+        1: {"cls": Worker, "options": {"nthreads": 2}},
+        "my-worker": {"cls": MyWorker, "options": {"nthreads": 3}},
     }
     with SpecCluster(workers=worker_spec, scheduler=scheduler, loop=loop) as cluster:
         assert cluster.worker_spec is worker_spec
@@ -64,9 +64,9 @@ def test_spec_sync(loop):
         assert isinstance(cluster.workers[1], Worker)
         assert isinstance(cluster.workers["my-worker"], MyWorker)
 
-        assert cluster.workers[0].ncores == 1
-        assert cluster.workers[1].ncores == 2
-        assert cluster.workers["my-worker"].ncores == 3
+        assert cluster.workers[0].nthreads == 1
+        assert cluster.workers[1].nthreads == 2
+        assert cluster.workers["my-worker"].nthreads == 3
 
         with Client(cluster, loop=loop) as client:
             assert cluster.loop is cluster.scheduler.loop
@@ -83,7 +83,7 @@ def test_loop_started():
 
 @pytest.mark.asyncio
 async def test_scale():
-    worker = {"cls": Worker, "options": {"ncores": 1}}
+    worker = {"cls": Worker, "options": {"nthreads": 1}}
     async with SpecCluster(
         asynchronous=True, scheduler=scheduler, worker=worker
     ) as cluster:
@@ -134,9 +134,9 @@ async def test_new_worker_spec():
     class MyCluster(SpecCluster):
         def new_worker_spec(self):
             i = len(self.worker_spec)
-            return i, {"cls": Worker, "options": {"ncores": i + 1}}
+            return i, {"cls": Worker, "options": {"nthreads": i + 1}}
 
     async with MyCluster(asynchronous=True, scheduler=scheduler) as cluster:
         cluster.scale(3)
         for i in range(3):
-            assert cluster.worker_spec[i]["options"]["ncores"] == i + 1
+            assert cluster.worker_spec[i]["options"]["nthreads"] == i + 1

--- a/distributed/deploy/utils_test.py
+++ b/distributed/deploy/utils_test.py
@@ -18,7 +18,7 @@ class ClusterTest(object):
     @pytest.mark.xfail()
     def test_cores(self):
         info = self.client.scheduler_info()
-        assert len(self.client.ncores()) == 2
+        assert len(self.client.nthreads()) == 2
 
     def test_submit(self):
         future = self.client.submit(lambda x: x + 1, 1)
@@ -27,7 +27,7 @@ class ClusterTest(object):
     def test_context_manager(self):
         with self.Cluster(**self.kwargs) as c:
             with Client(c) as e:
-                assert e.ncores()
+                assert e.nthreads()
 
     def test_no_workers(self):
         with self.Cluster(0, scheduler_port=0, **self.kwargs):

--- a/distributed/diagnostics/tests/test_eventstream.py
+++ b/distributed/diagnostics/tests/test_eventstream.py
@@ -11,7 +11,7 @@ from distributed.metrics import time
 from distributed.utils_test import div, gen_cluster
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 3)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
 def test_eventstream(c, s, *workers):
     pytest.importorskip("bokeh")
 

--- a/distributed/diagnostics/tests/test_plugin.py
+++ b/distributed/diagnostics/tests/test_plugin.py
@@ -34,7 +34,7 @@ def test_simple(c, s, a, b):
     assert counter not in s.plugins
 
 
-@gen_cluster(ncores=[], client=False)
+@gen_cluster(nthreads=[], client=False)
 def test_add_remove_worker(s):
     events = []
 

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -44,7 +44,7 @@ def test_TextProgressBar_empty(capsys):
     @gen_test()
     def f():
         s = yield Scheduler(port=0)
-        a, b = yield [Worker(s.address, ncores=1), Worker(s.address, ncores=1)]
+        a, b = yield [Worker(s.address, nthreads=1), Worker(s.address, nthreads=1)]
 
         progress = TextProgressBar([], scheduler=s.address, start=False, interval=0.01)
         yield progress.listen()

--- a/distributed/diagnostics/tests/test_task_stream.py
+++ b/distributed/diagnostics/tests/test_task_stream.py
@@ -14,7 +14,7 @@ from distributed.diagnostics.task_stream import TaskStreamPlugin
 from distributed.metrics import time
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 3)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
 def test_TaskStreamPlugin(c, s, *workers):
     es = TaskStreamPlugin(s)
     assert not es.buffer

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division, absolute_import
 from datetime import timedelta
 import logging
 from multiprocessing.queues import Empty
+import multiprocessing
 import os
 import psutil
 import shutil
@@ -32,7 +33,7 @@ from .utils import (
     PeriodicCallback,
     parse_timedelta,
 )
-from .worker import _ncores, run, parse_memory_limit, Worker
+from .worker import run, parse_memory_limit, Worker
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ class Nanny(ServerNode):
         scheduler_port=None,
         scheduler_file=None,
         worker_port=0,
+        nthreads=None,
         ncores=None,
         loop=None,
         local_dir="dask-worker-space",
@@ -96,8 +98,12 @@ class Nanny(ServerNode):
         else:
             self.scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))
 
+        if ncores is not None:
+            warnings.warn("the ncores= parameter has moved to nthreads=")
+            nthreads = ncores
+
         self._given_worker_port = worker_port
-        self.ncores = ncores or _ncores
+        self.nthreads = nthreads or multiprocessing.cpu_count()
         self.reconnect = reconnect
         self.validate = validate
         self.resources = resources
@@ -120,7 +126,7 @@ class Nanny(ServerNode):
         self.quiet = quiet
         self.auto_restart = True
 
-        self.memory_limit = parse_memory_limit(memory_limit, self.ncores)
+        self.memory_limit = parse_memory_limit(memory_limit, self.nthreads)
 
         if silence_logs:
             silence_logging(level=silence_logs)
@@ -160,7 +166,7 @@ class Nanny(ServerNode):
         self.status = "init"
 
     def __repr__(self):
-        return "<Nanny: %s, threads: %d>" % (self.worker_address, self.ncores)
+        return "<Nanny: %s, threads: %d>" % (self.worker_address, self.nthreads)
 
     @gen.coroutine
     def _unregister(self, timeout=10):
@@ -263,7 +269,7 @@ class Nanny(ServerNode):
         if self.process is None:
             worker_kwargs = dict(
                 scheduler_ip=self.scheduler_addr,
-                ncores=self.ncores,
+                nthreads=self.nthreads,
                 local_dir=self.local_dir,
                 services=self.services,
                 nanny=self.address,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -164,9 +164,9 @@ class WorkerState(object):
        The total memory size, in bytes, used by the tasks this worker
        holds in memory (i.e. the tasks in this worker's :attr:`has_what`).
 
-    .. attribute:: ncores: int
+    .. attribute:: nthreads: int
 
-       The number of CPU cores made available on this worker.
+       The number of CPU threads made available on this worker.
 
     .. attribute:: resources: {str: Number}
 
@@ -220,7 +220,7 @@ class WorkerState(object):
         "name",
         "nanny",
         "nbytes",
-        "ncores",
+        "nthreads",
         "occupancy",
         "pid",
         "processing",
@@ -236,7 +236,7 @@ class WorkerState(object):
         address=None,
         pid=0,
         name=None,
-        ncores=0,
+        nthreads=0,
         memory_limit=0,
         local_directory=None,
         services=None,
@@ -245,7 +245,7 @@ class WorkerState(object):
         self.address = address
         self.pid = pid
         self.name = name
-        self.ncores = ncores
+        self.nthreads = nthreads
         self.memory_limit = memory_limit
         self.local_directory = local_directory
         self.services = services or {}
@@ -274,7 +274,7 @@ class WorkerState(object):
             address=self.address,
             pid=self.pid,
             name=self.name,
-            ncores=self.ncores,
+            nthreads=self.nthreads,
             memory_limit=self.memory_limit,
             local_directory=self.local_directory,
             services=self.services,
@@ -301,7 +301,7 @@ class WorkerState(object):
             "resources": self.resources,
             "local_directory": self.local_directory,
             "name": self.name,
-            "ncores": self.ncores,
+            "nthreads": self.nthreads,
             "memory_limit": self.memory_limit,
             "last_seen": self.last_seen,
             "services": self.services,
@@ -963,7 +963,7 @@ class Scheduler(ServerNode):
         # Worker state
         self.workers = sortedcontainers.SortedDict()
         for old_attr, new_attr, wrap in [
-            ("ncores", "ncores", None),
+            ("nthreads", "nthreads", None),
             ("worker_bytes", "nbytes", None),
             ("worker_resources", "resources", None),
             ("used_resources", "used_resources", None),
@@ -980,7 +980,7 @@ class Scheduler(ServerNode):
         self.idle = sortedcontainers.SortedSet(key=operator.attrgetter("address"))
         self.saturated = set()
 
-        self.total_ncores = 0
+        self.total_nthreads = 0
         self.total_occupancy = 0
         self.host_info = defaultdict(dict)
         self.resources = defaultdict(dict)
@@ -1128,7 +1128,7 @@ class Scheduler(ServerNode):
         return '<Scheduler: "%s" processes: %d cores: %d>' % (
             self.address,
             len(self.workers),
-            self.total_ncores,
+            self.total_nthreads,
         )
 
     def identity(self, comm=None):
@@ -1394,7 +1394,7 @@ class Scheduler(ServerNode):
         comm=None,
         address=None,
         keys=(),
-        ncores=None,
+        nthreads=None,
         name=None,
         resolve_address=True,
         nbytes=None,
@@ -1422,7 +1422,7 @@ class Scheduler(ServerNode):
             self.workers[address] = ws = WorkerState(
                 address=address,
                 pid=pid,
-                ncores=ncores,
+                nthreads=nthreads,
                 memory_limit=memory_limit,
                 name=name,
                 local_directory=local_directory,
@@ -1440,12 +1440,12 @@ class Scheduler(ServerNode):
                 return
 
             if "addresses" not in self.host_info[host]:
-                self.host_info[host].update({"addresses": set(), "cores": 0})
+                self.host_info[host].update({"addresses": set(), "nthreads": 0})
 
             self.host_info[host]["addresses"].add(address)
-            self.host_info[host]["cores"] += ncores
+            self.host_info[host]["nthreads"] += nthreads
 
-            self.total_ncores += ncores
+            self.total_nthreads += nthreads
             self.aliases[name] = address
 
             response = self.heartbeat_worker(
@@ -1465,7 +1465,7 @@ class Scheduler(ServerNode):
 
             self.stream_comms[address] = BatchedSend(interval="5ms", loop=self.loop)
 
-            if ws.ncores > len(ws.processing):
+            if ws.nthreads > len(ws.processing):
                 self.idle.add(ws)
 
             for plugin in self.plugins[:]:
@@ -1906,9 +1906,9 @@ class Scheduler(ServerNode):
 
             self.remove_resources(address)
 
-            self.host_info[host]["cores"] -= ws.ncores
+            self.host_info[host]["nthreads"] -= ws.nthreads
             self.host_info[host]["addresses"].remove(address)
-            self.total_ncores -= ws.ncores
+            self.total_nthreads -= ws.nthreads
 
             if not self.host_info[host]["addresses"]:
                 del self.host_info[host]
@@ -2489,22 +2489,22 @@ class Scheduler(ServerNode):
                 raise gen.TimeoutError("No workers found")
 
         if workers is None:
-            ncores = {w: ws.ncores for w, ws in self.workers.items()}
+            nthreads = {w: ws.nthreads for w, ws in self.workers.items()}
         else:
             workers = [self.coerce_address(w) for w in workers]
-            ncores = {w: self.workers[w].ncores for w in workers}
+            nthreads = {w: self.workers[w].nthreads for w in workers}
 
         assert isinstance(data, dict)
 
         keys, who_has, nbytes = yield scatter_to_workers(
-            ncores, data, rpc=self.rpc, report=False
+            nthreads, data, rpc=self.rpc, report=False
         )
 
         self.update_data(who_has=who_has, nbytes=nbytes, client=client)
 
         if broadcast:
             if broadcast == True:  # noqa: E712
-                n = len(ncores)
+                n = len(nthreads)
             else:
                 n = broadcast
             yield self.replicate(keys=keys, workers=workers, n=n)
@@ -3283,9 +3283,9 @@ class Scheduler(ServerNode):
     def get_ncores(self, comm=None, workers=None):
         if workers is not None:
             workers = map(self.coerce_address, workers)
-            return {w: self.workers[w].ncores for w in workers if w in self.workers}
+            return {w: self.workers[w].nthreads for w in workers if w in self.workers}
         else:
-            return {w: ws.ncores for w, ws in self.workers.items()}
+            return {w: ws.nthreads for w, ws in self.workers.items()}
 
     @gen.coroutine
     def get_call_stack(self, comm=None, keys=None):
@@ -4363,19 +4363,19 @@ class Scheduler(ServerNode):
         -  Idle: do not have enough work to stay busy
 
         They are considered saturated if they both have enough tasks to occupy
-        all of their cores, and if the expected runtime of those tasks is large
-        enough.
+        all of their threads, and if the expected runtime of those tasks is
+        large enough.
 
         This is useful for load balancing and adaptivity.
         """
-        if self.total_ncores == 0 or ws.status == "closed":
+        if self.total_nthreads == 0 or ws.status == "closed":
             return
         if occ is None:
             occ = ws.occupancy
-        nc = ws.ncores
+        nc = ws.nthreads
         p = len(ws.processing)
 
-        avg = self.total_occupancy / self.total_ncores
+        avg = self.total_occupancy / self.total_nthreads
 
         if p < nc or occ / nc < avg / 2:
             self.idle.add(ws)
@@ -4538,7 +4538,7 @@ class Scheduler(ServerNode):
         comm_bytes = sum(
             [dts.get_nbytes() for dts in ts.dependencies if ws not in dts.who_has]
         )
-        stack_time = ws.occupancy / ws.ncores
+        stack_time = ws.occupancy / ws.nthreads
         start_time = comm_bytes / self.bandwidth + stack_time
 
         if ts.actor:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -333,7 +333,7 @@ class WorkStealing(SchedulerPlugin):
                 saturated = [
                     ws
                     for ws in saturated
-                    if combined_occupancy(ws) > 0.2 and len(ws.processing) > ws.ncores
+                    if combined_occupancy(ws) > 0.2 and len(ws.processing) > ws.nthreads
                 ]
             elif len(s.saturated) < 20:
                 saturated = sorted(saturated, key=combined_occupancy, reverse=True)
@@ -379,7 +379,7 @@ class WorkStealing(SchedulerPlugin):
                             continue
                         if combined_occupancy(sat) < 0.2:
                             continue
-                        if len(sat.processing) <= sat.ncores:
+                        if len(sat.processing) <= sat.nthreads:
                             continue
 
                         i += 1

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -341,13 +341,13 @@ def test_many_computations(c, s, a, b):
     done = c.submit(lambda x: None, futures)
 
     while not done.done():
-        assert len(s.processing) <= a.ncores + b.ncores
+        assert len(s.processing) <= a.nthreads + b.nthreads
         yield gen.sleep(0.01)
 
     yield done
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 5)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 5)] * 2)
 def test_thread_safety(c, s, a, b):
     class Unsafe(object):
         def __init__(self):
@@ -394,7 +394,7 @@ def test_load_balance(c, s, a, b):
     assert s.tasks[x.key].who_has != s.tasks[y.key].who_has  # second load balanced
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 5)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 5)
 def test_load_balance_map(c, s, *workers):
     class Foo(object):
         def __init__(self, x, y=None):
@@ -409,7 +409,7 @@ def test_load_balance_map(c, s, *workers):
     assert all(len(w.actors) == 2 for w in workers)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 4, Worker=Nanny)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4, Worker=Nanny)
 def bench_param_server(c, s, *workers):
     import dask.array as da
     import numpy as np
@@ -506,7 +506,7 @@ def test_compute_sync(client):
 
 @gen_cluster(
     client=True,
-    ncores=[("127.0.0.1", 1)],
+    nthreads=[("127.0.0.1", 1)],
     config={"distributed.worker.profile.interval": "1ms"},
 )
 def test_actors_in_profile(c, s, a):

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -188,7 +188,7 @@ def test_sparse_arrays(c, s, a, b):
     yield future
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 def test_delayed_none(c, s, w):
     x = dask.delayed(None)
     y = dask.delayed(123)

--- a/distributed/tests/test_ipython.py
+++ b/distributed/tests/test_ipython.py
@@ -88,7 +88,7 @@ def test_start_ipython_workers_magic(loop, zmq_ctx):
     with cluster(2) as (s, [a, b]):
 
         with Client(s["address"], loop=loop) as e, mock_ipython() as ip:
-            workers = list(e.ncores())[:2]
+            workers = list(e.nthreads())[:2]
             names = ["magic%i" % i for i in range(len(workers))]
             info_dict = e.start_ipython_workers(workers, magic_names=names)
 
@@ -116,7 +116,7 @@ def test_start_ipython_workers_magic_asterix(loop, zmq_ctx):
     with cluster(2) as (s, [a, b]):
 
         with Client(s["address"], loop=loop) as e, mock_ipython() as ip:
-            workers = list(e.ncores())[:2]
+            workers = list(e.nthreads())[:2]
             info_dict = e.start_ipython_workers(workers, magic_names="magic_*")
 
         expected = [
@@ -144,7 +144,7 @@ def test_start_ipython_remote(loop, zmq_ctx):
 
     with cluster(1) as (s, [a]):
         with Client(s["address"], loop=loop) as e, mock_ipython() as ip:
-            worker = first(e.ncores())
+            worker = first(e.nthreads())
             ip.user_ns["info"] = e.start_ipython_workers(worker)[worker]
             remote_magic("info 1")  # line magic
             remote_magic("info", "worker")  # cell magic
@@ -165,7 +165,7 @@ def test_start_ipython_qtconsole(loop):
         with mock.patch("distributed._ipython_utils.Popen", Popen), Client(
             s["address"], loop=loop
         ) as e:
-            worker = first(e.ncores())
+            worker = first(e.nthreads())
             e.start_ipython_workers(worker, qtconsole=True)
             e.start_ipython_workers(worker, qtconsole=True, qtconsole_args=["--debug"])
     assert Popen.call_count == 2

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -11,7 +11,7 @@ from distributed.utils_test import gen_cluster
 from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 8)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)
 def test_lock(c, s, a, b):
     c.set_metadata("locked", False)
 

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -83,7 +83,7 @@ def test_expand_persist(c, s, a, b):
     assert s.tasks[low.key].state == "processing"
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 def test_repeated_persists_same_priority(c, s, w):
     xs = [delayed(slowinc)(i, delay=0.05, dask_key_name="x-%d" % i) for i in range(10)]
     ys = [
@@ -107,7 +107,7 @@ def test_repeated_persists_same_priority(c, s, w):
     assert any(s.tasks[z.key].state == "memory" for z in zs)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 def test_last_in_first_out(c, s, w):
     xs = [c.submit(slowinc, i, delay=0.05) for i in range(5)]
     ys = [c.submit(slowinc, x, delay=0.05) for x in xs]

--- a/distributed/tests/test_pubsub.py
+++ b/distributed/tests/test_pubsub.py
@@ -49,7 +49,7 @@ def test_speed(c, s, a, b):
     # print('duration', stop - start)  # I get around 3ms/roundtrip on my laptop
 
 
-@gen_cluster(client=True, ncores=[])
+@gen_cluster(client=True, nthreads=[])
 def test_client(c, s):
     with pytest.raises(Exception):
         get_worker()

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 from datetime import timedelta
 from time import sleep
-import sys
 
 import pytest
 from tornado import gen
@@ -113,9 +112,8 @@ def test_picklability_sync(client):
     assert q.get() == 11
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="Multi-client issues")
 @pytest.mark.slow
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
 def test_race(c, s, *workers):
     def f(i):
         with worker_client() as c:

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -14,7 +14,7 @@ from distributed.utils_test import inc, gen_cluster, slowinc, slowadd
 from distributed.utils_test import client, cluster_fixture, loop, s, a, b  # noqa: F401
 
 
-@gen_cluster(client=True, ncores=[])
+@gen_cluster(client=True, nthreads=[])
 def test_resources(c, s):
     assert not s.worker_resources
     assert not s.resources
@@ -37,7 +37,7 @@ def test_resources(c, s):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 5}}),
         ("127.0.0.1", 1, {"resources": {"A": 1, "B": 1}}),
     ],
@@ -65,7 +65,7 @@ def test_resource_submit(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -80,7 +80,7 @@ def test_submit_many_non_overlapping(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -96,7 +96,7 @@ def test_move(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -114,7 +114,7 @@ def test_dont_work_steal(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -128,7 +128,7 @@ def test_map(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -147,7 +147,7 @@ def test_persist(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 11}}),
     ],
@@ -170,7 +170,7 @@ def test_compute(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -184,7 +184,7 @@ def test_get(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -222,7 +222,7 @@ def test_resources_str(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 4, {"resources": {"A": 2}}),
         ("127.0.0.1", 4, {"resources": {"A": 1}}),
     ],
@@ -240,7 +240,7 @@ def test_submit_many_non_overlapping(c, s, a, b):
     assert b.total_resources == b.available_resources
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 4, {"resources": {"A": 2, "B": 1}})])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 4, {"resources": {"A": 2, "B": 1}})])
 def test_minimum_resource(c, s, a):
     futures = c.map(slowinc, range(30), resources={"A": 1, "B": 1}, delay=0.02)
 
@@ -252,7 +252,7 @@ def test_minimum_resource(c, s, a):
     assert a.total_resources == a.available_resources
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2, {"resources": {"A": 1}})])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2, {"resources": {"A": 1}})])
 def test_prefer_constrained(c, s, a):
     futures = c.map(slowinc, range(1000), delay=0.1)
     constrained = c.map(inc, range(10), resources={"A": 1})
@@ -270,7 +270,7 @@ def test_prefer_constrained(c, s, a):
 @pytest.mark.skip(reason="")
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 2, {"resources": {"A": 1}}),
         ("127.0.0.1", 2, {"resources": {"A": 1}}),
     ],
@@ -284,7 +284,7 @@ def test_balance_resources(c, s, a, b):
     assert any(f.key in b.data for f in constrained)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2)])
 def test_set_resources(c, s, a):
     yield a.set_resources(A=2)
     assert a.total_resources["A"] == 2
@@ -303,7 +303,7 @@ def test_set_resources(c, s, a):
 
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -325,7 +325,7 @@ def test_persist_collections(c, s, a, b):
 @pytest.mark.skip(reason="Should protect resource keys from optimization")
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
@@ -346,7 +346,7 @@ def test_dont_optimize_out(c, s, a, b):
 @pytest.mark.xfail(reason="atop fusion seemed to break this")
 @gen_cluster(
     client=True,
-    ncores=[
+    nthreads=[
         ("127.0.0.1", 1, {"resources": {"A": 1}}),
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -37,7 +37,7 @@ teardown_module = nodebug_teardown_module
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2), ("127.0.0.2", 2)], timeout=20)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2), ("127.0.0.2", 2)], timeout=20)
 def test_work_stealing(c, s, a, b):
     [x] = yield c._scatter([1], workers=a.address)
     futures = c.map(slowadd, range(50), [x] * 50)
@@ -46,7 +46,7 @@ def test_work_stealing(c, s, a, b):
     assert len(b.data) > 10
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_dont_steal_expensive_data_fast_computation(c, s, a, b):
     np = pytest.importorskip("numpy")
     x = c.submit(np.arange, 1000000, workers=a.address)
@@ -64,7 +64,7 @@ def test_dont_steal_expensive_data_fast_computation(c, s, a, b):
     assert len(a.data) == 12
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_steal_cheap_data_slow_computation(c, s, a, b):
     x = c.submit(slowinc, 100, delay=0.1)  # learn that slowinc is slow
     yield wait(x)
@@ -77,7 +77,7 @@ def test_steal_cheap_data_slow_computation(c, s, a, b):
 
 
 @pytest.mark.avoid_travis
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_steal_expensive_data_slow_computation(c, s, a, b):
     np = pytest.importorskip("numpy")
 
@@ -94,7 +94,7 @@ def test_steal_expensive_data_slow_computation(c, s, a, b):
     assert b.data  # not empty
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
 def test_worksteal_many_thieves(c, s, *workers):
     x = c.submit(slowinc, -1, delay=0.1)
     yield x
@@ -110,7 +110,7 @@ def test_worksteal_many_thieves(c, s, *workers):
     assert sum(map(len, s.has_what.values())) < 150
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_dont_steal_unknown_functions(c, s, a, b):
     futures = c.map(inc, [1, 2], workers=a.address, allow_other_workers=True)
     yield wait(futures)
@@ -118,7 +118,7 @@ def test_dont_steal_unknown_functions(c, s, a, b):
     assert len(b.data) == 0
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_eventually_steal_unknown_functions(c, s, a, b):
     futures = c.map(
         slowinc, range(10), delay=0.1, workers=a.address, allow_other_workers=True
@@ -129,7 +129,7 @@ def test_eventually_steal_unknown_functions(c, s, a, b):
 
 
 @pytest.mark.skip(reason="")
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 3)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
 def test_steal_related_tasks(e, s, a, b, c):
     futures = e.map(
         slowinc, range(20), delay=0.05, workers=a.address, allow_other_workers=True
@@ -145,7 +145,7 @@ def test_steal_related_tasks(e, s, a, b, c):
     assert nearby > 10
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10, timeout=1000)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10, timeout=1000)
 def test_dont_steal_fast_tasks(c, s, *workers):
     np = pytest.importorskip("numpy")
     x = c.submit(np.random.random, 10000000, workers=workers[0].address)
@@ -163,7 +163,7 @@ def test_dont_steal_fast_tasks(c, s, *workers):
     assert len(s.has_what[workers[0].address]) == 1001
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)], timeout=20)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)], timeout=20)
 def test_new_worker_steals(c, s, a):
     yield wait(c.submit(slowinc, 1, delay=0.01))
 
@@ -172,7 +172,7 @@ def test_new_worker_steals(c, s, a):
     while len(a.task_state) < 10:
         yield gen.sleep(0.01)
 
-    b = yield Worker(s.address, loop=s.loop, ncores=1, memory_limit=TOTAL_MEMORY)
+    b = yield Worker(s.address, loop=s.loop, nthreads=1, memory_limit=TOTAL_MEMORY)
 
     result = yield total
     assert result == sum(map(inc, range(100)))
@@ -204,7 +204,7 @@ def test_work_steal_no_kwargs(c, s, a, b):
     assert result == sum(map(inc, range(100)))
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1), ("127.0.0.1", 2)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1), ("127.0.0.1", 2)])
 def test_dont_steal_worker_restrictions(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
     yield future
@@ -228,7 +228,7 @@ def test_dont_steal_worker_restrictions(c, s, a, b):
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1), ("127.0.0.2", 1)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1), ("127.0.0.2", 1)])
 def test_dont_steal_host_restrictions(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
     yield future
@@ -247,7 +247,7 @@ def test_dont_steal_host_restrictions(c, s, a, b):
 
 
 @gen_cluster(
-    client=True, ncores=[("127.0.0.1", 1, {"resources": {"A": 2}}), ("127.0.0.1", 1)]
+    client=True, nthreads=[("127.0.0.1", 1, {"resources": {"A": 2}}), ("127.0.0.1", 1)]
 )
 def test_dont_steal_resource_restrictions(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
@@ -267,7 +267,9 @@ def test_dont_steal_resource_restrictions(c, s, a, b):
 
 
 @pytest.mark.skip(reason="no stealing of resources")
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1, {"resources": {"A": 2}})], timeout=3)
+@gen_cluster(
+    client=True, nthreads=[("127.0.0.1", 1, {"resources": {"A": 2}})], timeout=3
+)
 def test_steal_resource_restrictions(c, s, a):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
     yield future
@@ -277,7 +279,7 @@ def test_steal_resource_restrictions(c, s, a):
         yield gen.sleep(0.01)
     assert len(a.task_state) == 101
 
-    b = yield Worker(s.address, loop=s.loop, ncores=1, resources={"A": 4})
+    b = yield Worker(s.address, loop=s.loop, nthreads=1, resources={"A": 4})
 
     start = time()
     while not b.task_state or len(a.task_state) == 101:
@@ -290,7 +292,7 @@ def test_steal_resource_restrictions(c, s, a):
     yield b.close()
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 5, timeout=20)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 5, timeout=20)
 def test_balance_without_dependencies(c, s, *workers):
     s.extensions["stealing"]._pc.callback_time = 20
 
@@ -306,7 +308,7 @@ def test_balance_without_dependencies(c, s, *workers):
     assert max(durations) / min(durations) < 3
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 4)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 4)] * 2)
 def test_dont_steal_executing_tasks(c, s, a, b):
     futures = c.map(
         slowinc, range(4), delay=0.1, workers=a.address, allow_other_workers=True
@@ -317,7 +319,7 @@ def test_dont_steal_executing_tasks(c, s, a, b):
     assert len(b.data) == 0
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
 def test_dont_steal_few_saturated_tasks_many_workers(c, s, a, *rest):
     s.extensions["stealing"]._pc.callback_time = 20
     x = c.submit(mul, b"0", 100000000, workers=a.address)  # 100 MB
@@ -334,7 +336,7 @@ def test_dont_steal_few_saturated_tasks_many_workers(c, s, a, *rest):
 
 @gen_cluster(
     client=True,
-    ncores=[("127.0.0.1", 1)] * 10,
+    nthreads=[("127.0.0.1", 1)] * 10,
     worker_kwargs={"memory_limit": TOTAL_MEMORY},
 )
 def test_steal_when_more_tasks(c, s, a, *rest):
@@ -351,7 +353,7 @@ def test_steal_when_more_tasks(c, s, a, *rest):
         assert time() < start + 1
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
 def test_steal_more_attractive_tasks(c, s, a, *rest):
     def slow2(x):
         sleep(1)
@@ -473,11 +475,11 @@ def assert_balanced(inp, expected, c, s, *workers):
 )
 def test_balance(inp, expected):
     test = lambda *args, **kwargs: assert_balanced(inp, expected, *args, **kwargs)
-    test = gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * len(inp))(test)
+    test = gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * len(inp))(test)
     test()
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2, Worker=Nanny, timeout=20)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2, Worker=Nanny, timeout=20)
 def test_restart(c, s, a, b):
     futures = c.map(
         slowinc, range(100), delay=0.1, workers=a.address, allow_other_workers=True
@@ -569,7 +571,7 @@ def test_dont_steal_executing_tasks(c, s, a, b):
     assert not b.executing
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_dont_steal_long_running_tasks(c, s, a, b):
     def long(delay):
         with worker_client() as c:
@@ -603,7 +605,7 @@ def test_dont_steal_long_running_tasks(c, s, a, b):
         ) <= 1
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 5)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 5)] * 2)
 def test_cleanup_repeated_tasks(c, s, a, b):
     class Foo(object):
         pass
@@ -635,7 +637,7 @@ def test_cleanup_repeated_tasks(c, s, a, b):
     assert not list(ws)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_lose_task(c, s, a, b):
     with captured_logger("distributed.stealing") as log:
         s.periodic_callbacks["stealing"].interval = 1

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -64,7 +64,7 @@ def test_stress_gc(loop, func, n):
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="test can leave dangling RPC objects"
 )
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 8, timeout=None)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 8, timeout=None)
 def test_cancel_stress(c, s, *workers):
     da = pytest.importorskip("dask.array")
     x = da.random.random((50, 50), chunks=(2, 2))
@@ -93,7 +93,7 @@ def test_cancel_stress_sync(loop):
                 c.cancel(f)
 
 
-@gen_cluster(ncores=[], client=True, timeout=None)
+@gen_cluster(nthreads=[], client=True, timeout=None)
 def test_stress_creation_and_deletion(c, s):
     # Assertions are handled by the validate mechanism in the scheduler
     s.allowed_failures = 100000
@@ -108,7 +108,7 @@ def test_stress_creation_and_deletion(c, s):
     def create_and_destroy_worker(delay):
         start = time()
         while time() < start + 5:
-            n = Nanny(s.address, ncores=2, loop=s.loop)
+            n = Nanny(s.address, nthreads=2, loop=s.loop)
             n.start(0)
 
             yield gen.sleep(delay)
@@ -122,7 +122,7 @@ def test_stress_creation_and_deletion(c, s):
     )
 
 
-@gen_cluster(ncores=[("127.0.0.1", 1)] * 10, client=True, timeout=60)
+@gen_cluster(nthreads=[("127.0.0.1", 1)] * 10, client=True, timeout=60)
 def test_stress_scatter_death(c, s, *workers):
     import random
 
@@ -198,7 +198,7 @@ def vsum(*args):
 
 @pytest.mark.avoid_travis
 @pytest.mark.slow
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 80, timeout=1000)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 80, timeout=1000)
 def test_stress_communication(c, s, *workers):
     s.validate = False  # very slow otherwise
     da = pytest.importorskip("dask.array")
@@ -218,7 +218,7 @@ def test_stress_communication(c, s, *workers):
 
 
 @pytest.mark.skip
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 10, timeout=60)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10, timeout=60)
 def test_stress_steal(c, s, *workers):
     s.validate = False
     for w in workers:
@@ -244,7 +244,7 @@ def test_stress_steal(c, s, *workers):
 
 
 @pytest.mark.slow
-@gen_cluster(ncores=[("127.0.0.1", 1)] * 10, client=True, timeout=120)
+@gen_cluster(nthreads=[("127.0.0.1", 1)] * 10, client=True, timeout=120)
 def test_close_connections(c, s, *workers):
     da = pytest.importorskip("dask.array")
     x = da.random.random(size=(1000, 1000), chunks=(1000, 1))
@@ -269,7 +269,7 @@ def test_close_connections(c, s, *workers):
     reason="IOStream._handle_write blocks on large write_buffer"
     " https://github.com/tornadoweb/tornado/issues/2110"
 )
-@gen_cluster(client=True, timeout=20, ncores=[("127.0.0.1", 1)])
+@gen_cluster(client=True, timeout=20, nthreads=[("127.0.0.1", 1)])
 def test_no_delay_during_large_transfer(c, s, w):
     pytest.importorskip("crick")
     np = pytest.importorskip("numpy")

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -82,7 +82,7 @@ def test_nanny(c, s, a, b):
         assert isinstance(n, Nanny)
         assert n.address.startswith("tls://")
         assert n.worker_address.startswith("tls://")
-    assert s.ncores == {n.worker_address: n.ncores for n in [a, b]}
+    assert s.nthreads == {n.worker_address: n.nthreads for n in [a, b]}
 
     x = c.submit(inc, 10)
     result = yield x
@@ -101,7 +101,7 @@ def test_rebalance(c, s, a, b):
     assert len(b.data) == 1
 
 
-@gen_tls_cluster(client=True, ncores=[("tls://127.0.0.1", 2)] * 2)
+@gen_tls_cluster(client=True, nthreads=[("tls://127.0.0.1", 2)] * 2)
 def test_work_stealing(c, s, a, b):
     [x] = yield c._scatter([1], workers=a.address)
     futures = c.map(slowadd, range(50), [x] * 50, delay=0.1)
@@ -127,7 +127,7 @@ def test_worker_client(c, s, a, b):
     assert yy == 20 + 1 + (20 + 1) * 2
 
 
-@gen_tls_cluster(client=True, ncores=[("tls://127.0.0.1", 1)] * 2)
+@gen_tls_cluster(client=True, nthreads=[("tls://127.0.0.1", 1)] * 2)
 def test_worker_client_gather(c, s, a, b):
     a_address = a.address
     b_address = b.address

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -50,7 +50,7 @@ def test_gen_cluster(c, s, a, b):
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
-    assert s.ncores == {w.address: w.ncores for w in [a, b]}
+    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
 
 
 @pytest.mark.skip(reason="This hangs on travis")
@@ -74,13 +74,13 @@ def test_gen_cluster_without_client(s, a, b):
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
-    assert s.ncores == {w.address: w.ncores for w in [a, b]}
+    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
 
 
 @gen_cluster(
     client=True,
     scheduler="tls://127.0.0.1",
-    ncores=[("tls://127.0.0.1", 1), ("tls://127.0.0.1", 2)],
+    nthreads=[("tls://127.0.0.1", 1), ("tls://127.0.0.1", 2)],
     security=tls_only_security(),
 )
 def test_gen_cluster_tls(e, s, a, b):
@@ -90,7 +90,7 @@ def test_gen_cluster_tls(e, s, a, b):
     for w in [a, b]:
         assert isinstance(w, Worker)
         assert w.address.startswith("tls://")
-    assert s.ncores == {w.address: w.ncores for w in [a, b]}
+    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
 
 
 @gen_test()

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -148,7 +148,7 @@ def test_timeout_get(c, s, a, b):
 
 @pytest.mark.skipif(sys.version_info[0] == 2, reason="Multi-client issues")
 @pytest.mark.slow
-@gen_cluster(client=True, ncores=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
 def test_race(c, s, *workers):
     NITERS = 50
 

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -42,7 +42,7 @@ def test_submit_from_worker(c, s, a, b):
     assert len([id for id in s.wants_what if id.lower().startswith("client")]) == 1
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_scatter_from_worker(c, s, a, b):
     def func():
         with worker_client() as c:
@@ -78,12 +78,12 @@ def test_scatter_from_worker(c, s, a, b):
     assert result is True
 
     start = time()
-    while not all(v == 1 for v in s.ncores.values()):
+    while not all(v == 1 for v in s.nthreads.values()):
         yield gen.sleep(0.1)
         assert time() < start + 5
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_scatter_singleton(c, s, a, b):
     np = pytest.importorskip("numpy")
 
@@ -96,7 +96,7 @@ def test_scatter_singleton(c, s, a, b):
     yield c.submit(func)
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 1)] * 2)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 def test_gather_multi_machine(c, s, a, b):
     a_address = a.address
     b_address = b.address
@@ -162,7 +162,7 @@ def test_async(c, s, a, b):
         assert time() < start + 3
 
 
-@gen_cluster(client=True, ncores=[("127.0.0.1", 3)])
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 3)])
 def test_separate_thread_false(c, s, a):
     a.count = 0
 

--- a/distributed/tests/test_worker_plugins.py
+++ b/distributed/tests/test_worker_plugins.py
@@ -19,7 +19,7 @@ class MyPlugin:
         self.worker._my_plugin_status = "teardown"
 
 
-@gen_cluster(client=True, ncores=[])
+@gen_cluster(client=True, nthreads=[])
 def test_create_with_client(c, s):
     yield c.register_worker_plugin(MyPlugin(123))
 

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -110,19 +110,19 @@ _round_robin_counter = [0]
 
 
 @gen.coroutine
-def scatter_to_workers(ncores, data, rpc=rpc, report=True, serializers=None):
+def scatter_to_workers(nthreads, data, rpc=rpc, report=True, serializers=None):
     """ Scatter data directly to workers
 
     This distributes data in a round-robin fashion to a set of workers based on
-    how many cores they have.  ncores should be a dictionary mapping worker
+    how many cores they have.  nthreads should be a dictionary mapping worker
     identities to numbers of cores.
 
     See scatter for parameter docstring
     """
-    assert isinstance(ncores, dict)
+    assert isinstance(nthreads, dict)
     assert isinstance(data, dict)
 
-    workers = list(concat([w] * nc for w, nc in ncores.items()))
+    workers = list(concat([w] * nc for w, nc in nthreads.items()))
     names, data = list(zip(*data.items()))
 
     worker_iter = drop(_round_robin_counter[0] % len(workers), cycle(workers))

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -5,6 +5,7 @@ from collections import defaultdict, deque
 from datetime import timedelta
 import heapq
 import logging
+import multiprocessing
 import os
 from pickle import PicklingError
 import random
@@ -53,7 +54,6 @@ from .utils import (
     _maybe_complex,
     log_errors,
     ignoring,
-    mp_context,
     import_file,
     silence_logging,
     thread_state,
@@ -68,8 +68,6 @@ from .utils import (
 )
 from .utils_comm import pack_data, gather_from_workers
 from .utils_perf import ThrottledGC, enable_gc_diagnosis, disable_gc_diagnosis
-
-_ncores = mp_context.cpu_count()
 
 logger = logging.getLogger(__name__)
 
@@ -116,8 +114,8 @@ class Worker(ServerNode):
 
     These attributes don't change significantly during execution.
 
-    * **ncores:** ``int``:
-        Number of cores used by this worker process
+    * **nthreads:** ``int``:
+        Number of nthreads used by this worker process
     * **executor:** ``concurrent.futures.ThreadPoolExecutor``:
         Executor used to perform computation
     * **local_dir:** ``path``:
@@ -233,7 +231,7 @@ class Worker(ServerNode):
     ip: str, optional
     data: MutableMapping, type, None
         The object to use for storage, builds a disk-backed LRU dict by default
-    ncores: int, optional
+    nthreads: int, optional
     loop: tornado.ioloop.IOLoop
     local_dir: str, optional
         Directory where we place local resources
@@ -241,7 +239,7 @@ class Worker(ServerNode):
     memory_limit: int, float, string
         Number of bytes of memory that this worker should use.
         Set to zero for no limit.  Set to 'auto' to calculate
-        as TOTAL_MEMORY * min(1, ncores / total_cores)
+        as TOTAL_MEMORY * min(1, nthreads / total_cores)
         Use strings or numbers like 5GB or 5e9
     memory_target_fraction: float
         Fraction of memory to try to stay beneath
@@ -281,6 +279,7 @@ class Worker(ServerNode):
         scheduler_port=None,
         scheduler_file=None,
         ncores=None,
+        nthreads=None,
         loop=None,
         local_dir=None,
         services=None,
@@ -432,7 +431,11 @@ class Worker(ServerNode):
             security=security,
         )
 
-        self.ncores = ncores or _ncores
+        if ncores is not None:
+            warnings.warn("the ncores= parameter has moved to nthreads=")
+            nthreads = ncores
+
+        self.nthreads = nthreads or multiprocessing.cpu_count()
         self.total_resources = resources or {}
         self.available_resources = (resources or {}).copy()
         self.death_timeout = parse_timedelta(death_timeout)
@@ -471,7 +474,7 @@ class Worker(ServerNode):
         self.connection_args = self.security.get_connection_args("worker")
         self.listen_args = self.security.get_listen_args("worker")
 
-        self.memory_limit = parse_memory_limit(memory_limit, self.ncores)
+        self.memory_limit = parse_memory_limit(memory_limit, self.nthreads)
 
         self.paused = False
 
@@ -526,7 +529,7 @@ class Worker(ServerNode):
         self._closed = Event()
         self.reconnect = reconnect
         self.executor = executor or ThreadPoolExecutor(
-            self.ncores, thread_name_prefix="Dask-Worker-Threads'"
+            self.nthreads, thread_name_prefix="Dask-Worker-Threads'"
         )
         self.actor_executor = ThreadPoolExecutor(
             1, thread_name_prefix="Dask-Actor-Threads"
@@ -658,7 +661,7 @@ class Worker(ServerNode):
                 self.status,
                 len(self.data),
                 len(self.executing),
-                self.ncores,
+                self.nthreads,
                 len(self.ready),
                 len(self.in_flight_tasks),
                 len(self.waiting_for_data),
@@ -687,7 +690,8 @@ class Worker(ServerNode):
             "type": type(self).__name__,
             "id": self.id,
             "scheduler": self.scheduler.address,
-            "ncores": self.ncores,
+            "nthreads": self.nthreads,
+            "ncores": self.nthreads,  # backwards compatibility
             "memory_limit": self.memory_limit,
         }
 
@@ -722,7 +726,7 @@ class Worker(ServerNode):
                         reply=False,
                         address=self.contact_address,
                         keys=list(self.data),
-                        ncores=self.ncores,
+                        nthreads=self.nthreads,
                         name=self.name,
                         nbytes=self.nbytes,
                         types=types,
@@ -941,7 +945,7 @@ class Worker(ServerNode):
             logger.info("  %16s at: %26s" % (k, listen_host + ":" + str(v)))
         logger.info("Waiting to connect to: %26s", self.scheduler.address)
         logger.info("-" * 49)
-        logger.info("              Threads: %26d", self.ncores)
+        logger.info("              Threads: %26d", self.nthreads)
         if self.memory_limit:
             logger.info("               Memory: %26s", format_bytes(self.memory_limit))
         logger.info("      Local Directory: %26s", self.local_dir)
@@ -2283,7 +2287,7 @@ class Worker(ServerNode):
         if self.paused:
             return
         try:
-            while self.constrained and len(self.executing) < self.ncores:
+            while self.constrained and len(self.executing) < self.nthreads:
                 key = self.constrained[0]
                 if self.task_state.get(key) != "constrained":
                     self.constrained.popleft()
@@ -2293,7 +2297,7 @@ class Worker(ServerNode):
                     self.transition(key, "executing")
                 else:
                     break
-            while self.ready and len(self.executing) < self.ncores:
+            while self.ready and len(self.executing) < self.nthreads:
                 _, key = heapq.heappop(self.ready)
                 if self.task_state.get(key) in READY:
                     self.transition(key, "executing")
@@ -2955,12 +2959,12 @@ class Reschedule(Exception):
     pass
 
 
-def parse_memory_limit(memory_limit, ncores, total_cores=_ncores):
+def parse_memory_limit(memory_limit, nthreads, total_cores=multiprocessing.cpu_count()):
     if memory_limit is None:
         return None
 
     if memory_limit == "auto":
-        memory_limit = int(TOTAL_MEMORY * min(1, ncores / total_cores))
+        memory_limit = int(TOTAL_MEMORY * min(1, nthreads / total_cores))
     with ignoring(ValueError, TypeError):
         memory_limit = float(memory_limit)
         if isinstance(memory_limit, float) and memory_limit <= 1:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -24,7 +24,7 @@ API
    Client.has_what
    Client.list_datasets
    Client.map
-   Client.ncores
+   Client.nthreads
    Client.persist
    Client.publish_dataset
    Client.profile

--- a/docs/source/local-cluster.rst
+++ b/docs/source/local-cluster.rst
@@ -7,7 +7,7 @@ For convenience you can start a local cluster from your Python session.
 
    >>> from distributed import Client, LocalCluster
    >>> cluster = LocalCluster()
-   LocalCluster("127.0.0.1:8786", workers=8, ncores=8)
+   LocalCluster("127.0.0.1:8786", workers=8, nthreads=8)
    >>> client = Client(cluster)
    <Client: scheduler=127.0.0.1:8786 processes=8 cores=8>
 

--- a/docs/source/protocol.rst
+++ b/docs/source/protocol.rst
@@ -25,7 +25,7 @@ In practice we represent these messages with dictionaries/mappings::
    {'op': 'register-worker',
     'address': '192.168.1.42',
     'name': 'alice',
-    'ncores': 4}
+    'nthreads': 4}
 
    {'x': b'...',
     'y': b'...'}

--- a/docs/source/scheduling-state.rst
+++ b/docs/source/scheduling-state.rst
@@ -112,7 +112,7 @@ containers to help with scheduling tasks:
 .. attribute:: Scheduler.saturated: {WorkerState}
 
    A set of workers whose computing power (as
-   measured by :attr:`WorkerState.ncores`) is fully exploited by processing
+   measured by :attr:`WorkerState.nthreads`) is fully exploited by processing
    tasks, and whose current :attr:`~WorkerState.occupancy` is a lot greater
    than the average.
 

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -100,7 +100,7 @@ are the available options::
      --name TEXT            Alias
      --memory-limit TEXT    Maximum bytes of memory that this worker should use.
                             Use 0 for unlimited, or 'auto' for
-                            TOTAL_MEMORY * min(1, ncores / total_cores)
+                            TOTAL_MEMORY * min(1, nthreads / total_nthreads)
      --no-nanny
      --help                 Show this message and exit.
 
@@ -151,7 +151,7 @@ command line ``--memory-limit`` keyword or the ``memory_limit=`` Python
 keyword argument, which sets the memory limit per worker processes launched
 by dask-worker ::
 
-    $ dask-worker tcp://scheduler:port --memory-limit=auto  # TOTAL_MEMORY * min(1, ncores / total_cores)
+    $ dask-worker tcp://scheduler:port --memory-limit=auto  # TOTAL_MEMORY * min(1, nthreads / total_nthreads)
     $ dask-worker tcp://scheduler:port --memory-limit=4e9  # four gigabytes per worker process.
 
 Workers use a few different heuristics to keep memory use beneath this limit:


### PR DESCRIPTION
As long as we're breaking things, we might as well break some more.

In some places we use nthreads, in others ncores.  This moves almost all use cases to nthreads, which is a little bit more literally correct.