### PR TITLE
Pass Client._asynchronous to Cluster._asynchronous

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -932,7 +932,9 @@ class Client(Node):
 
             try:
                 self.cluster = await LocalCluster(
-                    loop=self.loop, asynchronous=True, **self._startup_kwargs
+                    loop=self.loop,
+                    asynchronous=self._asynchronous,
+                    **self._startup_kwargs
                 )
             except (OSError, socket.error) as e:
                 if e.errno != errno.EADDRINUSE:

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -856,3 +856,10 @@ def test_dont_select_closed_worker():
 
         cluster2.close()
         c2.close()
+
+
+def test_client_cluster_synchronous(loop):
+    with clean(threads=False):
+        with Client(loop=loop, processes=False) as c:
+            assert not c.asynchronous
+            assert not c.cluster.asynchronous


### PR DESCRIPTION
Previously when starting a client/cluster with `Client()` the
underlying cluster would always be started with `asynchronous=True`.
This could be troublesome in some cases.

Now we pass through the `asynchronous=` value that was originally passed
to the Client object.