### PR TITLE
Add config for Adaptive arguments

### DIFF
--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -1,6 +1,6 @@
 from inspect import isawaitable
 import logging
-import math
+import dask.config
 
 from .adaptive_core import AdaptiveCore
 from ..utils import log_errors, parse_timedelta
@@ -76,17 +76,29 @@ class Adaptive(AdaptiveCore):
     def __init__(
         self,
         cluster=None,
-        interval="1s",
-        minimum=0,
-        maximum=math.inf,
-        wait_count=3,
-        target_duration="5s",
+        interval=None,
+        minimum=None,
+        maximum=None,
+        wait_count=None,
+        target_duration=None,
         worker_key=None,
         **kwargs
     ):
         self.cluster = cluster
         self.worker_key = worker_key
         self._workers_to_close_kwargs = kwargs
+
+        if interval is None:
+            interval = dask.config.get("distributed.adaptive.interval")
+        if minimum is None:
+            minimum = dask.config.get("distributed.adaptive.minimum")
+        if maximum is None:
+            maximum = dask.config.get("distributed.adaptive.maximum")
+        if wait_count is None:
+            wait_count = dask.config.get("distributed.adaptive.wait-count")
+        if target_duration is None:
+            target_duration = dask.config.get("distributed.adaptive.target-duration")
+
         self.target_duration = parse_timedelta(target_duration)
 
         super().__init__(

--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -71,6 +71,8 @@ class Adaptive(AdaptiveCore):
     resized. The default implementation checks if there are too many tasks
     per worker or too little memory available (see :meth:`Adaptive.needs_cpu`
     and :meth:`Adaptive.needs_memory`).
+    The values for interval, min, max, wait_count and target_duration can be
+    specified in the dask config under the distributed.adaptive key.
     '''
 
     def __init__(

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -1,3 +1,4 @@
+import math
 from time import sleep
 
 import dask
@@ -415,3 +416,14 @@ async def test_adapt_cores_memory(cleanup):
         )
         assert adapt.minimum == 3
         assert adapt.maximum == 5
+
+
+def test_adaptive_config():
+    with dask.config.set(
+        {"distributed.adaptive.minimum": 10, "distributed.adaptive.wait-count": 8}
+    ):
+        adapt = Adaptive(interval="5s")
+        assert adapt.minimum == 10
+        assert adapt.maximum == math.inf
+        assert adapt.interval == 5
+        assert adapt.wait_count == 8

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -75,11 +75,11 @@ distributed:
     lost-worker-timeout: 15s  # Interval after which to hard-close a lost worker job
 
   adaptive:
-    interval: 1s # interval between scaling evaluations
-    target-duration: 5s # time an entire graph calculation is desired to take ("1m", "30m")
-    minimum: 0 # minimum number of workers
-    maximum: 100000 # maximum number of workers
-    wait-count: 3 # number of times a worker should be suggested for removal before removing it
+    interval: 1s         # Interval between scaling evaluations
+    target-duration: 5s  # Time an entire graph calculation is desired to take ("1m", "30m")
+    minimum: 0           # Minimum number of workers
+    maximum: 100000      # Maximum number of workers
+    wait-count: 3        # Number of times a worker should be suggested for removal before removing it
 
   comm:
     retry:  # some operations (such as gathering data) are subject to re-tries with the below parameters
@@ -148,4 +148,3 @@ ucx:
   infiniband: null # enable Infiniband
   cuda_copy: null  # enable cuda-copy
   net-devices: null  # define which Infiniband device to use
-

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -78,7 +78,7 @@ distributed:
     interval: 1s         # Interval between scaling evaluations
     target-duration: 5s  # Time an entire graph calculation is desired to take ("1m", "30m")
     minimum: 0           # Minimum number of workers
-    maximum: 100000      # Maximum number of workers
+    maximum: .inf        # Maximum number of workers
     wait-count: 3        # Number of times a worker should be suggested for removal before removing it
 
   comm:

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -74,6 +74,13 @@ distributed:
   deploy:
     lost-worker-timeout: 15s  # Interval after which to hard-close a lost worker job
 
+  adaptive:
+    interval: 1s # interval between scaling evaluations
+    target-duration: 5s # time an entire graph calculation is desired to take ("1m", "30m")
+    minimum: 0 # minimum number of workers
+    maximum: 100000 # maximum number of workers
+    wait-count: 3 # number of times a worker should be suggested for removal before removing it
+
   comm:
     retry:  # some operations (such as gathering data) are subject to re-tries with the below parameters
       count: 0  # the maximum retry attempts. 0 disables re-trying.

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5199,7 +5199,7 @@ class Scheduler(ServerNode):
         if close:
             self.loop.add_callback(self.close)
 
-    def adaptive_target(self, comm=None, target_duration="5s"):
+    def adaptive_target(self, comm=None, target_duration=None):
         """ Desired number of workers based on the current workload
 
         This looks at the current running tasks and memory use, and returns a
@@ -5215,6 +5215,8 @@ class Scheduler(ServerNode):
         --------
         distributed.deploy.Adaptive
         """
+        if target_duration is None:
+            target_duration = dask.config.get("distributed.adaptive.target-duration")
         target_duration = parse_timedelta(target_duration)
 
         # CPU


### PR DESCRIPTION
I would like to add config options for the global task duration and the target-duration on a dask cluster basis to be able to tweak the behaviour of adaptive target for long-running tasks with many different and potentially not known function names.

I'm open to suggestions regarding a different name for the global task duration default.
Should this be documented and where would i document the config options?