### PR TITLE
Stop keep alives when worker reconnecting to the scheduler

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -798,6 +798,8 @@ class Worker(ServerNode):
 
     async def _register_with_scheduler(self):
         self.periodic_callbacks["heartbeat"].stop()
+        if self.periodic_callbacks.get("keep-alive"):
+            self.periodic_callbacks["keep-alive"].stop()
         start = time()
         if self.contact_address is None:
             self.contact_address = self.address


### PR DESCRIPTION
Related to #3488.

I don't think this fixes the problem,  but I think it should address the `CommClosedError` exceptions which are seen in the log.

When a worker registers with the scheduler it starts sending keepalive messages via a periodic callback. However that never seems to stop if the connection is broken. If the connection hangs for a long period of time the worker still attempts to send the keepalive messages.

This PR moves the definitions of the `BatchedSend` and `keep-alive` callback to the `__init__` and stops the callback during the reconnect. This is already being done for the heartbeat.