### PR TITLE
remove openssl 1.1.1d pin for Travis

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -79,9 +79,6 @@ if [[ $CRICK == true ]]; then
     python -m pip install -q git+https://github.com/jcrist/crick.git
 fi;
 
-# Pin openssl==1.1.1d (see https://github.com/dask/distributed/issues/3588)
-conda install -c conda-forge openssl==1.1.1d
-
 # Install distributed
 python -m pip install --no-deps -e .
 


### PR DESCRIPTION
OpenSSL 1.1.1f has been released with a fix for the bug introduced in
1.1.1e.  Pinning to 1.1.1d is no longer necessary.

closes #3588 