### PR TITLE
Don't overwrite `self.address` if it is present

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -29,7 +29,7 @@ class ProcessInterface:
     """
 
     def __init__(self, scheduler=None, name=None):
-        self.address = None
+        self.address = getattr(self, "address", None)
         self.external_address = None
         self.lock = asyncio.Lock()
         self.status = "created"

--- a/distributed/tests/test_spec.py
+++ b/distributed/tests/test_spec.py
@@ -1,0 +1,18 @@
+from distributed.deploy.spec import ProcessInterface
+
+
+def test_address_default_none():
+    p = ProcessInterface()
+    assert p.address is None
+
+
+def test_child_address_persists():
+    class Child(ProcessInterface):
+        def __init__(self, address=None):
+            self.address = address
+            super().__init__()
+
+    c = Child()
+    assert c.address is None
+    c = Child("localhost")
+    assert c.address == "localhost"


### PR DESCRIPTION
Testing out the new `SSHCluster` I was unable to connect to an IP that turned
out to be `None` -- the call to `super().__init__()` was overwriting
`self.address` with `None` by default.  Quick one-line fix to check if the
attribute has already been declared in a child class.