### PR TITLE
BUG: Handle buffer protocol objects in ensure_bytes

### DIFF
--- a/distributed/protocol/arrow.py
+++ b/distributed/protocol/arrow.py
@@ -34,7 +34,7 @@ def serialize_table(tbl):
     writer = pyarrow.RecordBatchStreamWriter(sink, tbl.schema)
     writer.write_table(tbl)
     writer.close()
-    buf = memoryview(sink.getvalue())
+    buf = sink.getvalue()
     header = {}
     frames = [buf]
     return header, frames

--- a/distributed/protocol/arrow.py
+++ b/distributed/protocol/arrow.py
@@ -34,7 +34,7 @@ def serialize_table(tbl):
     writer = pyarrow.RecordBatchStreamWriter(sink, tbl.schema)
     writer.write_table(tbl)
     writer.close()
-    buf = sink.getvalue()
+    buf = memoryview(sink.getvalue())
     header = {}
     frames = [buf]
     return header, frames

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,3 +1,4 @@
+import array
 import datetime
 from functools import partial
 import io
@@ -275,11 +276,23 @@ def test_funcname():
 
 
 def test_ensure_bytes():
-    data = [b"1", "1", memoryview(b"1"), bytearray(b"1")]
+    data = [b"1", "1", memoryview(b"1"), bytearray(b"1"), array.array("b", [49])]
     for d in data:
         result = ensure_bytes(d)
         assert isinstance(result, bytes)
         assert result == b"1"
+
+
+def test_ensure_bytes_ndarray():
+    result = ensure_bytes(np.arange(12))
+    assert isinstance(result, bytes)
+
+
+def test_ensure_bytes_pyarrow_buffer():
+    pa = pytest.importorskip("pyarrow")
+    buf = pa.py_buffer(b"123")
+    result = ensure_bytes(buf)
+    assert isinstance(result, bytes)
 
 
 def test_nbytes():

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -903,22 +903,43 @@ def tmpfile(extension=""):
 
 
 def ensure_bytes(s):
-    """ Turn string or bytes to bytes
+    """Attempt to turn `s` into bytes.
+
+    Parameters
+    ----------
+    s : Any
+        The object to be converted. Will correctly handled
+
+        * str
+        * bytes
+        * objects implementing the buffer protocol (memoryview, ndarray, etc.)
+
+    Returns
+    -------
+    b : bytes
+
+    Raises
+    ------
+    TypeError
+        When `s` cannot be converted
+
+    Examples
+    --------
 
     >>> ensure_bytes('123')
     b'123'
     >>> ensure_bytes(b'123')
     b'123'
     """
-    if isinstance(s, bytes):
-        return s
-    if isinstance(s, memoryview):
-        return s.tobytes()
-    if isinstance(s, bytearray):  # noqa: F821
-        return bytes(s)
     if hasattr(s, "encode"):
         return s.encode()
-    raise TypeError("Object %s is neither a bytes object nor has an encode method" % s)
+    else:
+        try:
+            return bytes(s)
+        except Exception as e:
+            raise TypeError(
+                "Object %s is neither a bytes object nor has an encode method" % s
+            ) from e
 
 
 def divide_n_among_bins(n, bins):


### PR DESCRIPTION
I'm a bit concerned that I'm just working around a problem with calling `maybe_compress` / `ensure_bytes` inside `dumps`. Would it be better to update `ensure_bytes` to handle pyarrow Buffer objects? For pyarrow, this would be something like

```
if hasattr(s, 'to_pybytes'):
    return s.to_pybytes()
```

or something like `bytes(s)` as the final condition?

Closes #2966