### PR TITLE
Except all exceptions when checking pynvml

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3397,7 +3397,7 @@ _global_workers = Worker._instances
 
 try:
     from .diagnostics import nvml
-except (ImportError, AttributeError):
+except Exception:
     pass
 else:
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3397,7 +3397,7 @@ _global_workers = Worker._instances
 
 try:
     from .diagnostics import nvml
-except ImportError:
+except (ImportError, AttributeError):
     pass
 else:
 


### PR DESCRIPTION
This handles the case where the user hhas installed pynvml, but doesn't
have nvml installed