### PR TITLE
remove reconnect from heartbeat

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -800,7 +800,6 @@ class Worker(ServerNode):
                 middle = (start + end) / 2
 
                 if response["status"] == "missing":
-                    await self._register_with_scheduler()
                     return
                 self.scheduler_delay = response["time"] - middle
                 self.periodic_callbacks["heartbeat"].callback_time = (


### PR DESCRIPTION
addresses #2525.

Heartbeat does no longer trigger reconnect, this implies there won't be double reconnects. Is this the way to go? If so, I'd be thankful for hints how to test this.