### PR TITLE
Check `nbytes` and `types` before reading `data`

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1836,13 +1836,16 @@ class Worker(ServerNode):
 
     def send_task_state_to_scheduler(self, key):
         if key in self.data or self.actors.get(key):
-            try:
-                value = self.data[key]
-            except KeyError:
-                value = self.actors[key]
-            nbytes = self.nbytes[key] or sizeof(value)
-            typ = self.types.get(key) or type(value)
-            del value
+            nbytes = self.nbytes[key]
+            typ = self.types.get(key)
+            if nbytes is None or typ is None:
+                try:
+                    value = self.data[key]
+                except KeyError:
+                    value = self.actors[key]
+                nbytes = self.nbytes[key] = sizeof(value)
+                typ = self.types[key] = type(value)
+                del value
             try:
                 typ_serialized = dumps_function(typ)
             except PicklingError:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1836,7 +1836,7 @@ class Worker(ServerNode):
 
     def send_task_state_to_scheduler(self, key):
         if key in self.data or self.actors.get(key):
-            nbytes = self.nbytes[key]
+            nbytes = self.nbytes.get(key)
             typ = self.types.get(key)
             if nbytes is None or typ is None:
                 try:


### PR DESCRIPTION
To avoid reading `data` when it is not needed, try checking `nbytes` and `types` beforehand. If the metadata is already there, continue on without reading `data`. Otherwise fallback to the reading `data`, but do make sure to cache the results of that read to avoid doing it again.

cc @madsbk @mrocklin