### PR TITLE
Add worker and tasks state for Prometheus data collection

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -240,25 +240,29 @@ class _PrometheusCollector(object):
         from prometheus_client.core import GaugeMetricFamily
 
         yield GaugeMetricFamily(
-            "dask_scheduler_workers",
-            "Number of workers connected.",
-            value=len(self.server.workers),
-        )
-        yield GaugeMetricFamily(
             "dask_scheduler_clients",
             "Number of clients connected.",
             value=len(self.server.clients),
         )
-        yield GaugeMetricFamily(
-            "dask_scheduler_received_tasks",
-            "Number of tasks received at scheduler",
-            value=len(self.server.tasks),
+
+        tasks = GaugeMetricFamily(
+            "dask_scheduler_workers",
+            "Number of workers known by scheduler.",
+            labels=["state"],
         )
-        yield GaugeMetricFamily(
-            "dask_scheduler_unrunnable_tasks",
-            "Number of unrunnable tasks at scheduler",
-            value=len(self.server.unrunnable),
+        tasks.add_metric(["connected"], len(self.server.workers))
+        tasks.add_metric(["saturated"], len(self.server.saturated))
+        tasks.add_metric(["idle"], len(self.server.idle))
+        yield tasks
+
+        tasks = GaugeMetricFamily(
+            "dask_scheduler_tasks",
+            "Number of tasks known by scheduler.",
+            labels=["state"],
         )
+        tasks.add_metric(["received"], len(self.server.tasks))
+        tasks.add_metric(["unrunnable"], len(self.server.unrunnable))
+        yield tasks
 
 
 class PrometheusHandler(RequestHandler):

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -23,9 +23,7 @@ Available metrics are as following
 +---------------------------------------------+------------------------------------------------+-----------+--------+
 | dask_scheduler_clients                      | Number of clients connected.                   |    Yes    |        |
 +---------------------------------------------+------------------------------------------------+-----------+--------+
-| dask_scheduler_received_tasks               | Number of tasks received at scheduler.         |    Yes    |        |
-+---------------------------------------------+------------------------------------------------+-----------+--------+
-| dask_scheduler_unrunnable_tasks             | Number of unrunnable tasks at scheduler.       |    Yes    |        |
+| dask_scheduler_tasks                        | Number of tasks at scheduler.                  |    Yes    |        |
 +---------------------------------------------+------------------------------------------------+-----------+--------+
 | dask_worker_tasks                           | Number of tasks at worker.                     |           |  Yes   |
 +---------------------------------------------+------------------------------------------------+-----------+--------+


### PR DESCRIPTION
Added additional worker and tasks state for Prometheus data collection. The data being collect is now

```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 5597.0
python_gc_objects_collected_total{generation="1"} 237.0
python_gc_objects_collected_total{generation="2"} 92.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 211.0
python_gc_collections_total{generation="1"} 15.0
python_gc_collections_total{generation="2"} 1.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="7",patchlevel="4",version="3.7.4"} 1.0
# HELP dask_scheduler_clients Number of clients connected.
# TYPE dask_scheduler_clients gauge
dask_scheduler_clients 1.0
# HELP dask_scheduler_workers Number of workers known by scheduler.
# TYPE dask_scheduler_workers gauge
dask_scheduler_workers{state="connected"} 0.0
dask_scheduler_workers{state="saturated"} 0.0
dask_scheduler_workers{state="idle"} 0.0
# HELP dask_scheduler_tasks Number of tasks known by scheduler.
# TYPE dask_scheduler_tasks gauge
dask_scheduler_tasks{state="received"} 0.0
dask_scheduler_tasks{state="unrunnable"} 0.0
```