### PR TITLE
Add cores= and memory= keywords to scale

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -334,27 +334,23 @@ class SpecCluster(Cluster):
     def scale(self, n=0, memory=None, cores=None):
         if memory is not None:
             try:
-                n = max(
-                    n,
-                    int(
-                        math.ceil(
-                            parse_bytes(memory)
-                            / parse_bytes(self.new_spec["options"]["memory_limit"])
-                        )
-                    ),
-                )
+                limit = self.new_spec["options"]["memory_limit"]
             except KeyError:
                 raise ValueError(
                     "to use scale(memory=...) your worker definition must include a memory_limit definition"
                 )
+            else:
+                n = max(n, int(math.ceil(parse_bytes(memory) / parse_bytes(limit))))
 
         if cores is not None:
             try:
-                n = max(n, int(math.ceil(cores / self.new_spec["options"]["nthreads"])))
+                threads_per_worker = self.new_spec["options"]["nthreads"]
             except KeyError:
                 raise ValueError(
                     "to use scale(threads=...) your worker definition must include an nthreads= definition"
                 )
+            else:
+                n = max(n, int(math.ceil(cores / threads_per_worker)))
 
         if len(self.worker_spec) > n:
             not_yet_launched = set(self.worker_spec) - {

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -1,13 +1,14 @@
 import asyncio
 import atexit
 import copy
+import math
 import weakref
 
 from tornado import gen
 
 from .cluster import Cluster
 from ..core import rpc, CommClosedError
-from ..utils import LoopRunner, silence_logging, ignoring
+from ..utils import LoopRunner, silence_logging, ignoring, parse_bytes
 from ..scheduler import Scheduler
 from ..security import Security
 
@@ -330,7 +331,31 @@ class SpecCluster(Cluster):
         self.close()
         self._loop_runner.stop()
 
-    def scale(self, n):
+    def scale(self, n=0, memory=None, cores=None):
+        if memory is not None:
+            try:
+                n = max(
+                    n,
+                    int(
+                        math.ceil(
+                            parse_bytes(memory)
+                            / parse_bytes(self.new_spec["options"]["memory_limit"])
+                        )
+                    ),
+                )
+            except KeyError:
+                raise ValueError(
+                    "to use scale(memory=...) your worker definition must include a memory_limit definition"
+                )
+
+        if cores is not None:
+            try:
+                n = max(n, int(math.ceil(cores / self.new_spec["options"]["nthreads"])))
+            except KeyError:
+                raise ValueError(
+                    "to use scale(threads=...) your worker definition must include an nthreads= definition"
+                )
+
         if len(self.worker_spec) > n:
             not_yet_launched = set(self.worker_spec) - {
                 v["name"] for v in self.scheduler_info["workers"].values()

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -347,7 +347,7 @@ class SpecCluster(Cluster):
                 threads_per_worker = self.new_spec["options"]["nthreads"]
             except KeyError:
                 raise ValueError(
-                    "to use scale(threads=...) your worker definition must include an nthreads= definition"
+                    "to use scale(cores=...) your worker definition must include an nthreads= definition"
                 )
             else:
                 n = max(n, int(math.ceil(cores / threads_per_worker)))

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -861,3 +861,25 @@ def test_client_cluster_synchronous(loop):
         with Client(loop=loop, processes=False) as c:
             assert not c.asynchronous
             assert not c.cluster.asynchronous
+
+
+@pytest.mark.asyncio
+async def test_scale_memory_cores(cleanup):
+    async with LocalCluster(
+        n_workers=0,
+        processes=False,
+        threads_per_worker=2,
+        memory_limit="2GB",
+        asynchronous=True,
+    ) as cluster:
+        cluster.scale(cores=4)
+        assert len(cluster.worker_spec) == 2
+
+        cluster.scale(memory="6GB")
+        assert len(cluster.worker_spec) == 3
+
+        cluster.scale(cores=1)
+        assert len(cluster.worker_spec) == 1
+
+        cluster.scale(memory="7GB")
+        assert len(cluster.worker_spec) == 4

--- a/distributed/protocol/cudf.py
+++ b/distributed/protocol/cudf.py
@@ -4,6 +4,7 @@ import cudf.groupby.groupby
 from .cuda import cuda_serialize, cuda_deserialize
 from ..utils import log_errors
 
+
 # all (de-)serializtion code lives in the cudf codebase
 # here we ammend the returned headers with `is_gpu` for
 # UCX buffer consumption


### PR DESCRIPTION
Dask-Jobqueue did this internally.
It seems like a decent idea to pull upstream.