### PR TITLE
Get CUDA context to finalize Numba `DeviceNDArray`

### DIFF
--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -14,31 +14,6 @@ except ImportError:
     from .numba import dask_deserialize_numba_array as dask_deserialize_cuda_buffer
 
 
-class PatchedCudaArrayInterface:
-    """This class does one thing:
-        1) Makes sure that the cuda context is active
-           when deallocating the base cuda array.
-        Notice, this is only needed when the array to deserialize
-        isn't a native cupy array.
-    """
-
-    def __init__(self, ary):
-        self.__cuda_array_interface__ = ary.__cuda_array_interface__
-        # Save a ref to ary so it won't go out of scope
-        self.base = ary
-
-    def __del__(self):
-        # Making sure that the cuda context is active
-        # when deallocating the base cuda array
-        try:
-            import numba.cuda
-
-            numba.cuda.current_context()
-        except ImportError:
-            pass
-        del self.base
-
-
 @cuda_serialize.register(cupy.ndarray)
 def cuda_serialize_cupy_ndarray(x):
     # Making sure `x` is behaving
@@ -60,8 +35,6 @@ def cuda_serialize_cupy_ndarray(x):
 @cuda_deserialize.register(cupy.ndarray)
 def cuda_deserialize_cupy_ndarray(header, frames):
     (frame,) = frames
-    if not isinstance(frame, cupy.ndarray):
-        frame = PatchedCudaArrayInterface(frame)
     arr = cupy.ndarray(
         shape=header["shape"],
         dtype=header["typestr"],

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -1,3 +1,5 @@
+import weakref
+
 import numba.cuda
 import numpy as np
 
@@ -59,6 +61,8 @@ def dask_deserialize_numba_array(header, frames):
         frames = [dask_deserialize_rmm_device_buffer(header, frames)]
     else:
         frames = [numba.cuda.to_device(np.asarray(memoryview(f))) for f in frames]
+        for f in frames:
+            weakref.finalize(f, numba.cuda.current_context)
 
     arr = cuda_deserialize_numba_ndarray(header, frames)
     return arr


### PR DESCRIPTION
Related to issue ( https://github.com/rapidsai/dask-cuda/issues/176 )
Follow-up to PR ( https://github.com/dask/distributed/pull/3240 )

This ensures that when a Numba `DeviceNDArray` is used to back any kind of CUDA memory allocation (either for receiving CUDA frames via UCX or restoring spilled data to device), we make sure to have a valid context before finalizing the object. Should make sure all CUDA objects are handled correctly. Also supplants the need for doing this with CuPy `ndarray`s in a special case fashion.

cc @pentschev @madsbk @rjzamora