### PR TITLE
UCX: trying to allocate CUDA arrays using RMM and Numba

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -116,12 +116,7 @@ class UCX(Comm):
             # Send frames
             for frame in frames:
                 if nbytes(frame) > 0:
-                    if hasattr(frame, "__array_interface__") or hasattr(
-                        frame, "__cuda_array_interface__"
-                    ):
-                        await self.ep.send(frame)
-                    else:
-                        await self.ep.send(frame)
+                    await self.ep.send(frame)
             return sum(map(nbytes, frames))
 
     async def read(self, deserializers=("cuda", "dask", "pickle", "error")):
@@ -156,10 +151,7 @@ class UCX(Comm):
                         else:
                             frame = np.empty(size, dtype=np.uint8)
                         await self.ep.recv(frame)
-                        if is_cuda:
-                            frames.append(frame)
-                        else:
-                            frames.append(frame.data)
+                        frames.append(frame)
                     else:
                         if is_cuda:
                             frames.append(numba.cuda.device_array((0,), dtype=np.uint8))

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -22,7 +22,7 @@ import os
 
 os.environ.setdefault("UCX_RNDV_SCHEME", "put_zcopy")
 os.environ.setdefault("UCX_MEMTYPE_CACHE", "n")
-os.environ.setdefault("UCX_TLS", "rc,cuda_copy,cuda_ipc")
+os.environ.setdefault("UCX_TLS", "tcp,rc,cuda_copy,cuda_ipc")
 
 logger = logging.getLogger(__name__)
 MAX_MSG_LOG = 23


### PR DESCRIPTION
In order to avoid double allocations, this PR tries to use [RMM](https://github.com/rapidsai/rmm) for CUDA array allocations. If RMM isn't available it tries to use Numba and raise exception if non of them are available.