### PR TITLE
RFC Retire worker with periodic callback

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -24,6 +24,7 @@ distributed:
     preload: []
     preload-argv: []
     default-task-durations: {}  # How long we expect function names to run ("1h", "1s") (helps for long tasks)
+    worker-retirement-interval: 10s
     dashboard:
       status:
         task-stream-length: 1000


### PR DESCRIPTION
## Context

We're currently experimenting with graceful termination of workers and see the issue that if we terminate multiple workers at once (or closely after each others) the replication logic will replicate to workers which are about to retire themselves, i.e. not ideal / prone to errors.

While the _proper_ solution would be a redesign of the replication logic as briefly discussed #3184 and #1002, the change in this PR could help in the meantime.

## Changes

Instead of immediately retiring upon calling `retire_workers`, only the intend to retire is logged, i.e. a list of workers "about to retire" is filled. A periodic callback will then mop up the intended retirements batch wise. The batch wise retirement should help with replication since all workers which are about to be retired won't be included in the replication attempt.

## PR state

The code is not properly cleaned up and probably a lot of test are still failing. If it is considered a feasible approach, I'll clean this up properly and add proper documentation.