### PR TITLE
Add support for collection serialization

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -179,7 +179,7 @@ def serialize(x, serializers=None, on_error="message", context=None):
             "sub-headers": headers,
             "is-collection": True,
             "frame-lengths": lengths,
-            "type-serialized": pickle.dumps(type(x)),
+            "type-serialized": type(x).__name__,
         }
         return headers, frames
 
@@ -229,7 +229,9 @@ def deserialize(header, frames, deserializers=None):
     if "is-collection" in header:
         headers = header["sub-headers"]
         lengths = header["frame-lengths"]
-        cls = pickle.loads(header["type-serialized"])
+        cls = {"tuple": tuple, "list": list, "set": set, "dict": dict}[
+            header["type-serialized"]
+        ]
 
         start = 0
         if cls is dict:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -144,9 +144,13 @@ def serialize(x, serializers=None, on_error="message", context=None):
         else:
             dict_safe = True
 
-    if (type(x) in (list, set, tuple) or (type(x) is dict and dict_safe)) and len(
-        x
-    ) <= 5:
+    if (
+        type(x) in (list, set, tuple)
+        and len(x) <= 5
+        or type(x) is dict
+        and len(x) <= 5
+        and dict_safe
+    ):
         if isinstance(x, dict):
             headers_frames = []
             for k, v in x.items():

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -157,14 +157,7 @@ def serialize(x, serializers=None, on_error="message", context=None):
                 _header, _frames = serialize(
                     v, serializers=serializers, on_error=on_error, context=context
                 )
