### PR TITLE
Pass GPU diagnostics from worker to scheduler

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -1,0 +1,20 @@
+import pynvml
+
+pynvml.nvmlInit()
+count = pynvml.nvmlDeviceGetCount()
+
+handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(count)]
+
+
+def real_time():
+    return {
+        "utilization": [pynvml.nvmlDeviceGetUtilizationRates(h).gpu for h in handles],
+        "memory-used": [pynvml.nvmlDeviceGetMemoryInfo(h).used for h in handles],
+    }
+
+
+def one_time():
+    return {
+        "memory-total": [pynvml.nvmlDeviceGetMemoryInfo(h).total for h in handles],
+        "name": [pynvml.nvmlDeviceGetName(h).decode() for h in handles],
+    }

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -210,6 +210,7 @@ class WorkerState(object):
     __slots__ = (
         "actors",
         "address",
+        "extra",
         "has_what",
         "last_seen",
         "local_directory",
@@ -239,6 +240,7 @@ class WorkerState(object):
         local_directory=None,
         services=None,
         nanny=None,
+        extra=None,
     ):
         self.address = address
         self.pid = pid
@@ -262,6 +264,8 @@ class WorkerState(object):
         self.resources = {}
         self.used_resources = {}
 
+        self.extra = extra or {}
+
     @property
     def host(self):
         return get_address_host(self.address)
@@ -277,6 +281,7 @@ class WorkerState(object):
             local_directory=self.local_directory,
             services=self.services,
             nanny=self.nanny,
+            extra=self.extra,
         )
         ws.processing = {ts.key for ts in self.processing}
         return ws
@@ -305,6 +310,7 @@ class WorkerState(object):
             "services": self.services,
             "metrics": self.metrics,
             "nanny": self.nanny,
+            **self.extra,
         }
 
     @property
@@ -1387,6 +1393,7 @@ class Scheduler(ServerNode):
         services=None,
         local_directory=None,
         nanny=None,
+        extra=None,
     ):
         """ Add a new worker to the cluster """
         with log_errors():
@@ -1407,6 +1414,7 @@ class Scheduler(ServerNode):
                 local_directory=local_directory,
                 services=services,
                 nanny=nanny,
+                extra=extra,
             )
 
             if name in self.aliases:

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1536,3 +1536,15 @@ async def test_lifetime_stagger(c, s, a, b):
     assert a.lifetime != b.lifetime
     assert 8 <= a.lifetime <= 12
     assert 8 <= b.lifetime <= 12
+
+
+@gen_cluster()
+async def test_gpu_metrics(s, a, b):
+    pytest.importorskip("pynvml")
+    from distributed.diagnostics.nvml import count
+
+    assert "gpu" in a.metrics
+    assert len(s.workers[a.address].metrics["gpu"]["memory-used"]) == count
+
+    assert "gpu" in a.startup_information
+    assert len(s.workers[a.address].extra["gpu"]["name"]) == count

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -45,6 +45,7 @@ from .security import Security
 from .sizeof import safe_sizeof as sizeof
 from .threadpoolexecutor import ThreadPoolExecutor, secede as tpe_secede
 from .utils import (
+    is_coroutine_function,
     get_ip,
     funcname,
     typename,
@@ -81,6 +82,10 @@ READY = ("ready", "constrained")
 
 
 DEFAULT_EXTENSIONS = [PubSubWorkerExtension]
+
+DEFAULT_METRICS = {}
+
+DEFAULT_STARTUP_INFORMATION = {}
 
 
 class Worker(ServerNode):
@@ -306,7 +311,8 @@ class Worker(ServerNode):
         contact_address=None,
         memory_monitor_interval="200ms",
         extensions=None,
-        metrics=None,
+        metrics=DEFAULT_METRICS,
+        startup_information=DEFAULT_STARTUP_INFORMATION,
         data=None,
         interface=None,
         host=None,
@@ -578,6 +584,9 @@ class Worker(ServerNode):
                 )
 
         self.metrics = dict(metrics) if metrics else {}
+        self.startup_information = (
+            dict(startup_information) if startup_information else {}
+        )
 
         self.low_level_profiler = low_level_profiler
 
@@ -716,7 +725,7 @@ class Worker(ServerNode):
         warnings.warn("The local_dir attribute has moved to local_directory")
         return self.local_directory
 
-    def get_metrics(self):
+    async def get_metrics(self):
         core = dict(
             executing=len(self.executing),
             in_memory=len(self.data),
@@ -724,9 +733,18 @@ class Worker(ServerNode):
             in_flight=len(self.in_flight_tasks),
             bandwidth=self.bandwidth,
         )
-        custom = {k: metric(self) for k, metric in self.metrics.items()}
+        custom = {
+            k: (await metric(self)) if is_coroutine_function(metric) else metric(self)
+            for k, metric in self.metrics.items()
+        }
 
         return merge(custom, self.monitor.recent(), core)
+
+    async def get_startup_information(self):
+        return {
+            k: (await f(self)) if is_coroutine_function(f) else f(self)
+            for k, f in self.startup_information.items()
+        }
 
     def identity(self, comm=None):
         return {
@@ -785,7 +803,8 @@ class Worker(ServerNode):
                         services=self.service_ports,
                         nanny=self.nanny,
                         pid=os.getpid(),
-                        metrics=self.get_metrics(),
+                        metrics=await self.get_metrics(),
+                        extra=await self.get_startup_information(),
                     ),
                     serializers=["msgpack"],
                 )
@@ -832,7 +851,9 @@ class Worker(ServerNode):
             try:
                 start = time()
                 response = await self.scheduler.heartbeat_worker(
-                    address=self.contact_address, now=time(), metrics=self.get_metrics()
+                    address=self.contact_address,
+                    now=time(),
+                    metrics=await self.get_metrics(),
                 )
                 end = time()
                 middle = (start + end) / 2
@@ -3361,3 +3382,21 @@ async def run(server, comm, function, args=(), kwargs={}, is_coro=None, wait=Tru
 
 
 _global_workers = Worker._instances
+
+try:
+    from .diagnostics import nvml
+except ImportError:
+    pass
+else:
+
+    @gen.coroutine
+    def gpu_metric(worker):
+        result = yield offload(nvml.real_time)
+        return result
+
+    DEFAULT_METRICS["gpu"] = gpu_metric
+
+    def gpu_startup(worker):
+        return nvml.one_time()
+
+    DEFAULT_STARTUP_INFORMATION["gpu"] = gpu_startup


### PR DESCRIPTION
This does a few things:

1.  Use `pynvml` to collect information about any CUDA GPUs present
2.  Optionally add those metrics to the worker's initial handshake and
    heartbeats
3.  Collect that information in the scheduler in the WorkerState object

For now these just hang out in the scheduler information,
but in the future they might be used for dashboards,
or possibly scheduling decisions in the future.

I believe that everything gpu-specific here is fairly well separated
and generalized (others should be able to follow this pattern to add
more diagnostics relatively easily) but it would be good to hear from
others on if this is out of scope.