### PR TITLE
Try to use pickle5 when available

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ pytest >= 3.2
 prometheus_client >= 0.6.0
 jupyter-server-proxy >= 1.1.0
 pytest-asyncio
+pickle5; python_version >= '3.6' and python_version < '3.8'

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -3,9 +3,7 @@ import sys
 
 import cloudpickle
 
-if sys.version_info.major == 2:
-    import cPickle as pickle
-elif sys.version_info.major == 3 and sys.version_info.minor < 8:
+if sys.version_info.major == 3 and sys.version_info.minor < 8:
     try:
         import pickle5 as pickle
     except ImportError:

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -5,7 +5,12 @@ import cloudpickle
 
 if sys.version_info.major == 2:
     import cPickle as pickle
-else:
+elif sys.version_info.major == 3 and sys.version_info.minor < 8:
+    try:
+        import pickle5 as pickle
+    except ImportError:
+        import pickle
+elif sys.version_info.minor:
     import pickle
 
 logger = logging.getLogger(__name__)

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -10,7 +10,7 @@ elif sys.version_info.major == 3 and sys.version_info.minor < 8:
         import pickle5 as pickle
     except ImportError:
         import pickle
-elif sys.version_info.minor:
+else:
     import pickle
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
As there are some improvements for buffer serialization in pickle protocol 5 and these can be opted in using a backports package on older Python versions. Try to leverage the backport package when available and fallback to the builtin pickle otherwise.

cc @quasiben @pentschev