### PR TITLE
Close workers more gracefully

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -382,6 +382,9 @@ class Nanny(ServerNode):
                     if self.auto_restart:
                         logger.warning("Restarting worker")
                         await self.instantiate()
+                elif self.status == "closing-gracefully":
+                    await self.close()
+
             except Exception:
                 logger.error(
                     "Failed to restart worker after its process exited", exc_info=True

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -15,7 +15,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop
 
 import dask
-from distributed import Nanny, rpc, Scheduler, Worker
+from distributed import Nanny, rpc, Scheduler, Worker, Client
 from distributed.core import CommClosedError
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps
@@ -398,3 +398,18 @@ async def test_nanny_closes_cleanly(cleanup):
         assert not n.process
         assert not proc.is_alive()
         assert proc.exitcode == 0
+
+
+@pytest.mark.asyncio
+async def test_nanny_closes_cleanly(cleanup):
+    async with Scheduler() as s:
+        async with Nanny(s.address) as n:
+            async with Client(s.address, asynchronous=True) as client:
+                with client.rpc(n.worker_address) as w:
+                    IOLoop.current().add_callback(w.terminate)
+                    start = time()
+                    while n.status != "closed":
+                        await gen.sleep(0.01)
+                        assert time() < start + 5
+
+                    assert n.status == "closed"

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -577,7 +577,7 @@ class Worker(ServerNode):
             "get_data": self.get_data,
             "update_data": self.update_data,
             "delete_data": self.delete_data,
-            "terminate": self.terminate,
+            "terminate": self.close,
             "ping": pingpong,
             "upload_file": self.upload_file,
             "start_ipython": self.start_ipython,
@@ -832,7 +832,7 @@ class Worker(ServerNode):
             logger.exception(e)
             raise
         finally:
-            if self.reconnect:
+            if self.reconnect and self.status == "running":
                 logger.info("Connection to scheduler broken.  Reconnecting...")
                 self.loop.add_callback(self._register_with_scheduler)
             else:
@@ -998,13 +998,6 @@ class Worker(ServerNode):
                         self.scheduler.unregister(address=self.contact_address),
                     )
             self.scheduler.close_rpc()
-            self.actor_executor._work_queue.queue.clear()
-            if isinstance(self.executor, ThreadPoolExecutor):
-                self.executor._work_queue.queue.clear()
-                self.executor.shutdown(wait=executor_wait, timeout=timeout)
-            else:
-                self.executor.shutdown(wait=False)
-            self.actor_executor.shutdown(wait=executor_wait, timeout=timeout)
             self._workdir.release()
 
             for k, v in self.services.items():
@@ -1016,9 +1009,13 @@ class Worker(ServerNode):
             if self.batched_stream:
                 self.batched_stream.close()
 
-            if nanny and self.nanny:
-                with self.rpc(self.nanny) as r:
-                    await r.terminate()
+            self.actor_executor._work_queue.queue.clear()
+            if isinstance(self.executor, ThreadPoolExecutor):
+                self.executor._work_queue.queue.clear()
+                self.executor.shutdown(wait=executor_wait, timeout=timeout)
+            else:
+                self.executor.shutdown(wait=False)
+            self.actor_executor.shutdown(wait=executor_wait, timeout=timeout)
 
             self.stop()
             self.rpc.close()
@@ -1028,9 +1025,10 @@ class Worker(ServerNode):
             await ServerNode.close(self)
 
             setproctitle("dask-worker [closed]")
+        return "OK"
 
-    async def terminate(self, comm, report=True):
-        await self.close(report=report)
+    async def terminate(self, comm, report=True, **kwargs):
+        await self.close(report=report, **kwargs)
         return "OK"
 
     async def wait_until_closed(self):


### PR DESCRIPTION
This commit does two things:

1.  We wait to shutdown the executor a little longer in case it is still
    in use
2.  The worker no longer asks the Nanny to terminate it.  Instead it
    asks the nanny to shutdown gracefully after it is gone, and then
    continues closing itself as normal.