### PR TITLE
Include code and summary in performance report

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -9,7 +9,7 @@ import copy
 import errno
 from functools import partial
 import html
-from inspect import isawaitable
+import inspect
 import itertools
 import json
 import logging
@@ -1189,7 +1189,7 @@ class Client(Node):
                         try:
                             handler = self._stream_handlers[op]
                             result = handler(**msg)
-                            if isawaitable(result):
+                            if inspect.isawaitable(result):
                                 await result
                         except Exception as e:
                             logger.exception(e)
@@ -4594,7 +4594,11 @@ class performance_report:
         await get_client().get_task_stream(start=0, stop=0)  # ensure plugin
 
     async def __aexit__(self, typ, value, traceback):
-        data = await get_client().scheduler.performance_report(start=self.start)
+        frame = inspect.currentframe().f_back
+        code = inspect.getsource(frame)
+        data = await get_client().scheduler.performance_report(
+            start=self.start, code=code
+        )
         with open(self.filename, "w") as f:
             f.write(data)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4593,9 +4593,10 @@ class performance_report:
         self.start = time()
         await get_client().get_task_stream(start=0, stop=0)  # ensure plugin
 
-    async def __aexit__(self, typ, value, traceback):
-        frame = inspect.currentframe().f_back
-        code = inspect.getsource(frame)
+    async def __aexit__(self, typ, value, traceback, code=None):
+        if not code:
+            frame = inspect.currentframe().f_back
+            code = inspect.getsource(frame)
         data = await get_client().scheduler.performance_report(
             start=self.start, code=code
         )
@@ -4606,7 +4607,9 @@ class performance_report:
         get_client().sync(self.__aenter__)
 
     def __exit__(self, typ, value, traceback):
-        get_client().sync(self.__aexit__, type, value, traceback)
+        frame = inspect.currentframe().f_back
+        code = inspect.getsource(frame)
+        get_client().sync(self.__aexit__, type, value, traceback, code=code)
 
 
 @contextmanager

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5920,6 +5920,7 @@ async def test_performance_report(c, s, a, b):
         assert "bokeh" in data
         assert "random" in data
         assert "Dask Performance Report" in data
+        assert "x = da.random" in data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This includes some basic details about the computation and the code that ran it as an extra tab.

Example: 
![Screenshot from 2020-02-09 17-41-14](https://user-images.githubusercontent.com/306380/74115296-6e253880-4b63-11ea-9702-d5fa73a17861.png)
https://gist.githack.com/mrocklin/a809280cd5cea47f53c5f3f8f3937239/raw/53d6526f2b2a1c096edccfc736f233b6108e4bc8/dask-report.html

```python
In [1]: from dask.distributed import Client, performance_report                                          

In [2]: client = Client()                                                                                

In [3]: import dask.array as da 
   ...: with performance_report(): 
   ...:     x = da.random.random((10000, 10000)) 
   ...:     (x + x.T).sum().compute() 
   ...:                                                                                                  

```