### PR TITLE
Fail fast when importing distributed.comm.ucx

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -5,6 +5,8 @@ See :ref:`communications` for more.
 
 .. _UCX: https://github.com/openucx/ucx
 """
+import ucp
+
 import logging
 import concurrent
 
@@ -18,7 +20,6 @@ from .utils import ensure_concrete_host, to_frames, from_frames
 from ..utils import ensure_ip, get_ip, get_ipv6, nbytes, log_errors
 
 import dask
-import ucp
 import numpy as np
 
 


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/5572

If we don't have UCX installed then we shouldn't try anything further.
In this commit we move the `import ucp` line to the top of the file.