### PR TITLE
Fix distributed.wait documentation

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4102,6 +4102,10 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
     fs: list of futures
     timeout: number, optional
         Time in seconds after which to raise a ``dask.distributed.TimeoutError``
+    return_when: str, optional
+        One of `ALL_COMPLETED` or `FIRST_COMPLETED`
+
+    Returns
     -------
     Named tuple of completed, not completed
     """


### PR DESCRIPTION
The current documentation for `distributed.wait` is slightly broken (see https://docs.dask.org/en/latest/futures.html#distributed.wait). This fixes the return not being rendered properly and adds a bit of documentation for the undocumented parameter `return_when`.