### PR TITLE
Optionally compress on a frame-by-frame basis

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -49,7 +49,7 @@ def dumps(msg, serializers=None, on_error="message", context=None):
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
             if "compression" not in head:
-                frames = frame_split_size(frames)
+                frames = sum(map(frame_split_size, frames), [])
                 if frames:
                     compression, frames = zip(*map(maybe_compress, frames))
                 else:

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -48,17 +48,27 @@ def dumps(msg, serializers=None, on_error="message", context=None):
         for key, (head, frames) in data.items():
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
-            if "compression" not in head:
-                frames = sum(map(frame_split_size, frames), [])
-                if frames:
-                    compression, frames = zip(*map(maybe_compress, frames))
-                else:
-                    compression = []
-                head["compression"] = compression
-            head["count"] = len(frames)
+
+            # Compress frames that are not yet compressed
+            out_compression = []
+            _out_frames = []
+            for frame, compression in zip(
+                frames, head.get("compression") or [None] * len(frames)
+            ):
+                if compression is None:  # default behavior
+                    _frames = frame_split_size(frame)
+                    _compression, _frames = zip(*map(maybe_compress, _frames))
+                    out_compression.extend(_compression)
+                    _out_frames.extend(_frames)
+                else:  # already specified, so pass
+                    out_compression.append(compression)
+                    _out_frames.append(frame)
+
+            head["compression"] = out_compression
+            head["count"] = len(_out_frames)
             header["headers"][key] = head
             header["keys"].append(key)
-            out_frames.extend(frames)
+            out_frames.extend(_out_frames)
 
         for key, (head, frames) in pre.items():
             if "lengths" not in head:

--- a/distributed/protocol/cuda.py
+++ b/distributed/protocol/cuda.py
@@ -18,7 +18,7 @@ def cuda_dumps(x):
     header, frames = dumps(x)
     header["type-serialized"] = pickle.dumps(type(x))
     header["serializer"] = "cuda"
-    header["compression"] = (None,) * len(frames)  # no compression for gpu data
+    header["compression"] = (False,) * len(frames)  # no compression for gpu data
     return header, frames
 
 

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -88,7 +88,7 @@ def serialize_numpy_ndarray(x):
         header["broadcast_to"] = broadcast_to
 
     if x.nbytes > 1e5:
-        frames = frame_split_size([data])
+        frames = frame_split_size(data)
     else:
         frames = [data]
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -436,7 +436,7 @@ def nested_deserialize(x):
 
 def serialize_bytelist(x, **kwargs):
     header, frames = serialize(x, **kwargs)
-    frames = frame_split_size(frames)
+    frames = sum(map(frame_split_size, frames), [])
     if frames:
         compression, frames = zip(*map(maybe_compress, frames))
     else:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -166,10 +166,12 @@ def serialize(x, serializers=None, on_error="message", context=None):
 
         frames = []
         lengths = []
+        compressions = []
         for _header, _frames in headers_frames:
             frames.extend(_frames)
             length = len(_frames)
             lengths.append(length)
+            compressions.extend(_header.get("compression") or [None] * len(_frames))
 
         headers = [obj[0] for obj in headers_frames]
         headers = {
@@ -178,6 +180,8 @@ def serialize(x, serializers=None, on_error="message", context=None):
             "frame-lengths": lengths,
             "type-serialized": type(x).__name__,
         }
+        if any(compression is not None for compression in compressions):
+            headers["compression"] = compressions
         return headers, frames
 
     tb = ""

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -374,3 +374,17 @@ async def test_profile_nested_sizeof():
 
     msg = {"data": original}
     frames = await to_frames(msg)
+
+
+def test_compression_numpy_list():
+    class MyObj:
+        pass
+
+    @dask_serialize.register(MyObj)
+    def _(x):
+        header = {"compression": [False]}
+        frames = [b""]
+        return header, frames
+
+    header, frames = serialize([MyObj(), MyObj()])
+    assert header["compression"] == [False, False]

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -41,7 +41,10 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
         except AttributeError:
             itemsize = 1
 
-        return [frame[i : i + n // itemsize] for i in range(0, nbytes(frame) // itemsize, n // itemsize)]
+        return [
+            frame[i : i + n // itemsize]
+            for i in range(0, nbytes(frame) // itemsize, n // itemsize)
+        ]
 
 
 def merge_frames(header, frames):

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -19,9 +19,9 @@ except TypeError:
     msgpack_opts["encoding"] = "utf-8"
 
 
-def frame_split_size(frames, n=BIG_BYTES_SHARD_SIZE):
+def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     """
-    Split a list of frames into a list of frames of maximum size
+    Split a frame into a list of frames of maximum size
 
     This helps us to avoid passing around very large bytestrings.
 
@@ -30,26 +30,18 @@ def frame_split_size(frames, n=BIG_BYTES_SHARD_SIZE):
     >>> frame_split_size([b'12345', b'678'], n=3)  # doctest: +SKIP
     [b'123', b'45', b'678']
     """
-    if not frames:
-        return frames
+    if nbytes(frame) <= n:
+        return [frame]
 
-    if max(map(nbytes, frames)) <= n:
-        return frames
+    if nbytes(frame) > n:
+        if isinstance(frame, (bytes, bytearray)):
+            frame = memoryview(frame)
+        try:
+            itemsize = frame.itemsize
+        except AttributeError:
+            itemsize = 1
 
-    out = []
-    for frame in frames:
-        if nbytes(frame) > n:
-            if isinstance(frame, (bytes, bytearray)):
-                frame = memoryview(frame)
-            try:
-                itemsize = frame.itemsize
-            except AttributeError:
-                itemsize = 1
-            for i in range(0, nbytes(frame) // itemsize, n // itemsize):
-                out.append(frame[i : i + n // itemsize])
-        else:
-            out.append(frame)
-    return out
+        return [frame[i : i + n // itemsize] for i in range(0, nbytes(frame) // itemsize, n // itemsize)]
 
 
 def merge_frames(header, frames):


### PR DESCRIPTION
Previously we used to do compression on an all-or-nothing basis for every message.  This presented challenges when we bundled multiple kinds of data into the same message, such as when we had a dict that contained both a numpy array and a cupy array. 

Now we explicitly walk through each frame and see if we've been asked to compress it or not. 

This required some changes to internal utility functions, like `frame_split_size`, to have them act in a more granular way.

Supercedes https://github.com/dask/distributed/pull/3584

Fixes #3580

cc @quasiben 