### PR TITLE
Support calling `cluster.scale` as async method

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -77,6 +77,19 @@ class ProcessInterface:
         await self.close()
 
 
+class NoOpAwaitable(object):
+    """An awaitable object that always returns None.
+
+    Useful to return from a method that can be called in both asynchronous and
+    synchronous contexts"""
+
+    def __await__(self):
+        async def f():
+            return None
+
+        return f().__await__()
+
+
 class SpecCluster(Cluster):
     """ Cluster that requires a full specification of workers
 
@@ -411,14 +424,14 @@ class SpecCluster(Cluster):
         while len(self.worker_spec) > n:
             self.worker_spec.popitem()
 
-        if self.status in ("closing", "closed"):
-            self.loop.add_callback(self._correct_state)
-            return
-
-        while len(self.worker_spec) < n:
-            self.worker_spec.update(self.new_worker_spec())
+        if self.status not in ("closing", "closed"):
+            while len(self.worker_spec) < n:
+                self.worker_spec.update(self.new_worker_spec())
 
         self.loop.add_callback(self._correct_state)
+
+        if self.asynchronous:
+            return NoOpAwaitable()
 
     def new_worker_spec(self):
         """ Return name and spec for the next worker

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -125,6 +125,11 @@ async def test_scale(cleanup):
         await cluster
         assert len(cluster.workers) == 1
 
+        # Can use with await
+        await cluster.scale(2)
+        await cluster
+        assert len(cluster.workers) == 2
+
 
 @pytest.mark.asyncio
 async def test_unexpected_closed_worker(cleanup):


### PR DESCRIPTION
This adds optional support for calling `cluster.scale` as an async
method (i.e. `await cluster.scale(...)`). This is currently optional and
backwards compatible - perhaps in the future we may want to deprecate
calling in the non-async context.

Fixes #3107 

See also https://github.com/dask/dask-labextension/pull/98.