### PR TITLE
Retry operations on network issues

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,3 +10,4 @@ ipykernel >= 4.5.2
 pytest >= 3.2
 prometheus_client >= 0.6.0
 jupyter-server-proxy >= 1.1.0
+pytest-asyncio

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -72,6 +72,10 @@ distributed:
     lost-worker-timeout: 15s  # Interval after which to hard-close a lost worker job
 
   comm:
+    retry_operations:  # some operations (such as gathering data) are subject to re-tries with the below parameters
+      max_retries: 0  # the maximum number to retry an operation in case of a connection problem
+      base_delay: 1s  # the first non-zero delay between re-tries
+      max_delay: 20s  # the maximum delay between re-tries
     compression: auto
     offload: 10MiB # Size after which we choose to offload serialization to another thread
     default-scheme: tcp

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -72,10 +72,11 @@ distributed:
     lost-worker-timeout: 15s  # Interval after which to hard-close a lost worker job
 
   comm:
-    retry_operations:  # some operations (such as gathering data) are subject to re-tries with the below parameters
-      max_retries: 0  # the maximum number to retry an operation in case of a connection problem
-      base_delay: 1s  # the first non-zero delay between re-tries
-      max_delay: 20s  # the maximum delay between re-tries
+    retry:  # some operations (such as gathering data) are subject to re-tries with the below parameters
+      count: 0  # the maximum retry attempts. 0 disables re-trying.
+      delay:
+         min: 1s  # the first non-zero delay between re-tries
+         max: 20s  # the maximum delay between re-tries
     compression: auto
     offload: 10MiB # Size after which we choose to offload serialization to another thread
     default-scheme: tcp

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -7,6 +7,7 @@ import json
 import operator
 import sys
 from time import sleep
+from unittest import mock
 import logging
 
 import dask
@@ -1749,7 +1750,8 @@ async def test_gather_failing_cnn_recover(c, s, a, b):
     x = await c.scatter({"x": 1}, workers=a.address)
 
     s.rpc = FlakyConnectionPool(failing_connections=1)
-    res = await s.gather(keys=["x"])
+    with mock.patch("distributed.utils_comm.retry_max_retries", 1):
+        res = await s.gather(keys=["x"])
     assert res["status"] == "OK"
 
 
@@ -1811,25 +1813,31 @@ async def test_gather_allow_worker_reconnect(c, s, a, b):
 
     s.rpc = FlakyConnectionPool(failing_connections=4)
 
-    with captured_logger(logging.getLogger("distributed.scheduler")) as sched_logger:
-        with captured_logger(logging.getLogger("distributed.client")) as client_logger:
-            with captured_logger(
-                logging.getLogger("distributed.worker")
-            ) as worker_logger:
-                # Gather using the client (as an ordinary user would)
-                # Upon a missing key, the client will reschedule the computations
-                res = await c.gather(z)
+    with captured_logger(
+        logging.getLogger("distributed.scheduler")
+    ) as sched_logger, captured_logger(
+        logging.getLogger("distributed.client")
+    ) as client_logger, captured_logger(
+        logging.getLogger("distributed.utils_comm")
+    ) as utils_comm_logger, mock.patch(
+        "distributed.utils_comm.retry_max_retries", 3
+    ), mock.patch(
+        "distributed.utils_comm.retry_base_delay", 0.5
+    ):
+        # Gather using the client (as an ordinary user would)
+        # Upon a missing key, the client will reschedule the computations
+        res = await c.gather(z)
 
     assert res == 5
 
     sched_logger = sched_logger.getvalue()
     client_logger = client_logger.getvalue()
-    worker_logger = worker_logger.getvalue()
+    utils_comm_logger = utils_comm_logger.getvalue()
 
     # Ensure that the communication was done via the scheduler, i.e. we actually hit a bad connection
     assert s.rpc.cnn_count > 0
 
-    assert "Encountered connection issue during data collection" in worker_logger
+    assert "Retrying get_data_from_worker after exception" in utils_comm_logger
 
     # The reducer task was actually not found upon first collection. The client will reschedule the graph
     assert "Couldn't gather 1 keys, rescheduling" in client_logger
@@ -1841,14 +1849,12 @@ async def test_gather_allow_worker_reconnect(c, s, a, b):
     # that the scheduler again knows about the result.
     # The final reduce step should then be used from the re-connected worker
     # instead of recomputing it.
