### PR TITLE
Enable more UCX tests

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -12,8 +12,6 @@ from distributed.deploy.local import LocalCluster
 from dask.dataframe.utils import assert_eq
 from distributed.utils_test import gen_test, loop, inc, cleanup, popen  # noqa: 401
 
-from .test_comms import check_deserialize
-
 
 try:
     HOST = ucp.get_address()
@@ -156,6 +154,10 @@ async def test_ping_pong_data():
 
 @gen_test()
 def test_ucx_deserialize():
+    try:
+        from .test_comms import check_deserialize
+    except Exception:
+        pytest.skip("Unable to import `check_deserialize`")
     yield check_deserialize("tcp://")
 
 

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -158,6 +158,7 @@ def test_ucx_deserialize():
     # `socket.gaierror: [Errno -5] No address associated with hostname`
     # This may be due to a system configuration issue.
     from .test_comms import check_deserialize
+
     yield check_deserialize("tcp://")
 
 

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -177,7 +177,9 @@ def test_ucx_deserialize():
         lambda cudf: cudf.DataFrame({"a": [1, 2, None], "b": [1.0, 2.0, None]}),
         pytest.param(
             lambda cudf: cudf.DataFrame({"a": ["Check", "str"], "b": ["Sup", "port"]}),
-            marks=pytest.mark.skip(reason="This test segfaults for some reason. So skip running it entirely."),
+            marks=pytest.mark.skip(
+                reason="This test segfaults for some reason. So skip running it entirely."
+            ),
         ),
     ],
 )
@@ -224,11 +226,7 @@ async def test_ping_pong_cupy(shape):
 @pytest.mark.slow
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "n",
-    [
-        int(1e9),
-        int(2.5e9),
-    ],
+    "n", [int(1e9), int(2.5e9),],
 )
 async def test_large_cupy(n, cleanup):
     cupy = pytest.importorskip("cupy")

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -169,23 +169,11 @@ def test_ucx_deserialize():
         lambda cudf: cudf.DataFrame([1]).head(0),
         lambda cudf: cudf.DataFrame([1.0]).head(0),
         lambda cudf: cudf.DataFrame({"a": []}),
-        pytest.param(
-            lambda cudf: cudf.DataFrame({"a": ["a"]}).head(0),
-            marks=pytest.mark.xfail(reason="0 length objects don't deseralize cleanly"),
-        ),
-        pytest.param(
-            lambda cudf: cudf.DataFrame({"a": [1.0]}).head(0),
-            marks=pytest.mark.xfail(reason="0 length objects don't deseralize cleanly"),
-        ),
-        pytest.param(
-            lambda cudf: cudf.DataFrame({"a": [1]}).head(0),
-            marks=pytest.mark.xfail(reason="0 length objects don't deseralize cleanly"),
-        ),
+        lambda cudf: cudf.DataFrame({"a": ["a"]}).head(0),
+        lambda cudf: cudf.DataFrame({"a": [1.0]}).head(0),
+        lambda cudf: cudf.DataFrame({"a": [1]}).head(0),
         lambda cudf: cudf.DataFrame({"a": [1, 2, None], "b": [1.0, 2.0, None]}),
-        pytest.param(
-            lambda cudf: cudf.DataFrame({"a": ["Check", "str"], "b": ["Sup", "port"]}),
-            marks=pytest.mark.xfail(reason="0 length objects don't deseralize cleanly"),
-        ),
+        lambda cudf: cudf.DataFrame({"a": ["Check", "str"], "b": ["Sup", "port"]}),
     ],
 )
 async def test_ping_pong_cudf(g):

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -154,10 +154,10 @@ async def test_ping_pong_data():
 
 @gen_test()
 def test_ucx_deserialize():
-    try:
-        from .test_comms import check_deserialize
-    except Exception:
-        pytest.skip("Unable to import `check_deserialize`")
+    # Note we see this error on some systems with this test:
+    # `socket.gaierror: [Errno -5] No address associated with hostname`
+    # This may be due to a system configuration issue.
+    from .test_comms import check_deserialize
     yield check_deserialize("tcp://")
 
 

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -225,9 +225,7 @@ async def test_ping_pong_cupy(shape):
     "n",
     [
         int(1e9),
-        pytest.param(
-            int(2.5e9), marks=[pytest.mark.xfail(reason="integer type in ucx-py")]
-        ),
+        int(2.5e9),
     ],
 )
 async def test_large_cupy(n, cleanup):

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -173,7 +173,10 @@ def test_ucx_deserialize():
         lambda cudf: cudf.DataFrame({"a": [1.0]}).head(0),
         lambda cudf: cudf.DataFrame({"a": [1]}).head(0),
         lambda cudf: cudf.DataFrame({"a": [1, 2, None], "b": [1.0, 2.0, None]}),
-        lambda cudf: cudf.DataFrame({"a": ["Check", "str"], "b": ["Sup", "port"]}),
+        pytest.param(
+            lambda cudf: cudf.DataFrame({"a": ["Check", "str"], "b": ["Sup", "port"]}),
+            marks=pytest.mark.skip(reason="This test segfaults for some reason. So skip running it entirely."),
+        ),
     ],
 )
 async def test_ping_pong_cudf(g):


### PR DESCRIPTION
Recently went back through the UCX tests in light of improvements we have made to UCX, serialization, and Dask itself. It seems many of these actually just work now AFAICT. So I've tried enabling them (and also have ran them locally). Please take a look.

cc @quasiben @pentschev @rjzamora @madsbk 