### PR TITLE
Docs - add example conda-dev-env

### DIFF
--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -22,6 +22,26 @@ and install it from source::
    cd distributed
    python setup.py install
 
+Using conda, for example::
+
+   git clone git@github.com:{your-fork}/distributed.git
+   cd distributed
+   conda create -y -n distributed python=3.6
+   conda activate distributed
+   python -m pip install -U -r requirements.txt
+   python -m pip install -U -r dev-requirements.txt
+   python -m pip install -e .
+
+To keep a fork in sync with the upstream source::
+
+   cd distributed
+   git remote add upstream git@github.com:dask/distributed.git
+   git remote -v
+   git fetch -a upstream
+   git checkout master
+   git pull upstream master
+   git push origin master
+
 Test
 ----
 


### PR DESCRIPTION
Split out of #3398 to be rebased later and adapted to provide a small snippet for dev-getting-started.

The intention is to provide a small one-stop-shop for a copy-paste snippet that works, with no doubts or questions about how to use the files involved.  There is great value in DRY consistent documentation, so it could be removed for the sake of doc-maintenance and consistency.  But, it currently places a burden on the reader to jump around to a few places to sift through the volumes to find a few kernels about how to get off the ground.