### PR TITLE
Run preload scripts before starting communication

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1206,6 +1206,8 @@ class Scheduler(ServerNode):
 
         self.clear_task_state()
 
+        preload_modules(self.preload, parameter=self, argv=self.preload_argv)
+
         with ignoring(AttributeError):
             for c in self._worker_coroutines:
                 c.cancel()
@@ -1242,8 +1244,6 @@ class Scheduler(ServerNode):
                     os.remove(fn)
 
             weakref.finalize(self, del_scheduler_file)
-
-        preload_modules(self.preload, parameter=self, argv=self.preload_argv)
 
         self.start_periodic_callbacks()
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -976,18 +976,19 @@ class Worker(ServerNode):
         enable_gc_diagnosis()
         thread_state.on_event_loop_thread = True
 
-        self.listen(self._start_address, listen_args=self.listen_args)
-        self.ip = get_address_host(self.address)
-
-        if self.name is None:
-            self.name = self.address
-
         preload_modules(
             self.preload,
             parameter=self,
             file_dir=self.local_directory,
             argv=self.preload_argv,
         )
+
+        self.listen(self._start_address, listen_args=self.listen_args)
+        self.ip = get_address_host(self.address)
+
+        if self.name is None:
+            self.name = self.address
+
         # Services listen on all addresses
         # Note Nanny is not a "real" service, just some metadata
         # passed in service_ports...


### PR DESCRIPTION
This ensures preload script runs before starting communications, allowing any initialization of communication libraries to happen before beginning. It also makes the name more consistent, as preload probably is intended to run before anything else.