### PR TITLE
Adjust `numba.cuda` import and add check

### DIFF
--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -20,6 +20,9 @@ def test_serialize_cupy_from_numba(dtype):
     cuda = pytest.importorskip("numba.cuda")
     np = pytest.importorskip("numpy")
 
+    if not cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     size = 10
     x_np = np.arange(size, dtype=dtype)
     x = cuda.to_device(x_np)

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -17,12 +17,12 @@ def test_serialize_cupy(size, dtype):
 
 @pytest.mark.parametrize("dtype", ["u1", "u4", "u8", "f4"])
 def test_serialize_cupy_from_numba(dtype):
-    numba = pytest.importorskip("numba")
+    cuda = pytest.importorskip("numba.cuda")
     np = pytest.importorskip("numpy")
 
     size = 10
     x_np = np.arange(size, dtype=dtype)
-    x = numba.cuda.to_device(x_np)
+    x = cuda.to_device(x_np)
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
     header["type-serialized"] = pickle.dumps(cupy.ndarray)
 


### PR DESCRIPTION
It seems `numba` now raises an `AttributeError` when accessing `numba.cuda` if it is not already imported. So go ahead and import `numba.cuda` in the test to ensure it is available. Also copies over @pentschev's fix from PR ( https://github.com/dask/distributed/pull/3255 ) to check that CUDA is available (or otherwise skip the test).