### PR TITLE
Set the x_range limit of the Meory utilization plot to memory-limit

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -483,6 +483,7 @@ class CurrentLoad(DashboardComponent):
                 self.nbytes_figure.title.text = "Bytes stored: " + format_bytes(
                     sum(nbytes)
                 )
+                self.nbytes_figure.x_range.end = max_limit
 
                 update(self.source, result)
 


### PR DESCRIPTION
This should give a better sense for how close we are to filling up
memory, which seems to be the biggest use of the memory plot.