### PR TITLE
Mark `None` as MessagePack serializable

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -547,7 +547,8 @@ def _deserialize_bytes(header, frames):
 def _is_msgpack_serializable(v):
     typ = type(v)
     return (
-        typ is str
+        v is None
+        or typ is str
         or typ is bool
         or typ is int
         or typ is float


### PR DESCRIPTION
As `None` values can be serialized by MessagePack (see code below), mark them as such in `_is_msgpack_serializable`.

```python
In [1]: import msgpack

In [2]: msgpack.dumps(None)
Out[2]: b'\xc0'

In [3]: msgpack.loads(b'\xc0') is None
Out[3]: True
```