### PR TITLE
Raise when workers initialization times out

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -373,7 +373,10 @@ def main(
 
     try:
         loop.run_sync(run)
-    except (KeyboardInterrupt, TimeoutError):
+    except TimeoutError:
+        # We already log the exception in nanny / worker. Don't do it again.
+        raise TimeoutError("Timed out starting worker.") from None
+    except KeyboardInterrupt:
         pass
     finally:
         logger.info("End worker")

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -304,7 +304,13 @@ class Nanny(ServerNode):
                 )
             except gen.TimeoutError:
                 yield self.close(timeout=self.death_timeout)
-                raise gen.Return("timed out")
+                logger.exception(
+                    "Timed out connecting Nanny '%s' to scheduler '%s'",
+                    self,
+                    self.scheduler_addr,
+                )
+                raise
+
         else:
             result = yield self.process.start()
         raise gen.Return(result)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -157,16 +157,6 @@ def test_nanny_alt_worker_class(c, s, w1, w2):
 
 
 @pytest.mark.slow
-@gen_cluster(client=False, nthreads=[])
-def test_nanny_death_timeout(s):
-    yield s.close()
-    w = yield Nanny(s.address, death_timeout=1)
-
-    yield gen.sleep(3)
-    assert w.status == "closed"
-
-
-@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_worker_death_timeout_raises():
     with pytest.raises(gen.TimeoutError):

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -166,6 +166,14 @@ def test_nanny_death_timeout(s):
     assert w.status == "closed"
 
 
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_worker_death_timeout_raises():
+    with pytest.raises(gen.TimeoutError):
+        w = Nanny("192.168.1.1:1234", death_timeout=1)
+        await w
+
+
 @gen_cluster(client=True, Worker=Nanny)
 def test_random_seed(c, s, a, b):
     @gen.coroutine

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -157,6 +157,16 @@ def test_nanny_alt_worker_class(c, s, w1, w2):
 
 
 @pytest.mark.slow
+@gen_cluster(client=False, nthreads=[])
+def test_nanny_death_timeout(s):
+    yield s.close()
+    w = yield Nanny(s.address, death_timeout=1)
+
+    yield gen.sleep(3)
+    assert w.status == "closed"
+
+
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_worker_death_timeout_raises():
     with pytest.raises(gen.TimeoutError):

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -160,18 +160,11 @@ def test_nanny_alt_worker_class(c, s, w1, w2):
 @gen_cluster(client=False, nthreads=[])
 def test_nanny_death_timeout(s):
     yield s.close()
-    w = yield Nanny(s.address, death_timeout=1)
-
-    yield gen.sleep(3)
-    assert w.status == "closed"
-
-
-@pytest.mark.slow
-@pytest.mark.asyncio
-async def test_worker_death_timeout_raises():
+    w = Nanny(s.address, death_timeout=1)
     with pytest.raises(gen.TimeoutError):
-        w = Nanny("192.168.1.1:1234", death_timeout=1)
-        await w
+        yield w
+
+    assert w.status == "closed"
 
 
 @gen_cluster(client=True, Worker=Nanny)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -736,18 +736,12 @@ def test_hold_onto_dependents(c, s, a, b):
 def test_worker_death_timeout(s):
     with dask.config.set({"distributed.comm.timeouts.connect": "1s"}):
         yield s.close()
-        w = yield Worker(s.address, death_timeout=1)
+        w = Worker(s.address, death_timeout=1)
 
-    yield gen.sleep(2)
-    assert w.status == "closed"
-
-
-@pytest.mark.slow
-@pytest.mark.asyncio
-async def test_worker_death_timeout_raises():
     with pytest.raises(gen.TimeoutError):
-        w = Worker("192.168.1.1:1234", death_timeout=1)
-        await w
+        yield w
+
+    assert w.status == "closed"
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -732,6 +732,17 @@ def test_hold_onto_dependents(c, s, a, b):
 
 
 @pytest.mark.slow
+@gen_cluster(client=False, nthreads=[])
+def test_worker_death_timeout(s):
+    with dask.config.set({"distributed.comm.timeouts.connect": "1s"}):
+        yield s.close()
+        w = yield Worker(s.address, death_timeout=1)
+
+    yield gen.sleep(2)
+    assert w.status == "closed"
+
+
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_worker_death_timeout_raises():
     with pytest.raises(gen.TimeoutError):

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -732,17 +732,6 @@ def test_hold_onto_dependents(c, s, a, b):
 
 
 @pytest.mark.slow
-@gen_cluster(client=False, nthreads=[])
-def test_worker_death_timeout(s):
-    with dask.config.set({"distributed.comm.timeouts.connect": "1s"}):
-        yield s.close()
-        w = yield Worker(s.address, death_timeout=1)
-
-    yield gen.sleep(2)
-    assert w.status == "closed"
-
-
-@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_worker_death_timeout_raises():
     with pytest.raises(gen.TimeoutError):

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -742,6 +742,14 @@ def test_worker_death_timeout(s):
     assert w.status == "closed"
 
 
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_worker_death_timeout_raises():
+    with pytest.raises(gen.TimeoutError):
+        w = Worker("192.168.1.1:1234", death_timeout=1)
+        await w
+
+
 @gen_cluster(client=True)
 def test_stop_doing_unnecessary_work(c, s, a, b):
     futures = c.map(slowinc, range(1000), delay=0.01)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -708,8 +708,14 @@ class Worker(ServerNode):
         logger.info("-" * 49)
         while True:
             if self.death_timeout and time() > start + self.death_timeout:
+                logger.exception(
+                    "Timed out when connecting to scheduler '%s'",
+                    self.scheduler.address,
+                )
                 yield self.close(timeout=1)
-                return
+                raise gen.TimeoutError(
+                    "Timed out connecting to scheduler '%s'" % self.scheduler.address
+                )
             if self.status in ("closed", "closing"):
                 raise gen.Return
             try:


### PR DESCRIPTION
This changes Worker / Nanny startup to raise when they timeout.

This bubbles up to the `dask-worker` CLI.

Closes #2781