### PR TITLE
Extend prometheus metrics endpoint (#2792)

### DIFF
--- a/distributed/dashboard/scheduler_html.py
+++ b/distributed/dashboard/scheduler_html.py
@@ -192,7 +192,11 @@ class _PrometheusCollector(object):
             "Number of clients.",
             value=len(self.server.clients),
         )
-
+        yield GaugeMetricFamily(
+            "dask_scheduler_tasks",
+            "Number of tasks",
+            value=len(self.server.tasks)
+        )
 
 class PrometheusHandler(RequestHandler):
     _initialized = False

--- a/distributed/dashboard/scheduler_html.py
+++ b/distributed/dashboard/scheduler_html.py
@@ -184,19 +184,25 @@ class _PrometheusCollector(object):
 
         yield GaugeMetricFamily(
             "dask_scheduler_workers",
-            "Number of workers.",
+            "Number of workers connected.",
             value=len(self.server.workers),
         )
         yield GaugeMetricFamily(
             "dask_scheduler_clients",
-            "Number of clients.",
+            "Number of clients connected.",
             value=len(self.server.clients),
         )
         yield GaugeMetricFamily(
-            "dask_scheduler_tasks",
-            "Number of tasks",
-            value=len(self.server.tasks)
+            "dask_scheduler_received_tasks",
+            "Number of tasks received at scheduler",
+            value=len(self.server.tasks),
         )
+        yield GaugeMetricFamily(
+            "dask_scheduler_unrunnable_tasks",
+            "Number of unrunnable tasks at scheduler",
+            value=len(self.server.unrunnable),
+        )
+
 
 class PrometheusHandler(RequestHandler):
     _initialized = False

--- a/distributed/dashboard/tests/test_worker_bokeh_html.py
+++ b/distributed/dashboard/tests/test_worker_bokeh_html.py
@@ -25,7 +25,7 @@ def test_prometheus(c, s, a, b):
 
         txt = response.body.decode("utf8")
         families = {familiy.name for familiy in text_string_to_metric_families(txt)}
-        assert len(families) > 0
+        assert "dask_worker_latency_seconds" in families
 
 
 @gen_cluster(client=True, worker_kwargs={"services": {("dashboard", 0): BokehWorker}})

--- a/distributed/dashboard/worker_html.py
+++ b/distributed/dashboard/worker_html.py
@@ -11,7 +11,9 @@ class _PrometheusCollector(object):
             import crick  # noqa: F401
         except ImportError:
             self.crick_available = False
-            self.logger.info("Digest-based metrics require crick to be installed")
+            self.logger.info(
+                "Not all prometheus metrics available are exported. Digest-based metrics require crick to be installed"
+            )
 
     def collect(self):
         from prometheus_client.core import GaugeMetricFamily

--- a/distributed/dashboard/worker_html.py
+++ b/distributed/dashboard/worker_html.py
@@ -8,10 +8,7 @@ class _PrometheusCollector(object):
         self.logger = logging.getLogger("distributed.dask_worker")
         self.crick_available = True
         try:
-            import crick
-
-            # usage of import necessary to comply with flake8 F401
-            crick_version = crick._version
+            import crick  # noqa: F401
         except ImportError:
             self.crick_available = False
             self.logger.info("Digest-based metrics require crick to be installed")

--- a/distributed/dashboard/worker_html.py
+++ b/distributed/dashboard/worker_html.py
@@ -1,41 +1,73 @@
+import logging
 from .utils import RequestHandler, redirect
 
 
 class _PrometheusCollector(object):
-    def __init__(self, server, prometheus_client):
+    def __init__(self, server):
         self.worker = server
+        self.logger = logging.getLogger("distributed.dask_worker")
+        self.crick_available = True
+        try:
+            import crick
+
+            # usage of import necessary to comply with flake8 F401
+            crick_version = crick._version
+        except ImportError:
+            self.crick_available = False
+            self.logger.info("Digest-based metrics require crick to be installed")
 
     def collect(self):
         from prometheus_client.core import GaugeMetricFamily
 
