### PR TITLE
Easier local installation

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -20,7 +20,7 @@ jobs:
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
           environment-file: continuous_integration/environment-windows.yml
-          activate-environment: distributed
+          activate-environment: dask-distributed
           auto-activate-base: false
 
       - name: Install tornado

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -19,8 +19,8 @@ jobs:
         with:
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
-          environment-file: continuous_integration/environment.yml
-          activate-environment: testenv
+          environment-file: continuous_integration/environment-windows.yml
+          activate-environment: distributed
           auto-activate-base: false
 
       - name: Install tornado

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ dist: trusty
 
 env:
   matrix:
-    - PYTHON=3.6 TESTS=true COVERAGE=true PACKAGES="scikit-learn lz4" TORNADO=5 CRICK=true
-    - PYTHON=3.7 TESTS=true PACKAGES="scikit-learn python-snappy python-blosc" TORNADO=6
-    - PYTHON=3.8 TESTS=true PACKAGES="scikit-learn python-snappy python-blosc" TORNADO=6
+    - PYTHON=3.6 TESTS=true COVERAGE=true PACKAGES="lz4" TORNADO=5 CRICK=true
+    - PYTHON=3.7 TESTS=true PACKAGES="python-snappy python-blosc" TORNADO=6
+    - PYTHON=3.8 TESTS=true PACKAGES="python-snappy python-blosc" TORNADO=6
 
 matrix:
   fast_finish: true
@@ -18,7 +18,7 @@ matrix:
     python: 3.6
     env: LINT=true
   - os: osx
-    env: PYTHON=3.7 TESTS=true PACKAGES="scikit-learn python-snappy python-blosc" TORNADO=6
+    env: PYTHON=3.7 TESTS=true PACKAGES="python-snappy python-blosc" TORNADO=6
     if: type != pull_request OR commit_message =~ test-osx  # Skip on PRs unless the commit message contains "test-osx"
 
   allow_failures:

--- a/continuous_integration/environment-windows.yml
+++ b/continuous_integration/environment-windows.yml
@@ -1,4 +1,4 @@
-name: testenv
+name: distributed
 channels:
   - conda-forge
 dependencies:

--- a/continuous_integration/environment-windows.yml
+++ b/continuous_integration/environment-windows.yml
@@ -1,4 +1,4 @@
-name: distributed
+name: dask-distributed
 channels:
   - conda-forge
 dependencies:

--- a/continuous_integration/environment-windows.yml
+++ b/continuous_integration/environment-windows.yml
@@ -1,6 +1,7 @@
 name: dask-distributed
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - zstandard
   - bokeh!=2.0.0
@@ -16,18 +17,18 @@ dependencies:
   - prometheus_client
   - psutil
   - pytest
+  - pytest-asyncio
+  - pytest-repeat
+  - pytest-timeout
+  - pytest-faulthandler
   - requests
+  - sortedcollections
   - toolz
   - tblib
   - zict
   - fsspec
   - pip
   - pip:
-      - pytest-repeat
-      - pytest-timeout
-      - pytest-faulthandler
-      - sortedcollections
-      - pytest-asyncio
       - git+https://github.com/dask/dask
       - git+https://github.com/joblib/joblib.git
       - git+https://github.com/dask/zict

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -69,7 +69,7 @@ conda install -c conda-forge \
 if [[ $PYTHON != 3.8 ]]; then
     # For low-level profiler, install libunwind and stacktrace from conda-forge
     # For stacktrace we use --no-deps to avoid upgrade of python
-    conda install -c pgks/main -c conda-forge libunwind
+    conda install -c pkgs/main -c conda-forge libunwind
     conda install --no-deps -c pgks/main -c numba -c conda-forge stacktrace
 fi
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -32,8 +32,8 @@ conda config --set always_yes yes --set quiet yes --set changeps1 no
 conda update conda
 
 # Create conda environment
-conda create -n distributed -c pkgs/main python=$PYTHON
-source activate distributed
+conda create -n dask-distributed -c pkgs/main python=$PYTHON
+source activate dask-distributed
 
 # Install dependencies
 conda install -c conda-forge \

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -70,7 +70,7 @@ if [[ $PYTHON != 3.8 ]]; then
     # For low-level profiler, install libunwind and stacktrace from conda-forge
     # For stacktrace we use --no-deps to avoid upgrade of python
     conda install -c pkgs/main -c conda-forge libunwind
-    conda install --no-deps -c pgks/main -c numba -c conda-forge stacktrace
+    conda install --no-deps -c pkgs/main -c numba -c conda-forge stacktrace
 fi
 
 python -m pip install -q "pytest>=4" pytest-repeat pytest-faulthandler pytest-asyncio

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -32,11 +32,7 @@ conda config --set always_yes yes --set quiet yes --set changeps1 no
 conda update conda
 
 # Create conda environment
-conda create -n dask-distributed -c pkgs/main python=$PYTHON
-source activate dask-distributed
-
-# Install dependencies
-conda install -c conda-forge \
+conda create -n dask-distributed -c conda-forge -c defaults \
     asyncssh \
     bokeh \
     click \
@@ -48,42 +44,47 @@ conda install -c conda-forge \
     ipywidgets \
     joblib \
     jupyter_client \
-    msgpack-python \
+    'msgpack-python>=0.6.0' \
     netcdf4 \
     paramiko \
     prometheus_client \
     psutil \
-    pytest \
+    'pytest>=4' \
+    pytest-asyncio \
+    pytest-faulthandler \
+    pytest-repeat \
     pytest-timeout \
+    python=$PYTHON \
     requests \
     scikit-learn \
     scipy \
-    tblib \
+    sortedcollections \
+    'tblib>=1.5.0' \
     toolz \
     tornado=$TORNADO \
     zstandard \
     $PACKAGES
