### PR TITLE
fix typo in docstring

### DIFF
--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -13,7 +13,7 @@ class AdaptiveCore:
     The core logic for adaptive deployments, with none of the cluster details
 
     This class controls our adaptive scaling behavior.  It is intended to be
-    sued as a super-class or mixin.  It expects the following state and methods:
+    used as a super-class or mixin.  It expects the following state and methods:
 
     **State**
 


### PR DESCRIPTION
"sued" -> "used" in adaptive_core.py docstring