### PR TITLE
Add logging message when closing idle dask scheduler

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5207,6 +5207,10 @@ class Scheduler(ServerNode):
             close = time() > last_task + self.idle_timeout
 
         if close:
+            logger.info(
+                "Scheduler closing after being idle for %s",
+                format_time(self.idle_timeout),
+            )
             self.loop.add_callback(self.close)
 
     def adaptive_target(self, comm=None, target_duration=None):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1542,15 +1542,20 @@ async def test_idle_timeout(c, s, a, b):
 
     assert s.status != "closed"
 
-    start = time()
-    while s.status != "closed":
-        await gen.sleep(0.01)
-        assert time() < start + 3
+    with captured_logger("distributed.scheduler") as logs:
+        start = time()
+        while s.status != "closed":
+            await gen.sleep(0.01)
+            assert time() < start + 3
 
-    start = time()
-    while not (a.status == "closed" and b.status == "closed"):
-        await gen.sleep(0.01)
-        assert time() < start + 1
+        start = time()
+        while not (a.status == "closed" and b.status == "closed"):
+            await gen.sleep(0.01)
+            assert time() < start + 1
+
+    assert "idle" in logs.getvalue()
+    assert "500" in logs.getvalue()
+    assert "ms" in logs.getvalue()
 
 
 @gen_cluster(client=True, config={"distributed.scheduler.bandwidth": "100 GB"})


### PR DESCRIPTION
```
$ dask-scheduler --idle-timeout "5 seconds"
distributed.scheduler - INFO - -----------------------------------------------
distributed.scheduler - INFO - Local Directory:    /tmp/scheduler-niju4kje
distributed.scheduler - INFO - -----------------------------------------------
distributed.scheduler - INFO - Clear task state
distributed.scheduler - INFO -   Scheduler at:   tcp://192.168.0.11:8786
distributed.scheduler - INFO -   dashboard at:                     :8787
distributed.scheduler - INFO - Scheduler closing after being idle for 5.00 s
distributed.scheduler - INFO - Scheduler closing...
distributed.scheduler - INFO - Scheduler closing all comms
distributed.scheduler - INFO - End scheduler at 'tcp://192.168.0.11:8786'
```