### PR TITLE
Xfail test_worksapce_concurrency on Python 3.6

### DIFF
--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -275,8 +275,8 @@ def _test_workspace_concurrency(tmpdir, timeout, max_procs):
 def test_workspace_concurrency(tmpdir):
     if WINDOWS:
         raise pytest.xfail.Exception("TODO: unknown failure on windows")
-    if sys.version_info < (3, 6):
-        raise pytest.xfail.Exception("TODO: unknown failure on Python 3.5")
+    if sys.version_info <= (3, 6):
+        raise pytest.xfail.Exception("TODO: unknown failure on Python 3.6")
     _test_workspace_concurrency(tmpdir, 2.0, 6)
 
 


### PR DESCRIPTION
I don't know why this has been failing, but it doesn't appear to be affecting anyone and I don't think we have the resources to track it down right now.