### PR TITLE
Remove circular reference in Cluster

### DIFF
--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import weakref
 
 import dask
 from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
@@ -80,6 +81,20 @@ def test_spec_sync(loop):
             assert cluster.loop is client.loop
             result = client.submit(lambda x: x + 1, 10).result()
             assert result == 11
+
+
+def test_no_circular_references(cleanup, loop):
+    import time
+
+    ref = weakref.ref(SpecCluster(scheduler=scheduler, loop=loop))
+
+    for i in range(50):
+        if ref() is None:
+            break
+        time.sleep(0.1)
+        print(i)
+    else:
+        assert False
 
 
 def test_loop_started():


### PR DESCRIPTION
Previously there was a circular reference in
`distributed.deploy.Cluster._watch_worker_status` that would keep the
cluster around after deletion. We fix this here, and add a test. Note
that cleanup isn't instantaneous after `del` since closing down the
cluster takes some time, so the test sleeps in a loop for a bit to check
for this.

Fixes #3112