### PR TITLE
Update function serialization caches

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -609,7 +609,7 @@ def test_lru():
     l["c"] = 3
     assert list(l.keys()) == ["a", "b", "c"]
 
-    # Use "a" and ensure it becomes the last recently used item
+    # Use "a" and ensure it becomes the most recently used item
     l["a"]
     assert list(l.keys()) == ["b", "c", "a"]
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -42,6 +42,7 @@ from distributed.utils import (
     parse_timedelta,
     warn_on_duration,
     format_dashboard_link,
+    LRU,
 )
 from distributed.utils_test import loop, loop_in_thread  # noqa: F401
 from distributed.utils_test import div, has_ipv6, inc, throws, gen_test, captured_logger
@@ -598,3 +599,21 @@ def test_format_dashboard_link():
         assert "hello" not in format_dashboard_link("host", 1234)
     finally:
         del os.environ["host"]
+
+
+def test_lru():
+
+    l = LRU(maxsize=3)
+    l["a"] = 1
+    l["b"] = 2
+    l["c"] = 3
+    assert list(l.keys()) == ["a", "b", "c"]
+
+    # Use "a" and ensure it becomes the last recently used item
+    l["a"]
+    assert list(l.keys()) == ["b", "c", "a"]
+
+    # Ensure maxsize is respected
+    l["d"] = 4
+    assert len(l) == 3
+    assert list(l.keys()) == ["c", "a", "d"]

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 import atexit
-from collections import deque
+from collections import deque, OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import timedelta
@@ -1399,3 +1399,23 @@ def deserialize_for_cli(data):
         The de-serialized data
     """
     return json.loads(base64.urlsafe_b64decode(data.encode()).decode())
+
+
+class LRU(OrderedDict):
+    """ Limited size mapping, evicting the least recently looked-up key when full
+    """
+
+    def __init__(self, maxsize):
+        self.maxsize = maxsize
+        super().__init__()
+
+    def __getitem__(self, key):
+        value = super().__getitem__(key)
+        self.move_to_end(key)
+        return value
+
+    def __setitem__(self, key, value):
+        if len(self) >= self.maxsize:
+            oldest = next(iter(self))
+            del self[oldest]
+        super().__setitem__(key, value)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 import atexit
-from collections import deque, OrderedDict
+from collections import deque, OrderedDict, UserDict
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import timedelta
@@ -1401,21 +1401,21 @@ def deserialize_for_cli(data):
     return json.loads(base64.urlsafe_b64decode(data.encode()).decode())
 
 
-class LRU(OrderedDict):
+class LRU(UserDict):
     """ Limited size mapping, evicting the least recently looked-up key when full
     """
 
     def __init__(self, maxsize):
-        self.maxsize = maxsize
         super().__init__()
+        self.data = OrderedDict()
+        self.maxsize = maxsize
 
     def __getitem__(self, key):
         value = super().__getitem__(key)
-        self.move_to_end(key)
+        self.data.move_to_end(key)
         return value
 
     def __setitem__(self, key, value):
         if len(self) >= self.maxsize:
-            oldest = next(iter(self))
-            del self[oldest]
+            self.data.popitem(last=False)
         super().__setitem__(key, value)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3151,13 +3151,14 @@ cache_loads = LRU(maxsize=100)
 
 def loads_function(bytes_object):
     """ Load a function from bytes, cache bytes """
-    try:
-        result = cache_loads[bytes_object]
-    except KeyError:
-        result = pickle.loads(bytes_object)
-        if len(bytes_object) < 100000:
+    if len(bytes_object) < 100000:
+        try:
+            result = cache_loads[bytes_object]
+        except KeyError:
+            result = pickle.loads(bytes_object)
             cache_loads[bytes_object] = result
-    return result
+        return result
+    return pickle.loads(bytes_object)
 
 
 def _deserialize(function=None, args=None, kwargs=None, task=no_value):


### PR DESCRIPTION
This PR switches to using `functools.lru_cache` for caching function serialization (and is currently used for the deserialization cache) on workers instead of `zict.LRU`. This still limits the cache from growing indefinitely but avoids an edge case where `zict.LRU` can end up in an inconsistent state (discussed in https://github.com/dask/zict/issues/29). 