### PR TITLE
Avoid offloading serialization for small messages

### DIFF
--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -1,6 +1,8 @@
 import logging
 import socket
 
+from dask.sizeof import sizeof
+
 from .. import protocol
 from ..utils import get_ip, get_ipv6, nbytes, offload
 
@@ -31,9 +33,10 @@ async def to_frames(msg, serializers=None, on_error="message", context=None):
             logger.exception(e)
             raise
 
-    res = await offload(_to_frames)
-
-    return res
+    if sizeof(msg) > FRAME_OFFLOAD_THRESHOLD:
+        return await offload(_to_frames)
+    else:
+        return _to_frames()
 
 
 async def from_frames(frames, deserialize=True, deserializers=None):


### PR DESCRIPTION
This was causing a fair amount of either cost or noise when profiling.

Fixes https://github.com/dask/distributed/issues/3223

See also https://github.com/dask/dask/pull/5578