### PR TITLE
Update bokeh dependency in Windows CI builds

### DIFF
--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - zstandard
-  - bokeh=1.4.0
+  - bokeh!=2.0.0
   - click
   - cloudpickle
   - dask


### PR DESCRIPTION
In https://github.com/dask/distributed/pull/3570 we pinned to `bokeh=1.4.0` to avoid an issue in `bokeh=2.0.0` where the `asyncio` event loop was being overwritten. That issue has since been fixed upstream (xref https://github.com/bokeh/bokeh/pull/9776) and should be included in the next `bokeh` release. This PR updates our CI conda environment file to restrict to `!=2.0.0` instead of pinning to `1.4.0`

Note: we can still use `bokeh=2.0.0` on Travis CI builds as the `bokeh` issue only arose when running on Windows with Python 3.8+