### PR TITLE
Enable WorkStealing case-by-case

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -89,9 +89,6 @@ DEFAULT_EXTENSIONS = [
     PubSubSchedulerExtension,
 ]
 
-if dask.config.get("distributed.scheduler.work-stealing"):
-    DEFAULT_EXTENSIONS.append(WorkStealing)
-
 ALL_TASK_STATES = {"released", "waiting", "no-worker", "processing", "erred", "memory"}
 
 
@@ -1333,7 +1330,9 @@ class Scheduler(ServerNode):
             self.periodic_callbacks["idle-timeout"] = pc
 
         if extensions is None:
-            extensions = DEFAULT_EXTENSIONS
+            extensions = list(DEFAULT_EXTENSIONS)
+            if dask.config.get("distributed.scheduler.work-stealing"):
+                extensions.append(WorkStealing)
         for ext in extensions:
             ext(self)
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -596,17 +596,17 @@ def test_coerce_address():
         yield [w.close() for w in [a, b, c]]
 
 
-@gen_test()
-def test_config_stealing():
+@pytest.mark.asyncio
+async def test_config_stealing(cleanup):
     # Regression test for https://github.com/dask/distributed/issues/3409
 
     with dask.config.set({"distributed.scheduler.work-stealing": True}):
-        s = yield Scheduler(port=0)
-        assert "stealing" in s.extensions
+        async with Scheduler(port=0) as s:
+            assert "stealing" in s.extensions
 
     with dask.config.set({"distributed.scheduler.work-stealing": False}):
-        s = yield Scheduler(port=0)
-        assert "stealing" not in s.extensions
+        async with Scheduler(port=0) as s:
+            assert "stealing" not in s.extensions
 
 
 @pytest.mark.skipif(

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -596,6 +596,19 @@ def test_coerce_address():
         yield [w.close() for w in [a, b, c]]
 
 
+@gen_test()
+def test_config_stealing():
+    # Regression test for https://github.com/dask/distributed/issues/3409
+
+    with dask.config.set({"distributed.scheduler.work-stealing": True}):
+        s = yield Scheduler(port=0)
+        assert "stealing" in s.extensions
+
+    with dask.config.set({"distributed.scheduler.work-stealing": False}):
+        s = yield Scheduler(port=0)
+        assert "stealing" not in s.extensions
+
+
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="file descriptors not really a thing"
 )


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/3409

Previously the decision to enable work-stealing was made when `distributed` was imported and could not be changed after that. This delays the decision until a scheduler is spun up and then makes sure to check `dask.config`.