### PR TITLE
Update Scheduler.rebalance return value when data is missing

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -587,7 +587,7 @@ class Client(Node):
         deserializers=None,
         extensions=DEFAULT_EXTENSIONS,
         direct_to_workers=None,
-        **kwargs
+        **kwargs,
     ):
         if timeout == no_default:
             timeout = dask.config.get("distributed.comm.timeouts.connect")
@@ -960,7 +960,7 @@ class Client(Node):
                 self.cluster = await LocalCluster(
                     loop=self.loop,
                     asynchronous=self._asynchronous,
-                    **self._startup_kwargs
+                    **self._startup_kwargs,
                 )
             except (OSError, socket.error) as e:
                 if e.errno != errno.EADDRINUSE:
@@ -970,7 +970,7 @@ class Client(Node):
                     scheduler_port=0,
                     loop=self.loop,
                     asynchronous=True,
-                    **self._startup_kwargs
+                    **self._startup_kwargs,
                 )
 
             # Wait for all workers to be ready
@@ -1422,7 +1422,7 @@ class Client(Node):
         actor=False,
         actors=False,
         pure=None,
-        **kwargs
+        **kwargs,
     ):
 
         """ Submit a function application to the scheduler
@@ -1542,7 +1542,7 @@ class Client(Node):
         actor=False,
         actors=False,
         pure=None,
-        **kwargs
+        **kwargs,
     ):
         """ Map a function on a sequence of arguments
 
@@ -2538,7 +2538,7 @@ class Client(Node):
         priority=0,
         fifo_timeout="60s",
         actors=None,
-        **kwargs
+        **kwargs,
     ):
         """ Compute dask graph
 
@@ -2669,7 +2669,7 @@ class Client(Node):
         fifo_timeout="60s",
         actors=None,
         traverse=True,
-        **kwargs
+        **kwargs,
     ):
         """ Compute dask collections on cluster
 
@@ -2817,7 +2817,7 @@ class Client(Node):
         priority=0,
         fifo_timeout="60s",
         actors=None,
-        **kwargs
+        **kwargs,
     ):
         """ Persist dask collections on cluster
 
@@ -3013,6 +3013,10 @@ class Client(Node):
         await _wait(futures)
         keys = list({tokey(f.key) for f in self.futures_of(futures)})
         result = await self.scheduler.rebalance(keys=keys, workers=workers)
+        if result["status"] == "missing-data":
+            raise ValueError(
+                f"During rebalance {len(result['keys'])} keys were found to be missing"
+            )
         assert result["status"] == "OK"
 
     def rebalance(self, futures=None, workers=None, **kwargs):
@@ -3023,7 +3027,7 @@ class Client(Node):
         depending on keyword arguments.
 
         This operation is generally not well tested against normal operation of
-        the scheduler.  It it not recommended to use it while waiting on
+        the scheduler.  It is not recommended to use it while waiting on
         computations.
 
         Parameters
@@ -3085,7 +3089,7 @@ class Client(Node):
             n=n,
             workers=workers,
             branching_factor=branching_factor,
-            **kwargs
+            **kwargs,
         )
 
     def nthreads(self, workers=None, **kwargs):
@@ -3505,7 +3509,7 @@ class Client(Node):
             self.scheduler.retire_workers,
             workers=workers,
             close_workers=close_workers,
-            **kwargs
+            **kwargs,
         )
 
     def set_metadata(self, key, value):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -30,6 +30,7 @@ from tlz import (
     second,
     compose,
     groupby,
+    concat,
 )
 from tornado.ioloop import IOLoop
 
@@ -3103,7 +3104,7 @@ class Scheduler(ServerNode):
                 if not all(r["status"] == "OK" for r in result):
                     return {
                         "status": "missing-data",
-                        "keys": sum([r["keys"] for r in result if "keys" in r], []),
+                        "keys": tuple(concat(r["keys"].keys() for r in result)),
                     }
 
                 for sender, recipient, ts in msgs:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4873,8 +4873,8 @@ def test_bytes_keys(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_unicode_ascii_keys(c, s, a, b):
-    uni_type = type(u"")
-    key = u"inc-123"
+    uni_type = type("")
+    key = "inc-123"
     future = c.submit(inc, 1, key=key)
     result = yield future
     assert type(future.key) is uni_type
@@ -4885,8 +4885,8 @@ def test_unicode_ascii_keys(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_unicode_keys(c, s, a, b):
-    uni_type = type(u"")
-    key = u"inc-123\u03bc"
+    uni_type = type("")
+    key = "inc-123\u03bc"
     future = c.submit(inc, 1, key=key)
     result = yield future
     assert type(future.key) is uni_type
@@ -4898,8 +4898,8 @@ def test_unicode_keys(c, s, a, b):
     result2 = yield future2
     assert result2 == 3
 
-    future3 = yield c.scatter({u"data-123": 123})
-    result3 = yield future3[u"data-123"]
+    future3 = yield c.scatter({"data-123": 123})
+    result3 = yield future3["data-123"]
     assert result3 == 123
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2877,6 +2877,15 @@ def test_rebalance_unprepared(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_rebalance_raises_missing_data(c, s, a, b):
+    with pytest.raises(ValueError, match=f"keys were found to be missing"):
+        futures = await c.scatter(range(100))
+        keys = [f.key for f in futures]
+        del futures
+        await c.rebalance(keys)
+
+
+@gen_cluster(client=True)
 def test_receive_lost_key(c, s, a, b):
     x = c.submit(inc, 1, workers=[a.address])
     result = yield x


### PR DESCRIPTION
This PR improves error handling in `Scheduler.rebalance` when keys which are being rebalanced are found to be missing on workers. Currently when we attempt to return the missing data keys here

https://github.com/dask/distributed/blob/4f11509b844c3569f164704983bb0affd009dd4c/distributed/scheduler.py#L3106

we get the following error:

```
TypeError: can only concatenate list (not "dict") to list
```

because `r["keys"]` is a dictionary. We update things here to return a tuple of keys.

<details>
<summary>Example to trigger missing data in rebalance:</summary>

```python
import time
import random
from itertools import count

import dask.array as da
from distributed import Client

with Client() as client:
    counter = count()
    while next(counter) < 10:
        x = da.random.normal(size=100, chunks=1)
        x = x.persist()
        
        time.sleep(random.random() * 0.1)
        x = None
        client.rebalance()
```

</details>

Note: there were also several trailing commas that `black` wanted to add