### PR TITLE
Add support for CUDA serialization to host

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -87,5 +87,7 @@ def _register_numba():
 
 @cuda_serialize.register_lazy("cudf")
 @cuda_deserialize.register_lazy("cudf")
+@cuda_host_serialize.register_lazy("cudf")
+@cuda_host_deserialize.register_lazy("cudf")
 def _register_cudf():
     from . import cudf

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -79,6 +79,8 @@ def _register_cupy():
 
 @cuda_serialize.register_lazy("numba")
 @cuda_deserialize.register_lazy("numba")
+@cuda_host_serialize.register_lazy("numba")
+@cuda_host_deserialize.register_lazy("numba")
 def _register_numba():
     from . import numba
 

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -4,7 +4,7 @@ from functools import partial
 
 from .compression import compressions, default_compression
 from .core import dumps, loads, maybe_compress, decompress, msgpack
-from .cuda import cuda_serialize, cuda_deserialize
+from .cuda import cuda_serialize, cuda_deserialize, cuda_host_serialize, cuda_host_deserialize
 from .serialize import (
     serialize,
     deserialize,
@@ -71,6 +71,8 @@ def _register_torch():
 
 @cuda_serialize.register_lazy("cupy")
 @cuda_deserialize.register_lazy("cupy")
+@cuda_host_serialize.register_lazy("cupy")
+@cuda_host_deserialize.register_lazy("cupy")
 def _register_cupy():
     from . import cupy
 

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -2,7 +2,7 @@
 Efficient serialization GPU arrays.
 """
 import cupy
-from .cuda import cuda_serialize, cuda_deserialize
+from .cuda import cuda_serialize, cuda_deserialize, cuda_host_serialize, cuda_host_deserialize
 
 
 @cuda_serialize.register(cupy.ndarray)
@@ -40,3 +40,15 @@ def deserialize_cupy_array(header, frames):
         pass
     arr = cupy.asarray(frame)
     return arr
+
+
+@cuda_host_serialize.register(cupy.ndarray)
+def serialize_cupy_host_ndarray(x):
+    header, frames = serialize_cupy_ndarray(x)
+    frame, = frames
+    return header, [frame.get()]
+
+
+@cuda_host_deserialize.register(cupy.ndarray)
+def deserialize_cupy_host_array(header, frames):
+    return deserialize_cupy_array(header, frames)

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -30,6 +30,7 @@ def serialize_cupy_ndarray(x):
 
 
 @cuda_deserialize.register(cupy.ndarray)
+@cuda_host_deserialize.register(cupy.ndarray)
 def deserialize_cupy_array(header, frames):
     frame, = frames
     # TODO: put this in ucx... as a kind of "fixup"
@@ -47,8 +48,3 @@ def serialize_cupy_host_ndarray(x):
     header, frames = serialize_cupy_ndarray(x)
     frame, = frames
     return header, [frame.get()]
-
-
-@cuda_host_deserialize.register(cupy.ndarray)
-def deserialize_cupy_host_array(header, frames):
-    return deserialize_cupy_array(header, frames)

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -1,5 +1,5 @@
 import numba.cuda
-from .cuda import cuda_serialize, cuda_deserialize
+from .cuda import cuda_serialize, cuda_deserialize, cuda_host_serialize, cuda_host_deserialize
 
 
 @cuda_serialize.register(numba.cuda.devicearray.DeviceNDArray)
@@ -59,3 +59,16 @@ def deserialize_numba_ndarray(header, frames):
 
     arr = numba.cuda.as_cuda_array(frame)
     return arr
+
+
+@cuda_host_serialize.register(numba.cuda.devicearray.DeviceNDArray)
+def serialize_numba_host_ndarray(x):
+    header, frames = serialize_numba_ndarray(x)
+    frame, = frames
+    return header, [frame.copy_to_host()]
+
+
+@cuda_host_deserialize.register(numba.cuda.devicearray.DeviceNDArray)
+def deserialize_numba_host_ndarray(header, frames):
+    frames = [numba.cuda.to_device(frames[0])]
+    return deserialize_numba_ndarray(header, frames)

--- a/distributed/protocol/tests/test_cudf.py
+++ b/distributed/protocol/tests/test_cudf.py
@@ -1,0 +1,35 @@
+from distributed.protocol import serialize, deserialize
+import numpy as np
+import pandas as pd
+import pytest
+
+cuda = pytest.importorskip("numba.cuda")
+cudf = pytest.importorskip("cudf")
+
+
+def test_serialize_cudf():
+    df = pd.DataFrame({
+        'a': [0, 1, 2, 3],
+        'b': [0.1, 0.2, None, 0.3]}
+    )
+    gdf = cudf.from_pandas(df)
+    header, frames = serialize(gdf, serializers=("cuda", "dask", "pickle"))
+    assert any([type(f) == cuda.cudadrv.devicearray.DeviceNDArray for f in frames])
+    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+    assert type(y) == cudf.DataFrame
+
+    pd.testing.assert_frame_equal(y.to_pandas(), df)
+
+
+def test_serialize_cudf_host():
+    df = pd.DataFrame({
+        'a': [0, 1, 2, 3],
+        'b': [0.1, 0.2, None, 0.3]}
+    )
+    gdf = cudf.from_pandas(df)
+    header, frames = serialize(gdf, serializers=("cuda_host", "dask", "pickle"))
+    assert any([type(f) == np.ndarray for f in frames])
+    y = deserialize(header, frames, deserializers=("cuda_host", "dask", "pickle", "error"))
+    assert type(y) == cudf.DataFrame
+
+    pd.testing.assert_frame_equal(y.to_pandas(), df)

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -1,4 +1,5 @@
 from distributed.protocol import serialize, deserialize
+import numpy as np
 import pytest
 
 cupy = pytest.importorskip("cupy")
@@ -7,6 +8,18 @@ cupy = pytest.importorskip("cupy")
 def test_serialize_cupy():
     x = cupy.arange(100)
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
+    assert type(frames[0]) == cupy.ndarray
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+    assert type(y) == cupy.ndarray
+
+    assert (x == y).all()
+
+
+def test_serialize_cupy_host():
+    x = cupy.arange(100)
+    header, frames = serialize(x, serializers=("cuda_host", "dask", "pickle"))
+    assert type(frames[0]) == np.ndarray
+    y = deserialize(header, frames, deserializers=("cuda_host", "dask", "pickle", "error"))
+    assert type(y) == cupy.ndarray
 
     assert (x == y).all()

--- a/distributed/protocol/tests/test_numba.py
+++ b/distributed/protocol/tests/test_numba.py
@@ -1,0 +1,25 @@
+from distributed.protocol import serialize, deserialize
+import numpy as np
+import pytest
+
+cuda = pytest.importorskip("numba.cuda")
+
+
+def test_serialize_numba():
+    x = cuda.to_device(np.arange(100))
+    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
+    assert type(frames[0]) == cuda.cudadrv.devicearray.DeviceNDArray
+    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+    assert type(y) == cuda.cudadrv.devicearray.DeviceNDArray
+
+    assert (x.copy_to_host() == y.copy_to_host()).all()
+
+
+def test_serialize_numba_host():
+    x = cuda.to_device(np.arange(100))
+    header, frames = serialize(x, serializers=("cuda_host", "dask", "pickle"))
+    assert type(frames[0]) == np.ndarray
+    y = deserialize(header, frames, deserializers=("cuda_host", "dask", "pickle", "error"))
+    assert type(y) == cuda.cudadrv.devicearray.DeviceNDArray
+
+    assert (x.copy_to_host() == y.copy_to_host()).all()


### PR DESCRIPTION
This PR adds support for serialization of CUDA objects to host. The current implementation allows serialization while keeping data on the device (useful for communication with UCX, for example), but to spill memory from the device to host, we need to actually move that data device<->host.

@mrocklin @quasiben could you take a look at this? It improves the memory spilling of CUDA objects and is the simplest change for dask-cuda to operate under those circumstances.