### PR TITLE
Add ProcessInterface

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -4,7 +4,7 @@ from . import config
 from dask.config import config
 from .actor import Actor, ActorFuture
 from .core import connect, rpc
-from .deploy import LocalCluster, Adaptive, SpecCluster
+from .deploy import LocalCluster, Adaptive, SpecCluster, SpecProcess
 from .diagnostics import progress
 from .client import (
     Client,

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -4,7 +4,7 @@ from . import config
 from dask.config import config
 from .actor import Actor, ActorFuture
 from .core import connect, rpc
-from .deploy import LocalCluster, Adaptive, SpecCluster, SpecProcess
+from .deploy import LocalCluster, Adaptive, SpecCluster
 from .diagnostics import progress
 from .client import (
     Client,

--- a/distributed/deploy/__init__.py
+++ b/distributed/deploy/__init__.py
@@ -4,7 +4,7 @@ from ..utils import ignoring
 
 from .cluster import Cluster
 from .local import LocalCluster
-from .spec import SpecCluster, SpecProcess
+from .spec import SpecCluster, ProcessInterface
 from .adaptive import Adaptive
 
 with ignoring(ImportError):

--- a/distributed/deploy/__init__.py
+++ b/distributed/deploy/__init__.py
@@ -4,7 +4,7 @@ from ..utils import ignoring
 
 from .cluster import Cluster
 from .local import LocalCluster
-from .spec import SpecCluster
+from .spec import SpecCluster, SpecProcess
 from .adaptive import Adaptive
 
 with ignoring(ImportError):

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -11,7 +11,7 @@ from ..scheduler import Scheduler
 from ..security import Security
 
 
-class SpecProcess:
+class ProcessInterface:
     """ An interface for Scheduler and Worker processes for use in SpecCluster
 
     Parameters

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -37,11 +37,6 @@ class ProcessInterface:
 
         return _().__await__()
 
-    @property
-    def worker_address(self):
-        """ For API compatibility with Nanny. """
-        return self.address
-
     async def start(self):
         """ Start the process. """
         self.status = "running"
@@ -368,7 +363,7 @@ class SpecCluster(Cluster):
         # TODO: this is linear cost.  We should be indexing by name or something
         to_close = [w for w in self.workers.values() if w.address in workers]
         for k, v in self.workers.items():
-            if v.worker_address in workers:
+            if getattr(v, "worker_address", v.address) in workers:
                 del self.worker_spec[k]
 
         await self

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -45,10 +45,6 @@ class ProcessInterface:
         """ Close the process. """
         self.status = "closed"
 
-    async def logs(self):
-        """ Generator which yeilds log messages. """
-        raise NotImplementedError()
-
     def __repr__(self):
         return "<%s: status=%s>" % (type(self).__name__, self.status)
 

--- a/distributed/deploy/ssh2.py
+++ b/distributed/deploy/ssh2.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import sys
 import warnings
@@ -6,7 +5,7 @@ import weakref
 
 import asyncssh
 
-from .spec import SpecCluster
+from .spec import SpecCluster, SpecProcess
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +15,7 @@ warnings.warn(
 )
 
 
-class Process:
+class Process(SpecProcess):
     """ A superclass for SSH Workers and Nannies
 
     See Also
@@ -25,27 +24,20 @@ class Process:
     Scheduler
     """
 
-    def __init__(self):
-        self.lock = asyncio.Lock()
+    def __init__(self, **kwargs):
         self.connection = None
         self.proc = None
-        self.status = "created"
+        super().__init__(**kwargs)
 
-    def __await__(self):
-        async def _():
-            async with self.lock:
-                if not self.connection:
-                    await self.start()
-                    assert self.connection
-                    weakref.finalize(self, self.proc.terminate)
-            return self
-
-        return _().__await__()
+    async def start(self):
+        assert self.connection
+        weakref.finalize(self, self.proc.terminate)
+        await super().start()
 
     async def close(self):
         self.proc.terminate()
         self.connection.close()
-        self.status = "closed"
+        await super().close()
 
     def __repr__(self):
         return "<SSH %s: status=%s>" % (type(self).__name__, self.status)
@@ -72,7 +64,7 @@ class Worker(Process):
         self.connect_kwargs = connect_kwargs
         self.kwargs = kwargs
 
-        super().__init__()
+        super().__init__(**kwargs)
 
     async def start(self):
         self.connection = await asyncssh.connect(self.address, **self.connect_kwargs)
@@ -97,6 +89,7 @@ class Worker(Process):
                 self.status = "running"
                 break
         logger.debug("%s", line)
+        super().start()
 
 
 class Scheduler(Process):
@@ -135,6 +128,7 @@ class Scheduler(Process):
                 self.address = line.split("Scheduler at:")[1].strip()
                 break
         logger.debug("%s", line)
+        super().start()
 
 
 def SSHCluster(hosts, connect_kwargs, **kwargs):

--- a/distributed/deploy/ssh2.py
+++ b/distributed/deploy/ssh2.py
@@ -64,7 +64,7 @@ class Worker(Process):
         self.connect_kwargs = connect_kwargs
         self.kwargs = kwargs
 
-        super().__init__(**kwargs)
+        super().__init__()
 
     async def start(self):
         self.connection = await asyncssh.connect(self.address, **self.connect_kwargs)
@@ -128,7 +128,7 @@ class Scheduler(Process):
                 self.address = line.split("Scheduler at:")[1].strip()
                 break
         logger.debug("%s", line)
-        super().start()
+        await super().start()
 
 
 def SSHCluster(hosts, connect_kwargs, **kwargs):

--- a/distributed/deploy/ssh2.py
+++ b/distributed/deploy/ssh2.py
@@ -89,7 +89,7 @@ class Worker(Process):
                 self.status = "running"
                 break
         logger.debug("%s", line)
-        super().start()
+        await super().start()
 
 
 class Scheduler(Process):

--- a/distributed/deploy/ssh2.py
+++ b/distributed/deploy/ssh2.py
@@ -5,7 +5,7 @@ import weakref
 
 import asyncssh
 
-from .spec import SpecCluster, SpecProcess
+from .spec import SpecCluster, ProcessInterface
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ warnings.warn(
 )
 
 
-class Process(SpecProcess):
+class Process(ProcessInterface):
     """ A superclass for SSH Workers and Nannies
 
     See Also

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,5 +1,5 @@
-from dask.distributed import SpecCluster, SpecProcess, Worker, Client, Scheduler, Nanny
-from distributed.deploy.spec import close_clusters
+from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
+from distributed.deploy.spec import close_clusters, ProcessInterface
 from distributed.utils_test import loop, cleanup  # noqa: F401
 import pytest
 
@@ -168,7 +168,7 @@ async def test_nanny_port():
 
 @pytest.mark.asyncio
 async def test_spec_process():
-    proc = SpecProcess()
+    proc = ProcessInterface()
     assert proc.status == "created"
     await proc
     assert proc.status == "running"

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,4 +1,4 @@
-from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
+from dask.distributed import SpecCluster, SpecProcess, Worker, Client, Scheduler, Nanny
 from distributed.deploy.spec import close_clusters
 from distributed.utils_test import loop, cleanup  # noqa: F401
 import pytest
@@ -164,3 +164,13 @@ async def test_nanny_port():
         scheduler=scheduler, workers=workers, asynchronous=True
     ) as cluster:
         pass
+
+
+@pytest.mark.asyncio
+async def test_spec_process():
+    proc = SpecProcess()
+    assert proc.status == "created"
+    await proc
+    assert proc.status == "running"
+    await proc.close()
+    assert proc.status == "closed"


### PR DESCRIPTION
Added `SpecProcess` which is an interface for custom schedulers and workers to inherit from for use in `SpecCluster`.

Not particularly excited about the name of this class. Suggestions welcome!