### PR TITLE
Update Python version checking

### DIFF
--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -1,5 +1,5 @@
 import re
-import uuid
+import sys
 
 import pytest
 
@@ -120,17 +120,7 @@ async def test_version_warning_in_cluster(s, a, b):
         )
 
 
-@gen_cluster()
-async def test_python_version_mismatch_warning(s, a, b):
-    # Set random Python version for one worker
-    random_version = uuid.uuid4().hex
-    orig = s.workers[a.address].versions["host"]["python"] = random_version
-
-    with pytest.warns(None) as record:
-        async with Client(s.address, asynchronous=True) as client:
-            pass
-
-    assert record
-    assert any("python" in str(r.message) for r in record)
-    assert any(random_version in str(r.message) for r in record)
-    assert any(a.address in str(r.message) for r in record)
+def test_python_version():
+    required = get_versions()["packages"]
+    assert "python" in required
+    assert required["python"] == ".".join(map(str, sys.version_info))

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -82,7 +82,7 @@ def version_of_package(pkg):
 def get_package_info(pkgs):
     """ get package versions for the passed required & optional packages """
 
-    pversions = []
+    pversions = [("python", ".".join(map(str, sys.version_info)))]
     for pkg in pkgs:
         if isinstance(pkg, (tuple, list)):
             modname, ver_f = pkg
@@ -121,9 +121,6 @@ def error_message(scheduler, workers, client, client_name="client"):
             for pkg, version in info["packages"].items():
                 node_packages[node][pkg] = version
                 packages.add(pkg)
-            # Collect Python version for each node
-            node_packages[node]["python"] = info["host"]["python"]
-            packages.add("python")
 
     errs = []
     for pkg in sorted(packages):


### PR DESCRIPTION
This PR adds Python directly to the list of required packages instead of getting items from the output of `get_system_info` (as originally proposed in #3568). This allows for version checking in a backwards compatible fashion (xref #3659). For example, using a `Client` with `distributed==2.12.0` and a `Scheduler` with the changes in this PR we get a successful version mismatch warning message:

```
distributed
+-----------+--------------------------+
|           | version                  |
+-----------+--------------------------+
| client    | 2.12.0                   |
| scheduler | 2.13.0+4.g926eb12a.dirty |
+-----------+--------------------------+
  warnings.warn(version_module.VersionMismatchWarning(msg[0]["warning"]))
```

cc @consideRatio @grantgustafson

Fixes #3659