### PR TITLE
Await signal cleanup function in dask-worker

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -398,7 +398,7 @@ def main(
         signal_fired = True
         if signum != signal.SIGINT:
             logger.info("Exiting on signal %d", signum)
-        asyncio.ensure_future(close_all())
+        return asyncio.ensure_future(close_all())
 
     async def run():
         await asyncio.gather(*nannies)


### PR DESCRIPTION
Currently the `on_signal` cleanup callback that's used to close worker processes started with the `dask-worker` CLI uses `asyncio.ensure_future` to create and schedule a new `asyncio.Task`. However, the task is not returned by `on_signal`:

https://github.com/dask/distributed/blob/71a8f4551f362a901d1911628c30197f3afccab1/distributed/cli/dask_worker.py#L396-L402

So we can have situations where the cleanup function isn't run before the event loop is closed in the `finally` block here:

https://github.com/dask/distributed/blob/71a8f4551f362a901d1911628c30197f3afccab1/distributed/cli/utils.py#L56-L60

This PR returns the cleanup `Task` so it can be awaited prior to closing the loop