### PR TITLE
Nanny/Worker with unspecified protocol will get from scheduler address

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -106,6 +106,11 @@ class Nanny(ServerNode):
         else:
             self.scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))
 
+        if protocol is None:
+            protocol_address = self.scheduler_addr.split("://")
+            if len(protocol_address) == 2:
+                protocol = protocol_address[0]
+
         if ncores is not None:
             warnings.warn("the ncores= parameter has moved to nthreads=")
             nthreads = ncores

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1500,7 +1500,7 @@ async def test_interface_async(loop, Worker):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("Worker", [Worker, Nanny])
 @pytest.mark.parametrize("protocol", ["tcp", "ucx"])
-async def test_protocol_from_scheduler_address(loop, Worker, protocol):
+async def test_protocol_from_scheduler_address(Worker, protocol):
     if protocol == "ucx":
         ucp = pytest.importorskip("ucp")
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1499,18 +1499,16 @@ async def test_interface_async(loop, Worker):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("Worker", [Worker, Nanny])
-@pytest.mark.parametrize("protocol", ["tcp", "ucx"])
-async def test_protocol_from_scheduler_address(Worker, protocol):
-    if protocol == "ucx":
-        ucp = pytest.importorskip("ucp")
+async def test_protocol_from_scheduler_address(Worker):
+    ucp = pytest.importorskip("ucp")
 
-    async with Scheduler(protocol=protocol) as s:
-        assert s.address.startswith(protocol)
+    async with Scheduler(protocol="ucx") as s:
+        assert s.address.startswith("ucx://")
         async with Worker(s.address) as w:
-            assert w.address.startswith(protocol)
+            assert w.address.startswith("ucx://")
             async with Client(s.address, asynchronous=True) as c:
                 info = c.scheduler_info()
-                assert info["address"].startswith(protocol)
+                assert info["address"].startswith("ucx://")
 
 
 @pytest.mark.asyncio

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -440,6 +440,11 @@ class Worker(ServerNode):
             scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))
         self.contact_address = contact_address
 
+        if protocol is None:
+            protocol_address = scheduler_addr.split("://")
+            if len(protocol_address) == 2:
+                protocol = protocol_address[0]
+
         # Target interface on which we contact the scheduler by default
         # TODO: it is unfortunate that we special-case inproc here
         if not host and not interface and not scheduler_addr.startswith("inproc://"):


### PR DESCRIPTION
This ensures protocol is taken from the scheduler address when unspecified. If the user doesn't pass it when using a different protocol (such as `ucx`), it will cause the worker to use `tcp` by default and make communication not work as intended. Therefore, it's safer to get from the scheduler address to prevent faulty behavior that can be difficult to detect.

cc @mrocklin 