### PR TITLE
Replace gen.TimeoutError with utils.TimeoutError

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -24,12 +24,10 @@ from .pubsub import Pub, Sub
 from .queues import Queue
 from .scheduler import Scheduler
 from .threadpoolexecutor import rejoin
-from .utils import sync
+from .utils import sync, TimeoutError
 from .variable import Variable
 from .worker import Worker, get_worker, get_client, secede, Reschedule
 from .worker_client import local_client, worker_client
-
-from tornado.gen import TimeoutError
 
 from ._version import get_versions
 

--- a/distributed/cfexecutor.py
+++ b/distributed/cfexecutor.py
@@ -6,7 +6,7 @@ from toolz import merge
 from tornado import gen
 
 from .metrics import time
-from .utils import sync
+from .utils import sync, TimeoutError
 
 
 @gen.coroutine
@@ -135,7 +135,7 @@ class ClientExecutor(cf.Executor):
                     if timeout is not None:
                         try:
                             yield future.result(end_time - time())
-                        except gen.TimeoutError:
+                        except TimeoutError:
                             raise cf.TimeoutError
                     else:
                         yield future.result()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -37,7 +37,6 @@ try:
 except ImportError:
     single_key = first
 from tornado import gen
-from tornado.gen import TimeoutError
 from tornado.locks import Event, Condition, Semaphore
 from tornado.ioloop import IOLoop
 from tornado.queues import Queue
@@ -85,6 +84,7 @@ from .utils import (
     Any,
     has_keyword,
     format_dashboard_link,
+    TimeoutError,
 )
 from . import versions as version_module
 
@@ -1265,7 +1265,7 @@ class Client(Node):
 
             # Give the scheduler 'stream-closed' message 100ms to come through
             # This makes the shutdown slightly smoother and quieter
-            with ignoring(AttributeError, CancelledError, asyncio.TimeoutError):
+            with ignoring(AttributeError, CancelledError, TimeoutError):
                 await asyncio.wait_for(
                     asyncio.shield(self._handle_scheduler_coroutine), 0.1
                 )
@@ -1957,7 +1957,7 @@ class Client(Node):
                     if nthreads is not None:
                         await asyncio.sleep(0.1)
                     if time() > start + timeout:
-                        raise gen.TimeoutError("No valid workers found")
+                        raise TimeoutError("No valid workers found")
                     nthreads = await self.scheduler.ncores(workers=workers)
                 if not nthreads:
                     raise ValueError("No valid workers")

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -6,7 +6,7 @@ import weakref
 import dask
 
 from ..metrics import time
-from ..utils import parse_timedelta, ignoring
+from ..utils import parse_timedelta, ignoring, TimeoutError
 from . import registry
 from .addressing import parse_address
 
@@ -209,7 +209,7 @@ async def connect(addr, timeout=None, deserialize=True, connection_args=None):
                 future = connector.connect(
                     loc, deserialize=deserialize, **(connection_args or {})
                 )
-                with ignoring(asyncio.TimeoutError):
+                with ignoring(TimeoutError):
                     comm = await asyncio.wait_for(
                         future, timeout=min(deadline - time(), 1)
                     )

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -7,6 +7,7 @@ import weakref
 
 import dask
 from tornado.locks import Event
+from tornado import gen
 
 from .adaptive import Adaptive
 from .cluster import Cluster
@@ -602,6 +603,6 @@ async def run_spec(spec: dict, *args):
 @atexit.register
 def close_clusters():
     for cluster in list(SpecCluster._instances):
-        with ignoring(TimeoutError):
+        with ignoring((gen.TimeoutError, TimeoutError)):
             if cluster.status != "closed":
                 cluster.close(timeout=10)

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -6,7 +6,6 @@ import math
 import weakref
 
 import dask
-from tornado import gen
 from tornado.locks import Event
 
 from .adaptive import Adaptive
@@ -19,6 +18,7 @@ from ..utils import (
     parse_bytes,
     parse_timedelta,
     import_term,
+    TimeoutError,
 )
 from ..scheduler import Scheduler
 from ..security import Security
@@ -602,6 +602,6 @@ async def run_spec(spec: dict, *args):
 @atexit.register
 def close_clusters():
     for cluster in list(SpecCluster._instances):
-        with ignoring(gen.TimeoutError):
+        with ignoring(TimeoutError):
             if cluster.status != "closed":
                 cluster.close(timeout=10)

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -31,7 +31,7 @@ from distributed.utils_test import (  # noqa: F401
     tls_only_security,
 )
 from distributed.utils_test import loop  # noqa: F401
