### PR TITLE
Drop unused line from `pack_frames_prelude`

### DIFF
--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -92,7 +92,6 @@ def merge_frames(header, frames):
 
 
 def pack_frames_prelude(frames):
-    lengths = [len(f) for f in frames]
     lengths = [struct.pack("Q", len(frames))] + [
         struct.pack("Q", nbytes(frame)) for frame in frames
     ]


### PR DESCRIPTION
`lengths` is replaced in the following line and the previous assignment does not appear to be used. So just drop it.