### PR TITLE
Improved visuals for task graph

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1177,7 +1177,7 @@ class TaskGraph(DashboardComponent):
             y="y",
             size=15,
             line_width=0,
-            color='black',
+            color='white',
             name="margin",
             source=self.node_source,
             view=node_view,


### PR DESCRIPTION
This implements the _visual_ changes shown in #3467. The algorithm for placing the nodes has __not__ been changed.

To address the performance concerns raised by @mrocklin the graph now uses bokeh's WebGL backend which effortlessly pushes 10k nodes on my integrated GPU. 
All elements in the graph have been chosen so that they play along nicely with WebGL.