### PR TITLE
Adds badges to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,20 @@
 Distributed
 ===========
 
+|Build Status| |Doc Status| |Gitter| |Version Status| |NumFOCUS|
+
 A library for distributed computation.  See documentation_ for more details.
 
-
-.. _documentation: https://distributed.readthedocs.io/en/latest
+.. _documentation: https://distributed.dask.org
+.. |Build Status| image:: https://travis-ci.org/dask/distributed.svg?branch=master
+   :target: https://travis-ci.org/dask/distributed
+.. |Doc Status| image:: https://readthedocs.org/projects/distributed/badge/?version=latest
+   :target: https://distributed.dask.org
+   :alt: Documentation Status
+.. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
+   :alt: Join the chat at https://gitter.im/dask/dask
+   :target: https://gitter.im/dask/dask?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+.. |Version Status| image:: https://img.shields.io/pypi/v/distributed.svg
+   :target: https://pypi.python.org/pypi/distributed/
+.. |NumFOCUS| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+   :target: https://www.numfocus.org/


### PR DESCRIPTION
This PR adds badges to `README.rst` for the current Travis CI status, readthedocs status, gitter, etc. similar to the `dask/dask` README