### PR TITLE
Avoid repeatedly adding same dependency to already in memory stack

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1608,7 +1608,7 @@ class Scheduler(ServerNode):
                     else:
                         child_deps = self.dependencies[dep]
                     if all(d in done for d in child_deps):
-                        if dep in self.tasks:
+                        if dep in self.tasks and dep not in done:
                             done.add(dep)
                             stack.append(dep)
 


### PR DESCRIPTION
This PR updates the logic in `update_graph` to avoid repeatedly adding the same dependency to the already in memory `stack`. This improves our performance when there are many tasks that share dependencies which are already in `memory` or `erred`.

Below is a small example to demonstrate the performance before and after these changes:

<details>
<summary>Example snippet:</summary>

```python
import time
import random

from dask import delayed, compute
from distributed import Client, wait

if __name__ == "__main__":

    random.seed(2)

    with Client(n_workers=1, threads_per_worker=1) as client:

        # Perform same calculation for increasing graph size
        for n in [50, 100, 150, 200]:
            # Generate 10 indepdent tasks
            x = [delayed(random.random)() for _ in range(10)]
            # Generate lots of interrelated dependent tasks
            for _ in range(10, n):
                random_subset = [random.choice(x) for _ in range(5)]
                random_max = delayed(max)(random_subset)
                x.append(random_max)

            # Persist tasks into distributed memory and wait to finish
            y = client.persist(x)
            wait(y)

            # Time computation
            t_start = time.time()
            compute(*x)
            dt = time.time() - t_start
            print(f"(n={n}) time taken = {dt:0.3f} sec")
```

</details>

<details>
<summary>Output on current master:</summary>

```
(n=50) time taken = 0.043 sec
(n=100) time taken = 0.683 sec
(n=150) time taken = 3.092 sec
(n=200) time taken = 11.783 sec
```

</details>

<details>
<summary>Output with changes here:</summary>

```
(n=50) time taken = 0.018 sec
(n=100) time taken = 0.030 sec
(n=150) time taken = 0.046 sec
(n=200) time taken = 0.061 sec
```

</details>