### PR TITLE
Dask-serialize dicts longer than five elements

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -132,15 +132,15 @@ def serialize(x, serializers=None, on_error="message", context=None):
     if isinstance(x, Serialized):
         return x.header, x.frames
 
-    # Check for "dask"-serializable data in large collections.
-    # We will iterate through small collections by default (<=5).
-    # We will not iterate through any collections larger than 64
+    # Check for "dask"-serializable data in large data structures.
+    # We will iterate through small structures by default (<=5).
+    # We will not iterate through any structures larger than 64
     supported = False
     if type(x) in (list, set, tuple):
         supported = len(x) <= 5
         if not supported and len(x) <= 64:
             try:
-                dask_serialize.dispatch(type(x[0]))
+                dask_serialize.dispatch(type(next(iter(x))))
                 supported = True
             except TypeError:
                 pass

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -147,11 +147,12 @@ def serialize(x, serializers=None, on_error="message", context=None):
         return x.header, x.frames
 
     # Check for "dask"-serializable data in dict/list/set
-    supported = check_dask_serializable(x)
-    special_case = isinstance(x, list) and "pickle" not in serializers
+    supported = isinstance(x, list) and "pickle" not in serializers
+    if not supported:
+        supported = check_dask_serializable(x)
 
     # Determine whether keys are safe to be serialized with msgpack
-    if type(x) is dict and (supported or special_case):
+    if type(x) is dict and supported:
         try:
             msgpack.dumps(list(x.keys()))
         except Exception:
@@ -161,9 +162,9 @@ def serialize(x, serializers=None, on_error="message", context=None):
 
     if (
         type(x) in (list, set, tuple)
-        and (supported or special_case)
+        and supported
         or type(x) is dict
-        and (supported or special_case)
+        and supported
         and dict_safe
     ):
         if isinstance(x, dict):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -93,7 +93,7 @@ register_serialization_family("error", None, serialization_error_loads)
 def check_dask_serializable_collection(x):
     supported = False
     if type(x) in (list, set, tuple):
-        supported = len <= 5
+        supported = len(x) <= 5
         if not supported:
             try:
                 dask_serialize.dispatch(type(next(iter(x))))
@@ -101,7 +101,7 @@ def check_dask_serializable_collection(x):
             except TypeError:
                 pass
     elif type(x) is dict:
-        supported = len <= 5
+        supported = len(x) <= 5
         if not supported:
             try:
                 dask_serialize.dispatch(type(next(iter(x.items()))[1]))

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -92,16 +92,12 @@ register_serialization_family("error", None, serialization_error_loads)
 
 def check_dask_serializable_collection(x):
     if type(x) in (list, set, tuple):
-        if len(x) <= 5:
-            return True
         try:
             dask_serialize.dispatch(type(next(iter(x))))
             return True
         except TypeError:
             pass
     elif type(x) is dict:
-        if len(x) <= 5:
-            return True
         try:
             dask_serialize.dispatch(type(next(iter(x.items()))[1]))
             return True
@@ -156,7 +152,7 @@ def serialize(x, serializers=None, on_error="message", context=None):
     supported = check_dask_serializable_collection(x)
 
     # Determine whether keys are safe to be serialized with msgpack
-    if type(x) is dict and supported:
+    if type(x) is dict and (supported or len(x) <= 5):
         try:
             msgpack.dumps(list(x.keys()))
         except Exception:
@@ -166,9 +162,9 @@ def serialize(x, serializers=None, on_error="message", context=None):
 
     if (
         type(x) in (list, set, tuple)
-        and supported
+        and (supported or len(x) <= 5)
         or type(x) is dict
-        and supported
+        and (supported or len(x) <= 5)
         and dict_safe
     ):
         if isinstance(x, dict):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -91,9 +91,9 @@ register_serialization_family("error", None, serialization_error_loads)
 
 
 def check_dask_serializable(x):
-    if type(x) in (list, set, tuple):
+    if type(x) in (list, set, tuple) and len(x):
         return check_dask_serializable(next(iter(x)))
-    elif type(x) is dict:
+    elif type(x) is dict and len(x):
         return check_dask_serializable(next(iter(x.items()))[1])
     else:
         try:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -147,9 +147,9 @@ def serialize(x, serializers=None, on_error="message", context=None):
         return x.header, x.frames
 
     # Check for "dask"-serializable data in dict/list/set
-    supported = isinstance(x, list) and "pickle" not in serializers
-    if not supported:
-        supported = check_dask_serializable(x)
+    supported = (
+        isinstance(x, list) and "pickle" not in serializers
+    ) or check_dask_serializable(x)
 
     # Determine whether keys are safe to be serialized with msgpack
     if type(x) is dict and supported:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -92,12 +92,16 @@ register_serialization_family("error", None, serialization_error_loads)
 
 def check_dask_serializable_collection(x):
     if type(x) in (list, set, tuple):
