### PR TITLE
Always add new TaskGroup to TaskPrefix

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -280,7 +280,11 @@ class _PrometheusCollector(object):
 
         yield CounterMetricFamily(
             "dask_scheduler_tasks_forgotten",
-            "Total number of processed tasks no longer in memory and already removed from the scheduler job queue.",
+            (
+                "Total number of processed tasks no longer in memory and already "
+                "removed from the scheduler job queue. Note task groups on the "
+                "scheduler which have all tasks in the forgotten state are not included."
+            ),
             value=task_counter.get("forgotten", 0.0),
         )
 

--- a/distributed/dashboard/tests/test_scheduler_bokeh_html.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh_html.py
@@ -171,7 +171,7 @@ async def test_prometheus_collect_task_states(c, s, a, b):
     active_metrics, forgotten_tasks = await fetch_metrics()
     assert active_metrics.keys() == expected
     assert sum(active_metrics.values()) == 0.0
-    assert sum(forgotten_tasks) == 1.0
+    assert sum(forgotten_tasks) == 0.0
 
 
 @gen_cluster(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1963,10 +1963,11 @@ class Scheduler(ServerNode):
             tp = self.task_prefixes[prefix_key] = TaskPrefix(prefix_key)
         ts.prefix = tp
 
+        group_key = ts.group_key or prefix_key
         try:
-            tg = self.task_groups[ts.group_key]
+            tg = self.task_groups[group_key]
         except KeyError:
-            tg = self.task_groups[ts.group_key] = TaskGroup(ts.group_key)
+            tg = self.task_groups[group_key] = TaskGroup(group_key)
             tg.prefix = tp
             tp.groups.append(tg)
         tg.add(ts)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1956,20 +1956,20 @@ class Scheduler(ServerNode):
         """ Create a new task, and associated states """
         ts = TaskState(key, spec)
         ts._state = state
-        try:
-            tg = self.task_groups[ts.group_key]
-        except KeyError:
-            tg = self.task_groups[ts.group_key] = TaskGroup(ts.group_key)
-        tg.add(ts)
         prefix_key = key_split(key)
         try:
             tp = self.task_prefixes[prefix_key]
         except KeyError:
-            tp = TaskPrefix(prefix_key)
-            tp.groups.append(tg)
-            self.task_prefixes[prefix_key] = tp
+            tp = self.task_prefixes[prefix_key] = TaskPrefix(prefix_key)
         ts.prefix = tp
-        tg.prefix = tp
+
+        try:
+            tg = self.task_groups[ts.group_key]
+        except KeyError:
+            tg = self.task_groups[ts.group_key] = TaskGroup(ts.group_key)
+            tg.prefix = tp
+            tp.groups.append(tg)
+        tg.add(ts)
         self.tasks[key] = ts
         return ts
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1794,11 +1794,13 @@ async def test_task_group_non_tuple_key(c, s, a, b):
 async def test_task_unique_groups(c, s, a, b):
     """ This test ensure that task groups remain unique when using submit
     """
-    h = await c.submit(sum, [3, 4])
-    g = await c.submit(len, [1, 2])
+    x = c.submit(sum, [1, 2])
+    y = c.submit(len, [1, 2])
+    z = c.submit(sum, [3, 4])
+    await asyncio.wait([x, y, z])
 
     assert s.task_prefixes["len"].states["memory"] == 1
-    assert s.task_prefixes["sum"].states["forgotten"] == 1
+    assert s.task_prefixes["sum"].states["memory"] == 2
 
 
 class BrokenComm(Comm):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1761,6 +1761,12 @@ async def test_task_prefix(c, s, a, b):
 
     assert s.task_prefixes["sum-aggregate"].states["memory"] == 1
 
+    a = da.arange(101, chunks=(20,))
+    b = (a + 1).sum().persist()
+    b = await b
+
+    assert s.task_prefixes["sum-aggregate"].states["memory"] == 2
+
 
 class BrokenComm(Comm):
     peer_address = None

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1967,7 +1967,7 @@ async def test_too_many_groups(c, s, a, b):
     while s.tasks:
         await asyncio.sleep(0.01)
 
-    assert len(s.task_groups) <= 3
+    assert len(s.task_groups) < 3
 
 
 @pytest.mark.asyncio

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -637,11 +637,11 @@ def key_split_group(x):
         elif x[0] == "<":
             return x.strip("<>").split()[0].split(".")[-1]
         else:
-            return ""
+            return key_split(x)
     elif typ is bytes:
         return key_split_group(x.decode())
     else:
-        return ""
+        return key_split(x)
 
 
 @contextmanager


### PR DESCRIPTION
Currently a `TaskGroup` is only added to a `TaskPrefix` when a new `TaskPrefix` is created:

https://github.com/dask/distributed/blob/d747f639d73c5f9b8961f2f80e407868de7da4cb/distributed/scheduler.py#L1969

I think we want to add append a `TaskGroup` to `TaskPrefix.groups` anytime a new group is created. 

Closes #3368