### PR TITLE
Support clusters that don't have .security or ._close methods

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -652,7 +652,7 @@ class Client(Node):
             with ignoring(AttributeError):
                 loop = address.loop
             if security is None:
-                security = self.cluster.security
+                security = getattr(self.cluster, "security", None)
 
         self.security = security or Security()
         assert isinstance(self.security, Security)
@@ -917,7 +917,7 @@ class Client(Node):
         if self.cluster is not None:
             # Ensure the cluster is started (no-op if already running)
             try:
-                await self.cluster._start()
+                await self.cluster
             except AttributeError:  # Some clusters don't have this method
                 pass
             except Exception:
@@ -1266,7 +1266,7 @@ class Client(Node):
                 self._release_key(key=key)
             if self._start_arg is None:
                 with ignoring(AttributeError):
-                    await self.cluster._close()
+                    await self.cluster.close()
             self.rpc.close()
             self.status = "closed"
             if _get_global_client() is self:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -918,8 +918,6 @@ class Client(Node):
             # Ensure the cluster is started (no-op if already running)
             try:
                 await self.cluster
-            except AttributeError:  # Some clusters don't have this method
-                pass
             except Exception:
                 logger.info(
                     "Tried to start cluster and received an error. Proceeding.",


### PR DESCRIPTION
Previously clients checked for attributes that may not be universally
present.  Now we only check on scheduler, scheduler_comm, close,
workers, and other elements defined in the `Cluster` interface.

Fixes https://github.com/dask/dask-jobqueue/issues/341