### PR TITLE
Pip install packages from configuration in Nanny.start

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -66,6 +66,9 @@ distributed:
   client:
     heartbeat: 5s  # time between client heartbeats
 
+  nanny:
+    pip: []
+
   deploy:
     lost-worker-timeout: 15s  # Interval after which to hard-close a lost worker job
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -484,6 +484,14 @@ class WorkerProcess(object):
         self.child_stop_q = mp_context.Queue()
         uid = uuid.uuid4().hex
 
+        if dask.config.get("distributed.nanny.pip"):
+            import subprocess, sys
+
+            subprocess.call(
+                [sys.executable, "-m", "pip", "install"]
+                + dask.config.get("distributed.nanny.pip")
+            )
+
         self.process = AsyncProcess(
             target=self._run,
             name="Dask Worker process (from Nanny)",


### PR DESCRIPTION
This is a different approach to #3216 and #3111 which places pip install packages in configuration.

This is mostly up here for conversation.  My guess is that @jcrist will likely veto it (which is entirely fine with me).  Mostly I wanted to talk about a few other options we have.

cc @jhamman @rabernat @TomAugspurger 