### PR TITLE
Check exact equality for worker state

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -276,13 +276,10 @@ class WorkerState:
         self.extra = extra or {}
 
     def __hash__(self):
-        return hash((self.name, self.host))
+        return hash(self.address)
 
     def __eq__(self, other):
-        return type(self) == type(other) and (self.name, self.host) == (
-            other.name,
-            other.host,
-        )
+        return type(self) == type(other) and self.address == other.address
 
     @property
     def host(self):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -279,7 +279,10 @@ class WorkerState:
         return hash((self.name, self.host))
 
     def __eq__(self, other):
-        return type(self) == type(other) and hash(self) == hash(other)
+        return type(self) == type(other) and (self.name, self.host) == (
+            other.name,
+            other.host,
+        )
 
     @property
     def host(self):


### PR DESCRIPTION
Per https://github.com/dask/distributed/pull/3321#discussion_r379826000, I agree it makes more sense to check for exact equality instead of relying on the hash (just in case 🙂).

I could see an argument for wrapping this tuple in a property so it can be reused, do we think that's preferable? I'd originally wanted to use `identity` for `hash` and `eq` but that has a bit too much going on IMO.