### PR TITLE
Pin numpydoc to avoid doubly-escaped `*`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,9 @@
+# We pin numpydoc to avoid doubly-escaped *args and **kwargs in rendered docs
+numpydoc==0.8.0
 tornado
 toolz
 cloudpickle
 dask
-numpydoc
 sphinx
 dask_sphinx_theme
 sphinx-click

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
 
 numpydoc_show_class_members = False
 
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
@@ -382,7 +383,7 @@ extlinks = {
 # and the Numpy documentation.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "numpy": ("http://docs.scipy.org/doc/numpy", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy", None),
 }
 
 # Redirects

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -96,6 +96,7 @@ delayed objects.  You can pass a dictionary mapping keys of the collection to
 resource requirements during compute or persist calls.
 
 .. code-block:: python
+
     from dask import core
     
     x = dd.read_csv(...)


### PR DESCRIPTION
Similar to dask/dask#5961, recent changes to `numpydoc` lead to function
signatures displayed using `autosummary` to have doubly-escaped `*`s.

This commit swaps out `numpydoc` in favor of `napoleon` -- there are a
couple of benefits:
* no more double-escaped function signatures
* one less dependency for docs (napoleon is shipped with sphinx)

I've added a make target to automatically generate API docs using
`sphinx-apidoc` but this isn't required for `autosummary` compatibility.
It can always be added as a requirement of the `html` target at a later
time.