### PR TITLE
Fix cluster map websocket URL when running with labextension

### DIFF
--- a/distributed/dashboard/static/js/individual-cluster-map.js
+++ b/distributed/dashboard/static/js/individual-cluster-map.js
@@ -340,12 +340,12 @@ class Dashboard {
 }
 
 function get_websocket_url(endpoint) {
-  var l = window.location;
+  var l = document.location;
   return (
     (l.protocol === "https:" ? "wss://" : "ws://") +
     l.hostname +
     (l.port != 80 && l.port != 443 ? ":" + l.port : "") +
-    endpoint
+    l.pathname.replace("/statics/individual-cluster-map.html", endpoint)
   );
 }
 


### PR DESCRIPTION
Get JavaScript document location instead of window and handle proxied urls.

Closes #3380

![Cluster Map running in Jupyter Lab](https://user-images.githubusercontent.com/1610850/72603660-5d412880-3911-11ea-8039-49cdc4201910.gif)
