### PR TITLE
Minor gen.Return cleanup

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -1,5 +1,4 @@
 import asyncio
-from tornado import gen
 import functools
 import threading
 from queue import Queue
@@ -169,7 +168,6 @@ class Actor(WrappedKey):
                     attribute=key, actor=self.key
                 )
                 return x["result"]
-                raise gen.Return(x["result"])
 
             return self._sync(get_actor_attribute_from_worker)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1909,7 +1909,7 @@ class Client(Node):
             isinstance(k, (bytes, str)) for k in data
         ):
             d = await self._scatter(keymap(tokey, data), workers, broadcast)
-            raise gen.Return({k: d[tokey(k)] for k in data})
+            return {k: d[tokey(k)] for k in data}
 
         if isinstance(data, type(range(0))):
             data = list(data)


### PR DESCRIPTION
This PR fixes a couple of instances where `gen.Return` wasn't being used properly