### PR TITLE
Support preload modules in Nanny

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -216,6 +216,14 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.argument(
     "preload_argv", nargs=-1, type=click.UNPROCESSED, callback=validate_preload_argv
 )
+@click.option(
+    "--preload-nanny",
+    type=str,
+    multiple=True,
+    is_eager=True,
+    help="Module that should be loaded by each nanny "
+    'like "foo.bar" or "/path/to/foo.py"',
+)
 @click.version_option()
 def main(
     scheduler,

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -248,6 +248,7 @@ def main(
     tls_key,
     dashboard_address,
     worker_class,
+    preload_nanny,
     **kwargs
 ):
     g0, g1, g2 = gc.get_threshold()  # https://github.com/dask/distributed/issues/1653
@@ -357,6 +358,7 @@ def main(
     worker_class = import_term(worker_class)
     if nanny:
         kwargs["worker_class"] = worker_class
+        kwargs["preload_nanny"] = preload_nanny
 
     if nanny:
         kwargs.update({"worker_port": worker_port, "listen_address": listen_address})

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -392,3 +392,28 @@ def test_idle_timeout(loop):
     )
     stop = time()
     assert 1 < stop - start < 10
+
+
+def test_multiple_workers(loop):
+    text = """
+def dask_setup(worker):
+    worker.foo = 'setup'
+"""
+    with popen(["dask-scheduler", "--no-dashboard"]) as s:
+        with popen(
+            [
+                "dask-worker",
+                "localhost:8786",
+                "--no-dashboard",
+                "--preload",
+                text,
+                "--preload-nanny",
+                text,
+            ]
+        ) as a:
+            with Client("127.0.0.1:8786", loop=loop) as c:
+                c.wait_for_workers(1)
+                [foo] = c.run(lambda dask_worker: dask_worker.foo).values()
+                assert foo == "setup"
+                [foo] = c.run(lambda dask_worker: dask_worker.foo, nanny=True).values()
+                assert foo == "setup"

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -22,8 +22,8 @@ distributed:
     work-stealing-interval: 100ms  # Callback time for work stealing
     worker-ttl: null        # like '60s'. Time to live for workers.  They must heartbeat faster than this
     pickle: True            # Is the scheduler allowed to deserialize arbitrary bytestrings
-    preload: []
-    preload-argv: []
+    preload: []             # Run custom modules with Scheduler
+    preload-argv: []        # See https://docs.dask.org/en/latest/setup/custom-startup.html
     unknown-task-duration: 500ms  # Default duration for all tasks with unknown durations ("15m", "2h")
     default-task-durations:  # How long we expect function names to run ("1h", "1s") (helps for long tasks)
       rechunk-split: 1us
@@ -48,8 +48,8 @@ distributed:
     connections:            # Maximum concurrent connections for data
       outgoing: 50          # This helps to control network saturation
       incoming: 10
-    preload: []
-    preload-argv: []
+    preload: []             # Run custom modules with Worker
+    preload-argv: []        # See https://docs.dask.org/en/latest/setup/custom-startup.html
     daemon: True
     validate: False         # Check worker state at every step for debugging
     lifetime:
@@ -72,8 +72,8 @@ distributed:
       terminate: 0.95  # fraction at which we terminate the worker
 
   nanny:
-    preload: []
-    preload-argv: []
+    preload: []             # Run custom modules with Nanny
+    preload-argv: []        # See https://docs.dask.org/en/latest/setup/custom-startup.html
 
   client:
     heartbeat: 5s  # time between client heartbeats

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -71,6 +71,10 @@ distributed:
       pause: 0.80  # fraction at which we pause worker threads
       terminate: 0.95  # fraction at which we terminate the worker
 
+  nanny:
+    preload: []
+    preload-argv: []
+
   client:
     heartbeat: 5s  # time between client heartbeats
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -264,7 +264,7 @@ class Nanny(ServerNode):
         self.ip = get_address_host(self.address)
 
         await preloading.on_start(
-            self._preload_modules, self, argv=self.preload_argv,
+            self._preload_modules, self, argv=self.preload_nanny_argv,
         )
 
         logger.info("        Start Nanny at: %r", self.address)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -79,8 +79,8 @@ class Nanny(ServerNode):
         death_timeout=None,
         preload=None,
         preload_argv=None,
-        nanny_preload=None,
-        nanny_preload_argv=None,
+        preload_nanny=None,
+        preload_nanny_argv=None,
         security=None,
         contact_address=None,
         listen_address=None,
@@ -133,12 +133,12 @@ class Nanny(ServerNode):
         if self.preload_argv is None:
             self.preload_argv = dask.config.get("distributed.worker.preload-argv")
 
-        self.nanny_preload = nanny_preload
-        if self.nanny_preload is None:
-            self.nanny_preload = dask.config.get("distributed.nanny.preload")
-        self.nanny_preload_argv = nanny_preload_argv
-        if self.nanny_preload_argv is None:
-            self.nanny_preload_argv = dask.config.get("distributed.nanny.preload-argv")
+        self.preload_nanny = preload_nanny
+        if self.preload_nanny is None:
+            self.preload_nanny = dask.config.get("distributed.nanny.preload")
+        self.preload_nanny_argv = preload_nanny_argv
+        if self.preload_nanny_argv is None:
+            self.preload_nanny_argv = dask.config.get("distributed.nanny.preload-argv")
 
         self.Worker = Worker if worker_class is None else worker_class
         self.env = env or {}
@@ -171,7 +171,7 @@ class Nanny(ServerNode):
         self.local_directory = local_directory
 
         self._preload_modules = preloading.on_creation(
-            self.nanny_preload, file_dir=self.local_directory
+            self.preload_nanny, file_dir=self.local_directory
         )
 
         self.services = services

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -452,7 +452,7 @@ class Worker(ServerNode):
         # Target interface on which we contact the scheduler by default
         # TODO: it is unfortunate that we special-case inproc here
         if not host and not interface and not scheduler_addr.startswith("inproc://"):
-            host = get_ip(get_address_host(scheduler_addr))
+            host = get_ip(get_address_host(scheduler_addr.split("://")[-1]))
 
         self._start_address = address_from_user_args(
             host=host,


### PR DESCRIPTION
Today we can run preload modules on workers or the scheduler, but not on the Nanny.

Now we can also run preload scripts on the nanny

```
dask-worker ... --preload-nanny my_module
```