### PR TITLE
Fix tornado typo in asynchronous docs

### DIFF
--- a/docs/source/asynchronous.rst
+++ b/docs/source/asynchronous.rst
@@ -108,7 +108,7 @@ Python 2/3 with Tornado
        future = client.submit(lambda x: x + 1, 10)
        result = yield future
        yield client.close()
-       raise gen.Result(result)
+       raise gen.Return(result)
 
    from tornado.ioloop import IOLoop
    IOLoop().run_sync(f)


### PR DESCRIPTION
This PR fixes a small typo (`gen.Result` -> `gen.Return`)