### PR TITLE
import from collections.abc to avoid a warning

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1,5 +1,5 @@
 import atexit
-from collections import defaultdict, Iterator
+from collections.abc import defaultdict, Iterator
 from concurrent.futures import ThreadPoolExecutor, CancelledError
 from concurrent.futures._base import DoneAndNotDoneFutures
 from contextlib import contextmanager


### PR DESCRIPTION
I keep having to manually change this in on my workstation.

I hope this works with all your supported versions.