### PR TITLE
Allow SpecCluster to scale by memory and cores

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -8,6 +8,7 @@ import weakref
 import dask
 from tornado import gen
 
+from .adaptive import Adaptive
 from .cluster import Cluster
 from ..core import rpc, CommClosedError
 from ..utils import LoopRunner, silence_logging, ignoring, parse_bytes, parse_timedelta
@@ -361,34 +362,40 @@ class SpecCluster(Cluster):
         self.close()
         self._loop_runner.stop()
 
+    def _threads_per_worker(self) -> int:
+        """ Return the number of threads per worker for new workers """
+        if not self.new_spec:
+            raise ValueError("To scale by cores= you must specify cores per worker")
+
+        for name in ["nthreads", "ncores", "threads", "cores"]:
+            with ignoring(KeyError):
+                return self.new_spec["options"][name]
+
+        if not self.new_spec:
+            raise ValueError("To scale by cores= you must specify cores per worker")
+
+    def _memory_per_worker(self) -> int:
+        """ Return the memory limit per worker for new workers """
+        if not self.new_spec:
+            raise ValueError(
+                "to scale by memory= your worker definition must include a memory_limit definition"
+            )
+
+        for name in ["memory_limit", "memory"]:
+            with ignoring(KeyError):
+                return parse_bytes(self.new_spec["options"][name])
+
+        if not self.new_spec:
+            raise ValueError(
+                "to use scale(memory=...) your worker definition must include a memory_limit definition"
+            )
+
     def scale(self, n=0, memory=None, cores=None):
         if memory is not None:
-            for name in ["memory_limit", "memory"]:
-                try:
-                    limit = self.new_spec["options"][name]
-                except KeyError:
-                    pass
-                else:
-                    n = max(n, int(math.ceil(parse_bytes(memory) / parse_bytes(limit))))
-                    break
-            else:
-                raise ValueError(
-                    "to use scale(memory=...) your worker definition must include a memory_limit definition"
-                )
+            n = max(n, int(math.ceil(parse_bytes(memory) / self._memory_per_worker())))
 
         if cores is not None:
-            for name in ["nthreads", "ncores", "threads", "cores"]:
-                try:
-                    threads_per_worker = self.new_spec["options"][name]
-                except KeyError:
-                    pass
-                else:
-                    n = max(n, int(math.ceil(cores / threads_per_worker)))
-                    break
-            else:
-                raise ValueError(
-                    "to use scale(cores=...) your worker definition must include an nthreads= definition"
-                )
+            n = max(n, int(math.ceil(cores / self._threads_per_worker())))
 
         if len(self.worker_spec) > n:
             not_yet_launched = set(self.worker_spec) - {
@@ -472,6 +479,67 @@ class SpecCluster(Cluster):
             else:
                 out.add(name)
         return out
+
+    def adapt(
+        self,
+        *args,
+        minimum=0,
+        maximum=math.inf,
+        minimum_cores: int = None,
+        maximum_cores: int = None,
+        minimum_memory: str = None,
+        maximum_memory: str = None,
+        **kwargs
+    ) -> Adaptive:
+        """ Turn on adaptivity
+
+        This scales Dask clusters automatically based on scheduler activity.
+
+        Parameters
+        ----------
+        minimum : int
+            Minimum number of workers
+        maximum : int
+            Maximum number of workers
+        minimum_cores : int
+            Minimum number of cores/threads to keep around in the cluster
+        maximum_cores : int
+            Maximum number of cores/threads to keep around in the cluster
+        minimum_memory : str
+            Minimum amount of memory to keep around in the cluster
+            Expressed as a string like "100 GiB"
+        maximum_cores : int
+            Maximum amount of memory to keep around in the cluster
+            Expressed as a string like "100 GiB"
+
+        Examples
+        --------
+        >>> cluster.adapt(minimum=0, maximum_memory="100 GiB", interval='500ms')
+
+        See Also
+        --------
+        dask.distributed.Adaptive : for more keyword arguments
+        """
+        if minimum_cores is not None:
+            minimum = max(
+                minimum or 0, math.ceil(minimum_cores / self._threads_per_worker())
+            )
+        if minimum_memory is not None:
+            minimum = max(
+                minimum or 0,
+                math.ceil(parse_bytes(minimum_memory) / self._memory_per_worker()),
+            )
+        if maximum_cores is not None:
+            maximum = min(
+                maximum, math.floor(maximum_cores / self._threads_per_worker())
+            )
+        if maximum_memory is not None:
+            maximum = min(
+                maximum,
+                math.floor(parse_bytes(maximum_memory) / self._memory_per_worker()),
+            )
+
+        return super().adapt(*args, minimum=minimum, maximum=maximum, **kwargs)
 
 
 @atexit.register

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -385,10 +385,9 @@ class SpecCluster(Cluster):
             with ignoring(KeyError):
                 return parse_bytes(self.new_spec["options"][name])
 
-        if not self.new_spec:
-            raise ValueError(
-                "to use scale(memory=...) your worker definition must include a memory_limit definition"
-            )
+        raise ValueError(
+            "to use scale(memory=...) your worker definition must include a memory_limit definition"
+        )
 
     def scale(self, n=0, memory=None, cores=None):
         if memory is not None:

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -397,3 +397,33 @@ async def test_worker_keys(cleanup):
 
         names = {ws.name for ws in cluster.scheduler.workers.values()}
         assert names == {"a-1", "a-2"} or names == {"b-1", "b-2"}
+
+
+@pytest.mark.asyncio
+async def test_adapt_cores_memory(cleanup):
+    async with LocalCluster(
+        0,
+        threads_per_worker=2,
+        memory_limit="3 GB",
+        scheduler_port=0,
+        silence_logs=False,
+        processes=False,
+        dashboard_address=None,
+        asynchronous=True,
+    ) as cluster:
+        adapt = cluster.adapt(minimum_cores=3, maximum_cores=9)
+        assert adapt.minimum == 2
+        assert adapt.maximum == 4
+
+        adapt = cluster.adapt(minimum_memory="7GB", maximum_memory="20 GB")
+        assert adapt.minimum == 3
+        assert adapt.maximum == 6
+
+        adapt = cluster.adapt(
+            minimum_cores=1,
+            minimum_memory="7GB",
+            maximum_cores=10,
+            maximum_memory="1 TB",
+        )
+        assert adapt.minimum == 3
+        assert adapt.maximum == 5

--- a/distributed/deploy/tests/test_slow_adaptive.py
+++ b/distributed/deploy/tests/test_slow_adaptive.py
@@ -47,7 +47,7 @@ async def test_startup(cleanup):
     ) as cluster:
         assert len(cluster.workers) == len(cluster.worker_spec) == 3
         assert time() < start + 5
-        assert 1 <= len(cluster.scheduler_info["workers"]) <= 2
+        assert 0 <= len(cluster.scheduler_info["workers"]) <= 2
 
         async with Client(cluster, asynchronous=True) as client:
             await client.wait_for_workers(n_workers=2)


### PR DESCRIPTION
```python
>>> cluster.adapt(minimum_cores=10, maximum_memory="100 GiB")
```

This came up when migrating dask-jobqueue to SpecCluster.

cc @guillaumeeb @lesteve @jcrist 