### PR TITLE
Update UCX variables to use sockcm by default

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -21,7 +21,8 @@ import os
 
 os.environ.setdefault("UCX_RNDV_SCHEME", "put_zcopy")
 os.environ.setdefault("UCX_MEMTYPE_CACHE", "n")
-os.environ.setdefault("UCX_TLS", "tcp,rc,cuda_copy,cuda_ipc")
+os.environ.setdefault("UCX_TLS", "tcp,sockcm,rc,cuda_copy,cuda_ipc")
+os.environ.setdefault("UCX_SOCKADDR_TLS_PRIORITY", "sockcm")
 
 logger = logging.getLogger(__name__)
 MAX_MSG_LOG = 23


### PR DESCRIPTION
Without `sockcm` workers/client can't connect to scheduler. For example `test_ucx_localcluster` won't pass without this.

@quasiben @madsbk could you please check if you agree with this change?