### PR TITLE
Bump dask version to 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click >= 6.6
 cloudpickle >= 0.2.2
-dask >= 2.5.2
+dask >= 2.7.0
 msgpack
 psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1


### PR DESCRIPTION
As a follow-up to #3199, this PR bumps the supported `dask` version to `dask >= 2.7.0` (to ensure `dask.system` exists)