### PR TITLE
Make ConnectionPool.close asynchronous

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1278,7 +1278,7 @@ class Client(Node):
             if self._start_arg is None:
                 with ignoring(AttributeError):
                     await self.cluster.close()
-            self.rpc.close()
+            await self.rpc.close()
             self.status = "closed"
             if _get_global_client() is self:
                 _set_global_client(None)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -951,11 +951,13 @@ class ConnectionPool(object):
 
     async def close(self):
         """
-        Close all communications abruptly.
+        Close all communications
         """
         for d in [self.available, self.occupied]:
             comms = [comm for comms in d.values() for comm in comms]
-            await asyncio.gather(*[comm.close() for comm in comms])
+            await asyncio.gather(
+                *[comm.close() for comm in comms], return_exceptions=True
+            )
             for _ in comms:
                 self.semaphore.release()
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -949,18 +949,15 @@ class ConnectionPool(object):
                 IOLoop.current().add_callback(comm.close)
                 self.semaphore.release()
 
-    def close(self):
+    async def close(self):
         """
         Close all communications abruptly.
         """
-        for comms in self.available.values():
-            for comm in comms:
-                comm.abort()
+        for d in [self.available, self.occupied]:
+            comms = [comm for comms in d.values() for comm in comms]
+            await asyncio.gather(*[comm.close() for comm in comms])
+            for _ in comms:
                 self.semaphore.release()
-        for comms in self.occupied.values():
-            for comm in comms:
-                self.semaphore.release()
-                comm.abort()
 
         for comm in self._created:
             IOLoop.current().add_callback(comm.abort)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -451,7 +451,7 @@ class Nanny(ServerNode):
         except Exception:
             pass
         self.process = None
-        self.rpc.close()
+        await self.rpc.close()
         self.status = "closed"
         if comm:
             await comm.write("OK")

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1304,7 +1304,7 @@ class Scheduler(ServerNode):
         for comm in self.client_comms.values():
             comm.abort()
 
-        self.rpc.close()
+        await self.rpc.close()
 
         self.status = "closed"
         self.stop()

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -562,7 +562,7 @@ async def test_connection_pool():
         await asyncio.sleep(0.01)
         assert time() < start + 2
 
-    rpc.close()
+    await rpc.close()
 
 
 @pytest.mark.asyncio
@@ -612,7 +612,7 @@ async def test_connection_pool_tls():
     await asyncio.gather(*[rpc(s.address).ping() for s in servers])
     assert rpc.active == 0
 
-    rpc.close()
+    await rpc.close()
 
 
 @pytest.mark.asyncio
@@ -651,7 +651,7 @@ async def test_connection_pool_remove():
     rpc.remove(serv.address)
     rpc.reuse(serv.address, comm)
 
-    rpc.close()
+    await rpc.close()
 
 
 @pytest.mark.asyncio

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1102,7 +1102,7 @@ class Worker(ServerNode):
             self.actor_executor.shutdown(wait=executor_wait, timeout=timeout)
 
             self.stop()
-            self.rpc.close()
+            await self.rpc.close()
 
             self.status = "closed"
             await ServerNode.close(self)


### PR DESCRIPTION
Previously we would call a hard abort rather than waiting for comms to
close more gracefully.

FYI @jcrist @madsbk 