### PR TITLE
Send noise over the wire to keep connection alive

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -182,11 +182,16 @@ def async_ssh(cmd_dict):
             )
             return True
 
+    # Get transport to current SSH client
+    transport = ssh.get_transport()
+
     # Wait for a message on the input_queue. Any message received signals this
     # thread to shut itself down.
     while cmd_dict["input_queue"].empty():
         # Kill some time so that this thread does not hog the CPU.
         time.sleep(1.0)
+        # Send noise down the pipe to keep connection active
+        transport.send_ignore()
         if communicate():
             break
 


### PR DESCRIPTION
This change keeps the `dask-ssh` connection alive, preventing ssh
timeouts from closing a pipe and killing workers/schedulers without user
action.

Note that for the `asyncssh` version, this won't be required as
`asyncssh` has a specific `keepalive` parameter that can be passed
through, but before that is the default, this should ease some pain.

Related to issue #3091 