### PR TITLE
Add module name to Future repr

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -383,7 +383,7 @@ class Future(WrappedKey):
     def __repr__(self):
         if self.type:
             try:
-                typ = self.type.__name__
+                typ = self.type.__module__.split(".")[0] + "." + self.type.__name__
             except AttributeError:
                 typ = str(self.type)
             return "<Future: status: %s, type: %s, key: %s>" % (
@@ -405,7 +405,7 @@ class Future(WrappedKey):
         }
         if self.type:
             try:
-                typ = self.type.__name__
+                typ = self.type.__module__.split(".")[0] + "." + self.type.__name__
             except AttributeError:
                 typ = str(self.type)
             text += '<font color="gray">type: </font>%s, ' % typ

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -386,13 +386,9 @@ class Future(WrappedKey):
                 typ = self.type.__module__.split(".")[0] + "." + self.type.__name__
             except AttributeError:
                 typ = str(self.type)
-            return "<Future: status: %s, type: %s, key: %s>" % (
-                self.status,
-                typ,
-                self.key,
-            )
+            return "<Future: %s, type: %s, key: %s>" % (self.status, typ, self.key)
         else:
-            return "<Future: status: %s, key: %s>" % (self.status, self.key)
+            return "<Future: %s, key: %s>" % (self.status, self.key)
 
     def _repr_html_(self):
         text = "<b>Future: %s</b> " % html.escape(key_split(self.key))

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -334,9 +334,11 @@ def test_retries_dask_array(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_future_repr(c, s, a, b):
+async def test_future_repr(c, s, a, b):
     x = c.submit(inc, 10)
+    await x
     for func in [repr, lambda x: x._repr_html_()]:
+        assert "int" in func(x)
         assert str(x.key) in func(x)
         assert str(x.status) in func(x)
         assert str(x.status) in repr(c.futures[x.key])

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -335,13 +335,20 @@ def test_retries_dask_array(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_future_repr(c, s, a, b):
+    pd = pytest.importorskip("pandas")
     x = c.submit(inc, 10)
+    y = c.submit(pd.DataFrame, {"x": [1, 2, 3]})
     await x
+    await y
+
     for func in [repr, lambda x: x._repr_html_()]:
-        assert "int" in func(x)
         assert str(x.key) in func(x)
         assert str(x.status) in func(x)
         assert str(x.status) in repr(c.futures[x.key])
+
+        assert "int" in func(x)
+        assert "pandas" in func(y)
+        assert "DataFrame" in func(y)
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
```python
In [1]: from dask.distributed import Client                                                                        
In [2]: client = Client()                                                                                          
In [3]: import pandas as pd                                                                                        
In [4]: future = client.submit(pd.DataFrame, {"x": [1, 2, 3]})                                                     
In [5]: future                                                                                                     
Out[5]: <Future: status: finished, type: pandas.DataFrame, key: DataFrame-b252094976e59eccc279c3e180e0cf1b>
```