### PR TITLE
Fix TaskProgress dashboard component when tasks are only in the no-worker state

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1418,12 +1418,13 @@ class TaskProgress(DashboardComponent):
             }
 
             for tp in self.scheduler.task_prefixes.values():
-                if any(tp.active_states.values()):
-                    state["memory"][tp.name] = tp.active_states["memory"]
-                    state["erred"][tp.name] = tp.active_states["erred"]
-                    state["released"][tp.name] = tp.active_states["released"]
-                    state["processing"][tp.name] = tp.active_states["processing"]
-                    state["waiting"][tp.name] = tp.active_states["waiting"]
+                active_states = tp.active_states
+                if any(active_states.get(s) for s in state.keys()):
+                    state["memory"][tp.name] = active_states["memory"]
+                    state["erred"][tp.name] = active_states["erred"]
+                    state["released"][tp.name] = active_states["released"]
+                    state["processing"][tp.name] = active_states["processing"]
+                    state["waiting"][tp.name] = active_states["waiting"]
 
             state["all"] = {
                 k: sum(v[k] for v in state.values()) for k in state["memory"]


### PR DESCRIPTION
Currently the `TaskProgress` dashboard component uses `TaskPrefix.active_states` to get the number of tasks in each state. However, `TaskPrefix.active_states` includes tasks in the `no-worker` state which `TaskProgress` doesn't track. This causes issues when we only have tasks in the `no-worker` state.

This PR updates `TaskProgress` to only rely on the states it's tracking, not all the states in `TaskPrefix.active_states` (i.e. ignore the `no-worker` state in `active_states`)

cc @jacobtomlinson 

Closes https://github.com/dask/distributed/issues/3399