### PR TITLE
Add Python version check

### DIFF
--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -123,11 +123,8 @@ async def test_version_warning_in_cluster(s, a, b):
 @gen_cluster()
 async def test_python_version_mismatch_warning(s, a, b):
     # Set random Python version for one worker
-    orig = s.workers[a.address].versions["host"]
-    updated = list(map(list, orig))  # List is needed to be mutable
     random_version = uuid.uuid4().hex
-    updated[0][1] = random_version
-    s.workers[a.address].versions["host"] = updated
+    orig = s.workers[a.address].versions["host"]["python"] = random_version
 
     with pytest.warns(None) as record:
         async with Client(s.address, asynchronous=True) as client:

--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 
 import pytest
 
@@ -117,3 +118,22 @@ async def test_version_warning_in_cluster(s, a, b):
         assert any(
             "0.0.0" in line.message and a.address in line.message for line in w.logs
         )
+
+
+@gen_cluster()
+async def test_python_version_mismatch_warning(s, a, b):
+    # Set random Python version for one worker
+    orig = s.workers[a.address].versions["host"]
+    updated = list(map(list, orig))  # List is needed to be mutable
+    random_version = uuid.uuid4().hex
+    updated[0][1] = random_version
+    s.workers[a.address].versions["host"] = updated
+
+    with pytest.warns(None) as record:
+        async with Client(s.address, asynchronous=True) as client:
+            pass
+
+    assert record
+    assert any("python" in str(r.message) for r in record)
+    assert any(random_version in str(r.message) for r in record)
+    assert any(a.address in str(r.message) for r in record)

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -122,6 +122,10 @@ def error_message(scheduler, workers, client, client_name="client"):
             for pkg, version in info["packages"].items():
                 node_packages[node][pkg] = version
                 packages.add(pkg)
+            # Collect Python version for each node
+            python_version = info["host"][0][1]
+            node_packages[node]["python"] = python_version
+            packages.add("python")
 
     errs = []
     for pkg in sorted(packages):

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -51,17 +51,17 @@ def get_versions(packages=None):
 
 def get_system_info():
     (sysname, nodename, release, version, machine, processor) = platform.uname()
-    host = [
-        ("python", "%d.%d.%d.%s.%s" % sys.version_info[:]),
-        ("python-bits", struct.calcsize("P") * 8),
-        ("OS", "%s" % sysname),
-        ("OS-release", "%s" % release),
-        ("machine", "%s" % machine),
-        ("processor", "%s" % processor),
-        ("byteorder", "%s" % sys.byteorder),
-        ("LC_ALL", "%s" % os.environ.get("LC_ALL", "None")),
-        ("LANG", "%s" % os.environ.get("LANG", "None")),
-    ]
+    host = {
+        "python": "%d.%d.%d.%s.%s" % sys.version_info[:],
+        "python-bits": struct.calcsize("P") * 8,
+        "OS": "%s" % sysname,
+        "OS-release": "%s" % release,
+        "machine": "%s" % machine,
+        "processor": "%s" % processor,
+        "byteorder": "%s" % sys.byteorder,
+        "LC_ALL": "%s" % os.environ.get("LC_ALL", "None"),
+        "LANG": "%s" % os.environ.get("LANG", "None"),
+    }
 
     return host
 
@@ -113,7 +113,6 @@ def error_message(scheduler, workers, client, client_name="client"):
 
     # Collect all package versions
     packages = set()
-
     for node, info in nodes.items():
         if info is None or not (isinstance(info, dict)) or "packages" not in info:
             node_packages[node] = defaultdict(lambda: "UNKNOWN")
@@ -123,8 +122,7 @@ def error_message(scheduler, workers, client, client_name="client"):
                 node_packages[node][pkg] = version
                 packages.add(pkg)
             # Collect Python version for each node
-            python_version = info["host"][0][1]
-            node_packages[node]["python"] = python_version
+            node_packages[node]["python"] = info["host"]["python"]
             packages.add("python")
 
     errs = []


### PR DESCRIPTION
This PR adds the Python version to our version mismatch check. I've also updated `get_system_info` to return a dictionary instead of a list-of-tuples. This is so the `"host"` and `"packages"` data structures returned by `get_versions` are the same, and it it also made `test_python_version_mismatch_warning` slightly cleaner to write. 

cc @mrocklin 

Closes https://github.com/dask/dask/issues/6007