+        if len(x) <= 5:
+            return True
         try:
             dask_serialize.dispatch(type(next(iter(x))))
             return True
         except TypeError:
             pass
     elif type(x) is dict:
+        if len(x) <= 5:
+            return True
         try:
             dask_serialize.dispatch(type(next(iter(x.items()))[1]))
             return True

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -148,9 +148,10 @@ def serialize(x, serializers=None, on_error="message", context=None):
 
     # Check for "dask"-serializable data in dict/list/set
     supported = check_dask_serializable(x)
+    special_case = isinstance(x, list) and "pickle" not in serializers
 
     # Determine whether keys are safe to be serialized with msgpack
-    if type(x) is dict and (supported or len(x) <= 5):
+    if type(x) is dict and (supported or special_case):
         try:
             msgpack.dumps(list(x.keys()))
         except Exception:
@@ -160,9 +161,9 @@ def serialize(x, serializers=None, on_error="message", context=None):
 
     if (
         type(x) in (list, set, tuple)
-        and (supported or len(x) <= 5)
+        and (supported or special_case)
         or type(x) is dict
-        and (supported or len(x) <= 5)
+        and (supported or special_case)
         and dict_safe
     ):
         if isinstance(x, dict):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -146,16 +146,22 @@ def serialize(x, serializers=None, on_error="message", context=None):
     if isinstance(x, Serialized):
         return x.header, x.frames
 
-    # Check for "dask"-serializable data in dict/list/set
-    # Note: "msgpack" will always convert lists to tuples
-    #       (see GitHub #3716), so we need to use
-    #       "pickle" or "dask" for list objects
-    supported = (
-        isinstance(x, list) and "msgpack" in serializers
-    ) or check_dask_serializable(x)
+    if type(x) in (list, set, tuple, dict):
+        iterate_collection = False
+        if type(x) is list and "msgpack" in serializers:
+            # Note: "msgpack" will always convert lists to tuples
+            #       (see GitHub #3716), so we should iterate
+            #       through the list if "msgpack" comes before "pickle"
+            #       in the list of serializers.
+            iterate_collection = ("pickle" not in serializers) or (
+                serializers.index("pickle") > serializers.index("msgpack")
+            )
+        if not iterate_collection:
+            # Check for "dask"-serializable data in dict/list/set
+            iterate_collection = check_dask_serializable(x)
 
     # Determine whether keys are safe to be serialized with msgpack
-    if type(x) is dict and supported:
+    if type(x) is dict and iterate_collection:
         try:
             msgpack.dumps(list(x.keys()))
         except Exception:
@@ -165,9 +171,9 @@ def serialize(x, serializers=None, on_error="message", context=None):
 
     if (
         type(x) in (list, set, tuple)
-        and supported
+        and iterate_collection
         or type(x) is dict
-        and supported
+        and iterate_collection
         and dict_safe
     ):
         if isinstance(x, dict):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -69,7 +69,7 @@ def msgpack_dumps(x):
 
 
 def msgpack_loads(header, frames):
-    return msgpack.loads(b"".join(frames), use_list=False, **msgpack_opts)
+    return msgpack.loads(b"".join(frames), **msgpack_opts)
 
 
 def serialization_error_loads(header, frames):
@@ -147,9 +147,7 @@ def serialize(x, serializers=None, on_error="message", context=None):
         return x.header, x.frames
 
     # Check for "dask"-serializable data in dict/list/set
-    supported = (
-        isinstance(x, list) and "pickle" not in serializers
-    ) or check_dask_serializable(x)
+    supported = check_dask_serializable(x)
 
     # Determine whether keys are safe to be serialized with msgpack
     if type(x) is dict and supported:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -151,7 +151,7 @@ def serialize(x, serializers=None, on_error="message", context=None):
     #       list (see GitHub PR#2000), so we need to use
     #       "pickle" or "dask" for list objects
     supported = (
-        isinstance(x, list) and "pickle" not in serializers
+        isinstance(x, list) or "msgpack" in serializers
     ) or check_dask_serializable(x)
 
     # Determine whether keys are safe to be serialized with msgpack

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -148,7 +148,7 @@ def serialize(x, serializers=None, on_error="message", context=None):
 
     # Check for "dask"-serializable data in dict/list/set
     # Note: "msgpack" will always convert lists to tuples
