### PR TITLE
Add HTTPS support for the dashboard

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -91,6 +91,7 @@ from .utils import (
     shutting_down,
     Any,
     has_keyword,
+    format_dashboard_link,
 )
 from .versions import get_versions
 
@@ -818,8 +819,7 @@ class Client(Node):
                 host = "localhost"
             else:
                 host = rest.split(":")[0]
-            template = dask.config.get("distributed.dashboard.link")
-            address = template.format(host=host, port=port, **os.environ)
+            address = format_dashboard_link(host, port)
             text += (
                 "  <li><b>Dashboard: </b><a href='%(web)s' target='_blank'>%(web)s</a>\n"
                 % {"web": address}

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -1,16 +1,21 @@
 from datetime import timedelta
 import logging
-import os
 from weakref import ref
 
-import dask
 from dask.utils import format_bytes
 from tornado import gen
 
 from .adaptive import Adaptive
 
 from ..compatibility import get_thread_identity
-from ..utils import PeriodicCallback, log_errors, ignoring, sync, thread_state
+from ..utils import (
+    PeriodicCallback,
+    log_errors,
+    ignoring,
+    sync,
+    thread_state,
+    format_dashboard_link,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -80,10 +85,9 @@ class Cluster(object):
 
     @property
     def dashboard_link(self):
-        template = dask.config.get("distributed.dashboard.link")
         host = self.scheduler.address.split("://")[1].split(":")[0]
         port = self.scheduler.services["dashboard"].port
-        return template.format(host=host, port=port, **os.environ)
+        return format_dashboard_link(host, port)
 
     def scale(self, n):
         """ Scale cluster to n workers

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -27,6 +27,11 @@ distributed:
         task-stream-length: 1000
       tasks:
         task-stream-length: 100000
+      tls:
+        ca-file: null
+        key: null
+        cert: null
+
 
   worker:
     blocked-handlers: []
@@ -88,7 +93,7 @@ distributed:
   ###################
 
   dashboard:
-    link: "http://{host}:{port}/status"
+    link: "{scheme}://{host}:{port}/status"
     export-tool: False
 
   ##################

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5224,20 +5224,21 @@ def test_quiet_scheduler_loss(c, s):
     assert "BrokenPipeError" not in text
 
 
-@pytest.mark.skipif("USER" not in os.environ, reason="no USER env variable")
-def test_diagnostics_link_env_variable(loop):
+def test_dashboard_link(loop, monkeypatch):
     pytest.importorskip("bokeh")
     from distributed.dashboard import BokehScheduler
+
+    monkeypatch.setenv("USER", "myusername")
 
     with cluster(
         scheduler_kwargs={"services": {("dashboard", 12355): BokehScheduler}}
     ) as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
             with dask.config.set(
-                {"distributed.dashboard.link": "http://foo-{USER}:{port}/status"}
+                {"distributed.dashboard.link": "{scheme}://foo-{USER}:{port}/status"}
             ):
                 text = c._repr_html_()
-                link = "http://foo-" + os.environ["USER"] + ":12355/status"
+                link = "http://foo-myusername:12355/status"
                 assert link in text
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1483,3 +1483,12 @@ def typename(typ):
         return typ.__module__ + "." + typ.__name__
     except AttributeError:
         return str(typ)
+
+
+def format_dashboard_link(host, port):
+    template = dask.config.get("distributed.dashboard.link")
+    if dask.config.get("distributed.scheduler.dashboard.tls.cert"):
+        scheme = "https"
+    else:
+        scheme = "http"
+    return template.format(scheme=scheme, host=host, port=port, **os.environ)


### PR DESCRIPTION
Adds optional HTTPS support for the scheduler dashboard. This is only
available via the configuration file, by setting the following fields:

- `distributed.scheduler.tls.cert`: the certificate file
- `distributed.scheduler.tls.key`: the key file, optional if the key
  file is concatenated with the cert above
- `distributed.scheduler.tls.ca-file`: the CA file, optional

These certs *may* be the same as those used for the
scheduler/worker/client communication, but aren't required to be. The
user is responsible for making this decision and providing the proper
configuration.

Likewise, the user is responsible for providing trusted certificates, or
understanding the security implications of telling their browser "I
understand the risks, trust this certificate" (this is more likely,
given the transient nature of dask clusters).

The generated dashboard links now format on an optional `scheme`
parameter, which is either `http` or `https`, depending on if the TLS
configuration fields above are configured.

Fixes #2775 