### PR TITLE
Add small section on disabling work stealing

### DIFF
--- a/docs/source/work-stealing.rst
+++ b/docs/source/work-stealing.rst
@@ -125,3 +125,12 @@ the task and sends a response to the scheduler:
 This avoids redundant work, and also the duplication of side effects for more
 exotic tasks.  However, concurrent or repeated execution of the same task *is
 still possible* in the event of worker death or a disrupted network connection.
+
+
+Disabling Work Stealing
+---------------------------
+
+Work stealing is a toggleable setting on the Dask Scheduler; to disable 
+work stealing, you can toggle the scheduler ``work-stealing`` configuration 
+option to ``"False"`` either by setting ``DASK_DISTRIBUTED__SCHEDULER__WORK_STEALING="False"``
+or through your `Dask configuration file <https://docs.dask.org/en/latest/configuration.html>`_


### PR DESCRIPTION
I figured this deserved a mention in the work stealing doc.

Also, this may be known but it appears that the Sphinx redirects aren't currently working, which affects the discoverability of the section on Dask configuration from the Distributed search (searching for "Configuration" on the distributed site points to [a broken link](http://distributed.dask.org/en/latest/configuration.html)).  I saw the config redirect was only added [6 days ago](https://github.com/dask/distributed/pull/3038), so maybe the docs haven't been rebuilt, but thought it was worth calling out.