### PR TITLE
Update heartbeat CommClosedError error handling

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -31,7 +31,7 @@ from distributed import (
     wait,
 )
 from distributed.compatibility import WINDOWS
-from distributed.core import rpc
+from distributed.core import rpc, CommClosedError
 from distributed.scheduler import Scheduler
 from distributed.metrics import time
 from distributed.worker import Worker, error_message, logger, parse_memory_limit
@@ -1629,3 +1629,24 @@ async def test_update_latency(cleanup):
 
             if w.digests is not None:
                 assert w.digests["latency"].size() > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reconnect", [True, False])
+async def test_heartbeat_comm_closed(cleanup, monkeypatch, reconnect):
+    with captured_logger("distributed.worker", level=logging.WARNING) as logger:
+        async with await Scheduler() as s:
+
+            def bad_heartbeat_worker(*args, **kwargs):
+                raise CommClosedError()
+
+            async with await Worker(s.address, reconnect=reconnect) as w:
+                # Trigger CommClosedError during worker heartbeat
+                monkeypatch.setattr(w.scheduler, "heartbeat_worker", bad_heartbeat_worker)
+
+                await w.heartbeat()
+                if reconnect:
+                    assert w.status == "running"
+                else:
+                    assert w.status == "closed"
+    assert "Heartbeat to scheduler failed" in logger.getvalue()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1642,7 +1642,9 @@ async def test_heartbeat_comm_closed(cleanup, monkeypatch, reconnect):
 
             async with await Worker(s.address, reconnect=reconnect) as w:
                 # Trigger CommClosedError during worker heartbeat
-                monkeypatch.setattr(w.scheduler, "heartbeat_worker", bad_heartbeat_worker)
+                monkeypatch.setattr(
+                    w.scheduler, "heartbeat_worker", bad_heartbeat_worker
+                )
 
                 await w.heartbeat()
                 if reconnect:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -913,14 +913,16 @@ class Worker(ServerNode):
                 )
                 self.bandwidth_workers.clear()
                 self.bandwidth_types.clear()
+            except CommClosedError:
+                logger.warning("Heartbeat to scheduler failed")
+                if not self.reconnect:
+                    await self.close(report=False)
             except IOError as e:
                 # Scheduler is gone. Respect distributed.comm.timeouts.connect
                 if "Timed out trying to connect" in str(e):
                     await self.close(report=False)
                 else:
                     raise e
-            except CommClosedError:
-                logger.warning("Heartbeat to scheduler failed")
             finally:
                 self.heartbeat_active = False
         else:


### PR DESCRIPTION
This moves an `except CommClosedError` inside the worker heartbeat to occur before a recently added `except IOError`. The `IOError` catching was added to catch timeout errors, but since `CommClosedError` is a subclass of `IOError` we're now catching more exceptions in the `IOError` block than originally intended. 

Additionally, I noticed that workers aren't closed when a heartbeat fails and `reconnect=False`. This PR also adds a `reconnect` check and closes the worker accordingly. 