### PR TITLE
Forcefully kill all processes before each test

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3312,7 +3312,7 @@ def test_get_foo_lost_keys(c, s, u, v, w):
     client=True,
     Worker=Nanny,
     worker_kwargs={"death_timeout": "500ms"},
-    clean_kwargs={"processes": False, "threads": False},
+    clean_kwargs={"threads": False},
 )
 def test_bad_tasks_fail(c, s, a, b):
     f = c.submit(sys.exit, 0)


### PR DESCRIPTION
This should hopefully help with some intermittent testing failures