### PR TITLE
Use moving average to reset rectangles in scheduler dashboard

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -859,7 +859,7 @@ class Events(DashboardComponent):
 
 
 class TaskStream(DashboardComponent):
-    def __init__(self, scheduler, n_rectangles=1000, clear_interval="20s", clear_multipler=10, **kwargs):
+    def __init__(self, scheduler, n_rectangles=1000, clear_interval="20s", clear_multipler=3, **kwargs):
         self.scheduler = scheduler
         self.offset = 0
         es = [p for p in self.scheduler.plugins if isinstance(p, TaskStreamPlugin)]
@@ -905,12 +905,15 @@ class TaskStream(DashboardComponent):
             if first_end > self.last:
                 last = self.last
                 self.last = first_end
-                # use moving average of previous rectangles and the value set in self.clear_interval to determine
-                # when to reset the view. Only reset when at least self.clear_multiplier x the moving average of the
-                # last 50 rectangles and at least self.clear_interval.
-                clear_interval_enhanced = np.maximum(np.mean(rectangles["duration"][-50:]) * self.clear_multiplier,
-                                                    self.clear_interval)
-                if first_end > last + clear_interval_enhanced * 1000:
+
+                # gap to previous is larger than clear_multiplier * average of currently visualized
+                # and greater than 10s
+                if len(self.source.data["start"]) > 2:
+                    gap_to_previous = self.source.data["start"][-1] - self.source.data["start"][-2] + self.source.data["duration"][-2]
+                else:
+                    gap_to_previous = 0
+                avg_duration_of_visualized = np.mean(self.source.data["duration"])
+                if (gap_to_previous > (avg_duration_of_visualized * self.clear_multiplier) > self.clear_interval*1000) or last == 0:
                     self.offset = min(rectangles["start"])
                     self.source.data.update({k: [] for k in rectangles})
 


### PR DESCRIPTION
PR to fix premature resetting of rectangles in the scheduler dashboard as described here: https://github.com/dask/distributed/issues/3130

Proposed solution:
Use moving average of previous rectangles and the value set in self.clear_interval to determine when to reset the view. Only reset when at least self.clear_multiplier x the moving average of the last 50 rectangles and at least self.clear_interval.