-
-    starts = []
-    finish_processing_transitions = 0
-    for transition in s.transition_log:
-        key, start, finish, recommendations, timestamp = transition
-        if "reducer" in key and finish == "processing":
-            finish_processing_transitions += 1
-    assert finish_processing_transitions == 1
+    transitions_to_processing = [
+        (key, start, timestamp)
+        for key, start, finish, recommendations, timestamp in s.transition_log
+        if finish == "processing" and "reducer" in key
+    ]
+    assert len(transitions_to_processing) == 1
 
 
 @pytest.mark.asyncio

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1750,7 +1750,7 @@ async def test_gather_failing_cnn_recover(c, s, a, b):
     x = await c.scatter({"x": 1}, workers=a.address)
 
     s.rpc = FlakyConnectionPool(failing_connections=1)
-    with mock.patch("distributed.utils_comm.retry_max_retries", 1):
+    with mock.patch("distributed.utils_comm.retry_count", 1):
         res = await s.gather(keys=["x"])
     assert res["status"] == "OK"
 
@@ -1820,9 +1820,9 @@ async def test_gather_allow_worker_reconnect(c, s, a, b):
     ) as client_logger, captured_logger(
         logging.getLogger("distributed.utils_comm")
     ) as utils_comm_logger, mock.patch(
-        "distributed.utils_comm.retry_max_retries", 3
+        "distributed.utils_comm.retry_count", 3
     ), mock.patch(
-        "distributed.utils_comm.retry_base_delay", 0.5
+        "distributed.utils_comm.retry_delay_min", 0.5
     ):
         # Gather using the client (as an ordinary user would)
         # Upon a missing key, the client will reschedule the computations

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -74,7 +74,7 @@ def test_retry_no_exception(loop):
         return retval
 
     assert (
-        loop.run_sync(lambda: retry(coro, max_retries=0, base_delay=-1, max_delay=-1))
+        loop.run_sync(lambda: retry(coro, count=0, delay_min=-1, delay_max=-1))
         is retval
     )
     assert n_calls == 1
@@ -91,7 +91,7 @@ def test_retry0_raises_immediately(loop):
         raise RuntimeError(f"RT_ERROR {n_calls}")
 
     with pytest.raises(RuntimeError, match="RT_ERROR 1"):
-        loop.run_sync(lambda: retry(coro, max_retries=0, base_delay=-1, max_delay=-1))
+        loop.run_sync(lambda: retry(coro, count=0, delay_min=-1, delay_max=-1))
 
     assert n_calls == 1
 
@@ -120,9 +120,9 @@ def test_retry_does_retry_and_sleep(loop):
                 lambda: retry(
                     coro,
                     retry_on_exceptions=(MyEx,),
-                    max_retries=5,
-                    base_delay=1.0,
-                    max_delay=6.0,
+                    count=5,
+                    delay_min=1.0,
+                    delay_max=6.0,
                     jitter_fraction=0.0,
                 )
             )

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -1,7 +1,11 @@
 from distributed.core import ConnectionPool
 from distributed.comm import Comm
-from distributed.utils_test import gen_cluster
-from distributed.utils_comm import pack_data, gather_from_workers
+from distributed.utils_test import gen_cluster, loop  # noqa: F401
+from distributed.utils_comm import pack_data, gather_from_workers, retry
+
+from unittest import mock
+
+import pytest
 
 
 def test_pack_data():
@@ -58,3 +62,70 @@ def test_gather_from_workers_permissive_flaky(c, s, a, b):
 
     assert missing == {"x": [a.address]}
     assert bad_workers == [a.address]
+
+
+def test_retry_no_exception(loop):
+    n_calls = 0
+    retval = object()
+
+    async def coro():
+        nonlocal n_calls
+        n_calls += 1
+        return retval
+
+    assert (
+        loop.run_sync(lambda: retry(coro, max_retries=0, base_delay=-1, max_delay=-1))
+        is retval
+    )
+    assert n_calls == 1
+
+
+def test_retry0_raises_immediately(loop):
+    # test that using max_reties=0 raises after 1 call
+
+    n_calls = 0
+
+    async def coro():
+        nonlocal n_calls
+        n_calls += 1
+        raise RuntimeError(f"RT_ERROR {n_calls}")
+
+    with pytest.raises(RuntimeError, match="RT_ERROR 1"):
+        loop.run_sync(lambda: retry(coro, max_retries=0, base_delay=-1, max_delay=-1))
+
+    assert n_calls == 1
+
+
+def test_retry_does_retry_and_sleep(loop):
+    # test the retry and sleep pattern of `retry`
+    n_calls = 0
+
+    class MyEx(Exception):
+        pass
+
+    async def coro():
+        nonlocal n_calls
+        n_calls += 1
+        raise MyEx(f"RT_ERROR {n_calls}")
+
+    sleep_calls = []
+
+    async def my_sleep(amount):
+        sleep_calls.append(amount)
+        return
+
+    with mock.patch("asyncio.sleep", my_sleep):
+        with pytest.raises(MyEx, match="RT_ERROR 6"):
+            loop.run_sync(
+                lambda: retry(
+                    coro,
+                    retry_on_exceptions=(MyEx,),
+                    max_retries=5,
+                    base_delay=1.0,
+                    max_delay=6.0,
+                    jitter_fraction=0.0,
+                )
+            )
+
+    assert n_calls == 6
+    assert sleep_calls == [0.0, 1.0, 3.0, 6.0, 6.0]

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -1,10 +1,13 @@
 import asyncio
 from collections import defaultdict
