### PR TITLE
Add dashboard_link property to Client

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5249,8 +5249,9 @@ def test_dashboard_link(loop, monkeypatch):
             with dask.config.set(
                 {"distributed.dashboard.link": "{scheme}://foo-{USER}:{port}/status"}
             ):
-                text = c._repr_html_()
                 link = "http://foo-myusername:12355/status"
+                assert link == c.dashboard_link
+                text = c._repr_html_()
                 assert link in text
 
 


### PR DESCRIPTION
Currently if you create a Dask cluster using a cluster manager object you can grab the dashboard web address using the `cluster.dashboard_link` attribute. When a client connects to that cluster you can also grab the address via `client.cluster.dashboard_link`.

We use this in the Dask Jupyter Lab Extension to auto-populate the address by grabbing the default client and then accessing the `client.cluster.dashboard_link` property. However if the cluster is created by another method, on the command line for example, the `client.cluster` property will be set to `None` and it is not possible to get the address.

However when displaying the HTML repr for the client we infer the dashboard address and expose it, this works regardless of the cluster setup method.

This PR pulls that logic out of the HTML repr into a new property so that this address can be accessed at `client.dashboard_link`. I had to add a little indirection with the `_get_scheduler_info()`  method as we now need to auto-detect the scheduler object and scheduler information in multiple places.

My plan if this is acceptable is to [update the lab extension here](https://github.com/dask/dask-labextension/blob/3915f6a4f354c917217ed3e4d830d7f345fad9b5/src/index.ts#L476) to get the address via `client.dashboard_link` instead of `client.cluster.dashboard_link`.

