### PR TITLE
add cuda_ipc to env vars for nvlink usage

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -21,7 +21,7 @@ import os
 
 os.environ.setdefault("UCX_RNDV_SCHEME", "put_zcopy")
 os.environ.setdefault("UCX_MEMTYPE_CACHE", "n")
-os.environ.setdefault("UCX_TLS", "rc,cuda_copy")
+os.environ.setdefault("UCX_TLS", "rc,cuda_copy,cuda_ipc")
 
 logger = logging.getLogger(__name__)
 MAX_MSG_LOG = 23


### PR DESCRIPTION
This PR is adds an env var for UCX to enable NVLINK.  @Akshay-Venkatesh has indicated that, should NVLINK not be supported by the hardware, the addition of the env var will not impact UCX usage.