-                try:
-                    k = msgpack.dumps(k)
-                except Exception:
-                    k = serialize(
-                        k, serializers=serializers, on_error=on_error, context=context
-                    )
-                else:
-                    _header["key"] = k
+                _header["key"] = k
                 headers_frames.append((_header, _frames))
         else:
             headers_frames = [
@@ -243,7 +236,6 @@ def deserialize(header, frames, deserializers=None):
             d = {}
             for _header, _length in zip(headers, lengths):
                 k = _header.pop("key")
-                k = msgpack.loads(k, raw=False)
                 d[k] = deserialize(
                     _header,
                     frames[start : start + _length],

--- a/distributed/protocol/tests/test_collection.py
+++ b/distributed/protocol/tests/test_collection.py
@@ -1,0 +1,64 @@
+from distributed.protocol import serialize, deserialize
+import pandas as pd
+import numpy as np
+from dask.dataframe.utils import assert_eq
+
+
+def test_serialize_cupy_cupy_tuple():
+    x = np.arange(100)
+    header, frames = serialize((x, x), serializers=("dask", "pickle"))
+    t = deserialize(header, frames, deserializers=("dask", "pickle", "error"))
+
+    assert header["is-collection"] is True
+    sub_headers = header["sub-headers"]
+    assert sub_headers[0]["serializer"] == "dask"
+    assert sub_headers[1]["serializer"] == "dask"
+    assert isinstance(t, tuple)
+
+    assert (t[0] == x).all()
+    assert (t[1] == x).all()
+
+
+def test_serialize_cupy_none_tuple():
+    x = np.arange(100)
+    header, frames = serialize((x, None), serializers=("dask", "pickle"))
+    t = deserialize(header, frames, deserializers=("dask", "pickle", "error"))
+
+    assert header["is-collection"] is True
+    sub_headers = header["sub-headers"]
+    assert sub_headers[0]["serializer"] == "dask"
+    assert sub_headers[1]["serializer"] == "pickle"
+    assert isinstance(t, tuple)
+
+    assert (t[0] == x).all()
+    assert t[1] is None
+
+
+def test_serialize_cudf_cudf_tuple():
+    df = pd.DataFrame({"A": [1, 2, None], "B": [1.0, 2.0, None]})
+    header, frames = serialize((df, df), serializers=("dask", "pickle"))
+    t = deserialize(header, frames, deserializers=("dask", "pickle"))
+
+    assert header["is-collection"] is True
+    sub_headers = header["sub-headers"]
+    assert sub_headers[0]["serializer"] == "pickle"
+    assert sub_headers[1]["serializer"] == "pickle"
+    assert isinstance(t, tuple)
+
+    assert_eq(t[0], df)
+    assert_eq(t[1], df)
+
+
+def test_serialize_cudf_none_tuple():
+    df = pd.DataFrame({"A": [1, 2, None], "B": [1.0, 2.0, None]})
+    header, frames = serialize((df, None), serializers=("dask", "pickle"))
+    t = deserialize(header, frames, deserializers=("dask", "pickle"))
+
+    assert header["is-collection"] is True
+    sub_headers = header["sub-headers"]
+    assert sub_headers[0]["serializer"] == "pickle"
+    assert sub_headers[1]["serializer"] == "pickle"
+    assert isinstance(t, tuple)
+
+    assert_eq(t[0], df)
+    assert t[1] is None

--- a/distributed/protocol/tests/test_collection.py
+++ b/distributed/protocol/tests/test_collection.py
@@ -1,64 +1,59 @@
+import pytest
 from distributed.protocol import serialize, deserialize
 import pandas as pd
 import numpy as np
 from dask.dataframe.utils import assert_eq
 
 
-def test_serialize_cupy_cupy_tuple():
+@pytest.mark.parametrize("collection", [tuple, dict])
+@pytest.mark.parametrize("y,y_serializer", [(np.arange(50), "dask"), (None, "pickle")])
+def test_serialize_numpy_numpy(collection, y, y_serializer):
     x = np.arange(100)
-    header, frames = serialize((x, x), serializers=("dask", "pickle"))
+    if issubclass(collection, dict):
+        header, frames = serialize({"x": x, "y": y}, serializers=("dask", "pickle"))
+    else:
+        header, frames = serialize((x, y), serializers=("dask", "pickle"))
     t = deserialize(header, frames, deserializers=("dask", "pickle", "error"))
 
     assert header["is-collection"] is True
     sub_headers = header["sub-headers"]
     assert sub_headers[0]["serializer"] == "dask"
-    assert sub_headers[1]["serializer"] == "dask"
-    assert isinstance(t, tuple)
+    assert sub_headers[1]["serializer"] == y_serializer
+    assert isinstance(t, collection)
 
-    assert (t[0] == x).all()
-    assert (t[1] == x).all()
-
-
-def test_serialize_cupy_none_tuple():
-    x = np.arange(100)
-    header, frames = serialize((x, None), serializers=("dask", "pickle"))
-    t = deserialize(header, frames, deserializers=("dask", "pickle", "error"))
-
-    assert header["is-collection"] is True
-    sub_headers = header["sub-headers"]
-    assert sub_headers[0]["serializer"] == "dask"
-    assert sub_headers[1]["serializer"] == "pickle"
-    assert isinstance(t, tuple)
-
-    assert (t[0] == x).all()
-    assert t[1] is None
+    assert ((t["x"] if isinstance(t, dict) else t[0]) == x).all()
+    if y is None:
+        assert (t["y"] if isinstance(t, dict) else t[1]) is None
+    else:
+        assert ((t["y"] if isinstance(t, dict) else t[1]) == y).all()
 
 
-def test_serialize_cudf_cudf_tuple():
-    df = pd.DataFrame({"A": [1, 2, None], "B": [1.0, 2.0, None]})
-    header, frames = serialize((df, df), serializers=("dask", "pickle"))
+@pytest.mark.parametrize("collection", [tuple, dict])
+@pytest.mark.parametrize(
+    "df2,df2_serializer",
+    [
+        (pd.DataFrame({"C": ["a", "b", None], "D": [2.5, 3.5, 4.5]}), "pickle"),
+        (None, "pickle"),
+    ],
+)
+def test_serialize_pandas_pandas(collection, df2, df2_serializer):
+    df1 = pd.DataFrame({"A": [1, 2, None], "B": [1.0, 2.0, None]})
+    if issubclass(collection, dict):
+        header, frames = serialize(
+            {"df1": df1, "df2": df2}, serializers=("dask", "pickle")
+        )
+    else:
+        header, frames = serialize((df1, df2), serializers=("dask", "pickle"))
     t = deserialize(header, frames, deserializers=("dask", "pickle"))
 
     assert header["is-collection"] is True
     sub_headers = header["sub-headers"]
     assert sub_headers[0]["serializer"] == "pickle"
     assert sub_headers[1]["serializer"] == "pickle"
-    assert isinstance(t, tuple)
+    assert isinstance(t, collection)
 
-    assert_eq(t[0], df)
-    assert_eq(t[1], df)
-
-
-def test_serialize_cudf_none_tuple():
-    df = pd.DataFrame({"A": [1, 2, None], "B": [1.0, 2.0, None]})
-    header, frames = serialize((df, None), serializers=("dask", "pickle"))
-    t = deserialize(header, frames, deserializers=("dask", "pickle"))
-
-    assert header["is-collection"] is True
-    sub_headers = header["sub-headers"]
-    assert sub_headers[0]["serializer"] == "pickle"
-    assert sub_headers[1]["serializer"] == "pickle"
-    assert isinstance(t, tuple)
-
-    assert_eq(t[0], df)
-    assert t[1] is None
+    assert_eq(t["df1"] if isinstance(t, dict) else t[0], df1)
+    if df2 is None:
+        assert (t["df2"] if isinstance(t, dict) else t[1]) is None
+    else:
+        assert_eq(t["df2"] if isinstance(t, dict) else t[1], df2)

--- a/distributed/protocol/tests/test_collection.py
+++ b/distributed/protocol/tests/test_collection.py
@@ -57,3 +57,16 @@ def test_serialize_pandas_pandas(collection, df2, df2_serializer):
         assert (t["df2"] if isinstance(t, dict) else t[1]) is None
     else:
         assert_eq(t["df2"] if isinstance(t, dict) else t[1], df2)
+
+
+def test_large_collections_serialize_simply():
+    header, frames = serialize(tuple(range(1000)))
+    assert len(frames) == 1
+
+
+def test_nested_types():
+    x = np.ones(5)
+    header, frames = serialize([[[x]]])
+    assert "dask" in str(header)
+    assert len(frames) == 1
+    assert x.data in frames

--- a/distributed/protocol/tests/test_collection_cuda.py
+++ b/distributed/protocol/tests/test_collection_cuda.py
@@ -1,0 +1,69 @@
+from distributed.protocol import serialize, deserialize
+from dask.dataframe.utils import assert_eq
+import pytest
+
+
+def test_serialize_cupy_cupy_tuple():
+    cupy = pytest.importorskip("cupy")
+    x = cupy.arange(100)
+    header, frames = serialize((x, x), serializers=("cuda", "dask", "pickle"))
+    t = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+
+    assert header["is-collection"] is True
+    sub_headers = header["sub-headers"]
+    assert sub_headers[0]["serializer"] == "cuda"
+    assert sub_headers[1]["serializer"] == "cuda"
+    assert isinstance(t, tuple)
+
+    assert (t[0] == x).all()
+    assert (t[1] == x).all()
+
+
+def test_serialize_cupy_none_tuple():
+    cupy = pytest.importorskip("cupy")
+    x = cupy.arange(100)
+    header, frames = serialize((x, None), serializers=("cuda", "dask", "pickle"))
+    t = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+
+    assert header["is-collection"] is True
+    sub_headers = header["sub-headers"]
+    assert sub_headers[0]["serializer"] == "cuda"
+    assert sub_headers[1]["serializer"] == "pickle"
+    assert isinstance(t, tuple)
+
+    assert (t[0] == x).all()
+    assert t[1] is None
+
+
+def test_serialize_cudf_cudf_tuple():
+    cudf = pytest.importorskip("cudf")
+
+    df = cudf.DataFrame({"A": [1, 2, None], "B": [1.0, 2.0, None]})
+    header, frames = serialize((df, df), serializers=("cuda", "dask", "pickle"))
+    t = deserialize(header, frames, deserializers=("cuda", "dask", "pickle"))
+
+    assert header["is-collection"] is True
+    sub_headers = header["sub-headers"]
+    assert sub_headers[0]["serializer"] == "cuda"
+    assert sub_headers[1]["serializer"] == "cuda"
+    assert isinstance(t, tuple)
+
+    assert_eq(t[0], df)
+    assert_eq(t[1], df)
+
+
+def test_serialize_cudf_none_tuple():
+    cudf = pytest.importorskip("cudf")
+
+    df = cudf.DataFrame({"A": [1, 2, None], "B": [1.0, 2.0, None]})
+    header, frames = serialize((df, None), serializers=("cuda", "dask", "pickle"))
+    t = deserialize(header, frames, deserializers=("cuda", "dask", "pickle"))
+
+    assert header["is-collection"] is True
+    sub_headers = header["sub-headers"]
+    assert sub_headers[0]["serializer"] == "cuda"
+    assert sub_headers[1]["serializer"] == "pickle"
+    assert isinstance(t, tuple)
+
+    assert_eq(t[0], df)
+    assert t[1] is None

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -46,7 +46,7 @@ register_serialization(MyObj, serialize_myobj, deserialize_myobj)
 
 
 def test_dumps_serialize():
-    for x in [123, [1, 2, 3]]:
+    for x in [123, [1, 2, 3, 4, 5, 6]]:
         header, frames = serialize(x)
         assert header["serializer"] == "pickle"
         assert len(frames) == 1
@@ -235,7 +235,7 @@ def test_malicious_exception():
 
 
 def test_errors():
-    msg = {"data": {"foo": to_serialize(inc)}}
+    msg = {"data": {"foo": to_serialize(inc)}, "a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
 
     header, frames = serialize(msg, serializers=["msgpack", "pickle"])
     assert header["serializer"] == "pickle"

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -228,7 +228,7 @@ def test_pickle_safe(c, s, a, b):
     try:
         yield c2.publish_dataset(x=[1, 2, 3])
         result = yield c2.get_dataset("x")
-        assert result == (1, 2, 3)
+        assert result == [1, 2, 3]
 
         with pytest.raises(TypeError):
             yield c2.publish_dataset(y=lambda x: x)


### PR DESCRIPTION
This PR adds support for serialization of collections using objects' native types, rather than pickling the entire collection. It is required for efficient serialization of CUDA objects in https://github.com/rapidsai/dask-cuda/issues/110.