### PR TITLE
don't make task graphs too big

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -35,7 +35,6 @@ from bokeh.transform import factor_cmap, linear_cmap
 from bokeh.io import curdoc
 import dask
 from dask.utils import format_bytes, key_split
-from dask.config import config
 from tlz import pipe
 from tlz.curried import map, concat, groupby
 from tornado import escape

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1172,7 +1172,7 @@ class TaskGraph(DashboardComponent):
         tap = TapTool(callback=OpenURL(url="info/task/@key.html"), renderers=[rect])
         rect.nonselection_glyph = None
         self.root.add_tools(hover, tap)
-        self.max_items = config.get('distributed.dashboard.graph-max-items', 5000)
+        self.max_items = config.get("distributed.dashboard.graph-max-items", 5000)
 
     @without_property_validation
     def update(self):

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1193,7 +1193,7 @@ class TaskGraph(DashboardComponent):
 
     @without_property_validation
     def add_new_nodes_edges(self, new, new_edges, update=False):
-        max_items = config.get('distributed.dashboard.graph_max_items', 2)
+        max_items = dask.config.get('distributed.dashboard.graph_max_items', 2)
         if new or update:
             node_key = []
             node_x = []

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -36,6 +36,7 @@ from distributed.dashboard.components.scheduler import (
     ProfileServer,
     MemoryByKey,
 )
+from distributed.utils_test import async_wait_for
 
 from distributed.dashboard import scheduler
 
@@ -499,6 +500,38 @@ def test_TaskGraph_clear(c, s, a, b):
         yield gen.sleep(0.1)
         gp.update()
         assert time() < start + 5
+
+
+@gen_cluster(
+    client=True,
+    config={
+        "distributed.dashboard.graph-max-items": 2,
+    },
+)
+def test_TaskGraph_limit(c, s, a, b):
+    gp = TaskGraph(s)
+
+    def func(x):
+        return x
+
+    f1 = c.submit(func, 1)
+    yield wait(f1)
+    gp.update()
+    assert len(gp.node_source.data['x']) == 1
+    f2 = c.submit(func, 2)
+    yield wait(f2)
+    gp.update()
+    assert len(gp.node_source.data['x']) == 2
+    f3 = c.submit(func, 3)
+    yield wait(f3)
+    gp.update()
+    assert len(gp.node_source.data['x']) == 2
+    del f1
+    del f2
+    del f3
+    _ = c.submit(func, 1)
+
+    async_wait_for(lambda: len(gp.node_source.data['x']) == 1, timeout=1)
 
 
 @gen_cluster(client=True, timeout=30)

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -503,10 +503,7 @@ def test_TaskGraph_clear(c, s, a, b):
 
 
 @gen_cluster(
-    client=True,
-    config={
-        "distributed.dashboard.graph-max-items": 2,
-    },
+    client=True, config={"distributed.dashboard.graph-max-items": 2,},
 )
 def test_TaskGraph_limit(c, s, a, b):
     gp = TaskGraph(s)
@@ -517,21 +514,21 @@ def test_TaskGraph_limit(c, s, a, b):
     f1 = c.submit(func, 1)
     yield wait(f1)
     gp.update()
-    assert len(gp.node_source.data['x']) == 1
+    assert len(gp.node_source.data["x"]) == 1
     f2 = c.submit(func, 2)
     yield wait(f2)
     gp.update()
-    assert len(gp.node_source.data['x']) == 2
+    assert len(gp.node_source.data["x"]) == 2
     f3 = c.submit(func, 3)
     yield wait(f3)
     gp.update()
-    assert len(gp.node_source.data['x']) == 2
+    assert len(gp.node_source.data["x"]) == 2
     del f1
     del f2
     del f3
     _ = c.submit(func, 1)
 
-    async_wait_for(lambda: len(gp.node_source.data['x']) == 1, timeout=1)
+    async_wait_for(lambda: len(gp.node_source.data["x"]) == 1, timeout=1)
 
 
 @gen_cluster(client=True, timeout=30)

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -129,6 +129,7 @@ distributed:
   dashboard:
     link: "{scheme}://{host}:{port}/status"
     export-tool: False
+    graph_max_items: 500  # maximum number of tasks to try to plot in graph view
 
   ##################
   # Administrative #

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -129,7 +129,7 @@ distributed:
   dashboard:
     link: "{scheme}://{host}:{port}/status"
     export-tool: False
-    graph_max_items: 500  # maximum number of tasks to try to plot in graph view
+    graph-max-items: 5000  # maximum number of tasks to try to plot in graph view
 
   ##################
   # Administrative #


### PR DESCRIPTION
Fixes #2979

I don't yet know how to test this (tested manually).

I worry that there may be potential bad behaviour when the number of tasks hovers around the limit, as allowed updates will always be complete datasets instead of incremental.