### PR TITLE
Ability to skip errors in client.compute

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2669,6 +2669,7 @@ class Client(Node):
         fifo_timeout="60s",
         actors=None,
         traverse=True,
+        errors="raise",
         **kwargs
     ):
         """ Compute dask collections on cluster
@@ -2712,6 +2713,9 @@ class Client(Node):
             Whether these tasks should exist on the worker as stateful actors.
             Specified on a global (True/False) or per-task (``{'x': True,
             'y': False}``) basis. See :doc:`actors` for additional details.
+        errors: string
+            Either 'raise' or 'skip' if we should raise if a dask object has
+            erred or skip its inclusion in the output collection
         **kwargs:
             Options to pass to the graph optimize calls
 
@@ -2797,7 +2801,7 @@ class Client(Node):
                 futures.append(arg)
 
         if sync:
-            result = self.gather(futures)
+            result = self.gather(futures, errors=errors)
         else:
             result = futures
 


### PR DESCRIPTION
Let me describe my use case and what I want to achieve. Example gist https://gist.github.com/whalebot-helmsman/a86aa313c550114b096e6a4c1e5da42a

I have a graph of computations, it is very complicated graph. From time to time I want to run not a whole graph, but part of it. To keep same graph building code for different execution paths I have to use `dask.delayed`. I use `client.compute` for graph execution. See https://gist.github.com/whalebot-helmsman/a86aa313c550114b096e6a4c1e5da42a#file-my_pipeline-py-L32-L48 . Problem is my tasks fail from time to time and `client.compute` doesn't support partial failing.

Futures and `client.gather` support partial failures. It is possible to use futures in same manner as `dask.delayed`, but I have to provide code for graph dependency resolution. I see `dask` as DAG computation handler and it's strange to manage graph dependencies in graph building code. See https://gist.github.com/whalebot-helmsman/a86aa313c550114b096e6a4c1e5da42a#file-my_pipeline-py-L51-L65 . 

In this PR I propose to add `errors=skip` for `client.compute` to combine `dask.delayed` non-submitting way of graph building and ability to handle partial fails during execution.