### PR TITLE
add performance report docs and color definitions to docs

### DIFF
--- a/docs/source/diagnosing-performance.rst
+++ b/docs/source/diagnosing-performance.rst
@@ -115,6 +115,35 @@ command on the workers:
    client.run(lambda dask_worker: dask_worker.incoming_transfer_log)
 
 
+Performance Reports
+-------------------
+
+Often when benchmarking and/or profiling, users may want to record a
+particular computation or even a full workflow.  Dask can save the bokeh
+dashboards as static HTML plots including the task stream, worker profiles,
+bandwidths, etc. This is done wrapping a computation with the ``performance_report`` context manager:
+
+.. code-block:: python
+
+    from dask.distributed import performance_report
+
+    with performance_report(filename="dask-report.html):
+        ## some dask computation
+
+The following video demonstrates the ``performance_report`` context manager in greater
+detail:
+
+.. raw:: html
+
+    <iframe width="560"
+            height="315"
+            src="https://www.youtube.com/embed/nTMGbkS761Q"
+            frameborder="0"
+            allow="autoplay; encrypted-media"
+            allowfullscreen>
+    </iframe>
+
+
 A note about times
 ------------------
 

--- a/docs/source/web.rst
+++ b/docs/source/web.rst
@@ -126,6 +126,15 @@ accordingly.
 .. image:: https://raw.githubusercontent.com/dask/dask-org/master/images/bokeh-task-stream.gif
    :alt: Task stream plot of Dask web interface
 
+The colors signifying the following:
+
+1.  Serialization (gray)
+2.  Communication between workers (red)
+3.  Disk I/O (orange)
+4.  Error (black)
+5.  Execution times (colored by task: purple, green, yellow, etc)
+
+
 If data transfer occurs between workers a *red* bar appears preceding the
 task bar showing the duration of the transfer.  If an error occurs than a
 *black* bar replaces the normal color.  This plot show the last 1000 tasks.


### PR DESCRIPTION
PR updates docs with `performance_report` info and adds definitions of colors to web interface page

cc @mrocklin 