### PR TITLE
Calls sync _correct_state() in SpecCluster.scale() if asynchronous=False

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -275,14 +275,20 @@ class SpecCluster(Cluster):
             self.worker_spec.popitem()
 
         if self.status in ("closing", "closed"):
-            self.loop.add_callback(self._correct_state)
+            if not self.asynchronous:
+                self.sync(self._correct_state)
+            else:
+                self.loop.add_callback(self._correct_state)
             return
 
         while len(self.worker_spec) < n:
             k, spec = self.new_worker_spec()
             self.worker_spec[k] = spec
 
-        self.loop.add_callback(self._correct_state)
+        if not self.asynchronous:
+            self.sync(self._correct_state)
+        else:
+            self.loop.add_callback(self._correct_state)
 
     def new_worker_spec(self):
         """ Return name and spec for the next worker


### PR DESCRIPTION
@mrocklin this ensures `LocalCluster` reports on workers correctly immediately after creation. I can't find a way to reproduce this issue purely here, but this is the reason why dask-cuda wasn't reporting workers correctly. To solve this quickly, I added a fix on that side https://github.com/rapidsai/dask-cuda/pull/78.

Also, I'm not sure the fix here is the most appropriate one, so feel free to suggest changes.