### PR TITLE
Replace gen.coroutine with async/await in core

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 import atexit
-import dask
 import logging
 import gc
 import os
@@ -16,9 +15,9 @@ import click
 from tornado.ioloop import IOLoop
 
 from distributed import Scheduler
+from distributed.preloading import validate_preload_argv
 from distributed.security import Security
 from distributed.cli.utils import check_python_3, install_signal_handlers
-from distributed.preloading import preload_modules, validate_preload_argv
 from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,
@@ -219,16 +218,9 @@ def main(
         dashboard_address=dashboard_address if dashboard else None,
         service_kwargs={"dashboard": {"prefix": dashboard_prefix}},
         idle_timeout=idle_timeout,
+        preload=preload,
+        preload_argv=preload_argv,
     )
-    scheduler.start()
-    if not preload:
-        preload = dask.config.get("distributed.scheduler.preload")
-    if not preload_argv:
-        preload_argv = dask.config.get("distributed.scheduler.preload-argv")
-    preload_modules(
-        preload, parameter=scheduler, file_dir=local_directory, argv=preload_argv
-    )
-
     logger.info("Local Directory: %26s", local_directory)
     logger.info("-" * 47)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -44,6 +44,7 @@ from tornado.locks import Event, Condition, Semaphore
 from tornado.ioloop import IOLoop
 from tornado.queues import Queue
 
+import asyncio
 from asyncio import iscoroutine
 
 from .batched import BatchedSend
@@ -231,32 +232,30 @@ class Future(WrappedKey):
         else:
             return result
 
-    @gen.coroutine
-    def _result(self, raiseit=True):
-        yield self._state.wait()
+    async def _result(self, raiseit=True):
+        await self._state.wait()
         if self.status == "error":
             exc = clean_exception(self._state.exception, self._state.traceback)
             if raiseit:
                 six.reraise(*exc)
             else:
-                raise gen.Return(exc)
+                return exc
         elif self.status == "cancelled":
             exception = CancelledError(self.key)
             if raiseit:
                 raise exception
             else:
-                raise gen.Return(exception)
+                return exception
         else:
-            result = yield self.client._gather([self])
-            raise gen.Return(result[0])
+            result = await self.client._gather([self])
+            return result[0]
 
-    @gen.coroutine
-    def _exception(self):
-        yield self._state.wait()
+    async def _exception(self):
+        await self._state.wait()
         if self.status == "error":
-            raise gen.Return(self._state.exception)
+            return self._state.exception
         else:
-            raise gen.Return(None)
+            return None
 
     def exception(self, timeout=None, **kwargs):
         """ Return the exception of a failed task
@@ -321,13 +320,12 @@ class Future(WrappedKey):
         """ Returns True if the future has been cancelled """
         return self._state.status == "cancelled"
 
-    @gen.coroutine
-    def _traceback(self):
-        yield self._state.wait()
+    async def _traceback(self):
+        await self._state.wait()
         if self.status == "error":
-            raise gen.Return(self._state.traceback)
+            return self._state.traceback
         else:
-            raise gen.Return(None)
+            return None
 
     def traceback(self, timeout=None, **kwargs):
         """ Return the traceback of a failed task
@@ -480,19 +478,17 @@ class FutureState(object):
         if self._event is not None:
             self._event.clear()
 
-    @gen.coroutine
-    def wait(self, timeout=None):
-        yield self._get_event().wait(timeout)
+    async def wait(self, timeout=None):
+        await self._get_event().wait(timeout)
 
     def __repr__(self):
         return "<%s: %s>" % (self.__class__.__name__, self.status)
 
 
-@gen.coroutine
-def done_callback(future, callback):
+async def done_callback(future, callback):
     """ Coroutine that waits on future, then calls callback """
     while future.status == "pending":
-        yield future._state.wait()
+        await future._state.wait()
     callback(future)
 
 
@@ -868,7 +864,7 @@ class Client(Node):
         self.status = "connecting"
 
         if self.asynchronous:
-            self._started = self._start(**kwargs)
+            self._started = asyncio.ensure_future(self._start(**kwargs))
         else:
             sync(self.loop, self._start, **kwargs)
 
@@ -877,9 +873,8 @@ class Client(Node):
             return self._started.__await__()
         else:
 
-            @gen.coroutine
-            def _():
-                raise gen.Return(self)
+            async def _():
+                return self
 
             return _().__await__()
 
@@ -902,8 +897,7 @@ class Client(Node):
                 "Message: %s" % (self.status, msg)
             )
 
-    @gen.coroutine
-    def _start(self, timeout=no_default, **kwargs):
+    async def _start(self, timeout=no_default, **kwargs):
         if timeout == no_default:
             timeout = self._timeout
         if timeout is not None:
@@ -913,7 +907,7 @@ class Client(Node):
         if self.cluster is not None:
             # Ensure the cluster is started (no-op if already running)
             try:
-                yield self.cluster._start()
+                await self.cluster._start()
             except AttributeError:  # Some clusters don't have this method
                 pass
             except Exception:
@@ -924,7 +918,7 @@ class Client(Node):
             address = self.cluster.scheduler_address
         elif self.scheduler_file is not None:
             while not os.path.exists(self.scheduler_file):
-                yield gen.sleep(0.01)
+                await gen.sleep(0.01)
             for i in range(10):
                 try:
                     with open(self.scheduler_file) as f:
@@ -932,33 +926,31 @@ class Client(Node):
                     address = cfg["address"]
                     break
                 except (ValueError, KeyError):  # JSON file not yet flushed
-                    yield gen.sleep(0.01)
+                    await gen.sleep(0.01)
         elif self._start_arg is None:
             from .deploy import LocalCluster
 
             try:
