### PR TITLE
Add Client.shutdown method

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1336,9 +1336,11 @@ class Client(Node):
             self._loop_runner.stop()
 
     async def _shutdown(self):
-        with ignoring(CommClosedError):
-            await self.scheduler.terminate(close_workers=True)
-        await self.close()
+        if self.cluster:
+            await self.cluster.close()
+        else:
+            with ignoring(CommClosedError):
+                await self.scheduler.terminate(close_workers=True)
 
     def shutdown(self):
         """ Shut down the connected scheduler and workers

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1335,14 +1335,22 @@ class Client(Node):
         if self._should_close_loop and not shutting_down():
             self._loop_runner.stop()
 
-    def shutdown(self, *args, **kwargs):
-        """ Deprecated, see close instead
+    async def _shutdown(self):
+        with ignoring(CommClosedError):
+            await self.scheduler.terminate(close_workers=True)
+        await self.close()
 
-        This was deprecated because "shutdown" was sometimes confusingly
-        thought to refer to the cluster rather than the client
+    def shutdown(self):
+        """ Shut down the connected scheduler and workers
+
+        Note, this may disrupt other clients that may be using the same
+        scheudler and workers.
+
+        See also
+        --------
+        Client.close: close only this client
         """
-        warnings.warn("Shutdown is deprecated.  Please use close instead")
-        return self.close(*args, **kwargs)
+        return self.sync(self._shutdown)
 
     def get_executor(self, **kwargs):
         """

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1336,6 +1336,7 @@ class Client(Node):
             self._loop_runner.stop()
 
     async def _shutdown(self):
+        logger.info("Shutting down scheduler from Client")
         if self.cluster:
             await self.cluster.close()
         else:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5636,5 +5636,16 @@ async def test_dashboard_link_cluster(cleanup):
             assert "http://foo.com" in client._repr_html_()
 
 
+@pytest.mark.asyncio
+async def test_shutdown(cleanup):
+    async with Scheduler(port=0) as s:
+        async with Worker(s.address) as w:
+            async with Client(s.address, asynchronous=True) as c:
+                await c.shutdown()
+
+            assert s.status == "closed"
+            assert w.status == "closed"
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # noqa F401

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5647,5 +5647,14 @@ async def test_shutdown(cleanup):
             assert w.status == "closed"
 
 
+@pytest.mark.asyncio
+async def test_shutdown_localcluster(cleanup):
+    async with LocalCluster(n_workers=1, asynchronous=True, processes=False) as lc:
+        async with Client(lc, asynchronous=True) as c:
+            await c.shutdown()
+
+        assert lc.scheduler.status == "closed"
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # noqa F401


### PR DESCRIPTION
This lets the client shut down the scheduler and workers

Asked for in https://stackoverflow.com/questions/50919227/is-it-possible-to-shutdown-a-dask-distributed-cluster-given-a-client-instance