### PR TITLE
do not log an error on unset variable delete

### DIFF
--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -42,7 +42,7 @@ def test_variable(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_delete_unset_variable(c, s, a, b):
+async def test_delete_unset_variable(c, s, a, b):
     x = Variable()
     assert x.client is c
     with captured_logger(logging.getLogger("distributed.utils")) as logger:

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -46,8 +46,8 @@ async def test_delete_unset_variable(c, s, a, b):
     x = Variable()
     assert x.client is c
     with captured_logger(logging.getLogger("distributed.utils")) as logger:
-        yield x.delete()
-        yield c.close()
+        await x.delete()
+        await c.close()
     text = logger.getvalue()
     assert "KeyError" not in text
 

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -39,6 +39,12 @@ def test_variable(c, s, a, b):
         assert time() < start + 5
 
 
+def test_delete_unset_variable(client):
+    x = Variable()
+    assert x.client is client
+    x.delete()
+
+
 @gen_cluster(client=True)
 def test_queue_with_data(c, s, a, b):
     x = Variable("x")

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -46,7 +46,7 @@ async def test_delete_unset_variable(c, s, a, b):
     x = Variable()
     assert x.client is c
     with captured_logger(logging.getLogger("distributed.utils")) as logger:
-        await x.delete()
+        x.delete()
         await c.close()
     text = logger.getvalue()
     assert "KeyError" not in text

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -113,14 +113,10 @@ class VariableExtension:
             else:
                 if old["type"] == "Future":
                     await self.release(old["value"], name)
-            try:
+            with ignoring(KeyError):
                 del self.waiting_conditions[name]
-            except KeyError:
-                pass
-            try:
+            with ignoring(KeyError):
                 del self.variables[name]
-            except KeyError:
-                pass
 
 
 class Variable:

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -113,8 +113,14 @@ class VariableExtension:
             else:
                 if old["type"] == "Future":
                     await self.release(old["value"], name)
-            del self.waiting_conditions[name]
-            del self.variables[name]
+            try:
+                del self.waiting_conditions[name]
+            except KeyError:
+                pass
+            try:
+                del self.variables[name]
+            except KeyError:
+                pass
 
 
 class Variable:


### PR DESCRIPTION
If a Variable is never set or accessed no entries are made in the
tracking attributes of VariableExtension.  Therefore there is no need to
raise or log an error when the variable is deleted.

closes #3492