+from functools import partial
 from itertools import cycle
 import logging
 import random
 
 from dask.optimization import SubgraphCallable
+import dask.config
+from dask.utils import parse_timedelta
 from toolz import merge, concat, groupby, drop
 
 from .core import rpc
@@ -275,3 +278,83 @@ def pack_data(o, d, key_types=object):
         return {k: pack_data(v, d, key_types=key_types) for k, v in o.items()}
     else:
         return o
+
+
+retry_max_retries = dask.config.get("distributed.comm.retry_operations.max_retries")
+retry_base_delay = parse_timedelta(
+    dask.config.get("distributed.comm.retry_operations.base_delay"), default="s"
+)
+retry_max_delay = parse_timedelta(
+    dask.config.get("distributed.comm.retry_operations.max_delay"), default="s"
+)
+
+
+async def retry(
+    coro,
+    max_retries,
+    base_delay,
+    max_delay,
+    jitter_fraction=0.1,
+    retry_on_exceptions=(EnvironmentError, IOError),
+    operation=None,
+):
+    """
+    Return the result of ``await coro()``, re-trying in case of exceptions
+
+    The delay between attempts is ``base_delay * (2 ** i - 1)`` where ``i`` enumerates the attempt that just failed
+    (starting at 0), but never larger than ``max_delay``.
+    This yields no delay between the first and second attempt, then ``base_delay``, ``3 * base_delay``, etc.
+    (The reason to re-try with no delay is that in most cases this is sufficient and will thus recover faster
+    from a communication failure).
+
+    Parameters
+    ----------
+    coro
+        The coroutine function to call and await
+    max_retries
+        The maximum number of re-tries before giving up. 0 means no re-try; must be >= 0.
+    base_delay
+        The base factor for the delay (in seconds); this is the first non-zero delay between re-tries.
+    max_delay
+        The maximum delay (in seconds) between consecutive re-tries (without jitter)
+    jitter_fraction
+        The maximum jitter to add to the delay, as fraction of the total delay. No jitter is added if this
+        value is <= 0.
+        Using a non-zero value here avoids "herd effects" of many operations re-tried at the same time
+    retry_on_exceptions
+        A tuple of exception classes to retry. Other exceptions are not caught and re-tried, but propagate immediately.
+    operation
+        A human-readable description of the operation attempted; used only for logging failures
+
+    Returns
+    -------
+    Any
+        Whatever `await `coro()` returned
+    """
+    # this loop is a no-op in case max_retries<=0
+    for i_try in range(max_retries):
+        try:
+            return await coro()
+        except retry_on_exceptions as ex:
+            operation = operation or str(coro)
+            logger.info(
+                f"Retrying {operation} after exception in attempt {i_try}/{max_retries}: {ex}"
+            )
+            delay = min(base_delay * (2 ** i_try - 1), max_delay)
+            if jitter_fraction > 0:
+                delay *= 1 + random.random() * jitter_fraction
+            await asyncio.sleep(delay)
+    return await coro()
+
+
+async def retry_operation(coro, *args, operation=None, **kwargs):
+    """
+    Retry an operation using the configuration values for the retry parameters
+    """
+    return await retry(
+        partial(coro, *args, **kwargs),
+        max_retries=retry_max_retries,
+        base_delay=retry_base_delay,
+        max_delay=retry_max_delay,
+        operation=operation,
+    )


### PR DESCRIPTION
We operate distributed in the cloud and see tcp connection aborts. Unfortunately, `distributed` often does not recover cleanly from such situations, although a simple re-try would have helped in most cases.
This PR proposes to add a more generic retry to some operations.

Notes:
 * only some operations are re-tried, as for some operations, triggering it twice may have undesired effects. There are probably more operations that can / should be re-tried, so this is just a start for operations where it's "obviously" safe to retry.
 * parameters for the re-tries (maximum number of retry attempts, delay between re-tries) is configurable. The default is to not re-try at all to not change the current behavior (some might rely on/prefer seeing all connection failures, fast)
