### PR TITLE
Register Cupyx

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black
       language_version: python3.7
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v2.5.0
     hooks:
     - id: flake8

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -78,6 +78,10 @@ def _register_torch():
 @cuda_deserialize.register_lazy("cupy")
 @dask_serialize.register_lazy("cupy")
 @dask_deserialize.register_lazy("cupy")
+@cuda_serialize.register_lazy("cupyx")
+@cuda_deserialize.register_lazy("cupyx")
+@dask_serialize.register_lazy("cupyx")
+@dask_deserialize.register_lazy("cupyx")
 def _register_cupy():
     from . import cupy
 

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -1,15 +1,29 @@
 """
 Efficient serialization GPU arrays.
 """
+import pickle
 import cupy
 
+from cupyx.scipy.sparse import spmatrix
+from cupyx.scipy.sparse import csr_matrix, csc_matrix, coo_matrix, dia_matrix
+
 from .cuda import cuda_deserialize, cuda_serialize
-from .serialize import dask_deserialize, dask_serialize, register_generic
+from .serialize import dask_deserialize, dask_serialize
+
 
 try:
     from .rmm import dask_deserialize_rmm_device_buffer as dask_deserialize_cuda_buffer
 except ImportError:
     from .numba import dask_deserialize_numba_array as dask_deserialize_cuda_buffer
+
+
+# lookup used for pulling out underlying CuPy bufffers
+data_lookup = {
+    csr_matrix: ["data", "indices", "indptr"],
+    coo_matrix: ["data", "row", "col"],
+    dia_matrix: ["data", "offsets"],
+}
+data_lookup[csc_matrix] = data_lookup[csr_matrix]
 
 
 class PatchedCudaArrayInterface:
@@ -35,6 +49,95 @@ class PatchedCudaArrayInterface:
         except ImportError:
             pass
         del self.base
+
+
+@cuda_serialize.register(spmatrix)
+def cuda_serialize_cupy_sparse(_x):
+    frames = []
+    all_headers = {}
+    all_headers["shape"] = _x.shape  # shape of full sparse data
+    for typ in data_lookup[type(_x)]:
+        x = getattr(_x, typ)
+        # Making sure `x` is behaving
+        if not (x.flags["C_CONTIGUOUS"] or x.flags["F_CONTIGUOUS"]):
+            x = cupy.array(x, copy=True)
+
+        header = x.__cuda_array_interface__.copy()
+        header["strides"] = tuple(x.strides)
+        frames.append(
+            cupy.ndarray(
+                shape=(x.nbytes,), dtype=cupy.dtype("u1"), memptr=x.data, strides=(1,)
+            )
+        )
+        all_headers[typ] = header
+
+    return all_headers, frames
+
+
+@cuda_deserialize.register(spmatrix)
+def cuda_deserialize_cupy_sparse(headers, frames):
+    _sparse_data = []
+    obj_typ = pickle.loads(headers["type-serialized"])
+    for idx, typ in enumerate(data_lookup[obj_typ]):
+        frame = frames[idx]
+        header = headers[typ]
+        if not isinstance(frame, cupy.ndarray):
+            frame = PatchedCudaArrayInterface(frame)
+
+        arr = cupy.ndarray(
+            shape=header["shape"],
+            dtype=header["typestr"],
+            memptr=cupy.asarray(frame).data,
+            strides=header["strides"],
+        )
+        _sparse_data.append(arr)
+
+    if obj_typ is coo_matrix:
+        data = _sparse_data[0]
+        row = _sparse_data[1]
+        col = _sparse_data[2]
+        return obj_typ((data, (row, col)))
+    elif obj_typ is dia_matrix:
+        data = _sparse_data[0]
+        offsets = _sparse_data[1]
+        shape = headers["shape"]
+        return obj_typ((data, offsets), shape=shape)
+    else:
+        return obj_typ(tuple(_sparse_data))
+
+
+@dask_serialize.register(spmatrix)
+def dask_serialize_cupy_sparse(x):
+    header, frames = cuda_serialize_cupy_sparse(x)
+    # To convert CuPy sparse matrices to SciPy, use get method of each CuPy
+    # sparse matrix class.
+    frames = [memoryview(f.get()) for f in frames]
+    return header, frames
+
+
+@dask_deserialize.register(spmatrix)
+def dask_deserialize_cupy_sparse(headers, frames):
+    _sparse_data = []
+    obj_typ = pickle.loads(headers["type-serialized"])
+    for idx, typ in enumerate(data_lookup[obj_typ]):
+        frame = frames[idx]
+        header = headers[typ]
+        frame = [dask_deserialize_cuda_buffer(header, [frame])]
+        arr = cuda_deserialize_cupy_ndarray(header, frame)
+        _sparse_data.append(arr)
+    obj_typ = pickle.loads(headers["type-serialized"])
+    if obj_typ is coo_matrix:
+        data = _sparse_data[0]
+        row = _sparse_data[1]
+        col = _sparse_data[2]
+        return obj_typ((data, (row, col)))
+    elif obj_typ is dia_matrix:
+        data = _sparse_data[0]
+        offsets = _sparse_data[1]
+        shape = headers["shape"]
+        return obj_typ((data, offsets), shape=shape)
+    else:
+        return obj_typ(tuple(_sparse_data))
 
 
 @cuda_serialize.register(cupy.ndarray)
