### PR TITLE
Use `DeviceBuffer` from newer RMM releases

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -46,7 +46,10 @@ def init_once():
     try:
         import rmm
 
-        cuda_array = lambda n: rmm.device_array(n, dtype=np.uint8)
+        if hasattr(rmm, "DeviceBuffer"):
+            cuda_array = lambda n: rmm.DeviceBuffer(size=n)
+        else:  # pre-0.12.0
+            cuda_array = lambda n: rmm.device_array(n, dtype=np.uint8)
     except ImportError:
         try:
             import numba.cuda


### PR DESCRIPTION
Depends on PR ( https://github.com/rapidsai/rmm/pull/177 )

If a newer version of RMM is around, use `DeviceBuffer` instead. Otherwise fallback to `device_array`. This is significantly faster to allocate.