### PR TITLE
Tweak `Logs` styling

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1453,12 +1453,13 @@ class Logs(dict):
 
     def _repr_html_(self):
         summaries = [
-            "<details>\n<summary>{title}</summary>\n{log}\n</details>".format(
-                title=title, log=log._repr_html_()
-            )
-            for title, log in self.items()
+            "<details>\n"
+            "<summary style='display:list-item'>{title}</summary>\n"
+            "{log}\n"
+            "</details>".format(title=title, log=log._repr_html_())
+            for title, log in sorted(self.items())
         ]
-        return "\n\n".join(summaries)
+        return "\n".join(summaries)
 
 
 def cli_keywords(d: dict, cls=None):


### PR DESCRIPTION
- Not all browsers render unstyled `summary` elements with the "carrot"
indicating they can be expanded. We style these so they always look the
same across browsers.
- We sort log elements when rendering.