### PR TITLE
Make version mismatch checking more robust

### DIFF
--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -92,7 +92,7 @@ def test_scheduler_mismatched_irrelevant_package(kwargs_matching):
 
 
 def test_scheduler_additional_irrelevant_package(kwargs_matching):
-    """An irrelevant package on the scheduler can have any version."""
+    """An irrelevant package on the scheduler does not need to be present elsewhere."""
     kwargs_matching["scheduler"]["packages"]["pyspark"] = "0.0.0"
 
     assert error_message(**kwargs_matching) == ""

--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -12,10 +12,10 @@ this_version = get_versions()
 mismatched_version = get_versions()
 mismatched_version["packages"]["distributed"] = "0.0.0.dev0"
 
-# for really old versions, the `package` key may be missing
+# for really old versions, the `package` key is missing - version is UNKNOWN
 key_err_version = {}
 
-# if one no key is available for one package, we assume it's MISSING
+# if no key is available for one package, we assume it's MISSING
 missing_version = get_versions()
 del missing_version["packages"]["distributed"]
 
@@ -82,4 +82,3 @@ def test_version_mismatch(node, effect, kwargs_not_matching, pattern):
     assert "Mismatched versions found" in msg
     assert "distributed" in msg
     assert re.search(node + r"\s+\|\s+" + pattern, msg)
-    print(msg)

--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -12,6 +12,9 @@ this_version = get_versions()
 mismatched_version = get_versions()
 mismatched_version["packages"]["distributed"] = "0.0.0.dev0"
 
+# for really old versions, the `package` key may be missing
+key_err_version = {}
+
 # if one no key is available for one package, we assume it's MISSING
 missing_version = get_versions()
 del missing_version["packages"]["distributed"]
@@ -40,7 +43,7 @@ def component(request):
     return request.param
 
 
-@pytest.fixture(params=['MISMATCHED', 'MISSING', 'UNKNOWN'])
+@pytest.fixture(params=['MISMATCHED', 'MISSING', 'KEY_ERROR', 'NONE'])
 def effect(request):
     """Compinont affected by version mismatch"""
     return request.param
@@ -51,7 +54,8 @@ def kwargs_not_matching(kwargs_matching, component, effect):
     affected_version = {
         "MISMATCHED": mismatched_version,
         "MISSING": missing_version,
-        "UNKNOWN": unknown_version,
+        "KEY_ERROR": key_err_version,
+        "NONE": unknown_version,
     }[effect]
     kwargs = kwargs_matching
     if component in kwargs["workers"]:
@@ -67,7 +71,8 @@ def pattern(effect):
     return {
         "MISMATCHED": r"0\.0\.0\.dev0",
         "MISSING": "MISSING",
-        "UNKNOWN": "UNKNOWN",
+        "KEY_ERROR": "UNKNOWN",
+        "NONE": "UNKNOWN",
     }[effect]
 
 

--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -1,0 +1,79 @@
+import re
+
+import pytest
+
+from distributed.versions import get_versions, error_message
+
+
+# if every component (client, scheduler, workers) have this version, we're good
+this_version = get_versions()
+
+# if one of the components reports this version, there's a mismatch
+mismatched_version = get_versions()
+mismatched_version["packages"]["distributed"] = "0.0.0.dev0"
+
+# if one no key is available for one package, we assume it's MISSING
+missing_version = get_versions()
+del missing_version["packages"]["distributed"]
+
+# if a component doesn't report any version info, we treat them as UNKNOWN
+# the happens if the node is pre-32cb96e, i.e. <=2.9.1
+unknown_version = None
+
+
+@pytest.fixture
+def kwargs_matching():
+    return dict(
+        scheduler=this_version,
+        workers={f"worker-{i}": this_version for i in range(3)},
+        client=this_version,
+    )
+
+
+def test_versions_match(kwargs_matching):
+    assert error_message(**kwargs_matching) == ""
+
+
+@pytest.fixture(params=['client', 'scheduler', 'worker-1'])
+def component(request):
+    """Component affected by version mismatch"""
+    return request.param
+
+
+@pytest.fixture(params=['MISMATCHED', 'MISSING', 'UNKNOWN'])
+def effect(request):
+    """Compinont affected by version mismatch"""
+    return request.param
+
+
+@pytest.fixture
+def kwargs_not_matching(kwargs_matching, component, effect):
+    affected_version = {
+        "MISMATCHED": mismatched_version,
+        "MISSING": missing_version,
+        "UNKNOWN": unknown_version,
+    }[effect]
+    kwargs = kwargs_matching
+    if component in kwargs["workers"]:
+        kwargs["workers"][component] = affected_version
+    else:
+        kwargs[component] = affected_version
+    return kwargs
+
+
+@pytest.fixture
+def pattern(effect):
+    """Pattern to match in the right-hand column."""
+    return {
+        "MISMATCHED": r"0\.0\.0\.dev0",
+        "MISSING": "MISSING",
+        "UNKNOWN": "UNKNOWN",
+    }[effect]
+
+
+def test_version_mismatch(component, effect, kwargs_not_matching, pattern):
+    msg = error_message(**kwargs_not_matching)
+
+    assert "Mismatched versions found" in msg
+    assert "distributed" in msg
+    assert re.search(component + r"\s+\|\s+" + pattern, msg)

