### PR TITLE
it's safe to add A robust case or omit the error

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2423,7 +2423,6 @@ class Scheduler(ServerNode):
         """
         if isinstance(plugin, type):
             plugin = plugin(self, **kwargs)
-tls://10.252.19.48:23530
         if idempotent and any(isinstance(p, type(plugin)) for p in self.plugins):
             return
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2423,7 +2423,7 @@ class Scheduler(ServerNode):
         """
         if isinstance(plugin, type):
             plugin = plugin(self, **kwargs)
-
+tls://10.252.19.48:23530
         if idempotent and any(isinstance(p, type(plugin)) for p in self.plugins):
             return
 
@@ -2443,6 +2443,8 @@ class Scheduler(ServerNode):
             self.stream_comms[worker].send(msg)
         except (CommClosedError, AttributeError):
             self.loop.add_callback(self.remove_worker, address=worker)
+        except KeyError:
+            pass
 
     ############################
     # Less common interactions #


### PR DESCRIPTION
for example,   
  worker0( 'tls://10.252.19.48:63530' ):  pub = Pub(topic_name)
  worker1( 'tls://10.252.19.49:63530' ):  sub = Sub(topic_name, worker=w)
  
if :
    del worker0
when calling:
                   scheduler.extensions["pubsub"].add_subscriber( name=topic_name, ...  )
then:
                  pubsub.scheduler.worker_send('tls://10.252.19.48:23530', {"op": "pubsub-add-subscriber", "address": 'tls://10.252.19.49:63530', "name": topic_name})
   may receive A  "KeyError"              


so it's safe to omit the error