### PR TITLE
All scheduler task states in prometheus

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -4,8 +4,12 @@ import logging
 
 import dask
 from dask.utils import format_bytes
-import toolz
-from toolz import merge
+
+try:
+    from cytoolz import merge, merge_with
+except ImportError:
+    from toolz import merge, merge_with
+
 from tornado import escape
 
 try:
@@ -42,6 +46,7 @@ from .worker import counters_doc
 from .proxy import GlobalProxyHandler
 from .utils import RequestHandler, redirect
 from ..utils import log_errors, format_time
+from ..scheduler import ALL_TASK_STATES
 
 
 ns = {
@@ -65,7 +70,7 @@ class Workers(RequestHandler):
                 "workers.html",
                 title="Workers",
                 scheduler=self.server,
-                **toolz.merge(self.server.__dict__, ns, self.extra, rel_path_statics),
+                **merge(self.server.__dict__, ns, self.extra, rel_path_statics),
             )
 
 
@@ -81,7 +86,7 @@ class Worker(RequestHandler):
                 title="Worker: " + worker,
                 scheduler=self.server,
                 Worker=worker,
-                **toolz.merge(self.server.__dict__, ns, self.extra, rel_path_statics),
+                **merge(self.server.__dict__, ns, self.extra, rel_path_statics),
             )
 
 
@@ -97,7 +102,7 @@ class Task(RequestHandler):
                 title="Task: " + task,
                 Task=task,
                 scheduler=self.server,
-                **toolz.merge(self.server.__dict__, ns, self.extra, rel_path_statics),
+                **merge(self.server.__dict__, ns, self.extra, rel_path_statics),
             )
 
 
@@ -109,7 +114,7 @@ class Logs(RequestHandler):
                 "logs.html",
                 title="Logs",
                 logs=logs,
-                **toolz.merge(self.extra, rel_path_statics),
+                **merge(self.extra, rel_path_statics),
             )
 
 
@@ -123,7 +128,7 @@ class WorkerLogs(RequestHandler):
                 "logs.html",
                 title="Logs: " + worker,
                 logs=logs,
-                **toolz.merge(self.extra, rel_path_statics),
+                **merge(self.extra, rel_path_statics),
             )
 
 
@@ -137,7 +142,7 @@ class WorkerCallStacks(RequestHandler):
                 "call-stack.html",
                 title="Call Stacks: " + worker,
                 call_stack=call_stack,
-                **toolz.merge(self.extra, rel_path_statics),
+                **merge(self.extra, rel_path_statics),
             )
 
 
@@ -156,7 +161,7 @@ class TaskCallStack(RequestHandler):
                     "call-stack.html",
                     title="Call Stack: " + key,
                     call_stack=call_stack,
-                    **toolz.merge(self.extra, rel_path_statics),
+                    **merge(self.extra, rel_path_statics),
                 )
 
 
@@ -239,7 +244,7 @@ class _PrometheusCollector(object):
         self.server = server
 
     def collect(self):
-        from prometheus_client.core import GaugeMetricFamily
+        from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily
 
         yield GaugeMetricFamily(
             "dask_scheduler_clients",
@@ -253,23 +258,34 @@ class _PrometheusCollector(object):
             value=self.server.adaptive_target(),
         )
 
-        tasks = GaugeMetricFamily(
+        worker_states = GaugeMetricFamily(
             "dask_scheduler_workers",
             "Number of workers known by scheduler.",
             labels=["state"],
         )
-        tasks.add_metric(["connected"], len(self.server.workers))
-        tasks.add_metric(["saturated"], len(self.server.saturated))
-        tasks.add_metric(["idle"], len(self.server.idle))
-        yield tasks
+        worker_states.add_metric(["connected"], len(self.server.workers))
+        worker_states.add_metric(["saturated"], len(self.server.saturated))
+        worker_states.add_metric(["idle"], len(self.server.idle))
+        yield worker_states
 
         tasks = GaugeMetricFamily(
             "dask_scheduler_tasks",
             "Number of tasks known by scheduler.",
             labels=["state"],
         )
-        tasks.add_metric(["received"], len(self.server.tasks))
-        tasks.add_metric(["unrunnable"], len(self.server.unrunnable))
+
+        task_counter = merge_with(
+            sum, (tp.states for tp in self.server.task_prefixes.values())
+        )
+
+        yield CounterMetricFamily(
+            "dask_scheduler_tasks_forgotten",
+            "Total number of processed tasks no longer in memory and already removed from the scheduler job queue.",
+            value=task_counter.get("forgotten", 0.0),
+        )
+
+        for state in ALL_TASK_STATES:
+            tasks.add_metric([state], task_counter.get(state, 0.0))
         yield tasks
 
 

--- a/distributed/dashboard/tests/test_scheduler_bokeh_html.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh_html.py
@@ -20,10 +20,10 @@ from distributed.dashboard import BokehScheduler, BokehWorker
     scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}},
     worker_kwargs={"services": {"dashboard": BokehWorker}},
 )
