### PR TITLE
Update latencies with heartbeats

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1586,3 +1586,15 @@ async def test_bad_startup(cleanup):
             w = await Worker(s.address, startup_information={"bad": bad_startup})
         except Exception:
             pytest.fail("Startup exception was raised")
+
+
+@pytest.mark.asyncio
+async def test_update_latency(cleanup):
+    async with await Scheduler() as s:
+        async with await Worker(s.address) as w:
+            original = w.latency
+            await w.heartbeat()
+            assert original != w.latency
+
+            if w.digests is not None:
+                assert w.digests["latency"].size() > 0

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -828,7 +828,7 @@ class Worker(ServerNode):
                 response = await future
                 _end = time()
                 middle = (_start + _end) / 2
-                self.latency = (_end - start) * 0.05 + self.latency * 0.95
+                self._update_latency(_end - start)
                 self.scheduler_delay = response["time"] - middle
                 self.status = "running"
                 break
@@ -862,6 +862,11 @@ class Worker(ServerNode):
         self.periodic_callbacks["heartbeat"].start()
         self.loop.add_callback(self.handle_scheduler, comm)
 
+    def _update_latency(self, latency):
+        self.latency = latency * 0.05 + self.latency * 0.95
+        if self.digests is not None:
+            self.digests["latency"].add(latency)
+
     async def heartbeat(self):
         if not self.heartbeat_active:
             self.heartbeat_active = True
@@ -876,6 +881,8 @@ class Worker(ServerNode):
                 )
                 end = time()
                 middle = (start + end) / 2
+
+                self._update_latency(end - start)
 
                 if response["status"] == "missing":
                     await self._register_with_scheduler()


### PR DESCRIPTION
The latency is currently only calculate once during connect. The heartbeat seemed to be a good periodic callback which could update this. Also the latency seems to be a good digest candidate, similar to the tick length