### PR TITLE
Update minimum tblib version to 1.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dask >= 2.9.0
 msgpack
 psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1
-tblib
+tblib >= 1.6.0
 toolz >= 0.7.4
 tornado >= 5
 zict >= 0.1.3


### PR DESCRIPTION
This PR updates our `tblib` minimum version to 1.6.0 to support the changes added in #3430. 

cc @aadamson if you get a chance to look at this