-    #       list (see GitHub PR#2000), so we need to use
+    #       (see GitHub #3716), so we need to use
     #       "pickle" or "dask" for list objects
     supported = (
         isinstance(x, list) and "msgpack" in serializers

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -69,7 +69,7 @@ def msgpack_dumps(x):
 
 
 def msgpack_loads(header, frames):
-    return msgpack.loads(b"".join(frames), **msgpack_opts)
+    return msgpack.loads(b"".join(frames), use_list=False, **msgpack_opts)
 
 
 def serialization_error_loads(header, frames):
@@ -147,7 +147,12 @@ def serialize(x, serializers=None, on_error="message", context=None):
         return x.header, x.frames
 
     # Check for "dask"-serializable data in dict/list/set
-    supported = check_dask_serializable(x)
+    # Note: "msgpack" will always convert lists to tuples
+    #       list (see GitHub PR#2000), so we need to use
+    #       "pickle" or "dask" for list objects
+    supported = (
+        isinstance(x, list) and "pickle" not in serializers
+    ) or check_dask_serializable(x)
 
     # Determine whether keys are safe to be serialized with msgpack
     if type(x) is dict and supported:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -151,7 +151,7 @@ def serialize(x, serializers=None, on_error="message", context=None):
     #       list (see GitHub PR#2000), so we need to use
     #       "pickle" or "dask" for list objects
     supported = (
-        isinstance(x, list) or "msgpack" in serializers
+        isinstance(x, list) and "msgpack" in serializers
     ) or check_dask_serializable(x)
 
     # Determine whether keys are safe to be serialized with msgpack

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -394,10 +394,8 @@ def test_compression_numpy_list():
 @pytest.mark.parametrize(
     "test_pair",
     [
-        ({"x": 1}, False),
-        (["x", "y", "z"], False),
+        ({i: i for i in range(10)}, False),
         (set(range(10)), False),
-        ({"x": {"y": "z"}}, False),
         (tuple(range(100)), False),
         ({"x": MyObj(5)}, True),
         pytest.param(

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -21,7 +21,7 @@ from distributed.protocol import (
     register_serialization_family,
     dask_serialize,
 )
-from distributed.protocol.serialize import check_dask_serializable_collection
+from distributed.protocol.serialize import check_dask_serializable
 from distributed.utils import nbytes
 from distributed.utils_test import inc, gen_test
 from distributed.comm.utils import to_frames, from_frames
@@ -398,6 +398,7 @@ def test_compression_numpy_list():
         (set(range(10)), False),
         (tuple(range(100)), False),
         ({"x": MyObj(5)}, True),
+        ({"x": {"y": MyObj(5)}}, True),
         pytest.param(
             ([1, MyObj(5)], True),
             marks=pytest.mark.xfail(reason="Only checks 0th element for now."),
@@ -407,8 +408,8 @@ def test_compression_numpy_list():
         ({("x", i): MyObj(5) for i in range(100)}, True),
     ],
 )
-def test_check_dask_serializable_collection(test_pair):
-    result = check_dask_serializable_collection(test_pair[0])
+def test_check_dask_serializable(test_pair):
+    result = check_dask_serializable(test_pair[0])
     expected = test_pair[1]
 
     assert result == expected

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -392,15 +392,18 @@ def test_compression_numpy_list():
 
 
 @pytest.mark.parametrize(
-    "test_pair",
+    "data,is_serializable",
     [
+        ([], False),
+        ({}, False),
         ({i: i for i in range(10)}, False),
         (set(range(10)), False),
         (tuple(range(100)), False),
         ({"x": MyObj(5)}, True),
         ({"x": {"y": MyObj(5)}}, True),
         pytest.param(
-            ([1, MyObj(5)], True),
+            [1, MyObj(5)],
+            True,
             marks=pytest.mark.xfail(reason="Only checks 0th element for now."),
         ),
         ([MyObj([0, 1, 2]), 1], True),
@@ -408,8 +411,8 @@ def test_compression_numpy_list():
         ({("x", i): MyObj(5) for i in range(100)}, True),
     ],
 )
-def test_check_dask_serializable(test_pair):
-    result = check_dask_serializable(test_pair[0])
-    expected = test_pair[1]
+def test_check_dask_serializable(data, is_serializable):
+    result = check_dask_serializable(data)
+    expected = is_serializable
 
     assert result == expected

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -416,3 +416,15 @@ def test_check_dask_serializable(data, is_serializable):
     expected = is_serializable
 
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "serializers",
+    [["msgpack"], ["pickle"], ["msgpack", "pickle"], ["pickle", "msgpack"]],
+)
+def test_serialize_lists(serializers):
+    data_in = ["a", 2, "c", None, "e", 6]
+    header, frames = serialize(data_in, serializers=serializers)
+    data_out = deserialize(header, frames)
+
+    assert data_in == data_out


### PR DESCRIPTION
Some dask.dataframe/dask_cudf shuffling algorithms utilize tasks that produce a dictionary of pandas/cudf DataFrame objects.  Since these dictionaries are typically larger than five elements, they are usually pickled when the output needs to be transferred between workers.  For the cudf-backed shuffle algorithm, this can seriously degrade performance (changing the dominant communication mechanism from IPC to TPC on systems with NVLink support).

This PR increases the minimum size of a list/set/dict for which each element will be separately serialized (from 5 to 64).  If the length is >5, the iterative serialization is only performed if the "first"  element is dask-serializable.  The check clearly doesnt assert that *all* items in the list/set/dict are dask-serializable, but always capture the case when all elements are. 