### PR TITLE
Don't send empty dependencies

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2489,6 +2489,7 @@ class Client(Node):
             dependencies = {
                 tokey(k): [tokey(dep) for dep in deps]
                 for k, deps in dependencies.items()
+                if deps
             }
             for k, deps in future_dependencies.items():
                 if deps:

--- a/distributed/diagnostics/graph_layout.py
+++ b/distributed/diagnostics/graph_layout.py
@@ -36,16 +36,16 @@ class GraphLayout(SchedulerPlugin):
             }
             priority = {k: ts.priority for k, ts in scheduler.tasks.items()}
             self.update_graph(
-                self.scheduler, dependencies=dependencies, priority=priority
+                self.scheduler, tasks=self.scheduler.tasks, dependencies=dependencies, priority=priority
             )
 
-    def update_graph(self, scheduler, dependencies=None, priority=None, **kwargs):
-        stack = sorted(dependencies, key=lambda k: priority.get(k, 0), reverse=True)
+    def update_graph(self, scheduler, dependencies=None, priority=None, tasks=None, **kwargs):
+        stack = sorted(tasks, key=lambda k: priority.get(k, 0), reverse=True)
         while stack:
             key = stack.pop()
             if key in self.x or key not in scheduler.tasks:
                 continue
-            deps = dependencies[key]
+            deps = dependencies.get(key, ())
             if deps:
                 if not all(dep in self.y for dep in deps):
                     stack.append(key)

--- a/distributed/diagnostics/graph_layout.py
+++ b/distributed/diagnostics/graph_layout.py
@@ -36,10 +36,15 @@ class GraphLayout(SchedulerPlugin):
             }
             priority = {k: ts.priority for k, ts in scheduler.tasks.items()}
             self.update_graph(
-                self.scheduler, tasks=self.scheduler.tasks, dependencies=dependencies, priority=priority
+                self.scheduler,
+                tasks=self.scheduler.tasks,
+                dependencies=dependencies,
+                priority=priority,
             )
 
-    def update_graph(self, scheduler, dependencies=None, priority=None, tasks=None, **kwargs):
+    def update_graph(
+        self, scheduler, dependencies=None, priority=None, tasks=None, **kwargs
+    ):
         stack = sorted(tasks, key=lambda k: priority.get(k, 0), reverse=True)
         while stack:
             key = stack.pop()


### PR DESCRIPTION
When a client sends the `update-graph` message, it sends a dictionary with dependencies of individual tasks. Tasks without dependencies needlessly occupy bandwidth in this message, since the scheduler anyway does something like `dependencies.get(task, ())` when it parses the message (if I'm wrong please let me know).

For example for this simple merge with a lot of tasks without dependencies:
```python
from dask import delayed
from dask.distributed import Client

client = Client("tcp://localhost:8786")

@delayed
def do_something(x):
    return x * 10

@delayed
def merge(*args):
    return sum(args)

xs = [do_something(x) for x in range(1000)]
result = merge(*xs).compute()
```

This PR changes the dependencies in the `update-graph` message from this:
```python
{
    "merge-3cfcfa4f-fa40-45ba-b181-54eb7554377f": ('do_something-ae852807-355c-4d87-85e4-72e6f1d0a146', 'do_something-3e003b98-363b-42ab-b270-691db098f222', ...),
    "do_something-9f9820f5-fbe9-4d31-ba9d-ac17996e4c35": (),
    "do_something-34c2c63b-2d3d-4e5c-8fef-f94ab635e19f": (),
    ... # 998 additional lines
}
```

into this:
```python
{
    "merge-3cfcfa4f-fa40-45ba-b181-54eb7554377f": ('do_something-ae852807-355c-4d87-85e4-72e6f1d0a146', 'do_something-3e003b98-363b-42ab-b270-691db098f222', ...),
}
```

For the aforementioned graph, it reduces the `update-graph` total frame byte size by the following amounts:

| Merge task # | Original size | Reduced size | % of original |
| ----------------- | ----------------- | ------------------ | ----------------- | 
| 5000 | 4170630 B | 3910628 B | 94 % |
| 10000 | 8340666 B | 7820664 B | 94 % |
| 15000 | 12510702 B | 11730700 B | 94 % |
| 20000 | 16680738 B | 15640736 B | 94 % |
| 25000 | 20850774 B | 19550772 B | 94 % |