### PR TITLE
[WIP] Send serialized device array

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -538,15 +538,6 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
         await comm.write(msg, serializers=serializers, on_error="raise")
         if reply:
             response = await comm.read(deserializers=deserializers)
-            try:
-                data = response["data"]
-                from dask_cuda import device_host_file
-            except:
-                pass
-            else:
-                for key in data.keys():
-                    if isinstance(data[key], device_host_file.DeviceSerialized):
-                        data[key] = device_host_file.host_to_device(data[key])
         else:
             response = None
     except EnvironmentError:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -538,6 +538,12 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
         await comm.write(msg, serializers=serializers, on_error="raise")
         if reply:
             response = await comm.read(deserializers=deserializers)
+            if "data" in response:
+                from dask_cuda import device_host_file
+                data = response["data"]
+                for key in data.keys():
+                    if isinstance(data[key], device_host_file.DeviceSerialized):
+                        data[key] = device_host_file.host_to_device(data[key])
         else:
             response = None
     except EnvironmentError:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -538,9 +538,12 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
         await comm.write(msg, serializers=serializers, on_error="raise")
         if reply:
             response = await comm.read(deserializers=deserializers)
-            if "data" in response:
-                from dask_cuda import device_host_file
+            try:
                 data = response["data"]
+                from dask_cuda import device_host_file
+            except:
+                pass
+            else:
                 for key in data.keys():
                     if isinstance(data[key], device_host_file.DeviceSerialized):
                         data[key] = device_host_file.host_to_device(data[key])

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1846,7 +1846,10 @@ class Worker(ServerNode):
     def send_task_state_to_scheduler(self, key):
         if key in self.data or self.actors.get(key):
             try:
-                value = self.data[key]
+                if hasattr(self.data, "get_from_dev_or_host_buffer"):
+                    value = self.data.get_from_dev_or_host_buffer(key)
+                else:
+                    value = self.data[key]
             except KeyError:
                 value = self.actors[key]
             nbytes = self.nbytes[key] or sizeof(value)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1228,7 +1228,6 @@ class Worker(ServerNode):
             return {"status": "busy"}
 
         self.outgoing_current_count += 1
-        #data = {k: self.data[k] for k in keys if k in self.data}
         data = {}
         for k in keys:
             if k in self.data:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1228,7 +1228,14 @@ class Worker(ServerNode):
             return {"status": "busy"}
 
         self.outgoing_current_count += 1
-        data = {k: self.data[k] for k in keys if k in self.data}
+        #data = {k: self.data[k] for k in keys if k in self.data}
+        data = {}
+        for k in keys:
+            if k in self.data:
+                if hasattr(self.data, "get_from_dev_or_host_buffer"):
+                    data[k] = self.data.get_from_dev_or_host_buffer(k)
+                else:
+                    data[k] = self.data[k]
 
         if len(data) < len(keys):
             for k in set(keys) - set(data):


### PR DESCRIPTION
This PR implements direct communication of spilled device data. It uses `get_from_dev_or_host_buffer()` to access work data if available. 