### PR TITLE
Convert Pythonic kwargs to CLI Keywords for SSHCluster

### DIFF
--- a/distributed/deploy/ssh2.py
+++ b/distributed/deploy/ssh2.py
@@ -98,6 +98,8 @@ class Worker(Process):
         # We watch stderr in order to get the address, then we return
         while True:
             line = await self.proc.stderr.readline()
+            if not line.strip():
+                raise Exception("Worker failed to start")
             logger.info(line.strip())
             if "worker at" in line:
                 self.address = line.split("worker at:")[1].strip()
@@ -143,6 +145,8 @@ class Scheduler(Process):
         # We watch stderr in order to get the address, then we return
         while True:
             line = await self.proc.stderr.readline()
+            if not line.strip():
+                raise Exception("Worker failed to start")
             logger.info(line.strip())
             if "Scheduler at" in line:
                 self.address = line.split("Scheduler at:")[1].strip()

--- a/distributed/deploy/ssh2.py
+++ b/distributed/deploy/ssh2.py
@@ -58,7 +58,7 @@ class Worker(Process):
     connect_kwargs: dict
         kwargs to be passed to asyncssh connections
     kwargs: dict
-        These will be happed through the dask-worker CLI to the
+        These will be passed through the dask-worker CLI to the
         dask.distributed.Worker class
     """
 
@@ -117,7 +117,7 @@ class Scheduler(Process):
     connect_kwargs: dict
         kwargs to be passed to asyncssh connections
     kwargs: dict
-        These will be happed through the dask-scheduler CLI to the
+        These will be passed through the dask-scheduler CLI to the
         dask.distributed.Scheduler class
     """
 
@@ -162,12 +162,12 @@ def SSHCluster(
         List of hostnames or addresses on which to launch our cluster
         The first will be used for the scheduler and the rest for workers
     connect_kwargs:
+        Keywords to pass through to asyncssh.connect
         known_hosts: List[str] or None
             The list of keys which will be used to validate the server host
             key presented during the SSH handshake.  If this is not specified,
             the keys will be looked up in the file .ssh/known_hosts.  If this
             is explicitly set to None, server host key validation will be disabled.
-        TODO
     scheduler_kwargs:
         Keywords to pass on to dask-scheduler
     worker_kwargs:

--- a/distributed/deploy/tests/test_ssh2.py
+++ b/distributed/deploy/tests/test_ssh2.py
@@ -26,7 +26,7 @@ async def test_keywords():
         ["127.0.0.1"] * 3,
         connect_kwargs=dict(known_hosts=None),
         asynchronous=True,
-        worker_kwargs={"nthreads": 2},
+        worker_kwargs={"nthreads": 2, "memory_limit": "2 GiB"},
         scheduler_kwargs={"idle_timeout": "5s", "port": 0},
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:

--- a/distributed/deploy/tests/test_ssh2.py
+++ b/distributed/deploy/tests/test_ssh2.py
@@ -9,9 +9,31 @@ from distributed.deploy.ssh2 import SSHCluster
 @pytest.mark.asyncio
 async def test_basic():
     async with SSHCluster(
-        ["127.0.0.1"] * 3, connect_kwargs=dict(known_hosts=None), asynchronous=True
+        ["127.0.0.1"] * 3,
+        connect_kwargs=dict(known_hosts=None),
+        asynchronous=True,
+        scheduler_kwargs={"port": 0},
     ) as cluster:
         assert len(cluster.workers) == 2
         async with Client(cluster, asynchronous=True) as client:
             result = await client.submit(lambda x: x + 1, 10)
             assert result == 11
+
+
+@pytest.mark.asyncio
+async def test_keywords():
+    async with SSHCluster(
+        ["127.0.0.1"] * 3,
+        connect_kwargs=dict(known_hosts=None),
+        asynchronous=True,
+        worker_kwargs={"nthreads": 2},
+        scheduler_kwargs={"idle_timeout": "5s", "port": 0},
+    ) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            assert (
+                await client.run_on_scheduler(
+                    lambda dask_scheduler: dask_scheduler.idle_timeout
+                )
+            ) == 5
+            d = client.scheduler_info()["workers"]
+            assert all(v["nthreads"] == 2 for v in d.values())

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1540,4 +1540,12 @@ def cli_keywords(d: dict, cls=None):
                     "Class %s does not support keyword %s" % (typename(cls), k)
                 )
 
-    return sum([["--" + k.replace("_", "-"), str(v)] for k, v in d.items()], [])
+    def convert_value(v):
+        out = str(v)
+        if " " in out and "'" not in out and '"' not in out:
+            out = '"' + out + '"'
+        return out
+
+    return sum(
+        [["--" + k.replace("_", "-"), convert_value(v)] for k, v in d.items()], []
+    )

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -803,7 +803,7 @@ def tokey(o):
     --------
 
     >>> tokey(b'x')
-    'x'
+    b'x'
     >>> tokey('x')
     'x'
     >>> tokey(1)
@@ -1210,7 +1210,7 @@ def parse_timedelta(s, default="seconds"):
     >>> parse_timedelta('300ms')
     0.3
     >>> parse_timedelta(timedelta(seconds=3))  # also supports timedeltas
-    3
+    3.0
     """
     if s is None:
         return None
@@ -1510,3 +1510,34 @@ class Logs(dict):
             for title, log in self.items()
         ]
         return "\n".join(summaries)
+
+
+def cli_keywords(d: dict, cls=None):
+    """ Convert a kwargs dictionary into a list of CLI keywords
+
+    Parameters
+    ----------
+    d: dict
+        The keywords to convert
+    cls: callable
+        The callable that consumes these terms to check them for validity
+
+    Examples
+    --------
+    >>> cli_keywords({"x": 123, "save_file": "foo.txt"})
+    ['--x', '123', '--save-file', 'foo.txt']
+
+    >>> from dask.distributed import Worker
+    >>> cli_keywords({"x": 123}, Worker)
+    Traceback (most recent call last):
+    ...
+    ValueError: Class distributed.worker.Worker does not support keyword x
+    """
+    if cls:
+        for k in d:
+            if not has_keyword(cls, k):
+                raise ValueError(
+                    "Class %s does not support keyword %s" % (typename(cls), k)
+                )
+
+    return sum([["--" + k.replace("_", "-"), str(v)] for k, v in d.items()], [])


### PR DESCRIPTION
In order to smooth over the translation from Python `foo_bar=123` to CLI friendly `--foo-bar 123` style keywords we make a small utility function.  This should make it easier to map Pythonic classes onto CLI utilities in the future.

To demonstrate this we enhance the experimental SSHCluster with keywords.