### PR TITLE
Dont reuse closed worker in get_worker

### DIFF
--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -834,17 +834,21 @@ def test_starts_up_sync(loop):
 
 
 def test_dont_select_closed_worker():
-    cluster = LocalCluster(n_workers=0, processes=False, threads_per_worker=2)
-    c = Client(cluster)
-    cluster.scale(2)
-    assert c == get_client()
+    with clean(threads=False):
+        cluster = LocalCluster(n_workers=0)
+        c = Client(cluster)
+        cluster.scale(2)
+        assert c == get_client()
 
-    c.close()
-    cluster.close()
+        c.close()
+        cluster.close()
 
-    cluster2 = LocalCluster(n_workers=0, processes=False, threads_per_worker=2)
-    c2 = Client(cluster2)
-    cluster2.scale(2)
+        cluster2 = LocalCluster(n_workers=0)
+        c2 = Client(cluster2)
+        cluster2.scale(2)
 
-    current_client = get_client()
-    assert c2 == current_client
+        current_client = get_client()
+        assert c2 == current_client
+
+        cluster2.close()
+        c2.close()

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -834,6 +834,8 @@ def test_starts_up_sync(loop):
 
 
 def test_dont_select_closed_worker():
+    # Make sure distributed does not try to reuse a client from a
+    # closed cluster (https://github.com/dask/distributed/issues/2840).
     with clean(threads=False):
         cluster = LocalCluster(n_workers=0)
         c = Client(cluster)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2857,7 +2857,7 @@ def get_worker():
         return thread_state.execution_state["worker"]
     except AttributeError:
         try:
-            return first(Worker._instances)
+            return first(w for w in Worker._instances if w.status != "closed")
         except StopIteration:
             raise ValueError("No workers found")
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2857,7 +2857,7 @@ def get_worker():
         return thread_state.execution_state["worker"]
     except AttributeError:
         try:
-            return first(w for w in Worker._instances if w.status != "closed")
+            return first(w for w in Worker._instances if w.status == "running")
         except StopIteration:
             raise ValueError("No workers found")
 


### PR DESCRIPTION
Fixes #2840 

Running git bisect on the reproducer, the "faulty commit" seems to be: https://github.com/dask/distributed/commit/1cbd324248db1973f1cfeb393e2d0dc7a5490d41#diff-5e2c0e4a5c31298584de13564b98fe49L949

Also, I noticed that, independently from the worker statuses, `get_worker` returns `toolz.first(Worker._instances)`. But `Worker._instances` is a weak set -- the notion of "first" relates to the elements hash values, which may not be the way we want to iterate on `Worker._instances` here.

Happy to make changes as requested.

