### PR TITLE
Fix/more ucx config options

### DIFF
--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -20,18 +20,30 @@ rmm = pytest.importorskip("rmm")
 @pytest.mark.asyncio
 async def test_ucx_config(cleanup):
 
-    ucx = {"nvlink": True, "infiniband": True, "net-devices": ""}
+    ucx = {
+        "nvlink": True,
+        "infiniband": True,
+        "net-devices": "",
+        "tcp": True,
+        "cuda_copy": True,
+    }
 
     with dask.config.set(ucx=ucx):
         ucx_config = _scrub_ucx_config()
         assert ucx_config.get("TLS") == "rc,tcp,sockcm,cuda_copy,cuda_ipc"
         assert ucx_config.get("NET_DEVICES") is None
 
-    ucx = {"nvlink": False, "infiniband": True, "net-devices": "mlx5_0:1"}
+    ucx = {
+        "nvlink": False,
+        "infiniband": True,
+        "net-devices": "mlx5_0:1",
+        "tcp": True,
+        "cuda_copy": False,
+    }
 
     with dask.config.set(ucx=ucx):
         ucx_config = _scrub_ucx_config()
-        assert ucx_config.get("TLS") == "rc,tcp,sockcm,cuda_copy"
+        assert ucx_config.get("TLS") == "rc,tcp,sockcm"
         assert ucx_config.get("NET_DEVICES") == "mlx5_0:1"
 
     ucx = {
@@ -39,6 +51,8 @@ async def test_ucx_config(cleanup):
         "infiniband": True,
         "net-devices": "all",
         "MEMTYPE_CACHE": "y",
+        "tcp": True,
+        "cuda_copy": True,
     }
 
     with dask.config.set(ucx=ucx):

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -60,6 +60,18 @@ async def test_ucx_config(cleanup):
         assert ucx_config.get("TLS") == "rc,tcp,sockcm,cuda_copy"
         assert ucx_config.get("MEMTYPE_CACHE") == "y"
 
+    ucx = {
+        "nvlink": False,
+        "infiniband": False,
+        "net-devices": "all",
+        "MEMTYPE_CACHE": "y",
+        "tcp": False,
+        "cuda_copy": True,
+    }
+    with dask.config.set(ucx=ucx):
+        with raises(ValueError):
+            ucx_config = _scrub_ucx_config()
+
 
 def test_ucx_config_w_env_var(cleanup, loop, monkeypatch):
     size = "1000.00 MB"

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -385,6 +385,10 @@ def _scrub_ucx_config():
         net_devices = dask.config.get("ucx.net-devices")
         if net_devices is not None and net_devices != "":
             options["NET_DEVICES"] = net_devices
+    else:
+        raise ValueError(
+            "UCX Dask config not set.  Please define at least one: ucx.tcp, ucx.nvlink, ucx.infiniband"
+        )
 
     # ANY UCX options defined in config will overwrite high level dask.ucx flags
     valid_ucx_keys = list(get_config().keys())

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -359,9 +359,21 @@ def _scrub_ucx_config():
 
     # if any of the high level flags are set, as long as they are not Null/None,
     # we assume we should configure basic TLS settings for UCX
-    if any([dask.config.get("ucx.nvlink"), dask.config.get("ucx.infiniband")]):
-        tls = "tcp,sockcm,cuda_copy"
+    if any(
+        [
+            dask.config.get("ucx.tcp"),
+            dask.config.get("ucx.nvlink"),
+            dask.config.get("ucx.infiniband"),
+        ]
+    ):
+        tls = "tcp,sockcm"
         tls_priority = "sockcm"
+
+        # CUDA COPY can optionally be used with ucx -- we rely on the user
+        # to define when messages will include CUDA objects.  Note:
+        # defining only the Infiniband flag will not enable cuda_copy
+        if any([dask.config.get("ucx.nvlink"), dask.config.get("ucx.cuda_copy")]):
+            tls = tls + ",cuda_copy"
 
         if dask.config.get("ucx.infiniband"):
             tls = "rc," + tls

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -136,7 +136,9 @@ distributed:
 rmm:
   pool-size: null
 ucx:
-  nvlink: null
-  infiniband: null
-  net-devices: null
+  tcp: null  # enable tcp
+  nvlink: null  # enable cuda_ipc
+  infiniband: null # enable Infiniband
+  cuda_copy: null  # enable cuda-copy
+  net-devices: null  # define which Infiniband device to use
 


### PR DESCRIPTION
Adds two more config options:

- ucx.tcp
- ucx.cuda_copy

`tcp` is necessary when _not_ using any accelerated devices but still wanting to use UCX
`cuda_copy` is necessary when _not_ passing any CUDA objects with UCX -- host memory only.  Potentially useful for IB+UCX with numpy/pandas only data

cc @pentschev 