### PR TITLE
Remove unused variable in SpecCluster scale down

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -319,10 +319,10 @@ class SpecCluster(Cluster):
         workers = set(workers)
 
         for k, v in self.workers.items():
-            if v.address in workers:
+            if v.worker_address in workers:
                 del self.worker_spec[k]
 
-        self.loop.add_callback(self._correct_state)
+        await self
 
     scale_up = scale  # backwards compatibility
 

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -318,13 +318,11 @@ class SpecCluster(Cluster):
     async def scale_down(self, workers):
         workers = set(workers)
 
-        # TODO: this is linear cost.  We should be indexing by name or something
-        to_close = [w for w in self.workers.values() if w.address in workers]
         for k, v in self.workers.items():
-            if v.worker_address in workers:
+            if v.address in workers:
                 del self.worker_spec[k]
 
-        await self
+        self.loop.add_callback(self._correct_state)
 
     scale_up = scale  # backwards compatibility
 


### PR DESCRIPTION
Fixes #2869.

I've made a few changes here to avoid issues I was having when scaling down a `SpecCluster`.

- Remove unused `to_close ` variable and comment.
- Update `worker_address` to `address`.
- Change `await self` to `self.loop.add_callback(self._correct_state)`. This was to make it consistent with `scale`. Happy to update `scale` if that approach is preferred.