### PR TITLE
Automatically assign resources based on serialized form of functions

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2426,10 +2426,12 @@ class Client(Node):
             if isinstance(retries, Number) and retries > 0:
                 retries = {k: retries for k in dsk3}
 
+            tasks = valmap(dumps_task, dsk3)
+
             self._send_to_scheduler(
                 {
                     "op": "update-graph",
-                    "tasks": valmap(dumps_task, dsk3),
+                    "tasks": tasks,
                     "dependencies": dependencies,
                     "keys": list(flatkeys),
                     "restrictions": restrictions or {},

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2426,12 +2426,10 @@ class Client(Node):
             if isinstance(retries, Number) and retries > 0:
                 retries = {k: retries for k in dsk3}
 
-            tasks = valmap(dumps_task, dsk3)
-
             self._send_to_scheduler(
                 {
                     "op": "update-graph",
-                    "tasks": tasks,
+                    "tasks": valmap(dumps_task, dsk3),
                     "dependencies": dependencies,
                     "keys": list(flatkeys),
                     "restrictions": restrictions or {},

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -32,6 +32,8 @@ distributed:
         ca-file: null
         key: null
         cert: null
+    resources:
+      auto: {}
 
   worker:
     blocked-handlers: []


### PR DESCRIPTION
This commit adds functionality to the scheduler to automatically assign
resources to tasks based on terms found in their serialized forms.

This would be useful, for example, to direct all tasks with cupy, cudf,
torch, or tensorflow module names in their serialized form, to be
automatically tagged with a GPU resource tag.  This would simplify
deploying GPU systems considerably, and would also allow for nicer mixed
CPU/GPU workloads.

This should maybe be coupled, in the future, with code that
automatically assigns resources based on the presence of GPUs.

In practice, I'm thinking that, at least for GPU computing, we might do something like the following:

```json
resources_auto={
    "GPU": {
        "names": ["cupy", "cuda", "cudf", "cuml", "pytorch", "tensorflow", "keras"], 
        "value": 1}
    }
}
```

This isn't perfect, but I'll bet that it does a decent job in practice.  This is free in the common case that nothing is registered.  I'm inclined to try this for a while and possibly remove it without warning in the future.

cc @pentschev 