### PR TITLE
Add processes keyword back into clean context manager

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1234,7 +1234,7 @@ def test_cancel_fire_and_forget(c, s, a, b):
     assert not s.tasks
 
 
-@gen_cluster(client=True, Worker=Nanny)
+@gen_cluster(client=True, Worker=Nanny, clean_kwargs={"processes": False})
 def test_log_tasks_during_restart(c, s, a, b):
     future = c.submit(sys.exit, 0)
     yield wait(future)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1528,14 +1528,14 @@ def check_instances():
 
 
 @contextmanager
-def clean(threads=not WINDOWS, instances=True, timeout=1):
+def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
     @contextmanager
     def null():
         yield
 
     with check_thread_leak() if threads else null():
         with pristine_loop() as loop:
-            with check_process_leak():
+            with check_process_leak() if processes else null():
                 with check_instances() if instances else null():
                     with check_active_rpc(loop, timeout):
                         reset_config()


### PR DESCRIPTION
This resolves some intermittent testing failures