### PR TITLE
add last seen column to worker table

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import json
 import logging
+from time import time
 
 import dask
 from dask.utils import format_bytes
@@ -55,7 +56,8 @@ from ..scheduler import ALL_TASK_STATES
 
 
 ns = {
-    func.__name__: func for func in [format_bytes, format_time, datetime.fromtimestamp]
+    func.__name__: func
+    for func in [format_bytes, format_time, datetime.fromtimestamp, time]
 }
 
 rel_path_statics = {"rel_path_statics": "../../"}

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -4,7 +4,6 @@ import os
 import os.path
 import json
 import logging
-from time import time
 
 import dask
 from dask.utils import format_bytes
@@ -51,6 +50,7 @@ from .worker import counters_doc
 from .proxy import GlobalProxyHandler
 from .utils import RequestHandler, redirect
 from ..diagnostics.websocket import WebsocketPlugin
+from ..metrics import time
 from ..utils import log_errors, format_time
 from ..scheduler import ALL_TASK_STATES
 

--- a/distributed/dashboard/templates/task.html
+++ b/distributed/dashboard/templates/task.html
@@ -122,9 +122,9 @@
                   <th> Recommended Action </th>
               </thead>
 
-              {% for key, start, finish, recommendations, time in scheduler.story(Task) %}
+              {% for key, start, finish, recommendations, transition_time in scheduler.story(Task) %}
               <tr>
-                  <td> {{ fromtimestamp(time) }} </td>
+                  <td> {{ fromtimestamp(transition_time) }} </td>
                   <td> <a href="{{ url_escape(key) }}.html">{{key}}</a> </td>
                   <td> {{ start }} </td>
                   <td> {{ finish }} </td>

--- a/distributed/dashboard/templates/worker-table.html
+++ b/distributed/dashboard/templates/worker-table.html
@@ -1,4 +1,4 @@
-   <table class="table is-striped is-hoverable">
+<table class="table is-striped is-hoverable">
     <tr>
         <th> Worker </th>
         <th> Name </th>
@@ -10,6 +10,7 @@
         <th> In-memory </th>
         <th> Services</th>
         <th> Logs </th>
+        <th> Last seen </th>
     </tr>
     {% for ws in worker_list %}
     <tr>
@@ -27,6 +28,7 @@
         <td> </td>
         {% end %}
         <td> <a href="../logs/{{ url_escape(ws.address) }}.html">logs</a></td>
+        <td> {{ format_time(time() - ws.last_seen) }} </td>
     </tr>
     {% end %}
   </table>

--- a/distributed/dashboard/templates/worker-table.html
+++ b/distributed/dashboard/templates/worker-table.html
@@ -13,7 +13,7 @@
         <th> Last seen </th>
     </tr>
     {% for ws in worker_list %}
-    <tr>
+    <tr {{ "style=background-color:#ffcdd2" if time() - ws.last_seen > 60 else ""}}>
         <td><a href="../worker/{{ url_escape(ws.address) }}.html">{{ws.address}}</a></td>
         <td> {{ ws.name if ws.name is not None else "" }} </td>
         <td> {{ ws.nthreads }} </td>


### PR DESCRIPTION
Had some problems with stalled workers and thought it'd be helpful to surface `last_seen` in the web interface. This change adds a column for "Last seen" in `worker-table.html`. It also might be worth coloring the row to raise visibility? I'm not super familiar with jinja templates but I'd be happy to take a stab at it if anyone has suggestions.

Fixes #2595