### PR TITLE
Efficiently serialize zero strided NumPy arrays

### DIFF
--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -46,8 +46,8 @@ def serialize_numpy_ndarray(x):
 
     # Only serialize non-broadcasted data for arrays with zero strided axes
     if 0 in x.strides:
-        broadcast_to = x.shape
-        x = x[tuple(slice(None) if s != 0 else 0 for s in x.strides)]
+        broadcast_to = (x.shape, x.flags.writeable)
+        x = x[tuple(slice(None) if s != 0 else slice(1) for s in x.strides)]
     else:
         broadcast_to = None
 
@@ -108,7 +108,9 @@ def deserialize_numpy_ndarray(header, frames):
         )
 
         if header.get("broadcast_to"):
-            x = np.broadcast_to(x, header["broadcast_to"])
+            shape, writeable = header["broadcast_to"]
+            x = np.broadcast_to(x, shape)
+            x.setflags(write=writeable)
 
         return x
 

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -19,6 +19,12 @@ def itemsize(dt):
     return result
 
 
+def _zero_strided_slice(x):
+    """ Collapse array dimensions with a zero stride
+    """
+    return x[tuple(slice(None) if s != 0 else slice(1) for s in x.strides)]
+
+
 @dask_serialize.register(np.ndarray)
 def serialize_numpy_ndarray(x):
     if x.dtype.hasobject:
@@ -47,7 +53,7 @@ def serialize_numpy_ndarray(x):
     # Only serialize non-broadcasted data for arrays with zero strided axes
     if 0 in x.strides:
         broadcast_to = (x.shape, x.flags.writeable)
-        x = x[tuple(slice(None) if s != 0 else slice(1) for s in x.strides)]
+        x = _zero_strided_slice(x)
     else:
         broadcast_to = None
 

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -19,12 +19,6 @@ def itemsize(dt):
     return result
 
 
-def _zero_strided_slice(x):
-    """ Collapse array dimensions with a zero stride
-    """
-    return x[tuple(slice(None) if s != 0 else slice(1) for s in x.strides)]
-
-
 @dask_serialize.register(np.ndarray)
 def serialize_numpy_ndarray(x):
     if x.dtype.hasobject:
@@ -53,7 +47,7 @@ def serialize_numpy_ndarray(x):
     # Only serialize non-broadcasted data for arrays with zero strided axes
     if 0 in x.strides:
         broadcast_to = (x.shape, x.flags.writeable)
-        x = _zero_strided_slice(x)
+        x = x[tuple(slice(None) if s != 0 else slice(1) for s in x.strides)]
     else:
         broadcast_to = None
 

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -71,6 +71,7 @@ def test_serialize():
         np.zeros((1, 1000, 1000)),
         np.arange(12)[::2],  # non-contiguous array
         np.ones(shape=(5, 6)).astype(dtype=[("total", "<f8"), ("n", "<f8")]),
+        np.broadcast_to(np.arange(3), shape=(10, 3)),  # zero-strided array
     ],
 )
 def test_dumps_serialize_numpy(x):
@@ -259,3 +260,27 @@ def test_large_numpy_array():
     x = np.ones((100000000,), dtype="u4")
     header, frames = serialize(x)
     assert sum(header["lengths"]) == sum(map(nbytes, frames))
+
+
+@pytest.mark.parametrize(
+    "x",
+    [
+        np.broadcast_to(np.arange(10), (20, 10)),  # Some strides are 0
+        np.broadcast_to(1, (3, 4, 2)),  # All strides are 0
+        np.broadcast_to(np.arange(100)[:1], 5),  # x.base is larger than x
+    ],
+)
+def test_zero_strided_numpy_array(x):
+    header, frames = serialize(x)
+    assert header["broadcast_to"] == x.shape
+    y = deserialize(header, frames)
+    np.testing.assert_equal(x, y)
+    # Ensure we transmit fewer bytes than the full array
+    assert sum(map(nbytes, frames)) < x.nbytes
+
+
+def test_non_zero_strided_array():
+    x = np.arange(10)
+    header, frames = serialize(x)
+    assert "broadcast_to" not in header
+    assert sum(map(nbytes, frames)) == x.nbytes

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -2,11 +2,6 @@ import logging
 
 from dask.sizeof import sizeof
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
-
 logger = logging.getLogger(__name__)
 
 
