### PR TITLE
Add as_completed.clear method

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4233,17 +4233,18 @@ class as_completed:
             except CancelledError as exc:
                 result = exc
         with self.lock:
-            self.futures[future] -= 1
-            if not self.futures[future]:
-                del self.futures[future]
-            if self.with_results:
-                self.queue.put_nowait((future, result))
-            else:
-                self.queue.put_nowait(future)
-            async with self.condition:
-                self.condition.notify()
-            with self.thread_condition:
-                self.thread_condition.notify()
+            if future in self.futures:
+                self.futures[future] -= 1
+                if not self.futures[future]:
+                    del self.futures[future]
+                if self.with_results:
+                    self.queue.put_nowait((future, result))
+                else:
+                    self.queue.put_nowait(future)
+                async with self.condition:
+                    self.condition.notify()
+                with self.thread_condition:
+                    self.thread_condition.notify()
 
     def update(self, futures):
         """ Add multiple futures to the collection.
@@ -4371,6 +4372,13 @@ class as_completed:
                 yield self.next_batch(block=True)
             except StopIteration:
                 return
+
+    def clear(self):
+        """ Clear out all submitted futures """
+        with self.lock:
+            self.futures.clear()
+            while not self.queue.empty():
+                self.queue.get()
 
 
 def AsCompleted(*args, **kwargs):

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Iterator
 from operator import add
 import queue
@@ -7,7 +8,7 @@ from time import sleep
 import pytest
 from tornado import gen
 
-from distributed.client import _as_completed, as_completed, _first_completed
+from distributed.client import _as_completed, as_completed, _first_completed, wait
 from distributed.utils import CancelledError
 from distributed.utils_test import gen_cluster, inc, throws
 from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
@@ -254,3 +255,17 @@ def test_as_completed_with_results_no_raise_async(c, s, a, b):
     assert isinstance(dd[y][0], CancelledError)
     assert isinstance(dd[x][0][1], RuntimeError)
     assert dd[z][0] == 2
+
+
+@gen_cluster(client=True, timeout=None)
+async def test_clear(c, s, a, b):
+    futures = c.map(inc, range(3))
+    ac = as_completed(futures)
+    await wait(futures)
+    ac.clear()
+    with pytest.raises(StopAsyncIteration):
+        await ac.__anext__()
+    del futures
+
+    while s.tasks:
+        await asyncio.sleep(0.3)


### PR DESCRIPTION
I wanted this when working on the Joblib + Dask connection