### PR TITLE
Collect worker-worker and type bandwidth information

### DIFF
--- a/distributed/dashboard/nvml.py
+++ b/distributed/dashboard/nvml.py
@@ -183,5 +183,12 @@ def gpu_utilization_doc(scheduler, extra, doc):
     doc.theme = BOKEH_THEME
 
 
-applications["/individual-gpu-memory"] = gpu_memory_doc
-applications["/individual-gpu-utilization"] = gpu_utilization_doc
+try:
+    import pynvml
+
+    pynvml.nvmlInit()
+except Exception:
+    pass
+else:
+    applications["/individual-gpu-memory"] = gpu_memory_doc
+    applications["/individual-gpu-utilization"] = gpu_utilization_doc

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -351,9 +351,9 @@ class BandwidthTypes(DashboardComponent):
             bw = self.scheduler.bandwidth_types
             self.fig.y_range.factors = list(sorted(bw))
             result = {
-                "bandwidth": bw.values(),
+                "bandwidth": list(bw.values()),
                 "bandwidth-half": [b / 2 for b in bw.values()],
-                "type": bw.keys(),
+                "type": list(bw.keys()),
                 "bandwidth_text": list(map(format_bytes, bw.values())),
             }
             self.fig.title.text = "Bandwidth: " + format_bytes(self.scheduler.bandwidth)

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -1759,7 +1759,7 @@ def individual_workers_doc(scheduler, extra, doc):
 
 def individual_bandwidth_types(scheduler, extra, doc):
     with log_errors():
-        bw = BandwidthTypes(scheduler)
+        bw = BandwidthTypes(scheduler, sizing_mode="stretch_both")
         bw.update()
         add_periodic_callback(doc, bw, 500)
         doc.add_root(bw.fig)
@@ -1768,7 +1768,7 @@ def individual_bandwidth_types(scheduler, extra, doc):
 
 def individual_bandwidth_workers(scheduler, extra, doc):
     with log_errors():
-        bw = BandwidthWorkers(scheduler)
+        bw = BandwidthWorkers(scheduler, sizing_mode="stretch_both")
         bw.update()
         add_periodic_callback(doc, bw, 500)
         doc.add_root(bw.fig)

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -664,6 +664,11 @@ def test_https_support(c, s, a, b):
     ctx.load_verify_locations(get_cert("tls-ca-cert.pem"))
 
     http_client = AsyncHTTPClient()
+    response = yield http_client.fetch(
+        "https://localhost:%d/individual-plots.json" % port, ssl_options=ctx
+    )
+    response = json.loads(response.body.decode())
+
     for suffix in [
         "system",
         "counters",
@@ -672,13 +677,7 @@ def test_https_support(c, s, a, b):
         "tasks",
         "stealing",
         "graph",
-        "individual-task-stream",
-        "individual-progress",
-        "individual-graph",
-        "individual-nbytes",
-        "individual-nprocessing",
-        "individual-profile",
-    ]:
+    ] + [url.strip("/") for url in response.values()]:
         req = HTTPRequest(
             url="https://localhost:%d/%s" % (port, suffix), ssl_options=ctx
         )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1344,19 +1344,26 @@ class Scheduler(ServerNode):
         host_info = host_info or {}
 
         self.host_info[host]["last-seen"] = local_now
-        frac = 1 / 20 / len(self.workers)
+        frac = 1 / len(self.workers)
         try:
             self.bandwidth = (
                 self.bandwidth * (1 - frac) + metrics["bandwidth"]["total"] * frac
             )
             for other, value in metrics["bandwidth"]["workers"].items():
-                self.bandwidth_workers[address, other] = (
-                    self.bandwidth_workers[address, other] * (1 - frac) + value * frac
-                )
+                if (address, other) not in self.bandwidth_workers:
+                    self.bandwidth_workers[address, other] = value
+                else:
+                    self.bandwidth_workers[address, other] = (
+                        self.bandwidth_workers[address, other] * (1 - frac)
+                        + value * frac
+                    )
             for typ, value in metrics["bandwidth"]["types"].items():
