### PR TITLE
Move core functionality from SpecCluster to Cluster

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -198,7 +198,10 @@ class Cluster(object):
 
     def _widget_status(self):
         workers = len(self.scheduler_info["workers"])
-        requested = len(self.worker_spec)
+        try:
+            requested = len(self.workers)
+        except AttributeError:
+            requested = workers
         cores = sum(v["nthreads"] for v in self.scheduler_info["workers"].values())
         memory = sum(v["memory_limit"] for v in self.scheduler_info["workers"].values())
         memory = format_bytes(memory)

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -66,6 +66,9 @@ class Cluster(object):
         self.status = "running"
 
     async def _close(self):
+        if self.status == "closed":
+            return
+
         await self._watch_worker_status_comm.close()
         await self._watch_worker_status_task
 

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -294,3 +294,10 @@ class Cluster(object):
             self.scheduler_address,
             len(self.scheduler_info["workers"]),
         )
+
+    async def __aenter__(self):
+        await self
+        return self
+
+    async def __aexit__(self, typ, value, traceback):
+        await self.close()

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -8,7 +8,6 @@ from tornado import gen
 
 from .adaptive import Adaptive
 
-from ..core import rpc
 from ..utils import (
     PeriodicCallback,
     log_errors,
@@ -25,10 +24,28 @@ logger = logging.getLogger(__name__)
 
 
 class Cluster(object):
-    """ Superclass for cluster objects """
+    """ Superclass for cluster objects
 
-    scheduler_comm: rpc  # need to implement this
-    scheduler_address: str  # need to implement this
+    This class contains common functionality for Dask Cluster manager classes.
+
+    To implement this class, you must provide
+
+    1.  A ``scheduler_comm`` attribute, which is a connection to the scheduler
+        following the ``distributed.core.rpc`` API.
+    2.  Implement ``scale``, which takes an integer and scales the cluster to
+        that many workers, or else set ``_supports_scaling`` to False
+
+    For that, should should get the following:
+
+    1.  A standard ``__repr__``
+    2.  A live IPython widget
+    3.  Adaptive scaling
+    4.  Integration with dask-labextension
+    5.  A ``scheduler_info`` attribute which contains an up-to-date copy of
+        ``Scheduler.identity()``, which is used for much of the above
+    6.  Methods to gather logs
+    """
+
     _supports_scaling = True
 
     def __init__(self, asynchronous):
@@ -301,3 +318,7 @@ class Cluster(object):
 
     async def __aexit__(self, typ, value, traceback):
         await self.close()
+
+    @property
+    def scheduler_address(self):
+        return self.scheduler_comm.address

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -84,7 +84,8 @@ class Cluster(object):
 
     def __del__(self):
         if self.status != "closed":
-            self.loop.add_callback(self.close)
+            with ignoring(AttributeError, RuntimeError):  # during closing
+                self.loop.add_callback(self.close)
 
     async def _watch_worker_status(self, comm):
         """ Listen to scheduler for updates on adding and removing workers """

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -202,9 +202,11 @@ class Cluster(object):
 
     def _widget_status(self):
         workers = len(self.scheduler_info["workers"])
-        try:
+        if hasattr(self, "worker_spec"):
+            requested = len(self.worker_spec)
+        elif hasattr(self, "workers"):
             requested = len(self.workers)
-        except AttributeError:
+        else:
             requested = workers
         cores = sum(v["nthreads"] for v in self.scheduler_info["workers"].values())
         memory = sum(v["memory_limit"] for v in self.scheduler_info["workers"].values())

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -1,18 +1,21 @@
+import asyncio
 from datetime import timedelta
 import logging
 import threading
-from weakref import ref
 
 from dask.utils import format_bytes
 from tornado import gen
 
 from .adaptive import Adaptive
 
+from ..core import rpc
 from ..utils import (
     PeriodicCallback,
     log_errors,
     ignoring,
     sync,
+    Log,
+    Logs,
     thread_state,
     format_dashboard_link,
 )
@@ -22,47 +25,48 @@ logger = logging.getLogger(__name__)
 
 
 class Cluster(object):
-    """ Superclass for cluster objects
+    """ Superclass for cluster objects """
 
-    This expects a local Scheduler defined on the object.  It provides
-    common methods and an IPython widget display.
+    scheduler_comm: rpc  # need to implement this
+    scheduler_address: str  # need to implement this
 
-    Clusters inheriting from this class should provide the following:
+    def __init__(self, asynchronous):
+        self.scheduler_info = {}
+        self.periodic_callbacks = {}
+        self._asynchronous = asynchronous
+        self.status = "created"
 
-    1.  A local ``Scheduler`` object at ``.scheduler``
-    2.  scale_up and scale_down methods as defined below::
+    async def _start(self):
+        comm = await self.scheduler_comm.live_comm()
+        await comm.write({"op": "subscribe_worker_status"})
+        self.scheduler_info = await comm.read()
+        self._watch_worker_status_comm = comm
+        self._watch_worker_status_task = asyncio.ensure_future(
+            self._watch_worker_status(comm)
+        )
+        self.status = "running"
 
-        def scale_up(self, n: int):
-            ''' Brings total worker count up to ``n`` '''
+    async def _watch_worker_status(self, comm):
+        """ Listen to scheduler for updates on adding and removing workers """
+        while True:
+            try:
+                msgs = await comm.read()
+            except OSError:
+                break
 
-        def scale_down(self, workers: List[str]):
-            ''' Close the workers with the given addresses '''
+            for op, msg in msgs:
+                if op == "add":
+                    workers = msg.pop("workers")
+                    self.scheduler_info["workers"].update(workers)
+                    self.scheduler_info.update(msg)
+                elif op == "remove":
+                    del self.scheduler_info["workers"][msg]
+                else:
+                    raise ValueError("Invalid op", op, msg)
 
-    This will provide a general ``scale`` method as well as an IPython widget
-    for display.
+        await comm.close()
 
-    Examples
-    --------
-
-    >>> from distributed.deploy import Cluster
-    >>> class MyCluster(cluster):
-    ...     def scale_up(self, n):
-    ...         ''' Bring the total worker count up to n '''
-    ...         pass
-    ...     def scale_down(self, workers):
-    ...         ''' Close the workers with the given addresses '''
-    ...         pass
-
-    >>> cluster = MyCluster()
-    >>> cluster.scale(5)                       # scale manually
-    >>> cluster.adapt(minimum=1, maximum=100)  # scale automatically
-
-    See Also
-    --------
-    LocalCluster: a simple implementation with local workers
-    """
-
-    def adapt(self, Adaptive=Adaptive, **kwargs):
+    def adapt(self, Adaptive=Adaptive, **kwargs) -> Adaptive:
         """ Turn on adaptivity
 
         For keyword arguments see dask.distributed.Adaptive
@@ -79,17 +83,7 @@ class Cluster(object):
         self._adaptive = Adaptive(self, **self._adaptive_options)
         return self._adaptive
 
-    @property
-    def scheduler_address(self):
-        return self.scheduler.address
-
-    @property
-    def dashboard_link(self):
-        host = self.scheduler.address.split("://")[1].split(":")[0]
-        port = self.scheduler.services["dashboard"].port
-        return format_dashboard_link(host, port)
-
-    def scale(self, n):
+    def scale(self, n: int) -> None:
         """ Scale cluster to n workers
 
         Parameters
@@ -100,130 +94,8 @@ class Cluster(object):
         Example
         -------
         >>> cluster.scale(10)  # scale cluster to ten workers
-
-        See Also
-        --------
-        Cluster.scale_up
-        Cluster.scale_down
         """
-        with log_errors():
-            if n >= len(self.scheduler.workers):
-                self.scheduler.loop.add_callback(self.scale_up, n)
-            else:
-                to_close = self.scheduler.workers_to_close(
-                    n=len(self.scheduler.workers) - n
-                )
-                logger.debug("Closing workers: %s", to_close)
-                self.scheduler.loop.add_callback(
-                    self.scheduler.retire_workers, workers=to_close
-                )
-                self.scheduler.loop.add_callback(self.scale_down, to_close)
-
-    def _widget_status(self):
-        workers = len(self.scheduler.workers)
-        cores = sum(ws.nthreads for ws in self.scheduler.workers.values())
-        memory = sum(ws.memory_limit for ws in self.scheduler.workers.values())
-        memory = format_bytes(memory)
-        text = """
-<div>
-  <style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-  </style>
-  <table style="text-align: right;">
-    <tr><th>Workers</th> <td>%d</td></tr>
-    <tr><th>Cores</th> <td>%d</td></tr>
-    <tr><th>Memory</th> <td>%s</td></tr>
-  </table>
-</div>
-""" % (
-            workers,
-            cores,
-            memory,
-        )
-        return text
-
-    def _widget(self):
-        """ Create IPython widget for display within a notebook """
-        try:
-            return self._cached_widget
-        except AttributeError:
-            pass
-
-        from ipywidgets import Layout, VBox, HBox, IntText, Button, HTML, Accordion
-
-        layout = Layout(width="150px")
-
-        if "dashboard" in self.scheduler.services:
-            link = self.dashboard_link
-            link = '<p><b>Dashboard: </b><a href="%s" target="_blank">%s</a></p>\n' % (
-                link,
-                link,
-            )
-        else:
-            link = ""
-
-        title = "<h2>%s</h2>" % type(self).__name__
-        title = HTML(title)
-        dashboard = HTML(link)
-
-        status = HTML(self._widget_status(), layout=Layout(min_width="150px"))
-
-        request = IntText(0, description="Workers", layout=layout)
-        scale = Button(description="Scale", layout=layout)
-
-        minimum = IntText(0, description="Minimum", layout=layout)
-        maximum = IntText(0, description="Maximum", layout=layout)
-        adapt = Button(description="Adapt", layout=layout)
-
-        accordion = Accordion(
-            [HBox([request, scale]), HBox([minimum, maximum, adapt])],
-            layout=Layout(min_width="500px"),
-        )
-        accordion.selected_index = None
-        accordion.set_title(0, "Manual Scaling")
-        accordion.set_title(1, "Adaptive Scaling")
-
-        box = VBox([title, HBox([status, accordion]), dashboard])
-
-        self._cached_widget = box
-
-        def adapt_cb(b):
-            self.adapt(minimum=minimum.value, maximum=maximum.value)
-
-        adapt.on_click(adapt_cb)
-
-        def scale_cb(b):
-            with log_errors():
-                n = request.value
-                with ignoring(AttributeError):
-                    self._adaptive.stop()
-                self.scale(n)
-
-        scale.on_click(scale_cb)
-
-        scheduler_ref = ref(self.scheduler)
-
-        def update():
-            status.value = self._widget_status()
-
-        pc = PeriodicCallback(update, 500, io_loop=self.scheduler.loop)
-        self.scheduler.periodic_callbacks["cluster-repr"] = pc
-        pc.start()
-
-        return box
-
-    def _ipython_display_(self, **kwargs):
-        return self._widget()._ipython_display_(**kwargs)
+        raise NotImplementedError()
 
     @property
     def asynchronous(self):
@@ -243,3 +115,162 @@ class Cluster(object):
             return future
         else:
             return sync(self.loop, func, *args, **kwargs)
+
+    async def _logs(self, scheduler=True, workers=True):
+        logs = Logs()
+
+        if scheduler:
+            L = await self.scheduler_comm.logs()
+            logs["Scheduler"] = Log("\n".join(line for level, line in L))
+
+        if workers:
+            d = await self.scheduler_comm.worker_logs(workers=workers)
+            for k, v in d.items():
+                logs[k] = Log("\n".join(line for level, line in v))
+
+        return logs
+
+    def logs(self, scheduler=True, workers=True):
+        """ Return logs for the scheduler and workers
+
+        Parameters
+        ----------
+        scheduler : boolean
+            Whether or not to collect logs for the scheduler
+        workers : boolean or Iterable[str], optional
+            A list of worker addresses to select.
+            Defaults to all workers if `True` or no workers if `False`
+
+        Returns
+        -------
+        logs: Dict[str]
+            A dictionary of logs, with one item for the scheduler and one for
+            each worker
+        """
+        return self.sync(self._logs, scheduler=scheduler, workers=workers)
+
+    @property
+    def dashboard_link(self):
+        try:
+            port = self.scheduler_info["services"]["dashboard"]
+        except KeyError:
+            return ""
+        else:
+            host = self.scheduler_address.split("://")[1].split(":")[0]
+            return format_dashboard_link(host, port)
+
+    def _widget_status(self):
+        workers = len(self.scheduler_info["workers"])
+        requested = len(self.worker_spec)
+        cores = sum(v["nthreads"] for v in self.scheduler_info["workers"].values())
+        memory = sum(v["memory_limit"] for v in self.scheduler_info["workers"].values())
+        memory = format_bytes(memory)
+        text = """
+<div>
+  <style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+  </style>
+  <table style="text-align: right;">
+    <tr> <th>Workers</th> <td>%s</td></tr>
+    <tr> <th>Cores</th> <td>%d</td></tr>
+    <tr> <th>Memory</th> <td>%s</td></tr>
+  </table>
+</div>
+""" % (
+            workers if workers == requested else "%d / %d" % (workers, requested),
+            cores,
+            memory,
+        )
+        return text
+
+    def _widget(self):
+        """ Create IPython widget for display within a notebook """
+        try:
+            return self._cached_widget
+        except AttributeError:
+            pass
+
+        from ipywidgets import Layout, VBox, HBox, IntText, Button, HTML, Accordion
+
+        layout = Layout(width="150px")
+
+        if self.dashboard_link:
+            link = '<p><b>Dashboard: </b><a href="%s" target="_blank">%s</a></p>\n' % (
+                self.dashboard_link,
+                self.dashboard_link,
+            )
+        else:
+            link = ""
+
+        title = "<h2>%s</h2>" % type(self).__name__
+        title = HTML(title)
+        dashboard = HTML(link)
+
+        status = HTML(self._widget_status(), layout=Layout(min_width="150px"))
+
+        if self._supports_scaling:
+            request = IntText(0, description="Workers", layout=layout)
+            scale = Button(description="Scale", layout=layout)
+
+            minimum = IntText(0, description="Minimum", layout=layout)
+            maximum = IntText(0, description="Maximum", layout=layout)
+            adapt = Button(description="Adapt", layout=layout)
+
+            accordion = Accordion(
+                [HBox([request, scale]), HBox([minimum, maximum, adapt])],
+                layout=Layout(min_width="500px"),
+            )
+            accordion.selected_index = None
+            accordion.set_title(0, "Manual Scaling")
+            accordion.set_title(1, "Adaptive Scaling")
+
+            def adapt_cb(b):
+                self.adapt(minimum=minimum.value, maximum=maximum.value)
+                update()
+
+            adapt.on_click(adapt_cb)
+
+            def scale_cb(b):
+                with log_errors():
+                    n = request.value
+                    with ignoring(AttributeError):
+                        self._adaptive.stop()
+                    self.scale(n)
+                    update()
+
+            scale.on_click(scale_cb)
+        else:
+            accordion = HTML("")
+
+        box = VBox([title, HBox([status, accordion]), dashboard])
+
+        self._cached_widget = box
+
+        def update():
+            status.value = self._widget_status()
+
+        pc = PeriodicCallback(update, 500, io_loop=self.loop)
+        self.periodic_callbacks["cluster-repr"] = pc
+        pc.start()
+
+        return box
+
+    def _ipython_display_(self, **kwargs):
+        return self._widget()._ipython_display_(**kwargs)
+
+    def __repr__(self):
+        return "%s(%r, workers=%d)" % (
+            type(self).__name__,
+            self.scheduler_address,
+            len(self.scheduler_info["workers"]),
+        )

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -273,13 +273,6 @@ class SpecCluster(Cluster):
                 raise gen.TimeoutError("Worker unexpectedly closed")
             await asyncio.sleep(0.1)
 
-    async def __aenter__(self):
-        await self
-        return self
-
-    async def __aexit__(self, typ, value, traceback):
-        await self.close()
-
     async def _close(self):
         while self.status == "closing":
             await asyncio.sleep(0.1)

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -361,10 +361,6 @@ class SpecCluster(Cluster):
             len(self.workers),
         )
 
-    @property
-    def scheduler_address(self):
-        return self.scheduler.address
-
 
 @atexit.register
 def close_clusters():


### PR DESCRIPTION
This moves standard functionality from SpecClsuter to the Cluster
superclass.  It also removes the assumption that the Scheduler will be
local to the Cluster class.

cc @jcrist 