### PR TITLE
Simplify `unpack_frames`

### DIFF
--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -1,6 +1,9 @@
 import struct
 import msgpack
 
+from itertools import accumulate
+from tlz import cons, sliding_window
+
 from ..utils import ensure_bytes, nbytes
 
 BIG_BYTES_SHARD_SIZE = 2 ** 26
@@ -132,12 +135,7 @@ def unpack_frames(b):
     (n_frames,) = struct.unpack_from(fmt, b)
     lengths = struct.unpack_from(n_frames * fmt, b, fmt_itemsize)
 
-    frames = []
     start = (1 + n_frames) * fmt_itemsize
-    for i in range(n_frames):
-        (length,) = struct.unpack(fmt, b[(i + 1) * fmt_itemsize : (i + 2) * fmt_itemsize])
-        frame = b[start : start + length]
-        frames.append(frame)
-        start += length
+    frames = [b[i:j] for i, j in sliding_window(2, accumulate(cons(start, lengths)))]
 
     return frames

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -126,12 +126,15 @@ def unpack_frames(b):
     --------
     pack_frames
     """
-    (n_frames,) = struct.unpack("Q", b[:8])
+    fmt = "Q"
+    fmt_itemsize = struct.calcsize(fmt)
+
+    (n_frames,) = struct.unpack_from(fmt, b)
 
     frames = []
-    start = 8 + n_frames * 8
+    start = (1 + n_frames) * fmt_itemsize
     for i in range(n_frames):
-        (length,) = struct.unpack("Q", b[(i + 1) * 8 : (i + 2) * 8])
+        (length,) = struct.unpack(fmt, b[(i + 1) * fmt_itemsize : (i + 2) * fmt_itemsize])
         frame = b[start : start + length]
         frames.append(frame)
         start += length

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -1,9 +1,6 @@
 import struct
 import msgpack
 
-from itertools import accumulate
-from tlz import cons, sliding_window
-
 from ..utils import ensure_bytes, nbytes
 
 BIG_BYTES_SHARD_SIZE = 2 ** 26
@@ -135,7 +132,11 @@ def unpack_frames(b):
     (n_frames,) = struct.unpack_from(fmt, b)
     lengths = struct.unpack_from(n_frames * fmt, b, fmt_itemsize)
 
-    start = (1 + n_frames) * fmt_itemsize
-    frames = [b[i:j] for i, j in sliding_window(2, accumulate(cons(start, lengths)))]
+    frames = []
+    i = j = (1 + n_frames) * fmt_itemsize
+    for each_length in lengths:
+        j += each_length
+        frames.append(b[i:j])
+        i = j
 
     return frames

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -130,6 +130,7 @@ def unpack_frames(b):
     fmt_itemsize = struct.calcsize(fmt)
 
     (n_frames,) = struct.unpack_from(fmt, b)
+    lengths = struct.unpack_from(n_frames * fmt, b, fmt_itemsize)
 
     frames = []
     start = (1 + n_frames) * fmt_itemsize


### PR DESCRIPTION
Handles all of the `struct` work of unpacking `nframes` and `lengths` up front. Then simply iterates through the frames pulling out each one using its respective length.