-from distributed.utils import sync
+from distributed.utils import sync, TimeoutError
 
 from distributed.deploy.utils_test import ClusterTest
 
@@ -523,7 +523,7 @@ def test_memory_nanny(loop, n_workers):
 
 
 def test_death_timeout_raises(loop):
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         with LocalCluster(
             scheduler_port=0,
             silence_logs=False,

--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -6,7 +6,7 @@ import asyncio
 import tornado.locks
 
 from .client import _get_global_client
-from .utils import log_errors
+from .utils import log_errors, TimeoutError
 from .worker import get_worker
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class LockExtension(object):
                         future = asyncio.wait_for(future, timeout)
                     try:
                         await future
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         result = False
                         break
                     else:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -11,8 +11,7 @@ import weakref
 
 import dask
 from dask.system import CPU_COUNT
-from tornado import gen
-from tornado.ioloop import IOLoop, TimeoutError
+from tornado.ioloop import IOLoop
 from tornado.locks import Event
 
 from .comm import get_address_host, unparse_host_port
@@ -31,6 +30,7 @@ from .utils import (
     PeriodicCallback,
     parse_timedelta,
     ignoring,
+    TimeoutError,
 )
 from .worker import run, parse_memory_limit, Worker
 
@@ -214,7 +214,7 @@ class Nanny(ServerNode):
             return
 
         allowed_errors = (
-            gen.TimeoutError,
+            TimeoutError,
             CommClosedError,
             EnvironmentError,
             RPCClosed,
@@ -317,7 +317,7 @@ class Nanny(ServerNode):
                 result = await asyncio.wait_for(
                     self.process.start(), self.death_timeout
                 )
-            except gen.TimeoutError:
+            except TimeoutError:
                 await self.close(timeout=self.death_timeout)
                 logger.error(
                     "Timed out connecting Nanny '%s' to scheduler '%s'",
@@ -340,7 +340,7 @@ class Nanny(ServerNode):
 
         try:
             await asyncio.wait_for(_(), timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.error("Restart timed out, returning before finished")
             return "timed out"
         else:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -214,12 +214,7 @@ class Nanny(ServerNode):
         if worker_address is None:
             return
 
-        allowed_errors = (
-            TimeoutError,
-            CommClosedError,
-            EnvironmentError,
-            RPCClosed,
-        )
+        allowed_errors = (TimeoutError, CommClosedError, EnvironmentError, RPCClosed)
         with ignoring(allowed_errors):
             await asyncio.wait_for(
                 self.scheduler.unregister(address=self.worker_address), timeout

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -13,6 +13,7 @@ import dask
 from dask.system import CPU_COUNT
 from tornado.ioloop import IOLoop
 from tornado.locks import Event
+from tornado import gen
 
 from .comm import get_address_host, unparse_host_port
 from .comm.addressing import address_from_user_args
@@ -729,7 +730,7 @@ class WorkerProcess(object):
 
         try:
             loop.run_sync(run)
-        except TimeoutError:
+        except (TimeoutError, gen.TimeoutError):
             # Loop was stopped before wait_until_closed() returned, ignore
             pass
         except KeyboardInterrupt:

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -9,7 +9,7 @@ import dask
 
 from .core import Server, ConnectionPool
 from .versions import get_versions
-from .utils import DequeHandler
+from .utils import DequeHandler, TimeoutError
 
 
 class Node(object):
@@ -173,7 +173,7 @@ class ServerNode(Node, Server):
                         await asyncio.wait_for(future, timeout=timeout)
                     except Exception:
                         await self.close(timeout=1)
-                        raise asyncio.TimeoutError(
+                        raise TimeoutError(
                             "{} failed to start in {} seconds".format(
                                 type(self).__name__, timeout
                             )

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -8,7 +8,7 @@ import weakref
 import asyncio
 import dask
 
-from .utils import mp_context
+from .utils import mp_context, TimeoutError
 
 from tornado import gen
 from tornado.concurrent import Future
@@ -283,7 +283,7 @@ class AsyncProcess(object):
         else:
             try:
                 yield asyncio.wait_for(self._exit_future, timeout)
-            except gen.TimeoutError:
+            except TimeoutError:
                 pass
 
     def close(self):

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -5,6 +5,7 @@ import threading
 import weakref
 
 import tornado.locks
+from tornado import gen
 
 from .core import CommClosedError
 from .utils import sync, TimeoutError
@@ -402,7 +403,10 @@ class Sub(object):
                     raise TimeoutError()
             else:
                 timeout2 = None
-            await self.condition.wait(timeout=timeout2)
+            try:
+                await self.condition.wait(timeout=timeout2)
+            except gen.TimeoutError:
+                raise TimeoutError("Timed out waiting on Sub")
 
         return self.buffer.popleft()
 

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -5,10 +5,9 @@ import threading
 import weakref
 
 import tornado.locks
-from tornado import gen
 
 from .core import CommClosedError
-from .utils import sync
+from .utils import sync, TimeoutError
 from .protocol.serialize import to_serialize
 
 logger = logging.getLogger(__name__)
@@ -400,7 +399,7 @@ class Sub(object):
             if timeout is not None:
                 timeout2 = timeout - (datetime.datetime.now() - start)
                 if timeout2.total_seconds() < 0:
-                    raise gen.TimeoutError()
+                    raise TimeoutError()
             else:
                 timeout2 = None
             await self.condition.wait(timeout=timeout2)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -24,7 +24,6 @@ try:
 except ImportError:
     from toolz import frequencies, merge, pluck, merge_sorted, first, merge_with
 from toolz import valmap, second, compose, groupby
-from tornado import gen
 from tornado.ioloop import IOLoop
 
 import dask
@@ -60,6 +59,7 @@ from .utils import (
     key_split_group,
     empty_context,
     tmpfile,
+    TimeoutError,
 )
 from .utils_comm import scatter_to_workers, gather_from_workers, retry_operation
 from .utils_perf import enable_gc_diagnosis, disable_gc_diagnosis
@@ -2739,7 +2739,7 @@ class Scheduler(ServerNode):
         while not self.workers:
             await asyncio.sleep(0.2)
             if time() > start + timeout:
-                raise gen.TimeoutError("No workers found")
+                raise TimeoutError("No workers found")
 
         if workers is None:
             nthreads = {w: ws.nthreads for w, ws in self.workers.items()}
@@ -2883,7 +2883,7 @@ class Scheduler(ServerNode):
                     logger.error(
                         "Not all workers responded positively: %s", resps, exc_info=True
                     )
-            except gen.TimeoutError:
+            except TimeoutError:
                 logger.error(
                     "Nannies didn't report back restarted within "
                     "timeout.  Continuuing with restart process"

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -7,7 +7,7 @@ from toolz import assoc
 from distributed.batched import BatchedSend
 from distributed.core import listen, connect, CommClosedError
 from distributed.metrics import time
-from distributed.utils import All
+from distributed.utils import All, TimeoutError
 from distributed.utils_test import captured_logger
 from distributed.protocol import to_serialize
 
@@ -252,5 +252,5 @@ async def test_serializers():
         msg = await comm.read()
         assert list(msg) == [{"x": 123}, {"x": "hello"}]
 
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(TimeoutError):
             msg = await asyncio.wait_for(comm.read(), 0.1)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -496,7 +496,7 @@ def test_thread(c):
     assert x.result() == 2
 
     x = c.submit(slowinc, 1, delay=0.3)
-    with pytest.raises((gen.TimeoutError, asyncio.TimeoutError)):
+    with pytest.raises(TimeoutError):
         x.result(timeout=0.01)
     assert x.result() == 2
 
@@ -681,7 +681,7 @@ def test_wait_first_completed(c, s, a, b):
 @gen_cluster(client=True, timeout=2)
 def test_wait_timeout(c, s, a, b):
     future = c.submit(sleep, 0.3)
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield wait(future, timeout=0.01)
 
 
@@ -695,7 +695,7 @@ def test_wait_sync(c):
     assert x.status == y.status == "finished"
 
     future = c.submit(sleep, 0.3)
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         wait(future, timeout=0.01)
 
 
@@ -1394,7 +1394,7 @@ def test_scatter_direct_broadcast_target(c, s, *workers):
 
 @gen_cluster(client=True, nthreads=[])
 def test_scatter_direct_empty(c, s):
-    with pytest.raises((ValueError, gen.TimeoutError)):
+    with pytest.raises((ValueError, TimeoutError)):
         yield c.scatter(123, direct=True, timeout=0.1)
 
 
@@ -1801,12 +1801,12 @@ def test_allow_restrictions(c, s, a, b):
 def test_bad_address():
     try:
         Client("123.123.123.123:1234", timeout=0.1)
-    except (IOError, gen.TimeoutError) as e:
+    except (IOError, TimeoutError) as e:
         assert "connect" in str(e).lower()
 
     try:
         Client("127.0.0.1:1234", timeout=0.1)
-    except (IOError, gen.TimeoutError) as e:
+    except (IOError, TimeoutError) as e:
         assert "connect" in str(e).lower()
 
 
@@ -3501,7 +3501,7 @@ def test_persist_optimize_graph(c, s, a, b):
 
 @gen_cluster(client=True, nthreads=[])
 def test_scatter_raises_if_no_workers(c, s):
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield c.scatter(1, timeout=0.5)
 
 
@@ -5279,7 +5279,7 @@ def test_client_active_bad_port():
     http_server.listen(8080)
     with dask.config.set({"distributed.comm.timeouts.connect": "10ms"}):
         c = Client("127.0.0.1:8080", asynchronous=True)
-        with pytest.raises((asyncio.TimeoutError, IOError)):
+        with pytest.raises((TimeoutError, IOError)):
             yield c
         yield c._close(fast=True)
     http_server.stop()

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -20,7 +20,7 @@ from distributed import Nanny, rpc, Scheduler, Worker, Client, wait
 from distributed.core import CommClosedError
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps
-from distributed.utils import ignoring, tmpfile
+from distributed.utils import ignoring, tmpfile, TimeoutError
 from distributed.utils_test import (  # noqa: F401
     gen_cluster,
     gen_test,
@@ -184,7 +184,7 @@ def test_nanny_alt_worker_class(c, s, w1, w2):
 def test_nanny_death_timeout(s):
     yield s.close()
     w = Nanny(s.address, death_timeout=1)
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield w
 
     assert w.status == "closed"

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -4,7 +4,7 @@ import asyncio
 import pytest
 from tornado import gen
 
-from distributed import Client, Queue, Nanny, worker_client, wait
+from distributed import Client, Queue, Nanny, worker_client, wait, TimeoutError
 from distributed.metrics import time
 from distributed.utils_test import gen_cluster, inc, div
 from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
@@ -24,7 +24,7 @@ def test_queue(c, s, a, b):
     future2 = yield xx.get()
     assert future.key == future2.key
 
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield x.get(timeout=0.1)
 
     del future, future2
@@ -50,7 +50,7 @@ def test_queue_with_data(c, s, a, b):
 
     assert data == (1, "hello")
 
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield x.get(timeout=0.1)
 
 
@@ -181,7 +181,7 @@ def test_get_many(c, s, a, b):
     data = yield xx.get(batch=2)
     assert data == [1, 2]
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         data = yield asyncio.wait_for(xx.get(batch=2), 0.1)
 
 
@@ -248,7 +248,7 @@ def test_timeout(c, s, a, b):
     q = yield Queue("v", maxsize=1)
 
     start = time()
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield q.get(timeout=0.3)
     stop = time()
     assert 0.2 < stop - start < 2.0
@@ -256,7 +256,7 @@ def test_timeout(c, s, a, b):
     yield q.put(1)
 
     start = time()
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield q.put(2, timeout=0.3)
     stop = time()
     assert 0.1 < stop - start < 2.0

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -25,7 +25,7 @@ from distributed.client import wait
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps
 from distributed.worker import dumps_function, dumps_task
-from distributed.utils import tmpfile, typename
+from distributed.utils import tmpfile, typename, TimeoutError
 from distributed.utils_test import (  # noqa: F401
     captured_logger,
     cleanup,
@@ -145,7 +145,7 @@ def test_no_valid_workers(client, s, a, b, c):
 
     assert s.tasks[x.key] in s.unrunnable
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield asyncio.wait_for(x, 0.05)
 
 
@@ -165,7 +165,7 @@ def test_no_workers(client, s):
 
     assert s.tasks[x.key] in s.unrunnable
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield asyncio.wait_for(x, 0.05)
 
 
@@ -656,11 +656,11 @@ def test_story(c, s, a, b):
 
 @gen_cluster(nthreads=[], client=True)
 def test_scatter_no_workers(c, s):
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield s.scatter(data={"x": 1}, client="alice", timeout=0.1)
 
     start = time()
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield c.scatter(123, timeout=0.1)
     assert time() < start + 1.5
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -43,6 +43,7 @@ from distributed.utils import (
     warn_on_duration,
     format_dashboard_link,
     LRU,
+    TimeoutError,
 )
 from distributed.utils_test import loop, loop_in_thread  # noqa: F401
 from distributed.utils_test import div, has_ipv6, inc, throws, gen_test, captured_logger
@@ -109,7 +110,7 @@ def test_sync_error(loop_in_thread):
 
 def test_sync_timeout(loop_in_thread):
     loop = loop_in_thread
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         sync(loop_in_thread, gen.sleep, 0.5, callback_timeout=0.05)
 
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import array
 import datetime
 from functools import partial

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 from tornado import gen
 
-from distributed import Client, Variable, worker_client, Nanny, wait
+from distributed import Client, Variable, worker_client, Nanny, wait, TimeoutError
 from distributed.metrics import time
 from distributed.utils_test import gen_cluster, inc, div
 from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
@@ -84,7 +84,7 @@ def test_timeout(c, s, a, b):
     v = Variable("v")
 
     start = time()
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         yield v.get(timeout=0.1)
     stop = time()
     assert 0.1 < stop - start < 2.0
@@ -93,7 +93,7 @@ def test_timeout(c, s, a, b):
 def test_timeout_sync(client):
     v = Variable("v")
     start = time()
-    with pytest.raises(gen.TimeoutError):
+    with pytest.raises(TimeoutError):
         v.get(timeout=0.1)
     stop = time()
     assert 0.1 < stop - start < 2.0

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -35,7 +35,7 @@ from distributed.core import rpc
 from distributed.scheduler import Scheduler
 from distributed.metrics import time
 from distributed.worker import Worker, error_message, logger, parse_memory_limit
-from distributed.utils import tmpfile
+from distributed.utils import tmpfile, TimeoutError
 from distributed.utils_test import (  # noqa: F401
     cleanup,
     inc,
@@ -326,7 +326,7 @@ def test_worker_waits_for_scheduler(loop):
         w = Worker("127.0.0.1", 8007)
         try:
             yield asyncio.wait_for(w, 3)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
         else:
             assert False
@@ -761,7 +761,7 @@ def test_worker_death_timeout(s):
         yield s.close()
         w = Worker(s.address, death_timeout=1)
 
-    with pytest.raises(asyncio.TimeoutError) as info:
+    with pytest.raises(TimeoutError) as info:
         yield w
 
     assert "Worker" in str(info.value)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+from asyncio import TimeoutError
 import atexit
 from collections import deque, OrderedDict, UserDict
 from concurrent.futures import ThreadPoolExecutor
@@ -335,7 +336,7 @@ def sync(loop, func, *args, callback_timeout=None, **kwargs):
     loop.add_callback(f)
     if callback_timeout is not None:
         if not e.wait(callback_timeout):
-            raise gen.TimeoutError("timed out after %s s." % (callback_timeout,))
+            raise TimeoutError("timed out after %s s." % (callback_timeout,))
     else:
         while not e.is_set():
             e.wait(10)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -34,7 +34,6 @@ import pytest
 import dask
 from toolz import merge, memoize, assoc
 from tornado import gen, queues
-from tornado.gen import TimeoutError
 from tornado.ioloop import IOLoop
 
 from . import system
@@ -60,6 +59,7 @@ from .utils import (
     iscoroutinefunction,
     thread_state,
     _offload_executor,
+    TimeoutError,
 )
 from .worker import Worker
 from .nanny import Nanny
@@ -141,7 +141,7 @@ def loop():
             except RuntimeError as e:
                 if not re.match("IOLoop is clos(ed|ing)", str(e)):
                     raise
-            except gen.TimeoutError:
+            except TimeoutError:
                 pass
             else:
                 is_stopped.wait()

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 import logging
 import uuid
 
-from tornado import gen
 import tornado.locks
 
 try:
@@ -13,7 +12,7 @@ except ImportError:
 
 from .client import Future, _get_global_client, Client
 from .metrics import time
-from .utils import tokey, log_errors
+from .utils import tokey, log_errors, TimeoutError
 from .worker import get_client
 
 logger = logging.getLogger(__name__)
@@ -82,7 +81,7 @@ class VariableExtension(object):
             else:
                 left = None
             if left and left < 0:
-                raise gen.TimeoutError()
+                raise TimeoutError()
             await self.started.wait(timeout=left)
         record = self.variables[name]
         if record["type"] == "Future":

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 
 import tornado.locks
+from tornado import gen
 
 try:
     from cytoolz import merge
@@ -82,7 +83,10 @@ class VariableExtension(object):
                 left = None
             if left and left < 0:
                 raise TimeoutError()
-            await self.started.wait(timeout=left)
+            try:
+                await self.started.wait(timeout=left)
+            except gen.TimeoutError:
+                raise TimeoutError("Timed out waiting for Variable.get")
         record = self.variables[name]
         if record["type"] == "Future":
             key = record["value"]


### PR DESCRIPTION
Previously we had a mix of gen.TimeoutError and asyncio.TimeoutError
within the code.  This import asyncio.TimeoutError within utils.py (and
our top level imports) and then uses that consistently throughout the
codebase

cc @jrbourbeau 

(disclaimer, I haven't yet fully tested this, so this may still need some love)