### PR TITLE
Add support for separate external address for SpecCluster scheduler

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -226,7 +226,7 @@ class SpecCluster(Cluster):
         self.status = "starting"
         self.scheduler = await self.scheduler
         self.scheduler_comm = rpc(
-            self.scheduler.external_address or self.scheduler.address,
+            getattr(self.scheduler, "external_address", None) or self.scheduler.address,
             connection_args=self.security.get_connection_args("client"),
         )
         await super()._start()

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -23,6 +23,7 @@ class ProcessInterface:
 
     def __init__(self):
         self.address = None
+        self.external_address = None
         self.lock = asyncio.Lock()
         self.status = "created"
 
@@ -225,7 +226,7 @@ class SpecCluster(Cluster):
         self.status = "starting"
         self.scheduler = await self.scheduler
         self.scheduler_comm = rpc(
-            self.scheduler.address,
+            self.scheduler.external_address or self.scheduler.address,
             connection_args=self.security.get_connection_args("client"),
         )
         await super()._start()


### PR DESCRIPTION
Minimal implementation which closes #2962.

Allow `SpecCluster` scheduler tasks to set an optional `external_address` property which will be used for the RPC connection instead of the scheduler address.

Allows clusters to be created and managed externally while allowing workers to continue to talk on an internal network.