### PR TITLE
Support Spec jobs that generate multiple workers

### DIFF
--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -98,18 +98,15 @@ class Adaptive(AdaptiveCore):
 
     @property
     def plan(self):
-        try:
-            return set(self.cluster.worker_spec)
-        except AttributeError:
-            return set(self.cluster.workers)
+        return self.cluster.plan
 
     @property
     def requested(self):
-        return set(self.cluster.workers)
+        return self.cluster.requested
 
     @property
     def observed(self):
-        return {d["name"] for d in self.cluster.scheduler_info["workers"].values()}
+        return self.cluster.observed
 
     async def target(self):
         return await self.scheduler.adaptive_target(

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -48,7 +48,7 @@ class AdaptiveCore:
         Scales the cluster up to a target number of workers, presumably
         changing at least ``plan`` and hopefully eventually also ``requested``
 
-   scale_down : Set[worker] -> None
+    scale_down : Set[worker] -> None
         Closes the provided set of workers
 
     Parameters

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -339,3 +339,15 @@ class Cluster(object):
 
         text += ")"
         return text
+
+    @property
+    def plan(self):
+        return set(self.workers)
+
+    @property
+    def requested(self):
+        return set(self.workers)
+
+    @property
+    def observed(self):
+        return {d["name"] for d in self.scheduler_info["workers"].values()}


### PR DESCRIPTION
Sometimes a single entry in the worker_spec will generate multiple Dask
workers.  We add an entry, "group", to the spec that shows how
worker_spec entries map to dask-workers that connect to the scheduler