### PR TITLE
Serialize sparse arrays

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -30,6 +30,12 @@ def _register_numpy():
     from . import numpy
 
 
+@dask_serialize.register_lazy("scipy")
+@dask_deserialize.register_lazy("scipy")
+def _register_scipy():
+    from . import scipy
+
+
 @dask_serialize.register_lazy("h5py")
 @dask_deserialize.register_lazy("h5py")
 def _register_h5py():

--- a/distributed/protocol/scipy.py
+++ b/distributed/protocol/scipy.py
@@ -6,3 +6,25 @@ import scipy
 from .serialize import dask_deserialize, dask_serialize, register_generic
 
 register_generic(scipy.sparse.spmatrix, "dask", dask_serialize, dask_deserialize)
+
+
+@dask_serialize.register(scipy.sparse.dok.dok_matrix)
+def serialize_scipy_sparse_dok(x):
+    x_coo = x.tocoo()
+    coo_header, coo_frames = dask_serialize(x.tocoo())
+
+    header = {"coo_header": coo_header}
+    frames = coo_frames
+
+    return header, frames
+
+
+@dask_deserialize.register(scipy.sparse.dok.dok_matrix)
+def deserialize_scipy_sparse_dok(header, frames):
+    coo_header = header["coo_header"]
+    coo_frames = frames
+    x_coo = dask_deserialize(coo_header, coo_frames)
+
+    x = x_coo.todok()
+
+    return x

--- a/distributed/protocol/scipy.py
+++ b/distributed/protocol/scipy.py
@@ -1,0 +1,8 @@
+"""
+Efficient serialization of SciPy sparse matrices.
+"""
+import scipy
+
+from .serialize import dask_deserialize, dask_serialize, register_generic
+
+register_generic(scipy.sparse.spmatrix, "dask", dask_serialize, dask_deserialize)

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -4,6 +4,7 @@ import pytest
 from distributed.protocol import deserialize, serialize
 
 cupy = pytest.importorskip("cupy")
+cupy_sparse = pytest.importorskip("cupyx.scipy.sparse")
 numpy = pytest.importorskip("numpy")
 
 
@@ -62,3 +63,34 @@ def test_serialize_cupy_from_rmm(size):
     y = deserialize(header, frames, deserializers=("cuda", "dask", "pickle", "error"))
 
     assert (x_np == cupy.asnumpy(y)).all()
+
+
+@pytest.mark.parametrize(
+    "sparse_type",
+    [
+        cupy_sparse.coo_matrix,
+        cupy_sparse.csc_matrix,
+        cupy_sparse.csr_matrix,
+        cupy_sparse.dia_matrix,
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [numpy.dtype("<f4"), numpy.dtype(">f4"), numpy.dtype("<f8"), numpy.dtype(">f8"),],
+)
+@pytest.mark.parametrize("serializer", ["cuda", "dask",])
+def test_serialize_cupy_sparse(sparse_type, dtype, serializer):
+    a_host = numpy.array([[0, 1, 0], [2, 0, 3], [0, 4, 0]], dtype=dtype)
+    a = cupy.asarray(a_host)
+
+    anz = a.nonzero()
+    acoo = cupy_sparse.coo_matrix((a[anz], anz))
+    asp = sparse_type(acoo)
+
+    header, frames = serialize(asp, serializers=[serializer])
+    asp2 = deserialize(header, frames)
+
+    a2 = asp2.todense()
+    a2_host = cupy.asnumpy(a2)
+
+    assert (a_host == a2_host).all()

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -1,6 +1,7 @@
-from distributed.protocol import serialize, deserialize
 import pickle
+
 import pytest
+from distributed.protocol import deserialize, serialize
 
 cupy = pytest.importorskip("cupy")
 numpy = pytest.importorskip("numpy")

--- a/distributed/protocol/tests/test_scipy.py
+++ b/distributed/protocol/tests/test_scipy.py
@@ -1,0 +1,37 @@
+import pytest
+from distributed.protocol import deserialize, serialize
+
+numpy = pytest.importorskip("numpy")
+scipy = pytest.importorskip("scipy")
+scipy_sparse = pytest.importorskip("scipy.sparse")
+
+
+@pytest.mark.parametrize(
+    "sparse_type",
+    [
+        scipy_sparse.bsr_matrix,
+        scipy_sparse.coo_matrix,
+        scipy_sparse.csc_matrix,
+        scipy_sparse.csr_matrix,
+        scipy_sparse.dia_matrix,
+        scipy_sparse.dok_matrix,
+        scipy_sparse.lil_matrix,
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [numpy.dtype("<f4"), numpy.dtype(">f4"), numpy.dtype("<f8"), numpy.dtype(">f8"),],
+)
+def test_serialize_scipy_sparse(sparse_type, dtype):
+    a = numpy.array([[0, 1, 0], [2, 0, 3], [0, 4, 0]], dtype=dtype)
+
+    anz = a.nonzero()
+    acoo = scipy_sparse.coo_matrix((a[anz], anz))
+    asp = sparse_type(acoo)
+
+    header, frames = serialize(asp, serializers=["dask"])
+    asp2 = deserialize(header, frames)
+
+    a2 = asp2.todense()
+
+    assert (a == a2).all()


### PR DESCRIPTION
Builds off of PR ( https://github.com/dask/distributed/pull/3536 )

Adds support for more efficient serialization of sparse arrays from both SciPy and CuPy. As both implementations frequently are simple classes that contain objects that are already serializable like NumPy's or CuPy's `ndarray`s, this just uses `register_generic` to recurse through the accepted object's `__dict__` serializing anything it finds. The deserialization process works more-or-less the same. As a result, the underlying data can be transformed into frames efficiently and transmitted without needing to resort to `pickle`.

Mostly this just works with the exception of SciPy's `dok_matrix`, which is a weird hybrid of a `dict` and a `spmatrix`. Unfortunately this confuses Dask as it isn't quite sure how to serialize it. So we special case this and convert to a `coo_matrix`, which is very similar in layout and a bit easier for us to serialize.

cc @dantegd @cjnolet @quasiben