### PR TITLE
Run preload at import, start, and teardown

### DIFF
--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -111,7 +111,7 @@ def _import_module(name, file_dir=None):
     }
 
 
-def on_creation(names, file_dir=None):
+def on_creation(names, file_dir: str = None) -> dict:
     """ Imports each of the preload modules
 
     Parameters
@@ -127,13 +127,13 @@ def on_creation(names, file_dir=None):
     return {name: _import_module(name, file_dir=file_dir) for name in names}
 
 
-async def on_start(names, dask_server=None, file_dir: str = None, argv=None):
-    """ Imports modules, handles `dask_setup` and `dask_teardown`.
+async def on_start(modules: dict, dask_server=None, argv=None):
+    """ Run when the server finishes its start method
 
     Parameters
     ----------
-    names: list of strings
-        Module names or file paths
+    modules: Dict[str, module]
+        The imported modules, from on_creation
     dask_server: dask.distributed.Server
         The Worker or Scheduler
     argv: [string]
@@ -141,7 +141,7 @@ async def on_start(names, dask_server=None, file_dir: str = None, argv=None):
     file_dir: string
         Path of a directory where files should be copied
     """
-    for name, interface in on_creation(names, file_dir).items():
+    for name, interface in modules.items():
         dask_setup = interface.get("dask_setup", None)
 
         if dask_setup:
@@ -157,17 +157,17 @@ async def on_start(names, dask_server=None, file_dir: str = None, argv=None):
                 logger.info("Run preload setup function: %s", name)
 
 
-async def on_teardown(names, dask_server=None, file_dir=None):
-    """ Imports modules, handles `dask_setup` and `dask_teardown`.
+async def on_teardown(modules: dict, dask_server=None):
+    """ Run when the server starts its close method
 
     Parameters
     ----------
