### PR TITLE
make _get_ip return an IP address when defaulting

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -143,7 +143,14 @@ def _get_ip(host, port, family):
             "reaching %r, defaulting to hostname: %s" % (host, e),
             RuntimeWarning,
         )
-        return socket.getfqdn(socket.gethostname())
+        addr_info = socket.getaddrinfo(
+            socket.gethostname(),
+            port,
+            family,
+            socket.SOCK_DGRAM,
+            socket.IPPROTO_UDP
+        )[0]
+        return addr_info[4][0]
     finally:
         sock.close()
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -138,13 +138,12 @@ def _get_ip(host, port, family):
         ip = sock.getsockname()[0]
         return ip
     except EnvironmentError as e:
-        # XXX Should first try getaddrinfo() on socket.gethostname() and getfqdn()
         warnings.warn(
             "Couldn't detect a suitable IP address for "
             "reaching %r, defaulting to hostname: %s" % (host, e),
             RuntimeWarning,
         )
-        return socket.gethostname()
+        return socket.getfqdn(socket.gethostname())
     finally:
         sock.close()
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -144,11 +144,7 @@ def _get_ip(host, port, family):
             RuntimeWarning,
         )
         addr_info = socket.getaddrinfo(
-            socket.gethostname(),
-            port,
-            family,
-            socket.SOCK_DGRAM,
-            socket.IPPROTO_UDP
+            socket.gethostname(), port, family, socket.SOCK_DGRAM, socket.IPPROTO_UDP
         )[0]
         return addr_info[4][0]
     finally:


### PR DESCRIPTION
Fixes #3417 

Changing `socket.gethostname()` by `socket.getaddrinfo(socket.gethostname(), port, family)[0][4][0]` also works, but I don't know whether it is better than `socket.getfqdn(socket.gethostname())`. Maybe @pitrou has any clue, as the author of the useful `XXX` comment above :)

also pinging @jakirkham and @ogrisel 