-                self.cluster = LocalCluster(
+                self.cluster = await LocalCluster(
                     loop=self.loop, asynchronous=True, **self._startup_kwargs
                 )
-                yield self.cluster
             except (OSError, socket.error) as e:
                 if e.errno != errno.EADDRINUSE:
                     raise
                 # The default port was taken, use a random one
-                self.cluster = LocalCluster(
+                self.cluster = await LocalCluster(
                     scheduler_port=0,
                     loop=self.loop,
                     asynchronous=True,
                     **self._startup_kwargs
                 )
-                yield self.cluster
 
             # Wait for all workers to be ready
             # XXX should be a LocalCluster method instead
             while not self.cluster.workers or len(self.cluster.scheduler.workers) < len(
                 self.cluster.workers
             ):
-                yield gen.sleep(0.01)
+                await gen.sleep(0.01)
 
             address = self.cluster.scheduler_address
 
@@ -966,18 +958,17 @@ class Client(Node):
             self.scheduler = self.rpc(address)
         self.scheduler_comm = None
 
-        yield self._ensure_connected(timeout=timeout)
+        await self._ensure_connected(timeout=timeout)
 
         for pc in self._periodic_callbacks.values():
             pc.start()
 
-        self._handle_scheduler_coroutine = self._handle_report()
+        self._handle_scheduler_coroutine = asyncio.ensure_future(self._handle_report())
         self.coroutines.append(self._handle_scheduler_coroutine)
 
-        raise gen.Return(self)
+        return self
 
-    @gen.coroutine
-    def _reconnect(self):
+    async def _reconnect(self):
         with log_errors():
             assert self.scheduler_comm.comm.closed()
 
@@ -992,11 +983,11 @@ class Client(Node):
             deadline = self.loop.time() + timeout
             while timeout > 0 and self.status == "connecting":
                 try:
-                    yield self._ensure_connected(timeout=timeout)
+                    await self._ensure_connected(timeout=timeout)
                     break
                 except EnvironmentError:
                     # Wait a bit before retrying
-                    yield gen.sleep(0.1)
+                    await gen.sleep(0.1)
                     timeout = deadline - self.loop.time()
             else:
                 logger.error(
@@ -1004,10 +995,9 @@ class Client(Node):
                     "seconds, closing client",
                     self._timeout,
                 )
-                yield self._close()
+                await self._close()
 
-    @gen.coroutine
-    def _ensure_connected(self, timeout=None):
+    async def _ensure_connected(self, timeout=None):
         if (
             self.scheduler_comm
             and not self.scheduler_comm.closed()
@@ -1019,27 +1009,27 @@ class Client(Node):
         self._connecting_to_scheduler = True
 
         try:
-            comm = yield connect(
+            comm = await connect(
                 self.scheduler.address,
                 timeout=timeout,
                 connection_args=self.connection_args,
             )
             comm.name = "Client->Scheduler"
             if timeout is not None:
-                yield gen.with_timeout(
+                await gen.with_timeout(
                     timedelta(seconds=timeout), self._update_scheduler_info()
                 )
             else:
-                yield self._update_scheduler_info()
-            yield comm.write(
+                await self._update_scheduler_info()
+            await comm.write(
                 {"op": "register-client", "client": self.id, "reply": False}
             )
         finally:
             self._connecting_to_scheduler = False
         if timeout is not None:
-            msg = yield gen.with_timeout(timedelta(seconds=timeout), comm.read())
+            msg = await gen.with_timeout(timedelta(seconds=timeout), comm.read())
         else:
-            msg = yield comm.read()
+            msg = await comm.read()
         assert len(msg) == 1
         assert msg[0]["op"] == "stream-start"
 
@@ -1056,21 +1046,19 @@ class Client(Node):
 
         logger.debug("Started scheduling coroutines. Synchronized")
 
-    @gen.coroutine
-    def _update_scheduler_info(self):
+    async def _update_scheduler_info(self):
         if self.status not in ("running", "connecting"):
             return
         try:
-            self._scheduler_identity = yield self.scheduler.identity()
+            self._scheduler_identity = await self.scheduler.identity()
         except EnvironmentError:
             logger.debug("Not able to query scheduler for identity")
 
-    @gen.coroutine
-    def _wait_for_workers(self, n_workers=0):
-        info = yield self.scheduler.identity()
+    async def _wait_for_workers(self, n_workers=0):
+        info = await self.scheduler.identity()
         while n_workers and len(info["workers"]) < n_workers:
-            yield gen.sleep(0.1)
-            info = yield self.scheduler.identity()
+            await gen.sleep(0.1)
+            info = await self.scheduler.identity()
 
     def wait_for_workers(self, n_workers=0):
         """Blocking call to wait for n workers before continuing"""
@@ -1085,14 +1073,12 @@ class Client(Node):
             self.start()
         return self
 
-    @gen.coroutine
-    def __aenter__(self):
-        yield self._started
-        raise gen.Return(self)
+    async def __aenter__(self):
+        await self._started
+        return self
 
-    @gen.coroutine
-    def __aexit__(self, typ, value, traceback):
-        yield self._close()
+    async def __aexit__(self, typ, value, traceback):
+        await self._close()
 
     def __exit__(self, type, value, traceback):
         self.close()
@@ -1122,8 +1108,7 @@ class Client(Node):
                 {"op": "client-releases-keys", "keys": [key], "client": self.id}
             )
 
-    @gen.coroutine
-    def _handle_report(self):
+    async def _handle_report(self):
         """ Listen to scheduler """
         with log_errors():
             try:
@@ -1131,13 +1116,13 @@ class Client(Node):
                     if self.scheduler_comm is None:
                         break
                     try:
-                        msgs = yield self.scheduler_comm.comm.read()
+                        msgs = await self.scheduler_comm.comm.read()
                     except CommClosedError:
                         if self.status == "running":
                             logger.info("Client report stream closed to scheduler")
                             logger.info("Reconnecting...")
                             self.status = "connecting"
-                            yield self._reconnect()
+                            await self._reconnect()
                             continue
                         else:
                             break
@@ -1213,8 +1198,7 @@ class Client(Node):
         logger.warning("Scheduler exception:")
         logger.exception(exception)
 
-    @gen.coroutine
-    def _close(self, fast=False):
+    async def _close(self, fast=False):
         """ Send close signal and wait until scheduler completes """
         self.status = "closing"
 
@@ -1244,7 +1228,7 @@ class Client(Node):
             # Give the scheduler 'stream-closed' message 100ms to come through
             # This makes the shutdown slightly smoother and quieter
             with ignoring(AttributeError, gen.TimeoutError):
-                yield gen.with_timeout(
+                await gen.with_timeout(
                     timedelta(milliseconds=100),
                     self._handle_scheduler_coroutine,
                     quiet_exceptions=(CancelledError,),
@@ -1255,12 +1239,12 @@ class Client(Node):
                 and self.scheduler_comm.comm
                 and not self.scheduler_comm.comm.closed()
             ):
-                yield self.scheduler_comm.close()
+                await self.scheduler_comm.close()
             for key in list(self.futures):
                 self._release_key(key=key)
             if self._start_arg is None:
                 with ignoring(AttributeError):
-                    yield self.cluster._close()
+                    await self.cluster._close()
             self.rpc.close()
             self.status = "closed"
             if _get_global_client() is self:
@@ -1276,7 +1260,7 @@ class Client(Node):
             del self.coroutines[:]
             if not fast:
                 with ignoring(TimeoutError):
-                    yield gen.with_timeout(timedelta(seconds=2), list(coroutines))
+                    await gen.with_timeout(timedelta(seconds=2), list(coroutines))
             with ignoring(AttributeError):
                 self.scheduler.close_rpc()
             self.scheduler = None
@@ -1628,8 +1612,7 @@ class Client(Node):
 
         return [futures[tokey(k)] for k in keys]
 
-    @gen.coroutine
-    def _gather(self, futures, errors="raise", direct=None, local_worker=None):
+    async def _gather(self, futures, errors="raise", direct=None, local_worker=None):
         unpacked, future_set = unpack_remotedata(futures, byte_keys=True)
         keys = [tokey(future.key) for future in future_set]
         bad_data = dict()
@@ -1646,11 +1629,10 @@ class Client(Node):
                 if w.scheduler.address == self.scheduler.address:
                     direct = True
 
-        @gen.coroutine
-        def wait(k):
+        async def wait(k):
             """ Want to stop the All(...) early if we find an error """
             st = self.futures[k]
-            yield st.wait()
+            await st.wait()
             if st.status != "finished" and errors == "raise":
                 raise AllExit()
 
@@ -1658,7 +1640,7 @@ class Client(Node):
             logger.debug("Waiting on futures to clear before gather")
 
             with ignoring(AllExit):
-                yield All(
+                await All(
                     [wait(key) for key in keys if key in self.futures],
                     quiet_exceptions=AllExit,
                 )
@@ -1697,15 +1679,17 @@ class Client(Node):
             # We now do an actual remote communication with workers or scheduler
             if self._gather_future:  # attach onto another pending gather request
                 self._gather_keys |= set(keys)
-                response = yield self._gather_future
+                response = await self._gather_future
             else:  # no one waiting, go ahead
                 self._gather_keys = set(keys)
-                future = self._gather_remote(direct, local_worker)
+                future = asyncio.ensure_future(
+                    self._gather_remote(direct, local_worker)
+                )
                 if self._gather_keys is None:
                     self._gather_future = None
                 else:
                     self._gather_future = future
-                response = yield future
+                response = await future
 
             if response["status"] == "error":
                 log = logger.warning if errors == "raise" else logger.debug
@@ -1729,40 +1713,39 @@ class Client(Node):
 
         data.update(response["data"])
         result = pack_data(unpacked, merge(data, bad_data))
-        raise gen.Return(result)
+        return result
 
-    @gen.coroutine
-    def _gather_remote(self, direct, local_worker):
+    async def _gather_remote(self, direct, local_worker):
         """ Perform gather with workers or scheduler
 
         This method exists to limit and batch many concurrent gathers into a
         few.  In controls access using a Tornado semaphore, and picks up keys
         from other requests made recently.
         """
-        yield self._gather_semaphore.acquire()
+        await self._gather_semaphore.acquire()
         keys = list(self._gather_keys)
         self._gather_keys = None  # clear state, these keys are being sent off
         self._gather_future = None
 
         try:
             if direct or local_worker:  # gather directly from workers
-                who_has = yield self.scheduler.who_has(keys=keys)
-                data2, missing_keys, missing_workers = yield gather_from_workers(
+                who_has = await self.scheduler.who_has(keys=keys)
+                data2, missing_keys, missing_workers = await gather_from_workers(
                     who_has, rpc=self.rpc, close=False
                 )
                 response = {"status": "OK", "data": data2}
                 if missing_keys:
                     keys2 = [key for key in keys if key not in data2]
-                    response = yield self.scheduler.gather(keys=keys2)
+                    response = await self.scheduler.gather(keys=keys2)
                     if response["status"] == "OK":
                         response["data"].update(data2)
 
             else:  # ask scheduler to gather data for us
-                response = yield self.scheduler.gather(keys=keys)
+                response = await self.scheduler.gather(keys=keys)
         finally:
             self._gather_semaphore.release()
 
-        raise gen.Return(response)
+        return response
 
     def gather(self, futures, errors="raise", direct=None, asynchronous=None):
         """ Gather futures from distributed memory
@@ -1824,8 +1807,7 @@ class Client(Node):
                 asynchronous=asynchronous,
             )
 
-    @gen.coroutine
-    def _scatter(
+    async def _scatter(
         self,
         data,
         workers=None,
@@ -1842,7 +1824,7 @@ class Client(Node):
         if isinstance(data, dict) and not all(
             isinstance(k, (bytes, unicode)) for k in data
         ):
-            d = yield self._scatter(keymap(tokey, data), workers, broadcast)
+            d = await self._scatter(keymap(tokey, data), workers, broadcast)
             raise gen.Return({k: d[tokey(k)] for k in data})
 
         if isinstance(data, type(range(0))):
@@ -1882,7 +1864,7 @@ class Client(Node):
         if local_worker:  # running within task
             local_worker.update_data(data=data, report=False)
 
-            yield self.scheduler.update_data(
+            await self.scheduler.update_data(
                 who_has={key: [local_worker.address] for key in data},
                 nbytes=valmap(sizeof, data),
                 client=self.id,
@@ -1895,22 +1877,22 @@ class Client(Node):
                 start = time()
                 while not nthreads:
                     if nthreads is not None:
-                        yield gen.sleep(0.1)
+                        await gen.sleep(0.1)
                     if time() > start + timeout:
                         raise gen.TimeoutError("No valid workers found")
-                    nthreads = yield self.scheduler.ncores(workers=workers)
+                    nthreads = await self.scheduler.ncores(workers=workers)
                 if not nthreads:
                     raise ValueError("No valid workers")
 
-                _, who_has, nbytes = yield scatter_to_workers(
+                _, who_has, nbytes = await scatter_to_workers(
                     nthreads, data2, report=False, rpc=self.rpc
                 )
 
-                yield self.scheduler.update_data(
+                await self.scheduler.update_data(
                     who_has=who_has, nbytes=nbytes, client=self.id
                 )
             else:
-                yield self.scheduler.scatter(
+                await self.scheduler.scatter(
                     data=data2,
                     workers=workers,
                     client=self.id,
@@ -1924,7 +1906,7 @@ class Client(Node):
 
         if direct and broadcast:
             n = None if broadcast is True else broadcast
-            yield self._replicate(list(out.values()), workers=workers, n=n)
+            await self._replicate(list(out.values()), workers=workers, n=n)
 
         if issubclass(input_type, (list, tuple, set, frozenset)):
             out = input_type(out[k] for k in names)
@@ -1932,7 +1914,7 @@ class Client(Node):
         if unpack:
             assert len(out) == 1
             out = list(out.values())[0]
-        raise gen.Return(out)
+        return out
 
     def scatter(
         self,
@@ -2031,10 +2013,9 @@ class Client(Node):
             hash=hash,
         )
 
-    @gen.coroutine
-    def _cancel(self, futures, force=False):
+    async def _cancel(self, futures, force=False):
         keys = list({tokey(f.key) for f in futures_of(futures)})
-        yield self.scheduler.cancel(keys=keys, client=self.id, force=force)
+        await self.scheduler.cancel(keys=keys, client=self.id, force=force)
         for k in keys:
             st = self.futures.pop(k, None)
             if st is not None:
@@ -2056,10 +2037,9 @@ class Client(Node):
         """
         return self.sync(self._cancel, futures, asynchronous=asynchronous, force=force)
 
-    @gen.coroutine
-    def _retry(self, futures):
+    async def _retry(self, futures):
         keys = list({tokey(f.key) for f in futures_of(futures)})
-        response = yield self.scheduler.retry(keys=keys, client=self.id)
+        response = await self.scheduler.retry(keys=keys, client=self.id)
         for key in response:
             st = self.futures[key]
             st.retry()
@@ -2180,15 +2160,14 @@ class Client(Node):
         """
         return self.sync(self.scheduler.publish_list, **kwargs)
 
-    @gen.coroutine
-    def _get_dataset(self, name):
-        out = yield self.scheduler.publish_get(name=name, client=self.id)
+    async def _get_dataset(self, name):
+        out = await self.scheduler.publish_get(name=name, client=self.id)
         if out is None:
             raise KeyError("Dataset '%s' not found" % name)
 
         with temp_default_client(self):
             data = out["data"]
-        raise gen.Return(data)
+        return data
 
     def get_dataset(self, name, **kwargs):
         """
@@ -2201,15 +2180,14 @@ class Client(Node):
         """
         return self.sync(self._get_dataset, name, **kwargs)
 
-    @gen.coroutine
-    def _run_on_scheduler(self, function, *args, wait=True, **kwargs):
-        response = yield self.scheduler.run_function(
+    async def _run_on_scheduler(self, function, *args, wait=True, **kwargs):
+        response = await self.scheduler.run_function(
             function=dumps(function), args=dumps(args), kwargs=dumps(kwargs), wait=wait
         )
         if response["status"] == "error":
             six.reraise(*clean_exception(**response))
         else:
-            raise gen.Return(response["result"])
+            return response["result"]
 
     def run_on_scheduler(self, function, *args, **kwargs):
         """ Run a function on the scheduler process
@@ -2243,9 +2221,10 @@ class Client(Node):
         """
         return self.sync(self._run_on_scheduler, function, *args, **kwargs)
 
-    @gen.coroutine
-    def _run(self, function, *args, nanny=False, workers=None, wait=True, **kwargs):
-        responses = yield self.scheduler.broadcast(
+    async def _run(
+        self, function, *args, nanny=False, workers=None, wait=True, **kwargs
+    ):
+        responses = await self.scheduler.broadcast(
             msg=dict(
                 op="run",
                 function=dumps(function),
@@ -2263,7 +2242,7 @@ class Client(Node):
             elif resp["status"] == "error":
                 six.reraise(*clean_exception(**resp))
         if wait:
-            raise gen.Return(results)
+            return results
 
     def run(self, function, *args, **kwargs):
         """
@@ -2855,14 +2834,13 @@ class Client(Node):
     def upload_environment(self, name, zipfile):
         return self.sync(self._upload_environment, name, zipfile)
 
-    @gen.coroutine
-    def _restart(self, timeout=no_default):
+    async def _restart(self, timeout=no_default):
         if timeout == no_default:
             timeout = self._timeout * 2
         self._send_to_scheduler({"op": "restart", "timeout": timeout})
         self._restart_event = Event()
         try:
-            yield self._restart_event.wait(self.loop.time() + timeout)
+            await self._restart_event.wait(self.loop.time() + timeout)
         except gen.TimeoutError:
             logger.error("Restart timed out after %f seconds", timeout)
             pass
@@ -2870,7 +2848,7 @@ class Client(Node):
         with self._refcount_lock:
             self.refcount.clear()
 
-        raise gen.Return(self)
+        return self
 
     def restart(self, **kwargs):
         """ Restart the distributed network
@@ -2880,12 +2858,11 @@ class Client(Node):
         """
         return self.sync(self._restart, **kwargs)
 
-    @gen.coroutine
-    def _upload_file(self, filename, raise_on_error=True):
+    async def _upload_file(self, filename, raise_on_error=True):
         with open(filename, "rb") as f:
             data = f.read()
         _, fn = os.path.split(filename)
-        d = yield self.scheduler.broadcast(
+        d = await self.scheduler.broadcast(
             msg={"op": "upload_file", "filename": fn, "data": to_serialize(data)}
         )
 
@@ -2894,21 +2871,20 @@ class Client(Node):
             if raise_on_error:
                 raise exceptions[0]
             else:
-                raise gen.Return(exceptions[0])
+                return exceptions[0]
 
         assert all(len(data) == v["nbytes"] for v in d.values())
 
-    @gen.coroutine
-    def _upload_large_file(self, local_filename, remote_filename=None):
+    async def _upload_large_file(self, local_filename, remote_filename=None):
         if remote_filename is None:
             remote_filename = os.path.split(local_filename)[1]
 
         with open(local_filename, "rb") as f:
             data = f.read()
 
-        [future] = yield self._scatter([data])
+        [future] = await self._scatter([data])
         key = future.key
-        yield self._replicate(future)
+        await self._replicate(future)
 
         def dump_to_file(dask_worker=None):
             if not os.path.isabs(remote_filename):
@@ -2920,7 +2896,7 @@ class Client(Node):
 
             return len(dask_worker.data[key])
 
-        response = yield self._run(dump_to_file)
+        response = await self._run(dump_to_file)
 
         assert all(len(data) == v for v in response.values())
 
@@ -2950,11 +2926,10 @@ class Client(Node):
         else:
             return result
 
-    @gen.coroutine
-    def _rebalance(self, futures=None, workers=None):
-        yield _wait(futures)
+    async def _rebalance(self, futures=None, workers=None):
+        await _wait(futures)
         keys = list({tokey(f.key) for f in self.futures_of(futures)})
-        result = yield self.scheduler.rebalance(keys=keys, workers=workers)
+        result = await self.scheduler.rebalance(keys=keys, workers=workers)
         assert result["status"] == "OK"
 
     def rebalance(self, futures=None, workers=None, **kwargs):
@@ -2977,12 +2952,11 @@ class Client(Node):
         """
         return self.sync(self._rebalance, futures, workers, **kwargs)
 
-    @gen.coroutine
-    def _replicate(self, futures, n=None, workers=None, branching_factor=2):
+    async def _replicate(self, futures, n=None, workers=None, branching_factor=2):
         futures = self.futures_of(futures)
-        yield _wait(futures)
+        await _wait(futures)
         keys = {tokey(f.key) for f in futures}
-        yield self.scheduler.replicate(
+        await self.scheduler.replicate(
             keys=list(keys), n=n, workers=workers, branching_factor=branching_factor
         )
 
@@ -3263,8 +3237,7 @@ class Client(Node):
             filename=filename,
         )
 
-    @gen.coroutine
-    def _profile(
+    async def _profile(
         self,
         key=None,
         start=None,
@@ -3277,7 +3250,7 @@ class Client(Node):
         if isinstance(workers, six.string_types + (Number,)):
             workers = [workers]
 
-        state = yield self.scheduler.profile(
+        state = await self.scheduler.profile(
             key=key,
             workers=workers,
             merge_workers=merge_workers,
@@ -3301,10 +3274,10 @@ class Client(Node):
                 from bokeh.plotting import save
 
                 save(figure, title="Dask Profile", filename=filename)
-            raise gen.Return((state, figure))
+            return (state, figure)
 
         else:
-            raise gen.Return(state)
+            return state
 
     def scheduler_info(self, **kwargs):
         """ Basic information about the workers in the cluster
@@ -3550,15 +3523,14 @@ class Client(Node):
     def start_ipython(self, *args, **kwargs):
         raise Exception("Method moved to start_ipython_workers")
 
-    @gen.coroutine
-    def _start_ipython_workers(self, workers):
+    async def _start_ipython_workers(self, workers):
         if workers is None:
-            workers = yield self.scheduler.ncores()
+            workers = await self.scheduler.ncores()
 
-        responses = yield self.scheduler.broadcast(
+        responses = await self.scheduler.broadcast(
             msg=dict(op="start_ipython"), workers=workers
         )
-        raise gen.Return((workers, responses))
+        return workers, responses
 
     def start_ipython_workers(
         self, workers=None, magic_names=False, qtconsole=False, qtconsole_args=None
@@ -3873,11 +3845,10 @@ class Client(Node):
             filename=filename,
         )
 
-    @gen.coroutine
-    def _get_task_stream(
+    async def _get_task_stream(
         self, start=None, stop=None, count=None, plot=False, filename="task-stream.html"
     ):
-        msgs = yield self.scheduler.get_task_stream(start=start, stop=stop, count=count)
+        msgs = await self.scheduler.get_task_stream(start=start, stop=stop, count=count)
         if plot:
             from .diagnostics.task_stream import rectangles
 
@@ -3890,9 +3861,9 @@ class Client(Node):
                 from bokeh.plotting import save
 
                 save(figure, title="Dask Task Stream", filename=filename)
-            raise gen.Return((msgs, figure))
+            return (msgs, figure)
         else:
-            raise gen.Return(msgs)
+            return msgs
 
     def register_worker_callbacks(self, setup=None):
         """
@@ -3914,9 +3885,8 @@ class Client(Node):
         """
         return self.register_worker_plugin(_WorkerSetupPlugin(setup))
 
-    @gen.coroutine
-    def _register_worker_plugin(self, plugin=None, name=None):
-        responses = yield self.scheduler.register_worker_plugin(
+    async def _register_worker_plugin(self, plugin=None, name=None):
+        responses = await self.scheduler.register_worker_plugin(
             plugin=dumps(plugin), name=name
         )
         for response in responses.values():
@@ -3925,7 +3895,7 @@ class Client(Node):
                 typ = type(exc)
                 tb = response["traceback"]
                 six.reraise(typ, exc, tb)
-        raise gen.Return(responses)
+        return responses
 
     def register_worker_plugin(self, plugin=None, name=None):
         """
@@ -4009,8 +3979,7 @@ ALL_COMPLETED = "ALL_COMPLETED"
 FIRST_COMPLETED = "FIRST_COMPLETED"
 
 
-@gen.coroutine
-def _wait(fs, timeout=None, return_when=ALL_COMPLETED):
+async def _wait(fs, timeout=None, return_when=ALL_COMPLETED):
     if timeout is not None and not isinstance(timeout, Number):
         raise TypeError(
             "timeout= keyword received a non-numeric value.\n"
@@ -4031,7 +4000,7 @@ def _wait(fs, timeout=None, return_when=ALL_COMPLETED):
     future = wait_for({f._state.wait() for f in fs})
     if timeout is not None:
         future = gen.with_timeout(timedelta(seconds=timeout), future)
-    yield future
+    await future
 
     done, not_done = (
         {fu for fu in fs if fu.status != "pending"},
@@ -4041,7 +4010,7 @@ def _wait(fs, timeout=None, return_when=ALL_COMPLETED):
     if cancelled:
         raise CancelledError(cancelled)
 
-    raise gen.Return(DoneAndNotDoneFutures(done, not_done))
+    return DoneAndNotDoneFutures(done, not_done)
 
 
 def wait(fs, timeout=None, return_when=ALL_COMPLETED):
@@ -4060,32 +4029,32 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
     return result
 
 
-@gen.coroutine
-def _as_completed(fs, queue):
+async def _as_completed(fs, queue):
     fs = futures_of(fs)
     groups = groupby(lambda f: f.key, fs)
     firsts = [v[0] for v in groups.values()]
-    wait_iterator = gen.WaitIterator(*[f._state.wait() for f in firsts])
+    wait_iterator = gen.WaitIterator(
+        *map(asyncio.ensure_future, [f._state.wait() for f in firsts])
+    )
 
     while not wait_iterator.done():
-        yield wait_iterator.next()
+        await wait_iterator.next()
         # TODO: handle case of restarted futures
         future = firsts[wait_iterator.current_index]
         for f in groups[future.key]:
             queue.put_nowait(f)
 
 
-@gen.coroutine
-def _first_completed(futures):
+async def _first_completed(futures):
     """ Return a single completed future
 
     See Also:
         _as_completed
     """
     q = Queue()
-    yield _as_completed(futures, q)
-    result = yield q.get()
-    raise gen.Return(result)
+    await _as_completed(futures, q)
+    result = await q.get()
+    return result
 
 
 class as_completed(object):
@@ -4166,15 +4135,14 @@ class as_completed(object):
         with self.thread_condition:
             self.thread_condition.notify()
 
-    @gen.coroutine
-    def _track_future(self, future):
+    async def _track_future(self, future):
         try:
-            yield _wait(future)
+            await _wait(future)
         except CancelledError:
             pass
         if self.with_results:
             try:
-                result = yield future._result(raiseit=False)
+                result = await future._result(raiseit=False)
             except CancelledError as exc:
                 result = exc
         with self.lock:
@@ -4245,16 +4213,15 @@ class as_completed(object):
                 self.thread_condition.wait(timeout=0.100)
         return self._get_and_raise()
 
-    @gen.coroutine
-    def __anext__(self):
+    async def __anext__(self):
         if not self.futures and self.queue.empty():
             raise StopAsyncIteration
         while self.queue.empty():
             if not self.futures:
                 raise StopAsyncIteration
-            yield self.condition.wait()
+            await self.condition.wait()
 
-        raise gen.Return(self._get_and_raise())
+        return self._get_and_raise()
 
     next = __next__
 
@@ -4476,13 +4443,11 @@ class get_task_stream(object):
             L, self.figure = L
         self.data.extend(L)
 
-    @gen.coroutine
-    def __aenter__(self):
-        raise gen.Return(self)
+    async def __aenter__(self):
+        return self
 
-    @gen.coroutine
-    def __aexit__(self, typ, value, traceback):
-        L = yield self.client.get_task_stream(
+    async def __aexit__(self, typ, value, traceback):
+        L = await self.client.get_task_stream(
             start=self.start, plot=self._plot, filename=self._filename
         )
         if self._plot:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -445,6 +445,7 @@ class FutureState(object):
 
     def cancel(self):
         self.status = "cancelled"
+        self.exception = CancelledError()
         self._get_event().set()
 
     def finish(self, type=None):

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -211,7 +211,13 @@ def uri_from_host_port(host_arg, port_arg, default_port):
 
 
 def address_from_user_args(
-    host=None, port=None, interface=None, protocol=None, peer=None, security=None
+    host=None,
+    port=None,
+    interface=None,
+    protocol=None,
+    peer=None,
+    security=None,
+    default_port=0,
 ):
     """ Get an address to listen on from common user provided arguments """
     if security and security.require_encryption and not protocol:
@@ -235,7 +241,7 @@ def address_from_user_args(
         host = protocol.rstrip("://") + "://" + host
 
     if host or port:
-        addr = uri_from_host_port(host, port, 0)
+        addr = uri_from_host_port(host, port, default_port)
     else:
         addr = ""
 

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -178,8 +178,7 @@ class Connector(with_metaclass(ABCMeta)):
         """
 
 
-@gen.coroutine
-def connect(addr, timeout=None, deserialize=True, connection_args=None):
+async def connect(addr, timeout=None, deserialize=True, connection_args=None):
     """
     Connect to the given address (a URI such as ``tcp://127.0.0.1:1234``)
     and yield a ``Comm`` object.  If the connection attempt fails, it is
@@ -212,7 +211,7 @@ def connect(addr, timeout=None, deserialize=True, connection_args=None):
             future = connector.connect(
                 loc, deserialize=deserialize, **(connection_args or {})
             )
-            comm = yield gen.with_timeout(
+            comm = await gen.with_timeout(
                 timedelta(seconds=deadline - time()),
                 future,
                 quiet_exceptions=EnvironmentError,
@@ -222,7 +221,7 @@ def connect(addr, timeout=None, deserialize=True, connection_args=None):
         except EnvironmentError as e:
             error = str(e)
             if time() < deadline:
-                yield gen.sleep(0.01)
+                await gen.sleep(0.01)
                 logger.debug("sleeping on connect")
             else:
                 _raise(error)
@@ -231,7 +230,7 @@ def connect(addr, timeout=None, deserialize=True, connection_args=None):
         else:
             break
 
-    raise gen.Return(comm)
+    return comm
 
 
 def listen(addr, handle_comm, deserialize=True, connection_args=None):

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -7,7 +7,7 @@ import os
 import threading
 import weakref
 
-from tornado import gen, locks
+from tornado import locks
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 
@@ -180,12 +180,11 @@ class InProc(Comm):
     def peer_address(self):
         return self._peer_addr
 
-    @gen.coroutine
-    def read(self, deserializers="ignored"):
+    async def read(self, deserializers="ignored"):
         if self._closed:
             raise CommClosedError
 
-        msg = yield self._read_q.get()
+        msg = await self._read_q.get()
         if msg is _EOF:
             self._closed = True
             self._finalizer.detach()
@@ -193,20 +192,18 @@ class InProc(Comm):
 
         if self.deserialize:
             msg = nested_deserialize(msg)
-        raise gen.Return(msg)
+        return msg
 
-    @gen.coroutine
-    def write(self, msg, serializers=None, on_error=None):
+    async def write(self, msg, serializers=None, on_error=None):
         if self.closed():
             raise CommClosedError
 
         # Ensure we feed the queue in the same thread it is read from.
         self._write_loop.add_callback(self._write_q.put_nowait, msg)
 
-        raise gen.Return(1)
+        return 1
 
-    @gen.coroutine
-    def close(self):
+    async def close(self):
         self.abort()
 
     def abort(self):
@@ -288,8 +285,7 @@ class InProcConnector(Connector):
     def __init__(self, manager):
         self.manager = manager
 
-    @gen.coroutine
-    def connect(self, address, deserialize=True, **connection_args):
+    async def connect(self, address, deserialize=True, **connection_args):
         listener = self.manager.get_listener_for(address)
         if listener is None:
             raise IOError("no endpoint for inproc address %r" % (address,))
@@ -305,7 +301,7 @@ class InProcConnector(Connector):
         # Wait for connection acknowledgement
         # (do not pretend we're connected if the other comm never gets
         #  created, for example if the listener was stopped in the meantime)
-        yield conn_req.conn_event.wait()
+        await conn_req.conn_event.wait()
 
         comm = InProc(
             local_addr="inproc://" + conn_req.c_addr,
@@ -315,7 +311,7 @@ class InProcConnector(Connector):
             write_loop=listener.loop,
             deserialize=deserialize,
         )
-        raise gen.Return(comm)
+        return comm
 
 
 class InProcBackend(Backend):

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -246,10 +246,9 @@ class InProcListener(Listener):
         self.deserialize = deserialize
         self.listen_q = Queue()
 
-    @gen.coroutine
-    def _listen(self):
+    async def _listen(self):
         while True:
-            conn_req = yield self.listen_q.get()
+            conn_req = await self.listen_q.get()
             if conn_req is None:
                 break
             comm = InProc(
@@ -262,7 +261,7 @@ class InProcListener(Listener):
             )
             # Notify connector
             conn_req.c_loop.add_callback(conn_req.conn_event.set)
-            self.comm_handler(comm)
+            IOLoop.current().add_callback(self.comm_handler, comm)
 
     def connect_threadsafe(self, conn_req):
         self.loop.add_callback(self.listen_q.put_nowait, conn_req)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -13,7 +13,7 @@ except ImportError:
 
 import dask
 import tornado
-from tornado import gen, netutil
+from tornado import netutil
 from tornado.iostream import StreamClosedError, IOStream
 from tornado.tcpclient import TCPClient
 from tornado.tcpserver import TCPServer
@@ -184,16 +184,15 @@ class TCP(Comm):
     def peer_address(self):
         return self._peer_addr
 
-    @gen.coroutine
-    def read(self, deserializers=None):
+    async def read(self, deserializers=None):
         stream = self.stream
         if stream is None:
             raise CommClosedError
 
         try:
-            n_frames = yield stream.read_bytes(8)
+            n_frames = await stream.read_bytes(8)
             n_frames = struct.unpack("Q", n_frames)[0]
-            lengths = yield stream.read_bytes(8 * n_frames)
+            lengths = await stream.read_bytes(8 * n_frames)
             lengths = struct.unpack("Q" * n_frames, lengths)
 
             frames = []
@@ -201,10 +200,10 @@ class TCP(Comm):
                 if length:
                     if PY3 and self._iostream_has_read_into:
                         frame = bytearray(length)
-                        n = yield stream.read_into(frame)
+                        n = await stream.read_into(frame)
                         assert n == length, (n, length)
                     else:
-                        frame = yield stream.read_bytes(length)
+                        frame = await stream.read_bytes(length)
                 else:
                     frame = b""
                 frames.append(frame)
@@ -214,23 +213,22 @@ class TCP(Comm):
                 convert_stream_closed_error(self, e)
         else:
             try:
-                msg = yield from_frames(
+                msg = await from_frames(
                     frames, deserialize=self.deserialize, deserializers=deserializers
                 )
             except EOFError:
                 # Frames possibly garbled or truncated by communication error
                 self.abort()
                 raise CommClosedError("aborted stream on truncated data")
-            raise gen.Return(msg)
+            return msg
 
-    @gen.coroutine
-    def write(self, msg, serializers=None, on_error="message"):
+    async def write(self, msg, serializers=None, on_error="message"):
         stream = self.stream
         bytes_since_last_yield = 0
         if stream is None:
             raise CommClosedError
 
-        frames = yield to_frames(
+        frames = await to_frames(
             msg,
             serializers=serializers,
             on_error=on_error,
@@ -257,7 +255,7 @@ class TCP(Comm):
                     future = stream.write(frame)
                     bytes_since_last_yield += nbytes(frame)
                     if bytes_since_last_yield > 32e6:
-                        yield future
+                        await future
                         bytes_since_last_yield = 0
         except StreamClosedError as e:
             stream = None
@@ -268,16 +266,15 @@ class TCP(Comm):
             else:
                 raise
 
-        raise gen.Return(sum(map(nbytes, frames)))
+        return sum(map(nbytes, frames))
 
-    @gen.coroutine
-    def close(self):
+    async def close(self):
         stream, self.stream = self.stream, None
         if stream is not None and not stream.closed():
             try:
                 # Flush the stream's write buffer by waiting for a last write.
                 if stream.writing():
-                    yield stream.write(b"")
+                    await stream.write(b"")
                 stream.socket.shutdown(socket.SHUT_RDWR)
             except EnvironmentError:
                 pass
@@ -348,14 +345,13 @@ class BaseTCPConnector(Connector, RequireEncryptionMixin):
         _resolver = None
     client = TCPClient(resolver=_resolver)
 
-    @gen.coroutine
-    def connect(self, address, deserialize=True, **connection_args):
+    async def connect(self, address, deserialize=True, **connection_args):
         self._check_encryption(address, connection_args)
         ip, port = parse_host_port(address)
         kwargs = self._get_connect_args(**connection_args)
 
         try:
-            stream = yield BaseTCPConnector.client.connect(
+            stream = await BaseTCPConnector.client.connect(
                 ip, port, max_buffer_size=MAX_BUFFER_SIZE, **kwargs
             )
 
@@ -371,8 +367,8 @@ class BaseTCPConnector(Connector, RequireEncryptionMixin):
             convert_stream_closed_error(self, e)
 
         local_address = self.prefix + get_stream_address(stream)
-        raise gen.Return(
-            self.comm_class(stream, local_address, self.prefix + address, deserialize)
+        return self.comm_class(
+            stream, local_address, self.prefix + address, deserialize
         )
 
 
@@ -442,17 +438,16 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         if self.tcp_server is None:
             raise ValueError("invalid operation on non-started TCPListener")
 
-    @gen.coroutine
-    def _handle_stream(self, stream, address):
+    async def _handle_stream(self, stream, address):
         address = self.prefix + unparse_host_port(*address[:2])
-        stream = yield self._prepare_stream(stream, address)
+        stream = await self._prepare_stream(stream, address)
         if stream is None:
             # Preparation failed
             return
         logger.debug("Incoming connection from %r to %r", address, self.contact_address)
         local_address = self.prefix + get_stream_address(stream)
         comm = self.comm_class(stream, local_address, address, self.deserialize)
-        yield self.comm_handler(comm)
+        await self.comm_handler(comm)
 
     def get_host_port(self):
         """
@@ -490,9 +485,8 @@ class TCPListener(BaseTCPListener):
     def _get_server_args(self, **connection_args):
         return {}
 
-    @gen.coroutine
-    def _prepare_stream(self, stream, address):
-        raise gen.Return(stream)
+    async def _prepare_stream(self, stream, address):
+        return stream
 
 
 class TLSListener(BaseTCPListener):
@@ -504,10 +498,9 @@ class TLSListener(BaseTCPListener):
         ctx = _expect_tls_context(connection_args)
         return {"ssl_options": ctx}
 
-    @gen.coroutine
-    def _prepare_stream(self, stream, address):
+    async def _prepare_stream(self, stream, address):
         try:
-            yield stream.wait_for_handshake()
+            await stream.wait_for_handshake()
         except EnvironmentError as e:
             # The handshake went wrong, log and ignore
             logger.warning(
@@ -517,7 +510,7 @@ class TLSListener(BaseTCPListener):
                 getattr(e, "real_error", None) or e,
             )
         else:
-            raise gen.Return(stream)
+            return stream
 
 
 class BaseTCPBackend(Backend):

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -800,14 +800,14 @@ def test_inproc_comm_closed_explicit_2():
             assert comm.closed()
             listener_errors.append(True)
         else:
-            comm.close()
+            yield comm.close()
 
     listener = listen("inproc://", handle_comm)
     listener.start()
     contact_addr = listener.contact_address
 
     comm = yield connect(contact_addr)
-    comm.close()
+    yield comm.close()
     assert comm.closed()
     start = time()
     while len(listener_errors) < 1:
@@ -821,7 +821,7 @@ def test_inproc_comm_closed_explicit_2():
         yield comm.write("foo")
 
     comm = yield connect(contact_addr)
-    comm.write("foo")
+    yield comm.write("foo")
     with pytest.raises(CommClosedError):
         yield comm.read()
     with pytest.raises(CommClosedError):
@@ -829,15 +829,15 @@ def test_inproc_comm_closed_explicit_2():
     assert comm.closed()
 
     comm = yield connect(contact_addr)
-    comm.write("foo")
+    yield comm.write("foo")
 
     start = time()
     while not comm.closed():
         yield gen.sleep(0.01)
         assert time() < start + 2
 
-    comm.close()
-    comm.close()
+    yield comm.close()
+    yield comm.close()
 
 
 #

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -660,10 +660,12 @@ class rpc(object):
 
         for comm in list(self.comms):
             if comm and not comm.closed():
-                IOLoop.current().add_callback(_close_comm, comm)
+                # IOLoop.current().add_callback(_close_comm, comm)
+                asyncio.ensure_future(_close_comm(comm))
         for comm in list(self._created):
             if comm and not comm.closed():
-                IOLoop.current().add_callback(_close_comm, comm)
+                # IOLoop.current().add_callback(_close_comm, comm)
+                asyncio.ensure_future(_close_comm(comm))
         self.comms.clear()
 
     def __getattr__(self, key):

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -30,6 +30,7 @@ from .metrics import time
 from . import profile
 from .system_monitor import SystemMonitor
 from .utils import (
+    is_coroutine_function,
     get_traceback,
     truncate_exception,
     ignoring,
@@ -472,10 +473,13 @@ class Server(object):
                                 closed = True
                                 break
                             handler = self.stream_handlers[op]
-                            self.loop.add_callback(handler, **merge(extra, msg))
-                            await gen.sleep(0)
+                            if is_coroutine_function(handler):
+                                self.loop.add_callback(handler, **merge(extra, msg))
+                            else:
+                                handler(**merge(extra, msg))
                         else:
                             logger.error("odd message %s", msg)
+                    await gen.sleep(0)
 
                 for func in every_cycle:
                     func()

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -407,7 +407,7 @@ class Server(object):
                     logger.debug("Calling into handler %s", handler.__name__)
                     try:
                         result = handler(comm, **msg)
-                        if type(result) is gen.Future:
+                        if hasattr(result, "__await__"):
                             self._ongoing_coroutines.add(result)
                             result = yield result
                     except (CommClosedError, CancelledError) as e:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -665,12 +665,10 @@ class rpc(object):
             if comm and not comm.closed():
                 # IOLoop.current().add_callback(_close_comm, comm)
                 task = asyncio.ensure_future(_close_comm(comm))
-                breakpoint
         for comm in list(self._created):
             if comm and not comm.closed():
                 # IOLoop.current().add_callback(_close_comm, comm)
                 task = asyncio.ensure_future(_close_comm(comm))
-                breakpoint()
         self.comms.clear()
 
     def __getattr__(self, key):

--- a/distributed/dashboard/components.py
+++ b/distributed/dashboard/components.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import asyncio
 from bisect import bisect
 from operator import add
 from time import time
@@ -549,8 +550,7 @@ class ProfileTimePlot(DashboardComponent):
 
     @without_property_validation
     def trigger_update(self, update_metadata=True):
-        @gen.coroutine
-        def cb():
+        async def cb():
             with log_errors():
                 prof = self.server.get_profile(
                     key=self.key, start=self.start, stop=self.stop
@@ -560,7 +560,7 @@ class ProfileTimePlot(DashboardComponent):
                 else:
                     metadata = None
                 if isinstance(prof, gen.Future):
-                    prof, metadata = yield [prof, metadata]
+                    prof, metadata = await asyncio.gather(prof, metadata)
                 self.doc().add_next_tick_callback(lambda: self.update(prof, metadata))
 
         self.server.loop.add_callback(cb)

--- a/distributed/dashboard/scheduler_html.py
+++ b/distributed/dashboard/scheduler_html.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from dask.utils import format_bytes
 import toolz
 from tornado import escape
-from tornado import gen
 
 from ..utils import log_errors, format_time
 from .proxy import GlobalProxyHandler
@@ -59,22 +58,20 @@ class Logs(RequestHandler):
 
 
 class WorkerLogs(RequestHandler):
-    @gen.coroutine
-    def get(self, worker):
+    async def get(self, worker):
         with log_errors():
             worker = escape.url_unescape(worker)
-            logs = yield self.server.get_worker_logs(workers=[worker])
+            logs = await self.server.get_worker_logs(workers=[worker])
             logs = logs[worker]
             self.render("logs.html", title="Logs: " + worker, logs=logs, **self.extra)
 
 
 class WorkerCallStacks(RequestHandler):
-    @gen.coroutine
-    def get(self, worker):
+    async def get(self, worker):
         with log_errors():
             worker = escape.url_unescape(worker)
             keys = self.server.processing[worker]
-            call_stack = yield self.server.get_call_stack(keys=keys)
+            call_stack = await self.server.get_call_stack(keys=keys)
             self.render(
                 "call-stack.html",
                 title="Call Stacks: " + worker,
@@ -84,11 +81,10 @@ class WorkerCallStacks(RequestHandler):
 
 
 class TaskCallStack(RequestHandler):
-    @gen.coroutine
-    def get(self, key):
+    async def get(self, key):
         with log_errors():
             key = escape.url_unescape(key)
-            call_stack = yield self.server.get_call_stack(keys=[key])
+            call_stack = await self.server.get_call_stack(keys=[key])
             if not call_stack:
                 self.write(
                     "<p>Task not actively running. "

--- a/distributed/dashboard/tests/test_components.py
+++ b/distributed/dashboard/tests/test_components.py
@@ -25,7 +25,7 @@ def test_basic(Component):
     assert isinstance(c.root, Model)
 
 
-@gen_cluster(client=True, check_new_threads=False)
+@gen_cluster(client=True, clean_kwarg={"threads": False})
 def test_profile_plot(c, s, a, b):
     p = ProfilePlot()
     assert not p.source.data["left"]
@@ -34,7 +34,7 @@ def test_profile_plot(c, s, a, b):
     assert len(p.source.data["left"]) >= 1
 
 
-@gen_cluster(client=True, check_new_threads=False)
+@gen_cluster(client=True, clean_kwarg={"threads": False})
 def test_profile_time_plot(c, s, a, b):
     from bokeh.io import curdoc
 

--- a/distributed/dashboard/tests/test_components.py
+++ b/distributed/dashboard/tests/test_components.py
@@ -25,7 +25,7 @@ def test_basic(Component):
     assert isinstance(c.root, Model)
 
 
-@gen_cluster(client=True, clean_kwarg={"threads": False})
+@gen_cluster(client=True, clean_kwargs={"threads": False})
 def test_profile_plot(c, s, a, b):
     p = ProfilePlot()
     assert not p.source.data["left"]
@@ -34,7 +34,7 @@ def test_profile_plot(c, s, a, b):
     assert len(p.source.data["left"]) >= 1
 
 
-@gen_cluster(client=True, clean_kwarg={"threads": False})
+@gen_cluster(client=True, clean_kwargs={"threads": False})
 def test_profile_time_plot(c, s, a, b):
     from bokeh.io import curdoc
 

--- a/distributed/dashboard/tests/test_scheduler_bokeh_html.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh_html.py
@@ -73,7 +73,7 @@ def test_prefix(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    check_new_threads=False,
+    clean_kwarg={"threads": False},
     scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}},
 )
 def test_prometheus(c, s, a, b):
@@ -98,7 +98,7 @@ def test_prometheus(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    check_new_threads=False,
+    clean_kwarg={"threads": False},
     scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}},
 )
 def test_health(c, s, a, b):

--- a/distributed/dashboard/tests/test_scheduler_bokeh_html.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh_html.py
@@ -73,7 +73,7 @@ def test_prefix(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    clean_kwarg={"threads": False},
+    clean_kwargs={"threads": False},
     scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}},
 )
 def test_prometheus(c, s, a, b):
@@ -98,7 +98,7 @@ def test_prometheus(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    clean_kwarg={"threads": False},
+    clean_kwargs={"threads": False},
     scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}},
 )
 def test_health(c, s, a, b):

--- a/distributed/dashboard/tests/test_worker_bokeh.py
+++ b/distributed/dashboard/tests/test_worker_bokeh.py
@@ -169,7 +169,7 @@ def test_CommunicatingStream(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    check_new_threads=False,
+    clean_kwarg={"threads": False},
     worker_kwargs={"services": {("dashboard", 0): BokehWorker}},
 )
 def test_prometheus(c, s, a, b):

--- a/distributed/dashboard/tests/test_worker_bokeh.py
+++ b/distributed/dashboard/tests/test_worker_bokeh.py
@@ -169,7 +169,7 @@ def test_CommunicatingStream(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    clean_kwarg={"threads": False},
+    clean_kwargs={"threads": False},
     worker_kwargs={"services": {("dashboard", 0): BokehWorker}},
 )
 def test_prometheus(c, s, a, b):

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -272,7 +272,7 @@ class SpecCluster(Cluster):
 
     def __del__(self):
         if self.status != "closed":
-            self.close()
+            self.loop.add_callback(self.close)
 
     def __enter__(self):
         self.sync(self._correct_state)

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -133,7 +133,7 @@ class SpecCluster(Cluster):
         self.loop = self._loop_runner.loop
 
         self.scheduler = self.scheduler_spec["cls"](
-            loop=self.loop, **self.scheduler_spec["options"]
+            loop=self.loop, **self.scheduler_spec.get("options", {})
         )
         self.status = "created"
         self._instances.add(self)

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -401,8 +401,9 @@ def test_silent_startup():
         from time import sleep
         from distributed import LocalCluster
 
-        with LocalCluster(1, dashboard_address=None, scheduler_port=0):
-            sleep(1.5)
+        if __name__ == "__main__":
+            with LocalCluster(1, dashboard_address=None, scheduler_port=0):
+                sleep(1.5)
         """
 
     out = subprocess.check_output(

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,4 +1,4 @@
-from dask.distributed import SpecCluster, Worker, Client, Scheduler
+from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
 from distributed.deploy.spec import close_clusters
 from distributed.utils_test import loop  # noqa: F401
 import pytest
@@ -140,3 +140,14 @@ async def test_new_worker_spec():
         cluster.scale(3)
         for i in range(3):
             assert cluster.worker_spec[i]["options"]["nthreads"] == i + 1
+
+
+@pytest.mark.asyncio
+async def test_nanny_port():
+    scheduler = {"cls": Scheduler}
+    workers = {0: {"cls": Nanny, "options": {"port": 9200}}}
+
+    async with SpecCluster(
+        scheduler=scheduler, workers=workers, asynchronous=True
+    ) as cluster:
+        pass

--- a/distributed/diagnostics/eventstream.py
+++ b/distributed/diagnostics/eventstream.py
@@ -2,8 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 
-from tornado import gen
-
 from .plugin import SchedulerPlugin
 
 from ..core import connect, coerce_to_address
@@ -37,8 +35,7 @@ def teardown(scheduler, es):
     scheduler.remove_plugin(es)
 
 
-@gen.coroutine
-def eventstream(address, interval):
+async def eventstream(address, interval):
     """ Open a TCP connection to scheduler, receive batched task messages
 
     The messages coming back are lists of dicts.  Each dict is of the following
@@ -59,14 +56,14 @@ def eventstream(address, interval):
 
     Examples
     --------
-    >>> stream = yield eventstream('127.0.0.1:8786', 0.100)  # doctest: +SKIP
-    >>> print(yield read(stream))  # doctest: +SKIP
+    >>> stream = await eventstream('127.0.0.1:8786', 0.100)  # doctest: +SKIP
+    >>> print(await read(stream))  # doctest: +SKIP
     [{'key': 'x', 'status': 'OK', 'worker': '192.168.0.1:54684', ...},
      {'key': 'y', 'status': 'error', 'worker': '192.168.0.1:54684', ...}]
     """
     address = coerce_to_address(address)
-    comm = yield connect(address)
-    yield comm.write(
+    comm = await connect(address)
+    await comm.write(
         {
             "op": "feed",
             "setup": dumps_function(EventStream),
@@ -75,4 +72,4 @@ def eventstream(address, interval):
             "teardown": dumps_function(teardown),
         }
     )
-    raise gen.Return(comm)
+    return comm

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -74,12 +74,11 @@ class Progress(SchedulerPlugin):
         self.status = None
         self.extra = {}
 
-    @gen.coroutine
-    def setup(self):
+    async def setup(self):
         keys = self.keys
 
         while not keys.issubset(self.scheduler.tasks):
-            yield gen.sleep(0.05)
+            await gen.sleep(0.05)
 
         tasks = [self.scheduler.tasks[k] for k in keys]
 
@@ -163,12 +162,11 @@ class MultiProgress(Progress):
             self, keys, scheduler, minimum=minimum, dt=dt, complete=complete
         )
 
-    @gen.coroutine
-    def setup(self):
+    async def setup(self):
         keys = self.keys
 
         while not keys.issubset(self.scheduler.tasks):
-            yield gen.sleep(0.05)
+            await gen.sleep(0.05)
 
         tasks = [self.scheduler.tasks[k] for k in keys]
 

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division, absolute_import
 import logging
 
 from toolz import valmap, merge
-from tornado import gen
 
 from .progress import AllProgress
 
@@ -26,8 +25,7 @@ def counts(scheduler, allprogress):
     )
 
 
-@gen.coroutine
-def progress_stream(address, interval):
+async def progress_stream(address, interval):
     """ Open a TCP connection to scheduler, receive progress messages
 
     The messages coming back are dicts containing counts of key groups::
@@ -42,12 +40,12 @@ def progress_stream(address, interval):
 
     Examples
     --------
-    >>> stream = yield eventstream('127.0.0.1:8786', 0.100)  # doctest: +SKIP
-    >>> print(yield read(stream))  # doctest: +SKIP
+    >>> stream = await eventstream('127.0.0.1:8786', 0.100)  # doctest: +SKIP
+    >>> print(await read(stream))  # doctest: +SKIP
     """
     address = coerce_to_address(address)
-    comm = yield connect(address)
-    yield comm.write(
+    comm = await connect(address)
+    await comm.write(
         {
             "op": "feed",
             "setup": dumps_function(AllProgress),
@@ -56,7 +54,7 @@ def progress_stream(address, interval):
             "teardown": dumps_function(Scheduler.remove_plugin),
         }
     )
-    raise gen.Return(comm)
+    return comm
 
 
 def nbytes_bar(nbytes):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -512,7 +512,7 @@ class WorkerProcess(object):
             assert r is not None
             if r != 0:
                 msg = self._death_message(self.process.pid, r)
-                logger.warning(msg)
+                logger.info(msg)
             self.status = "stopped"
             self.stopped.set()
             # Release resources

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -191,8 +191,7 @@ class Nanny(ServerNode):
     def __repr__(self):
         return "<Nanny: %s, threads: %d>" % (self.worker_address, self.nthreads)
 
-    @gen.coroutine
-    def _unregister(self, timeout=10):
+    async def _unregister(self, timeout=10):
         if self.process is None:
             return
         worker_address = self.process.worker_address
@@ -206,7 +205,7 @@ class Nanny(ServerNode):
             RPCClosed,
         )
         try:
-            yield gen.with_timeout(
+            await gen.with_timeout(
                 timedelta(seconds=timeout),
                 self.scheduler.unregister(address=self.worker_address),
                 quiet_exceptions=allowed_errors,
@@ -222,26 +221,24 @@ class Nanny(ServerNode):
     def worker_dir(self):
         return None if self.process is None else self.process.worker_dir
 
-    @gen.coroutine
-    def start(self):
+    async def start(self):
         """ Start nanny, start local process, start watching """
         self.listen(self._start_address, listen_args=self.listen_args)
         self.ip = get_address_host(self.address)
 
         logger.info("        Start Nanny at: %r", self.address)
-        response = yield self.instantiate()
+        response = await self.instantiate()
         if response == "running":
             assert self.worker_address
             self.status = "running"
         else:
-            yield self.close()
+            await self.close()
 
         self.start_periodic_callbacks()
 
         return self
 
-    @gen.coroutine
-    def kill(self, comm=None, timeout=2):
+    async def kill(self, comm=None, timeout=2):
         """ Kill the local worker process
 
         Blocks until both the process is down and the scheduler is properly
@@ -249,13 +246,12 @@ class Nanny(ServerNode):
         """
         self.auto_restart = False
         if self.process is None:
-            raise gen.Return("OK")
+            return "OK"
 
         deadline = self.loop.time() + timeout
-        yield self.process.kill(timeout=0.8 * (deadline - self.loop.time()))
+        await self.process.kill(timeout=0.8 * (deadline - self.loop.time()))
 
-    @gen.coroutine
-    def instantiate(self, comm=None):
+    async def instantiate(self, comm=None):
         """ Start a local worker process
 
         Blocks until the process is up and the scheduler is properly informed
@@ -292,7 +288,7 @@ class Nanny(ServerNode):
                 worker_kwargs=worker_kwargs,
                 worker_start_args=(start_arg,),
                 silence_logs=self.silence_logs,
-                on_exit=self._on_exit,
+                on_exit=self._on_exit_sync,
                 worker=self.Worker,
                 env=self.env,
             )
@@ -300,11 +296,11 @@ class Nanny(ServerNode):
         self.auto_restart = True
         if self.death_timeout:
             try:
-                result = yield gen.with_timeout(
+                result = await gen.with_timeout(
                     timedelta(seconds=self.death_timeout), self.process.start()
                 )
             except gen.TimeoutError:
-                yield self.close(timeout=self.death_timeout)
+                await self.close(timeout=self.death_timeout)
                 logger.exception(
                     "Timed out connecting Nanny '%s' to scheduler '%s'",
                     self,
@@ -313,26 +309,24 @@ class Nanny(ServerNode):
                 raise
 
         else:
-            result = yield self.process.start()
-        raise gen.Return(result)
+            result = await self.process.start()
+        return result
 
-    @gen.coroutine
-    def restart(self, comm=None, timeout=2, executor_wait=True):
+    async def restart(self, comm=None, timeout=2, executor_wait=True):
         start = time()
 
-        @gen.coroutine
-        def _():
+        async def _():
             if self.process is not None:
-                yield self.kill()
-                yield self.instantiate()
+                await self.kill()
+                await self.instantiate()
 
         try:
-            yield gen.with_timeout(timedelta(seconds=timeout), _())
+            await gen.with_timeout(timedelta(seconds=timeout), _())
         except gen.TimeoutError:
             logger.error("Restart timed out, returning before finished")
-            raise gen.Return("timed out")
+            return "timed out"
         else:
-            raise gen.Return("OK")
+            return "OK"
 
     def memory_monitor(self):
         """ Track worker's memory.  Restart if it goes above terminate fraction """
@@ -360,21 +354,23 @@ class Nanny(ServerNode):
     def run(self, *args, **kwargs):
         return run(self, *args, **kwargs)
 
-    @gen.coroutine
-    def _on_exit(self, exitcode):
+    def _on_exit_sync(self, exitcode):
+        self.loop.add_callback(self._on_exit, exitcode)
+
+    async def _on_exit(self, exitcode):
         if self.status not in ("closing", "closed"):
             try:
-                yield self.scheduler.unregister(address=self.worker_address)
+                await self.scheduler.unregister(address=self.worker_address)
             except (EnvironmentError, CommClosedError):
                 if not self.reconnect:
-                    yield self.close()
+                    await self.close()
                     return
 
             try:
                 if self.status not in ("closing", "closed", "closing-gracefully"):
                     if self.auto_restart:
                         logger.warning("Restarting worker")
-                        yield self.instantiate()
+                        await self.instantiate()
             except Exception:
                 logger.error(
                     "Failed to restart worker after its process exited", exc_info=True
@@ -440,17 +436,16 @@ class WorkerProcess(object):
         self.worker_dir = None
         self.worker_address = None
 
-    @gen.coroutine
-    def start(self):
+    async def start(self):
         """
         Ensure the worker process is started.
         """
         enable_proctitle_on_children()
         if self.status == "running":
-            raise gen.Return(self.status)
+            return self.status
         if self.status == "starting":
-            yield self.running.wait()
-            raise gen.Return(self.status)
+            await self.running.wait()
+            return self.status
 
         self.init_result_q = init_q = mp_context.Queue()
         self.child_stop_q = mp_context.Queue()
@@ -475,10 +470,10 @@ class WorkerProcess(object):
         self.running = Event()
         self.stopped = Event()
         self.status = "starting"
-        yield self.process.start()
-        msg = yield self._wait_until_connected(uid)
+        await self.process.start()
+        msg = await self._wait_until_connected(uid)
         if not msg:
-            raise gen.Return(self.status)
+            return self.status
         self.worker_address = msg["address"]
         self.worker_dir = msg["dir"]
         assert self.worker_address
@@ -487,7 +482,7 @@ class WorkerProcess(object):
 
         init_q.close()
 
-        raise gen.Return(self.status)
+        return self.status
 
     def _on_exit(self, proc):
         if proc is not self.process:
@@ -533,8 +528,7 @@ class WorkerProcess(object):
             if self.on_exit is not None:
                 self.on_exit(r)
 
-    @gen.coroutine
-    def kill(self, timeout=2, executor_wait=True):
+    async def kill(self, timeout=2, executor_wait=True):
         """
         Ensure the worker process is stopped, waiting at most
         *timeout* seconds before terminating it abruptly.
@@ -545,7 +539,7 @@ class WorkerProcess(object):
         if self.status == "stopped":
             return
         if self.status == "stopping":
-            yield self.stopped.wait()
+            await self.stopped.wait()
             return
         assert self.status in ("starting", "running")
         self.status = "stopping"
@@ -561,19 +555,18 @@ class WorkerProcess(object):
         self.child_stop_q.close()
 
         while process.is_alive() and loop.time() < deadline:
-            yield gen.sleep(0.05)
+            await gen.sleep(0.05)
 
         if process.is_alive():
             logger.warning(
                 "Worker process still alive after %d seconds, killing", timeout
             )
             try:
-                yield process.terminate()
+                await process.terminate()
             except Exception as e:
                 logger.error("Failed to kill worker process: %s", e)
 
-    @gen.coroutine
-    def _wait_until_connected(self, uid):
+    async def _wait_until_connected(self, uid):
         delay = 0.05
         while True:
             if self.status != "starting":
@@ -581,7 +574,7 @@ class WorkerProcess(object):
             try:
                 msg = self.init_result_q.get_nowait()
             except Empty:
-                yield gen.sleep(delay)
+                await gen.sleep(delay)
                 continue
 
             if msg["uid"] != uid:  # ensure that we didn't cross queues
@@ -591,10 +584,10 @@ class WorkerProcess(object):
                 logger.error(
                     "Failed while trying to start worker process: %s", msg["exception"]
                 )
-                yield self.process.join()
+                await self.process.join()
                 raise msg
             else:
-                raise gen.Return(msg)
+                return msg
 
     @classmethod
     def _run(
@@ -624,10 +617,9 @@ class WorkerProcess(object):
         loop.make_current()
         worker = Worker(**worker_kwargs)
 
-        @gen.coroutine
-        def do_stop(timeout=5, executor_wait=True):
+        async def do_stop(timeout=5, executor_wait=True):
             try:
-                yield worker.close(
+                await worker.close(
                     report=False,
                     nanny=False,
                     executor_wait=executor_wait,
@@ -656,13 +648,12 @@ class WorkerProcess(object):
         t.daemon = True
         t.start()
 
-        @gen.coroutine
-        def run():
+        async def run():
             """
             Try to start worker and inform parent of outcome.
             """
             try:
-                yield worker
+                await worker
             except Exception as e:
                 logger.exception("Failed to start worker")
                 init_result_q.put({"uid": uid, "exception": e})
@@ -673,7 +664,7 @@ class WorkerProcess(object):
                     {"address": worker.address, "dir": worker.local_dir, "uid": uid}
                 )
                 init_result_q.close()
-                yield worker.wait_until_closed()
+                await worker.wait_until_closed()
                 logger.info("Worker closed")
 
         try:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -396,13 +396,12 @@ class Nanny(ServerNode):
         """
         self.status = "closing-gracefully"
 
-    @gen.coroutine
-    def close(self, comm=None, timeout=5, report=None):
+    async def close(self, comm=None, timeout=5, report=None):
         """
         Close the worker process, stop all comms.
         """
         if self.status == "closing":
-            yield self.finished()
+            await self.finished()
             assert self.status == "closed"
 
         if self.status == "closed":
@@ -413,15 +412,15 @@ class Nanny(ServerNode):
         self.stop()
         try:
             if self.process is not None:
-                yield self.kill(timeout=timeout)
+                await self.kill(timeout=timeout)
         except Exception:
             pass
         self.process = None
         self.rpc.close()
         self.status = "closed"
         if comm:
-            yield comm.write("OK")
-        yield ServerNode.close(self)
+            await comm.write("OK")
+        await ServerNode.close(self)
 
 
 class WorkerProcess(object):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -600,8 +600,6 @@ class WorkerProcess(object):
         IOLoop.clear_instance()
         loop = IOLoop()
         loop.make_current()
-        print(worker_kwargs)
-        print(worker_start_args)
         worker = Worker(**worker_kwargs)
 
         @gen.coroutine

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -470,7 +470,13 @@ class WorkerProcess(object):
         self.running = Event()
         self.stopped = Event()
         self.status = "starting"
-        await self.process.start()
+        try:
+            await self.process.start()
+        except OSError:
+            logger.exception("Nanny failed to start process", exc_info=True)
+            self.process.terminate()
+            return
+
         msg = await self._wait_until_connected(uid)
         if not msg:
             return self.status

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -202,6 +202,9 @@ class Nanny(ServerNode):
     @gen.coroutine
     def _start(self, addr_or_port=0):
         """ Start nanny, start local process, start watching """
+        if self.status == "running":
+            return self
+
         addr_or_port = addr_or_port or self._start_address
 
         # XXX Factor this out

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -4,6 +4,7 @@ import warnings
 import logging
 
 from tornado.ioloop import IOLoop
+from tornado import gen
 import dask
 
 from .compatibility import unicode, finalize
@@ -159,3 +160,12 @@ class ServerNode(Node, Server):
 
     async def __aexit__(self, typ, value, traceback):
         await self.close()
+
+    def __await__(self):
+        if self.status == "running":
+            return gen.sleep(0).__await__()
+        else:
+            return self.start().__await__()
+
+    async def start(self):  # subclasses should implement this
+        return self

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -332,7 +332,7 @@ def _cleanup_dangling():
     for proc in list(_dangling):
         if proc.is_alive():
             try:
-                logger.warning("reaping stray process %s" % (proc,))
+                logger.info("reaping stray process %s" % (proc,))
                 proc.terminate()
             except OSError:
                 pass

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -308,10 +308,9 @@ class Pub(object):
             self.loop.add_callback(pubsub.publishers[name].add, self)
             finalize(self, pubsub.trigger_cleanup)
 
-    @gen.coroutine
-    def _start(self):
+    async def _start(self):
         if self.worker:
-            result = yield self.scheduler.pubsub_add_publisher(
+            result = await self.scheduler.pubsub_add_publisher(
                 name=self.name, worker=self.worker.address
             )
             pubsub = self.worker.extensions["pubsub"]
@@ -388,8 +387,7 @@ class Sub(object):
 
         finalize(self, pubsub.trigger_cleanup)
 
-    @gen.coroutine
-    def _get(self, timeout=None):
+    async def _get(self, timeout=None):
         if timeout is not None:
             timeout = datetime.timedelta(seconds=timeout)
         start = datetime.datetime.now()
@@ -400,9 +398,9 @@ class Sub(object):
                     raise gen.TimeoutError()
             else:
                 timeout2 = None
-            yield self.condition.wait(timeout=timeout2)
+            await self.condition.wait(timeout=timeout2)
 
-        raise gen.Return(self.buffer.popleft())
+        return self.buffer.popleft()
 
     __anext__ = _get
 

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -65,10 +65,9 @@ class QueueExtension(object):
             del self.client_refcount[name]
             futures = self.queues[name]._queue
             del self.queues[name]
-            self.scheduler.client_releases_keys(
-                keys=[d["value"] for d in futures if d["type"] == "Future"],
-                client="queue-%s" % name,
-            )
+            keys = [d["value"] for d in futures if d["type"] == "Future"]
+            if keys:
+                self.scheduler.client_releases_keys(keys=keys, client="queue-%s" % name)
 
     async def put(
         self, stream=None, name=None, key=None, data=None, client=None, timeout=None

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -5,8 +5,8 @@ import datetime
 import logging
 import uuid
 
-from tornado import gen
 import tornado.queues
+from tornado.locks import Event
 
 from .client import Future, _get_global_client, Client
 from .utils import tokey, sync, thread_state
@@ -49,6 +49,7 @@ class QueueExtension(object):
         self.scheduler.extensions["queues"] = self
 
     def create(self, stream=None, name=None, client=None, maxsize=0):
+        print("name", name)
         if name not in self.queues:
             self.queues[name] = tornado.queues.Queue(maxsize=maxsize)
             self.client_refcount[name] = 1
@@ -69,8 +70,7 @@ class QueueExtension(object):
                 client="queue-%s" % name,
             )
 
-    @gen.coroutine
-    def put(
+    async def put(
         self, stream=None, name=None, key=None, data=None, client=None, timeout=None
     ):
         if key is not None:
@@ -81,7 +81,7 @@ class QueueExtension(object):
             record = {"type": "msgpack", "value": data}
         if timeout is not None:
             timeout = datetime.timedelta(seconds=(timeout))
-        yield self.queues[name].put(record, timeout=timeout)
+        await self.queues[name].put(record, timeout=timeout)
 
     def future_release(self, name=None, key=None, client=None):
         self.future_refcount[name, key] -= 1
@@ -89,8 +89,7 @@ class QueueExtension(object):
             self.scheduler.client_releases_keys(keys=[key], client="queue-%s" % name)
             del self.future_refcount[name, key]
 
-    @gen.coroutine
-    def get(self, stream=None, name=None, client=None, timeout=None, batch=False):
+    async def get(self, stream=None, name=None, client=None, timeout=None, batch=False):
         def process(record):
             """ Add task status if known """
             if record["type"] == "Future":
@@ -111,7 +110,7 @@ class QueueExtension(object):
             out = []
             if batch is True:
                 while not q.empty():
-                    record = yield q.get()
+                    record = await q.get()
                     out.append(record)
             else:
                 if timeout is not None:
@@ -121,16 +120,16 @@ class QueueExtension(object):
                     )
                     raise NotImplementedError(msg)
                 for i in range(batch):
-                    record = yield q.get()
+                    record = await q.get()
                     out.append(record)
             out = [process(o) for o in out]
-            raise gen.Return(out)
+            return out
         else:
             if timeout is not None:
                 timeout = datetime.timedelta(seconds=timeout)
-            record = yield self.queues[name].get(timeout=timeout)
+            record = await self.queues[name].get(timeout=timeout)
             record = process(record)
-            raise gen.Return(record)
+            return record
 
     def qsize(self, stream=None, name=None, client=None):
         return self.queues[name].qsize()
@@ -168,12 +167,18 @@ class Queue(object):
     def __init__(self, name=None, client=None, maxsize=0):
         self.client = client or _get_global_client()
         self.name = name or "queue-" + uuid.uuid4().hex
+        self._event_started = Event()
         if self.client.asynchronous or getattr(
             thread_state, "on_event_loop_thread", False
         ):
-            self._started = self.client.scheduler.queue_create(
-                name=self.name, maxsize=maxsize
-            )
+
+            async def _create_queue():
+                await self.client.scheduler.queue_create(
+                    name=self.name, maxsize=maxsize
+                )
+                self._event_started.set()
+
+            self.client.loop.add_callback(_create_queue)
         else:
             sync(
                 self.client.loop,
@@ -181,24 +186,22 @@ class Queue(object):
                 name=self.name,
                 maxsize=maxsize,
             )
-            self._started = gen.moment
+            self._event_started.set()
 
     def __await__(self):
-        @gen.coroutine
-        def _():
-            yield self._started
-            raise gen.Return(self)
+        async def _():
+            await self._event_started.wait()
+            return self
 
         return _().__await__()
 
-    @gen.coroutine
-    def _put(self, value, timeout=None):
+    async def _put(self, value, timeout=None):
         if isinstance(value, Future):
-            yield self.client.scheduler.queue_put(
+            await self.client.scheduler.queue_put(
                 key=tokey(value.key), timeout=timeout, name=self.name
             )
         else:
-            yield self.client.scheduler.queue_put(
+            await self.client.scheduler.queue_put(
                 data=value, timeout=timeout, name=self.name
             )
 
@@ -224,9 +227,8 @@ class Queue(object):
         """ Current number of elements in the queue """
         return self.client.sync(self._qsize, **kwargs)
 
-    @gen.coroutine
-    def _get(self, timeout=None, batch=False):
-        resp = yield self.client.scheduler.queue_get(
+    async def _get(self, timeout=None, batch=False):
+        resp = await self.client.scheduler.queue_get(
             timeout=timeout, name=self.name, batch=batch
         )
 
@@ -248,12 +250,11 @@ class Queue(object):
         else:
             result = list(map(process, resp))
 
-        raise gen.Return(result)
+        return result
 
-    @gen.coroutine
-    def _qsize(self):
-        result = yield self.client.scheduler.queue_qsize(name=self.name)
-        raise gen.Return(result)
+    async def _qsize(self):
+        result = await self.client.scheduler.queue_qsize(name=self.name)
+        return result
 
     def close(self):
         if self.client.status == "running":  # TODO: can leave zombie futures

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2526,7 +2526,7 @@ class Scheduler(ServerNode):
                             self.transitions({key: "released"})
 
         self.log_event("all", {"action": "gather", "count": len(keys)})
-        raise gen.Return(result)
+        return result
 
     def clear_task_state(self):
         # XXX what about nested state such as ClientState.wants_what
@@ -2639,7 +2639,7 @@ class Scheduler(ServerNode):
             )
             comm.name = "Scheduler Broadcast"
             resp = await send_recv(comm, close=True, serializers=serializers, **msg)
-            raise gen.Return(resp)
+            return resp
 
         results = await All(
             [send_message(address) for address in addresses if address is not None]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -841,7 +841,7 @@ class Scheduler(ServerNode):
         idle_timeout=None,
         interface=None,
         host=None,
-        port=8786,
+        port=0,
         protocol=None,
         dashboard_address=None,
         **kwargs
@@ -1097,6 +1097,7 @@ class Scheduler(ServerNode):
             interface=interface,
             protocol=protocol,
             security=security,
+            default_port=self.default_port,
         )
 
         super(Scheduler, self).__init__(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1177,6 +1177,7 @@ class Scheduler(ServerNode):
         else:
             return ws.host, port
 
+    @gen.coroutine
     def start(self, addr_or_port=None, start_queues=True):
         """ Clear out old state and restart all running coroutines """
         enable_gc_diagnosis()
@@ -1239,16 +1240,8 @@ class Scheduler(ServerNode):
 
         setproctitle("dask-scheduler [%s]" % (self.address,))
 
-        return self.finished()
-
-    def __await__(self):
-        self.start()
-
-        @gen.coroutine
-        def _():
-            return self
-
-        return _().__await__()
+        yield self.finished()
+        return self
 
     @gen.coroutine
     def finished(self):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3216,7 +3216,7 @@ class Scheduler(ServerNode):
             if teardown:
                 teardown = pickle.loads(teardown)
             state = setup(self) if setup else None
-            if isinstance(state, gen.Future):
+            if hasattr(state, "__await__"):
                 state = await state
             try:
                 while self.status == "running":

--- a/distributed/tests/py3_test_pubsub.py
+++ b/distributed/tests/py3_test_pubsub.py
@@ -1,6 +1,7 @@
 from distributed import Pub, Sub
 from distributed.utils_test import gen_cluster
 
+import asyncio
 import toolz
 from tornado import gen
 import pytest
@@ -22,7 +23,7 @@ def test_basic(c, s, a, b):
         sub = Sub("a")
         return list(toolz.take(5, sub))
 
-    c.run(publish, workers=[a.address])
+    asyncio.ensure_future(c.run(publish, workers=[a.address]))
 
     tasks = [c.submit(f, i) for i in range(4)]
     results = yield c.gather(tasks)

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -238,7 +238,7 @@ def test_as_completed_with_results_no_raise_async(c, s, a, b):
     z = c.submit(inc, 1)
 
     ac = as_completed([x, y, z], with_results=True, raise_errors=False)
-    y.cancel()
+    c.loop.add_callback(y.cancel)
     first = yield ac.__anext__()
     second = yield ac.__anext__()
     third = yield ac.__anext__()

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -134,7 +134,7 @@ def test_close_closed():
         b.start(comm)
 
         b.send(123)
-        comm.close()  # external closing
+        yield comm.close()  # external closing
 
         yield b.close()
         assert "closed" in repr(b)
@@ -185,7 +185,7 @@ def test_stress():
         yield All([send(), recv()])
 
         assert L == list(range(0, 10000, 1))
-        comm.close()
+        yield comm.close()
 
 
 @gen.coroutine
@@ -222,7 +222,7 @@ def run_traffic_jam(nsends, nbytes):
 
         assert results == list(range(nsends))
 
-        comm.close()  # external closing
+        yield comm.close()  # external closing
         yield b.close()
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5343,13 +5343,13 @@ def test_de_serialization_none(s, a, b):
 
 @gen_cluster()
 def test_client_repr_closed(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
+    c = yield Client(s.address, asynchronous=True, dashboard_address=None)
     yield c.close()
     c._repr_html_()
 
 
 def test_client_repr_closed_sync(loop):
-    with Client(loop=loop, processes=False) as c:
+    with Client(loop=loop, processes=False, dashboard_address=None) as c:
         c.close()
         c._repr_html_()
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4616,9 +4616,9 @@ def test_threadsafe_get(c):
 
     from concurrent.futures import ThreadPoolExecutor
 
-    e = ThreadPoolExecutor(30)
-    results = list(e.map(f, range(30)))
-    assert results and all(results)
+    with ThreadPoolExecutor(30) as e:
+        results = list(e.map(f, range(30)))
+        assert results and all(results)
 
 
 @pytest.mark.slow

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3311,11 +3311,11 @@ def test_get_foo_lost_keys(c, s, u, v, w):
 @gen_cluster(
     client=True,
     Worker=Nanny,
-    check_new_threads=False,
     worker_kwargs={"death_timeout": "500ms"},
+    clean_kwargs={"processes": False, "threads": False},
 )
 def test_bad_tasks_fail(c, s, a, b):
-    f = c.submit(sys.exit, 1)
+    f = c.submit(sys.exit, 0)
     with pytest.raises(KilledWorker) as info:
         yield f
 
@@ -4031,7 +4031,7 @@ def test_distribute_tasks_by_nthreads(c, s, a, b):
     assert len(b.data) > 2 * len(a.data)
 
 
-@gen_cluster(client=True, check_new_threads=False)
+@gen_cluster(client=True, clean_kwargs={"threads": False})
 def test_add_done_callback(c, s, a, b):
     S = set()
 
@@ -5498,7 +5498,7 @@ def test_released_dependencies(c, s, a, b):
         assert result == 101
 
 
-@gen_cluster(client=True, check_new_threads=False)
+@gen_cluster(client=True, clean_kwargs={"threads": False})
 def test_profile_bokeh(c, s, a, b):
     pytest.importorskip("bokeh.plotting")
     from bokeh.model import Model

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division, absolute_import
 
-from operator import add
-
+import asyncio
 from collections import deque
 from concurrent.futures import CancelledError
 import gc
 import logging
+from operator import add
 import os
 import pickle
 import random
@@ -5578,7 +5578,7 @@ def test_instances(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_wait_for_workers(c, s, a, b):
-    future = c.wait_for_workers(n_workers=3)
+    future = asyncio.ensure_future(c.wait_for_workers(n_workers=3))
     yield gen.sleep(0.22)  # 2 chances
     assert not future.done()
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3486,7 +3486,7 @@ def test_scatter_raises_if_no_workers(c, s):
 @pytest.mark.slow
 def test_reconnect(loop):
     w = Worker("127.0.0.1", 9393, loop=loop)
-    w.start()
+    loop.add_callback(w.start)
 
     scheduler_cli = [
         "dask-scheduler",

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -39,8 +39,7 @@ def test_submit_after_failed_worker_sync(loop):
 
 @gen_cluster(client=True, timeout=60, active_rpc_timeout=10)
 def test_submit_after_failed_worker_async(c, s, a, b):
-    n = Nanny(s.address, nthreads=2, loop=s.loop)
-    n.start(0)
+    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
     while len(s.workers) < 3:
         yield gen.sleep(0.1)
 
@@ -315,8 +314,7 @@ def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
 @gen_cluster(client=True, timeout=60, active_rpc_timeout=10)
 def test_broken_worker_during_computation(c, s, a, b):
     s.allowed_failures = 100
-    n = Nanny(s.address, nthreads=2, loop=s.loop)
-    n.start(0)
+    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
 
     start = time()
     while len(s.nthreads) < 3:
@@ -374,8 +372,7 @@ def test_restart_during_computation(c, s, a, b):
 
 @gen_cluster(client=True, timeout=60)
 def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
-    n = Nanny(s.address, nthreads=2, loop=s.loop)
-    n.start(0)
+    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
 
     start = time()
     while len(s.nthreads) < 3:

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -13,7 +13,7 @@ from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)
 def test_lock(c, s, a, b):
-    c.set_metadata("locked", False)
+    yield c.set_metadata("locked", False)
 
     def f(x):
         client = get_client()

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -82,7 +82,7 @@ def test_nanny_process_failure(c, s):
     pid = n.pid
     assert pid is not None
     with ignoring(CommClosedError):
-        yield c._run(os._exit, 0, workers=[n.worker_address])
+        yield c.run(os._exit, 0, workers=[n.worker_address])
 
     start = time()
     while n.pid == pid:  # wait while process dies and comes back
@@ -90,6 +90,7 @@ def test_nanny_process_failure(c, s):
         assert time() - start < 5
 
     start = time()
+    yield gen.sleep(1)
     while not n.is_alive():  # wait while process comes back
         yield gen.sleep(0.01)
         assert time() - start < 5

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -229,8 +229,7 @@ def test_worker_uses_same_host_as_nanny(c, s):
 @gen_test()
 def test_scheduler_file():
     with tmpfile() as fn:
-        s = Scheduler(scheduler_file=fn)
-        s.start(8008)
+        s = yield Scheduler(scheduler_file=fn, port=8008)
         w = yield Nanny(scheduler_file=fn)
         assert set(s.workers) == {w.worker_address}
         yield w.close()

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -267,7 +267,7 @@ def test_nanny_timeout(c, s, a):
     Worker=Nanny,
     worker_kwargs={"memory_limit": 1e8},
     timeout=20,
-    check_new_threads=False,
+    clean_kwargs={"threads": False},
 )
 def test_nanny_terminate(c, s, a):
     from time import sleep

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 from toolz import valmap, first
 from tornado import gen
+from tornado.ioloop import IOLoop
 
 import dask
 from distributed import Nanny, rpc, Scheduler, Worker
@@ -320,7 +321,7 @@ def test_scheduler_address_config(c, s):
 def test_wait_for_scheduler():
     with captured_logger("distributed") as log:
         w = Nanny("127.0.0.1:44737")
-        w.start()
+        IOLoop.current().add_callback(w.start)
         yield gen.sleep(6)
         yield w.close()
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -216,8 +216,7 @@ def test_num_fds(s):
 @gen_cluster(client=True, nthreads=[])
 def test_worker_uses_same_host_as_nanny(c, s):
     for host in ["tcp://0.0.0.0", "tcp://127.0.0.2"]:
-        n = Nanny(s.address)
-        yield n._start(host)
+        n = yield Nanny(s.address, host=host)
 
         def func(dask_worker):
             return dask_worker.listener.listen_address

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -6,32 +6,34 @@ import dask
 from dask import delayed, persist
 
 from distributed.utils_test import gen_cluster, inc, slowinc, slowdec
-from distributed import wait
+from distributed import wait, Worker
 from distributed.utils import tokey
 
 
-@gen_cluster(client=True)
-def test_submit(c, s, a, b):
+@gen_cluster(client=True, ncores=[])
+async def test_submit(c, s):
     low = c.submit(inc, 1, priority=-1)
     futures = c.map(slowinc, range(10), delay=0.1)
     high = c.submit(inc, 2, priority=1)
-    yield wait(high)
-    assert all(s.processing.values())
-    assert s.tasks[low.key].state == "processing"
+    async with Worker(s.address, nthreads=1):
+        await wait(high)
+        assert all(s.processing.values())
+        assert s.tasks[low.key].state == "processing"
 
 
-@gen_cluster(client=True)
-def test_map(c, s, a, b):
+@gen_cluster(client=True, ncores=[])
+async def test_map(c, s):
     low = c.map(inc, [1, 2, 3], priority=-1)
     futures = c.map(slowinc, range(10), delay=0.1)
     high = c.map(inc, [4, 5, 6], priority=1)
-    yield wait(high)
-    assert all(s.processing.values())
-    assert s.tasks[low[0].key].state == "processing"
+    async with Worker(s.address, nthreads=1):
+        await wait(high)
+        assert all(s.processing.values())
+        assert s.tasks[low[0].key].state == "processing"
 
 
-@gen_cluster(client=True)
-def test_compute(c, s, a, b):
+@gen_cluster(client=True, nthreads=[])
+async def test_compute(c, s):
     da = pytest.importorskip("dask.array")
     x = da.random.random((10, 10), chunks=(5, 5))
     y = da.random.random((10, 10), chunks=(5, 5))
@@ -39,13 +41,14 @@ def test_compute(c, s, a, b):
     low = c.compute(x, priority=-1)
     futures = c.map(slowinc, range(10), delay=0.1)
     high = c.compute(y, priority=1)
-    yield wait(high)
-    assert all(s.processing.values())
-    assert s.tasks[tokey(low.key)].state in ("processing", "waiting")
+    async with Worker(s.address, nthreads=1):
+        await wait(high)
+        assert all(s.processing.values())
+        assert s.tasks[tokey(low.key)].state in ("processing", "waiting")
 
 
-@gen_cluster(client=True)
-def test_persist(c, s, a, b):
+@gen_cluster(client=True, nthreads=[])
+async def test_persist(c, s):
     da = pytest.importorskip("dask.array")
     x = da.random.random((10, 10), chunks=(5, 5))
     y = da.random.random((10, 10), chunks=(5, 5))
@@ -53,12 +56,13 @@ def test_persist(c, s, a, b):
     low = x.persist(priority=-1)
     futures = c.map(slowinc, range(10), delay=0.1)
     high = y.persist(priority=1)
-    yield wait(high)
-    assert all(s.processing.values())
-    assert all(
-        s.tasks[tokey(k)].state in ("processing", "waiting")
-        for k in flatten(low.__dask_keys__())
-    )
+    async with Worker(s.address, nthreads=1):
+        await wait(high)
+        assert all(s.processing.values())
+        assert all(
+            s.tasks[tokey(k)].state in ("processing", "waiting")
+            for k in flatten(low.__dask_keys__())
+        )
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -10,7 +10,7 @@ from distributed import wait, Worker
 from distributed.utils import tokey
 
 
-@gen_cluster(client=True, ncores=[])
+@gen_cluster(client=True, nthreads=[])
 async def test_submit(c, s):
     low = c.submit(inc, 1, priority=-1)
     futures = c.map(slowinc, range(10), delay=0.1)
@@ -21,7 +21,7 @@ async def test_submit(c, s):
         assert s.tasks[low.key].state == "processing"
 
 
-@gen_cluster(client=True, ncores=[])
+@gen_cluster(client=True, nthreads=[])
 async def test_map(c, s):
     low = c.map(inc, [1, 2, 3], priority=-1)
     futures = c.map(slowinc, range(10), delay=0.1)

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -223,7 +223,7 @@ def test_Future_knows_status_immediately(c, s, a, b):
 @gen_cluster(client=True)
 def test_erred_future(c, s, a, b):
     future = c.submit(div, 1, 0)
-    q = Queue()
+    q = yield Queue()
     yield q.put(future)
     yield gen.sleep(0.1)
     future2 = yield q.get()
@@ -236,10 +236,7 @@ def test_erred_future(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_close(c, s, a, b):
-    q = Queue()
-
-    while q.name not in s.extensions["queues"].queues:
-        yield gen.sleep(0.01)
+    q = yield Queue()
 
     q.close()
     q.close()
@@ -250,7 +247,7 @@ def test_close(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_timeout(c, s, a, b):
-    q = Queue("v", maxsize=1)
+    q = yield Queue("v", maxsize=1)
 
     start = time()
     with pytest.raises(gen.TimeoutError):

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -380,8 +380,8 @@ def test_full_collections(c, s, a, b):
 def test_collections_get(client, optimize_graph, s, a, b):
     da = pytest.importorskip("dask.array")
 
-    def f(dask_worker):
-        dask_worker.set_resources(**{"A": 1})
+    async def f(dask_worker):
+        await dask_worker.set_resources(**{"A": 1})
 
     client.run(f, workers=[a["address"]])
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -110,7 +110,7 @@ def test_decide_worker_with_many_independent_leaves(c, s, a, b):
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
 def test_decide_worker_with_restrictions(client, s, a, b, c):
     x = client.submit(inc, 1, workers=[a.address, b.address])
-    yield wait(x)
+    yield x
     assert x.key in a.data or x.key in b.data
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -256,7 +256,6 @@ def test_add_worker(s, a, b):
     w = Worker(s.address, nthreads=3)
     w.data["x-5"] = 6
     w.data["y"] = 1
-    yield w
 
     dsk = {("x-%d" % i): (inc, i) for i in range(10)}
     s.update_graph(
@@ -265,11 +264,8 @@ def test_add_worker(s, a, b):
         client="client",
         dependencies={k: set() for k in dsk},
     )
-
-    s.add_worker(
-        address=w.address, keys=list(w.data), nthreads=w.nthreads, services=s.services
-    )
-
+    s.validate_state()
+    yield w
     s.validate_state()
 
     assert w.ip in s.host_info
@@ -1172,7 +1168,7 @@ def test_correct_bad_time_estimate(c, s, *workers):
 
 
 @gen_test()
-def test_service_hosts():
+async def test_service_hosts():
     pytest.importorskip("bokeh")
     from distributed.dashboard import BokehScheduler
 
@@ -1184,25 +1180,20 @@ def test_service_hosts():
     ]:
         services = {("dashboard", port): BokehScheduler}
 
-        s = yield Scheduler(host=url, services=services)
-
-        sock = first(s.services["dashboard"].server._http._sockets.values())
-        if isinstance(expected, tuple):
-            assert sock.getsockname()[0] in expected
-        else:
-            assert sock.getsockname()[0] == expected
-        yield s.close()
+        async with Scheduler(host=url, services=services) as s:
+            sock = first(s.services["dashboard"].server._http._sockets.values())
+            if isinstance(expected, tuple):
+                assert sock.getsockname()[0] in expected
+            else:
+                assert sock.getsockname()[0] == expected
 
     port = ("127.0.0.1", 0)
     for url in ["tcp://0.0.0.0", "tcp://127.0.0.1", "tcp://127.0.0.1:38275"]:
         services = {("dashboard", port): BokehScheduler}
 
-        s = Scheduler(services=services)
-        yield s.start(url)
-
-        sock = first(s.services["dashboard"].server._http._sockets.values())
-        assert sock.getsockname()[0] == "127.0.0.1"
-        yield s.close()
+        async with Scheduler(services=services, host=url) as s:
+            sock = first(s.services["dashboard"].server._http._sockets.values())
+            assert sock.getsockname()[0] == "127.0.0.1"
 
 
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1184,8 +1184,7 @@ def test_service_hosts():
     ]:
         services = {("dashboard", port): BokehScheduler}
 
-        s = Scheduler(services=services)
-        yield s.start(url)
+        s = yield Scheduler(host=url, services=services)
 
         sock = first(s.services["dashboard"].server._http._sockets.values())
         if isinstance(expected, tuple):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -948,7 +948,7 @@ def test_worker_breaks_and_returns(c, s, a):
 
     yield wait(future)
 
-    a.batched_stream.comm.close()
+    yield a.batched_stream.comm.close()
 
     yield gen.sleep(0.1)
     start = time()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -621,14 +621,6 @@ def test_update_graph_culls(s, a, b):
     assert "z" not in s.dependencies
 
 
-@gen_cluster(nthreads=[])
-def test_add_worker_is_idempotent(s):
-    s.add_worker(address=alice, nthreads=1, resolve_address=False)
-    nthreads = dict(s.nthreads)
-    s.add_worker(address=alice, resolve_address=False)
-    assert s.nthreads == s.nthreads
-
-
 def test_io_loop(loop):
     s = Scheduler(loop=loop, validate=True)
     assert s.io_loop is loop
@@ -1146,11 +1138,13 @@ def test_scheduler_file():
 
 @pytest.mark.xfail(reason="")
 @gen_cluster(client=True, nthreads=[])
-def test_non_existent_worker(c, s):
+async def test_non_existent_worker(c, s):
     with dask.config.set({"distributed.comm.timeouts.connect": "100ms"}):
-        s.add_worker(address="127.0.0.1:5738", nthreads=2, nbytes={}, host_info={})
+        await s.add_worker(
+            address="127.0.0.1:5738", nthreads=2, nbytes={}, host_info={}
+        )
         futures = c.map(inc, range(10))
-        yield gen.sleep(0.300)
+        await gen.sleep(0.300)
         assert not s.workers
         assert all(ts.state == "no-worker" for ts in s.tasks.values())
 
@@ -1317,19 +1311,19 @@ def test_retries(c, s, a, b):
 
 @pytest.mark.xfail(reason="second worker also errant for some reason")
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3, timeout=5)
-def test_mising_data_errant_worker(c, s, w1, w2, w3):
+async def test_mising_data_errant_worker(c, s, w1, w2, w3):
     with dask.config.set({"distributed.comm.timeouts.connect": "1s"}):
         np = pytest.importorskip("numpy")
 
         x = c.submit(np.random.random, 10000000, workers=w1.address)
-        yield wait(x)
-        yield c.replicate(x, workers=[w1.address, w2.address])
+        await wait(x)
+        await c.replicate(x, workers=[w1.address, w2.address])
 
         y = c.submit(len, x, workers=w3.address)
         while not w3.tasks:
-            yield gen.sleep(0.001)
-        w1.close()
-        yield wait(y)
+            await gen.sleep(0.001)
+        await w1.close()
+        await wait(y)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -665,7 +665,7 @@ def test_scatter_no_workers(c, s):
     assert time() < start + 1.5
 
     w = Worker(s.address, nthreads=3)
-    yield [c.scatter(data={"y": 2}, timeout=5), w._start()]
+    yield [c.scatter(data={"y": 2}, timeout=5), w]
 
     assert w.data["y"] == 2
     yield w.close()

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -234,7 +234,7 @@ def test_dont_steal_host_restrictions(c, s, a, b):
     yield future
 
     futures = c.map(slowinc, range(100), delay=0.1, workers="127.0.0.1")
-    while len(a.task_state) < 10:
+    while len(a.task_state) + len(b.task_state) < 100:
         yield gen.sleep(0.01)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -254,7 +254,7 @@ def test_dont_steal_resource_restrictions(c, s, a, b):
     yield future
 
     futures = c.map(slowinc, range(100), delay=0.1, resources={"A": 1})
-    while len(a.task_state) < 10:
+    while len(a.task_state) + len(b.task_state) < 100:
         yield gen.sleep(0.01)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -108,11 +108,8 @@ def test_stress_creation_and_deletion(c, s):
     def create_and_destroy_worker(delay):
         start = time()
         while time() < start + 5:
-            n = Nanny(s.address, nthreads=2, loop=s.loop)
-            n.start(0)
-
+            n = yield Nanny(s.address, nthreads=2, loop=s.loop)
             yield gen.sleep(delay)
-
             yield n.close()
             print("Killed nanny")
 

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -14,7 +14,7 @@ from toolz import concat, sliding_window
 from distributed import Client, wait, Nanny
 from distributed.config import config
 from distributed.metrics import time
-from distributed.utils import All
+from distributed.utils import All, ignoring
 from distributed.utils_test import (
     gen_cluster,
     cluster,
@@ -126,7 +126,7 @@ def test_stress_scatter_death(c, s, *workers):
     s.allowed_failures = 1000
     np = pytest.importorskip("numpy")
     L = yield c.scatter([np.random.random(10000) for i in range(len(workers))])
-    yield c._replicate(L, n=2)
+    yield c.replicate(L, n=2)
 
     adds = [
         delayed(slowadd, pure=True)(
@@ -166,27 +166,10 @@ def test_stress_scatter_death(c, s, *workers):
         yield w.close()
         alive.remove(w)
 
-    try:
-        yield gen.with_timeout(timedelta(seconds=25), c._gather(futures))
-    except gen.TimeoutError:
-        ws = {w.address: w for w in workers if w.status != "closed"}
-        print(s.processing)
-        print(ws)
-        print(futures)
-        try:
-            worker = [w for w in ws.values() if w.waiting_for_data][0]
-        except Exception:
-            pass
-        if config.get("log-on-err"):
-            import pdb
+    with ignoring(CancelledError):
+        yield c.gather(futures)
 
-            pdb.set_trace()
-        else:
-            raise
-    except CancelledError:
-        pass
-    finally:
-        futures = None
+    futures = None
 
 
 def vsum(*args):

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -19,8 +19,8 @@ from distributed.utils_test import gen_tls_cluster, inc, double, slowinc, slowad
 def test_Queue(c, s, a, b):
     assert s.address.startswith("tls://")
 
-    x = Queue("x")
-    y = Queue("y")
+    x = yield Queue("x")
+    y = yield Queue("y")
 
     size = yield x.qsize()
     assert size == 0

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -13,6 +13,7 @@ from distributed import Scheduler, Worker, Client, config, default_client
 from distributed.core import rpc
 from distributed.metrics import time
 from distributed.utils_test import (  # noqa: F401
+    cleanup,
     cluster,
     gen_cluster,
     inc,
@@ -175,10 +176,10 @@ def test_tls_cluster(tls_client):
     assert tls_client.security
 
 
-def test_tls_scheduler(security, loop):
-    s = yield Scheduler(security=security, loop=loop, host="localhost")
-    assert s.address.startswith("tls")
-    yield s.close()
+@pytest.mark.asyncio
+async def test_tls_scheduler(security, cleanup):
+    async with Scheduler(security=security, host="localhost") as s:
+        assert s.address.startswith("tls")
 
 
 if sys.version_info >= (3, 5):

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -176,10 +176,9 @@ def test_tls_cluster(tls_client):
 
 
 def test_tls_scheduler(security, loop):
-    s = Scheduler(security=security, loop=loop)
-    s.start("localhost")
+    s = yield Scheduler(security=security, loop=loop, host="localhost")
     assert s.address.startswith("tls")
-    s.close()
+    yield s.close()
 
 
 if sys.version_info >= (3, 5):

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1051,7 +1051,14 @@ def test_statistical_profiling(c, s, a, b):
 
 @pytest.mark.slow
 @nodebug
-@gen_cluster(client=True, timeout=20)
+@gen_cluster(
+    client=True,
+    timeout=30,
+    config={
+        "distributed.worker.profile.interval": "1ms",
+        "distributed.worker.profile.cycle": "100ms",
+    },
+)
 def test_statistical_profiling_2(c, s, a, b):
     da = pytest.importorskip("dask.array")
     while True:

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -978,20 +978,23 @@ def test_service_hosts_match_worker(s):
 
     services = {("dashboard", ":0"): BokehWorker}
 
-    w = Worker(s.address, services={("dashboard", ":0"): BokehWorker})
-    yield w._start("tcp://0.0.0.0")
+    w = yield Worker(
+        s.address, services={("dashboard", ":0"): BokehWorker}, host="tcp://0.0.0.0"
+    )
     sock = first(w.services["dashboard"].server._http._sockets.values())
     assert sock.getsockname()[0] in ("::", "0.0.0.0")
     yield w.close()
 
-    w = Worker(s.address, services={("dashboard", ":0"): BokehWorker})
-    yield w._start("tcp://127.0.0.1")
+    w = yield Worker(
+        s.address, services={("dashboard", ":0"): BokehWorker}, host="tcp://127.0.0.1"
+    )
     sock = first(w.services["dashboard"].server._http._sockets.values())
     assert sock.getsockname()[0] in ("::", "0.0.0.0")
     yield w.close()
 
-    w = Worker(s.address, services={("dashboard", 0): BokehWorker})
-    yield w._start("tcp://127.0.0.1")
+    w = yield Worker(
+        s.address, services={("dashboard", 0): BokehWorker}, host="tcp://127.0.0.1"
+    )
     sock = first(w.services["dashboard"].server._http._sockets.values())
     assert sock.getsockname()[0] == "127.0.0.1"
     yield w.close()
@@ -1004,8 +1007,7 @@ def test_start_services(s):
 
     services = {("dashboard", ":1234"): BokehWorker}
 
-    w = Worker(s.address, services=services)
-    yield w._start()
+    w = yield Worker(s.address, services=services)
 
     assert w.services["dashboard"].server.port == 1234
     yield w.close()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -501,7 +501,8 @@ def test_memory_limit_auto():
     assert isinstance(a.memory_limit, Number)
     assert isinstance(b.memory_limit, Number)
 
-    assert a.memory_limit < b.memory_limit
+    if multiprocessing.cpu_count() > 1:
+        assert a.memory_limit < b.memory_limit
 
     assert c.memory_limit == d.memory_limit
 

--- a/distributed/tests/test_worker_plugins.py
+++ b/distributed/tests/test_worker_plugins.py
@@ -27,7 +27,7 @@ def test_create_with_client(c, s):
     assert worker._my_plugin_status == "setup"
     assert worker._my_plugin_data == 123
 
-    yield worker._close()
+    yield worker.close()
     assert worker._my_plugin_status == "teardown"
 
 

--- a/distributed/tests/test_worker_plugins.py
+++ b/distributed/tests/test_worker_plugins.py
@@ -23,8 +23,7 @@ class MyPlugin:
 def test_create_with_client(c, s):
     yield c.register_worker_plugin(MyPlugin(123))
 
-    worker = Worker(s.address, loop=s.loop)
-    yield worker._start()
+    worker = yield Worker(s.address, loop=s.loop)
     assert worker._my_plugin_status == "setup"
     assert worker._my_plugin_data == 123
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -220,7 +220,8 @@ async def All(args, quiet_exceptions=()):
         except quiet_exceptions:
             pass
 
-    return await asyncio.gather(*[quiet(arg) for arg in args])
+    result = await asyncio.gather(*[quiet(arg) for arg in args])
+    return result
 
 
 @gen.coroutine

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import asyncio
 import atexit
 from collections import deque
 from contextlib import contextmanager
@@ -1395,7 +1396,6 @@ if "asyncio" in sys.modules and tornado.version_info[0] >= 5:
         )
 
     if not jupyter_event_loop_initialized:
-        import asyncio
         import tornado.platform.asyncio
 
         asyncio.set_event_loop_policy(
@@ -1487,3 +1487,7 @@ def format_dashboard_link(host, port):
     else:
         scheme = "http"
     return template.format(scheme=scheme, host=host, port=port, **os.environ)
+
+
+def is_coroutine_function(f):
+    return asyncio.iscoroutinefunction(f) or gen.is_coroutine_function(f)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -241,8 +241,7 @@ async def All(args, quiet_exceptions=()):
     return results
 
 
-@gen.coroutine
-def Any(args, quiet_exceptions=()):
+async def Any(args, quiet_exceptions=()):
     """ Wait on many tasks at the same time and return when any is finished
 
     Err once any of the tasks err.
@@ -253,11 +252,11 @@ def Any(args, quiet_exceptions=()):
     quiet_exceptions: tuple, Exception
         Exception types to avoid logging if they fail
     """
-    tasks = gen.WaitIterator(*args)
+    tasks = gen.WaitIterator(*map(asyncio.ensure_future, args))
     results = [None for _ in args]
     while not tasks.done():
         try:
-            result = yield tasks.next()
+            result = await tasks.next()
         except Exception:
 
             @gen.coroutine
@@ -279,7 +278,7 @@ def Any(args, quiet_exceptions=()):
 
         results[tasks.current_index] = result
         break
-    raise gen.Return(results)
+    return results
 
 
 def sync(loop, func, *args, callback_timeout=None, **kwargs):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -861,7 +861,7 @@ def gen_cluster(
     client_kwargs={},
     active_rpc_timeout=1,
     config={},
-    check_new_threads=True,
+    clean_kwargs={},
 ):
     from distributed import Client
 
@@ -890,7 +890,7 @@ def gen_cluster(
         def test_func():
             result = None
             workers = []
-            with clean(threads=check_new_threads, timeout=active_rpc_timeout) as loop:
+            with clean(timeout=active_rpc_timeout, **clean_kwargs) as loop:
 
                 @gen.coroutine
                 def coro():

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -794,9 +794,14 @@ def start_cluster(
     worker_kwargs={},
 ):
     s = Scheduler(
-        loop=loop, validate=True, security=security, port=0, **scheduler_kwargs
+        loop=loop,
+        validate=True,
+        security=security,
+        port=0,
+        host=scheduler_addr,
+        **scheduler_kwargs
     )
-    done = s.start(scheduler_addr)
+    done = s.start()
     workers = [
         Worker(
             s.address,

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -491,7 +491,7 @@ def run_worker(q, scheduler_q, **kwargs):
             scheduler_addr = scheduler_q.get()
 
             async def _():
-                worker = await Worker(scheduler_addr)  # , validate=True, **kwargs)
+                worker = await Worker(scheduler_addr, validate=True, **kwargs)
                 q.put(worker.address)
                 await worker.finished()
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -111,10 +111,9 @@ def invalid_python_script(tmpdir_factory):
     return local_file
 
 
-@gen.coroutine
-def cleanup_global_workers():
+async def cleanup_global_workers():
     for worker in Worker._instances:
-        worker.close(report=False, executor_wait=False)
+        await worker.close(report=False, executor_wait=False)
 
 
 @pytest.fixture
@@ -1508,9 +1507,9 @@ def check_instances():
 
     for w in Worker._instances:
         with ignoring(RuntimeError):  # closed IOLoop
-            w.close(report=False, executor_wait=False)
+            w.loop.add_callback(w.close, report=False, executor_wait=False)
             if w.status == "running":
-                w.close()
+                w.loop.add_callback(w.close)
     Worker._instances.clear()
 
     for i in range(5):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -486,7 +486,7 @@ def run_worker(q, scheduler_q, **kwargs):
         with pristine_loop() as loop:
             scheduler_addr = scheduler_q.get()
             worker = Worker(scheduler_addr, validate=True, **kwargs)
-            loop.run_sync(lambda: worker._start())
+            loop.run_sync(worker.start)
             q.put(worker.address)
             try:
 
@@ -504,7 +504,7 @@ def run_nanny(q, scheduler_q, **kwargs):
         with pristine_loop() as loop:
             scheduler_addr = scheduler_q.get()
             worker = Nanny(scheduler_addr, validate=True, **kwargs)
-            loop.run_sync(lambda: worker._start())
+            loop.run_sync(worker.start)
             q.put(worker.address)
             try:
                 loop.start()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -876,7 +876,7 @@ def gen_cluster(
         end
     """
     if ncores is not None:
-        warnings.warn("ncores= has moved to nthreads=")
+        warnings.warn("ncores= has moved to nthreads=", stacklevel=2)
         nthreads = ncores
 
     worker_kwargs = merge(

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -63,10 +63,9 @@ class VariableExtension(object):
             self.started.notify_all()
         self.variables[name] = record
 
-    @gen.coroutine
-    def release(self, key, name):
+    async def release(self, key, name):
         while self.waiting[key, name]:
-            yield self.waiting_conditions[name].wait()
+            await self.waiting_conditions[name].wait()
 
         self.scheduler.client_releases_keys(keys=[key], client="variable-%s" % name)
         del self.waiting[key, name]
@@ -76,8 +75,7 @@ class VariableExtension(object):
         if not self.waiting[key, name]:
             self.waiting_conditions[name].notify_all()
 
-    @gen.coroutine
-    def get(self, stream=None, name=None, client=None, timeout=None):
+    async def get(self, stream=None, name=None, client=None, timeout=None):
         start = time()
         while name not in self.variables:
             if timeout is not None:
@@ -86,7 +84,7 @@ class VariableExtension(object):
                 left = None
             if left and left < 0:
                 raise gen.TimeoutError()
-            yield self.started.wait(timeout=left)
+            await self.started.wait(timeout=left)
         record = self.variables[name]
         if record["type"] == "Future":
             key = record["value"]
@@ -99,10 +97,9 @@ class VariableExtension(object):
                 msg["traceback"] = ts.exception_blame.traceback
             record = merge(record, msg)
             self.waiting[key, name].add(token)
-        raise gen.Return(record)
+        return record
 
-    @gen.coroutine
-    def delete(self, stream=None, name=None, client=None):
+    async def delete(self, stream=None, name=None, client=None):
         with log_errors():
             try:
                 old = self.variables[name]
@@ -110,7 +107,7 @@ class VariableExtension(object):
                 pass
             else:
                 if old["type"] == "Future":
-                    yield self.release(old["value"], name)
+                    await self.release(old["value"], name)
             del self.waiting_conditions[name]
             del self.variables[name]
 
@@ -151,14 +148,13 @@ class Variable(object):
         self.client = client or _get_global_client()
         self.name = name or "variable-" + uuid.uuid4().hex
 
-    @gen.coroutine
-    def _set(self, value):
+    async def _set(self, value):
         if isinstance(value, Future):
-            yield self.client.scheduler.variable_set(
+            await self.client.scheduler.variable_set(
                 key=tokey(value.key), name=self.name
             )
         else:
-            yield self.client.scheduler.variable_set(data=value, name=self.name)
+            await self.client.scheduler.variable_set(data=value, name=self.name)
 
     def set(self, value, **kwargs):
         """ Set the value of this variable
@@ -170,9 +166,8 @@ class Variable(object):
         """
         return self.client.sync(self._set, value, **kwargs)
 
-    @gen.coroutine
-    def _get(self, timeout=None):
-        d = yield self.client.scheduler.variable_get(
+    async def _get(self, timeout=None):
+        d = await self.client.scheduler.variable_get(
             timeout=timeout, name=self.name, client=self.client.id
         )
         if d["type"] == "Future":
@@ -189,7 +184,7 @@ class Variable(object):
             )
         else:
             value = d["value"]
-        raise gen.Return(value)
+        return value
 
     def get(self, timeout=None, **kwargs):
         """ Get the value of this variable """

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
+import asyncio
 from collections import defaultdict
 import logging
 import uuid
@@ -58,7 +59,7 @@ class VariableExtension(object):
             pass
         else:
             if old["type"] == "Future" and old["value"] != key:
-                self.release(old["value"], name)
+                asyncio.ensure_future(self.release(old["value"], name))
         if name not in self.variables:
             self.started.notify_all()
         self.variables[name] = record

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -899,7 +899,6 @@ class Worker(ServerNode):
 
         self.listen(self._start_address, listen_args=self.listen_args)
         self.ip = get_address_host(self.address)
-        self.ip = get_address_host(self.listen_address)
 
         if self.name is None:
             self.name = self.address

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -892,7 +892,7 @@ class Worker(ServerNode):
     #############
 
     @gen.coroutine
-    def _start(self, addr_or_port=0):
+    def start(self, addr_or_port=0):
         assert self.status is None
         addr_or_port = addr_or_port or self._start_address
 
@@ -964,21 +964,7 @@ class Worker(ServerNode):
         yield self._register_with_scheduler()
 
         self.start_periodic_callbacks()
-        raise gen.Return(self)
-
-    def __await__(self):
-        if self.status is not None:
-
-            @gen.coroutine  # idempotent
-            def _():
-                raise gen.Return(self)
-
-            return _().__await__()
-        else:
-            return self._start().__await__()
-
-    def start(self, port=0):
-        self.loop.add_callback(self._start, port)
+        return self
 
     def _close(self, *args, **kwargs):
         warnings.warn("Worker._close has moved to Worker.close", stacklevel=2)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -895,7 +895,7 @@ class Worker(ServerNode):
     #############
 
     async def start(self):
-        assert self.status is None
+        assert self.status is None, self.status
 
         enable_gc_diagnosis()
         thread_state.on_event_loop_thread = True
@@ -961,6 +961,8 @@ class Worker(ServerNode):
                 logger.info("Stopping worker at %s", self.address)
             except ValueError:  # address not available if already closed
                 logger.info("Stopping worker")
+            if self.status != "running":
+                logger.info("Closed worker has not yet started: %s", self.status)
             self.status = "closing"
 
             if nanny and self.nanny:

--- a/docs/source/adaptive.rst
+++ b/docs/source/adaptive.rst
@@ -60,8 +60,7 @@ the correct times.
 .. code-block:: python
 
    class MyCluster(object):
-       @gen.coroutine
-       def scale_up(self, n, **kwargs):
+       async def scale_up(self, n, **kwargs):
            """
            Bring the total count of workers up to ``n``
 
@@ -72,8 +71,7 @@ the correct times.
            """
            raise NotImplementedError()
 
-       @gen.coroutine
-       def scale_down(self, workers):
+       async def scale_down(self, workers):
            """
            Remove ``workers`` from the cluster
 

--- a/docs/source/client.rst
+++ b/docs/source/client.rst
@@ -149,8 +149,8 @@ keyword argument.  In this case keys are randomly generated (by ``uuid4``.)
 .. _pure: https://toolz.readthedocs.io/en/latest/purity.html
 
 
-Tornado Coroutines
-------------------
+Async/await Operation
+---------------------
 
 If we are operating in an asynchronous environment then the blocking functions
 listed above become asynchronous equivalents.  You must start your client
@@ -159,11 +159,10 @@ functions.
 
 .. code-block:: python
 
-   @gen.coroutine
-   def f():
-       client = yield Client(asynchronous=True)
+   async def f():
+       client = await Client(asynchronous=True)
        future = client.submit(func, *args)
-       result = yield future
+       result = await future
        return result
 
 If you want to reuse the same client in asynchronous and synchronous
@@ -174,10 +173,9 @@ call.
 
    client = Client()  # normal blocking client
 
-   @gen.coroutine
-   def f():
+   async def f():
        futures = client.map(func, L)
-       results = yield client.gather(futures, asynchronous=True)
+       results = await client.gather(futures, asynchronous=True)
        return results
 
 See the :doc:`Asynchronous <asynchronous>` documentation for more information.


### PR DESCRIPTION
This replaces the use of Tornado `gen.coroutine`s and the `yield` keyword with `async def` functions and the `await` keyword.  Additionally, because these have slightly different semantics this also changes a few internal bits to smooth over this transition.

This is still a work in progress.  The current implementation introduces a couple of small bugs and the conversion is not complete.

cc @jcrist (who requested this a while ago) and @jacobtomlinson who might find this easier to work with than gen.coroutine.