### PR TITLE
Pass through connection/listen_args as splatted keywords

### DIFF
--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -32,7 +32,9 @@ def test_defaults(loop):
         @gen.coroutine
         def f():
             # Default behaviour is to listen on all addresses
-            yield [assert_can_connect_from_everywhere_4_6(8786, 5.0)]  # main port
+            yield [
+                assert_can_connect_from_everywhere_4_6(8786, timeout=5.0)
+            ]  # main port
 
         with Client("127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
             c.sync(f)
@@ -50,7 +52,7 @@ def test_hostport(loop):
         def f():
             yield [
                 # The scheduler's main port can't be contacted from the outside
-                assert_can_connect_locally_4(8978, 5.0)
+                assert_can_connect_locally_4(8978, timeout=5.0)
             ]
 
         with Client("127.0.0.1:8978", loop=loop) as c:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1044,9 +1044,7 @@ class Client(Node):
 
         try:
             comm = await connect(
-                self.scheduler.address,
-                timeout=timeout,
-                connection_args=self.connection_args,
+                self.scheduler.address, timeout=timeout, **self.connection_args,
             )
             comm.name = "Client->Scheduler"
             if timeout is not None:

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -184,7 +184,7 @@ class Connector(ABC):
         """
 
 
-async def connect(addr, timeout=None, deserialize=True, connection_args=None):
+async def connect(addr, timeout=None, deserialize=True, **connection_args):
     """
     Connect to the given address (a URI such as ``tcp://127.0.0.1:1234``)
     and yield a ``Comm`` object.  If the connection attempt fails, it is
@@ -221,7 +221,7 @@ async def connect(addr, timeout=None, deserialize=True, connection_args=None):
         try:
             while deadline - time() > 0:
                 future = connector.connect(
-                    loc, deserialize=deserialize, **(connection_args or {})
+                    loc, deserialize=deserialize, **connection_args
                 )
                 with ignoring(TimeoutError):
                     comm = await asyncio.wait_for(
@@ -247,7 +247,7 @@ async def connect(addr, timeout=None, deserialize=True, connection_args=None):
     return comm
 
 
-def listen(addr, handle_comm, deserialize=True, connection_args=None):
+def listen(addr, handle_comm, deserialize=True, **kwargs):
     """
     Create a listener object with the given parameters.  When its ``start()``
     method is called, the listener will listen on the given address
@@ -259,7 +259,7 @@ def listen(addr, handle_comm, deserialize=True, connection_args=None):
     try:
         scheme, loc = parse_address(addr, strict=True)
     except ValueError:
-        if connection_args and connection_args.get("ssl_context"):
+        if kwargs.get("ssl_context"):
             addr = "tls://" + addr
         else:
             addr = "tcp://" + addr
@@ -267,6 +267,4 @@ def listen(addr, handle_comm, deserialize=True, connection_args=None):
 
     backend = registry.get_backend(scheme)
 
-    return backend.get_listener(
-        loc, handle_comm, deserialize, **(connection_args or {})
-    )
+    return backend.get_listener(loc, handle_comm, deserialize, **kwargs)

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -26,18 +26,16 @@ def test_registered():
 
 
 async def get_comm_pair(
-    listen_addr="ucx://" + HOST, listen_args=None, connect_args=None, **kwargs
+    listen_addr="ucx://" + HOST, listen_args={}, connect_args={}, **kwargs
 ):
     q = asyncio.queues.Queue()
 
     async def handle_comm(comm):
         await q.put(comm)
 
-    listener = listen(listen_addr, handle_comm, connection_args=listen_args, **kwargs)
+    listener = listen(listen_addr, handle_comm, **listen_args, **kwargs)
     async with listener:
-        comm = await connect(
-            listener.contact_address, connection_args=connect_args, **kwargs
-        )
+        comm = await connect(listener.contact_address, **connect_args, **kwargs)
         serv_comm = await q.get()
         return (comm, serv_comm)
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -302,7 +302,7 @@ class Server:
     def identity(self, comm=None):
         return {"type": type(self).__name__, "id": self.id}
 
-    async def listen(self, port_or_addr=None, listen_args=None):
+    async def listen(self, port_or_addr=None, **kwargs):
         if port_or_addr is None:
             port_or_addr = self.default_port
         if isinstance(port_or_addr, int):
@@ -313,10 +313,7 @@ class Server:
             addr = port_or_addr
             assert isinstance(addr, str)
         listener = await listen(
-            addr,
-            self.handle_comm,
-            deserialize=self.deserialize,
-            connection_args=listen_args,
+            addr, self.handle_comm, deserialize=self.deserialize, **kwargs,
         )
         self.listeners.append(listener)
 
@@ -606,7 +603,7 @@ class rpc:
         self.deserialize = deserialize
         self.serializers = serializers
         self.deserializers = deserializers if deserializers is not None else serializers
-        self.connection_args = connection_args
+        self.connection_args = connection_args or {}
         self._created = weakref.WeakSet()
         rpc.active.add(self)
 
@@ -644,7 +641,7 @@ class rpc:
                 self.address,
                 self.timeout,
                 deserialize=self.deserialize,
-                connection_args=self.connection_args,
+                **self.connection_args,
             )
             comm.name = "rpc"
         self.comms[comm] = False  # mark as taken
@@ -905,7 +902,7 @@ class ConnectionPool:
                 addr,
                 timeout=timeout or self.timeout,
                 deserialize=self.deserialize,
-                connection_args=self.connection_args,
+                **self.connection_args,
             )
             comm.name = "ConnectionPool"
             comm._pool = weakref.ref(self)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -829,7 +829,7 @@ class ConnectionPool:
         self.deserialize = deserialize
         self.serializers = serializers
         self.deserializers = deserializers if deserializers is not None else serializers
-        self.connection_args = connection_args
+        self.connection_args = connection_args or {}
         self.timeout = timeout
         self._n_connecting = 0
         self.server = weakref.ref(server) if server else None

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -734,9 +734,9 @@ def test_local_tls(loop, temporary):
             loop,
             assert_can_connect_from_everywhere_4,
             c.scheduler.port,
-            connection_args=c.security.get_connection_args("client"),
             protocol="tls",
             timeout=3,
+            **c.security.get_connection_args("client"),
         )
 
         # If we connect to a TLS localculster without ssl information we should fail
@@ -744,8 +744,8 @@ def test_local_tls(loop, temporary):
             loop,
             assert_cannot_connect,
             addr="tcp://127.0.0.1:%d" % c.scheduler.port,
-            connection_args=c.security.get_connection_args("client"),
             exception_class=RuntimeError,
+            **c.security.get_connection_args("client"),
         )
 
 

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -63,8 +63,7 @@ class ProgressBar:
             return result
 
         self.comm = await connect(
-            self.scheduler,
-            connection_args=self.client().connection_args if self.client else None,
+            self.scheduler, **(self.client().connection_args if self.client else {}),
         )
         logger.debug("Progressbar Connected to scheduler")
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -95,7 +95,6 @@ class Nanny(ServerNode):
         self.security = security or Security()
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args("worker")
-        self.listen_args = self.security.get_listen_args("worker")
 
         if scheduler_file:
             cfg = json_load_robust(scheduler_file)
@@ -244,7 +243,9 @@ class Nanny(ServerNode):
 
         await super().start()
 
-        await self.listen(self._start_address, listen_args=self.listen_args)
+        await self.listen(
+            self._start_address, **self.security.get_listen_args("worker")
+        )
         self.ip = get_address_host(self.address)
 
         logger.info("        Start Nanny at: %r", self.address)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1110,7 +1110,6 @@ class Scheduler(ServerNode):
         self.security = security or Security()
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args("scheduler")
-        self.listen_args = self.security.get_listen_args("scheduler")
 
         if dashboard_address is not None:
             try:
@@ -1430,7 +1429,7 @@ class Scheduler(ServerNode):
 
         if self.status != "running":
             for addr in self._start_address:
-                await self.listen(addr, listen_args=self.listen_args)
+                await self.listen(addr, **self.security.get_listen_args("scheduler"))
                 self.ip = get_address_host(self.listen_address)
                 listen_ip = self.ip
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -230,12 +230,10 @@ async def test_server_listen():
 
     sec = tls_security()
     async with listen_on(
-        Server, "tls://", listen_args=sec.get_listen_args("scheduler")
+        Server, "tls://", **sec.get_listen_args("scheduler")
     ) as server:
         assert server.address.startswith("tls://")
-        await assert_can_connect(
-            server.address, connection_args=sec.get_connection_args("client")
-        )
+        await assert_can_connect(server.address, **sec.get_connection_args("client"))
 
     # InProc
 
@@ -253,9 +251,9 @@ async def test_server_listen():
         await assert_cannot_connect(inproc_addr2)
 
 
-async def check_rpc(listen_addr, rpc_addr=None, listen_args=None, connection_args=None):
+async def check_rpc(listen_addr, rpc_addr=None, listen_args={}, connection_args={}):
     server = Server({"ping": pingpong})
-    await server.listen(listen_addr, listen_args=listen_args)
+    await server.listen(listen_addr, **listen_args)
     if rpc_addr is None:
         rpc_addr = server.address
 
@@ -603,7 +601,7 @@ async def test_connection_pool_tls():
 
     servers = [Server({"ping": ping}) for i in range(10)]
     for server in servers:
-        await server.listen("tls://", listen_args=listen_args)
+        await server.listen("tls://", **listen_args)
 
     rpc = await ConnectionPool(limit=5, connection_args=connection_args)
 

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -281,10 +281,10 @@ async def test_tls_listen_connect():
         forced_cipher_sec = Security()
 
     async with listen(
-        "tls://", handle_comm, connection_args=sec.get_listen_args("scheduler")
+        "tls://", handle_comm, **sec.get_listen_args("scheduler")
     ) as listener:
         comm = await connect(
-            listener.contact_address, connection_args=sec.get_connection_args("worker")
+            listener.contact_address, **sec.get_connection_args("worker")
         )
         msg = await comm.read()
         assert msg == "hello"
@@ -293,14 +293,12 @@ async def test_tls_listen_connect():
         # No SSL context for client
         with pytest.raises(TypeError):
             await connect(
-                listener.contact_address,
-                connection_args=sec.get_connection_args("client"),
+                listener.contact_address, **sec.get_connection_args("client"),
             )
 
         # Check forced cipher
         comm = await connect(
-            listener.contact_address,
-            connection_args=forced_cipher_sec.get_connection_args("worker"),
+            listener.contact_address, **forced_cipher_sec.get_connection_args("worker"),
         )
         cipher, _, _ = comm.extra_info["cipher"]
         assert cipher in [FORCED_CIPHER] + TLS_13_CIPHERS
@@ -331,20 +329,18 @@ async def test_require_encryption():
 
     for listen_addr in ["inproc://", "tls://"]:
         async with listen(
-            listen_addr, handle_comm, connection_args=sec.get_listen_args("scheduler")
+            listen_addr, handle_comm, **sec.get_listen_args("scheduler")
         ) as listener:
             comm = await connect(
-                listener.contact_address,
-                connection_args=sec2.get_connection_args("worker"),
+                listener.contact_address, **sec2.get_connection_args("worker"),
             )
             comm.abort()
 
         async with listen(
-            listen_addr, handle_comm, connection_args=sec2.get_listen_args("scheduler")
+            listen_addr, handle_comm, **sec2.get_listen_args("scheduler")
         ) as listener:
             comm = await connect(
-                listener.contact_address,
-                connection_args=sec2.get_connection_args("worker"),
+                listener.contact_address, **sec2.get_connection_args("worker"),
             )
             comm.abort()
 
@@ -356,25 +352,21 @@ async def test_require_encryption():
 
     for listen_addr in ["tcp://"]:
         async with listen(
-            listen_addr, handle_comm, connection_args=sec.get_listen_args("scheduler")
+            listen_addr, handle_comm, **sec.get_listen_args("scheduler")
         ) as listener:
             comm = await connect(
-                listener.contact_address,
-                connection_args=sec.get_connection_args("worker"),
+                listener.contact_address, **sec.get_connection_args("worker"),
             )
             comm.abort()
 
             with pytest.raises(RuntimeError):
                 await connect(
-                    listener.contact_address,
-                    connection_args=sec2.get_connection_args("worker"),
+                    listener.contact_address, **sec2.get_connection_args("worker"),
                 )
 
         with pytest.raises(RuntimeError):
             listen(
-                listen_addr,
-                handle_comm,
-                connection_args=sec2.get_listen_args("scheduler"),
+                listen_addr, handle_comm, **sec2.get_listen_args("scheduler"),
             )
 
 
@@ -408,10 +400,10 @@ async def test_tls_temporary_credentials_functional():
     sec = Security.temporary()
 
     async with listen(
-        "tls://", handle_comm, connection_args=sec.get_listen_args("scheduler")
+        "tls://", handle_comm, **sec.get_listen_args("scheduler")
     ) as listener:
         comm = await connect(
-            listener.contact_address, connection_args=sec.get_connection_args("worker")
+            listener.contact_address, **sec.get_connection_args("worker")
         )
         msg = await comm.read()
         assert msg == "hello"

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -12,6 +12,11 @@ from distributed.utils_test import gen_tls_cluster, inc, double, slowinc, slowad
 
 
 @gen_tls_cluster(client=True)
+def test_basic(c, s, a, b):
+    pass
+
+
+@gen_tls_cluster(client=True)
 def test_Queue(c, s, a, b):
     assert s.address.startswith("tls://")
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -507,7 +507,6 @@ class Worker(ServerNode):
         self.security = security or Security()
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args("worker")
-        self.listen_args = self.security.get_listen_args("worker")
 
         self.memory_limit = parse_memory_limit(memory_limit, self.nthreads)
 
@@ -811,9 +810,7 @@ class Worker(ServerNode):
         while True:
             try:
                 _start = time()
-                comm = await connect(
-                    self.scheduler.address, connection_args=self.connection_args
-                )
+                comm = await connect(self.scheduler.address, **self.connection_args)
                 comm.name = "Worker->Scheduler"
                 comm._server = weakref.ref(self)
                 await comm.write(
@@ -1017,7 +1014,9 @@ class Worker(ServerNode):
         enable_gc_diagnosis()
         thread_state.on_event_loop_thread = True
 
-        await self.listen(self._start_address, listen_args=self.listen_args)
+        await self.listen(
+            self._start_address, **self.security.get_listen_args("worker")
+        )
         self.ip = get_address_host(self.address)
 
         if self.name is None:
@@ -1180,7 +1179,7 @@ class Worker(ServerNode):
 
             async def batched_send_connect():
                 comm = await connect(
-                    address, connection_args=self.connection_args  # TODO, serialization
+                    address, **self.connection_args  # TODO, serialization
                 )
                 comm.name = "Worker->Worker"
                 await comm.write({"op": "connection_stream"})


### PR DESCRIPTION
Previously we would accept a specific keyword connection_args or
listen_args for security information like `ssl_context`.

Now we pass in these keywords directly,
and let the listener handle them without intermediary.

This different is mostly cosmetic, but does allow the passing of
other keywords to third-party listeners if needed.