### PR TITLE
Replace Example with Examples in docstrings

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -22,8 +22,8 @@ class BatchedSend:
     Batching several messages at once helps performance when sending
     a myriad of tiny messages.
 
-    Example
-    -------
+    Examples
+    --------
     >>> stream = yield connect(address)
     >>> bstream = BatchedSend(interval='10 ms')
     >>> bstream.start(stream)

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -135,8 +135,8 @@ class Cluster:
         n: int
             Target number of workers
 
-        Example
-        -------
+        Examples
+        --------
         >>> cluster.scale(10)  # scale cluster to ten workers
         """
         raise NotImplementedError()

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -79,8 +79,8 @@ def process(frame, child, state, stop=None, omit=None):
     This recursively adds counts to the existing state dictionary and creates
     new entries for new functions.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import sys, threading
     >>> ident = threading.get_ident()  # replace with your thread of interest
     >>> frame = sys._current_frames()[ident]

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -272,8 +272,8 @@ def deserialize(header, frames, deserializers=None):
 class Serialize:
     """ Mark an object that should be serialized
 
-    Example
-    -------
+    Examples
+    --------
     >>> msg = {'op': 'update', 'data': to_serialize(123)}
     >>> msg  # doctest: +SKIP
     {'op': 'update', 'data': <Serialize: 123>}


### PR DESCRIPTION
This was causing warnings in sphinx, and doesn't get rendered properly