### PR TITLE
Protocol of cupy and numba handles serialization exclusively 

### DIFF
--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -8,7 +8,7 @@ from .cuda import cuda_serialize, cuda_deserialize
 @cuda_serialize.register(cupy.ndarray)
 def serialize_cupy_ndarray(x):
     # Making sure `x` is behaving
-    if not x.flags.c_contiguous or True:
+    if not x.flags.c_contiguous:
         x = cupy.array(x, copy=True)
 
     header = x.__cuda_array_interface__.copy()

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -7,36 +7,18 @@ from .cuda import cuda_serialize, cuda_deserialize
 
 @cuda_serialize.register(cupy.ndarray)
 def serialize_cupy_ndarray(x):
-    # TODO: handle non-contiguous
-    # TODO: Handle order='K' ravel
-    # TODO: 0d
+    # Making sure `x` is behaving
+    if not x.flags.c_contiguous or True:
+        x = cupy.array(x, copy=True)
 
-    if x.flags.c_contiguous or x.flags.f_contiguous:
-        strides = x.strides
-        data = x.ravel()  # order='K'
-    else:
-        x = cupy.ascontiguousarray(x)
-        strides = x.strides
-        data = x.ravel()
-
-    dtype = (0, x.dtype.str)
-
-    # used in the ucx comms for gpu/cpu message passing
-    # 'lengths' set by dask
     header = x.__cuda_array_interface__.copy()
-    header["is_cuda"] = 1
-    header["dtype"] = dtype
-    return header, [data]
+    return header, [x]
 
 
 @cuda_deserialize.register(cupy.ndarray)
 def deserialize_cupy_array(header, frames):
     (frame,) = frames
-    # TODO: put this in ucx... as a kind of "fixup"
-    try:
-        frame.typestr = header["typestr"]
-        frame.shape = header["shape"]
-    except AttributeError:
-        pass
-    arr = cupy.asarray(frame)
+    arr = cupy.ndarray(
+        header["shape"], dtype=header["typestr"], memptr=cupy.asarray(frame).data
+    )
     return arr

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -1,61 +1,27 @@
+import numpy as np
 import numba.cuda
 from .cuda import cuda_serialize, cuda_deserialize
 
 
 @cuda_serialize.register(numba.cuda.devicearray.DeviceNDArray)
 def serialize_numba_ndarray(x):
-    # TODO: handle non-contiguous
-    # TODO: handle 2d
-    # TODO: 0d
-
-    if x.flags["C_CONTIGUOUS"] or x.flags["F_CONTIGUOUS"]:
-        strides = x.strides
-        if x.ndim > 1:
-            data = x.ravel()  # order='K'
-        else:
-            data = x
-    else:
-        raise ValueError("Array must be contiguous")
-        x = numba.ascontiguousarray(x)
-        strides = x.strides
-        if x.ndim > 1:
-            data = x.ravel()
-        else:
-            data = x
-
-    dtype = (0, x.dtype.str)
-    nbytes = data.dtype.itemsize * data.size
-
-    # used in the ucx comms for gpu/cpu message passing
-    # 'lengths' set by dask
+    # Making sure `x` is behaving
+    if not x.is_c_contiguous() or True:
+        shape = x.shape
+        t = numba.cuda.device_array(shape, dtype=x.dtype)
+        t.copy_to_device(x)
+        x = t
     header = x.__cuda_array_interface__.copy()
-    header["is_cuda"] = 1
-    header["dtype"] = dtype
-    return header, [data]
+    return header, [x]
 
 
 @cuda_deserialize.register(numba.cuda.devicearray.DeviceNDArray)
 def deserialize_numba_ndarray(header, frames):
     (frame,) = frames
-    # TODO: put this in ucx... as a kind of "fixup"
-    if isinstance(frame, bytes):
-        import numpy as np
-
-        arr2 = np.frombuffer(frame, header["typestr"])
-        return numba.cuda.to_device(arr2)
-
-    frame.typestr = header["typestr"]
-    frame.shape = header["shape"]
-
-    # numba & cupy don't properly roundtrip length-zero arrays.
-    if frame.shape[0] == 0:
-        arr = numba.cuda.device_array(
-            header["shape"],
-            header["typestr"]
-            # strides?
-            # order?
-        )
-        return arr
-
-    arr = numba.cuda.as_cuda_array(frame)
+    arr = numba.cuda.devicearray.DeviceNDArray(
+        header["shape"],
+        header["strides"],
+        np.dtype(header["typestr"]),
+        gpu_data=numba.cuda.as_cuda_array(frame).gpu_data,
+    )
     return arr

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -6,7 +6,7 @@ from .cuda import cuda_serialize, cuda_deserialize
 @cuda_serialize.register(numba.cuda.devicearray.DeviceNDArray)
 def serialize_numba_ndarray(x):
     # Making sure `x` is behaving
-    if not x.is_c_contiguous() or True:
+    if not x.is_c_contiguous():
         shape = x.shape
         t = numba.cuda.device_array(shape, dtype=x.dtype)
         t.copy_to_device(x)

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -4,8 +4,10 @@ import pytest
 cupy = pytest.importorskip("cupy")
 
 
-def test_serialize_cupy():
-    x = cupy.arange(100)
+@pytest.mark.parametrize("size", [0, 10])
+@pytest.mark.parametrize("dtype", ["u1", "u4", "u8", "f4"])
+def test_serialize_cupy(size, dtype):
+    x = cupy.arange(size, dtype=dtype)
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
 

--- a/distributed/protocol/tests/test_numba.py
+++ b/distributed/protocol/tests/test_numba.py
@@ -1,0 +1,19 @@
+from distributed.protocol import serialize, deserialize
+import pytest
+
+cuda = pytest.importorskip("numba.cuda")
+np = pytest.importorskip("numpy")
+
+
+@pytest.mark.parametrize("dtype", ["u1", "u4", "u8", "f4"])
+def test_serialize_cupy(dtype):
+    ary = np.arange(100, dtype=dtype)
+    x = cuda.to_device(ary)
+    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
+    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+
+    hx = np.empty_like(ary)
+    hy = np.empty_like(ary)
+    x.copy_to_host(hx)
+    y.copy_to_host(hy)
+    assert (hx == hy).all()


### PR DESCRIPTION
This PR delegates all serialization responsibility of cupy and numba arrays to the protocols.

Before, the deserializers of the protocols partial depended on the communicator to pass along meta data such as shape.

Additionally, both the cupy and numba protocols support non-contiguous multidimensional arrays now.

cc. @mrocklin @quasiben 

