### PR TITLE
Fix diagnostics page for memory_limit=None

### DIFF
--- a/distributed/dashboard/templates/worker-table.html
+++ b/distributed/dashboard/templates/worker-table.html
@@ -16,7 +16,7 @@
         <td><a href="../worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
         <td> {{ ws.name if ws.name is not None else "" }} </td>
         <td> {{ ws.nthreads }} </td>
-        <td> {{ format_bytes(ws.memory_limit) }} </td>
+        <td> {{ format_bytes(ws.memory_limit) if ws.memory_limit is not None else "" }} </td>
         <td> <progress class="progress" value="{{ ws.metrics['memory'] }}" max="{{ ws.memory_limit }}"></progress> </td>
         <td> {{ format_time(ws.occupancy) }} </td>
         <td> {{ len(ws.processing) }} </td>

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2456,7 +2456,8 @@ class Worker(ServerNode):
                     "Process memory: %s -- Worker memory limit: %s",
                     int(frac * 100),
                     format_bytes(proc.memory_info().rss),
-                    format_bytes(self.memory_limit),
+                    format_bytes(self.memory_limit)
+                    if self.memory_limit is not None else "None",
                 )
                 self.paused = True
         elif self.paused:
@@ -2465,7 +2466,8 @@ class Worker(ServerNode):
                 "Process memory: %s -- Worker memory limit: %s",
                 int(frac * 100),
                 format_bytes(proc.memory_info().rss),
-                format_bytes(self.memory_limit),
+                format_bytes(self.memory_limit)
+                if self.memory_limit is not None else "None",
             )
             self.paused = False
             self.ensure_computing()
@@ -2483,7 +2485,8 @@ class Worker(ServerNode):
                         "is leaking memory?  Process memory: %s -- "
                         "Worker memory limit: %s",
                         format_bytes(proc.memory_info().rss),
-                        format_bytes(self.memory_limit),
+                        format_bytes(self.memory_limit)
+                        if self.memory_limit is not None else "None",
                     )
                     break
                 k, v, weight = self.data.fast.evict()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2457,7 +2457,8 @@ class Worker(ServerNode):
                     int(frac * 100),
                     format_bytes(proc.memory_info().rss),
                     format_bytes(self.memory_limit)
-                    if self.memory_limit is not None else "None",
+                    if self.memory_limit is not None
+                    else "None",
                 )
                 self.paused = True
         elif self.paused:
@@ -2467,7 +2468,8 @@ class Worker(ServerNode):
                 int(frac * 100),
                 format_bytes(proc.memory_info().rss),
                 format_bytes(self.memory_limit)
-                if self.memory_limit is not None else "None",
+                if self.memory_limit is not None
+                else "None",
             )
             self.paused = False
             self.ensure_computing()
@@ -2486,7 +2488,8 @@ class Worker(ServerNode):
                         "Worker memory limit: %s",
                         format_bytes(proc.memory_info().rss),
                         format_bytes(self.memory_limit)
-                        if self.memory_limit is not None else "None",
+                        if self.memory_limit is not None
+                        else "None",
                     )
                     break
                 k, v, weight = self.data.fast.evict()


### PR DESCRIPTION
Similar to #2255: w/ no memory limit some parts of the diagnostics page don't work because of this formatting code. This is one way to fix it, or I guess you could change all the callers to pass `inf` instead...?