### PR TITLE
Fix scheduler state in case of worker name collision

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2118,10 +2118,12 @@ class Scheduler(ServerNode):
         with log_errors():
             if self.status == "closed":
                 return
+
+            address = self.coerce_address(address)
+
             if address not in self.workers:
                 return "already-removed"
 
-            address = self.coerce_address(address)
             host = get_address_host(address)
 
             ws = self.workers[address]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1619,6 +1619,16 @@ class Scheduler(ServerNode):
             if ws is not None:
                 raise ValueError("Worker already exists %s" % ws)
 
+            if name in self.aliases:
+                msg = {
+                    "status": "error",
+                    "message": "name taken, %s" % name,
+                    "time": time(),
+                }
+                if comm:
+                    await comm.write(msg)
+                return
+
             self.workers[address] = ws = WorkerState(
                 address=address,
                 pid=pid,
@@ -1631,16 +1641,6 @@ class Scheduler(ServerNode):
                 nanny=nanny,
                 extra=extra,
             )
-
-            if name in self.aliases:
-                msg = {
-                    "status": "error",
-                    "message": "name taken, %s" % name,
-                    "time": time(),
-                }
-                if comm:
-                    await comm.write(msg)
-                return
 
             if "addresses" not in self.host_info[host]:
                 self.host_info[host].update({"addresses": set(), "nthreads": 0})

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -217,6 +217,15 @@ def test_remove_worker_from_scheduler(s, a, b):
     s.validate_state()
 
 
+@gen_cluster()
+def test_remove_worker_by_name_from_scheduler(s, a, b):
+    assert a.address in s.stream_comms
+    assert s.remove_worker(address=a.name) == "OK"
+    assert a.address not in s.nthreads
+    assert s.remove_worker(address=a.address) == "already-removed"
+    s.validate_state()
+
+
 @gen_cluster(config={"distributed.scheduler.events-cleanup-delay": "10 ms"})
 def test_clear_events_worker_removal(s, a, b):
     assert a.address in s.events

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -575,7 +575,7 @@ def test_coerce_address():
             "tcp://127.0.0.1:8000",
             "tcp://[::1]:8000",
         )
-        assert s.coerce_address(u"localhost:8000") in (
+        assert s.coerce_address("localhost:8000") in (
             "tcp://127.0.0.1:8000",
             "tcp://[::1]:8000",
         )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1096,7 +1096,7 @@ class Worker(ServerNode):
             for pc in self.periodic_callbacks.values():
                 pc.stop()
             with ignoring(EnvironmentError, gen.TimeoutError):
-                if report:
+                if report and self.contact_address is not None:
                     await gen.with_timeout(
                         timedelta(seconds=timeout),
                         self.scheduler.unregister(


### PR DESCRIPTION
This fixes two bugs that leave the state of the Scheduler in an inconsistent state in case of errors / exceptions.