### PR TITLE
Add Client.wait_to_workers to Client autosummary table

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -44,6 +44,7 @@ API
    Client.unpublish_dataset
    Client.upload_file
    Client.who_has
+   Client.wait_for_workers
 
 .. currentmodule:: distributed
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -43,8 +43,8 @@ API
    Client.submit
    Client.unpublish_dataset
    Client.upload_file
-   Client.who_has
    Client.wait_for_workers
+   Client.who_has
 
 .. currentmodule:: distributed
 


### PR DESCRIPTION
It was appearing during the `Client` `autoclass`, but not in the `autosummary` table at the top of the API page 