### PR TITLE
Replace connection/listen_args where possible

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -261,7 +261,7 @@ def deserialize(header, frames, deserializers=None):
     name = header.get("serializer")
     if deserializers is not None and name not in deserializers:
         raise TypeError(
-            "Data serialized with %s but only able to deserialize "
+            "Data serialized with '%s' but only able to deserialize "
             "data with %s" % (name, str(list(deserializers)))
         )
     dumps, loads, wants_context = families[name]


### PR DESCRIPTION
Previously we used the security object to create connection_args and listen_args
This was some unnecessary redundant state and makes it a bit harder to
change things in the future
(see https://github.com/dask/distributed/issues/3339)

Now we remove excess calls to connect and instead try to centralize
everything to the `ConnectionPool`.  Hopefully we can isolate changes to
that in the future.