### PR TITLE
Raise exception if the user passes in unused keywords to Client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -643,6 +643,11 @@ class Client(Node):
             if address:
                 logger.info("Config value `scheduler-address` found: %s", address)
 
+        if address is not None and kwargs:
+            raise ValueError(
+                "Unexpected keyword arguments: {}".format(str(sorted(kwargs)))
+            )
+
         if isinstance(address, (rpc, PooledRPCCall)):
             self.scheduler = address
         elif hasattr(address, "scheduler_address"):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -644,9 +644,13 @@ class Client(Node):
                 logger.info("Config value `scheduler-address` found: %s", address)
 
         if address is not None and kwargs:
-            raise ValueError(
-                "Unexpected keyword arguments: {}".format(str(sorted(kwargs)))
-            )
+            unused_arg = [
+                arg for arg in kwargs if arg not in ["silence_logs"] and kwargs.get(arg) != None
+            ]
+            if unused_arg and any(unused_arg):
+                raise ValueError(
+                    "Unexpected keyword arguments: {}".format(str(sorted(kwargs)))
+                )
 
         if isinstance(address, (rpc, PooledRPCCall)):
             self.scheduler = address

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -644,15 +644,9 @@ class Client(Node):
                 logger.info("Config value `scheduler-address` found: %s", address)
 
         if address is not None and kwargs:
-            unused_arg = [
-                arg
-                for arg in kwargs
-                if arg not in ["silence_logs"] and kwargs.get(arg) is not None
-            ]
-            if unused_arg and any(unused_arg):
-                raise ValueError(
-                    "Unexpected keyword arguments: {}".format(str(sorted(unused_arg)))
-                )
+            raise ValueError(
+                "Unexpected keyword arguments: {}".format(str(sorted(kwargs)))
+            )
 
         if isinstance(address, (rpc, PooledRPCCall)):
             self.scheduler = address

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -645,11 +645,13 @@ class Client(Node):
 
         if address is not None and kwargs:
             unused_arg = [
-                arg for arg in kwargs if arg not in ["silence_logs"] and kwargs.get(arg) != None
+                arg
+                for arg in kwargs
+                if arg not in ["silence_logs"] and kwargs.get(arg) is not None
             ]
             if unused_arg and any(unused_arg):
                 raise ValueError(
-                    "Unexpected keyword arguments: {}".format(str(sorted(kwargs)))
+                    "Unexpected keyword arguments: {}".format(str(sorted(unused_arg)))
                 )
 
         if isinstance(address, (rpc, PooledRPCCall)):

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -219,6 +219,27 @@ def test_Client_kwargs(loop):
     assert c.cluster.status == "closed"
 
 
+def test_Client_unused_kwargs_with_cluster(loop):
+    with LocalCluster() as cluster:
+        with pytest.raises(Exception) as argexcept:
+            c = Client(cluster, n_workers=2, dashboard_port=8000, silence_logs=None)
+        assert (
+            str(argexcept.value)
+            == "Unexpected keyword arguments: ['dashboard_port', 'n_workers']"
+        )
+
+
+def test_Client_unused_kwargs_with_address(loop):
+    with pytest.raises(Exception) as argexcept:
+        c = Client(
+            "127.0.0.1:8786", n_workers=2, dashboard_port=8000, silence_logs=None
+        )
+    assert (
+        str(argexcept.value)
+        == "Unexpected keyword arguments: ['dashboard_port', 'n_workers']"
+    )
+
+
 def test_Client_twice(loop):
     with Client(loop=loop, silence_logs=False, dashboard_address=None) as c:
         with Client(loop=loop, silence_logs=False, dashboard_address=None) as f:

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -225,7 +225,7 @@ def test_Client_unused_kwargs_with_cluster(loop):
             c = Client(cluster, n_workers=2, dashboard_port=8000, silence_logs=None)
         assert (
             str(argexcept.value)
-            == "Unexpected keyword arguments: ['dashboard_port', 'n_workers']"
+            == "Unexpected keyword arguments: ['dashboard_port', 'n_workers', 'silence_logs']"
         )
 
 
@@ -236,7 +236,7 @@ def test_Client_unused_kwargs_with_address(loop):
         )
     assert (
         str(argexcept.value)
-        == "Unexpected keyword arguments: ['dashboard_port', 'n_workers']"
+        == "Unexpected keyword arguments: ['dashboard_port', 'n_workers', 'silence_logs']"
     )
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5010,9 +5010,7 @@ def test_profile_keys(c, s, a, b):
 @gen_cluster()
 def test_client_with_name(s, a, b):
     with captured_logger("distributed.scheduler") as sio:
-        client = yield Client(
-            s.address, asynchronous=True, name="foo", silence_logs=False
-        )
+        client = yield Client(s.address, asynchronous=True, name="foo")
         assert "foo" in client.id
         yield client.close()
 
@@ -5356,7 +5354,7 @@ def test_de_serialization_none(s, a, b):
 
 @gen_cluster()
 def test_client_repr_closed(s, a, b):
-    c = yield Client(s.address, asynchronous=True, dashboard_address=None)
+    c = yield Client(s.address, asynchronous=True)
     yield c.close()
     c._repr_html_()
 


### PR DESCRIPTION
Exceptions are raised using the simple approach [suggested by mrocklin](https://github.com/dask/distributed/issues/3014#issuecomment-538349320).

It seems that some tests like [test_client_with_name](https://github.com/dask/distributed/blob/670f2e84a7607b685cbc2f8fbdbfb29aa8267c84/distributed/tests/test_client.py#L5014) fail since they pass in keywords like `silence_logs`.

In this case, are we in favor of working around these tests until they pass or change where these extra arguments are placed? What are best practices here?

#3014 