-def test_connect(c, s, a, b):
+async def test_connect(c, s, a, b):
     future = c.submit(lambda x: x + 1, 1)
     x = c.submit(slowinc, 1, delay=1, retries=5)
-    yield future
+    await future
     http_client = AsyncHTTPClient()
     for suffix in [
         "info/main/workers.html",
@@ -38,7 +38,7 @@ def test_connect(c, s, a, b):
         "json/index.html",
         "individual-plots.json",
     ]:
-        response = yield http_client.fetch(
+        response = await http_client.fetch(
             "http://localhost:%d/%s" % (s.services["dashboard"].port, suffix)
         )
         assert response.code == 200
@@ -55,15 +55,15 @@ def test_connect(c, s, a, b):
     nthreads=[],
     scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}},
 )
-def test_worker_404(c, s):
+async def test_worker_404(c, s):
     http_client = AsyncHTTPClient()
     with pytest.raises(HTTPClientError) as err:
-        yield http_client.fetch(
+        await http_client.fetch(
             "http://localhost:%d/info/worker/unknown" % s.services["dashboard"].port
         )
     assert err.value.code == 404
     with pytest.raises(HTTPClientError) as err:
-        yield http_client.fetch(
+        await http_client.fetch(
             "http://localhost:%d/info/task/unknown" % s.services["dashboard"].port
         )
     assert err.value.code == 404
@@ -75,10 +75,10 @@ def test_worker_404(c, s):
         "services": {("dashboard", 0): (BokehScheduler, {"prefix": "/foo"})}
     },
 )
-def test_prefix(c, s, a, b):
+async def test_prefix(c, s, a, b):
     http_client = AsyncHTTPClient()
     for suffix in ["foo/info/main/workers.html", "foo/json/index.html", "foo/system"]:
-        response = yield http_client.fetch(
+        response = await http_client.fetch(
             "http://localhost:%d/%s" % (s.services["dashboard"].port, suffix)
         )
         assert response.code == 200
@@ -94,7 +94,7 @@ def test_prefix(c, s, a, b):
     clean_kwargs={"threads": False},
     scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}},
 )
-def test_prometheus(c, s, a, b):
+async def test_prometheus(c, s, a, b):
     pytest.importorskip("prometheus_client")
     from prometheus_client.parser import text_string_to_metric_families
 
@@ -103,7 +103,7 @@ def test_prometheus(c, s, a, b):
     # request data twice since there once was a case where metrics got registered multiple times resulting in
     # prometheus_client errors
     for _ in range(2):
-        response = yield http_client.fetch(
+        response = await http_client.fetch(
             "http://localhost:%d/metrics" % s.services["dashboard"].port
         )
         assert response.code == 200
@@ -119,10 +119,70 @@ def test_prometheus(c, s, a, b):
     clean_kwargs={"threads": False},
     scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}},
 )
-def test_health(c, s, a, b):
+async def test_prometheus_collect_task_states(c, s, a, b):
+    pytest.importorskip("prometheus_client")
+    from prometheus_client.parser import text_string_to_metric_families
+
     http_client = AsyncHTTPClient()
 
