### PR TITLE
Update NumPy array serialization to handle non-contiguous slices

### DIFF
--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -268,6 +268,7 @@ def test_large_numpy_array():
         np.broadcast_to(np.arange(10), (20, 10)),  # Some strides are 0
         np.broadcast_to(1, (3, 4, 2)),  # All strides are 0
         np.broadcast_to(np.arange(100)[:1], 5),  # x.base is larger than x
+        np.broadcast_to(np.arange(5), (4, 5))[:, ::-1],
     ],
 )
 @pytest.mark.parametrize("writeable", [True, False])


### PR DESCRIPTION
Our current serialization of NumPy arrays with a zero stride fails when the slice taken here

https://github.com/dask/distributed/blob/ca88aa7327820fc934b2254b884721cea94991e5/distributed/protocol/numpy.py#L50

results in a non-contiguous memory layout. For example

```python
import numpy as np
from distributed.protocol import serialize, deserialize

x = np.broadcast_to(np.arange(5), (4, 5))[:, ::-1]
y = deserialize(*serialize(x))
print(y)
```

will currently fail with `ValueError: strides is incompatible with shape of requested array and size of buffer` because the sliced version of the array is non-contiguous and breaks when broadcasting later during deserialization

This PR adds an additional contiguous check and will create a contiguous version of an array with the appropriate strides when needed