### PR TITLE
Ensure Client connection pool semaphore attaches to the Client's event loop

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -709,6 +709,14 @@ class Client(Node):
             "erred": self._handle_task_erred,
         }
 
+        super(Client, self).__init__(
+            connection_args=self.connection_args,
+            io_loop=self.loop,
+            serializers=serializers,
+            deserializers=deserializers,
+            timeout=timeout,
+        )
+
         for ext in extensions:
             ext(self)
 
@@ -918,16 +926,7 @@ class Client(Node):
 
     async def _start(self, timeout=no_default, **kwargs):
 
-        # This __init__ needs to be called here instead of in Client.__init__
-        # so that the resulting ConnectionPool.semaphore created attaches to
-        # the Client's event loop
-        super(Client, self).__init__(
-            connection_args=self.connection_args,
-            io_loop=self.loop,
-            serializers=self._serializers,
-            deserializers=self._deserializers,
-            timeout=timeout,
-        )
+        await super().start()
 
         if timeout == no_default:
             timeout = self._timeout

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -709,14 +709,6 @@ class Client(Node):
             "erred": self._handle_task_erred,
         }
 
-        super(Client, self).__init__(
-            connection_args=self.connection_args,
-            io_loop=self.loop,
-            serializers=serializers,
-            deserializers=deserializers,
-            timeout=timeout,
-        )
-
         for ext in extensions:
             ext(self)
 
@@ -925,6 +917,18 @@ class Client(Node):
             )
 
     async def _start(self, timeout=no_default, **kwargs):
+
+        # This __init__ needs to be called here instead of in Client.__init__
+        # so that the resulting ConnectionPool.semaphore created attaches to
+        # the Client's event loop
+        super(Client, self).__init__(
+            connection_args=self.connection_args,
+            io_loop=self.loop,
+            serializers=self._serializers,
+            deserializers=self._deserializers,
+            timeout=timeout,
+        )
+
         if timeout == no_default:
             timeout = self._timeout
         if timeout is not None:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -833,19 +833,12 @@ class ConnectionPool:
         self.deserializers = deserializers if deserializers is not None else serializers
         self.connection_args = connection_args
         self.timeout = timeout
+        # Invariant: semaphore._value == limit - open - _n_connecting
+        self.semaphore = asyncio.Semaphore(self.limit)
         self._n_connecting = 0
         self.server = weakref.ref(server) if server else None
         self._created = weakref.WeakSet()
         self._instances.add(self)
-
-    @property
-    def semaphore(self):
-        # Invariant: semaphore._value == limit - open - _n_connecting
-        try:
-            return self._semaphore
-        except AttributeError:
-            self._semaphore = asyncio.Semaphore(self.limit)
-            return self._semaphore
 
     def _validate(self):
         """

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -833,9 +833,9 @@ class ConnectionPool:
         self.deserializers = deserializers if deserializers is not None else serializers
         self.connection_args = connection_args
         self.timeout = timeout
+        self._n_connecting = 0
         # Invariant: semaphore._value == limit - open - _n_connecting
         self.semaphore = asyncio.Semaphore(self.limit)
-        self._n_connecting = 0
         self.server = weakref.ref(server) if server else None
         self._created = weakref.WeakSet()
         self._instances.add(self)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -868,6 +868,13 @@ class ConnectionPool:
             addr, self, serializers=self.serializers, deserializers=self.deserializers
         )
 
+    def __await__(self):
+        async def _():
+            await self.start()
+            return self
+
+        return _().__await__()
+
     async def start(self):
         # Invariant: semaphore._value == limit - open - _n_connecting
         self.semaphore = asyncio.Semaphore(self.limit)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -834,8 +834,6 @@ class ConnectionPool:
         self.connection_args = connection_args
         self.timeout = timeout
         self._n_connecting = 0
-        # Invariant: semaphore._value == limit - open - _n_connecting
-        self.semaphore = asyncio.Semaphore(self.limit)
         self.server = weakref.ref(server) if server else None
         self._created = weakref.WeakSet()
         self._instances.add(self)
@@ -869,6 +867,10 @@ class ConnectionPool:
         return PooledRPCCall(
             addr, self, serializers=self.serializers, deserializers=self.deserializers
         )
+
+    async def start(self):
+        # Invariant: semaphore._value == limit - open - _n_connecting
+        self.semaphore = asyncio.Semaphore(self.limit)
 
     async def connect(self, addr, timeout=None):
         """

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -834,11 +834,18 @@ class ConnectionPool:
         self.connection_args = connection_args
         self.timeout = timeout
         self._n_connecting = 0
