### PR TITLE
[WIP] Better track worker failures in SpecificationCluster

### DIFF
--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -108,7 +108,7 @@ async def test_scale():
 
 @pytest.mark.asyncio
 async def test_broken_worker():
-    with pytest.raises(Exception) as info:
+    with pytest.raises(RuntimeError) as info:
         async with SpecCluster(
             asynchronous=True,
             workers={"good": {"cls": Worker}, "bad": {"cls": BrokenWorker}},
@@ -116,7 +116,7 @@ async def test_broken_worker():
         ) as cluster:
             pass
 
-    assert "Broken" in str(info.value)
+    assert "1 workers failed" in str(info.value)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This refactores `SpecificationCluster` to allow responding to errors
raised during worker startup, allowing better error messages to be
reported to the user. All started tasks now have their results
inspected, removing `asyncio` default handling of logging background
errors.

The end goal of this is to be able to provide better user errors during
cluster startup failure (not necessarily cluster scale up errors).

Aims to address #2708.