### PR TITLE
Skip Security.temporary() tests if cryptography not installed

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -74,8 +74,6 @@ if [[ $CRICK == true ]]; then
     pip install -q git+https://github.com/jcrist/crick.git
 fi;
 
-conda uninstall --force cryptography
-
 # Install distributed
 pip install --no-deps -e .
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -74,6 +74,8 @@ if [[ $CRICK == true ]]; then
     pip install -q git+https://github.com/jcrist/crick.git
 fi;
 
+conda uninstall --force cryptography
+
 # Install distributed
 pip install --no-deps -e .
 

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -250,6 +250,7 @@ def test_Client_twice(loop):
 
 @pytest.mark.asyncio
 async def test_client_constructor_with_temporary_security(cleanup):
+    pytest.importorskip("cryptography")
     async with Client(
         security=True, silence_logs=False, dashboard_address=None, asynchronous=True
     ) as c:
@@ -990,6 +991,7 @@ async def test_repr(cleanup):
 @pytest.mark.parametrize("temporary", [True, False])
 async def test_capture_security(cleanup, temporary):
     if temporary:
+        pytest.importorskip("cryptography")
         security = True
     else:
         security = tls_only_security()

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -709,6 +709,7 @@ def test_adapt_then_manual(loop):
 @pytest.mark.parametrize("temporary", [True, False])
 def test_local_tls(loop, temporary):
     if temporary:
+        pytest.importorskip("cryptography")
         security = True
     else:
         security = tls_only_security()

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -379,6 +379,8 @@ async def test_require_encryption():
 
 
 def test_temporary_credentials():
+    pytest.importorskip("cryptography")
+
     sec = Security.temporary()
     sec_repr = repr(sec)
     fields = ["tls_ca_file"]


### PR DESCRIPTION
The use of `Security.temporary()` in `test_temporary_credentials` requires the `cryptography` package to be installed