### PR TITLE
Mark `bool` as MessagePack serializable

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -548,6 +548,7 @@ def _is_msgpack_serializable(v):
     typ = type(v)
     return (
         typ is str
+        or typ is bool
         or typ is int
         or typ is float
         or isinstance(v, dict)


### PR DESCRIPTION
As `bool` values can be serialized by MessagePack (see code below), mark them as such in `_is_msgpack_serializable`.

```python
In [1]: import msgpack

In [2]: (msgpack.dumps(False), msgpack.dumps(True))
Out[2]: (b'\xc2', b'\xc3')

In [3]: (msgpack.loads(b'\xc2'), msgpack.loads(b'\xc3'))
Out[3]: (False, True)
```