### PR TITLE
Use `makedirs` when constructing `local_directory`

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -152,8 +152,7 @@ class Nanny(ServerNode):
 
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
-            if not os.path.exists(local_directory):
-                os.mkdir(local_directory)
+            os.makedirs(local_directory, exist_ok=True)
             local_directory = os.path.join(local_directory, "dask-worker-space")
 
         self.local_directory = local_directory

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -152,7 +152,8 @@ class Nanny(ServerNode):
 
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
-            os.makedirs(local_directory, exist_ok=True)
+            if not os.path.exists(local_directory):
+                os.makedirs(local_directory)
             local_directory = os.path.join(local_directory, "dask-worker-space")
 
         self.local_directory = local_directory

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -491,7 +491,8 @@ class Worker(ServerNode):
 
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
-            os.makedirs(local_directory, exist_ok=True)
+            if not os.path.exists(local_directory):
+                os.makedirs(local_directory)
             local_directory = os.path.join(local_directory, "dask-worker-space")
 
         with warn_on_duration(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -491,8 +491,7 @@ class Worker(ServerNode):
 
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
-            if not os.path.exists(local_directory):
-                os.mkdir(local_directory)
+            os.makedirs(local_directory, exist_ok=True)
             local_directory = os.path.join(local_directory, "dask-worker-space")
 
         with warn_on_duration(


### PR DESCRIPTION
Make sure the full path to the `temporary-directory` provided exists. Also make sure that if the path already exists no error is raised.