### PR TITLE
Use Cluster.scheduler_info for workers= value in repr

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -365,7 +365,7 @@ class Cluster(object):
         text = "%s(%r, workers=%d, threads=%d" % (
             self._cluster_class_name,
             self.scheduler_address,
-            len(self.workers),
+            len(self.scheduler_info["workers"]),
             sum(w["nthreads"] for w in self.scheduler_info["workers"].values()),
         )
 

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -374,6 +374,8 @@ async def test_MultiWorker(cleanup):
             assert len(cluster.worker_spec) == 2
             await client.wait_for_workers(4)
 
+            assert "workers=4" in repr(cluster)
+
             cluster.scale(1)
             await cluster
             assert len(s.workers) == 2


### PR DESCRIPTION
Previously we would use `Cluster.workers`, which might differ from the
number of Dask workers if a single job generated several Dask workers.

Now, we use the reported number of workers from the scheduler.

cc @lesteve 