### PR TITLE
development document revisions

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -78,28 +78,33 @@ The test suite contains three kinds of tests
     These are rare and mostly for testing the command line interface.
 
 If you are comfortable with the Tornado interface then you will be happiest
-using the ``@gen_cluster`` style of test
+using the ``@gen_cluster`` style of test, e.g.
 
 .. code-block:: python
 
-   from distributed.utils_test import gen_cluster
+    # tests/test_submit.py
 
-   @gen_cluster(client=True)
-   def test_submit(c, s, a, b):
-       assert isinstance(c, Client)
-       assert isinstance(s, Scheduler)
-       assert isinstance(a, Worker)
-       assert isinstance(b, Worker)
+    from distributed.utils_test import gen_cluster, inc
+    from distributed import Client, Future, Scheduler, Worker
 
-       future = c.submit(inc, 1)
-       assert future.key in c.futures
+    @gen_cluster(client=True)
+    def test_submit(c, s, a, b):
+        assert isinstance(c, Client)
+        assert isinstance(s, Scheduler)
+        assert isinstance(a, Worker)
+        assert isinstance(b, Worker)
 
-       # result = future.result()  # This synchronous API call would block
-       result = yield future
-       assert result == 2
+        future = c.submit(inc, 1)
+        assert isinstance(future, Future)
+        assert future.key in c.futures
 
-       assert future.key in s.tasks
-       assert future.key in a.data or future.key in b.data
+        # result = future.result()  # This synchronous API call would block
+        result = yield future
+        assert result == 2
+
+        assert future.key in s.tasks
+        assert future.key in a.data or future.key in b.data
+
 
 The ``@gen_cluster`` decorator sets up a scheduler, client, and workers for
 you and cleans them up after the test.  It also allows you to directly inspect


### PR DESCRIPTION
Maybe the docs are deliberately sparse and this PR can be trashed, but a little extra detail might be useful for some folks.

While using the example unit tests from the dev-doc, ran into some problems that might find a way to get updated in this or another PR.  The following is not (yet) in this PR because it's not entirely clear how it should work, i.e. the working code with comments on failures is like:

```python
# import all the dask distributed pytest fixtures
from distributed import Future
from distributed.utils_test import *  # pylint: disable=wildcard-import


def test_sync_submit(client):
    future = client.submit(inc, 10)
    assert isinstance(future, Future)
    assert future.result() == 11  # use the synchronous/blocking API here


def test_sync_submit_full(client, s, a, b):
    """
    In this style of test you do not have access to the scheduler or workers.
    The variables s, a, b are now dictionaries holding a multiprocessing.Process
    object and a port integer. However, you can now use the normal synchronous
    API (never use yield in this style of test) and you can close processes
    easily by terminating them.
    """
    assert isinstance(client, Client)
    assert isinstance(s, dict)
    assert client.scheduler.address == s['address']
    assert isinstance(a, dict)  # worker-a
    assert isinstance(b, dict)  # worker-b

    future = client.submit(inc, 10)
    assert isinstance(future, Future)
    assert future.result() == 11  # use the synchronous/blocking API here

    fixed_test = False
    if fixed_test:
        # killing a worker fails the test cleanup checks:
        # Failed: some RPCs left active by test

        worker_process = a['proc']()  # call weakref to get worker process
        worker_process.terminate()  # kill one of the workers
        # client.retire_workers()  # also not a clean test teardown

        result = future.result()  # test that future remains valid
        assert isinstance(future, Future)
        assert result == 11
```