### PR TITLE
Document distributed.Reschedule in API docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -167,6 +167,7 @@ Other
 .. autofunction:: distributed.get_client
 .. autofunction:: distributed.secede
 .. autofunction:: distributed.rejoin
+.. autoclass:: distributed.Reschedule
 .. autoclass:: get_task_stream
 
 .. autoclass:: Lock


### PR DESCRIPTION
Currently `distributed.Reschedule` is part of the public API, but the docstring isn't being rendered