### PR TITLE
Add dask serialization of CUDA objects

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -82,6 +82,8 @@ def _register_numba():
 
 @cuda_serialize.register_lazy("rmm")
 @cuda_deserialize.register_lazy("rmm")
+@dask_serialize.register_lazy("rmm")
+@dask_deserialize.register_lazy("rmm")
 def _register_rmm():
     from . import rmm
 

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -76,6 +76,8 @@ def _register_cupy():
 
 @cuda_serialize.register_lazy("numba")
 @cuda_deserialize.register_lazy("numba")
+@dask_serialize.register_lazy("numba")
+@dask_deserialize.register_lazy("numba")
 def _register_numba():
     from . import numba
 

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -70,6 +70,8 @@ def _register_torch():
 
 @cuda_serialize.register_lazy("cupy")
 @cuda_deserialize.register_lazy("cupy")
+@dask_serialize.register_lazy("cupy")
+@dask_deserialize.register_lazy("cupy")
 def _register_cupy():
     from . import cupy
 

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -48,7 +48,7 @@ def serialize_cupy_ndarray(x):
 
 
 @cuda_deserialize.register(cupy.ndarray)
-def deserialize_cupy_array(header, frames):
+def deserialize_cupy_ndarray(header, frames):
     (frame,) = frames
     if not isinstance(frame, cupy.ndarray):
         frame = PatchedCudaArrayInterface(frame)

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -2,7 +2,8 @@
 Efficient serialization GPU arrays.
 """
 import cupy
-from .cuda import cuda_serialize, cuda_deserialize
+
+from .cuda import cuda_deserialize, cuda_serialize
 
 
 class PatchedCudaArrayInterface:

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -38,7 +38,7 @@ class PatchedCudaArrayInterface:
 
 
 @cuda_serialize.register(cupy.ndarray)
-def serialize_cupy_ndarray(x):
+def cuda_serialize_cupy_ndarray(x):
     # Making sure `x` is behaving
     if not x.flags.c_contiguous:
         x = cupy.array(x, copy=True)
@@ -48,7 +48,7 @@ def serialize_cupy_ndarray(x):
 
 
 @cuda_deserialize.register(cupy.ndarray)
-def deserialize_cupy_ndarray(header, frames):
+def cuda_deserialize_cupy_ndarray(header, frames):
     (frame,) = frames
     if not isinstance(frame, cupy.ndarray):
         frame = PatchedCudaArrayInterface(frame)

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -1,6 +1,7 @@
-import numpy as np
 import numba.cuda
-from .cuda import cuda_serialize, cuda_deserialize
+import numpy as np
+
+from .cuda import cuda_deserialize, cuda_serialize
 
 
 @cuda_serialize.register(numba.cuda.devicearray.DeviceNDArray)

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -5,7 +5,7 @@ from .cuda import cuda_deserialize, cuda_serialize
 
 
 @cuda_serialize.register(numba.cuda.devicearray.DeviceNDArray)
-def serialize_numba_ndarray(x):
+def cuda_serialize_numba_ndarray(x):
     # Making sure `x` is behaving
     if not x.is_c_contiguous():
         shape = x.shape
@@ -17,7 +17,7 @@ def serialize_numba_ndarray(x):
 
 
 @cuda_deserialize.register(numba.cuda.devicearray.DeviceNDArray)
-def deserialize_numba_ndarray(header, frames):
+def cuda_deserialize_numba_ndarray(header, frames):
     (frame,) = frames
     shape = header["shape"]
     strides = header["strides"]

--- a/distributed/protocol/rmm.py
+++ b/distributed/protocol/rmm.py
@@ -6,13 +6,13 @@ from .cuda import cuda_deserialize, cuda_serialize
 if hasattr(rmm, "DeviceBuffer"):
 
     @cuda_serialize.register(rmm.DeviceBuffer)
-    def serialize_rmm_device_buffer(x):
+    def cuda_serialize_rmm_device_buffer(x):
         header = x.__cuda_array_interface__.copy()
         frames = [x]
         return header, frames
 
     @cuda_deserialize.register(rmm.DeviceBuffer)
-    def deserialize_rmm_device_buffer(header, frames):
+    def cuda_deserialize_rmm_device_buffer(header, frames):
         (arr,) = frames
 
         # We should already have `DeviceBuffer`

--- a/distributed/protocol/rmm.py
+++ b/distributed/protocol/rmm.py
@@ -1,6 +1,6 @@
 import rmm
-from .cuda import cuda_serialize, cuda_deserialize
 
+from .cuda import cuda_deserialize, cuda_serialize
 
 # Used for RMM 0.11.0+ otherwise Numba serializers used
 if hasattr(rmm, "DeviceBuffer"):

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -16,6 +16,11 @@ def test_serialize_cupy(shape, dtype, order, serializers):
     header, frames = serialize(x, serializers=serializers)
     y = deserialize(header, frames, deserializers=serializers)
 
+    if serializers[0] == "cuda":
+        assert all(hasattr(f, "__cuda_array_interface__") for f in frames)
+    elif serializers[0] == "dask":
+        assert all(isinstance(f, memoryview) for f in frames)
+
     assert (x == y).all()
 
 

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -9,11 +9,12 @@ numpy = pytest.importorskip("numpy")
 @pytest.mark.parametrize("shape", [(0,), (5,), (4, 6), (10, 11), (2, 3, 5)])
 @pytest.mark.parametrize("dtype", ["u1", "u4", "u8", "f4"])
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_serialize_cupy(shape, dtype, order):
+@pytest.mark.parametrize("serializers", [("cuda",), ("dask",), ("pickle",)])
+def test_serialize_cupy(shape, dtype, order, serializers):
     x = cupy.arange(numpy.product(shape), dtype=dtype)
     x = cupy.ndarray(shape, dtype=x.dtype, memptr=x.data, order=order)
-    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
-    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+    header, frames = serialize(x, serializers=serializers)
+    y = deserialize(header, frames, deserializers=serializers)
 
     assert (x == y).all()
 

--- a/distributed/protocol/tests/test_numba.py
+++ b/distributed/protocol/tests/test_numba.py
@@ -9,15 +9,16 @@ np = pytest.importorskip("numpy")
 @pytest.mark.parametrize("shape", [(0,), (5,), (4, 6), (10, 11), (2, 3, 5)])
 @pytest.mark.parametrize("dtype", ["u1", "u4", "u8", "f4"])
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_serialize_numba(shape, dtype, order):
+@pytest.mark.parametrize("serializers", [("cuda",), ("dask",)])
+def test_serialize_numba(shape, dtype, order, serializers):
     if not cuda.is_available():
         pytest.skip("CUDA is not available")
 
     ary = np.arange(np.product(shape), dtype=dtype)
     ary = np.ndarray(shape, dtype=ary.dtype, buffer=ary.data, order=order)
     x = cuda.to_device(ary)
-    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
-    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+    header, frames = serialize(x, serializers=serializers)
+    y = deserialize(header, frames, deserializers=serializers)
 
     hx = np.empty_like(ary)
     hy = np.empty_like(ary)

--- a/distributed/protocol/tests/test_numba.py
+++ b/distributed/protocol/tests/test_numba.py
@@ -20,6 +20,11 @@ def test_serialize_numba(shape, dtype, order, serializers):
     header, frames = serialize(x, serializers=serializers)
     y = deserialize(header, frames, deserializers=serializers)
 
+    if serializers[0] == "cuda":
+        assert all(hasattr(f, "__cuda_array_interface__") for f in frames)
+    elif serializers[0] == "dask":
+        assert all(isinstance(f, memoryview) for f in frames)
+
     hx = np.empty_like(ary)
     hy = np.empty_like(ary)
     x.copy_to_host(hx)

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -20,4 +20,9 @@ def test_serialize_rmm_device_buffer(size, serializers):
     y = deserialize(header, frames, deserializers=serializers)
     y_np = y.copy_to_host()
 
+    if serializers[0] == "cuda":
+        assert all(hasattr(f, "__cuda_array_interface__") for f in frames)
+    elif serializers[0] == "dask":
+        assert all(isinstance(f, memoryview) for f in frames)
+
     assert (x_np == y_np).all()

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -7,7 +7,8 @@ rmm = pytest.importorskip("rmm")
 
 
 @pytest.mark.parametrize("size", [0, 3, 10])
-def test_serialize_rmm_device_buffer(size):
+@pytest.mark.parametrize("serializers", [("cuda",), ("dask",), ("pickle",)])
+def test_serialize_rmm_device_buffer(size, serializers):
     if not hasattr(rmm, "DeviceBuffer"):
         pytest.skip("RMM pre-0.11.0 does not have DeviceBuffer")
 
@@ -15,8 +16,8 @@ def test_serialize_rmm_device_buffer(size):
     x = rmm.DeviceBuffer(size=size)
     cuda.to_device(x_np, to=cuda.as_cuda_array(x))
 
-    header, frames = serialize(x, serializers=("cuda", "dask", "pickle"))
-    y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
+    header, frames = serialize(x, serializers=serializers)
+    y = deserialize(header, frames, deserializers=serializers)
     y_np = y.copy_to_host()
 
     assert (x_np == y_np).all()


### PR DESCRIPTION
This implements `"dask"` serialization for CUDA objects. All serializers work by first performing `"cuda"` serialization on the different objects and then performing a device-to-host transfer. The deserializers perform a host-to-device transfer before running the respective `"cuda"` deserializer for the object considered. Should provide an alternative way to do TCP transfers with CUDA objects that does not rely on pickling.

Note: Just like with UCX transfers, we preferentially add objects to the RMM pool if RMM is available. Otherwise we fallback to using Numba.