### PR TITLE
Permit more keyword options when scaling with cores and memory

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -333,24 +333,32 @@ class SpecCluster(Cluster):
 
     def scale(self, n=0, memory=None, cores=None):
         if memory is not None:
-            try:
-                limit = self.new_spec["options"]["memory_limit"]
-            except KeyError:
+            for name in ["memory_limit", "memory"]:
+                try:
+                    limit = self.new_spec["options"][name]
+                except KeyError:
+                    pass
+                else:
+                    n = max(n, int(math.ceil(parse_bytes(memory) / parse_bytes(limit))))
+                    break
+            else:
                 raise ValueError(
                     "to use scale(memory=...) your worker definition must include a memory_limit definition"
                 )
-            else:
-                n = max(n, int(math.ceil(parse_bytes(memory) / parse_bytes(limit))))
 
         if cores is not None:
-            try:
-                threads_per_worker = self.new_spec["options"]["nthreads"]
-            except KeyError:
+            for name in ["nthreads", "ncores", "threads", "cores"]:
+                try:
+                    threads_per_worker = self.new_spec["options"][name]
+                except KeyError:
+                    pass
+                else:
+                    n = max(n, int(math.ceil(cores / threads_per_worker)))
+                    break
+            else:
                 raise ValueError(
                     "to use scale(cores=...) your worker definition must include an nthreads= definition"
                 )
-            else:
-                n = max(n, int(math.ceil(cores / threads_per_worker)))
 
         if len(self.worker_spec) > n:
             not_yet_launched = set(self.worker_spec) - {

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -268,3 +268,18 @@ async def test_widget(cleanup):
 
         cluster.scale(5)
         assert "3 / 5" in cluster._widget_status()
+
+
+@pytest.mark.asyncio
+async def test_scale_cores_memory(cleanup):
+    async with SpecCluster(
+        scheduler=scheduler,
+        worker={"cls": Worker, "options": {"nthreads": 1}},
+        asynchronous=True,
+    ) as cluster:
+        cluster.scale(cores=2)
+        assert len(cluster.worker_spec) == 2
+        with pytest.raises(ValueError) as info:
+            cluster.scale(memory="5GB")
+
+        assert "memory" in str(info.value)


### PR DESCRIPTION
Some cluster managers use options like nthreads or cores.
We should be robust to a few common choices.