### PR TITLE
Use 'temporary-directory' from dask.config for Nanny's directory

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -66,7 +66,7 @@ class Nanny(ServerNode):
         ncores=None,
         loop=None,
         local_dir=None,
-        local_directory="dask-worker-space",
+        local_directory=None,
         services=None,
         name=None,
         memory_limit="auto",
@@ -149,6 +149,12 @@ class Nanny(ServerNode):
         if local_dir is not None:
             warnings.warn("The local_dir keyword has moved to local_directory")
             local_directory = local_dir
+
+        if local_directory is None:
+            local_directory = dask.config.get("temporary-directory") or os.getcwd()
+            if not os.path.exists(local_directory):
+                os.mkdir(local_directory)
+            local_directory = os.path.join(local_directory, "dask-worker-space")
 
         self.local_directory = local_directory
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -409,6 +409,7 @@ def test_local_directory(s):
             w = yield Nanny(s.address)
             assert w.local_directory.startswith(fn)
             assert "dask-worker-space" in w.local_directory
+            yield w.close()
 
 
 def _noop(x):

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -402,6 +402,15 @@ def test_data_types(c, s):
     yield w.close()
 
 
+@gen_cluster(nthreads=[])
+def test_local_directory(s):
+    with tmpfile() as fn:
+        with dask.config.set(temporary_directory=fn):
+            w = yield Nanny(s.address)
+            assert w.local_directory.startswith(fn)
+            assert "dask-worker-space" in w.local_directory
+
+
 def _noop(x):
     """Define here because closures aren't pickleable."""
     pass


### PR DESCRIPTION
Analogous to PR ( https://github.com/dask/distributed/pull/2654 ) for the `Nanny`.