### PR TITLE
RST syntax and tree fixes

### DIFF
--- a/docs/source/client.rst
+++ b/docs/source/client.rst
@@ -3,7 +3,7 @@ Client
 
 The Client is the primary entry point for users of ``dask.distributed``.
 
-After we :doc:`setup a cluster <setup>`, we initialize a ``Client`` by pointing
+After we `setup a cluster <https://docs.dask.org/en/latest/setup.html>`_, we initialize a ``Client`` by pointing
 it to the address of a ``Scheduler``:
 
 .. code-block:: python

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -391,6 +391,7 @@ redirect_files = [
     # old html, new html
     ("joblib.html", "https://ml.dask.org/joblib.html"),
     ("setup.html", "https://docs.dask.org/en/latest/setup.html"),
+    ("ec2.html", "https://dask.pydata.org/en/latest/setup/cloud.html"),
 ]
 
 

--- a/docs/source/ec2.rst
+++ b/docs/source/ec2.rst
@@ -1,1 +1,4 @@
+Cloud Deployment
+=================
+
 See `Dask's cloud deployment documentation <https://dask.pydata.org/en/latest/setup/cloud.html>`_ for up-to-date documentation for deployment on Amazon's Cloud.

--- a/docs/source/ec2.rst
+++ b/docs/source/ec2.rst
@@ -1,4 +1,0 @@
-Cloud Deployment
-=================
-
-See `Dask's cloud deployment documentation <https://dask.pydata.org/en/latest/setup/cloud.html>`_ for up-to-date documentation for deployment on Amazon's Cloud.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,7 +28,7 @@ In particular it meets the following needs:
     Python standard library.  Compatible with `dask`_ API for parallel
     algorithms
 *   **Easy Setup:** As a Pure Python package distributed is ``pip`` installable
-    and easy to :doc:`set up <https://docs.dask.org/en/latest/setup.html>`_ on your own cluster.
+    and easy to `set up <https://docs.dask.org/en/latest/setup.html>`_ on your own cluster.
 
 .. _`concurrent.futures`: https://www.python.org/dev/peps/pep-3148/
 .. _`dask`: https://dask.org
@@ -80,6 +80,7 @@ Contents
    Setup <https://docs.dask.org/en/latest/setup.html>
    client
    api
+   examples-overview
    faq
 
 .. toctree::
@@ -124,6 +125,7 @@ Contents
    :caption: Developer Documentation
 
    changelog
+   ec2
    communications
    develop
    foundations

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -125,7 +125,6 @@ Contents
    :caption: Developer Documentation
 
    changelog
-   ec2
    communications
    develop
    foundations

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -239,7 +239,7 @@ Nanny
 Dask workers are by default launched, monitored, and managed by a small Nanny
 process.
 
-.. autoclass:: distributed.worker.Nanny
+.. autoclass:: distributed.nanny.Nanny
 
 
 API Documentation


### PR DESCRIPTION
Remaining Sphinx warnings:
```
WARNING: error while formatting arguments for distributed.diagnostics.progress: module 'distributed.diagnostics.progress' has no attribute '__mro__'
WARNING: html_static_path entry '~/code/distributed/docs/source/_static' does not exist
```
