### PR TITLE
Fix widget with spec that generate multiple workers

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -207,7 +207,8 @@ class Cluster(object):
     def _widget_status(self):
         workers = len(self.scheduler_info["workers"])
         if hasattr(self, "worker_spec"):
-            requested = len(self.worker_spec)
+            requested = sum(1 if 'group' not in each else len(each['group'])
+                            for each in self.worker_spec.values())
         elif hasattr(self, "workers"):
             requested = len(self.workers)
         else:

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -207,8 +207,10 @@ class Cluster(object):
     def _widget_status(self):
         workers = len(self.scheduler_info["workers"])
         if hasattr(self, "worker_spec"):
-            requested = sum(1 if 'group' not in each else len(each['group'])
-                            for each in self.worker_spec.values())
+            requested = sum(
+                1 if "group" not in each else len(each["group"])
+                for each in self.worker_spec.values()
+            )
         elif hasattr(self, "workers"):
             requested = len(self.workers)
         else:

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 
 import dask
 from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
@@ -375,6 +376,8 @@ async def test_MultiWorker(cleanup):
             await client.wait_for_workers(4)
 
             assert "workers=4" in repr(cluster)
+            workers_line = re.search('(Workers.+)', cluster._widget_status()).group(1)
+            assert re.match("Workers.*<td>4</td>", workers_line)
 
             cluster.scale(1)
             await cluster

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -376,7 +376,7 @@ async def test_MultiWorker(cleanup):
             await client.wait_for_workers(4)
 
             assert "workers=4" in repr(cluster)
-            workers_line = re.search('(Workers.+)', cluster._widget_status()).group(1)
+            workers_line = re.search("(Workers.+)", cluster._widget_status()).group(1)
             assert re.match("Workers.*<td>4</td>", workers_line)
 
             cluster.scale(1)


### PR DESCRIPTION
The widget says things like: `Workers: 2 / 1`

```py
from distributed.deploy.tests.test_spec_cluster import MultiWorker
from distributed import Scheduler
from distributed import SpecCluster

cluster = SpecCluster(
    scheduler = {'cls': Scheduler},
    worker={
        "cls": MultiWorker,
        "options": {"n": 2, "nthreads": 4, "memory_limit": "4 GB"},
        "group": ["-0", "-1"],
})

cluster.scale(1)        
cluster
```

![image](https://user-images.githubusercontent.com/1680079/65214932-08e58380-daac-11e9-9fad-f1309dc16720.png)

Seen in https://github.com/dask/dask-jobqueue/pull/307#issuecomment-532857120.