### PR TITLE
Lowered default bokeh log level

### DIFF
--- a/distributed/config.py
+++ b/distributed/config.py
@@ -76,7 +76,7 @@ def _initialize_logging_old_style(config):
     loggers = {  # default values
         "distributed": "info",
         "distributed.client": "warning",
-        "bokeh": "critical",
+        "bokeh": "error",
         "tornado": "critical",
         "tornado.application": "error",
     }

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -212,7 +212,7 @@ class SpecCluster(Cluster):
         if silence_logs:
             self._old_logging_level = silence_logging(level=silence_logs)
             self._old_bokeh_logging_level = silence_logging(
-                level=logging.CRITICAL, root='bokeh'
+                level=silence_logs, root='bokeh'
             )
 
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -212,7 +212,7 @@ class SpecCluster(Cluster):
         if silence_logs:
             self._old_logging_level = silence_logging(level=silence_logs)
             self._old_bokeh_logging_level = silence_logging(
-                level=silence_logs, root='bokeh'
+                level=silence_logs, root="bokeh"
             )
 
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
@@ -354,7 +354,7 @@ class SpecCluster(Cluster):
         if hasattr(self, "_old_logging_level"):
             silence_logging(self._old_logging_level)
         if hasattr(self, "_old_bokeh_logging_level"):
-            silence_logging(self._old_bokeh_logging_level, root='bokeh')
+            silence_logging(self._old_bokeh_logging_level, root="bokeh")
 
         await super()._close()
 

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -211,6 +211,9 @@ class SpecCluster(Cluster):
 
         if silence_logs:
             self._old_logging_level = silence_logging(level=silence_logs)
+            self._old_bokeh_logging_level = silence_logging(
+                level=logging.CRITICAL, root='bokeh'
+            )
 
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
         self.loop = self._loop_runner.loop
@@ -350,6 +353,8 @@ class SpecCluster(Cluster):
 
         if hasattr(self, "_old_logging_level"):
             silence_logging(self._old_logging_level)
+        if hasattr(self, "_old_bokeh_logging_level"):
+            silence_logging(self._old_bokeh_logging_level, root='bokeh')
 
         await super()._close()
 


### PR DESCRIPTION
This PR lowers the default bokeh log level to ERROR from CRITICAL. This ensures that simply importing distributed does not hide relevant log output for users who merely import distributed or some other library that imports distributed (e.g. xarray, datashader etc.). Additionally this respects the `silence_logs` argument to ``SpecCluster`` ensuring that when starting a cluster interactively the logging is still suppressed.

Fixes https://github.com/dask/distributed/issues/1683