### PR TITLE
Added Scheduler and Worker memory tracking

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3479,7 +3479,6 @@ class Scheduler(ServerNode):
             s.discard(ts)
             if not s and not dts.who_wants:
                 recommendations[dts.key] = "released"
-                print(dts, dts.nbytes, ts.prefix)
                 if dts.nbytes:
                     self.task_net_nbytes[ts.prefix] -= dts.nbytes
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3479,11 +3479,14 @@ class Scheduler(ServerNode):
             s.discard(ts)
             if not s and not dts.who_wants:
                 recommendations[dts.key] = "released"
-                self.task_net_nbytes[ts.prefix] -= dts.nbytes
+                print(dts, dts.nbytes, ts.prefix)
+                if dts.nbytes:
+                    self.task_net_nbytes[ts.prefix] -= dts.nbytes
 
         if not ts.waiters and not ts.who_wants:
             recommendations[ts.key] = "released"
-            self.task_net_nbytes[ts.prefix] -= ts.nbytes
+            if ts.nbytes:
+                self.task_net_nbytes[ts.prefix] -= ts.nbytes
         else:
             msg = {"op": "key-in-memory", "key": ts.key}
             if type is not None:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -819,7 +819,7 @@ class Scheduler(ServerNode):
         report results
     * **task_duration:** ``{key-prefix: time}``
         Time we expect certain functions to take, e.g. ``{'sum': 0.25}``
-    * **task_net_nbytes** ``{key-prefix:: int}``
+    * **task_net_nbytes** ``{key-prefix: int}``
         Expected change in cluster memory usage, in bytes, from completing
         a task with a given prefix
     * **coroutines:** ``[Futures]``:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1621,22 +1621,7 @@ def test_net_nbytes(c, s, a, b):
     assert result == bytearray(10)
     assert s.task_net_nbytes["a"] > 0
     assert s.task_net_nbytes["b"] < 0
-
-    # now that we've learned some things, submit again, and
-    # check the workers.
-
-    dsk["b-3"] = (lambda t, u: t[:5], "a-1", "a-2")
-    x = c.get(dsk, "b-3", sync=False)
-    yield x
-    # avoid defaultdict
-    if "a" in a.net_nbytes:
-        assert a.net_nbytes["a"] > 0
-    else:
-        assert b.net_nbytes["a"] > 0
-    if "b" in a.net_nbytes:
-        assert a.net_nbytes["b"] < 0
-    else:
-        assert b.net_nbytes["b"] < 0
+    # TODO: Add asserts on the worker's properties
 
 
 @pytest.mark.asyncio

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1609,6 +1609,36 @@ async def test_async_context_manager():
         assert not s.workers
 
 
+@gen_cluster(client=True)
+def test_net_nbytes(c, s, a, b):
+    dsk = {
+        "a-1": (bytearray, 1000),
+        "a-2": (bytearray, 1000),
+        "b-2": (lambda t, u: t[:10], "a-1", "a-2"),
+    }
+    x = c.get(dsk, "b-2", sync=False)
+    result = yield x
+    assert result == bytearray(10)
+    assert s.task_net_nbytes["a"] > 0
+    assert s.task_net_nbytes["b"] < 0
+
+    # now that we've learned some things, submit again, and
+    # check the workers.
+
+    dsk["b-3"] = (lambda t, u: t[:5], "a-1", "a-2")
+    x = c.get(dsk, "b-3", sync=False)
+    yield x
+    # avoid defaultdict
+    if "a" in a.net_nbytes:
+        assert a.net_nbytes["a"] > 0
+    else:
+        assert b.net_nbytes["a"] > 0
+    if "b" in a.net_nbytes:
+        assert a.net_nbytes["b"] < 0
+    else:
+        assert b.net_nbytes["b"] < 0
+
+
 @pytest.mark.asyncio
 async def test_allowed_failures_config():
     async with Scheduler(port=0, allowed_failures=10) as s:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -167,7 +167,7 @@ class Worker(ServerNode):
     * **data_needed**: deque(keys)
         The keys whose data we still lack, arranged in a deque
     * **waiting_for_data**: ``{kep: {deps}}``
-        A dynamic verion of dependencies.  All dependencies that we still don't
+        A dynamic version of dependencies. All dependencies that we still don't
         have for a particular key.
     * **ready**: [keys]
         Keys that are ready to run.  Stored in a LIFO stack
@@ -355,6 +355,7 @@ class Worker(ServerNode):
         self.priorities = dict()
         self.generation = 0
         self.durations = dict()
+        self.net_nbytes = defaultdict(lambda: 0)
         self.startstops = defaultdict(list)
         self.resource_restrictions = dict()
 
@@ -1233,6 +1234,7 @@ class Worker(ServerNode):
         nbytes=None,
         priority=None,
         duration=None,
+        net_nbytes=None,
         resource_restrictions=None,
         actor=False,
         **kwargs2
@@ -1256,6 +1258,9 @@ class Worker(ServerNode):
             if priority is not None:
                 priority = tuple(priority) + (self.generation,)
                 self.generation -= 1
+
+            if net_nbytes is not None:
+                self.net_nbytes[key_split(key)] = net_nbytes
 
             if self.dep_state.get(key) == "memory":
                 self.task_state[key] = "memory"


### PR DESCRIPTION
Part 1 of https://github.com/dask/distributed/issues/2602.

This adds 

- Scheduler.task_net_nbytes
- Worker.net_nybtes

modeled after `task_duration` / `durations` (with the primary difference that the `Worker.net_nbytes` is at the prefix, rather than task level).

The basic idea is to learn a per-prefix measure of the *net* memory usage of running a task. We already know

1. the memory usage of a tasks' output
2. the memory usage of each dependency

Now we just do a bit of arithmetic when we complete a task and when we release dependencies.

This information is passed to works to aid with scheduling, but that part will be done in a separate PR.