### PR TITLE
Support automatic TLS

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -56,7 +56,10 @@ class LocalCluster(SpecCluster):
         like ``['feed', 'run_function']``
     service_kwargs: Dict[str, Dict]
         Extra keywords to hand to the running services
-    security : Security
+    security : Security or bool, optional
+        Configures communication security in this cluster. Can be a security
+        object, or True. If True, temporary self-signed credentials will
+        be created automatically.
     protocol: str (optional)
         Protocol to use like ``tcp://``, ``tls://``, ``inproc://``
         This defaults to sensible choice given other keyword arguments like
@@ -122,7 +125,15 @@ class LocalCluster(SpecCluster):
 
         self.status = None
         self.processes = processes
-        security = security or Security()
+
+        if security is None:
+            # Falsey values load the default configuration
+            security = Security()
+        elif security is True:
+            # True indicates self-signed temporary credentials should be used
+            security = Security.temporary()
+        elif not isinstance(security, Security):
+            raise TypeError("security must be a Security object")
 
         if protocol is None:
             if host and "://" in host:

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -1,3 +1,7 @@
+import datetime
+import tempfile
+import os
+
 try:
     import ssl
 except ImportError:
@@ -76,6 +80,67 @@ class Security(object):
         self._set_field(kwargs, "tls_worker_key", "distributed.comm.tls.worker.key")
         self._set_field(kwargs, "tls_worker_cert", "distributed.comm.tls.worker.cert")
 
+    @classmethod
+    def temporary(cls):
+        """Create a new temporary Security object.
+
+        This creates a new self-signed key/cert pair suitable for securing
+        communication for all roles in a Dask cluster. These keys/certs exist
+        only in memory, and are stored in this object.
+
+        This method requires the library ``cryptography`` be installed.
+        """
+        try:
+            from cryptography import x509
+            from cryptography.hazmat.backends import default_backend
+            from cryptography.hazmat.primitives import hashes
+            from cryptography.hazmat.primitives import serialization
+            from cryptography.hazmat.primitives.asymmetric import rsa
+            from cryptography.x509.oid import NameOID
+        except ImportError:
+            raise ImportError(
+                "Using `Security.temporary` requires `cryptography`, please "
+                "install it using either pip or conda"
+            )
+        key = rsa.generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend()
+        )
+        key_contents = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+
+        dask_internal = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, "dask-internal")]
+        )
+        altnames = x509.SubjectAlternativeName([x509.DNSName("dask-internal")])
+        now = datetime.datetime.utcnow()
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(dask_internal)
+            .issuer_name(dask_internal)
+            .add_extension(altnames, critical=False)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + datetime.timedelta(days=365))
+            .sign(key, hashes.SHA256(), default_backend())
+        )
+
+        cert_contents = cert.public_bytes(serialization.Encoding.PEM).decode()
+
+        return cls(
+            require_encryption=True,
+            tls_ca_file=cert_contents,
+            tls_client_key=key_contents,
+            tls_client_cert=cert_contents,
+            tls_scheduler_key=key_contents,
+            tls_scheduler_cert=cert_contents,
+            tls_worker_key=key_contents,
+            tls_worker_cert=cert_contents,
+        )
+
     def _set_field(self, kwargs, field, config_name):
         if field in kwargs:
             out = kwargs[field]
@@ -84,12 +149,16 @@ class Security(object):
         setattr(self, field, out)
 
     def __repr__(self):
-        items = sorted((k, getattr(self, k)) for k in self.__slots__)
-        return (
-            "Security("
-            + ", ".join("%s=%r" % (k, v) for k, v in items if v is not None)
-            + ")"
-        )
+        keys = sorted(self.__slots__)
+        items = []
+        for k in keys:
+            val = getattr(self, k)
+            if val is not None:
+                if isinstance(val, str) and "\n" in val:
+                    items.append((k, "..."))
+                else:
+                    items.append((k, repr(val)))
+        return "Security(" + ", ".join("%s=%s" % (k, v) for k, v in items) + ")"
 
     def get_tls_config_for_role(self, role):
         """
@@ -106,14 +175,41 @@ class Security(object):
 
     def _get_tls_context(self, tls, purpose):
         if tls.get("ca_file") and tls.get("cert"):
-            ctx = ssl.create_default_context(purpose=purpose, cafile=tls["ca_file"])
+            ca = tls["ca_file"]
+            cert_path = cert = tls["cert"]
+            key_path = key = tls.get("key")
+
+            if "\n" in ca:
+                ctx = ssl.create_default_context(purpose=purpose, cadata=ca)
+            else:
+                ctx = ssl.create_default_context(purpose=purpose, cafile=ca)
+
+            cert_in_memory = "\n" in cert
+            key_in_memory = key is not None and "\n" in key
+            if cert_in_memory or key_in_memory:
+                with tempfile.TemporaryDirectory() as tempdir:
+                    if cert_in_memory:
+                        cert_path = os.path.join(tempdir, "dask.crt")
+                        with open(cert_path, "w") as f:
+                            f.write(cert)
+                    if key_in_memory:
+                        key_path = os.path.join(tempdir, "dask.pem")
+                        with open(key_path, "w") as f:
+                            f.write(key)
+                    ctx.load_cert_chain(cert_path, key_path)
+            else:
+                ctx.load_cert_chain(cert_path, key_path)
+
+            # Bidirectional authentication
             ctx.verify_mode = ssl.CERT_REQUIRED
+
             # We expect a dedicated CA for the cluster and people using
             # IP addresses rather than hostnames
             ctx.check_hostname = False
-            ctx.load_cert_chain(tls["cert"], tls.get("key"))
+
             if tls.get("ciphers"):
                 ctx.set_ciphers(tls.get("ciphers"))
+
             return ctx
 
     def get_connection_args(self, role):


### PR DESCRIPTION
This adds support for automatically securing cluster communication with
TLS. This can be useful for situations where you don't have existing
credentials.

This required the following changes:

- ``Security`` objects now support either paths or contents for all
`key`/`cert`/`ca` fields. Due to limitations in Python's ``ssl`` module,
if contents are provided they must be written to a temporary directory
before being loaded back in. We make sure to use secure methods for
doing this. We also change the ``__repr__`` to not show the raw cert
values in the case they're stored in memory.

- ``Security`` objects now have a classmethod ``temporary``, which can
be used to create temporary credentials using self-signed certs. This
requires ``cryptography`` to be installed. Most environments will
already have ``cryptography``, so this isn't a huge new dependency.

```python
>>> sec = Security.temporary()
```

- Both ``Client`` and ``LocalCluster`` now support passing in
``security=True``, which will generate temporary credentials
automatically for use with that cluster. This api could be supported by
other cluster managers, but for now we restrict to ``LocalCluster``
only.

```python
>>> client = Client(security=True)
>>> client
<Client: 'tls://127.0.0.1:52616' processes=4 threads=8, memory=17.18 GB>
```

Fixes #1686