### PR TITLE
[WIP] Support different Security class implementations

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -15,7 +15,7 @@ from tornado.ioloop import IOLoop
 
 from distributed import Scheduler
 from distributed.preloading import validate_preload_argv
-from distributed.security import Security
+from distributed.security import TLSSecurity
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.utils import deserialize_for_cli
 from distributed.proctitle import (
@@ -164,7 +164,7 @@ def main(
     if port is None and (not host or not re.search(r":\d", host)):
         port = 8786
 
-    sec = Security(
+    sec = TLSSecurity(
         **{
             k: v
             for k, v in [

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -12,7 +12,7 @@ import dask
 from dask.utils import ignoring
 from dask.system import CPU_COUNT
 from distributed import Nanny, Worker
-from distributed.security import Security
+from distributed.security import TLSSecurity
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.comm import get_address_host_port
 from distributed.preloading import validate_preload_argv
@@ -253,7 +253,7 @@ def main(
         )
         dashboard = bokeh
 
-    sec = Security(
+    sec = TLSSecurity(
         **{
             k: v
             for k, v in [

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -64,7 +64,7 @@ from .protocol import to_serialize
 from .protocol.pickle import dumps, loads
 from .publish import Datasets
 from .pubsub import PubSubClientExtension
-from .security import Security
+from .security import TLSSecurity
 from .sizeof import sizeof
 from .threadpoolexecutor import rejoin
 from .worker import dumps_task, get_client, get_worker, secede
@@ -660,11 +660,11 @@ class Client(Node):
                 security = getattr(self.cluster, "security", None)
 
         if security is None:
-            security = Security()
+            security = TLSSecurity()
         elif security is True:
-            security = Security.temporary()
+            security = TLSSecurity.temporary()
             self._startup_kwargs["security"] = security
-        elif not isinstance(security, Security):
+        elif not isinstance(security, TLSSecurity):
             raise TypeError("security must be a Security object")
 
         self.security = security

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -10,7 +10,7 @@ from dask.system import CPU_COUNT
 from .spec import SpecCluster
 from ..nanny import Nanny
 from ..scheduler import Scheduler
-from ..security import Security
+from ..security import TLSSecurity
 from ..worker import Worker, parse_memory_limit
 
 logger = logging.getLogger(__name__)
@@ -128,11 +128,11 @@ class LocalCluster(SpecCluster):
 
         if security is None:
             # Falsey values load the default configuration
-            security = Security()
+            security = TLSSecurity()
         elif security is True:
             # True indicates self-signed temporary credentials should be used
-            security = Security.temporary()
-        elif not isinstance(security, Security):
+            security = TLSSecurity.temporary()
+        elif not isinstance(security, TLSSecurity):
             raise TypeError("security must be a Security object")
 
         if protocol is None:

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -21,7 +21,7 @@ from ..utils import (
     import_term,
 )
 from ..scheduler import Scheduler
-from ..security import Security
+from ..security import TLSSecurity
 
 
 logger = logging.getLogger(__name__)
@@ -232,7 +232,7 @@ class SpecCluster(Cluster):
         self.new_spec = copy.copy(worker)
         self.workers = {}
         self._i = 0
-        self.security = security or Security()
+        self.security = security or TLSSecurity()
         self.scheduler_comm = None
         self._futures = set()
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -23,7 +23,7 @@ from .metrics import time
 from .node import ServerNode
 from .process import AsyncProcess
 from .proctitle import enable_proctitle_on_children
-from .security import Security
+from .security import TLSSecurity
 from .utils import (
     get_ip,
     mp_context,
@@ -92,8 +92,8 @@ class Nanny(ServerNode):
     ):
         self._setup_logging(logger)
         self.loop = loop or IOLoop.current()
-        self.security = security or Security()
-        assert isinstance(self.security, Security)
+        self.security = security or TLSSecurity()
+        assert isinstance(self.security, TLSSecurity)
         self.connection_args = self.security.get_connection_args("worker")
         self.listen_args = self.security.get_listen_args("worker")
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -44,7 +44,7 @@ from .metrics import time
 from .node import ServerNode
 from .preloading import preload_modules
 from .proctitle import setproctitle
-from .security import Security
+from .security import TLSSecurity
 from .utils import (
     All,
     ignoring,
@@ -1080,8 +1080,8 @@ class Scheduler(ServerNode):
         self.preload = preload
         self.preload_argv = preload_argv
 
-        self.security = security or Security()
-        assert isinstance(self.security, Security)
+        self.security = security or TLSSecurity()
+        assert isinstance(self.security, TLSSecurity)
         self.connection_args = self.security.get_connection_args("scheduler")
         self.listen_args = self.security.get_listen_args("scheduler")
 

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -10,11 +10,11 @@ except ImportError:
 import dask
 
 
-__all__ = ("Security",)
+__all__ = ("TLSSecurity",)
 
 
-class Security(object):
-    """Security configuration for a Dask cluster.
+class TLSSecurity(object):
+    """TLSSecurity configuration for a Dask cluster.
 
     Default values are loaded from Dask's configuration files, and can be
     overridden in the constructor.

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -48,7 +48,7 @@ from .deploy import SpecCluster
 from .metrics import time
 from .process import _cleanup_dangling
 from .proctitle import enable_proctitle_on_children
-from .security import Security
+from .security import TLSSecurity
 from .utils import (
     ignoring,
     log_errors,
@@ -1355,7 +1355,7 @@ def tls_security():
     A Security object with proper TLS configuration.
     """
     with new_config(tls_config()):
-        sec = Security()
+        sec = TLSSecurity()
     return sec
 
 
@@ -1365,7 +1365,7 @@ def tls_only_security():
     TCP communications.
     """
     with new_config(tls_only_config()):
-        sec = Security()
+        sec = TLSSecurity()
     assert sec.require_encryption
     return sec
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -40,7 +40,7 @@ from .preloading import preload_modules
 from .proctitle import setproctitle
 from .protocol import pickle, to_serialize, deserialize_bytes, serialize_bytelist
 from .pubsub import PubSubWorkerExtension
-from .security import Security
+from .security import TLSSecurity
 from .sizeof import safe_sizeof as sizeof
 from .threadpoolexecutor import ThreadPoolExecutor, secede as tpe_secede
 from .utils import (
@@ -505,8 +505,8 @@ class Worker(ServerNode):
             self._workdir = self._workspace.new_work_dir(prefix="worker-")
             self.local_directory = self._workdir.dir_path
 
-        self.security = security or Security()
-        assert isinstance(self.security, Security)
+        self.security = security or TLSSecurity()
+        assert isinstance(self.security, TLSSecurity)
         self.connection_args = self.security.get_connection_args("worker")
         self.listen_args = self.security.get_listen_args("worker")
 


### PR DESCRIPTION
This PR does/will do three things:
  - [ ] Renames distributed.security.Security to distributed.security.TLSSecurity
  - [ ] Creates a new abstract base class called distributed.security.Security. This new class defines the calls to get_connection_args and get_listen_args.
  - [ ] Replaces instanceof checking against TLSSecurity, to the new abstract base class.

Other things to consider:
  - Are implementations of the security class inherently tied to a Comm object? If so, should it move to distributed.comms?
  - Investigate a TLSSecurity mode based on mutual tls authentication, scroll to [Using PKI for Services](https://blog.cloudflare.com/how-to-build-your-own-public-key-infrastructure/), with separate CAs for Client, Server and Workers.