### PR TITLE
Adding PatchedDeviceArray to drop stride attribute for cupy<7.0

### DIFF
--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -12,7 +12,7 @@ class PatchedCudaArrayInterface(object):
     def __init__(self, ary):
         vsn = LooseVersion(cupy.__version__)
         cai = ary.__cuda_array_interface__
-        if vsn < "7.0.0" and cai.get("strides") is None:
+        if vsn < "7.0.0rc1" and cai.get("strides") is None:
             cai.pop("strides", None)
         self.__cuda_array_interface__ = cai
 

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -19,7 +19,7 @@ class PatchedDeviceArray(object):
         if self.vsn >= "7.0.0" or name != "__cuda_array_interface__":
             return getattr(self.parent, name)
         else:
-            # Cupy<7.0 cannot handle 
+            # Cupy<7.0 cannot handle
             # __cuda_array_interface__['strides'] == None
             rtn = self.parent.__cuda_array_interface__
             if rtn.get("strides") is None:
@@ -41,8 +41,8 @@ def serialize_cupy_ndarray(x):
 def deserialize_cupy_array(header, frames):
     (frame,) = frames
     arr = cupy.ndarray(
-        header["shape"], dtype=header["typestr"], memptr=cupy.asarray(
-            PatchedDeviceArray(frame)
-        ).data
+        header["shape"],
+        dtype=header["typestr"],
+        memptr=cupy.asarray(PatchedDeviceArray(frame)).data,
     )
     return arr

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -10,7 +10,7 @@ class PatchedCudaArrayInterface(object):
     #       once Cupy<7.0 is no longer supported
     def __init__(self, ary):
         cai = ary.__cuda_array_interface__
-        cai_cupy_vsn = cupy.ndarray(0).__cuda_array_interface__["version"]
+        cai_cupy_vsn = cupy.ndarray(None).__cuda_array_interface__["version"]
         if cai.get("strides") is None and cai_cupy_vsn < 2:
             cai.pop("strides", None)
         self.__cuda_array_interface__ = cai

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -13,7 +13,7 @@ class PatchedCudaArrayInterface(object):
         vsn = LooseVersion(cupy.__version__)
         cai = ary.__cuda_array_interface__
         if vsn < "7.0.0" and cai.get("strides") is None:
-            cai.pop("strides")
+            cai.pop("strides", None)
         self.__cuda_array_interface__ = cai
 
 
@@ -30,9 +30,9 @@ def serialize_cupy_ndarray(x):
 @cuda_deserialize.register(cupy.ndarray)
 def deserialize_cupy_array(header, frames):
     (frame,) = frames
+    if not isinstance(frame, cupy.ndarray):
+        frame = PatchedCudaArrayInterface(frame)
     arr = cupy.ndarray(
-        header["shape"],
-        dtype=header["typestr"],
-        memptr=cupy.asarray(PatchedCudaArrayInterface(frame)).data,
+        header["shape"], dtype=header["typestr"], memptr=cupy.asarray(frame).data
     )
     return arr

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -10,7 +10,7 @@ class PatchedCudaArrayInterface(object):
     #       once Cupy<7.0 is no longer supported
     def __init__(self, ary):
         cai = ary.__cuda_array_interface__
-        cai_cupy_vsn = cupy.ndarray(None).__cuda_array_interface__["version"]
+        cai_cupy_vsn = cupy.ndarray(0).__cuda_array_interface__["version"]
         if cai.get("strides") is None and cai_cupy_vsn < 2:
             cai.pop("strides", None)
         self.__cuda_array_interface__ = cai

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -3,16 +3,15 @@ Efficient serialization GPU arrays.
 """
 import cupy
 from .cuda import cuda_serialize, cuda_deserialize
-from distutils.version import LooseVersion
 
 
 class PatchedCudaArrayInterface(object):
     # TODO: This class wont be necessary
     #       once Cupy<7.0 is no longer supported
     def __init__(self, ary):
-        vsn = LooseVersion(cupy.__version__)
         cai = ary.__cuda_array_interface__
-        if vsn < "7.0.0rc1" and cai.get("strides") is None:
+        cai_cupy_vsn = cupy.ndarray(0).__cuda_array_interface__["version"]
+        if cai.get("strides") is None and cai_cupy_vsn < 2:
             cai.pop("strides", None)
         self.__cuda_array_interface__ = cai
 

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -1,4 +1,5 @@
 from distributed.protocol import serialize, deserialize
+import pickle
 import pytest
 
 cupy = pytest.importorskip("cupy")
@@ -12,3 +13,19 @@ def test_serialize_cupy(size, dtype):
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
 
     assert (x == y).all()
+
+
+@pytest.mark.parametrize("dtype", ["u1", "u4", "u8", "f4"])
+def test_serialize_cupy_from_numba(dtype):
+    numba = pytest.importorskip("numba")
+    np = pytest.importorskip("numpy")
+
+    size = 10
+    x_np = np.arange(size, dtype=dtype)
+    x = numba.cuda.to_device(x_np)
+    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
+    header["type-serialized"] = pickle.dumps(cupy.ndarray)
+
+    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+
+    assert (x_np == cupy.asnumpy(y)).all()


### PR DESCRIPTION
As discussed in [cudf#3236](https://github.com/rapidsai/cudf/pull/3236), cupy does not handle the case that `__cuda_array_interface__['strides'] == None`.  However, numba 0.46+ **does**.  This leads to deserialization failures in the `cupy.asarray` call with problematic numba/cupy package combinations.  

To avoid errors in `deserialize_cupy_array`  (e.g. `TypeError: zip argument #2 must support iteration`), I am just copying the approach used by @brandon-b-miller in cudf.

