### PR TITLE
Close connection comm on retry

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -1,14 +1,12 @@
 from abc import ABC, abstractmethod, abstractproperty
 import asyncio
-from datetime import timedelta
 import logging
 import weakref
 
 import dask
-from tornado import gen
 
 from ..metrics import time
-from ..utils import parse_timedelta, ignoring
+from ..utils import parse_timedelta
 from . import registry
 from .addressing import parse_address
 
@@ -211,13 +209,13 @@ async def connect(addr, timeout=None, deserialize=True, connection_args=None):
                 future = connector.connect(
                     loc, deserialize=deserialize, **(connection_args or {})
                 )
-                with ignoring(gen.TimeoutError):
-                    comm = await gen.with_timeout(
-                        timedelta(seconds=min(deadline - time(), 1)),
-                        future,
-                        quiet_exceptions=EnvironmentError,
+                try:
+                    comm = await asyncio.wait_for(
+                        future, timeout=min(deadline - time(), 1)
                     )
                     break
+                except asyncio.TimeoutError:
+                    pass
             if not comm:
                 _raise(error)
         except FatalCommClosedError:

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -6,7 +6,7 @@ import weakref
 import dask
 
 from ..metrics import time
-from ..utils import parse_timedelta
+from ..utils import parse_timedelta, ignoring
 from . import registry
 from .addressing import parse_address
 
@@ -209,13 +209,11 @@ async def connect(addr, timeout=None, deserialize=True, connection_args=None):
                 future = connector.connect(
                     loc, deserialize=deserialize, **(connection_args or {})
                 )
-                try:
+                with ignoring(asyncio.TimeoutError):
                     comm = await asyncio.wait_for(
                         future, timeout=min(deadline - time(), 1)
                     )
                     break
-                except asyncio.TimeoutError:
-                    pass
             if not comm:
                 _raise(error)
         except FatalCommClosedError:


### PR DESCRIPTION
Currently when making new comm connections, we do so with [`gen.with_timeout`](https://www.tornadoweb.org/en/stable/gen.html#tornado.gen.with_timeout) here

https://github.com/dask/distributed/blob/baf5903c6994a286e02c36f9df48c87776b062d7/distributed/comm/core.py#L215-L219

and retry the connection if a timeout is reached. However, `gen.with_timeout` does not cancel a task when it's timeout expires. Not cancelling these tasks can lead to a "Closing dangling stream" warning being raised here

https://github.com/dask/distributed/blob/baf5903c6994a286e02c36f9df48c87776b062d7/distributed/comm/tcp.py#L169

when `TCP` class instances from previously timed out connection task are garbage collected. 

Switching to [`asyncio.wait_for`](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for) allows us to keep a similar timeout-then-retry connection behavior, but also cancels a connection task if a timeout occurs. 

This is just one proposed improvement to the situation. Alternatively we could make the currently hardcoded 1s in the timeout configurable. 