### PR TITLE
Improve get_ip_interface error message when interface does not exist

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -149,8 +149,16 @@ def test_get_ip_interface():
         assert get_ip_interface("lo") == "127.0.0.1"
     else:
         pytest.skip("test needs to be enhanced for platform %r" % (sys.platform,))
-    with pytest.raises(KeyError):
-        get_ip_interface("__non-existent-interface")
+
+    non_existent_interface = "__non-existent-interface"
+    expected_error_message = ("{!r} is not a valid network interface.+"
+                              "Valid network interfaces are:".format(non_existent_interface))
+    if sys.platform == 'darwin':
+        expected_error_message += ".+'lo0'"
+    elif sys.platform.startswith("linux"):
+        expected_error_message += ".+'lo'"
+    with pytest.raises(KeyError, match=expected_error_message):
+        get_ip_interface(non_existent_interface)
 
 
 def test_truncate_exception():

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -151,15 +151,13 @@ def test_get_ip_interface():
         pytest.skip("test needs to be enhanced for platform %r" % (sys.platform,))
 
     non_existent_interface = "__non-existent-interface"
-    expected_error_message = (
-        "{!r} is not a valid network interface.+"
-        "Valid network interfaces are:".format(non_existent_interface)
-    )
+    expected_error_message = "{!r}.+network interface.+".format(non_existent_interface)
+
     if sys.platform == "darwin":
-        expected_error_message += ".+'lo0'"
+        expected_error_message += "'lo0'"
     elif sys.platform.startswith("linux"):
-        expected_error_message += ".+'lo'"
-    with pytest.raises(KeyError, match=expected_error_message):
+        expected_error_message += "'lo'"
+    with pytest.raises(ValueError, match=expected_error_message):
         get_ip_interface(non_existent_interface)
 
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -151,9 +151,11 @@ def test_get_ip_interface():
         pytest.skip("test needs to be enhanced for platform %r" % (sys.platform,))
 
     non_existent_interface = "__non-existent-interface"
-    expected_error_message = ("{!r} is not a valid network interface.+"
-                              "Valid network interfaces are:".format(non_existent_interface))
-    if sys.platform == 'darwin':
+    expected_error_message = (
+        "{!r} is not a valid network interface.+"
+        "Valid network interfaces are:".format(non_existent_interface)
+    )
+    if sys.platform == "darwin":
         expected_error_message += ".+'lo0'"
     elif sys.platform.startswith("linux"):
         expected_error_message += ".+'lo'"

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -173,7 +173,7 @@ def get_ip_interface(ifname):
 
     if ifname not in net_if_addrs:
         allowed_ifnames = list(net_if_addrs.keys())
-        raise KeyError(
+        raise ValueError(
             "{!r} is not a valid network interface. "
             "Valid network interfaces are: {}".format(ifname, allowed_ifnames)
         )

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -173,8 +173,10 @@ def get_ip_interface(ifname):
 
     if ifname not in net_if_addrs:
         allowed_ifnames = list(net_if_addrs.keys())
-        raise KeyError('{!r} is not a valid network interface. '
-                         'Valid network interfaces are: {}'.format(ifname, allowed_ifnames))
+        raise KeyError(
+            "{!r} is not a valid network interface. "
+            "Valid network interfaces are: {}".format(ifname, allowed_ifnames)
+        )
 
     for info in net_if_addrs[ifname]:
         if info.family == socket.AF_INET:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -169,7 +169,14 @@ def get_ip_interface(ifname):
     """
     import psutil
 
-    for info in psutil.net_if_addrs()[ifname]:
+    net_if_addrs = psutil.net_if_addrs()
+
+    if ifname not in net_if_addrs:
+        allowed_ifnames = list(net_if_addrs.keys())
+        raise KeyError('{!r} is not a valid network interface. '
+                         'Valid network interfaces are: {}'.format(ifname, allowed_ifnames))
+
+    for info in net_if_addrs[ifname]:
         if info.family == socket.AF_INET:
             return info.address
     raise ValueError("interface %r doesn't have an IPv4 address" % (ifname,))


### PR DESCRIPTION
Context: in `dask-jobqueue` you need some tweaking to find the right network interface to use on your cluster. People may not be familiar with what a network interface is and the current error message is a bit cryptic.

The main thing I am wondering about is whether we should keep the same error type `KeyError` with backward-compatibility in mind or switch to `ValueError` since `ValueError` is already the type of the error you get when the network interface does not have a valid IPv4 address.

My personal preference would be to switch to `ValueError` but I have kept `KeyError` for now.


Error message on master:
```
In [1]: from distributed.utils import get_ip_interface 
   ...: get_ip_interface('asdf')                                                                                                                                                   
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-1-cf8f3124444e> in <module>
      1 from distributed.utils import get_ip_interface
----> 2 get_ip_interface('asdf')

/home/local/lesteve/dev/distributed/distributed/utils.py in get_ip_interface(ifname)
    170     import psutil
    171 
--> 172     for info in psutil.net_if_addrs()[ifname]:
    173         if info.family == socket.AF_INET:
    174             return info.address

KeyError: 'asdf'
```

Error message in this PR:
```
In [1]: from distributed.utils import get_ip_interface 
   ...: get_ip_interface('asdf')                                                                                                                                                   
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-1-cf8f3124444e> in <module>
      1 from distributed.utils import get_ip_interface
----> 2 get_ip_interface('asdf')

/home/local/lesteve/dev/distributed/distributed/utils.py in get_ip_interface(ifname)
    175         allowed_ifnames = list(net_if_addrs.keys())
    176         raise KeyError('{!r} is not a valid network interface. '
--> 177                          'Valid network interfaces are: {}'.format(ifname, allowed_ifnames))
    178 
    179     for info in net_if_addrs[ifname]:

KeyError: "'asdf' is not a valid network interface. Valid network interfaces are: ['lo', 'enp0s25', 'br-e1ab2121f792', 'docker0', 'br-9f15079dee0d']"
```