### PR TITLE
Remove locale check that fails on OS X

### DIFF
--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -7,7 +7,6 @@ import platform
 import struct
 import os
 import sys
-import locale
 import importlib
 
 
@@ -56,7 +55,6 @@ def get_system_info():
         ("byteorder", "%s" % sys.byteorder),
         ("LC_ALL", "%s" % os.environ.get("LC_ALL", "None")),
         ("LANG", "%s" % os.environ.get("LANG", "None")),
-        ("LOCALE", "%s.%s" % locale.getlocale()),
     ]
 
     return host


### PR DESCRIPTION
Closes #3359

Getting the system locale on OS X fails with default settings. This is a known Python issue on OS X.

Given that few people will probably be interested in this information it is probably better to remove it rather than cause exceptions for OS X users.