### PR TITLE
Add client join and leave hooks

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -905,7 +905,6 @@ class Client(Node):
         if self.status in ("running", "closing"):
             try:
                 self.scheduler_comm.send(msg)
-                print("Graph sent")
             except (CommClosedError, AttributeError):
                 if self.status == "running":
                     raise

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -905,6 +905,7 @@ class Client(Node):
         if self.status in ("running", "closing"):
             try:
                 self.scheduler_comm.send(msg)
+                print("Graph sent")
             except (CommClosedError, AttributeError):
                 if self.status == "running":
                     raise
@@ -2433,6 +2434,7 @@ class Client(Node):
         actors=None,
     ):
         with self._refcount_lock:
+            self._send_to_scheduler({"op": "preparing-update-graph"})
             if resources:
                 resources = self._expand_resources(
                     resources, all_keys=itertools.chain(dsk, keys)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2433,7 +2433,6 @@ class Client(Node):
         actors=None,
     ):
         with self._refcount_lock:
-            self._send_to_scheduler({"op": "preparing-update-graph"})
             if resources:
                 resources = self._expand_resources(
                     resources, all_keys=itertools.chain(dsk, keys)

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -37,9 +37,6 @@ class SchedulerPlugin(object):
     >>> scheduler.add_plugin(plugin)  # doctest: +SKIP
     """
 
-    def preparing_update_graph(self, scheduler, client=None, **kwargs):
-        """ Run when a new graph / tasks will enter the scheduler soon """
-
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         """ Run when a new graph / tasks enter the scheduler """
 

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -37,6 +37,9 @@ class SchedulerPlugin(object):
     >>> scheduler.add_plugin(plugin)  # doctest: +SKIP
     """
 
+    def preparing_update_graph(self, scheduler, client=None, **kwargs):
+        """ Run when a new graph / tasks will enter the scheduler soon """
+
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         """ Run when a new graph / tasks enter the scheduler """
 
@@ -62,7 +65,13 @@ class SchedulerPlugin(object):
         """ Run when a new worker enters the cluster """
 
     def remove_worker(self, scheduler=None, worker=None, **kwargs):
-        """ Run when a worker leaves the cluster"""
+        """ Run when a worker leaves the cluster """
+
+    def add_client(self, scheduler=None, client=None, **kwargs):
+        """ Run when a new client connects """
+
+    def remove_client(self, scheduler=None, client=None, **kwargs):
+        """ Run when a client disconnects """
 
 
 class WorkerPlugin(object):

--- a/distributed/diagnostics/websocket.py
+++ b/distributed/diagnostics/websocket.py
@@ -28,10 +28,6 @@ class WebsocketPlugin(SchedulerPlugin):
         """ Run when a client disconnects """
         self.socket.send("remove_client", {"client": client})
 
-    def preparing_update_graph(self, scheduler, client=None, **kwargs):
-        """ Run when a new graph / tasks will enter the scheduler soon """
-        self.socket.send("preparing_update_graph", {"client": client})
-
     def update_graph(self, scheduler, client=None, **kwargs):
         """ Run when a new graph / tasks enter the scheduler """
         self.socket.send("update_graph", {"client": client})

--- a/distributed/diagnostics/websocket.py
+++ b/distributed/diagnostics/websocket.py
@@ -20,6 +20,22 @@ class WebsocketPlugin(SchedulerPlugin):
         """ Run when a worker leaves the cluster"""
         self.socket.send("remove_worker", {"worker": worker})
 
+    def add_client(self, scheduler=None, client=None, **kwargs):
+        """ Run when a new client connects """
+        self.socket.send("add_client", {"client": client})
+
+    def remove_client(self, scheduler=None, client=None, **kwargs):
+        """ Run when a client disconnects """
+        self.socket.send("remove_client", {"client": client})
+
+    def preparing_update_graph(self, scheduler, client=None, **kwargs):
+        """ Run when a new graph / tasks will enter the scheduler soon """
+        self.socket.send("preparing_update_graph", {"client": client})
+
+    def update_graph(self, scheduler, client=None, **kwargs):
+        """ Run when a new graph / tasks enter the scheduler """
+        self.socket.send("update_graph", {"client": client})
+
     def transition(self, key, start, finish, *args, **kwargs):
         """ Run whenever a task changes state
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1232,7 +1232,6 @@ class Scheduler(ServerNode):
         }
 
         client_handlers = {
-            "preparing-update-graph": self.preparing_update_graph,
             "update-graph": self.update_graph,
             "client-desires-keys": self.client_desires_keys,
             "update-data": self.update_data,
@@ -1726,19 +1725,6 @@ class Scheduler(ServerNode):
             if comm:
                 await comm.write(msg)
             await self.handle_worker(comm=comm, worker=address)
-
-    def preparing_update_graph(self, client=None):
-        """
-        New computations will be sent through via the update_graph method shortly.
-
-        This happens whenever the Client start processing a call to submit, map, get, or compute.
-        As the serialisation of the graph can take a while the client is being curteous and giving us a heads up.
-        """
-        for plugin in self.plugins[:]:
-            try:
-                plugin.preparing_update_graph(self, client=client)
-            except Exception as e:
-                logger.exception(e)
 
     def update_graph(
         self,


### PR DESCRIPTION
This is a simpler version of #3363 with just the client join and leave hooks. The discussion around `_send_to_scheduler` is a little trickier than I'd first anticipated so I think it makes sense to break this up into two PRs.

In this PR I've added two scheduler hooks for when clients come and go. I've also updated the websocket plugin to pass along these hooks as well as the update graph hook.