### PR TITLE
Support serializing/deserializing `rmm.DeviceBuffer`s

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -80,6 +80,12 @@ def _register_numba():
     from . import numba
 
 
+@cuda_serialize.register_lazy("rmm")
+@cuda_deserialize.register_lazy("rmm")
+def _register_rmm():
+    from . import rmm
+
+
 @cuda_serialize.register_lazy("cudf")
 @cuda_deserialize.register_lazy("cudf")
 def _register_cudf():

--- a/distributed/protocol/rmm.py
+++ b/distributed/protocol/rmm.py
@@ -15,10 +15,9 @@ if hasattr(rmm, "DeviceBuffer"):
     def deserialize_rmm_device_buffer(header, frames):
         (arr,) = frames
 
-        # Copy data into new `DeviceBuffer` if needed
-        if not isinstance(arr, rmm.DeviceBuffer):
-            (ptr, _) = arr.__cuda_array_interface__["data"]
-            (size,) = header["shape"]
-            arr = rmm.DeviceBuffer(ptr=ptr, size=size)
+        # We should already have `DeviceBuffer`
+        # as RMM is used preferably for allocations
+        # when it is available (as it is here).
+        assert isinstance(arr, rmm.DeviceBuffer)
 
         return arr

--- a/distributed/protocol/rmm.py
+++ b/distributed/protocol/rmm.py
@@ -1,0 +1,24 @@
+import rmm
+from .cuda import cuda_serialize, cuda_deserialize
+
+
+# Used for RMM 0.11.0+ otherwise Numba serializers used
+if hasattr(rmm, "DeviceBuffer"):
+    @cuda_serialize.register(rmm.DeviceBuffer)
+    def serialize_rmm_device_buffer(x):
+        header = x.__cuda_array_interface__.copy()
+        frames = [x]
+        return header, frames
+
+
+    @cuda_deserialize.register(rmm.DeviceBuffer)
+    def deserialize_rmm_device_buffer(header, frames):
+        (arr,) = frames
+
+        # Copy data into new `DeviceBuffer` if needed
+        if not isinstance(arr, rmm.DeviceBuffer):
+            (ptr, _) = arr.__cuda_array_interface__["data"]
+            (size,) = header["shape"]
+            arr = rmm.DeviceBuffer(ptr=ptr, size=size)
+
+        return arr

--- a/distributed/protocol/rmm.py
+++ b/distributed/protocol/rmm.py
@@ -4,12 +4,12 @@ from .cuda import cuda_serialize, cuda_deserialize
 
 # Used for RMM 0.11.0+ otherwise Numba serializers used
 if hasattr(rmm, "DeviceBuffer"):
+
     @cuda_serialize.register(rmm.DeviceBuffer)
     def serialize_rmm_device_buffer(x):
         header = x.__cuda_array_interface__.copy()
         frames = [x]
         return header, frames
-
 
     @cuda_deserialize.register(rmm.DeviceBuffer)
     def deserialize_rmm_device_buffer(header, frames):

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -29,3 +29,23 @@ def test_serialize_cupy_from_numba(dtype):
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
 
     assert (x_np == cupy.asnumpy(y)).all()
+
+
+@pytest.mark.parametrize("size", [0, 3, 10])
+def test_serialize_cupy_from_rmm(size):
+    np = pytest.importorskip("numpy")
+    rmm = pytest.importorskip("rmm")
+
+    x_np = np.arange(size, dtype="u1")
+
+    x_np_desc = x_np.__array_interface__
+    (x_np_ptr, _) = x_np_desc["data"]
+    (x_np_size,) = x_np_desc["shape"]
+    x = rmm.DeviceBuffer(ptr=x_np_ptr, size=x_np_size)
+
+    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
+    header["type-serialized"] = pickle.dumps(cupy.ndarray)
+
+    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+
+    assert (x_np == cupy.asnumpy(y)).all()

--- a/distributed/protocol/tests/test_numba.py
+++ b/distributed/protocol/tests/test_numba.py
@@ -1,4 +1,5 @@
 from distributed.protocol import serialize, deserialize
+import pickle
 import pytest
 
 cuda = pytest.importorskip("numba.cuda")
@@ -20,3 +21,26 @@ def test_serialize_cupy(dtype):
     x.copy_to_host(hx)
     y.copy_to_host(hy)
     assert (hx == hy).all()
+
+
+@pytest.mark.parametrize("size", [0, 3, 10])
+def test_serialize_numba_from_rmm(size):
+    np = pytest.importorskip("numpy")
+    rmm = pytest.importorskip("rmm")
+
+    if not cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    x_np = np.arange(size, dtype="u1")
+
+    x_np_desc = x_np.__array_interface__
+    (x_np_ptr, _) = x_np_desc["data"]
+    (x_np_size,) = x_np_desc["shape"]
+    x = rmm.DeviceBuffer(ptr=x_np_ptr, size=x_np_size)
+
+    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
+    header["type-serialized"] = pickle.dumps(cuda.devicearray.DeviceNDArray)
+
+    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+
+    assert (x_np == y.copy_to_host()).all()

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -19,7 +19,7 @@ def test_serialize_rmm_device_buffer(size):
 
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
-    y_np = cuda.as_cuda_array(y).copy_to_host()
+    y_np = y.copy_to_host()
 
     assert (x_np == y_np).all()
 

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -9,12 +9,11 @@ rmm = pytest.importorskip("rmm")
 
 @pytest.mark.parametrize("size", [0, 3, 10])
 def test_serialize_rmm_device_buffer(size):
