### PR TITLE
Use relative URL in scheduler dashboard

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1090,7 +1090,7 @@ def task_stream_figure(clear_interval="20s", **kwargs):
             """,
     )
 
-    tap = TapTool(callback=OpenURL(url="/profile?key=@name"))
+    tap = TapTool(callback=OpenURL(url="./profile?key=@name"))
 
     root.add_tools(
         hover,


### PR DESCRIPTION
As done for other examples of `OpenURL` in the same file. This is important for cases where the dashboard is exposed at a non-root prefix (e.g. via the `--dashboard-prefix` option to `dask-scheduler`)