### PR TITLE
Raise informative warning when rescheduling an unknown task

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4363,7 +4363,14 @@ class Scheduler(ServerNode):
         Things may have shifted and this task may now be better suited to run
         elsewhere
         """
-        ts = self.tasks[key]
+        try:
+            ts = self.tasks[key]
+        except KeyError:
+            logger.warning(
+                "Attempting to reschedule task {}, which was not "
+                "found on the scheduler. Aborting reschedule.".format(key)
+            )
+            return
         if ts.state != "processing":
             return
         if worker and ts.processing_on.address != worker:


### PR DESCRIPTION
When tasks are quickly asked to be rescheduled, and also quickly canceled, it can lead to the task key being removed from the scheduler, but before the task can be canceled, the task begins running on the worker. Then when `Reschedule` is raised, the scheduler no longer has a key for the rescheduled task. Here's a (contrived) example of this behavior:

```python
from distributed import Client, Reschedule

if __name__ == "__main__":

    def f(x):
        raise Reschedule

    with Client(processes=False, threads_per_worker=1) as client:
        for i in range(100):
            z = client.submit(f, i)
            z.cancel()
```

which raises a `KeyError` when the scheduler attempts to reschedule the (already canceled) task:

```
distributed.core - ERROR - 'f-eb18a99a0c19477232670692e952f322'
Traceback (most recent call last):
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/core.py", line 416, in handle_comm
    result = await result
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/scheduler.py", line 1489, in add_worker
    await self.handle_worker(comm=comm, worker=address)
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/scheduler.py", line 2404, in handle_worker
    await self.handle_stream(comm=comm, extra={"worker": worker})
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/core.py", line 477, in handle_stream
    handler(**merge(extra, msg))
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/scheduler.py", line 4366, in reschedule
    ts = self.tasks[key]
KeyError: 'f-eb18a99a0c19477232670692e952f322'
```

This PR adds an informative warning if attempting to reschedule a key not found on the scheduler and aborts the rescheduling process. 