### PR TITLE
Fix layout scaling on profile plots

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1852,7 +1852,7 @@ def individual_bandwidth_workers_doc(scheduler, extra, doc):
 def profile_doc(scheduler, extra, doc):
     with log_errors():
         doc.title = "Dask: Profile"
-        prof = ProfileTimePlot(scheduler, sizing_mode="scale_width", doc=doc)
+        prof = ProfileTimePlot(scheduler, sizing_mode="stretch_both", doc=doc)
         doc.add_root(prof.root)
         doc.template = env.get_template("simple.html")
         doc.template_variables.update(extra)
@@ -1864,7 +1864,7 @@ def profile_doc(scheduler, extra, doc):
 def profile_server_doc(scheduler, extra, doc):
     with log_errors():
         doc.title = "Dask: Profile of Event Loop"
-        prof = ProfileServer(scheduler, sizing_mode="scale_width", doc=doc)
+        prof = ProfileServer(scheduler, sizing_mode="stretch_both", doc=doc)
         doc.add_root(prof.root)
         doc.template = env.get_template("simple.html")
         doc.template_variables.update(extra)

--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -312,12 +312,12 @@ class ProfileTimePlot(DashboardComponent):
         self.ts_source = ColumnDataSource({"time": [], "count": []})
         self.ts_plot = figure(
             title="Activity over time",
-            height=100,
+            height=150,
             x_axis_type="datetime",
             active_drag="xbox_select",
             y_range=[0, 1 / profile_interval],
             tools="xpan,xwheel_zoom,xbox_select,reset",
-            **kwargs
+            sizing_mode="stretch_width",
         )
         self.ts_plot.line("time", "count", source=self.ts_source)
         self.ts_plot.circle(
@@ -367,6 +367,7 @@ class ProfileTimePlot(DashboardComponent):
                 self.reset_button,
                 self.update_button,
                 sizing_mode="scale_width",
+                height=250,
             ),
             self.profile_plot,
             self.ts_plot,
@@ -464,12 +465,12 @@ class ProfileServer(DashboardComponent):
         self.ts_source = ColumnDataSource({"time": [], "count": []})
         self.ts_plot = figure(
             title="Activity over time",
-            height=100,
+            height=150,
             x_axis_type="datetime",
             active_drag="xbox_select",
             y_range=[0, 1 / profile_interval],
             tools="xpan,xwheel_zoom,xbox_select,reset",
-            **kwargs
+            sizing_mode="stretch_width",
         )
         self.ts_plot.line("time", "count", source=self.ts_source)
         self.ts_plot.circle(


### PR DESCRIPTION
This PR changes the Bokeh layouts to ensure plots a responsive with page size but some elements are fixed height (buttons and lower plot).

Fixes #3206

![ezgif com-optimize](https://user-images.githubusercontent.com/1610850/69650732-f2891480-1066-11ea-806b-3cb73539c21e.gif)

## Profile

### Before
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/1610850/69650316-54954a00-1066-11ea-87e4-f58914a50c8a.png">

### After

<img width="959" alt="image" src="https://user-images.githubusercontent.com/1610850/69650232-34658b00-1066-11ea-86c4-bbf12c590771.png">

## Profile Server

### Before

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/1610850/69650303-4e9f6900-1066-11ea-9aa5-b383abe0e8c9.png">

### After

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/1610850/69650264-42b3a700-1066-11ea-8b3f-47260495b40a.png">