-    response = yield http_client.fetch(
+    async def fetch_metrics():
+        bokeh_scheduler = s.services["dashboard"]
+        assert s.services["dashboard"].scheduler is s
+        response = await http_client.fetch(
+            f"http://{bokeh_scheduler.server.address}:{bokeh_scheduler.port}/metrics"
+        )
+        txt = response.body.decode("utf8")
+        families = {
+            family.name: family for family in text_string_to_metric_families(txt)
+        }
+
+        active_metrics = {
+            sample.labels["state"]: sample.value
+            for sample in families["dask_scheduler_tasks"].samples
+        }
+        forgotten_tasks = [
+            sample.value
+            for sample in families["dask_scheduler_tasks_forgotten"].samples
+        ]
+        return active_metrics, forgotten_tasks
+
+    expected = {"memory", "released", "processing", "waiting", "no-worker", "erred"}
+
+    # Ensure that we get full zero metrics for all states even though the
+    # scheduler did nothing, yet
+    assert not s.tasks
+    active_metrics, forgotten_tasks = await fetch_metrics()
+    assert active_metrics.keys() == expected
+    assert sum(active_metrics.values()) == 0.0
+    assert sum(forgotten_tasks) == 0.0
+
+    # submit a task which should show up in the prometheus scraping
+    future = c.submit(slowinc, 1, delay=0.5)
+
+    active_metrics, forgotten_tasks = await fetch_metrics()
+    assert active_metrics.keys() == expected
+    assert sum(active_metrics.values()) == 1.0
+    assert sum(forgotten_tasks) == 0.0
+
+    res = await c.gather(future)
+    assert res == 2
+
+    del future
+    active_metrics, forgotten_tasks = await fetch_metrics()
+    assert active_metrics.keys() == expected
+    assert sum(active_metrics.values()) == 0.0
+    assert sum(forgotten_tasks) == 1.0
+
+
+@gen_cluster(
+    client=True,
+    clean_kwargs={"threads": False},
+    scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}},
+)
+async def test_health(c, s, a, b):
+    http_client = AsyncHTTPClient()
+
+    response = await http_client.fetch(
         "http://localhost:%d/health" % s.services["dashboard"].port
     )
     assert response.code == 200
@@ -135,14 +195,14 @@ def test_health(c, s, a, b):
 @gen_cluster(
     client=True, scheduler_kwargs={"services": {("dashboard", 0): BokehScheduler}}
 )
-def test_task_page(c, s, a, b):
+async def test_task_page(c, s, a, b):
     future = c.submit(lambda x: x + 1, 1, workers=a.address)
     x = c.submit(inc, 1)
-    yield future
+    await future
     http_client = AsyncHTTPClient()
 
     "info/task/" + url_escape(future.key) + ".html",
-    response = yield http_client.fetch(
+    response = await http_client.fetch(
         "http://localhost:%d/info/task/" % s.services["dashboard"].port
         + url_escape(future.key)
         + ".html"
@@ -167,13 +227,13 @@ def test_task_page(c, s, a, b):
         }
     },
 )
-def test_allow_websocket_origin(c, s, a, b):
+async def test_allow_websocket_origin(c, s, a, b):
     url = (
         "ws://localhost:%d/status/ws?bokeh-protocol-version=1.0&bokeh-session-id=1"
         % s.services["dashboard"].port
     )
     with pytest.raises(HTTPClientError) as err:
-        yield websocket_connect(
+        await websocket_connect(
             HTTPRequest(url, headers={"Origin": "http://evil.invalid"})
         )
     assert err.value.code == 403


### PR DESCRIPTION
This exposes *all* task states as a prometheus metric. The current behaviour only captures the scheduler state partially and uses descriptions which are different than what is used internally. I believe the state machine of the cluster is already complex enough and using different names for the states only introduces confusion.

This also better aligns with what is visible on the bokeh dashboard.

If backwards compatibility is of concern we could still export the old ones or define a new metrics name, of course. I'm wondering how the whole prometheus metrics are supposed to be treated in terms of versioning/stability since IMHO some of them are _should_ probably be changed to offer real value (I haven't opened issues, yet)

cc @darindf are the received/unrunnable states something you rely upon?

A note regarding the test:
I wanted to add a proper unit test for this but am struggling to get it running on travis. I'm facing the usual problem "works on my machine" but on travis the metrics fetch *always* returns an empty metric (tried different approaches with waiting and scraping multiple times already but couldn't succeed)
Is there anything I'm doing wrong here or is there something I could try to get it running? I do not like changing stuff without a test and my creativity is running low on this one so a hint would be appreciated.