### PR TITLE
Remove --verbose flag from CI runs

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -43,4 +43,4 @@ jobs:
         shell: bash -l {0}
         env:
           PYTHONFAULTHANDLER: 1
-        run: py.test -m "not avoid_travis" distributed --verbose -r s --timeout-method=thread --timeout=300 --durations=20
+        run: py.test -m "not avoid_travis" distributed -r s --timeout-method=thread --timeout=300 --durations=20

--- a/continuous_integration/travis/run_tests.sh
+++ b/continuous_integration/travis/run_tests.sh
@@ -1,4 +1,4 @@
-export PYTEST_OPTIONS="--verbose -r s --timeout-method=thread --timeout=300 --durations=20"
+export PYTEST_OPTIONS="-r s --timeout-method=thread --timeout=300 --durations=20"
 if [[ $RUNSLOW != false ]]; then
     export PYTEST_OPTIONS="$PYTEST_OPTIONS --runslow"
 fi

--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -272,12 +272,13 @@ def _test_workspace_concurrency(tmpdir, timeout, max_procs):
     return n_created, n_purged
 
 
+@pytest.mark.slow
 def test_workspace_concurrency(tmpdir):
     if WINDOWS:
         raise pytest.xfail.Exception("TODO: unknown failure on windows")
     if sys.version_info < (3, 7):
         raise pytest.xfail.Exception("TODO: unknown failure on Python 3.6")
-    _test_workspace_concurrency(tmpdir, 2.0, 6)
+    _test_workspace_concurrency(tmpdir, 5.0, 6)
 
 
 @pytest.mark.slow

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ tag_prefix =
 parentdir_prefix = distributed-
 
 [tool:pytest]
-addopts = -rsx -v --durations=10
+addopts = -rsx --durations=10
 minversion = 3.2
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
Historically we included the verbose flag because if things hung it was
useful to see which test in particular was causing the hang.  This
hasn't been so important recently.

It's somewhat annoying to scroll through all of the tests one by one.
This seems more important today than the hung test case.