### PR TITLE
[docs] Add newlines to ensure code formatting for `retire_workers`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3489,9 +3489,11 @@ class Client(Node):
         Examples
         --------
         You can get information about active workers using the following:
+
         >>> workers = client.scheduler_info()['workers']
 
         From that list you may want to select some workers to close
+
         >>> client.retire_workers(workers=['tcp://address:port', ...])
 
         See Also


### PR DESCRIPTION
Without the newlines, the code samples don't seem to be parsed as such,
and so aren't set apart or formatted properly.