### PR TITLE
Avoid diagnostics time in performance report

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4999,6 +4999,7 @@ class Scheduler(ServerNode):
         return {"counts": counts, "keys": keys}
 
     async def performance_report(self, comm=None, start=None, code=""):
+        stop = time()
         # Profiles
         compute, scheduler, workers = await asyncio.gather(
             *[
@@ -5060,7 +5061,7 @@ class Scheduler(ServerNode):
 {code}
         </pre>
         """.format(
-            time=format_time(time() - start),
+            time=format_time(stop - start),
             address=self.address,
             nworkers=len(self.workers),
             threads=sum(w.nthreads for w in self.workers.values()),


### PR DESCRIPTION
Previously we would include all of the time taken to generate the
performance report in the reported time.  Now we record the time before
we generate plots and use that instead.

This came from a comment in https://github.com/dask/dask-ml/pull/619#issuecomment-605455005