### PR TITLE
Add setuptools to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ toolz >= 0.7.4
 tornado >= 5
 zict >= 0.1.3
 pyyaml
+setuptools


### PR DESCRIPTION
In #3305 we added an import of `pkg_resources`. This PR adds `setuptools` (which includes `pkg_resources`) to our requirements. 

cc @TomAugspurger 