### PR TITLE
Update inlining Futures in task graph in Client._graph_to_futures

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2434,10 +2434,12 @@ class Client(Node):
             futures = {key: Future(key, self, inform=False) for key in keyset}
 
             values = {
-                k for k, v in dsk.items() if isinstance(v, Future) and k not in keyset
+                k: v
+                for k, v in dsk.items()
+                if isinstance(v, Future) and k not in keyset
             }
             if values:
-                dsk = dask.optimization.inline(dsk, keys=values)
+                dsk = pack_data(dsk, values)
 
             d = {k: unpack_remotedata(v, byte_keys=True) for k, v in dsk.items()}
             extra_futures = set.union(*[v[1] for v in d.values()]) if d else set()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -51,6 +51,7 @@ from .utils_comm import (
     WrappedKey,
     unpack_remotedata,
     pack_data,
+    subs_multiple,
     scatter_to_workers,
     gather_from_workers,
 )
@@ -2439,7 +2440,7 @@ class Client(Node):
                 if isinstance(v, Future) and k not in keyset
             }
             if values:
-                dsk = pack_data(dsk, values)
+                dsk = subs_multiple(dsk, values)
 
             d = {k: unpack_remotedata(v, byte_keys=True) for k, v in dsk.items()}
             extra_futures = set.union(*[v[1] for v in d.values()]) if d else set()

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -23,6 +23,11 @@ def test_subs_multiple():
     dsk = {"a": (sum, ["x", "y"])}
     assert subs_multiple(dsk, data) == {"a": (sum, [1, 2])}
 
+    # Tuple key
+    data = {"x": 1, ("y", 0): 2}
+    dsk = {"a": (sum, ["x", ("y", 0)])}
+    assert subs_multiple(dsk, data) == {"a": (sum, [1, 2])}
+
 
 @gen_cluster(client=True)
 def test_gather_from_workers_permissive(c, s, a, b):

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -1,7 +1,7 @@
 from distributed.core import ConnectionPool
 from distributed.comm import Comm
 from distributed.utils_test import gen_cluster
-from distributed.utils_comm import pack_data, gather_from_workers
+from distributed.utils_comm import pack_data, subs_multiple, gather_from_workers
 
 
 def test_pack_data():
@@ -9,6 +9,15 @@ def test_pack_data():
     assert pack_data(("x", "y"), data) == (1, "y")
     assert pack_data({"a": "x", "b": "y"}, data) == {"a": 1, "b": "y"}
     assert pack_data({"a": ["x"], "b": "y"}, data) == {"a": [1], "b": "y"}
+
+
+def test_subs_multiple():
+    data = {"x": 1, "y": 2}
+    assert subs_multiple((sum, [0, "x", "y", "z"]), data) == (sum, [0, 1, 2, "z"])
+    assert subs_multiple((sum, [0, ["x", "y", "z"]]), data) == (sum, [0, [1, 2, "z"]])
+
+    dsk = {"a": (sum, ["x", "y"])}
+    assert subs_multiple(dsk, data) == {"a": (sum, [1, 2])}
 
 
 @gen_cluster(client=True)

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -275,3 +275,33 @@ def pack_data(o, d, key_types=object):
         return {k: pack_data(v, d, key_types=key_types) for k, v in o.items()}
     else:
         return o
+
+
+def subs_multiple(o, d):
+    """ Perform substitutions on a tasks
+
+    Parameters
+    ----------
+    o:
+        Core data structures containing literals and keys
+    d: dict
+        Mapping of keys to values
+
+    Examples
+    --------
+    >>> dsk = {"a": (sum, ["x", 2])}
+    >>> data = {"x": 1}
+    >>> subs_multiple(dsk, data)  # doctest: +SKIP
+    {'a': (sum, [1, 2])}
+
+    """
+    typ = type(o)
+    if typ is tuple and o and callable(o[0]):  # istask(o)
+        return (o[0],) + tuple(subs_multiple(i, d) for i in o[1:])
+    elif typ is list:
+        return typ([subs_multiple(i, d) for i in o])
+    elif typ is dict:
+        return {k: subs_multiple(v, d) for (k, v) in o.items()}
+    elif typ is str:
+        return d.get(o, o)
+    return o

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -15,8 +15,6 @@ from .utils import All, tokey
 
 logger = logging.getLogger(__name__)
 
-__no_value__ = "__no_value__"
-
 
 async def gather_from_workers(who_has, rpc, close=True, serializers=None, who=None):
     """ Gather data directly from peers
@@ -301,20 +299,17 @@ def subs_multiple(o, d):
 
     """
     typ = type(o)
