### PR TITLE
Use CPU count from dask

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -10,9 +10,9 @@ import warnings
 import click
 import dask
 from dask.utils import ignoring
+from dask.system import CPU_COUNT
 from distributed import Nanny, Worker
 from distributed.security import Security
-from distributed.system import CPU_COUNT
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.comm import get_address_host_port
 from distributed.preloading import validate_preload_argv

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -5,8 +5,8 @@ import warnings
 import weakref
 
 from dask.utils import factors
+from dask.system import CPU_COUNT
 
-from .. import system
 from .spec import SpecCluster
 from ..nanny import Nanny
 from ..scheduler import Scheduler
@@ -157,12 +157,12 @@ class LocalCluster(SpecCluster):
                 n_workers, threads_per_worker = nprocesses_nthreads()
             else:
                 n_workers = 1
-                threads_per_worker = system.CPU_COUNT
+                threads_per_worker = CPU_COUNT
         if n_workers is None and threads_per_worker is not None:
-            n_workers = max(1, system.CPU_COUNT // threads_per_worker)
+            n_workers = max(1, CPU_COUNT // threads_per_worker)
         if n_workers and threads_per_worker is None:
             # Overcommit threads per worker, rather than undercommit
-            threads_per_worker = max(1, int(math.ceil(system.CPU_COUNT / n_workers)))
+            threads_per_worker = max(1, int(math.ceil(CPU_COUNT / n_workers)))
         if n_workers and "memory_limit" not in worker_kwargs:
             worker_kwargs["memory_limit"] = parse_memory_limit("auto", 1, n_workers)
 
@@ -217,7 +217,7 @@ class LocalCluster(SpecCluster):
         )
 
 
-def nprocesses_nthreads(n=system.CPU_COUNT):
+def nprocesses_nthreads(n=CPU_COUNT):
     """
     The default breakdown of processes and threads for a given number of cores
 

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -12,10 +12,11 @@ from tornado.ioloop import IOLoop
 from tornado import gen
 import pytest
 
+from dask.system import CPU_COUNT
 from distributed import Client, Worker, Nanny, get_client
 from distributed.deploy.local import LocalCluster, nprocesses_nthreads
 from distributed.metrics import time
-from distributed.system import CPU_COUNT, MEMORY_LIMIT
+from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import (  # noqa: F401
     clean,
     cleanup,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -10,6 +10,7 @@ import warnings
 import weakref
 
 import dask
+from dask.system import CPU_COUNT
 from tornado import gen
 from tornado.ioloop import IOLoop, TimeoutError
 from tornado.locks import Event
@@ -22,7 +23,6 @@ from .node import ServerNode
 from .process import AsyncProcess
 from .proctitle import enable_proctitle_on_children
 from .security import Security
-from .system import CPU_COUNT
 from .utils import (
     get_ip,
     mp_context,

--- a/distributed/system.py
+++ b/distributed/system.py
@@ -1,10 +1,8 @@
-import math
-import os
 import sys
 
 import psutil
 
-__all__ = ("memory_limit", "cpu_count", "MEMORY_LIMIT", "CPU_COUNT")
+__all__ = ("memory_limit", "MEMORY_LIMIT")
 
 
 def memory_limit():
@@ -41,44 +39,4 @@ def memory_limit():
     return limit
 
 
-def cpu_count():
-    """Get the available CPU count for this system.
-
-    Takes the minimum value from the following locations:
-
-    - Total system cpus available on the host.
-    - CPU Affinity (if set)
-    - Cgroups limit (if set)
-    """
-    count = os.cpu_count()
-
-    # Check CPU affinity if available
-    try:
-        affinity_count = len(psutil.Process().cpu_affinity())
-        if affinity_count > 0:
-            count = min(count, affinity_count)
-    except Exception:
-        pass
-
-    # Check cgroups if available
-    if sys.platform == "linux":
-        # The directory name isn't standardized across linux distros, check both
-        for dirname in ["cpuacct,cpu", "cpu,cpuacct"]:
-            try:
-                with open("/sys/fs/cgroup/%s/cpu.cfs_quota_us" % dirname) as f:
-                    quota = int(f.read())
-                with open("/sys/fs/cgroup/%s/cpu.cfs_period_us" % dirname) as f:
-                    period = int(f.read())
-                # We round up on fractional CPUs
-                cgroups_count = math.ceil(quota / period)
-                if cgroups_count > 0:
-                    count = min(count, cgroups_count)
-                break
-            except Exception:
-                pass
-
-    return count
-
-
 MEMORY_LIMIT = memory_limit()
-CPU_COUNT = cpu_count()

--- a/distributed/tests/test_system.py
+++ b/distributed/tests/test_system.py
@@ -1,57 +1,11 @@
 import builtins
 import io
-import os
 import sys
 
 import psutil
 import pytest
 
-from distributed.system import cpu_count, memory_limit
-
-
-def test_cpu_count():
-    count = cpu_count()
-    assert isinstance(count, int)
-    assert count <= os.cpu_count()
-    assert count >= 1
-
-
-@pytest.mark.parametrize("dirname", ["cpuacct,cpu", "cpu,cpuacct", None])
-def test_cpu_count_cgroups(dirname, monkeypatch):
-    def mycpu_count():
-        # Absurdly high, unlikely to match real value
-        return 250
-
-    monkeypatch.setattr(os, "cpu_count", mycpu_count)
-
-    class MyProcess(object):
-        def cpu_affinity(self):
-            # No affinity set
-            return []
-
-    monkeypatch.setattr(psutil, "Process", MyProcess)
-
-    if dirname:
-        paths = {
-            "/sys/fs/cgroup/%s/cpu.cfs_quota_us" % dirname: io.StringIO("2005"),
-            "/sys/fs/cgroup/%s/cpu.cfs_period_us" % dirname: io.StringIO("10"),
-        }
-        builtin_open = builtins.open
-
-        def myopen(path, *args, **kwargs):
-            if path in paths:
-                return paths.get(path)
-            return builtin_open(path, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "open", myopen)
-        monkeypatch.setattr(sys, "platform", "linux")
-
-    count = cpu_count()
-    if dirname:
-        # Rounds up
-        assert count == 201
-    else:
-        assert count == 250
+from distributed.system import memory_limit
 
 
 def test_memory_limit():

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -14,6 +14,7 @@ import traceback
 import dask
 from dask import delayed
 from dask.utils import format_bytes
+from dask.system import CPU_COUNT
 import pytest
 from toolz import pluck, sliding_window, first
 import tornado
@@ -29,7 +30,6 @@ from distributed import (
     get_worker,
     Reschedule,
     wait,
-    system,
 )
 from distributed.compatibility import WINDOWS
 from distributed.core import rpc
@@ -62,7 +62,7 @@ from distributed.utils_test import (  # noqa: F401
 def test_worker_nthreads():
     w = Worker("127.0.0.1", 8019)
     try:
-        assert w.executor._max_workers == system.CPU_COUNT
+        assert w.executor._max_workers == CPU_COUNT
     finally:
         shutil.rmtree(w.local_directory)
 
@@ -516,7 +516,7 @@ def test_memory_limit_auto():
     assert isinstance(a.memory_limit, Number)
     assert isinstance(b.memory_limit, Number)
 
-    if system.CPU_COUNT > 1:
+    if CPU_COUNT > 1:
         assert a.memory_limit < b.memory_limit
 
     assert c.memory_limit == d.memory_limit

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -18,6 +18,7 @@ import dask
 from dask.core import istask
 from dask.compatibility import apply
 from dask.utils import format_bytes, funcname
+from dask.system import CPU_COUNT
 
 try:
     from cytoolz import pluck, partial, merge, first, keymap
@@ -462,7 +463,7 @@ class Worker(ServerNode):
             warnings.warn("the ncores= parameter has moved to nthreads=")
             nthreads = ncores
 
-        self.nthreads = nthreads or system.CPU_COUNT
+        self.nthreads = nthreads or CPU_COUNT
         self.total_resources = resources or {}
         self.available_resources = (resources or {}).copy()
         self.death_timeout = parse_timedelta(death_timeout)
@@ -3071,7 +3072,7 @@ class Reschedule(Exception):
     pass
 
 
-def parse_memory_limit(memory_limit, nthreads, total_cores=system.CPU_COUNT):
+def parse_memory_limit(memory_limit, nthreads, total_cores=CPU_COUNT):
     if memory_limit is None:
         return None
 


### PR DESCRIPTION
In https://github.com/dask/dask/pull/5499 the existing `CPU_COUNT` from `distributed.system` was copied to `dask.system`. This is a follow-up PR which imports `CPU_COUNT` from `dask` to avoid duplicate code. 