### PR TITLE
Make await/start more consistent across Scheduler/Worker/Nanny

### DIFF
--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -211,7 +211,13 @@ def uri_from_host_port(host_arg, port_arg, default_port):
 
 
 def address_from_user_args(
-    host=None, port=None, interface=None, protocol=None, peer=None, security=None
+    host=None,
+    port=None,
+    interface=None,
+    protocol=None,
+    peer=None,
+    security=None,
+    default_port=0,
 ):
     """ Get an address to listen on from common user provided arguments """
     if security and security.require_encryption and not protocol:
@@ -235,7 +241,7 @@ def address_from_user_args(
         host = protocol.rstrip("://") + "://" + host
 
     if host or port:
-        addr = uri_from_host_port(host, port, 0)
+        addr = uri_from_host_port(host, port, default_port)
     else:
         addr = ""
 

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -133,7 +133,7 @@ class SpecCluster(Cluster):
         self.loop = self._loop_runner.loop
 
         self.scheduler = self.scheduler_spec["cls"](
-            loop=self.loop, **self.scheduler_spec["options"]
+            loop=self.loop, **self.scheduler_spec.get("options", {})
         )
         self.status = "created"
         self._instances.add(self)

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,4 +1,4 @@
-from dask.distributed import SpecCluster, Worker, Client, Scheduler
+from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
 from distributed.deploy.spec import close_clusters
 from distributed.utils_test import loop  # noqa: F401
 import pytest
@@ -140,3 +140,14 @@ async def test_new_worker_spec():
         cluster.scale(3)
         for i in range(3):
             assert cluster.worker_spec[i]["options"]["nthreads"] == i + 1
+
+
+@pytest.mark.asyncio
+async def test_nanny_port():
+    scheduler = {"cls": Scheduler}
+    workers = {0: {"cls": Nanny, "options": {"port": 9200}}}
+
+    async with SpecCluster(
+        scheduler=scheduler, workers=workers, asynchronous=True
+    ) as cluster:
+        pass

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -600,8 +600,6 @@ class WorkerProcess(object):
         IOLoop.clear_instance()
         loop = IOLoop()
         loop.make_current()
-        print(worker_kwargs)
-        print(worker_start_args)
         worker = Worker(**worker_kwargs)
 
         @gen.coroutine

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -202,6 +202,9 @@ class Nanny(ServerNode):
     @gen.coroutine
     def _start(self, addr_or_port=0):
         """ Start nanny, start local process, start watching """
+        if self.status == "running":
+            return self
+
         addr_or_port = addr_or_port or self._start_address
 
         # XXX Factor this out

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -26,6 +26,7 @@ from .process import AsyncProcess
 from .proctitle import enable_proctitle_on_children
 from .security import Security
 from .utils import (
+    get_ip,
     mp_context,
     silence_logging,
     json_load_robust,
@@ -167,6 +168,9 @@ class Nanny(ServerNode):
         if self.memory_limit:
             pc = PeriodicCallback(self.memory_monitor, 100, io_loop=self.loop)
             self.periodic_callbacks["memory"] = pc
+
+        if not host and not interface:
+            host = get_ip(get_address_host(self.scheduler.address))
 
         self._start_address = address_from_user_args(
             host=host,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -119,8 +119,14 @@ class Nanny(ServerNode):
         self.preload_argv = preload_argv
         self.Worker = Worker if worker_class is None else worker_class
         self.env = env or {}
-        if worker_port:
-            worker_kwargs["port"] = worker_port
+        worker_kwargs.update(
+            {
+                "port": worker_port,
+                "interface": interface,
+                "protocol": protocol,
+                "host": host,
+            }
+        )
         self.worker_kwargs = worker_kwargs
 
         self.contact_address = contact_address

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -169,7 +169,11 @@ class Nanny(ServerNode):
             pc = PeriodicCallback(self.memory_monitor, 100, io_loop=self.loop)
             self.periodic_callbacks["memory"] = pc
 
-        if not host and not interface:
+        if (
+            not host
+            and not interface
+            and not self.scheduler_addr.startswith("inproc://")
+        ):
             host = get_ip(get_address_host(self.scheduler.address))
 
         self._start_address = address_from_user_args(

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -4,6 +4,7 @@ import warnings
 import logging
 
 from tornado.ioloop import IOLoop
+from tornado import gen
 import dask
 
 from .compatibility import unicode, finalize
@@ -159,3 +160,12 @@ class ServerNode(Node, Server):
 
     async def __aexit__(self, typ, value, traceback):
         await self.close()
+
+    def __await__(self):
+        if self.status == "running":
+            return gen.sleep(0).__await__()
+        else:
+            return self.start().__await__()
+
+    async def start(self):  # subclasses should implement this
+        return self

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -841,7 +841,7 @@ class Scheduler(ServerNode):
         idle_timeout=None,
         interface=None,
         host=None,
-        port=8786,
+        port=0,
         protocol=None,
         dashboard_address=None,
         **kwargs
@@ -1097,6 +1097,7 @@ class Scheduler(ServerNode):
             interface=interface,
             protocol=protocol,
             security=security,
+            default_port=self.default_port,
         )
 
         super(Scheduler, self).__init__(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1177,6 +1177,7 @@ class Scheduler(ServerNode):
         else:
             return ws.host, port
 
+    @gen.coroutine
     def start(self, addr_or_port=None, start_queues=True):
         """ Clear out old state and restart all running coroutines """
         enable_gc_diagnosis()
@@ -1239,16 +1240,8 @@ class Scheduler(ServerNode):
 
         setproctitle("dask-scheduler [%s]" % (self.address,))
 
-        return self.finished()
-
-    def __await__(self):
-        self.start()
-
-        @gen.coroutine
-        def _():
-            return self
-
-        return _().__await__()
+        yield self.finished()
+        return self
 
     @gen.coroutine
     def finished(self):

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -373,13 +373,13 @@ def check_rpc_with_many_connections(listen_arg):
     server = Server({"ping": pingpong})
     server.listen(listen_arg)
 
-    remote = rpc(server.address)
-    yield [g() for i in range(10)]
+    with rpc(server.address) as remote:
+        yield [g() for i in range(10)]
 
-    server.stop()
+        server.stop()
 
-    remote.close_comms()
-    assert all(comm.closed() for comm in remote.comms)
+        remote.close_comms()
+        assert all(comm.closed() for comm in remote.comms)
 
 
 @gen_test()

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -39,8 +39,7 @@ def test_submit_after_failed_worker_sync(loop):
 
 @gen_cluster(client=True, timeout=60, active_rpc_timeout=10)
 def test_submit_after_failed_worker_async(c, s, a, b):
-    n = Nanny(s.address, nthreads=2, loop=s.loop)
-    n.start(0)
+    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
     while len(s.workers) < 3:
         yield gen.sleep(0.1)
 
@@ -128,7 +127,7 @@ def test_failed_worker_without_warning(c, s, a, b):
     assert all(len(keys) > 0 for keys in s.has_what.values())
     nthreads2 = dict(s.nthreads)
 
-    yield c._restart()
+    yield c.restart()
 
     L = c.map(inc, range(10))
     yield wait(L)
@@ -148,7 +147,7 @@ def test_restart(c, s, a, b):
 
     assert set(s.who_has) == {x.key, y.key}
 
-    f = yield c._restart()
+    f = yield c.restart()
     assert f is c
 
     assert len(s.workers) == 2
@@ -171,7 +170,7 @@ def test_restart_cleared(c, s, a, b):
     f = c.compute(x)
     yield wait([f])
 
-    yield c._restart()
+    yield c.restart()
 
     for coll in [s.tasks, s.unrunnable]:
         assert not coll
@@ -212,7 +211,7 @@ def test_restart_fast(c, s, a, b):
     L = c.map(sleep, range(10))
 
     start = time()
-    yield c._restart()
+    yield c.restart()
     assert time() - start < 10
     assert len(s.nthreads) == 2
 
@@ -255,7 +254,7 @@ def test_fast_kill(c, s, a, b):
     L = c.map(sleep, range(10))
 
     start = time()
-    yield c._restart()
+    yield c.restart()
     assert time() - start < 10
 
     assert all(x.status == "cancelled" for x in L)
@@ -302,7 +301,7 @@ def test_restart_scheduler(s, a, b):
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
 def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
     x = c.submit(inc, 1)
-    yield c._restart()
+    yield c.restart()
     y = c.submit(inc, 1)
     del x
     import gc
@@ -315,8 +314,7 @@ def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
 @gen_cluster(client=True, timeout=60, active_rpc_timeout=10)
 def test_broken_worker_during_computation(c, s, a, b):
     s.allowed_failures = 100
-    n = Nanny(s.address, nthreads=2, loop=s.loop)
-    n.start(0)
+    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
 
     start = time()
     while len(s.nthreads) < 3:
@@ -365,7 +363,7 @@ def test_restart_during_computation(c, s, a, b):
 
     yield gen.sleep(0.5)
     assert s.rprocessing
-    yield c._restart()
+    yield c.restart()
     assert not s.rprocessing
 
     assert len(s.nthreads) == 2
@@ -374,8 +372,7 @@ def test_restart_during_computation(c, s, a, b):
 
 @gen_cluster(client=True, timeout=60)
 def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
-    n = Nanny(s.address, nthreads=2, loop=s.loop)
-    n.start(0)
+    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
 
     start = time()
     while len(s.nthreads) < 3:

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -229,8 +229,7 @@ def test_worker_uses_same_host_as_nanny(c, s):
 @gen_test()
 def test_scheduler_file():
     with tmpfile() as fn:
-        s = Scheduler(scheduler_file=fn)
-        s.start(8008)
+        s = yield Scheduler(scheduler_file=fn, port=8008)
         w = yield Nanny(scheduler_file=fn)
         assert set(s.workers) == {w.worker_address}
         yield w.close()

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -216,8 +216,7 @@ def test_num_fds(s):
 @gen_cluster(client=True, nthreads=[])
 def test_worker_uses_same_host_as_nanny(c, s):
     for host in ["tcp://0.0.0.0", "tcp://127.0.0.2"]:
-        n = Nanny(s.address)
-        yield n._start(host)
+        n = yield Nanny(s.address, host=host)
 
         def func(dask_worker):
             return dask_worker.listener.listen_address

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -253,7 +253,7 @@ def test_clear_events_client_removal(c, s, a, b):
 
 @gen_cluster()
 def test_add_worker(s, a, b):
-    w = Worker(s.address, nthreads=3, host="127.0.0.1")
+    w = Worker(s.address, nthreads=3)
     w.data["x-5"] = 6
     w.data["y"] = 1
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -256,7 +256,6 @@ def test_add_worker(s, a, b):
     w = Worker(s.address, nthreads=3)
     w.data["x-5"] = 6
     w.data["y"] = 1
-    yield w
 
     dsk = {("x-%d" % i): (inc, i) for i in range(10)}
     s.update_graph(
@@ -265,11 +264,8 @@ def test_add_worker(s, a, b):
         client="client",
         dependencies={k: set() for k in dsk},
     )
-
-    s.add_worker(
-        address=w.address, keys=list(w.data), nthreads=w.nthreads, services=s.services
-    )
-
+    s.validate_state()
+    yield w
     s.validate_state()
 
     assert w.ip in s.host_info
@@ -1172,7 +1168,7 @@ def test_correct_bad_time_estimate(c, s, *workers):
 
 
 @gen_test()
-def test_service_hosts():
+async def test_service_hosts():
     pytest.importorskip("bokeh")
     from distributed.dashboard import BokehScheduler
 
@@ -1184,25 +1180,20 @@ def test_service_hosts():
     ]:
         services = {("dashboard", port): BokehScheduler}
 
-        s = yield Scheduler(host=url, services=services)
-
-        sock = first(s.services["dashboard"].server._http._sockets.values())
-        if isinstance(expected, tuple):
-            assert sock.getsockname()[0] in expected
-        else:
-            assert sock.getsockname()[0] == expected
-        yield s.close()
+        async with Scheduler(host=url, services=services) as s:
+            sock = first(s.services["dashboard"].server._http._sockets.values())
+            if isinstance(expected, tuple):
+                assert sock.getsockname()[0] in expected
+            else:
+                assert sock.getsockname()[0] == expected
 
     port = ("127.0.0.1", 0)
     for url in ["tcp://0.0.0.0", "tcp://127.0.0.1", "tcp://127.0.0.1:38275"]:
         services = {("dashboard", port): BokehScheduler}
 
-        s = Scheduler(services=services)
-        yield s.start(url)
-
-        sock = first(s.services["dashboard"].server._http._sockets.values())
-        assert sock.getsockname()[0] == "127.0.0.1"
-        yield s.close()
+        async with Scheduler(services=services, host=url) as s:
+            sock = first(s.services["dashboard"].server._http._sockets.values())
+            assert sock.getsockname()[0] == "127.0.0.1"
 
 
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1184,8 +1184,7 @@ def test_service_hosts():
     ]:
         services = {("dashboard", port): BokehScheduler}
 
-        s = Scheduler(services=services)
-        yield s.start(url)
+        s = yield Scheduler(host=url, services=services)
 
         sock = first(s.services["dashboard"].server._http._sockets.values())
         if isinstance(expected, tuple):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -253,7 +253,7 @@ def test_clear_events_client_removal(c, s, a, b):
 
 @gen_cluster()
 def test_add_worker(s, a, b):
-    w = Worker(s.address, nthreads=3)
+    w = Worker(s.address, nthreads=3, host="127.0.0.1")
     w.data["x-5"] = 6
     w.data["y"] = 1
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -665,7 +665,7 @@ def test_scatter_no_workers(c, s):
     assert time() < start + 1.5
 
     w = Worker(s.address, nthreads=3)
-    yield [c.scatter(data={"y": 2}, timeout=5), w._start()]
+    yield [c.scatter(data={"y": 2}, timeout=5), w]
 
     assert w.data["y"] == 2
     yield w.close()

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -108,11 +108,8 @@ def test_stress_creation_and_deletion(c, s):
     def create_and_destroy_worker(delay):
         start = time()
         while time() < start + 5:
-            n = Nanny(s.address, nthreads=2, loop=s.loop)
-            n.start(0)
-
+            n = yield Nanny(s.address, nthreads=2, loop=s.loop)
             yield gen.sleep(delay)
-
             yield n.close()
             print("Killed nanny")
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -176,10 +176,9 @@ def test_tls_cluster(tls_client):
 
 
 def test_tls_scheduler(security, loop):
-    s = Scheduler(security=security, loop=loop)
-    s.start("localhost")
+    s = yield Scheduler(security=security, loop=loop, host="localhost")
     assert s.address.startswith("tls")
-    s.close()
+    yield s.close()
 
 
 if sys.version_info >= (3, 5):

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -978,20 +978,23 @@ def test_service_hosts_match_worker(s):
 
     services = {("dashboard", ":0"): BokehWorker}
 
-    w = Worker(s.address, services={("dashboard", ":0"): BokehWorker})
-    yield w._start("tcp://0.0.0.0")
+    w = yield Worker(
+        s.address, services={("dashboard", ":0"): BokehWorker}, host="tcp://0.0.0.0"
+    )
     sock = first(w.services["dashboard"].server._http._sockets.values())
     assert sock.getsockname()[0] in ("::", "0.0.0.0")
     yield w.close()
 
-    w = Worker(s.address, services={("dashboard", ":0"): BokehWorker})
-    yield w._start("tcp://127.0.0.1")
+    w = yield Worker(
+        s.address, services={("dashboard", ":0"): BokehWorker}, host="tcp://127.0.0.1"
+    )
     sock = first(w.services["dashboard"].server._http._sockets.values())
     assert sock.getsockname()[0] in ("::", "0.0.0.0")
     yield w.close()
 
-    w = Worker(s.address, services={("dashboard", 0): BokehWorker})
-    yield w._start("tcp://127.0.0.1")
+    w = yield Worker(
+        s.address, services={("dashboard", 0): BokehWorker}, host="tcp://127.0.0.1"
+    )
     sock = first(w.services["dashboard"].server._http._sockets.values())
     assert sock.getsockname()[0] == "127.0.0.1"
     yield w.close()
@@ -1004,8 +1007,7 @@ def test_start_services(s):
 
     services = {("dashboard", ":1234"): BokehWorker}
 
-    w = Worker(s.address, services=services)
-    yield w._start()
+    w = yield Worker(s.address, services=services)
 
     assert w.services["dashboard"].server.port == 1234
     yield w.close()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1482,3 +1482,12 @@ async def test_interface_async(loop, Worker):
                 info = c.scheduler_info()
                 assert "tcp://127.0.0.1" in info["address"]
                 assert all("127.0.0.1" == d["host"] for d in info["workers"].values())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("Worker", [Worker, Nanny])
+async def test_worker_listens_on_same_interface_by_default(Worker):
+    async with Scheduler(host="localhost") as s:
+        assert s.ip in {"127.0.0.1", "localhost"}
+        async with Worker(s.address) as w:
+            assert s.ip == w.ip

--- a/distributed/tests/test_worker_plugins.py
+++ b/distributed/tests/test_worker_plugins.py
@@ -23,8 +23,7 @@ class MyPlugin:
 def test_create_with_client(c, s):
     yield c.register_worker_plugin(MyPlugin(123))
 
-    worker = Worker(s.address, loop=s.loop)
-    yield worker._start()
+    worker = yield Worker(s.address, loop=s.loop)
     assert worker._my_plugin_status == "setup"
     assert worker._my_plugin_data == 123
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -794,9 +794,14 @@ def start_cluster(
     worker_kwargs={},
 ):
     s = Scheduler(
-        loop=loop, validate=True, security=security, port=0, **scheduler_kwargs
+        loop=loop,
+        validate=True,
+        security=security,
+        port=0,
+        host=scheduler_addr,
+        **scheduler_kwargs
     )
-    done = s.start(scheduler_addr)
+    done = s.start()
     workers = [
         Worker(
             s.address,

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -486,7 +486,7 @@ def run_worker(q, scheduler_q, **kwargs):
         with pristine_loop() as loop:
             scheduler_addr = scheduler_q.get()
             worker = Worker(scheduler_addr, validate=True, **kwargs)
-            loop.run_sync(lambda: worker._start())
+            loop.run_sync(worker.start)
             q.put(worker.address)
             try:
 
@@ -504,7 +504,7 @@ def run_nanny(q, scheduler_q, **kwargs):
         with pristine_loop() as loop:
             scheduler_addr = scheduler_q.get()
             worker = Nanny(scheduler_addr, validate=True, **kwargs)
-            loop.run_sync(lambda: worker._start())
+            loop.run_sync(worker.start)
             q.put(worker.address)
             try:
                 loop.start()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -423,7 +423,9 @@ class Worker(ServerNode):
             scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))
         self.contact_address = contact_address
 
-        if not host and not interface:
+        # Target interface on which we contact the scheduler by default
+        # TODO: it is unfortunate that we special-case inproc here
+        if not host and not interface and not scheduler_addr.startswith("inproc://"):
             host = get_ip(get_address_host(scheduler_addr))
 
         self._start_address = address_from_user_args(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -899,7 +899,6 @@ class Worker(ServerNode):
 
         self.listen(self._start_address, listen_args=self.listen_args)
         self.ip = get_address_host(self.address)
-        self.ip = get_address_host(self.listen_address)
 
         if self.name is None:
             self.name = self.address

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -50,6 +50,7 @@ from .threadpoolexecutor import ThreadPoolExecutor, secede as tpe_secede
 from .utils import (
     funcname,
     typename,
+    get_ip,
     has_arg,
     _maybe_complex,
     log_errors,
@@ -421,6 +422,9 @@ class Worker(ServerNode):
         else:
             scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))
         self.contact_address = contact_address
+
+        if not host and not interface:
+            host = get_ip(get_address_host(scheduler_addr))
 
         self._start_address = address_from_user_args(
             host=host,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -892,7 +892,7 @@ class Worker(ServerNode):
     #############
 
     @gen.coroutine
-    def _start(self, addr_or_port=0):
+    def start(self, addr_or_port=0):
         assert self.status is None
         addr_or_port = addr_or_port or self._start_address
 
@@ -964,21 +964,7 @@ class Worker(ServerNode):
         yield self._register_with_scheduler()
 
         self.start_periodic_callbacks()
-        raise gen.Return(self)
-
-    def __await__(self):
-        if self.status is not None:
-
-            @gen.coroutine  # idempotent
-            def _():
-                raise gen.Return(self)
-
-            return _().__await__()
-        else:
-            return self._start().__await__()
-
-    def start(self, port=0):
-        self.loop.add_callback(self._start, port)
+        return self
 
     def _close(self, *args, **kwargs):
         warnings.warn("Worker._close has moved to Worker.close", stacklevel=2)


### PR DESCRIPTION
Now every ServerNode has a start async method that returns itself.
And the __await__ method is handled in the superclass

cc @jcrist , this is in a theme of things that you've asked for

Fixes https://github.com/dask/distributed/issues/2685  cc @MichaelSchreier