### PR TITLE
Use inspect.isawaitable where relevant

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -2,6 +2,7 @@ import asyncio
 from collections import defaultdict, deque
 from concurrent.futures import CancelledError
 from functools import partial
+from inspect import isawaitable
 import logging
 import threading
 import traceback
@@ -397,7 +398,7 @@ class Server(object):
                     logger.debug("Calling into handler %s", handler.__name__)
                     try:
                         result = handler(comm, **msg)
-                        if hasattr(result, "__await__"):
+                        if isawaitable(result):
                             result = asyncio.ensure_future(result)
                             self._ongoing_coroutines.add(result)
                             result = await result

--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -1,3 +1,4 @@
+from inspect import isawaitable
 import logging
 import math
 
@@ -158,7 +159,7 @@ class Adaptive(AdaptiveCore):
             # close workers more forcefully
             logger.info("Retiring workers %s", workers)
             f = self.cluster.scale_down(workers)
-            if hasattr(f, "__await__"):
+            if isawaitable(f):
                 await f
 
     async def scale_up(self, n):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3,6 +3,7 @@ from collections import defaultdict, deque, OrderedDict
 from collections.abc import Mapping, Set
 from datetime import timedelta
 from functools import partial
+from inspect import isawaitable
 import itertools
 import json
 import logging
@@ -3283,7 +3284,7 @@ class Scheduler(ServerNode):
             if teardown:
                 teardown = pickle.loads(teardown)
             state = setup(self) if setup else None
-            if hasattr(state, "__await__"):
+            if isawaitable(state):
                 state = await state
             try:
                 while self.status == "running":


### PR DESCRIPTION
Noticed a few places in distributed where `hasattr(x, '__await__')` was checked. This should use `inspect.isawaitable` instead for readability/correctness. Updated accordingly.