### PR TITLE
UCX simplify receiving frames in `comm`s

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -160,9 +160,9 @@ class UCX(Comm):
                     np.array([nbytes(f) for f in frames], dtype=np.uint64)
                 )
                 # Send frames
-                for frame in frames:
-                    if nbytes(frame) > 0:
-                        await self.ep.send(frame)
+                for each_frame in frames:
+                    if nbytes(each_frame) > 0:
+                        await self.ep.send(each_frame)
                 return sum(map(nbytes, frames))
             except (ucp.exceptions.UCXBaseException):
                 self.abort()
@@ -190,17 +190,17 @@ class UCX(Comm):
             else:
                 # Recv frames
                 frames = []
-                for is_cuda, size in zip(is_cudas.tolist(), sizes.tolist()):
-                    if size > 0:
+                for is_cuda, each_size in zip(is_cudas.tolist(), sizes.tolist()):
+                    if each_size > 0:
                         if is_cuda:
-                            frame = cuda_array(size)
+                            each_frame = cuda_array(each_size)
                         else:
-                            frame = np.empty(size, dtype=np.uint8)
-                        await self.ep.recv(frame)
-                        frames.append(frame)
+                            each_frame = np.empty(each_size, dtype=np.uint8)
+                        await self.ep.recv(each_frame)
+                        frames.append(each_frame)
                     else:
                         if is_cuda:
-                            frames.append(cuda_array(size))
+                            frames.append(cuda_array(each_size))
                         else:
                             frames.append(b"")
                 msg = await from_frames(

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -189,15 +189,15 @@ class UCX(Comm):
                 raise CommClosedError("While reading, the connection was closed")
             else:
                 # Recv frames
-                frames = []
-                for is_cuda, each_size in zip(is_cudas.tolist(), sizes.tolist()):
-                    if is_cuda:
-                        each_frame = cuda_array(each_size)
-                    else:
-                        each_frame = np.empty(each_size, dtype=np.uint8)
-                    if each_size > 0:
+                frames = [
+                    cuda_array(each_size)
+                    if is_cuda
+                    else np.empty(each_size, dtype=np.uint8)
+                    for is_cuda, each_size in zip(is_cudas.tolist(), sizes.tolist())
+                ]
+                for each_frame in frames:
+                    if len(each_frame) > 0:
                         await self.ep.recv(each_frame)
-                    frames.append(each_frame)
                 msg = await from_frames(
                     frames, deserialize=self.deserialize, deserializers=deserializers
                 )

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -202,7 +202,7 @@ class UCX(Comm):
                         if is_cuda:
                             frames.append(cuda_array(each_size))
                         else:
-                            frames.append(b"")
+                            each_frame = np.empty(each_size, dtype=np.uint8)
                 msg = await from_frames(
                     frames, deserialize=self.deserialize, deserializers=deserializers
                 )

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -191,18 +191,13 @@ class UCX(Comm):
                 # Recv frames
                 frames = []
                 for is_cuda, each_size in zip(is_cudas.tolist(), sizes.tolist()):
-                    if each_size > 0:
-                        if is_cuda:
-                            each_frame = cuda_array(each_size)
-                        else:
-                            each_frame = np.empty(each_size, dtype=np.uint8)
-                        await self.ep.recv(each_frame)
-                        frames.append(each_frame)
+                    if is_cuda:
+                        each_frame = cuda_array(each_size)
                     else:
-                        if is_cuda:
-                            frames.append(cuda_array(each_size))
-                        else:
-                            each_frame = np.empty(each_size, dtype=np.uint8)
+                        each_frame = np.empty(each_size, dtype=np.uint8)
+                    if each_size > 0:
+                        await self.ep.recv(each_frame)
+                    frames.append(each_frame)
                 msg = await from_frames(
                     frames, deserialize=self.deserialize, deserializers=deserializers
                 )


### PR DESCRIPTION
Basically a redux of PR ( https://github.com/dask/distributed/pull/3599 ) with UCX changes only.

Simplifies the logic for receiving frames in `ucx`. Also preallocates buffers to receive data into beforehand (and subselects the non-0-length buffers). Then hands off control to the underlying library receiving data to fill these buffers. Afterwards handles any sanity checks.

cc @quasiben @pentschev