### PR TITLE
[REVIEW] Subprocesses inherit the global dask config

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -9,6 +9,7 @@ import tempfile
 import warnings
 
 import click
+import dask
 
 from tornado.ioloop import IOLoop
 
@@ -16,6 +17,7 @@ from distributed import Scheduler
 from distributed.preloading import validate_preload_argv
 from distributed.security import Security
 from distributed.cli.utils import check_python_3, install_signal_handlers
+from distributed.utils import deserialize_for_cli
 from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,
@@ -173,6 +175,11 @@ def main(
             if v is not None
         }
     )
+
+    if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
+        config = deserialize_for_cli(os.environ["DASK_INTERNAL_INHERIT_CONFIG"])
+        # Update the global config given priority to the existing global config
+        dask.config.update(dask.config.global_config, config, priority="old")
 
     if not host and (tls_ca_file or tls_cert or tls_key):
         host = "tls://"

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -20,6 +20,7 @@ from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,
 )
+from distributed.utils import deserialize_for_cli
 
 from toolz import valmap
 from tornado.ioloop import IOLoop, TimeoutError
@@ -358,6 +359,11 @@ def main(
 
     with ignoring(TypeError, ValueError):
         name = int(name)
+
+    if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
+        config = deserialize_for_cli(os.environ["DASK_INTERNAL_INHERIT_CONFIG"])
+        # Update the global config given priority to the existing global config
+        dask.config.update(dask.config.global_config, config, priority="old")
 
     nannies = [
         t(

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -4,10 +4,13 @@ from typing import List
 import warnings
 import weakref
 
+import dask
+
 from .spec import SpecCluster, ProcessInterface
 from ..utils import cli_keywords
 from ..scheduler import Scheduler as _Scheduler
 from ..worker import Worker as _Worker
+from ..utils import serialize_for_cli
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +89,8 @@ class Worker(Process):
         self.proc = await self.connection.create_process(
             " ".join(
                 [
+                    'DASK_INTERNAL_INHERIT_CONFIG="%s"'
+                    % serialize_for_cli(dask.config.global_config),
                     sys.executable,
                     "-m",
                     self.worker_module,
@@ -141,7 +146,13 @@ class Scheduler(Process):
 
         self.proc = await self.connection.create_process(
             " ".join(
-                [sys.executable, "-m", "distributed.cli.dask_scheduler"]
+                [
+                    'DASK_INTERNAL_INHERIT_CONFIG="%s"'
+                    % serialize_for_cli(dask.config.global_config),
+                    sys.executable,
+                    "-m",
+                    "distributed.cli.dask_scheduler",
+                ]
                 + cli_keywords(self.kwargs, cls=_Scheduler)
             )
         )

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -112,7 +112,7 @@ class Worker(Process):
 
 
 class Scheduler(Process):
-    """ A Remote Dask Scheduler controled by SSH
+    """ A Remote Dask Scheduler controlled by SSH
 
     Parameters
     ----------
@@ -191,7 +191,7 @@ def SSHCluster(
     The SSHCluster function deploys a Dask Scheduler and Workers for you on a
     set of machine addresses that you provide.  The first address will be used
     for the scheduler while the rest will be used for the workers (feel free to
-    repeat the first hostname if you want to have the scheudler and worker
+    repeat the first hostname if you want to have the scheduler and worker
     co-habitate one machine.)
 
     You may configure the scheduler and workers by passing

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -6,6 +6,7 @@ from queue import Queue as PyQueue
 import re
 import threading
 import weakref
+import dask
 
 from .utils import mp_context
 
@@ -71,7 +72,14 @@ class AsyncProcess(object):
         self._process = mp_context.Process(
             target=self._run,
             name=name,
-            args=(target, args, kwargs, parent_alive_pipe, self._keep_child_alive),
+            args=(
+                target,
+                args,
+                kwargs,
+                parent_alive_pipe,
+                self._keep_child_alive,
+                dask.config.global_config,
+            ),
         )
         _dangling.add(self._process)
         self._name = self._process.name
@@ -163,7 +171,9 @@ class AsyncProcess(object):
                 handler.createLock()
 
     @classmethod
-    def _run(cls, target, args, kwargs, parent_alive_pipe, _keep_child_alive):
+    def _run(
+        cls, target, args, kwargs, parent_alive_pipe, _keep_child_alive, inherit_config
+    ):
         # On Python 2 with the fork method, we inherit the _keep_child_alive fd,
         # whether it is passed or not. Therefore, pass it unconditionally and
         # close it here, so that there are no other references to the pipe lying
@@ -176,6 +186,8 @@ class AsyncProcess(object):
         cls._immediate_exit_when_closed(parent_alive_pipe)
 
         threading.current_thread().name = "MainThread"
+        # Update the global config given priority to the existing global config
+        dask.config.update(dask.config.global_config, inherit_config, priority="old")
         target(*args, **kwargs)
 
     @classmethod

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5654,5 +5654,17 @@ async def test_shutdown_localcluster(cleanup):
         assert lc.scheduler.status == "closed"
 
 
+@pytest.mark.asyncio
+async def test_config_inherit_by_subprocess(cleanup):
+    def f(x):
+        return dask.config.get("foo") + 1
+
+    with dask.config.set(foo=100):
+        async with LocalCluster(n_workers=1, asynchronous=True, processes=True) as lc:
+            async with Client(lc, asynchronous=True) as c:
+                result = await c.submit(f, 1)
+                assert result == 101
+
+
 if sys.version_info >= (3, 5):
     from distributed.tests.py3_test_client import *  # noqa F401

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5655,7 +5655,7 @@ async def test_shutdown_localcluster(cleanup):
 
 
 @pytest.mark.asyncio
-async def test_config_inherit_by_subprocess(cleanup):
+async def test_config_inherited_by_subprocess(cleanup):
     def f(x):
         return dask.config.get("foo") + 1
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -24,6 +24,7 @@ import threading
 import warnings
 import weakref
 import pkgutil
+import base64
 import tblib.pickling_support
 import xml.etree.ElementTree
 
@@ -1368,3 +1369,33 @@ weakref.finalize(_offload_executor, _offload_executor.shutdown)
 async def offload(fn, *args, **kwargs):
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(_offload_executor, fn, *args, **kwargs)
+
+
+def serialize_for_cli(data):
+    """ Serialize data into a string that can be passthrough cli
+
+    Parameters
+    ----------
+    data: json-serializable object
+        The data to serialize
+    Returns
+    -------
+    serialized_data: str
+        The serialized data as a string
+    """
+    return base64.urlsafe_b64encode(json.dumps(data).encode()).decode()
+
+
+def deserialize_for_cli(data):
+    """ De-serialize data into the original object
+
+    Parameters
+    ----------
+    data: str
+        String serialied by serialize_for_cli()
+    Returns
+    -------
+    deserialized_data: obj
+        The de-serialized data
+    """
+    return json.loads(base64.urlsafe_b64decode(data.encode()).decode())


### PR DESCRIPTION
This PR makes a new process (local or remote) inherent the global config of the parent process.

WIP:
- [X]  Support `AsyncProcess`
- [x]  Support `SSHCluster`

I will use this PR as a consistent way to pass UCX arguments to new processes.

cc. @mrocklin 