### PR TITLE
WIP: Include frame lengths of CUDA objects in `header["lengths"]`

### DIFF
--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -47,6 +47,7 @@ def cuda_serialize_cupy_ndarray(x):
 
     header = x.__cuda_array_interface__.copy()
     header["strides"] = tuple(x.strides)
+    header["lengths"] = [x.nbytes]
     frames = [
         cupy.ndarray(
             shape=(x.nbytes,), dtype=cupy.dtype("u1"), memptr=x.data, strides=(1,)

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -21,6 +21,7 @@ def cuda_serialize_numba_ndarray(x):
 
     header = x.__cuda_array_interface__.copy()
     header["strides"] = tuple(x.strides)
+    header["lengths"] = [x.nbytes]
     frames = [
         numba.cuda.cudadrv.devicearray.DeviceNDArray(
             shape=(x.nbytes,), strides=(1,), dtype=np.dtype("u1"), gpu_data=x.gpu_data,

--- a/distributed/protocol/rmm.py
+++ b/distributed/protocol/rmm.py
@@ -12,6 +12,7 @@ if hasattr(rmm, "DeviceBuffer"):
     @cuda_serialize.register(rmm.DeviceBuffer)
     def cuda_serialize_rmm_device_buffer(x):
         header = x.__cuda_array_interface__.copy()
+        header["lengths"] = [x.nbytes]
         frames = [x]
         return header, frames
 

--- a/distributed/protocol/rmm.py
+++ b/distributed/protocol/rmm.py
@@ -28,8 +28,8 @@ if hasattr(rmm, "DeviceBuffer"):
 
     @dask_serialize.register(rmm.DeviceBuffer)
     def dask_serialize_rmm_device_buffer(x):
-        header = x.__cuda_array_interface__.copy()
-        frames = [numba.cuda.as_cuda_array(x).copy_to_host().data]
+        header, frames = cuda_serialize_rmm_device_buffer(x)
+        frames = [numba.cuda.as_cuda_array(f).copy_to_host().data for f in frames]
         return header, frames
 
     @dask_deserialize.register(rmm.DeviceBuffer)


### PR DESCRIPTION
As going through `"dask"` serialization can result in data being split for better compression, ensure the original number of bytes in the frame is stored in `header["lengths"]`. That way on `"dask"` deserialization the frames can be merged back into their original sizes before `"cuda"` serialization is performed.