### PR TITLE
Retry scheduler connect multiple times

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -207,7 +207,7 @@ async def connect(addr, timeout=None, deserialize=True, connection_args=None):
     # This starts a thread
     while True:
         try:
-            while deadline - time():
+            while deadline - time() > 0:
                 future = connector.connect(
                     loc, deserialize=deserialize, **(connection_args or {})
                 )

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -1,14 +1,13 @@
 from abc import ABC, abstractmethod, abstractproperty
 from datetime import timedelta
 import logging
-from warnings import ignoring
 import weakref
 
 import dask
 from tornado import gen
 
 from ..metrics import time
-from ..utils import parse_timedelta
+from ..utils import parse_timedelta, ignoring
 from . import registry
 from .addressing import parse_address
 

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -212,7 +212,9 @@ async def connect(addr, timeout=None, deserialize=True, connection_args=None):
                 )
                 with ignoring(gen.TimeoutError):
                     comm = await gen.with_timeout(
-                        timedelta(seconds=1), future, quiet_exceptions=EnvironmentError
+                        timedelta(seconds=min(deadline - time(), 1)),
+                        future,
+                        quiet_exceptions=EnvironmentError,
                     )
                     break
             if not comm:


### PR DESCRIPTION
Closes #3084 

Instead of waiting for the scheduler connection for a long time we are waiting for a shorter time but retrying until the original timeout. If the connection is never made then we raise.