### PR TITLE
Return dictionaries from new_worker_spec rather than name/worker pairs

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -375,8 +375,7 @@ class SpecCluster(Cluster):
             return
 
         while len(self.worker_spec) < n:
-            k, spec = self.new_worker_spec()
-            self.worker_spec[k] = spec
+            self.worker_spec.update(self.new_worker_spec())
 
         self.loop.add_callback(self._correct_state)
 
@@ -385,8 +384,7 @@ class SpecCluster(Cluster):
 
         Returns
         -------
-        name: identifier for worker
-        spec: dict
+        d: dict mapping names to worker specs
 
         See Also
         --------
@@ -395,7 +393,7 @@ class SpecCluster(Cluster):
         while self._i in self.worker_spec:
             self._i += 1
 
-        return self._i, self.new_spec
+        return {self._i: self.new_spec}
 
     @property
     def _supports_scaling(self):

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -152,7 +152,7 @@ async def test_new_worker_spec(cleanup):
     class MyCluster(SpecCluster):
         def new_worker_spec(self):
             i = len(self.worker_spec)
-            return i, {"cls": Worker, "options": {"nthreads": i + 1}}
+            return {i: {"cls": Worker, "options": {"nthreads": i + 1}}}
 
     async with MyCluster(asynchronous=True, scheduler=scheduler) as cluster:
         cluster.scale(3)


### PR DESCRIPTION
This allows for larger collections of workers, such as when launching
many workers in one HPC job.

Fixes https://github.com/dask/distributed/issues/2999