### PR TITLE
Register Dask cuDF serializers

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -88,5 +88,7 @@ def _register_rmm():
 
 @cuda_serialize.register_lazy("cudf")
 @cuda_deserialize.register_lazy("cudf")
+@dask_serialize.register_lazy("cudf")
+@dask_deserialize.register_lazy("cudf")
 def _register_cudf():
     from cudf.comm import serialize


### PR DESCRIPTION
As cuDF is gaining support for serializing using the Dask protocol as well ( https://github.com/rapidsai/cudf/pull/4153 ), make sure to register it's serializers there as well. cuDF versions lacking this support will continue to behave the same (falling back to pickle). However cuDF versions with this support will bypass pickle. So only pay the cost of a host-to-device transfer.