### PR TITLE
Don't create output Futures in Client when there are mixed Client Futures

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2452,8 +2452,6 @@ class Client(Node):
                 actors = list(self._expand_key(actors))
 
             keyset = set(keys)
-            flatkeys = list(map(tokey, keys))
-            futures = {key: Future(key, self, inform=False) for key in keyset}
 
             values = {
                 k: v
@@ -2506,12 +2504,13 @@ class Client(Node):
             if isinstance(retries, Number) and retries > 0:
                 retries = {k: retries for k in dsk3}
 
+            futures = {key: Future(key, self, inform=False) for key in keyset}
             self._send_to_scheduler(
                 {
                     "op": "update-graph",
                     "tasks": valmap(dumps_task, dsk3),
                     "dependencies": dependencies,
-                    "keys": list(flatkeys),
+                    "keys": list(map(tokey, keys)),
                     "restrictions": restrictions or {},
                     "loose_restrictions": loose_restrictions,
                     "priority": priority,

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5449,6 +5449,9 @@ def test_mixing_clients(s, a, b):
     future = c1.submit(inc, 1)
     with pytest.raises(ValueError):
         c2.submit(inc, future)
+
+    assert not c2.futures  # Don't create Futures on second Client
+
     yield c1.close()
     yield c2.close()
 


### PR DESCRIPTION
Currently when we submit a task graph for execution that contains `Future`s from another `Client` we first create output `Future`s for the task graph:

https://github.com/dask/distributed/blob/2e64ae9c256069d8e5ca93b1a1b7356a8c29f3c5/distributed/client.py#L2456

and then raise an error as mixing `Future`s between `Client`s isn't supported:

https://github.com/dask/distributed/blob/2e64ae9c256069d8e5ca93b1a1b7356a8c29f3c5/distributed/client.py#L2473-L2474

Unfortunately this can create a race condition between the deletion of the output `Future`s and creation of new `Future`s with the same key on the same `Client`. For those who are curious, I've included an example snippet which runs into this race condition. 

This PR moves `Future` creation in `_graph_to_futures` towards the end of the function body. It turns out the output `Future`s aren't needed until the `return` line in `_graph_to_futures` anyways. This avoids the `Future` deletion / creation race condition as `Future`s are never created if the `created by another client` error is raised.

There are still improvements to be made on how we handle rapidly creating and deleting `Future`s with the same key (see https://github.com/dask/dask/issues/6027) but when dealing with `Future`s from different `Client`s we can sidestep the problem altogether by not creating output `Future`s in the first place. 

cc @mrocklin @jacobtomlinson if either of you get a moment to look at this


<details>
<summary>Race condition example:</summary>

I'm using a `for`-loop in the example below because the race condition isn't consistently hit. On my laptop, it's triggered about 1-out-of-20 times. 


```python
import dask
import dask.array as da
from dask.distributed import Client, wait

# Should return a float
x = da.random.normal(size=10, chunks=7).sum()

# Create some Futures
with Client(n_workers=1, threads_per_worker=1):
    p = x.persist()
    wait(p)

n = 50
for i in range(n):
    print(f"i = {i}")
    with Client(n_workers=1, threads_per_worker=1) as client:
        with dask.config.set({"optimizations": [client._optimize_insert_futures]}):
            try:
                p.compute()
            except ValueError as e:
                # Inputs contain futures that were created by another client
                pass

            # This will occasionally return an unexpected result like
            # ('sum-aggregate-4dd6f6785a927e4b519b0391c599d6ba',)
            # Due to a race condition between Futures in the x.compute()
            # below and garbage collection of the Futures in the previous
            # p.compute() with the same key
            result = x.compute()
            if not isinstance(result, float):
                print(f"Non-float result = {result}")
                break

```

outputs


```
i = 0
i = 1
i = 2
i = 3
i = 4
i = 5
i = 6
i = 7
i = 8
i = 9
i = 10
i = 11
i = 12
i = 13
i = 14
i = 15
Non-float result = ('sum-aggregate-c6abc9b4729ed7ac7fb0a010f0d072e9',)
```

</details>