### PR TITLE
Make spec repr generic

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -315,7 +315,8 @@ class SpecCluster(Cluster):
     scale_up = scale  # backwards compatibility
 
     def __repr__(self):
-        return "SpecCluster(%r, workers=%d)" % (
+        return "%s(%r, workers=%d)" % (
+            type(self).__name__,
             self.scheduler_address,
             len(self.workers),
         )

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -82,6 +82,15 @@ def test_loop_started():
 
 
 @pytest.mark.asyncio
+async def test_repr():
+    class MyCluster(SpecCluster):
+        pass
+
+    async with MyCluster(..., asynchronous=True) as cluster:
+        assert "MyCluster" in str(cluster)
+
+
+@pytest.mark.asyncio
 async def test_scale():
     worker = {"cls": Worker, "options": {"nthreads": 1}}
     async with SpecCluster(

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -83,10 +83,14 @@ def test_loop_started():
 
 @pytest.mark.asyncio
 async def test_repr():
+    worker = {"cls": Worker, "options": {"nthreads": 1}}
+
     class MyCluster(SpecCluster):
         pass
 
-    async with MyCluster(..., asynchronous=True) as cluster:
+    async with MyCluster(
+        asynchronous=True, scheduler=scheduler, worker=worker
+    ) as cluster:
         assert "MyCluster" in str(cluster)
 
 


### PR DESCRIPTION
Set `SpecCluster` repr to use type for class name. Useful when subclassing.