### PR TITLE
Support using other serializers with `register_generic`

### DIFF
--- a/distributed/protocol/cuda.py
+++ b/distributed/protocol/cuda.py
@@ -1,7 +1,7 @@
 import dask
 
 from . import pickle
-from .serialize import register_serialization_family
+from .serialize import ObjectDictSerializer, register_serialization_family
 from dask.utils import typename
 
 cuda_serialize = dask.utils.Dispatch("cuda_serialize")
@@ -29,3 +29,8 @@ def cuda_loads(header, frames):
 
 
 register_serialization_family("cuda", cuda_dumps, cuda_loads)
+
+
+cuda_object_with_dict_serializer = ObjectDictSerializer("cuda")
+
+cuda_deserialize.register(dict)(cuda_object_with_dict_serializer.deserialize)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -614,8 +614,13 @@ dask_object_with_dict_serializer = ObjectDictSerializer("dask")
 dask_deserialize.register(dict)(dask_object_with_dict_serializer.deserialize)
 
 
-def register_generic(cls):
-    """ Register dask_(de)serialize to traverse through __dict__
+def register_generic(
+    cls,
+    serializer_name="dask",
+    serialize_func=dask_serialize,
+    deserialize_func=dask_deserialize,
+):
+    """ Register (de)serialize to traverse through __dict__
 
     Normally when registering new classes for Dask's custom serialization you
     need to manage headers and frames, which can be tedious.  If all you want
@@ -646,5 +651,6 @@ def register_generic(cls):
     dask_serialize
     dask_deserialize
     """
-    dask_serialize.register(cls)(dask_object_with_dict_serializer.serialize)
-    dask_deserialize.register(cls)(dask_object_with_dict_serializer.deserialize)
+    object_with_dict_serializer = ObjectDictSerializer(serializer_name)
+    serialize_func.register(cls)(object_with_dict_serializer.serialize)
+    deserialize_func.register(cls)(object_with_dict_serializer.deserialize)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -609,7 +609,9 @@ class ObjectDictSerializer:
         return obj
 
 
-dask_deserialize.register(dict)(deserialize_object_with_dict)
+dask_object_with_dict_serializer = ObjectDictSerializer("dask")
+
+dask_deserialize.register(dict)(dask_object_with_dict_serializer.deserialize)
 
 
 def register_generic(cls):
@@ -644,5 +646,5 @@ def register_generic(cls):
     dask_serialize
     dask_deserialize
     """
-    dask_serialize.register(cls)(serialize_object_with_dict)
-    dask_deserialize.register(cls)(deserialize_object_with_dict)
+    dask_serialize.register(cls)(dask_object_with_dict_serializer.serialize)
+    dask_deserialize.register(cls)(dask_object_with_dict_serializer.deserialize)


### PR DESCRIPTION
This changes `register_generic` (and surrounding machinery) to support using other protocols when traversing through an object's `__dict__`. This can be handy if another serialization protocol (like `"cuda"` 😉) is need for an object that contains content that can already be serialized using this protocol. A couple examples of this are other CuPy objects (like sparse matrices) and cuML models ( https://github.com/rapidsai/cuml/issues/1732 ).

cc @cjnolet @dantegd