### PR TITLE
Pynvml initialization fix

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -1,21 +1,19 @@
 import pynvml
 
-pynvml_initialized = False
 handles = None
 
 
-def _ensure_pynvml_initialized():
-    global pynvml_initialized, handles
-    if not pynvml_initialized:
+def _pynvml_handles():
+    global handles
+    if handles is None:
         pynvml.nvmlInit()
         count = pynvml.nvmlDeviceGetCount()
         handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(count)]
-        pynvml_initialized = True
+    return handles
 
 
 def real_time():
-    global handles
-    _ensure_pynvml_initialized()
+    handles = _pynvml_handles()
     return {
         "utilization": [pynvml.nvmlDeviceGetUtilizationRates(h).gpu for h in handles],
         "memory-used": [pynvml.nvmlDeviceGetMemoryInfo(h).used for h in handles],
@@ -23,8 +21,7 @@ def real_time():
 
 
 def one_time():
-    global handles
-    _ensure_pynvml_initialized()
+    handles = _pynvml_handles()
     return {
         "memory-total": [pynvml.nvmlDeviceGetMemoryInfo(h).total for h in handles],
         "name": [pynvml.nvmlDeviceGetName(h).decode() for h in handles],

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -3,6 +3,7 @@ import pynvml
 need_pynvml_init = True
 handles = None
 
+
 def _initialize_pynvml():
     global need_pynvml_init, handles
     pynvml.nvmlInit()
@@ -29,4 +30,3 @@ def one_time():
         "memory-total": [pynvml.nvmlDeviceGetMemoryInfo(h).total for h in handles],
         "name": [pynvml.nvmlDeviceGetName(h).decode() for h in handles],
     }
-

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -1,12 +1,20 @@
 import pynvml
 
-pynvml.nvmlInit()
-count = pynvml.nvmlDeviceGetCount()
+need_pynvml_init = True
+handles = None
 
-handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(count)]
+def _initialize_pynvml():
+    global need_pynvml_init, handles
+    pynvml.nvmlInit()
+    count = pynvml.nvmlDeviceGetCount()
+    handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(count)]
+    need_pynvml_init = False
 
 
 def real_time():
+    global need_pynvml_init, handles
+    if need_pynvml_init:
+        _initialize_pynvml()
     return {
         "utilization": [pynvml.nvmlDeviceGetUtilizationRates(h).gpu for h in handles],
         "memory-used": [pynvml.nvmlDeviceGetMemoryInfo(h).used for h in handles],
@@ -14,7 +22,11 @@ def real_time():
 
 
 def one_time():
+    global need_pynvml_init, handles
+    if need_pynvml_init:
+        _initialize_pynvml()
     return {
         "memory-total": [pynvml.nvmlDeviceGetMemoryInfo(h).total for h in handles],
         "name": [pynvml.nvmlDeviceGetName(h).decode() for h in handles],
     }
+


### PR DESCRIPTION
Addressing [#2992](https://github.com/dask/distributed/issues/2992) by explicitly checking if pynvml needs initialization (and doing so if needed) inside `real_time` and  `one_time`.

After these changes, I get the following behavior:

```
docker run --runtime=nvidia --rm -it -p ... rapidsai/rapidsai-nightly:cuda9.2-runtime-ubuntu16.04
```

Then, after rebuilding distributed with `rjzamora:pynvml-fix` - **In Jupyter notebook**:

```python
from dask_cuda import LocalCUDACluster
cluster = LocalCUDACluster()
cluster.scheduler.workers[cluster.scheduler.workers.keys()[0]].metrics
```
**Output**:
```
{'gpu': {'utilization': (0, 0, 0, 0, 0, 0, 0, 0),
  'memory-used': (3447259136,
   23938531328,
   10172825600,
   10697113600,
   22126592000,
   439943168,
   439943168,
   439943168)},
 'cpu': 0.0,
 'memory': 110350336,
 'time': 1566581704.5954611,
 'read_bytes': 0.0,
 'write_bytes': 0.0,
 'num_fds': 24,
 'executing': 0,
 'in_memory': 0,
 'ready': 0,
 'in_flight': 0,
 'bandwidth': 100000000}
```
Before these changes, the `'gpu'` infromation was missing from the `metrics` dictionary.

Please let me know if we should add a new test (to assert that the `metrics` include `'gpu'`) for systems with pynvml installed.