### PR TITLE
Register cuML serializers

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -92,3 +92,11 @@ def _register_rmm():
 @dask_deserialize.register_lazy("cudf")
 def _register_cudf():
     from cudf.comm import serialize
+
+
+@cuda_serialize.register_lazy("cuml")
+@cuda_deserialize.register_lazy("cuml")
+@dask_serialize.register_lazy("cuml")
+@dask_deserialize.register_lazy("cuml")
+def _register_cuml():
+    from cuml.comm import serialize


### PR DESCRIPTION
Leverages the changes in PR ( https://github.com/rapidsai/cuml/pull/1689 ) (and subsequent PRs) to register cuML objects for serialization with Dask.