### PR TITLE
Typo in bokeh service_kwargs for dask-worker

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -346,7 +346,7 @@ def main(
             host=host,
             port=port,
             dashboard_address=dashboard_address if dashboard else None,
-            service_kwargs={"bokhe": {"prefix": dashboard_prefix}},
+            service_kwargs={"dashboard": {"prefix": dashboard_prefix}},
             name=name if nprocs == 1 or not name else name + "-" + str(i),
             **kwargs
         )


### PR DESCRIPTION
Saw this while poking around dask-worker. I suspect this was missed in the bokeh -> dashboard migration because of the typo.

I've split into a separate PR, in case you request tests @mrocklin :) If so I'll put something together.