### PR TITLE
fix-task-groups

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1973,7 +1973,10 @@ class Scheduler(ServerNode):
         ts = TaskState(key, spec)
         ts._state = state
         try:
-            tg = self.task_groups[ts.group_key]
+            if not ts.group_key:
+                tg = self.task_groups[ts.group_key] = TaskGroup(ts.group_key)
+            else:
+                tg = self.task_groups[ts.group_key]
         except KeyError:
             tg = self.task_groups[ts.group_key] = TaskGroup(ts.group_key)
         tg.add(ts)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1784,6 +1784,20 @@ async def test_task_prefix(c, s, a, b):
     assert s.task_prefixes["sum-aggregate"].states["memory"] == 1
 
 
+@gen_cluster(client=True)
+async def test_task_unique_groups(c, s, a, b):
+    """ This test ensure that task groups remain unique
+    when using submit
+    """
+    h = await c.submit(sum, [3, 4])
+    g = await c.submit(len, [1, 2])
+
+    assert s.task_prefixes["len"].states["memory"] == 1
+    assert s.task_prefixes["sum"].states["forgotten"] == 1
+    print(s.task_prefixes)
+    print("\n\n")
+
+
 class BrokenComm(Comm):
     peer_address = None
     local_address = None

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1794,8 +1794,6 @@ async def test_task_unique_groups(c, s, a, b):
 
     assert s.task_prefixes["len"].states["memory"] == 1
     assert s.task_prefixes["sum"].states["forgotten"] == 1
-    print(s.task_prefixes)
-    print("\n\n")
 
 
 class BrokenComm(Comm):


### PR DESCRIPTION
fixes https://github.com/dask/distributed/issues/3368

Previously, tasks were grouped around a key like `("x-123", 0)`.  However, for tasks which are submitted directly to the scheduler:

> h = c.submit(sum, [3, 4])   

the group key (`group_key`) is an empty string.  We can see this more clearly by looking at the following:

```python
from distributed.utils import key_split_group
# `len-442307e1c8fb4925fb9b0fbc7e7eb56d` is a key from a submitted task
key_split_group('len-442307e1c8fb4925fb9b0fbc7e7eb56d')
''
```

This PR rectifies this issue by constructing a new group for each empty group string.  Alternatively, we could consider a non-empty string output for `key_split_group` 
