### PR TITLE
Skip exceptions in startup information

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1558,3 +1558,15 @@ async def test_bad_metrics(cleanup):
     async with Scheduler() as s:
         async with Worker(s.address, metrics={"bad": bad_metric}) as w:
             assert "bad" not in s.workers[w.address].metrics
+
+
+@pytest.mark.asyncio
+async def test_bad_startup(cleanup):
+    def bad_startup(w):
+        raise Exception("Hello")
+
+    async with Scheduler() as s:
+        try:
+            w = await Worker(s.address, startup_information={"bad": bad_startup})
+        except Exception:
+            pytest.fail("Startup exception was raised")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -748,10 +748,14 @@ class Worker(ServerNode):
     async def get_startup_information(self):
         result = {}
         for k, f in self.startup_information.items():
-            v = f(self)
-            if hasattr(v, "__await__"):
-                v = await v
-            result[k] = v
+            try:
+                v = f(self)
+                if hasattr(v, "__await__"):
+                    v = await v
+                result[k] = v
+            except Exception:  # TODO: log error once
+                pass
+
         return result
 
     def identity(self, comm=None):


### PR DESCRIPTION
Turns out #2984 doesn't completely solve rapidsai/dask-cuda#122. Not sure why my local testing was working yesterday as today it doesn't.

We also need to skip exceptions when gathering startup information as that may also use pynvml.