### PR TITLE
Merge frames in `deserialize_bytes`

### DIFF
--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -190,9 +190,12 @@ def test_empty_loads_deep():
     assert isinstance(e2[0][0][0], Empty)
 
 
-def test_serialize_bytes():
-    for x in [1, "abc", np.arange(5), b"ab" * int(40e6)]:
-        b = serialize_bytes(x)
+@pytest.mark.parametrize(
+    "kwargs", [{}, {"serializers": ["pickle"]},],
+)
+def test_serialize_bytes(kwargs):
+    for x in [1, "abc", np.arange(5), b"ab" * int(40e6), 2 ** 26 * b"ab"]:
+        b = serialize_bytes(x, **kwargs)
         assert isinstance(b, bytes)
         y = deserialize_bytes(b)
         assert str(x) == str(y)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -194,7 +194,14 @@ def test_empty_loads_deep():
     "kwargs", [{}, {"serializers": ["pickle"]},],
 )
 def test_serialize_bytes(kwargs):
-    for x in [1, "abc", np.arange(5), b"ab" * int(40e6), 2 ** 26 * b"ab"]:
+    for x in [
+        1,
+        "abc",
+        np.arange(5),
+        b"ab" * int(40e6),
+        2 ** 26 * b"ab",
+        (2 ** 25 * b"ab", 2 ** 25 * b"ab"),
+    ]:
         b = serialize_bytes(x, **kwargs)
         assert isinstance(b, bytes)
         y = deserialize_bytes(b)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -199,8 +199,8 @@ def test_serialize_bytes(kwargs):
         "abc",
         np.arange(5),
         b"ab" * int(40e6),
-        2 ** 26 * b"ab",
-        (2 ** 25 * b"ab", 2 ** 25 * b"ab"),
+        int(2 ** 26) * b"ab",
+        (int(2 ** 25) * b"ab", int(2 ** 25) * b"ab"),
     ]:
         b = serialize_bytes(x, **kwargs)
         assert isinstance(b, bytes)

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -59,9 +59,6 @@ def merge_frames(header, frames):
     """
     lengths = list(header["lengths"])
 
-    if not frames:
-        return frames
-
     assert sum(lengths) == sum(map(nbytes, frames))
 
     if all(len(f) == l for f, l in zip(frames, lengths)):

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -67,9 +67,6 @@ def merge_frames(header, frames):
     if all(len(f) == l for f, l in zip(frames, lengths)):
         return frames
 
-    if len(lengths) == 1 and len(frames) == 1:
-        return frames
-
     frames = frames[::-1]
     lengths = lengths[::-1]
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -67,8 +67,8 @@ def merge_frames(header, frames):
     if all(len(f) == l for f, l in zip(frames, lengths)):
         return frames
 
-    if len(lengths) == 1:
-        return [b"".join(map(ensure_bytes, frames))]
+    if len(lengths) == 1 and len(frames) == 1:
+        return frames
 
     frames = frames[::-1]
     lengths = lengths[::-1]

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -67,6 +67,9 @@ def merge_frames(header, frames):
     if all(len(f) == l for f, l in zip(frames, lengths)):
         return frames
 
+    if len(lengths) == 1:
+        return [b"".join(map(ensure_bytes, frames))]
+
     frames = frames[::-1]
     lengths = lengths[::-1]
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -931,7 +931,9 @@ def ensure_bytes(s):
     >>> ensure_bytes(b'123')
     b'123'
     """
-    if hasattr(s, "encode"):
+    if isinstance(s, bytes):
+        return s
+    elif hasattr(s, "encode"):
         return s.encode()
     else:
         try:


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/3851

It appears that we are splitting frames in `serialize_byteslist` so that we can compress them. However we are not merging them back together afterwards during deserialization. This can cause an exception to be raised by serializers that expected their frames to be structured in a particular way.

To fix this, we make sure to call `merge_frames` after `decompress` in `deserialize_bytes`. Further we make sure to pack the `lengths` of the original `frames` in the `header` (if not already present) in `serialize_byteslist`. This should ensure deserializers get the original frame structuring back when they operate on them.