-        # Invariant: semaphore._value == limit - open - _n_connecting
-        self.semaphore = asyncio.Semaphore(self.limit)
         self.server = weakref.ref(server) if server else None
         self._created = weakref.WeakSet()
         self._instances.add(self)
+
+    @property
+    def semaphore(self):
+        # Invariant: semaphore._value == limit - open - _n_connecting
+        try:
+            return self._semaphore
+        except AttributeError:
+            self._semaphore = asyncio.Semaphore(self.limit)
+            return self._semaphore
 
     def _validate(self):
         """

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -241,6 +241,9 @@ class Nanny(ServerNode):
 
     async def start(self):
         """ Start nanny, start local process, start watching """
+
+        await super().start()
+
         await self.listen(self._start_address, listen_args=self.listen_args)
         self.ip = get_address_host(self.address)
 

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -38,6 +38,9 @@ class Node:
             server=self,
         )
 
+    async def start(self):
+        await self.rpc.start()
+
 
 class ServerNode(Node, Server):
     """
@@ -182,5 +185,7 @@ class ServerNode(Node, Server):
                 future = wait_for(future, timeout=timeout)
             return future.__await__()
 
-    async def start(self):  # subclasses should implement this
+    async def start(self):
+        # subclasses should implement their own start method whichs calls super().start()
+        await Node.start(self)
         return self

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1401,6 +1401,9 @@ class Scheduler(ServerNode):
 
     async def start(self):
         """ Clear out old state and restart all running coroutines """
+
+        await super().start()
+
         enable_gc_diagnosis()
 
         self.clear_task_state()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5944,6 +5944,6 @@ def test_as_completed_condition_loop(c, s, a, b):
     assert ac.condition._loop == c.loop.asyncio_loop
 
 
-def test_client_connectionpool_semaphor_loop(s, a, b):
+def test_client_connectionpool_semaphore_loop(s, a, b):
     with Client(s["address"]) as c:
         assert c.rpc.semaphore._loop is c.loop.asyncio_loop

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5942,3 +5942,8 @@ def test_as_completed_condition_loop(c, s, a, b):
     seq = c.map(inc, range(5))
     ac = as_completed(seq)
     assert ac.condition._loop == c.loop.asyncio_loop
+
+
+def test_client_connectionpool_semaphor_loop(s, a, b):
+    with Client(s["address"]) as c:
+        assert c.rpc.semaphore._loop is c.loop.asyncio_loop

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -527,6 +527,7 @@ async def test_connection_pool():
         await server.listen(0)
 
     rpc = ConnectionPool(limit=5)