-        yield GaugeMetricFamily(
-            "dask_worker_tasks_stored",
-            "Number of tasks stored",
-            value=len(self.worker.data),
+        tasks = GaugeMetricFamily(
+            "dask_worker_tasks", "Number of tasks at worker.", labels=["state"]
         )
-        yield GaugeMetricFamily(
-            "dask_worker_tasks_ready",
-            "Number of tasks ready",
-            value=len(self.worker.ready),
-        )
-        yield GaugeMetricFamily(
-            "dask_worker_tasks_waiting",
-            "Number of tasks waiting",
-            value=len(self.worker.waiting_for_data),
-        )
+        tasks.add_metric(["stored"], len(self.worker.data))
+        tasks.add_metric(["ready"], len(self.worker.ready))
+        tasks.add_metric(["waiting"], len(self.worker.waiting_for_data))
+        tasks.add_metric(["serving"], len(self.worker._comms))
+        yield tasks
+
         yield GaugeMetricFamily(
             "dask_worker_connections",
-            "Number of task connections",
+            "Number of task connections to other workers.",
             value=len(self.worker.in_flight_workers),
         )
+
         yield GaugeMetricFamily(
-            "dask_worker_tasks_serving",
-            "Number of tasks serving",
-            value=len(self.worker._comms),
+            "dask_worker_threads",
+            "Number of worker threads.",
+            value=self.worker.nthreads,
         )
+
         yield GaugeMetricFamily(
-            "dask_worker_nthreads", "Number of threads", value=self.worker.nthreads
+            "dask_worker_latency_seconds",
+            "Latency of worker connection.",
+            value=self.worker.latency,
         )
+
+        # all metrics using digests require crick to be installed
+        # the following metrics will export NaN, if the corresponding digests are None
+        if self.crick_available:
+            yield GaugeMetricFamily(
+                "dask_worker_tick_duration_median_seconds",
+                "Median tick duration at worker.",
+                value=self.worker.digests["tick-duration"].components[1].quantile(50),
+            )
+
+            yield GaugeMetricFamily(
+                "dask_worker_task_duration_median_seconds",
+                "Median task runtime at worker.",
+                value=self.worker.digests["task-duration"].components[1].quantile(50),
+            )
+
+            yield GaugeMetricFamily(
+                "dask_worker_transfer_bandwidth_median_bytes",
+                "Bandwidth for transfer at worker in Bytes.",
+                value=self.worker.digests["transfer-bandwidth"]
+                .components[1]
+                .quantile(50),
+            )
 
 
 class PrometheusHandler(RequestHandler):
@@ -49,9 +81,7 @@ class PrometheusHandler(RequestHandler):
         if PrometheusHandler._initialized:
             return
 
-        prometheus_client.REGISTRY.register(
-            _PrometheusCollector(self.server, prometheus_client)
-        )
+        prometheus_client.REGISTRY.register(_PrometheusCollector(self.server))
 
         PrometheusHandler._initialized = True
 

--- a/distributed/dashboard/worker_html.py
+++ b/distributed/dashboard/worker_html.py
@@ -3,21 +3,39 @@ from .utils import RequestHandler, redirect
 
 class _PrometheusCollector(object):
     def __init__(self, server, prometheus_client):
-        self.server = server
+        self.worker = server
 
     def collect(self):
-        # add your metrics here:
-        #
-        # 1. remove the following lines
-        while False:
-            yield None
-        #
-        # 2. yield your metrics
-        #     yield prometheus_client.core.GaugeMetricFamily(
-        #         'dask_worker_connections',
-        #         'Number of connections currently open.',
-        #         value=???,
-        #     )
+        from prometheus_client.core import GaugeMetricFamily
+
+        yield GaugeMetricFamily(
+            "dask_worker_tasks_stored",
+            "Number of tasks stored",
+            value=len(self.worker.data),
+        )
+        yield GaugeMetricFamily(
+            "dask_worker_tasks_ready",
+            "Number of tasks ready",
+            value=len(self.worker.ready),
+        )
+        yield GaugeMetricFamily(
+            "dask_worker_tasks_waiting",
+            "Number of tasks waiting",
+            value=len(self.worker.waiting_for_data),
+        )
+        yield GaugeMetricFamily(
+            "dask_worker_connections",
+            "Number of task connections",
+            value=len(self.worker.in_flight_workers),
+        )
+        yield GaugeMetricFamily(
+            "dask_worker_tasks_serving",
+            "Number of tasks serving",
+            value=len(self.worker._comms),
+        )
+        yield GaugeMetricFamily(
+            "dask_worker_nthreads", "Number of threads", value=self.worker.nthreads
+        )
 
 
 class PrometheusHandler(RequestHandler):


### PR DESCRIPTION
This PR introduces the following prometheus metrics:
- scheduler
    - number of tasks that were received
    - number of unrunnable tasks
- worker
   - tasks: stored, ready, waiting and serving 
   - number of connections to other workers
   - number of worker threads
   - latency
   - median tick duration
   - median task duration
   - median transfer bandwidth

The requirement of crick for the digest-based metrics is handled by checking if crick is available.
If crick is not available there is a log message on loglevel info regarding the missing crick and the metrics, which require crick are not exposed.

Regarding what @mrocklin mentioned in the issue(#2792) about the digest metrics not being exposed individually. The problem here is that the metrics names would not be compliant with prometheus naming. Additionally expressive descriptions would not be available either if the metrics were not exposed individually.