### PR TITLE
Skip numba.cuda tests if CUDA is not available

### DIFF
--- a/distributed/protocol/tests/test_numba.py
+++ b/distributed/protocol/tests/test_numba.py
@@ -7,6 +7,9 @@ np = pytest.importorskip("numpy")
 
 @pytest.mark.parametrize("dtype", ["u1", "u4", "u8", "f4"])
 def test_serialize_cupy(dtype):
+    if not cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     ary = np.arange(100, dtype=dtype)
     x = cuda.to_device(ary)
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))


### PR DESCRIPTION
Fixes #3254 