### PR TITLE
Support multiple listeners in the scheduler

### DIFF
--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -1,3 +1,4 @@
+import itertools
 import dask
 
 from . import registry
@@ -206,6 +207,54 @@ def uri_from_host_port(host_arg, port_arg, default_port):
     return addr
 
 
+def addresses_from_user_args(
+    host=None,
+    port=None,
+    interface=None,
+    protocol=None,
+    peer=None,
+    security=None,
+    default_port=0,
+) -> list:
+    """ Get a list of addresses if the inputs are lists
+
+    This is like ``address_from_user_args`` except that it also accepts lists
+    for some of the arguments.  If these arguments are lists then it will map
+    over them accordingly.
+
+    Examples
+    --------
+    >>> addresses_from_user_args(host="127.0.0.1", protocol=["inproc", "tcp"])
+    ["inproc://127.0.0.1:", "tcp://127.0.0.1:"]
+    """
+
+    def listify(obj):
+        if isinstance(obj, (tuple, list)):
+            return obj
+        else:
+            return itertools.repeat(obj)
+
+    if any(isinstance(x, (tuple, list)) for x in (host, port, interface, protocol)):
+        return [
+            address_from_user_args(
+                host=h,
+                port=p,
+                interface=i,
+                protocol=pr,
+                peer=peer,
+                security=security,
+                default_port=default_port,
+            )
+            for h, p, i, pr in zip(*map(listify, (host, port, interface, protocol)))
+        ]
+    else:
+        return [
+            address_from_user_args(
+                host, port, interface, protocol, peer, security, default_port
+            )
+        ]
+
+
 def address_from_user_args(
     host=None,
     port=None,
@@ -214,8 +263,9 @@ def address_from_user_args(
     peer=None,
     security=None,
     default_port=0,
-):
+) -> str:
     """ Get an address to listen on from common user provided arguments """
+
     if security and security.require_encryption and not protocol:
         protocol = "tls"
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -136,7 +136,7 @@ class Server(object):
         self._ongoing_coroutines = weakref.WeakSet()
         self._event_finished = Event()
 
-        self.listener = None
+        self.listeners = []
         self.io_loop = io_loop or IOLoop.current()
         self.loop = self.io_loop
 
@@ -221,7 +221,7 @@ class Server(object):
     def stop(self):
         if not self.__stopped:
             self.__stopped = True
-            if self.listener is not None:
+            for listener in self.listeners:
                 # Delay closing the server socket until the next IO loop tick.
                 # Otherwise race conditions can appear if an event handler
                 # for an accept() call is already scheduled by the IO loop,
@@ -229,7 +229,14 @@ class Server(object):
                 # The demonstrator for this is Worker.terminate(), which
                 # closes the server socket in response to an incoming message.
                 # See https://github.com/tornadoweb/tornado/issues/2069
-                self.io_loop.add_callback(self.listener.stop)
+                self.io_loop.add_callback(listener.stop)
+
+    @property
+    def listener(self):
+        if self.listeners:
+            return self.listeners[0]
+        else:
+            return None
 
     def _measure_tick(self):
         now = time()
@@ -305,13 +312,14 @@ class Server(object):
         else:
             addr = port_or_addr
             assert isinstance(addr, str)
-        self.listener = listen(
+        listener = listen(
             addr,
             self.handle_comm,
             deserialize=self.deserialize,
             connection_args=listen_args,
         )
-        await self.listener.start()
+        await listener.start()
+        self.listeners.append(listener)
 
     async def handle_comm(self, comm, shutting_down=shutting_down):
         """ Dispatch new communications to coroutine-handlers
@@ -487,7 +495,7 @@ class Server(object):
     def close(self):
         for pc in self.periodic_callbacks.values():
             pc.stop()
-        if self.listener:
+        for listener in self.listeners:
             self.listener.stop()
         for i in range(20):  # let comms close naturally for a second
             if not self._comms:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -36,7 +36,7 @@ from .comm import (
     get_address_host,
     unparse_host_port,
 )
-from .comm.addressing import address_from_user_args
+from .comm.addressing import addresses_from_user_args
 from .core import rpc, connect, send_recv, clean_exception, CommClosedError
 from .diagnostics.plugin import SchedulerPlugin
 from . import profile
@@ -1118,7 +1118,7 @@ class Scheduler(ServerNode):
 
         connection_limit = get_fileno_limit() / 2
 
-        self._start_address = address_from_user_args(
+        self._start_address = addresses_from_user_args(
             host=host,
             port=port,
             interface=interface,
@@ -1215,14 +1215,15 @@ class Scheduler(ServerNode):
                 c.cancel()
 
         if self.status != "running":
-            await self.listen(self._start_address, listen_args=self.listen_args)
-            self.ip = get_address_host(self.listen_address)
-            listen_ip = self.ip
+            for addr in self._start_address:
+                await self.listen(addr, listen_args=self.listen_args)
+                self.ip = get_address_host(self.listen_address)
+                listen_ip = self.ip
 
-            if listen_ip == "0.0.0.0":
-                listen_ip = ""
+                if listen_ip == "0.0.0.0":
+                    listen_ip = ""
 
-            if self._start_address.startswith("inproc://"):
+            if self.address.startswith("inproc://"):
                 listen_ip = "localhost"
 
             # Services listen on all addresses

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1862,3 +1862,7 @@ async def test_multiple_listeners(cleanup):
                 async with Client(s.address, asynchronous=True) as c:
                     futures = c.map(inc, range(20))
                     await wait(futures)
+
+                    # Force inter-worker communication both ways
+                    await c.submit(sum, futures, workers=[a.address])
+                    await c.submit(len, futures, workers=[b.address])

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1847,3 +1847,18 @@ async def test_gather_allow_worker_reconnect(c, s, a, b):
         if "reducer" in key and finish == "processing":
             finish_processing_transitions += 1
     assert finish_processing_transitions == 1
+
+
+@pytest.mark.asyncio
+async def test_multiple_listeners(cleanup):
+    async with Scheduler(port=0, protocol=["inproc", "tcp"]) as s:
+        async with Worker(s.listeners[0].contact_address) as a:
+            async with Worker(s.listeners[1].contact_address) as b:
+                assert a.address.startswith("inproc")
+                assert a.scheduler.address.startswith("inproc")
+                assert b.address.startswith("tcp")
+                assert b.scheduler.address.startswith("tcp")
+
+                async with Client(s.address, asynchronous=True) as c:
+                    futures = c.map(inc, range(20))
+                    await wait(futures)


### PR DESCRIPTION
This allows the scheduler to listen on multiple different listeners at
once. This can be useful when the client and workers are on different
interfaces, or have different security concerns.

So far this isn't documented. 

cc @jcrist @jacobtomlinson for review