### PR TITLE
Pinned Msgpack in requirements.txt to 0.6.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click >= 6.6
 cloudpickle >= 0.2.2
 dask >= 2.9.0
-msgpack
+msgpack ~= 0.6.2
 psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1
 tblib >= 1.6.0


### PR DESCRIPTION
Msgpack 1.0.0 was released and caused breaking changes in our code base. We had to pin msgpack to 0.6.2 and noticed that dask does not specify the version of msgpack. 