@@ -80,20 +183,3 @@ def dask_deserialize_cupy_ndarray(header, frames):
     frames = [dask_deserialize_cuda_buffer(header, frames)]
     arr = cuda_deserialize_cupy_ndarray(header, frames)
     return arr
-
-
-try:
-    from cupy.cusparse import MatDescriptor
-    from cupyx.scipy.sparse import spmatrix
-
-    cupy_sparse_types = [MatDescriptor, spmatrix]
-except ImportError:
-    cupy_sparse_types = []
-
-
-for t in cupy_sparse_types:
-    for n, s, d in [
-        ("cuda", cuda_serialize, cuda_deserialize),
-        ("dask", dask_serialize, dask_deserialize),
-    ]:
-        register_generic(t, n, s, d)

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -73,7 +73,7 @@ def test_serialize_cupy_from_rmm(size):
     "dtype", [numpy.dtype("<f4"), numpy.dtype("<f8"),],
 )
 @pytest.mark.parametrize("serializer", ["cuda", "dask",])
-def test_serialize_cupy_sparse_diag(sparse_type, dtype, serializer):
+def test_serialize_cupy_sparse_dia(sparse_type, dtype, serializer):
     data = numpy.array([[0, 1, 2], [3, 4, 5]], dtype)
     offsets = numpy.array([0, -1], "i")
     shape = (3, 4)
@@ -90,76 +90,27 @@ def test_serialize_cupy_sparse_diag(sparse_type, dtype, serializer):
     assert (a_host == a2_host).all()
 
 
-@pytest.mark.skip(reason="malloc_consolidate()")
 @pytest.mark.parametrize(
-    "sparse_type", [cupy_sparse.csr_matrix,],
+    "sparse_type",
+    [cupy_sparse.csr_matrix, cupy_sparse.csc_matrix, cupy_sparse.coo_matrix,],
 )
 @pytest.mark.parametrize(
     "dtype", [numpy.dtype("<f4"), numpy.dtype("<f8")],
 )
 @pytest.mark.parametrize("serializer", ["cuda", "dask",])
-def test_serialize_cupy_sparse_csr(sparse_type, dtype, serializer):
-    a_host = numpy.array([[0, 1, 0], [2, 0, 3], [0, 4, 0]], dtype=dtype)
-    a = cupy.asarray(a_host)
+def test_serialize_cupy_sparse(sparse_type, dtype, serializer):
+    data = cupy.array([0, 1, 2, 3], dtype)
+    indices = cupy.array([0, 1, 3, 2], "i")
+    indptr = cupy.array([0, 2, 3, 4], "i")
 
-    anz = a.nonzero()
-    acoo = cupy_sparse.coo_matrix((a[anz], anz))
-    asp = sparse_type(acoo)
-
-    header, frames = serialize(asp, serializers=[serializer])
-    asp2 = deserialize(header, frames)
-
-    a2 = asp2.todense()
-    a2_host = cupy.asnumpy(a2)
-
-    assert (a_host == a2_host).all()
-
-
-@pytest.mark.skip(reason="malloc_consolidate()")
-@pytest.mark.parametrize(
-    "sparse_type", [cupy_sparse.csc_matrix,],
-)
-@pytest.mark.parametrize(
-    "dtype", [numpy.dtype("<f4"), numpy.dtype("<f8"),],
-)
-@pytest.mark.parametrize("serializer", ["cuda", "dask",])
-def test_serialize_cupy_sparse_csc(sparse_type, dtype, serializer):
-    a_host = numpy.array([[0, 1, 0], [2, 0, 3], [0, 4, 0]], dtype=dtype)
-    a = cupy.asarray(a_host)
-
-    anz = a.nonzero()
-    acoo = cupy_sparse.coo_matrix((a[anz], anz))
-    asp = sparse_type(acoo)
+    if sparse_type is cupy_sparse.coo_matrix:
+        asp = sparse_type((data, (indices, indptr)))
+    else:
+        asp = sparse_type((data, indices, indptr))
 
     header, frames = serialize(asp, serializers=[serializer])
     asp2 = deserialize(header, frames)
 
