### PR TITLE
Drop Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ dist: trusty
 
 env:
   matrix:
-    - PYTHON=3.5.4 TESTS=true COVERAGE=true PACKAGES="python-blosc lz4" CRICK=true
-    - PYTHON=3.6 TESTS=true PACKAGES="scikit-learn lz4" TORNADO=5
+    - PYTHON=3.6 TESTS=true COVERAGE=true PACKAGES="scikit-learn lz4" TORNADO=5 CRICK=true
     - PYTHON=3.7 TESTS=true PACKAGES="scikit-learn python-snappy python-blosc" TORNADO=6
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,14 @@ environment:
 
   matrix:
     # Since appveyor is quite slow, we only use a single configuration
-    - PYTHON: "3.5"
+    - PYTHON: "3.6"
       ARCH: "64"
       CONDA_ENV: testenv
 
 init:
   # Use AppVeyor's provided Miniconda: https://www.appveyor.com/docs/installed-software#python
-  - if "%ARCH%" == "64" set MINICONDA=C:\Miniconda35-x64
-  - if "%ARCH%" == "32" set MINICONDA=C:\Miniconda35
+  - if "%ARCH%" == "64" set MINICONDA=C:\Miniconda36-x64
+  - if "%ARCH%" == "32" set MINICONDA=C:\Miniconda36
   - set PATH=%MINICONDA%;%MINICONDA%/Scripts;%MINICONDA%/Library/bin;%PATH%
 
 install:

--- a/continuous_integration/setup_conda_environment.cmd
+++ b/continuous_integration/setup_conda_environment.cmd
@@ -24,7 +24,6 @@ call deactivate
     cloudpickle ^
     dask ^
     dill ^
-    futures ^
     lz4 ^
     ipykernel ^
     ipywidgets ^

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -21,7 +21,8 @@ import os
 
 os.environ.setdefault("UCX_RNDV_SCHEME", "put_zcopy")
 os.environ.setdefault("UCX_MEMTYPE_CACHE", "n")
-os.environ.setdefault("UCX_TLS", "tcp,rc,cuda_copy,cuda_ipc")
+os.environ.setdefault("UCX_TLS", "tcp,sockcm,rc,cuda_copy,cuda_ipc")
+os.environ.setdefault("UCX_SOCKADDR_TLS_PRIORITY", "sockcm")
 
 logger = logging.getLogger(__name__)
 MAX_MSG_LOG = 23

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -697,6 +697,12 @@ class rpc(object):
     def __exit__(self, *args):
         asyncio.ensure_future(self.close_rpc())
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        await self.close_rpc()
+
     def __del__(self):
         if self.status != "closed":
             rpc.active.discard(self)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3322,10 +3322,7 @@ def test_get_foo_lost_keys(c, s, u, v, w):
 
 @pytest.mark.slow
 @gen_cluster(
-    client=True,
-    Worker=Nanny,
-    worker_kwargs={"death_timeout": "500ms"},
-    clean_kwargs={"threads": False, "processes": False},
+    client=True, Worker=Nanny, clean_kwargs={"threads": False, "processes": False}
 )
 def test_bad_tasks_fail(c, s, a, b):
     f = c.submit(sys.exit, 0)

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -196,6 +196,9 @@ def test_connection_args():
     basic_checks(ctx)
     if sys.version_info >= (3, 6):
         supported_ciphers = ctx.get_ciphers()
+        from pprint import pprint
+
+        pprint(supported_ciphers, stream=sys.stderr)
         tls_12_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.2"]
         assert len(tls_12_ciphers) == 1
         tls_13_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.3"]
@@ -249,6 +252,9 @@ def test_listen_args():
     basic_checks(ctx)
     if sys.version_info >= (3, 6):
         supported_ciphers = ctx.get_ciphers()
+        from pprint import pprint
+
+        pprint(supported_ciphers, stream=sys.stderr)
         tls_12_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.2"]
         assert len(tls_12_ciphers) == 1
         tls_13_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.3"]

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -10,6 +10,7 @@ import pytest
 from tornado import gen
 
 from distributed.comm import connect, listen
+from distributed.compatibility import WINDOWS
 from distributed.security import Security
 from distributed.utils_test import get_cert, gen_test
 
@@ -150,6 +151,7 @@ def test_tls_config_for_role():
         sec.get_tls_config_for_role("supervisor")
 
 
+@pytest.mark.xfail(WINDOWS, reason="Unknown TLS cipher issues on Windows")
 def test_connection_args():
     def basic_checks(ctx):
         assert ctx.verify_mode == ssl.CERT_REQUIRED
@@ -196,9 +198,6 @@ def test_connection_args():
     basic_checks(ctx)
     if sys.version_info >= (3, 6):
         supported_ciphers = ctx.get_ciphers()
