### PR TITLE
Add --worker-class option to dask-worker CLI

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -194,8 +194,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "--worker-class",
     type=str,
     default=None,
-    help="Worker class used to instantiate workers from. Defaults to "
-    "distributed.worker.Worker. Only supported when using --nanny.",
+    help="Worker class used to instantiate workers from. Defaults "
+    "to distributed.worker.Worker.",
 )
 @click.option(
     "--lifetime-restart/--no-lifetime-restart",

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -348,12 +348,11 @@ def main(
 
     worker_class = kwargs.pop("worker_class")
     if worker_class is not None:
+        worker_class = import_term(worker_class)
         if nanny:
-            kwargs["worker_class"] = import_term(worker_class)
-        else:
-            raise ValueError(
-                "Cannot use the --worker-class option without using the --nanny option"
-            )
+            kwargs["worker_class"] = worker_class
+    else:
+        worker_class = Worker
 
     if nanny:
         kwargs.update({"worker_port": worker_port, "listen_address": listen_address})
@@ -361,7 +360,7 @@ def main(
     else:
         if nanny_port:
             kwargs["service_ports"] = {"nanny": nanny_port}
-        t = Worker
+        t = worker_class
 
     if (
         not scheduler

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -240,6 +240,7 @@ def main(
     tls_cert,
     tls_key,
     dashboard_address,
+    worker_class,
     **kwargs
 ):
     g0, g1, g2 = gc.get_threshold()  # https://github.com/dask/distributed/issues/1653
@@ -346,7 +347,6 @@ def main(
 
     loop = IOLoop.current()
 
-    worker_class = kwargs.pop("worker_class")
     if worker_class is not None:
         worker_class = import_term(worker_class)
         if nanny:

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -11,7 +11,7 @@ import click
 import dask
 from dask.utils import ignoring
 from dask.system import CPU_COUNT
-from distributed import Nanny, Worker
+from distributed import Nanny
 from distributed.security import Security
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.comm import get_address_host_port
@@ -193,9 +193,9 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--worker-class",
     type=str,
-    default=None,
-    help="Worker class used to instantiate workers from. Defaults "
-    "to distributed.worker.Worker.",
+    default="distributed.worker.Worker",
+    show_default=True,
+    help="Worker class used to instantiate workers from.",
 )
 @click.option(
     "--lifetime-restart/--no-lifetime-restart",
@@ -347,12 +347,9 @@ def main(
 
     loop = IOLoop.current()
 
-    if worker_class is not None:
-        worker_class = import_term(worker_class)
-        if nanny:
-            kwargs["worker_class"] = worker_class
-    else:
-        worker_class = Worker
+    worker_class = import_term(worker_class)
+    if nanny:
+        kwargs["worker_class"] = worker_class
 
     if nanny:
         kwargs.update({"worker_port": worker_port, "listen_address": listen_address})

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -193,7 +193,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--worker-class",
     type=str,
-    default="distributed.worker.Worker",
+    default="dask.distributed.Worker",
     show_default=True,
     help="Worker class used to instantiate workers from.",
 )

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -342,18 +342,16 @@ async def test_integer_names(cleanup):
             assert ws.name == 123
 
 
-WORKER_CLASS_TEXT = """
+@pytest.mark.asyncio
+@pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
+async def test_worker_class(cleanup, tmp_path, nanny):
+    # Create module with custom worker class
+    WORKER_CLASS_TEXT = """
 from distributed.worker import Worker
 
 class MyWorker(Worker):
     pass
 """
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
-async def test_worker_class(cleanup, tmp_path, nanny):
-    # Create module with custom worker class
     tmpdir = str(tmp_path)
     tmpfile = str(tmp_path / "myworker.py")
     with open(tmpfile, "w") as f:


### PR DESCRIPTION
This allows users to specify a custom worker class when using `dask-worker`. For example:

```
dask-worker <scheduler-address> --worker-class mymodule.SpecialWorker
```