### PR TITLE
Add documentation of parameters in coordination primitives

### DIFF
--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -78,9 +78,13 @@ class Lock:
 
     Parameters
     ----------
-    name: string
+    name: string (optional)
         Name of the lock to acquire.  Choosing the same name allows two
-        disconnected processes to coordinate a lock.
+        disconnected processes to coordinate a lock.  If not given, a random
+        name will be generated.
+    client: Client (optional)
+        Client to use for communication with the scheduler.  If not given, the
+        default global client will be used.
 
     Examples
     --------

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -240,7 +240,13 @@ class Pub:
     Parameters
     ----------
     name: object (msgpack serializable)
-        The name of the group of Pubs and Subs on which to participate
+        The name of the group of Pubs and Subs on which to participate.
+    worker: Worker (optional)
+        The worker to be used for publishing data. Defaults to the value of
+        ```get_worker()```. If given, ``client`` must be ``None``.
+    client: Client (optional)
+        Client used for communication with the scheduler. Defaults to
+        the value of ``get_client()``. If given, ``worker`` must be ``None``.
 
     Examples
     --------

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -155,6 +155,18 @@ class Queue:
 
        This object is experimental and has known issues in Python 2
 
+    Parameters
+    ----------
+    name: string (optional)
+        Name used by other clients and the scheduler to identify the queue. If
+        not given, a random name will be generated.
+    client: Client (optional)
+        Client used for communication with the scheduler. Defaults to the
+        value of ``_get_global_client()``.
+    maxsize: int (optional)
+        Number of items allowed in the queue. If 0 (the default), the queue
+        size is unbounded.
+
     Examples
     --------
     >>> from dask.distributed import Client, Queue  # doctest: +SKIP

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -130,6 +130,15 @@ class Variable:
 
        This object is experimental and has known issues in Python 2
 
+    Parameters
+    ----------
+    name: string (optional)
+        Name used by other clients and the scheduler to identify the variable.
+        If not given, a random name will be generated.
+    client: Client (optional)
+        Client used for communication with the scheduler. Defaults to the
+        value of ``_get_global_client()``.
+
     Examples
     --------
     >>> from dask.distributed import Client, Variable # doctest: +SKIP


### PR DESCRIPTION
This closes #3343. A few questions:

* I left the `name` parameter as a `string`, because that's what was given in the docstring for `Lock`. However, `Pub`/`Sub` just specify that it should be a general msgpack-serializable object; is that supported for all of them? Then I'll go ahead and change it.
* It looks like the `maxsize` parameter in `Variable` is unused (maybe a result of copying from `Queue`?) Should that be removed? It breaks API backwards compatibility but given that it didn't do anything, chances are this is unproblematic?
* In general, there's some inconsistency in whether a period is followed by a single space or two spaces; should this be consistent?