-    if not (typ is tuple and o and callable(o[0])):  # not istask(o)
-        try:  # Is o a key to substitute?
-            result = d.get(o, __no_value__)
-            if result is not __no_value__:
-                return result
-        except TypeError:  # unhashable type
-            pass
-        if typ is list:
-            return typ([subs_multiple(i, d) for i in o])
-        elif typ is dict:
-            return {k: subs_multiple(v, d) for (k, v) in o.items()}
-        return o
-    else:
+    if typ is tuple and o and callable(o[0]):  # istask(o)
         return (o[0],) + tuple(subs_multiple(i, d) for i in o[1:])
+    elif typ is list:
+        return [subs_multiple(i, d) for i in o]
+    elif typ is dict:
+        return {k: subs_multiple(v, d) for (k, v) in o.items()}
+    else:
+        try:
+            return d.get(o, o)
+        except TypeError:
+            return o
 
 
 retry_count = dask.config.get("distributed.comm.retry.count")


### PR DESCRIPTION
This PR updates `Client._graph_to_futures` to use `distributed.utils_comm.pack_data` to inline `Future`s instead of `dask.optimization.inline` here

https://github.com/dask/distributed/blob/4a8a4f3bce378406e83a099e8a12fc9bc12ef25c/distributed/client.py#L2436-L2440

E.g. transforming a task graph like:

```
{'inc-18a8806d490eca53bbf2c39a744bc349': <Future: finished, type: builtins.int, key: inc-18a8806d490eca53bbf2c39a744bc349>,
 'inc-2541182851e5e0087c5c5387feefcf99': <Future: finished, type: builtins.int, key: inc-2541182851e5e0087c5c5387feefcf99>,
 'inc-74961de59174673d7c8aaf11df6fd815': <Future: finished, type: builtins.int, key: inc-74961de59174673d7c8aaf11df6fd815>,
 'sum-of-future-results': (<built-in function sum>,
                           ['inc-2541182851e5e0087c5c5387feefcf99',
                            'inc-18a8806d490eca53bbf2c39a744bc349',
                            'inc-74961de59174673d7c8aaf11df6fd815'])}
```

into:

```
{'inc-18a8806d490eca53bbf2c39a744bc349': <Future: finished, type: builtins.int, key: inc-18a8806d490eca53bbf2c39a744bc349>,
 'inc-2541182851e5e0087c5c5387feefcf99': <Future: finished, type: builtins.int, key: inc-2541182851e5e0087c5c5387feefcf99>,
 'inc-74961de59174673d7c8aaf11df6fd815': <Future: finished, type: builtins.int, key: inc-74961de59174673d7c8aaf11df6fd815>,
 'sum-of-future-results': (<built-in function sum>,
                           [<Future: finished, type: builtins.int, key: inc-2541182851e5e0087c5c5387feefcf99>,
                            <Future: finished, type: builtins.int, key: inc-18a8806d490eca53bbf2c39a744bc349>,
                            <Future: finished, type: builtins.int, key: inc-74961de59174673d7c8aaf11df6fd815>])}
```

This is motivated by `pack_data` performing better than `inline` for large graphs (see benchmark below) and should, I think, perform the same substitutions.

<details>
<summary>Example benchmark:</summary>

```python
import time

from dask.optimization import inline
from distributed import Client, wait, Future
from distributed.utils_comm import pack_data


def inc(x):
    return x + 1


if __name__ == "__main__":

    with Client() as client:
        # Create a lots of Futures and wait for them to finish
        futures = client.map(inc, range(5_000))
        wait(futures)

        # Create task graph from Futures
        dsk = {f.key: f for f in futures}

        # Add new task which depends on Futures
        sum_key = "sum-of-future-results"
        dsk[sum_key] = (sum, [f.key for f in futures])

        # Use two different methods to inline the Futures in dsk:
        #   1. distributed.utils_comm.pack_data
        #   2. dask.optimization.inline

        # Using pack_data
        values = {k: v for k, v in dsk.items() if isinstance(v, Future)}
        t_start = time.time()
        pack_result = pack_data(dsk, values)
        dt = time.time() - t_start
        print(f"pack_data took {dt} seconds")

        # Using inline
        values = {k for k, v in dsk.items() if isinstance(v, Future)}
        t_start = time.time()
        inline_result = inline(dsk, values)
        dt = time.time() - t_start
        print(f"inline took {dt} seconds")

        assert pack_result == inline_result

```

outputs (on my laptop)

```
pack_data took 0.005619049072265625 seconds
inline took 11.879703044891357 seconds
```
</details>

cc @jcrist if you get a moment to look at this 


xref https://github.com/dask/dask/issues/5299