--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -37,13 +37,13 @@ def test_versions_match(kwargs_matching):
     assert error_message(**kwargs_matching) == ""
 
 
-@pytest.fixture(params=['client', 'scheduler', 'worker-1'])
+@pytest.fixture(params=["client", "scheduler", "worker-1"])
 def component(request):
     """Component affected by version mismatch"""
     return request.param
 
 
-@pytest.fixture(params=['MISMATCHED', 'MISSING', 'KEY_ERROR', 'NONE'])
+@pytest.fixture(params=["MISMATCHED", "MISSING", "KEY_ERROR", "NONE"])
 def effect(request):
     """Compinont affected by version mismatch"""
     return request.param

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -26,6 +26,12 @@ optional_packages = [
 ]
 
 
+# only these scheduler packages will be checked for version mismatch
+scheduler_relevant_packages = set(pkg for pkg, _ in required_packages) | set(
+    ["lz4", "blosc"]
+)
+
+
 def get_versions(packages=None):
     """
     Return basic information on our software installation, and our installed versions of packages.
@@ -119,7 +125,11 @@ def error_message(scheduler, workers, client, client_name="client"):
 
     errs = []
     for pkg in sorted(packages):
-        versions = set(node_packages[node][pkg] for node in nodes)
+        versions = set(
+            node_packages[node][pkg]
+            for node in nodes
+            if node != "scheduler" or pkg in scheduler_relevant_packages
+        )
         if len(versions) <= 1:
             continue
         rows = [

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -28,7 +28,7 @@ optional_packages = [
 
 def get_versions(packages=None):
     """