+
+source activate dask-distributed
 
 # stacktrace is not currently avaiable for Python 3.8.
 # Remove the version check block below when it is avaiable.
 if [[ $PYTHON != 3.8 ]]; then
     # For low-level profiler, install libunwind and stacktrace from conda-forge
     # For stacktrace we use --no-deps to avoid upgrade of python
-    conda install -c pkgs/main -c conda-forge libunwind
-    conda install --no-deps -c pkgs/main -c numba -c conda-forge stacktrace
+    conda install -c conda-forge -c defaults libunwind
+    conda install --no-deps -c conda-forge -c defaults -c numba stacktrace
 fi
 
-python -m pip install -q "pytest>=4" pytest-repeat pytest-faulthandler pytest-asyncio
 python -m pip install -q git+https://github.com/dask/dask.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/joblib/joblib.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/intake/filesystem_spec.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
-python -m pip install -q sortedcollections --no-deps
 python -m pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then
-    conda install -c pkgs/main cython
+    conda install -c conda-forge -c defaults cython
     python -m pip install -q git+https://github.com/jcrist/crick.git
 fi
 

--- a/continuous_integration/travis/run_tests.sh
+++ b/continuous_integration/travis/run_tests.sh
@@ -19,7 +19,7 @@ echo "--"
 ulimit -a -H
 
 if [[ $COVERAGE == true ]]; then
-    coverage run $(which py.test) distributed -m "not avoid_travis" $PYTEST_OPTIONS;
+    coverage run $(which py.test) distributed -m "not avoid_travis" $PYTEST_OPTIONS
 else
-    py.test -m "not avoid_travis" distributed $PYTEST_OPTIONS;
-fi;
+    py.test -m "not avoid_travis" distributed $PYTEST_OPTIONS
+fi

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -43,6 +43,7 @@ API
    Client.submit
    Client.unpublish_dataset
    Client.upload_file
+   Client.wait_for_workers
    Client.who_has
 
 .. currentmodule:: distributed

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -16,7 +16,7 @@ Clone this repository with git::
    git clone git@github.com:dask/distributed.git
    cd distributed
 
-Install all dependencies to match CI:
+Install all dependencies:
 
 On Linux / MacOSX::
 

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -27,8 +27,8 @@ On Windows:
 1. Install anaconda or miniconda
 2. ::
 
-    conda create -n distributed python=3.8 tornado=6
-    conda activate distributed
+    conda create -n dask-distributed python=3.8 tornado=6
+    conda activate dask-distributed
     conda env update --file continuous_integration/environment-windows.yml
     python -m pip install .
 

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -7,30 +7,44 @@ and documentation and style standards are available at the `Dask developer
 guidelines`_ in the main documentation.
 
 .. _Dask: http://dask.org
-.. _`Dask developer guidelines`: http://docs.dask.org/en/latest/develop.html
 
 Install
 -------
 
-After setting up an environment as described in the `Dask developer
-guidelines`_ you can clone this repository with git::
+Clone this repository with git::
 
    git clone git@github.com:dask/distributed.git
-
-and install it from source::
-
    cd distributed
-   python setup.py install
 
-Using conda, for example::
+Install all dependencies to match CI:
+
+On Linux / MacOSX::
+
+    source continuous_integration/travis/install.sh
+
+On Windows:
+
+1. Install anaconda or miniconda
+2. ::
+
+    conda create -n distributed python=3.8 tornado=6
+    conda activate distributed
+    conda env update --file continuous_integration/environment-windows.yml
+    python -m pip install .
+
+Alternative instructions, without using conda::
 
    git clone git@github.com:{your-fork}/distributed.git
    cd distributed
-   conda create -y -n distributed python=3.6
-   conda activate distributed
+   python -m venv $HOME/distributed
+   export PATH=$HOME/distributed/bin:$PATH
    python -m pip install -U -r requirements.txt
    python -m pip install -U -r dev-requirements.txt
    python -m pip install -e .
+
+.. note::
+   There may be subtle differences between pip and conda; the distributed CI uses conda.
+
 
 To keep a fork in sync with the upstream source::
 

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -27,24 +27,10 @@ On Windows:
 1. Install anaconda or miniconda
 2. ::
 
-    conda create -n dask-distributed python=3.8 tornado=6
+    conda create -n dask-distributed -c conda-forge -c defaults python=3.8 tornado=6
     conda activate dask-distributed
     conda env update --file continuous_integration/environment-windows.yml
     python -m pip install .
-
-Alternative instructions, without using conda::
-
-   git clone git@github.com:{your-fork}/distributed.git
-   cd distributed
-   python -m venv $HOME/distributed
-   export PATH=$HOME/distributed/bin:$PATH
-   python -m pip install -U -r requirements.txt
-   python -m pip install -U -r dev-requirements.txt
-   python -m pip install -e .
-
-.. note::
-   There may be subtle differences between pip and conda; the distributed CI uses conda.
-
 
 To keep a fork in sync with the upstream source::
 

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -7,6 +7,7 @@ and documentation and style standards are available at the `Dask developer
 guidelines`_ in the main documentation.
 
 .. _Dask: http://dask.org
+.. _`Dask developer guidelines`: http://docs.dask.org/en/latest/develop.html
 
 Install
 -------


### PR DESCRIPTION
This PR streamlines the CI installation script, with the main purpose of making it easier to replicate on a Linux/MacOSX dev box the exact same environment that exists on CI.

- Apply safe defaults for environment variables if the script is not invoked by travis
- Do not install miniconda if the 'conda' command is already available
- Explicitly state conda channel every time to avoid relying on ~/.condarc
- Recommend using conda in developer docs