### PR TITLE
Add client preparing graph hook

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -905,7 +905,6 @@ class Client(Node):
         if self.status in ("running", "closing"):
             try:
                 self.scheduler_comm.send(msg)
-                print("Graph sent")
             except (CommClosedError, AttributeError):
                 if self.status == "running":
                     raise

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -905,6 +905,7 @@ class Client(Node):
         if self.status in ("running", "closing"):
             try:
                 self.scheduler_comm.send(msg)
+                print("Graph sent")
             except (CommClosedError, AttributeError):
                 if self.status == "running":
                     raise
@@ -2433,6 +2434,7 @@ class Client(Node):
         actors=None,
     ):
         with self._refcount_lock:
+            self._send_to_scheduler({"op": "preparing-update-graph"})
             if resources:
                 resources = self._expand_resources(
                     resources, all_keys=itertools.chain(dsk, keys)

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -65,13 +65,7 @@ class SchedulerPlugin(object):
         """ Run when a new worker enters the cluster """
 
     def remove_worker(self, scheduler=None, worker=None, **kwargs):
-        """ Run when a worker leaves the cluster """
-
-    def add_client(self, scheduler=None, client=None, **kwargs):
-        """ Run when a new client connects """
-
-    def remove_client(self, scheduler=None, client=None, **kwargs):
-        """ Run when a client disconnects """
+        """ Run when a worker leaves the cluster"""
 
 
 class WorkerPlugin(object):

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -37,6 +37,9 @@ class SchedulerPlugin(object):
     >>> scheduler.add_plugin(plugin)  # doctest: +SKIP
     """
 
+    def preparing_update_graph(self, scheduler, client=None, **kwargs):
+        """ Run when a new graph / tasks will enter the scheduler soon """
+
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         """ Run when a new graph / tasks enter the scheduler """
 
@@ -62,7 +65,13 @@ class SchedulerPlugin(object):
         """ Run when a new worker enters the cluster """
 
     def remove_worker(self, scheduler=None, worker=None, **kwargs):
-        """ Run when a worker leaves the cluster"""
+        """ Run when a worker leaves the cluster """
+
+    def add_client(self, scheduler=None, client=None, **kwargs):
+        """ Run when a new client connects """
+
+    def remove_client(self, scheduler=None, client=None, **kwargs):
+        """ Run when a client disconnects """
 
 
 class WorkerPlugin(object):

--- a/distributed/diagnostics/websocket.py
+++ b/distributed/diagnostics/websocket.py
@@ -20,21 +20,9 @@ class WebsocketPlugin(SchedulerPlugin):
         """ Run when a worker leaves the cluster"""
         self.socket.send("remove_worker", {"worker": worker})
 
-    def add_client(self, scheduler=None, client=None, **kwargs):
-        """ Run when a new client connects """
-        self.socket.send("add_client", {"client": client})
-
-    def remove_client(self, scheduler=None, client=None, **kwargs):
-        """ Run when a client disconnects """
-        self.socket.send("remove_client", {"client": client})
-
     def preparing_update_graph(self, scheduler, client=None, **kwargs):
         """ Run when a new graph / tasks will enter the scheduler soon """
         self.socket.send("preparing_update_graph", {"client": client})
-
-    def update_graph(self, scheduler, client=None, **kwargs):
-        """ Run when a new graph / tasks enter the scheduler """
-        self.socket.send("update_graph", {"client": client})
 
     def transition(self, key, start, finish, *args, **kwargs):
         """ Run whenever a task changes state

--- a/distributed/diagnostics/websocket.py
+++ b/distributed/diagnostics/websocket.py
@@ -20,6 +20,22 @@ class WebsocketPlugin(SchedulerPlugin):
         """ Run when a worker leaves the cluster"""
         self.socket.send("remove_worker", {"worker": worker})
 
+    def add_client(self, scheduler=None, client=None, **kwargs):
+        """ Run when a new client connects """
+        self.socket.send("add_client", {"client": client})
+
+    def remove_client(self, scheduler=None, client=None, **kwargs):
+        """ Run when a client disconnects """
+        self.socket.send("remove_client", {"client": client})
+
+    def preparing_update_graph(self, scheduler, client=None, **kwargs):
+        """ Run when a new graph / tasks will enter the scheduler soon """
+        self.socket.send("preparing_update_graph", {"client": client})
+
+    def update_graph(self, scheduler, client=None, **kwargs):
+        """ Run when a new graph / tasks enter the scheduler """
+        self.socket.send("update_graph", {"client": client})
+
     def transition(self, key, start, finish, *args, **kwargs):
         """ Run whenever a task changes state
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2479,12 +2479,6 @@ class Scheduler(ServerNode):
         self.log_event(["all", client], {"action": "add-client", "client": client})
         self.clients[client] = ClientState(client, versions=versions)
 
-        for plugin in self.plugins[:]:
-            try:
-                plugin.add_client(scheduler=self, client=client)
-            except Exception as e:
-                logger.exception(e)
-
         try:
             bcomm = BatchedSend(interval="2ms", loop=self.loop)
             bcomm.start(comm)
@@ -2531,12 +2525,6 @@ class Scheduler(ServerNode):
                 keys=[ts.key for ts in cs.wants_what], client=cs.client_key
             )
             del self.clients[client]
-
-            for plugin in self.plugins[:]:
-                try:
-                    plugin.remove_client(scheduler=self, client=client)
-                except Exception as e:
-                    logger.exception(e)
 
         def remove_client_from_events():
             # If the client isn't registered anymore after the delay, remove from events


### PR DESCRIPTION
When a client serializes a large task graph and submits it to the scheduler things can appear to hang for before the dashboard kicks into action.

I'd like to add some visual feedback in various places that things are happening client side within the dashboard. 

To start I've added a new `"preparing-update-graph"` RPC call (not set on the name) which a client sends when it is about to start preparing to make an `"update-graph"` call. On the scheduler side this just runs a plugin hook for now but we could expand on this later to show some feedback with the dashboard plugins.

I've also added a couple more plugin hooks for when clients connect and disconnect called `add_client` and `remove_client`, although this could also be `client_connect` and `client_disconnect` if that is preferable.

These are all just hooks for now which could be built off later.