### PR TITLE
Robust gather in case of connection failures

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -59,7 +59,7 @@ class Comm(ABC):
         """
 
     @abstractmethod
-    def write(self, msg, on_error=None):
+    def write(self, msg, serializers=None, on_error=None):
         """
         Write a message (a Python object).
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2553,8 +2553,6 @@ class Scheduler(ServerNode):
             )
             result = {"status": "error", "keys": missing_keys}
             with log_errors():
-                for worker in missing_workers:
-                    self.remove_worker(address=worker)  # this is extreme
                 for key, workers in missing_keys.items():
                     if not workers:
                         continue

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2545,7 +2545,7 @@ class Scheduler(ServerNode):
                 (self.tasks[key].state if key in self.tasks else None)
                 for key in missing_keys
             ]
-            logger.debug(
+            logger.exception(
                 "Couldn't gather keys %s state: %s workers: %s",
                 missing_keys,
                 missing_states,
@@ -2553,15 +2553,21 @@ class Scheduler(ServerNode):
             )
             result = {"status": "error", "keys": missing_keys}
             with log_errors():
+                # Remove suspicious workers from the scheduler but allow them to
+                # reconnect.
+                for worker in missing_workers:
+                    self.remove_worker(address=worker, close=False)
                 for key, workers in missing_keys.items():
-                    if not workers:
-                        continue
-                    ts = self.tasks[key]
+                    # Task may already be gone if it was held by a
+                    # `missing_worker`
+                    ts = self.tasks.get(key)
                     logger.exception(
                         "Workers don't have promised key: %s, %s",
                         str(workers),
                         str(key),
                     )
+                    if not workers or ts is None:
+                        continue
                     for worker in workers:
                         ws = self.workers.get(worker)
                         if ws is not None and ts in ws.has_what:

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -1,6 +1,5 @@
-import pytest
-
-from distributed.core import rpc
+from distributed.core import ConnectionPool
+from distributed.comm import Comm
 from distributed.utils_test import gen_cluster
 from distributed.utils_comm import pack_data, gather_from_workers
 
@@ -12,9 +11,9 @@ def test_pack_data():
     assert pack_data({"a": ["x"], "b": "y"}, data) == {"a": [1], "b": "y"}
 
 
-@pytest.mark.xfail(reason="rpc now needs to be a connection pool")
 @gen_cluster(client=True)
 def test_gather_from_workers_permissive(c, s, a, b):
+    rpc = ConnectionPool()
     x = yield c.scatter({"x": 1}, workers=a.address)
 
     data, missing, bad_workers = yield gather_from_workers(
@@ -23,3 +22,39 @@ def test_gather_from_workers_permissive(c, s, a, b):
 
     assert data == {"x": 1}
     assert list(missing) == ["y"]
+
+
+class BrokenComm(Comm):
+    peer_address = None
+    local_address = None
+
+    def close(self):
+        pass
+
+    def closed(self):
+        pass
+
+    def abort(self):
+        pass
+
+    def read(self, deserializers=None):
+        raise EnvironmentError
+
+    def write(self, msg, serializers=None, on_error=None):
+        raise EnvironmentError
+
+
+class BrokenConnectionPool(ConnectionPool):
+    async def connect(self, *args, **kwargs):
+        return BrokenComm()
+
+
+@gen_cluster(client=True)
+def test_gather_from_workers_permissive_flaky(c, s, a, b):
+    x = yield c.scatter({"x": 1}, workers=a.address)
+
+    rpc = BrokenConnectionPool()
+    data, missing, bad_workers = yield gather_from_workers({"x": [a.address]}, rpc=rpc)
+
+    assert missing == {"x": [a.address]}
+    assert bad_workers == [a.address]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3141,7 +3141,7 @@ async def get_data_from_worker(
                     await comm.write("OK")
             break
         except (EnvironmentError, CommClosedError):
-            if retry_count <= max_retries:
+            if retry_count < max_retries:
                 await asyncio.sleep(0.1 * (2 ** retry_count))
                 retry_count += 1
                 logger.info(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3116,27 +3116,46 @@ async def get_data_from_worker(
     if deserializers is None:
         deserializers = rpc.deserializers
 
-    comm = await rpc.connect(worker)
-    comm.name = "Ephemeral Worker->Worker for gather"
-    try:
-        response = await send_recv(
-            comm,
-            serializers=serializers,
-            deserializers=deserializers,
-            op="get_data",
-            keys=keys,
-            who=who,
-            max_connections=max_connections,
-        )
+    retry_count = 0
+    max_retries = 3
+
+    while True:
+        comm = await rpc.connect(worker)
+        comm.name = "Ephemeral Worker->Worker for gather"
         try:
-            status = response["status"]
-        except KeyError:
-            raise ValueError("Unexpected response", response)
-        else:
-            if status == "OK":
-                await comm.write("OK")
-    finally:
-        rpc.reuse(worker, comm)
+            response = await send_recv(
+                comm,
+                serializers=serializers,
+                deserializers=deserializers,
+                op="get_data",
+                keys=keys,
+                who=who,
+                max_connections=max_connections,
+            )
+            try:
+                status = response["status"]
+            except KeyError:
+                raise ValueError("Unexpected response", response)
+            else:
+                if status == "OK":
+                    await comm.write("OK")
+            break
+        except (EnvironmentError, CommClosedError):
+            if retry_count <= max_retries:
+                await asyncio.sleep(0.1 * (2 ** retry_count))
+                retry_count += 1
+                logger.info(
+                    "Encountered connection issue during data collection of keys %s on worker %s. Retrying (%s / %s)",
+                    keys,
+                    worker,
+                    retry_count,
+                    max_retries,
+                )
+                continue
+            else:
+                raise
+        finally:
+            rpc.reuse(worker, comm)
 
     return response
 


### PR DESCRIPTION
## Issue description

We're observing stability issues when gathering data. What we can currently reconstruct is the following

1. During gathering a connection issue happens which we see as an `EnvironmentError` (Root cause unknown, worker seems healthy otherwise).
2. The data collection logic (`gather_from_workers`) flags the worker for which the connection fails as missing.
3. The missing worker is closed forcefully [here](https://github.com/dask/distributed/blob/029ed174dce249ea1493fe60f1427827322aa2f5/distributed/scheduler.py#L2557). Since this worker holds the final result we will loose the result as well. Since the dependencies of the final task were already transitioned to `released` earlier on this amounts to a full data loss and the entire graph is rescheduled.
4. Reschedule the lost key, i.e. the entire graph.


## Root cause
[This](https://github.com/dask/distributed/blob/029ed174dce249ea1493fe60f1427827322aa2f5/distributed/scheduler.py#L2557) line removes workers if they are considered missing. As the comment already notes this is _extreme_ and tbh I'm missing the reasoning there.
imho, this is not the place for dead worker cleanup and one should defer this responsibility to tasks which are intended for it, e.g. worker TTL. If there is a reason for this implementation, I'll happily learn something new and will add a comment there.

## Changes in this PR

My intention is it to establish a better robustness in case of failure scenarios. My proposed implementation would get rid of the worker closing and would rely on another mechanism to clean up actual dead or misbehaving workers.
If we face a connection issue we retry previously failed workers until "no improvement" is detected but at least three times (there is obviously room for refinement). For happy path scenarios this behaves just like before but for connection failures we should be much more robust.
I hard coded the backoff and retry count since I wasn't sure if this is a good configuration parameter.

## Open Question

I'm wondering how _deep_ we should patch this in the stack. In this particular instance we have a call chain of
`gather_from_workers` -> `get_data_from_worker` -> `send_recv`/`comm.read`/`comm.write`
Where I could argue that even the `comm.read/write` should already retry but I'm not sure about the implications or if this isn't implemented intentionally this way.
