### PR TITLE
Add Python version to version checking

### DIFF
--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 import pytest
 
@@ -117,3 +118,9 @@ async def test_version_warning_in_cluster(s, a, b):
         assert any(
             "0.0.0" in line.message and a.address in line.message for line in w.logs
         )
+
+
+def test_python():
+    d = get_versions()
+    assert "python" in str(d)
+    assert ".".join(map(str, sys.version_info[:3])) in str(d)

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -45,7 +45,6 @@ def get_versions(packages=None):
             required_packages + optional_packages + list(packages)
         ),
     }
-
     return d
 
 
@@ -82,7 +81,7 @@ def version_of_package(pkg):
 def get_package_info(pkgs):
     """ get package versions for the passed required & optional packages """
 
-    pversions = []
+    pversions = [("python", ".".join(map(str, sys.version_info[:3])))]
     for pkg in pkgs:
         if isinstance(pkg, (tuple, list)):
             modname, ver_f = pkg


### PR DESCRIPTION
Previously we would capture the Python version, but not actually raise a
warning message if it differed, like we would do with package versions.

Now we also include the Python version in the list of packages so that
it gets the same version checking treatment.

Fixes #6007

Example
-------

    distributed.worker - WARNING - Mismatched versions found

    python
    +-----------------------+---------+
    |                       | version |
    +-----------------------+---------+
    | This Worker           | 3.7.4   |
    | scheduler             | 3.7.4   |
    | tcp://127.0.0.1:42441 | 3.7.4   |
    | tcp://127.0.0.1:46325 | 3.8.1   |
    +-----------------------+---------+