### PR TITLE
fix case where key, rather than TaskState, could end up in ts.waiting_on

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3559,7 +3559,7 @@ class Scheduler(ServerNode):
             for dts in ts.dependencies:
                 dep = dts.key
                 if not dts.who_has:
-                    ts.waiting_on.add(dep)
+                    ts.waiting_on.add(dts)
                 if dts.state == "released":
                     recommendations[dep] = "waiting"
                 else:


### PR DESCRIPTION
Ideally there would be a test for this, I know :|  Hopefully this is an uncontroversial change even without adding that, though...