### PR TITLE
Skip test_open_close_many_workers on Python 3.6

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3581,7 +3581,7 @@ def test_reconnect_timeout(c, s):
 
 @pytest.mark.slow
 @pytest.mark.skipif(WINDOWS, reason="num_fds not supported on windows")
-@pytest.mark.xfail(reason="TODO: intermittent failures")
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="TODO: intermittent failures")
 @pytest.mark.parametrize("worker,count,repeat", [(Worker, 100, 5), (Nanny, 10, 20)])
 def test_open_close_many_workers(loop, worker, count, repeat):
     psutil = pytest.importorskip("psutil")


### PR DESCRIPTION
This test has caused intermittent failures in the past.
Previously we had marked it as xfail, but it would still cause CI to
break because it would cause things to hang.

In #3419 it was observed that the failure seems to only occur on Python
3.6.  This commit changes the universal xfail to a skipif for Python 3.6
and below.

We still don't know what causes the failure, other than that GC seems to
take up all of the CPU time

Fixes #3419