### PR TITLE
Handle exception in faulthandler

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,10 @@ try:
 except ImportError:
     pass
 else:
-    faulthandler.enable()
+    try:
+        faulthandler.enable()
+    except Exception:
+        pass
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
For some reason `faulthandler.enable()` fails when VSCode tries to discover tests. Silencing it to allow tests to be discovered.