### PR TITLE
Identify lost workers in SpecCluster based on address not name

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -307,8 +307,12 @@ class SpecCluster(Cluster):
 
             def f():
                 if (
-                    msg in [w.worker_address for w in self.workers.values()]
+                    name in self.workers
                     and msg not in self.scheduler_info["workers"]
+                    and not any(
+                        d["name"] == name
+                        for d in self.scheduler_info["workers"].values()
+                    )
                 ):
                     self._futures.add(asyncio.ensure_future(self.workers[name].close()))
                     del self.workers[name]

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -306,7 +306,10 @@ class SpecCluster(Cluster):
             name = self.scheduler_info["workers"][msg]["name"]
 
             def f():
-                if name in self.workers and msg not in self.scheduler_info:
+                if (
+                    msg in [w.worker_address for w in self.workers.values()]
+                    and msg not in self.scheduler_info["workers"]
+                ):
                     self._futures.add(asyncio.ensure_future(self.workers[name].close()))
                     del self.workers[name]
 

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -160,7 +160,7 @@ async def test_unexpected_closed_worker(cleanup):
 @pytest.mark.asyncio
 async def test_restart(cleanup):
     # Regression test for https://github.com/dask/distributed/issues/3062
-    worker = {"cls": Worker, "options": {"nthreads": 1}}
+    worker = {"cls": Nanny, "options": {"nthreads": 1}}
     with dask.config.set({"distributed.deploy.lost-worker-timeout": "2s"}):
         async with SpecCluster(
             asynchronous=True, scheduler=scheduler, worker=worker

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -156,6 +156,26 @@ async def test_unexpected_closed_worker(cleanup):
             assert len(cluster.workers) == 2
 
 
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_restart(cleanup):
+    # Regression test for https://github.com/dask/distributed/issues/3062
+    worker = {"cls": Worker, "options": {"nthreads": 1}}
+    with dask.config.set({"distributed.deploy.lost-worker-timeout": "2s"}):
+        async with SpecCluster(
+            asynchronous=True, scheduler=scheduler, worker=worker
+        ) as cluster:
+            async with Client(cluster, asynchronous=True) as client:
+                cluster.scale(2)
+                await cluster
+                assert len(cluster.workers) == 2
+
+                await client.restart()
+                await asyncio.sleep(3)
+
+                assert len(cluster.workers) == 2
+
+
 @pytest.mark.asyncio
 async def test_broken_worker():
     with pytest.raises(Exception) as info:


### PR DESCRIPTION
This PR slightly modifies the logic for removing lost workers from `SpecCluster.workers` introduced in #2990 to identify workers by their address, not their `name`.

When nanny's restart workers, the restarted worker has the same name but a different address (please correct me if this is not always the case!). For example we might initially have a worker with `(name, address) = ('alice', 'tcp://127.0.0.1:53081')`, and then after the worker process is restarted by the nanny it may have `(name, address) = ('alice', 'tcp://127.0.0.1:53088')`.

So after restarting, the current

https://github.com/dask/distributed/blob/4953f81d7b6856f6a22f00e27476d4a554a120c2/distributed/deploy/spec.py#L309

logic will find the restarted worker by it's name (same as the original, pre-restarting worker) and close the restarted worker. 

The changes proposed here replace the named-based worker lookup with address-based worker lookup. Although, I'm definitely open to other suggestions. 

Note, I also updated `self.scheduler_info` -> `self.scheduler_info["workers"]` as `msg` is a worker address, which are the keys in `self.scheduler_info["workers"]`.

Fixes #3062