### PR TITLE
Split dashboard host on additional slashes to handle inproc

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -199,7 +199,7 @@ class Cluster:
         except KeyError:
             return ""
         else:
-            host = self.scheduler_address.split("://")[1].split(":")[0]
+            host = self.scheduler_address.split("://")[1].split("/")[0].split(":")[0]
             return format_dashboard_link(host, port)
 
     def _widget_status(self):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5255,6 +5255,12 @@ def test_dashboard_link(loop, monkeypatch):
                 assert link in text
 
 
+def test_dashboard_link_inproc(loop, monkeypatch):
+    with Client(processes=False, loop=loop) as c:
+        with dask.config.set({"distributed.dashboard.link": "{host}"}):
+            assert "/" not in c.dashboard_link
+
+
 @gen_test()
 def test_client_timeout_2():
     with dask.config.set({"distributed.comm.timeouts.connect": "10ms"}):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5255,8 +5255,9 @@ def test_dashboard_link(loop, monkeypatch):
                 assert link in text
 
 
-def test_dashboard_link_inproc(loop, monkeypatch):
-    with Client(processes=False, loop=loop) as c:
+@pytest.mark.asyncio
+async def test_dashboard_link_inproc(cleanup):
+    async with Client(processes=False, asynchronous=True) as c:
         with dask.config.set({"distributed.dashboard.link": "{host}"}):
             assert "/" not in c.dashboard_link
 


### PR DESCRIPTION
When the Dask scheduler is run with `processes=False` and the scheduler uses an `inproc://` address the dashboard url logic fails. This is because the scheduler host contains the process pid info separated by slashes `inproc://192.168.0.11/535/1`. 

Current logic strips off the protocol but leaves the pid info. This PR strips that off too and adds a test to avoid a regression.

Closes #3456