### PR TITLE
Use mock from unittest standard library.

### DIFF
--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -30,7 +30,6 @@ call deactivate
     ipywidgets ^
     joblib ^
     jupyter_client ^
-    mock ^
     msgpack-python ^
     prometheus_client ^
     psutil ^

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -39,7 +39,6 @@ conda install -q \
     ipywidgets \
     joblib \
     jupyter_client \
-    mock \
     netcdf4 \
     paramiko \
     prometheus_client \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 joblib >= 0.10.2
-mock >= 2.0.0
 pandas >= 0.19.2
 numpy >= 1.11.0
 bokeh >= 0.12.3

--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -6,8 +6,8 @@ import shutil
 import subprocess
 import sys
 from time import sleep
+from unittest import mock
 
-import mock
 import pytest
 
 import dask

--- a/distributed/tests/test_ipython.py
+++ b/distributed/tests/test_ipython.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 import pytest
 from toolz import first

--- a/distributed/tests/test_submit_cli.py
+++ b/distributed/tests/test_submit_cli.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 
 from tornado import gen
 from tornado.ioloop import IOLoop

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -191,7 +191,7 @@ def pristine_loop():
 
 @contextmanager
 def mock_ipython():
-    import mock
+    from unittest import mock
     from distributed._ipython_utils import remote_magic
 
     ip = mock.Mock()


### PR DESCRIPTION
Since distributed depends on Python 3.5+, there's no need to use the external mock package any more.