### PR TITLE
Respect protocol if given to Scheduler

### DIFF
--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -241,7 +241,7 @@ def address_from_user_args(
     else:
         addr = ""
 
-    if protocol and "://" not in addr:
-        addr = protocol.rstrip("://") + "://" + addr
+    if protocol:
+        addr = protocol.rstrip("://") + "://" + addr.split("://")[-1]
 
     return addr

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -326,3 +326,10 @@ async def test_transpose(cleanup):
 
                 y = (x + x.T).sum()
                 await y
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("port", [0, 1234])
+async def test_ucx_protocol(cleanup, port):
+    async with Scheduler(protocol="ucx", port=port) as s:
+        assert s.address.startswith("ucx://")


### PR DESCRIPTION
Previously calling the following

    dask-scheduler --protocol ucx

Without specifying an interface would result in a tcp:// protocol

Now we are a bit more forceful about respecting a protocol if given.