### PR TITLE
Make profile coroutines consistent between Scheduler and Worker

### DIFF
--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -321,11 +321,11 @@ class ProfileTimePlot(DashboardComponent):
     def trigger_update(self, update_metadata=True):
         async def cb():
             with log_errors():
-                prof = self.server.get_profile(
+                prof = await self.server.get_profile(
                     key=self.key, start=self.start, stop=self.stop
                 )
                 if update_metadata:
-                    metadata = self.server.get_profile_metadata()
+                    metadata = await self.server.get_profile_metadata()
                 else:
                     metadata = None
                 if isinstance(prof, gen.Future):

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1079,7 +1079,7 @@ def test_statistical_profiling_2(c, s, a, b):
         y = (x + x * 2) - x.sum().persist()
         yield wait(y)
 
-        profile = a.get_profile()
+        profile = yield a.get_profile()
         text = str(profile)
         if profile["count"] and "sum" in text and "random" in text:
             break
@@ -1165,15 +1165,15 @@ def test_statistical_profiling_cycle(c, s, a, b):
     end = time()
     assert len(a.profile_history) > 3
 
-    x = a.get_profile(start=time() + 10, stop=time() + 20)
+    x = yield a.get_profile(start=time() + 10, stop=time() + 20)
     assert not x["count"]
 
-    x = a.get_profile(start=0, stop=time())
+    x = yield a.get_profile(start=0, stop=time())
     actual = sum(p["count"] for _, p in a.profile_history) + a.profile_recent["count"]
-    x2 = a.get_profile(start=0, stop=time())
+    x2 = yield a.get_profile(start=0, stop=time())
     assert x["count"] <= actual <= x2["count"]
 
-    y = a.get_profile(start=end - 0.300, stop=time())
+    y = yield a.get_profile(start=end - 0.300, stop=time())
     assert 0 < y["count"] <= x["count"]
 
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2655,7 +2655,9 @@ class Worker(ServerNode):
         if self.digests is not None:
             self.digests["profile-duration"].add(stop - start)
 
-    def get_profile(self, comm=None, start=None, stop=None, key=None, server=False):
+    async def get_profile(
+        self, comm=None, start=None, stop=None, key=None, server=False
+    ):
         now = time() + self.scheduler_delay
         if server:
             history = self.io_loop.profile
@@ -2696,7 +2698,7 @@ class Worker(ServerNode):
 
         return prof
 
-    def get_profile_metadata(self, comm=None, start=0, stop=None):
+    async def get_profile_metadata(self, comm=None, start=0, stop=None):
         if stop is None:
             add_recent = True
         now = time() + self.scheduler_delay


### PR DESCRIPTION
Previously scheduler get_profile(_metadata) methods were asynchronous
while worker methods were synchronous.  This caused consistency issues
with dashboard plots.  Now we make the worker methods asynchronous
(needlessly) for consistency.

cc @madsbk 