### PR TITLE
Serialize 1-D, contiguous, `uint8` CUDA frames

### DIFF
--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -43,6 +43,7 @@ def serialize_cupy_ndarray(x):
         x = cupy.array(x, copy=True)
 
     header = x.__cuda_array_interface__.copy()
+    header["strides"] = tuple(x.strides)
     frames = [x]
 
     return header, frames

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -55,6 +55,9 @@ def deserialize_cupy_array(header, frames):
     if not isinstance(frame, cupy.ndarray):
         frame = PatchedCudaArrayInterface(frame)
     arr = cupy.ndarray(
-        shape=header["shape"], dtype=header["typestr"], memptr=cupy.asarray(frame).data
+        shape=header["shape"],
+        dtype=header["typestr"],
+        memptr=cupy.asarray(frame).data,
+        strides=header["strides"],
     )
     return arr

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -33,7 +33,7 @@ class PatchedCudaArrayInterface:
 @cuda_serialize.register(cupy.ndarray)
 def serialize_cupy_ndarray(x):
     # Making sure `x` is behaving
-    if not x.flags["C_CONTIGUOUS"]:
+    if not (x.flags["C_CONTIGUOUS"] or x.flags["F_CONTIGUOUS"]):
         x = cupy.array(x, copy=True)
 
     header = x.__cuda_array_interface__.copy()

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -43,8 +43,9 @@ def serialize_cupy_ndarray(x):
         x = cupy.array(x, copy=True)
 
     header = x.__cuda_array_interface__.copy()
+    frames = [x]
 
-    return header, [x]
+    return header, frames
 
 
 @cuda_deserialize.register(cupy.ndarray)

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -40,7 +40,7 @@ def serialize_cupy_ndarray(x):
     header["strides"] = tuple(x.strides)
     frames = [
         cupy.ndarray(
-            shape=(x.size,), dtype=x.dtype, memptr=x.data, strides=(x.dtype.itemsize,)
+            shape=(x.nbytes,), dtype=cupy.dtype("u1"), memptr=x.data, strides=(1,)
         )
     ]
 

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -6,21 +6,15 @@ from .cuda import cuda_serialize, cuda_deserialize
 
 
 class PatchedCudaArrayInterface:
