### PR TITLE
Add total row to workers plot in dashboard

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1556,7 +1556,7 @@ class WorkerTable(DashboardComponent):
             point_policy="follow_mouse",
             tooltips="""
                 <div>
-                  <span style="font-size: 10px; font-family: Monaco, monospace;">@worker: </span>
+                  <span style="font-size: 10px; font-family: Monaco, monospace;">Worker (@name): </span>
                   <span style="font-size: 10px; font-family: Monaco, monospace;">@memory_percent</span>
                 </div>
                 """,
@@ -1585,7 +1585,7 @@ class WorkerTable(DashboardComponent):
             point_policy="follow_mouse",
             tooltips="""
                 <div>
-                  <span style="font-size: 10px; font-family: Monaco, monospace;">@worker: </span>
+                  <span style="font-size: 10px; font-family: Monaco, monospace;">Worker (@name): </span>
                   <span style="font-size: 10px; font-family: Monaco, monospace;">@cpu</span>
                 </div>
                 """,
@@ -1640,6 +1640,15 @@ class WorkerTable(DashboardComponent):
             data["cpu"][-1] = ws.metrics["cpu"] / 100.0
             data["cpu_fraction"][-1] = ws.metrics["cpu"] / 100.0 / ws.nthreads
             data["nthreads"][-1] = ws.nthreads
+
+        for name in self.names + self.extra_names:
+            if name == "name":
+                data[name].append("Total ({nworkers})".format(nworkers=len(data[name])))
+                continue
+            try:
+                data[name].append(sum(data[name]))
+            except TypeError:
+                data[name].append(None)
 
         self.source.data.update(data)
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1643,7 +1643,9 @@ class WorkerTable(DashboardComponent):
 
         for name in self.names + self.extra_names:
             if name == "name":
-                data[name].insert(0, "Total ({nworkers})".format(nworkers=len(data[name])))
+                data[name].insert(
+                    0, "Total ({nworkers})".format(nworkers=len(data[name]))
+                )
                 continue
             try:
                 data[name].insert(0, sum(data[name]))

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1643,12 +1643,12 @@ class WorkerTable(DashboardComponent):
 
         for name in self.names + self.extra_names:
             if name == "name":
-                data[name].append("Total ({nworkers})".format(nworkers=len(data[name])))
+                data[name].insert(0, "Total ({nworkers})".format(nworkers=len(data[name])))
                 continue
             try:
-                data[name].append(sum(data[name]))
+                data[name].insert(0, sum(data[name]))
             except TypeError:
-                data[name].append(None)
+                data[name].insert(0, None)
 
         self.source.data.update(data)
 

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -300,10 +300,13 @@ def test_WorkerTable(c, s, a, b):
         for L in wt.source.data.values()
         for v in L
     ), {type(v).__name__ for L in wt.source.data.values() for v in L}
-    assert all(len(v) == 2 for v in wt.source.data.values())
+
+    assert all(len(v) == 3 for v in wt.source.data.values())
+    assert wt.source.data["name"][0] == "Total (2)"
 
     nthreads = wt.source.data["nthreads"]
     assert all(nthreads)
+    assert nthreads[0] == nthreads[1] + nthreads[2]
 
 
 @gen_cluster(client=True)
@@ -334,7 +337,7 @@ def test_WorkerTable_custom_metrics(c, s, a, b):
         assert name in data
 
     assert all(data.values())
-    assert all(len(v) == 2 for v in data.values())
+    assert all(len(v) == 3 for v in data.values())
     my_index = data["address"].index(a.address), data["address"].index(b.address)
     assert [data["metric_port"][i] for i in my_index] == [a.port, b.port]
     assert [data["metric_address"][i] for i in my_index] == [a.address, b.address]
@@ -359,7 +362,7 @@ def test_WorkerTable_different_metrics(c, s, a, b):
     assert "metric_a" in data
     assert "metric_b" in data
     assert all(data.values())
-    assert all(len(v) == 2 for v in data.values())
+    assert all(len(v) == 3 for v in data.values())
     my_index = data["address"].index(a.address), data["address"].index(b.address)
     assert [data["metric_a"][i] for i in my_index] == [a.port, None]
     assert [data["metric_b"][i] for i in my_index] == [None, b.port]
@@ -379,7 +382,7 @@ def test_WorkerTable_metrics_with_different_metric_2(c, s, a, b):
 
     assert "metric_a" in data
     assert all(data.values())
-    assert all(len(v) == 2 for v in data.values())
+    assert all(len(v) == 3 for v in data.values())
     my_index = data["address"].index(a.address), data["address"].index(b.address)
     assert [data["metric_a"][i] for i in my_index] == [a.port, None]
 


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/5275

![image](https://user-images.githubusercontent.com/4806877/74178914-65d40880-4c0a-11ea-8d1e-1de53d058aa0.png)

Note that the `Total` is also included in the circle plots above the table. I added the worker name to the hover to make it clear which one is which:

![Screenshot from 2020-02-10 13-40-10](https://user-images.githubusercontent.com/4806877/74179321-2ce86380-4c0b-11ea-9a3e-a7a6f883b2e2.png)

But I would like some input on whether to take it out of those, or make it another color. 