### PR TITLE
Msgpack 1.0 compatibility

### DIFF
--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - ipywidgets
   - joblib
   - jupyter_client
-  - msgpack-python
+  - msgpack-python>=0.6.0
   - prometheus_client
   - psutil
   - pytest

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -40,6 +40,7 @@ conda install -c conda-forge -q \
     ipywidgets \
     joblib \
     jupyter_client \
+    msgpack-python>=0.6.0 \
     netcdf4 \
     paramiko \
     prometheus_client \
@@ -71,7 +72,7 @@ python -m pip install -q git+https://github.com/joblib/joblib.git --upgrade --no
 python -m pip install -q git+https://github.com/intake/filesystem_spec.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
-python -m pip install -q sortedcollections msgpack --no-deps
+python -m pip install -q sortedcollections --no-deps
 python -m pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -71,7 +71,7 @@ python -m pip install -q git+https://github.com/joblib/joblib.git --upgrade --no
 python -m pip install -q git+https://github.com/intake/filesystem_spec.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
-python -m pip install -q sortedcollections msgpack-python --no-deps
+python -m pip install -q sortedcollections msgpack --no-deps
 python -m pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -71,8 +71,7 @@ python -m pip install -q git+https://github.com/joblib/joblib.git --upgrade --no
 python -m pip install -q git+https://github.com/intake/filesystem_spec.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
-python -m pip install -q sortedcollections --no-deps
-python -m pip install -q git+https://github.com/msgpack/msgpack-python --no-deps
+python -m pip install -q sortedcollections msgpack-python --no-deps
 python -m pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -71,7 +71,7 @@ python -m pip install -q git+https://github.com/joblib/joblib.git --upgrade --no
 python -m pip install -q git+https://github.com/intake/filesystem_spec.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
-python -m pip install -q sortedcollections msgpack --no-deps
+python -m pip install -q sortedcollections msgpack>=1 --no-deps
 python -m pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -71,7 +71,8 @@ python -m pip install -q git+https://github.com/joblib/joblib.git --upgrade --no
 python -m pip install -q git+https://github.com/intake/filesystem_spec.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
-python -m pip install -q sortedcollections msgpack --no-deps
+python -m pip install -q sortedcollections --no-deps
+python -m pip install -q git+https://github.com/msgpack/msgpack-python --no-deps
 python -m pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -71,7 +71,7 @@ python -m pip install -q git+https://github.com/joblib/joblib.git --upgrade --no
 python -m pip install -q git+https://github.com/intake/filesystem_spec.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
-python -m pip install -q sortedcollections msgpack>=1 --no-deps
+python -m pip install -q sortedcollections msgpack --no-deps
 python -m pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -196,7 +196,7 @@ def test_compress_numpy():
     frames = dumps({"x": to_serialize(x)})
     assert sum(map(nbytes, frames)) < x.nbytes
 
-    header = msgpack.loads(frames[2], raw=False, use_list=False)
+    header = msgpack.loads(frames[2], raw=False, use_list=False, strict_map_key=False)
     try:
         import blosc  # noqa: F401
     except ImportError:

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -166,7 +166,9 @@ def test_loads_without_deserialization_avoids_compression():
 
 def eq_frames(a, b):
     if b"headers" in a:
-        return msgpack.loads(a, use_list=False) == msgpack.loads(b, use_list=False)
+        return msgpack.loads(a, use_list=False, strict_map_key=False) == msgpack.loads(
+            b, use_list=False, strict_map_key=False
+        )
     else:
         return a == b
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -9,6 +9,7 @@ BIG_BYTES_SHARD_SIZE = 2 ** 26
 msgpack_opts = {
     ("max_%s_len" % x): 2 ** 31 - 1 for x in ["str", "bin", "array", "map", "ext"]
 }
+msgpack_opts["strict_map_key"] = False
 
 try:
     msgpack.loads(msgpack.dumps(""), raw=False, **msgpack_opts)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click >= 6.6
 cloudpickle >= 0.2.2
 dask >= 2.9.0
-msgpack
+msgpack >= 0.6.0
 psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1
 tblib >= 1.6.0


### PR DESCRIPTION
In msgpack 1.0 the default value for `strict_map_key` was changed from `False` to `True` (see https://github.com/msgpack/msgpack-python#major-breaking-changes-in-msgpack-10). This causes failures for us as we use map keys which are not `bytes` or `str`. This PR updates our use of `msgpack.loads` to include `strict_map_key=False`

Closes #3491 