### PR TITLE
worker.close() awaits batched_stream.close()

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -123,13 +123,16 @@ class BatchedSend(object):
             self.waker.set()
 
     @gen.coroutine
-    def close(self):
-        """ Flush existing messages and then close comm """
+    def close(self, timeout=None):
+        """ Flush existing messages and then close comm
+
+        If set, raises `tornado.util.TimeoutError` after a timeout.
+        """
         if self.comm is None:
             return
         self.please_stop = True
         self.waker.set()
-        yield self.stopped.wait()
+        yield self.stopped.wait(timeout=timeout)
         if not self.comm.closed():
             try:
                 if self.buffer:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1512,8 +1512,10 @@ def test_idle_timeout(c, s, a, b):
         yield gen.sleep(0.01)
     assert time() < start + 3
 
-    assert a.status == "closed"
-    assert b.status == "closed"
+    start = time()
+    while not (a.status == "closed" and b.status == "closed"):
+        yield gen.sleep(0.01)
+        assert time() < start + 1
 
 
 @gen_cluster(client=True, config={"distributed.scheduler.bandwidth": "100 GB"})

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1089,7 +1089,8 @@ class Worker(ServerNode):
                 self.batched_stream.send({"op": "close-stream"})
 
             if self.batched_stream:
-                await self.batched_stream.close()
+                with ignoring(gen.TimeoutError):
+                    await self.batched_stream.close(timedelta(seconds=timeout))
 
             self.actor_executor._work_queue.queue.clear()
             if isinstance(self.executor, ThreadPoolExecutor):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1089,7 +1089,7 @@ class Worker(ServerNode):
                 self.batched_stream.send({"op": "close-stream"})
 
             if self.batched_stream:
-                self.batched_stream.close()
+                await self.batched_stream.close()
 
             self.actor_executor._work_queue.queue.clear()
             if isinstance(self.executor, ThreadPoolExecutor):


### PR DESCRIPTION
This PR fixes https://github.com/dask/distributed/issues/3186 and fixes https://github.com/dask/distributed/issues/3213.