### PR TITLE
Fix old_ssh redirecting output to logfile in non-bash default shell

### DIFF
--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -233,6 +233,7 @@ def start_scheduler(
         cmd += "&> {logdir}/dask_scheduler_{addr}:{port}.log".format(
             addr=addr, port=port, logdir=logdir
         )
+        cmd = '/bin/bash -c "{cmd}"'.format(cmd=cmd)
 
     # Format output labels we can prepend to each line of output, and create
     # a 'status' key to keep track of jobs that terminate prematurely.
@@ -327,6 +328,7 @@ def start_worker(
         cmd += "&> {logdir}/dask_scheduler_{addr}.log".format(
             addr=worker_addr, logdir=logdir
         )
+        cmd = '/bin/bash -c "{cmd}"'.format(cmd=cmd)
 
     label = "worker {addr}".format(addr=worker_addr)
 


### PR DESCRIPTION
Using `--log-directory` with `dask-ssh` command fails in non-bash default shell. This PR forces run the command in bash. 