### PR TITLE
Add plugin entry point for out-of-tree comms library

### DIFF
--- a/distributed/comm/registry.py
+++ b/distributed/comm/registry.py
@@ -60,14 +60,8 @@ backends = {}
 def get_backend(scheme):
     """
     Get the Backend instance for the given *scheme*.
-
-    New backends can be registered using setuptools entry_points, e.g.:
-    setup(..., entry_points={
-            'distributed.comm.backends': [
-                'udp=dask_udp.backend:UDPBackend',
-            ]
-        },
-    )
+    It looks for matching scheme in dask's internal cache, and falls-back to
+    package metadata for the group name ``distributed.comm.backends``
     """
 
     backend = backends.get(scheme)

--- a/distributed/comm/registry.py
+++ b/distributed/comm/registry.py
@@ -1,7 +1,5 @@
 from abc import ABC, abstractmethod
 
-import pkg_resources
-
 
 class Backend(ABC):
     """
@@ -72,17 +70,22 @@ def get_backend(scheme):
     )
     """
 
-    backend = backends.get(scheme) or next(
-        iter(
-            backend_class_ep.load()()
-            for backend_class_ep in pkg_resources.iter_entry_points(
-                "distributed.comm.backends", scheme
-            )
-        ),
-        None,
-    )
+    backend = backends.get(scheme)
     if backend is None:
-        raise ValueError(
-            "unknown address scheme %r (known schemes: %s)" % (scheme, sorted(backends))
+        import pkg_resources
+
+        backend = next(
+            iter(
+                backend_class_ep.load()()
+                for backend_class_ep in pkg_resources.iter_entry_points(
+                    "distributed.comm.backends", scheme
+                )
+            ),
+            None,
         )
+        if backend is None:
+            raise ValueError(
+                "unknown address scheme %r (known schemes: %s)"
+                % (scheme, sorted(backends))
+            )
     return backend

--- a/distributed/comm/registry.py
+++ b/distributed/comm/registry.py
@@ -82,4 +82,6 @@ def get_backend(scheme):
                 "unknown address scheme %r (known schemes: %s)"
                 % (scheme, sorted(backends))
             )
+        else:
+            backends[scheme] = backend
     return backend

--- a/docs/source/communications.rst
+++ b/docs/source/communications.rst
@@ -103,14 +103,14 @@ would register its UDP backend class by including the following in its ``setup.p
 
 .. code-block:: python
 
-setup(name="dask_udp",
-      entry_points={
-        "distributed.comm.backends": [
-            "udp=dask_udp.backend:UDPBackend",
-        ]
-      },
-      ...
-)
+    setup(name="dask_udp",
+          entry_points={
+            "distributed.comm.backends": [
+                "udp=dask_udp.backend:UDPBackend",
+            ]
+          },
+          ...
+    )
 
 .. autoclass:: distributed.comm.registry.Backend
    :members:

--- a/docs/source/communications.rst
+++ b/docs/source/communications.rst
@@ -99,7 +99,7 @@ entry points into all transport-specific routines.
 
 Out-of-tree backends can be registered under the group ``distributed.comm.backends``
 in setuptools `entry_points`_. For example, a hypothetical ``dask_udp`` package
-would register its UDP backend class by including the following in its ``setup.py``file:
+would register its UDP backend class by including the following in its ``setup.py`` file:
 
 .. code-block:: python
 

--- a/docs/source/communications.rst
+++ b/docs/source/communications.rst
@@ -97,6 +97,22 @@ Each transport is represented by a URI scheme (such as ``tcp``) and
 backed by a dedicated :class:`Backend` implementation, which provides
 entry points into all transport-specific routines.
 
+Out-of-tree backends can be registered under the group ``distributed.comm.backends``
+in setuptools `entry_points`_. For example, a hypothetical ``dask_udp`` package
+would register its UDP backend class by including the following in its ``setup.py``file:
+
+.. code-block:: python
+
+setup(name="dask_udp",
+      entry_points={
+        "distributed.comm.backends": [
+            "udp=dask_udp.backend:UDPBackend",
+        ]
+      },
+      ...
+)
 
 .. autoclass:: distributed.comm.registry.Backend
    :members:
+
+.. _entry_points: https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata


### PR DESCRIPTION
This PR adds the ability to include external comms plugins without
having to directly access comm.backends.

It has the advantage to not require a library to be preloaded in order
to work, e.g. dask-spec does not have preloading support.