### PR TITLE
Fix Numba serialization when strides is None

### DIFF
--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -25,7 +25,7 @@ def deserialize_numba_ndarray(header, frames):
     # meaning the array is C-contiguous, so we have to calculate it.
     if strides is None:
         itemsize = np.dtype(header["typestr"]).itemsize
-        strides = tuple((np.cumprod((1, ) + shape[:0:-1]) * itemsize).tolist())
+        strides = tuple((np.cumprod((1,) + shape[:0:-1]) * itemsize).tolist())
 
     arr = numba.cuda.devicearray.DeviceNDArray(
         shape,

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -18,19 +18,17 @@ def serialize_numba_ndarray(x):
 @cuda_deserialize.register(numba.cuda.devicearray.DeviceNDArray)
 def deserialize_numba_ndarray(header, frames):
     (frame,) = frames
+    shape = header["shape"]
     strides = header["strides"]
 
     # Starting with __cuda_array_interface__ version 2, strides can be None,
     # meaning the array is C-contiguous, so we have to calculate it.
     if strides is None:
         itemsize = np.dtype(header["typestr"]).itemsize
-        strides = list(header["shape"][1:]) + [itemsize]
-        for i in range(len(strides) - 1, 0, -1):
-            strides[i - 1] *= strides[i]
-        strides = tuple(strides)
+        strides = tuple((np.cumprod((1, ) + shape[:0:-1]) * itemsize).tolist())
 
     arr = numba.cuda.devicearray.DeviceNDArray(
-        header["shape"],
+        shape,
         strides,
         np.dtype(header["typestr"]),
         gpu_data=numba.cuda.as_cuda_array(frame).gpu_data,

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -18,9 +18,20 @@ def serialize_numba_ndarray(x):
 @cuda_deserialize.register(numba.cuda.devicearray.DeviceNDArray)
 def deserialize_numba_ndarray(header, frames):
     (frame,) = frames
+    strides = header["strides"]
+
+    # Starting with __cuda_array_interface__ version 2, strides can be None,
+    # meaning the array is C-contiguous, so we have to calculate it.
+    if strides is None:
+        itemsize = np.dtype(header["typestr"]).itemsize
+        strides = list(header["shape"][1:]) + [itemsize]
+        for i in range(len(strides)-1, 0, -1):
+            strides[i-1] *= strides[i]
+        strides = tuple(strides)
+
     arr = numba.cuda.devicearray.DeviceNDArray(
         header["shape"],
-        header["strides"],
+        strides,
         np.dtype(header["typestr"]),
         gpu_data=numba.cuda.as_cuda_array(frame).gpu_data,
     )

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -25,8 +25,8 @@ def deserialize_numba_ndarray(header, frames):
     if strides is None:
         itemsize = np.dtype(header["typestr"]).itemsize
         strides = list(header["shape"][1:]) + [itemsize]
-        for i in range(len(strides)-1, 0, -1):
-            strides[i-1] *= strides[i]
+        for i in range(len(strides) - 1, 0, -1):
+            strides[i - 1] *= strides[i]
         strides = tuple(strides)
 
     arr = numba.cuda.devicearray.DeviceNDArray(


### PR DESCRIPTION
This is necessary for newer Numba versions with `__cuda_array_interface__` version 2.

The existing test fails for Numba 0.46.0, so this case is automatically covered, but I'm not sure if we can really have a specific test for this.

cc @quasiben @madsbk 