### PR TITLE
forgot to fix slow test

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -303,7 +303,11 @@ async def test_stress(cleanup):
     chunksize = "10 MB"
 
     async with LocalCluster(
-        protocol="ucx", dashboard_address=None, asynchronous=True, processes=False
+        protocol="ucx",
+        dashboard_address=None,
+        asynchronous=True,
+        processes=False,
+        host=HOST,
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             rs = da.random.RandomState()


### PR DESCRIPTION
My apologies, when I last ran the ucx tests I didn't include the `--runslow` option and missed the `test_stress` test.  This PR fixes the last UCX test in distributed.