### PR TITLE
give option for longer errors tracebacks

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -969,7 +969,7 @@ def error_message(e, status="error"):
     --------
     clean_exception: deserialize and unpack message into exception/traceback
     """
-    MAX_ERROR_LEN = dask.config.get("distributed.admin.max_error_len")
+    MAX_ERROR_LEN = dask.config.get("distributed.admin.max-error-length")
     tb = get_traceback()
     e2 = truncate_exception(e, MAX_ERROR_LEN)
     try:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -969,8 +969,9 @@ def error_message(e, status="error"):
     --------
     clean_exception: deserialize and unpack message into exception/traceback
     """
+    MAX_ERROR_LEN = dask.config.get("distributed.admin.max_error_len")
     tb = get_traceback()
-    e2 = truncate_exception(e, 1000)
+    e2 = truncate_exception(e, MAX_ERROR_LEN)
     try:
         e3 = protocol.pickle.dumps(e2)
         protocol.pickle.loads(e3)
@@ -982,7 +983,7 @@ def error_message(e, status="error"):
     except Exception:
         tb = tb2 = "".join(traceback.format_tb(tb))
 
-    if len(tb2) > 10000:
+    if len(tb2) > MAX_ERROR_LEN:
         tb_result = None
     else:
         tb_result = protocol.to_serialize(tb)

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -117,7 +117,7 @@ distributed:
       interval: 20ms  # time between event loop health checks
       limit: 3s       # time allowed before triggering a warning
 
-    max_error_len: 10000 # Maximum size traceback after error to return
+    max-error-length: 10000 # Maximum size traceback after error to return
     log-length: 10000  # default length of logs to keep in memory
     log-format: '%(name)s - %(levelname)s - %(message)s'
     pdb-on-err: False       # enter debug mode on scheduling error

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -117,6 +117,7 @@ distributed:
       interval: 20ms  # time between event loop health checks
       limit: 3s       # time allowed before triggering a warning
 
+    max_error_len: 10000 # Maximum size traceback after error to return
     log-length: 10000  # default length of logs to keep in memory
     log-format: '%(name)s - %(levelname)s - %(message)s'
     pdb-on-err: False       # enter debug mode on scheduling error

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -353,9 +353,6 @@ def test_error_message():
         def __str__(self):
             return "MyException(%s)" % self.args
 
-        def __getnewargs__(self):
-            return self.args
-
     msg = error_message(MyException("Hello", "World!"))
     assert "Hello" in str(msg["exception"])
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -353,8 +353,27 @@ def test_error_message():
         def __str__(self):
             return "MyException(%s)" % self.args
 
+        def __getnewargs__(self):
+            return self.args
+
     msg = error_message(MyException("Hello", "World!"))
     assert "Hello" in str(msg["exception"])
+
+    max_error_len = 100
+    with dask.config.set({"distributed.admin.max_error_len": max_error_len}):
+        msg = error_message(RuntimeError("-"*max_error_len))
+        assert len(msg["text"]) <= max_error_len
+        assert len(msg["text"]) < max_error_len*2
+        msg = error_message(RuntimeError("-"*max_error_len*20))
+        cut_text = msg["text"].replace("('Long error message', '", "")[:-2]
+        assert len(cut_text) == max_error_len
+
+    max_error_len = 1000000
+    with dask.config.set({"distributed.admin.max_error_len": max_error_len}):
+        msg = error_message(RuntimeError("-"*max_error_len*2))
+        cut_text = msg["text"].replace("('Long error message', '", "")[:-2]
+        assert len(cut_text) == max_error_len
+        assert len(msg["text"]) > 10100  # default + 100
 
 
 @gen_cluster()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -357,17 +357,17 @@ def test_error_message():
     assert "Hello" in str(msg["exception"])
 
     max_error_len = 100
-    with dask.config.set({"distributed.admin.max_error_len": max_error_len}):
-        msg = error_message(RuntimeError("-"*max_error_len))
+    with dask.config.set({"distributed.admin.max-error-length": max_error_len}):
+        msg = error_message(RuntimeError("-" * max_error_len))
         assert len(msg["text"]) <= max_error_len
-        assert len(msg["text"]) < max_error_len*2
-        msg = error_message(RuntimeError("-"*max_error_len*20))
+        assert len(msg["text"]) < max_error_len * 2
+        msg = error_message(RuntimeError("-" * max_error_len * 20))
         cut_text = msg["text"].replace("('Long error message', '", "")[:-2]
         assert len(cut_text) == max_error_len
 
     max_error_len = 1000000
-    with dask.config.set({"distributed.admin.max_error_len": max_error_len}):
-        msg = error_message(RuntimeError("-"*max_error_len*2))
+    with dask.config.set({"distributed.admin.max-error-length": max_error_len}):
+        msg = error_message(RuntimeError("-" * max_error_len * 2))
         cut_text = msg["text"].replace("('Long error message', '", "")[:-2]
         assert len(cut_text) == max_error_len
         assert len(msg["text"]) > 10100  # default + 100


### PR DESCRIPTION
I often am forced to run long 'subprocess' commands, and have for a long time now just hacked the `error_message` function to not truncate at all.  I figured it might be useful for others to adjust this in case your ridiculously long subprocess command fails and you want to know exactly what failed. 

in my case -- nothing is worse than getting a traceback back that is missing half of the error message that I need to help reproduce the error.

I personally think this is really useful, but I understand if you do not think it is worth adding.