### PR TITLE
Add task state counts to Scheduler identity

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -53,7 +53,7 @@ from distributed.client import (
 from distributed.compatibility import WINDOWS
 
 from distributed.metrics import time
-from distributed.scheduler import Scheduler, KilledWorker
+from distributed.scheduler import Scheduler, KilledWorker, ALL_TASK_STATES
 from distributed.sizeof import sizeof
 from distributed.utils import (
     ignoring,
@@ -3690,6 +3690,16 @@ def test_scheduler_info(c):
     info = c.scheduler_info()
     assert isinstance(info, dict)
     assert len(info["workers"]) == 2
+
+
+def test_scheduler_info_task_counts(c):
+    info = c.scheduler_info()
+    assert info["task_counts"].keys() == ALL_TASK_STATES
+    assert all(i == 0 for i in info["task_counts"].values())
+    futures = c.map(inc, range(7))
+    wait(futures)
+    info = c.scheduler_info()
+    assert info["task_counts"]["memory"] == 7
 
 
 def test_write_scheduler_file(c):


### PR DESCRIPTION
This PR adds `"task_counts"` and `"time"` keys to `Scheduler.identity`. This provides a convenient way to quickly get the distribution of task states (i.e. how many are processing, how many are in memory, etc.).

In addition, since `Client._update_scheduler_info` is used in a `PeriodicCallback`, adding `"task_counts"` to `Scheduler.identity` allows users to get the most recently cached distribution of tasks without an additional round trip to the scheduler. This is nice in situations where the scheduler becomes unresponsive for a period of time (e.g. when processing a large task graph). 

I also wanted to note that adding a `Scheduler.task_counts` attribute isn't strictly necessary as `Scheduler.tasks` contains all the necessary information to determine how many tasks are in each state. However, since `Client._update_scheduler_info` is used in a `PeriodicCallback`, I wanted to avoid repeated loops over all tasks the `Scheduler` is tracking. 