### PR TITLE
Make Client.get_versions async

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3454,18 +3454,19 @@ class Client(Node):
 
         >>> c.get_versions(packages=['sklearn', 'geopandas'])  # doctest: +SKIP
         """
+        return self.sync(self._get_versions, check=check, packages=packages)
+
+    async def _get_versions(self, check=False, packages=[]):
         client = get_versions(packages=packages)
         try:
-            scheduler = sync(self.loop, self.scheduler.versions, packages=packages)
+            scheduler = await self.scheduler.versions(packages=packages)
         except KeyError:
             scheduler = None
         except TypeError:  # packages keyword not supported
-            scheduler = sync(self.loop, self.scheduler.versions)  # this raises
+            scheduler = await self.scheduler.versions()  # this raises
 
-        workers = sync(
-            self.loop,
-            self.scheduler.broadcast,
-            msg={"op": "versions", "packages": packages},
+        workers = await self.scheduler.broadcast(
+            msg={"op": "versions", "packages": packages}
         )
         result = {"scheduler": scheduler, "workers": workers, "client": client}
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -91,6 +91,7 @@ from distributed.utils_test import (
 from distributed.utils_test import (  # noqa: F401
     client as c,
     client_secondary as c2,
+    async_client as ac,
     cluster_fixture,
     loop,
     loop_in_thread,
@@ -3722,6 +3723,11 @@ def test_get_versions(c):
 
     v = c.get_versions(packages=["requests"])
     assert dict(v["client"]["packages"]["optional"])["requests"] == requests.__version__
+
+
+@pytest.mark.asyncio
+async def test_async_get_versions(ac):
+    await ac.get_versions(check=True)
 
 
 def test_threaded_get_within_distributed(c):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -91,7 +91,6 @@ from distributed.utils_test import (
 from distributed.utils_test import (  # noqa: F401
     client as c,
     client_secondary as c2,
-    async_client as ac,
     cluster_fixture,
     loop,
     loop_in_thread,
@@ -3725,9 +3724,9 @@ def test_get_versions(c):
     assert dict(v["client"]["packages"]["optional"])["requests"] == requests.__version__
 
 
-@pytest.mark.asyncio
-async def test_async_get_versions(ac):
-    await ac.get_versions(check=True)
+@gen_cluster(client=True)
+async def test_async_get_versions(c, s, a, b):
+    await c.get_versions(check=True)
 
 
 def test_threaded_get_within_distributed(c):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -44,7 +44,7 @@ from .compatibility import WINDOWS
 from .comm import Comm
 from .config import initialize_logging
 from .core import connect, rpc, CommClosedError
-from .deploy import LocalCluster, SpecCluster
+from .deploy import SpecCluster
 from .metrics import time
 from .process import _cleanup_dangling
 from .proctitle import enable_proctitle_on_children
@@ -570,13 +570,6 @@ def client_secondary(loop, cluster_fixture):
     scheduler, workers = cluster_fixture
     with Client(scheduler["address"], loop=loop) as client:
         yield client
-
-
-@pytest.fixture
-async def async_client():
-    async with LocalCluster(asynchronous=True) as cluster:
-        async with Client(cluster, asynchronous=True) as client:
-            yield client
 
 
 @contextmanager

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -44,7 +44,7 @@ from .compatibility import WINDOWS
 from .comm import Comm
 from .config import initialize_logging
 from .core import connect, rpc, CommClosedError
-from .deploy import SpecCluster
+from .deploy import LocalCluster, SpecCluster
 from .metrics import time
 from .process import _cleanup_dangling
 from .proctitle import enable_proctitle_on_children
@@ -570,6 +570,13 @@ def client_secondary(loop, cluster_fixture):
     scheduler, workers = cluster_fixture
     with Client(scheduler["address"], loop=loop) as client:
         yield client
+
+
+@pytest.fixture
+async def async_client():
+    async with LocalCluster(asynchronous=True) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            yield client
 
 
 @contextmanager


### PR DESCRIPTION
Switched `Client.get_versions` to be async and renamed to `_get_versions` and use `self.sync` to call it synchronously under the original name.

Also added an async client fixture for testing.