### PR TITLE
Bump checkout GitHub action to v2

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v1

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup Conda Environment
         uses: goanpeca/setup-miniconda@v1

--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,9 @@ else:
     faulthandler.enable()
 
 
+raise ValueError("AAAAAAAAAAHHHHHHHHH")
+
+
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", help="run slow tests")
 

--- a/conftest.py
+++ b/conftest.py
@@ -15,9 +15,6 @@ else:
     faulthandler.enable()
 
 
-raise ValueError("AAAAAAAAAAHHHHHHHHH")
-
-
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", help="run slow tests")
 


### PR DESCRIPTION
I think this will fix an issue where restarting GitHub actions CI builds would fail during code checkout 