### PR TITLE
Avoid setting inf x_range

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -585,7 +585,7 @@ class CurrentLoad(DashboardComponent):
                     or inf
                 )
 
-                if limit > max_limit:
+                if limit > max_limit and limit != inf:
                     max_limit = limit
 
                 if nb > limit:


### PR DESCRIPTION
When trying to view the dashboard, workers with no `memory_limit` lead to the following error:
`ValueError: Out of range float values are not JSON compliant`

It looks like this was fixed in #2770 , but has broken again since then.