### PR TITLE
Add SubgraphCallables to serialization cache

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -42,7 +42,6 @@ from distributed.worker import (
     parse_memory_limit,
     dumps_function,
     cache_dumps,
-    _subgraphcallable_cache_key,
 )
 from distributed.utils import tmpfile, TimeoutError
 from distributed.utils_test import (  # noqa: F401
@@ -1666,15 +1665,5 @@ async def test_heartbeat_comm_closed(cleanup, monkeypatch, reconnect):
 def test_dumps_function_subgraphcallable_cached():
     dsk = {"x": 1, "y": (slowinc, "x")}
     func = SubgraphCallable(dsk, outkey="y", inkeys=())
-    key = _subgraphcallable_cache_key(func)
-    if key is func:
-        pytest.skip(
-            "Caching serialized SubgraphCallables is not supported for this version of Dask"
-        )
-    else:
-        dumps_function(func)
-        assert key in cache_dumps
-
-        # Ensure SubgraphCallables are removed from cache_dumps once garbage collected
-        del func
-        assert key not in cache_dumps
+    dumps_function(func)
+    assert id(func) in cache_dumps

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -18,6 +18,7 @@ import weakref
 import dask
 from dask.core import istask
 from dask.compatibility import apply
+from dask.optimization import SubgraphCallable
 from dask.utils import format_bytes, funcname
 from dask.system import CPU_COUNT
 
@@ -3279,15 +3280,16 @@ _cache_lock = threading.Lock()
 
 def dumps_function(func):
     """ Dump a function to bytes, cache functions """
+    key = func if not isinstance(func, SubgraphCallable) else id(func)
     try:
         with _cache_lock:
-            result = cache_dumps[func]
+            result = cache_dumps[key]
     except KeyError:
         result = pickle.dumps(func)
         if len(result) < 100000:
             with _cache_lock:
-                cache_dumps[func] = result
-    except TypeError:  # Unhashable function
+                cache_dumps[key] = result
+    except TypeError:  # Unhashable key
         result = pickle.dumps(func)
     return result
 


### PR DESCRIPTION
Currently when serializing `SubgraphCallable`s in `dumps_function`, because `SubgraphCallable`s aren't hashable, we can't use them as keys in the `cache_dumps` serialization cache. Instead we end up trigger the `TypeError` here

https://github.com/dask/distributed/blob/2acffc3172ec32e173547ee4c39a01b6c94e74a1/distributed/worker.py#L3288-L3289

and must re-serialize the same `SubgraphCallable` each time it is encountered. 

One solution would be to implement a `SubgraphCallable.__hash__` method, however I don't think we can reliably hash `SubgraphCallable`s as they contain a dask graph which in general can contain non-hashable things. 

This PR proposes we place `SubgraphCallable`s in the serialization cache using their `id` as a key. Having the same `SubgraphCallable` instance occur in many tasks is common when working with dask array and dask dataframe collections. This shouldn't noticeably impact workloads that don't use `SubgraphCallable`s, and will decreasing graph processing time for workloads that do.

<details>
<summary>Example benchmark:</summary>

For example, with the changes in this PR we have:

```python
In [1]: from toolz import valmap
   ...:
   ...: import dask.array as da
   ...: from distributed.worker import dumps_task
   ...:
   ...: # Do some array computation
   ...: x = da.arange(100_000, chunks=100)
   ...: y = da.mean(x) + x
   ...: z = da.cos(y)
   ...:
   ...: # Optimized graph
   ...: dsk_optimized = z.__dask_optimize__(z.dask, keys=z.__dask_keys__())
   ...:
   ...: # Serialize optimized graph
   ...: %timeit valmap(dumps_task, dsk_optimized)
25 ms ± 793 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

and on the current `master` branch the same code snippet gives:

```
3.67 s ± 311 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

</details>


cc @mrocklin if you get a chance to look at this