### PR TITLE
Add websocket scheduler plugin

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from functools import partial
+import json
 import logging
 
 import dask
@@ -11,6 +12,7 @@ except ImportError:
     from toolz import merge, merge_with
 
 from tornado import escape
+from tornado.websocket import WebSocketHandler
 
 try:
     import numpy as np
@@ -45,6 +47,7 @@ from .core import BokehServer
 from .worker import counters_doc
 from .proxy import GlobalProxyHandler
 from .utils import RequestHandler, redirect
+from ..diagnostics.websocket import WebsocketPlugin
 from ..utils import log_errors, format_time
 from ..scheduler import ALL_TASK_STATES
 
@@ -319,6 +322,34 @@ class HealthHandler(RequestHandler):
         self.set_header("Content-Type", "text/plain")
 
 
+class EventsHandler(WebSocketHandler):
+    def initialize(self, server=None, extra=None):
+        self.server = server
+        self.extra = extra or {}
+        self.plugin = WebsocketPlugin(self, server)
+        self.server.add_plugin(self.plugin)
+
+    def send(self, name, data):
+        data["name"] = name
+        for k in list(data):
+            # Drop bytes objects for now
+            if isinstance(data[k], bytes):
+                del data[k]
+        self.write_message(json.dumps(data))
+
+    def open(self):
+        for worker in self.server.workers:
+            self.plugin.add_worker(self.server, worker)
+
+    def on_message(self, message):
+        message = json.loads(message)
+        if message["name"] == "ping":
+            self.send("pong", {"timestamp": str(datetime.now())})
+
+    def on_close(self):
+        self.server.remove_plugin(self.plugin)
+
+
 routes = [
     (r"info", redirect("info/main/workers.html")),
     (r"info/main/workers.html", Workers),
@@ -334,6 +365,7 @@ routes = [
     (r"individual-plots.json", IndividualPlots),
     (r"metrics", PrometheusHandler),
     (r"health", HealthHandler),
+    (r"events", EventsHandler),
     (r"proxy/(\d+)/(.*?)/(.*)", GlobalProxyHandler),
 ]
 

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -322,7 +322,7 @@ class HealthHandler(RequestHandler):
         self.set_header("Content-Type", "text/plain")
 
 
-class EventsHandler(WebSocketHandler):
+class EventstreamHandler(WebSocketHandler):
     def initialize(self, server=None, extra=None):
         self.server = server
         self.extra = extra or {}
@@ -365,7 +365,7 @@ routes = [
     (r"individual-plots.json", IndividualPlots),
     (r"metrics", PrometheusHandler),
     (r"health", HealthHandler),
-    (r"events", EventsHandler),
+    (r"eventstream", EventstreamHandler),
     (r"proxy/(\d+)/(.*?)/(.*)", GlobalProxyHandler),
 ]
 

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -335,7 +335,7 @@ class EventstreamHandler(WebSocketHandler):
             # Drop bytes objects for now
             if isinstance(data[k], bytes):
                 del data[k]
-        self.write_message(json.dumps(data))
+        self.write_message(data)
 
     def open(self):
         for worker in self.server.workers:

--- a/distributed/diagnostics/websocket.py
+++ b/distributed/diagnostics/websocket.py
@@ -1,12 +1,10 @@
-import tornado.websocket
-
 from .plugin import SchedulerPlugin
 from ..utils import key_split
 from .task_stream import colors
 
 
 class WebsocketPlugin(SchedulerPlugin):
-    def __init__(self, socket: tornado.websocket.WebSocketHandler, scheduler):
+    def __init__(self, socket, scheduler):
         self.socket = socket
         self.scheduler = scheduler
 

--- a/distributed/diagnostics/websocket.py
+++ b/distributed/diagnostics/websocket.py
@@ -1,0 +1,54 @@
+import tornado.websocket
+
+from .plugin import SchedulerPlugin
+from ..utils import key_split
+from .task_stream import colors
+
+
+class WebsocketPlugin(SchedulerPlugin):
+    def __init__(self, socket: tornado.websocket.WebSocketHandler, scheduler):
+        self.socket = socket
+        self.scheduler = scheduler
+
+    def restart(self, scheduler, **kwargs):
+        """ Run when the scheduler restarts itself """
+        self.socket.send("restart", {})
+
+    def add_worker(self, scheduler=None, worker=None, **kwargs):
+        """ Run when a new worker enters the cluster """
+        self.socket.send("add_worker", {"worker": worker})
+
+    def remove_worker(self, scheduler=None, worker=None, **kwargs):
+        """ Run when a worker leaves the cluster"""
+        self.socket.send("remove_worker", {"worker": worker})
+
+    def transition(self, key, start, finish, *args, **kwargs):
+        """ Run whenever a task changes state
+
+        Parameters
+        ----------
+        key: string
+        start: string
+            Start state of the transition.
+            One of released, waiting, processing, memory, error.
+        finish: string
+            Final state of the transition.
+        *args, **kwargs: More options passed when transitioning
+            This may include worker ID, compute time, etc.
+        """
+        if key not in self.scheduler.tasks:
+            return
+        kwargs["key"] = key
+        startstops = kwargs.get("startstops", [])
+        for startstop in startstops:
+            color = colors[startstop["action"]]
+            if type(color) is not str:
+                color = color(kwargs)
+            data = {
+                "key": key,
+                "name": key_split(key),
+                "color": color,
+                **kwargs,
+                **startstop,
+            }
+            self.socket.send("transition", data)


### PR DESCRIPTION
This PR adds a new `/events` API endpoint which provides a websocket plugin to the scheduler.

When a client opens a websocket connection to this endpoint a scheduler plugin is registered which forwards all plugin events (`restart`, `add_worker`, `remove_worker` and startstops from `transition` events) into the websocket. Clients can also ping the scheduler via the socket to check that it is still alive.

This enables the building of custom dashboards such as the one proposed in #3318.

I'm raising this ahead of the dashboard as I'd like some feedback on the design here, and thoughts on whether it will affect performance .