### PR TITLE
Use latest release of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: cad4138050b86d1c8570b926883e32f7465c2880
+    rev: stable
     hooks:
     - id: black
       language_version: python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 script:
   - if [[ $TESTS == true ]]; then source continuous_integration/travis/run_tests.sh ; fi
   - if [[ $LINT == true ]]; then pip install flake8 ; flake8 distributed ; fi
-  - if [[ $LINT == true ]]; then pip install git+https://github.com/psf/black@cad4138050b86d1c8570b926883e32f7465c2880; black distributed --check; fi
+  - if [[ $LINT == true ]]; then pip install black ; black distributed --check; fi
 
 after_success:
   - if [[ $COVERAGE == true ]]; then coverage report; pip install -q coveralls ; coveralls ; fi


### PR DESCRIPTION
We pinned `black` to a specific commit to avoid formatting issues with Python 3.5. We've since dropped support for 3.5, so we should be able to use the latest release of `black` now.

This will help avoid discrepancies where users `pip install black` and manually run `black dask` instead of using the pre-commit hook

Corresponding PR in `dask/dask`: https://github.com/dask/dask/pull/5798