### PR TITLE
WIP: Handle other contiguous CUDA arrays

### DIFF
--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -40,7 +40,7 @@ class PatchedCudaArrayInterface:
 def serialize_cupy_ndarray(x):
     # Making sure `x` is behaving
     if not x.flags.c_contiguous:
-        x = cupy.array(x, copy=True)
+        x = x.copy(order="C")
 
     header = x.__cuda_array_interface__.copy()
     return header, [x]

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -9,9 +9,20 @@ def serialize_numba_ndarray(x):
 
     # Making sure `x` is behaving
     if x.is_c_contiguous():
-        x = x.ravel(order="C")
+        x = numba.cuda.devicearray.DeviceNDArray(
+            (int(np.product(x.shape)),),
+            (x.dtype.itemsize,),
+            x.dtype,
+            gpu_data=x.gpu_data,
+        )
     elif x.is_f_contiguous():
-        x = x.ravel(order="F")
+        header["strides"] = header["strides"][::-1]
+        x = numba.cuda.devicearray.DeviceNDArray(
+            (int(np.product(x.shape)),),
+            (x.dtype.itemsize,),
+            x.dtype,
+            gpu_data=x.gpu_data,
+        )
     else:
         shape = x.shape
         t = numba.cuda.device_array(shape, dtype=x.dtype, order="C")

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -8,7 +8,7 @@ def serialize_numba_ndarray(x):
     # Making sure `x` is behaving
     if not x.is_c_contiguous():
         shape = x.shape
-        t = numba.cuda.device_array(shape, dtype=x.dtype)
+        t = numba.cuda.device_array(shape, dtype=x.dtype, order="C")
         t.copy_to_device(x)
         x = t
     header = x.__cuda_array_interface__.copy()

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -3,12 +3,15 @@ import pickle
 import pytest
 
 cupy = pytest.importorskip("cupy")
+numpy = pytest.importorskip("numpy")
 
 
-@pytest.mark.parametrize("size", [0, 10])
+@pytest.mark.parametrize("shape", [(0,), (5,), (4, 6), (10, 11), (2, 3, 5)])
 @pytest.mark.parametrize("dtype", ["u1", "u4", "u8", "f4"])
-def test_serialize_cupy(size, dtype):
-    x = cupy.arange(size, dtype=dtype)
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_serialize_cupy(shape, dtype, order):
+    x = cupy.arange(numpy.product(shape), dtype=dtype)
+    x = cupy.ndarray(shape, dtype=x.dtype, memptr=x.data, order=order)
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
 


### PR DESCRIPTION
To avoid copying in more cases, check for different types of contiguous arrays and make sure they are sent through as-is. For arrays that we still cannot recognize as contiguous, go ahead and copy them to C-order (as was the case previously) before sending them over.