### PR TITLE
Add performance_report context manager for static report generation

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -16,6 +16,7 @@ from .client import (
     Future,
     futures_of,
     get_task_stream,
+    performance_report,
 )
 from .lock import Lock
 from .nanny import Nanny


### PR DESCRIPTION
This generates a static HTML file with many of the same plots as the dashboard.

Example
-------

```python
from dask.distributed import Client, performance_report
client = Client()

import dask.array as da
x = da.random.random((30000, 30000), chunks=(1000, 1000))

with performance_report():
    x = x.persist()
    (x + x.T).sum().compute()
```

Result
------

https://matthewrocklin.com/raw-host/dask-report.html