### PR TITLE
Update TaskGroup removal logic to work for fire-and-forget tasks

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4649,7 +4649,7 @@ class Scheduler(ServerNode):
                 if ts.state == "forgotten":
                     del self.tasks[ts.key]
 
-            if ts.state == "forgotten":
+            if ts.state == "forgotten" and ts.group.name in self.task_groups:
                 # Remove TaskGroup if all tasks are in the forgotten state
                 tg = ts.group
                 if not any(tg.states.get(s) for s in ALL_TASK_STATES):


### PR DESCRIPTION
tl;dr: Currently `fire-and-forget` tasks result in nested task transitions which both end in the `forgotten` state and cause an error to be raised (xref #3465 and #3551). This PR updates the task group removal logic to work for these situations. A longer explanation follows below. 

cc @bnaul @mgh35 if you get a change to take a look

When a fired-and-forgotten task has been executed, as it's being added to the set of tasks in memory here (part of the `processing`->`memory` transition):

https://github.com/dask/distributed/blob/ae74b5ea18fac7e272c9f25b5d9f2775956aa943/distributed/scheduler.py#L3821-L3823

it is also transitioned to the `forgotten` state here

https://github.com/dask/distributed/blob/ae74b5ea18fac7e272c9f25b5d9f2775956aa943/distributed/scheduler.py#L2295

Overall this has the affect of doing a nested transition (`memory`->`forgotten` happening inside the `processing` -> `memory` transition).

Before the task completes the `processing` -> `memory` transition, it goes through the `memory`->`forgotten` transition where the task is put into the `forgotten` state and the corresponding task group is deleted. Then when the `processing` -> `memory` transition is resumed, the task has already been put into the `forgotten` state and a second attempt to delete the (already deleted) task group causes an error to be raised.

Fixes #3465, fixes #3551