### PR TITLE
Replace tornado.queues with asyncio.queues

### DIFF
--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -9,7 +9,7 @@ import warnings
 import pkg_resources
 import pytest
 
-from tornado import ioloop, queues
+from tornado import ioloop
 from tornado.concurrent import Future
 
 import distributed
@@ -78,7 +78,7 @@ tls_kwargs = dict(
 
 @pytest.mark.asyncio
 async def get_comm_pair(listen_addr, listen_args=None, connect_args=None, **kwargs):
-    q = queues.Queue()
+    q = asyncio.Queue()
 
     async def handle_comm(comm):
         await q.put(comm)
@@ -883,7 +883,7 @@ async def test_inproc_many_listeners():
 
 
 async def check_listener_deserialize(addr, deserialize, in_value, check_out):
-    q = queues.Queue()
+    q = asyncio.Queue()
 
     async def handle_comm(comm):
         msg = await comm.read()

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -80,8 +80,8 @@ tls_kwargs = dict(
 async def get_comm_pair(listen_addr, listen_args=None, connect_args=None, **kwargs):
     q = queues.Queue()
 
-    def handle_comm(comm):
-        q.put(comm)
+    async def handle_comm(comm):
+        await q.put(comm)
 
     listener = listen(listen_addr, handle_comm, connection_args=listen_args, **kwargs)
     await listener.start()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -33,7 +33,7 @@ import pytest
 
 import dask
 from tlz import merge, memoize, assoc
-from tornado import gen, queues
+from tornado import gen
 from tornado.ioloop import IOLoop
 
 from . import system
@@ -429,7 +429,7 @@ async def readone(comm):
     try:
         q = _readone_queues[comm]
     except KeyError:
-        q = _readone_queues[comm] = queues.Queue()
+        q = _readone_queues[comm] = asyncio.Queue()
 
         async def background_read():
             while True:


### PR DESCRIPTION
This fixes a `TypeError: object NoneType can't be used in 'await' expression` that was being raised in `test_comms.py` (xref #3600) and replaces the use of tornado `Queue`s with equivalent asyncio `Queue`s.

cc @jakirkham 

Closes #3600 