### PR TITLE
LINT: Fixup black string normalization

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -215,7 +215,7 @@ def main(
         port=port,
         dashboard_address=dashboard_address if dashboard else None,
         service_kwargs={"dashboard": {"prefix": dashboard_prefix}},
-        **kwargs,
+        **kwargs
     )
     logger.info("Local Directory: %26s", local_directory)
     logger.info("-" * 47)

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -139,7 +139,7 @@ def main(
     tls_cert,
     tls_key,
     dashboard_address,
-    **kwargs
+    **kwargs,
 ):
     g0, g1, g2 = gc.get_threshold()  # https://github.com/dask/distributed/issues/1653
     gc.set_threshold(g0 * 3, g1 * 3, g2 * 3)

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -139,7 +139,7 @@ def main(
     tls_cert,
     tls_key,
     dashboard_address,
-    **kwargs,
+    **kwargs
 ):
     g0, g1, g2 = gc.get_threshold()  # https://github.com/dask/distributed/issues/1653
     gc.set_threshold(g0 * 3, g1 * 3, g2 * 3)

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -84,7 +84,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "--listen-address",
     type=str,
     default=None,
-    help="The address to which the worker binds. " "Example: tcp://0.0.0.0:9000",
+    help="The address to which the worker binds. Example: tcp://0.0.0.0:9000",
 )
 @click.option(
     "--contact-address",

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -905,7 +905,7 @@ class Client(Node):
                 pass
             except Exception:
                 logger.info(
-                    "Tried to start cluster and received an error. " "Proceeding.",
+                    "Tried to start cluster and received an error. Proceeding.",
                     exc_info=True,
                 )
             address = self.cluster.scheduler_address
@@ -2383,9 +2383,7 @@ class Client(Node):
             dsk3 = {k: v for k, v in dsk2.items() if k is not v}
             for future in extra_futures:
                 if future.client is not self:
-                    msg = (
-                        "Inputs contain futures that were created by " "another client."
-                    )
+                    msg = "Inputs contain futures that were created by another client."
                     raise ValueError(msg)
 
             if restrictions:
@@ -3485,7 +3483,7 @@ class Client(Node):
                     errs.append("%s\n%s" % (pkg, asciitable(["", "version"], rows)))
 
                 raise ValueError(
-                    "Mismatched versions found\n" "\n" "%s" % ("\n\n".join(errs))
+                    "Mismatched versions found\n\n%s" % ("\n\n".join(errs))
                 )
 
         return result
@@ -3967,7 +3965,7 @@ async def _wait(fs, timeout=None, return_when=ALL_COMPLETED):
         wait_for = Any
     else:
         raise NotImplementedError(
-            "Only return_when='ALL_COMPLETED' and 'FIRST_COMPLETED' are " "supported"
+            "Only return_when='ALL_COMPLETED' and 'FIRST_COMPLETED' are supported"
         )
 
     future = wait_for({f._state.wait() for f in fs})

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -123,7 +123,7 @@ def get_address_host_port(addr, strict=False):
         return backend.get_address_host_port(loc)
     except NotImplementedError:
         raise ValueError(
-            "don't know how to extract host and port " "for address %r" % (addr,)
+            "don't know how to extract host and port for address %r" % (addr,)
         )
 
 

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -261,7 +261,7 @@ def test_ucx_localcluster(loop, processes):
         threads_per_worker=1,
         processes=processes,
         loop=loop,
-        **kwargs,
+        **kwargs
     ) as cluster:
         with Client(cluster) as client:
             x = client.submit(inc, 1)

--- a/distributed/diskutils.py
+++ b/distributed/diskutils.py
@@ -237,7 +237,7 @@ class WorkSpace(object):
             self._purge_leftovers()
         except OSError:
             logger.error(
-                "Failed to clean up lingering worker directories " "in path: %s ",
+                "Failed to clean up lingering worker directories in path: %s ",
                 exc_info=True,
             )
         return WorkDir(self, **kwargs)

--- a/distributed/protocol/keras.py
+++ b/distributed/protocol/keras.py
@@ -9,7 +9,7 @@ def serialize_keras_model(model):
 
     if keras.__version__ < "1.2.0":
         raise ImportError(
-            "Need Keras >= 1.2.0. " "Try pip install keras --upgrade --no-deps"
+            "Need Keras >= 1.2.0. Try pip install keras --upgrade --no-deps"
         )
 
     header = model._updated_config()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2366,9 +2366,7 @@ class Scheduler(ServerNode):
 
         ws = ts.processing_on
         if ws is None:
-            logger.debug(
-                "Received long-running signal from duplicate task. " "Ignoring."
-            )
+            logger.debug("Received long-running signal from duplicate task. Ignoring.")
             return
 
         if compute_duration:
@@ -4730,7 +4728,7 @@ class Scheduler(ServerNode):
         for ws in self.workers.values():
             if ws.last_seen < now - self.worker_ttl:
                 logger.warning(
-                    "Worker failed to heartbeat within %s seconds. " "Closing: %s",
+                    "Worker failed to heartbeat within %s seconds. Closing: %s",
                     self.worker_ttl,
                     ws,
                 )

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -464,7 +464,7 @@ def test_Executor(c, s):
 
 
 @pytest.mark.skip(
-    reason="Other tests leak memory, so process-level checks" "trigger immediately"
+    reason="Other tests leak memory, so process-level checks trigger immediately"
 )
 @gen_cluster(
     client=True,

--- a/distributed/utils_perf.py
+++ b/distributed/utils_perf.py
@@ -42,7 +42,7 @@ class ThrottledGC(object):
         elapsed = max(collect_start - self.last_collect, MIN_RUNTIME)
         if self.last_gc_duration / elapsed < self.max_in_gc_frac:
             self.logger.debug(
-                "Calling gc.collect(). %0.3fs elapsed since " "previous call.", elapsed
+                "Calling gc.collect(). %0.3fs elapsed since previous call.", elapsed
             )
             gc.collect()
             self.last_collect = collect_start

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3354,7 +3354,7 @@ async def run(server, comm, function, args=(), kwargs={}, is_coro=None, wait=Tru
 
     except Exception as e:
         logger.warning(
-            " Run Failed\n" "Function: %s\n" "args:     %s\n" "kwargs:   %s\n",
+            "Run Failed\nFunction: %s\nargs:     %s\nkwargs:   %s\n",
             str(funcname(function))[:1000],
             convert_args_to_str(args, max_len=1000),
             convert_kwargs_to_str(kwargs, max_len=1000),


### PR DESCRIPTION
After running black, several places in our codebase were rewritten from
something like

```
raise ValueError("part one of the message "
                 "part two")
```

to

```
raise ValueError("part one of the message " "part two")
```

This fixes those cases, removing the unnecessary two-part string.

Stumbled across this when doing some other work, and it was a
quick fix. See also https://github.com/dask/dask/pull/5227.