### PR TITLE
Support out-of-tree comms backends using entrypoints

### DIFF
--- a/distributed/comm/registry.py
+++ b/distributed/comm/registry.py
@@ -1,7 +1,5 @@
 from abc import ABC, abstractmethod
 
-import pkg_resources
-
 
 class Backend(ABC):
     """
@@ -72,17 +70,22 @@ def get_backend(scheme):
     )
     """
 
-    backend = backends.get(scheme) or next(
-        iter(
-            backend_class_ep.load()()
-            for backend_class_ep in pkg_resources.iter_entry_points(
-                "distributed.comm.backends", scheme
-            )
-        ),
-        None,
-    )
+    backend = backends.get(scheme)
     if backend is None:
-        raise ValueError(
-            "unknown address scheme %r (known schemes: %s)" % (scheme, sorted(backends))
+        import pkg_resources
+
+        backend = next(
+            iter(
+                backend_class_ep.load()()
+                for backend_class_ep in pkg_resources.iter_entry_points(
+                    "distributed.comm.backends", scheme
+                )
+            ),
+            None,
         )
+        if backend is None:
+            raise ValueError(
+                "unknown address scheme %r (known schemes: %s)"
+                % (scheme, sorted(backends))
+            )
     return backend

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -1,18 +1,16 @@
 import asyncio
-import types
 from functools import partial
 import os
 import sys
 import threading
 import warnings
 
-import pkg_resources
+import entrypoints
 import pytest
 
 from tornado import ioloop, locks, queues
 from tornado.concurrent import Future
 
-import distributed
 from distributed.metrics import time
 from distributed.utils import get_ip, get_ipv6
 from distributed.utils_test import (
@@ -1159,26 +1157,17 @@ async def test_inproc_adresses():
     await check_addresses(a, b)
 
 
-def test_register_backend_entrypoint():
-    # Code adapted from pandas backend entry point testing
-    # https://github.com/pandas-dev/pandas/blob/2470690b9f0826a8feb426927694fa3500c3e8d2/pandas/tests/plotting/test_backend.py#L50-L76
+class MockBackendEntryPoint:
+    @staticmethod
+    def load():
+        return lambda: 1
 
-    dist = pkg_resources.get_distribution("distributed")
-    if dist.module_path not in distributed.__file__:
-        # We are running from a non-installed distributed, and this test is invalid
-        pytest.skip("Testing a non-installed distributed")
 
-    mod = types.ModuleType("dask_udp")
-    mod.UDPBackend = lambda: 1
-    sys.modules[mod.__name__] = mod
+def test_register_backend_entrypoint(monkeypatch):
+    def mock_get_single(*args, **kwargs):
+        return MockBackendEntryPoint()
 
-    entry_point_name = "distributed.comm.backends"
-    backends_entry_map = pkg_resources.get_entry_map("distributed")
-    if entry_point_name not in backends_entry_map:
-        backends_entry_map[entry_point_name] = dict()
-    backends_entry_map[entry_point_name]["udp"] = pkg_resources.EntryPoint(
-        "udp", mod.__name__, attrs=["UDPBackend"], dist=dist
-    )
-
-    result = get_backend("udp")
-    assert result == 1
+    with monkeypatch.context() as c:
+        monkeypatch.setattr(entrypoints, "get_single", mock_get_single)
+        result = get_backend("udp")
+        assert result == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 click >= 6.6
 cloudpickle >= 0.2.2
 dask >= 2.7.0
+entrypoints >= 0.3
 msgpack
 psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1


### PR DESCRIPTION
This in an alternative version to #3305, but using the faster `entrypoints` library. 

cc: @jcrist 
