### PR TITLE
xfail test_workspace_concurrency for Python 3.6

### DIFF
--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -275,7 +275,7 @@ def _test_workspace_concurrency(tmpdir, timeout, max_procs):
 def test_workspace_concurrency(tmpdir):
     if WINDOWS:
         raise pytest.xfail.Exception("TODO: unknown failure on windows")
-    if sys.version_info <= (3, 6):
+    if sys.version_info < (3, 7):
         raise pytest.xfail.Exception("TODO: unknown failure on Python 3.6")
     _test_workspace_concurrency(tmpdir, 2.0, 6)
 


### PR DESCRIPTION
This only seems to fail for this version.
We actually intended to do this before, but the condition was imprecise.