### PR TITLE
Add 'local_directory' option to dask-ssh

### DIFF
--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -81,7 +81,7 @@ from distributed.cli.utils import check_python_3
     "--local-directory",
     default=None,
     type=click.Path(exists=True),
-    help="Directory to place workers and scheduler files.",
+    help="Directory to use on to all cluster nodes to place workers and scheduler files.",
 )
 @click.option(
     "--remote-python", default=None, type=str, help="Path to Python on remote nodes."

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -81,9 +81,9 @@ from distributed.cli.utils import check_python_3
     "--local-directory",
     default=None,
     type=click.Path(exists=True),
-    help=("Directory to use on all cluster nodes to place workers "
-          "and scheduler files.")
-    ,
+    help=(
+        "Directory to use on all cluster nodes to place workers " "and scheduler files."
+    ),
 )
 @click.option(
     "--remote-python", default=None, type=str, help="Path to Python on remote nodes."

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -78,6 +78,12 @@ from distributed.cli.utils import check_python_3
     ),
 )
 @click.option(
+    "--local-directory",
+    default=None,
+    type=click.Path(exists=True),
+    help="Directory to place workers and scheduler files.",
+)
+@click.option(
     "--remote-python", default=None, type=str, help="Path to Python on remote nodes."
 )
 @click.option(
@@ -126,6 +132,7 @@ def main(
     worker_port,
     nanny_port,
     remote_dask_worker,
+    local_directory,
 ):
     try:
         hostnames = list(hostnames)
@@ -157,6 +164,7 @@ def main(
         worker_port,
         nanny_port,
         remote_dask_worker,
+        local_directory,
     )
 
     import distributed

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -81,7 +81,9 @@ from distributed.cli.utils import check_python_3
     "--local-directory",
     default=None,
     type=click.Path(exists=True),
-    help="Directory to use on to all cluster nodes to place workers and scheduler files.",
+    help=("Directory to use on all cluster nodes to place workers "
+          "and scheduler files.")
+    ,
 )
 @click.option(
     "--remote-python", default=None, type=str, help="Path to Python on remote nodes."

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -209,14 +209,23 @@ def async_ssh(cmd_dict):
 
 
 def start_scheduler(
-    logdir, addr, port, ssh_username, ssh_port, ssh_private_key, remote_python=None, local_directory=None
+    logdir,
+    addr,
+    port,
+    ssh_username,
+    ssh_port,
+    ssh_private_key,
+    remote_python=None,
+    local_directory=None,
 ):
     cmd = "{python} -m distributed.cli.dask_scheduler --port {port}".format(
         python=remote_python or sys.executable, port=port, logdir=logdir
     )
 
     if local_directory is not None:
-        cmd += " --local-directory {local_directory}".format(local_directory=local_directory)
+        cmd += " --local-directory {local_directory}".format(
+            local_directory=local_directory
+        )
 
     # Optionally re-direct stdout and stderr to a logfile
     if logdir is not None:
@@ -308,7 +317,9 @@ def start_worker(
     )
 
     if local_directory is not None:
-        cmd += " --local-directory {local_directory}".format(local_directory=local_directory)
+        cmd += " --local-directory {local_directory}".format(
+            local_directory=local_directory
+        )
 
     # Optionally redirect stdout and stderr to a logfile
     if logdir is not None:

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -209,11 +209,14 @@ def async_ssh(cmd_dict):
 
 
 def start_scheduler(
-    logdir, addr, port, ssh_username, ssh_port, ssh_private_key, remote_python=None
+    logdir, addr, port, ssh_username, ssh_port, ssh_private_key, remote_python=None, local_directory=None
 ):
     cmd = "{python} -m distributed.cli.dask_scheduler --port {port}".format(
         python=remote_python or sys.executable, port=port, logdir=logdir
     )
+
+    if local_directory is not None:
+        cmd += " --local-directory {local_directory}".format(local_directory=local_directory)
 
     # Optionally re-direct stdout and stderr to a logfile
     if logdir is not None:
@@ -270,6 +273,7 @@ def start_worker(
     nanny_port,
     remote_python=None,
     remote_dask_worker="distributed.cli.dask_worker",
+    local_directory=None,
 ):
 
     cmd = (
@@ -302,6 +306,9 @@ def start_worker(
         worker_port=worker_port,
         nanny_port=nanny_port,
     )
+
+    if local_directory is not None:
+        cmd += " --local-directory {local_directory}".format(local_directory=local_directory)
 
     # Optionally redirect stdout and stderr to a logfile
     if logdir is not None:
@@ -353,6 +360,7 @@ class SSHCluster:
         worker_port=None,
         nanny_port=None,
         remote_dask_worker="distributed.cli.dask_worker",
+        local_directory=None,
     ):
 
         self.scheduler_addr = scheduler_addr
@@ -372,6 +380,7 @@ class SSHCluster:
         self.worker_port = worker_port
         self.nanny_port = nanny_port
         self.remote_dask_worker = remote_dask_worker
+        self.local_directory = local_directory
 
         # Generate a universal timestamp to use for log files
         import datetime
@@ -402,6 +411,7 @@ class SSHCluster:
             ssh_port,
             ssh_private_key,
             remote_python,
+            local_directory,
         )
 
         # Start worker nodes
@@ -455,6 +465,7 @@ class SSHCluster:
                 self.nanny_port,
                 self.remote_python,
                 self.remote_dask_worker,
+                self.local_directory,
             )
         )
 


### PR DESCRIPTION
This PR enables `--local-directory` option in `dask-ssh` cli to change the default location where workers and scheduler place their files.