### PR TITLE
Allow modification of distributed.comm.retry at runtime

### DIFF
--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -312,15 +312,6 @@ def subs_multiple(o, d):
             return o
 
 
-retry_count = dask.config.get("distributed.comm.retry.count")
-retry_delay_min = parse_timedelta(
-    dask.config.get("distributed.comm.retry.delay.min"), default="s"
-)
-retry_delay_max = parse_timedelta(
-    dask.config.get("distributed.comm.retry.delay.max"), default="s"
-)
-
-
 async def retry(
     coro,
     count,
@@ -383,6 +374,14 @@ async def retry_operation(coro, *args, operation=None, **kwargs):
     """
     Retry an operation using the configuration values for the retry parameters
     """
+
+    retry_count = dask.config.get("distributed.comm.retry.count")
+    retry_delay_min = parse_timedelta(
+        dask.config.get("distributed.comm.retry.delay.min"), default="s"
+    )
+    retry_delay_max = parse_timedelta(
+        dask.config.get("distributed.comm.retry.delay.max"), default="s"
+    )
     return await retry(
         partial(coro, *args, **kwargs),
         count=retry_count,


### PR DESCRIPTION
This allows the modification of the retry options at runtime such that the ordinary `dask.config` context manager can be used. Makes tests much more intuitive and also makes sense to be configurable to give users more control about this behaviour. 