### PR TITLE
Enable saving profile information from server threads

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3273,6 +3273,14 @@ class Client(Node):
         stop: time
         workers: list
             List of workers to restrict profile information
+        server : bool
+            If true, return the profile of the worker's administrative thread
+            rather than the worker threads.
+            This is useful when profiling Dask itself, rather than user code.
+        scheduler: bool
+            If true, return the profile information from the scheduler's
+            administrative thread rather than the workers.
+            This is useful when profiling Dask's scheduling itself.
         plot: boolean or string
             Whether or not to return a plot object
         filename: str

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3259,6 +3259,8 @@ class Client(Node):
         merge_workers=True,
         plot=False,
         filename=None,
+        server=False,
+        scheduler=False,
     ):
         """ Collect statistical profiling information about recent work
 
@@ -3293,6 +3295,8 @@ class Client(Node):
             stop=stop,
             plot=plot,
             filename=filename,
+            server=server,
+            scheduler=scheduler,
         )
 
     async def _profile(
@@ -3304,6 +3308,8 @@ class Client(Node):
         merge_workers=True,
         plot=False,
         filename=None,
+        server=False,
+        scheduler=False,
     ):
         if isinstance(workers, (str, Number)):
             workers = [workers]
@@ -3314,6 +3320,8 @@ class Client(Node):
             merge_workers=merge_workers,
             start=start,
             stop=stop,
+            server=server,
+            scheduler=scheduler,
         )
 
         if filename:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4623,6 +4623,8 @@ class Scheduler(ServerNode):
         self,
         comm=None,
         workers=None,
+        scheduler=False,
+        server=False,
         merge_workers=True,
         start=None,
         stop=None,
@@ -4632,8 +4634,15 @@ class Scheduler(ServerNode):
             workers = self.workers
         else:
             workers = set(self.workers) & set(workers)
+
+        if scheduler:
+            return profile.get_profile(self.io_loop.profile, start=start, stop=stop)
+
         results = await asyncio.gather(
-            *(self.rpc(w).profile(start=start, stop=stop, key=key) for w in workers)
+            *(
+                self.rpc(w).profile(start=start, stop=stop, key=key, server=server)
+                for w in workers
+            )
         )
 
         if merge_workers:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2655,12 +2655,15 @@ class Worker(ServerNode):
         if self.digests is not None:
             self.digests["profile-duration"].add(stop - start)
 
-    def get_profile(self, comm=None, start=None, stop=None, key=None):
+    def get_profile(self, comm=None, start=None, stop=None, key=None, server=False):
         now = time() + self.scheduler_delay
-        if key is None:
+        if server:
+            history = self.io_loop.profile
+        elif key is None:
             history = self.profile_history
         else:
             history = [(t, d[key]) for t, d in self.profile_keys_history if key in d]
+
         if start is None:
             istart = 0
         else:


### PR DESCRIPTION
Previously we could only save information from the worker threads
and had to rely ont the dashboard to effectively operate on the
administrative threads of the scheduler and workers.

Now we can do both.