### PR TITLE
Bump dask dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click >= 6.6
 cloudpickle >= 0.2.2
-dask >= 2.3
+dask >= 2.5.2
 msgpack
 psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1


### PR DESCRIPTION
Due to moving some things around (e.g. https://github.com/dask/distributed/pull/3042), distributed 2.5 now relies on dask 2.5. We bump the required version to account for this.

 See https://github.com/dask/dask/issues/5465#issuecomment-538917319.