### PR TITLE
Use TaskPrefix.name in Graph layout

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1219,7 +1219,7 @@ class TaskGraph(DashboardComponent):
                 node_x.append(xx)
                 node_y.append(yy)
                 node_state.append(task.state)
-                node_name.append(task.prefix)
+                node_name.append(task.prefix.name)
 
             for a, b in new_edges:
                 try:

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -442,6 +442,8 @@ def test_TaskGraph(c, s, a, b):
     gp.update()
     assert set(map(len, gp.node_source.data.values())) == {6}
     assert set(map(len, gp.edge_source.data.values())) == {5}
+    json.dumps(gp.edge_source.data)
+    json.dumps(gp.node_source.data)
 
     da = pytest.importorskip("dask.array")
     x = da.random.random((20, 20), chunks=(10, 10)).persist()


### PR DESCRIPTION
Fixes #3327

cc @TomAugspurger 

We don't have any tests for this yet 