### PR TITLE
Remove lost workers from SpecCluster.workers

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -8,6 +8,7 @@ import warnings
 
 import click
 import dask
+from dask.utils import ignoring
 from distributed import Nanny, Worker
 from distributed.security import Security
 from distributed.cli.utils import check_python_3, install_signal_handlers
@@ -354,6 +355,9 @@ def main(
             "dask-worker SCHEDULER_ADDRESS:8786"
         )
 
+    with ignoring(TypeError, ValueError):
+        name = int(name)
+
     nannies = [
         t(
             scheduler,
@@ -367,7 +371,7 @@ def main(
             port=port,
             dashboard_address=dashboard_address if dashboard else None,
             service_kwargs={"dashboard": {"prefix": dashboard_prefix}},
-            name=name if nprocs == 1 or not name else name + "-" + str(i),
+            name=name if nprocs == 1 or not name else str(name) + "-" + str(i),
             **kwargs
         )
         for i in range(nprocs)

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from click.testing import CliRunner
 
@@ -9,11 +10,11 @@ import os
 from time import sleep
 
 import distributed.cli.dask_worker
-from distributed import Client
+from distributed import Client, Scheduler
 from distributed.metrics import time
 from distributed.utils import sync, tmpfile
 from distributed.utils_test import popen, terminate_process, wait_for_port
-from distributed.utils_test import loop  # noqa: F401
+from distributed.utils_test import loop, cleanup  # noqa: F401
 
 
 def test_nanny_worker_ports(loop):
@@ -330,3 +331,13 @@ def test_bokeh_deprecation():
         except ValueError:
             # didn't pass scheduler
             pass
+
+
+@pytest.mark.asyncio
+async def test_integer_names(cleanup):
+    async with Scheduler(port=0) as s:
+        with popen(["dask-worker", s.address, "--name", "123"]) as worker:
+            while not s.workers:
+                await asyncio.sleep(0.01)
+            [ws] = s.workers.values()
+            assert ws.name == 123

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -107,10 +107,9 @@ class Cluster(object):
             self.scheduler_info["workers"].update(workers)
             self.scheduler_info.update(msg)
         elif op == "remove":
-             del self.scheduler_info["workers"][msg]
+            del self.scheduler_info["workers"][msg]
         else:
             raise ValueError("Invalid op", op, msg)
-
 
     def adapt(self, Adaptive=Adaptive, **kwargs) -> Adaptive:
         """ Turn on adaptivity

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -95,17 +95,22 @@ class Cluster(object):
             except OSError:
                 break
 
-            for op, msg in msgs:
-                if op == "add":
-                    workers = msg.pop("workers")
-                    self.scheduler_info["workers"].update(workers)
-                    self.scheduler_info.update(msg)
-                elif op == "remove":
-                    del self.scheduler_info["workers"][msg]
-                else:
-                    raise ValueError("Invalid op", op, msg)
+            with log_errors():
+                for op, msg in msgs:
+                    self._update_worker_status(op, msg)
 
         await comm.close()
+
+    def _update_worker_status(self, op, msg):
+        if op == "add":
+            workers = msg.pop("workers")
+            self.scheduler_info["workers"].update(workers)
+            self.scheduler_info.update(msg)
+        elif op == "remove":
+             del self.scheduler_info["workers"][msg]
+        else:
+            raise ValueError("Invalid op", op, msg)
+
 
     def adapt(self, Adaptive=Adaptive, **kwargs) -> Adaptive:
         """ Turn on adaptivity

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -304,11 +304,6 @@ class SpecCluster(Cluster):
             # if worker_id.isdigit():
             #    worker_id = int(worker_id)
             if worker_id in self.workers:
-                logger.warning(
-                    "Worker {} of name {} has been unexpectedly removed from the Scheduler.".format(
-                        msg, worker_id
-                    )
-                )
                 del self.workers[worker_id]
         super()._update_worker_status(op, msg)
 

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -125,6 +125,32 @@ async def test_scale(cleanup):
 
 
 @pytest.mark.asyncio
+async def test_unexpected_closed_worker(cleanup):
+    worker = {"cls": Worker, "options": {"nthreads": 1}}
+    async with SpecCluster(
+        asynchronous=True, scheduler=scheduler, worker=worker
+    ) as cluster:
+        assert not cluster.workers
+        assert not cluster.worker_spec
+
+        # Scale up
+        cluster.scale(2)
+        assert not cluster.workers
+        assert cluster.worker_spec
+
+        await cluster
+        assert len(cluster.workers) == 2
+
+        # Close one
+        await list(cluster.workers.values())[0].close()
+        assert len(cluster.workers) == 1
+        assert len(cluster.worker_spec) == 2
+
+        await cluster
+        assert len(cluster.workers) == 2
+
+
+@pytest.mark.asyncio
 async def test_broken_worker():
     with pytest.raises(Exception) as info:
         async with SpecCluster(

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,8 +1,8 @@
 import asyncio
-from time import time
 
 from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
 from distributed.deploy.spec import close_clusters, ProcessInterface
+from distributed.metrics import time
 from distributed.utils_test import loop, cleanup  # noqa: F401
 from distributed.utils import is_valid_xml
 import toolz
@@ -143,6 +143,10 @@ async def test_unexpected_closed_worker(cleanup):
 
         # Close one
         await list(cluster.workers.values())[0].close()
+        start = time()
+        while len(cluster.workers) > 1:  # wait for messages to flow around
+            await asyncio.sleep(0.01)
+            assert time() < start + 2
         assert len(cluster.workers) == 1
         assert len(cluster.worker_spec) == 2
 

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -65,6 +65,9 @@ distributed:
   client:
     heartbeat: 5s  # time between client heartbeats
 
+  deploy:
+    lost-worker-timeout: 15s  # Interval after which to hard-close a lost worker job
+
   comm:
     compression: auto
     default-scheme: tcp


### PR DESCRIPTION
Closes #2968. First attempt...

Still in work in progress as I'm experiencing some unexpected difficulties. I guess this must be some kind of race conditions with async methods, The test I added is failing in a way I don't understand.

I also encountered some issues when testing with https://github.com/dask/dask-jobqueue/pull/307, which is that `cluster.scheduler_info["workers"]` objects have String `id` and `name` attribute, whereas in `cluster.workers` and `cluster.worker_spec` these are integer. But this is not always the case with other Speccluster classes.

Another thing: I assumed we must only remove the killed worker from `cluster.workers`, and not from `cluster.worker_spec`. This way, the user could always `await cluster` or call `cluster._correct_state()`to restart lost workers. Not sure if this is the best thing to do...