### PR TITLE
Add unknown markers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,11 @@ universal=1
 [tool:pytest]
 addopts = -rsx -v --durations=10
 minversion = 3.2
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    avoid_travis: marks tests as flaky on TravisCI.
+    ipython: mark a test as exercising IPython
+
 # filterwarnings =
 #     error
 #     ignore::UserWarning


### PR DESCRIPTION
Fixes a few warnings like

```
/Users/taugspurger/Envs/dask-dev/lib/python3.7/site-packages/_pytest/mark/structures.py:324
  /Users/taugspurger/Envs/dask-dev/lib/python3.7/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.ipython - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,
```