### PR TITLE
UCX synchronize default stream only on CUDA frames

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -175,7 +175,8 @@ class UCX(Comm):
                 #  syncing the default stream will wait for other non-blocking CUDA streams.
                 # Note this is only sufficient if the memory being sent is not currently in use on
                 # non-blocking CUDA streams.
-                synchronize_stream(0)
+                if any([hasattr(f, "__cuda_array_interface__") for f in frames]):
+                    synchronize_stream(0)
 
                 for frame in frames:
                     if nbytes(frame) > 0:
@@ -222,7 +223,8 @@ class UCX(Comm):
 
                 # It is necessary to first populate `frames` with CUDA arrays and synchronize
                 # the default stream before starting receiving to ensure buffers have been allocated
-                synchronize_stream(0)
+                if any(is_cudas.tolist()):
+                    synchronize_stream(0)
                 for i, (is_cuda, size) in enumerate(
                     zip(is_cudas.tolist(), sizes.tolist())
                 ):

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -158,9 +158,9 @@ class UCX(Comm):
                 )
 
                 # Send meta data
-                cuda_frames = [hasattr(f, "__cuda_array_interface__") for f in frames]
+                cuda_frames = np.array([hasattr(f, "__cuda_array_interface__") for f in frames], dtype=np.bool)
                 await self.ep.send(np.array([len(frames)], dtype=np.uint64))
-                await self.ep.send(np.array(cuda_frames, dtype=np.bool))
+                await self.ep.send(cuda_frames)
                 await self.ep.send(
                     np.array([nbytes(f) for f in frames], dtype=np.uint64)
                 )
@@ -171,7 +171,7 @@ class UCX(Comm):
                 #  syncing the default stream will wait for other non-blocking CUDA streams.
                 # Note this is only sufficient if the memory being sent is not currently in use on
                 # non-blocking CUDA streams.
-                if any(cuda_frames):
+                if cuda_frames.any():
                     synchronize_stream(0)
 
                 for frame in frames:

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -158,7 +158,10 @@ class UCX(Comm):
                 )
 
                 # Send meta data
-                cuda_frames = np.array([hasattr(f, "__cuda_array_interface__") for f in frames], dtype=np.bool)
+                cuda_frames = np.array(
+                    [hasattr(f, "__cuda_array_interface__") for f in frames],
+                    dtype=np.bool,
+                )
                 await self.ep.send(np.array([len(frames)], dtype=np.uint64))
                 await self.ep.send(cuda_frames)
                 await self.ep.send(


### PR DESCRIPTION
Avoid unnecessary CUDA default stream synchronizations if frames don't have CUDA buffers.