@@ -16,11 +11,6 @@ def safe_sizeof(obj, default_size=1e6):
     This returns a default size of 1e6 if the sizeof function fails
     """
     try:
-        # Handle zero-strided NumPy arrays
-        if np is not None and isinstance(obj, np.ndarray) and 0 in obj.strides:
-            from .protocol.numpy import _zero_strided_slice
-
-            obj = _zero_strided_slice(obj)
         return sizeof(obj)
     except Exception:
         logger.warning("Sizeof calculation failed.  Defaulting to 1MB", exc_info=True)

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -2,6 +2,11 @@ import logging
 
 from dask.sizeof import sizeof
 
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
 logger = logging.getLogger(__name__)
 
 
@@ -11,6 +16,11 @@ def safe_sizeof(obj, default_size=1e6):
     This returns a default size of 1e6 if the sizeof function fails
     """
     try:
+        # Handle zero-strided NumPy arrays
+        if np is not None and isinstance(obj, np.ndarray) and 0 in obj.strides:
+            from .protocol.numpy import _zero_strided_slice
+
+            obj = _zero_strided_slice(obj)
         return sizeof(obj)
     except Exception:
         logger.warning("Sizeof calculation failed.  Defaulting to 1MB", exc_info=True)

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -1,0 +1,33 @@
+import pytest
+import logging
+from dask.sizeof import sizeof
+
+from distributed.sizeof import safe_sizeof
+from distributed.utils_test import captured_logger
+
+
+@pytest.mark.parametrize("obj", [list(range(10)), tuple(range(10)), set(range(10))])
+def test_safe_sizeof(obj):
+    assert safe_sizeof(obj) == sizeof(obj)
+
+
+def test_safe_sizeof_raises():
+    class BadlySized:
+        def __sizeof__(self):
+            raise ValueError("bar")
+
+    foo = BadlySized()
+    with captured_logger(logging.getLogger("distributed.sizeof")) as logs:
+        assert safe_sizeof(foo) == 1e6
+
+    assert "Sizeof calculation failed.  Defaulting to 1MB" in logs.getvalue()
+
+
+def test_safe_sizeof_zero_strided_array():
+    np = pytest.importorskip("numpy")
+    x = np.broadcast_to(np.arange(10), (10, 10))
+    assert safe_sizeof(x) < sizeof(x)
+
+    y = np.broadcast_to(1, (10, 10))
+    assert safe_sizeof(y) < sizeof(y)
+    assert safe_sizeof(y) == y.itemsize

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -21,13 +21,3 @@ def test_safe_sizeof_raises():
         assert safe_sizeof(foo) == 1e6
 
     assert "Sizeof calculation failed.  Defaulting to 1MB" in logs.getvalue()
-
-
-def test_safe_sizeof_zero_strided_array():
-    np = pytest.importorskip("numpy")
-    x = np.broadcast_to(np.arange(10), (10, 10))
-    assert safe_sizeof(x) < sizeof(x)
-
-    y = np.broadcast_to(1, (10, 10))
-    assert safe_sizeof(y) < sizeof(y)
-    assert safe_sizeof(y) == y.itemsize


### PR DESCRIPTION
This PR updates how NumPy arrays with zero-strided axes are serialized in order to avoid transmitting the entire array where possible. Instead dimensions with a zero stride are collapsed, this collapsed array is serialized, and upon deserialization the smaller array is then broadcasted to the appropriate shape.

Taking the following as an example:

```python
In [1]: import numpy as np

In [2]: a = np.arange(3)

In [3]: x = np.broadcast_to(a, (5, 3))

In [4]: x
Out[4]:
array([[0, 1, 2],
       [0, 1, 2],
       [0, 1, 2],
       [0, 1, 2],
       [0, 1, 2]])
```

Instead of serializing the entire `x` array (with `x.shape = (5,3)`), we would serialize the smaller `[0, 1, 2]` array. Then after deserializing the smaller array, we use `np.broadcast_to` to reproduce the expected `x` array with shape `(5,3)`. 