### PR TITLE
Remove dill from CI environments.

### DIFF
--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - click
   - cloudpickle
   - dask
-  - dill
   - lz4
   - ipykernel
   - ipywidgets

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -33,7 +33,6 @@ conda install -c conda-forge -q \
     click \
     coverage \
     dask \
-    dill \
     flake8 \
     h5py \
     ipykernel \


### PR DESCRIPTION
dill was removed in https://github.com/dask/distributed/commit/6dc1f3f202fbef0e530b7e89c300e4f4d59dbc30 (November 2015) from the `.py` files but never removed from CI environments.