### PR TITLE
Use UCX default configuration instead of raising

### DIFF
--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -60,18 +60,6 @@ async def test_ucx_config(cleanup):
         assert ucx_config.get("TLS") == "rc,tcp,sockcm,cuda_copy"
         assert ucx_config.get("MEMTYPE_CACHE") == "y"
 
-    ucx = {
-        "nvlink": False,
-        "infiniband": False,
-        "net-devices": "all",
-        "MEMTYPE_CACHE": "y",
-        "tcp": False,
-        "cuda_copy": True,
-    }
-    with dask.config.set(ucx=ucx):
-        with pytest.raises(ValueError):
-            ucx_config = _scrub_ucx_config()
-
 
 def test_ucx_config_w_env_var(cleanup, loop, monkeypatch):
     size = "1000.00 MB"

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -358,7 +358,8 @@ def _scrub_ucx_config():
     options = {}
 
     # if any of the high level flags are set, as long as they are not Null/None,
-    # we assume we should configure basic TLS settings for UCX
+    # we assume we should configure basic TLS settings for UCX, otherwise we
+    # leave UCX to its default configuration
     if any(
         [
             dask.config.get("ucx.tcp"),
@@ -385,10 +386,6 @@ def _scrub_ucx_config():
         net_devices = dask.config.get("ucx.net-devices")
         if net_devices is not None and net_devices != "":
             options["NET_DEVICES"] = net_devices
-    else:
-        raise ValueError(
-            "UCX Dask config not set.  Please define at least one: ucx.tcp, ucx.nvlink, ucx.infiniband"
-        )
 
     # ANY UCX options defined in config will overwrite high level dask.ucx flags
     valid_ucx_keys = list(get_config().keys())


### PR DESCRIPTION
Raising an error can be a problem with scheduler, given that we don't configure it in `LocalCluster`, thus removing that for the time being.