-        from pprint import pprint
-
-        pprint(supported_ciphers, stream=sys.stderr)
         tls_12_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.2"]
         assert len(tls_12_ciphers) == 1
         tls_13_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.3"]
@@ -206,6 +205,7 @@ def test_connection_args():
             assert len(tls_13_ciphers) == 3
 
 
+@pytest.mark.xfail(WINDOWS, reason="Unknown TLS cipher issues on Windows")
 def test_listen_args():
     def basic_checks(ctx):
         assert ctx.verify_mode == ssl.CERT_REQUIRED
@@ -252,9 +252,6 @@ def test_listen_args():
     basic_checks(ctx)
     if sys.version_info >= (3, 6):
         supported_ciphers = ctx.get_ciphers()
-        from pprint import pprint
-
-        pprint(supported_ciphers, stream=sys.stderr)
         tls_12_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.2"]
         assert len(tls_12_ciphers) == 1
         tls_13_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.3"]

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -10,7 +10,6 @@ import pytest
 from tornado import gen
 
 from distributed.comm import connect, listen
-from distributed.compatibility import WINDOWS
 from distributed.security import Security
 from distributed.utils_test import get_cert, gen_test
 
@@ -151,7 +150,6 @@ def test_tls_config_for_role():
         sec.get_tls_config_for_role("supervisor")
 
 
-@pytest.mark.xfail(WINDOWS, reason="Unknown TLS cipher issues on Windows")
 def test_connection_args():
     def basic_checks(ctx):
         assert ctx.verify_mode == ssl.CERT_REQUIRED
@@ -198,14 +196,13 @@ def test_connection_args():
     basic_checks(ctx)
     if sys.version_info >= (3, 6):
         supported_ciphers = ctx.get_ciphers()
-        tls_12_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.2"]
+        tls_12_ciphers = [c for c in supported_ciphers if "TLSv1.2" in c["description"]]
         assert len(tls_12_ciphers) == 1
-        tls_13_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.3"]
+        tls_13_ciphers = [c for c in supported_ciphers if "TLSv1.3" in c["description"]]
         if len(tls_13_ciphers):
             assert len(tls_13_ciphers) == 3
 
 
-@pytest.mark.xfail(WINDOWS, reason="Unknown TLS cipher issues on Windows")
 def test_listen_args():
     def basic_checks(ctx):
         assert ctx.verify_mode == ssl.CERT_REQUIRED
@@ -252,9 +249,9 @@ def test_listen_args():
     basic_checks(ctx)
     if sys.version_info >= (3, 6):
         supported_ciphers = ctx.get_ciphers()
-        tls_12_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.2"]
+        tls_12_ciphers = [c for c in supported_ciphers if "TLSv1.2" in c["description"]]
         assert len(tls_12_ciphers) == 1
-        tls_13_ciphers = [c for c in supported_ciphers if c["protocol"] == "TLSv1.3"]
+        tls_13_ciphers = [c for c in supported_ciphers if "TLSv1.3" in c["description"]]
         if len(tls_13_ciphers):
             assert len(tls_13_ciphers) == 3
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -865,7 +865,7 @@ def gen_cluster(
         nthreads = ncores
 
     worker_kwargs = merge(
-        {"memory_limit": system.MEMORY_LIMIT, "death_timeout": 5}, worker_kwargs
+        {"memory_limit": system.MEMORY_LIMIT, "death_timeout": 10}, worker_kwargs
     )
 
     def _(func):

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -35,13 +35,9 @@ Notes
 -----
 
 **Note for Macports users:** There `is a known issue
-<https://trac.macports.org/ticket/50058>`_.  with python from macports that
+<https://trac.macports.org/ticket/50058>`_.  with Python from macports that
 makes executables be placed in a location that is not available by default. A
 simple solution is to extend the ``PATH`` environment variable to the location
-where python from macports install the binaries::
+where Python from macports install the binaries. For example, for Python 3.6::
 
-    $ export PATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.5/bin:$PATH
-
-    or
-
-    $ export PATH=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/bin:$PATH
+    $ export PATH=/opt/local/Library/Frameworks/Python.framework/Versions/3.6/bin:$PATH

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url="https://distributed.dask.org",
     maintainer="Matthew Rocklin",
     maintainer_email="mrocklin@gmail.com",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     license="BSD",
     package_data={
         "": ["templates/index.html", "template.html"],
@@ -46,7 +46,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering",


### PR DESCRIPTION
This PR drops support for Python 3.5 and is a companion PR to https://github.com/dask/dask/pull/5528 in which we dropped Python 3.5 in `dask/dask`