### PR TITLE
Workaround for hanging test now calls `ucp.fin()`

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -35,7 +35,7 @@ async def get_comm_pair(
     # Workaround for hanging test in
     # pytest distributed/comm/tests/test_ucx.py::test_comm_objs -vs --count=2
     # on the second time through.
-    # ucp._libs.ucp_py.reader_added = 0
+    ucp._libs.ucp_py.fin()
 
     listener = listen(listen_addr, handle_comm, connection_args=listen_args, **kwargs)
     with listener:


### PR DESCRIPTION
The workaround in `test_ucx.py` to fix hanging is now calling `ucp._libs.ucp_py.fin()`.
Calling `ucp._libs.ucp_py.reader_added = 0` didn't work since it would only partial reset the system.
Hopefully, when UCX-Py is more mature this won't be necessary.

(cc @mrocklin)