### PR TITLE
Use instance-level TCP client in BaseTCPConnector

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -345,7 +345,7 @@ class BaseTCPConnector(Connector, RequireEncryptionMixin):
         kwargs = self._get_connect_args(**connection_args)
 
         try:
-            stream = await BaseTCPConnector.client.connect(
+            stream = await self.client.connect(
                 ip, port, max_buffer_size=MAX_BUFFER_SIZE, **kwargs
             )
 


### PR DESCRIPTION
Currently we create a TCP stream using the class-level `BaseTCPConnector.client` attribute. I came across a case where using a subclass of the tornado `TCPClient` is needed. However, since we use the class-level `TCPConnector.client` attribute, instead of an instance-level `self.client`, we're not currently set up to easily swap out different `TCPClient` objects. 

This PR updates the `BaseTCPConnector.connect` method to use the instance-level TCP client object (`self.client`) instead of the class-level one. 

To be clear, this is a niche edge case. We shouldn't bend over backwards to support it. That said, I think this is a relatively small change that doesn't break any existing behavior (that I'm aware of) or increase our maintainability burden. 

cc @mrocklin 