-    a2 = asp2.todense()
-    a2_host = cupy.asnumpy(a2)
-
-    assert (a_host == a2_host).all()
-
-
-@pytest.mark.skip(reason="malloc_consolidate()")
-@pytest.mark.parametrize(
-    "sparse_type", [cupy_sparse.coo_matrix,],
-)
-@pytest.mark.parametrize(
-    "dtype", [numpy.dtype("<f4"), numpy.dtype("<f8"),],
-)
-@pytest.mark.parametrize("serializer", ["cuda", "dask",])
-def test_serialize_cupy_sparse_coo(sparse_type, dtype, serializer):
-    a_host = numpy.array([[0, 1, 0], [2, 0, 3], [0, 4, 0]], dtype=dtype)
-    a = cupy.asarray(a_host)
-
-    anz = a.nonzero()
-    acoo = cupy_sparse.coo_matrix((a[anz], anz))
-    asp = sparse_type(acoo)
-
-    header, frames = serialize(asp, serializers=[serializer])
-    asp2 = deserialize(header, frames)
-
-    a2 = asp2.todense()
-    a2_host = cupy.asnumpy(a2)
-
-    assert (a_host == a2_host).all()
+    for k in asp.__dict__.keys():
+        if isinstance(asp.__dict__[k], cupy.ndarray):
+            cupy.testing.assert_array_equal(asp.__dict__[k], asp2.__dict__[k])


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/3547

PR adds cupyx to list of registered (de-)serializers

This does pass but it does produce some nastiness at the end (we can probably ignore but thought it was worth mentioning)

```
distributed/protocol/tests/test_cupy.py::test_serialize_cupy_sparse[cuda-dtype0-coo_matrix] PASSED
distributed/protocol/tests/test_cupy.py::test_serialize_cupy_sparse[cuda-dtype0-csc_matrix] PASSED
distributed/protocol/tests/test_cupy.py::test_serialize_cupy_sparse[cuda-dtype0-csr_matrix] malloc_consolidate(): invalid chunk size
Fatal Python error: Aborted

Current thread 0x00007f6989001740 (most recent call first):
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/logging.py", line 628 in _runtest_for_main
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/contextlib.py", line 81 in __enter__
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/logging.py", line 607 in _runtest_for
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/contextlib.py", line 81 in __enter__
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/logging.py", line 645 in pytest_runtest_setup
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/callers.py", line 182 in _multicall
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/manager.py", line 81 in <lambda>
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/manager.py", line 87 in _hookexec
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/hooks.py", line 289 in __call__
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/runner.py", line 210 in <lambda>
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/runner.py", line 237 in from_call
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/runner.py", line 210 in call_runtest_hook
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/runner.py", line 185 in call_and_report
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/runner.py", line 93 in runtestprotocol
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/runner.py", line 84 in pytest_runtest_protocol
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/manager.py", line 81 in <lambda>
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/manager.py", line 87 in _hookexec
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/hooks.py", line 289 in __call__
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/main.py", line 271 in pytest_runtestloop
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/manager.py", line 81 in <lambda>
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/manager.py", line 87 in _hookexec
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/hooks.py", line 289 in __call__
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/main.py", line 247 in _main
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/main.py", line 197 in wrap_session
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/main.py", line 240 in pytest_cmdline_main
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/manager.py", line 81 in <lambda>
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/manager.py", line 87 in _hookexec
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pluggy/hooks.py", line 289 in __call__
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/_pytest/config/__init__.py", line 93 in main
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/site-packages/pytest/__main__.py", line 7 in <module>
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/runpy.py", line 85 in _run_code
  File "/datasets/bzaitlen/miniconda3/envs/20200302/lib/python3.6/runpy.py", line 193 in _run_module_as_main
```