### PR TITLE
Unpin openssl and handle exception

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -79,9 +79,6 @@ if [[ $CRICK == true ]]; then
     python -m pip install -q git+https://github.com/jcrist/crick.git
 fi;
 
-# Pin openssl==1.1.1d (see https://github.com/dask/distributed/issues/3588)
-conda install -c conda-forge openssl==1.1.1d
-
 # Install distributed
 python -m pip install --no-deps -e .
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -79,6 +79,9 @@ if [[ $CRICK == true ]]; then
     python -m pip install -q git+https://github.com/jcrist/crick.git
 fi;
 
+# TODO: REMOVE THE LINE BELOW
+conda install -c conda-forge openssl==1.1.1e
+
 # Install distributed
 python -m pip install --no-deps -e .
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -202,7 +202,13 @@ class TCP(Comm):
                 else:
                     frame = b""
                 frames.append(frame)
-        except StreamClosedError as e:
+        except (StreamClosedError, ssl.SSLError) as e:
+            if isinstance(e, ssl.SSLError):
+                if "unexpected eof while reading" not in str(e):
+                    raise e
+                else:
+                    e = StreamClosedError(str(e))
+
             self.stream = None
             if not shutting_down():
                 convert_stream_closed_error(self, e)


### PR DESCRIPTION
Instead of pinning the version of openssl this PR catching the broad `ssl.SSLError` and if it contains the new `unexpected eof while reading` message from `1.1.1e` it converts that to a `StreamClosedError` and treats it like that.