### PR TITLE
set task duration based on current duration

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -23,6 +23,7 @@ distributed:
     pickle: True            # Is the scheduler allowed to deserialize arbitrary bytestrings
     preload: []
     preload-argv: []
+    default-task-durations: {}  # How long we expect function names to run ("1h", "1s") (helps for long tasks)
     dashboard:
       status:
         task-stream-length: 1000

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -570,7 +570,6 @@ class TaskState(object):
         "loose_restrictions",
         # === Task state ===
         "state",
-        "time_started",
         # Whether some dependencies were forgotten
         "has_lost_dependencies",
         # If in 'waiting' state, which tasks need to complete
@@ -599,7 +598,6 @@ class TaskState(object):
         self.prefix = key_split(key)
         self.run_spec = run_spec
         self.state = None
-        self.time_started = None
         self.exception = self.traceback = self.exception_blame = None
         self.suspicious = self.retries = 0
         self.nbytes = None
@@ -3676,7 +3674,6 @@ class Scheduler(ServerNode):
             ws.occupancy += duration + comm
             self.total_occupancy += duration + comm
             ts.state = "processing"
-            ts.time_started = time()
             self.consume_resources(ts, ws)
             self.check_idle_saturated(ws)
             self.n_tasks += 1
@@ -4721,12 +4718,8 @@ class Scheduler(ServerNode):
 
         new = 0
         nbytes = 0
-        current_time = time()
         for ts in ws.processing:
             duration = self.get_task_duration(ts)
-            # duration is at 'least' current running time
-            if ts.prefix in self.unknown_durations and ts.time_started:
-                duration = current_time - ts.time_started
             comm = self.get_comm_cost(ts, ws)
             ws.processing[ts] = duration + comm
             new += duration + comm

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -964,6 +964,8 @@ class Scheduler(ServerNode):
 
         # Prefix-keyed containers
         self.task_duration = {prefix: 0.00001 for prefix in fast_tasks}
+        for k, v in dask.config.get("distributed.scheduler.default-task-durations", {}).items():
+            self.task_duration[k] = parse_timedelta(v)
         self.unknown_durations = defaultdict(set)
 
         # Client state

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -570,6 +570,7 @@ class TaskState(object):
         "loose_restrictions",
         # === Task state ===
         "state",
+        "time_started",
         # Whether some dependencies were forgotten
         "has_lost_dependencies",
         # If in 'waiting' state, which tasks need to complete
@@ -598,6 +599,7 @@ class TaskState(object):
         self.prefix = key_split(key)
         self.run_spec = run_spec
         self.state = None
+        self.time_started = None
         self.exception = self.traceback = self.exception_blame = None
         self.suspicious = self.retries = 0
         self.nbytes = None
@@ -3674,6 +3676,7 @@ class Scheduler(ServerNode):
             ws.occupancy += duration + comm
             self.total_occupancy += duration + comm
             ts.state = "processing"
+            ts.time_started = time()
             self.consume_resources(ts, ws)
             self.check_idle_saturated(ws)
             self.n_tasks += 1
@@ -4718,8 +4721,12 @@ class Scheduler(ServerNode):
 
         new = 0
         nbytes = 0
+        current_time = time()
         for ts in ws.processing:
             duration = self.get_task_duration(ts)
+            # duration is at 'least' current running time
+            if ts.prefix in self.unknown_durations and ts.time_started:
+                duration = current_time - ts.time_started
             comm = self.get_comm_cost(ts, ws)
             ws.processing[ts] = duration + comm
             new += duration + comm

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -964,7 +964,9 @@ class Scheduler(ServerNode):
 
         # Prefix-keyed containers
         self.task_duration = {prefix: 0.00001 for prefix in fast_tasks}
-        for k, v in dask.config.get("distributed.scheduler.default-task-durations", {}).items():
+        for k, v in dask.config.get(
+            "distributed.scheduler.default-task-durations", {}
+        ).items():
             self.task_duration[k] = parse_timedelta(v)
         self.unknown_durations = defaultdict(set)
 


### PR DESCRIPTION
not 100% sure if i have the details correct, but as i understand it:
if you have a task that takes 1hr+ currently the scheduler adapts based on occupancy which when set can be boiled down to essentially (but not exactly)

task_duration = 0.5 seconds (until 1 task finishes)
target_duration = 5 seconds (set at the beginning of `.adapt`)
target_num_cpus = (task_duration*number_of_tasks) / target_duration

so for 200 tasks target_num_cpus == (0.5 * 200) / 5 == 20

so when adapting with jobs that are 1hr+, the scheduler will wait until one of those jobs finishes, and 
THEN it will scale up because it says 'oh now I know the duration of this function prefix, it's really long, lets get more workers'

if we track how much time a TaskState is alive since it started processing, we can then make a better guess of how long a task will take, and thus-adapt better.

however... I'm not 100% sure `"processing"` actually means the task has started, or if it's just on the worker waiting to be run.  If `"processing"`  means 'ready to run' then I should probably think of an alternative method.  does anyone have any insight on that?