### PR TITLE
Connectionpool: don't hand out closed connections

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -832,7 +832,12 @@ class ConnectionPool(object):
         self._created = weakref.WeakSet()
         self._instances.add(self)
 
-    def validate(self):
+    def _validate(self):
+        """
+        Validate important invariants of this class
+
+        Used only for testing / debugging
+        """
         assert self.semaphore._value == self.limit - self.open - self._n_connecting
 
     @property

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3532,9 +3532,6 @@ def test_reconnect(loop):
         assert time() < start + 5
         sleep(0.01)
 
-    with pytest.raises(Exception):
-        c.nthreads()
-
     assert x.status == "cancelled"
     with pytest.raises(CancelledError):
         x.result()

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -775,7 +775,10 @@ async def test_connection_pool_detects_remote_close():
     conn2 = await p.connect(server.address)
     assert conn2 is not conn
     p.reuse(server.address, conn2)
+    # check that `conn` has ben removed from the internal data structures
+    assert p.open == 1 and p.active == 0
 
-    # check connection pool invariants:
-    p.validate()
+    # check connection pool invariants hold even after it detects a closed connection
+    # while creating conn2:
+    p._validate()
     p.close()

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -750,3 +750,32 @@ async def test_deserialize_error():
     assert type(info.value) == Exception
     for c in str(info.value):
         assert c.isalpha() or c in "(',!)"  # no crazy bytestrings
+
+
+@pytest.mark.asyncio
+async def test_connection_pool_detects_remote_close():
+    server = Server({"ping": pingpong})
+    await server.listen("tcp://")
+
+    # open a connection, use it and give it back to the pool
+    p = ConnectionPool(limit=10)
+    conn = await p.connect(server.address)
+    await send_recv(conn, op="ping")
+    p.reuse(server.address, conn)
+
+    # now close this connection on the *server*
+    assert len(server._comms) == 1
+    server_conn = list(server._comms.keys())[0]
+    await server_conn.close()
+
+    # give the ConnectionPool some time to realize that the connection is closed
+    await asyncio.sleep(0.1)
+
+    # the connection pool should not hand out `conn` again
+    conn2 = await p.connect(server.address)
+    assert conn2 is not conn
+    p.reuse(server.address, conn2)
+
+    # check connection pool invariants:
+    p.validate()
+    p.close()


### PR DESCRIPTION
Operating long-running dask clusters (sometimes, they run for many days without interruptions), we found that connection issues we observe are likely related to a behavior of the ConnectionPool of handing out connections that are already closed by the remote end (e.g. because a connection has been established some days ago, easily above connection timeouts).

It also fixes another bug in the connecitonpool's bookkeeping of connections.