### PR TITLE
Idempotent semaphore acquire with retries

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -44,6 +44,7 @@ distributed:
         check_unused_sessions_milliseconds: 500
     locks:
       lease-validation-interval: 10s  # The time to wait until an acquired semaphore is released if the Client goes out of scope
+      lease-timeout: 30s  # The timeout after which a lease will be released if not refreshed
 
     http:
       routes:


### PR DESCRIPTION
This adds a lot of logging information to the semaphore but most importantly refactors the internal structures to make the acquire call idempotent.

This relieves us from using the Client itself as a lifetime anchor for the leases and exchanges this scheme with an explicit refresh of the leases and lease specific timeouts.

This gives the following benefits:
* I can create a unique ID for each acquire/lease which can be used for tracing using logs to debug the behaviour
* The acquire requests themselves are idempotent, i.e. upon connection failures this can be retried
* The requests are simpler since we no longer need to handle the client ID which was in the original implementation somehow redundant anyhow
* If any weird "proxy did not get ACK" issues arise (e.g. scheduler logged the lease but the OK was never received by the client) the system will eventually self heal / not deadlock
* The internal structure is subjectively more simple since we have only one dict to maintain which now holds timestamps


at the cost of additional complexity:
* The client will spawn a new periodic callback to refresh the leases. This replaces the implicit coupling to the client heartbeat. I think this is a complexity worth taking since it decouples this implementation a bit from assumptions about the lifetime management of the client.
* Another configuration option (I would argue this makes it more transparent to the users, though)


I sneaked in another change regarding the configurability of the retry options. Will open another PR for this but I needed it for the tests to succeed