### PR TITLE
Frame offload calls gc.collect()

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1298,7 +1298,7 @@ class Client(Node):
                 with ignoring(TimeoutError):
                     await gen.with_timeout(timedelta(seconds=2), list(coroutines))
             with ignoring(AttributeError):
-                self.scheduler.close_rpc()
+                await self.scheduler.close_rpc()
             self.scheduler = None
 
         self.status = "closed"

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -213,14 +213,13 @@ class TCP(Comm):
                 raise CommClosedError("aborted stream on truncated data")
             return msg
 
-    @gen.coroutine
-    def write(self, msg, serializers=None, on_error="message"):
+    async def write(self, msg, serializers=None, on_error="message"):
         stream = self.stream
         bytes_since_last_yield = 0
         if stream is None:
             raise CommClosedError
 
-        frames = yield to_frames(
+        frames = await to_frames(
             msg,
             serializers=serializers,
             on_error=on_error,
@@ -247,7 +246,7 @@ class TCP(Comm):
                     future = stream.write(frame)
                     bytes_since_last_yield += nbytes(frame)
                     if bytes_since_last_yield > 32e6:
-                        yield future
+                        await future
                         bytes_since_last_yield = 0
         except StreamClosedError as e:
             stream = None

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -220,7 +220,6 @@ class UCXConnector(Connector):
 
 
 class UCXListener(Listener):
-    # MAX_LISTENERS 256 in ucx-py
     prefix = UCXConnector.prefix
     comm_class = UCXConnector.comm_class
     encrypted = UCXConnector.encrypted
@@ -250,7 +249,7 @@ class UCXListener(Listener):
             ucx = UCX(
                 client_ep,
                 local_addr=self.address,
-                peer_addr=self.address,  # TODO: https://github.com/Akshay-Venkatesh/ucx-py/issues/111
+                peer_addr=self.address,
                 deserialize=self.deserialize,
             )
             if self.comm_handler:

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -63,8 +63,6 @@ def from_frames(frames, deserialize=True, deserializers=None):
 
     if deserialize and size > FRAME_OFFLOAD_THRESHOLD:
         res = yield offload(_from_frames)
-        # offload() may result in cyclic references
-        gc.collect()
     else:
         res = _from_frames()
 

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -1,11 +1,10 @@
 import logging
 import socket
-import gc
 
 from tornado import gen
 
 from .. import protocol
-from ..utils import get_ip, get_ipv6, nbytes, offload
+from ..utils import get_ip, get_ipv6, nbytes, offload, offload_to_current_event_loop
 
 
 logger = logging.getLogger(__name__)
@@ -35,7 +34,7 @@ def to_frames(msg, serializers=None, on_error="message", context=None):
             logger.exception(e)
             raise
 
-    res = yield offload(_to_frames)
+    res = yield offload_to_current_event_loop(_to_frames)
 
     raise gen.Return(res)
 
@@ -62,7 +61,7 @@ def from_frames(frames, deserialize=True, deserializers=None):
             raise
 
     if deserialize and size > FRAME_OFFLOAD_THRESHOLD:
-        res = yield offload(_from_frames)
+        res = yield offload_to_current_event_loop(_from_frames)
     else:
         res = _from_frames()
 

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -1,5 +1,6 @@
 import logging
 import socket
+import gc
 
 from tornado import gen
 
@@ -62,6 +63,8 @@ def from_frames(frames, deserialize=True, deserializers=None):
 
     if deserialize and size > FRAME_OFFLOAD_THRESHOLD:
         res = yield offload(_from_frames)
+        # offload() may result in cyclic references
+        gc.collect()
     else:
         res = _from_frames()
 

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -74,7 +74,7 @@ class Cluster(object):
 
         for pc in self.periodic_callbacks.values():
             pc.stop()
-        self.scheduler_comm.close_rpc()
+        await self.scheduler_comm.close_rpc()
 
         self.status = "closed"
 

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1011,7 +1011,7 @@ async def test_capture_security(cleanup, temporary):
 @pytest.mark.skipif(
     sys.version_info < (3, 7), reason="asyncio.all_tasks not implemented"
 )
-async def test_no_dangilng_asyncio_tasks(cleanup):
+async def test_no_danglng_asyncio_tasks(cleanup):
     start = asyncio.all_tasks()
     async with LocalCluster(asynchronous=True, processes=False):
         await asyncio.sleep(0.01)

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1,3 +1,4 @@
+import asyncio
 from functools import partial
 import gc
 import subprocess
@@ -1004,3 +1005,13 @@ async def test_capture_security(cleanup, temporary):
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             assert client.security == cluster.security
+
+
+@pytest.mark.asyncio
+async def test_no_dangilng_asyncio_tasks(cleanup):
+    start = asyncio.all_tasks()
+    async with LocalCluster(asynchronous=True, processes=False):
+        await asyncio.sleep(0.01)
+
+    tasks = asyncio.all_tasks()
+    assert tasks == start

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -456,7 +456,7 @@ def test_silent_startup():
 
         if __name__ == "__main__":
             with LocalCluster(1, dashboard_address=None, scheduler_port=0):
-                sleep(1.5)
+                sleep(.1)
         """
 
     out = subprocess.check_output(

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1008,6 +1008,9 @@ async def test_capture_security(cleanup, temporary):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="asyncio.all_tasks not implemented"
+)
 async def test_no_dangilng_asyncio_tasks(cleanup):
     start = asyncio.all_tasks()
     async with LocalCluster(asynchronous=True, processes=False):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2642,8 +2642,7 @@ class Scheduler(ServerNode):
                     "timeout.  Continuuing with restart process"
                 )
             finally:
-                for nanny in nannies:
-                    nanny.close_rpc()
+                await asyncio.gather(*[nanny.close_rpc() for nanny in nannies])
 
             await self.start()
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -299,13 +299,14 @@ def test_rpc_inproc():
     yield check_rpc("inproc://", None)
 
 
-def test_rpc_inputs():
+@pytest.mark.asyncio
+async def test_rpc_inputs():
     L = [rpc("127.0.0.1:8884"), rpc(("127.0.0.1", 8884)), rpc("tcp://127.0.0.1:8884")]
 
     assert all(r.address == "tcp://127.0.0.1:8884" for r in L), L
 
     for r in L:
-        r.close_rpc()
+        await r.close_rpc()
 
 
 async def check_rpc_message_lifetime(*listen_args):

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -115,7 +115,7 @@ def test_nanny_process_failure(c, s):
     assert not os.path.exists(second_dir)
     assert not os.path.exists(first_dir)
     assert first_dir != n.worker_dir
-    ww.close_rpc()
+    yield ww.close_rpc()
     s.stop()
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1695,7 +1695,7 @@ def test_get_task_duration():
 @pytest.mark.skipif(
     sys.version_info < (3, 7), reason="asyncio.all_tasks not implemented"
 )
-async def test_no_dangilng_asyncio_tasks(cleanup):
+async def test_no_danglng_asyncio_tasks(cleanup):
     start = asyncio.all_tasks()
     async with Scheduler(port=0) as s:
         async with Worker(s.address, name="0") as a:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1692,6 +1692,9 @@ def test_get_task_duration():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="asyncio.all_tasks not implemented"
+)
 async def test_no_dangilng_asyncio_tasks(cleanup):
     start = asyncio.all_tasks()
     async with Scheduler(port=0) as s:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1,3 +1,4 @@
+import asyncio
 import cloudpickle
 import pickle
 from collections import defaultdict
@@ -1688,3 +1689,15 @@ def test_get_task_duration():
         assert s.get_task_duration(ts_pref2_2) == 0.5  # default
         assert len(s.unknown_durations) == 1
         assert len(s.unknown_durations["prefix_2"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_no_dangilng_asyncio_tasks(cleanup):
+    start = asyncio.all_tasks()
+    async with Scheduler(port=0) as s:
+        async with Worker(s.address, name="0") as a:
+            async with Client(s.address, asynchronous=True) as c:
+                await asyncio.sleep(0.01)
+
+    tasks = asyncio.all_tasks()
+    assert tasks == start

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -173,7 +173,7 @@ def dont_test_delete_data_with_missing_worker(c, a, b):
     assert not c.has_what[bad]
     assert not c.has_what[a.address]
 
-    cc.close_rpc()
+    yield cc.close_rpc()
 
 
 @gen_cluster(client=True)
@@ -998,32 +998,27 @@ def test_worker_fds(s):
 
 
 @gen_cluster(nthreads=[])
-def test_service_hosts_match_worker(s):
+async def test_service_hosts_match_worker(s):
     pytest.importorskip("bokeh")
     from distributed.dashboard import BokehWorker
 
-    services = {("dashboard", ":0"): BokehWorker}
-
-    w = yield Worker(
+    async with Worker(
         s.address, services={("dashboard", ":0"): BokehWorker}, host="tcp://0.0.0.0"
-    )
-    sock = first(w.services["dashboard"].server._http._sockets.values())
-    assert sock.getsockname()[0] in ("::", "0.0.0.0")
-    yield w.close()
+    ) as w:
+        sock = first(w.services["dashboard"].server._http._sockets.values())
+        assert sock.getsockname()[0] in ("::", "0.0.0.0")
 
-    w = yield Worker(
+    async with Worker(
         s.address, services={("dashboard", ":0"): BokehWorker}, host="tcp://127.0.0.1"
-    )
-    sock = first(w.services["dashboard"].server._http._sockets.values())
-    assert sock.getsockname()[0] in ("::", "0.0.0.0")
-    yield w.close()
+    ) as w:
+        sock = first(w.services["dashboard"].server._http._sockets.values())
+        assert sock.getsockname()[0] in ("::", "0.0.0.0")
 
-    w = yield Worker(
+    async with Worker(
         s.address, services={("dashboard", 0): BokehWorker}, host="tcp://127.0.0.1"
-    )
-    sock = first(w.services["dashboard"].server._http._sockets.values())
-    assert sock.getsockname()[0] == "127.0.0.1"
-    yield w.close()
+    ) as w:
+        sock = first(w.services["dashboard"].server._http._sockets.values())
+        assert sock.getsockname()[0] == "127.0.0.1"
 
 
 @gen_cluster(nthreads=[])

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1365,6 +1365,6 @@ except TypeError:
 weakref.finalize(_offload_executor, _offload_executor.shutdown)
 
 
-@gen.coroutine
-def offload(fn, *args, **kwargs):
-    return (yield _offload_executor.submit(fn, *args, **kwargs))
+async def offload(fn, *args, **kwargs):
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(_offload_executor, fn, *args, **kwargs)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1365,6 +1365,11 @@ except TypeError:
 weakref.finalize(_offload_executor, _offload_executor.shutdown)
 
 
-async def offload(fn, *args, **kwargs):
+@gen.coroutine
+def offload(fn, *args, **kwargs):
+    return (yield _offload_executor.submit(fn, *args, **kwargs))
+
+
+async def offload_to_current_event_loop(fn, *args, **kwargs):
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(_offload_executor, fn, *args, **kwargs)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1365,11 +1365,6 @@ except TypeError:
 weakref.finalize(_offload_executor, _offload_executor.shutdown)
 
 
-@gen.coroutine
-def offload(fn, *args, **kwargs):
-    return (yield _offload_executor.submit(fn, *args, **kwargs))
-
-
-async def offload_to_current_event_loop(fn, *args, **kwargs):
+async def offload(fn, *args, **kwargs):
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(_offload_executor, fn, *args, **kwargs)

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -84,7 +84,7 @@ async def gather_from_workers(who_has, rpc, close=True, serializers=None, who=No
                     response.update(r["data"])
         finally:
             for r in rpcs.values():
-                r.close_rpc()
+                await r.close_rpc()
 
         bad_addresses |= {v for k, v in rev.items() if k not in response}
         results.update(response)
@@ -148,7 +148,7 @@ async def scatter_to_workers(nthreads, data, rpc=rpc, report=True, serializers=N
         )
     finally:
         for r in rpcs.values():
-            r.close_rpc()
+            await r.close_rpc()
 
     nbytes = merge(o["nbytes"] for o in out)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1063,7 +1063,7 @@ class Worker(ServerNode):
                             address=self.contact_address, safe=safe
                         ),
                     )
-            self.scheduler.close_rpc()
+            await self.scheduler.close_rpc()
             self._workdir.release()
 
             for k, v in self.services.items():


### PR DESCRIPTION
This PR makes `from_frames()` call the garbage collector before returning.

When a frame size is larger than `FRAME_OFFLOAD_THRESHOLD`, `from_frames()` uses offloading which might create cyclic references. 

The following code runs out of memory on must systems before the automatic garbage collector runs:
```python
import asyncio
import gc
from distributed.comm.utils import from_frames, to_frames, FRAME_OFFLOAD_THRESHOLD
from distributed.protocol import to_serialize
import numpy as np
import psutil

ITER = 100
GC_COLLECT = False
SIZE = FRAME_OFFLOAD_THRESHOLD * 10

async def work():
    ary = np.arange(SIZE)
    frames = await to_frames({"data": to_serialize(ary)})
    await from_frames(frames)

async def main():
    for _ in range(ITER):
        await work()
        if GC_COLLECT:
            gc.collect()
        print("CPU Bytes Used:", psutil.virtual_memory().used)

loop = asyncio.get_event_loop()
loop.run_until_complete(main())
```
Setting `GC_COLLECT = True` or  `SIZE` to something less than `FRAME_OFFLOAD_THRESHOLD` will fix the problem in this case.

cc @pentschev @quasiben 