### PR TITLE
Add prometheus metric for suspicious tasks

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -292,7 +292,7 @@ class _PrometheusCollector:
         suspicious_tasks = CounterMetricFamily(
             "dask_scheduler_tasks_suspicious",
             "Total number of times a task has been marked suspicious",
-            labels=["name"],
+            labels=["task_name"],
         )
 
         suspicious_by_prefix = {

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -292,11 +292,11 @@ class _PrometheusCollector:
         suspicious_tasks = CounterMetricFamily(
             "dask_scheduler_tasks_suspicious",
             "Total number of times a task has been marked suspicious",
-            labels=["task_name"],
+            labels=["task_prefix_name"],
         )
 
-        for name, val in self.server.suspicious_by_prefix.items():
-            suspicious_tasks.add_metric([name], val)
+        for tp in self.server.task_prefixes.values():
+            suspicious_tasks.add_metric([tp.name], tp.suspicious)
         yield suspicious_tasks
 
         yield CounterMetricFamily(

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -1,4 +1,3 @@
-from collections import Counter
 from datetime import datetime
 from functools import partial
 import os
@@ -296,11 +295,7 @@ class _PrometheusCollector:
             labels=["task_name"],
         )
 
-        suspicious_by_prefix = Counter()
-        for task in self.server.tasks.values():
-            suspicious_by_prefix[task.prefix.name] += task.suspicious
-
-        for name, val in suspicious_by_prefix.items():
+        for name, val in self.server.suspicious_by_prefix.items():
             suspicious_tasks.add_metric([name], val)
         yield suspicious_tasks
 

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from datetime import datetime
 from functools import partial
 import os
@@ -295,13 +296,9 @@ class _PrometheusCollector:
             labels=["task_name"],
         )
 
-        suspicious_by_prefix = {
-            prefix.name: 0 for prefix in self.server.task_prefixes.values()
-        }
-
+        suspicious_by_prefix = Counter()
         for task in self.server.tasks.values():
-            if task.suspicious > 0:
-                suspicious_by_prefix[task.prefix.name] += task.suspicious
+            suspicious_by_prefix[task.prefix.name] += task.suspicious
 
         for name, val in suspicious_by_prefix.items():
             suspicious_tasks.add_metric([name], val)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -791,7 +791,7 @@ class TaskPrefix:
 
     .. attribute:: suspicious: int
 
-       Numbers of tasks marked as suspicious with this prefix
+       Numbers of times a task was marked as suspicious with this prefix
 
 
     See Also

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections import defaultdict, deque, OrderedDict
+from collections import Counter, defaultdict, deque, OrderedDict
 from collections.abc import Mapping, Set
 from datetime import timedelta
 from functools import partial
@@ -1001,6 +1001,8 @@ class Scheduler(ServerNode):
         Tasks currently known to the scheduler
     * **unrunnable:** ``{TaskState}``
         Tasks in the "no-worker" state
+    * **suspicious_by_prefix** ``Counter(prefix name: int)``
+        Numbers of tasks marked as suspicious by prefix
 
     * **workers:** ``{worker key: WorkerState}``
         Workers currently connected to the scheduler
@@ -1168,6 +1170,7 @@ class Scheduler(ServerNode):
         self._last_client = None
         self._last_time = 0
         self.unrunnable = set()
+        self.suspicious_by_prefix = Counter()
 
         self.n_tasks = 0
         self.task_metadata = dict()
@@ -2190,6 +2193,7 @@ class Scheduler(ServerNode):
                 recommendations[k] = "released"
                 if not safe:
                     ts.suspicious += 1
+                    self.suspicious_by_prefix[ts.prefix.name] += 1
                     if ts.suspicious > self.allowed_failures:
                         del recommendations[k]
                         e = pickle.dumps(


### PR DESCRIPTION
This PR adds a prometheus metric for suspicious tasks parted by the task prefix name.