### PR TITLE
Add dashboard grid layout

### DIFF
--- a/distributed/dashboard/static/css/grid.css
+++ b/distributed/dashboard/static/css/grid.css
@@ -1,0 +1,69 @@
+body {
+  /* background-color: #eee; */
+}
+
+nav img {
+  height: 28px;
+  padding: 5px 15px;
+}
+
+.grid-stack {
+  height: 100%;
+  width: 100%;
+}
+
+.grid-stack-item {
+  padding: 10px;
+  background-color: white;
+}
+
+.grid-stack-item iframe {
+  width: 100%;
+  height: 90%;
+  border: none;
+  /* background-color: white; */
+}
+
+.grid-stack-item .tab {
+  background-color: white;
+}
+
+.grid-stack-item .tab:hover {
+  cursor: grab;
+}
+
+.grid-stack > .grid-stack-item > .grid-stack-item-content {
+  position: relative;
+}
+
+#add-plot {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  width: 50px;
+  height: 50px;
+  line-height: 50px;
+  background-color: yellowgreen;
+  border-radius: 50%;
+  text-align: center;
+  vertical-align: middle;
+  font-size: 40px;
+  color: white;
+}
+
+#add-plot:hover {
+  background-color: green;
+  cursor: pointer;
+}
+
+#plot-menu {
+  width: 100;
+  display: none;
+}
+
+.plot-menu-item {
+  background-color: orange;
+  border-radius: 25%;
+  padding: 5px;
+  margin: 10px;
+}

--- a/distributed/dashboard/static/grid.html
+++ b/distributed/dashboard/static/grid.html
@@ -1,0 +1,149 @@
+<html>
+  <head>
+    <title>Dask: Grid Layout</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/gridstack@1.0.0/dist/gridstack.min.css"
+    />
+    <link rel="stylesheet" href="css/grid.css" />
+    <link rel="stylesheet" href="../statics/css/base.css" />
+  </head>
+
+  <body>
+    <div class="navbar" id="myTopnav">
+      <ul>
+        <li id="dask-logo">
+          <a href="https://dask.org/">
+            <img src="../statics/images/dask-logo.svg" />
+          </a>
+        </li>
+
+        <li>
+          <a href="../status">Status</a>
+        </li>
+
+        <li>
+          <a href="../workers">Workers</a>
+        </li>
+
+        <li>
+          <a href="../tasks">Tasks</a>
+        </li>
+
+        <li>
+          <a href="../system">System</a>
+        </li>
+
+        <li>
+          <a href="../profile">Profile</a>
+        </li>
+
+        <li>
+          <a href="../graph">Graph</a>
+        </li>
+
+        <li>
+          <a href="../info">Info</a>
+        </li>
+      </ul>
+    </div>
+
+    <div class="grid-stack"></div>
+
+    <div id="add-plot">+</div>
+
+    <div id="plot-menu"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/gridstack@1.0.0/dist/gridstack.all.js"></script>
+    <script type="text/javascript">
+      var grid = GridStack.init({ verticalMargin: 0 });
+      grid.enable();
+      var plots;
+
+      fetch("../individual-plots.json")
+        .then(response => {
+          return response.json();
+        })
+        .then(data => {
+          console.log(data);
+          plots = data;
+          plotNames = Object.keys(plots);
+          let menu = document.getElementById("plot-menu");
+          for (i = 0; i < plotNames.length; i++) {
+            console.log("Appending");
+            var newPlot = document.createElement("span");
+            newPlot.setAttribute("class", "plot-menu-item");
+            var newContent = document.createTextNode(
+              plotNames[i].replace("Individual ", "")
+            );
+            newPlot.appendChild(newContent);
+            menu.appendChild(newPlot);
+          }
+        });
+
+      function addWidget() {
+        let plot = randomProperty(plots);
+        var newWidget = document.createElement("div");
+        var newTab = document.createElement("div");
+        var newClose = document.createElement("div");
+        newTab.setAttribute("class", "tab grid-stack-item-content");
+        var newContent = document.createTextNode(
+          plot.replace("Individual ", "")
+        );
+        var newIframe = document.createElement("iframe");
+        newIframe.setAttribute("src", plots[plot]);
+        newIframe.setAttribute("class", "plot");
+        newTab.appendChild(newContent);
+        newWidget.appendChild(newTab);
+        newWidget.appendChild(newIframe);
+        let w = grid.addWidget(newWidget, 0, 0, 6, 5, true);
+        grid.movable(w, true);
+      }
+
+      function hide_plots() {
+        var x = document.getElementsByClassName("plot");
+        var i;
+        for (i = 0; i < x.length; i++) {
+          x[i].style.display = "none";
+        }
+      }
+
+      function show_plots(element) {
+        var x = document.getElementsByClassName("plot");
+        var i;
+        for (i = 0; i < x.length; i++) {
+          x[i].style.display = "block";
+          element.getElementsByTagName("IFRAME")[0].src += ""; // Reload iframe after resize in case plot doesn't handle dynamic resize
+        }
+      }
+
+      grid.on("resizestart", function(event, ui) {
+        hide_plots();
+      });
+
+      grid.on("gsresizestop", function(event, element) {
+        show_plots(element);
+      });
+
+      grid.on("dragstart", function(event, ui) {
+        hide_plots();
+      });
+
+      grid.on("dragstop", function(event, ui) {
+        show_plots(event.target);
+      });
+
+      var randomProperty = function(obj) {
+        var keys = Object.keys(obj);
+        return keys[(keys.length * Math.random()) << 0];
+      };
+
+      document.getElementById("add-plot").addEventListener("click", addWidget);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
During one of the working sessions at the Dask workshop in DC I threw together a quick prototype of a configurable grid layout in the Dask dashboard.

![Dash dashboard grid layout](https://user-images.githubusercontent.com/1610850/75561985-c99a6600-5a3f-11ea-8e9b-43070210196d.gif)

This demo uses [gridstack.js](https://gridstackjs.com/) to enable positioning and resizing of plots. Clicking the "plus" button randomly adds a plot from the `/individual-plots.json` endpoint which is the same list that Jupyter Lab uses. Each plot is an iframe which displays one of the individual plot pages which were originally created for the Jupyter Lab integration.

Still to do:
- [ ] Add close button to each plot
- [ ] Add plot picker to plus button instead of adding a random plot
- [ ] Persist the layout in a cookie between page refreshes
- [ ] CSS tweaks and fixes to make the layout clearer

We could also potentially replace the whole dashboard with this. Currently the dashboard is a collection of fixed Bokeh pages, each of which are made from one or more plots.

Instead we could replace each page with the grid layout with the default configuration set to match the current layout. Users could then customise the layout of each page. We could also add a way to add new pages to the menu bar at the top to enable custom pages to be created.