### PR TITLE
Use worker name in logs

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -291,14 +291,12 @@ class WorkerState(object):
         return ws
 
     def __repr__(self):
-        return "<Worker %r, memory: %d, processing: %d>" % (
+        return "<Worker %r, name: %s, memory: %d, processing: %d>" % (
             self.address,
+            self.name,
             len(self.has_what),
             len(self.processing),
         )
-
-    def __str__(self):
-        return self.address
 
     def identity(self):
         return {
@@ -1435,7 +1433,7 @@ class Scheduler(ServerNode):
 
             ws = self.workers.get(address)
             if ws is not None:
-                raise ValueError("Worker already exists %s" % address)
+                raise ValueError("Worker already exists %s" % ws)
 
             self.workers[address] = ws = WorkerState(
                 address=address,
@@ -1518,7 +1516,7 @@ class Scheduler(ServerNode):
 
             self.log_event(address, {"action": "add-worker"})
             self.log_event("all", {"action": "add-worker", "worker": address})
-            logger.info("Register %s", str(address))
+            logger.info("Register worker %s", ws)
 
             if comm:
                 await comm.write(
@@ -1920,7 +1918,7 @@ class Scheduler(ServerNode):
                     "processing-tasks": dict(ws.processing),
                 },
             )
-            logger.info("Remove worker %s", address)
+            logger.info("Remove worker %s", ws)
             if close:
                 with ignoring(AttributeError, CommClosedError):
                     self.stream_comms[address].send({"op": "close", "report": False})
@@ -1991,7 +1989,7 @@ class Scheduler(ServerNode):
                 dask.config.get("distributed.scheduler.events-cleanup-delay")
             )
             self.loop.call_later(cleanup_delay, remove_worker_from_events)
-            logger.debug("Removed worker %s", address)
+            logger.debug("Removed worker %s", ws)
 
         return "OK"
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from datetime import timedelta
 import functools
 from hashlib import md5
+import html
 import inspect
 import json
 import logging
@@ -1296,7 +1297,9 @@ class Log(str):
     """ A container for logs """
 
     def _repr_html_(self):
-        return "<pre><code>\n{log}\n</code></pre>".format(log=self.rstrip())
+        return "<pre><code>\n{log}\n</code></pre>".format(
+            log=html.escape(self.rstrip())
+        )
 
 
 class Logs(dict):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -709,10 +709,11 @@ class Worker(ServerNode):
 
     def __repr__(self):
         return (
-            "<%s: %s, %s, stored: %d, running: %d/%d, ready: %d, comm: %d, waiting: %d>"
+            "<%s: %r, %s, %s, stored: %d, running: %d/%d, ready: %d, comm: %d, waiting: %d>"
             % (
                 self.__class__.__name__,
                 self.address,
+                self.name,
                 self.status,
                 len(self.data),
                 len(self.executing),


### PR DESCRIPTION
## Current Behaviour

Workers can get started with a `--name` property

    dask-worker --name myworker-de820c tcp://192.168.0.144:8786

This property is used on the UI but not within the scheduler logs. This can make it difficult to identify particular worker instances during debugging. 

    distributed.scheduler - INFO - Register worker tcp://192.168.0.144:39535
    distributed.scheduler - INFO - Starting worker compute stream, tcp://192.168.0.144:39535
    distributed.core - INFO - Starting established connection
    distributed.scheduler - INFO - Remove worker tcp://192.168.0.144:39535
    distributed.core - INFO - Removing comms to tcp://192.168.0.144:39535
    distributed.scheduler - INFO - Lost all workers

## Expected Behavior
When starting a worker with `--name` the name is consistently used within scheduler logs

    distributed.scheduler - INFO - Register worker myworker-de820c (tcp://192.168.0.144:40607)
    distributed.scheduler - INFO - Starting worker compute stream, tcp://192.168.0.144:40607
    distributed.core - INFO - Starting established connection
    distributed.scheduler - INFO - Remove worker myworker-de820c (tcp://192.168.0.144:40607)
    distributed.core - INFO - Removing comms to tcp://192.168.0.144:40607
    distributed.scheduler - INFO - Lost all workers
