### PR TITLE
Make spec.ProcessInterface a valid no-op worker

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -22,7 +22,7 @@ class ProcessInterface:
     It should implement the methods below, like ``start`` and ``close``
     """
 
-    def __init__(self):
+    def __init__(self, scheduler=None, name=None):
         self.address = None
         self.external_address = None
         self.lock = asyncio.Lock()

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -283,3 +283,17 @@ async def test_scale_cores_memory(cleanup):
             cluster.scale(memory="5GB")
 
         assert "memory" in str(info.value)
+
+
+@pytest.mark.asyncio
+async def test_ProcessInterfaceValid(cleanup):
+    async with SpecCluster(
+        scheduler=scheduler, worker={"cls": ProcessInterface}, asynchronous=True
+    ) as cluster:
+        cluster.scale(2)
+        await cluster
+        assert len(cluster.worker_spec) == len(cluster.workers) == 2
+
+        cluster.scale(1)
+        await cluster
+        assert len(cluster.worker_spec) == len(cluster.workers) == 1


### PR DESCRIPTION
This allows it to be placed into specs as-is as a placeholder for
testing.