### PR TITLE
Stop dask scheduler gracefully

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -227,7 +227,10 @@ def main(
     logger.info("Local Directory: %26s", local_directory)
     logger.info("-" * 47)
 
-    install_signal_handlers(loop)
+    async def on_signal(signum):
+        await scheduler.close()
+
+    install_signal_handlers(loop, cleanup=on_signal)
 
     async def run():
         await scheduler


### PR DESCRIPTION
Currently if you terminating dask-scheduler following exception occurs:
```
Traceback (most recent call last):
  File "/usr/local/bin/dask-scheduler", line 8, in <module>
    sys.exit(go())
  File "/usr/local/lib/python3.6/dist-packages/distributed/cli/dask_scheduler.py", line 248, in go
    main()
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/distributed/cli/dask_scheduler.py", line 237, in main
    loop.run_sync(run)
  File "/usr/local/lib/python3.6/dist-packages/tornado/ioloop.py", line 531, in run_sync
    raise TimeoutError("Operation timed out after %s seconds" % timeout)
tornado.util.TimeoutError: Operation timed out after None seconds
```