### PR TITLE
WIP: Aggregate received data into a large allocation

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -30,10 +30,7 @@ import asyncio
 from itertools import starmap
 from operator import add
 
-try:
-    from cytoolz import accumulate, cons, sliding_window
-except ImportError:
-    from toolz import accumulate, cons, sliding_window
+from tlz import accumulate, cons, sliding_window
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -57,7 +57,7 @@ def init_once():
         import rmm
 
         if hasattr(rmm, "DeviceBuffer"):
-            cuda_array = lambda n: rmm.DeviceBuffer(size=n)
+            cuda_array = lambda n: as_cuda_array(rmm.DeviceBuffer(size=n))
         else:  # pre-0.11.0
             cuda_array = lambda n: rmm.device_array(n, dtype=np.uint8)
     except ImportError:

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -42,6 +42,16 @@ def init_once():
     ucp = _ucp
     ucp.init(options=dask.config.get("ucx"), env_takes_precedence=True)
 
+    # Find the function, `as_cuda_array()`, to get array-likes from CUDA
+    try:
+        import numba.cuda
+
+        as_cuda_array = lambda a: numba.cuda.as_cuda_array(a)
+    except ImportError:
+
+        def as_cuda_array(a):
+            raise RuntimeError("In order to send/recv CUDA arrays, Numba is required")
+
     # Find the function, `cuda_array()`, to use when allocating new CUDA arrays
     try:
         import rmm

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -69,7 +69,7 @@ def init_once():
 
             def cuda_array(n):
                 raise RuntimeError(
-                    "In order to send/recv CUDA arrays, Numba or RMM is required"
+                    "In order to send/recv CUDA arrays, Numba and RMM are required"
                 )
 
 

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -26,10 +26,7 @@ import asyncio
 from itertools import starmap
 from operator import add
 
-try:
-    from cytoolz import accumulate, cons, sliding_window
-except ImportError:
-    from toolz import accumulate, cons, sliding_window
+from tlz import accumulate, cons, sliding_window
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
**Note:** This is **still** being worked. So there may be bugs, test failures, bad behavior, etc. At this stage, all of these should be expected. You have been warned. 😉

<br>

As we have seen some issues due to churn and fragmentation from small allocations, this tries to allocate one large buffer up front before receiving. This buffer is then split up into small views onto that larger allocation. Once this setup is done we receive into all of these views. The views are then passed to deserialization much as the smaller buffers were before.

We take views onto the data so send and deserialization methods can work on data they are familiar with. A follow-up to this work might be to figure out how deserialization and receive can work on larger buffers to start with to avoid this split of the buffer into views. Though the intent is to not require this at this stage and only follow-up on it as needed later.

To help illustrate the motivation of this this change. Assume we are receiving a Dataframe. Previously we would create multiple allocations for each column along with their relevant internal data (masks, indices, etc.). With this change, we should make one host (and one device) allocation for the whole Dataframe and then fill out its content.

As a bonus of performing this allocation up front and parceling it into the relevant views, we are able to get rid of the old looping behavior around each receive and instead hand all of these to asyncio. This could potentially (though this yet to be verified) get more out of the available bandwidth and benefit from things like non-blocking sends.

Have added this change to both TCP and UCX. The former to aid in testing and discussion. The latter is of interest for improving performance in that use case. Though hopefully both will get a boost from this work.