-    Return basic information on our software installation, and out installed versions of packages.
+    Return basic information on our software installation, and our installed versions of packages.
     """
     if packages is None:
         packages = []

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -100,10 +100,7 @@ def get_package_info(pkgs):
 def error_message(scheduler, workers, client, client_name="client"):
     from .utils import asciitable
 
-    MISSING, UNKNOWN = "MISSING", "UNKNOWN"
-    scheduler_name = "scheduler"
-
-    nodes = {**{client_name: client}, **{scheduler_name: scheduler}, **workers}
+    nodes = {**{client_name: client}, **{"scheduler": scheduler}, **workers}
 
     # Hold all versions, e.g. versions["scheduler"]["distributed"] = 2.9.3
     node_packages = defaultdict(dict)
@@ -113,9 +110,9 @@ def error_message(scheduler, workers, client, client_name="client"):
 
     for node, info in nodes.items():
         if info is None or not (isinstance(info, dict)) or "packages" not in info:
-            node_packages[node] = defaultdict(lambda: UNKNOWN)
+            node_packages[node] = defaultdict(lambda: "UNKNOWN")
         else:
-            node_packages[node] = defaultdict(lambda: MISSING)
+            node_packages[node] = defaultdict(lambda: "MISSING")
             for pkg, version in info["packages"].items():
                 node_packages[node][pkg] = version
                 packages.add(pkg)

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -126,8 +126,7 @@ def error_message(scheduler, workers, client, client_name="client"):
         if len(versions) <= 1:
             continue
         rows = [
-            (node_name, node_packages[node_name][pkg])
-            for node_name in nodes.keys()
+            (node_name, node_packages[node_name][pkg]) for node_name in nodes.keys()
         ]
         errs.append("%s\n%s" % (pkg, asciitable(["", "version"], rows)))
     if errs:

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -103,31 +103,31 @@ def error_message(scheduler, workers, client, client_name="client"):
     MISSING, UNKNOWN = "MISSING", "UNKNOWN"
     scheduler_name = "scheduler"
 
-    components = {**{client_name: client}, **{scheduler_name: scheduler}, **workers}
+    nodes = {**{client_name: client}, **{scheduler_name: scheduler}, **workers}
 
     # Hold all versions, e.g. versions["scheduler"]["distributed"] = 2.9.3
-    component_packages = defaultdict(dict)
+    node_packages = defaultdict(dict)
 
     # Collect all package versions
     packages = set()
 
-    for component, info in components.items():
+    for node, info in nodes.items():
         if info is None or not (isinstance(info, dict)) or "packages" not in info:
-            component_packages[component] = defaultdict(lambda: UNKNOWN)
+            node_packages[node] = defaultdict(lambda: UNKNOWN)
         else:
-            component_packages[component] = defaultdict(lambda: MISSING)
+            node_packages[node] = defaultdict(lambda: MISSING)
             for pkg, version in info["packages"].items():
-                component_packages[component][pkg] = version
+                node_packages[node][pkg] = version
                 packages.add(pkg)
 
     errs = []
     for pkg in sorted(packages):
-        versions = set(component_packages[component][pkg] for component in components)
+        versions = set(node_packages[node][pkg] for node in nodes)
         if len(versions) <= 1:
             continue
         rows = [
-            (component_name, component_packages[component_name][pkg])
-            for component_name in components.keys()
+            (node_name, node_packages[node_name][pkg])
+            for node_name in nodes.keys()
         ]
         errs.append("%s\n%s" % (pkg, asciitable(["", "version"], rows)))
     if errs:


### PR DESCRIPTION
This PR address #3379 

The entire change is confined to `distributed.versions.error_message()`.

The PR should allow handling following with informative messages:
1. one (or more) nodes (scheduler/worker/client) has a mismatched version. E.g.:
`client["packages"]["distributed"] == 2.9.2`, but `client["packages"]["distributed"] == 2.9.3`.

2. one node does not appear to have a package, though same package is available on one of the other nodes - we report it as `MISSING`

3. one of the nodes does not conform to the latest version info format:
  - it could be returning `None`, as in #3379 - i.e. a worker `@distributed<=2.9.1`
  - it could be missing the ["packages"] key (older versions)
  In these cases, we record the package version as `UNKNOWN`

## Message examples
(only excerpts shown)
```
distributed
+-----------+-------------------------+
|           | version                 |
+-----------+-------------------------+
| client    | 2.9.3+4.g366851e2.dirty |
| scheduler | 2.9.3+4.g366851e2.dirty |
| worker-0  | 2.9.3+4.g366851e2.dirty |
| worker-1  | 0.0.0.dev0              |
| worker-2  | 2.9.3+4.g366851e2.dirty |
+-----------+-------------------------+
```
```
tornado
+-----------+---------+
|           | version |
+-----------+---------+
| client    | 6.0.3   |
| scheduler | UNKNOWN |
| worker-0  | 6.0.3   |
| worker-1  | 6.0.3   |
| worker-2  | 6.0.3   |
+-----------+---------+
```
```
lz4
+-----------+---------+
|           | version |
+-----------+---------+
| client    | None    |
| scheduler | UNKNOWN |
| worker-0  | None    |
| worker-1  | None    |
| worker-2  | None    |
+-----------+---------+
```
```
distributed
+-----------+-------------------------+
|           | version                 |
+-----------+-------------------------+
| client    | MISSING                 |
| scheduler | 2.9.3+4.g366851e2.dirty |
| worker-0  | 2.9.3+4.g366851e2.dirty |
| worker-1  | 2.9.3+4.g366851e2.dirty |
| worker-2  | 2.9.3+4.g366851e2.dirty |
+-----------+-------------------------+
```