### PR TITLE
Request feed of worker information from Scheduler to SpecCluster

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -228,6 +228,7 @@ class SpecCluster(Cluster):
         )
         await comm.write({"op": "subscribe_worker_status"})
         self.scheduler_info = await comm.read()
+        self._watch_worker_status_comm = comm
         self._watch_worker_status_task = asyncio.ensure_future(
             self._watch_worker_status(comm)
         )
@@ -345,6 +346,7 @@ class SpecCluster(Cluster):
             with ignoring(CommClosedError):
                 await self.scheduler_comm.close(close_workers=True)
         await self.scheduler.close()
+        await self._watch_worker_status_comm.close()
         await self._watch_worker_status_task
         for w in self._created:
             assert w.status == "closed"

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -21,9 +21,8 @@ class ProcessInterface:
 
     """
 
-    def __init__(self, loop=None):
+    def __init__(self):
         self.address = None
-        self.loop = loop
         self.lock = asyncio.Lock()
         self.status = "created"
 
@@ -194,7 +193,7 @@ class SpecCluster(Cluster):
                 services = {("dashboard", 8787): BokehScheduler}
             self.scheduler_spec = {"cls": Scheduler, "options": {"services": services}}
         self.scheduler = self.scheduler_spec["cls"](
-            loop=self.loop, **self.scheduler_spec.get("options", {})
+            **self.scheduler_spec.get("options", {})
         )
 
         self._lock = asyncio.Lock()

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -198,6 +198,8 @@ class SpecCluster(Cluster):
         if self.status == "closed":
             raise ValueError("Cluster is closed")
 
+        self._lock = asyncio.Lock()
+
         if self.scheduler_spec is None:
             try:
                 from distributed.dashboard import BokehScheduler
@@ -210,7 +212,6 @@ class SpecCluster(Cluster):
             **self.scheduler_spec.get("options", {})
         )
 
-        self._lock = asyncio.Lock()
         self.status = "starting"
         self.scheduler = await self.scheduler
         self.scheduler_comm = rpc(

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -221,7 +221,7 @@ class SpecCluster(Cluster):
             self.scheduler_address,
             connection_args=self.security.get_connection_args("client"),
         )
-        await comm.write({"op": "subscribe-worker-status"})
+        await comm.write({"op": "subscribe_worker_status"})
         self.scheduler_info = await comm.read()
         self._watch_worker_status_task = asyncio.ensure_future(
             self._watch_worker_status(comm)

--- a/distributed/deploy/ssh2.py
+++ b/distributed/deploy/ssh2.py
@@ -123,7 +123,7 @@ class Scheduler(Process):
         dask.distributed.Scheduler class
     """
 
-    def __init__(self, address: str, connect_kwargs: dict, kwargs: dict, loop=None):
+    def __init__(self, address: str, connect_kwargs: dict, kwargs: dict):
         self.address = address
         self.kwargs = kwargs
         self.connect_kwargs = connect_kwargs

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -258,7 +258,5 @@ async def test_widget(cleanup):
             await asyncio.sleep(0.01)
             assert time() < start + 1
 
-        if str(len(worker_spec)) not in cluster._widget_status():
-            breakpoint()
         assert "3" in cluster._widget_status()
         assert "GB" in cluster._widget_status()

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,3 +1,6 @@
+import asyncio
+from time import time
+
 from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
 from distributed.deploy.spec import close_clusters, ProcessInterface
 from distributed.utils_test import loop, cleanup  # noqa: F401
@@ -205,3 +208,27 @@ async def test_logs(cleanup):
         w = toolz.first(cluster.scheduler.workers)
         logs = await cluster.logs(scheduler=False, workers=[w])
         assert set(logs) == {w}
+
+
+@pytest.mark.asyncio
+async def test_scheduler_info(cleanup):
+    async with SpecCluster(
+        workers=worker_spec, scheduler=scheduler, asynchronous=True
+    ) as cluster:
+        assert (
+            cluster.scheduler_info["id"] == cluster.scheduler.id
+        )  # present at startup
+
+        start = time()  # wait for all workers
+        while len(cluster.scheduler_info["workers"]) < len(cluster.workers):
+            await asyncio.sleep(0.01)
+            assert time() < start + 1
+
+        assert set(cluster.scheduler.identity()["workers"]) == set(
+            cluster.scheduler_info["workers"]
+        )
+        assert (
+            cluster.scheduler.identity()["services"]
+            == cluster.scheduler_info["services"]
+        )
+        assert len(cluster.scheduler_info["workers"]) == len(cluster.workers)

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -232,3 +232,16 @@ async def test_scheduler_info(cleanup):
             == cluster.scheduler_info["services"]
         )
         assert len(cluster.scheduler_info["workers"]) == len(cluster.workers)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_link(cleanup):
+    async with SpecCluster(
+        workers=worker_spec,
+        scheduler={
+            "cls": Scheduler,
+            "options": {"port": 0, "dashboard_address": ":12345"},
+        },
+        asynchronous=True,
+    ) as cluster:
+        assert "12345" in cluster.dashboard_link

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -60,7 +60,7 @@ def test_spec_sync(loop):
         "my-worker": {"cls": MyWorker, "options": {"nthreads": 3}},
     }
     with SpecCluster(workers=worker_spec, scheduler=scheduler, loop=loop) as cluster:
-        assert cluster.worker_spec is worker_spec
+        assert cluster.worker_spec == worker_spec
 
         assert len(cluster.workers) == 3
         assert set(cluster.workers) == set(worker_spec)

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -33,7 +33,7 @@ async def test_specification(cleanup):
     async with SpecCluster(
         workers=worker_spec, scheduler=scheduler, asynchronous=True
     ) as cluster:
-        assert cluster.worker_spec is worker_spec
+        assert cluster.worker_spec == worker_spec
 
         assert len(cluster.workers) == 3
         assert set(cluster.workers) == set(worker_spec)
@@ -245,3 +245,20 @@ async def test_dashboard_link(cleanup):
         asynchronous=True,
     ) as cluster:
         assert "12345" in cluster.dashboard_link
+
+
+@pytest.mark.asyncio
+async def test_widget(cleanup):
+    async with SpecCluster(
+        workers=worker_spec, scheduler=scheduler, asynchronous=True
+    ) as cluster:
+
+        start = time()  # wait for all workers
+        while len(cluster.scheduler_info["workers"]) < len(cluster.worker_spec):
+            await asyncio.sleep(0.01)
+            assert time() < start + 1
+
+        if str(len(worker_spec)) not in cluster._widget_status():
+            breakpoint()
+        assert "3" in cluster._widget_status()
+        assert "GB" in cluster._widget_status()

--- a/distributed/deploy/tests/test_ssh2.py
+++ b/distributed/deploy/tests/test_ssh2.py
@@ -18,6 +18,7 @@ async def test_basic():
         async with Client(cluster, asynchronous=True) as client:
             result = await client.submit(lambda x: x + 1, 10)
             assert result == 11
+        assert not cluster._supports_scaling
 
 
 @pytest.mark.asyncio

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4969,6 +4969,9 @@ class KilledWorker(Exception):
 class WorkerStatus(SchedulerPlugin):
     """
     An extension and plugin to share worker status with a remote observer
+
+    This is used in cluster managers to keep updated about the status of the
+    scheduler.
     """
 
     def __init__(self, scheduler):


### PR DESCRIPTION
The SpecCluster now queries the Scheduler to get up-to-date information about workers and services.  This is useful for things like ...

1.  Adaptivity
2.  Dashboard links
3.  Displaying cores/memory in the dashboard
4.  Available services