### PR TITLE
 Use only remote connection to scheduler in Adaptive

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -62,7 +62,7 @@ class Cluster(object):
     LocalCluster: a simple implementation with local workers
     """
 
-    def adapt(self, **kwargs):
+    def adapt(self, Adaptive=Adaptive, **kwargs):
         """ Turn on adaptivity
 
         For keyword arguments see dask.distributed.Adaptive
@@ -76,7 +76,7 @@ class Cluster(object):
         if not hasattr(self, "_adaptive_options"):
             self._adaptive_options = {}
         self._adaptive_options.update(kwargs)
-        self._adaptive = Adaptive(self.scheduler, self, **self._adaptive_options)
+        self._adaptive = Adaptive(self, **self._adaptive_options)
         return self._adaptive
 
     @property

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -2,18 +2,19 @@ from __future__ import print_function, division, absolute_import
 
 from time import sleep
 
+import pytest
 from toolz import frequencies, pluck
 from tornado import gen
 from tornado.ioloop import IOLoop
 
 from distributed import Client, wait, Adaptive, LocalCluster, SpecCluster, Worker
-from distributed.utils_test import gen_cluster, gen_test, slowinc, clean
+from distributed.utils_test import gen_test, slowinc, clean
 from distributed.utils_test import loop, nodebug  # noqa: F401
 from distributed.metrics import time
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
-def test_simultaneous_scale_up_and_down(c, s, *workers):
+@pytest.mark.asyncio
+async def test_simultaneous_scale_up_and_down():
     class TestAdaptive(Adaptive):
         def get_scale_up_kwargs(self):
             assert False
@@ -21,38 +22,35 @@ def test_simultaneous_scale_up_and_down(c, s, *workers):
         def _retire_workers(self):
             assert False
 
-    class TestCluster(object):
+    class TestCluster(LocalCluster):
         def scale_up(self, n, **kwargs):
             assert False
 
         def scale_down(self, workers):
             assert False
 
-        @property
-        def loop(self):
-            return s.loop
+    async with TestCluster(n_workers=4, processes=False, asynchronous=True) as cluster:
+        async with Client(cluster, asynchronous=True) as c:
+            s = cluster.scheduler
+            s.task_duration["a"] = 4
+            s.task_duration["b"] = 4
+            s.task_duration["c"] = 1
 
-    cluster = TestCluster()
+            future = c.map(slowinc, [1, 1, 1], key=["a-4", "b-4", "c-1"])
 
-    s.task_duration["a"] = 4
-    s.task_duration["b"] = 4
-    s.task_duration["c"] = 1
+            while len(s.rprocessing) < 3:
+                await gen.sleep(0.001)
 
-    future = c.map(slowinc, [1, 1, 1], key=["a-4", "b-4", "c-1"])
+            ta = cluster.adapt(interval="100 ms", scale_factor=2, Adaptive=TestAdaptive)
 
-    while len(s.rprocessing) < 3:
-        yield gen.sleep(0.001)
-
-    ta = TestAdaptive(s, cluster, interval=100, scale_factor=2)
-
-    yield gen.sleep(0.3)
+            await gen.sleep(0.3)
 
 
 def test_adaptive_local_cluster(loop):
     with LocalCluster(
         0, scheduler_port=0, silence_logs=False, dashboard_address=None, loop=loop
     ) as cluster:
-        alc = Adaptive(cluster.scheduler, cluster, interval=100)
+        alc = cluster.adapt(interval="100 ms")
         with Client(cluster, loop=loop) as c:
             assert not c.nthreads()
             future = c.submit(lambda x: x + 1, 1)
@@ -117,45 +115,34 @@ def test_adaptive_local_cluster_multi_workers():
         yield cluster.close()
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10, active_rpc_timeout=10)
-def test_adaptive_scale_down_override(c, s, *workers):
+@pytest.mark.asyncio
+async def test_adaptive_scale_down_override():
     class TestAdaptive(Adaptive):
         def __init__(self, *args, **kwargs):
             self.min_size = kwargs.pop("min_size", 0)
             Adaptive.__init__(self, *args, **kwargs)
 
-        def workers_to_close(self, **kwargs):
-            num_workers = len(self.scheduler.workers)
-            to_close = self.scheduler.workers_to_close(**kwargs)
+        async def workers_to_close(self, **kwargs):
+            num_workers = len(self.cluster.workers)
+            to_close = await self.scheduler.workers_to_close(**kwargs)
             if num_workers - len(to_close) < self.min_size:
                 to_close = to_close[: num_workers - self.min_size]
 
             return to_close
 
-    class TestCluster(object):
+    class TestCluster(LocalCluster):
         def scale_up(self, n, **kwargs):
             assert False
 
-        def scale_down(self, workers):
-            assert False
+    async with TestCluster(n_workers=10, processes=False, asynchronous=True) as cluster:
+        ta = cluster.adapt(
+            min_size=2, interval=0.1, scale_factor=2, Adaptive=TestAdaptive
+        )
+        await gen.sleep(0.3)
 
