### PR TITLE
Clear task stream based on recent behavior

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -916,7 +916,6 @@ class TaskStream(DashboardComponent):
                     sum(self.source.data["duration"])
                     / len(self.workers)
                     / (old_end - old_start)
-                    / 1000
                 )
 
                 # If whitespace is more than 3x the old width

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -912,11 +912,6 @@ class TaskStream(DashboardComponent):
                     )
                 )
 
-                from dask.utils import format_time
-
-                print("Whitespace", format_time(new_start - old_end))
-                print("Old width", format_time(old_end - old_start))
-
                 # If whitespace is more than 3x the old width
                 if new_start - old_end > (old_end - old_start) * 3:
                     self.source.data.update({k: [] for k in rectangles})  # clear

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1,7 +1,7 @@
 import logging
 import math
 from numbers import Number
-from operator import add
+import operator
 import os
 
 from bokeh.layouts import column, row
@@ -873,6 +873,7 @@ class TaskStream(DashboardComponent):
         clear_interval = parse_timedelta(clear_interval, default="ms")
         self.clear_interval = clear_interval
         self.last = 0
+        self.last_seen = 0
 
         self.source, self.root = task_stream_figure(clear_interval, **kwargs)
 
@@ -899,16 +900,30 @@ class TaskStream(DashboardComponent):
             if not rectangles["start"]:
                 return
 
-            # If there has been a significant delay then clear old rectangles
-            first_end = min(map(add, rectangles["start"], rectangles["duration"]))
-            if first_end > self.last:
-                last = self.last
-                self.last = first_end
-                if first_end > last + self.clear_interval * 1000:
-                    self.offset = min(rectangles["start"])
-                    self.source.data.update({k: [] for k in rectangles})
+            # If it has been a while since we've updated the plot
+            if time() > self.last_seen + self.clear_interval:
+                new_start = min(rectangles["start"]) - self.offset
+                old_start = min(self.source.data["start"])
+                old_end = max(
+                    map(
+                        operator.add,
+                        self.source.data["start"],
+                        self.source.data["duration"],
+                    )
+                )
+
+                from dask.utils import format_time
+
+                print("Whitespace", format_time(new_start - old_end))
+                print("Old width", format_time(old_end - old_start))
+
+                # If whitespace is more than 3x the old width
+                if new_start - old_end > (old_end - old_start) * 3:
+                    self.source.data.update({k: [] for k in rectangles})  # clear
+                    self.offset = min(rectangles["start"])  # redefine offset
 
             rectangles["start"] = [x - self.offset for x in rectangles["start"]]
+            self.last_seen = time()
 
             # Convert to numpy for serialization speed
             if n >= 10 and np:
@@ -1707,7 +1722,7 @@ def status_doc(scheduler, extra, doc):
             n_rectangles=dask.config.get(
                 "distributed.scheduler.dashboard.status.task-stream-length"
             ),
-            clear_interval="10s",
+            clear_interval="2s",
             sizing_mode="stretch_both",
         )
         task_stream.update()


### PR DESCRIPTION
Alternative to #3190 cc @dickreuter

I tried to breifly implement my proposed solution to clearing the task stream based on recent behavior.  It only runs the check if we haven't seen an update in a suitable amount of time (which is nice for performance) and then bases the decision on the current timespan of the rectangles in the plot.  In principle this works fairly nicely. 

However, it does have a fail case when building up a larger and larger task stream plot over time.  If you start having these large gaps in the stream then things can get harder and harder to clear out.  Probably we should have some other check as well that attempts to understand the amount of whitespace in the plot currently.  Perhaps some measure of the sum of the durations / workers over the total timespan.  

@dickreuter I mostly wanted to share this to communicate what I was trying to say in the issue earlier.  Maybe it helps make my original intent more clear.

<img width="793" alt="Screen Shot 2019-11-05 at 3 56 47 PM" src="https://user-images.githubusercontent.com/306380/68256463-0bad2100-ffe5-11e9-8af4-43e173f780f7.png">
