### PR TITLE
Use click's show_default=True in relevant places

### DIFF
--- a/distributed/cli/dask_remote.py
+++ b/distributed/cli/dask_remote.py
@@ -7,7 +7,7 @@ from distributed.submit import _remote
 
 @click.command()
 @click.option("--host", type=str, default=None, help="IP or hostname of this server")
-@click.option("--port", type=int, default=8788, help="Remote Client Port")
+@click.option("--port", type=int, default=8788, show_default=True, help="Remote Client Port")
 @click.version_option()
 def main(host, port):
     _remote(host, port)

--- a/distributed/cli/dask_remote.py
+++ b/distributed/cli/dask_remote.py
@@ -7,7 +7,9 @@ from distributed.submit import _remote
 
 @click.command()
 @click.option("--host", type=str, default=None, help="IP or hostname of this server")
-@click.option("--port", type=int, default=8788, show_default=True, help="Remote Client Port")
+@click.option(
+    "--port", type=int, default=8788, show_default=True, help="Remote Client Port"
+)
 @click.version_option()
 def main(host, port):
     _remote(host, port)

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -68,6 +68,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "--dashboard-address",
     type=str,
     default=":8787",
+    show_default=True,
     help="Address on which to listen for diagnostics dashboard",
 )
 @click.option(
@@ -85,7 +86,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     required=False,
     help="Deprecated.  See --dashboard/--no-dashboard.",
 )
-@click.option("--show/--no-show", default=False, help="Show web UI")
+@click.option("--show/--no-show", default=False, show_default=True, help="Show web UI")
 @click.option(
     "--dashboard-prefix", type=str, default=None, help="Prefix for the dashboard app"
 )

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -75,9 +75,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "--dashboard/--no-dashboard",
     "dashboard",
     default=True,
-    show_default=True,
     required=False,
-    help="Launch the Dashboard",
+    help="Launch the Dashboard [default: --dashboard]",
 )
 @click.option(
     "--bokeh/--no-bokeh",
@@ -86,7 +85,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     required=False,
     help="Deprecated.  See --dashboard/--no-dashboard.",
 )
-@click.option("--show/--no-show", default=False, show_default=True, help="Show web UI")
+@click.option("--show/--no-show", default=False, help="Show web UI [default: --show]")
 @click.option(
     "--dashboard-prefix", type=str, default=None, help="Prefix for the dashboard app"
 )

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -22,8 +22,9 @@ from distributed.cli.utils import check_python_3
 @click.option(
     "--scheduler-port",
     default=8786,
+    show_default=True,
     type=int,
-    help="Specify scheduler port number.  Defaults to port 8786.",
+    help="Specify scheduler port number.",
 )
 @click.option(
     "--nthreads",
@@ -38,8 +39,9 @@ from distributed.cli.utils import check_python_3
 @click.option(
     "--nprocs",
     default=1,
+    show_default=True,
     type=int,
-    help="Number of worker processes per host.  Defaults to one.",
+    help="Number of worker processes per host.",
 )
 @click.argument("hostnames", nargs=-1, type=str)
 @click.option(
@@ -55,7 +57,8 @@ from distributed.cli.utils import check_python_3
     help="Username to use when establishing SSH connections.",
 )
 @click.option(
-    "--ssh-port", default=22, type=int, help="Port to use for SSH connections."
+    "--ssh-port", default=22, type=int, show_default=True,
+    help="Port to use for SSH connections."
 )
 @click.option(
     "--ssh-private-key",
@@ -79,6 +82,7 @@ from distributed.cli.utils import check_python_3
 @click.option(
     "--memory-limit",
     default="auto",
+    show_default=True,
     help="Bytes of memory that the worker can use. "
     "This can be an integer (bytes), "
     "float (fraction of total system memory), "
@@ -97,8 +101,9 @@ from distributed.cli.utils import check_python_3
 @click.option(
     "--remote-dask-worker",
     default="distributed.cli.dask_worker",
+    show_default=True,
     type=str,
-    help="Worker to run. Defaults to distributed.cli.dask_worker",
+    help="Worker to run.",
 )
 @click.pass_context
 @click.version_option()

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -57,8 +57,11 @@ from distributed.cli.utils import check_python_3
     help="Username to use when establishing SSH connections.",
 )
 @click.option(
-    "--ssh-port", default=22, type=int, show_default=True,
-    help="Port to use for SSH connections."
+    "--ssh-port",
+    default=22,
+    type=int,
+    show_default=True,
+    help="Port to use for SSH connections.",
 )
 @click.option(
     "--ssh-private-key",

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -73,9 +73,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "--dashboard/--no-dashboard",
     "dashboard",
     default=True,
-    show_default=True,
     required=False,
-    help="Launch the Dashboard",
+    help="Launch the Dashboard [default: --dashboard]",
 )
 @click.option(
     "--bokeh/--no-bokeh",
@@ -143,14 +142,12 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--reconnect/--no-reconnect",
     default=True,
-    show_default=True,
-    help="Reconnect to scheduler if disconnected",
+    help="Reconnect to scheduler if disconnected [default: --reconnect]",
 )
 @click.option(
     "--nanny/--no-nanny",
     default=True,
-    show_default=True,
-    help="Start workers in nanny process for management",
+    help="Start workers in nanny process for management [default: --nanny]",
 )
 @click.option("--pid-file", type=str, default="", help="File to write the process PID")
 @click.option(

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -119,7 +119,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "--nprocs",
     type=int,
     default=1,
-    help="Number of worker processes to launch.  Defaults to one.",
+    show_default=True,
+    help="Number of worker processes to launch.",
 )
 @click.option(
     "--name",
@@ -132,6 +133,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--memory-limit",
     default="auto",
+    show_default=True,
     help="Bytes of memory per process that the worker can use. "
     "This can be an integer (bytes), "
     "float (fraction of total system memory), "
@@ -141,11 +143,13 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--reconnect/--no-reconnect",
     default=True,
+    show_default=True,
     help="Reconnect to scheduler if disconnected",
 )
 @click.option(
     "--nanny/--no-nanny",
     default=True,
+    show_default=True,
     help="Start workers in nanny process for management",
 )
 @click.option("--pid-file", type=str, default="", help="File to write the process PID")


### PR DESCRIPTION
For some reason, if you specify a default value for an option with click, it will not show that default value in the generated `--help` usage doc unless you also specify `show_default=True`.  So, for example, it's not clear from reading the usage doc that `dask-worker`'s default is to use a nanny process, etc. and I had to go read the code to be sure of that.

The following pull request adds `show_default=True` to relevant click options and switches some options from a hardcoded explanation of the default in the `help=` text to also use that. I think this makes the output of `--help` clearer for less experienced users.

My only question actually is for the options like `--nanny / --no-nanny`. Click will now show `[default: True]`. It might be clearer to hardcode this to be something like `[default: --nanny]`. What do folks think?

If this is generally deemed useful and merged, I'll do the same thing for the dask/dask repo.