-                self.bandwidth_types[typ] = (
-                    self.bandwidth_types[typ] * (1 - frac) + value * frac
-                )
+                if typ not in self.bandwidth_types:
+                    self.bandwidth_types[typ] = value
+                else:
+                    self.bandwidth_types[typ] = (
+                        self.bandwidth_types[typ] * (1 - frac) + value * frac
+                    )
         except KeyError:
             pass
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1963,6 +1963,10 @@ class Scheduler(ServerNode):
             if not self.workers:
                 logger.info("Lost all workers")
 
+            for w in self.workers:
+                self.bandwidth_workers.pop((address, w), None)
+                self.bandwidth_workers.pop((w, address), None)
+
             def remove_worker_from_events():
                 # If the worker isn't registered anymore after the delay, remove from events
                 if address not in self.workers and address in self.events:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1517,7 +1517,7 @@ def test_idle_timeout(c, s, a, b):
 @gen_cluster(client=True, config={"distributed.scheduler.bandwidth": "100 GB"})
 def test_bandwidth(c, s, a, b):
     start = s.bandwidth
-    x = c.submit(operator.mul, b"0", 20000, workers=a.address)
+    x = c.submit(operator.mul, b"0", 1000000, workers=a.address)
     y = c.submit(lambda x: x, x, workers=b.address)
     yield y
     yield b.heartbeat()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -22,7 +22,7 @@ from distributed.client import wait
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps
 from distributed.worker import dumps_function, dumps_task
-from distributed.utils import tmpfile
+from distributed.utils import tmpfile, typename
 from distributed.utils_test import (  # noqa: F401
     captured_logger,
     cleanup,
@@ -1523,6 +1523,10 @@ def test_bandwidth(c, s, a, b):
     yield b.heartbeat()
     assert s.bandwidth < start  # we've learned that we're slower
     assert b.latency
+    assert a.address in b.bandwidth_workers
+    assert bytes in b.bandwidth_types
+    assert typename(bytes) in s.bandwidth_types
+    assert (b.address, a.address) in s.bandwidth_workers
 
 
 @gen_cluster()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1927,7 +1927,7 @@ class Worker(ServerNode):
                         "who": worker,
                     }
                 )
-                if total_bytes > 10000:
+                if total_bytes > 1000000:
                     self.bandwidth = self.bandwidth * 0.95 + bandwidth * 0.05
                     if worker not in self.bandwidth_workers:
                         self.bandwidth_workers[worker] = bandwidth

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1929,15 +1929,21 @@ class Worker(ServerNode):
                 )
                 if total_bytes > 10000:
                     self.bandwidth = self.bandwidth * 0.95 + bandwidth * 0.05
-                    self.bandwidth_workers[worker] = (
-                        self.bandwidth_workers[worker] * 0.95 + bandwidth * 0.05
-                    )
+                    if worker not in self.bandwidth_workers:
+                        self.bandwidth_workers[worker] = bandwidth
+                    else:
+                        self.bandwidth_workers[worker] = (
+                            self.bandwidth_workers[worker] * 0.95 + bandwidth * 0.05
+                        )
                     types = set(map(type, response["data"].values()))
                     if len(types) == 1:
                         [typ] = types
-                        self.bandwidth_types[typ] = (
-                            self.bandwidth_types[typ] * 0.95 + bandwidth * 0.05
-                        )
+                        if typ not in self.bandwidth_types:
+                            self.bandwidth_types[typ] = bandwidth
+                        else:
+                            self.bandwidth_types[typ] = (
+                                self.bandwidth_types[typ] * 0.95 + bandwidth * 0.05
+                            )
                 if self.digests is not None:
                     self.digests["transfer-bandwidth"].add(total_bytes / duration)
                     self.digests["transfer-duration"].add(duration)


### PR DESCRIPTION
This collects the bandwidth that we observe both by type,
and by worker-worker pair.

This is currently used in dashboards plots (see below) and may be used in scheduling decisions in the future:

cc @quasiben @pentschev 

<img width="615" alt="Screen Shot 2019-09-26 at 4 39 07 PM" src="https://user-images.githubusercontent.com/306380/65727055-4635ac80-e07c-11e9-8d7f-020366768195.png">