-        @property
-        def workers(self):
-            return s.workers
-
-        @property
-        def loop(self):
-            return s.loop
-
-    assert len(s.workers) == 10
-
-    # Assert that adaptive cycle does not reduce cluster below minimum size
-    # as determined via override.
-    cluster = TestCluster()
-    ta = TestAdaptive(s, cluster, min_size=2, interval=0.1, scale_factor=2)
-    yield gen.sleep(0.3)
-
-    assert len(s.workers) == 2
+        # Assert that adaptive cycle does not reduce cluster below minimum size
+        # as determined via override.
+        assert len(cluster.scheduler.workers) == 2
 
 
 @gen_test()
@@ -169,14 +156,7 @@ def test_min_max():
         asynchronous=True,
     )
     try:
-        adapt = Adaptive(
-            cluster.scheduler,
-            cluster,
-            minimum=1,
-            maximum=2,
-            interval="20 ms",
-            wait_count=10,
-        )
+        adapt = cluster.adapt(minimum=1, maximum=2, interval="20 ms", wait_count=10)
         c = yield Client(cluster, asynchronous=True)
 
         start = time()
@@ -230,7 +210,7 @@ def test_avoid_churn():
     )
     client = yield Client(cluster, asynchronous=True)
     try:
-        adapt = Adaptive(cluster.scheduler, cluster, interval="20 ms", wait_count=5)
+        adapt = cluster.adapt(interval="20 ms", wait_count=5)
 
         for i in range(10):
             yield client.submit(slowinc, i, delay=0.040)
@@ -260,7 +240,7 @@ def test_adapt_quickly():
         dashboard_address=None,
     )
     client = yield Client(cluster, asynchronous=True)
-    adapt = Adaptive(cluster.scheduler, cluster, interval=20, wait_count=5, maximum=10)
+    adapt = cluster.adapt(interval=20, wait_count=5, maximum=10)
     try:
         future = client.submit(slowinc, 1, delay=0.100)
         yield wait(future)
@@ -339,9 +319,7 @@ def test_no_more_workers_than_tasks():
     )
     yield cluster._start()
     try:
-        adapt = Adaptive(
-            cluster.scheduler, cluster, minimum=0, maximum=4, interval="10 ms"
-        )
+        adapt = cluster.adapt(minimum=0, maximum=4, interval="10 ms")
         client = yield Client(cluster, asynchronous=True, loop=loop)
         cluster.scheduler.task_duration["slowinc"] = 1000
 

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -20,6 +20,7 @@ distributed:
     transition-log-length: 100000
     work-stealing: True     # workers should steal tasks from each other
     worker-ttl: null        # like '60s'. Time to live for workers.  They must heartbeat faster than this
+    pickle: True            # Is the scheduler allowed to deserialize arbitrary bytestrings
     preload: []
     preload-argv: []
     dashboard:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1070,6 +1070,7 @@ class Scheduler(ServerNode):
             "get_task_stream": self.get_task_stream,
             "register_worker_plugin": self.register_worker_plugin,
             "adaptive_target": self.adaptive_target,
+            "workers_to_close": self.workers_to_close,
         }
 
         self._transitions = {
@@ -2935,7 +2936,9 @@ class Scheduler(ServerNode):
             },
         )
 
-    def workers_to_close(self, memory_ratio=None, n=None, key=None, minimum=None):
+    def workers_to_close(
+        self, comm=None, memory_ratio=None, n=None, key=None, minimum=None
+    ):
         """
         Find workers that we can close with low cost
 
@@ -4730,7 +4733,7 @@ class Scheduler(ServerNode):
         if close:
             self.loop.add_callback(self.close)
 
-    def adaptive_target(self, target_duration="5s"):
+    def adaptive_target(self, comm=None, target_duration="5s"):
         """ Desired number of workers based on the current workload
 
         This looks at the current running tasks and memory use, and returns a

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3000,6 +3000,10 @@ class Scheduler(ServerNode):
 
             if key is None:
                 key = lambda ws: ws.address
+            if isinstance(key, bytes) and dask.config.get(
+                "distributed.scheduler.pickle"
+            ):
+                key = pickle.loads(key)
 
             groups = groupby(key, self.workers.values())
 
@@ -3228,6 +3232,14 @@ class Scheduler(ServerNode):
         Caution: this runs arbitrary Python code on the scheduler.  This should
         eventually be phased out.  It is mostly used by diagnostics.
         """
+        if not dask.config.get("distributed.scheduler.pickle"):
+            logger.warn(
+                "Tried to call 'feed' route with custom fucntions, but "
+                "pickle is disallowed.  Set the 'distributed.scheduler.pickle'"
+                "config value to True to use the 'feed' route (this is mostly "
+                "commonly used with progress bars)"
+            )
+            return
         import pickle
 
         interval = parse_timedelta(interval)


### PR DESCRIPTION
This modifies the Adaptive class to only touch the scheduler through
communication, rather than direct access.  This should enable adaptive
scheduling when the scheduler is deployed in a remote process.

Fixes #2858

Note that this breaks the `Adaptive` API, but the `cluster.adapt` API, which I think we mostly use in examples should still be fine.  I think that this will make some people sad, but I'm ok with that personally.

cc @jacobtomlinson @jcrist 