### PR TITLE
Suppress cuML `ImportError`

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -1,4 +1,3 @@
-from contextlib import suppress
 from functools import partial
 from distutils.version import LooseVersion
 
@@ -100,5 +99,5 @@ def _register_cudf():
 @dask_serialize.register_lazy("cuml")
 @dask_deserialize.register_lazy("cuml")
 def _register_cuml():
-    with suppress(ImportError):
+    with ignoring(ImportError):
         from cuml.comm import serialize

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from functools import partial
 from distutils.version import LooseVersion
 
@@ -99,4 +100,5 @@ def _register_cudf():
 @dask_serialize.register_lazy("cuml")
 @dask_deserialize.register_lazy("cuml")
 def _register_cuml():
-    from cuml.comm import serialize
+    with suppress(ImportError):
+        from cuml.comm import serialize


### PR DESCRIPTION
If cuML is present, but `cuml.comm` does not yet exist, make sure to suppress the `ImportError`. After all there is nothing to do here in this case and we don't want to raise unnecessary errors.

cc @dantegd