### PR TITLE
Use `Struct.unpack_from`

### DIFF
--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -1,6 +1,9 @@
 import struct
 import msgpack
 
+from itertools import accumulate
+from tlz import cons, sliding_window
+
 from ..utils import ensure_bytes, nbytes
 
 BIG_BYTES_SHARD_SIZE = 2 ** 26
@@ -132,9 +135,8 @@ def unpack_frames(b):
     lengths = struct.unpack_from(n_frames * fmt, b, fmt_itemsize)
 
     frames = []
-    offset = fmt_itemsize * (1 + n_frames)
-    for each_length in lengths:
-        frames.append(b[offset : offset + each_length])
-        offset += each_length
+    start = fmt_itemsize * (1 + n_frames)
+    for i, j in sliding_window(2, accumulate(cons(start, lengths))):
+        frames.append(b[i:j])
 
     return frames

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -126,17 +126,17 @@ def unpack_frames(b):
     --------
     pack_frames
     """
-    itemsize = struct.calcsize("Q")
+    parser = struct.Struct("Q")
     offset = 0
 
-    (n_frames,) = struct.unpack_from("Q", b, offset)
-    offset += itemsize
+    (n_frames,) = parser.unpack_from(b, offset)
+    offset += parser.size
 
     frames = []
-    start = (1 + n_frames) * itemsize
+    start = (1 + n_frames) * parser.size
     for i in range(n_frames):
-        (length,) = struct.unpack_from("Q", b, offset)
-        offset += itemsize
+        (length,) = parser.unpack_from(b, offset)
+        offset += parser.size
 
         frame = b[start : start + length]
         frames.append(frame)

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -126,16 +126,17 @@ def unpack_frames(b):
     --------
     pack_frames
     """
+    itemsize = struct.calcsize("Q")
     offset = 0
 
     (n_frames,) = struct.unpack_from("Q", b, offset)
-    offset += 8
+    offset += itemsize
 
     frames = []
-    start = 8 + n_frames * 8
+    start = (1 + n_frames) * itemsize
     for i in range(n_frames):
         (length,) = struct.unpack_from("Q", b, offset)
-        offset += 8
+        offset += itemsize
 
         frame = b[start : start + length]
         frames.append(frame)

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -127,19 +127,19 @@ def unpack_frames(b):
     pack_frames
     """
     parser = struct.Struct("Q")
-    offset = 0
 
+    offset = 0
     (n_frames,) = parser.unpack_from(b, offset)
-    offset += parser.size
+
+    lengths = []
+    frames_offset = parser.size * (1 + n_frames)
+    for offset in range(parser.size, frames_offset, parser.size):
+        lengths.extend(parser.unpack_from(b, offset))
 
     frames = []
-    start = (1 + n_frames) * parser.size
-    for i in range(n_frames):
-        (length,) = parser.unpack_from(b, offset)
-        offset += parser.size
-
-        frame = b[start : start + length]
-        frames.append(frame)
-        start += length
+    offset = frames_offset
+    for each_length in lengths:
+        frames.append(b[offset : offset + each_length])
+        offset += each_length
 
     return frames

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -126,12 +126,17 @@ def unpack_frames(b):
     --------
     pack_frames
     """
-    (n_frames,) = struct.unpack("Q", b[:8])
+    offset = 0
+
+    (n_frames,) = struct.unpack_from("Q", b, offset)
+    offset += 8
 
     frames = []
     start = 8 + n_frames * 8
     for i in range(n_frames):
-        (length,) = struct.unpack("Q", b[(i + 1) * 8 : (i + 2) * 8])
+        (length,) = struct.unpack_from("Q", b, offset)
+        offset += 8
+
         frame = b[start : start + length]
         frames.append(frame)
         start += length

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -126,18 +126,13 @@ def unpack_frames(b):
     --------
     pack_frames
     """
-    parser = struct.Struct("Q")
-
-    offset = 0
-    (n_frames,) = parser.unpack_from(b, offset)
-
-    lengths = []
-    frames_offset = parser.size * (1 + n_frames)
-    for offset in range(parser.size, frames_offset, parser.size):
-        lengths.extend(parser.unpack_from(b, offset))
+    fmt = "Q"
+    fmt_itemsize = struct.calcsize(fmt)
+    (n_frames,) = struct.unpack_from(fmt, b)
+    lengths = struct.unpack_from(n_frames * fmt, b, fmt_itemsize)
 
     frames = []
-    offset = frames_offset
+    offset = fmt_itemsize * (1 + n_frames)
     for each_length in lengths:
         frames.append(b[offset : offset + each_length])
         offset += each_length


### PR DESCRIPTION
Simplifies `unpack_frames` a bit by simply tracking an `offset` (close to what the code was doing before) and using `struct.unpack_from`. This gets rid of the index arithmetic making the code more readable while preserving the functionality of the code.

Also builds a `Struct` object for the type, `"Q"`, that we will be parsing to simplify updating the `offset` by the `itemsize` of the `format`.