-    DeviceBuffer = getattr(rmm, "DeviceBuffer", None)
-    if not DeviceBuffer:
+    if not hasattr(rmm, "DeviceBuffer"):
         pytest.skip("RMM pre-0.11.0 does not have DeviceBuffer")
 
     x_np = numpy.arange(size, dtype="u1")
-    x = DeviceBuffer(size=size)
+    x = rmm.DeviceBuffer(size=size)
     cuda.to_device(x_np, to=cuda.as_cuda_array(x))
 
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
@@ -26,15 +25,14 @@ def test_serialize_rmm_device_buffer(size):
 
 @pytest.mark.parametrize("size", [0, 3, 10])
 def test_serialize_rmm_device_buffer_from_numba_array(size):
-    DeviceBuffer = getattr(rmm, "DeviceBuffer", None)
-    if not DeviceBuffer:
+    if not hasattr(rmm, "DeviceBuffer"):
         pytest.skip("RMM pre-0.11.0 does not have DeviceBuffer")
 
     x_np = numpy.arange(size, dtype="u1")
     x = cuda.to_device(x_np)
 
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
-    header["type-serialized"] = pickle.dumps(DeviceBuffer)
+    header["type-serialized"] = pickle.dumps(rmm.DeviceBuffer)
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
     y_np = cuda.as_cuda_array(y).copy_to_host()
 

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -1,4 +1,5 @@
 from distributed.protocol import serialize, deserialize
+import pickle
 import pytest
 
 numpy = pytest.importorskip("numpy")
@@ -17,6 +18,23 @@ def test_serialize_rmm_device_buffer(size):
     cuda.to_device(x_np, to=cuda.as_cuda_array(x))
 
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
+    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+    y_np = cuda.as_cuda_array(y).copy_to_host()
+
+    assert (x_np == y_np).all()
+
+
+@pytest.mark.parametrize("size", [0, 3, 10])
+def test_serialize_rmm_device_buffer_from_numba_array(size):
+    DeviceBuffer = getattr(rmm, "DeviceBuffer", None)
+    if not DeviceBuffer:
+        pytest.skip("RMM pre-0.11.0 does not have DeviceBuffer")
+
+    x_np = numpy.arange(size, dtype="u1")
+    x = cuda.to_device(x_np)
+
+    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
+    header["type-serialized"] = pickle.dumps(DeviceBuffer)
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
     y_np = cuda.as_cuda_array(y).copy_to_host()
 

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -1,5 +1,4 @@
 from distributed.protocol import serialize, deserialize
-import pickle
 import pytest
 
 numpy = pytest.importorskip("numpy")

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -21,19 +21,3 @@ def test_serialize_rmm_device_buffer(size):
     y_np = y.copy_to_host()
 
     assert (x_np == y_np).all()
-
-
-@pytest.mark.parametrize("size", [0, 3, 10])
-def test_serialize_rmm_device_buffer_from_numba_array(size):
-    if not hasattr(rmm, "DeviceBuffer"):
-        pytest.skip("RMM pre-0.11.0 does not have DeviceBuffer")
-
-    x_np = numpy.arange(size, dtype="u1")
-    x = cuda.to_device(x_np)
-
-    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
-    header["type-serialized"] = pickle.dumps(rmm.DeviceBuffer)
-    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
-    y_np = cuda.as_cuda_array(y).copy_to_host()
-
-    assert (x_np == y_np).all()

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -1,0 +1,23 @@
+from distributed.protocol import serialize, deserialize
+import pytest
+
+numpy = pytest.importorskip("numpy")
+cuda = pytest.importorskip("numba.cuda")
+rmm = pytest.importorskip("rmm")
+
+
+@pytest.mark.parametrize("size", [0, 3, 10])
+def test_serialize_rmm_device_buffer(size):
+    DeviceBuffer = getattr(rmm, "DeviceBuffer", None)
+    if not DeviceBuffer:
+        pytest.skip("RMM pre-0.11.0 does not have DeviceBuffer")
+
+    x_np = numpy.arange(size, dtype="u1")
+    x = DeviceBuffer(size=size)
+    cuda.to_device(x_np, to=cuda.as_cuda_array(x))
+
+    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
+    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+    y_np = cuda.as_cuda_array(y).copy_to_host()
+
+    assert (x_np == y_np).all()


### PR DESCRIPTION
This adds support for serializing and deserializing `rmm.DeviceBuffer` within `distributed`. As it is a very simple object supporting `__cuda_array_interface__`, this is pretty straightforward. For the most part deserialization should be trivial if RMM is available since we prefer using that when transmitting data. Otherwise construct a new `DeviceBuffer` using a pointer to the data in the frame and its size.