### PR TITLE
Add timeouts to processes in SSH tests

### DIFF
--- a/distributed/deploy/ssh2.py
+++ b/distributed/deploy/ssh2.py
@@ -34,11 +34,13 @@ class Process(ProcessInterface):
 
     async def start(self):
         assert self.connection
-        weakref.finalize(self, self.proc.terminate)
+        weakref.finalize(
+            self, self.proc.kill
+        )  # https://github.com/ronf/asyncssh/issues/112
         await super().start()
 
     async def close(self):
-        self.proc.terminate()
+        self.proc.kill()  # https://github.com/ronf/asyncssh/issues/112
         self.connection.close()
         await super().close()
 

--- a/distributed/deploy/tests/test_ssh2.py
+++ b/distributed/deploy/tests/test_ssh2.py
@@ -12,7 +12,8 @@ async def test_basic():
         ["127.0.0.1"] * 3,
         connect_kwargs=dict(known_hosts=None),
         asynchronous=True,
-        scheduler_kwargs={"port": 0},
+        scheduler_kwargs={"port": 0, "idle_timeout": "5s"},
+        worker_kwargs={"death_timeout": "5s"},
     ) as cluster:
         assert len(cluster.workers) == 2
         async with Client(cluster, asynchronous=True) as client:
@@ -29,7 +30,7 @@ async def test_keywords():
         ["127.0.0.1"] * 3,
         connect_kwargs=dict(known_hosts=None),
         asynchronous=True,
-        worker_kwargs={"nthreads": 2, "memory_limit": "2 GiB"},
+        worker_kwargs={"nthreads": 2, "memory_limit": "2 GiB", "death_timeout": "5s"},
         scheduler_kwargs={"idle_timeout": "5s", "port": 0},
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:


### PR DESCRIPTION
It turns out that OpenSSH doesn't pass through terminate/kill signals,
so we had some zombie processes hanging around sending signals around where
they shouldn't.

Now we place idle and death timeouts on the launched processes to keep them in
check.

See https://github.com/ronf/asyncssh/issues/112 for more information on the
underlying issue.