### PR TITLE
Fixes Worker docstring code formatting 

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -97,7 +97,7 @@ class Worker(ServerNode):
 
         $ dask-worker scheduler-ip:port
 
-    Use the ``--help`` flag to see more options
+    Use the ``--help`` flag to see more options::
 
         $ dask-worker --help
 


### PR DESCRIPTION
This PR fixes the rendering of `dask-worker --help`. Currently, it looks like:

![Screen Shot 2019-08-07 at 1 03 45 PM](https://user-images.githubusercontent.com/11656932/62646480-138cf480-b914-11e9-8f60-4d00d7c531e1.png)

With the changes in this PR, it looks like:

![Screen Shot 2019-08-07 at 1 06 08 PM](https://user-images.githubusercontent.com/11656932/62646528-2bfd0f00-b914-11e9-919e-e59cd4362fee.png)


Part of a Dask docs sprint https://github.com/dask/community/issues/2