+    await rpc.start()
 
     # Reuse connections
     await asyncio.gather(
@@ -584,6 +585,7 @@ async def test_connection_pool_respects_limit():
         await server.listen(0)
 
     pool = ConnectionPool(limit=limit)
+    await pool.start()
 
     await asyncio.gather(*[do_ping(pool, s.port) for s in servers])
 
@@ -606,6 +608,7 @@ async def test_connection_pool_tls():
         await server.listen("tls://", listen_args=listen_args)
 
     rpc = ConnectionPool(limit=5, connection_args=connection_args)
+    await rpc.start()
 
     await asyncio.gather(*[rpc(s.address).ping() for s in servers[:5]])
     await asyncio.gather(*[rpc(s.address).ping() for s in servers[::2]])
@@ -626,6 +629,7 @@ async def test_connection_pool_remove():
         await server.listen(0)
 
     rpc = ConnectionPool(limit=10)
+    await rpc.start()
     serv = servers.pop()
     await asyncio.gather(*[rpc(s.address).ping() for s in servers])
     await asyncio.gather(*[rpc(serv.address).ping() for i in range(3)])
@@ -759,6 +763,7 @@ async def test_connection_pool_detects_remote_close():
 
     # open a connection, use it and give it back to the pool
     p = ConnectionPool(limit=10)
+    await p.start()
     conn = await p.connect(server.address)
     await send_recv(conn, op="ping")
     p.reuse(server.address, conn)

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -526,8 +526,7 @@ async def test_connection_pool():
     for server in servers:
         await server.listen(0)
 
-    rpc = ConnectionPool(limit=5)
-    await rpc.start()
+    rpc = await ConnectionPool(limit=5)
 
     # Reuse connections
     await asyncio.gather(
@@ -584,8 +583,7 @@ async def test_connection_pool_respects_limit():
     for server in servers:
         await server.listen(0)
 
-    pool = ConnectionPool(limit=limit)
-    await pool.start()
+    pool = await ConnectionPool(limit=limit)
 
     await asyncio.gather(*[do_ping(pool, s.port) for s in servers])
 
@@ -607,8 +605,7 @@ async def test_connection_pool_tls():
     for server in servers:
         await server.listen("tls://", listen_args=listen_args)
 
-    rpc = ConnectionPool(limit=5, connection_args=connection_args)
-    await rpc.start()
+    rpc = await ConnectionPool(limit=5, connection_args=connection_args)
 
     await asyncio.gather(*[rpc(s.address).ping() for s in servers[:5]])
     await asyncio.gather(*[rpc(s.address).ping() for s in servers[::2]])
@@ -628,8 +625,7 @@ async def test_connection_pool_remove():
     for server in servers:
         await server.listen(0)
 
-    rpc = ConnectionPool(limit=10)
-    await rpc.start()
+    rpc = await ConnectionPool(limit=10)
     serv = servers.pop()
     await asyncio.gather(*[rpc(s.address).ping() for s in servers])
     await asyncio.gather(*[rpc(serv.address).ping() for i in range(3)])
@@ -762,8 +758,7 @@ async def test_connection_pool_detects_remote_close():
     await server.listen("tcp://")
 
     # open a connection, use it and give it back to the pool
-    p = ConnectionPool(limit=10)
-    await p.start()
+    p = await ConnectionPool(limit=10)
     conn = await p.connect(server.address)
     await send_recv(conn, op="ping")
     p.reuse(server.address, conn)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1876,8 +1876,7 @@ async def test_gather_failing_cnn_recover(c, s, a, b):
     orig_rpc = s.rpc
     x = await c.scatter({"x": 1}, workers=a.address)
 
-    s.rpc = FlakyConnectionPool(failing_connections=1)
-    await s.rpc.start()
+    s.rpc = await FlakyConnectionPool(failing_connections=1)
     with mock.patch("distributed.utils_comm.retry_count", 1):
         res = await s.gather(keys=["x"])
     assert res["status"] == "OK"
@@ -1888,8 +1887,7 @@ async def test_gather_failing_cnn_error(c, s, a, b):
     orig_rpc = s.rpc
     x = await c.scatter({"x": 1}, workers=a.address)
 
-    s.rpc = FlakyConnectionPool(failing_connections=10)
-    await s.rpc.start()
+    s.rpc = await FlakyConnectionPool(failing_connections=10)
     res = await s.gather(keys=["x"])
     assert res["status"] == "error"
     assert list(res["keys"]) == ["x"]
@@ -1940,8 +1938,7 @@ async def test_gather_allow_worker_reconnect(c, s, a, b):
 
     z = c.submit(reducer, x, y)
 
-    s.rpc = FlakyConnectionPool(failing_connections=4)
-    await s.rpc.start()
+    s.rpc = await FlakyConnectionPool(failing_connections=4)
 
     with captured_logger(
         logging.getLogger("distributed.scheduler")

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1877,6 +1877,7 @@ async def test_gather_failing_cnn_recover(c, s, a, b):
     x = await c.scatter({"x": 1}, workers=a.address)
 
     s.rpc = FlakyConnectionPool(failing_connections=1)
+    await s.rpc.start()
     with mock.patch("distributed.utils_comm.retry_count", 1):
         res = await s.gather(keys=["x"])
     assert res["status"] == "OK"
@@ -1888,6 +1889,7 @@ async def test_gather_failing_cnn_error(c, s, a, b):
     x = await c.scatter({"x": 1}, workers=a.address)
 
     s.rpc = FlakyConnectionPool(failing_connections=10)
+    await s.rpc.start()
     res = await s.gather(keys=["x"])
     assert res["status"] == "error"
     assert list(res["keys"]) == ["x"]
@@ -1939,6 +1941,7 @@ async def test_gather_allow_worker_reconnect(c, s, a, b):
     z = c.submit(reducer, x, y)
 
     s.rpc = FlakyConnectionPool(failing_connections=4)
+    await s.rpc.start()
 
     with captured_logger(
         logging.getLogger("distributed.scheduler")

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -30,12 +30,11 @@ def test_subs_multiple():
 
 
 @gen_cluster(client=True)
-def test_gather_from_workers_permissive(c, s, a, b):
-    rpc = ConnectionPool()
-    yield rpc.start()
-    x = yield c.scatter({"x": 1}, workers=a.address)
+async def test_gather_from_workers_permissive(c, s, a, b):
+    rpc = await ConnectionPool()
+    x = await c.scatter({"x": 1}, workers=a.address)
 
-    data, missing, bad_workers = yield gather_from_workers(
+    data, missing, bad_workers = await gather_from_workers(
         {"x": [a.address], "y": [b.address]}, rpc=rpc
     )
 
@@ -69,11 +68,11 @@ class BrokenConnectionPool(ConnectionPool):
 
 
 @gen_cluster(client=True)
-def test_gather_from_workers_permissive_flaky(c, s, a, b):
-    x = yield c.scatter({"x": 1}, workers=a.address)
+async def test_gather_from_workers_permissive_flaky(c, s, a, b):
+    x = await c.scatter({"x": 1}, workers=a.address)
 
-    rpc = BrokenConnectionPool()
-    data, missing, bad_workers = yield gather_from_workers({"x": [a.address]}, rpc=rpc)
+    rpc = await BrokenConnectionPool()
+    data, missing, bad_workers = await gather_from_workers({"x": [a.address]}, rpc=rpc)
 
     assert missing == {"x": [a.address]}
     assert bad_workers == [a.address]

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -32,6 +32,7 @@ def test_subs_multiple():
 @gen_cluster(client=True)
 def test_gather_from_workers_permissive(c, s, a, b):
     rpc = ConnectionPool()
+    yield rpc.start()
     x = yield c.scatter({"x": 1}, workers=a.address)
 
     data, missing, bad_workers = yield gather_from_workers(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1014,6 +1014,8 @@ class Worker(ServerNode):
             return
         assert self.status is None, self.status
 
+        await super().start()
+
         enable_gc_diagnosis()
         thread_state.on_event_loop_thread = True
 


### PR DESCRIPTION
When creating a `Client` a `ConnectionPool` is created when the `Client` superclass constructor is called here

https://github.com/dask/distributed/blob/d8d0d4e71023ac6c1507b443b90d7805e2bf7ad2/distributed/client.py#L712-L718

Currently, when operating in in synchronous mode, the `ConnectionPool` semaphore attaches the main thread's event loop instead of the `Client`'s event loop (the same situation as outlined in https://github.com/dask/distributed/pull/3397#discussion_r373733554).

When we need to acquire the `ConnectionPool` semaphore, we end up getting errors about it being attached to the wrong loop. For example, the following example

```python
import asyncio
from distributed import Client

if __name__ == "__main__":

    with Client() as c:
        x = c.sync(asyncio.gather, *[c.scheduler.who_has() for _ in range(1000)])
        print(x)
```

currently results in a `RuntimeError: Future <Future pending> attached to a different loop`

<details>
<summary>Full traceback:</summary>

```
Traceback (most recent call last):
  File "test-sempahore.py", line 8, in <module>
    x = c.sync(asyncio.gather, *[c.scheduler.who_has() for _ in range(1000)])
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/client.py", line 779, in sync
    return sync(
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/utils.py", line 348, in sync
    raise exc.with_traceback(tb)
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/utils.py", line 332, in f
    result[0] = yield future
  File "/Users/jbourbeau/miniconda/envs/distributed-ql/lib/python3.8/site-packages/tornado/gen.py", line 735, in run
    value = future.result()
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/core.py", line 754, in send_recv_from_rpc
    comm = await self.pool.connect(self.addr)
  File "/Users/jbourbeau/github/Quansight-Labs/distributed/distributed/core.py", line 891, in connect
    await self.semaphore.acquire()
  File "/Users/jbourbeau/miniconda/envs/distributed-ql/lib/python3.8/asyncio/locks.py", line 496, in acquire
    await fut
RuntimeError: Task <Task pending name='Task-548' coro=<PooledRPCCall.__getattr__.<locals>.send_recv_from_rpc() running at /Users/jbourbeau/github/Quansight-Labs/distributed/distributed/core.py:754> cb=[gather.<locals>._done_callback() at /Users/jbourbeau/miniconda/envs/distributed-ql/lib/python3.8/asyncio/tasks.py:751]> got Future <Future pending> attached to a different loop
```

</details>

(Note that I had to run `$ ulimit -n 5000` locally in my terminal to increase the number of allowed connections and trigger acquiring the semaphore)

This PR delays the creation of `ConnectionPool.semaphore` to happen inside an async function so it attaches to the correct event loop (like was done in #3437). 

cc @mrocklin 