-    """This class do two things:
-        1) Makes sure that __cuda_array_interface__['strides']
-           behaves as specified in the protocol.
-        2) Makes sure that the cuda context is active
+    """This class does one thing:
+        1) Makes sure that the cuda context is active
            when deallocating the base cuda array.
         Notice, this is only needed when the array to deserialize
         isn't a native cupy array.
     """
 
     def __init__(self, ary):
-        cai = ary.__cuda_array_interface__
-        cai_cupy_vsn = cupy.ndarray(0).__cuda_array_interface__["version"]
-        if cai.get("strides") is None and cai_cupy_vsn < 2:
-            cai.pop("strides", None)
-        self.__cuda_array_interface__ = cai
+        self.__cuda_array_interface__ = ary.__cuda_array_interface__
         # Save a ref to ary so it won't go out of scope
         self.base = ary
 

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -54,6 +54,6 @@ def deserialize_cupy_array(header, frames):
     if not isinstance(frame, cupy.ndarray):
         frame = PatchedCudaArrayInterface(frame)
     arr = cupy.ndarray(
-        header["shape"], dtype=header["typestr"], memptr=cupy.asarray(frame).data
+        shape=header["shape"], dtype=header["typestr"], memptr=cupy.asarray(frame).data
     )
     return arr

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -43,6 +43,7 @@ def serialize_cupy_ndarray(x):
         x = cupy.array(x, copy=True)
 
     header = x.__cuda_array_interface__.copy()
+
     return header, [x]
 
 

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -39,7 +39,7 @@ class PatchedCudaArrayInterface:
 @cuda_serialize.register(cupy.ndarray)
 def serialize_cupy_ndarray(x):
     # Making sure `x` is behaving
-    if not x.flags.c_contiguous:
+    if not x.flags["C_CONTIGUOUS"]:
         x = cupy.array(x, copy=True)
 
     header = x.__cuda_array_interface__.copy()

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -38,7 +38,11 @@ def serialize_cupy_ndarray(x):
 
     header = x.__cuda_array_interface__.copy()
     header["strides"] = tuple(x.strides)
-    frames = [x]
+    frames = [
+        cupy.ndarray(
+            shape=(x.size,), dtype=x.dtype, memptr=x.data, strides=(x.dtype.itemsize,)
+        )
+    ]
 
     return header, frames
 

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -25,12 +25,6 @@ def deserialize_numba_ndarray(header, frames):
     shape = header["shape"]
     strides = header["strides"]
 
-    # Starting with __cuda_array_interface__ version 2, strides can be None,
-    # meaning the array is C-contiguous, so we have to calculate it.
-    if strides is None:
-        itemsize = np.dtype(header["typestr"]).itemsize
-        strides = tuple((np.cumprod((1,) + shape[:0:-1]) * itemsize).tolist())
-
     arr = numba.cuda.devicearray.DeviceNDArray(
         shape=shape,
         strides=strides,

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -6,7 +6,7 @@ from .cuda import cuda_serialize, cuda_deserialize
 @cuda_serialize.register(numba.cuda.devicearray.DeviceNDArray)
 def serialize_numba_ndarray(x):
     # Making sure `x` is behaving
-    if not x.flags["C_CONTIGUOUS"]:
+    if not (x.flags["C_CONTIGUOUS"] or x.flags["F_CONTIGUOUS"]):
         shape = x.shape
         t = numba.cuda.device_array(shape, dtype=x.dtype)
         t.copy_to_device(x)

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -16,10 +16,7 @@ def serialize_numba_ndarray(x):
     header["strides"] = tuple(x.strides)
     frames = [
         numba.cuda.cudadrv.devicearray.DeviceNDArray(
-            shape=(x.size,),
-            strides=(x.dtype.itemsize,),
-            dtype=x.dtype,
-            gpu_data=x.gpu_data,
+            shape=(x.nbytes,), strides=(1,), dtype=np.dtype("u1"), gpu_data=x.gpu_data,
         )
     ]
 

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -31,9 +31,9 @@ def deserialize_numba_ndarray(header, frames):
         strides = tuple((np.cumprod((1,) + shape[:0:-1]) * itemsize).tolist())
 
     arr = numba.cuda.devicearray.DeviceNDArray(
-        shape,
-        strides,
-        np.dtype(header["typestr"]),
+        shape=shape,
+        strides=strides,
+        dtype=np.dtype(header["typestr"]),
         gpu_data=numba.cuda.as_cuda_array(frame).gpu_data,
     )
     return arr

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -6,7 +6,7 @@ from .cuda import cuda_serialize, cuda_deserialize
 @cuda_serialize.register(numba.cuda.devicearray.DeviceNDArray)
 def serialize_numba_ndarray(x):
     # Making sure `x` is behaving
-    if not x.is_c_contiguous():
+    if not x.flags["C_CONTIGUOUS"]:
         shape = x.shape
         t = numba.cuda.device_array(shape, dtype=x.dtype)
         t.copy_to_device(x)

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -13,8 +13,9 @@ def serialize_numba_ndarray(x):
         x = t
 
     header = x.__cuda_array_interface__.copy()
+    frames = [x]
 
-    return header, [x]
+    return header, frames
 
 
 @cuda_deserialize.register(numba.cuda.devicearray.DeviceNDArray)

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -13,6 +13,7 @@ def serialize_numba_ndarray(x):
         x = t
 
     header = x.__cuda_array_interface__.copy()
+    header["strides"] = tuple(x.strides)
     frames = [x]
 
     return header, frames

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -14,7 +14,14 @@ def serialize_numba_ndarray(x):
 
     header = x.__cuda_array_interface__.copy()
     header["strides"] = tuple(x.strides)
-    frames = [x]
+    frames = [
+        numba.cuda.cudadrv.devicearray.DeviceNDArray(
+            shape=(x.size,),
+            strides=(x.dtype.itemsize,),
+            dtype=x.dtype,
+            gpu_data=x.gpu_data,
+        )
+    ]
 
     return header, frames
 

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -11,7 +11,9 @@ def serialize_numba_ndarray(x):
         t = numba.cuda.device_array(shape, dtype=x.dtype)
         t.copy_to_device(x)
         x = t
+
     header = x.__cuda_array_interface__.copy()
+
     return header, [x]
 
 

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -3,12 +3,15 @@ import pickle
 import pytest
 
 cupy = pytest.importorskip("cupy")
+numpy = pytest.importorskip("numpy")
 
 
-@pytest.mark.parametrize("size", [0, 10])
+@pytest.mark.parametrize("shape", [(0,), (5,), (4, 6), (10, 11), (2, 3, 5)])
 @pytest.mark.parametrize("dtype", ["u1", "u4", "u8", "f4"])
-def test_serialize_cupy(size, dtype):
-    x = cupy.arange(size, dtype=dtype)
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_serialize_cupy(shape, dtype, order):
+    x = cupy.arange(numpy.product(shape), dtype=dtype)
+    x = cupy.ndarray(shape, dtype=x.dtype, memptr=x.data, order=order)
     header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
 


### PR DESCRIPTION
When performing serialization of CUDA frames, make sure they are converted to 1-D, contiguous, `uint8` frames. This makes them significantly easier to work with in later pipeline steps that operate on this serialized data. For example checking the data is contiguous is as simple as ensuring the `strides` are `(1,)`. Similarly the number of bytes to transmit can be extracted from the `shape` as it will be `(nbytes,)`. Additionally this gives us greater confidence that generic objects that merely contain some number of bytes can adequately receive more complex objects and represent them correctly. Finally this has the added benefit of handling F-contiguous data just as easily as C-contiguous data is handled, which can be useful for algorithms expecting this particular data layout. As we now guarantee `strides` is not `None` to simplify data reconstruction, we were able to get rid of some older workarounds and hopefully clarify things a bit.