### PR TITLE
Wrap offload in gen.coroutine

### DIFF
--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -1,12 +1,10 @@
-from concurrent.futures import ThreadPoolExecutor
 import logging
 import socket
-import weakref
 
 from tornado import gen
 
 from .. import protocol
-from ..utils import get_ip, get_ipv6, nbytes
+from ..utils import get_ip, get_ipv6, nbytes, offload
 
 
 logger = logging.getLogger(__name__)
@@ -16,18 +14,6 @@ logger = logging.getLogger(__name__)
 # We use at most 4 threads to allow for parallel processing of large messages.
 
 FRAME_OFFLOAD_THRESHOLD = 10 * 1024 ** 2  # 10 MB
-
-try:
-    _offload_executor = ThreadPoolExecutor(
-        max_workers=1, thread_name_prefix="Dask-Offload"
-    )
-except TypeError:
-    _offload_executor = ThreadPoolExecutor(max_workers=1)
-weakref.finalize(_offload_executor, _offload_executor.shutdown)
-
-
-def offload(fn, *args, **kwargs):
-    return _offload_executor.submit(fn, *args, **kwargs)
 
 
 @gen.coroutine

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -41,7 +41,6 @@ from tornado.ioloop import IOLoop
 from .client import default_client, _global_clients, Client
 from .compatibility import WINDOWS
 from .comm import Comm
-from .comm.utils import offload
 from .config import initialize_logging
 from .core import connect, rpc, CommClosedError
 from .deploy import SpecCluster
@@ -56,6 +55,7 @@ from .utils import (
     get_ip,
     get_ipv6,
     DequeHandler,
+    offload,
     reset_logger_locks,
     sync,
     iscoroutinefunction,

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -55,11 +55,11 @@ from .utils import (
     get_ip,
     get_ipv6,
     DequeHandler,
-    offload,
     reset_logger_locks,
     sync,
     iscoroutinefunction,
     thread_state,
+    _offload_executor,
 )
 from .worker import Worker, TOTAL_MEMORY
 from .nanny import Nanny
@@ -80,7 +80,7 @@ logging_levels = {
 }
 
 
-offload(lambda: None).result()  # create thread during import
+_offload_executor.submit(lambda: None).result()  # create thread during import
 
 
 @pytest.fixture(scope="session")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -30,7 +30,6 @@ from tornado.ioloop import IOLoop
 from . import profile, comm
 from .batched import BatchedSend
 from .comm import get_address_host, connect
-from .comm.utils import offload
 from .comm.addressing import address_from_user_args
 from .core import error_message, CommClosedError, send_recv, pingpong, coerce_to_address
 from .diskutils import WorkSpace
@@ -56,6 +55,7 @@ from .utils import (
     thread_state,
     json_load_robust,
     key_split,
+    offload,
     PeriodicCallback,
     parse_bytes,
     parse_timedelta,


### PR DESCRIPTION
Previously we would return the bare concurrent.future.Future
which was not awaitable.  Now we rely on Tornado's gen.coroutine
logic to handle this.

Fixes https://github.com/dask/distributed/issues/2928