-    names: list of strings
-        Module names or file paths
+    modules: Dict[str, module]
+        The imported modules, from on_creation
     dask_server: dask.distributed.Server
         The Worker or Scheduler
     """
-    for name, interface in on_creation(names, file_dir).items():
+    for name, interface in modules.items():
         dask_teardown = interface.get("dask_teardown", None)
         if dask_teardown:
             future = dask_teardown(dask_server)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1464,7 +1464,7 @@ class Scheduler(ServerNode):
 
             weakref.finalize(self, del_scheduler_file)
 
-        await preloading.on_start(self.preload, parameter=self, argv=self.preload_argv)
+        await preloading.on_start(self.preload, self, argv=self.preload_argv)
 
         await asyncio.gather(*[plugin.start(self) for plugin in self.plugins])
 
@@ -1488,7 +1488,7 @@ class Scheduler(ServerNode):
         logger.info("Scheduler closing...")
         setproctitle("dask-scheduler [closing]")
 
-        await preloading.on_teardown(self.preload, parameter=self)
+        await preloading.on_teardown(self.preload, self)
 
         if close_workers:
             await self.broadcast(msg={"op": "close_gracefully"}, nanny=True)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3,7 +3,7 @@ from collections import defaultdict, deque, OrderedDict
 from collections.abc import Mapping, Set
 from datetime import timedelta
 from functools import partial
-from inspect import isawaitable
+import inspect
 import itertools
 import json
 import logging
@@ -49,7 +49,7 @@ from .diagnostics.plugin import SchedulerPlugin
 from . import profile
 from .metrics import time
 from .node import ServerNode
-from .preloading import preload_modules
+from . import preloading
 from .proctitle import setproctitle
 from .security import Security
 from .utils import (
@@ -1106,6 +1106,7 @@ class Scheduler(ServerNode):
             preload_argv = dask.config.get("distributed.scheduler.preload-argv")
         self.preload = preload
         self.preload_argv = preload_argv
+        preloading.on_creation(self.preload)
 
         self.security = security or Security()
         assert isinstance(self.security, Security)
@@ -1463,7 +1464,7 @@ class Scheduler(ServerNode):
 
             weakref.finalize(self, del_scheduler_file)
 
-        preload_modules(self.preload, parameter=self, argv=self.preload_argv)
+        await preloading.on_start(self.preload, parameter=self, argv=self.preload_argv)
 
         await asyncio.gather(*[plugin.start(self) for plugin in self.plugins])
 
@@ -1486,6 +1487,8 @@ class Scheduler(ServerNode):
 
         logger.info("Scheduler closing...")
         setproctitle("dask-scheduler [closing]")
+
+        await preloading.on_teardown(self.preload, parameter=self)
 
         if close_workers:
             await self.broadcast(msg={"op": "close_gracefully"}, nanny=True)
@@ -3584,7 +3587,7 @@ class Scheduler(ServerNode):
             if teardown:
                 teardown = pickle.loads(teardown)
             state = setup(self) if setup else None
-            if isawaitable(state):
+            if inspect.isawaitable(state):
                 state = await state
             try:
                 while self.status == "running":

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1027,10 +1027,7 @@ class Worker(ServerNode):
             self.name = self.address
 
         await preloading.on_start(
-            self.preload,
-            parameter=self,
-            argv=self.preload_argv,
-            file_dir=self.local_directory,
+            self.preload, self, argv=self.preload_argv, file_dir=self.local_directory,
         )
 
         # Services listen on all addresses
@@ -1090,7 +1087,7 @@ class Worker(ServerNode):
             self.status = "closing"
 
             await preloading.on_teardown(
-                self.preload, parameter=self, file_dir=self.local_directory
+                self.preload, self, file_dir=self.local_directory
             )
 
             if nanny and self.nanny:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -34,7 +34,7 @@ from .core import error_message, CommClosedError, send_recv, pingpong, coerce_to
 from .diskutils import WorkSpace
 from .metrics import time
 from .node import ServerNode
-from .preloading import preload_modules
+from . import preloading
 from .proctitle import setproctitle
 from .protocol import pickle, to_serialize, deserialize_bytes, serialize_bytelist
 from .pubsub import PubSubWorkerExtension
@@ -470,12 +470,7 @@ class Worker(ServerNode):
         self.total_resources = resources or {}
         self.available_resources = (resources or {}).copy()
         self.death_timeout = parse_timedelta(death_timeout)
-        self.preload = preload
-        if self.preload is None:
-            self.preload = dask.config.get("distributed.worker.preload")
-        self.preload_argv = preload_argv
-        if self.preload_argv is None:
-            self.preload_argv = dask.config.get("distributed.worker.preload-argv")
+
         self.memory_monitor_interval = parse_timedelta(
             memory_monitor_interval, default="ms"
         )
@@ -503,6 +498,14 @@ class Worker(ServerNode):
             self._workspace = WorkSpace(os.path.abspath(local_directory))
             self._workdir = self._workspace.new_work_dir(prefix="worker-")
             self.local_directory = self._workdir.dir_path
+
+        self.preload = preload
+        if self.preload is None:
+            self.preload = dask.config.get("distributed.worker.preload")
+        self.preload_argv = preload_argv
+        if self.preload_argv is None:
+            self.preload_argv = dask.config.get("distributed.worker.preload-argv")
+        preloading.on_creation(self.preload, file_dir=self.local_directory)
 
         self.security = security or Security()
         assert isinstance(self.security, Security)
@@ -1023,12 +1026,13 @@ class Worker(ServerNode):
         if self.name is None:
             self.name = self.address
 
-        preload_modules(
+        await preloading.on_start(
             self.preload,
             parameter=self,
-            file_dir=self.local_directory,
             argv=self.preload_argv,
+            file_dir=self.local_directory,
         )
+
         # Services listen on all addresses
         # Note Nanny is not a "real" service, just some metadata
         # passed in service_ports...
@@ -1084,6 +1088,10 @@ class Worker(ServerNode):
             if self.status not in ("running", "closing-gracefully"):
                 logger.info("Closed worker has not yet started: %s", self.status)
             self.status = "closing"
+
+            await preloading.on_teardown(
+                self.preload, parameter=self, file_dir=self.local_directory
+            )
 
             if nanny and self.nanny:
                 with self.rpc(self.nanny) as r:


### PR DESCRIPTION
Previously we only ran preload scripts after the server had started.
This made it difficult to modify the server before certain actions had
taken place.  For example, a test in this PR registers a new Comm
backend for the server to use.  This would not have been possible
before.

Now we run different preload functions when

1.  we first instantiate the server
2.  we first start the server
3.  we close the server (we used to run teardown at `atexit` time

cc @pentschev I think that you asked for this at one point.