### PR TITLE
Fix asyncio.get_running_loop import for Python < 3.7

### DIFF
--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -7,3 +7,8 @@ logging_names.update(logging._nameToLevel)
 
 PYPY = platform.python_implementation().lower() == "pypy"
 WINDOWS = sys.platform.startswith("win")
+
+if sys.version_info[:2] >= (3, 7):
+    from asyncio import get_running_loop
+else:
+    from asyncio import _get_running_loop as get_running_loop  # noqa: F401

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -56,7 +56,7 @@ try:
 except ImportError:
     PollIOLoop = None  # dropped in tornado 6.0
 
-from .compatibility import PYPY, WINDOWS
+from .compatibility import PYPY, WINDOWS, get_running_loop
 from .metrics import time
 
 
@@ -1204,7 +1204,7 @@ if tornado.version_info[0] >= 5:
 
         if is_kernel():
             try:
-                asyncio.get_running_loop()
+                get_running_loop()
             except RuntimeError:
                 is_kernel_and_no_running_loop = True
 


### PR DESCRIPTION
This PR adds a compatibility check to make sure we don't import `asyncio.get_running_loop` on Python < 3.7

I confirmed locally that `import distributed` works in Jupyter with Python 3.6

Closes https://github.com/dask/distributed/issues/3381