### PR TITLE
async... await in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dask-worker-space/
 *.swp
 .ycm_extra_conf.py
 tags
+.ipynb_checkpoints

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -28,9 +28,9 @@ import distributed.cli.dask_scheduler
 def test_defaults(loop):
     with popen(["dask-scheduler", "--no-dashboard"]) as proc:
 
-        def f():
+        async def f():
             # Default behaviour is to listen on all addresses
-            yield assert_can_connect_from_everywhere_4_6(8786, timeout=5.0)
+            await assert_can_connect_from_everywhere_4_6(8786, timeout=5.0)
 
         with Client("127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
             c.sync(f)
@@ -45,9 +45,9 @@ def test_defaults(loop):
 def test_hostport(loop):
     with popen(["dask-scheduler", "--no-dashboard", "--host", "127.0.0.1:8978"]):
 
-        def f():
+        async def f():
             # The scheduler's main port can't be contacted from the outside
-            yield assert_can_connect_locally_4(8978, timeout=5.0)
+            await assert_can_connect_locally_4(8978, timeout=5.0)
 
         with Client("127.0.0.1:8978", loop=loop) as c:
             assert len(c.nthreads()) == 0

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -10,7 +10,6 @@ import sys
 import tempfile
 from time import sleep
 
-from tornado import gen
 from click.testing import CliRunner
 
 import distributed
@@ -29,12 +28,9 @@ import distributed.cli.dask_scheduler
 def test_defaults(loop):
     with popen(["dask-scheduler", "--no-dashboard"]) as proc:
 
-        @gen.coroutine
         def f():
             # Default behaviour is to listen on all addresses
-            yield [
-                assert_can_connect_from_everywhere_4_6(8786, timeout=5.0)
-            ]  # main port
+            yield assert_can_connect_from_everywhere_4_6(8786, timeout=5.0)
 
         with Client("127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
             c.sync(f)
@@ -49,12 +45,9 @@ def test_defaults(loop):
 def test_hostport(loop):
     with popen(["dask-scheduler", "--no-dashboard", "--host", "127.0.0.1:8978"]):
 
-        @gen.coroutine
         def f():
-            yield [
-                # The scheduler's main port can't be contacted from the outside
-                assert_can_connect_locally_4(8978, timeout=5.0)
-            ]
+            # The scheduler's main port can't be contacted from the outside
+            yield assert_can_connect_locally_4(8978, timeout=5.0)
 
         with Client("127.0.0.1:8978", loop=loop) as c:
             assert len(c.nthreads()) == 0

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -1,4 +1,3 @@
-from tornado import gen
 from tornado.ioloop import IOLoop
 
 
@@ -51,7 +50,6 @@ def install_signal_handlers(loop=None, cleanup=None):
     old_handlers = {}
 
     def handle_signal(sig, frame):
-        @gen.coroutine
         def cleanup_and_stop():
             try:
                 if cleanup is not None:

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -50,10 +50,10 @@ def install_signal_handlers(loop=None, cleanup=None):
     old_handlers = {}
 
     def handle_signal(sig, frame):
-        def cleanup_and_stop():
+        async def cleanup_and_stop():
             try:
                 if cleanup is not None:
-                    yield cleanup(sig)
+                    await cleanup(sig)
             finally:
                 loop.stop()
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -102,7 +102,6 @@ def _get_global_client():
             return c
         else:
             del _global_clients[k]
-    del L
     return None
 
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1339,6 +1339,10 @@ class Client(Node):
             timeout = self._timeout * 2
         # XXX handling of self.status here is not thread-safe
         if self.status == "closed":
+            if self.asynchronous:
+                future = asyncio.Future()
+                future.set_result(None)
+                return future
             return
         self.status = "closing"
 

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -151,13 +151,13 @@ async def test_ping_pong_data():
 
 
 @gen_test()
-def test_ucx_deserialize():
+async def test_ucx_deserialize():
     # Note we see this error on some systems with this test:
     # `socket.gaierror: [Errno -5] No address associated with hostname`
     # This may be due to a system configuration issue.
     from .test_comms import check_deserialize
 
-    yield check_deserialize("tcp://")
+    await check_deserialize("tcp://")
 
 
 @pytest.mark.asyncio

--- a/distributed/dashboard/tests/test_components.py
+++ b/distributed/dashboard/tests/test_components.py
@@ -1,9 +1,10 @@
+import asyncio
+
 import pytest
 
 pytest.importorskip("bokeh")
 
 from bokeh.models import ColumnDataSource, Model
-from tornado import gen
 
 from distributed.utils_test import slowinc, gen_cluster
 from distributed.dashboard.components.shared import (
@@ -45,4 +46,4 @@ async def test_profile_time_plot(c, s, a, b):
     await c.gather(c.map(slowinc, range(10), delay=0.05))
     ap.trigger_update()
     sp.trigger_update()
-    await gen.sleep(0.05)
+    await asyncio.sleep(0.05)

--- a/distributed/dashboard/tests/test_components.py
+++ b/distributed/dashboard/tests/test_components.py
@@ -24,7 +24,7 @@ def test_basic(Component):
 def test_profile_plot(c, s, a, b):
     p = ProfilePlot()
     assert not p.source.data["left"]
-    yield c.map(slowinc, range(10), delay=0.05)
+    yield c.gather(c.map(slowinc, range(10), delay=0.05))
     p.update(a.profile_recent)
     assert len(p.source.data["left"]) >= 1
 
@@ -42,7 +42,7 @@ def test_profile_time_plot(c, s, a, b):
     assert len(sp.source.data["left"]) <= 1
     assert len(ap.source.data["left"]) <= 1
 
-    yield c.map(slowinc, range(10), delay=0.05)
+    yield c.gather(c.map(slowinc, range(10), delay=0.05))
     ap.trigger_update()
     sp.trigger_update()
     yield gen.sleep(0.05)

--- a/distributed/dashboard/tests/test_components.py
+++ b/distributed/dashboard/tests/test_components.py
@@ -21,16 +21,16 @@ def test_basic(Component):
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
-def test_profile_plot(c, s, a, b):
+async def test_profile_plot(c, s, a, b):
     p = ProfilePlot()
     assert not p.source.data["left"]
-    yield c.gather(c.map(slowinc, range(10), delay=0.05))
+    await c.gather(c.map(slowinc, range(10), delay=0.05))
     p.update(a.profile_recent)
     assert len(p.source.data["left"]) >= 1
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
-def test_profile_time_plot(c, s, a, b):
+async def test_profile_time_plot(c, s, a, b):
     from bokeh.io import curdoc
 
     sp = ProfileTimePlot(s, doc=curdoc())
@@ -42,7 +42,7 @@ def test_profile_time_plot(c, s, a, b):
     assert len(sp.source.data["left"]) <= 1
     assert len(ap.source.data["left"]) <= 1
 
-    yield c.gather(c.map(slowinc, range(10), delay=0.05))
+    await c.gather(c.map(slowinc, range(10), delay=0.05))
     ap.trigger_update()
     sp.trigger_update()
-    yield gen.sleep(0.05)
+    await gen.sleep(0.05)

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -62,7 +62,7 @@ async def test_simple(c, s, a, b):
 
 
 @gen_cluster(client=True, worker_kwargs={"dashboard": True})
-def test_basic(c, s, a, b):
+async def test_basic(c, s, a, b):
     for component in [TaskStream, SystemMonitor, Occupancy, StealingTimeSeries]:
         ss = component(s)
 

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -9,7 +9,6 @@ import pytest
 
 pytest.importorskip("bokeh")
 from tlz import first
-from tornado import gen
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 import dask
@@ -46,7 +45,7 @@ async def test_simple(c, s, a, b):
     port = s.http_server.port
 
     future = c.submit(sleep, 1)
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
 
     http_client = AsyncHTTPClient()
     for suffix in applications:
@@ -78,16 +77,16 @@ def test_basic(c, s, a, b):
 async def test_counters(c, s, a, b):
     pytest.importorskip("crick")
     while "tick-duration" not in s.digests:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
     ss = Counters(s)
 
     ss.update()
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     ss.update()
 
     start = time()
     while not len(ss.digest_sources["tick-duration"][0].data["x"]):
-        await gen.sleep(1)
+        await asyncio.sleep(1)
         assert time() < start + 5
 
 
@@ -100,7 +99,7 @@ async def test_stealing_events(c, s, a, b):
     )
 
     while not b.task_state:  # will steal soon
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     se.update()
 
@@ -116,7 +115,7 @@ async def test_events(c, s, a, b):
     )
 
     while not b.task_state:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     e.update()
     d = dict(e.source.data)
@@ -177,7 +176,7 @@ async def test_task_stream_clear_interval(c, s, a, b):
 
     await wait(c.map(inc, range(10)))
     ts.update()
-    await gen.sleep(0.010)
+    await asyncio.sleep(0.010)
     await wait(c.map(dec, range(10)))
     ts.update()
 
@@ -185,7 +184,7 @@ async def test_task_stream_clear_interval(c, s, a, b):
     assert ts.source.data["name"].count("inc") == 10
     assert ts.source.data["name"].count("dec") == 10
 
-    await gen.sleep(0.300)
+    await asyncio.sleep(0.300)
     await wait(c.map(inc, range(10, 20)))
     ts.update()
 
@@ -217,7 +216,7 @@ async def test_TaskProgress(c, s, a, b):
     del futures, futures2
 
     while s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     tp.update()
     assert not tp.source.data["all"]
@@ -234,7 +233,7 @@ async def test_TaskProgress_empty(c, s, a, b):
 
     del futures
     while s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
     tp.update()
 
     assert not any(len(v) for v in tp.source.data.values())
@@ -264,7 +263,7 @@ async def test_ProcessingHistogram(c, s, a, b):
 
     futures = c.map(slowinc, range(10), delay=0.050)
     while not s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     ph.update()
     assert ph.source.data["right"][-1] > 2
@@ -460,7 +459,7 @@ async def test_TaskGraph(c, s, a, b):
     key = future.key
     del future, future2
     while key in s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert "memory" in gp.node_source.data["state"]
 
@@ -482,14 +481,14 @@ async def test_TaskGraph_clear(c, s, a, b):
     del total, futures
 
     while s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     gp.update()
     gp.update()
 
     start = time()
     while any(gp.node_source.data.values()) or any(gp.edge_source.data.values()):
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         gp.update()
         assert time() < start + 5
 
@@ -533,7 +532,7 @@ async def test_TaskGraph_complex(c, s, a, b):
     assert len(gp.layout.index) == len(gp.node_source.data["x"])
     assert len(gp.layout.index) == len(s.tasks)
     del z
-    await gen.sleep(0.2)
+    await asyncio.sleep(0.2)
     gp.update()
     assert len(gp.layout.index) == sum(
         v == "True" for v in gp.node_source.data["visible"]
@@ -570,9 +569,9 @@ async def test_TaskGraph_order(c, s, a, b):
 async def test_profile_server(c, s, a, b):
     ptp = ProfileServer(s)
     start = time()
-    await gen.sleep(0.100)
+    await asyncio.sleep(0.100)
     while len(ptp.ts_source.data["time"]) < 2:
-        await gen.sleep(0.100)
+        await asyncio.sleep(0.100)
         ptp.trigger_update()
         assert time() < start + 2
 

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -42,20 +42,20 @@ scheduler.PROFILING = False
 
 
 @gen_cluster(client=True, scheduler_kwargs={"dashboard": True})
-def test_simple(c, s, a, b):
+async def test_simple(c, s, a, b):
     port = s.http_server.port
 
     future = c.submit(sleep, 1)
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
     http_client = AsyncHTTPClient()
     for suffix in applications:
-        response = yield http_client.fetch("http://localhost:%d%s" % (port, suffix))
+        response = await http_client.fetch("http://localhost:%d%s" % (port, suffix))
         body = response.body.decode()
         assert "bokeh" in body.lower()
         assert not re.search("href=./", body)  # no absolute links
 
-    response = yield http_client.fetch(
+    response = await http_client.fetch(
         "http://localhost:%d/individual-plots.json" % port
     )
     response = json.loads(response.body.decode())
@@ -75,24 +75,24 @@ def test_basic(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_counters(c, s, a, b):
+async def test_counters(c, s, a, b):
     pytest.importorskip("crick")
     while "tick-duration" not in s.digests:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
     ss = Counters(s)
 
     ss.update()
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     ss.update()
 
     start = time()
     while not len(ss.digest_sources["tick-duration"][0].data["x"]):
-        yield gen.sleep(1)
+        await gen.sleep(1)
         assert time() < start + 5
 
 
 @gen_cluster(client=True)
-def test_stealing_events(c, s, a, b):
+async def test_stealing_events(c, s, a, b):
     se = StealingEvents(s)
 
     futures = c.map(
@@ -100,7 +100,7 @@ def test_stealing_events(c, s, a, b):
     )
 
     while not b.task_state:  # will steal soon
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     se.update()
 
@@ -108,7 +108,7 @@ def test_stealing_events(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_events(c, s, a, b):
+async def test_events(c, s, a, b):
     e = Events(s, "all")
 
     futures = c.map(
@@ -116,7 +116,7 @@ def test_events(c, s, a, b):
     )
 
     while not b.task_state:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     e.update()
     d = dict(e.source.data)
@@ -124,12 +124,12 @@ def test_events(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_task_stream(c, s, a, b):
+async def test_task_stream(c, s, a, b):
     ts = TaskStream(s)
 
     futures = c.map(slowinc, range(10), delay=0.001)
 
-    yield wait(futures)
+    await wait(futures)
 
     ts.update()
     d = dict(ts.source.data)
@@ -142,7 +142,7 @@ def test_task_stream(c, s, a, b):
     assert all(len(L) == 10 for L in d.values())
 
     total = c.submit(sum, futures)
-    yield wait(total)
+    await wait(total)
 
     ts.update()
     d = dict(ts.source.data)
@@ -150,21 +150,21 @@ def test_task_stream(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_task_stream_n_rectangles(c, s, a, b):
+async def test_task_stream_n_rectangles(c, s, a, b):
     ts = TaskStream(s, n_rectangles=10)
     futures = c.map(slowinc, range(10), delay=0.001)
-    yield wait(futures)
+    await wait(futures)
     ts.update()
 
     assert len(ts.source.data["start"]) == 10
 
 
 @gen_cluster(client=True)
-def test_task_stream_second_plugin(c, s, a, b):
+async def test_task_stream_second_plugin(c, s, a, b):
     ts = TaskStream(s, n_rectangles=10, clear_interval=10)
     ts.update()
     futures = c.map(inc, range(10))
-    yield wait(futures)
+    await wait(futures)
     ts.update()
 
     ts2 = TaskStream(s, n_rectangles=5, clear_interval=10)
@@ -172,21 +172,21 @@ def test_task_stream_second_plugin(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_task_stream_clear_interval(c, s, a, b):
+async def test_task_stream_clear_interval(c, s, a, b):
     ts = TaskStream(s, clear_interval=200)
 
-    yield wait(c.map(inc, range(10)))
+    await wait(c.map(inc, range(10)))
     ts.update()
-    yield gen.sleep(0.010)
-    yield wait(c.map(dec, range(10)))
+    await gen.sleep(0.010)
+    await wait(c.map(dec, range(10)))
     ts.update()
 
     assert len(set(map(len, ts.source.data.values()))) == 1
     assert ts.source.data["name"].count("inc") == 10
     assert ts.source.data["name"].count("dec") == 10
 
-    yield gen.sleep(0.300)
-    yield wait(c.map(inc, range(10, 20)))
+    await gen.sleep(0.300)
+    await wait(c.map(inc, range(10, 20)))
     ts.update()
 
     assert len(set(map(len, ts.source.data.values()))) == 1
@@ -195,11 +195,11 @@ def test_task_stream_clear_interval(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_TaskProgress(c, s, a, b):
+async def test_TaskProgress(c, s, a, b):
     tp = TaskProgress(s)
 
     futures = c.map(slowinc, range(10), delay=0.001)
-    yield wait(futures)
+    await wait(futures)
 
     tp.update()
     d = dict(tp.source.data)
@@ -207,7 +207,7 @@ def test_TaskProgress(c, s, a, b):
     assert d["name"] == ["slowinc"]
 
     futures2 = c.map(dec, range(5))
-    yield wait(futures2)
+    await wait(futures2)
 
     tp.update()
     d = dict(tp.source.data)
@@ -217,35 +217,35 @@ def test_TaskProgress(c, s, a, b):
     del futures, futures2
 
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     tp.update()
     assert not tp.source.data["all"]
 
 
 @gen_cluster(client=True)
-def test_TaskProgress_empty(c, s, a, b):
+async def test_TaskProgress_empty(c, s, a, b):
     tp = TaskProgress(s)
     tp.update()
 
     futures = [c.submit(inc, i, key="f-" + "a" * i) for i in range(20)]
-    yield wait(futures)
+    await wait(futures)
     tp.update()
 
     del futures
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
     tp.update()
 
     assert not any(len(v) for v in tp.source.data.values())
 
 
 @gen_cluster(client=True)
-def test_CurrentLoad(c, s, a, b):
+async def test_CurrentLoad(c, s, a, b):
     cl = CurrentLoad(s)
 
     futures = c.map(slowinc, range(10), delay=0.001)
-    yield wait(futures)
+    await wait(futures)
 
     cl.update()
     d = dict(cl.source.data)
@@ -257,34 +257,34 @@ def test_CurrentLoad(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_ProcessingHistogram(c, s, a, b):
+async def test_ProcessingHistogram(c, s, a, b):
     ph = ProcessingHistogram(s)
     ph.update()
     assert (ph.source.data["top"] != 0).sum() == 1
 
     futures = c.map(slowinc, range(10), delay=0.050)
     while not s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     ph.update()
     assert ph.source.data["right"][-1] > 2
 
 
 @gen_cluster(client=True)
-def test_NBytesHistogram(c, s, a, b):
+async def test_NBytesHistogram(c, s, a, b):
     nh = NBytesHistogram(s)
     nh.update()
     assert (nh.source.data["top"] != 0).sum() == 1
 
     futures = c.map(inc, range(10))
-    yield wait(futures)
+    await wait(futures)
 
     nh.update()
     assert nh.source.data["right"][-1] > 5 * 20
 
 
 @gen_cluster(client=True)
-def test_WorkerTable(c, s, a, b):
+async def test_WorkerTable(c, s, a, b):
     wt = WorkerTable(s)
     wt.update()
     assert all(wt.source.data.values())
@@ -303,7 +303,7 @@ def test_WorkerTable(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_WorkerTable_custom_metrics(c, s, a, b):
+async def test_WorkerTable_custom_metrics(c, s, a, b):
     def metric_port(worker):
         return worker.port
 
@@ -316,7 +316,7 @@ def test_WorkerTable_custom_metrics(c, s, a, b):
         for name, func in metrics.items():
             w.metrics[name] = func
 
-    yield asyncio.gather(a.heartbeat(), b.heartbeat())
+    await asyncio.gather(a.heartbeat(), b.heartbeat())
 
     for w in [a, b]:
         assert s.workers[w.address].metrics["metric_port"] == w.port
@@ -337,13 +337,13 @@ def test_WorkerTable_custom_metrics(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_WorkerTable_different_metrics(c, s, a, b):
+async def test_WorkerTable_different_metrics(c, s, a, b):
     def metric_port(worker):
         return worker.port
 
     a.metrics["metric_a"] = metric_port
     b.metrics["metric_b"] = metric_port
-    yield asyncio.gather(a.heartbeat(), b.heartbeat())
+    await asyncio.gather(a.heartbeat(), b.heartbeat())
 
     assert s.workers[a.address].metrics["metric_a"] == a.port
     assert s.workers[b.address].metrics["metric_b"] == b.port
@@ -362,12 +362,12 @@ def test_WorkerTable_different_metrics(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_WorkerTable_metrics_with_different_metric_2(c, s, a, b):
+async def test_WorkerTable_metrics_with_different_metric_2(c, s, a, b):
     def metric_port(worker):
         return worker.port
 
     a.metrics["metric_a"] = metric_port
-    yield asyncio.gather(a.heartbeat(), b.heartbeat())
+    await asyncio.gather(a.heartbeat(), b.heartbeat())
 
     wt = WorkerTable(s)
     wt.update()
@@ -381,13 +381,13 @@ def test_WorkerTable_metrics_with_different_metric_2(c, s, a, b):
 
 
 @gen_cluster(client=True, worker_kwargs={"metrics": {"my_port": lambda w: w.port}})
-def test_WorkerTable_add_and_remove_metrics(c, s, a, b):
+async def test_WorkerTable_add_and_remove_metrics(c, s, a, b):
     def metric_port(worker):
         return worker.port
 
     a.metrics["metric_a"] = metric_port
     b.metrics["metric_b"] = metric_port
-    yield asyncio.gather(a.heartbeat(), b.heartbeat())
+    await asyncio.gather(a.heartbeat(), b.heartbeat())
 
     assert s.workers[a.address].metrics["metric_a"] == a.port
     assert s.workers[b.address].metrics["metric_b"] == b.port
@@ -399,14 +399,14 @@ def test_WorkerTable_add_and_remove_metrics(c, s, a, b):
 
     # Remove 'metric_b' from worker b
     del b.metrics["metric_b"]
-    yield asyncio.gather(a.heartbeat(), b.heartbeat())
+    await asyncio.gather(a.heartbeat(), b.heartbeat())
 
     wt = WorkerTable(s)
     wt.update()
     assert "metric_a" in wt.source.data
 
     del a.metrics["metric_a"]
-    yield asyncio.gather(a.heartbeat(), b.heartbeat())
+    await asyncio.gather(a.heartbeat(), b.heartbeat())
 
     wt = WorkerTable(s)
     wt.update()
@@ -414,14 +414,14 @@ def test_WorkerTable_add_and_remove_metrics(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_WorkerTable_custom_metric_overlap_with_core_metric(c, s, a, b):
+async def test_WorkerTable_custom_metric_overlap_with_core_metric(c, s, a, b):
     def metric(worker):
         return -999
 
     a.metrics["executing"] = metric
     a.metrics["cpu"] = metric
     a.metrics["metric"] = metric
-    yield asyncio.gather(a.heartbeat(), b.heartbeat())
+    await asyncio.gather(a.heartbeat(), b.heartbeat())
 
     assert s.workers[a.address].metrics["executing"] != -999
     assert s.workers[a.address].metrics["cpu"] != -999
@@ -429,11 +429,11 @@ def test_WorkerTable_custom_metric_overlap_with_core_metric(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_TaskGraph(c, s, a, b):
+async def test_TaskGraph(c, s, a, b):
     gp = TaskGraph(s)
     futures = c.map(inc, range(5))
     total = c.submit(sum, futures)
-    yield total
+    await total
 
     gp.update()
     assert set(map(len, gp.node_source.data.values())) == {6}
@@ -445,22 +445,22 @@ def test_TaskGraph(c, s, a, b):
     x = da.random.random((20, 20), chunks=(10, 10)).persist()
     y = (x + x.T) - x.mean(axis=0)
     y = y.persist()
-    yield wait(y)
+    await wait(y)
 
     gp.update()
     gp.update()
 
-    yield c.compute((x + y).sum())
+    await c.compute((x + y).sum())
 
     gp.update()
 
     future = c.submit(inc, 10)
     future2 = c.submit(inc, future)
-    yield wait(future2)
+    await wait(future2)
     key = future.key
     del future, future2
     while key in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert "memory" in gp.node_source.data["state"]
 
@@ -471,25 +471,25 @@ def test_TaskGraph(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_TaskGraph_clear(c, s, a, b):
+async def test_TaskGraph_clear(c, s, a, b):
     gp = TaskGraph(s)
     futures = c.map(inc, range(5))
     total = c.submit(sum, futures)
-    yield total
+    await total
 
     gp.update()
 
     del total, futures
 
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     gp.update()
     gp.update()
 
     start = time()
     while any(gp.node_source.data.values()) or any(gp.edge_source.data.values()):
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         gp.update()
         assert time() < start + 5
 
@@ -497,43 +497,43 @@ def test_TaskGraph_clear(c, s, a, b):
 @gen_cluster(
     client=True, config={"distributed.dashboard.graph-max-items": 2,},
 )
-def test_TaskGraph_limit(c, s, a, b):
+async def test_TaskGraph_limit(c, s, a, b):
     gp = TaskGraph(s)
 
     def func(x):
         return x
 
     f1 = c.submit(func, 1)
-    yield wait(f1)
+    await wait(f1)
     gp.update()
     assert len(gp.node_source.data["x"]) == 1
     f2 = c.submit(func, 2)
-    yield wait(f2)
+    await wait(f2)
     gp.update()
     assert len(gp.node_source.data["x"]) == 2
     f3 = c.submit(func, 3)
-    yield wait(f3)
+    await wait(f3)
     gp.update()
     assert len(gp.node_source.data["x"]) == 2
 
 
 @gen_cluster(client=True, timeout=30)
-def test_TaskGraph_complex(c, s, a, b):
+async def test_TaskGraph_complex(c, s, a, b):
     da = pytest.importorskip("dask.array")
     gp = TaskGraph(s)
     x = da.random.random((2000, 2000), chunks=(1000, 1000))
     y = ((x + x.T) - x.mean(axis=0)).persist()
-    yield wait(y)
+    await wait(y)
     gp.update()
     assert len(gp.layout.index) == len(gp.node_source.data["x"])
     assert len(gp.layout.index) == len(s.tasks)
     z = (x - y).sum().persist()
-    yield wait(z)
+    await wait(z)
     gp.update()
     assert len(gp.layout.index) == len(gp.node_source.data["x"])
     assert len(gp.layout.index) == len(s.tasks)
     del z
-    yield gen.sleep(0.2)
+    await gen.sleep(0.2)
     gp.update()
     assert len(gp.layout.index) == sum(
         v == "True" for v in gp.node_source.data["visible"]
@@ -549,10 +549,10 @@ def test_TaskGraph_complex(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_TaskGraph_order(c, s, a, b):
+async def test_TaskGraph_order(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(div, 1, 0)
-    yield wait(y)
+    await wait(y)
 
     gp = TaskGraph(s)
     gp.update()
@@ -567,12 +567,12 @@ def test_TaskGraph_order(c, s, a, b):
         "distributed.worker.profile.cycle": "50ms",
     },
 )
-def test_profile_server(c, s, a, b):
+async def test_profile_server(c, s, a, b):
     ptp = ProfileServer(s)
     start = time()
-    yield gen.sleep(0.100)
+    await gen.sleep(0.100)
     while len(ptp.ts_source.data["time"]) < 2:
-        yield gen.sleep(0.100)
+        await gen.sleep(0.100)
         ptp.trigger_update()
         assert time() < start + 2
 
@@ -580,9 +580,9 @@ def test_profile_server(c, s, a, b):
 @gen_cluster(
     client=True, scheduler_kwargs={"dashboard": True},
 )
-def test_root_redirect(c, s, a, b):
+async def test_root_redirect(c, s, a, b):
     http_client = AsyncHTTPClient()
-    response = yield http_client.fetch("http://localhost:%d/" % s.http_server.port)
+    response = await http_client.fetch("http://localhost:%d/" % s.http_server.port)
     assert response.code == 200
     assert "/status" in response.effective_url
 
@@ -593,7 +593,7 @@ def test_root_redirect(c, s, a, b):
     worker_kwargs={"dashboard": True},
     timeout=180,
 )
-def test_proxy_to_workers(c, s, a, b):
+async def test_proxy_to_workers(c, s, a, b):
     try:
         import jupyter_server_proxy  # noqa: F401
 
@@ -603,7 +603,7 @@ def test_proxy_to_workers(c, s, a, b):
 
     dashboard_port = s.http_server.port
     http_client = AsyncHTTPClient()
-    response = yield http_client.fetch("http://localhost:%d/" % dashboard_port)
+    response = await http_client.fetch("http://localhost:%d/" % dashboard_port)
     assert response.code == 200
     assert "/status" in response.effective_url
 
@@ -617,8 +617,8 @@ def test_proxy_to_workers(c, s, a, b):
         )
         direct_url = "http://localhost:%s/status" % port
         http_client = AsyncHTTPClient()
-        response_proxy = yield http_client.fetch(proxy_url)
-        response_direct = yield http_client.fetch(direct_url)
+        response_proxy = await http_client.fetch(proxy_url)
+        response_direct = await http_client.fetch(direct_url)
 
         assert response_proxy.code == 200
         if proxy_exists:
@@ -666,7 +666,7 @@ async def test_lots_of_tasks(c, s, a, b):
         "distributed.scheduler.dashboard.tls.ca-file": get_cert("tls-ca-cert.pem"),
     },
 )
-def test_https_support(c, s, a, b):
+async def test_https_support(c, s, a, b):
     port = s.http_server.port
 
     assert (
@@ -677,7 +677,7 @@ def test_https_support(c, s, a, b):
     ctx.load_verify_locations(get_cert("tls-ca-cert.pem"))
 
     http_client = AsyncHTTPClient()
-    response = yield http_client.fetch(
+    response = await http_client.fetch(
         "https://localhost:%d/individual-plots.json" % port, ssl_options=ctx
     )
     response = json.loads(response.body.decode())
@@ -694,7 +694,7 @@ def test_https_support(c, s, a, b):
         req = HTTPRequest(
             url="https://localhost:%d/%s" % (port, suffix), ssl_options=ctx
         )
-        response = yield http_client.fetch(req)
+        response = await http_client.fetch(req)
         assert response.code < 300
         body = response.body.decode()
         assert not re.search("href=./", body)  # no absolute links

--- a/distributed/dashboard/tests/test_worker_bokeh.py
+++ b/distributed/dashboard/tests/test_worker_bokeh.py
@@ -28,20 +28,20 @@ from distributed.dashboard.components.worker import (
     worker_kwargs={"dashboard": True},
     scheduler_kwargs={"dashboard": True},
 )
-def test_routes(c, s, a, b):
+async def test_routes(c, s, a, b):
     port = a.http_server.port
 
     future = c.submit(sleep, 1)
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
     http_client = AsyncHTTPClient()
     for suffix in ["status", "counters", "system", "profile", "profile-server"]:
-        response = yield http_client.fetch("http://localhost:%d/%s" % (port, suffix))
+        response = await http_client.fetch("http://localhost:%d/%s" % (port, suffix))
         body = response.body.decode()
         assert "bokeh" in body.lower()
         assert not re.search("href=./", body)  # no absolute links
 
-    response = yield http_client.fetch(
+    response = await http_client.fetch(
         "http://localhost:%d/info/main/workers.html" % s.http_server.port
     )
 
@@ -49,16 +49,16 @@ def test_routes(c, s, a, b):
 
 
 @gen_cluster(client=True, worker_kwargs={"dashboard": True})
-def test_simple(c, s, a, b):
+async def test_simple(c, s, a, b):
     assert s.workers[a.address].services == {"dashboard": a.http_server.port}
     assert s.workers[b.address].services == {"dashboard": b.http_server.port}
 
     future = c.submit(sleep, 1)
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
     http_client = AsyncHTTPClient()
     for suffix in ["crossfilter", "system"]:
-        response = yield http_client.fetch(
+        response = await http_client.fetch(
             "http://localhost:%d/%s" % (a.http_server.port, suffix)
         )
         assert "bokeh" in response.body.decode().lower()
@@ -67,12 +67,12 @@ def test_simple(c, s, a, b):
 @gen_cluster(
     client=True, worker_kwargs={"dashboard": True},
 )
-def test_services_kwargs(c, s, a, b):
+async def test_services_kwargs(c, s, a, b):
     assert s.workers[a.address].services == {"dashboard": a.http_server.port}
 
 
 @gen_cluster(client=True)
-def test_basic(c, s, a, b):
+async def test_basic(c, s, a, b):
     for component in [
         StateTable,
         ExecutingTimeSeries,
@@ -92,7 +92,7 @@ def test_basic(c, s, a, b):
 
         x = c.submit(slowall, xs, ys, 1, workers=a.address)
         y = c.submit(slowall, xs, ys, 2, workers=b.address)
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
 
         aa.update()
         bb.update()
@@ -103,19 +103,19 @@ def test_basic(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_counters(c, s, a, b):
+async def test_counters(c, s, a, b):
     pytest.importorskip("crick")
     while "tick-duration" not in a.digests:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
     aa = Counters(a)
 
     aa.update()
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     aa.update()
 
     start = time()
     while not len(aa.digest_sources["tick-duration"][0].data["x"]):
-        yield gen.sleep(1)
+        await gen.sleep(1)
         assert time() < start + 5
 
     a.digests["foo"].add(1)
@@ -134,7 +134,7 @@ def test_counters(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_CommunicatingStream(c, s, a, b):
+async def test_CommunicatingStream(c, s, a, b):
     aa = CommunicatingStream(a)
     bb = CommunicatingStream(b)
 
@@ -143,7 +143,7 @@ def test_CommunicatingStream(c, s, a, b):
     adds = c.map(add, xs, ys, workers=a.address)
     subs = c.map(sub, xs, ys, workers=b.address)
 
-    yield wait([adds, subs])
+    await wait([adds, subs])
 
     aa.update()
     bb.update()
@@ -159,12 +159,12 @@ def test_CommunicatingStream(c, s, a, b):
 @gen_cluster(
     client=True, clean_kwargs={"threads": False}, worker_kwargs={"dashboard": True},
 )
-def test_prometheus(c, s, a, b):
+async def test_prometheus(c, s, a, b):
     pytest.importorskip("prometheus_client")
 
     http_client = AsyncHTTPClient()
     for suffix in ["metrics"]:
-        response = yield http_client.fetch(
+        response = await http_client.fetch(
             "http://localhost:%d/%s" % (a.http_server.port, suffix)
         )
         assert response.code == 200

--- a/distributed/dashboard/tests/test_worker_bokeh.py
+++ b/distributed/dashboard/tests/test_worker_bokeh.py
@@ -1,12 +1,12 @@
-from operator import add, sub
+import asyncio
 import re
+from operator import add, sub
 from time import sleep
 
 import pytest
 
 pytest.importorskip("bokeh")
 from tlz import first
-from tornado import gen
 from tornado.httpclient import AsyncHTTPClient
 
 from distributed.client import wait
@@ -32,7 +32,7 @@ async def test_routes(c, s, a, b):
     port = a.http_server.port
 
     future = c.submit(sleep, 1)
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
 
     http_client = AsyncHTTPClient()
     for suffix in ["status", "counters", "system", "profile", "profile-server"]:
@@ -54,7 +54,7 @@ async def test_simple(c, s, a, b):
     assert s.workers[b.address].services == {"dashboard": b.http_server.port}
 
     future = c.submit(sleep, 1)
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
 
     http_client = AsyncHTTPClient()
     for suffix in ["crossfilter", "system"]:
@@ -92,7 +92,7 @@ async def test_basic(c, s, a, b):
 
         x = c.submit(slowall, xs, ys, 1, workers=a.address)
         y = c.submit(slowall, xs, ys, 2, workers=b.address)
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
 
         aa.update()
         bb.update()
@@ -106,16 +106,16 @@ async def test_basic(c, s, a, b):
 async def test_counters(c, s, a, b):
     pytest.importorskip("crick")
     while "tick-duration" not in a.digests:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
     aa = Counters(a)
 
     aa.update()
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     aa.update()
 
     start = time()
     while not len(aa.digest_sources["tick-duration"][0].data["x"]):
-        await gen.sleep(1)
+        await asyncio.sleep(1)
         assert time() < start + 5
 
     a.digests["foo"].add(1)

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -215,7 +215,7 @@ async def test_avoid_churn(cleanup):
             assert len(adapt.log) == 1
 
 
-@gen_test(timeout=None)
+@pytest.mark.asyncio
 async def test_adapt_quickly():
     """ We want to avoid creating and deleting workers frequently
 
@@ -332,7 +332,7 @@ def test_basic_no_loop(loop):
             loop.add_callback(loop.stop)
 
 
-@gen_test(timeout=None)
+@pytest.mark.asyncio
 async def test_target_duration():
     """ Ensure that redefining adapt with a lower maximum removes workers """
     with dask.config.set(

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -844,7 +844,6 @@ def test_asynchronous_property(loop):
         loop=loop,
     ) as cluster:
 
-        @gen.coroutine
         def _():
             assert cluster.asynchronous
 

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -10,7 +10,6 @@ import weakref
 from distutils.version import LooseVersion
 
 from tornado.ioloop import IOLoop
-from tornado import gen
 import tornado
 from tornado.httpclient import AsyncHTTPClient
 import pytest
@@ -784,14 +783,14 @@ async def test_scale_retires_workers():
 
     start = time()
     while len(cluster.scheduler.workers) != 2:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 3
 
     await cluster.scale(1)
 
     start = time()
     while len(cluster.scheduler.workers) != 1:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 3
 
     await c.close()

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -761,13 +761,13 @@ def test_local_tls(loop, temporary):
 
 
 @gen_test()
-def test_scale_retires_workers():
+async def test_scale_retires_workers():
     class MyCluster(LocalCluster):
         def scale_down(self, *args, **kwargs):
             pass
 
     loop = IOLoop.current()
-    cluster = yield MyCluster(
+    cluster = await MyCluster(
         0,
         scheduler_port=0,
         processes=False,
@@ -776,26 +776,26 @@ def test_scale_retires_workers():
         loop=loop,
         asynchronous=True,
     )
-    c = yield Client(cluster, asynchronous=True)
+    c = await Client(cluster, asynchronous=True)
 
     assert not cluster.workers
 
-    yield cluster.scale(2)
+    await cluster.scale(2)
 
     start = time()
     while len(cluster.scheduler.workers) != 2:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 3
 
-    yield cluster.scale(1)
+    await cluster.scale(1)
 
     start = time()
     while len(cluster.scheduler.workers) != 1:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 3
 
-    yield c.close()
-    yield cluster.close()
+    await c.close()
+    await cluster.close()
 
 
 def test_local_tls_restart(loop):
@@ -844,7 +844,7 @@ def test_asynchronous_property(loop):
         loop=loop,
     ) as cluster:
 
-        def _():
+        async def _():
             assert cluster.asynchronous
 
         cluster.sync(_)

--- a/distributed/diagnostics/tests/test_eventstream.py
+++ b/distributed/diagnostics/tests/test_eventstream.py
@@ -10,7 +10,7 @@ from distributed.utils_test import div, gen_cluster
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_eventstream(c, s, *workers):
+async def test_eventstream(c, s, *workers):
     pytest.importorskip("bokeh")
 
     es = EventStream()
@@ -19,8 +19,8 @@ def test_eventstream(c, s, *workers):
 
     futures = c.map(div, [1] * 10, range(10))
     total = c.submit(sum, futures[1:])
-    yield wait(total)
-    yield wait(futures)
+    await wait(total)
+    await wait(futures)
 
     assert len(es.buffer) == 11
 
@@ -43,13 +43,13 @@ def test_eventstream(c, s, *workers):
 
 
 @gen_cluster(client=True)
-def test_eventstream_remote(c, s, a, b):
+async def test_eventstream_remote(c, s, a, b):
     base_plugins = len(s.plugins)
-    comm = yield eventstream(s.address, interval=0.010)
+    comm = await eventstream(s.address, interval=0.010)
 
     start = time()
     while len(s.plugins) == base_plugins:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     futures = c.map(div, [1] * 10, range(10))
@@ -57,13 +57,13 @@ def test_eventstream_remote(c, s, a, b):
     start = time()
     total = []
     while len(total) < 10:
-        msgs = yield comm.read()
+        msgs = await comm.read()
         assert isinstance(msgs, tuple)
         total.extend(msgs)
         assert time() < start + 5
 
-    yield comm.close()
+    await comm.close()
     start = time()
     while len(s.plugins) > base_plugins:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5

--- a/distributed/diagnostics/tests/test_eventstream.py
+++ b/distributed/diagnostics/tests/test_eventstream.py
@@ -1,7 +1,7 @@
+import asyncio
 import collections
 
 import pytest
-from tornado import gen
 
 from distributed.client import wait
 from distributed.diagnostics.eventstream import EventStream, eventstream
@@ -49,7 +49,7 @@ async def test_eventstream_remote(c, s, a, b):
 
     start = time()
     while len(s.plugins) == base_plugins:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 5
 
     futures = c.map(div, [1] * 10, range(10))
@@ -65,5 +65,5 @@ async def test_eventstream_remote(c, s, a, b):
     await comm.close()
     start = time()
     while len(s.plugins) > base_plugins:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 5

--- a/distributed/diagnostics/tests/test_graph_layout.py
+++ b/distributed/diagnostics/tests/test_graph_layout.py
@@ -7,12 +7,12 @@ from tornado import gen
 
 
 @gen_cluster(client=True)
-def test_basic(c, s, a, b):
+async def test_basic(c, s, a, b):
     gl = GraphLayout(s)
     futures = c.map(inc, range(5))
     total = c.submit(sum, futures)
 
-    yield total
+    await total
 
     assert len(gl.x) == len(gl.y) == 6
     assert all(gl.x[f.key] == 0 for f in futures)
@@ -21,11 +21,11 @@ def test_basic(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_construct_after_call(c, s, a, b):
+async def test_construct_after_call(c, s, a, b):
     futures = c.map(inc, range(5))
     total = c.submit(sum, futures)
 
-    yield total
+    await total
 
     gl = GraphLayout(s)
 
@@ -36,13 +36,13 @@ def test_construct_after_call(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_states(c, s, a, b):
+async def test_states(c, s, a, b):
     gl = GraphLayout(s)
     futures = c.map(inc, range(5))
     total = c.submit(sum, futures)
     del futures
 
-    yield total
+    await total
 
     updates = {state for idx, state in gl.state_updates}
     assert "memory" in updates
@@ -51,31 +51,31 @@ def test_states(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_release_tasks(c, s, a, b):
+async def test_release_tasks(c, s, a, b):
     gl = GraphLayout(s)
     futures = c.map(inc, range(5))
     total = c.submit(sum, futures)
 
-    yield total
+    await total
     key = total.key
     del total
     while key in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert len(gl.visible_updates) == 1
     assert len(gl.visible_edge_updates) == 5
 
 
 @gen_cluster(client=True)
-def test_forget(c, s, a, b):
+async def test_forget(c, s, a, b):
     gl = GraphLayout(s)
 
     futures = c.map(inc, range(10))
     futures = c.map(inc, futures)
-    yield wait(futures)
+    await wait(futures)
     del futures
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert not gl.x
     assert not gl.y
@@ -85,12 +85,12 @@ def test_forget(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_unique_positions(c, s, a, b):
+async def test_unique_positions(c, s, a, b):
     gl = GraphLayout(s)
 
     x = c.submit(inc, 1)
     ys = [c.submit(operator.add, x, i) for i in range(5)]
-    yield wait(ys)
+    await wait(ys)
 
     y_positions = [(gl.x[k], gl.y[k]) for k in gl.x]
     assert len(y_positions) == len(set(y_positions))

--- a/distributed/diagnostics/tests/test_graph_layout.py
+++ b/distributed/diagnostics/tests/test_graph_layout.py
@@ -1,9 +1,9 @@
+import asyncio
 import operator
 
 from distributed.utils_test import gen_cluster, inc
 from distributed.diagnostics import GraphLayout
 from distributed import wait
-from tornado import gen
 
 
 @gen_cluster(client=True)
@@ -60,7 +60,7 @@ async def test_release_tasks(c, s, a, b):
     key = total.key
     del total
     while key in s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert len(gl.visible_updates) == 1
     assert len(gl.visible_edge_updates) == 5
@@ -75,7 +75,7 @@ async def test_forget(c, s, a, b):
     await wait(futures)
     del futures
     while s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert not gl.x
     assert not gl.y

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-from tornado import gen
 
 from distributed import Nanny
 from distributed.client import wait
@@ -42,7 +41,7 @@ async def test_many_Progress(c, s, a, b):
 
     start = time()
     while not all(b.status == "finished" for b in bars):
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 5
 
 
@@ -127,7 +126,7 @@ async def test_AllProgress(c, s, a, b):
     gc.collect()
 
     while any(k in s.who_has for k in keys):
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert p.state["released"]["inc"] == keys
     assert p.all["inc"] == keys
@@ -146,7 +145,7 @@ async def test_AllProgress(c, s, a, b):
     gc.collect()
 
     while tkey in s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     for coll in [p.all, p.nbytes] + list(p.state.values()):
         assert "inc" not in coll
@@ -161,7 +160,7 @@ async def test_AllProgress(c, s, a, b):
 
     gc.collect()
 
-    await gen.sleep(1)
+    await asyncio.sleep(1)
 
     await wait([future])
     assert p.state["memory"] == {"f": {future.key}}
@@ -189,7 +188,7 @@ async def test_AllProgress_lost_key(c, s, a, b, timeout=None):
 
     start = time()
     while len(p.state["memory"]["inc"]) > 0:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 5
 
 
@@ -213,6 +212,6 @@ async def test_GroupProgress(c, s, a, b):
 
     del x, y, z
     while s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert not fp.groups

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -30,24 +30,24 @@ def h(*args):
 
 @nodebug
 @gen_cluster(client=True)
-def test_many_Progress(c, s, a, b):
+async def test_many_Progress(c, s, a, b):
     x = c.submit(f, 1)
     y = c.submit(g, x)
     z = c.submit(h, y)
 
     bars = [Progress(keys=[z], scheduler=s) for _ in range(10)]
-    yield asyncio.gather(*(bar.setup() for bar in bars))
+    await asyncio.gather(*(bar.setup() for bar in bars))
 
-    yield z
+    await z
 
     start = time()
     while not all(b.status == "finished" for b in bars):
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         assert time() < start + 5
 
 
 @gen_cluster(client=True)
-def test_multiprogress(c, s, a, b):
+async def test_multiprogress(c, s, a, b):
     x1 = c.submit(f, 1)
     x2 = c.submit(f, x1)
     x3 = c.submit(f, x2)
@@ -55,18 +55,18 @@ def test_multiprogress(c, s, a, b):
     y2 = c.submit(g, y1)
 
     p = MultiProgress([y2], scheduler=s, complete=True)
-    yield p.setup()
+    await p.setup()
 
     assert p.all_keys == {
         "f": {f.key for f in [x1, x2, x3]},
         "g": {f.key for f in [y1, y2]},
     }
 
-    yield x3
+    await x3
 
     assert p.keys["f"] == set()
 
-    yield y2
+    await y2
 
     assert p.keys == {"f": set(), "g": set()}
 
@@ -74,7 +74,7 @@ def test_multiprogress(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_robust_to_bad_plugin(c, s, a, b):
+async def test_robust_to_bad_plugin(c, s, a, b):
     class Bad(SchedulerPlugin):
         def transition(self, key, start, finish, **kwargs):
             raise Exception()
@@ -84,7 +84,7 @@ def test_robust_to_bad_plugin(c, s, a, b):
 
     x = c.submit(inc, 1)
     y = c.submit(inc, x)
-    result = yield y
+    result = await y
     assert result == 3
 
 
@@ -96,11 +96,11 @@ def check_bar_completed(capsys, width=40):
 
 
 @gen_cluster(client=True, Worker=Nanny, timeout=None)
-def test_AllProgress(c, s, a, b):
+async def test_AllProgress(c, s, a, b):
     x, y, z = c.map(inc, [1, 2, 3])
     xx, yy, zz = c.map(dec, [x, y, z])
 
-    yield wait([x, y, z])
+    await wait([x, y, z])
     p = AllProgress(s)
     assert p.all["inc"] == {x.key, y.key, z.key}
     assert p.state["memory"]["inc"] == {x.key, y.key, z.key}
@@ -110,7 +110,7 @@ def test_AllProgress(c, s, a, b):
     assert isinstance(p.nbytes["inc"], int)
     assert p.nbytes["inc"] > 0
 
-    yield wait([xx, yy, zz])
+    await wait([xx, yy, zz])
     assert p.all["dec"] == {xx.key, yy.key, zz.key}
     assert p.state["memory"]["dec"] == {xx.key, yy.key, zz.key}
     assert p.state["released"] == {}
@@ -118,7 +118,7 @@ def test_AllProgress(c, s, a, b):
     assert p.nbytes["inc"] == p.nbytes["dec"]
 
     t = c.submit(sum, [x, y, z])
-    yield t
+    await t
 
     keys = {x.key, y.key, z.key}
     del x, y, z
@@ -127,7 +127,7 @@ def test_AllProgress(c, s, a, b):
     gc.collect()
 
     while any(k in s.who_has for k in keys):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert p.state["released"]["inc"] == keys
     assert p.all["inc"] == keys
@@ -136,7 +136,7 @@ def test_AllProgress(c, s, a, b):
         assert p.nbytes["inc"] == 0
 
     xxx = c.submit(div, 1, 0)
-    yield wait([xxx])
+    await wait([xxx])
     assert p.state["erred"] == {"div": {xxx.key}}
 
     tkey = t.key
@@ -146,7 +146,7 @@ def test_AllProgress(c, s, a, b):
     gc.collect()
 
     while tkey in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     for coll in [p.all, p.nbytes] + list(p.state.values()):
         assert "inc" not in coll
@@ -161,47 +161,47 @@ def test_AllProgress(c, s, a, b):
 
     gc.collect()
 
-    yield gen.sleep(1)
+    await gen.sleep(1)
 
-    yield wait([future])
+    await wait([future])
     assert p.state["memory"] == {"f": {future.key}}
 
-    yield c._restart()
+    await c._restart()
 
     for coll in [p.all] + list(p.state.values()):
         assert not coll
 
     x = c.submit(div, 1, 2)
-    yield wait([x])
+    await wait([x])
     assert set(p.all) == {"div"}
     assert all(set(d) == {"div"} for d in p.state.values())
 
 
 @gen_cluster(client=True, Worker=Nanny)
-def test_AllProgress_lost_key(c, s, a, b, timeout=None):
+async def test_AllProgress_lost_key(c, s, a, b, timeout=None):
     p = AllProgress(s)
     futures = c.map(inc, range(5))
-    yield wait(futures)
+    await wait(futures)
     assert len(p.state["memory"]["inc"]) == 5
 
-    yield a.close()
-    yield b.close()
+    await a.close()
+    await b.close()
 
     start = time()
     while len(p.state["memory"]["inc"]) > 0:
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         assert time() < start + 5
 
 
 @gen_cluster(client=True)
-def test_GroupProgress(c, s, a, b):
+async def test_GroupProgress(c, s, a, b):
     da = pytest.importorskip("dask.array")
     fp = GroupProgress(s)
     x = da.ones(100, chunks=10)
     y = x + 1
     z = (x * y).sum().persist(optimize_graph=False)
 
-    yield wait(z)
+    await wait(z)
     assert 3 < len(fp.groups) < 10
     for k, g in fp.groups.items():
         assert fp.keys[k]
@@ -213,6 +213,6 @@ def test_GroupProgress(c, s, a, b):
 
     del x, y, z
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert not fp.groups

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -1,5 +1,6 @@
-import pytest
+import asyncio
 
+import pytest
 from tornado import gen
 
 from distributed import Nanny
@@ -34,8 +35,8 @@ def test_many_Progress(c, s, a, b):
     y = c.submit(g, x)
     z = c.submit(h, y)
 
-    bars = [Progress(keys=[z], scheduler=s) for i in range(10)]
-    yield [bar.setup() for bar in bars]
+    bars = [Progress(keys=[z], scheduler=s) for _ in range(10)]
+    yield asyncio.gather(*(bar.setup() for bar in bars))
 
     yield z
 

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -56,7 +56,7 @@ def test_progress_quads_too_many():
 
 
 @gen_cluster(client=True)
-def test_progress_stream(c, s, a, b):
+async def test_progress_stream(c, s, a, b):
     futures = c.map(div, [1] * 10, range(10))
 
     x = 1
@@ -64,10 +64,10 @@ def test_progress_stream(c, s, a, b):
         x = delayed(inc)(x)
     future = c.compute(x)
 
-    yield wait(futures + [future])
+    await wait(futures + [future])
 
-    comm = yield progress_stream(s.address, interval=0.010)
-    msg = yield comm.read()
+    comm = await progress_stream(s.address, interval=0.010)
+    msg = await comm.read()
     nbytes = msg.pop("nbytes")
     assert msg == {
         "all": {"div": 10, "inc": 5},
@@ -81,7 +81,7 @@ def test_progress_stream(c, s, a, b):
 
     assert progress_quads(msg)
 
-    yield comm.close()
+    await comm.close()
 
 
 def test_progress_quads_many_functions():

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -25,17 +25,17 @@ def test_text_progressbar(capsys, client):
 
 
 @gen_cluster(client=True)
-def test_TextProgressBar_error(c, s, a, b):
+async def test_TextProgressBar_error(c, s, a, b):
     x = c.submit(div, 1, 0)
 
     progress = TextProgressBar([x.key], scheduler=s.address, start=False, interval=0.01)
-    yield progress.listen()
+    await progress.listen()
 
     assert progress.status == "error"
     assert progress.comm.closed()
 
     progress = TextProgressBar([x.key], scheduler=s.address, start=False, interval=0.01)
-    yield progress.listen()
+    await progress.listen()
     assert progress.status == "error"
     assert progress.comm.closed()
 

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -4,7 +4,7 @@ from distributed.utils_test import inc, gen_cluster, cleanup  # noqa: F401
 
 
 @gen_cluster(client=True)
-def test_simple(c, s, a, b):
+async def test_simple(c, s, a, b):
     class Counter(SchedulerPlugin):
         def start(self, scheduler):
             self.scheduler = scheduler
@@ -25,7 +25,7 @@ def test_simple(c, s, a, b):
     y = c.submit(inc, x)
     z = c.submit(inc, y)
 
-    yield z
+    await z
 
     assert counter.count == 3
     s.remove_plugin(counter)
@@ -33,7 +33,7 @@ def test_simple(c, s, a, b):
 
 
 @gen_cluster(nthreads=[], client=False)
-def test_add_remove_worker(s):
+async def test_add_remove_worker(s):
     events = []
 
     class MyPlugin(SchedulerPlugin):
@@ -51,10 +51,10 @@ def test_add_remove_worker(s):
 
     a = Worker(s.address)
     b = Worker(s.address)
-    yield a
-    yield b
-    yield a.close()
-    yield b.close()
+    await a
+    await b
+    await a.close()
+    await b.close()
 
     assert events == [
         ("add_worker", a.address),
@@ -65,8 +65,8 @@ def test_add_remove_worker(s):
 
     events[:] = []
     s.remove_plugin(plugin)
-    a = yield Worker(s.address)
-    yield a.close()
+    a = await Worker(s.address)
+    await a.close()
     assert events == []
 
 

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -88,24 +88,24 @@ from distributed.diagnostics.progressbar import (
 
 
 @gen_cluster(client=True)
-def test_progressbar_widget(c, s, a, b):
+async def test_progressbar_widget(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(inc, x)
     z = c.submit(inc, y)
-    yield wait(z)
+    await wait(z)
 
     progress = ProgressWidget([z.key], scheduler=s.address, complete=True)
-    yield progress.listen()
+    await progress.listen()
 
     assert progress.bar.value == 1.0
     assert "3 / 3" in progress.bar_text.value
 
     progress = ProgressWidget([z.key], scheduler=s.address)
-    yield progress.listen()
+    await progress.listen()
 
 
 @gen_cluster(client=True)
-def test_multi_progressbar_widget(c, s, a, b):
+async def test_multi_progressbar_widget(c, s, a, b):
     x1 = c.submit(inc, 1)
     x2 = c.submit(inc, x1)
     x3 = c.submit(inc, x2)
@@ -113,10 +113,10 @@ def test_multi_progressbar_widget(c, s, a, b):
     y2 = c.submit(dec, y1)
     e = c.submit(throws, y2)
     other = c.submit(inc, 123)
-    yield wait([other, e])
+    await wait([other, e])
 
     p = MultiProgressWidget([e.key], scheduler=s.address, complete=True)
-    yield p.listen()
+    await p.listen()
 
     assert p.bars["inc"].value == 1.0
     assert p.bars["dec"].value == 1.0
@@ -145,7 +145,7 @@ def test_multi_progressbar_widget(c, s, a, b):
 
 
 @gen_cluster()
-def test_multi_progressbar_widget_after_close(s, a, b):
+async def test_multi_progressbar_widget_after_close(s, a, b):
     s.update_graph(
         tasks=valmap(
             dumps_task,
@@ -170,7 +170,7 @@ def test_multi_progressbar_widget_after_close(s, a, b):
     )
 
     p = MultiProgressWidget(["x-1", "x-2", "x-3"], scheduler=s.address)
-    yield p.listen()
+    await p.listen()
 
     assert "x" in p.bars
 
@@ -231,7 +231,7 @@ def test_progressbar_cancel(client):
 
 
 @gen_cluster()
-def test_multibar_complete(s, a, b):
+async def test_multibar_complete(s, a, b):
     s.update_graph(
         tasks=valmap(
             dumps_task,
@@ -256,7 +256,7 @@ def test_multibar_complete(s, a, b):
     )
 
     p = MultiProgressWidget(["e"], scheduler=s.address, complete=True)
-    yield p.listen()
+    await p.listen()
 
     assert p._last_response["all"] == {"x": 3, "y": 2, "e": 1}
     assert all(b.value == 1.0 for k, b in p.bars.items() if k != "e")
@@ -274,28 +274,28 @@ def test_fast(client):
 
 
 @gen_cluster(client=True, client_kwargs={"serializers": ["msgpack"]})
-def test_serializers(c, s, a, b):
+async def test_serializers(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(inc, x)
     z = c.submit(inc, y)
-    yield wait(z)
+    await wait(z)
 
     progress = ProgressWidget([z], scheduler=s.address, complete=True)
-    yield progress.listen()
+    await progress.listen()
 
     assert progress.bar.value == 1.0
     assert "3 / 3" in progress.bar_text.value
 
 
 @gen_tls_cluster(client=True)
-def test_tls(c, s, a, b):
+async def test_tls(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(inc, x)
     z = c.submit(inc, y)
-    yield wait(z)
+    await wait(z)
 
     progress = ProgressWidget([z], scheduler=s.address, complete=True)
-    yield progress.listen()
+    await progress.listen()
 
     assert progress.bar.value == 1.0
     assert "3 / 3" in progress.bar_text.value

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -5,7 +5,7 @@ from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True)
-def test_prometheus(c, s, a, b):
+async def test_prometheus(c, s, a, b):
     pytest.importorskip("prometheus_client")
     from prometheus_client.parser import text_string_to_metric_families
 
@@ -14,7 +14,7 @@ def test_prometheus(c, s, a, b):
     # request data twice since there once was a case where metrics got registered
     # multiple times resulting in prometheus_client errors
     for _ in range(2):
-        response = yield http_client.fetch(
+        response = await http_client.fetch(
             "http://localhost:%d/metrics" % a.http_server.port
         )
         assert response.code == 200
@@ -26,10 +26,10 @@ def test_prometheus(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_health(c, s, a, b):
+async def test_health(c, s, a, b):
     http_client = AsyncHTTPClient()
 
-    response = yield http_client.fetch(
+    response = await http_client.fetch(
         "http://localhost:%d/health" % a.http_server.port
     )
     assert response.code == 200

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -11,8 +11,8 @@ def test_prometheus(c, s, a, b):
 
     http_client = AsyncHTTPClient()
 
-    # request data twice since there once was a case where metrics got registered multiple times resulting in
-    # prometheus_client errors
+    # request data twice since there once was a case where metrics got registered
+    # multiple times resulting in prometheus_client errors
     for _ in range(2):
         response = yield http_client.fetch(
             "http://localhost:%d/metrics" % a.http_server.port

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -3,9 +3,9 @@ import logging
 import warnings
 import weakref
 
+from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.httpserver import HTTPServer
-from tornado import gen
 import tlz
 import dask
 

--- a/distributed/protocol/tests/test_arrow.py
+++ b/distributed/protocol/tests/test_arrow.py
@@ -28,10 +28,10 @@ def echo(arg):
 @pytest.mark.parametrize("obj", [batch, tbl], ids=["RecordBatch", "Table"])
 def test_scatter(obj):
     @gen_cluster(client=True)
-    def run_test(client, scheduler, worker1, worker2):
-        obj_fut = yield client.scatter(obj)
+    async def run_test(client, scheduler, worker1, worker2):
+        obj_fut = await client.scatter(obj)
         fut = client.submit(echo, obj_fut)
-        result = yield fut
+        result = await fut
         assert obj.equals(result)
 
     run_test()

--- a/distributed/protocol/tests/test_h5py.py
+++ b/distributed/protocol/tests/test_h5py.py
@@ -90,7 +90,7 @@ import dask.array as da
 
 @silence_h5py_issue775
 @gen_cluster(client=True)
-def test_h5py_serialize(c, s, a, b):
+async def test_h5py_serialize(c, s, a, b):
     from dask.utils import SerializableLock
 
     lock = SerializableLock("hdf5")
@@ -102,12 +102,12 @@ def test_h5py_serialize(c, s, a, b):
             dset = f["/group/x"]
             x = da.from_array(dset, chunks=dset.chunks, lock=lock)
             y = c.compute(x)
-            y = yield y
+            y = await y
             assert (y[:] == dset[:]).all()
 
 
 @gen_cluster(client=True)
-def test_h5py_serialize_2(c, s, a, b):
+async def test_h5py_serialize_2(c, s, a, b):
     with tmpfile() as fn:
         with h5py.File(fn, mode="a") as f:
             x = f.create_dataset("/group/x", shape=(12,), dtype="i4", chunks=(4,))
@@ -116,5 +116,5 @@ def test_h5py_serialize_2(c, s, a, b):
             dset = f["/group/x"]
             x = da.from_array(dset, chunks=(3,))
             y = c.compute(x.sum())
-            y = yield y
+            y = await y
             assert y == (1 + 2 + 3 + 4) * 3

--- a/distributed/protocol/tests/test_netcdf4.py
+++ b/distributed/protocol/tests/test_netcdf4.py
@@ -82,12 +82,12 @@ import dask.array as da
 
 
 @gen_cluster(client=True)
-def test_netcdf4_serialize(c, s, a, b):
+async def test_netcdf4_serialize(c, s, a, b):
     with tmpfile() as fn:
         create_test_dataset(fn)
         with netCDF4.Dataset(fn, mode="r") as f:
             dset = f.variables["x"]
             x = da.from_array(dset, chunks=2)
             y = c.compute(x)
-            y = yield y
+            y = await y
             assert (y[:] == dset[:]).all()

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -233,9 +233,9 @@ def test_dont_compress_uncompressable_data():
 
 
 @gen_cluster(client=True, timeout=60)
-def test_dumps_large_blosc(c, s, a, b):
+async def test_dumps_large_blosc(c, s, a, b):
     x = c.submit(np.ones, BIG_BYTES_SHARD_SIZE * 2, dtype="u1")
-    yield x
+    await x
 
 
 @pytest.mark.skipif(sys.version_info[0] < 3, reason="numpy doesnt use memoryviews")

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -235,7 +235,7 @@ def test_dont_compress_uncompressable_data():
 @gen_cluster(client=True, timeout=60)
 def test_dumps_large_blosc(c, s, a, b):
     x = c.submit(np.ones, BIG_BYTES_SHARD_SIZE * 2, dtype="u1")
-    result = yield x
+    yield x
 
 
 @pytest.mark.skipif(sys.version_info[0] < 3, reason="numpy doesnt use memoryviews")

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -254,7 +254,7 @@ def test_err_on_bad_deserializer():
     result = yield from_frames(frames, deserializers=["pickle", "foo"])
     assert result == {"x": 1234}
 
-    with pytest.raises(TypeError) as info:
+    with pytest.raises(TypeError):
         yield from_frames(frames, deserializers=["msgpack"])
 
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -119,34 +119,34 @@ from dask import delayed
 
 
 @gen_cluster(client=True)
-def test_object_in_graph(c, s, a, b):
+async def test_object_in_graph(c, s, a, b):
     o = MyObj(123)
     v = delayed(o)
     v2 = delayed(identity)(v)
 
     future = c.compute(v2)
-    result = yield future
+    result = await future
 
     assert isinstance(result, MyObj)
     assert result.data == 123
 
 
 @gen_cluster(client=True)
-def test_scatter(c, s, a, b):
+async def test_scatter(c, s, a, b):
     o = MyObj(123)
-    [future] = yield c._scatter([o])
-    yield c._replicate(o)
-    o2 = yield c._gather(future)
+    [future] = await c._scatter([o])
+    await c._replicate(o)
+    o2 = await c._gather(future)
     assert isinstance(o2, MyObj)
     assert o2.data == 123
 
 
 @gen_cluster(client=True)
-def test_inter_worker_comms(c, s, a, b):
+async def test_inter_worker_comms(c, s, a, b):
     o = MyObj(123)
-    [future] = yield c._scatter([o], workers=a.address)
+    [future] = await c._scatter([o], workers=a.address)
     future2 = c.submit(identity, future, workers=b.address)
-    o2 = yield c._gather(future2)
+    o2 = await c._gather(future2)
     assert isinstance(o2, MyObj)
     assert o2.data == 123
 
@@ -248,14 +248,14 @@ def test_errors():
 
 
 @gen_test()
-def test_err_on_bad_deserializer():
-    frames = yield to_frames({"x": to_serialize(1234)}, serializers=["pickle"])
+async def test_err_on_bad_deserializer():
+    frames = await to_frames({"x": to_serialize(1234)}, serializers=["pickle"])
 
-    result = yield from_frames(frames, deserializers=["pickle", "foo"])
+    result = await from_frames(frames, deserializers=["pickle", "foo"])
     assert result == {"x": 1234}
 
     with pytest.raises(TypeError):
-        yield from_frames(frames, deserializers=["msgpack"])
+        await from_frames(frames, deserializers=["msgpack"])
 
 
 class MyObject:
@@ -289,7 +289,7 @@ def my_loads(header, frames):
     client_kwargs={"serializers": ["my-ser", "pickle"]},
     worker_kwargs={"serializers": ["my-ser", "pickle"]},
 )
-def test_context_specific_serialization(c, s, a, b):
+async def test_context_specific_serialization(c, s, a, b):
     register_serialization_family("my-ser", my_dumps, my_loads)
 
     try:
@@ -297,7 +297,7 @@ def test_context_specific_serialization(c, s, a, b):
         x = c.submit(MyObject, x=1, y=2, workers=a.address)
         y = c.submit(lambda x: x, x, workers=b.address)
 
-        yield wait(y)
+        await wait(y)
 
         key = y.key
 
@@ -306,11 +306,11 @@ def test_context_specific_serialization(c, s, a, b):
             my_obj = dask_worker.data[key]
             return my_obj.context
 
-        result = yield c.run(check, workers=[b.address])
+        result = await c.run(check, workers=[b.address])
         expected = {"sender": a.address, "recipient": b.address}
         assert result[b.address]["sender"] == a.address  # see origin worker
 
-        z = yield y  # bring object to local process
+        z = await y  # bring object to local process
 
         assert z.x == 1 and z.y == 2
         assert z.context["sender"] == b.address
@@ -321,14 +321,14 @@ def test_context_specific_serialization(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_context_specific_serialization_class(c, s, a, b):
+async def test_context_specific_serialization_class(c, s, a, b):
     register_serialization(MyObject, my_dumps, my_loads)
 
     # Create the object on A, force communication to B
     x = c.submit(MyObject, x=1, y=2, workers=a.address)
     y = c.submit(lambda x: x, x, workers=b.address)
 
-    yield wait(y)
+    await wait(y)
 
     key = y.key
 
@@ -337,11 +337,11 @@ def test_context_specific_serialization_class(c, s, a, b):
         my_obj = dask_worker.data[key]
         return my_obj.context
 
-    result = yield c.run(check, workers=[b.address])
+    result = await c.run(check, workers=[b.address])
     expected = {"sender": a.address, "recipient": b.address}
     assert result[b.address]["sender"] == a.address  # see origin worker
 
-    z = yield y  # bring object to local process
+    z = await y  # bring object to local process
 
     assert z.x == 1 and z.y == 2
     assert z.context["sender"] == b.address

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -51,20 +51,20 @@ class ParameterServer:
 @pytest.mark.parametrize("direct_to_workers", [True, False])
 def test_client_actions(direct_to_workers):
     @gen_cluster(client=True)
-    def test(c, s, a, b):
-        c = yield Client(
+    async def test(c, s, a, b):
+        c = await Client(
             s.address, asynchronous=True, direct_to_workers=direct_to_workers
         )
 
         counter = c.submit(Counter, workers=[a.address], actor=True)
         assert isinstance(counter, Future)
-        counter = yield counter
+        counter = await counter
         assert counter._address
         assert hasattr(counter, "increment")
         assert hasattr(counter, "add")
         assert hasattr(counter, "n")
 
-        n = yield counter.n
+        n = await counter.n
         assert n == 0
 
         assert counter._address == a.address
@@ -72,17 +72,17 @@ def test_client_actions(direct_to_workers):
         assert isinstance(a.actors[counter.key], Counter)
         assert s.tasks[counter.key].actor
 
-        yield asyncio.gather(counter.increment(), counter.increment())
+        await asyncio.gather(counter.increment(), counter.increment())
 
-        n = yield counter.n
+        n = await counter.n
         assert n == 2
 
         counter.add(10)
-        while (yield counter.n) != 10 + 2:
-            n = yield counter.n
-            yield gen.sleep(0.01)
+        while (await counter.n) != 10 + 2:
+            n = await counter.n
+            await gen.sleep(0.01)
 
-        yield c.close()
+        await c.close()
 
     test()
 
@@ -90,7 +90,7 @@ def test_client_actions(direct_to_workers):
 @pytest.mark.parametrize("separate_thread", [False, True])
 def test_worker_actions(separate_thread):
     @gen_cluster(client=True)
-    def test(c, s, a, b):
+    async def test(c, s, a, b):
         counter = c.submit(Counter, workers=[a.address], actor=True)
         a_address = a.address
 
@@ -107,17 +107,17 @@ def test_worker_actions(separate_thread):
             assert end > start
 
         futures = [c.submit(f, counter, pure=False) for _ in range(10)]
-        yield c.gather(futures)
+        await c.gather(futures)
 
-        counter = yield counter
-        assert yield counter.n == 10
+        counter = await counter
+        assert await counter.n == 10
 
     test()
 
 
 @gen_cluster(client=True)
-def test_Actor(c, s, a, b):
-    counter = yield c.submit(Counter, actor=True)
+async def test_Actor(c, s, a, b):
+    counter = await c.submit(Counter, actor=True)
 
     assert counter._cls == Counter
 
@@ -133,22 +133,22 @@ def test_Actor(c, s, a, b):
     + "Should rely on sending small messages rather than rpc"
 )
 @gen_cluster(client=True)
-def test_linear_access(c, s, a, b):
+async def test_linear_access(c, s, a, b):
     start = time()
     future = c.submit(sleep, 0.2)
     actor = c.submit(List, actor=True, dummy=future)
-    actor = yield actor
+    actor = await actor
 
     for i in range(100):
         actor.append(i)
 
     while True:
-        yield gen.sleep(0.1)
-        L = yield actor.L
+        await gen.sleep(0.1)
+        L = await actor.L
         if len(L) == 100:
             break
 
-    L = yield actor.L
+    L = await actor.L
     stop = time()
     assert L == tuple(range(100))
 
@@ -156,7 +156,7 @@ def test_linear_access(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_exceptions_create(c, s, a, b):
+async def test_exceptions_create(c, s, a, b):
     class Foo:
         x = 0
 
@@ -164,62 +164,62 @@ def test_exceptions_create(c, s, a, b):
             raise ValueError("bar")
 
     with pytest.raises(ValueError) as info:
-        yield c.submit(Foo, actor=True)
+        await c.submit(Foo, actor=True)
 
     assert "bar" in str(info.value)
 
 
 @gen_cluster(client=True)
-def test_exceptions_method(c, s, a, b):
+async def test_exceptions_method(c, s, a, b):
     class Foo:
         def throw(self):
             1 / 0
 
-    foo = yield c.submit(Foo, actor=True)
+    foo = await c.submit(Foo, actor=True)
     with pytest.raises(ZeroDivisionError):
-        yield foo.throw()
+        await foo.throw()
 
 
 @gen_cluster(client=True)
-def test_gc(c, s, a, b):
+async def test_gc(c, s, a, b):
     actor = c.submit(Counter, actor=True)
-    yield wait(actor)
+    await wait(actor)
     del actor
 
     while a.actors or b.actors:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
 
 @gen_cluster(client=True)
-def test_track_dependencies(c, s, a, b):
+async def test_track_dependencies(c, s, a, b):
     actor = c.submit(Counter, actor=True)
-    yield wait(actor)
+    await wait(actor)
     x = c.submit(sleep, 0.5)
     y = c.submit(lambda x, y: x, x, actor)
     del actor
 
-    yield gen.sleep(0.3)
+    await gen.sleep(0.3)
 
     assert a.actors or b.actors
 
 
 @gen_cluster(client=True)
-def test_future(c, s, a, b):
+async def test_future(c, s, a, b):
     counter = c.submit(Counter, actor=True, workers=[a.address])
     assert isinstance(counter, Future)
-    yield wait(counter)
+    await wait(counter)
     assert isinstance(a.actors[counter.key], Counter)
 
-    counter = yield counter
+    counter = await counter
     assert isinstance(counter, Actor)
     assert counter._address
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert counter.key in c.futures  # don't lose future
 
 
 @gen_cluster(client=True)
-def test_future_dependencies(c, s, a, b):
+async def test_future_dependencies(c, s, a, b):
     counter = c.submit(Counter, actor=True, workers=[a.address])
 
     def f(a):
@@ -227,13 +227,13 @@ def test_future_dependencies(c, s, a, b):
         assert a._cls == Counter
 
     x = c.submit(f, counter, workers=[b.address])
-    yield x
+    await x
 
     assert {ts.key for ts in s.tasks[x.key].dependencies} == {counter.key}
     assert {ts.key for ts in s.tasks[counter.key].dependents} == {x.key}
 
     y = c.submit(f, counter, workers=[a.address], pure=False)
-    yield y
+    await y
 
     assert {ts.key for ts in s.tasks[y.key].dependencies} == {counter.key}
     assert {ts.key for ts in s.tasks[counter.key].dependents} == {x.key, y.key}
@@ -257,15 +257,15 @@ def test_sync(client):
 
 
 @gen_cluster(client=True, config={"distributed.comm.timeouts.connect": "1s"})
-def test_failed_worker(c, s, a, b):
+async def test_failed_worker(c, s, a, b):
     future = c.submit(Counter, actor=True, workers=[a.address])
-    yield wait(future)
-    counter = yield future
+    await wait(future)
+    counter = await future
 
-    yield a.close()
+    await a.close()
 
     with pytest.raises(Exception) as info:
-        yield counter.increment()
+        await counter.increment()
 
     assert "actor" in str(info.value).lower()
     assert "worker" in str(info.value).lower()
@@ -273,45 +273,45 @@ def test_failed_worker(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def bench(c, s, a, b):
-    counter = yield c.submit(Counter, actor=True)
+async def bench(c, s, a, b):
+    counter = await c.submit(Counter, actor=True)
 
     for i in range(1000):
-        yield counter.increment()
+        await counter.increment()
 
 
 @gen_cluster(client=True)
-def test_numpy_roundtrip(c, s, a, b):
+async def test_numpy_roundtrip(c, s, a, b):
     np = pytest.importorskip("numpy")
 
-    server = yield c.submit(ParameterServer, actor=True)
+    server = await c.submit(ParameterServer, actor=True)
 
     x = np.random.random(1000)
-    yield server.put("x", x)
+    await server.put("x", x)
 
-    y = yield server.get("x")
+    y = await server.get("x")
 
     assert (x == y).all()
 
 
 @gen_cluster(client=True)
-def test_numpy_roundtrip_getattr(c, s, a, b):
+async def test_numpy_roundtrip_getattr(c, s, a, b):
     np = pytest.importorskip("numpy")
 
-    counter = yield c.submit(Counter, actor=True)
+    counter = await c.submit(Counter, actor=True)
 
     x = np.random.random(1000)
 
-    yield counter.add(x)
+    await counter.add(x)
 
-    y = yield counter.n
+    y = await counter.n
 
     assert (x == y).all()
 
 
 @gen_cluster(client=True)
-def test_repr(c, s, a, b):
-    counter = yield c.submit(Counter, actor=True)
+async def test_repr(c, s, a, b):
+    counter = await c.submit(Counter, actor=True)
 
     assert "Counter" in repr(counter)
     assert "Actor" in repr(counter)
@@ -320,8 +320,8 @@ def test_repr(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_dir(c, s, a, b):
-    counter = yield c.submit(Counter, actor=True)
+async def test_dir(c, s, a, b):
+    counter = await c.submit(Counter, actor=True)
 
     d = set(dir(counter))
 
@@ -331,8 +331,8 @@ def test_dir(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_many_computations(c, s, a, b):
-    counter = yield c.submit(Counter, actor=True)
+async def test_many_computations(c, s, a, b):
+    counter = await c.submit(Counter, actor=True)
 
     def add(n, counter):
         for i in range(n):
@@ -343,13 +343,13 @@ def test_many_computations(c, s, a, b):
 
     while not done.done():
         assert len(s.processing) <= a.nthreads + b.nthreads
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
-    yield done
+    await done
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 5)] * 2)
-def test_thread_safety(c, s, a, b):
+async def test_thread_safety(c, s, a, b):
     class Unsafe:
         def __init__(self):
             self.n = 0
@@ -363,32 +363,32 @@ def test_thread_safety(c, s, a, b):
                 assert self.n == 1
             self.n = 0
 
-    unsafe = yield c.submit(Unsafe, actor=True)
+    unsafe = await c.submit(Unsafe, actor=True)
 
     futures = [unsafe.f() for i in range(10)]
-    yield c.gather(futures)
+    await c.gather(futures)
 
 
 @gen_cluster(client=True)
-def test_Actors_create_dependencies(c, s, a, b):
-    counter = yield c.submit(Counter, actor=True)
+async def test_Actors_create_dependencies(c, s, a, b):
+    counter = await c.submit(Counter, actor=True)
     future = c.submit(lambda x: None, counter)
-    yield wait(future)
+    await wait(future)
     assert s.tasks[future.key].dependencies == {s.tasks[counter.key]}
 
 
 @gen_cluster(client=True)
-def test_load_balance(c, s, a, b):
+async def test_load_balance(c, s, a, b):
     class Foo:
         def __init__(self, x):
             pass
 
     b = c.submit(operator.mul, "b", 1000000)
-    yield wait(b)
+    await wait(b)
     [ws] = s.tasks[b.key].who_has
 
-    x = yield c.submit(Foo, b, actor=True)
-    y = yield c.submit(Foo, b, actor=True)
+    x = await c.submit(Foo, b, actor=True)
+    y = await c.submit(Foo, b, actor=True)
     assert x.key != y.key  # actors assumed not pure
 
     assert s.tasks[x.key].who_has == {ws}  # first went to best match
@@ -396,28 +396,28 @@ def test_load_balance(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 5)
-def test_load_balance_map(c, s, *workers):
+async def test_load_balance_map(c, s, *workers):
     class Foo:
         def __init__(self, x, y=None):
             pass
 
     b = c.submit(operator.mul, "b", 1000000)
-    yield wait(b)
+    await wait(b)
 
     actors = c.map(Foo, range(10), y=b, actor=True)
-    yield wait(actors)
+    await wait(actors)
 
     assert all(len(w.actors) == 2 for w in workers)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4, Worker=Nanny)
-def bench_param_server(c, s, *workers):
+async def bench_param_server(c, s, *workers):
     import dask.array as da
     import numpy as np
 
     x = da.random.random((500000, 1000), chunks=(1000, 1000))
     x = x.persist()
-    yield wait(x)
+    await wait(x)
 
     class ParameterServer:
         data = None
@@ -444,17 +444,17 @@ def bench_param_server(c, s, *workers):
     from distributed.utils import format_time
 
     start = time()
-    ps = yield c.submit(ParameterServer, x.shape[1], actor=True)
+    ps = await c.submit(ParameterServer, x.shape[1], actor=True)
     y = x.map_blocks(f, ps=ps, dtype=x.dtype)
-    # result = yield c.compute(y.mean())
-    yield wait(y.persist())
+    # result = await c.compute(y.mean())
+    await wait(y.persist())
     end = time()
     print(format_time(end - start))
 
 
 @pytest.mark.xfail(reason="unknown")
 @gen_cluster(client=True)
-def test_compute(c, s, a, b):
+async def test_compute(c, s, a, b):
     @dask.delayed
     def f(n, counter):
         assert isinstance(counter, Actor)
@@ -469,12 +469,12 @@ def test_compute(c, s, a, b):
     values = [f(i, counter) for i in range(5)]
     final = check(counter, values)
 
-    result = yield c.compute(final, actors=counter)
+    result = await c.compute(final, actors=counter)
     assert result == 0 + 1 + 2 + 3 + 4
 
     start = time()
     while a.data or b.data:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
@@ -510,15 +510,15 @@ def test_compute_sync(client):
     nthreads=[("127.0.0.1", 1)],
     config={"distributed.worker.profile.interval": "1ms"},
 )
-def test_actors_in_profile(c, s, a):
+async def test_actors_in_profile(c, s, a):
     class Sleeper:
         def sleep(self, time):
             sleep(time)
 
-    sleeper = yield c.submit(Sleeper, actor=True)
+    sleeper = await c.submit(Sleeper, actor=True)
 
     for i in range(5):
-        yield sleeper.sleep(0.200)
+        await sleeper.sleep(0.200)
         if (
             list(a.profile_recent["children"])[0].startswith("sleep")
             or "Sleeper.sleep" in a.profile_keys
@@ -528,26 +528,26 @@ def test_actors_in_profile(c, s, a):
 
 
 @gen_cluster(client=True)
-def test_waiter(c, s, a, b):
+async def test_waiter(c, s, a, b):
     from tornado.locks import Event
 
     class Waiter:
         def __init__(self):
             self.event = Event()
 
-        def set(self):
+        async def set(self):
             self.event.set()
 
-        def wait(self):
-            yield self.event.wait()
+        async def wait(self):
+            await self.event.wait()
 
-    waiter = yield c.submit(Waiter, actor=True)
+    waiter = await c.submit(Waiter, actor=True)
 
     futures = [waiter.wait() for _ in range(5)]  # way more than we have actor threads
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert not any(future.done() for future in futures)
 
-    yield waiter.set()
+    await waiter.set()
 
-    yield c.gather(futures)
+    await c.gather(futures)

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -1,7 +1,6 @@
 import asyncio
 import operator
 from time import sleep
-from tornado import gen
 
 import pytest
 
@@ -80,7 +79,7 @@ def test_client_actions(direct_to_workers):
         counter.add(10)
         while (await counter.n) != 10 + 2:
             n = await counter.n
-            await gen.sleep(0.01)
+            await asyncio.sleep(0.01)
 
         await c.close()
 
@@ -143,7 +142,7 @@ async def test_linear_access(c, s, a, b):
         actor.append(i)
 
     while True:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         L = await actor.L
         if len(L) == 100:
             break
@@ -187,7 +186,7 @@ async def test_gc(c, s, a, b):
     del actor
 
     while a.actors or b.actors:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
 
 @gen_cluster(client=True)
@@ -198,7 +197,7 @@ async def test_track_dependencies(c, s, a, b):
     y = c.submit(lambda x, y: x, x, actor)
     del actor
 
-    await gen.sleep(0.3)
+    await asyncio.sleep(0.3)
 
     assert a.actors or b.actors
 
@@ -214,7 +213,7 @@ async def test_future(c, s, a, b):
     assert isinstance(counter, Actor)
     assert counter._address
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     assert counter.key in c.futures  # don't lose future
 
 
@@ -343,7 +342,7 @@ async def test_many_computations(c, s, a, b):
 
     while not done.done():
         assert len(s.processing) <= a.nthreads + b.nthreads
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     await done
 
@@ -474,7 +473,7 @@ async def test_compute(c, s, a, b):
 
     start = time()
     while a.data or b.data:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 5
 
 
@@ -545,7 +544,7 @@ async def test_waiter(c, s, a, b):
 
     futures = [waiter.wait() for _ in range(5)]  # way more than we have actor threads
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     assert not any(future.done() for future in futures)
 
     await waiter.set()

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -6,7 +6,6 @@ import random
 from time import sleep
 
 import pytest
-from tornado import gen
 
 from distributed.client import _as_completed, as_completed, _first_completed, wait
 from distributed.metrics import time
@@ -130,7 +129,7 @@ def test_as_completed_cancel_last(client):
     y = client.submit(inc, 0.3)
 
     async def _():
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         await w.cancel(asynchronous=True)
         await y.cancel(asynchronous=True)
 

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -16,18 +16,18 @@ from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
 
 
 @gen_cluster(client=True)
-def test__as_completed(c, s, a, b):
+async def test__as_completed(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(inc, 1)
     z = c.submit(inc, 2)
 
     q = queue.Queue()
-    yield _as_completed([x, y, z], q)
+    await _as_completed([x, y, z], q)
 
     assert q.qsize() == 3
     assert {q.get(), q.get(), q.get()} == {x, y, z}
 
-    result = yield _first_completed([x, y, z])
+    result = await _first_completed([x, y, z])
     assert result in [x, y, z]
 
 
@@ -129,10 +129,10 @@ def test_as_completed_cancel_last(client):
     x = client.submit(inc, 1)
     y = client.submit(inc, 0.3)
 
-    def _():
-        yield gen.sleep(0.1)
-        yield w.cancel(asynchronous=True)
-        yield y.cancel(asynchronous=True)
+    async def _():
+        await gen.sleep(0.1)
+        await w.cancel(asynchronous=True)
+        await y.cancel(asynchronous=True)
 
     client.loop.add_callback(_)
 
@@ -143,7 +143,7 @@ def test_as_completed_cancel_last(client):
 
 
 @gen_cluster(client=True)
-def test_async_for_py2_equivalent(c, s, a, b):
+async def test_async_for_py2_equivalent(c, s, a, b):
     futures = c.map(sleep, [0.01] * 3, pure=False)
     seq = as_completed(futures)
     x, y, z = [el async for el in seq]
@@ -154,7 +154,7 @@ def test_async_for_py2_equivalent(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_as_completed_error_async(c, s, a, b):
+async def test_as_completed_error_async(c, s, a, b):
     x = c.submit(throws, 1)
     y = c.submit(inc, 1)
 
@@ -190,13 +190,13 @@ def test_as_completed_with_results(client):
 
 
 @gen_cluster(client=True)
-def test_as_completed_with_results_async(c, s, a, b):
+async def test_as_completed_with_results_async(c, s, a, b):
     x = c.submit(throws, 1)
     y = c.submit(inc, 5)
     z = c.submit(inc, 1)
 
     ac = as_completed([x, y, z], with_results=True)
-    yield y.cancel()
+    await y.cancel()
     with pytest.raises(RuntimeError) as exc:
         async for _ in ac:
             pass
@@ -241,7 +241,7 @@ async def test_str(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_as_completed_with_results_no_raise_async(c, s, a, b):
+async def test_as_completed_with_results_no_raise_async(c, s, a, b):
     x = c.submit(throws, 1)
     y = c.submit(inc, 5)
     z = c.submit(inc, 1)

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -50,7 +50,7 @@ def threads_info(q):
 @pytest.mark.xfail(reason="Intermittent failure")
 @nodebug
 @gen_test()
-def test_simple():
+async def test_simple():
     to_child = mp_context.Queue()
     from_child = mp_context.Queue()
 
@@ -67,15 +67,15 @@ def test_simple():
 
     # join() before start()
     with pytest.raises(AssertionError):
-        yield proc.join()
+        await proc.join()
 
-    yield proc.start()
+    await proc.start()
     assert proc.is_alive()
     assert proc.pid is not None
     assert proc.exitcode is None
 
     t1 = time()
-    yield proc.join(timeout=0.02)
+    await proc.join(timeout=0.02)
     dt = time() - t1
     assert 0.2 >= dt >= 0.01
     assert proc.is_alive()
@@ -91,7 +91,7 @@ def test_simple():
 
     # child should be stopping now
     t1 = time()
-    yield proc.join(timeout=10)
+    await proc.join(timeout=10)
     dt = time() - t1
     assert dt <= 1.0
     assert not proc.is_alive()
@@ -100,7 +100,7 @@ def test_simple():
 
     # join() again
     t1 = time()
-    yield proc.join()
+    await proc.join()
     dt = time() - t1
     assert dt <= 0.6
 
@@ -133,14 +133,14 @@ def test_simple():
         pytest.fail("AsyncProcess should have been destroyed")
     t1 = time()
     while wr2() is not None:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         gc.collect()
         dt = time() - t1
         assert dt < 2.0
 
 
 @gen_test()
-def test_exitcode():
+async def test_exitcode():
     q = mp_context.Queue()
 
     proc = AsyncProcess(target=exit, kwargs={"q": q})
@@ -148,81 +148,81 @@ def test_exitcode():
     assert not proc.is_alive()
     assert proc.exitcode is None
 
-    yield proc.start()
+    await proc.start()
     assert proc.is_alive()
     assert proc.exitcode is None
 
     q.put(5)
-    yield proc.join(timeout=3.0)
+    await proc.join(timeout=3.0)
     assert not proc.is_alive()
     assert proc.exitcode == 5
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
 @gen_test()
-def test_signal():
+async def test_signal():
     proc = AsyncProcess(target=exit_with_signal, args=(signal.SIGINT,))
     proc.daemon = True
     assert not proc.is_alive()
     assert proc.exitcode is None
 
-    yield proc.start()
-    yield proc.join(timeout=3.0)
+    await proc.start()
+    await proc.join(timeout=3.0)
 
     assert not proc.is_alive()
     # Can be 255 with forkserver, see https://bugs.python.org/issue30589
     assert proc.exitcode in (-signal.SIGINT, 255)
 
     proc = AsyncProcess(target=wait)
-    yield proc.start()
+    await proc.start()
     os.kill(proc.pid, signal.SIGTERM)
-    yield proc.join(timeout=3.0)
+    await proc.join(timeout=3.0)
 
     assert not proc.is_alive()
     assert proc.exitcode in (-signal.SIGTERM, 255)
 
 
 @gen_test()
-def test_terminate():
+async def test_terminate():
     proc = AsyncProcess(target=wait)
     proc.daemon = True
-    yield proc.start()
-    yield proc.terminate()
+    await proc.start()
+    await proc.terminate()
 
-    yield proc.join(timeout=3.0)
+    await proc.join(timeout=3.0)
     assert not proc.is_alive()
     assert proc.exitcode in (-signal.SIGTERM, 255)
 
 
 @gen_test()
-def test_close():
+async def test_close():
     proc = AsyncProcess(target=exit_now)
     proc.close()
     with pytest.raises(ValueError):
-        yield proc.start()
+        await proc.start()
 
     proc = AsyncProcess(target=exit_now)
-    yield proc.start()
+    await proc.start()
     proc.close()
     with pytest.raises(ValueError):
-        yield proc.terminate()
+        await proc.terminate()
 
     proc = AsyncProcess(target=exit_now)
-    yield proc.start()
-    yield proc.join()
+    await proc.start()
+    await proc.join()
     proc.close()
     with pytest.raises(ValueError):
-        yield proc.join()
+        await proc.join()
     proc.close()
 
 
 @gen_test()
-def test_exit_callback():
+async def test_exit_callback():
     to_child = mp_context.Queue()
     from_child = mp_context.Queue()
     evt = Event()
 
-    # FIXME: this breaks if changed to def...
+    # FIXME: this breaks if changed to async def...
     @gen.coroutine
     def on_stop(_proc):
         assert _proc is proc
@@ -235,13 +235,13 @@ def test_exit_callback():
     proc.set_exit_callback(on_stop)
     proc.daemon = True
 
-    yield proc.start()
-    yield gen.sleep(0.05)
+    await proc.start()
+    await gen.sleep(0.05)
     assert proc.is_alive()
     assert not evt.is_set()
 
     to_child.put(None)
-    yield evt.wait(timedelta(seconds=3))
+    await evt.wait(timedelta(seconds=3))
     assert evt.is_set()
     assert not proc.is_alive()
 
@@ -251,25 +251,25 @@ def test_exit_callback():
     proc.set_exit_callback(on_stop)
     proc.daemon = True
 
-    yield proc.start()
-    yield gen.sleep(0.05)
+    await proc.start()
+    await gen.sleep(0.05)
     assert proc.is_alive()
     assert not evt.is_set()
 
-    yield proc.terminate()
-    yield evt.wait(timedelta(seconds=3))
+    await proc.terminate()
+    await evt.wait(timedelta(seconds=3))
     assert evt.is_set()
 
 
 @gen_test()
-def test_child_main_thread():
+async def test_child_main_thread():
     """
     The main thread in the child should be called "MainThread".
     """
     q = mp_context.Queue()
     proc = AsyncProcess(target=threads_info, args=(q,))
-    yield proc.start()
-    yield proc.join()
+    await proc.start()
+    await proc.join()
     n_threads = q.get()
     main_name = q.get()
     assert n_threads <= 3
@@ -283,38 +283,38 @@ def test_child_main_thread():
     sys.platform.startswith("win"), reason="num_fds not supported on windows"
 )
 @gen_test()
-def test_num_fds():
+async def test_num_fds():
     psutil = pytest.importorskip("psutil")
 
     # Warm up
     proc = AsyncProcess(target=exit_now)
     proc.daemon = True
-    yield proc.start()
-    yield proc.join()
+    await proc.start()
+    await proc.join()
 
     p = psutil.Process()
     before = p.num_fds()
 
     proc = AsyncProcess(target=exit_now)
     proc.daemon = True
-    yield proc.start()
-    yield proc.join()
+    await proc.start()
+    await proc.join()
     assert not proc.is_alive()
     assert proc.exitcode == 0
 
     start = time()
     while p.num_fds() > before:
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         print("fds:", before, p.num_fds())
         assert time() < start + 10
 
 
 @gen_test()
-def test_terminate_after_stop():
+async def test_terminate_after_stop():
     proc = AsyncProcess(target=sleep, args=(0,))
-    yield proc.start()
-    yield gen.sleep(0.1)
-    yield proc.terminate()
+    await proc.start()
+    await gen.sleep(0.1)
+    await proc.terminate()
 
 
 def _worker_process(worker_ready, child_pipe):
@@ -343,12 +343,12 @@ def _parent_process(child_pipe):
     The child_alive pipe is held open for as long as the child is alive, and can
     be used to determine if it exited correctly. """
 
-    def parent_process_coroutine():
+    async def parent_process_coroutine():
         worker_ready = mp_context.Event()
 
         worker = AsyncProcess(target=_worker_process, args=(worker_ready, child_pipe))
 
-        yield worker.start()
+        await worker.start()
 
         # Wait for the child process to have started.
         worker_ready.wait()

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -222,6 +222,7 @@ def test_exit_callback():
     from_child = mp_context.Queue()
     evt = Event()
 
+    # FIXME: this breaks if changed to def...
     @gen.coroutine
     def on_stop(_proc):
         assert _proc is proc
@@ -359,7 +360,7 @@ def _parent_process(child_pipe):
 
     with pristine_loop() as loop:
         try:
-            loop.run_sync(gen.coroutine(parent_process_coroutine), timeout=10)
+            loop.run_sync(parent_process_coroutine(), timeout=10)
         finally:
             loop.stop()
 

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -1,11 +1,12 @@
-from datetime import timedelta
+import asyncio
 import gc
 import os
 import signal
 import sys
 import threading
-from time import sleep
 import weakref
+from datetime import timedelta
+from time import sleep
 
 import pytest
 from tornado import gen
@@ -133,7 +134,7 @@ async def test_simple():
         pytest.fail("AsyncProcess should have been destroyed")
     t1 = time()
     while wr2() is not None:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         gc.collect()
         dt = time() - t1
         assert dt < 2.0
@@ -236,7 +237,7 @@ async def test_exit_callback():
     proc.daemon = True
 
     await proc.start()
-    await gen.sleep(0.05)
+    await asyncio.sleep(0.05)
     assert proc.is_alive()
     assert not evt.is_set()
 
@@ -252,7 +253,7 @@ async def test_exit_callback():
     proc.daemon = True
 
     await proc.start()
-    await gen.sleep(0.05)
+    await asyncio.sleep(0.05)
     assert proc.is_alive()
     assert not evt.is_set()
 
@@ -304,7 +305,7 @@ async def test_num_fds():
 
     start = time()
     while p.num_fds() > before:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         print("fds:", before, p.num_fds())
         assert time() < start + 10
 
@@ -313,7 +314,7 @@ async def test_num_fds():
 async def test_terminate_after_stop():
     proc = AsyncProcess(target=sleep, args=(0,))
     await proc.start()
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     await proc.terminate()
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2293,7 +2293,10 @@ async def test_cancel_collection(c, s, a, b):
     await c.cancel(x)
     await c.cancel([x])
     assert all(f.cancelled() for f in L)
-    assert not s.tasks
+    start = time()
+    while s.tasks:
+        assert time() < start + 1
+        await time.sleep(0.01)
 
 
 def test_cancel(c):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -105,79 +105,79 @@ from distributed.utils_test import (  # noqa: F401
 
 
 @gen_cluster(client=True, timeout=None)
-def test_submit(c, s, a, b):
+async def test_submit(c, s, a, b):
     x = c.submit(inc, 10)
     assert not x.done()
 
     assert isinstance(x, Future)
     assert x.client is c
 
-    result = yield x
+    result = await x
     assert result == 11
     assert x.done()
 
     y = c.submit(inc, 20)
     z = c.submit(add, x, y)
 
-    result = yield z
+    result = await z
     assert result == 11 + 21
     s.validate_state()
 
 
 @gen_cluster(client=True)
-def test_map(c, s, a, b):
+async def test_map(c, s, a, b):
     L1 = c.map(inc, range(5))
     assert len(L1) == 5
     assert isdistinct(x.key for x in L1)
     assert all(isinstance(x, Future) for x in L1)
 
-    result = yield L1[0]
+    result = await L1[0]
     assert result == inc(0)
     assert len(s.tasks) == 5
 
     L2 = c.map(inc, L1)
 
-    result = yield L2[1]
+    result = await L2[1]
     assert result == inc(inc(1))
     assert len(s.tasks) == 10
     # assert L1[0].key in s.tasks[L2[0].key]
 
     total = c.submit(sum, L2)
-    result = yield total
+    result = await total
     assert result == sum(map(inc, map(inc, range(5))))
 
     L3 = c.map(add, L1, L2)
-    result = yield L3[1]
+    result = await L3[1]
     assert result == inc(1) + inc(inc(1))
 
     L4 = c.map(add, range(3), range(4))
-    results = yield c.gather(L4)
+    results = await c.gather(L4)
     assert results == list(map(add, range(3), range(4)))
 
     def f(x, y=10):
         return x + y
 
     L5 = c.map(f, range(5), y=5)
-    results = yield c.gather(L5)
+    results = await c.gather(L5)
     assert results == list(range(5, 10))
 
     y = c.submit(f, 10)
     L6 = c.map(f, range(5), y=y)
-    results = yield c.gather(L6)
+    results = await c.gather(L6)
     assert results == list(range(20, 25))
     s.validate_state()
 
 
 @gen_cluster(client=True)
-def test_map_empty(c, s, a, b):
+async def test_map_empty(c, s, a, b):
     L1 = c.map(inc, [], pure=False)
     assert len(L1) == 0
-    results = yield c.gather(L1)
+    results = await c.gather(L1)
     assert results == []
 
 
 @gen_cluster(client=True)
-def test_map_keynames(c, s, a, b):
+async def test_map_keynames(c, s, a, b):
     futures = c.map(inc, range(4), key="INC")
     assert all(f.key.startswith("INC") for f in futures)
     assert isdistinct(f.key for f in futures)
@@ -191,7 +191,7 @@ def test_map_keynames(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_map_retries(c, s, a, b):
+async def test_map_retries(c, s, a, b):
     args = [
         [ZeroDivisionError("one"), 2, 3],
         [4, 5, 6],
@@ -199,44 +199,44 @@ def test_map_retries(c, s, a, b):
     ]
 
     x, y, z = c.map(*map_varying(args), retries=2)
-    assert yield x == 2
-    assert yield y == 4
-    assert yield z == 9
+    assert await x == 2
+    assert await y == 4
+    assert await z == 9
 
     x, y, z = c.map(*map_varying(args), retries=1, pure=False)
-    assert yield x == 2
-    assert yield y == 4
+    assert await x == 2
+    assert await y == 4
     with pytest.raises(ZeroDivisionError, match="eight"):
-        yield z
+        await z
 
     x, y, z = c.map(*map_varying(args), retries=0, pure=False)
     with pytest.raises(ZeroDivisionError, match="one"):
-        yield x
-    assert yield y == 4
+        await x
+    assert await y == 4
     with pytest.raises(ZeroDivisionError, match="seven"):
-        yield z
+        await z
 
 
 @gen_cluster(client=True)
-def test_compute_retries(c, s, a, b):
+async def test_compute_retries(c, s, a, b):
     args = [ZeroDivisionError("one"), ZeroDivisionError("two"), 3]
 
     # Sanity check for varying() use
     x = c.compute(delayed(varying(args))())
     with pytest.raises(ZeroDivisionError, match="one"):
-        yield x
+        await x
 
     # Same retries for all
     x = c.compute(delayed(varying(args))(), retries=1)
     with pytest.raises(ZeroDivisionError, match="two"):
-        yield x
+        await x
 
     x = c.compute(delayed(varying(args))(), retries=2)
-    assert yield x == 3
+    assert await x == 3
 
     args.append(4)
     x = c.compute(delayed(varying(args))(), retries=2)
-    assert yield x == 3
+    assert await x == 3
 
     # Per-future retries
     xargs = [ZeroDivisionError("one"), ZeroDivisionError("two"), 30, 40]
@@ -247,17 +247,17 @@ def test_compute_retries(c, s, a, b):
     x, y = c.compute([x, y], retries={x: 2})
     gc.collect()
 
-    assert yield x == 30
+    assert await x == 30
     with pytest.raises(ZeroDivisionError, match="five"):
-        yield y
+        await y
 
     x, y, z = [delayed(varying(args))() for args in (xargs, yargs, zargs)]
     x, y, z = c.compute([x, y, z], retries={(y, z): 2})
 
     with pytest.raises(ZeroDivisionError, match="one"):
-        yield x
-    assert yield y == 70
-    assert yield z == 80
+        await x
+    assert await y == 70
+    assert await z == 80
 
 
 def test_retries_get(c):
@@ -272,43 +272,43 @@ def test_retries_get(c):
 
 
 @gen_cluster(client=True)
-def test_compute_persisted_retries(c, s, a, b):
+async def test_compute_persisted_retries(c, s, a, b):
     args = [ZeroDivisionError("one"), ZeroDivisionError("two"), 3]
 
     # Sanity check
     x = c.persist(delayed(varying(args))())
     fut = c.compute(x)
     with pytest.raises(ZeroDivisionError, match="one"):
-        yield fut
+        await fut
 
     x = c.persist(delayed(varying(args))())
     fut = c.compute(x, retries=1)
     with pytest.raises(ZeroDivisionError, match="two"):
-        yield fut
+        await fut
 
     x = c.persist(delayed(varying(args))())
     fut = c.compute(x, retries=2)
-    assert yield fut == 3
+    assert await fut == 3
 
     args.append(4)
     x = c.persist(delayed(varying(args))())
     fut = c.compute(x, retries=3)
-    assert yield fut == 3
+    assert await fut == 3
 
 
 @gen_cluster(client=True)
-def test_persist_retries(c, s, a, b):
+async def test_persist_retries(c, s, a, b):
     # Same retries for all
     args = [ZeroDivisionError("one"), ZeroDivisionError("two"), 3]
 
     x = c.persist(delayed(varying(args))(), retries=1)
     x = c.compute(x)
     with pytest.raises(ZeroDivisionError, match="two"):
-        yield x
+        await x
 
     x = c.persist(delayed(varying(args))(), retries=2)
     x = c.compute(x)
-    assert yield x == 3
+    assert await x == 3
 
     # Per-key retries
     xargs = [ZeroDivisionError("one"), ZeroDivisionError("two"), 30, 40]
@@ -320,17 +320,17 @@ def test_persist_retries(c, s, a, b):
     x, y, z = c.compute([x, y, z])
 
     with pytest.raises(ZeroDivisionError, match="one"):
-        yield x
-    assert yield y == 70
-    assert yield z == 80
+        await x
+    assert await y == 70
+    assert await z == 80
 
 
 @gen_cluster(client=True)
-def test_retries_dask_array(c, s, a, b):
+async def test_retries_dask_array(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.ones((10, 10), chunks=(3, 3))
     future = c.compute(x.sum(), retries=2)
-    y = yield future
+    y = await future
     assert y == 100
 
 
@@ -353,7 +353,7 @@ async def test_future_repr(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_future_tuple_repr(c, s, a, b):
+async def test_future_tuple_repr(c, s, a, b):
     da = pytest.importorskip("dask.array")
     y = da.arange(10, chunks=(5,)).persist()
     f = futures_of(y)[0]
@@ -363,13 +363,13 @@ def test_future_tuple_repr(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_Future_exception(c, s, a, b):
+async def test_Future_exception(c, s, a, b):
     x = c.submit(div, 1, 0)
-    result = yield x.exception()
+    result = await x.exception()
     assert isinstance(result, ZeroDivisionError)
 
     x = c.submit(div, 1, 1)
-    result = yield x.exception()
+    result = await x.exception()
     assert result is None
 
 
@@ -382,23 +382,23 @@ def test_Future_exception_sync(c):
 
 
 @gen_cluster(client=True)
-def test_Future_release(c, s, a, b):
+async def test_Future_release(c, s, a, b):
     # Released Futures should be removed timely from the Client
     x = c.submit(div, 1, 1)
-    yield x
+    await x
     x.release()
-    yield gen.sleep(0)
+    await gen.sleep(0)
     assert not c.futures
 
     x = c.submit(slowinc, 1, delay=0.5)
     x.release()
-    yield gen.sleep(0)
+    await gen.sleep(0)
     assert not c.futures
 
     x = c.submit(div, 1, 0)
-    yield x.exception()
+    await x.exception()
     x.release()
-    yield gen.sleep(0)
+    await gen.sleep(0)
     assert not c.futures
 
 
@@ -437,7 +437,7 @@ def test_short_tracebacks(loop, c):
 
 
 @gen_cluster(client=True)
-def test_map_naming(c, s, a, b):
+async def test_map_naming(c, s, a, b):
     L1 = c.map(inc, range(5))
     L2 = c.map(inc, range(5))
 
@@ -451,7 +451,7 @@ def test_map_naming(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_submit_naming(c, s, a, b):
+async def test_submit_naming(c, s, a, b):
     a = c.submit(inc, 1)
     b = c.submit(inc, 1)
 
@@ -462,33 +462,33 @@ def test_submit_naming(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_exceptions(c, s, a, b):
+async def test_exceptions(c, s, a, b):
     x = c.submit(div, 1, 2)
-    result = yield x
+    result = await x
     assert result == 1 / 2
 
     x = c.submit(div, 1, 0)
     with pytest.raises(ZeroDivisionError):
-        yield x
+        await x
 
     x = c.submit(div, 10, 2)  # continues to operate
-    result = yield x
+    result = await x
     assert result == 10 / 2
 
 
 @gen_cluster()
-def test_gc(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
+async def test_gc(s, a, b):
+    c = await Client(s.address, asynchronous=True)
 
     x = c.submit(inc, 10)
-    yield x
+    await x
     assert s.tasks[x.key].who_has
     x.__del__()
-    yield async_wait_for(
+    await async_wait_for(
         lambda: x.key not in s.tasks or not s.tasks[x.key].who_has, timeout=0.3
     )
 
-    yield c.close()
+    await c.close()
 
 
 def test_thread(c):
@@ -517,27 +517,27 @@ def test_sync_exceptions(c):
 
 
 @gen_cluster(client=True)
-def test_gather(c, s, a, b):
+async def test_gather(c, s, a, b):
     x = c.submit(inc, 10)
     y = c.submit(inc, x)
 
-    result = yield c.gather(x)
+    result = await c.gather(x)
     assert result == 11
-    result = yield c.gather([x])
+    result = await c.gather([x])
     assert result == [11]
-    result = yield c.gather({"x": x, "y": [y]})
+    result = await c.gather({"x": x, "y": [y]})
     assert result == {"x": 11, "y": [12]}
 
 
 @gen_cluster(client=True)
-def test_gather_lost(c, s, a, b):
-    [x] = yield c.scatter([1], workers=a.address)
+async def test_gather_lost(c, s, a, b):
+    [x] = await c.scatter([1], workers=a.address)
     y = c.submit(inc, 1, workers=b.address)
 
-    yield a.close()
+    await a.close()
 
     with pytest.raises(Exception):
-        yield c.gather([x, y])
+        await c.gather([x, y])
 
 
 def test_gather_sync(c):
@@ -554,25 +554,25 @@ def test_gather_sync(c):
 
 
 @gen_cluster(client=True)
-def test_gather_strict(c, s, a, b):
+async def test_gather_strict(c, s, a, b):
     x = c.submit(div, 2, 1)
     y = c.submit(div, 1, 0)
 
     with pytest.raises(ZeroDivisionError):
-        yield c.gather([x, y])
+        await c.gather([x, y])
 
-    [xx] = yield c.gather([x, y], errors="skip")
+    [xx] = await c.gather([x, y], errors="skip")
     assert xx == 2
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_gather_skip(c, s, a):
+async def test_gather_skip(c, s, a):
     x = c.submit(div, 1, 0, priority=10)
     y = c.submit(slowinc, 1, delay=0.5)
 
     with captured_logger(logging.getLogger("distributed.scheduler")) as sched:
         with captured_logger(logging.getLogger("distributed.client")) as client:
-            L = yield c.gather([x, y], errors="skip")
+            L = await c.gather([x, y], errors="skip")
             assert L == [2]
 
     assert not client.getvalue()
@@ -580,29 +580,29 @@ def test_gather_skip(c, s, a):
 
 
 @gen_cluster(client=True)
-def test_limit_concurrent_gathering(c, s, a, b):
+async def test_limit_concurrent_gathering(c, s, a, b):
     futures = c.map(inc, range(100))
-    yield c.gather(futures)
+    await c.gather(futures)
     assert len(a.outgoing_transfer_log) + len(b.outgoing_transfer_log) < 100
 
 
 @gen_cluster(client=True, timeout=None)
-def test_get(c, s, a, b):
+async def test_get(c, s, a, b):
     future = c.get({"x": (inc, 1)}, "x", sync=False)
     assert isinstance(future, Future)
-    result = yield future
+    result = await future
     assert result == 2
 
     futures = c.get({"x": (inc, 1)}, ["x"], sync=False)
     assert isinstance(futures[0], Future)
-    result = yield c.gather(futures)
+    result = await c.gather(futures)
     assert result == [2]
 
     futures = c.get({}, [], sync=False)
-    result = yield c.gather(futures)
+    result = await c.gather(futures)
     assert result == []
 
-    result = yield c.get(
+    result = await c.get(
         {("x", 1): (inc, 1), ("x", 2): (inc, ("x", 1))}, ("x", 2), sync=False
     )
     assert result == 3
@@ -634,7 +634,7 @@ def test_get_sync_optimize_graph_passes_through(c):
 
 
 @gen_cluster(client=True)
-def test_gather_errors(c, s, a, b):
+async def test_gather_errors(c, s, a, b):
     def f(a, b):
         raise TypeError
 
@@ -644,20 +644,20 @@ def test_gather_errors(c, s, a, b):
     future_f = c.submit(f, 1, 2)
     future_g = c.submit(g, 1, 2)
     with pytest.raises(TypeError):
-        yield c.gather(future_f)
+        await c.gather(future_f)
     with pytest.raises(AttributeError):
-        yield c.gather(future_g)
+        await c.gather(future_g)
 
-    yield a.close()
+    await a.close()
 
 
 @gen_cluster(client=True)
-def test_wait(c, s, a, b):
+async def test_wait(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(inc, 1)
     z = c.submit(inc, 2)
 
-    done, not_done = yield wait([x, y, z])
+    done, not_done = await wait([x, y, z])
 
     assert done == {x, y, z}
     assert not_done == set()
@@ -665,12 +665,12 @@ def test_wait(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_wait_first_completed(c, s, a, b):
+async def test_wait_first_completed(c, s, a, b):
     x = c.submit(slowinc, 1)
     y = c.submit(slowinc, 1)
     z = c.submit(inc, 2)
 
-    done, not_done = yield wait([x, y, z], return_when="FIRST_COMPLETED")
+    done, not_done = await wait([x, y, z], return_when="FIRST_COMPLETED")
 
     assert done == {z}
     assert not_done == {x, y}
@@ -680,10 +680,10 @@ def test_wait_first_completed(c, s, a, b):
 
 
 @gen_cluster(client=True, timeout=2)
-def test_wait_timeout(c, s, a, b):
+async def test_wait_timeout(c, s, a, b):
     future = c.submit(sleep, 0.3)
     with pytest.raises(TimeoutError):
-        yield wait(future, timeout=0.01)
+        await wait(future, timeout=0.01)
 
 
 def test_wait_sync(c):
@@ -712,31 +712,31 @@ def test_wait_informative_error_for_timeouts(c):
 
 
 @gen_cluster(client=True)
-def test_garbage_collection(c, s, a, b):
+async def test_garbage_collection(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(inc, 1)
 
     assert c.refcount[x.key] == 2
     x.__del__()
-    yield gen.sleep(0)
+    await gen.sleep(0)
     assert c.refcount[x.key] == 1
 
     z = c.submit(inc, y)
     y.__del__()
-    yield gen.sleep(0)
+    await gen.sleep(0)
 
-    result = yield z
+    result = await z
     assert result == 3
 
     ykey = y.key
     y.__del__()
-    yield gen.sleep(0)
+    await gen.sleep(0)
     assert ykey not in c.futures
 
 
 @gen_cluster(client=True)
-def test_garbage_collection_with_scatter(c, s, a, b):
-    [future] = yield c.scatter([1])
+async def test_garbage_collection_with_scatter(c, s, a, b):
+    [future] = await c.scatter([1])
     assert future.key in c.futures
     assert future.status == "finished"
     assert s.who_wants[future.key] == {c.id}
@@ -744,7 +744,7 @@ def test_garbage_collection_with_scatter(c, s, a, b):
     key = future.key
     assert c.refcount[key] == 1
     future.__del__()
-    yield gen.sleep(0)
+    await gen.sleep(0)
     assert c.refcount[key] == 0
 
     start = time()
@@ -753,50 +753,50 @@ def test_garbage_collection_with_scatter(c, s, a, b):
             break
         else:
             assert time() < start + 3
-            yield gen.sleep(0.1)
+            await gen.sleep(0.1)
 
 
 @gen_cluster(timeout=1000, client=True)
-def test_recompute_released_key(c, s, a, b):
+async def test_recompute_released_key(c, s, a, b):
     x = c.submit(inc, 100)
-    result1 = yield x
+    result1 = await x
     xkey = x.key
     del x
     import gc
 
     gc.collect()
-    yield gen.sleep(0)
+    await gen.sleep(0)
     assert c.refcount[xkey] == 0
 
     # 1 second batching needs a second action to trigger
     while xkey in s.tasks and s.tasks[xkey].who_has or xkey in a.data or xkey in b.data:
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
 
     x = c.submit(inc, 100)
     assert x.key in c.futures
-    result2 = yield x
+    result2 = await x
     assert result1 == result2
 
 
 @pytest.mark.slow
 @gen_cluster(client=True)
-def test_long_tasks_dont_trigger_timeout(c, s, a, b):
+async def test_long_tasks_dont_trigger_timeout(c, s, a, b):
     from time import sleep
 
     x = c.submit(sleep, 3)
-    yield x
+    await x
 
 
 @pytest.mark.skip
 @gen_cluster(client=True)
-def test_missing_data_heals(c, s, a, b):
+async def test_missing_data_heals(c, s, a, b):
     a.validate = False
     b.validate = False
     x = c.submit(inc, 1)
     y = c.submit(inc, x)
     z = c.submit(inc, y)
 
-    yield wait([x, y, z])
+    await wait([x, y, z])
 
     # Secretly delete y's key
     if y.key in a.data:
@@ -805,36 +805,36 @@ def test_missing_data_heals(c, s, a, b):
     if y.key in b.data:
         del b.data[y.key]
         b.release_key(y.key)
-    yield gen.sleep(0)
+    await gen.sleep(0)
 
     w = c.submit(add, y, z)
 
-    result = yield w
+    result = await w
     assert result == 3 + 4
 
 
 @pytest.mark.skip
 @gen_cluster(client=True)
-def test_gather_robust_to_missing_data(c, s, a, b):
+async def test_gather_robust_to_missing_data(c, s, a, b):
     a.validate = False
     b.validate = False
     x, y, z = c.map(inc, range(3))
-    yield wait([x, y, z])  # everything computed
+    await wait([x, y, z])  # everything computed
 
     for f in [x, y]:
         for w in [a, b]:
             if f.key in w.data:
                 del w.data[f.key]
-                yield gen.sleep(0)
+                await gen.sleep(0)
                 w.release_key(f.key)
 
-    xx, yy, zz = yield c.gather([x, y, z])
+    xx, yy, zz = await c.gather([x, y, z])
     assert (xx, yy, zz) == (1, 2, 3)
 
 
 @pytest.mark.skip
 @gen_cluster(client=True)
-def test_gather_robust_to_nested_missing_data(c, s, a, b):
+async def test_gather_robust_to_nested_missing_data(c, s, a, b):
     a.validate = False
     b.validate = False
     w = c.submit(inc, 1)
@@ -842,22 +842,22 @@ def test_gather_robust_to_nested_missing_data(c, s, a, b):
     y = c.submit(inc, x)
     z = c.submit(inc, y)
 
-    yield wait([z])
+    await wait([z])
 
     for worker in [a, b]:
         for datum in [y, z]:
             if datum.key in worker.data:
                 del worker.data[datum.key]
-                yield gen.sleep(0)
+                await gen.sleep(0)
                 worker.release_key(datum.key)
 
-    result = yield c.gather([z])
+    result = await c.gather([z])
 
     assert result == [inc(inc(inc(inc(1))))]
 
 
 @gen_cluster(client=True)
-def test_tokenize_on_futures(c, s, a, b):
+async def test_tokenize_on_futures(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(inc, 1)
     tok = tokenize(x)
@@ -873,10 +873,10 @@ def test_tokenize_on_futures(c, s, a, b):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True)
-def test_restrictions_submit(c, s, a, b):
+async def test_restrictions_submit(c, s, a, b):
     x = c.submit(inc, 1, workers={a.ip})
     y = c.submit(inc, x, workers={b.ip})
-    yield wait([x, y])
+    await wait([x, y])
 
     assert s.host_restrictions[x.key] == {a.ip}
     assert x.key in a.data
@@ -886,10 +886,10 @@ def test_restrictions_submit(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_restrictions_ip_port(c, s, a, b):
+async def test_restrictions_ip_port(c, s, a, b):
     x = c.submit(inc, 1, workers={a.address})
     y = c.submit(inc, x, workers={b.address})
-    yield wait([x, y])
+    await wait([x, y])
 
     assert s.worker_restrictions[x.key] == {a.address}
     assert x.key in a.data
@@ -902,9 +902,9 @@ def test_restrictions_ip_port(c, s, a, b):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True)
-def test_restrictions_map(c, s, a, b):
+async def test_restrictions_map(c, s, a, b):
     L = c.map(inc, range(5), workers={a.ip})
-    yield wait(L)
+    await wait(L)
 
     assert set(a.data) == {x.key for x in L}
     assert not b.data
@@ -912,7 +912,7 @@ def test_restrictions_map(c, s, a, b):
         assert s.host_restrictions[x.key] == {a.ip}
 
     L = c.map(inc, [10, 11, 12], workers=[{a.ip}, {a.ip, b.ip}, {b.ip}])
-    yield wait(L)
+    await wait(L)
 
     assert s.host_restrictions[L[0].key] == {a.ip}
     assert s.host_restrictions[L[1].key] == {a.ip, b.ip}
@@ -926,22 +926,22 @@ def test_restrictions_map(c, s, a, b):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True)
-def test_restrictions_get(c, s, a, b):
+async def test_restrictions_get(c, s, a, b):
     dsk = {"x": 1, "y": (inc, "x"), "z": (inc, "y")}
     restrictions = {"y": {a.ip}, "z": {b.ip}}
 
     futures = c.get(dsk, ["y", "z"], restrictions, sync=False)
-    result = yield c.gather(futures)
+    result = await c.gather(futures)
     assert result == [2, 3]
     assert "y" in a.data
     assert "z" in b.data
 
 
 @gen_cluster(client=True)
-def dont_test_bad_restrictions_raise_exception(c, s, a, b):
+async def dont_test_bad_restrictions_raise_exception(c, s, a, b):
     z = c.submit(inc, 2, workers={"bad-address"})
     try:
-        yield z
+        await z
         assert False
     except ValueError as e:
         assert "bad-address" in str(e)
@@ -949,133 +949,133 @@ def dont_test_bad_restrictions_raise_exception(c, s, a, b):
 
 
 @gen_cluster(client=True, timeout=None)
-def test_remove_worker(c, s, a, b):
+async def test_remove_worker(c, s, a, b):
     L = c.map(inc, range(20))
-    yield wait(L)
+    await wait(L)
 
-    yield b.close()
+    await b.close()
 
     assert b.address not in s.workers
 
-    result = yield c.gather(L)
+    result = await c.gather(L)
     assert result == list(map(inc, range(20)))
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)
-def test_errors_dont_block(c, s, w):
+async def test_errors_dont_block(c, s, w):
     L = [c.submit(inc, 1), c.submit(throws, 1), c.submit(inc, 2), c.submit(throws, 2)]
 
     start = time()
     while not (L[0].status == L[2].status == "finished"):
         assert time() < start + 5
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
-    result = yield c.gather([L[0], L[2]])
+    result = await c.gather([L[0], L[2]])
     assert result == [2, 3]
 
 
 @gen_cluster(client=True)
-def test_submit_quotes(c, s, a, b):
+async def test_submit_quotes(c, s, a, b):
     def assert_list(x, z=[]):
         return isinstance(x, list) and isinstance(z, list)
 
     x = c.submit(assert_list, [1, 2, 3])
-    result = yield x
+    result = await x
     assert result
 
     x = c.submit(assert_list, [1, 2, 3], z=[4, 5, 6])
-    result = yield x
+    result = await x
     assert result
 
     x = c.submit(inc, 1)
     y = c.submit(inc, 2)
     z = c.submit(assert_list, [x, y])
-    result = yield z
+    result = await z
     assert result
 
 
 @gen_cluster(client=True)
-def test_map_quotes(c, s, a, b):
+async def test_map_quotes(c, s, a, b):
     def assert_list(x, z=[]):
         return isinstance(x, list) and isinstance(z, list)
 
     L = c.map(assert_list, [[1, 2, 3], [4]])
-    result = yield c.gather(L)
+    result = await c.gather(L)
     assert all(result)
 
     L = c.map(assert_list, [[1, 2, 3], [4]], z=[10])
-    result = yield c.gather(L)
+    result = await c.gather(L)
     assert all(result)
 
     L = c.map(assert_list, [[1, 2, 3], [4]], [[]] * 3)
-    result = yield c.gather(L)
+    result = await c.gather(L)
     assert all(result)
 
 
 @gen_cluster()
-def test_two_consecutive_clients_share_results(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
+async def test_two_consecutive_clients_share_results(s, a, b):
+    c = await Client(s.address, asynchronous=True)
 
     x = c.submit(random.randint, 0, 1000, pure=True)
-    xx = yield x
+    xx = await x
 
-    f = yield Client(s.address, asynchronous=True)
+    f = await Client(s.address, asynchronous=True)
 
     y = f.submit(random.randint, 0, 1000, pure=True)
-    yy = yield y
+    yy = await y
 
     assert xx == yy
 
-    yield c.close()
-    yield f.close()
+    await c.close()
+    await f.close()
 
 
 @gen_cluster(client=True)
-def test_submit_then_get_with_Future(c, s, a, b):
+async def test_submit_then_get_with_Future(c, s, a, b):
     x = c.submit(slowinc, 1)
     dsk = {"y": (inc, x)}
 
-    result = yield c.get(dsk, "y", sync=False)
+    result = await c.get(dsk, "y", sync=False)
     assert result == 3
 
 
 @gen_cluster(client=True)
-def test_aliases(c, s, a, b):
+async def test_aliases(c, s, a, b):
     x = c.submit(inc, 1)
 
     dsk = {"y": x}
-    result = yield c.get(dsk, "y", sync=False)
+    result = await c.get(dsk, "y", sync=False)
     assert result == 2
 
 
 @gen_cluster(client=True)
-def test_aliases_2(c, s, a, b):
+async def test_aliases_2(c, s, a, b):
     dsk_keys = [
         ({"x": (inc, 1), "y": "x", "z": "x", "w": (add, "y", "z")}, ["y", "w"]),
         ({"x": "y", "y": 1}, ["x"]),
         ({"x": 1, "y": "x", "z": "y", "w": (inc, "z")}, ["w"]),
     ]
     for dsk, keys in dsk_keys:
-        result = yield c.gather(c.get(dsk, keys, sync=False))
+        result = await c.gather(c.get(dsk, keys, sync=False))
         assert list(result) == list(dask.get(dsk, keys))
-        yield gen.sleep(0)
+        await gen.sleep(0)
 
 
 @gen_cluster(client=True)
-def test_scatter(c, s, a, b):
-    d = yield c.scatter({"y": 20})
+async def test_scatter(c, s, a, b):
+    d = await c.scatter({"y": 20})
     assert isinstance(d["y"], Future)
     assert a.data.get("y") == 20 or b.data.get("y") == 20
     y_who_has = s.get_who_has(keys=["y"])["y"]
     assert a.address in y_who_has or b.address in y_who_has
     assert s.get_nbytes(summary=False) == {"y": sizeof(20)}
-    yy = yield c.gather([d["y"]])
+    yy = await c.gather([d["y"]])
     assert yy == [20]
 
-    [x] = yield c.scatter([10])
+    [x] = await c.scatter([10])
     assert isinstance(x, Future)
     assert a.data.get(x.key) == 10 or b.data.get(x.key) == 10
-    xx = yield c.gather([x])
+    xx = await c.gather([x])
     x_who_has = s.get_who_has(keys=[x.key])[x.key]
     assert s.tasks[x.key].who_has
     assert (
@@ -1086,49 +1086,49 @@ def test_scatter(c, s, a, b):
     assert xx == [10]
 
     z = c.submit(add, x, d["y"])  # submit works on Future
-    result = yield z
+    result = await z
     assert result == 10 + 20
-    result = yield c.gather([z, x])
+    result = await c.gather([z, x])
     assert result == [30, 10]
 
 
 @gen_cluster(client=True)
-def test_scatter_types(c, s, a, b):
-    d = yield c.scatter({"x": 1})
+async def test_scatter_types(c, s, a, b):
+    d = await c.scatter({"x": 1})
     assert isinstance(d, dict)
     assert list(d) == ["x"]
 
     for seq in [[1], (1,), {1}, frozenset([1])]:
-        L = yield c.scatter(seq)
+        L = await c.scatter(seq)
         assert isinstance(L, type(seq))
         assert len(L) == 1
         s.validate_state()
 
-    seq = yield c.scatter(range(5))
+    seq = await c.scatter(range(5))
     assert isinstance(seq, list)
     assert len(seq) == 5
     s.validate_state()
 
 
 @gen_cluster(client=True)
-def test_scatter_non_list(c, s, a, b):
-    x = yield c.scatter(1)
+async def test_scatter_non_list(c, s, a, b):
+    x = await c.scatter(1)
     assert isinstance(x, Future)
-    result = yield x
+    result = await x
     assert result == 1
 
 
 @gen_cluster(client=True)
-def test_scatter_hash(c, s, a, b):
-    [a] = yield c.scatter([1])
-    [b] = yield c.scatter([1])
+async def test_scatter_hash(c, s, a, b):
+    [a] = await c.scatter([1])
+    [b] = await c.scatter([1])
 
     assert a.key == b.key
     s.validate_state()
 
 
 @gen_cluster(client=True)
-def test_scatter_tokenize_local(c, s, a, b):
+async def test_scatter_tokenize_local(c, s, a, b):
     from dask.base import normalize_token
 
     class MyObj:
@@ -1143,46 +1143,46 @@ def test_scatter_tokenize_local(c, s, a, b):
 
     obj = MyObj()
 
-    future = yield c.scatter(obj)
+    future = await c.scatter(obj)
     assert L and L[0] is obj
 
 
 @gen_cluster(client=True)
-def test_scatter_singletons(c, s, a, b):
+async def test_scatter_singletons(c, s, a, b):
     np = pytest.importorskip("numpy")
     pd = pytest.importorskip("pandas")
     for x in [1, np.ones(5), pd.DataFrame({"x": [1, 2, 3]})]:
-        future = yield c.scatter(x)
-        result = yield future
+        future = await c.scatter(x)
+        result = await future
         assert str(result) == str(x)
 
 
 @gen_cluster(client=True)
-def test_scatter_typename(c, s, a, b):
-    future = yield c.scatter(123)
+async def test_scatter_typename(c, s, a, b):
+    future = await c.scatter(123)
     assert future.key.startswith("int")
 
 
 @gen_cluster(client=True)
-def test_scatter_hash(c, s, a, b):
-    x = yield c.scatter(123)
-    y = yield c.scatter(123)
+async def test_scatter_hash(c, s, a, b):
+    x = await c.scatter(123)
+    y = await c.scatter(123)
     assert x.key == y.key
 
-    z = yield c.scatter(123, hash=False)
+    z = await c.scatter(123, hash=False)
     assert z.key != y.key
 
 
 @gen_cluster(client=True)
-def test_get_releases_data(c, s, a, b):
-    yield c.gather(c.get({"x": (inc, 1)}, ["x"], sync=False))
+async def test_get_releases_data(c, s, a, b):
+    await c.gather(c.get({"x": (inc, 1)}, ["x"], sync=False))
     import gc
 
     gc.collect()
 
     start = time()
     while c.refcount["x"]:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
 
 
@@ -1213,26 +1213,26 @@ def test_global_clients(loop):
 
 
 @gen_cluster(client=True)
-def test_exception_on_exception(c, s, a, b):
+async def test_exception_on_exception(c, s, a, b):
     x = c.submit(lambda: 1 / 0)
     y = c.submit(inc, x)
 
     with pytest.raises(ZeroDivisionError):
-        yield y
+        await y
 
     z = c.submit(inc, y)
 
     with pytest.raises(ZeroDivisionError):
-        yield z
+        await z
 
 
 @gen_cluster(client=True)
-def test_get_nbytes(c, s, a, b):
-    [x] = yield c.scatter([1])
+async def test_get_nbytes(c, s, a, b):
+    [x] = await c.scatter([1])
     assert s.get_nbytes(summary=False) == {x.key: sizeof(1)}
 
     y = c.submit(inc, x)
-    yield y
+    await y
 
     assert s.get_nbytes(summary=False) == {x.key: sizeof(1), y.key: sizeof(2)}
 
@@ -1241,24 +1241,24 @@ def test_get_nbytes(c, s, a, b):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True)
-def test_nbytes_determines_worker(c, s, a, b):
+async def test_nbytes_determines_worker(c, s, a, b):
     x = c.submit(identity, 1, workers=[a.ip])
     y = c.submit(identity, tuple(range(100)), workers=[b.ip])
-    yield c.gather([x, y])
+    await c.gather([x, y])
 
     z = c.submit(lambda x, y: None, x, y)
-    yield z
+    await z
     assert s.tasks[z.key].who_has == {s.workers[b.address]}
 
 
 @gen_cluster(client=True)
-def test_if_intermediates_clear_on_error(c, s, a, b):
+async def test_if_intermediates_clear_on_error(c, s, a, b):
     x = delayed(div, pure=True)(1, 0)
     y = delayed(div, pure=True)(1, 2)
     z = delayed(add, pure=True)(x, y)
     f = c.compute(z)
     with pytest.raises(ZeroDivisionError):
-        yield f
+        await f
     s.validate_state()
     assert not any(ts.who_has for ts in s.tasks.values())
 
@@ -1266,7 +1266,7 @@ def test_if_intermediates_clear_on_error(c, s, a, b):
 @gen_cluster(
     client=True, config={"distributed.scheduler.default-task-durations": {"f": "1ms"}}
 )
-def test_pragmatic_move_small_data_to_large_data(c, s, a, b):
+async def test_pragmatic_move_small_data_to_large_data(c, s, a, b):
     np = pytest.importorskip("numpy")
     lists = c.map(np.ones, [10000] * 10, pure=False)
     sums = c.map(np.sum, lists)
@@ -1277,8 +1277,8 @@ def test_pragmatic_move_small_data_to_large_data(c, s, a, b):
 
     results = c.map(f, lists, [total] * 10)
 
-    yield wait([total])
-    yield wait(results)
+    await wait([total])
+    await wait(results)
 
     assert (
         sum(
@@ -1290,20 +1290,20 @@ def test_pragmatic_move_small_data_to_large_data(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_get_with_non_list_key(c, s, a, b):
+async def test_get_with_non_list_key(c, s, a, b):
     dsk = {("x", 0): (inc, 1), 5: (inc, 2)}
 
-    x = yield c.get(dsk, ("x", 0), sync=False)
-    y = yield c.get(dsk, 5, sync=False)
+    x = await c.get(dsk, ("x", 0), sync=False)
+    y = await c.get(dsk, 5, sync=False)
     assert x == 2
     assert y == 3
 
 
 @gen_cluster(client=True)
-def test_get_with_error(c, s, a, b):
+async def test_get_with_error(c, s, a, b):
     dsk = {"x": (div, 1, 0), "y": (inc, "x")}
     with pytest.raises(ZeroDivisionError):
-        yield c.get(dsk, "y", sync=False)
+        await c.get(dsk, "y", sync=False)
 
 
 def test_get_with_error_sync(c):
@@ -1313,12 +1313,12 @@ def test_get_with_error_sync(c):
 
 
 @gen_cluster(client=True)
-def test_directed_scatter(c, s, a, b):
-    yield c.scatter([1, 2, 3], workers=[a.address])
+async def test_directed_scatter(c, s, a, b):
+    await c.scatter([1, 2, 3], workers=[a.address])
     assert len(a.data) == 3
     assert not b.data
 
-    yield c.scatter([4, 5], workers=[b.name])
+    await c.scatter([4, 5], workers=[b.name])
     assert len(b.data) == 2
 
 
@@ -1330,56 +1330,56 @@ def test_directed_scatter_sync(c, s, a, b, loop):
 
 
 @gen_cluster(client=True)
-def test_scatter_direct(c, s, a, b):
-    future = yield c.scatter(123, direct=True)
+async def test_scatter_direct(c, s, a, b):
+    future = await c.scatter(123, direct=True)
     assert future.key in a.data or future.key in b.data
     assert s.tasks[future.key].who_has
     assert future.status == "finished"
-    result = yield future
+    result = await future
     assert result == 123
     assert not s.counters["op"].components[0]["scatter"]
 
-    result = yield future
+    result = await future
     assert not s.counters["op"].components[0]["gather"]
 
-    result = yield c.gather(future)
+    result = await c.gather(future)
     assert not s.counters["op"].components[0]["gather"]
 
 
 @gen_cluster(client=True)
-def test_scatter_direct_numpy(c, s, a, b):
+async def test_scatter_direct_numpy(c, s, a, b):
     np = pytest.importorskip("numpy")
     x = np.ones(5)
-    future = yield c.scatter(x, direct=True)
-    result = yield future
+    future = await c.scatter(x, direct=True)
+    result = await future
     assert np.allclose(x, result)
     assert not s.counters["op"].components[0]["scatter"]
 
 
 @gen_cluster(client=True)
-def test_scatter_direct_broadcast(c, s, a, b):
-    future2 = yield c.scatter(456, direct=True, broadcast=True)
+async def test_scatter_direct_broadcast(c, s, a, b):
+    future2 = await c.scatter(456, direct=True, broadcast=True)
     assert future2.key in a.data
     assert future2.key in b.data
     assert s.tasks[future2.key].who_has == {s.workers[a.address], s.workers[b.address]}
-    result = yield future2
+    result = await future2
     assert result == 456
     assert not s.counters["op"].components[0]["scatter"]
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
-def test_scatter_direct_balanced(c, s, *workers):
-    futures = yield c.scatter([1, 2, 3], direct=True)
+async def test_scatter_direct_balanced(c, s, *workers):
+    futures = await c.scatter([1, 2, 3], direct=True)
     assert sorted([len(w.data) for w in workers]) == [0, 1, 1, 1]
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
-def test_scatter_direct_broadcast_target(c, s, *workers):
-    futures = yield c.scatter([123, 456], direct=True, workers=workers[0].address)
+async def test_scatter_direct_broadcast_target(c, s, *workers):
+    futures = await c.scatter([123, 456], direct=True, workers=workers[0].address)
     assert futures[0].key in workers[0].data
     assert futures[1].key in workers[0].data
 
-    futures = yield c.scatter(
+    futures = await c.scatter(
         [123, 456],
         direct=True,
         broadcast=True,
@@ -1393,16 +1393,16 @@ def test_scatter_direct_broadcast_target(c, s, *workers):
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_scatter_direct_empty(c, s):
+async def test_scatter_direct_empty(c, s):
     with pytest.raises((ValueError, TimeoutError)):
-        yield c.scatter(123, direct=True, timeout=0.1)
+        await c.scatter(123, direct=True, timeout=0.1)
 
 
 @gen_cluster(client=True, timeout=None, nthreads=[("127.0.0.1", 1)] * 5)
-def test_scatter_direct_spread_evenly(c, s, *workers):
+async def test_scatter_direct_spread_evenly(c, s, *workers):
     futures = []
     for i in range(10):
-        future = yield c.scatter(i, direct=True)
+        future = await c.scatter(i, direct=True)
         futures.append(future)
 
     assert all(w.data for w in workers)
@@ -1419,32 +1419,32 @@ def test_scatter_gather_sync(c, direct, broadcast):
 
 
 @gen_cluster(client=True)
-def test_gather_direct(c, s, a, b):
-    futures = yield c.scatter([1, 2, 3])
+async def test_gather_direct(c, s, a, b):
+    futures = await c.scatter([1, 2, 3])
 
-    data = yield c.gather(futures, direct=True)
+    data = await c.gather(futures, direct=True)
     assert data == [1, 2, 3]
 
 
 @gen_cluster(client=True)
-def test_many_submits_spread_evenly(c, s, a, b):
+async def test_many_submits_spread_evenly(c, s, a, b):
     L = [c.submit(inc, i) for i in range(10)]
-    yield wait(L)
+    await wait(L)
 
     assert a.data and b.data
 
 
 @gen_cluster(client=True)
-def test_traceback(c, s, a, b):
+async def test_traceback(c, s, a, b):
     x = c.submit(div, 1, 0)
-    tb = yield x.traceback()
+    tb = await x.traceback()
     assert any("x / y" in line for line in pluck(3, traceback.extract_tb(tb)))
 
 
 @gen_cluster(client=True)
-def test_get_traceback(c, s, a, b):
+async def test_get_traceback(c, s, a, b):
     try:
-        yield c.get({"x": (div, 1, 0)}, "x", sync=False)
+        await c.get({"x": (div, 1, 0)}, "x", sync=False)
     except ZeroDivisionError:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         L = traceback.format_tb(exc_traceback)
@@ -1452,10 +1452,10 @@ def test_get_traceback(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_gather_traceback(c, s, a, b):
+async def test_gather_traceback(c, s, a, b):
     x = c.submit(div, 1, 0)
     try:
-        yield c.gather(x)
+        await c.gather(x)
     except ZeroDivisionError:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         L = traceback.format_tb(exc_traceback)
@@ -1484,7 +1484,7 @@ def test_traceback_sync(c):
 
 
 @gen_cluster(client=True)
-def test_upload_file(c, s, a, b):
+async def test_upload_file(c, s, a, b):
     def g():
         import myfile
 
@@ -1493,21 +1493,21 @@ def test_upload_file(c, s, a, b):
     with save_sys_modules():
         for value in [123, 456]:
             with tmp_text("myfile.py", "def f():\n    return {}".format(value)) as fn:
-                yield c.upload_file(fn)
+                await c.upload_file(fn)
 
             x = c.submit(g, pure=False)
-            result = yield x
+            result = await x
             assert result == value
 
 
 @gen_cluster(client=True)
-def test_upload_file_no_extension(c, s, a, b):
+async def test_upload_file_no_extension(c, s, a, b):
     with tmp_text("myfile", "") as fn:
-        yield c.upload_file(fn)
+        await c.upload_file(fn)
 
 
 @gen_cluster(client=True)
-def test_upload_file_zip(c, s, a, b):
+async def test_upload_file_zip(c, s, a, b):
     def g():
         import myfile
 
@@ -1521,10 +1521,10 @@ def test_upload_file_zip(c, s, a, b):
                 ) as fn_my_file:
                     with zipfile.ZipFile("myfile.zip", "w") as z:
                         z.write(fn_my_file, arcname=os.path.basename(fn_my_file))
-                    yield c.upload_file("myfile.zip")
+                    await c.upload_file("myfile.zip")
 
                     x = c.submit(g, pure=False)
-                    result = yield x
+                    result = await x
                     assert result == value
         finally:
             if os.path.exists("myfile.zip"):
@@ -1532,7 +1532,7 @@ def test_upload_file_zip(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_upload_file_egg(c, s, a, b):
+async def test_upload_file_egg(c, s, a, b):
     def g():
         import package_1, package_2
 
@@ -1581,22 +1581,22 @@ def test_upload_file_egg(c, s, a, b):
                 ][0]
                 egg_path = os.path.join(egg_root, egg_name)
 
-                yield c.upload_file(egg_path)
+                await c.upload_file(egg_path)
                 os.remove(egg_path)
 
                 x = c.submit(g, pure=False)
-                result = yield x
+                result = await x
                 assert result == (value, value)
 
 
 @gen_cluster(client=True)
-def test_upload_large_file(c, s, a, b):
+async def test_upload_large_file(c, s, a, b):
     assert a.local_directory
     assert b.local_directory
     with tmp_text("myfile", "abc") as fn:
         with tmp_text("myfile2", "def") as fn2:
-            yield c._upload_large_file(fn, remote_filename="x")
-            yield c._upload_large_file(fn2)
+            await c._upload_large_file(fn, remote_filename="x")
+            await c._upload_large_file(fn2)
 
             for w in [a, b]:
                 assert os.path.exists(os.path.join(w.local_directory, "x"))
@@ -1620,10 +1620,10 @@ def test_upload_file_sync(c):
 
 
 @gen_cluster(client=True)
-def test_upload_file_exception(c, s, a, b):
+async def test_upload_file_exception(c, s, a, b):
     with tmp_text("myfile.py", "syntax-error!") as fn:
         with pytest.raises(SyntaxError):
-            yield c.upload_file(fn)
+            await c.upload_file(fn)
 
 
 def test_upload_file_exception_sync(c):
@@ -1634,29 +1634,29 @@ def test_upload_file_exception_sync(c):
 
 @pytest.mark.skip
 @gen_cluster()
-def test_multiple_clients(s, a, b):
-    a = yield Client(s.address, asynchronous=True)
-    b = yield Client(s.address, asynchronous=True)
+async def test_multiple_clients(s, a, b):
+    a = await Client(s.address, asynchronous=True)
+    b = await Client(s.address, asynchronous=True)
 
     x = a.submit(inc, 1)
     y = b.submit(inc, 2)
     assert x.client is a
     assert y.client is b
-    xx = yield x
-    yy = yield y
+    xx = await x
+    yy = await y
     assert xx == 2
     assert yy == 3
     z = a.submit(add, x, y)
     assert z.client is a
-    zz = yield z
+    zz = await z
     assert zz == 5
 
-    yield a.close()
-    yield b.close()
+    await a.close()
+    await b.close()
 
 
 @gen_cluster(client=True)
-def test_async_compute(c, s, a, b):
+async def test_async_compute(c, s, a, b):
     from dask.delayed import delayed
 
     x = delayed(1)
@@ -1668,7 +1668,7 @@ def test_async_compute(c, s, a, b):
     assert isinstance(zz, Future)
     assert aa == 3
 
-    result = yield c.gather([yy, zz])
+    result = await c.gather([yy, zz])
     assert result == [2, 0]
 
     assert isinstance(c.compute(y), Future)
@@ -1676,8 +1676,8 @@ def test_async_compute(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_async_compute_with_scatter(c, s, a, b):
-    d = yield c.scatter({("x", 1): 1, ("y", 1): 2})
+async def test_async_compute_with_scatter(c, s, a, b):
+    d = await c.scatter({("x", 1): 1, ("y", 1): 2})
     x, y = d[("x", 1)], d[("y", 1)]
 
     from dask.delayed import delayed
@@ -1685,7 +1685,7 @@ def test_async_compute_with_scatter(c, s, a, b):
     z = delayed(add)(delayed(inc)(x), delayed(inc)(y))
     zz = c.compute(z)
 
-    [result] = yield c.gather([zz])
+    [result] = await c.gather([zz])
     assert result == 2 + 3
 
 
@@ -1699,22 +1699,22 @@ def test_sync_compute(c):
 
 
 @gen_cluster(client=True)
-def test_remote_scatter_gather(c, s, a, b):
-    x, y, z = yield c.scatter([1, 2, 3])
+async def test_remote_scatter_gather(c, s, a, b):
+    x, y, z = await c.scatter([1, 2, 3])
 
     assert x.key in a.data or x.key in b.data
     assert y.key in a.data or y.key in b.data
     assert z.key in a.data or z.key in b.data
 
-    xx, yy, zz = yield c.gather([x, y, z])
+    xx, yy, zz = await c.gather([x, y, z])
     assert (xx, yy, zz) == (1, 2, 3)
 
 
 @gen_cluster(timeout=1000, client=True)
-def test_remote_submit_on_Future(c, s, a, b):
+async def test_remote_submit_on_Future(c, s, a, b):
     x = c.submit(lambda x: x + 1, 1)
     y = c.submit(lambda x: x + 1, x)
-    result = yield y
+    result = await y
     assert result == 3
 
 
@@ -1728,22 +1728,22 @@ def test_start_is_idempotent(c):
 
 
 @gen_cluster(client=True)
-def test_client_with_scheduler(c, s, a, b):
+async def test_client_with_scheduler(c, s, a, b):
     assert s.nthreads == {a.address: a.nthreads, b.address: b.nthreads}
 
     x = c.submit(inc, 1)
     y = c.submit(inc, 2)
     z = c.submit(add, x, y)
-    result = yield x
+    result = await x
     assert result == 1 + 1
-    result = yield z
+    result = await z
     assert result == 1 + 1 + 1 + 2
 
-    A, B, C = yield c.scatter([1, 2, 3])
-    AA, BB, xx = yield c.gather([A, B, x])
+    A, B, C = await c.scatter([1, 2, 3])
+    AA, BB, xx = await c.gather([A, B, x])
     assert (AA, BB, xx) == (1, 2, 2)
 
-    result = yield c.get({"x": (inc, 1), "y": (add, "x", 10)}, "y", sync=False)
+    result = await c.get({"x": (inc, 1), "y": (add, "x", 10)}, "y", sync=False)
     assert result == 12
 
 
@@ -1751,33 +1751,33 @@ def test_client_with_scheduler(c, s, a, b):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True)
-def test_allow_restrictions(c, s, a, b):
+async def test_allow_restrictions(c, s, a, b):
     aws = s.workers[a.address]
     bws = s.workers[a.address]
 
     x = c.submit(inc, 1, workers=a.ip)
-    yield x
+    await x
     assert s.tasks[x.key].who_has == {aws}
     assert not s.loose_restrictions
 
     x = c.submit(inc, 2, workers=a.ip, allow_other_workers=True)
-    yield x
+    await x
     assert s.tasks[x.key].who_has == {aws}
     assert x.key in s.loose_restrictions
 
     L = c.map(inc, range(3, 13), workers=a.ip, allow_other_workers=True)
-    yield wait(L)
+    await wait(L)
     assert all(s.tasks[f.key].who_has == {aws} for f in L)
     assert {f.key for f in L}.issubset(s.loose_restrictions)
 
     x = c.submit(inc, 15, workers="127.0.0.3", allow_other_workers=True)
 
-    yield x
+    await x
     assert s.tasks[x.key].who_has
     assert x.key in s.loose_restrictions
 
     L = c.map(inc, range(15, 25), workers="127.0.0.3", allow_other_workers=True)
-    yield wait(L)
+    await wait(L)
     assert all(s.tasks[f.key].who_has for f in L)
     assert {f.key for f in L}.issubset(s.loose_restrictions)
 
@@ -1808,18 +1808,18 @@ def test_bad_address():
 
 
 @gen_cluster(client=True)
-def test_long_error(c, s, a, b):
+async def test_long_error(c, s, a, b):
     def bad(x):
         raise ValueError("a" * 100000)
 
     x = c.submit(bad, 10)
 
     try:
-        yield x
+        await x
     except ValueError as e:
         assert len(str(e)) < 100000
 
-    tb = yield x.traceback()
+    tb = await x.traceback()
     assert all(
         len(line) < 100000
         for line in concat(traceback.extract_tb(tb))
@@ -1828,18 +1828,18 @@ def test_long_error(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_map_on_futures_with_kwargs(c, s, a, b):
+async def test_map_on_futures_with_kwargs(c, s, a, b):
     def f(x, y=10):
         return x + y
 
     futures = c.map(inc, range(10))
     futures2 = c.map(f, futures, y=20)
-    results = yield c.gather(futures2)
+    results = await c.gather(futures2)
     assert results == [i + 1 + 20 for i in range(10)]
 
     future = c.submit(inc, 100)
     future2 = c.submit(f, future, y=200)
-    result = yield future2
+    result = await future2
     assert result == 100 + 1 + 200
 
 
@@ -1863,19 +1863,19 @@ class FatallySerializedObject:
 
 
 @gen_cluster(client=True)
-def test_badly_serialized_input(c, s, a, b):
+async def test_badly_serialized_input(c, s, a, b):
     o = BadlySerializedObject()
 
     future = c.submit(inc, o)
     futures = c.map(inc, range(10))
 
-    L = yield c.gather(futures)
+    L = await c.gather(futures)
     assert list(L) == list(map(inc, range(10)))
     assert future.status == "error"
 
 
 @pytest.mark.skipif("True", reason="")
-def test_badly_serialized_input_stderr(capsys, c):
+async def test_badly_serialized_input_stderr(capsys, c):
     o = BadlySerializedObject()
     future = c.submit(inc, o)
 
@@ -1908,37 +1908,37 @@ def test_repr(loop):
 
 
 @gen_cluster(client=True)
-def test_repr_async(c, s, a, b):
+async def test_repr_async(c, s, a, b):
     c._repr_html_()
 
 
 @gen_cluster(client=True, worker_kwargs={"memory_limit": None})
-def test_repr_no_memory_limit(c, s, a, b):
+async def test_repr_no_memory_limit(c, s, a, b):
     c._repr_html_()
 
 
 @gen_test()
-def test_repr_localcluster():
-    cluster = yield LocalCluster(
+async def test_repr_localcluster():
+    cluster = await LocalCluster(
         processes=False, dashboard_address=None, asynchronous=True
     )
-    client = yield Client(cluster, asynchronous=True)
+    client = await Client(cluster, asynchronous=True)
     try:
         text = client._repr_html_()
         assert cluster.scheduler.address in text
         assert is_valid_xml(client._repr_html_())
     finally:
-        yield client.close()
-        yield cluster.close()
+        await client.close()
+        await cluster.close()
 
 
 @gen_cluster(client=True)
-def test_forget_simple(c, s, a, b):
+async def test_forget_simple(c, s, a, b):
     x = c.submit(inc, 1, retries=2)
     y = c.submit(inc, 2)
     z = c.submit(add, x, y, workers=[a.ip], allow_other_workers=True)
 
-    yield wait([x, y, z])
+    await wait([x, y, z])
     assert not s.waiting_data.get(x.key)
     assert not s.waiting_data.get(y.key)
 
@@ -1957,14 +1957,14 @@ def test_forget_simple(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_forget_complex(e, s, A, B):
-    a, b, c, d = yield e.scatter(list(range(4)))
+async def test_forget_complex(e, s, A, B):
+    a, b, c, d = await e.scatter(list(range(4)))
     ab = e.submit(add, a, b)
     cd = e.submit(add, c, d)
     ac = e.submit(add, a, c)
     acab = e.submit(add, ac, ab)
 
-    yield wait([a, b, c, d, ab, ac, cd, acab])
+    await wait([a, b, c, d, ab, ac, cd, acab])
 
     assert set(s.tasks) == {f.key for f in [ab, ac, cd, acab, a, b, c, d]}
 
@@ -1980,7 +1980,7 @@ def test_forget_complex(e, s, A, B):
 
     start = time()
     while b.key in A.data or b.key in B.data:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 10
 
     s.client_releases_keys(keys=[ac.key], client=e.id)
@@ -1988,7 +1988,7 @@ def test_forget_complex(e, s, A, B):
 
 
 @gen_cluster(client=True)
-def test_forget_in_flight(e, s, A, B):
+async def test_forget_in_flight(e, s, A, B):
     delayed2 = partial(delayed, pure=True)
     a, b, c, d = [delayed2(slowinc)(i) for i in range(4)]
     ab = delayed2(slowadd)(a, b, dask_key_name="ab")
@@ -2000,7 +2000,7 @@ def test_forget_in_flight(e, s, A, B):
     s.validate_state()
 
     for i in range(5):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         s.validate_state()
 
     s.client_releases_keys(keys=[y.key], client=e.id)
@@ -2011,11 +2011,11 @@ def test_forget_in_flight(e, s, A, B):
 
 
 @gen_cluster(client=True)
-def test_forget_errors(c, s, a, b):
+async def test_forget_errors(c, s, a, b):
     x = c.submit(div, 1, 0)
     y = c.submit(inc, x)
     z = c.submit(inc, y)
-    yield wait([y])
+    await wait([y])
 
     assert x.key in s.exceptions
     assert x.key in s.exceptions_blame
@@ -2054,21 +2054,21 @@ def test_repr_sync(c):
 
 
 @gen_cluster(client=True)
-def test_waiting_data(c, s, a, b):
+async def test_waiting_data(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(inc, 2)
     z = c.submit(add, x, y, workers=[a.ip], allow_other_workers=True)
 
-    yield wait([x, y, z])
+    await wait([x, y, z])
 
     assert not s.waiting_data.get(x.key)
     assert not s.waiting_data.get(y.key)
 
 
 @gen_cluster()
-def test_multi_client(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
-    f = yield Client(s.address, asynchronous=True)
+async def test_multi_client(s, a, b):
+    c = await Client(s.address, asynchronous=True)
+    f = await Client(s.address, asynchronous=True)
 
     assert set(s.client_comms) == {c.id, f.id}
 
@@ -2078,7 +2078,7 @@ def test_multi_client(s, a, b):
 
     assert y.key == y2.key
 
-    yield wait([x, y])
+    await wait([x, y])
 
     assert s.wants_what == {
         c.id: {x.key, y.key},
@@ -2087,22 +2087,22 @@ def test_multi_client(s, a, b):
     }
     assert s.who_wants == {x.key: {c.id}, y.key: {c.id, f.id}}
 
-    yield c.close()
+    await c.close()
 
     start = time()
     while c.id in s.wants_what:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     assert c.id not in s.wants_what
     assert c.id not in s.who_wants[y.key]
     assert x.key not in s.who_wants
 
-    yield f.close()
+    await f.close()
 
     start = time()
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2, s.tasks
 
 
@@ -2115,29 +2115,29 @@ def long_running_client_connection(address):
 
 
 @gen_cluster()
-def test_cleanup_after_broken_client_connection(s, a, b):
+async def test_cleanup_after_broken_client_connection(s, a, b):
     proc = mp_context.Process(target=long_running_client_connection, args=(s.address,))
     proc.daemon = True
     proc.start()
 
     start = time()
     while not s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     proc.terminate()
 
     start = time()
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
 @gen_cluster()
-def test_multi_garbage_collection(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
+async def test_multi_garbage_collection(s, a, b):
+    c = await Client(s.address, asynchronous=True)
 
-    f = yield Client(s.address, asynchronous=True)
+    f = await Client(s.address, asynchronous=True)
 
     x = c.submit(inc, 1)
     y = f.submit(inc, 2)
@@ -2145,12 +2145,12 @@ def test_multi_garbage_collection(s, a, b):
 
     assert y.key == y2.key
 
-    yield wait([x, y])
+    await wait([x, y])
 
     x.__del__()
     start = time()
     while x.key in a.data or x.key in b.data:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     assert s.wants_what == {c.id: {y.key}, f.id: {y.key}, "fire-and-forget": set()}
@@ -2159,10 +2159,10 @@ def test_multi_garbage_collection(s, a, b):
     y.__del__()
     start = time()
     while x.key in s.wants_what[f.id]:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert y.key in a.data or y.key in b.data
     assert s.wants_what == {c.id: {y.key}, f.id: set(), "fire-and-forget": set()}
     assert s.who_wants == {y.key: {c.id}}
@@ -2170,32 +2170,32 @@ def test_multi_garbage_collection(s, a, b):
     y2.__del__()
     start = time()
     while y.key in a.data or y.key in b.data:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     assert not any(v for v in s.wants_what.values())
     assert not s.who_wants
 
-    yield c.close()
-    yield f.close()
+    await c.close()
+    await f.close()
 
 
 @gen_cluster(client=True)
-def test__broadcast(c, s, a, b):
-    x, y = yield c.scatter([1, 2], broadcast=True)
+async def test__broadcast(c, s, a, b):
+    x, y = await c.scatter([1, 2], broadcast=True)
     assert a.data == b.data == {x.key: 1, y.key: 2}
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
-def test__broadcast_integer(c, s, *workers):
-    x, y = yield c.scatter([1, 2], broadcast=2)
+async def test__broadcast_integer(c, s, *workers):
+    x, y = await c.scatter([1, 2], broadcast=2)
     assert len(s.tasks[x.key].who_has) == 2
     assert len(s.tasks[y.key].who_has) == 2
 
 
 @gen_cluster(client=True)
-def test__broadcast_dict(c, s, a, b):
-    d = yield c.scatter({"x": 1}, broadcast=True)
+async def test__broadcast_dict(c, s, a, b):
+    d = await c.scatter({"x": 1}, broadcast=True)
     assert a.data == b.data == {"x": 1}
 
 
@@ -2219,20 +2219,20 @@ def test_broadcast(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_proxy(c, s, a, b):
-    msg = yield c.scheduler.proxy(msg={"op": "identity"}, worker=a.address)
+async def test_proxy(c, s, a, b):
+    msg = await c.scheduler.proxy(msg={"op": "identity"}, worker=a.address)
     assert msg["id"] == a.identity()["id"]
 
 
 @gen_cluster(client=True)
-def test__cancel(c, s, a, b):
+async def test__cancel(c, s, a, b):
     x = c.submit(slowinc, 1)
     y = c.submit(slowinc, x)
 
     while y.key not in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
-    yield c.cancel([x])
+    await c.cancel([x])
 
     assert x.cancelled()
     assert "cancel" in str(x)
@@ -2240,7 +2240,7 @@ def test__cancel(c, s, a, b):
 
     start = time()
     while not y.cancelled():
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     assert not s.tasks
@@ -2248,51 +2248,51 @@ def test__cancel(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_cancel_tuple_key(c, s, a, b):
+async def test_cancel_tuple_key(c, s, a, b):
     x = c.submit(inc, 1, key=("x", 0, 1))
-    yield x
-    yield c.cancel(x)
+    await x
+    await c.cancel(x)
     with pytest.raises(CancelledError):
-        yield x
+        await x
 
 
 @gen_cluster()
-def test_cancel_multi_client(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
-    f = yield Client(s.address, asynchronous=True)
+async def test_cancel_multi_client(s, a, b):
+    c = await Client(s.address, asynchronous=True)
+    f = await Client(s.address, asynchronous=True)
 
     x = c.submit(slowinc, 1)
     y = f.submit(slowinc, 1)
 
     assert x.key == y.key
 
-    yield c.cancel([x])
+    await c.cancel([x])
 
     assert x.cancelled()
     assert not y.cancelled()
 
     start = time()
     while y.key not in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
-    out = yield y
+    out = await y
     assert out == 2
 
     with pytest.raises(CancelledError):
-        yield x
+        await x
 
-    yield c.close()
-    yield f.close()
+    await c.close()
+    await f.close()
 
 
 @gen_cluster(client=True)
-def test_cancel_collection(c, s, a, b):
+async def test_cancel_collection(c, s, a, b):
     L = c.map(double, [[1], [2], [3]])
     x = db.Bag({("b", i): f for i, f in enumerate(L)}, "b", 3)
 
-    yield c.cancel(x)
-    yield c.cancel([x])
+    await c.cancel(x)
+    await c.cancel([x])
     assert all(f.cancelled() for f in L)
     assert not s.tasks
 
@@ -2316,18 +2316,18 @@ def test_cancel(c):
 
 
 @gen_cluster(client=True)
-def test_future_type(c, s, a, b):
+async def test_future_type(c, s, a, b):
     x = c.submit(inc, 1)
-    yield wait([x])
+    await wait([x])
     assert x.type == int
     assert "int" in str(x)
 
 
 @gen_cluster(client=True)
-def test_traceback_clean(c, s, a, b):
+async def test_traceback_clean(c, s, a, b):
     x = c.submit(div, 1, 0)
     try:
-        yield x
+        await x
     except Exception as e:
         f = e
         exc_type, exc_value, tb = sys.exc_info()
@@ -2338,7 +2338,7 @@ def test_traceback_clean(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_map_differnet_lengths(c, s, a, b):
+async def test_map_differnet_lengths(c, s, a, b):
     assert len(c.map(add, [1, 2], [1, 2, 3])) == 2
 
 
@@ -2354,7 +2354,7 @@ def test_Future_exception_sync_2(loop, capsys):
 
 
 @gen_cluster(timeout=60, client=True)
-def test_async_persist(c, s, a, b):
+async def test_async_persist(c, s, a, b):
     from dask.delayed import delayed, Delayed
 
     x = delayed(1)
@@ -2372,13 +2372,13 @@ def test_async_persist(c, s, a, b):
     assert w.__dask_keys__() == ww.__dask_keys__()
 
     while y.key not in s.tasks and w.key not in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert s.who_wants[y.key] == {c.id}
     assert s.who_wants[w.key] == {c.id}
 
     yyf, wwf = c.compute([yy, ww])
-    yyy, www = yield c.gather([yyf, wwf])
+    yyy, www = await c.gather([yyf, wwf])
     assert yyy == inc(1)
     assert www == add(inc(1), dec(1))
 
@@ -2387,7 +2387,7 @@ def test_async_persist(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test__persist(c, s, a, b):
+async def test__persist(c, s, a, b):
     pytest.importorskip("dask.array")
     import dask.array as da
 
@@ -2403,7 +2403,7 @@ def test__persist(c, s, a, b):
 
     g, h = c.compute([y, yy])
 
-    gg, hh = yield c.gather([g, h])
+    gg, hh = await c.gather([g, h])
     assert (gg == hh).all()
 
 
@@ -2426,7 +2426,7 @@ def test_persist(c):
 
 
 @gen_cluster(timeout=60, client=True)
-def test_long_traceback(c, s, a, b):
+async def test_long_traceback(c, s, a, b):
     from distributed.protocol.pickle import dumps
 
     def deep(n):
@@ -2436,22 +2436,22 @@ def test_long_traceback(c, s, a, b):
             return deep(n - 1)
 
     x = c.submit(deep, 200)
-    yield wait([x])
+    await wait([x])
     assert len(dumps(c.futures[x.key].traceback)) < 10000
     assert isinstance(c.futures[x.key].exception, ZeroDivisionError)
 
 
 @gen_cluster(client=True)
-def test_wait_on_collections(c, s, a, b):
+async def test_wait_on_collections(c, s, a, b):
     L = c.map(double, [[1], [2], [3]])
     x = db.Bag({("b", i): f for i, f in enumerate(L)}, "b", 3)
 
-    yield wait(x)
+    await wait(x)
     assert all(f.key in a.data or f.key in b.data for f in L)
 
 
 @gen_cluster(client=True)
-def test_futures_of_get(c, s, a, b):
+async def test_futures_of_get(c, s, a, b):
     x, y, z = c.map(inc, [1, 2, 3])
 
     assert set(futures_of(0)) == set()
@@ -2477,15 +2477,15 @@ def test_futures_of_class():
 
 
 @gen_cluster(client=True)
-def test_futures_of_cancelled_raises(c, s, a, b):
+async def test_futures_of_cancelled_raises(c, s, a, b):
     x = c.submit(inc, 1)
-    yield c.cancel([x])
+    await c.cancel([x])
 
     with pytest.raises(CancelledError):
-        yield x
+        await x
 
     with pytest.raises(CancelledError):
-        yield c.get({"x": (inc, x), "y": (inc, 2)}, ["x", "y"], sync=False)
+        await c.get({"x": (inc, x), "y": (inc, 2)}, ["x", "y"], sync=False)
 
     with pytest.raises(CancelledError):
         c.submit(inc, x)
@@ -2501,69 +2501,69 @@ def test_futures_of_cancelled_raises(c, s, a, b):
 
 @pytest.mark.skip
 @gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)
-def test_dont_delete_recomputed_results(c, s, w):
+async def test_dont_delete_recomputed_results(c, s, w):
     x = c.submit(inc, 1)  # compute first time
-    yield wait([x])
+    await wait([x])
     x.__del__()  # trigger garbage collection
-    yield gen.sleep(0)
+    await gen.sleep(0)
     xx = c.submit(inc, 1)  # compute second time
 
     start = time()
     while xx.key not in w.data:  # data shows up
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 1
 
     while time() < start + (s.delete_interval + 100) / 1000:  # and stays
         assert xx.key in w.data
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
 
 @gen_cluster(nthreads=[], client=True)
-def test_fatally_serialized_input(c, s):
+async def test_fatally_serialized_input(c, s):
     o = FatallySerializedObject()
 
     future = c.submit(inc, o)
 
     while not s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
 
 @pytest.mark.skip(reason="Use fast random selection now")
 @gen_cluster(client=True)
-def test_balance_tasks_by_stacks(c, s, a, b):
+async def test_balance_tasks_by_stacks(c, s, a, b):
     x = c.submit(inc, 1)
-    yield wait(x)
+    await wait(x)
 
     y = c.submit(inc, 2)
-    yield wait(y)
+    await wait(y)
 
     assert len(a.data) == len(b.data) == 1
 
 
 @gen_cluster(client=True)
-def test_run(c, s, a, b):
-    results = yield c.run(inc, 1)
+async def test_run(c, s, a, b):
+    results = await c.run(inc, 1)
     assert results == {a.address: 2, b.address: 2}
 
-    results = yield c.run(inc, 1, workers=[a.address])
+    results = await c.run(inc, 1, workers=[a.address])
     assert results == {a.address: 2}
 
-    results = yield c.run(inc, 1, workers=[])
+    results = await c.run(inc, 1, workers=[])
     assert results == {}
 
 
 @gen_cluster(client=True)
-def test_run_handles_picklable_data(c, s, a, b):
+async def test_run_handles_picklable_data(c, s, a, b):
     futures = c.map(inc, range(10))
-    yield wait(futures)
+    await wait(futures)
 
     def func():
         return {}, set(), [], (), 1, "hello", b"100"
 
-    results = yield c.run_on_scheduler(func)
+    results = await c.run_on_scheduler(func)
     assert results == func()
 
-    results = yield c.run(func)
+    results = await c.run(func)
     assert results == {w.address: func() for w in [a, b]}
 
 
@@ -2579,20 +2579,20 @@ def test_run_sync(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_run_coroutine(c, s, a, b):
-    results = yield c.run(geninc, 1, delay=0.05)
+async def test_run_coroutine(c, s, a, b):
+    results = await c.run(geninc, 1, delay=0.05)
     assert results == {a.address: 2, b.address: 2}
 
-    results = yield c.run(geninc, 1, delay=0.05, workers=[a.address])
+    results = await c.run(geninc, 1, delay=0.05, workers=[a.address])
     assert results == {a.address: 2}
 
-    results = yield c.run(geninc, 1, workers=[])
+    results = await c.run(geninc, 1, workers=[])
     assert results == {}
 
     with pytest.raises(RuntimeError, match="hello"):
-        yield c.run(throws, 1)
+        await c.run(throws, 1)
 
-    results = yield c.run(asyncinc, 2, delay=0.01)
+    results = await c.run(asyncinc, 2, delay=0.01)
     assert results == {a.address: 3, b.address: 3}
 
 
@@ -2670,38 +2670,38 @@ def test_diagnostic_nbytes_sync(c):
 
 
 @gen_cluster(client=True)
-def test_diagnostic_nbytes(c, s, a, b):
+async def test_diagnostic_nbytes(c, s, a, b):
     incs = c.map(inc, [1, 2, 3])
     doubles = c.map(double, [1, 2, 3])
-    yield wait(incs + doubles)
+    await wait(incs + doubles)
 
     assert s.get_nbytes(summary=False) == {k.key: sizeof(1) for k in incs + doubles}
     assert s.get_nbytes(summary=True) == {"inc": sizeof(1) * 3, "double": sizeof(1) * 3}
 
 
 @gen_test()
-def test_worker_aliases():
-    s = yield Scheduler(validate=True, port=0)
+async def test_worker_aliases():
+    s = await Scheduler(validate=True, port=0)
     a = Worker(s.address, name="alice")
     b = Worker(s.address, name="bob")
     w = Worker(s.address, name=3)
-    yield asyncio.gather(a, b, w)
-    c = yield Client(s.address, asynchronous=True)
+    await asyncio.gather(a, b, w)
+    c = await Client(s.address, asynchronous=True)
 
     L = c.map(inc, range(10), workers="alice")
-    future = yield c.scatter(123, workers=3)
-    yield wait(L)
+    future = await c.scatter(123, workers=3)
+    await wait(L)
     assert len(a.data) == 10
     assert len(b.data) == 0
     assert dict(w.data) == {future.key: 123}
 
     for i, alias in enumerate([3, [3], "alice"]):
-        result = yield c.submit(lambda x: x + 1, i, workers=alias)
+        result = await c.submit(lambda x: x + 1, i, workers=alias)
         assert result == i + 1
 
-    yield c.close()
-    yield asyncio.gather(a.close(), b.close(), w.close())
-    yield s.close()
+    await c.close()
+    await asyncio.gather(a.close(), b.close(), w.close())
+    await s.close()
 
 
 def test_persist_get_sync(c):
@@ -2718,7 +2718,7 @@ def test_persist_get_sync(c):
 
 
 @gen_cluster(client=True)
-def test_persist_get(c, s, a, b):
+async def test_persist_get(c, s, a, b):
     dadd = delayed(add)
     x, y = delayed(1), delayed(2)
     xx = delayed(add)(x, x)
@@ -2728,17 +2728,17 @@ def test_persist_get(c, s, a, b):
     xxyy2 = c.persist(xxyy)
     xxyy3 = delayed(add)(xxyy2, 10)
 
-    yield gen.sleep(0.5)
-    result = yield c.gather(c.get(xxyy3.dask, xxyy3.__dask_keys__(), sync=False))
+    await gen.sleep(0.5)
+    result = await c.gather(c.get(xxyy3.dask, xxyy3.__dask_keys__(), sync=False))
     assert result[0] == ((1 + 1) + (2 + 2)) + 10
 
-    result = yield c.compute(xxyy3)
+    result = await c.compute(xxyy3)
     assert result == ((1 + 1) + (2 + 2)) + 10
 
-    result = yield c.compute(xxyy3)
+    result = await c.compute(xxyy3)
     assert result == ((1 + 1) + (2 + 2)) + 10
 
-    result = yield c.compute(xxyy3)
+    result = await c.compute(xxyy3)
     assert result == ((1 + 1) + (2 + 2)) + 10
 
 
@@ -2759,12 +2759,12 @@ def test_client_num_fds(loop):
 
 
 @gen_cluster()
-def test_startup_close_startup(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
-    yield c.close()
+async def test_startup_close_startup(s, a, b):
+    c = await Client(s.address, asynchronous=True)
+    await c.close()
 
-    c = yield Client(s.address, asynchronous=True)
-    yield c.close()
+    c = await Client(s.address, asynchronous=True)
+    await c.close()
 
 
 def test_startup_close_startup_sync(loop):
@@ -2781,7 +2781,7 @@ def test_startup_close_startup_sync(loop):
 
 
 @gen_cluster(client=True)
-def test_badly_serialized_exceptions(c, s, a, b):
+async def test_badly_serialized_exceptions(c, s, a, b):
     def f():
         class BadlySerializedException(Exception):
             def __reduce__(self):
@@ -2792,7 +2792,7 @@ def test_badly_serialized_exceptions(c, s, a, b):
     x = c.submit(f)
 
     try:
-        result = yield x
+        result = await x
     except Exception as e:
         assert "hello world" in str(e)
     else:
@@ -2800,16 +2800,16 @@ def test_badly_serialized_exceptions(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_rebalance(c, s, a, b):
+async def test_rebalance(c, s, a, b):
     aws = s.workers[a.address]
     bws = s.workers[b.address]
 
-    x, y = yield c.scatter([1, 2], workers=[a.address])
+    x, y = await c.scatter([1, 2], workers=[a.address])
     assert len(a.data) == 2
     assert len(b.data) == 0
 
     s.validate_state()
-    yield c.rebalance()
+    await c.rebalance()
     s.validate_state()
 
     assert len(b.data) == 1
@@ -2822,21 +2822,21 @@ def test_rebalance(c, s, a, b):
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)] * 4, client=True)
-def test_rebalance_workers(e, s, a, b, c, d):
-    w, x, y, z = yield e.scatter([1, 2, 3, 4], workers=[a.address])
+async def test_rebalance_workers(e, s, a, b, c, d):
+    w, x, y, z = await e.scatter([1, 2, 3, 4], workers=[a.address])
     assert len(a.data) == 4
     assert len(b.data) == 0
     assert len(c.data) == 0
     assert len(d.data) == 0
 
-    yield e.rebalance([x, y], workers=[a.address, c.address])
+    await e.rebalance([x, y], workers=[a.address, c.address])
     assert len(a.data) == 3
     assert len(b.data) == 0
     assert len(c.data) == 1
     assert len(d.data) == 0
     assert c.data == {x.key: 2} or c.data == {y.key: 3}
 
-    yield e.rebalance()
+    await e.rebalance()
     assert len(a.data) == 1
     assert len(b.data) == 1
     assert len(c.data) == 1
@@ -2845,9 +2845,9 @@ def test_rebalance_workers(e, s, a, b, c, d):
 
 
 @gen_cluster(client=True)
-def test_rebalance_execution(c, s, a, b):
+async def test_rebalance_execution(c, s, a, b):
     futures = c.map(inc, range(10), workers=a.address)
-    yield c.rebalance(futures)
+    await c.rebalance(futures)
     assert len(a.data) == len(b.data) == 5
     s.validate_state()
 
@@ -2862,10 +2862,10 @@ def test_rebalance_sync(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_rebalance_unprepared(c, s, a, b):
+async def test_rebalance_unprepared(c, s, a, b):
     futures = c.map(slowinc, range(10), delay=0.05, workers=a.address)
-    yield gen.sleep(0.1)
-    yield c.rebalance(futures)
+    await gen.sleep(0.1)
+    await c.rebalance(futures)
     s.validate_state()
 
 
@@ -2879,63 +2879,63 @@ async def test_rebalance_raises_missing_data(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_receive_lost_key(c, s, a, b):
+async def test_receive_lost_key(c, s, a, b):
     x = c.submit(inc, 1, workers=[a.address])
-    yield x
-    yield a.close()
+    await x
+    await a.close()
 
     start = time()
     while x.status == "finished":
         assert time() < start + 5
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
 
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True)
-def test_unrunnable_task_runs(c, s, a, b):
+async def test_unrunnable_task_runs(c, s, a, b):
     x = c.submit(inc, 1, workers=[a.ip])
-    yield x
+    await x
 
-    yield a.close()
+    await a.close()
     start = time()
     while x.status == "finished":
         assert time() < start + 5
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert s.tasks[x.key] in s.unrunnable
     assert s.get_task_status(keys=[x.key]) == {x.key: "no-worker"}
 
-    w = yield Worker(s.address, loop=s.loop)
+    w = await Worker(s.address, loop=s.loop)
 
     start = time()
     while x.status != "finished":
         assert time() < start + 2
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert s.tasks[x.key] not in s.unrunnable
-    result = yield x
+    result = await x
     assert result == 2
-    yield w.close()
+    await w.close()
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_add_worker_after_tasks(c, s):
+async def test_add_worker_after_tasks(c, s):
     futures = c.map(inc, range(10))
-    n = yield Nanny(s.address, nthreads=2, loop=s.loop, port=0)
-    yield c.gather(futures)
-    yield n.close()
+    n = await Nanny(s.address, nthreads=2, loop=s.loop, port=0)
+    await c.gather(futures)
+    await n.close()
 
 
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True)
-def test_workers_register_indirect_data(c, s, a, b):
-    [x] = yield c.scatter([1], workers=a.address)
+async def test_workers_register_indirect_data(c, s, a, b):
+    [x] = await c.scatter([1], workers=a.address)
     y = c.submit(inc, x, workers=b.ip)
-    yield y
+    await y
     assert b.data[x.key] == 1
     assert s.tasks[x.key].who_has == {s.workers[a.address], s.workers[b.address]}
     assert s.workers[b.address].has_what == {s.tasks[x.key], s.tasks[y.key]}
@@ -2943,20 +2943,20 @@ def test_workers_register_indirect_data(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_submit_on_cancelled_future(c, s, a, b):
+async def test_submit_on_cancelled_future(c, s, a, b):
     x = c.submit(inc, 1)
-    yield x
+    await x
 
-    yield c.cancel(x)
+    await c.cancel(x)
 
     with pytest.raises(CancelledError):
         c.submit(inc, x)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
-def test_replicate(c, s, *workers):
-    [a, b] = yield c.scatter([1, 2])
-    yield s.replicate(keys=[a.key, b.key], n=5)
+async def test_replicate(c, s, *workers):
+    [a, b] = await c.scatter([1, 2])
+    await s.replicate(keys=[a.key, b.key], n=5)
     s.validate_state()
 
     assert len(s.tasks[a.key].who_has) == 5
@@ -2967,22 +2967,22 @@ def test_replicate(c, s, *workers):
 
 
 @gen_cluster(client=True)
-def test_replicate_tuple_keys(c, s, a, b):
+async def test_replicate_tuple_keys(c, s, a, b):
     x = delayed(inc)(1, dask_key_name=("x", 1))
     f = c.persist(x)
-    yield c.replicate(f, n=5)
+    await c.replicate(f, n=5)
     s.validate_state()
     assert a.data and b.data
 
-    yield c.rebalance(f)
+    await c.rebalance(f)
     s.validate_state()
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
-def test_replicate_workers(c, s, *workers):
+async def test_replicate_workers(c, s, *workers):
 
-    [a, b] = yield c.scatter([1, 2], workers=[workers[0].address])
-    yield s.replicate(
+    [a, b] = await c.scatter([1, 2], workers=[workers[0].address])
+    await s.replicate(
         keys=[a.key, b.key], n=5, workers=[w.address for w in workers[:5]]
     )
 
@@ -2994,7 +2994,7 @@ def test_replicate_workers(c, s, *workers):
     assert sum(a.key in w.data for w in workers[5:]) == 0
     assert sum(b.key in w.data for w in workers[5:]) == 0
 
-    yield s.replicate(keys=[a.key, b.key], n=1)
+    await s.replicate(keys=[a.key, b.key], n=1)
 
     assert len(s.tasks[a.key].who_has) == 1
     assert len(s.tasks[b.key].who_has) == 1
@@ -3003,12 +3003,12 @@ def test_replicate_workers(c, s, *workers):
 
     s.validate_state()
 
-    yield s.replicate(keys=[a.key, b.key], n=None)  # all
+    await s.replicate(keys=[a.key, b.key], n=None)  # all
     assert len(s.tasks[a.key].who_has) == 10
     assert len(s.tasks[b.key].who_has) == 10
     s.validate_state()
 
-    yield s.replicate(
+    await s.replicate(
         keys=[a.key, b.key], n=1, workers=[w.address for w in workers[:5]]
     )
     assert sum(a.key in w.data for w in workers[:5]) == 1
@@ -3030,30 +3030,30 @@ class CountSerialization:
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
-def test_replicate_tree_branching(c, s, *workers):
+async def test_replicate_tree_branching(c, s, *workers):
     obj = CountSerialization()
-    [future] = yield c.scatter([obj])
-    yield s.replicate(keys=[future.key], n=10)
+    [future] = await c.scatter([obj])
+    await s.replicate(keys=[future.key], n=10)
 
     max_count = max(w.data[future.key].n for w in workers)
     assert max_count > 1
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
-def test_client_replicate(c, s, *workers):
+async def test_client_replicate(c, s, *workers):
     x = c.submit(inc, 1)
     y = c.submit(inc, 2)
-    yield c.replicate([x, y], n=5)
+    await c.replicate([x, y], n=5)
 
     assert len(s.tasks[x.key].who_has) == 5
     assert len(s.tasks[y.key].who_has) == 5
 
-    yield c.replicate([x, y], n=3)
+    await c.replicate([x, y], n=3)
 
     assert len(s.tasks[x.key].who_has) == 3
     assert len(s.tasks[y.key].who_has) == 3
 
-    yield c.replicate([x, y])
+    await c.replicate([x, y])
     s.validate_state()
 
     assert len(s.tasks[x.key].who_has) == 10
@@ -3068,19 +3068,19 @@ def test_client_replicate(c, s, *workers):
     nthreads=[("127.0.0.1", 1), ("127.0.0.2", 1), ("127.0.0.2", 1)],
     timeout=None,
 )
-def test_client_replicate_host(client, s, a, b, c):
+async def test_client_replicate_host(client, s, a, b, c):
     aws = s.workers[a.address]
     bws = s.workers[b.address]
     cws = s.workers[c.address]
 
     x = client.submit(inc, 1, workers="127.0.0.2")
-    yield wait([x])
+    await wait([x])
     assert s.tasks[x.key].who_has == {bws} or s.tasks[x.key].who_has == {cws}
 
-    yield client.replicate([x], workers=["127.0.0.2"])
+    await client.replicate([x], workers=["127.0.0.2"])
     assert s.tasks[x.key].who_has == {bws, cws}
 
-    yield client.replicate([x], workers=["127.0.0.1"])
+    await client.replicate([x], workers=["127.0.0.1"])
     assert s.tasks[x.key].who_has == {aws, bws, cws}
 
 
@@ -3100,25 +3100,25 @@ def test_client_replicate_sync(c):
 
 @pytest.mark.skipif(WINDOWS, reason="Windows timer too coarse-grained")
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 4)] * 1)
-def test_task_load_adapts_quickly(c, s, a):
+async def test_task_load_adapts_quickly(c, s, a):
     future = c.submit(slowinc, 1, delay=0.2)  # slow
-    yield wait(future)
+    await wait(future)
     assert 0.15 < s.task_prefixes["slowinc"].duration_average < 0.4
 
     futures = c.map(slowinc, range(10), delay=0)  # very fast
-    yield wait(futures)
+    await wait(futures)
 
     assert 0 < s.task_prefixes["slowinc"].duration_average < 0.1
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_even_load_after_fast_functions(c, s, a, b):
+async def test_even_load_after_fast_functions(c, s, a, b):
     x = c.submit(inc, 1, workers=a.address)  # very fast
     y = c.submit(inc, 2, workers=b.address)  # very fast
-    yield wait([x, y])
+    await wait([x, y])
 
     futures = c.map(inc, range(2, 11))
-    yield wait(futures)
+    await wait(futures)
     assert any(f.key in a.data for f in futures)
     assert any(f.key in b.data for f in futures)
 
@@ -3126,17 +3126,17 @@ def test_even_load_after_fast_functions(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_even_load_on_startup(c, s, a, b):
+async def test_even_load_on_startup(c, s, a, b):
     x, y = c.map(inc, [1, 2])
-    yield wait([x, y])
+    await wait([x, y])
     assert len(a.data) == len(b.data) == 1
 
 
 @pytest.mark.skip
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 2)] * 2)
-def test_contiguous_load(c, s, a, b):
+async def test_contiguous_load(c, s, a, b):
     w, x, y, z = c.map(inc, [1, 2, 3, 4])
-    yield wait([w, x, y, z])
+    await wait([w, x, y, z])
 
     groups = [set(a.data), set(b.data)]
     assert {w.key, x.key} in groups
@@ -3144,24 +3144,24 @@ def test_contiguous_load(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
-def test_balanced_with_submit(c, s, *workers):
+async def test_balanced_with_submit(c, s, *workers):
     L = [c.submit(slowinc, i) for i in range(4)]
-    yield wait(L)
+    await wait(L)
     for w in workers:
         assert len(w.data) == 1
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
-def test_balanced_with_submit_and_resident_data(c, s, *workers):
-    [x] = yield c.scatter([10], broadcast=True)
+async def test_balanced_with_submit_and_resident_data(c, s, *workers):
+    [x] = await c.scatter([10], broadcast=True)
     L = [c.submit(slowinc, x, pure=False) for i in range(4)]
-    yield wait(L)
+    await wait(L)
     for w in workers:
         assert len(w.data) == 2
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 20)] * 2)
-def test_scheduler_saturates_cores(c, s, a, b):
+async def test_scheduler_saturates_cores(c, s, a, b):
     for delay in [0, 0.01, 0.1]:
         futures = c.map(slowinc, range(100), delay=delay)
         futures = c.map(slowinc, futures, delay=delay / 10)
@@ -3172,11 +3172,11 @@ def test_scheduler_saturates_cores(c, s, a, b):
                     for w in s.workers.values()
                     for p in w.processing.values()
                 )
-            yield gen.sleep(0.01)
+            await gen.sleep(0.01)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 20)] * 2)
-def test_scheduler_saturates_cores_random(c, s, a, b):
+async def test_scheduler_saturates_cores_random(c, s, a, b):
     for delay in [0, 0.01, 0.1]:
         futures = c.map(randominc, range(100), scale=0.1)
         while not s.tasks:
@@ -3186,22 +3186,22 @@ def test_scheduler_saturates_cores_random(c, s, a, b):
                     for w in s.workers.values()
                     for p in w.processing.values()
                 )
-            yield gen.sleep(0.01)
+            await gen.sleep(0.01)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
-def test_cancel_clears_processing(c, s, *workers):
+async def test_cancel_clears_processing(c, s, *workers):
     da = pytest.importorskip("dask.array")
     x = c.submit(slowinc, 1, delay=0.2)
     while not s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
-    yield c.cancel(x)
+    await c.cancel(x)
 
     start = time()
     while any(v for w in s.workers.values() for v in w.processing):
         assert time() < start + 0.2
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
     s.validate_state()
 
 
@@ -3244,50 +3244,50 @@ def test_default_get():
 
 
 @gen_cluster(client=True)
-def test_get_processing(c, s, a, b):
-    processing = yield c.processing()
+async def test_get_processing(c, s, a, b):
+    processing = await c.processing()
     assert processing == valmap(tuple, s.processing)
 
     futures = c.map(
         slowinc, range(10), delay=0.1, workers=[a.address], allow_other_workers=True
     )
 
-    yield gen.sleep(0.2)
+    await gen.sleep(0.2)
 
-    x = yield c.processing()
+    x = await c.processing()
     assert set(x) == {a.address, b.address}
 
-    x = yield c.processing(workers=[a.address])
+    x = await c.processing(workers=[a.address])
     assert isinstance(x[a.address], (list, tuple))
 
 
 @gen_cluster(client=True)
-def test_get_foo(c, s, a, b):
+async def test_get_foo(c, s, a, b):
     futures = c.map(inc, range(10))
-    yield wait(futures)
+    await wait(futures)
 
-    x = yield c.scheduler.ncores()
+    x = await c.scheduler.ncores()
     assert x == s.nthreads
 
-    x = yield c.scheduler.ncores(workers=[a.address])
+    x = await c.scheduler.ncores(workers=[a.address])
     assert x == {a.address: s.nthreads[a.address]}
 
-    x = yield c.scheduler.has_what()
+    x = await c.scheduler.has_what()
     assert valmap(sorted, x) == valmap(sorted, s.has_what)
 
-    x = yield c.scheduler.has_what(workers=[a.address])
+    x = await c.scheduler.has_what(workers=[a.address])
     assert valmap(sorted, x) == {a.address: sorted(s.has_what[a.address])}
 
-    x = yield c.scheduler.nbytes(summary=False)
+    x = await c.scheduler.nbytes(summary=False)
     assert x == s.get_nbytes(summary=False)
 
-    x = yield c.scheduler.nbytes(keys=[futures[0].key], summary=False)
+    x = await c.scheduler.nbytes(keys=[futures[0].key], summary=False)
     assert x == {futures[0].key: s.tasks[futures[0].key].nbytes}
 
-    x = yield c.scheduler.who_has()
+    x = await c.scheduler.who_has()
     assert valmap(sorted, x) == valmap(sorted, s.who_has)
 
-    x = yield c.scheduler.who_has(keys=[futures[0].key])
+    x = await c.scheduler.who_has(keys=[futures[0].key])
     assert valmap(sorted, x) == {futures[0].key: sorted(s.who_has[futures[0].key])}
 
 
@@ -3300,34 +3300,34 @@ def assert_dict_key_equal(expected, actual):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_get_foo_lost_keys(c, s, u, v, w):
+async def test_get_foo_lost_keys(c, s, u, v, w):
     x = c.submit(inc, 1, workers=[u.address])
-    y = yield c.scatter(3, workers=[v.address])
-    yield wait([x, y])
+    y = await c.scatter(3, workers=[v.address])
+    await wait([x, y])
 
     ua, va, wa = u.address, v.address, w.address
 
-    d = yield c.scheduler.has_what()
+    d = await c.scheduler.has_what()
     assert_dict_key_equal(d, {ua: [x.key], va: [y.key], wa: []})
-    d = yield c.scheduler.has_what(workers=[ua, va])
+    d = await c.scheduler.has_what(workers=[ua, va])
     assert_dict_key_equal(d, {ua: [x.key], va: [y.key]})
-    d = yield c.scheduler.who_has()
+    d = await c.scheduler.who_has()
     assert_dict_key_equal(d, {x.key: [ua], y.key: [va]})
-    d = yield c.scheduler.who_has(keys=[x.key, y.key])
+    d = await c.scheduler.who_has(keys=[x.key, y.key])
     assert_dict_key_equal(d, {x.key: [ua], y.key: [va]})
 
-    yield u.close()
-    yield v.close()
+    await u.close()
+    await v.close()
 
-    d = yield c.scheduler.has_what()
+    d = await c.scheduler.has_what()
     assert_dict_key_equal(d, {wa: []})
-    d = yield c.scheduler.has_what(workers=[ua, va])
+    d = await c.scheduler.has_what(workers=[ua, va])
     assert_dict_key_equal(d, {ua: [], va: []})
     # The scattered key cannot be recomputed so it is forgotten
-    d = yield c.scheduler.who_has()
+    d = await c.scheduler.who_has()
     assert_dict_key_equal(d, {x.key: []})
     # ... but when passed explicitly, it is included in the result
-    d = yield c.scheduler.who_has(keys=[x.key, y.key])
+    d = await c.scheduler.who_has(keys=[x.key, y.key])
     assert_dict_key_equal(d, {x.key: [], y.key: []})
 
 
@@ -3335,13 +3335,13 @@ def test_get_foo_lost_keys(c, s, u, v, w):
 @gen_cluster(
     client=True, Worker=Nanny, clean_kwargs={"threads": False, "processes": False}
 )
-def test_bad_tasks_fail(c, s, a, b):
+async def test_bad_tasks_fail(c, s, a, b):
     f = c.submit(sys.exit, 0)
     with pytest.raises(KilledWorker) as info:
-        yield f
+        await f
 
     assert info.value.last_worker.nanny in {a.address, b.address}
-    yield asyncio.gather(a.close(), b.close())
+    await asyncio.gather(a.close(), b.close())
 
 
 def test_get_processing_sync(c, s, a, b):
@@ -3391,11 +3391,11 @@ def test_get_returns_early(c):
 
 @pytest.mark.slow
 @gen_cluster(Worker=Nanny, client=True)
-def test_Client_clears_references_after_restart(c, s, a, b):
+async def test_Client_clears_references_after_restart(c, s, a, b):
     x = c.submit(inc, 1)
     assert x.key in c.refcount
 
-    yield c.restart()
+    await c.restart()
     assert x.key not in c.refcount
 
     key = x.key
@@ -3403,7 +3403,7 @@ def test_Client_clears_references_after_restart(c, s, a, b):
     import gc
 
     gc.collect()
-    yield gen.sleep(0)
+    await gen.sleep(0)
 
     assert key not in c.refcount
 
@@ -3461,21 +3461,21 @@ def test_as_completed_next_batch(c):
 
 
 @gen_test()
-def test_status():
-    s = yield Scheduler(port=0)
+async def test_status():
+    s = await Scheduler(port=0)
 
-    c = yield Client(s.address, asynchronous=True)
+    c = await Client(s.address, asynchronous=True)
     assert c.status == "running"
     x = c.submit(inc, 1)
 
-    yield c.close()
+    await c.close()
     assert c.status == "closed"
 
-    yield s.close()
+    await s.close()
 
 
 @gen_cluster(client=True)
-def test_persist_optimize_graph(c, s, a, b):
+async def test_persist_optimize_graph(c, s, a, b):
     i = 10
     for method in [c.persist, c.compute]:
         b = db.range(i, npartitions=2)
@@ -3484,7 +3484,7 @@ def test_persist_optimize_graph(c, s, a, b):
         b3 = b2.map(inc)
 
         b4 = method(b3, optimize_graph=False)
-        yield wait(b4)
+        await wait(b4)
 
         assert set(map(tokey, b3.__dask_keys__())).issubset(s.tasks)
 
@@ -3494,15 +3494,15 @@ def test_persist_optimize_graph(c, s, a, b):
         b3 = b2.map(inc)
 
         b4 = method(b3, optimize_graph=True)
-        yield wait(b4)
+        await wait(b4)
 
         assert not any(tokey(k) in s.tasks for k in b2.__dask_keys__())
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_scatter_raises_if_no_workers(c, s):
+async def test_scatter_raises_if_no_workers(c, s):
     with pytest.raises(TimeoutError):
-        yield c.scatter(1, timeout=0.5)
+        await c.scatter(1, timeout=0.5)
 
 
 @pytest.mark.slow
@@ -3567,13 +3567,13 @@ def test_reconnect(loop):
 
 
 @gen_cluster(client=True, nthreads=[], client_kwargs={"timeout": 0.5})
-def test_reconnect_timeout(c, s):
+async def test_reconnect_timeout(c, s):
     with captured_logger(logging.getLogger("distributed.client")) as logger:
-        yield s.close()
+        await s.close()
         start = time()
         while c.status != "closed":
-            yield c._update_scheduler_info()
-            yield gen.sleep(0.05)
+            await c._update_scheduler_info()
+            await gen.sleep(0.05)
             assert time() < start + 5, "Timeout waiting for reconnect to fail"
     text = logger.getvalue()
     assert "Failed to reconnect" in text
@@ -3595,21 +3595,21 @@ def test_open_close_many_workers(loop, worker, count, repeat):
         workers = set()
         status = True
 
-        def start_worker(sleep, duration, repeat=1):
+        async def start_worker(sleep, duration, repeat=1):
             for i in range(repeat):
-                yield gen.sleep(sleep)
+                await gen.sleep(sleep)
                 if not status:
                     return
                 w = worker(s["address"], loop=loop)
                 running[w] = None
                 workers.add(w)
-                yield w
+                await w
                 addr = w.worker_address
                 running[w] = addr
-                yield gen.sleep(duration)
-                yield w.close()
+                await gen.sleep(duration)
+                await w.close()
                 del w
-                yield gen.sleep(0)
+                await gen.sleep(0)
             done.release()
 
         for i in range(count):
@@ -3645,34 +3645,34 @@ def test_open_close_many_workers(loop, worker, count, repeat):
 
 
 @gen_cluster(client=False, timeout=None)
-def test_idempotence(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
-    f = yield Client(s.address, asynchronous=True)
+async def test_idempotence(s, a, b):
+    c = await Client(s.address, asynchronous=True)
+    f = await Client(s.address, asynchronous=True)
 
     # Submit
     x = c.submit(inc, 1)
-    yield x
+    await x
     log = list(s.transition_log)
 
     len_single_submit = len(log)  # see last assert
 
     y = f.submit(inc, 1)
     assert x.key == y.key
-    yield y
-    yield gen.sleep(0.1)
+    await y
+    await gen.sleep(0.1)
     log2 = list(s.transition_log)
     assert log == log2
 
     # Error
     a = c.submit(div, 1, 0)
-    yield wait(a)
+    await wait(a)
     assert a.status == "error"
     log = list(s.transition_log)
 
     b = f.submit(div, 1, 0)
     assert a.key == b.key
-    yield wait(b)
-    yield gen.sleep(0.1)
+    await wait(b)
+    await gen.sleep(0.1)
     log2 = list(s.transition_log)
     assert log == log2
 
@@ -3680,12 +3680,12 @@ def test_idempotence(s, a, b):
     # Simultaneous Submit
     d = c.submit(inc, 2)
     e = c.submit(inc, 2)
-    yield wait([d, e])
+    await wait([d, e])
 
     assert len(s.transition_log) == len_single_submit
 
-    yield c.close()
-    yield f.close()
+    await c.close()
+    await f.close()
 
 
 def test_scheduler_info(c):
@@ -3744,40 +3744,40 @@ def test_threaded_get_within_distributed(c):
 
 
 @gen_cluster(client=True)
-def test_lose_scattered_data(c, s, a, b):
-    [x] = yield c.scatter([1], workers=a.address)
+async def test_lose_scattered_data(c, s, a, b):
+    [x] = await c.scatter([1], workers=a.address)
 
-    yield a.close()
-    yield gen.sleep(0.1)
+    await a.close()
+    await gen.sleep(0.1)
 
     assert x.status == "cancelled"
     assert x.key not in s.tasks
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_partially_lose_scattered_data(e, s, a, b, c):
-    x = yield e.scatter(1, workers=a.address)
-    yield e.replicate(x, n=2)
+async def test_partially_lose_scattered_data(e, s, a, b, c):
+    x = await e.scatter(1, workers=a.address)
+    await e.replicate(x, n=2)
 
-    yield a.close()
-    yield gen.sleep(0.1)
+    await a.close()
+    await gen.sleep(0.1)
 
     assert x.status == "finished"
     assert s.get_task_status(keys=[x.key]) == {x.key: "memory"}
 
 
 @gen_cluster(client=True)
-def test_scatter_compute_lose(c, s, a, b):
-    [x] = yield c.scatter([[1, 2, 3, 4]], workers=a.address)
+async def test_scatter_compute_lose(c, s, a, b):
+    [x] = await c.scatter([[1, 2, 3, 4]], workers=a.address)
     y = c.submit(inc, 1, workers=b.address)
 
     z = c.submit(slowadd, x, y, delay=0.2)
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
-    yield a.close()
+    await a.close()
 
     with pytest.raises(CancelledError):
-        yield wait(z)
+        await wait(z)
 
     assert x.status == "cancelled"
     assert y.status == "finished"
@@ -3785,7 +3785,7 @@ def test_scatter_compute_lose(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_scatter_compute_store_lose(c, s, a, b):
+async def test_scatter_compute_store_lose(c, s, a, b):
     """
     Create irreplaceable data on one machine,
     cause a dependent computation to occur on another and complete
@@ -3793,18 +3793,18 @@ def test_scatter_compute_store_lose(c, s, a, b):
     Kill the machine with the irreplaceable data.  What happens to the complete
     result?  How about after it GCs and tries to come back?
     """
-    x = yield c.scatter(1, workers=a.address)
+    x = await c.scatter(1, workers=a.address)
     xx = c.submit(inc, x, workers=a.address)
     y = c.submit(inc, 1)
 
     z = c.submit(slowadd, xx, y, delay=0.2, workers=b.address)
-    yield wait(z)
+    await wait(z)
 
-    yield a.close()
+    await a.close()
 
     start = time()
     while x.status == "finished":
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
 
     # assert xx.status == 'finished'
@@ -3812,14 +3812,14 @@ def test_scatter_compute_store_lose(c, s, a, b):
     assert z.status == "finished"
 
     zz = c.submit(inc, z)
-    yield wait(zz)
+    await wait(zz)
 
     zkey = z.key
     del z
 
     start = time()
     while s.get_task_status(keys=[zkey]) != {zkey: "released"}:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
 
     xxkey = xx.key
@@ -3827,12 +3827,12 @@ def test_scatter_compute_store_lose(c, s, a, b):
 
     start = time()
     while x.key in s.tasks and zkey not in s.tasks and xxkey not in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
 
 
 @gen_cluster(client=True)
-def test_scatter_compute_store_lose_processing(c, s, a, b):
+async def test_scatter_compute_store_lose_processing(c, s, a, b):
     """
     Create irreplaceable data on one machine,
     cause a dependent computation to occur on another and complete
@@ -3840,16 +3840,16 @@ def test_scatter_compute_store_lose_processing(c, s, a, b):
     Kill the machine with the irreplaceable data.  What happens to the complete
     result?  How about after it GCs and tries to come back?
     """
-    [x] = yield c.scatter([1], workers=a.address)
+    [x] = await c.scatter([1], workers=a.address)
 
     y = c.submit(slowinc, x, delay=0.2)
     z = c.submit(inc, y)
-    yield gen.sleep(0.1)
-    yield a.close()
+    await gen.sleep(0.1)
+    await a.close()
 
     start = time()
     while x.status == "finished":
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
 
     assert y.status == "cancelled"
@@ -3857,28 +3857,28 @@ def test_scatter_compute_store_lose_processing(c, s, a, b):
 
 
 @gen_cluster(client=False)
-def test_serialize_future(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
-    f = yield Client(s.address, asynchronous=True)
+async def test_serialize_future(s, a, b):
+    c = await Client(s.address, asynchronous=True)
+    f = await Client(s.address, asynchronous=True)
 
     future = c.submit(lambda: 1)
-    result = yield future
+    result = await future
 
     with temp_default_client(f):
         future2 = pickle.loads(pickle.dumps(future))
         assert future2.client is f
         assert tokey(future2.key) in f.futures
-        result2 = yield future2
+        result2 = await future2
         assert result == result2
 
-    yield c.close()
-    yield f.close()
+    await c.close()
+    await f.close()
 
 
 @gen_cluster(client=False)
-def test_temp_client(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
-    f = yield Client(s.address, asynchronous=True)
+async def test_temp_client(s, a, b):
+    c = await Client(s.address, asynchronous=True)
+    f = await Client(s.address, asynchronous=True)
 
     with temp_default_client(c):
         assert default_client() is c
@@ -3888,13 +3888,13 @@ def test_temp_client(s, a, b):
         assert default_client() is f
         assert default_client(c) is c
 
-    yield c.close()
-    yield f.close()
+    await c.close()
+    await f.close()
 
 
 @nodebug  # test timing is fragile
 @gen_cluster(nthreads=[("127.0.0.1", 1)] * 3, client=True)
-def test_persist_workers(e, s, a, b, c):
+async def test_persist_workers(e, s, a, b, c):
     L1 = [delayed(inc)(i) for i in range(4)]
     total = delayed(sum)(L1)
     L2 = [delayed(add)(i, total) for i in L1]
@@ -3911,7 +3911,7 @@ def test_persist_workers(e, s, a, b, c):
         allow_other_workers=L2 + [total2],
     )
 
-    yield wait(out)
+    await wait(out)
     assert all(v.key in a.data for v in L1)
     assert total.key in b.data
 
@@ -3919,7 +3919,7 @@ def test_persist_workers(e, s, a, b, c):
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)] * 3, client=True)
-def test_compute_workers(e, s, a, b, c):
+async def test_compute_workers(e, s, a, b, c):
     L1 = [delayed(inc)(i) for i in range(4)]
     total = delayed(sum)(L1)
     L2 = [delayed(add)(i, total) for i in L1]
@@ -3930,7 +3930,7 @@ def test_compute_workers(e, s, a, b, c):
         allow_other_workers=L1 + [total],
     )
 
-    yield wait(out)
+    await wait(out)
     for v in L1:
         assert s.worker_restrictions[v.key] == {a.address}
     for v in L2:
@@ -3941,13 +3941,13 @@ def test_compute_workers(e, s, a, b, c):
 
 
 @gen_cluster(client=True)
-def test_compute_nested_containers(c, s, a, b):
+async def test_compute_nested_containers(c, s, a, b):
     da = pytest.importorskip("dask.array")
     np = pytest.importorskip("numpy")
     x = da.ones(10, chunks=(5,)) + 1
 
     future = c.compute({"x": [x], "y": 123})
-    result = yield future
+    result = await future
 
     assert isinstance(result, dict)
     assert (result["x"][0] == np.ones(10) + 1).all()
@@ -3977,19 +3977,19 @@ def test_get_restrictions():
 
 
 @gen_cluster(client=True)
-def test_scatter_type(c, s, a, b):
-    [future] = yield c.scatter([1])
+async def test_scatter_type(c, s, a, b):
+    [future] = await c.scatter([1])
     assert future.type == int
 
-    d = yield c.scatter({"x": 1.0})
+    d = await c.scatter({"x": 1.0})
     assert d["x"].type == float
 
 
 @gen_cluster(client=True)
-def test_retire_workers_2(c, s, a, b):
-    [x] = yield c.scatter([1], workers=a.address)
+async def test_retire_workers_2(c, s, a, b):
+    [x] = await c.scatter([1], workers=a.address)
 
-    yield s.retire_workers(workers=[a.address])
+    await s.retire_workers(workers=[a.address])
     assert b.data == {x.key: 1}
     assert s.who_has == {x.key: {b.address}}
     assert s.has_what == {b.address: {x.key}}
@@ -3998,16 +3998,16 @@ def test_retire_workers_2(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
-def test_retire_many_workers(c, s, *workers):
-    futures = yield c.scatter(list(range(100)))
+async def test_retire_many_workers(c, s, *workers):
+    futures = await c.scatter(list(range(100)))
 
-    yield s.retire_workers(workers=[w.address for w in workers[:7]])
+    await s.retire_workers(workers=[w.address for w in workers[:7]])
 
-    results = yield c.gather(futures)
+    results = await c.gather(futures)
     assert results == list(range(100))
 
     while len(s.workers) != 3:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert len(s.has_what) == len(s.nthreads) == 3
 
@@ -4022,19 +4022,19 @@ def test_retire_many_workers(c, s, *workers):
     nthreads=[("127.0.0.1", 3)] * 2,
     config={"distributed.scheduler.default-task-durations": {"f": "10ms"}},
 )
-def test_weight_occupancy_against_data_movement(c, s, a, b):
+async def test_weight_occupancy_against_data_movement(c, s, a, b):
     s.extensions["stealing"]._pc.callback_time = 1000000
 
     def f(x, y=0, z=0):
         sleep(0.01)
         return x
 
-    y = yield c.scatter([[1, 2, 3, 4]], workers=[a.address])
-    z = yield c.scatter([1], workers=[b.address])
+    y = await c.scatter([[1, 2, 3, 4]], workers=[a.address])
+    z = await c.scatter([1], workers=[b.address])
 
     futures = c.map(f, [1, 2, 3, 4], y=y, z=z)
 
-    yield wait(futures)
+    await wait(futures)
 
     assert sum(f.key in a.data for f in futures) >= 2
     assert sum(f.key in b.data for f in futures) >= 1
@@ -4045,24 +4045,24 @@ def test_weight_occupancy_against_data_movement(c, s, a, b):
     nthreads=[("127.0.0.1", 1), ("127.0.0.1", 10)],
     config={"distributed.scheduler.default-task-durations": {"f": "10ms"}},
 )
-def test_distribute_tasks_by_nthreads(c, s, a, b):
+async def test_distribute_tasks_by_nthreads(c, s, a, b):
     s.extensions["stealing"]._pc.callback_time = 1000000
 
     def f(x, y=0):
         sleep(0.01)
         return x
 
-    y = yield c.scatter([1], broadcast=True)
+    y = await c.scatter([1], broadcast=True)
 
     futures = c.map(f, range(20), y=y)
 
-    yield wait(futures)
+    await wait(futures)
 
     assert len(b.data) > 2 * len(a.data)
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
-def test_add_done_callback(c, s, a, b):
+async def test_add_done_callback(c, s, a, b):
     S = set()
 
     def f(future):
@@ -4079,19 +4079,19 @@ def test_add_done_callback(c, s, a, b):
     v.add_done_callback(f)
     w.add_done_callback(f)
 
-    yield wait((u, v, w, x))
+    await wait((u, v, w, x))
 
     x.add_done_callback(f)
 
     t = time()
     while len(S) < 4 and time() - t < 2.0:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert S == {(f.key, f.status) for f in (u, v, w, x)}
 
 
 @gen_cluster(client=True)
-def test_normalize_collection(c, s, a, b):
+async def test_normalize_collection(c, s, a, b):
     x = delayed(inc)(1)
     y = delayed(inc)(x)
     z = delayed(inc)(y)
@@ -4106,7 +4106,7 @@ def test_normalize_collection(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_normalize_collection_dask_array(c, s, a, b):
+async def test_normalize_collection_dask_array(c, s, a, b):
     da = pytest.importorskip("dask.array")
 
     x = da.ones(10, chunks=(5,))
@@ -4124,8 +4124,8 @@ def test_normalize_collection_dask_array(c, s, a, b):
     for k, v in yy.dask.items():
         assert zz.dask[k].key == v.key
 
-    result1 = yield c.compute(z)
-    result2 = yield c.compute(zz)
+    result1 = await c.compute(z)
+    result2 = await c.compute(zz)
     assert result1 == result2
 
 
@@ -4148,7 +4148,7 @@ def test_normalize_collection_with_released_futures(c):
 
 
 @gen_cluster(client=True)
-def test_auto_normalize_collection(c, s, a, b):
+async def test_auto_normalize_collection(c, s, a, b):
     da = pytest.importorskip("dask.array")
 
     x = da.ones(10, chunks=5)
@@ -4158,17 +4158,17 @@ def test_auto_normalize_collection(c, s, a, b):
         y = x.map_blocks(slowinc, delay=1, dtype=x.dtype)
         yy = c.persist(y)
 
-        yield wait(yy)
+        await wait(yy)
 
         start = time()
         future = c.compute(y.sum())
-        yield future
+        await future
         end = time()
         assert end - start < 1
 
         start = time()
         z = c.persist(y + 1)
-        yield wait(z)
+        await wait(z)
         end = time()
         assert end - start < 1
 
@@ -4197,7 +4197,7 @@ def assert_no_data_loss(scheduler):
 
 
 @gen_cluster(client=True, timeout=None)
-def test_interleave_computations(c, s, a, b):
+async def test_interleave_computations(c, s, a, b):
     import distributed
 
     distributed.g = s
@@ -4211,14 +4211,14 @@ def test_interleave_computations(c, s, a, b):
 
     done = ("memory", "released")
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
     x_keys = [x.key for x in xs]
     y_keys = [y.key for y in ys]
     z_keys = [z.key for z in zs]
 
     while not s.tasks or any(w.processing for w in s.workers.values()):
-        yield gen.sleep(0.05)
+        await gen.sleep(0.05)
         x_done = sum(state in done for state in s.get_task_status(keys=x_keys).values())
         y_done = sum(state in done for state in s.get_task_status(keys=y_keys).values())
         z_done = sum(state in done for state in s.get_task_status(keys=z_keys).values())
@@ -4232,7 +4232,7 @@ def test_interleave_computations(c, s, a, b):
 
 @pytest.mark.skip(reason="Now prefer first-in-first-out")
 @gen_cluster(client=True, timeout=None)
-def test_interleave_computations_map(c, s, a, b):
+async def test_interleave_computations_map(c, s, a, b):
     xs = c.map(slowinc, range(30), delay=0.02)
     ys = c.map(slowdec, xs, delay=0.02)
     zs = c.map(slowadd, xs, ys, delay=0.02)
@@ -4244,7 +4244,7 @@ def test_interleave_computations_map(c, s, a, b):
     z_keys = [z.key for z in zs]
 
     while not s.tasks or any(w.processing for w in s.workers.values()):
-        yield gen.sleep(0.05)
+        await gen.sleep(0.05)
         x_done = sum(state in done for state in s.get_task_status(keys=x_keys).values())
         y_done = sum(state in done for state in s.get_task_status(keys=y_keys).values())
         z_done = sum(state in done for state in s.get_task_status(keys=z_keys).values())
@@ -4255,78 +4255,78 @@ def test_interleave_computations_map(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_scatter_dict_workers(c, s, a, b):
-    yield c.scatter({"a": 10}, workers=[a.address, b.address])
+async def test_scatter_dict_workers(c, s, a, b):
+    await c.scatter({"a": 10}, workers=[a.address, b.address])
     assert "a" in a.data or "a" in b.data
 
 
 @pytest.mark.slow
 @gen_test()
-def test_client_timeout():
+async def test_client_timeout():
     c = Client("127.0.0.1:57484", asynchronous=True)
 
     s = Scheduler(loop=c.loop, port=57484)
-    yield gen.sleep(4)
+    await gen.sleep(4)
     try:
-        yield s
+        await s
     except EnvironmentError:  # port in use
-        yield c.close()
+        await c.close()
         return
 
     start = time()
-    yield c
+    await c
     try:
         assert time() < start + 2
     finally:
-        yield c.close()
-        yield s.close()
+        await c.close()
+        await s.close()
 
 
 @gen_cluster(client=True)
-def test_submit_list_kwargs(c, s, a, b):
-    futures = yield c.scatter([1, 2, 3])
+async def test_submit_list_kwargs(c, s, a, b):
+    futures = await c.scatter([1, 2, 3])
 
     def f(L=None):
         return sum(L)
 
     future = c.submit(f, L=futures)
-    result = yield future
+    result = await future
     assert result == 1 + 2 + 3
 
 
 @gen_cluster(client=True)
-def test_map_list_kwargs(c, s, a, b):
-    futures = yield c.scatter([1, 2, 3])
+async def test_map_list_kwargs(c, s, a, b):
+    futures = await c.scatter([1, 2, 3])
 
     def f(i, L=None):
         return i + sum(L)
 
     futures = c.map(f, range(10), L=futures)
-    results = yield c.gather(futures)
+    results = await c.gather(futures)
     assert results == [i + 6 for i in range(10)]
 
 
 @gen_cluster(client=True)
-def test_dont_clear_waiting_data(c, s, a, b):
+async def test_dont_clear_waiting_data(c, s, a, b):
     start = time()
-    x = yield c.scatter(1)
+    x = await c.scatter(1)
     y = c.submit(slowinc, x, delay=0.5)
     while y.key not in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
     key = x.key
     del x
     for i in range(5):
         assert s.waiting_data[key]
-        yield gen.sleep(0)
+        await gen.sleep(0)
 
 
 @gen_cluster(client=True)
-def test_get_future_error_simple(c, s, a, b):
+async def test_get_future_error_simple(c, s, a, b):
     f = c.submit(div, 1, 0)
-    yield wait(f)
+    await wait(f)
     assert f.status == "error"
 
-    function, args, kwargs, deps = yield c._get_futures_error(f)
+    function, args, kwargs, deps = await c._get_futures_error(f)
     # args contains only solid values, not keys
     assert function.__name__ == "div"
     with pytest.raises(ZeroDivisionError):
@@ -4334,7 +4334,7 @@ def test_get_future_error_simple(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_get_futures_error(c, s, a, b):
+async def test_get_futures_error(c, s, a, b):
     x0 = delayed(dec)(2, dask_key_name="x0")
     y0 = delayed(dec)(1, dask_key_name="y0")
     x = delayed(div)(1, x0, dask_key_name="x")
@@ -4342,16 +4342,16 @@ def test_get_futures_error(c, s, a, b):
     tot = delayed(sum)(x, y, dask_key_name="tot")
 
     f = c.compute(tot)
-    yield wait(f)
+    await wait(f)
     assert f.status == "error"
 
-    function, args, kwargs, deps = yield c._get_futures_error(f)
+    function, args, kwargs, deps = await c._get_futures_error(f)
     assert function.__name__ == "div"
     assert args == (1, y0.key)
 
 
 @gen_cluster(client=True)
-def test_recreate_error_delayed(c, s, a, b):
+async def test_recreate_error_delayed(c, s, a, b):
     x0 = delayed(dec)(2)
     y0 = delayed(dec)(1)
     x = delayed(div)(1, x0)
@@ -4362,7 +4362,7 @@ def test_recreate_error_delayed(c, s, a, b):
 
     assert f.status == "pending"
 
-    function, args, kwargs = yield c._recreate_error_locally(f)
+    function, args, kwargs = await c._recreate_error_locally(f)
     assert f.status == "error"
     assert function.__name__ == "div"
     assert args == (1, 0)
@@ -4371,7 +4371,7 @@ def test_recreate_error_delayed(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_recreate_error_futures(c, s, a, b):
+async def test_recreate_error_futures(c, s, a, b):
     x0 = c.submit(dec, 2)
     y0 = c.submit(dec, 1)
     x = c.submit(div, 1, x0)
@@ -4381,7 +4381,7 @@ def test_recreate_error_futures(c, s, a, b):
 
     assert f.status == "pending"
 
-    function, args, kwargs = yield c._recreate_error_locally(f)
+    function, args, kwargs = await c._recreate_error_locally(f)
     assert f.status == "error"
     assert function.__name__ == "div"
     assert args == (1, 0)
@@ -4390,13 +4390,13 @@ def test_recreate_error_futures(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_recreate_error_collection(c, s, a, b):
+async def test_recreate_error_collection(c, s, a, b):
     b = db.range(10, npartitions=4)
     b = b.map(lambda x: 1 / x)
     b = b.persist()
     f = c.compute(b)
 
-    function, args, kwargs = yield c._recreate_error_locally(f)
+    function, args, kwargs = await c._recreate_error_locally(f)
     with pytest.raises(ZeroDivisionError):
         function(*args, **kwargs)
 
@@ -4413,24 +4413,24 @@ def test_recreate_error_collection(c, s, a, b):
 
     df2 = df.a.map(make_err)
     f = c.compute(df2)
-    function, args, kwargs = yield c._recreate_error_locally(f)
+    function, args, kwargs = await c._recreate_error_locally(f)
     with pytest.raises(ValueError):
         function(*args, **kwargs)
 
     # with persist
     df3 = c.persist(df2)
-    function, args, kwargs = yield c._recreate_error_locally(df3)
+    function, args, kwargs = await c._recreate_error_locally(df3)
     with pytest.raises(ValueError):
         function(*args, **kwargs)
 
 
 @gen_cluster(client=True)
-def test_recreate_error_array(c, s, a, b):
+async def test_recreate_error_array(c, s, a, b):
     da = pytest.importorskip("dask.array")
     pytest.importorskip("scipy")
     z = (da.linalg.inv(da.zeros((10, 10), chunks=10)) + 1).sum()
     zz = z.persist()
-    func, args, kwargs = yield c._recreate_error_locally(zz)
+    func, args, kwargs = await c._recreate_error_locally(zz)
     assert "0.,0.,0." in str(args).replace(" ", "")  # args contain actual arrays
 
 
@@ -4454,14 +4454,14 @@ def test_recreate_error_not_error(c):
 
 
 @gen_cluster(client=True)
-def test_retire_workers(c, s, a, b):
+async def test_retire_workers(c, s, a, b):
     assert set(s.workers) == {a.address, b.address}
-    yield c.retire_workers(workers=[a.address], close_workers=True)
+    await c.retire_workers(workers=[a.address], close_workers=True)
     assert set(s.workers) == {b.address}
 
     start = time()
     while a.status != "closed":
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
@@ -4470,7 +4470,7 @@ class MyException(Exception):
 
 
 @gen_cluster(client=True)
-def test_robust_unserializable(c, s, a, b):
+async def test_robust_unserializable(c, s, a, b):
     class Foo:
         def __getstate__(self):
             raise MyException()
@@ -4479,14 +4479,14 @@ def test_robust_unserializable(c, s, a, b):
         future = c.submit(identity, Foo())
 
     futures = c.map(inc, range(10))
-    results = yield c.gather(futures)
+    results = await c.gather(futures)
 
     assert results == list(map(inc, range(10)))
     assert a.data and b.data
 
 
 @gen_cluster(client=True)
-def test_robust_undeserializable(c, s, a, b):
+async def test_robust_undeserializable(c, s, a, b):
     class Foo:
         def __getstate__(self):
             return 1
@@ -4496,17 +4496,17 @@ def test_robust_undeserializable(c, s, a, b):
 
     future = c.submit(identity, Foo())
     with pytest.raises(MyException):
-        yield future
+        await future
 
     futures = c.map(inc, range(10))
-    results = yield c.gather(futures)
+    results = await c.gather(futures)
 
     assert results == list(map(inc, range(10)))
     assert a.data and b.data
 
 
 @gen_cluster(client=True)
-def test_robust_undeserializable_function(c, s, a, b):
+async def test_robust_undeserializable_function(c, s, a, b):
     class Foo:
         def __getstate__(self):
             return 1
@@ -4519,17 +4519,17 @@ def test_robust_undeserializable_function(c, s, a, b):
 
     future = c.submit(Foo(), 1)
     with pytest.raises(MyException):
-        yield future
+        await future
 
     futures = c.map(inc, range(10))
-    results = yield c.gather(futures)
+    results = await c.gather(futures)
 
     assert results == list(map(inc, range(10)))
     assert a.data and b.data
 
 
 @gen_cluster(client=True)
-def test_fire_and_forget(c, s, a, b):
+async def test_fire_and_forget(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.1)
     import distributed
 
@@ -4541,7 +4541,7 @@ def test_fire_and_forget(c, s, a, b):
 
         start = time()
         while not hasattr(distributed, "foo"):
-            yield gen.sleep(0.01)
+            await gen.sleep(0.01)
             assert time() < start + 2
         assert distributed.foo == 123
     finally:
@@ -4549,7 +4549,7 @@ def test_fire_and_forget(c, s, a, b):
 
     start = time()
     while len(s.tasks) > 1:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
 
     assert set(s.who_wants) == {future.key}
@@ -4557,14 +4557,14 @@ def test_fire_and_forget(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_fire_and_forget_err(c, s, a, b):
+async def test_fire_and_forget_err(c, s, a, b):
     fire_and_forget(c.submit(div, 1, 0))
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
     # erred task should clear out quickly
     start = time()
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 1
 
 
@@ -4600,16 +4600,16 @@ def test_quiet_client_close_when_cluster_is_closed_before_client(loop):
 
 
 @gen_cluster()
-def test_close(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
+async def test_close(s, a, b):
+    c = await Client(s.address, asynchronous=True)
     future = c.submit(inc, 1)
-    yield wait(future)
+    await wait(future)
     assert c.id in s.wants_what
-    yield c.close()
+    await c.close()
 
     start = time()
     while c.id in s.wants_what or s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
@@ -4672,7 +4672,7 @@ def test_threadsafe_compute(c):
 
 
 @gen_cluster(client=True)
-def test_identity(c, s, a, b):
+async def test_identity(c, s, a, b):
     assert c.id.lower().startswith("client")
     assert a.id.lower().startswith("worker")
     assert b.id.lower().startswith("worker")
@@ -4680,7 +4680,7 @@ def test_identity(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 4)] * 2)
-def test_get_client(c, s, a, b):
+async def test_get_client(c, s, a, b):
     assert get_client() is c
     assert c.asynchronous
 
@@ -4698,7 +4698,7 @@ def test_get_client(c, s, a, b):
     distributed.tmp_client = c
     try:
         futures = c.map(f, range(5))
-        results = yield c.gather(futures)
+        results = await c.gather(futures)
         assert results == list(map(inc, range(5)))
     finally:
         del distributed.tmp_client
@@ -4715,7 +4715,7 @@ def test_get_client_no_cluster():
 
 
 @gen_cluster(client=True)
-def test_serialize_collections(c, s, a, b):
+async def test_serialize_collections(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.arange(10, chunks=(5,)).persist()
 
@@ -4724,24 +4724,24 @@ def test_serialize_collections(c, s, a, b):
         return x.sum().compute()
 
     future = c.submit(f, x)
-    result = yield future
+    result = await future
     assert result == sum(range(10))
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 1, timeout=100)
-def test_secede_simple(c, s, a):
+async def test_secede_simple(c, s, a):
     def f():
         client = get_client()
         secede()
         return client.submit(inc, 1).result()
 
-    result = yield c.submit(f)
+    result = await c.submit(f)
     assert result == 2
 
 
 @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2, timeout=60)
-def test_secede_balances(c, s, a, b):
+async def test_secede_balances(c, s, a, b):
     count = threading.active_count()
 
     def f(x):
@@ -4755,24 +4755,24 @@ def test_secede_balances(c, s, a, b):
     futures = c.map(f, range(100))
     start = time()
     while not all(f.status == "finished" for f in futures):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert threading.active_count() < count + 50
 
     assert len(a.log) < 2 * len(b.log)
     assert len(b.log) < 2 * len(a.log)
 
-    results = yield c.gather(futures)
+    results = await c.gather(futures)
     assert results == [sum(map(inc, range(10)))] * 100
 
 
 @gen_cluster(client=True)
-def test_sub_submit_priority(c, s, a, b):
+async def test_sub_submit_priority(c, s, a, b):
     def f():
         client = get_client()
         client.submit(slowinc, 1, delay=0.2, key="slowinc")
 
     future = c.submit(f, key="f")
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     if len(s.tasks) == 2:
         assert (
             s.priorities["f"] > s.priorities["slowinc"]
@@ -4788,17 +4788,17 @@ def test_get_client_sync(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_serialize_collections_of_futures(c, s, a, b):
+async def test_serialize_collections_of_futures(c, s, a, b):
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
     from dask.dataframe.utils import assert_eq
 
     df = pd.DataFrame({"x": [1, 2, 3]})
     ddf = dd.from_pandas(df, npartitions=2).persist()
-    future = yield c.scatter(ddf)
+    future = await c.scatter(ddf)
 
-    ddf2 = yield future
-    df2 = yield c.compute(ddf2)
+    ddf2 = await future
+    df2 = await c.compute(ddf2)
 
     assert_eq(df, df2)
 
@@ -4850,10 +4850,10 @@ def test_dynamic_workloads_sync_random(c):
 
 
 @gen_cluster(client=True)
-def test_bytes_keys(c, s, a, b):
+async def test_bytes_keys(c, s, a, b):
     key = b"inc-123"
     future = c.submit(inc, 1, key=key)
-    result = yield future
+    result = await future
     assert type(future.key) is bytes
     assert set(s.tasks) == {key}
     assert key in a.data or key in b.data
@@ -4861,11 +4861,11 @@ def test_bytes_keys(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_unicode_ascii_keys(c, s, a, b):
+async def test_unicode_ascii_keys(c, s, a, b):
     uni_type = type("")
     key = "inc-123"
     future = c.submit(inc, 1, key=key)
-    result = yield future
+    result = await future
     assert type(future.key) is uni_type
     assert set(s.tasks) == {key}
     assert key in a.data or key in b.data
@@ -4873,30 +4873,30 @@ def test_unicode_ascii_keys(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_unicode_keys(c, s, a, b):
+async def test_unicode_keys(c, s, a, b):
     uni_type = type("")
     key = "inc-123\u03bc"
     future = c.submit(inc, 1, key=key)
-    result = yield future
+    result = await future
     assert type(future.key) is uni_type
     assert set(s.tasks) == {key}
     assert key in a.data or key in b.data
     assert result == 2
 
     future2 = c.submit(inc, future)
-    result2 = yield future2
+    result2 = await future2
     assert result2 == 3
 
-    future3 = yield c.scatter({"data-123": 123})
-    result3 = yield future3["data-123"]
+    future3 = await c.scatter({"data-123": 123})
+    result3 = await future3["data-123"]
     assert result3 == 123
 
 
 def test_use_synchronous_client_in_async_context(loop, c):
-    def f():
-        x = yield c.scatter(123)
+    async def f():
+        x = await c.scatter(123)
         y = c.submit(inc, x)
-        z = yield c.gather(y)
+        z = await c.gather(y)
         return z
 
     z = sync(loop, f)
@@ -4928,11 +4928,11 @@ def test_warn_executor(loop, s, a, b):
 
 
 @gen_cluster([("127.0.0.1", 4)] * 2, client=True)
-def test_call_stack_future(c, s, a, b):
+async def test_call_stack_future(c, s, a, b):
     x = c.submit(slowdec, 1, delay=0.5)
     future = c.submit(slowinc, 1, delay=0.5)
-    yield gen.sleep(0.1)
-    results = yield asyncio.gather(
+    await gen.sleep(0.1)
+    results = await asyncio.gather(
         c.call_stack(future), c.call_stack(keys=[future.key])
     )
     assert all(list(first(result.values())) == [future.key] for result in results)
@@ -4946,11 +4946,11 @@ def test_call_stack_future(c, s, a, b):
 
 
 @gen_cluster([("127.0.0.1", 4)] * 2, client=True)
-def test_call_stack_all(c, s, a, b):
+async def test_call_stack_all(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.8)
     while not a.executing and not b.executing:
-        yield gen.sleep(0.01)
-    result = yield c.call_stack()
+        await gen.sleep(0.01)
+    result = await c.call_stack()
     w = a if a.executing else b
     assert list(result) == [w.address]
     assert list(result[w.address]) == [future.key]
@@ -4958,100 +4958,100 @@ def test_call_stack_all(c, s, a, b):
 
 
 @gen_cluster([("127.0.0.1", 4)] * 2, client=True)
-def test_call_stack_collections(c, s, a, b):
+async def test_call_stack_collections(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.random.random(100, chunks=(10,)).map_blocks(slowinc, delay=0.5).persist()
     while not a.executing and not b.executing:
-        yield gen.sleep(0.001)
-    result = yield c.call_stack(x)
+        await gen.sleep(0.001)
+    result = await c.call_stack(x)
     assert result
 
 
 @gen_cluster([("127.0.0.1", 4)] * 2, client=True)
-def test_call_stack_collections_all(c, s, a, b):
+async def test_call_stack_collections_all(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.random.random(100, chunks=(10,)).map_blocks(slowinc, delay=0.5).persist()
     while not a.executing and not b.executing:
-        yield gen.sleep(0.001)
-    result = yield c.call_stack()
+        await gen.sleep(0.001)
+    result = await c.call_stack()
     assert result
 
 
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
-def test_profile(c, s, a, b):
+async def test_profile(c, s, a, b):
     futures = c.map(slowinc, range(10), delay=0.05, workers=a.address)
-    yield wait(futures)
+    await wait(futures)
 
-    x = yield c.profile(start=time() + 10, stop=time() + 20)
+    x = await c.profile(start=time() + 10, stop=time() + 20)
     assert not x["count"]
 
-    x = yield c.profile(start=0, stop=time())
+    x = await c.profile(start=0, stop=time())
     assert (
         x["count"]
         == sum(p["count"] for _, p in a.profile_history) + a.profile_recent["count"]
     )
 
-    y = yield c.profile(start=time() - 0.300, stop=time())
+    y = await c.profile(start=time() - 0.300, stop=time())
     assert 0 < y["count"] < x["count"]
 
     assert not any(p["count"] for _, p in b.profile_history)
-    result = yield c.profile(workers=b.address)
+    result = await c.profile(workers=b.address)
     assert not result["count"]
 
 
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
-def test_profile_keys(c, s, a, b):
+async def test_profile_keys(c, s, a, b):
     x = c.map(slowinc, range(10), delay=0.05, workers=a.address)
     y = c.map(slowdec, range(10), delay=0.05, workers=a.address)
-    yield wait(x + y)
+    await wait(x + y)
 
-    xp = yield c.profile("slowinc")
-    yp = yield c.profile("slowdec")
-    p = yield c.profile()
+    xp = await c.profile("slowinc")
+    yp = await c.profile("slowdec")
+    p = await c.profile()
 
     assert p["count"] == xp["count"] + yp["count"]
 
     with captured_logger(logging.getLogger("distributed")) as logger:
-        prof = yield c.profile("does-not-exist")
+        prof = await c.profile("does-not-exist")
         assert prof == profile.create()
     out = logger.getvalue()
     assert not out
 
 
 @gen_cluster()
-def test_client_with_name(s, a, b):
+async def test_client_with_name(s, a, b):
     with captured_logger("distributed.scheduler") as sio:
-        client = yield Client(s.address, asynchronous=True, name="foo")
+        client = await Client(s.address, asynchronous=True, name="foo")
         assert "foo" in client.id
-        yield client.close()
+        await client.close()
 
     text = sio.getvalue()
     assert "foo" in text
 
 
 @gen_cluster(client=True)
-def test_future_defaults_to_default_client(c, s, a, b):
+async def test_future_defaults_to_default_client(c, s, a, b):
     x = c.submit(inc, 1)
-    yield wait(x)
+    await wait(x)
 
     future = Future(x.key)
     assert future.client is c
 
 
 @gen_cluster(client=True)
-def test_future_auto_inform(c, s, a, b):
+async def test_future_auto_inform(c, s, a, b):
     x = c.submit(inc, 1)
-    yield wait(x)
+    await wait(x)
 
-    client = yield Client(s.address, asynchronous=True)
+    client = await Client(s.address, asynchronous=True)
     future = Future(x.key, client)
 
     start = time()
     while future.status != "finished":
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 1
 
-    yield client.close()
+    await client.close()
 
 
 def test_client_async_before_loop_starts():
@@ -5063,7 +5063,7 @@ def test_client_async_before_loop_starts():
 
 @pytest.mark.slow
 @gen_cluster(client=True, Worker=Nanny, timeout=60, nthreads=[("127.0.0.1", 3)] * 2)
-def test_nested_compute(c, s, a, b):
+async def test_nested_compute(c, s, a, b):
     def fib(x):
         assert get_worker().get_current_task()
         if x < 2:
@@ -5074,71 +5074,71 @@ def test_nested_compute(c, s, a, b):
         return c.compute()
 
     future = c.submit(fib, 8)
-    result = yield future
+    result = await future
     assert result == 21
     assert len(s.transition_log) > 50
 
 
 @gen_cluster(client=True)
-def test_task_metadata(c, s, a, b):
-    yield c.set_metadata("x", 1)
-    result = yield c.get_metadata("x")
+async def test_task_metadata(c, s, a, b):
+    await c.set_metadata("x", 1)
+    result = await c.get_metadata("x")
     assert result == 1
 
     future = c.submit(inc, 1)
     key = future.key
-    yield wait(future)
-    yield c.set_metadata(key, 123)
-    result = yield c.get_metadata(key)
+    await wait(future)
+    await c.set_metadata(key, 123)
+    result = await c.get_metadata(key)
     assert result == 123
 
     del future
 
     while key in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     with pytest.raises(KeyError):
-        yield c.get_metadata(key)
+        await c.get_metadata(key)
 
-    result = yield c.get_metadata(key, None)
+    result = await c.get_metadata(key, None)
     assert result is None
 
-    yield c.set_metadata(["x", "a"], 1)
-    result = yield c.get_metadata("x")
+    await c.set_metadata(["x", "a"], 1)
+    result = await c.get_metadata("x")
     assert result == {"a": 1}
-    yield c.set_metadata(["x", "b"], 2)
-    result = yield c.get_metadata("x")
+    await c.set_metadata(["x", "b"], 2)
+    result = await c.get_metadata("x")
     assert result == {"a": 1, "b": 2}
-    result = yield c.get_metadata(["x", "a"])
+    result = await c.get_metadata(["x", "a"])
     assert result == 1
 
-    yield c.set_metadata(["x", "a", "c", "d"], 1)
-    result = yield c.get_metadata("x")
+    await c.set_metadata(["x", "a", "c", "d"], 1)
+    result = await c.get_metadata("x")
     assert result == {"a": {"c": {"d": 1}}, "b": 2}
 
 
 @gen_cluster(client=True, Worker=Nanny)
-def test_logs(c, s, a, b):
-    yield wait(c.map(inc, range(5)))
-    logs = yield c.get_scheduler_logs(n=5)
+async def test_logs(c, s, a, b):
+    await wait(c.map(inc, range(5)))
+    logs = await c.get_scheduler_logs(n=5)
     assert logs
 
     for _, msg in logs:
         assert "distributed.scheduler" in msg
 
-    w_logs = yield c.get_worker_logs(n=5)
+    w_logs = await c.get_worker_logs(n=5)
     assert set(w_logs.keys()) == {a.worker_address, b.worker_address}
     for log in w_logs.values():
         for _, msg in log:
             assert "distributed.worker" in msg
 
-    n_logs = yield c.get_worker_logs(nanny=True)
+    n_logs = await c.get_worker_logs(nanny=True)
     assert set(n_logs.keys()) == {a.worker_address, b.worker_address}
     for log in n_logs.values():
         for _, msg in log:
             assert "distributed.nanny" in msg
 
-    n_logs = yield c.get_worker_logs(nanny=True, workers=[a.worker_address])
+    n_logs = await c.get_worker_logs(nanny=True, workers=[a.worker_address])
     assert set(n_logs.keys()) == {a.worker_address}
     for log in n_logs.values():
         for _, msg in log:
@@ -5146,29 +5146,29 @@ def test_logs(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_avoid_delayed_finalize(c, s, a, b):
+async def test_avoid_delayed_finalize(c, s, a, b):
     x = delayed(inc)(1)
     future = c.compute(x)
-    result = yield future
+    result = await future
     assert result == 2
     assert list(s.tasks) == [future.key] == [x.key]
 
 
 @gen_cluster()
-def test_config_scheduler_address(s, a, b):
+async def test_config_scheduler_address(s, a, b):
     with dask.config.set({"scheduler-address": s.address}):
         with captured_logger("distributed.client") as sio:
-            c = yield Client(asynchronous=True)
+            c = await Client(asynchronous=True)
             assert c.scheduler.address == s.address
 
         text = sio.getvalue()
         assert s.address in text
 
-        yield c.close()
+        await c.close()
 
 
 @gen_cluster(client=True)
-def test_warn_when_submitting_large_values(c, s, a, b):
+async def test_warn_when_submitting_large_values(c, s, a, b):
     with warnings.catch_warnings(record=True) as record:
         future = c.submit(lambda x: x + 1, b"0" * 2000000)
 
@@ -5189,33 +5189,33 @@ def test_warn_when_submitting_large_values(c, s, a, b):
 
 
 @gen_cluster()
-def test_scatter_direct(s, a, b):
-    c = yield Client(s.address, asynchronous=True, heartbeat_interval=10)
+async def test_scatter_direct(s, a, b):
+    c = await Client(s.address, asynchronous=True, heartbeat_interval=10)
 
     last = s.clients[c.id].last_seen
 
     start = time()
     while s.clients[c.id].last_seen == last:
-        yield gen.sleep(0.10)
+        await gen.sleep(0.10)
         assert time() < start + 5
 
-    yield c.close()
+    await c.close()
 
 
 @gen_cluster(client=True)
-def test_unhashable_function(c, s, a, b):
+async def test_unhashable_function(c, s, a, b):
     d = {"a": 1}
-    result = yield c.submit(d.get, "a")
+    result = await c.submit(d.get, "a")
     assert result == 1
 
 
 @gen_cluster()
-def test_client_name(s, a, b):
+async def test_client_name(s, a, b):
     with dask.config.set({"client-name": "hello-world"}):
-        c = yield Client(s.address, asynchronous=True)
+        c = await Client(s.address, asynchronous=True)
         assert any("hello-world" in name for name in list(s.clients))
 
-    yield c.close()
+    await c.close()
 
 
 def test_client_doesnt_close_given_loop(loop, s, a, b):
@@ -5226,11 +5226,11 @@ def test_client_doesnt_close_given_loop(loop, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_quiet_scheduler_loss(c, s):
+async def test_quiet_scheduler_loss(c, s):
     c._periodic_callbacks["scheduler-info"].interval = 10
     with captured_logger(logging.getLogger("distributed.client")) as logger:
-        yield s.close()
-        yield c._update_scheduler_info()
+        await s.close()
+        await c._update_scheduler_info()
     text = logger.getvalue()
     assert "BrokenPipeError" not in text
 
@@ -5257,22 +5257,22 @@ async def test_dashboard_link_inproc(cleanup):
 
 
 @gen_test()
-def test_client_timeout_2():
+async def test_client_timeout_2():
     with dask.config.set({"distributed.comm.timeouts.connect": "10ms"}):
         start = time()
         c = Client("127.0.0.1:3755", asynchronous=True)
         with pytest.raises((TimeoutError, IOError)):
-            yield c
+            await c
         stop = time()
 
         assert c.status == "closed"
-        yield c.close()
+        await c.close()
 
         assert stop - start < 1
 
 
 @gen_test()
-def test_client_active_bad_port():
+async def test_client_active_bad_port():
     import tornado.web
     import tornado.httpserver
 
@@ -5282,8 +5282,8 @@ def test_client_active_bad_port():
     with dask.config.set({"distributed.comm.timeouts.connect": "10ms"}):
         c = Client("127.0.0.1:8080", asynchronous=True)
         with pytest.raises((TimeoutError, IOError)):
-            yield c
-        yield c._close(fast=True)
+            await c
+        await c._close(fast=True)
     http_server.stop()
 
 
@@ -5328,10 +5328,10 @@ def test_turn_off_pickle(direct):
 
 
 @gen_cluster()
-def test_de_serialization(s, a, b):
+async def test_de_serialization(s, a, b):
     import numpy as np
 
-    c = yield Client(
+    c = await Client(
         s.address,
         asynchronous=True,
         serializers=["msgpack", "pickle"],
@@ -5339,35 +5339,35 @@ def test_de_serialization(s, a, b):
     )
     try:
         # Can send complex data
-        future = yield c.scatter(np.ones(5))
+        future = await c.scatter(np.ones(5))
 
         # But can not retrieve it
         with pytest.raises(TypeError):
-            result = yield future
+            result = await future
     finally:
-        yield c.close()
+        await c.close()
 
 
 @gen_cluster()
-def test_de_serialization_none(s, a, b):
+async def test_de_serialization_none(s, a, b):
     import numpy as np
 
-    c = yield Client(s.address, asynchronous=True, deserializers=["msgpack"])
+    c = await Client(s.address, asynchronous=True, deserializers=["msgpack"])
     try:
         # Can send complex data
-        future = yield c.scatter(np.ones(5))
+        future = await c.scatter(np.ones(5))
 
         # But can not retrieve it
         with pytest.raises(TypeError):
-            result = yield future
+            result = await future
     finally:
-        yield c.close()
+        await c.close()
 
 
 @gen_cluster()
-def test_client_repr_closed(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
-    yield c.close()
+async def test_client_repr_closed(s, a, b):
+    c = await Client(s.address, asynchronous=True)
+    await c.close()
     c._repr_html_()
 
 
@@ -5378,7 +5378,7 @@ def test_client_repr_closed_sync(loop):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_nested_prioritization(c, s, w):
+async def test_nested_prioritization(c, s, w):
     x = delayed(inc)(1, dask_key_name=("a", 2))
     y = delayed(inc)(2, dask_key_name=("a", 10))
 
@@ -5386,7 +5386,7 @@ def test_nested_prioritization(c, s, w):
 
     fx, fy = c.compute([x, y])
 
-    yield wait([fx, fy])
+    await wait([fx, fy])
 
     assert (o[x.key] < o[y.key]) == (
         s.tasks[tokey(fx.key)].priority < s.tasks[tokey(fy.key)].priority
@@ -5394,18 +5394,18 @@ def test_nested_prioritization(c, s, w):
 
 
 @gen_cluster(client=True)
-def test_scatter_error_cancel(c, s, a, b):
+async def test_scatter_error_cancel(c, s, a, b):
     # https://github.com/dask/distributed/issues/2038
     def bad_fn(x):
         raise Exception("lol")
 
-    x = yield c.scatter(1)
+    x = await c.scatter(1)
     y = c.submit(bad_fn, x)
     del x
 
-    yield wait(y)
+    await wait(y)
     assert y.status == "error"
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert y.status == "error"  # not cancelled
 
 
@@ -5415,14 +5415,14 @@ def test_no_threads_lingering():
 
 
 @gen_cluster()
-def test_direct_async(s, a, b):
-    c = yield Client(s.address, asynchronous=True, direct_to_workers=True)
+async def test_direct_async(s, a, b):
+    c = await Client(s.address, asynchronous=True, direct_to_workers=True)
     assert c.direct_to_workers
-    yield c.close()
+    await c.close()
 
-    c = yield Client(s.address, asynchronous=True, direct_to_workers=False)
+    c = await Client(s.address, asynchronous=True, direct_to_workers=False)
     assert not c.direct_to_workers
-    yield c.close()
+    await c.close()
 
 
 def test_direct_sync(c):
@@ -5435,9 +5435,9 @@ def test_direct_sync(c):
 
 
 @gen_cluster()
-def test_mixing_clients(s, a, b):
-    c1 = yield Client(s.address, asynchronous=True)
-    c2 = yield Client(s.address, asynchronous=True)
+async def test_mixing_clients(s, a, b):
+    c1 = await Client(s.address, asynchronous=True)
+    c2 = await Client(s.address, asynchronous=True)
 
     future = c1.submit(inc, 1)
     with pytest.raises(ValueError):
@@ -5445,16 +5445,16 @@ def test_mixing_clients(s, a, b):
 
     assert not c2.futures  # Don't create Futures on second Client
 
-    yield c1.close()
-    yield c2.close()
+    await c1.close()
+    await c2.close()
 
 
 @gen_cluster(client=True)
-def test_tuple_keys(c, s, a, b):
+async def test_tuple_keys(c, s, a, b):
     x = dask.delayed(inc)(1, dask_key_name=("x", 1))
     y = dask.delayed(inc)(x, dask_key_name=("y", 1))
     future = c.compute(y)
-    assert (yield future) == 3
+    assert (await future) == 3
 
 
 @gen_cluster(client=True)
@@ -5466,34 +5466,34 @@ async def test_multiple_scatter(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_map_large_kwargs_in_graph(c, s, a, b):
+async def test_map_large_kwargs_in_graph(c, s, a, b):
     np = pytest.importorskip("numpy")
     x = np.random.random(100000)
     futures = c.map(lambda a, b: a + b, range(100), b=x)
     while not s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert len(s.tasks) == 101
     assert any(k.startswith("ndarray") for k in s.tasks)
 
 
 @gen_cluster(client=True)
-def test_retry(c, s, a, b):
+async def test_retry(c, s, a, b):
     def f():
         assert dask.config.get("foo")
 
     with dask.config.set(foo=False):
         future = c.submit(f)
         with pytest.raises(AssertionError):
-            yield future
+            await future
 
     with dask.config.set(foo=True):
-        yield future.retry()
-        yield future
+        await future.retry()
+        await future
 
 
 @gen_cluster(client=True)
-def test_retry_dependencies(c, s, a, b):
+async def test_retry_dependencies(c, s, a, b):
     def f():
         return dask.config.get("foo")
 
@@ -5501,21 +5501,21 @@ def test_retry_dependencies(c, s, a, b):
     y = c.submit(inc, x)
 
     with pytest.raises(KeyError):
-        yield y
+        await y
 
     with dask.config.set(foo=100):
-        yield y.retry()
-        result = yield y
+        await y.retry()
+        result = await y
         assert result == 101
 
-        yield y.retry()
-        yield x.retry()
-        result = yield y
+        await y.retry()
+        await x.retry()
+        result = await y
         assert result == 101
 
 
 @gen_cluster(client=True)
-def test_released_dependencies(c, s, a, b):
+async def test_released_dependencies(c, s, a, b):
     def f(x):
         return dask.config.get("foo") + 1
 
@@ -5524,26 +5524,26 @@ def test_released_dependencies(c, s, a, b):
     del x
 
     with pytest.raises(KeyError):
-        yield y
+        await y
 
     with dask.config.set(foo=100):
-        yield y.retry()
-        result = yield y
+        await y.retry()
+        result = await y
         assert result == 101
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
-def test_profile_bokeh(c, s, a, b):
+async def test_profile_bokeh(c, s, a, b):
     pytest.importorskip("bokeh.plotting")
     from bokeh.model import Model
 
-    yield c.gather(c.map(slowinc, range(10), delay=0.2))
-    state, figure = yield c.profile(plot=True)
+    await c.gather(c.map(slowinc, range(10), delay=0.2))
+    state, figure = await c.profile(plot=True)
     assert isinstance(figure, Model)
 
     with tmpfile("html") as fn:
         try:
-            yield c.profile(filename=fn)
+            await c.profile(filename=fn)
         except PermissionError:
             if WINDOWS:
                 pytest.xfail()
@@ -5551,7 +5551,7 @@ def test_profile_bokeh(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_get_mix_futures_and_SubgraphCallable(c, s, a, b):
+async def test_get_mix_futures_and_SubgraphCallable(c, s, a, b):
     future = c.submit(add, 1, 2)
 
     subgraph = SubgraphCallable(
@@ -5560,7 +5560,7 @@ def test_get_mix_futures_and_SubgraphCallable(c, s, a, b):
     dsk = {"a": 1, "b": 2, "c": (subgraph, "a", "b"), "d": (subgraph, "c", "b")}
 
     future2 = c.get(dsk, "d", sync=False)
-    result = yield future2
+    result = await future2
     assert result == 11
 
     # Nested subgraphs
@@ -5576,12 +5576,12 @@ def test_get_mix_futures_and_SubgraphCallable(c, s, a, b):
 
     dsk2 = {"e": 1, "f": 2, "g": (subgraph2, "e", "f")}
 
-    result = yield c.get(dsk2, "g", sync=False)
+    result = await c.get(dsk2, "g", sync=False)
     assert result == 22
 
 
 @gen_cluster(client=True)
-def test_get_mix_futures_and_SubgraphCallable_dask_dataframe(c, s, a, b):
+async def test_get_mix_futures_and_SubgraphCallable_dask_dataframe(c, s, a, b):
     dd = pytest.importorskip("dask.dataframe")
     import pandas as pd
 
@@ -5591,7 +5591,7 @@ def test_get_mix_futures_and_SubgraphCallable_dask_dataframe(c, s, a, b):
     ddf["x"] = ddf["x"].astype("f8")
     ddf = ddf.map_partitions(lambda x: x)
     ddf["x"] = ddf["x"].astype("f8")
-    result = yield c.compute(ddf)
+    result = await c.compute(ddf)
     assert result.equals(df.astype("f8"))
 
 
@@ -5604,23 +5604,23 @@ def test_direct_to_workers(s, loop):
 
 
 @gen_cluster(client=True)
-def test_instances(c, s, a, b):
+async def test_instances(c, s, a, b):
     assert list(Client._instances) == [c]
     assert list(Scheduler._instances) == [s]
     assert set(Worker._instances) == {a, b}
 
 
 @gen_cluster(client=True)
-def test_wait_for_workers(c, s, a, b):
+async def test_wait_for_workers(c, s, a, b):
     future = asyncio.ensure_future(c.wait_for_workers(n_workers=3))
-    yield gen.sleep(0.22)  # 2 chances
+    await gen.sleep(0.22)  # 2 chances
     assert not future.done()
 
-    w = yield Worker(s.address)
+    w = await Worker(s.address)
     start = time()
-    yield future
+    await future
     assert time() < start + 1
-    yield w.close()
+    await w.close()
 
 
 @pytest.mark.skipif(WINDOWS, reason="num_fds not supported on windows")
@@ -5723,14 +5723,14 @@ async def test_profile_server(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_await_future(c, s, a, b):
+async def test_await_future(c, s, a, b):
     future = c.submit(inc, 1)
 
     async def f():  # flake8: noqa
         result = await future
         assert result == 2
 
-    yield f()
+    await f()
 
     future = c.submit(div, 1, 0)
 
@@ -5738,11 +5738,11 @@ def test_await_future(c, s, a, b):
         with pytest.raises(ZeroDivisionError):
             await future
 
-    yield f()
+    await f()
 
 
 @gen_cluster(client=True)
-def test_as_completed_async_for(c, s, a, b):
+async def test_as_completed_async_for(c, s, a, b):
     futures = c.map(inc, range(10))
     ac = as_completed(futures)
     results = []
@@ -5752,13 +5752,13 @@ def test_as_completed_async_for(c, s, a, b):
             result = await future
             results.append(result)
 
-    yield f()
+    await f()
 
     assert set(results) == set(range(1, 11))
 
 
 @gen_cluster(client=True)
-def test_as_completed_async_for_results(c, s, a, b):
+async def test_as_completed_async_for_results(c, s, a, b):
     futures = c.map(inc, range(10))
     ac = as_completed(futures, with_results=True)
     results = []
@@ -5767,14 +5767,14 @@ def test_as_completed_async_for_results(c, s, a, b):
         async for future, result in ac:
             results.append(result)
 
-    yield f()
+    await f()
 
     assert set(results) == set(range(1, 11))
     assert not s.counters["op"].components[0]["gather"]
 
 
 @gen_cluster(client=True)
-def test_as_completed_async_for_cancel(c, s, a, b):
+async def test_as_completed_async_for_cancel(c, s, a, b):
     x = c.submit(inc, 1)
     y = c.submit(sleep, 0.3)
     ac = as_completed([x, y])
@@ -5791,7 +5791,7 @@ def test_as_completed_async_for_cancel(c, s, a, b):
         async for future in ac:
             L.append(future)
 
-    yield f()
+    await f()
 
     assert L == [x, y]
 
@@ -5946,7 +5946,7 @@ async def test_client_gather_semaphor_loop(cleanup):
 
 
 @gen_cluster(client=True)
-def test_as_completed_condition_loop(c, s, a, b):
+async def test_as_completed_condition_loop(c, s, a, b):
     seq = c.map(inc, range(5))
     ac = as_completed(seq)
     assert ac.condition._loop == c.loop.asyncio_loop

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2296,7 +2296,7 @@ async def test_cancel_collection(c, s, a, b):
     start = time()
     while s.tasks:
         assert time() < start + 1
-        await time.sleep(0.01)
+        await asyncio.sleep(0.01)
 
 
 def test_cancel(c):

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -68,7 +68,7 @@ def test_dataframes(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test__dask_array_collections(c, s, a, b):
+def test_dask_array_collections(c, s, a, b):
     import dask.array as da
 
     s.validate = False
@@ -199,5 +199,5 @@ def test_delayed_none(c, s, w):
     x = dask.delayed(None)
     y = dask.delayed(123)
     [xx, yy] = c.compute([x, y])
-    assert (yield xx) is None
-    assert (yield yy) == 123
+    assert yield xx is None
+    assert yield yy == 123

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -34,7 +34,7 @@ def assert_equal(a, b):
 
 
 @gen_cluster(timeout=240, client=True)
-def test_dataframes(c, s, a, b):
+async def test_dataframes(c, s, a, b):
     df = pd.DataFrame(
         {"x": np.random.random(1000), "y": np.random.random(1000)},
         index=np.arange(1000),
@@ -46,7 +46,7 @@ def test_dataframes(c, s, a, b):
     assert rdf.divisions == ldf.divisions
 
     remote = c.compute(rdf)
-    result = yield remote
+    result = await remote
 
     tm.assert_frame_equal(result, ldf.compute(scheduler="sync"))
 
@@ -63,19 +63,19 @@ def test_dataframes(c, s, a, b):
     for f in exprs:
         local = f(ldf).compute(scheduler="sync")
         remote = c.compute(f(rdf))
-        remote = yield remote
+        remote = await remote
         assert_equal(local, remote)
 
 
 @gen_cluster(client=True)
-def test_dask_array_collections(c, s, a, b):
+async def test_dask_array_collections(c, s, a, b):
     import dask.array as da
 
     s.validate = False
     x_dsk = {("x", i, j): np.random.random((3, 3)) for i in range(3) for j in range(2)}
     y_dsk = {("y", i, j): np.random.random((3, 3)) for i in range(2) for j in range(3)}
-    x_futures = yield c.scatter(x_dsk)
-    y_futures = yield c.scatter(y_dsk)
+    x_futures = await c.scatter(x_dsk)
+    y_futures = await c.scatter(y_dsk)
 
     dt = np.random.random(0).dtype
     x_local = da.Array(x_dsk, "x", ((3, 3, 3), (3, 3)), dt)
@@ -95,13 +95,13 @@ def test_dask_array_collections(c, s, a, b):
         local = expr(x_local, y_local).compute(scheduler="sync")
 
         remote = c.compute(expr(x_remote, y_remote))
-        remote = yield remote
+        remote = await remote
 
         assert np.all(local == remote)
 
 
 @gen_cluster(client=True)
-def test_bag_groupby_tasks_default(c, s, a, b):
+async def test_bag_groupby_tasks_default(c, s, a, b):
     b = db.range(100, npartitions=10)
     b2 = b.groupby(lambda x: x % 13)
     assert not any("partd" in k[0] for k in b2.dask)
@@ -147,11 +147,11 @@ def test_rolling_sync(client):
 
 
 @gen_cluster(client=True)
-def test_loc(c, s, a, b):
+async def test_loc(c, s, a, b):
     df = make_time_dataframe()
     ddf = dd.from_pandas(df, npartitions=10)
     future = c.compute(ddf.loc["2000-01-17":"2000-01-24"])
-    yield future
+    await future
 
 
 def test_dataframe_groupby_tasks(client):
@@ -182,7 +182,7 @@ def test_dataframe_groupby_tasks(client):
 
 
 @gen_cluster(client=True)
-def test_sparse_arrays(c, s, a, b):
+async def test_sparse_arrays(c, s, a, b):
     sparse = pytest.importorskip("sparse")
     da = pytest.importorskip("dask.array")
 
@@ -191,13 +191,13 @@ def test_sparse_arrays(c, s, a, b):
     s = x.map_blocks(sparse.COO)
     future = c.compute(s.sum(axis=0)[:10])
 
-    yield future
+    await future
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_delayed_none(c, s, w):
+async def test_delayed_none(c, s, w):
     x = dask.delayed(None)
     y = dask.delayed(123)
     [xx, yy] = c.compute([x, y])
-    assert yield xx is None
-    assert yield yy == 123
+    assert await xx is None
+    assert await yy == 123

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -732,7 +732,7 @@ def test_rpc_serialization(loop):
 
 
 @gen_cluster()
-def test_thread_id(s, a, b):
+async def test_thread_id(s, a, b):
     assert s.thread_id == a.thread_id == b.thread_id == threading.get_ident()
 
 

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -35,30 +35,30 @@ def test_submit_after_failed_worker_sync(loop):
 
 
 @gen_cluster(client=True, timeout=60, active_rpc_timeout=10)
-def test_submit_after_failed_worker_async(c, s, a, b):
-    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
+async def test_submit_after_failed_worker_async(c, s, a, b):
+    n = await Nanny(s.address, nthreads=2, loop=s.loop)
     while len(s.workers) < 3:
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
 
     L = c.map(inc, range(10))
-    yield wait(L)
+    await wait(L)
 
     s.loop.add_callback(n.kill)
     total = c.submit(sum, L)
-    result = yield total
+    result = await total
     assert result == sum(map(inc, range(10)))
 
-    yield n.close()
+    await n.close()
 
 
 @gen_cluster(client=True, timeout=60)
-def test_submit_after_failed_worker(c, s, a, b):
+async def test_submit_after_failed_worker(c, s, a, b):
     L = c.map(inc, range(10))
-    yield wait(L)
-    yield a.close()
+    await wait(L)
+    await a.close()
 
     total = c.submit(sum, L)
-    result = yield total
+    result = await total
     assert result == sum(map(inc, range(10)))
 
 
@@ -78,73 +78,73 @@ def test_gather_after_failed_worker(loop):
     nthreads=[("127.0.0.1", 1)] * 4,
     config={"distributed.comm.timeouts.connect": "1s"},
 )
-def test_gather_then_submit_after_failed_workers(c, s, w, x, y, z):
+async def test_gather_then_submit_after_failed_workers(c, s, w, x, y, z):
     L = c.map(inc, range(20))
-    yield wait(L)
+    await wait(L)
 
     w.process.process._process.terminate()
     total = c.submit(sum, L)
 
     for i in range(3):
-        yield wait(total)
+        await wait(total)
         addr = first(s.tasks[total.key].who_has).address
         for worker in [x, y, z]:
             if worker.worker_address == addr:
                 worker.process.process._process.terminate()
                 break
 
-        result = yield c.gather([total])
+        result = await c.gather([total])
         assert result == [sum(map(inc, range(20)))]
 
 
 @gen_cluster(Worker=Nanny, timeout=60, client=True)
-def test_failed_worker_without_warning(c, s, a, b):
+async def test_failed_worker_without_warning(c, s, a, b):
     L = c.map(inc, range(10))
-    yield wait(L)
+    await wait(L)
 
     original_pid = a.pid
     with ignoring(CommClosedError):
-        yield c._run(os._exit, 1, workers=[a.worker_address])
+        await c._run(os._exit, 1, workers=[a.worker_address])
     start = time()
     while a.pid == original_pid:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() - start < 10
 
-    yield gen.sleep(0.5)
+    await gen.sleep(0.5)
 
     start = time()
     while len(s.nthreads) < 2:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() - start < 10
 
-    yield wait(L)
+    await wait(L)
 
     L2 = c.map(inc, range(10, 20))
-    yield wait(L2)
+    await wait(L2)
     assert all(len(keys) > 0 for keys in s.has_what.values())
     nthreads2 = dict(s.nthreads)
 
-    yield c.restart()
+    await c.restart()
 
     L = c.map(inc, range(10))
-    yield wait(L)
+    await wait(L)
     assert all(len(keys) > 0 for keys in s.has_what.values())
 
     assert not (set(nthreads2) & set(s.nthreads))  # no overlap
 
 
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
-def test_restart(c, s, a, b):
+async def test_restart(c, s, a, b):
     assert s.nthreads == {a.worker_address: 1, b.worker_address: 2}
 
     x = c.submit(inc, 1)
     y = c.submit(inc, x)
     z = c.submit(div, 1, 0)
-    yield y
+    await y
 
     assert set(s.who_has) == {x.key, y.key}
 
-    f = yield c.restart()
+    f = await c.restart()
     assert f is c
 
     assert len(s.workers) == 2
@@ -162,12 +162,12 @@ def test_restart(c, s, a, b):
 
 
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
-def test_restart_cleared(c, s, a, b):
+async def test_restart_cleared(c, s, a, b):
     x = 2 * delayed(1) + 1
     f = c.compute(x)
-    yield wait([f])
+    await wait([f])
 
-    yield c.restart()
+    await c.restart()
 
     for coll in [s.tasks, s.unrunnable]:
         assert not coll
@@ -204,18 +204,18 @@ def test_restart_sync(loop):
 
 
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
-def test_restart_fast(c, s, a, b):
+async def test_restart_fast(c, s, a, b):
     L = c.map(sleep, range(10))
 
     start = time()
-    yield c.restart()
+    await c.restart()
     assert time() - start < 10
     assert len(s.nthreads) == 2
 
     assert all(x.status == "cancelled" for x in L)
 
     x = c.submit(inc, 1)
-    result = yield x
+    result = await x
     assert result == 2
 
 
@@ -247,51 +247,51 @@ def test_restart_fast_sync(loop):
 
 
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
-def test_fast_kill(c, s, a, b):
+async def test_fast_kill(c, s, a, b):
     L = c.map(sleep, range(10))
 
     start = time()
-    yield c.restart()
+    await c.restart()
     assert time() - start < 10
 
     assert all(x.status == "cancelled" for x in L)
 
     x = c.submit(inc, 1)
-    result = yield x
+    result = await x
     assert result == 2
 
 
 @gen_cluster(Worker=Nanny, timeout=60)
-def test_multiple_clients_restart(s, a, b):
-    c1 = yield Client(s.address, asynchronous=True)
-    c2 = yield Client(s.address, asynchronous=True)
+async def test_multiple_clients_restart(s, a, b):
+    c1 = await Client(s.address, asynchronous=True)
+    c2 = await Client(s.address, asynchronous=True)
 
     x = c1.submit(inc, 1)
     y = c2.submit(inc, 2)
-    xx = yield x
-    yy = yield y
+    xx = await x
+    yy = await y
     assert xx == 2
     assert yy == 3
 
-    yield c1.restart()
+    await c1.restart()
 
     assert x.cancelled()
     start = time()
     while not y.cancelled():
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
-    yield c1.close()
-    yield c2.close()
+    await c1.close()
+    await c2.close()
 
 
 @gen_cluster(Worker=Nanny, timeout=60)
-def test_restart_scheduler(s, a, b):
+async def test_restart_scheduler(s, a, b):
     import gc
 
     gc.collect()
     addrs = (a.worker_address, b.worker_address)
-    yield s.restart()
+    await s.restart()
     assert len(s.nthreads) == 2
     addrs2 = (a.worker_address, b.worker_address)
 
@@ -299,26 +299,26 @@ def test_restart_scheduler(s, a, b):
 
 
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
-def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
+async def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
     x = c.submit(inc, 1)
-    yield c.restart()
+    await c.restart()
     y = c.submit(inc, 1)
     del x
     import gc
 
     gc.collect()
-    yield gen.sleep(0.1)
-    yield y
+    await gen.sleep(0.1)
+    await y
 
 
 @gen_cluster(client=True, timeout=60, active_rpc_timeout=10)
-def test_broken_worker_during_computation(c, s, a, b):
+async def test_broken_worker_during_computation(c, s, a, b):
     s.allowed_failures = 100
-    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
+    n = await Nanny(s.address, nthreads=2, loop=s.loop)
 
     start = time()
     while len(s.nthreads) < 3:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     N = 256
@@ -333,37 +333,37 @@ def test_broken_worker_during_computation(c, s, a, b):
             key=["add-%d-%d" % (i, j) for j in range(len(L) // 2)]
         )
 
-    yield gen.sleep(random.random() / 20)
+    await gen.sleep(random.random() / 20)
     with ignoring(CommClosedError):  # comm will be closed abrupty
-        yield c._run(os._exit, 1, workers=[n.worker_address])
+        await c._run(os._exit, 1, workers=[n.worker_address])
 
-    yield gen.sleep(random.random() / 20)
+    await gen.sleep(random.random() / 20)
     while len(s.workers) < 3:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     with ignoring(
         CommClosedError, EnvironmentError
     ):  # perhaps new worker can't be contacted yet
-        yield c._run(os._exit, 1, workers=[n.worker_address])
+        await c._run(os._exit, 1, workers=[n.worker_address])
 
-    [result] = yield c.gather(L)
+    [result] = await c.gather(L)
     assert isinstance(result, int)
     assert result == expected_result
 
-    yield n.close()
+    await n.close()
 
 
 @gen_cluster(client=True, Worker=Nanny, timeout=60)
-def test_restart_during_computation(c, s, a, b):
+async def test_restart_during_computation(c, s, a, b):
     xs = [delayed(slowinc)(i, delay=0.01) for i in range(50)]
     ys = [delayed(slowinc)(i, delay=0.01) for i in xs]
     zs = [delayed(slowadd)(x, y, delay=0.01) for x, y in zip(xs, ys)]
     total = delayed(sum)(zs)
     result = c.compute(total)
 
-    yield gen.sleep(0.5)
+    await gen.sleep(0.5)
     assert s.rprocessing
-    yield c.restart()
+    await c.restart()
     assert not s.rprocessing
 
     assert len(s.nthreads) == 2
@@ -371,59 +371,59 @@ def test_restart_during_computation(c, s, a, b):
 
 
 @gen_cluster(client=True, timeout=60)
-def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
-    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
+async def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
+    n = await Nanny(s.address, nthreads=2, loop=s.loop)
 
     start = time()
     while len(s.nthreads) < 3:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     futures = c.map(slowinc, range(20), delay=0.01, key=["f%d" % i for i in range(20)])
-    yield wait(futures)
+    await wait(futures)
 
-    result = yield c.submit(sum, futures, workers=a.address)
+    result = await c.submit(sum, futures, workers=a.address)
     for dep in set(a.dep_state) - set(a.task_state):
         a.release_dep(dep, report=True)
 
     n_worker_address = n.worker_address
     with ignoring(CommClosedError):
-        yield c._run(os._exit, 1, workers=[n_worker_address])
+        await c._run(os._exit, 1, workers=[n_worker_address])
 
     while len(s.workers) > 2:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     total = c.submit(sum, futures, workers=a.address)
-    yield total
+    await total
 
     assert not a.has_what.get(n_worker_address)
     assert not any(n_worker_address in s for s in a.who_has.values())
 
-    yield n.close()
+    await n.close()
 
 
 @pytest.mark.slow
 @gen_cluster(client=True, timeout=60, Worker=Nanny, nthreads=[("127.0.0.1", 1)])
-def test_restart_timeout_on_long_running_task(c, s, a):
+async def test_restart_timeout_on_long_running_task(c, s, a):
     with captured_logger("distributed.scheduler") as sio:
         future = c.submit(sleep, 3600)
-        yield gen.sleep(0.1)
-        yield c.restart(timeout=20)
+        await gen.sleep(0.1)
+        await c.restart(timeout=20)
 
     text = sio.getvalue()
     assert "timeout" not in text.lower()
 
 
 @gen_cluster(client=True, scheduler_kwargs={"worker_ttl": "500ms"})
-def test_worker_time_to_live(c, s, a, b):
+async def test_worker_time_to_live(c, s, a, b):
     assert set(s.workers) == {a.address, b.address}
     a.periodic_callbacks["heartbeat"].stop()
-    yield gen.sleep(0.010)
+    await gen.sleep(0.010)
     assert set(s.workers) == {a.address, b.address}
 
     start = time()
     while set(s.workers) == {a.address, b.address}:
-        yield gen.sleep(0.050)
+        await gen.sleep(0.050)
         assert time() < start + 2
 
     set(s.workers) == {b.address}

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -10,8 +10,8 @@ from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)
-def test_lock(c, s, a, b):
-    yield c.set_metadata("locked", False)
+async def test_lock(c, s, a, b):
+    await c.set_metadata("locked", False)
 
     def f(x):
         client = get_client()
@@ -23,16 +23,16 @@ def test_lock(c, s, a, b):
             client.set_metadata("locked", False)
 
     futures = c.map(f, range(20))
-    yield c.gather(futures)
+    await c.gather(futures)
     assert not s.extensions["locks"].events
     assert not s.extensions["locks"].ids
 
 
 @gen_cluster(client=True)
-def test_timeout(c, s, a, b):
+async def test_timeout(c, s, a, b):
     locks = s.extensions["locks"]
     lock = Lock("x")
-    result = yield lock.acquire()
+    result = await lock.acquire()
     assert result is True
     assert locks.ids["x"] == lock.id
 
@@ -40,35 +40,35 @@ def test_timeout(c, s, a, b):
     assert lock.id != lock2.id
 
     start = time()
-    result = yield lock2.acquire(timeout=0.1)
+    result = await lock2.acquire(timeout=0.1)
     stop = time()
     assert stop - start < 0.3
     assert result is False
     assert locks.ids["x"] == lock.id
     assert not locks.events["x"]
 
-    yield lock.release()
+    await lock.release()
 
 
 @gen_cluster(client=True)
-def test_acquires_with_zero_timeout(c, s, a, b):
+async def test_acquires_with_zero_timeout(c, s, a, b):
     lock = Lock("x")
-    yield lock.acquire(timeout=0)
+    await lock.acquire(timeout=0)
     assert lock.locked()
-    yield lock.release()
+    await lock.release()
 
-    yield lock.acquire(timeout=1)
-    yield lock.release()
-    yield lock.acquire(timeout=1)
-    yield lock.release()
+    await lock.acquire(timeout=1)
+    await lock.release()
+    await lock.acquire(timeout=1)
+    await lock.release()
 
 
 @gen_cluster(client=True)
-def test_acquires_blocking(c, s, a, b):
+async def test_acquires_blocking(c, s, a, b):
     lock = Lock("x")
-    yield lock.acquire(blocking=False)
+    await lock.acquire(blocking=False)
     assert lock.locked()
-    yield lock.release()
+    await lock.release()
     assert not lock.locked()
 
     with pytest.raises(ValueError):
@@ -81,10 +81,10 @@ def test_timeout_sync(client):
 
 
 @gen_cluster(client=True)
-def test_errors(c, s, a, b):
+async def test_errors(c, s, a, b):
     lock = Lock("x")
     with pytest.raises(ValueError):
-        yield lock.release()
+        await lock.release()
 
 
 def test_lock_sync(client):
@@ -103,19 +103,19 @@ def test_lock_sync(client):
 
 
 @gen_cluster(client=True)
-def test_lock_types(c, s, a, b):
+async def test_lock_types(c, s, a, b):
     for name in [1, ("a", 1), ["a", 1], b"123", "123"]:
         lock = Lock(name)
         assert lock.name == name
 
-        yield lock.acquire()
-        yield lock.release()
+        await lock.acquire()
+        await lock.release()
 
     assert not s.extensions["locks"].events
 
 
 @gen_cluster(client=True)
-def test_serializable(c, s, a, b):
+async def test_serializable(c, s, a, b):
     def f(x, lock=None):
         with lock:
             assert lock.name == "x"
@@ -123,7 +123,7 @@ def test_serializable(c, s, a, b):
 
     lock = Lock("x")
     futures = c.map(f, range(10), lock=lock)
-    yield c.gather(futures)
+    await c.gather(futures)
 
     lock2 = pickle.loads(pickle.dumps(lock))
     assert lock2.name == lock.name

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -23,7 +23,7 @@ def test_lock(c, s, a, b):
             client.set_metadata("locked", False)
 
     futures = c.map(f, range(20))
-    results = yield futures
+    yield c.gather(futures)
     assert not s.extensions["locks"].events
     assert not s.extensions["locks"].ids
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -10,7 +10,6 @@ import numpy as np
 
 import pytest
 from tlz import valmap, first
-from tornado import gen
 from tornado.ioloop import IOLoop
 
 import dask
@@ -93,20 +92,20 @@ async def test_nanny_process_failure(c, s):
 
     start = time()
     while n.pid == pid:  # wait while process dies and comes back
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() - start < 5
 
     start = time()
-    await gen.sleep(1)
+    await asyncio.sleep(1)
     while not n.is_alive():  # wait while process comes back
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() - start < 5
 
     # assert n.worker_address != original_address  # most likely
 
     start = time()
     while n.worker_address not in s.nthreads or n.worker_dir is None:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() - start < 5
 
     second_dir = n.worker_dir
@@ -155,7 +154,7 @@ async def test_close_on_disconnect(s, w):
 
     start = time()
     while w.status != "closed":
-        await gen.sleep(0.05)
+        await asyncio.sleep(0.05)
         assert time() < start + 9
 
 
@@ -221,13 +220,13 @@ async def test_num_fds(s):
 
     for i in range(3):
         w = await Nanny(s.address)
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         await w.close()
 
     start = time()
     while proc.num_fds() > before:
         print("fds:", before, proc.num_fds())
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 10
 
 
@@ -270,7 +269,7 @@ async def test_nanny_timeout(c, s, a):
 
     start = time()
     while x.status != "cancelled":
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 7
 
 
@@ -296,7 +295,7 @@ async def test_nanny_terminate(c, s, a):
         future = c.submit(leak)
         start = time()
         while a.process.pid == proc:
-            await gen.sleep(0.1)
+            await asyncio.sleep(0.1)
             assert time() < start + 10
         out = logger.getvalue()
         assert "restart" in out.lower()
@@ -348,7 +347,7 @@ async def test_avoid_memory_monitor_if_zero_limit(c, s):
 
     future = c.submit(inc, 1)
     assert await future == 2
-    await gen.sleep(0.02)
+    await asyncio.sleep(0.02)
 
     await c.submit(inc, 2)  # worker doesn't pause
 
@@ -363,7 +362,7 @@ async def test_scheduler_address_config(c, s):
 
         start = time()
         while not s.workers:
-            await gen.sleep(0.1)
+            await asyncio.sleep(0.1)
             assert time() < start + 10
 
     await nanny.close()
@@ -375,7 +374,7 @@ async def test_wait_for_scheduler():
     with captured_logger("distributed") as log:
         w = Nanny("127.0.0.1:44737")
         IOLoop.current().add_callback(w.start)
-        await gen.sleep(6)
+        await asyncio.sleep(6)
         await w.close()
 
     log = log.getvalue()
@@ -489,7 +488,7 @@ async def test_nanny_closes_cleanly(cleanup):
                     IOLoop.current().add_callback(w.terminate)
                     start = time()
                     while n.status != "closed":
-                        await gen.sleep(0.01)
+                        await asyncio.sleep(0.01)
                         assert time() < start + 5
 
                     assert n.status == "closed"

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -28,7 +28,8 @@ from distributed.utils_test import (  # noqa: F401
 )
 
 
-@gen_cluster(nthreads=[])
+# FIXME why does this leave behind unclosed Comm objects?
+@gen_cluster(nthreads=[], allow_unclosed=True)
 async def test_nanny(s):
     async with Nanny(s.address, nthreads=2, loop=s.loop) as n:
         async with rpc(n.address) as nn:
@@ -68,7 +69,7 @@ async def test_many_kills(s):
 
 
 @gen_cluster(Worker=Nanny)
-def test_str(s, a, b):
+async def test_str(s, a, b):
     assert a.worker_address in str(a)
     assert a.worker_address in repr(a)
     assert str(a.nthreads) in str(a)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -60,12 +60,12 @@ async def test_nanny(s):
 
 
 @gen_cluster(nthreads=[])
-def test_many_kills(s):
-    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
+async def test_many_kills(s):
+    n = await Nanny(s.address, nthreads=2, loop=s.loop)
     assert n.is_alive()
-    yield asyncio.gather(*(n.kill() for _ in range(5)))
-    yield asyncio.gather(*(n.kill() for _ in range(5)))
-    yield n.close()
+    await asyncio.gather(*(n.kill() for _ in range(5)))
+    await asyncio.gather(*(n.kill() for _ in range(5)))
+    await n.close()
 
 
 @gen_cluster(Worker=Nanny)
@@ -77,59 +77,59 @@ def test_str(s, a, b):
 
 
 @gen_cluster(nthreads=[], timeout=20, client=True)
-def test_nanny_process_failure(c, s):
-    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
+async def test_nanny_process_failure(c, s):
+    n = await Nanny(s.address, nthreads=2, loop=s.loop)
     first_dir = n.worker_dir
 
     assert os.path.exists(first_dir)
 
     original_address = n.worker_address
     ww = rpc(n.worker_address)
-    yield ww.update_data(data=valmap(dumps, {"x": 1, "y": 2}))
+    await ww.update_data(data=valmap(dumps, {"x": 1, "y": 2}))
     pid = n.pid
     assert pid is not None
     with ignoring(CommClosedError):
-        yield c.run(os._exit, 0, workers=[n.worker_address])
+        await c.run(os._exit, 0, workers=[n.worker_address])
 
     start = time()
     while n.pid == pid:  # wait while process dies and comes back
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() - start < 5
 
     start = time()
-    yield gen.sleep(1)
+    await gen.sleep(1)
     while not n.is_alive():  # wait while process comes back
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() - start < 5
 
     # assert n.worker_address != original_address  # most likely
 
     start = time()
     while n.worker_address not in s.nthreads or n.worker_dir is None:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() - start < 5
 
     second_dir = n.worker_dir
 
-    yield n.close()
+    await n.close()
     assert not os.path.exists(second_dir)
     assert not os.path.exists(first_dir)
     assert first_dir != n.worker_dir
-    yield ww.close_rpc()
+    await ww.close_rpc()
     s.stop()
 
 
 @gen_cluster(nthreads=[])
-def test_run(s):
+async def test_run(s):
     pytest.importorskip("psutil")
-    n = yield Nanny(s.address, nthreads=2, loop=s.loop)
+    n = await Nanny(s.address, nthreads=2, loop=s.loop)
 
     with rpc(n.address) as nn:
-        response = yield nn.run(function=dumps(lambda: 1))
+        response = await nn.run(function=dumps(lambda: 1))
         assert response["status"] == "OK"
         assert response["result"] == 1
 
-    yield n.close()
+    await n.close()
 
 
 @pytest.mark.slow
@@ -150,12 +150,12 @@ async def test_no_hang_when_scheduler_closes(s, a, b):
 @gen_cluster(
     Worker=Nanny, nthreads=[("127.0.0.1", 1)], worker_kwargs={"reconnect": False}
 )
-def test_close_on_disconnect(s, w):
-    yield s.close()
+async def test_close_on_disconnect(s, w):
+    await s.close()
 
     start = time()
     while w.status != "closed":
-        yield gen.sleep(0.05)
+        await gen.sleep(0.05)
         assert time() < start + 9
 
 
@@ -165,69 +165,69 @@ class Something(Worker):
 
 
 @gen_cluster(client=True, Worker=Nanny)
-def test_nanny_worker_class(c, s, w1, w2):
-    out = yield c._run(lambda dask_worker=None: str(dask_worker.__class__))
+async def test_nanny_worker_class(c, s, w1, w2):
+    out = await c._run(lambda dask_worker=None: str(dask_worker.__class__))
     assert "Worker" in list(out.values())[0]
     assert w1.Worker is Worker
 
 
 @gen_cluster(client=True, Worker=Nanny, worker_kwargs={"worker_class": Something})
-def test_nanny_alt_worker_class(c, s, w1, w2):
-    out = yield c._run(lambda dask_worker=None: str(dask_worker.__class__))
+async def test_nanny_alt_worker_class(c, s, w1, w2):
+    out = await c._run(lambda dask_worker=None: str(dask_worker.__class__))
     assert "Something" in list(out.values())[0]
     assert w1.Worker is Something
 
 
 @pytest.mark.slow
 @gen_cluster(client=False, nthreads=[])
-def test_nanny_death_timeout(s):
-    yield s.close()
+async def test_nanny_death_timeout(s):
+    await s.close()
     w = Nanny(s.address, death_timeout=1)
     with pytest.raises(TimeoutError):
-        yield w
+        await w
 
     assert w.status == "closed"
 
 
 @gen_cluster(client=True, Worker=Nanny)
-def test_random_seed(c, s, a, b):
-    def check_func(func):
+async def test_random_seed(c, s, a, b):
+    async def check_func(func):
         x = c.submit(func, 0, 2 ** 31, pure=False, workers=a.worker_address)
         y = c.submit(func, 0, 2 ** 31, pure=False, workers=b.worker_address)
         assert x.key != y.key
-        x = yield x
-        y = yield y
+        x = await x
+        y = await y
         assert x != y
 
-    yield check_func(lambda a, b: random.randint(a, b))
-    yield check_func(lambda a, b: np.random.randint(a, b))
+    await check_func(lambda a, b: random.randint(a, b))
+    await check_func(lambda a, b: np.random.randint(a, b))
 
 
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="num_fds not supported on windows"
 )
 @gen_cluster(client=False, nthreads=[])
-def test_num_fds(s):
+async def test_num_fds(s):
     psutil = pytest.importorskip("psutil")
     proc = psutil.Process()
 
     # Warm up
-    w = yield Nanny(s.address)
-    yield w.close()
+    w = await Nanny(s.address)
+    await w.close()
     del w
     gc.collect()
 
     before = proc.num_fds()
 
     for i in range(3):
-        w = yield Nanny(s.address)
-        yield gen.sleep(0.1)
-        yield w.close()
+        w = await Nanny(s.address)
+        await gen.sleep(0.1)
+        await w.close()
 
     start = time()
     while proc.num_fds() > before:
         print("fds:", before, proc.num_fds())
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         assert time() < start + 10
 
 
@@ -235,42 +235,42 @@ def test_num_fds(s):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster(client=True, nthreads=[])
-def test_worker_uses_same_host_as_nanny(c, s):
+async def test_worker_uses_same_host_as_nanny(c, s):
     for host in ["tcp://0.0.0.0", "tcp://127.0.0.2"]:
-        n = yield Nanny(s.address, host=host)
+        n = await Nanny(s.address, host=host)
 
         def func(dask_worker):
             return dask_worker.listener.listen_address
 
-        result = yield c.run(func)
+        result = await c.run(func)
         assert host in first(result.values())
-        yield n.close()
+        await n.close()
 
 
 @gen_test()
-def test_scheduler_file():
+async def test_scheduler_file():
     with tmpfile() as fn:
-        s = yield Scheduler(scheduler_file=fn, port=8008)
-        w = yield Nanny(scheduler_file=fn)
+        s = await Scheduler(scheduler_file=fn, port=8008)
+        w = await Nanny(scheduler_file=fn)
         assert set(s.workers) == {w.worker_address}
-        yield w.close()
+        await w.close()
         s.stop()
 
 
 @gen_cluster(client=True, Worker=Nanny, nthreads=[("127.0.0.1", 2)])
-def test_nanny_timeout(c, s, a):
-    x = yield c.scatter(123)
+async def test_nanny_timeout(c, s, a):
+    x = await c.scatter(123)
     with captured_logger(
         logging.getLogger("distributed.nanny"), level=logging.ERROR
     ) as logger:
-        response = yield a.restart(timeout=0.1)
+        response = await a.restart(timeout=0.1)
 
     out = logger.getvalue()
     assert "timed out" in out.lower()
 
     start = time()
     while x.status != "cancelled":
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         assert time() < start + 7
 
 
@@ -282,7 +282,7 @@ def test_nanny_timeout(c, s, a):
     timeout=20,
     clean_kwargs={"threads": False},
 )
-def test_nanny_terminate(c, s, a):
+async def test_nanny_terminate(c, s, a):
     from time import sleep
 
     def leak():
@@ -296,7 +296,7 @@ def test_nanny_terminate(c, s, a):
         future = c.submit(leak)
         start = time()
         while a.process.pid == proc:
-            yield gen.sleep(0.1)
+            await gen.sleep(0.1)
             assert time() < start + 10
         out = logger.getvalue()
         assert "restart" in out.lower()
@@ -338,45 +338,45 @@ async def test_throttle_outgoing_connections(c, s, a, *workers):
 
 
 @gen_cluster(nthreads=[], client=True)
-def test_avoid_memory_monitor_if_zero_limit(c, s):
-    nanny = yield Nanny(s.address, loop=s.loop, memory_limit=0)
-    typ = yield c.run(lambda dask_worker: type(dask_worker.data))
+async def test_avoid_memory_monitor_if_zero_limit(c, s):
+    nanny = await Nanny(s.address, loop=s.loop, memory_limit=0)
+    typ = await c.run(lambda dask_worker: type(dask_worker.data))
     assert typ == {nanny.worker_address: dict}
-    pcs = yield c.run(lambda dask_worker: list(dask_worker.periodic_callbacks))
+    pcs = await c.run(lambda dask_worker: list(dask_worker.periodic_callbacks))
     assert "memory" not in pcs
     assert "memory" not in nanny.periodic_callbacks
 
     future = c.submit(inc, 1)
-    assert yield future == 2
-    yield gen.sleep(0.02)
+    assert await future == 2
+    await gen.sleep(0.02)
 
-    yield c.submit(inc, 2)  # worker doesn't pause
+    await c.submit(inc, 2)  # worker doesn't pause
 
-    yield nanny.close()
+    await nanny.close()
 
 
 @gen_cluster(nthreads=[], client=True)
-def test_scheduler_address_config(c, s):
+async def test_scheduler_address_config(c, s):
     with dask.config.set({"scheduler-address": s.address}):
-        nanny = yield Nanny(loop=s.loop)
+        nanny = await Nanny(loop=s.loop)
         assert nanny.scheduler.address == s.address
 
         start = time()
         while not s.workers:
-            yield gen.sleep(0.1)
+            await gen.sleep(0.1)
             assert time() < start + 10
 
-    yield nanny.close()
+    await nanny.close()
 
 
 @pytest.mark.slow
 @gen_test(timeout=20)
-def test_wait_for_scheduler():
+async def test_wait_for_scheduler():
     with captured_logger("distributed") as log:
         w = Nanny("127.0.0.1:44737")
         IOLoop.current().add_callback(w.start)
-        yield gen.sleep(6)
-        yield w.close()
+        await gen.sleep(6)
+        await w.close()
 
     log = log.getvalue()
     assert "error" not in log.lower(), log
@@ -384,31 +384,31 @@ def test_wait_for_scheduler():
 
 
 @gen_cluster(nthreads=[], client=True)
-def test_environment_variable(c, s):
+async def test_environment_variable(c, s):
     a = Nanny(s.address, loop=s.loop, memory_limit=0, env={"FOO": "123"})
     b = Nanny(s.address, loop=s.loop, memory_limit=0, env={"FOO": "456"})
-    yield asyncio.gather(a, b)
-    results = yield c.run(lambda: os.environ["FOO"])
+    await asyncio.gather(a, b)
+    results = await c.run(lambda: os.environ["FOO"])
     assert results == {a.worker_address: "123", b.worker_address: "456"}
-    yield asyncio.gather(a.close(), b.close())
+    await asyncio.gather(a.close(), b.close())
 
 
 @gen_cluster(nthreads=[], client=True)
-def test_data_types(c, s):
-    w = yield Nanny(s.address, data=dict)
-    r = yield c.run(lambda dask_worker: type(dask_worker.data))
+async def test_data_types(c, s):
+    w = await Nanny(s.address, data=dict)
+    r = await c.run(lambda dask_worker: type(dask_worker.data))
     assert r[w.worker_address] == dict
-    yield w.close()
+    await w.close()
 
 
 @gen_cluster(nthreads=[])
-def test_local_directory(s):
+async def test_local_directory(s):
     with tmpfile() as fn:
         with dask.config.set(temporary_directory=fn):
-            w = yield Nanny(s.address)
+            w = await Nanny(s.address)
             assert w.local_directory.startswith(fn)
             assert "dask-worker-space" in w.local_directory
-            yield w.close()
+            await w.close()
 
 
 def _noop(x):
@@ -422,13 +422,13 @@ def _noop(x):
     Worker=Nanny,
     config={"distributed.worker.daemon": False},
 )
-def test_mp_process_worker_no_daemon(c, s, a):
+async def test_mp_process_worker_no_daemon(c, s, a):
     def multiprocessing_worker():
         p = mp.Process(target=_noop, args=(None,))
         p.start()
         p.join()
 
-    yield c.submit(multiprocessing_worker)
+    await c.submit(multiprocessing_worker)
 
 
 @gen_cluster(
@@ -437,12 +437,12 @@ def test_mp_process_worker_no_daemon(c, s, a):
     Worker=Nanny,
     config={"distributed.worker.daemon": False},
 )
-def test_mp_pool_worker_no_daemon(c, s, a):
+async def test_mp_pool_worker_no_daemon(c, s, a):
     def pool_worker(world_size):
         with mp.Pool(processes=world_size) as p:
             p.map(_noop, range(world_size))
 
-    yield c.submit(pool_worker, 4)
+    await c.submit(pool_worker, 4)
 
 
 @pytest.mark.asyncio

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -66,29 +66,29 @@ async def test_persist(c, s):
 
 
 @gen_cluster(client=True)
-def test_expand_compute(c, s, a, b):
+async def test_expand_compute(c, s, a, b):
     low = delayed(inc)(1)
     many = [delayed(slowinc)(i, delay=0.1) for i in range(10)]
     high = delayed(inc)(2)
 
     low, many, high = c.compute([low, many, high], priority={low: -1, high: 1})
-    yield wait(high)
+    await wait(high)
     assert s.tasks[low.key].state == "processing"
 
 
 @gen_cluster(client=True)
-def test_expand_persist(c, s, a, b):
+async def test_expand_persist(c, s, a, b):
     low = delayed(inc)(1, dask_key_name="low")
     many = [delayed(slowinc)(i, delay=0.1) for i in range(4)]
     high = delayed(inc)(2, dask_key_name="high")
 
     low, high, x, y, z, w = persist(low, high, *many, priority={low: -1, high: 1})
-    yield wait(high)
+    await wait(high)
     assert s.tasks[low.key].state == "processing"
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_repeated_persists_same_priority(c, s, w):
+async def test_repeated_persists_same_priority(c, s, w):
     xs = [delayed(slowinc)(i, delay=0.05, dask_key_name="x-%d" % i) for i in range(10)]
     ys = [
         delayed(slowinc)(x, delay=0.05, dask_key_name="y-%d" % i)
@@ -105,19 +105,19 @@ def test_repeated_persists_same_priority(c, s, w):
     while (
         sum(t.state == "memory" for t in s.tasks.values()) < 5
     ):  # TODO: reduce this number
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert any(s.tasks[y.key].state == "memory" for y in ys)
     assert any(s.tasks[z.key].state == "memory" for z in zs)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_last_in_first_out(c, s, w):
+async def test_last_in_first_out(c, s, w):
     xs = [c.submit(slowinc, i, delay=0.05) for i in range(5)]
     ys = [c.submit(slowinc, x, delay=0.05) for x in xs]
     zs = [c.submit(slowinc, y, delay=0.05) for y in ys]
 
     while len(s.tasks) < 15 or not any(s.tasks[z.key].state == "memory" for z in zs):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert not all(s.tasks[x.key].state == "memory" for x in xs)

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -1,5 +1,6 @@
+import asyncio
+
 import pytest
-from tornado import gen
 
 from dask.core import flatten
 import dask
@@ -105,7 +106,7 @@ async def test_repeated_persists_same_priority(c, s, w):
     while (
         sum(t.state == "memory" for t in s.tasks.values()) < 5
     ):  # TODO: reduce this number
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert any(s.tasks[y.key].state == "memory" for y in ys)
     assert any(s.tasks[z.key].state == "memory" for z in zs)
@@ -118,6 +119,6 @@ async def test_last_in_first_out(c, s, w):
     zs = [c.submit(slowinc, y, delay=0.05) for y in ys]
 
     while len(s.tasks) < 15 or not any(s.tasks[z.key].state == "memory" for z in zs):
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert not all(s.tasks[x.key].state == "memory" for x in xs)

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -12,90 +12,90 @@ from tornado import gen
 
 
 @gen_cluster(client=False)
-def test_publish_simple(s, a, b):
+async def test_publish_simple(s, a, b):
     c = Client(s.address, asynchronous=True)
     f = Client(s.address, asynchronous=True)
-    yield asyncio.gather(c, f)
+    await asyncio.gather(c, f)
 
-    data = yield c.scatter(range(3))
-    yield c.publish_dataset(data=data)
+    data = await c.scatter(range(3))
+    await c.publish_dataset(data=data)
     assert "data" in s.extensions["publish"].datasets
     assert isinstance(s.extensions["publish"].datasets["data"]["data"], Serialized)
 
     with pytest.raises(KeyError) as exc_info:
-        yield c.publish_dataset(data=data)
+        await c.publish_dataset(data=data)
 
     assert "exists" in str(exc_info.value)
     assert "data" in str(exc_info.value)
 
-    result = yield c.scheduler.publish_list()
+    result = await c.scheduler.publish_list()
     assert result == ("data",)
 
-    result = yield f.scheduler.publish_list()
+    result = await f.scheduler.publish_list()
     assert result == ("data",)
 
-    yield asyncio.gather(c.close(), f.close())
+    await asyncio.gather(c.close(), f.close())
 
 
 @gen_cluster(client=False)
-def test_publish_non_string_key(s, a, b):
+async def test_publish_non_string_key(s, a, b):
     async with Client(s.address, asynchronous=True) as c:
         for name in [("a", "b"), 9.0, 8]:
-            data = yield c.scatter(range(3))
-            yield c.publish_dataset(data, name=name)
+            data = await c.scatter(range(3))
+            await c.publish_dataset(data, name=name)
             assert name in s.extensions["publish"].datasets
             assert isinstance(
                 s.extensions["publish"].datasets[name]["data"], Serialized
             )
 
-            datasets = yield c.scheduler.publish_list()
+            datasets = await c.scheduler.publish_list()
             assert name in datasets
 
 
 @gen_cluster(client=False)
-def test_publish_roundtrip(s, a, b):
-    c = yield Client(s.address, asynchronous=True)
-    f = yield Client(s.address, asynchronous=True)
+async def test_publish_roundtrip(s, a, b):
+    c = await Client(s.address, asynchronous=True)
+    f = await Client(s.address, asynchronous=True)
 
-    data = yield c.scatter([0, 1, 2])
-    yield c.publish_dataset(data=data)
+    data = await c.scatter([0, 1, 2])
+    await c.publish_dataset(data=data)
 
     assert "published-data" in s.who_wants[data[0].key]
-    result = yield f.get_dataset(name="data")
+    result = await f.get_dataset(name="data")
 
     assert len(result) == len(data)
-    out = yield f.gather(result)
+    out = await f.gather(result)
     assert out == [0, 1, 2]
 
     with pytest.raises(KeyError) as exc_info:
-        yield f.get_dataset(name="nonexistent")
+        await f.get_dataset(name="nonexistent")
 
     assert "not found" in str(exc_info.value)
     assert "nonexistent" in str(exc_info.value)
 
-    yield c.close()
-    yield f.close()
+    await c.close()
+    await f.close()
 
 
 @gen_cluster(client=True)
-def test_unpublish(c, s, a, b):
-    data = yield c.scatter([0, 1, 2])
-    yield c.publish_dataset(data=data)
+async def test_unpublish(c, s, a, b):
+    data = await c.scatter([0, 1, 2])
+    await c.publish_dataset(data=data)
 
     key = data[0].key
     del data
 
-    yield c.scheduler.publish_delete(name="data")
+    await c.scheduler.publish_delete(name="data")
 
     assert "data" not in s.extensions["publish"].datasets
 
     start = time()
     while key in s.who_wants:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     with pytest.raises(KeyError) as exc_info:
-        yield c.get_dataset(name="data")
+        await c.get_dataset(name="data")
 
     assert "not found" in str(exc_info.value)
     assert "data" in str(exc_info.value)
@@ -114,12 +114,12 @@ def test_unpublish_sync(client):
 
 
 @gen_cluster(client=True)
-def test_publish_multiple_datasets(c, s, a, b):
+async def test_publish_multiple_datasets(c, s, a, b):
     x = delayed(inc)(1)
     y = delayed(inc)(2)
 
-    yield c.publish_dataset(x=x, y=y)
-    datasets = yield c.scheduler.publish_list()
+    await c.publish_dataset(x=x, y=y)
+    datasets = await c.scheduler.publish_list()
     assert set(datasets) == {"x", "y"}
 
 
@@ -148,10 +148,10 @@ def test_unpublish_multiple_datasets_sync(client):
 
 
 @gen_cluster(client=False)
-def test_publish_bag(s, a, b):
+async def test_publish_bag(s, a, b):
     db = pytest.importorskip("dask.bag")
-    c = yield Client(s.address, asynchronous=True)
-    f = yield Client(s.address, asynchronous=True)
+    c = await Client(s.address, asynchronous=True)
+    f = await Client(s.address, asynchronous=True)
 
     bag = db.from_sequence([0, 1, 2])
     bagp = c.persist(bag)
@@ -160,19 +160,19 @@ def test_publish_bag(s, a, b):
     keys = {f.key for f in futures_of(bagp)}
     assert keys == set(bag.dask)
 
-    yield c.publish_dataset(data=bagp)
+    await c.publish_dataset(data=bagp)
 
     # check that serialization didn't affect original bag's dask
     assert len(futures_of(bagp)) == 3
 
-    result = yield f.get_dataset("data")
+    result = await f.get_dataset("data")
     assert set(result.dask.keys()) == set(bagp.dask.keys())
     assert {f.key for f in result.dask.values()} == {f.key for f in bagp.dask.values()}
 
-    out = yield f.compute(result)
+    out = await f.compute(result)
     assert out == [0, 1, 2]
-    yield c.close()
-    yield f.close()
+    await c.close()
+    await f.close()
 
 
 def test_datasets_setitem(client):
@@ -217,16 +217,16 @@ def test_datasets_iter(client):
 
 
 @gen_cluster(client=True)
-def test_pickle_safe(c, s, a, b):
+async def test_pickle_safe(c, s, a, b):
     async with Client(s.address, asynchronous=True, serializers=["msgpack"]) as c2:
-        yield c2.publish_dataset(x=[1, 2, 3])
-        result = yield c2.get_dataset("x")
+        await c2.publish_dataset(x=[1, 2, 3])
+        result = await c2.get_dataset("x")
         assert result == [1, 2, 3]
 
         with pytest.raises(TypeError):
-            yield c2.publish_dataset(y=lambda x: x)
+            await c2.publish_dataset(y=lambda x: x)
 
-        yield c.publish_dataset(z=lambda x: x)  # this can use pickle
+        await c.publish_dataset(z=lambda x: x)  # this can use pickle
 
         with pytest.raises(TypeError):
-            yield c2.get_dataset("z")
+            await c2.get_dataset("z")

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -8,7 +8,6 @@ from distributed.metrics import time
 from distributed.utils_test import gen_cluster, inc
 from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
 from distributed.protocol import Serialized
-from tornado import gen
 
 
 @gen_cluster(client=False)
@@ -91,7 +90,7 @@ async def test_unpublish(c, s, a, b):
 
     start = time()
     while key in s.who_wants:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 5
 
     with pytest.raises(KeyError) as exc_info:

--- a/distributed/tests/test_pubsub.py
+++ b/distributed/tests/test_pubsub.py
@@ -2,7 +2,6 @@ import asyncio
 from time import sleep
 
 import pytest
-from tornado import gen
 import tlz as toolz
 
 from distributed import Pub, Sub, wait, get_worker, TimeoutError
@@ -62,7 +61,7 @@ async def test_client(c, s):
 
     start = time()
     while not set(sps.client_subscribers["a"]) == {c.id}:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 3
 
     pub.put(123)
@@ -101,7 +100,7 @@ async def test_client_worker(c, s, a, b):
         or bps.publishers["a"]
         or len(sps.client_subscribers["a"]) != 1
     ):
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 3
 
     del sub
@@ -112,7 +111,7 @@ async def test_client_worker(c, s, a, b):
         or any(aps.publish_to_scheduler.values())
         or any(bps.publish_to_scheduler.values())
     ):
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 3
 
 
@@ -146,7 +145,7 @@ async def test_basic(c, s, a, b):
 
         i = 0
         while True:
-            await gen.sleep(0.01)
+            await asyncio.sleep(0.01)
             pub._put(i)
             i += 1
 

--- a/distributed/tests/test_pubsub.py
+++ b/distributed/tests/test_pubsub.py
@@ -11,7 +11,7 @@ from distributed.metrics import time
 
 
 @gen_cluster(client=True, timeout=None)
-def test_speed(c, s, a, b):
+async def test_speed(c, s, a, b):
     """
     This tests how quickly we can move messages back and forth
 
@@ -45,13 +45,13 @@ def test_speed(c, s, a, b):
     y = c.submit(pingpong, "b", "a", n=100)
 
     start = time()
-    yield c.gather([x, y])
+    await c.gather([x, y])
     stop = time()
     # print('duration', stop - start)  # I get around 3ms/roundtrip on my laptop
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_client(c, s):
+async def test_client(c, s):
     with pytest.raises(Exception):
         get_worker()
     sub = Sub("a")
@@ -62,17 +62,17 @@ def test_client(c, s):
 
     start = time()
     while not set(sps.client_subscribers["a"]) == {c.id}:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 3
 
     pub.put(123)
 
-    result = yield sub.__anext__()
+    result = await sub.__anext__()
     assert result == 123
 
 
 @gen_cluster(client=True)
-def test_client_worker(c, s, a, b):
+async def test_client_worker(c, s, a, b):
     sub = Sub("a", client=c, worker=None)
 
     def f(x):
@@ -80,11 +80,11 @@ def test_client_worker(c, s, a, b):
         pub.put(x)
 
     futures = c.map(f, range(10))
-    yield wait(futures)
+    await wait(futures)
 
     L = []
     for i in range(10):
-        result = yield sub.get()
+        result = await sub.get()
         L.append(result)
 
     assert set(L) == set(range(10))
@@ -101,7 +101,7 @@ def test_client_worker(c, s, a, b):
         or bps.publishers["a"]
         or len(sps.client_subscribers["a"]) != 1
     ):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 3
 
     del sub
@@ -112,20 +112,20 @@ def test_client_worker(c, s, a, b):
         or any(aps.publish_to_scheduler.values())
         or any(bps.publish_to_scheduler.values())
     ):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 3
 
 
 @gen_cluster(client=True)
-def test_timeouts(c, s, a, b):
+async def test_timeouts(c, s, a, b):
     sub = Sub("a", client=c, worker=None)
     start = time()
     with pytest.raises(TimeoutError):
-        yield sub.get(timeout=0.1)
+        await sub.get(timeout=0.1)
     stop = time()
     assert stop - start < 1
     with pytest.raises(TimeoutError):
-        yield sub.get(timeout=0.01)
+        await sub.get(timeout=0.01)
 
 
 @gen_cluster(client=True)
@@ -140,7 +140,7 @@ async def test_repr(c, s, a, b):
 
 @pytest.mark.xfail(reason="out of order execution")
 @gen_cluster(client=True)
-def test_basic(c, s, a, b):
+async def test_basic(c, s, a, b):
     async def publish():
         pub = Pub("a")
 
@@ -157,7 +157,7 @@ def test_basic(c, s, a, b):
     asyncio.ensure_future(c.run(publish, workers=[a.address]))
 
     tasks = [c.submit(f, i) for i in range(4)]
-    results = yield c.gather(tasks)
+    results = await c.gather(tasks)
 
     for r in results:
         x = r[0]

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -11,47 +11,47 @@ from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
 
 
 @gen_cluster(client=True)
-def test_queue(c, s, a, b):
-    x = yield Queue("x")
-    y = yield Queue("y")
-    xx = yield Queue("x")
+async def test_queue(c, s, a, b):
+    x = await Queue("x")
+    y = await Queue("y")
+    xx = await Queue("x")
     assert x.client is c
 
     future = c.submit(inc, 1)
 
-    yield x.put(future)
-    yield y.put(future)
-    future2 = yield xx.get()
+    await x.put(future)
+    await y.put(future)
+    future2 = await xx.get()
     assert future.key == future2.key
 
     with pytest.raises(TimeoutError):
-        yield x.get(timeout=0.1)
+        await x.get(timeout=0.1)
 
     del future, future2
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert s.tasks  # future still present in y's queue
-    yield y.get()  # burn future
+    await y.get()  # burn future
 
     start = time()
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
 @gen_cluster(client=True)
-def test_queue_with_data(c, s, a, b):
-    x = yield Queue("x")
-    xx = yield Queue("x")
+async def test_queue_with_data(c, s, a, b):
+    x = await Queue("x")
+    xx = await Queue("x")
     assert x.client is c
 
-    yield x.put((1, "hello"))
-    data = yield xx.get()
+    await x.put((1, "hello"))
+    data = await xx.get()
 
     assert data == (1, "hello")
 
     with pytest.raises(TimeoutError):
-        yield x.get(timeout=0.1)
+        await x.get(timeout=0.1)
 
 
 def test_sync(client):
@@ -67,35 +67,35 @@ def test_sync(client):
 
 
 @gen_cluster()
-def test_hold_futures(s, a, b):
-    c1 = yield Client(s.address, asynchronous=True)
+async def test_hold_futures(s, a, b):
+    c1 = await Client(s.address, asynchronous=True)
     future = c1.submit(lambda x: x + 1, 10)
-    q1 = yield Queue("q")
-    yield q1.put(future)
+    q1 = await Queue("q")
+    await q1.put(future)
     del q1
-    yield c1.close()
+    await c1.close()
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
-    c2 = yield Client(s.address, asynchronous=True)
-    q2 = yield Queue("q")
-    future2 = yield q2.get()
-    result = yield future2
+    c2 = await Client(s.address, asynchronous=True)
+    q2 = await Queue("q")
+    future2 = await q2.get()
+    result = await future2
 
     assert result == 11
-    yield c2.close()
+    await c2.close()
 
 
 @pytest.mark.skip(reason="getting same client from main thread")
 @gen_cluster(client=True)
-def test_picklability(c, s, a, b):
+async def test_picklability(c, s, a, b):
     q = Queue()
 
     def f(x):
         q.put(x + 1)
 
-    yield c.submit(f, 10)
-    result = yield q.get()
+    await c.submit(f, 10)
+    result = await q.get()
     assert result == 11
 
 
@@ -112,7 +112,7 @@ def test_picklability_sync(client):
 
 @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
-def test_race(c, s, *workers):
+async def test_race(c, s, *workers):
     def f(i):
         with worker_client() as c:
             q = Queue("x", client=c)
@@ -126,144 +126,144 @@ def test_race(c, s, *workers):
             return result
 
     q = Queue("x", client=c)
-    L = yield c.scatter(range(5))
+    L = await c.scatter(range(5))
     for future in L:
-        yield q.put(future)
+        await q.put(future)
 
     futures = c.map(f, range(5))
-    results = yield c.gather(futures)
+    results = await c.gather(futures)
     assert all(r > 50 for r in results)
     assert sum(results) == 510
-    qsize = yield q.qsize()
+    qsize = await q.qsize()
     assert not qsize
 
 
 @gen_cluster(client=True)
-def test_same_futures(c, s, a, b):
+async def test_same_futures(c, s, a, b):
     q = Queue("x")
-    future = yield c.scatter(123)
+    future = await c.scatter(123)
 
     for i in range(5):
-        yield q.put(future)
+        await q.put(future)
 
     assert s.wants_what["queue-x"] == {future.key}
 
     for i in range(4):
-        future2 = yield q.get()
+        future2 = await q.get()
         assert s.wants_what["queue-x"] == {future.key}
-        yield gen.sleep(0.05)
+        await gen.sleep(0.05)
         assert s.wants_what["queue-x"] == {future.key}
 
-    yield q.get()
+    await q.get()
 
     start = time()
     while s.wants_what["queue-x"]:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() - start < 2
 
 
 @gen_cluster(client=True)
-def test_get_many(c, s, a, b):
-    x = yield Queue("x")
-    xx = yield Queue("x")
+async def test_get_many(c, s, a, b):
+    x = await Queue("x")
+    xx = await Queue("x")
 
-    yield x.put(1)
-    yield x.put(2)
-    yield x.put(3)
+    await x.put(1)
+    await x.put(2)
+    await x.put(3)
 
-    data = yield xx.get(batch=True)
+    data = await xx.get(batch=True)
     assert data == [1, 2, 3]
 
-    yield x.put(1)
-    yield x.put(2)
-    yield x.put(3)
+    await x.put(1)
+    await x.put(2)
+    await x.put(3)
 
-    data = yield xx.get(batch=2)
+    data = await xx.get(batch=2)
     assert data == [1, 2]
 
     with pytest.raises(TimeoutError):
-        yield asyncio.wait_for(xx.get(batch=2), 0.1)
+        await asyncio.wait_for(xx.get(batch=2), 0.1)
 
 
 @gen_cluster(client=True)
-def test_Future_knows_status_immediately(c, s, a, b):
-    x = yield c.scatter(123)
-    q = yield Queue("q")
-    yield q.put(x)
+async def test_Future_knows_status_immediately(c, s, a, b):
+    x = await c.scatter(123)
+    q = await Queue("q")
+    await q.put(x)
 
-    c2 = yield Client(s.address, asynchronous=True)
-    q2 = yield Queue("q", client=c2)
-    future = yield q2.get()
+    c2 = await Client(s.address, asynchronous=True)
+    q2 = await Queue("q", client=c2)
+    future = await q2.get()
     assert future.status == "finished"
 
     x = c.submit(div, 1, 0)
-    yield wait(x)
-    yield q.put(x)
+    await wait(x)
+    await q.put(x)
 
-    future2 = yield q2.get()
+    future2 = await q2.get()
     assert future2.status == "error"
     with pytest.raises(Exception):
-        yield future2
+        await future2
 
     start = time()
     while True:  # we learn about the true error eventually
         try:
-            yield future2
+            await future2
         except ZeroDivisionError:
             break
         except Exception:
             assert time() < start + 5
-            yield gen.sleep(0.05)
+            await gen.sleep(0.05)
 
-    yield c2.close()
+    await c2.close()
 
 
 @gen_cluster(client=True)
-def test_erred_future(c, s, a, b):
+async def test_erred_future(c, s, a, b):
     future = c.submit(div, 1, 0)
-    q = yield Queue()
-    yield q.put(future)
-    yield gen.sleep(0.1)
-    future2 = yield q.get()
+    q = await Queue()
+    await q.put(future)
+    await gen.sleep(0.1)
+    future2 = await q.get()
     with pytest.raises(ZeroDivisionError):
-        yield future2.result()
+        await future2.result()
 
-    exc = yield future2.exception()
+    exc = await future2.exception()
     assert isinstance(exc, ZeroDivisionError)
 
 
 @gen_cluster(client=True)
-def test_close(c, s, a, b):
-    q = yield Queue()
+async def test_close(c, s, a, b):
+    q = await Queue()
 
     q.close()
     q.close()
 
     while q.name in s.extensions["queues"].queues:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
 
 @gen_cluster(client=True)
-def test_timeout(c, s, a, b):
-    q = yield Queue("v", maxsize=1)
+async def test_timeout(c, s, a, b):
+    q = await Queue("v", maxsize=1)
 
     start = time()
     with pytest.raises(TimeoutError):
-        yield q.get(timeout=0.3)
+        await q.get(timeout=0.3)
     stop = time()
     assert 0.2 < stop - start < 2.0
 
-    yield q.put(1)
+    await q.put(1)
 
     start = time()
     with pytest.raises(TimeoutError):
-        yield q.put(2, timeout=0.3)
+        await q.put(2, timeout=0.3)
     stop = time()
     assert 0.1 < stop - start < 2.0
 
 
 @gen_cluster(client=True)
-def test_2220(c, s, a, b):
+async def test_2220(c, s, a, b):
     q = Queue()
 
     def put():
@@ -275,4 +275,4 @@ def test_2220(c, s, a, b):
     fut = c.submit(put)
     res = c.submit(get)
 
-    yield c.gather([res, fut])
+    await c.gather([res, fut])

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -1,8 +1,7 @@
-from time import sleep
 import asyncio
+from time import sleep
 
 import pytest
-from tornado import gen
 
 from distributed import Client, Queue, Nanny, worker_client, wait, TimeoutError
 from distributed.metrics import time
@@ -29,13 +28,13 @@ async def test_queue(c, s, a, b):
 
     del future, future2
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     assert s.tasks  # future still present in y's queue
     await y.get()  # burn future
 
     start = time()
     while s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 5
 
 
@@ -75,7 +74,7 @@ async def test_hold_futures(s, a, b):
     del q1
     await c1.close()
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
 
     c2 = await Client(s.address, asynchronous=True)
     q2 = await Queue("q")
@@ -151,14 +150,14 @@ async def test_same_futures(c, s, a, b):
     for i in range(4):
         future2 = await q.get()
         assert s.wants_what["queue-x"] == {future.key}
-        await gen.sleep(0.05)
+        await asyncio.sleep(0.05)
         assert s.wants_what["queue-x"] == {future.key}
 
     await q.get()
 
     start = time()
     while s.wants_what["queue-x"]:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() - start < 2
 
 
@@ -213,7 +212,7 @@ async def test_Future_knows_status_immediately(c, s, a, b):
             break
         except Exception:
             assert time() < start + 5
-            await gen.sleep(0.05)
+            await asyncio.sleep(0.05)
 
     await c2.close()
 
@@ -223,7 +222,7 @@ async def test_erred_future(c, s, a, b):
     future = c.submit(div, 1, 0)
     q = await Queue()
     await q.put(future)
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     future2 = await q.get()
     with pytest.raises(ZeroDivisionError):
         await future2.result()
@@ -240,7 +239,7 @@ async def test_close(c, s, a, b):
     q.close()
 
     while q.name in s.extensions["queues"].queues:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -182,7 +182,7 @@ def test_get_many(c, s, a, b):
     assert data == [1, 2]
 
     with pytest.raises(TimeoutError):
-        data = yield asyncio.wait_for(xx.get(batch=2), 0.1)
+        yield asyncio.wait_for(xx.get(batch=2), 0.1)
 
 
 @gen_cluster(client=True)
@@ -275,4 +275,4 @@ def test_2220(c, s, a, b):
     fut = c.submit(put)
     res = c.submit(get)
 
-    yield [res, fut]
+    yield c.gather([res, fut])

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -14,23 +14,23 @@ from distributed.utils_test import client, cluster_fixture, loop, s, a, b  # noq
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_resources(c, s):
+async def test_resources(c, s):
     assert not s.worker_resources
     assert not s.resources
 
     a = Worker(s.address, loop=s.loop, resources={"GPU": 2})
     b = Worker(s.address, loop=s.loop, resources={"GPU": 1, "DB": 1})
-    yield asyncio.gather(a, b)
+    await asyncio.gather(a, b)
 
     assert s.resources == {"GPU": {a.address: 2, b.address: 1}, "DB": {b.address: 1}}
     assert s.worker_resources == {a.address: {"GPU": 2}, b.address: {"GPU": 1, "DB": 1}}
 
-    yield b.close()
+    await b.close()
 
     assert s.resources == {"GPU": {a.address: 2}, "DB": {}}
     assert s.worker_resources == {a.address: {"GPU": 2}}
 
-    yield a.close()
+    await a.close()
 
 
 @gen_cluster(
@@ -40,25 +40,25 @@ def test_resources(c, s):
         ("127.0.0.1", 1, {"resources": {"A": 1, "B": 1}}),
     ],
 )
-def test_resource_submit(c, s, a, b):
+async def test_resource_submit(c, s, a, b):
     x = c.submit(inc, 1, resources={"A": 3})
     y = c.submit(inc, 2, resources={"B": 1})
     z = c.submit(inc, 3, resources={"C": 2})
 
-    yield wait(x)
+    await wait(x)
     assert x.key in a.data
 
-    yield wait(y)
+    await wait(y)
     assert y.key in b.data
 
     assert s.get_task_status(keys=[z.key]) == {z.key: "no-worker"}
 
-    d = yield Worker(s.address, loop=s.loop, resources={"C": 10})
+    d = await Worker(s.address, loop=s.loop, resources={"C": 10})
 
-    yield wait(z)
+    await wait(z)
     assert z.key in d.data
 
-    yield d.close()
+    await d.close()
 
 
 @gen_cluster(
@@ -68,9 +68,9 @@ def test_resource_submit(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_submit_many_non_overlapping(c, s, a, b):
+async def test_submit_many_non_overlapping(c, s, a, b):
     futures = [c.submit(inc, i, resources={"A": 1}) for i in range(5)]
-    yield wait(futures)
+    await wait(futures)
 
     assert len(a.data) == 5
     assert len(b.data) == 0
@@ -83,12 +83,12 @@ def test_submit_many_non_overlapping(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_move(c, s, a, b):
-    [x] = yield c._scatter([1], workers=b.address)
+async def test_move(c, s, a, b):
+    [x] = await c._scatter([1], workers=b.address)
 
     future = c.submit(inc, x, resources={"A": 1})
 
-    yield wait(future)
+    await wait(future)
     assert a.data[future.key] == 2
 
 
@@ -99,14 +99,14 @@ def test_move(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_dont_work_steal(c, s, a, b):
-    [x] = yield c._scatter([1], workers=a.address)
+async def test_dont_work_steal(c, s, a, b):
+    [x] = await c._scatter([1], workers=a.address)
 
     futures = [
         c.submit(slowadd, x, i, resources={"A": 1}, delay=0.05) for i in range(10)
     ]
 
-    yield wait(futures)
+    await wait(futures)
     assert all(f.key in a.data for f in futures)
 
 
@@ -117,9 +117,9 @@ def test_dont_work_steal(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_map(c, s, a, b):
+async def test_map(c, s, a, b):
     futures = c.map(inc, range(10), resources={"B": 1})
-    yield wait(futures)
+    await wait(futures)
     assert set(b.data) == {f.key for f in futures}
     assert not a.data
 
@@ -131,13 +131,13 @@ def test_map(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_persist(c, s, a, b):
+async def test_persist(c, s, a, b):
     x = delayed(inc)(1)
     y = delayed(inc)(x)
 
     xx, yy = c.persist([x, y], resources={x: {"A": 1}, y: {"B": 1}})
 
-    yield wait([xx, yy])
+    await wait([xx, yy])
 
     assert x.key in a.data
     assert y.key in b.data
@@ -150,18 +150,18 @@ def test_persist(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 11}}),
     ],
 )
-def test_compute(c, s, a, b):
+async def test_compute(c, s, a, b):
     x = delayed(inc)(1)
     y = delayed(inc)(x)
 
     yy = c.compute(y, resources={x: {"A": 1}, y: {"B": 1}})
-    yield wait(yy)
+    await wait(yy)
 
     assert b.data
 
     xs = [delayed(inc)(i) for i in range(10, 20)]
     xxs = c.compute(xs, resources={"B": 1})
-    yield wait(xxs)
+    await wait(xxs)
 
     assert len(b.data) > 10
 
@@ -173,10 +173,10 @@ def test_compute(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_get(c, s, a, b):
+async def test_get(c, s, a, b):
     dsk = {"x": (inc, 1), "y": (inc, "x")}
 
-    result = yield c.get(dsk, "y", resources={"y": {"A": 1}}, sync=False)
+    result = await c.get(dsk, "y", resources={"y": {"A": 1}}, sync=False)
     assert result == 3
 
 
@@ -187,13 +187,13 @@ def test_get(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_persist_tuple(c, s, a, b):
+async def test_persist_tuple(c, s, a, b):
     x = delayed(inc)(1)
     y = delayed(inc)(x)
 
     xx, yy = c.persist([x, y], resources={(x, y): {"A": 1}})
 
-    yield wait([xx, yy])
+    await wait([xx, yy])
 
     assert x.key in a.data
     assert y.key in a.data
@@ -201,16 +201,16 @@ def test_persist_tuple(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_resources_str(c, s, a, b):
+async def test_resources_str(c, s, a, b):
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
 
-    yield a.set_resources(MyRes=1)
+    await a.set_resources(MyRes=1)
 
     x = dd.from_pandas(pd.DataFrame({"A": [1, 2], "B": [3, 4]}), npartitions=1)
     y = x.apply(lambda row: row.sum(), axis=1, meta=(None, "int64"))
     yy = y.persist(resources={"MyRes": 1})
-    yield wait(yy)
+    await wait(yy)
 
     ts_first = s.tasks[tokey(y.__dask_keys__()[0])]
     assert ts_first.resource_restrictions == {"MyRes": 1}
@@ -225,38 +225,38 @@ def test_resources_str(c, s, a, b):
         ("127.0.0.1", 4, {"resources": {"A": 1}}),
     ],
 )
-def test_submit_many_non_overlapping(c, s, a, b):
+async def test_submit_many_non_overlapping(c, s, a, b):
     futures = c.map(slowinc, range(100), resources={"A": 1}, delay=0.02)
 
     while len(a.data) + len(b.data) < 100:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert len(a.executing) <= 2
         assert len(b.executing) <= 1
 
-    yield wait(futures)
+    await wait(futures)
     assert a.total_resources == a.available_resources
     assert b.total_resources == b.available_resources
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 4, {"resources": {"A": 2, "B": 1}})])
-def test_minimum_resource(c, s, a):
+async def test_minimum_resource(c, s, a):
     futures = c.map(slowinc, range(30), resources={"A": 1, "B": 1}, delay=0.02)
 
     while len(a.data) < 30:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert len(a.executing) <= 1
 
-    yield wait(futures)
+    await wait(futures)
     assert a.total_resources == a.available_resources
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 2, {"resources": {"A": 1}})])
-def test_prefer_constrained(c, s, a):
+async def test_prefer_constrained(c, s, a):
     futures = c.map(slowinc, range(1000), delay=0.1)
     constrained = c.map(inc, range(10), resources={"A": 1})
 
     start = time()
-    yield wait(constrained)
+    await wait(constrained)
     end = time()
     assert end - start < 4
     has_what = dict(s.has_what)
@@ -273,27 +273,27 @@ def test_prefer_constrained(c, s, a):
         ("127.0.0.1", 2, {"resources": {"A": 1}}),
     ],
 )
-def test_balance_resources(c, s, a, b):
+async def test_balance_resources(c, s, a, b):
     futures = c.map(slowinc, range(100), delay=0.1, workers=a.address)
     constrained = c.map(inc, range(2), resources={"A": 1})
 
-    yield wait(constrained)
+    await wait(constrained)
     assert any(f.key in a.data for f in constrained)  # share
     assert any(f.key in b.data for f in constrained)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 2)])
-def test_set_resources(c, s, a):
-    yield a.set_resources(A=2)
+async def test_set_resources(c, s, a):
+    await a.set_resources(A=2)
     assert a.total_resources["A"] == 2
     assert a.available_resources["A"] == 2
     assert s.worker_resources[a.address] == {"A": 2}
 
     future = c.submit(slowinc, 1, delay=1, resources={"A": 1})
     while a.available_resources["A"] == 2:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
-    yield a.set_resources(A=3)
+    await a.set_resources(A=3)
     assert a.total_resources["A"] == 3
     assert a.available_resources["A"] == 2
     assert s.worker_resources[a.address] == {"A": 3}
@@ -306,7 +306,7 @@ def test_set_resources(c, s, a):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_persist_collections(c, s, a, b):
+async def test_persist_collections(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.arange(10, chunks=(5,))
     y = x.map_blocks(lambda x: x + 1)
@@ -315,7 +315,7 @@ def test_persist_collections(c, s, a, b):
 
     ww, yy = c.persist([w, y], resources={tuple(y.__dask_keys__()): {"A": 1}})
 
-    yield wait([ww, yy])
+    await wait([ww, yy])
 
     assert all(tokey(key) in a.data for key in y.__dask_keys__())
 
@@ -328,14 +328,14 @@ def test_persist_collections(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_dont_optimize_out(c, s, a, b):
+async def test_dont_optimize_out(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.arange(10, chunks=(5,))
     y = x.map_blocks(lambda x: x + 1)
     z = y.map_blocks(lambda x: 2 * x)
     w = z.sum()
 
-    yield c.compute(w, resources={tuple(y.__dask_keys__()): {"A": 1}})
+    await c.compute(w, resources={tuple(y.__dask_keys__()): {"A": 1}})
 
     for key in map(tokey, y.__dask_keys__()):
         assert "executing" in str(a.story(key))
@@ -349,14 +349,14 @@ def test_dont_optimize_out(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-def test_full_collections(c, s, a, b):
+async def test_full_collections(c, s, a, b):
     dd = pytest.importorskip("dask.dataframe")
     df = dd.demo.make_timeseries(
         freq="60s", partition_freq="1d", start="2000-01-01", end="2000-01-31"
     )
     z = df.x + df.y  # some extra nodes in the graph
 
-    yield c.compute(z, resources={tuple(z.dask): {"A": 1}})
+    await c.compute(z, resources={tuple(z.dask): {"A": 1}})
     assert a.log
     assert not b.log
 

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -3,7 +3,6 @@ from time import time
 
 from dask import delayed
 import pytest
-from tornado import gen
 
 from distributed import Worker
 from distributed.client import wait
@@ -229,7 +228,7 @@ async def test_submit_many_non_overlapping(c, s, a, b):
     futures = c.map(slowinc, range(100), resources={"A": 1}, delay=0.02)
 
     while len(a.data) + len(b.data) < 100:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert len(a.executing) <= 2
         assert len(b.executing) <= 1
 
@@ -243,7 +242,7 @@ async def test_minimum_resource(c, s, a):
     futures = c.map(slowinc, range(30), resources={"A": 1, "B": 1}, delay=0.02)
 
     while len(a.data) < 30:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert len(a.executing) <= 1
 
     await wait(futures)
@@ -291,7 +290,7 @@ async def test_set_resources(c, s, a):
 
     future = c.submit(slowinc, 1, delay=1, resources={"A": 1})
     while a.available_resources["A"] == 2:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     await a.set_resources(A=3)
     assert a.total_resources["A"] == 3

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -1,3 +1,4 @@
+import asyncio
 from time import time
 
 from dask import delayed
@@ -19,8 +20,7 @@ def test_resources(c, s):
 
     a = Worker(s.address, loop=s.loop, resources={"GPU": 2})
     b = Worker(s.address, loop=s.loop, resources={"GPU": 1, "DB": 1})
-
-    yield [a, b]
+    yield asyncio.gather(a, b)
 
     assert s.resources == {"GPU": {a.address: 2, b.address: 1}, "DB": {b.address: 1}}
     assert s.worker_resources == {a.address: {"GPU": 2}, b.address: {"GPU": 1, "DB": 1}}

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -58,11 +58,11 @@ def test_administration(s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_respect_data_in_memory(c, s, a):
+async def test_respect_data_in_memory(c, s, a):
     x = delayed(inc)(1)
     y = delayed(inc)(x)
     f = c.persist(y)
-    yield wait([f])
+    await wait([f])
 
     assert s.tasks[y.key].who_has == {s.workers[a.address]}
 
@@ -70,29 +70,29 @@ def test_respect_data_in_memory(c, s, a):
     f2 = c.persist(z)
     while f2.key not in s.tasks or not s.tasks[f2.key]:
         assert s.tasks[y.key].who_has
-        yield gen.sleep(0.0001)
+        await gen.sleep(0.0001)
 
 
 @gen_cluster(client=True)
-def test_recompute_released_results(c, s, a, b):
+async def test_recompute_released_results(c, s, a, b):
     x = delayed(inc)(1)
     y = delayed(inc)(x)
 
     yy = c.persist(y)
-    yield wait(yy)
+    await wait(yy)
 
     while s.tasks[x.key].who_has or x.key in a.data or x.key in b.data:  # let x go away
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     z = delayed(dec)(x)
     zz = c.compute(z)
-    result = yield zz
+    result = await zz
     assert result == 1
 
 
 @gen_cluster(client=True)
-def test_decide_worker_with_many_independent_leaves(c, s, a, b):
-    xs = yield asyncio.gather(
+async def test_decide_worker_with_many_independent_leaves(c, s, a, b):
+    xs = await asyncio.gather(
         c.scatter(list(range(0, 100, 2)), workers=a.address),
         c.scatter(list(range(1, 100, 2)), workers=b.address),
     )
@@ -100,7 +100,7 @@ def test_decide_worker_with_many_independent_leaves(c, s, a, b):
     ys = [delayed(inc)(x) for x in xs]
 
     y2s = c.persist(ys)
-    yield wait(y2s)
+    await wait(y2s)
 
     nhits = sum(y.key in a.data for y in y2s[::2]) + sum(
         y.key in b.data for y in y2s[1::2]
@@ -110,70 +110,70 @@ def test_decide_worker_with_many_independent_leaves(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_decide_worker_with_restrictions(client, s, a, b, c):
+async def test_decide_worker_with_restrictions(client, s, a, b, c):
     x = client.submit(inc, 1, workers=[a.address, b.address])
-    yield x
+    await x
     assert x.key in a.data or x.key in b.data
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_move_data_over_break_restrictions(client, s, a, b, c):
-    [x] = yield client.scatter([1], workers=b.address)
+async def test_move_data_over_break_restrictions(client, s, a, b, c):
+    [x] = await client.scatter([1], workers=b.address)
     y = client.submit(inc, x, workers=[a.address, b.address])
-    yield wait(y)
+    await wait(y)
     assert y.key in a.data or y.key in b.data
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_balance_with_restrictions(client, s, a, b, c):
-    [x], [y] = yield asyncio.gather(
+async def test_balance_with_restrictions(client, s, a, b, c):
+    [x], [y] = await asyncio.gather(
         client.scatter([[1, 2, 3]], workers=a.address),
         client.scatter([1], workers=c.address),
     )
     z = client.submit(inc, 1, workers=[a.address, c.address])
-    yield wait(z)
+    await wait(z)
 
     assert s.tasks[z.key].who_has == {s.workers[c.address]}
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_no_valid_workers(client, s, a, b, c):
+async def test_no_valid_workers(client, s, a, b, c):
     x = client.submit(inc, 1, workers="127.0.0.5:9999")
     while not s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert s.tasks[x.key] in s.unrunnable
 
     with pytest.raises(TimeoutError):
-        yield asyncio.wait_for(x, 0.05)
+        await asyncio.wait_for(x, 0.05)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_no_valid_workers_loose_restrictions(client, s, a, b, c):
+async def test_no_valid_workers_loose_restrictions(client, s, a, b, c):
     x = client.submit(inc, 1, workers="127.0.0.5:9999", allow_other_workers=True)
-    result = yield x
+    result = await x
     assert result == 2
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_no_workers(client, s):
+async def test_no_workers(client, s):
     x = client.submit(inc, 1)
     while not s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert s.tasks[x.key] in s.unrunnable
 
     with pytest.raises(TimeoutError):
-        yield asyncio.wait_for(x, 0.05)
+        await asyncio.wait_for(x, 0.05)
 
 
 @gen_cluster(nthreads=[])
-def test_retire_workers_empty(s):
-    yield s.retire_workers(workers=[])
+async def test_retire_workers_empty(s):
+    await s.retire_workers(workers=[])
 
 
 @gen_cluster()
-def test_remove_client(s, a, b):
+async def test_remove_client(s, a, b):
     s.update_graph(
         tasks={"x": dumps_task((inc, 1)), "y": dumps_task((inc, "x"))},
         dependencies={"x": [], "y": ["x"]},
@@ -191,15 +191,15 @@ def test_remove_client(s, a, b):
 
 
 @gen_cluster()
-def test_server_listens_to_other_ops(s, a, b):
+async def test_server_listens_to_other_ops(s, a, b):
     with rpc(s.address) as r:
-        ident = yield r.identity()
+        ident = await r.identity()
         assert ident["type"] == "Scheduler"
         assert ident["id"].lower().startswith("scheduler")
 
 
 @gen_cluster()
-def test_remove_worker_from_scheduler(s, a, b):
+async def test_remove_worker_from_scheduler(s, a, b):
     dsk = {("x-%d" % i): (inc, i) for i in range(20)}
     s.update_graph(
         tasks=valmap(dumps_task, dsk),
@@ -215,7 +215,7 @@ def test_remove_worker_from_scheduler(s, a, b):
 
 
 @gen_cluster()
-def test_remove_worker_by_name_from_scheduler(s, a, b):
+async def test_remove_worker_by_name_from_scheduler(s, a, b):
     assert a.address in s.stream_comms
     assert s.remove_worker(address=a.name) == "OK"
     assert a.address not in s.nthreads
@@ -224,7 +224,7 @@ def test_remove_worker_by_name_from_scheduler(s, a, b):
 
 
 @gen_cluster(config={"distributed.scheduler.events-cleanup-delay": "10 ms"})
-def test_clear_events_worker_removal(s, a, b):
+async def test_clear_events_worker_removal(s, a, b):
     assert a.address in s.events
     assert a.address in s.nthreads
     assert b.address in s.events
@@ -238,7 +238,7 @@ def test_clear_events_worker_removal(s, a, b):
 
     start = time()
     while a.address in s.events:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
     assert b.address in s.events
 
@@ -246,7 +246,7 @@ def test_clear_events_worker_removal(s, a, b):
 @gen_cluster(
     config={"distributed.scheduler.events-cleanup-delay": "10 ms"}, client=True
 )
-def test_clear_events_client_removal(c, s, a, b):
+async def test_clear_events_client_removal(c, s, a, b):
     assert c.id in s.events
     s.remove_client(c.id)
 
@@ -258,12 +258,12 @@ def test_clear_events_client_removal(c, s, a, b):
     # If it doesn't reconnect after a given time, the events log should be cleared
     start = time()
     while c.id in s.events:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
 
 
 @gen_cluster()
-def test_add_worker(s, a, b):
+async def test_add_worker(s, a, b):
     w = Worker(s.address, nthreads=3)
     w.data["x-5"] = 6
     w.data["y"] = 1
@@ -276,23 +276,23 @@ def test_add_worker(s, a, b):
         dependencies={k: set() for k in dsk},
     )
     s.validate_state()
-    yield w
+    await w
     s.validate_state()
 
     assert w.ip in s.host_info
     assert s.host_info[w.ip]["addresses"] == {a.address, b.address, w.address}
-    yield w.close()
+    await w.close()
 
 
 @gen_cluster(scheduler_kwargs={"blocked_handlers": ["feed"]})
-def test_blocked_handlers_are_respected(s, a, b):
+async def test_blocked_handlers_are_respected(s, a, b):
     def func(scheduler):
         return dumps(dict(scheduler.worker_info))
 
-    comm = yield connect(s.address)
-    yield comm.write({"op": "feed", "function": dumps(func), "interval": 0.01})
+    comm = await connect(s.address)
+    await comm.write({"op": "feed", "function": dumps(func), "interval": 0.01})
 
-    response = yield comm.read()
+    response = await comm.read()
 
     assert "exception" in response
     assert isinstance(response["exception"], ValueError)
@@ -300,7 +300,7 @@ def test_blocked_handlers_are_respected(s, a, b):
         response["exception"]
     )
 
-    yield comm.close()
+    await comm.close()
 
 
 def test_scheduler_init_pulls_blocked_handlers_from_config():
@@ -310,23 +310,23 @@ def test_scheduler_init_pulls_blocked_handlers_from_config():
 
 
 @gen_cluster()
-def test_feed(s, a, b):
+async def test_feed(s, a, b):
     def func(scheduler):
         return dumps(dict(scheduler.worker_info))
 
-    comm = yield connect(s.address)
-    yield comm.write({"op": "feed", "function": dumps(func), "interval": 0.01})
+    comm = await connect(s.address)
+    await comm.write({"op": "feed", "function": dumps(func), "interval": 0.01})
 
     for i in range(5):
-        response = yield comm.read()
+        response = await comm.read()
         expected = dict(s.worker_info)
         assert cloudpickle.loads(response) == expected
 
-    yield comm.close()
+    await comm.close()
 
 
 @gen_cluster()
-def test_feed_setup_teardown(s, a, b):
+async def test_feed_setup_teardown(s, a, b):
     def setup(scheduler):
         return 1
 
@@ -337,8 +337,8 @@ def test_feed_setup_teardown(s, a, b):
     def teardown(scheduler, state):
         scheduler.flag = "done"
 
-    comm = yield connect(s.address)
-    yield comm.write(
+    comm = await connect(s.address)
+    await comm.write(
         {
             "op": "feed",
             "function": dumps(func),
@@ -349,18 +349,18 @@ def test_feed_setup_teardown(s, a, b):
     )
 
     for i in range(5):
-        response = yield comm.read()
+        response = await comm.read()
         assert response == "OK"
 
-    yield comm.close()
+    await comm.close()
     start = time()
     while not hasattr(s, "flag"):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() - start < 5
 
 
 @gen_cluster()
-def test_feed_large_bytestring(s, a, b):
+async def test_feed_large_bytestring(s, a, b):
     np = pytest.importorskip("numpy")
 
     x = np.ones(10000000)
@@ -369,19 +369,19 @@ def test_feed_large_bytestring(s, a, b):
         y = x
         return True
 
-    comm = yield connect(s.address)
-    yield comm.write({"op": "feed", "function": dumps(func), "interval": 0.05})
+    comm = await connect(s.address)
+    await comm.write({"op": "feed", "function": dumps(func), "interval": 0.05})
 
     for i in range(5):
-        response = yield comm.read()
+        response = await comm.read()
         assert response is True
 
-    yield comm.close()
+    await comm.close()
 
 
 @gen_cluster(client=True)
-def test_delete_data(c, s, a, b):
-    d = yield c.scatter({"x": 1, "y": 2, "z": 3})
+async def test_delete_data(c, s, a, b):
+    d = await c.scatter({"x": 1, "y": 2, "z": 3})
 
     assert {ts.key for ts in s.tasks.values() if ts.who_has} == {"x", "y", "z"}
     assert set(a.data) | set(b.data) == {"x", "y", "z"}
@@ -392,36 +392,36 @@ def test_delete_data(c, s, a, b):
 
     start = time()
     while set(a.data) | set(b.data) != {"z"}:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_delete(c, s, a):
+async def test_delete(c, s, a):
     x = c.submit(inc, 1)
-    yield x
+    await x
     assert x.key in a.data
 
-    yield c._cancel(x)
+    await c._cancel(x)
 
     start = time()
     while x.key in a.data:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
 @gen_cluster()
-def test_filtered_communication(s, a, b):
-    c = yield connect(s.address)
-    f = yield connect(s.address)
-    yield c.write({"op": "register-client", "client": "c", "versions": {}})
-    yield f.write({"op": "register-client", "client": "f", "versions": {}})
-    yield c.read()
-    yield f.read()
+async def test_filtered_communication(s, a, b):
+    c = await connect(s.address)
+    f = await connect(s.address)
+    await c.write({"op": "register-client", "client": "c", "versions": {}})
+    await f.write({"op": "register-client", "client": "f", "versions": {}})
+    await c.read()
+    await f.read()
 
     assert set(s.client_comms) == {"c", "f"}
 
-    yield c.write(
+    await c.write(
         {
             "op": "update-graph",
             "tasks": {"x": dumps_task((inc, 1)), "y": dumps_task((inc, "x"))},
@@ -431,7 +431,7 @@ def test_filtered_communication(s, a, b):
         }
     )
 
-    yield f.write(
+    await f.write(
         {
             "op": "update-graph",
             "tasks": {
@@ -443,10 +443,10 @@ def test_filtered_communication(s, a, b):
             "keys": ["z"],
         }
     )
-    (msg,) = yield c.read()
+    (msg,) = await c.read()
     assert msg["op"] == "key-in-memory"
     assert msg["key"] == "y"
-    (msg,) = yield f.read()
+    (msg,) = await f.read()
     assert msg["op"] == "key-in-memory"
     assert msg["key"] == "z"
 
@@ -496,11 +496,11 @@ def test_ready_remove_worker(s, a, b):
 
 
 @gen_cluster(client=True, Worker=Nanny)
-def test_restart(c, s, a, b):
+async def test_restart(c, s, a, b):
     futures = c.map(inc, range(20))
-    yield wait(futures)
+    await wait(futures)
 
-    yield s.restart()
+    await s.restart()
 
     assert len(s.workers) == 2
 
@@ -513,56 +513,56 @@ def test_restart(c, s, a, b):
 
 
 @gen_cluster()
-def test_broadcast(s, a, b):
-    result = yield s.broadcast(msg={"op": "ping"})
+async def test_broadcast(s, a, b):
+    result = await s.broadcast(msg={"op": "ping"})
     assert result == {a.address: b"pong", b.address: b"pong"}
 
-    result = yield s.broadcast(msg={"op": "ping"}, workers=[a.address])
+    result = await s.broadcast(msg={"op": "ping"}, workers=[a.address])
     assert result == {a.address: b"pong"}
 
-    result = yield s.broadcast(msg={"op": "ping"}, hosts=[a.ip])
+    result = await s.broadcast(msg={"op": "ping"}, hosts=[a.ip])
     assert result == {a.address: b"pong", b.address: b"pong"}
 
 
 @gen_cluster(Worker=Nanny)
-def test_broadcast_nanny(s, a, b):
-    result1 = yield s.broadcast(msg={"op": "identity"}, nanny=True)
+async def test_broadcast_nanny(s, a, b):
+    result1 = await s.broadcast(msg={"op": "identity"}, nanny=True)
     assert all(d["type"] == "Nanny" for d in result1.values())
 
-    result2 = yield s.broadcast(
+    result2 = await s.broadcast(
         msg={"op": "identity"}, workers=[a.worker_address], nanny=True
     )
     assert len(result2) == 1
     assert first(result2.values())["id"] == a.id
 
-    result3 = yield s.broadcast(msg={"op": "identity"}, hosts=[a.ip], nanny=True)
+    result3 = await s.broadcast(msg={"op": "identity"}, hosts=[a.ip], nanny=True)
     assert result1 == result3
 
 
 @gen_test()
-def test_worker_name():
-    s = yield Scheduler(validate=True, port=0)
-    w = yield Worker(s.address, name="alice")
+async def test_worker_name():
+    s = await Scheduler(validate=True, port=0)
+    w = await Worker(s.address, name="alice")
     assert s.workers[w.address].name == "alice"
     assert s.aliases["alice"] == w.address
 
     with pytest.raises(ValueError):
-        w2 = yield Worker(s.address, name="alice")
-        yield w2.close()
+        w2 = await Worker(s.address, name="alice")
+        await w2.close()
 
-    yield w.close()
-    yield s.close()
+    await w.close()
+    await s.close()
 
 
 @gen_test()
-def test_coerce_address():
+async def test_coerce_address():
     with dask.config.set({"distributed.comm.timeouts.connect": "100ms"}):
-        s = yield Scheduler(validate=True, port=0)
+        s = await Scheduler(validate=True, port=0)
         print("scheduler:", s.address, s.listen_address)
         a = Worker(s.address, name="alice")
         b = Worker(s.address, name=123)
         c = Worker("127.0.0.1", s.port, name="charlie")
-        yield asyncio.gather(a, b, c)
+        await asyncio.gather(a, b, c)
 
         assert s.coerce_address("127.0.0.1:8000") == "tcp://127.0.0.1:8000"
         assert s.coerce_address("[::1]:8000") == "tcp://[::1]:8000"
@@ -590,8 +590,8 @@ def test_coerce_address():
 
         assert s.coerce_address("zzzt:8000", resolve=False) == "tcp://zzzt:8000"
 
-        yield s.close()
-        yield asyncio.gather(a.close(), b.close(), c.close())
+        await s.close()
+        await asyncio.gather(a.close(), b.close(), c.close())
 
 
 @pytest.mark.asyncio
@@ -611,24 +611,24 @@ async def test_config_stealing(cleanup):
     sys.platform.startswith("win"), reason="file descriptors not really a thing"
 )
 @gen_cluster(nthreads=[])
-def test_file_descriptors_dont_leak(s):
+async def test_file_descriptors_dont_leak(s):
     psutil = pytest.importorskip("psutil")
     proc = psutil.Process()
     before = proc.num_fds()
 
-    w = yield Worker(s.address)
-    yield w.close()
+    w = await Worker(s.address)
+    await w.close()
 
     during = proc.num_fds()
 
     start = time()
     while proc.num_fds() > before:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
 @gen_cluster()
-def test_update_graph_culls(s, a, b):
+async def test_update_graph_culls(s, a, b):
     s.update_graph(
         tasks={
             "x": dumps_task((inc, 1)),
@@ -649,11 +649,11 @@ def test_io_loop(loop):
 
 
 @gen_cluster(client=True)
-def test_story(c, s, a, b):
+async def test_story(c, s, a, b):
     x = delayed(inc)(1)
     y = delayed(inc)(x)
     f = c.persist(y)
-    yield wait([f])
+    await wait([f])
 
     assert s.transition_log
 
@@ -666,38 +666,38 @@ def test_story(c, s, a, b):
 
 
 @gen_cluster(nthreads=[], client=True)
-def test_scatter_no_workers(c, s):
+async def test_scatter_no_workers(c, s):
     with pytest.raises(TimeoutError):
-        yield s.scatter(data={"x": 1}, client="alice", timeout=0.1)
+        await s.scatter(data={"x": 1}, client="alice", timeout=0.1)
 
     start = time()
     with pytest.raises(TimeoutError):
-        yield c.scatter(123, timeout=0.1)
+        await c.scatter(123, timeout=0.1)
     assert time() < start + 1.5
 
     w = Worker(s.address, nthreads=3)
-    yield asyncio.gather(c.scatter(data={"y": 2}, timeout=5), w)
+    await asyncio.gather(c.scatter(data={"y": 2}, timeout=5), w)
 
     assert w.data["y"] == 2
-    yield w.close()
+    await w.close()
 
 
 @gen_cluster(nthreads=[])
-def test_scheduler_sees_memory_limits(s):
-    w = yield Worker(s.address, nthreads=3, memory_limit=12345)
+async def test_scheduler_sees_memory_limits(s):
+    w = await Worker(s.address, nthreads=3, memory_limit=12345)
 
     assert s.workers[w.address].memory_limit == 12345
-    yield w.close()
+    await w.close()
 
 
 @gen_cluster(client=True, timeout=1000)
-def test_retire_workers(c, s, a, b):
-    [x] = yield c.scatter([1], workers=a.address)
-    [y] = yield c.scatter([list(range(1000))], workers=b.address)
+async def test_retire_workers(c, s, a, b):
+    [x] = await c.scatter([1], workers=a.address)
+    [y] = await c.scatter([list(range(1000))], workers=b.address)
 
     assert s.workers_to_close() == [a.address]
 
-    workers = yield s.retire_workers()
+    workers = await s.retire_workers()
     assert list(workers) == [a.address]
     assert workers[a.address]["nthreads"] == a.nthreads
     assert list(s.nthreads) == [b.address]
@@ -706,26 +706,26 @@ def test_retire_workers(c, s, a, b):
 
     assert s.workers[b.address].has_what == {s.tasks[x.key], s.tasks[y.key]}
 
-    workers = yield s.retire_workers()
+    workers = await s.retire_workers()
     assert not workers
 
 
 @gen_cluster(client=True)
-def test_retire_workers_n(c, s, a, b):
-    yield s.retire_workers(n=1, close_workers=True)
+async def test_retire_workers_n(c, s, a, b):
+    await s.retire_workers(n=1, close_workers=True)
     assert len(s.workers) == 1
 
-    yield s.retire_workers(n=0, close_workers=True)
+    await s.retire_workers(n=0, close_workers=True)
     assert len(s.workers) == 1
 
-    yield s.retire_workers(n=1, close_workers=True)
+    await s.retire_workers(n=1, close_workers=True)
     assert len(s.workers) == 0
 
-    yield s.retire_workers(n=0, close_workers=True)
+    await s.retire_workers(n=0, close_workers=True)
     assert len(s.workers) == 0
 
     while not (a.status.startswith("clos") and b.status.startswith("clos")):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
@@ -743,7 +743,7 @@ async def test_workers_to_close(cl, s, *workers):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
-def test_workers_to_close_grouped(c, s, *workers):
+async def test_workers_to_close_grouped(c, s, *workers):
     groups = {
         workers[0].address: "a",
         workers[1].address: "a",
@@ -759,30 +759,30 @@ def test_workers_to_close_grouped(c, s, *workers):
     # Assert that job in one worker blocks closure of group
     future = c.submit(slowinc, 1, delay=0.2, workers=workers[0].address)
     while len(s.rprocessing) < 1:
-        yield gen.sleep(0.001)
+        await gen.sleep(0.001)
 
     assert set(s.workers_to_close(key=key)) == {workers[2].address, workers[3].address}
 
     del future
 
     while len(s.rprocessing) > 0:
-        yield gen.sleep(0.001)
+        await gen.sleep(0.001)
 
     # Assert that *total* byte count in group determines group priority
-    av = yield c.scatter("a" * 100, workers=workers[0].address)
-    bv = yield c.scatter("b" * 75, workers=workers[2].address)
-    bv2 = yield c.scatter("b" * 75, workers=workers[3].address)
+    av = await c.scatter("a" * 100, workers=workers[0].address)
+    bv = await c.scatter("b" * 75, workers=workers[2].address)
+    bv2 = await c.scatter("b" * 75, workers=workers[3].address)
 
     assert set(s.workers_to_close(key=key)) == {workers[0].address, workers[1].address}
 
 
 @gen_cluster(client=True)
-def test_retire_workers_no_suspicious_tasks(c, s, a, b):
+async def test_retire_workers_no_suspicious_tasks(c, s, a, b):
     future = c.submit(
         slowinc, 100, delay=0.5, workers=a.address, allow_other_workers=True
     )
-    yield gen.sleep(0.2)
-    yield s.retire_workers(workers=[a.address])
+    await gen.sleep(0.2)
+    await s.retire_workers(workers=[a.address])
 
     assert all(ts.suspicious == 0 for ts in s.tasks.values())
     assert all(tp.suspicious == 0 for tp in s.task_prefixes.values())
@@ -793,46 +793,46 @@ def test_retire_workers_no_suspicious_tasks(c, s, a, b):
     sys.platform.startswith("win"), reason="file descriptors not really a thing"
 )
 @gen_cluster(client=True, nthreads=[], timeout=240)
-def test_file_descriptors(c, s):
-    yield gen.sleep(0.1)
+async def test_file_descriptors(c, s):
+    await gen.sleep(0.1)
     psutil = pytest.importorskip("psutil")
     da = pytest.importorskip("dask.array")
     proc = psutil.Process()
     num_fds_1 = proc.num_fds()
 
     N = 20
-    nannies = yield asyncio.gather(*[Nanny(s.address, loop=s.loop) for _ in range(N)])
+    nannies = await asyncio.gather(*[Nanny(s.address, loop=s.loop) for _ in range(N)])
 
     while len(s.nthreads) < N:
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
 
     num_fds_2 = proc.num_fds()
 
-    yield gen.sleep(0.2)
+    await gen.sleep(0.2)
 
     num_fds_3 = proc.num_fds()
     assert num_fds_3 <= num_fds_2 + N  # add some heartbeats
 
     x = da.random.random(size=(1000, 1000), chunks=(25, 25))
     x = c.persist(x)
-    yield wait(x)
+    await wait(x)
 
     num_fds_4 = proc.num_fds()
     assert num_fds_4 <= num_fds_2 + 2 * N
 
     y = c.persist(x + x.T)
-    yield wait(y)
+    await wait(y)
 
     num_fds_5 = proc.num_fds()
     assert num_fds_5 < num_fds_4 + N
 
-    yield gen.sleep(1)
+    await gen.sleep(1)
 
     num_fds_6 = proc.num_fds()
     assert num_fds_6 < num_fds_5 + N
 
-    yield asyncio.gather(*[n.close() for n in nannies])
-    yield c.close()
+    await asyncio.gather(*[n.close() for n in nannies])
+    await c.close()
 
     assert not s.rpc.open
     for addr, occ in c.rpc.occupied.items():
@@ -842,17 +842,17 @@ def test_file_descriptors(c, s):
 
     start = time()
     while proc.num_fds() > num_fds_1 + N:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 3
 
 
 @pytest.mark.slow
 @nodebug
 @gen_cluster(client=True)
-def test_learn_occupancy(c, s, a, b):
+async def test_learn_occupancy(c, s, a, b):
     futures = c.map(slowinc, range(1000), delay=0.2)
     while sum(len(ts.who_has) for ts in s.tasks.values()) < 10:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert 100 < s.total_occupancy < 1000
     for w in [a, b]:
@@ -862,23 +862,23 @@ def test_learn_occupancy(c, s, a, b):
 @pytest.mark.slow
 @nodebug
 @gen_cluster(client=True)
-def test_learn_occupancy_2(c, s, a, b):
+async def test_learn_occupancy_2(c, s, a, b):
     future = c.map(slowinc, range(1000), delay=0.2)
     while not any(ts.who_has for ts in s.tasks.values()):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert 100 < s.total_occupancy < 1000
 
 
 @gen_cluster(client=True)
-def test_occupancy_cleardown(c, s, a, b):
+async def test_occupancy_cleardown(c, s, a, b):
     s.validate = False
 
     # Inject excess values in s.occupancy
     s.workers[a.address].occupancy = 2
     s.total_occupancy += 2
     futures = c.map(slowinc, range(100), delay=0.01)
-    yield wait(futures)
+    await wait(futures)
 
     # Verify that occupancy values have been zeroed out
     assert abs(s.total_occupancy) < 0.01
@@ -887,28 +887,28 @@ def test_occupancy_cleardown(c, s, a, b):
 
 @nodebug
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 30)
-def test_balance_many_workers(c, s, *workers):
+async def test_balance_many_workers(c, s, *workers):
     futures = c.map(slowinc, range(20), delay=0.2)
-    yield wait(futures)
+    await wait(futures)
     assert {len(w.has_what) for w in s.workers.values()} == {0, 1}
 
 
 @nodebug
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 30)
-def test_balance_many_workers_2(c, s, *workers):
+async def test_balance_many_workers_2(c, s, *workers):
     s.extensions["stealing"]._pc.callback_time = 100000000
     futures = c.map(slowinc, range(90), delay=0.2)
-    yield wait(futures)
+    await wait(futures)
     assert {len(w.has_what) for w in s.workers.values()} == {3}
 
 
 @gen_cluster(client=True)
-def test_learn_occupancy_multiple_workers(c, s, a, b):
+async def test_learn_occupancy_multiple_workers(c, s, a, b):
     x = c.submit(slowinc, 1, delay=0.2, workers=a.address)
-    yield gen.sleep(0.05)
+    await gen.sleep(0.05)
     futures = c.map(slowinc, range(100), delay=0.2)
 
-    yield wait(x)
+    await wait(x)
 
     assert not any(v == 0.5 for w in s.workers.values() for v in w.processing.values())
     s.validate_state()
@@ -932,7 +932,7 @@ async def test_include_communication_in_occupancy(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_worker_arrives_with_processing_data(c, s, a, b):
+async def test_worker_arrives_with_processing_data(c, s, a, b):
     x = delayed(slowinc)(1, delay=0.4)
     y = delayed(slowinc)(x, delay=0.4)
     z = delayed(slowinc)(y, delay=0.4)
@@ -940,17 +940,17 @@ def test_worker_arrives_with_processing_data(c, s, a, b):
     yy, zz = c.persist([y, z])
 
     while not any(w.processing for w in s.workers.values()):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     w = Worker(s.address, nthreads=1)
     w.put_key_in_memory(y.key, 3)
 
-    yield w
+    await w
 
     start = time()
 
     while len(s.workers) < 3:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert s.get_task_status(keys={x.key, y.key, z.key}) == {
         x.key: "released",
@@ -958,23 +958,23 @@ def test_worker_arrives_with_processing_data(c, s, a, b):
         z.key: "processing",
     }
 
-    yield w.close()
+    await w.close()
 
 
 @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_worker_breaks_and_returns(c, s, a):
+async def test_worker_breaks_and_returns(c, s, a):
     future = c.submit(slowinc, 1, delay=0.1)
     for i in range(20):
         future = c.submit(slowinc, future, delay=0.1)
 
-    yield wait(future)
+    await wait(future)
 
-    yield a.batched_stream.comm.close()
+    await a.batched_stream.comm.close()
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     start = time()
-    yield wait(future, timeout=10)
+    await wait(future, timeout=10)
     end = time()
 
     assert end - start < 2
@@ -984,7 +984,7 @@ def test_worker_breaks_and_returns(c, s, a):
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_no_workers_to_memory(c, s):
+async def test_no_workers_to_memory(c, s):
     x = delayed(slowinc)(1, delay=0.4)
     y = delayed(slowinc)(x, delay=0.4)
     z = delayed(slowinc)(y, delay=0.4)
@@ -992,17 +992,17 @@ def test_no_workers_to_memory(c, s):
     yy, zz = c.persist([y, z])
 
     while not s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     w = Worker(s.address, nthreads=1)
     w.put_key_in_memory(y.key, 3)
 
-    yield w
+    await w
 
     start = time()
 
     while not s.workers:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert s.get_task_status(keys={x.key, y.key, z.key}) == {
         x.key: "released",
@@ -1010,11 +1010,11 @@ def test_no_workers_to_memory(c, s):
         z.key: "processing",
     }
 
-    yield w.close()
+    await w.close()
 
 
 @gen_cluster(client=True)
-def test_no_worker_to_memory_restrictions(c, s, a, b):
+async def test_no_worker_to_memory_restrictions(c, s, a, b):
     x = delayed(slowinc)(1, delay=0.4)
     y = delayed(slowinc)(x, delay=0.4)
     z = delayed(slowinc)(y, delay=0.4)
@@ -1022,16 +1022,16 @@ def test_no_worker_to_memory_restrictions(c, s, a, b):
     yy, zz = c.persist([y, z], workers={(x, y, z): "alice"})
 
     while not s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     w = Worker(s.address, nthreads=1, name="alice")
     w.put_key_in_memory(y.key, 3)
 
-    yield w
+    await w
 
     while len(s.workers) < 3:
-        yield gen.sleep(0.01)
-    yield gen.sleep(0.3)
+        await gen.sleep(0.01)
+    await gen.sleep(0.3)
 
     assert s.get_task_status(keys={x.key, y.key, z.key}) == {
         x.key: "released",
@@ -1039,7 +1039,7 @@ def test_no_worker_to_memory_restrictions(c, s, a, b):
         z.key: "processing",
     }
 
-    yield w.close()
+    await w.close()
 
 
 def test_run_on_scheduler_sync(loop):
@@ -1056,78 +1056,78 @@ def test_run_on_scheduler_sync(loop):
 
 
 @gen_cluster(client=True)
-def test_run_on_scheduler(c, s, a, b):
+async def test_run_on_scheduler(c, s, a, b):
     def f(dask_scheduler=None):
         return dask_scheduler.address
 
-    response = yield c._run_on_scheduler(f)
+    response = await c._run_on_scheduler(f)
     assert response == s.address
 
 
 @gen_cluster(client=True)
-def test_close_worker(c, s, a, b):
+async def test_close_worker(c, s, a, b):
     assert len(s.workers) == 2
 
-    yield s.close_worker(worker=a.address)
+    await s.close_worker(worker=a.address)
 
     assert len(s.workers) == 1
     assert a.address not in s.workers
 
-    yield gen.sleep(0.5)
+    await gen.sleep(0.5)
 
     assert len(s.workers) == 1
 
 
 @pytest.mark.slow
 @gen_cluster(client=True, Worker=Nanny, timeout=20)
-def test_close_nanny(c, s, a, b):
+async def test_close_nanny(c, s, a, b):
     assert len(s.workers) == 2
 
     assert a.process.is_alive()
     a_worker_address = a.worker_address
     start = time()
-    yield s.close_worker(worker=a_worker_address)
+    await s.close_worker(worker=a_worker_address)
 
     assert len(s.workers) == 1
     assert a_worker_address not in s.workers
 
     start = time()
     while a.is_alive():
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         assert time() < start + 5
 
     assert not a.is_alive()
     assert a.pid is None
 
     for i in range(10):
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         assert len(s.workers) == 1
         assert not a.is_alive()
         assert a.pid is None
 
     while a.status != "closed":
-        yield gen.sleep(0.05)
+        await gen.sleep(0.05)
         assert time() < start + 10
 
 
 @gen_cluster(client=True, timeout=20)
-def test_retire_workers_close(c, s, a, b):
-    yield s.retire_workers(close_workers=True)
+async def test_retire_workers_close(c, s, a, b):
+    await s.retire_workers(close_workers=True)
     assert not s.workers
     while a.status != "closed" and b.status != "closed":
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
 
 @gen_cluster(client=True, timeout=20, Worker=Nanny)
-def test_retire_nannies_close(c, s, a, b):
+async def test_retire_nannies_close(c, s, a, b):
     nannies = [a, b]
-    yield s.retire_workers(close_workers=True, remove=True)
+    await s.retire_workers(close_workers=True, remove=True)
     assert not s.workers
 
     start = time()
 
     while any(n.status != "closed" for n in nannies):
-        yield gen.sleep(0.05)
+        await gen.sleep(0.05)
         assert time() < start + 10
 
     assert not any(n.is_alive() for n in nannies)
@@ -1135,27 +1135,27 @@ def test_retire_nannies_close(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 2)])
-def test_fifo_submission(c, s, w):
+async def test_fifo_submission(c, s, w):
     futures = []
     for i in range(20):
         future = c.submit(slowinc, i, delay=0.1, key="inc-%02d" % i, fifo_timeout=0.01)
         futures.append(future)
-        yield gen.sleep(0.02)
-    yield wait(futures[-1])
+        await gen.sleep(0.02)
+    await wait(futures[-1])
     assert futures[10].status == "finished"
 
 
 @gen_test()
-def test_scheduler_file():
+async def test_scheduler_file():
     with tmpfile() as fn:
-        s = yield Scheduler(scheduler_file=fn, port=0)
+        s = await Scheduler(scheduler_file=fn, port=0)
         with open(fn) as f:
             data = json.load(f)
         assert data["address"] == s.address
 
-        c = yield Client(scheduler_file=fn, loop=s.loop, asynchronous=True)
-        yield c.close()
-        yield s.close()
+        c = await Client(scheduler_file=fn, loop=s.loop, asynchronous=True)
+        await c.close()
+        await s.close()
 
 
 @pytest.mark.xfail(reason="")
@@ -1172,15 +1172,15 @@ async def test_non_existent_worker(c, s):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_correct_bad_time_estimate(c, s, *workers):
+async def test_correct_bad_time_estimate(c, s, *workers):
     future = c.submit(slowinc, 1, delay=0)
-    yield wait(future)
+    await wait(future)
 
     futures = [c.submit(slowinc, future, delay=0.1, pure=False) for i in range(20)]
 
-    yield gen.sleep(0.5)
+    await gen.sleep(0.5)
 
-    yield wait(futures)
+    await wait(futures)
 
     assert all(w.data for w in workers), [sorted(w.data) for w in workers]
 
@@ -1208,13 +1208,13 @@ async def test_service_hosts():
 
 
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
-def test_profile_metadata(c, s, a, b):
+async def test_profile_metadata(c, s, a, b):
     start = time() - 1
     futures = c.map(slowinc, range(10), delay=0.05, workers=a.address)
-    yield wait(futures)
-    yield gen.sleep(0.200)
+    await wait(futures)
+    await gen.sleep(0.200)
 
-    meta = yield s.get_profile_metadata(profile_cycle_interval=0.100)
+    meta = await s.get_profile_metadata(profile_cycle_interval=0.100)
     now = time() + 1
     assert meta
     assert all(start < t < now for t, count in meta["counts"])
@@ -1223,12 +1223,12 @@ def test_profile_metadata(c, s, a, b):
 
 
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
-def test_profile_metadata_keys(c, s, a, b):
+async def test_profile_metadata_keys(c, s, a, b):
     x = c.map(slowinc, range(10), delay=0.05)
     y = c.map(slowdec, range(10), delay=0.05)
-    yield wait(x + y)
+    await wait(x + y)
 
-    meta = yield s.get_profile_metadata(profile_cycle_interval=0.100)
+    meta = await s.get_profile_metadata(profile_cycle_interval=0.100)
     assert set(meta["keys"]) == {"slowinc", "slowdec"}
     assert (
         len(meta["counts"]) - 3 <= len(meta["keys"]["slowinc"]) <= len(meta["counts"])
@@ -1236,7 +1236,7 @@ def test_profile_metadata_keys(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_cancel_fire_and_forget(c, s, a, b):
+async def test_cancel_fire_and_forget(c, s, a, b):
     x = delayed(slowinc)(1, delay=0.05)
     y = delayed(slowinc)(x, delay=0.05)
     z = delayed(slowinc)(y, delay=0.05)
@@ -1244,8 +1244,8 @@ def test_cancel_fire_and_forget(c, s, a, b):
     future = c.compute(w)
     fire_and_forget(future)
 
-    yield gen.sleep(0.05)
-    yield future.cancel(force=True)
+    await gen.sleep(0.05)
+    await future.cancel(force=True)
     assert future.status == "cancelled"
     assert not s.tasks
 
@@ -1253,28 +1253,28 @@ def test_cancel_fire_and_forget(c, s, a, b):
 @gen_cluster(
     client=True, Worker=Nanny, clean_kwargs={"processes": False, "threads": False}
 )
-def test_log_tasks_during_restart(c, s, a, b):
+async def test_log_tasks_during_restart(c, s, a, b):
     future = c.submit(sys.exit, 0)
-    yield wait(future)
+    await wait(future)
     assert "exit" in str(s.events)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_reschedule(c, s, a, b):
-    yield c.submit(slowinc, -1, delay=0.1)  # learn cost
+async def test_reschedule(c, s, a, b):
+    await c.submit(slowinc, -1, delay=0.1)  # learn cost
     x = c.map(slowinc, range(4), delay=0.1)
 
     # add much more work onto worker a
     futures = c.map(slowinc, range(10, 20), delay=0.1, workers=a.address)
 
     while len(s.tasks) < len(x) + len(futures):
-        yield gen.sleep(0.001)
+        await gen.sleep(0.001)
 
     for future in x:
         s.reschedule(key=future.key)
 
     # Worker b gets more of the original tasks
-    yield wait(x)
+    await wait(x)
     assert sum(future.key in b.data for future in x) >= 3
     assert sum(future.key in a.data for future in x) <= 1
 
@@ -1289,11 +1289,11 @@ def test_reschedule_warns(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_get_task_status(c, s, a, b):
+async def test_get_task_status(c, s, a, b):
     future = c.submit(inc, 1)
-    yield wait(future)
+    await wait(future)
 
-    result = yield a.scheduler.get_task_status(keys=[future.key])
+    result = await a.scheduler.get_task_status(keys=[future.key])
     assert result == {future.key: "memory"}
 
 
@@ -1310,29 +1310,29 @@ def test_deque_handler():
 
 
 @gen_cluster(client=True)
-def test_retries(c, s, a, b):
+async def test_retries(c, s, a, b):
     args = [ZeroDivisionError("one"), ZeroDivisionError("two"), 42]
 
     future = c.submit(varying(args), retries=3)
-    result = yield future
+    result = await future
     assert result == 42
     assert s.tasks[future.key].retries == 1
     assert future.key not in s.exceptions
 
     future = c.submit(varying(args), retries=2, pure=False)
-    result = yield future
+    result = await future
     assert result == 42
     assert s.tasks[future.key].retries == 0
     assert future.key not in s.exceptions
 
     future = c.submit(varying(args), retries=1, pure=False)
     with pytest.raises(ZeroDivisionError) as exc_info:
-        yield future
+        await future
     exc_info.match("two")
 
     future = c.submit(varying(args), retries=0, pure=False)
     with pytest.raises(ZeroDivisionError) as exc_info:
-        yield future
+        await future
     exc_info.match("one")
 
 
@@ -1354,143 +1354,143 @@ async def test_mising_data_errant_worker(c, s, w1, w2, w3):
 
 
 @gen_cluster(client=True)
-def test_dont_recompute_if_persisted(c, s, a, b):
+async def test_dont_recompute_if_persisted(c, s, a, b):
     x = delayed(inc)(1, dask_key_name="x")
     y = delayed(inc)(x, dask_key_name="y")
 
     yy = y.persist()
-    yield wait(yy)
+    await wait(yy)
 
     old = list(s.transition_log)
 
     yyy = y.persist()
-    yield wait(yyy)
+    await wait(yyy)
 
-    yield gen.sleep(0.100)
+    await gen.sleep(0.100)
     assert list(s.transition_log) == old
 
 
 @gen_cluster(client=True)
-def test_dont_recompute_if_persisted_2(c, s, a, b):
+async def test_dont_recompute_if_persisted_2(c, s, a, b):
     x = delayed(inc)(1, dask_key_name="x")
     y = delayed(inc)(x, dask_key_name="y")
     z = delayed(inc)(y, dask_key_name="z")
 
     yy = y.persist()
-    yield wait(yy)
+    await wait(yy)
 
     old = s.story("x", "y")
 
     zz = z.persist()
-    yield wait(zz)
+    await wait(zz)
 
-    yield gen.sleep(0.100)
+    await gen.sleep(0.100)
     assert s.story("x", "y") == old
 
 
 @gen_cluster(client=True)
-def test_dont_recompute_if_persisted_3(c, s, a, b):
+async def test_dont_recompute_if_persisted_3(c, s, a, b):
     x = delayed(inc)(1, dask_key_name="x")
     y = delayed(inc)(2, dask_key_name="y")
     z = delayed(inc)(y, dask_key_name="z")
     w = delayed(operator.add)(x, z, dask_key_name="w")
 
     ww = w.persist()
-    yield wait(ww)
+    await wait(ww)
 
     old = list(s.transition_log)
 
     www = w.persist()
-    yield wait(www)
-    yield gen.sleep(0.100)
+    await wait(www)
+    await gen.sleep(0.100)
     assert list(s.transition_log) == old
 
 
 @gen_cluster(client=True)
-def test_dont_recompute_if_persisted_4(c, s, a, b):
+async def test_dont_recompute_if_persisted_4(c, s, a, b):
     x = delayed(inc)(1, dask_key_name="x")
     y = delayed(inc)(x, dask_key_name="y")
     z = delayed(inc)(x, dask_key_name="z")
 
     yy = y.persist()
-    yield wait(yy)
+    await wait(yy)
 
     old = s.story("x")
 
     while s.tasks["x"].state == "memory":
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     yyy, zzz = dask.persist(y, z)
-    yield wait([yyy, zzz])
+    await wait([yyy, zzz])
 
     new = s.story("x")
     assert len(new) > len(old)
 
 
 @gen_cluster(client=True)
-def test_dont_forget_released_keys(c, s, a, b):
+async def test_dont_forget_released_keys(c, s, a, b):
     x = c.submit(inc, 1, key="x")
     y = c.submit(inc, x, key="y")
     z = c.submit(dec, x, key="z")
     del x
-    yield wait([y, z])
+    await wait([y, z])
     del z
 
     while "z" in s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert "x" in s.tasks
 
 
 @gen_cluster(client=True)
-def test_dont_recompute_if_erred(c, s, a, b):
+async def test_dont_recompute_if_erred(c, s, a, b):
     x = delayed(inc)(1, dask_key_name="x")
     y = delayed(div)(x, 0, dask_key_name="y")
 
     yy = y.persist()
-    yield wait(yy)
+    await wait(yy)
 
     old = list(s.transition_log)
 
     yyy = y.persist()
-    yield wait(yyy)
+    await wait(yyy)
 
-    yield gen.sleep(0.100)
+    await gen.sleep(0.100)
     assert list(s.transition_log) == old
 
 
 @gen_cluster()
-def test_closing_scheduler_closes_workers(s, a, b):
-    yield s.close()
+async def test_closing_scheduler_closes_workers(s, a, b):
+    await s.close()
 
     start = time()
     while a.status != "closed" or b.status != "closed":
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
 
 
 @gen_cluster(
     client=True, nthreads=[("127.0.0.1", 1)], worker_kwargs={"resources": {"A": 1}}
 )
-def test_resources_reset_after_cancelled_task(c, s, w):
+async def test_resources_reset_after_cancelled_task(c, s, w):
     future = c.submit(sleep, 0.2, resources={"A": 1})
 
     while not w.executing:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
-    yield future.cancel()
+    await future.cancel()
 
     while w.executing:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert not s.workers[w.address].used_resources["A"]
     assert w.available_resources == {"A": 1}
 
-    yield c.submit(inc, 1, resources={"A": 1})
+    await c.submit(inc, 1, resources={"A": 1})
 
 
 @gen_cluster(client=True)
-def test_gh2187(c, s, a, b):
+async def test_gh2187(c, s, a, b):
     def foo():
         return "foo"
 
@@ -1507,12 +1507,12 @@ def test_gh2187(c, s, a, b):
     w = c.submit(foo, key="w")
     x = c.submit(bar, w, key="x")
     y = c.submit(baz, x, key="y")
-    yield y
+    await y
     z = c.submit(qux, y, key="z")
     del y
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     f = c.submit(bar, x, key="y")
-    yield f
+    await f
 
 
 @gen_cluster(client=True)
@@ -1593,16 +1593,16 @@ def test_workerstate_clean(s, a, b):
 
 
 @gen_cluster(client=True)
-def test_result_type(c, s, a, b):
+async def test_result_type(c, s, a, b):
     x = c.submit(lambda: 1)
-    yield x
+    await x
 
     assert "int" in s.tasks[x.key].type
 
 
 @gen_cluster()
-def test_close_workers(s, a, b):
-    yield s.close(close_workers=True)
+async def test_close_workers(s, a, b):
+    await s.close(close_workers=True)
     assert a.status == "closed"
     assert b.status == "closed"
 
@@ -1611,22 +1611,22 @@ def test_close_workers(s, a, b):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_test()
-def test_host_address():
-    s = yield Scheduler(host="127.0.0.2", port=0)
+async def test_host_address():
+    s = await Scheduler(host="127.0.0.2", port=0)
     assert "127.0.0.2" in s.address
-    yield s.close()
+    await s.close()
 
 
 @gen_test()
-def test_dashboard_address():
+async def test_dashboard_address():
     pytest.importorskip("bokeh")
-    s = yield Scheduler(dashboard_address="127.0.0.1:8901", port=0)
+    s = await Scheduler(dashboard_address="127.0.0.1:8901", port=0)
     assert s.services["dashboard"].port == 8901
-    yield s.close()
+    await s.close()
 
-    s = yield Scheduler(dashboard_address="127.0.0.1", port=0)
+    s = await Scheduler(dashboard_address="127.0.0.1", port=0)
     assert s.services["dashboard"].port
-    yield s.close()
+    await s.close()
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -49,7 +49,7 @@ occupancy = defaultdict(lambda: 0)
 
 
 @gen_cluster()
-def test_administration(s, a, b):
+async def test_administration(s, a, b):
     assert isinstance(s.address, str)
     assert s.address in str(s)
     assert str(sum(s.nthreads.values())) in repr(s)
@@ -478,7 +478,7 @@ def test_dumps_task():
 
 
 @gen_cluster()
-def test_ready_remove_worker(s, a, b):
+async def test_ready_remove_worker(s, a, b):
     s.update_graph(
         tasks={"x-%d" % i: dumps_task((inc, i)) for i in range(20)},
         keys=["x-%d" % i for i in range(20)],
@@ -1279,7 +1279,7 @@ async def test_reschedule(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_reschedule_warns(c, s, a, b):
+async def test_reschedule_warns(c, s, a, b):
     with captured_logger(logging.getLogger("distributed.scheduler")) as sched:
         s.reschedule(key="__this-key-does-not-exist__")
 
@@ -1515,7 +1515,7 @@ async def test_gh2187(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_collect_versions(c, s, a, b):
+async def test_collect_versions(c, s, a, b):
     cs = s.clients[c.id]
     (w1, w2) = s.workers.values()
     assert cs.versions
@@ -1584,7 +1584,7 @@ async def test_bandwidth_clear(c, s, a, b):
 
 
 @gen_cluster()
-def test_workerstate_clean(s, a, b):
+async def test_workerstate_clean(s, a, b):
     ws = s.workers[a.address].clean()
     assert ws.address == a.address
     b = pickle.dumps(ws)

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -325,17 +325,15 @@ async def test_oversubscribing_leases(c, s, a, b):
     accept new leases as long as the semaphore is oversubscribed.
 
     Oversubscription may occur if tasks hold the GIL for a longer time than the
-    lease-timeout is configured causing the lease refreshs to go stale and
-    timeout.
+    lease-timeout is configured causing the lease refresh to go stale and timeout.
 
     We cannot protect ourselves entirely from this but we can ensure that while
     a task with a timed out lease is still running, we block further
     acquisitions until we return to normal.
 
     An example would be a task which continuously locks the GIL for a longer
-    time than the lease timeout but this continous lock only makes up a
+    time than the lease timeout but this continuous lock only makes up a
     fraction of the tasks runtime.
-
     """
     # GH3705
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -108,10 +108,9 @@ async def test_worksteal_many_thieves(c, s, *workers):
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 async def test_dont_steal_unknown_functions(c, s, a, b):
-    futures = c.map(inc, [1, 2], workers=a.address, allow_other_workers=True)
+    futures = c.map(inc, range(100), workers=a.address, allow_other_workers=True)
     await wait(futures)
-    assert len(a.data) == 2, [len(a.data), len(b.data)]
-    assert len(b.data) == 0, [len(a.data), len(b.data)]
+    assert len(a.data) >= 95, [len(a.data), len(b.data)]
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
@@ -120,8 +119,8 @@ async def test_eventually_steal_unknown_functions(c, s, a, b):
         slowinc, range(10), delay=0.1, workers=a.address, allow_other_workers=True
     )
     await wait(futures)
-    assert len(a.data) >= 3
-    assert len(b.data) >= 3
+    assert len(a.data) >= 3, [len(a.data), len(b.data)]
+    assert len(b.data) >= 3, [len(a.data), len(b.data)]
 
 
 @pytest.mark.skip(reason="")

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -35,70 +35,70 @@ teardown_module = nodebug_teardown_module
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 2), ("127.0.0.2", 2)], timeout=20)
-def test_work_stealing(c, s, a, b):
-    [x] = yield c._scatter([1], workers=a.address)
+async def test_work_stealing(c, s, a, b):
+    [x] = await c._scatter([1], workers=a.address)
     futures = c.map(slowadd, range(50), [x] * 50)
-    yield wait(futures)
+    await wait(futures)
     assert len(a.data) > 10
     assert len(b.data) > 10
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_dont_steal_expensive_data_fast_computation(c, s, a, b):
+async def test_dont_steal_expensive_data_fast_computation(c, s, a, b):
     np = pytest.importorskip("numpy")
     x = c.submit(np.arange, 1000000, workers=a.address)
-    yield wait([x])
+    await wait([x])
     future = c.submit(np.sum, [1], workers=a.address)  # learn that sum is fast
-    yield wait([future])
+    await wait([future])
 
     cheap = [
         c.submit(np.sum, x, pure=False, workers=a.address, allow_other_workers=True)
         for i in range(10)
     ]
-    yield wait(cheap)
+    await wait(cheap)
     assert len(s.who_has[x.key]) == 1
     assert len(b.data) == 0
     assert len(a.data) == 12
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_steal_cheap_data_slow_computation(c, s, a, b):
+async def test_steal_cheap_data_slow_computation(c, s, a, b):
     x = c.submit(slowinc, 100, delay=0.1)  # learn that slowinc is slow
-    yield wait(x)
+    await wait(x)
 
     futures = c.map(
         slowinc, range(10), delay=0.1, workers=a.address, allow_other_workers=True
     )
-    yield wait(futures)
+    await wait(futures)
     assert abs(len(a.data) - len(b.data)) <= 5
 
 
 @pytest.mark.avoid_travis
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_steal_expensive_data_slow_computation(c, s, a, b):
+async def test_steal_expensive_data_slow_computation(c, s, a, b):
     np = pytest.importorskip("numpy")
 
     x = c.submit(slowinc, 100, delay=0.2, workers=a.address)
-    yield wait(x)  # learn that slowinc is slow
+    await wait(x)  # learn that slowinc is slow
 
     x = c.submit(np.arange, 1000000, workers=a.address)  # put expensive data
-    yield wait(x)
+    await wait(x)
 
     slow = [c.submit(slowinc, x, delay=0.1, pure=False) for i in range(20)]
-    yield wait(slow)
+    await wait(slow)
     assert len(s.who_has[x.key]) > 1
 
     assert b.data  # not empty
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
-def test_worksteal_many_thieves(c, s, *workers):
+async def test_worksteal_many_thieves(c, s, *workers):
     x = c.submit(slowinc, -1, delay=0.1)
-    yield x
+    await x
 
     xs = c.map(slowinc, [x] * 100, pure=False, delay=0.1)
 
-    yield wait(xs)
+    await wait(xs)
 
     for w, keys in s.has_what.items():
         assert 2 < len(keys) < 30
@@ -108,31 +108,31 @@ def test_worksteal_many_thieves(c, s, *workers):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_dont_steal_unknown_functions(c, s, a, b):
+async def test_dont_steal_unknown_functions(c, s, a, b):
     futures = c.map(inc, [1, 2], workers=a.address, allow_other_workers=True)
-    yield wait(futures)
+    await wait(futures)
     assert len(a.data) == 2, [len(a.data), len(b.data)]
     assert len(b.data) == 0, [len(a.data), len(b.data)]
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_eventually_steal_unknown_functions(c, s, a, b):
+async def test_eventually_steal_unknown_functions(c, s, a, b):
     futures = c.map(
         slowinc, range(10), delay=0.1, workers=a.address, allow_other_workers=True
     )
-    yield wait(futures)
+    await wait(futures)
     assert len(a.data) >= 3
     assert len(b.data) >= 3
 
 
 @pytest.mark.skip(reason="")
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_steal_related_tasks(e, s, a, b, c):
+async def test_steal_related_tasks(e, s, a, b, c):
     futures = e.map(
         slowinc, range(20), delay=0.05, workers=a.address, allow_other_workers=True
     )
 
-    yield wait(futures)
+    await wait(futures)
 
     nearby = 0
     for f1, f2 in sliding_window(2, futures):
@@ -199,17 +199,17 @@ async def test_dont_steal_fast_tasks_blacklist(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)], timeout=20)
-def test_new_worker_steals(c, s, a):
-    yield wait(c.submit(slowinc, 1, delay=0.01))
+async def test_new_worker_steals(c, s, a):
+    await wait(c.submit(slowinc, 1, delay=0.01))
 
     futures = c.map(slowinc, range(100), delay=0.05)
     total = c.submit(sum, futures)
     while len(a.task_state) < 10:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
-    b = yield Worker(s.address, loop=s.loop, nthreads=1, memory_limit=MEMORY_LIMIT)
+    b = await Worker(s.address, loop=s.loop, nthreads=1, memory_limit=MEMORY_LIMIT)
 
-    result = yield total
+    result = await total
     assert result == sum(map(inc, range(100)))
 
     for w in [a, b]:
@@ -217,44 +217,44 @@ def test_new_worker_steals(c, s, a):
 
     assert b.data
 
-    yield b.close()
+    await b.close()
 
 
 @gen_cluster(client=True, timeout=20)
-def test_work_steal_no_kwargs(c, s, a, b):
-    yield wait(c.submit(slowinc, 1, delay=0.05))
+async def test_work_steal_no_kwargs(c, s, a, b):
+    await wait(c.submit(slowinc, 1, delay=0.05))
 
     futures = c.map(
         slowinc, range(100), workers=a.address, allow_other_workers=True, delay=0.05
     )
 
-    yield wait(futures)
+    await wait(futures)
 
     assert 20 < len(a.data) < 80
     assert 20 < len(b.data) < 80
 
     total = c.submit(sum, futures)
-    result = yield total
+    result = await total
 
     assert result == sum(map(inc, range(100)))
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1), ("127.0.0.1", 2)])
-def test_dont_steal_worker_restrictions(c, s, a, b):
+async def test_dont_steal_worker_restrictions(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
-    yield future
+    await future
 
     futures = c.map(slowinc, range(100), delay=0.1, workers=a.address)
 
     while len(a.task_state) + len(b.task_state) < 100:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
     result = s.extensions["stealing"].balance()
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
@@ -263,15 +263,15 @@ def test_dont_steal_worker_restrictions(c, s, a, b):
 @gen_cluster(
     client=True, nthreads=[("127.0.0.1", 1), ("127.0.0.1", 2), ("127.0.0.1", 2)]
 )
-def test_steal_worker_restrictions(c, s, wa, wb, wc):
+async def test_steal_worker_restrictions(c, s, wa, wb, wc):
     future = c.submit(slowinc, 1, delay=0.1, workers={wa.address, wb.address})
-    yield future
+    await future
 
     ntasks = 100
     futures = c.map(slowinc, range(ntasks), delay=0.1, workers={wa.address, wb.address})
 
     while sum(len(w.task_state) for w in [wa, wb, wc]) < ntasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert 0 < len(wa.task_state) < ntasks
     assert 0 < len(wb.task_state) < ntasks
@@ -279,7 +279,7 @@ def test_steal_worker_restrictions(c, s, wa, wb, wc):
 
     s.extensions["stealing"].balance()
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
     assert 0 < len(wa.task_state) < ntasks
     assert 0 < len(wb.task_state) < ntasks
@@ -290,19 +290,19 @@ def test_steal_worker_restrictions(c, s, wa, wb, wc):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1), ("127.0.0.2", 1)])
-def test_dont_steal_host_restrictions(c, s, a, b):
+async def test_dont_steal_host_restrictions(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
-    yield future
+    await future
 
     futures = c.map(slowinc, range(100), delay=0.1, workers="127.0.0.1")
     while len(a.task_state) + len(b.task_state) < 100:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
     result = s.extensions["stealing"].balance()
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
@@ -311,25 +311,25 @@ def test_dont_steal_host_restrictions(c, s, a, b):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1), ("127.0.0.2", 2)])
-def test_steal_host_restrictions(c, s, wa, wb):
+async def test_steal_host_restrictions(c, s, wa, wb):
     future = c.submit(slowinc, 1, delay=0.10, workers=wa.address)
-    yield future
+    await future
 
     ntasks = 100
     futures = c.map(slowinc, range(ntasks), delay=0.1, workers="127.0.0.1")
     while len(wa.task_state) < ntasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
     assert len(wa.task_state) == ntasks
     assert len(wb.task_state) == 0
 
-    wc = yield Worker(s.address, nthreads=1)
+    wc = await Worker(s.address, nthreads=1)
 
     start = time()
     while not wc.task_state or len(wa.task_state) == ntasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 3
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert 0 < len(wa.task_state) < ntasks
     assert len(wb.task_state) == 0
     assert 0 < len(wc.task_state) < ntasks
@@ -338,19 +338,19 @@ def test_steal_host_restrictions(c, s, wa, wb):
 @gen_cluster(
     client=True, nthreads=[("127.0.0.1", 1, {"resources": {"A": 2}}), ("127.0.0.1", 1)]
 )
-def test_dont_steal_resource_restrictions(c, s, a, b):
+async def test_dont_steal_resource_restrictions(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
-    yield future
+    await future
 
     futures = c.map(slowinc, range(100), delay=0.1, resources={"A": 1})
     while len(a.task_state) + len(b.task_state) < 100:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
     result = s.extensions["stealing"].balance()
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
@@ -358,30 +358,30 @@ def test_dont_steal_resource_restrictions(c, s, a, b):
 @gen_cluster(
     client=True, nthreads=[("127.0.0.1", 1, {"resources": {"A": 2}})], timeout=3
 )
-def test_steal_resource_restrictions(c, s, a):
+async def test_steal_resource_restrictions(c, s, a):
     future = c.submit(slowinc, 1, delay=0.10, workers=a.address)
-    yield future
+    await future
 
     futures = c.map(slowinc, range(100), delay=0.2, resources={"A": 1})
     while len(a.task_state) < 101:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
     assert len(a.task_state) == 101
 
-    b = yield Worker(s.address, loop=s.loop, nthreads=1, resources={"A": 4})
+    b = await Worker(s.address, loop=s.loop, nthreads=1, resources={"A": 4})
 
     start = time()
     while not b.task_state or len(a.task_state) == 101:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 3
 
     assert len(b.task_state) > 0
     assert len(a.task_state) < 101
 
-    yield b.close()
+    await b.close()
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 5, timeout=20)
-def test_balance_without_dependencies(c, s, *workers):
+async def test_balance_without_dependencies(c, s, *workers):
     s.extensions["stealing"]._pc.callback_time = 20
 
     def slow(x):
@@ -390,19 +390,19 @@ def test_balance_without_dependencies(c, s, *workers):
         return y
 
     futures = c.map(slow, range(100))
-    yield wait(futures)
+    await wait(futures)
 
     durations = [sum(w.data.values()) for w in workers]
     assert max(durations) / min(durations) < 3
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 4)] * 2)
-def test_dont_steal_executing_tasks(c, s, a, b):
+async def test_dont_steal_executing_tasks(c, s, a, b):
     futures = c.map(
         slowinc, range(4), delay=0.1, workers=a.address, allow_other_workers=True
     )
 
-    yield wait(futures)
+    await wait(futures)
     assert len(a.data) == 4
     assert len(b.data) == 0
 
@@ -412,14 +412,14 @@ def test_dont_steal_executing_tasks(c, s, a, b):
     nthreads=[("127.0.0.1", 1)] * 10,
     config={"distributed.scheduler.default-task-durations": {"slowidentity": 0.2}},
 )
-def test_dont_steal_few_saturated_tasks_many_workers(c, s, a, *rest):
+async def test_dont_steal_few_saturated_tasks_many_workers(c, s, a, *rest):
     s.extensions["stealing"]._pc.callback_time = 20
     x = c.submit(mul, b"0", 100000000, workers=a.address)  # 100 MB
-    yield wait(x)
+    await wait(x)
 
     futures = [c.submit(slowidentity, x, pure=False, delay=0.2) for i in range(2)]
 
-    yield wait(futures)
+    await wait(futures)
 
     assert len(a.data) == 3
     assert not any(w.task_state for w in rest)
@@ -431,16 +431,16 @@ def test_dont_steal_few_saturated_tasks_many_workers(c, s, a, *rest):
     worker_kwargs={"memory_limit": MEMORY_LIMIT},
     config={"distributed.scheduler.default-task-durations": {"slowidentity": 0.2}},
 )
-def test_steal_when_more_tasks(c, s, a, *rest):
+async def test_steal_when_more_tasks(c, s, a, *rest):
     s.extensions["stealing"]._pc.callback_time = 20
     x = c.submit(mul, b"0", 50000000, workers=a.address)  # 50 MB
-    yield wait(x)
+    await wait(x)
 
     futures = [c.submit(slowidentity, x, pure=False, delay=0.2) for i in range(20)]
 
     start = time()
     while not any(w.task_state for w in rest):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 1
 
 
@@ -454,20 +454,20 @@ def test_steal_when_more_tasks(c, s, a, *rest):
         }
     },
 )
-def test_steal_more_attractive_tasks(c, s, a, *rest):
+async def test_steal_more_attractive_tasks(c, s, a, *rest):
     def slow2(x):
         sleep(1)
         return x
 
     s.extensions["stealing"]._pc.callback_time = 20
     x = c.submit(mul, b"0", 100000000, workers=a.address)  # 100 MB
-    yield wait(x)
+    await wait(x)
 
     futures = [c.submit(slowidentity, x, pure=False, delay=0.2) for i in range(10)]
     future = c.submit(slow2, x, priority=-1)
 
     while not any(w.task_state for w in rest):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     # good future moves first
     assert any(future.key in w.task_state for w in rest)
@@ -477,7 +477,7 @@ def func(x):
     sleep(1)
 
 
-def assert_balanced(inp, expected, c, s, *workers):
+async def assert_balanced(inp, expected, c, s, *workers):
     steal = s.extensions["stealing"]
     steal._pc.stop()
 
@@ -489,7 +489,7 @@ def assert_balanced(inp, expected, c, s, *workers):
     for w, ts in zip(workers, inp):
         for t in sorted(ts, reverse=True):
             if t:
-                [dat] = yield c.scatter([next(data_seq)], workers=w.address)
+                [dat] = await c.scatter([next(data_seq)], workers=w.address)
                 ts = s.tasks[dat.key]
                 # Ensure scheduler state stays consistent
                 old_nbytes = ts.nbytes
@@ -511,13 +511,13 @@ def assert_balanced(inp, expected, c, s, *workers):
             futures.append(f)
 
     while len(s.rprocessing) < len(futures):
-        yield gen.sleep(0.001)
+        await gen.sleep(0.001)
 
     for i in range(10):
         steal.balance()
 
         while steal.in_flight:
-            yield gen.sleep(0.001)
+            await gen.sleep(0.001)
 
         result = [
             sorted([int(key_split(k)) for k in s.processing[w.address]], reverse=True)
@@ -584,18 +584,18 @@ def test_balance(inp, expected):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2, Worker=Nanny, timeout=20)
-def test_restart(c, s, a, b):
+async def test_restart(c, s, a, b):
     futures = c.map(
         slowinc, range(100), delay=0.1, workers=a.address, allow_other_workers=True
     )
     while not s.processing[b.worker_address]:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     steal = s.extensions["stealing"]
     assert any(st for st in steal.stealable_all)
     assert any(x for L in steal.stealable.values() for x in L)
 
-    yield c.restart(timeout=10)
+    await c.restart(timeout=10)
 
     assert not any(x for x in steal.stealable_all)
     assert not any(x for L in steal.stealable.values() for x in L)
@@ -605,7 +605,7 @@ def test_restart(c, s, a, b):
     client=True,
     config={"distributed.scheduler.default-task-durations": {"slowadd": 0.001}},
 )
-def test_steal_communication_heavy_tasks(c, s, a, b):
+async def test_steal_communication_heavy_tasks(c, s, a, b):
     steal = s.extensions["stealing"]
     x = c.submit(mul, b"0", int(s.bandwidth), workers=a.address)
     y = c.submit(mul, b"1", int(s.bandwidth), workers=b.address)
@@ -624,29 +624,29 @@ def test_steal_communication_heavy_tasks(c, s, a, b):
     ]
 
     while not any(f.key in s.rprocessing for f in futures):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     steal.balance()
     while steal.in_flight:
-        yield gen.sleep(0.001)
+        await gen.sleep(0.001)
 
     assert s.processing[b.address]
 
 
 @gen_cluster(client=True)
-def test_steal_twice(c, s, a, b):
+async def test_steal_twice(c, s, a, b):
     x = c.submit(inc, 1, workers=a.address)
-    yield wait(x)
+    await wait(x)
 
     futures = [c.submit(slowadd, x, i, delay=0.2) for i in range(100)]
 
     while len(s.tasks) < 100:  # tasks are all allocated
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     # Army of new workers arrives to help
-    workers = yield asyncio.gather(*[Worker(s.address, loop=s.loop) for _ in range(20)])
+    workers = await asyncio.gather(*[Worker(s.address, loop=s.loop) for _ in range(20)])
 
-    yield wait(futures)
+    await wait(futures)
 
     has_what = dict(s.has_what)  # take snapshot
     empty_workers = [w for w, keys in has_what.items() if not len(keys)]
@@ -657,42 +657,42 @@ def test_steal_twice(c, s, a, b):
         )
     assert max(map(len, has_what.values())) < 30
 
-    yield c._close()
-    yield asyncio.gather(*[w.close() for w in workers])
+    await c._close()
+    await asyncio.gather(*[w.close() for w in workers])
 
 
 @gen_cluster(client=True)
-def test_dont_steal_executing_tasks(c, s, a, b):
+async def test_dont_steal_executing_tasks(c, s, a, b):
     steal = s.extensions["stealing"]
 
     future = c.submit(slowinc, 1, delay=0.5, workers=a.address)
     while not a.executing:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     steal.move_task_request(
         s.tasks[future.key], s.workers[a.address], s.workers[b.address]
     )
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert future.key in a.executing
     assert not b.executing
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_dont_steal_long_running_tasks(c, s, a, b):
+async def test_dont_steal_long_running_tasks(c, s, a, b):
     def long(delay):
         with worker_client() as c:
             sleep(delay)
 
-    yield c.submit(long, 0.1)  # learn duration
-    yield c.submit(inc, 1)  # learn duration
+    await c.submit(long, 0.1)  # learn duration
+    await c.submit(inc, 1)  # learn duration
 
     long_tasks = c.map(long, [0.5, 0.6], workers=a.address, allow_other_workers=True)
     while sum(map(len, s.processing.values())) < 2:  # let them start
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     start = time()
     while any(t.key in s.extensions["stealing"].key_stealable for t in long_tasks):
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 1
 
     na = len(a.executing)
@@ -700,9 +700,9 @@ def test_dont_steal_long_running_tasks(c, s, a, b):
 
     incs = c.map(inc, range(100), workers=a.address, allow_other_workers=True)
 
-    yield gen.sleep(0.2)
+    await gen.sleep(0.2)
 
-    yield wait(long_tasks)
+    await wait(long_tasks)
 
     for t in long_tasks:
         assert (
@@ -717,19 +717,19 @@ def test_dont_steal_long_running_tasks(c, s, a, b):
     strict=False,
 )
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 5)] * 2)
-def test_cleanup_repeated_tasks(c, s, a, b):
+async def test_cleanup_repeated_tasks(c, s, a, b):
     class Foo:
         pass
 
     s.extensions["stealing"]._pc.callback_time = 20
-    yield c.submit(slowidentity, -1, delay=0.1)
+    await c.submit(slowidentity, -1, delay=0.1)
     objects = [c.submit(Foo, pure=False, workers=a.address) for _ in range(50)]
 
     x = c.map(
         slowidentity, objects, workers=a.address, allow_other_workers=True, delay=0.05
     )
     del objects
-    yield wait(x)
+    await wait(x)
     assert a.data and b.data
     assert len(a.data) + len(b.data) > 10
     ws = weakref.WeakSet()
@@ -739,7 +739,7 @@ def test_cleanup_repeated_tasks(c, s, a, b):
 
     start = time()
     while a.data or b.data:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 1
 
     assert not s.who_has
@@ -749,7 +749,7 @@ def test_cleanup_repeated_tasks(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_lose_task(c, s, a, b):
+async def test_lose_task(c, s, a, b):
     with captured_logger("distributed.stealing") as log:
         s.periodic_callbacks["stealing"].interval = 1
         for i in range(100):
@@ -761,7 +761,7 @@ def test_lose_task(c, s, a, b):
                 workers=a.address,
                 allow_other_workers=True,
             )
-            yield gen.sleep(0.01)
+            await gen.sleep(0.01)
             del futures
 
     out = log.getvalue()
@@ -769,7 +769,7 @@ def test_lose_task(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_worker_stealing_interval(c, s, a, b):
+async def test_worker_stealing_interval(c, s, a, b):
     from distributed.scheduler import WorkStealing
 
     ws = WorkStealing(s)

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1,3 +1,4 @@
+import asyncio
 import itertools
 import random
 import sys
@@ -643,7 +644,7 @@ def test_steal_twice(c, s, a, b):
         yield gen.sleep(0.01)
 
     # Army of new workers arrives to help
-    workers = yield [Worker(s.address, loop=s.loop) for _ in range(20)]
+    workers = yield asyncio.gather(*[Worker(s.address, loop=s.loop) for _ in range(20)])
 
     yield wait(futures)
 
@@ -657,7 +658,7 @@ def test_steal_twice(c, s, a, b):
     assert max(map(len, has_what.values())) < 30
 
     yield c._close()
-    yield [w.close() for w in workers]
+    yield asyncio.gather(*[w.close() for w in workers])
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -24,7 +24,6 @@ from distributed.utils_test import (
     slowinc,
 )
 from tlz import concat, sliding_window
-from tornado import gen
 
 # Most tests here are timing-dependent
 setup_module = nodebug_setup_module
@@ -205,7 +204,7 @@ async def test_new_worker_steals(c, s, a):
     futures = c.map(slowinc, range(100), delay=0.05)
     total = c.submit(sum, futures)
     while len(a.task_state) < 10:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     b = await Worker(s.address, loop=s.loop, nthreads=1, memory_limit=MEMORY_LIMIT)
 
@@ -247,14 +246,14 @@ async def test_dont_steal_worker_restrictions(c, s, a, b):
     futures = c.map(slowinc, range(100), delay=0.1, workers=a.address)
 
     while len(a.task_state) + len(b.task_state) < 100:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
     result = s.extensions["stealing"].balance()
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
 
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
@@ -271,7 +270,7 @@ async def test_steal_worker_restrictions(c, s, wa, wb, wc):
     futures = c.map(slowinc, range(ntasks), delay=0.1, workers={wa.address, wb.address})
 
     while sum(len(w.task_state) for w in [wa, wb, wc]) < ntasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert 0 < len(wa.task_state) < ntasks
     assert 0 < len(wb.task_state) < ntasks
@@ -279,7 +278,7 @@ async def test_steal_worker_restrictions(c, s, wa, wb, wc):
 
     s.extensions["stealing"].balance()
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
 
     assert 0 < len(wa.task_state) < ntasks
     assert 0 < len(wb.task_state) < ntasks
@@ -296,13 +295,13 @@ async def test_dont_steal_host_restrictions(c, s, a, b):
 
     futures = c.map(slowinc, range(100), delay=0.1, workers="127.0.0.1")
     while len(a.task_state) + len(b.task_state) < 100:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
     result = s.extensions["stealing"].balance()
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
@@ -318,7 +317,7 @@ async def test_steal_host_restrictions(c, s, wa, wb):
     ntasks = 100
     futures = c.map(slowinc, range(ntasks), delay=0.1, workers="127.0.0.1")
     while len(wa.task_state) < ntasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
     assert len(wa.task_state) == ntasks
     assert len(wb.task_state) == 0
 
@@ -326,10 +325,10 @@ async def test_steal_host_restrictions(c, s, wa, wb):
 
     start = time()
     while not wc.task_state or len(wa.task_state) == ntasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 3
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     assert 0 < len(wa.task_state) < ntasks
     assert len(wb.task_state) == 0
     assert 0 < len(wc.task_state) < ntasks
@@ -344,13 +343,13 @@ async def test_dont_steal_resource_restrictions(c, s, a, b):
 
     futures = c.map(slowinc, range(100), delay=0.1, resources={"A": 1})
     while len(a.task_state) + len(b.task_state) < 100:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
     result = s.extensions["stealing"].balance()
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     assert len(a.task_state) == 100
     assert len(b.task_state) == 0
 
@@ -364,14 +363,14 @@ async def test_steal_resource_restrictions(c, s, a):
 
     futures = c.map(slowinc, range(100), delay=0.2, resources={"A": 1})
     while len(a.task_state) < 101:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
     assert len(a.task_state) == 101
 
     b = await Worker(s.address, loop=s.loop, nthreads=1, resources={"A": 4})
 
     start = time()
     while not b.task_state or len(a.task_state) == 101:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 3
 
     assert len(b.task_state) > 0
@@ -440,7 +439,7 @@ async def test_steal_when_more_tasks(c, s, a, *rest):
 
     start = time()
     while not any(w.task_state for w in rest):
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 1
 
 
@@ -467,7 +466,7 @@ async def test_steal_more_attractive_tasks(c, s, a, *rest):
     future = c.submit(slow2, x, priority=-1)
 
     while not any(w.task_state for w in rest):
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     # good future moves first
     assert any(future.key in w.task_state for w in rest)
@@ -511,13 +510,13 @@ async def assert_balanced(inp, expected, c, s, *workers):
             futures.append(f)
 
     while len(s.rprocessing) < len(futures):
-        await gen.sleep(0.001)
+        await asyncio.sleep(0.001)
 
     for i in range(10):
         steal.balance()
 
         while steal.in_flight:
-            await gen.sleep(0.001)
+            await asyncio.sleep(0.001)
 
         result = [
             sorted([int(key_split(k)) for k in s.processing[w.address]], reverse=True)
@@ -589,7 +588,7 @@ async def test_restart(c, s, a, b):
         slowinc, range(100), delay=0.1, workers=a.address, allow_other_workers=True
     )
     while not s.processing[b.worker_address]:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     steal = s.extensions["stealing"]
     assert any(st for st in steal.stealable_all)
@@ -624,11 +623,11 @@ async def test_steal_communication_heavy_tasks(c, s, a, b):
     ]
 
     while not any(f.key in s.rprocessing for f in futures):
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     steal.balance()
     while steal.in_flight:
-        await gen.sleep(0.001)
+        await asyncio.sleep(0.001)
 
     assert s.processing[b.address]
 
@@ -641,7 +640,7 @@ async def test_steal_twice(c, s, a, b):
     futures = [c.submit(slowadd, x, i, delay=0.2) for i in range(100)]
 
     while len(s.tasks) < 100:  # tasks are all allocated
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     # Army of new workers arrives to help
     workers = await asyncio.gather(*[Worker(s.address, loop=s.loop) for _ in range(20)])
@@ -667,12 +666,12 @@ async def test_dont_steal_executing_tasks(c, s, a, b):
 
     future = c.submit(slowinc, 1, delay=0.5, workers=a.address)
     while not a.executing:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     steal.move_task_request(
         s.tasks[future.key], s.workers[a.address], s.workers[b.address]
     )
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     assert future.key in a.executing
     assert not b.executing
 
@@ -688,11 +687,11 @@ async def test_dont_steal_long_running_tasks(c, s, a, b):
 
     long_tasks = c.map(long, [0.5, 0.6], workers=a.address, allow_other_workers=True)
     while sum(map(len, s.processing.values())) < 2:  # let them start
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     start = time()
     while any(t.key in s.extensions["stealing"].key_stealable for t in long_tasks):
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 1
 
     na = len(a.executing)
@@ -700,7 +699,7 @@ async def test_dont_steal_long_running_tasks(c, s, a, b):
 
     incs = c.map(inc, range(100), workers=a.address, allow_other_workers=True)
 
-    await gen.sleep(0.2)
+    await asyncio.sleep(0.2)
 
     await wait(long_tasks)
 
@@ -739,7 +738,7 @@ async def test_cleanup_repeated_tasks(c, s, a, b):
 
     start = time()
     while a.data or b.data:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 1
 
     assert not s.who_has
@@ -761,7 +760,7 @@ async def test_lose_task(c, s, a, b):
                 workers=a.address,
                 allow_other_workers=True,
             )
-            await gen.sleep(0.01)
+            await asyncio.sleep(0.01)
             del futures
 
     out = log.getvalue()

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -569,7 +569,9 @@ async def assert_balanced(inp, expected, c, s, *workers):
     ],
 )
 def test_balance(inp, expected):
-    test = lambda *args, **kwargs: assert_balanced(inp, expected, *args, **kwargs)
+    async def test(*args, **kwargs):
+        await assert_balanced(inp, expected, *args, **kwargs)
+
     test = gen_cluster(
         client=True,
         nthreads=[("127.0.0.1", 1)] * len(inp),

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -101,7 +101,6 @@ def test_stress_creation_and_deletion(c, s):
 
     z = c.persist(y)
 
-    @gen.coroutine
     def create_and_destroy_worker(delay):
         start = time()
         while time() < start + 5:

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -36,14 +36,14 @@ teardown_module = nodebug_teardown_module
 
 
 @gen_cluster(client=True)
-def test_stress_1(c, s, a, b):
+async def test_stress_1(c, s, a, b):
     n = 2 ** 6
 
     seq = c.map(inc, range(n))
     while len(seq) > 1:
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         seq = [c.submit(add, seq[i], seq[i + 1]) for i in range(0, len(seq), 2)]
-    result = yield seq[0]
+    result = await seq[0]
     assert result == sum(map(inc, range(n)))
 
 
@@ -62,18 +62,18 @@ def test_stress_gc(loop, func, n):
     sys.platform.startswith("win"), reason="test can leave dangling RPC objects"
 )
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 8, timeout=None)
-def test_cancel_stress(c, s, *workers):
+async def test_cancel_stress(c, s, *workers):
     da = pytest.importorskip("dask.array")
     x = da.random.random((50, 50), chunks=(2, 2))
     x = c.persist(x)
-    yield wait([x])
+    await wait([x])
     y = (x.sum(axis=0) + x.sum(axis=1) + 1).std()
     n_todo = len(y.dask) - len(x.dask)
     for i in range(5):
         f = c.compute(y)
         while len(s.waiting) > (random.random() + 1) * 0.5 * n_todo:
-            yield gen.sleep(0.01)
-        yield c._cancel(f)
+            await gen.sleep(0.01)
+        await c._cancel(f)
 
 
 def test_cancel_stress_sync(loop):
@@ -91,7 +91,7 @@ def test_cancel_stress_sync(loop):
 
 
 @gen_cluster(nthreads=[], client=True, timeout=None)
-def test_stress_creation_and_deletion(c, s):
+async def test_stress_creation_and_deletion(c, s):
     # Assertions are handled by the validate mechanism in the scheduler
     s.allowed_failures = 100000
     da = pytest.importorskip("dask.array")
@@ -101,27 +101,27 @@ def test_stress_creation_and_deletion(c, s):
 
     z = c.persist(y)
 
-    def create_and_destroy_worker(delay):
+    async def create_and_destroy_worker(delay):
         start = time()
         while time() < start + 5:
-            n = yield Nanny(s.address, nthreads=2, loop=s.loop)
-            yield gen.sleep(delay)
-            yield n.close()
+            n = await Nanny(s.address, nthreads=2, loop=s.loop)
+            await gen.sleep(delay)
+            await n.close()
             print("Killed nanny")
 
-    yield asyncio.wait_for(
+    await asyncio.wait_for(
         All([create_and_destroy_worker(0.1 * i) for i in range(20)]), 60
     )
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)] * 10, client=True, timeout=60)
-def test_stress_scatter_death(c, s, *workers):
+async def test_stress_scatter_death(c, s, *workers):
     import random
 
     s.allowed_failures = 1000
     np = pytest.importorskip("numpy")
-    L = yield c.scatter([np.random.random(10000) for i in range(len(workers))])
-    yield c.replicate(L, n=2)
+    L = await c.scatter([np.random.random(10000) for i in range(len(workers))])
+    await c.replicate(L, n=2)
 
     adds = [
         delayed(slowadd, pure=True)(
@@ -146,7 +146,7 @@ def test_stress_scatter_death(c, s, *workers):
     from distributed.scheduler import logger
 
     for i in range(7):
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         try:
             s.validate_state()
         except Exception as c:
@@ -158,11 +158,11 @@ def test_stress_scatter_death(c, s, *workers):
             else:
                 raise
         w = random.choice(alive)
-        yield w.close()
+        await w.close()
         alive.remove(w)
 
     with ignoring(CancelledError):
-        yield c.gather(futures)
+        await c.gather(futures)
 
     futures = None
 
@@ -174,7 +174,7 @@ def vsum(*args):
 @pytest.mark.avoid_travis
 @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 80, timeout=1000)
-def test_stress_communication(c, s, *workers):
+async def test_stress_communication(c, s, *workers):
     s.validate = False  # very slow otherwise
     da = pytest.importorskip("dask.array")
     # Test consumes many file descriptors and can hang if the limit is too low
@@ -188,13 +188,13 @@ def test_stress_communication(c, s, *workers):
 
     future = c.compute(z.sum())
 
-    result = yield future
+    result = await future
     assert isinstance(result, float)
 
 
 @pytest.mark.skip
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10, timeout=60)
-def test_stress_steal(c, s, *workers):
+async def test_stress_steal(c, s, *workers):
     s.validate = False
     for w in workers:
         w.validate = False
@@ -208,7 +208,7 @@ def test_stress_steal(c, s, *workers):
     future = c.compute(total)
 
     while future.status != "finished":
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         for i in range(3):
             a = random.choice(workers)
             b = random.choice(workers)
@@ -220,7 +220,7 @@ def test_stress_steal(c, s, *workers):
 
 @pytest.mark.slow
 @gen_cluster(nthreads=[("127.0.0.1", 1)] * 10, client=True, timeout=120)
-def test_close_connections(c, s, *workers):
+async def test_close_connections(c, s, *workers):
     da = pytest.importorskip("dask.array")
     x = da.random.random(size=(1000, 1000), chunks=(1000, 1))
     for i in range(3):
@@ -229,7 +229,7 @@ def test_close_connections(c, s, *workers):
 
     future = c.compute(x.sum())
     while any(s.processing.values()):
-        yield gen.sleep(0.5)
+        await gen.sleep(0.5)
         worker = random.choice(list(workers))
         for comm in worker._comms:
             comm.abort()
@@ -237,7 +237,7 @@ def test_close_connections(c, s, *workers):
         # for w in workers:
         #     print(w)
 
-    yield wait(future)
+    await wait(future)
 
 
 @pytest.mark.xfail(
@@ -245,7 +245,7 @@ def test_close_connections(c, s, *workers):
     " https://github.com/tornadoweb/tornado/issues/2110"
 )
 @gen_cluster(client=True, timeout=20, nthreads=[("127.0.0.1", 1)])
-def test_no_delay_during_large_transfer(c, s, w):
+async def test_no_delay_during_large_transfer(c, s, w):
     pytest.importorskip("crick")
     np = pytest.importorskip("numpy")
     x = np.random.random(100000000)
@@ -262,8 +262,8 @@ def test_no_delay_during_large_transfer(c, s, w):
         server._last_tick = time()
 
     with ResourceProfiler(dt=0.01) as rprof:
-        future = yield c.scatter(x, direct=True, hash=False)
-        yield gen.sleep(0.5)
+        future = await c.scatter(x, direct=True, hash=False)
+        await gen.sleep(0.5)
 
     rprof.close()
     x = None  # lose ref

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -12,7 +12,7 @@ from distributed.utils_test import gen_tls_cluster, inc, double, slowinc, slowad
 
 
 @gen_tls_cluster(client=True)
-def test_basic(c, s, a, b):
+async def test_basic(c, s, a, b):
     pass
 
 

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -2,7 +2,7 @@
 Various functional tests for TLS networking.
 Most are taken from other test files and adapted.
 """
-from tornado import gen
+import asyncio
 
 from distributed import Nanny, worker_client, Queue
 from distributed.client import wait
@@ -106,7 +106,7 @@ async def test_rebalance(c, s, a, b):
 async def test_work_stealing(c, s, a, b):
     [x] = await c._scatter([1], workers=a.address)
     futures = c.map(slowadd, range(50), [x] * 50, delay=0.1)
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     await wait(futures)
     assert len(a.data) > 10
     assert len(b.data) > 10
@@ -170,5 +170,5 @@ async def test_retire_workers(c, s, a, b):
 
     start = time()
     while a.status != "closed":
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 5

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -45,7 +45,7 @@ def test_client_submit(c, s, a, b):
     yy = [c.submit(slowinc, i) for i in range(10)]
     results = []
     for y in yy:
-        results.append((yield y))
+        results.append(yield y)
     assert results == list(range(1, 11))
 
 

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -17,67 +17,67 @@ def test_basic(c, s, a, b):
 
 
 @gen_tls_cluster(client=True)
-def test_Queue(c, s, a, b):
+async def test_Queue(c, s, a, b):
     assert s.address.startswith("tls://")
 
-    x = yield Queue("x")
-    y = yield Queue("y")
+    x = await Queue("x")
+    y = await Queue("y")
 
-    size = yield x.qsize()
+    size = await x.qsize()
     assert size == 0
 
     future = c.submit(inc, 1)
 
-    yield x.put(future)
+    await x.put(future)
 
-    future2 = yield x.get()
+    future2 = await x.get()
     assert future.key == future2.key
 
 
 @gen_tls_cluster(client=True, timeout=None)
-def test_client_submit(c, s, a, b):
+async def test_client_submit(c, s, a, b):
     assert s.address.startswith("tls://")
 
     x = c.submit(inc, 10)
-    result = yield x
+    result = await x
     assert result == 11
 
     yy = [c.submit(slowinc, i) for i in range(10)]
     results = []
     for y in yy:
-        results.append(yield y)
+        results.append(await y)
     assert results == list(range(1, 11))
 
 
 @gen_tls_cluster(client=True)
-def test_gather(c, s, a, b):
+async def test_gather(c, s, a, b):
     assert s.address.startswith("tls://")
 
     x = c.submit(inc, 10)
     y = c.submit(inc, x)
 
-    result = yield c._gather(x)
+    result = await c._gather(x)
     assert result == 11
-    result = yield c._gather([x])
+    result = await c._gather([x])
     assert result == [11]
-    result = yield c._gather({"x": x, "y": [y]})
+    result = await c._gather({"x": x, "y": [y]})
     assert result == {"x": 11, "y": [12]}
 
 
 @gen_tls_cluster(client=True)
-def test_scatter(c, s, a, b):
+async def test_scatter(c, s, a, b):
     assert s.address.startswith("tls://")
 
-    d = yield c._scatter({"y": 20})
+    d = await c._scatter({"y": 20})
     ts = s.tasks["y"]
     assert ts.who_has
     assert ts.nbytes > 0
-    yy = yield c._gather([d["y"]])
+    yy = await c._gather([d["y"]])
     assert yy == [20]
 
 
 @gen_tls_cluster(client=True, Worker=Nanny)
-def test_nanny(c, s, a, b):
+async def test_nanny(c, s, a, b):
     assert s.address.startswith("tls://")
     for n in [a, b]:
         assert isinstance(n, Nanny)
@@ -86,34 +86,34 @@ def test_nanny(c, s, a, b):
     assert s.nthreads == {n.worker_address: n.nthreads for n in [a, b]}
 
     x = c.submit(inc, 10)
-    result = yield x
+    result = await x
     assert result == 11
 
 
 @gen_tls_cluster(client=True)
-def test_rebalance(c, s, a, b):
-    x, y = yield c._scatter([1, 2], workers=[a.address])
+async def test_rebalance(c, s, a, b):
+    x, y = await c._scatter([1, 2], workers=[a.address])
     assert len(a.data) == 2
     assert len(b.data) == 0
 
-    yield c._rebalance()
+    await c._rebalance()
 
     assert len(a.data) == 1
     assert len(b.data) == 1
 
 
 @gen_tls_cluster(client=True, nthreads=[("tls://127.0.0.1", 2)] * 2)
-def test_work_stealing(c, s, a, b):
-    [x] = yield c._scatter([1], workers=a.address)
+async def test_work_stealing(c, s, a, b):
+    [x] = await c._scatter([1], workers=a.address)
     futures = c.map(slowadd, range(50), [x] * 50, delay=0.1)
-    yield gen.sleep(0.1)
-    yield wait(futures)
+    await gen.sleep(0.1)
+    await wait(futures)
     assert len(a.data) > 10
     assert len(b.data) > 10
 
 
 @gen_tls_cluster(client=True)
-def test_worker_client(c, s, a, b):
+async def test_worker_client(c, s, a, b):
     def func(x):
         with worker_client() as c:
             x = c.submit(inc, x)
@@ -122,14 +122,14 @@ def test_worker_client(c, s, a, b):
             return result
 
     x, y = c.map(func, [10, 20])
-    xx, yy = yield c._gather([x, y])
+    xx, yy = await c._gather([x, y])
 
     assert xx == 10 + 1 + (10 + 1) * 2
     assert yy == 20 + 1 + (20 + 1) * 2
 
 
 @gen_tls_cluster(client=True, nthreads=[("tls://127.0.0.1", 1)] * 2)
-def test_worker_client_gather(c, s, a, b):
+async def test_worker_client_gather(c, s, a, b):
     a_address = a.address
     b_address = b.address
     assert a_address.startswith("tls://")
@@ -145,30 +145,30 @@ def test_worker_client_gather(c, s, a, b):
         return xx, yy
 
     future = c.submit(func)
-    result = yield future
+    result = await future
 
     assert result == (2, 3)
 
 
 @gen_tls_cluster(client=True)
-def test_worker_client_executor(c, s, a, b):
+async def test_worker_client_executor(c, s, a, b):
     def mysum():
         with worker_client() as c:
             with c.get_executor() as e:
                 return sum(e.map(double, range(30)))
 
     future = c.submit(mysum)
-    result = yield future
+    result = await future
     assert result == 30 * 29
 
 
 @gen_tls_cluster(client=True, Worker=Nanny)
-def test_retire_workers(c, s, a, b):
+async def test_retire_workers(c, s, a, b):
     assert set(s.workers) == {a.worker_address, b.worker_address}
-    yield c.retire_workers(workers=[a.worker_address], close_workers=True)
+    await c.retire_workers(workers=[a.worker_address], close_workers=True)
     assert set(s.workers) == {b.worker_address}
 
     start = time()
     while a.status != "closed":
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import array
 import datetime
 from functools import partial
@@ -11,7 +12,6 @@ import traceback
 
 import numpy as np
 import pytest
-from tornado import gen
 from tornado.ioloop import IOLoop
 
 import dask
@@ -55,7 +55,7 @@ def test_All(loop):
         1 / 0
 
     async def slow():
-        await gen.sleep(10)
+        await asyncio.sleep(10)
 
     async def inc(x):
         return x + 1
@@ -107,7 +107,7 @@ def test_sync_error(loop_in_thread):
 def test_sync_timeout(loop_in_thread):
     loop = loop_in_thread
     with pytest.raises(TimeoutError):
-        sync(loop_in_thread, gen.sleep, 0.5, callback_timeout=0.05)
+        sync(loop_in_thread, asyncio.sleep, 0.5, callback_timeout=0.05)
 
 
 def test_sync_closed_loop():
@@ -483,13 +483,13 @@ async def test_loop_runner_gen():
     runner = LoopRunner(asynchronous=True)
     assert runner.loop is IOLoop.current()
     assert not runner.is_started()
-    await gen.sleep(0.01)
+    await asyncio.sleep(0.01)
     runner.start()
     assert runner.is_started()
-    await gen.sleep(0.01)
+    await asyncio.sleep(0.01)
     runner.stop()
     assert not runner.is_started()
-    await gen.sleep(0.01)
+    await asyncio.sleep(0.01)
 
 
 def test_parse_bytes():
@@ -545,7 +545,7 @@ async def test_all_exceptions_logging():
         import gc
 
         gc.collect()
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
 
     assert "foo1234" not in sio.getvalue()
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -51,21 +51,16 @@ from distributed.utils_test import div, has_ipv6, inc, throws, gen_test, capture
 
 
 def test_All(loop):
-    @gen.coroutine
     def throws():
         1 / 0
 
-    @gen.coroutine
     def slow():
         yield gen.sleep(10)
 
-    @gen.coroutine
     def inc(x):
-        raise gen.Return(x + 1)
+        return x + 1
 
-    @gen.coroutine
     def f():
-
         results = yield All([inc(i) for i in range(10)])
         assert results == list(range(1, 11))
 
@@ -538,7 +533,6 @@ def test_parse_timedelta():
 
 @gen_test()
 def test_all_exceptions_logging():
-    @gen.coroutine
     def throws():
         raise Exception("foo1234")
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -51,23 +51,23 @@ from distributed.utils_test import div, has_ipv6, inc, throws, gen_test, capture
 
 
 def test_All(loop):
-    def throws():
+    async def throws():
         1 / 0
 
-    def slow():
-        yield gen.sleep(10)
+    async def slow():
+        await gen.sleep(10)
 
-    def inc(x):
+    async def inc(x):
         return x + 1
 
-    def f():
-        results = yield All([inc(i) for i in range(10)])
+    async def f():
+        results = await All([inc(i) for i in range(10)])
         assert results == list(range(1, 11))
 
         start = time()
         for tasks in [[throws(), slow()], [slow(), throws()]]:
             try:
-                yield All(tasks)
+                await All(tasks)
                 assert False
             except ZeroDivisionError:
                 pass
@@ -479,17 +479,17 @@ def test_two_loop_runners(loop_in_thread):
 
 
 @gen_test()
-def test_loop_runner_gen():
+async def test_loop_runner_gen():
     runner = LoopRunner(asynchronous=True)
     assert runner.loop is IOLoop.current()
     assert not runner.is_started()
-    yield gen.sleep(0.01)
+    await gen.sleep(0.01)
     runner.start()
     assert runner.is_started()
-    yield gen.sleep(0.01)
+    await gen.sleep(0.01)
     runner.stop()
     assert not runner.is_started()
-    yield gen.sleep(0.01)
+    await gen.sleep(0.01)
 
 
 def test_parse_bytes():
@@ -532,20 +532,20 @@ def test_parse_timedelta():
 
 
 @gen_test()
-def test_all_exceptions_logging():
-    def throws():
+async def test_all_exceptions_logging():
+    async def throws():
         raise Exception("foo1234")
 
     with captured_logger("") as sio:
         try:
-            yield All([throws() for _ in range(5)], quiet_exceptions=Exception)
+            await All([throws() for _ in range(5)], quiet_exceptions=Exception)
         except Exception:
             pass
 
         import gc
 
         gc.collect()
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
 
     assert "foo1234" not in sio.getvalue()
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -155,7 +155,7 @@ def test_new_config():
 def test_lingering_client():
     @gen_cluster()
     def f(s, a, b):
-        c = yield Client(s.address, asynchronous=True)
+        yield Client(s.address, asynchronous=True)
 
     f()
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -58,9 +58,9 @@ def test_gen_cluster_cleans_up_client(loop):
     assert not dask.config.get("get", None)
 
     @gen_cluster(client=True)
-    def f(c, s, a, b):
+    async def f(c, s, a, b):
         assert dask.config.get("get", None)
-        yield c.submit(inc, 1)
+        await c.submit(inc, 1)
 
     f()
 
@@ -92,8 +92,8 @@ def test_gen_cluster_tls(e, s, a, b):
 
 
 @gen_test()
-def test_gen_test():
-    yield gen.sleep(0.01)
+async def test_gen_test():
+    await gen.sleep(0.01)
 
 
 @contextmanager
@@ -154,8 +154,8 @@ def test_new_config():
 
 def test_lingering_client():
     @gen_cluster()
-    def f(s, a, b):
-        yield Client(s.address, asynchronous=True)
+    async def f(s, a, b):
+        await Client(s.address, asynchronous=True)
 
     f()
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1,10 +1,10 @@
+import asyncio
 from contextlib import contextmanager
 import socket
 import threading
 from time import sleep
 
 import pytest
-from tornado import gen
 
 from distributed import Scheduler, Worker, Client, config, default_client
 from distributed.core import rpc
@@ -93,7 +93,7 @@ def test_gen_cluster_tls(e, s, a, b):
 
 @gen_test()
 async def test_gen_test():
-    await gen.sleep(0.01)
+    await asyncio.sleep(0.01)
 
 
 @contextmanager
@@ -189,4 +189,4 @@ async def test_gen_cluster_async(s, a, b):  # flake8: noqa
 
 @gen_test()
 async def test_gen_test_async():  # flake8: noqa
-    await gen.sleep(0.001)
+    await asyncio.sleep(0.001)

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -1,7 +1,6 @@
 import asyncio
 import random
 from time import sleep
-import sys
 import logging
 
 import pytest
@@ -174,7 +173,6 @@ def test_timeout_get(c, s, a, b):
     assert result == 1
 
 
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="Multi-client issues")
 @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
 def test_race(c, s, *workers):

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -4,7 +4,6 @@ from time import sleep
 import logging
 
 import pytest
-from tornado import gen
 from tornado.ioloop import IOLoop
 
 from distributed import Client, Variable, worker_client, Nanny, wait, TimeoutError
@@ -29,14 +28,14 @@ async def test_variable(c, s, a, b):
 
     del future, future2
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     assert s.tasks  # future still present
 
     x.delete()
 
     start = time()
     while s.tasks:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() < start + 5
 
 
@@ -82,7 +81,7 @@ async def test_hold_futures(s, a, b):
     del x1
     await c1.close()
 
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
 
     c2 = await Client(s.address, asynchronous=True)
     x2 = Variable("x")
@@ -138,10 +137,10 @@ async def test_cleanup(c, s, a, b):
 
     await v.set(x)
     del x
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
 
     t_future = xx = asyncio.ensure_future(vv._get())
-    await gen.sleep(0)
+    await asyncio.sleep(0)
     asyncio.ensure_future(v.set(y))
 
     future = await t_future
@@ -201,7 +200,7 @@ async def test_race(c, s, *workers):
 
     start = time()
     while len(s.wants_what["variable-x"]) != 1:
-        await gen.sleep(0.01)
+        await asyncio.sleep(0.01)
         assert time() - start < 2
 
 
@@ -233,7 +232,7 @@ async def test_Future_knows_status_immediately(c, s, a, b):
             break
         except Exception:
             assert time() < start + 5
-            await gen.sleep(0.05)
+            await asyncio.sleep(0.05)
 
     await c2.close()
 
@@ -243,7 +242,7 @@ async def test_erred_future(c, s, a, b):
     future = c.submit(div, 1, 0)
     var = Variable()
     await var.set(future)
-    await gen.sleep(0.1)
+    await asyncio.sleep(0.1)
     future2 = await var.get()
     with pytest.raises(ZeroDivisionError):
         await future2.result()

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -16,27 +16,27 @@ from distributed.utils_test import captured_logger
 
 
 @gen_cluster(client=True)
-def test_variable(c, s, a, b):
+async def test_variable(c, s, a, b):
     x = Variable("x")
     xx = Variable("x")
     assert x.client is c
 
     future = c.submit(inc, 1)
 
-    yield x.set(future)
-    future2 = yield xx.get()
+    await x.set(future)
+    future2 = await xx.get()
     assert future.key == future2.key
 
     del future, future2
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert s.tasks  # future still present
 
     x.delete()
 
     start = time()
     while s.tasks:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
@@ -52,13 +52,13 @@ async def test_delete_unset_variable(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_queue_with_data(c, s, a, b):
+async def test_queue_with_data(c, s, a, b):
     x = Variable("x")
     xx = Variable("x")
     assert x.client is c
 
-    yield x.set((1, "hello"))
-    data = yield xx.get()
+    await x.set((1, "hello"))
+    data = await xx.get()
 
     assert data == (1, "hello")
 
@@ -74,32 +74,32 @@ def test_sync(client):
 
 
 @gen_cluster()
-def test_hold_futures(s, a, b):
-    c1 = yield Client(s.address, asynchronous=True)
+async def test_hold_futures(s, a, b):
+    c1 = await Client(s.address, asynchronous=True)
     future = c1.submit(lambda x: x + 1, 10)
     x1 = Variable("x")
-    yield x1.set(future)
+    await x1.set(future)
     del x1
-    yield c1.close()
+    await c1.close()
 
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
-    c2 = yield Client(s.address, asynchronous=True)
+    c2 = await Client(s.address, asynchronous=True)
     x2 = Variable("x")
-    future2 = yield x2.get()
-    result = yield future2
+    future2 = await x2.get()
+    result = await future2
 
     assert result == 11
-    yield c2.close()
+    await c2.close()
 
 
 @gen_cluster(client=True)
-def test_timeout(c, s, a, b):
+async def test_timeout(c, s, a, b):
     v = Variable("v")
 
     start = IOLoop.current().time()
     with pytest.raises(TimeoutError):
-        yield v.get(timeout=0.2)
+        await v.get(timeout=0.2)
     stop = IOLoop.current().time()
 
     if WINDOWS:  # timing is weird with asyncio and Windows
@@ -108,7 +108,7 @@ def test_timeout(c, s, a, b):
         assert 0.2 < stop - start < 2.0
 
     with pytest.raises(TimeoutError):
-        yield v.get(timeout=0.01)
+        await v.get(timeout=0.01)
 
 
 def test_timeout_sync(client):
@@ -161,21 +161,21 @@ def test_pickleable(client):
 
 
 @gen_cluster(client=True)
-def test_timeout_get(c, s, a, b):
+async def test_timeout_get(c, s, a, b):
     v = Variable("v")
 
     tornado_future = v.get()
 
     vv = Variable("v")
-    yield vv.set(1)
+    await vv.set(1)
 
-    result = yield tornado_future
+    result = await tornado_future
     assert result == 1
 
 
 @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 2)] * 5, Worker=Nanny, timeout=None)
-def test_race(c, s, *workers):
+async def test_race(c, s, *workers):
     NITERS = 50
 
     def f(i):
@@ -192,63 +192,63 @@ def test_race(c, s, *workers):
             return result
 
     v = Variable("x", client=c)
-    x = yield c.scatter(1)
-    yield v.set(x)
+    x = await c.scatter(1)
+    await v.set(x)
 
     futures = c.map(f, range(15))
-    results = yield c.gather(futures)
+    results = await c.gather(futures)
     assert all(r > NITERS * 0.8 for r in results)
 
     start = time()
     while len(s.wants_what["variable-x"]) != 1:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() - start < 2
 
 
 @gen_cluster(client=True)
-def test_Future_knows_status_immediately(c, s, a, b):
-    x = yield c.scatter(123)
+async def test_Future_knows_status_immediately(c, s, a, b):
+    x = await c.scatter(123)
     v = Variable("x")
-    yield v.set(x)
+    await v.set(x)
 
-    c2 = yield Client(s.address, asynchronous=True)
+    c2 = await Client(s.address, asynchronous=True)
     v2 = Variable("x", client=c2)
-    future = yield v2.get()
+    future = await v2.get()
     assert future.status == "finished"
 
     x = c.submit(div, 1, 0)
-    yield wait(x)
-    yield v.set(x)
+    await wait(x)
+    await v.set(x)
 
-    future2 = yield v2.get()
+    future2 = await v2.get()
     assert future2.status == "error"
     with pytest.raises(Exception):
-        yield future2
+        await future2
 
     start = time()
     while True:  # we learn about the true error eventually
         try:
-            yield future2
+            await future2
         except ZeroDivisionError:
             break
         except Exception:
             assert time() < start + 5
-            yield gen.sleep(0.05)
+            await gen.sleep(0.05)
 
-    yield c2.close()
+    await c2.close()
 
 
 @gen_cluster(client=True)
-def test_erred_future(c, s, a, b):
+async def test_erred_future(c, s, a, b):
     future = c.submit(div, 1, 0)
     var = Variable()
-    yield var.set(future)
-    yield gen.sleep(0.1)
-    future2 = yield var.get()
+    await var.set(future)
+    await gen.sleep(0.1)
+    future2 = await var.get()
     with pytest.raises(ZeroDivisionError):
-        yield future2.result()
+        await future2.result()
 
-    exc = yield future2.exception()
+    exc = await future2.exception()
     assert isinstance(exc, ZeroDivisionError)
 
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -837,7 +837,7 @@ def test_worker_dir(worker):
     with tmpfile() as fn:
 
         @gen_cluster(client=True, worker_kwargs={"local_directory": fn})
-        def test_worker_dir(c, s, a, b):
+        async def test_worker_dir(c, s, a, b):
             directories = [w.local_directory for w in s.workers.values()]
             assert all(d.startswith(fn) for d in directories)
             assert len(set(directories)) == 2  # distinct
@@ -1244,7 +1244,7 @@ async def test_avoid_memory_monitor_if_zero_limit(c, s):
         "distributed.worker.memory.target": False,
     },
 )
-def test_dict_data_if_no_spill_to_disk(s, w):
+async def test_dict_data_if_no_spill_to_disk(s, w):
     assert type(w.data) is dict
 
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -63,7 +63,7 @@ async def test_worker_nthreads(cleanup):
 
 
 @gen_cluster()
-def test_str(s, a, b):
+async def test_str(s, a, b):
     assert a.address in str(a)
     assert a.address in repr(a)
     assert str(a.nthreads) in str(a)
@@ -83,7 +83,7 @@ async def test_identity(cleanup):
 
 
 @gen_cluster(client=True)
-def test_worker_bad_args(c, s, a, b):
+async def test_worker_bad_args(c, s, a, b):
     class NoReprObj:
         """ This object cannot be properly represented as a string. """
 
@@ -94,7 +94,7 @@ def test_worker_bad_args(c, s, a, b):
             raise ValueError("I have no repr representation.")
 
     x = c.submit(NoReprObj, workers=a.address)
-    yield wait(x)
+    await wait(x)
     assert not a.executing
     assert a.data
 
@@ -125,16 +125,16 @@ def test_worker_bad_args(c, s, a, b):
     logger.setLevel(logging.DEBUG)
     logger.addHandler(hdlr)
     y = c.submit(bad_func, x, k=x, workers=b.address)
-    yield wait(y)
+    await wait(y)
 
     assert not b.executing
     assert y.status == "error"
     # Make sure job died because of bad func and not because of bad
     # argument.
     with pytest.raises(ZeroDivisionError):
-        yield y
+        await y
 
-    tb = yield y._traceback()
+    tb = await y._traceback()
     assert any("1 / 0" in line for line in pluck(3, traceback.extract_tb(tb)) if line)
     assert "Compute Failed" in hdlr.messages["warning"][0]
     logger.setLevel(old_level)
@@ -144,14 +144,14 @@ def test_worker_bad_args(c, s, a, b):
     xx = c.submit(add, 1, 2, workers=a.address)
     yy = c.submit(add, 3, 4, workers=b.address)
 
-    results = yield c._gather([xx, yy])
+    results = await c._gather([xx, yy])
 
     assert tuple(results) == (3, 7)
 
 
 @pytest.mark.slow
 @gen_cluster()
-def dont_test_delete_data_with_missing_worker(c, a, b):
+async def dont_test_delete_data_with_missing_worker(c, a, b):
     bad = "127.0.0.1:9001"  # this worker doesn't exist
     c.who_has["z"].add(bad)
     c.who_has["z"].add(a.address)
@@ -161,23 +161,23 @@ def dont_test_delete_data_with_missing_worker(c, a, b):
 
     cc = rpc(ip=c.ip, port=c.port)
 
-    yield cc.delete_data(keys=["z"])  # TODO: this hangs for a while
+    await cc.delete_data(keys=["z"])  # TODO: this hangs for a while
     assert "z" not in a.data
     assert not c.who_has["z"]
     assert not c.has_what[bad]
     assert not c.has_what[a.address]
 
-    yield cc.close_rpc()
+    await cc.close_rpc()
 
 
 @gen_cluster(client=True)
-def test_upload_file(c, s, a, b):
+async def test_upload_file(c, s, a, b):
     assert not os.path.exists(os.path.join(a.local_directory, "foobar.py"))
     assert not os.path.exists(os.path.join(b.local_directory, "foobar.py"))
     assert a.local_directory != b.local_directory
 
     with rpc(a.address) as aa, rpc(b.address) as bb:
-        yield asyncio.gather(
+        await asyncio.gather(
             aa.upload_file(filename="foobar.py", data=b"x = 123"),
             bb.upload_file(filename="foobar.py", data="x = 123"),
         )
@@ -191,17 +191,17 @@ def test_upload_file(c, s, a, b):
         return foobar.x
 
     future = c.submit(g, workers=a.address)
-    result = yield future
+    result = await future
     assert result == 123
 
-    yield c.close()
-    yield s.close(close_workers=True)
+    await c.close()
+    await s.close(close_workers=True)
     assert not os.path.exists(os.path.join(a.local_directory, "foobar.py"))
 
 
 @pytest.mark.skip(reason="don't yet support uploading pyc files")
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_upload_file_pyc(c, s, w):
+async def test_upload_file_pyc(c, s, w):
     with tmpfile() as dirname:
         os.mkdir(dirname)
         with open(os.path.join(dirname, "foo.py"), mode="w") as f:
@@ -214,7 +214,7 @@ def test_upload_file_pyc(c, s, w):
             assert foo.f() == 123
             pyc = importlib.util.cache_from_source(os.path.join(dirname, "foo.py"))
             assert os.path.exists(pyc)
-            yield c.upload_file(pyc)
+            await c.upload_file(pyc)
 
             def g():
                 import foo
@@ -222,21 +222,21 @@ def test_upload_file_pyc(c, s, w):
                 return foo.x
 
             future = c.submit(g)
-            result = yield future
+            result = await future
             assert result == 123
         finally:
             sys.path.remove(dirname)
 
 
 @gen_cluster(client=True)
-def test_upload_egg(c, s, a, b):
+async def test_upload_egg(c, s, a, b):
     eggname = "testegg-1.0.0-py3.4.egg"
     local_file = __file__.replace("test_worker.py", eggname)
     assert not os.path.exists(os.path.join(a.local_directory, eggname))
     assert not os.path.exists(os.path.join(b.local_directory, eggname))
     assert a.local_directory != b.local_directory
 
-    yield c.upload_file(filename=local_file)
+    await c.upload_file(filename=local_file)
 
     assert os.path.exists(os.path.join(a.local_directory, eggname))
     assert os.path.exists(os.path.join(b.local_directory, eggname))
@@ -247,25 +247,25 @@ def test_upload_egg(c, s, a, b):
         return testegg.inc(x)
 
     future = c.submit(g, 10, workers=a.address)
-    result = yield future
+    result = await future
     assert result == 10 + 1
 
-    yield c.close()
-    yield s.close()
-    yield a.close()
-    yield b.close()
+    await c.close()
+    await s.close()
+    await a.close()
+    await b.close()
     assert not os.path.exists(os.path.join(a.local_directory, eggname))
 
 
 @gen_cluster(client=True)
-def test_upload_pyz(c, s, a, b):
+async def test_upload_pyz(c, s, a, b):
     pyzname = "mytest.pyz"
     local_file = __file__.replace("test_worker.py", pyzname)
     assert not os.path.exists(os.path.join(a.local_directory, pyzname))
     assert not os.path.exists(os.path.join(b.local_directory, pyzname))
     assert a.local_directory != b.local_directory
 
-    yield c.upload_file(filename=local_file)
+    await c.upload_file(filename=local_file)
 
     assert os.path.exists(os.path.join(a.local_directory, pyzname))
     assert os.path.exists(os.path.join(b.local_directory, pyzname))
@@ -276,42 +276,42 @@ def test_upload_pyz(c, s, a, b):
         return mytest.inc(x)
 
     future = c.submit(g, 10, workers=a.address)
-    result = yield future
+    result = await future
     assert result == 10 + 1
 
-    yield c.close()
-    yield s.close()
-    yield a.close()
-    yield b.close()
+    await c.close()
+    await s.close()
+    await a.close()
+    await b.close()
     assert not os.path.exists(os.path.join(a.local_directory, pyzname))
 
 
 @pytest.mark.xfail(reason="Still lose time to network I/O")
 @gen_cluster(client=True)
-def test_upload_large_file(c, s, a, b):
+async def test_upload_large_file(c, s, a, b):
     pytest.importorskip("crick")
-    yield gen.sleep(0.05)
+    await gen.sleep(0.05)
     with rpc(a.address) as aa:
-        yield aa.upload_file(filename="myfile.dat", data=b"0" * 100000000)
-        yield gen.sleep(0.05)
+        await aa.upload_file(filename="myfile.dat", data=b"0" * 100000000)
+        await gen.sleep(0.05)
         assert a.digests["tick-duration"].components[0].max() < 0.050
 
 
 @gen_cluster()
-def test_broadcast(s, a, b):
+async def test_broadcast(s, a, b):
     with rpc(s.address) as cc:
-        results = yield cc.broadcast(msg={"op": "ping"})
+        results = await cc.broadcast(msg={"op": "ping"})
         assert results == {a.address: b"pong", b.address: b"pong"}
 
 
 @gen_test()
-def test_worker_with_port_zero():
-    s = yield Scheduler(port=8007)
-    w = yield Worker(s.address)
+async def test_worker_with_port_zero():
+    s = await Scheduler(port=8007)
+    w = await Worker(s.address)
     assert isinstance(w.port, int)
     assert w.port > 1024
 
-    yield w.close()
+    await w.close()
 
 
 @pytest.mark.slow
@@ -329,10 +329,10 @@ async def test_worker_waits_for_scheduler(cleanup):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_worker_task_data(c, s, w):
+async def test_worker_task_data(c, s, w):
     x = delayed(2)
     xx = c.persist(x)
-    yield wait(xx)
+    await wait(xx)
     assert w.data[x.key] == 2
 
 
@@ -365,7 +365,7 @@ def test_error_message():
 
 
 @gen_cluster(client=True)
-def test_chained_error_message(c, s, a, b):
+async def test_chained_error_message(c, s, a, b):
     def chained_exception_fn():
         class MyException(Exception):
             def __init__(self, msg):
@@ -384,18 +384,18 @@ def test_chained_error_message(c, s, a, b):
 
     f = c.submit(chained_exception_fn)
     try:
-        yield f
+        await f
     except Exception as e:
         assert e.__cause__ is not None
         assert "Bar" in str(e.__cause__)
 
 
 @gen_cluster()
-def test_gather(s, a, b):
+async def test_gather(s, a, b):
     b.data["x"] = 1
     b.data["y"] = 2
     with rpc(a.address) as aa:
-        resp = yield aa.gather(who_has={"x": [b.address], "y": [b.address]})
+        resp = await aa.gather(who_has={"x": [b.address], "y": [b.address]})
         assert resp["status"] == "OK"
 
         assert a.data["x"] == b.data["x"]
@@ -410,9 +410,9 @@ async def test_io_loop(cleanup):
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_spill_to_disk(c, s):
+async def test_spill_to_disk(c, s):
     np = pytest.importorskip("numpy")
-    w = yield Worker(
+    w = await Worker(
         s.address,
         loop=s.loop,
         memory_limit=1200 / 0.6,
@@ -421,75 +421,75 @@ def test_spill_to_disk(c, s):
     )
 
     x = c.submit(np.random.randint, 0, 255, size=500, dtype="u1", key="x")
-    yield wait(x)
+    await wait(x)
     y = c.submit(np.random.randint, 0, 255, size=500, dtype="u1", key="y")
-    yield wait(y)
+    await wait(y)
 
     assert set(w.data) == {x.key, y.key}
     assert set(w.data.memory) == {x.key, y.key}
     assert set(w.data.fast) == set(w.data.memory)
 
     z = c.submit(np.random.randint, 0, 255, size=500, dtype="u1", key="z")
-    yield wait(z)
+    await wait(z)
     assert set(w.data) == {x.key, y.key, z.key}
     assert set(w.data.memory) == {y.key, z.key}
     assert set(w.data.disk) == {x.key} or set(w.data.slow) == {x.key, y.key}
     assert set(w.data.fast) == set(w.data.memory)
     assert set(w.data.slow) == set(w.data.disk)
 
-    yield x
+    await x
     assert set(w.data.memory) == {x.key, z.key}
     assert set(w.data.disk) == {y.key} or set(w.data.slow) == {x.key, y.key}
     assert set(w.data.fast) == set(w.data.memory)
     assert set(w.data.slow) == set(w.data.disk)
-    yield w.close()
+    await w.close()
 
 
 @gen_cluster(client=True)
-def test_access_key(c, s, a, b):
+async def test_access_key(c, s, a, b):
     def f(i):
         from distributed.worker import thread_state
 
         return thread_state.key
 
     futures = [c.submit(f, i, key="x-%d" % i) for i in range(20)]
-    results = yield c._gather(futures)
+    results = await c._gather(futures)
     assert list(results) == ["x-%d" % i for i in range(20)]
 
 
 @gen_cluster(client=True)
-def test_run_dask_worker(c, s, a, b):
+async def test_run_dask_worker(c, s, a, b):
     def f(dask_worker=None):
         return dask_worker.id
 
-    response = yield c._run(f)
+    response = await c._run(f)
     assert response == {a.address: a.id, b.address: b.id}
 
 
 @gen_cluster(client=True)
-def test_run_coroutine_dask_worker(c, s, a, b):
-    def f(dask_worker=None):
-        yield gen.sleep(0.001)
+async def test_run_coroutine_dask_worker(c, s, a, b):
+    async def f(dask_worker=None):
+        await gen.sleep(0.001)
         return dask_worker.id
 
-    response = yield c.run(f)
+    response = await c.run(f)
     assert response == {a.address: a.id, b.address: b.id}
 
 
 @gen_cluster(client=True, nthreads=[])
-def test_Executor(c, s):
+async def test_Executor(c, s):
     with ThreadPoolExecutor(2) as e:
         w = Worker(s.address, executor=e)
         assert w.executor is e
-        w = yield w
+        w = await w
 
         future = c.submit(inc, 1)
-        result = yield future
+        result = await future
         assert result == 2
 
         assert e._threads  # had to do some work
 
-        yield w.close()
+        await w.close()
 
 
 @pytest.mark.skip(
@@ -501,22 +501,22 @@ def test_Executor(c, s):
     timeout=30,
     worker_kwargs={"memory_limit": 10e6},
 )
-def test_spill_by_default(c, s, w):
+async def test_spill_by_default(c, s, w):
     da = pytest.importorskip("dask.array")
     x = da.ones(int(10e6 * 0.7), chunks=1e6, dtype="u1")
     y = c.persist(x)
-    yield wait(y)
+    await wait(y)
     assert len(w.data.disk)  # something is on disk
     del x, y
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], worker_kwargs={"reconnect": False})
-def test_close_on_disconnect(s, w):
-    yield s.close()
+async def test_close_on_disconnect(s, w):
+    await s.close()
 
     start = time()
     while w.status != "closed":
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
 
@@ -538,20 +538,20 @@ async def test_memory_limit_auto():
 
 
 @gen_cluster(client=True)
-def test_inter_worker_communication(c, s, a, b):
-    [x, y] = yield c._scatter([1, 2], workers=a.address)
+async def test_inter_worker_communication(c, s, a, b):
+    [x, y] = await c._scatter([1, 2], workers=a.address)
 
     future = c.submit(add, x, y, workers=b.address)
-    result = yield future
+    result = await future
     assert result == 3
 
 
 @gen_cluster(client=True)
-def test_clean(c, s, a, b):
+async def test_clean(c, s, a, b):
     x = c.submit(inc, 1, workers=a.address)
     y = c.submit(inc, x, workers=b.address)
 
-    yield y
+    await y
 
     collections = [
         a.tasks,
@@ -571,20 +571,20 @@ def test_clean(c, s, a, b):
     y.release()
 
     while x.key in a.task_state:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     for c in collections:
         assert not c
 
 
 @gen_cluster(client=True)
-def test_message_breakup(c, s, a, b):
+async def test_message_breakup(c, s, a, b):
     n = 100000
     a.target_message_size = 10 * n
     b.target_message_size = 10 * n
     xs = [c.submit(mul, b"%d" % i, n, workers=a.address) for i in range(30)]
     y = c.submit(lambda *args: None, xs, workers=b.address)
-    yield y
+    await y
 
     assert 2 <= len(b.incoming_transfer_log) <= 20
     assert 2 <= len(a.outgoing_transfer_log) <= 20
@@ -594,29 +594,29 @@ def test_message_breakup(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_types(c, s, a, b):
+async def test_types(c, s, a, b):
     assert not a.types
     assert not b.types
     x = c.submit(inc, 1, workers=a.address)
-    yield wait(x)
+    await wait(x)
     assert a.types[x.key] == int
 
     y = c.submit(inc, x, workers=b.address)
-    yield wait(y)
+    await wait(y)
     assert b.types == {x.key: int, y.key: int}
 
-    yield c._cancel(y)
+    await c._cancel(y)
 
     start = time()
     while y.key in b.data:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 5
 
     assert y.key not in b.types
 
 
 @gen_cluster()
-def test_system_monitor(s, a, b):
+async def test_system_monitor(s, a, b):
     assert b.monitor
     b.monitor.update()
 
@@ -624,38 +624,38 @@ def test_system_monitor(s, a, b):
 @gen_cluster(
     client=True, nthreads=[("127.0.0.1", 2, {"resources": {"A": 1}}), ("127.0.0.1", 1)]
 )
-def test_restrictions(c, s, a, b):
+async def test_restrictions(c, s, a, b):
     # Resource restrictions
     x = c.submit(inc, 1, resources={"A": 1})
-    yield x
+    await x
     assert a.resource_restrictions == {x.key: {"A": 1}}
-    yield c._cancel(x)
+    await c._cancel(x)
 
     while x.key in a.task_state:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
 
     assert a.resource_restrictions == {}
 
 
 @pytest.mark.xfail
 @gen_cluster(client=True)
-def test_clean_nbytes(c, s, a, b):
+async def test_clean_nbytes(c, s, a, b):
     L = [delayed(inc)(i) for i in range(10)]
     for i in range(5):
         L = [delayed(add)(x, y) for x, y in sliding_window(2, L)]
     total = delayed(sum)(L)
 
     future = c.compute(total)
-    yield wait(future)
+    await wait(future)
 
-    yield gen.sleep(1)
+    await gen.sleep(1)
     assert len(a.nbytes) + len(b.nbytes) == 1
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 20)
-def test_gather_many_small(c, s, a, *workers):
+async def test_gather_many_small(c, s, a, *workers):
     a.total_out_connections = 2
-    futures = yield c._scatter(list(range(100)))
+    futures = await c._scatter(list(range(100)))
 
     assert all(w.data for w in workers)
 
@@ -663,7 +663,7 @@ def test_gather_many_small(c, s, a, *workers):
         return 10
 
     future = c.submit(f, *futures, workers=a.address)
-    yield wait(future)
+    await wait(future)
 
     types = list(pluck(0, a.log))
     req = [i for i, t in enumerate(types) if t == "request-dep"]
@@ -674,12 +674,12 @@ def test_gather_many_small(c, s, a, *workers):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_multiple_transfers(c, s, w1, w2, w3):
+async def test_multiple_transfers(c, s, w1, w2, w3):
     x = c.submit(inc, 1, workers=w1.address)
     y = c.submit(inc, 2, workers=w2.address)
     z = c.submit(add, x, y, workers=w3.address)
 
-    yield wait(z)
+    await wait(z)
 
     r = w3.startstops[z.key]
     transfers = [t for t in r if t["action"] == "transfer"]
@@ -687,25 +687,25 @@ def test_multiple_transfers(c, s, w1, w2, w3):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
-def test_share_communication(c, s, w1, w2, w3):
+async def test_share_communication(c, s, w1, w2, w3):
     x = c.submit(mul, b"1", int(w3.target_message_size + 1), workers=w1.address)
     y = c.submit(mul, b"2", int(w3.target_message_size + 1), workers=w2.address)
-    yield wait([x, y])
-    yield c._replicate([x, y], workers=[w1.address, w2.address])
+    await wait([x, y])
+    await c._replicate([x, y], workers=[w1.address, w2.address])
     z = c.submit(add, x, y, workers=w3.address)
-    yield wait(z)
+    await wait(z)
     assert len(w3.incoming_transfer_log) == 2
     assert w1.outgoing_transfer_log
     assert w2.outgoing_transfer_log
 
 
 @gen_cluster(client=True)
-def test_dont_overlap_communications_to_same_worker(c, s, a, b):
+async def test_dont_overlap_communications_to_same_worker(c, s, a, b):
     x = c.submit(mul, b"1", int(b.target_message_size + 1), workers=a.address)
     y = c.submit(mul, b"2", int(b.target_message_size + 1), workers=a.address)
-    yield wait([x, y])
+    await wait([x, y])
     z = c.submit(add, x, y, workers=b.address)
-    yield wait(z)
+    await wait(z)
     assert len(b.incoming_transfer_log) == 2
     l1, l2 = b.incoming_transfer_log
 
@@ -714,7 +714,7 @@ def test_dont_overlap_communications_to_same_worker(c, s, a, b):
 
 @pytest.mark.avoid_travis
 @gen_cluster(client=True)
-def test_log_exception_on_failed_task(c, s, a, b):
+async def test_log_exception_on_failed_task(c, s, a, b):
     with tmpfile() as fn:
         fh = logging.FileHandler(fn)
         try:
@@ -723,9 +723,9 @@ def test_log_exception_on_failed_task(c, s, a, b):
             logger.addHandler(fh)
 
             future = c.submit(div, 1, 0)
-            yield wait(future)
+            await wait(future)
 
-            yield gen.sleep(0.1)
+            await gen.sleep(0.1)
             fh.flush()
             with open(fn) as f:
                 text = f.read()
@@ -737,7 +737,7 @@ def test_log_exception_on_failed_task(c, s, a, b):
 
 
 @gen_cluster(client=True)
-def test_clean_up_dependencies(c, s, a, b):
+async def test_clean_up_dependencies(c, s, a, b):
     x = delayed(inc)(1)
     y = delayed(inc)(2)
     xx = delayed(inc)(x)
@@ -745,26 +745,26 @@ def test_clean_up_dependencies(c, s, a, b):
     z = delayed(add)(xx, yy)
 
     zz = c.persist(z)
-    yield wait(zz)
+    await wait(zz)
 
     start = time()
     while len(a.data) + len(b.data) > 1:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
 
     assert set(a.data) | set(b.data) == {zz.key}
 
 
 @gen_cluster(client=True)
-def test_hold_onto_dependents(c, s, a, b):
+async def test_hold_onto_dependents(c, s, a, b):
     x = c.submit(inc, 1, workers=a.address)
     y = c.submit(inc, x, workers=b.address)
-    yield wait(y)
+    await wait(y)
 
     assert x.key in b.data
 
-    yield c._cancel(y)
-    yield gen.sleep(0.1)
+    await c._cancel(y)
+    await gen.sleep(0.1)
 
     assert x.key in b.data
 
@@ -786,20 +786,20 @@ async def test_worker_death_timeout(s):
 
 
 @gen_cluster(client=True)
-def test_stop_doing_unnecessary_work(c, s, a, b):
+async def test_stop_doing_unnecessary_work(c, s, a, b):
     futures = c.map(slowinc, range(1000), delay=0.01)
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
 
     del futures
 
     start = time()
     while a.executing:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() - start < 0.5
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-def test_priorities(c, s, w):
+async def test_priorities(c, s, w):
     values = []
     for i in range(10):
         a = delayed(slowinc)(i, dask_key_name="a-%d" % i, delay=0.01)
@@ -811,7 +811,7 @@ def test_priorities(c, s, w):
         values.append(b1)
 
     futures = c.compute(values)
-    yield wait(futures)
+    await wait(futures)
 
     log = [
         t[0]
@@ -823,12 +823,12 @@ def test_priorities(c, s, w):
 
 
 @gen_cluster(client=True)
-def test_heartbeats(c, s, a, b):
+async def test_heartbeats(c, s, a, b):
     x = s.workers[a.address].last_seen
     start = time()
-    yield gen.sleep(a.periodic_callbacks["heartbeat"].callback_time / 1000 + 0.1)
+    await gen.sleep(a.periodic_callbacks["heartbeat"].callback_time / 1000 + 0.1)
     while s.workers[a.address].last_seen == x:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 2
     assert a.periodic_callbacks["heartbeat"].callback_time < 1000
 
@@ -847,7 +847,7 @@ def test_worker_dir(worker):
 
 
 @gen_cluster(client=True)
-def test_dataframe_attribute_error(c, s, a, b):
+async def test_dataframe_attribute_error(c, s, a, b):
     class BadSize:
         def __init__(self, data):
             self.data = data
@@ -856,12 +856,12 @@ def test_dataframe_attribute_error(c, s, a, b):
             raise TypeError("Hello")
 
     future = c.submit(BadSize, 123)
-    result = yield future
+    result = await future
     assert result.data == 123
 
 
 @gen_cluster(client=True)
-def test_fail_write_to_disk(c, s, a, b):
+async def test_fail_write_to_disk(c, s, a, b):
     class Bad:
         def __getstate__(self):
             raise TypeError()
@@ -870,15 +870,15 @@ def test_fail_write_to_disk(c, s, a, b):
             return int(100e9)
 
     future = c.submit(Bad)
-    yield wait(future)
+    await wait(future)
 
     assert future.status == "error"
 
     with pytest.raises(TypeError):
-        yield future
+        await future
 
     futures = c.map(inc, range(10))
-    results = yield c._gather(futures)
+    results = await c._gather(futures)
     assert results == list(map(inc, range(10)))
 
 
@@ -886,9 +886,9 @@ def test_fail_write_to_disk(c, s, a, b):
 @gen_cluster(
     nthreads=[("127.0.0.1", 2)], client=True, worker_kwargs={"memory_limit": 10e9}
 )
-def test_fail_write_many_to_disk(c, s, a):
+async def test_fail_write_many_to_disk(c, s, a):
     a.validate = False
-    yield gen.sleep(0.1)
+    await gen.sleep(0.1)
     assert not a.paused
 
     class Bad:
@@ -904,23 +904,23 @@ def test_fail_write_many_to_disk(c, s, a):
     futures = c.map(Bad, range(11))
     future = c.submit(lambda *args: 123, *futures)
 
-    yield wait(future)
+    await wait(future)
 
     with pytest.raises(Exception) as info:
-        yield future
+        await future
 
     # workers still operational
-    result = yield c.submit(inc, 1, workers=a.address)
+    result = await c.submit(inc, 1, workers=a.address)
     assert result == 2
 
 
 @gen_cluster()
-def test_pid(s, a, b):
+async def test_pid(s, a, b):
     assert s.workers[a.address].pid == os.getpid()
 
 
 @gen_cluster(client=True)
-def test_get_client(c, s, a, b):
+async def test_get_client(c, s, a, b):
     def f(x):
         cc = get_client()
         future = cc.submit(inc, x)
@@ -929,7 +929,7 @@ def test_get_client(c, s, a, b):
     assert default_client() is c
 
     future = c.submit(f, 10, workers=a.address)
-    result = yield future
+    result = await future
     assert result == 11
 
     assert a._client
@@ -941,7 +941,7 @@ def test_get_client(c, s, a, b):
     a_client = a._client
 
     for i in range(10):
-        yield wait(c.submit(f, i))
+        await wait(c.submit(f, i))
 
     assert a._client is a_client
 
@@ -957,22 +957,22 @@ def test_get_client_sync(client):
 
 
 @gen_cluster(client=True)
-def test_get_client_coroutine(c, s, a, b):
-    def f():
-        client = yield get_client()
+async def test_get_client_coroutine(c, s, a, b):
+    async def f():
+        client = await get_client()
         future = client.submit(inc, 10)
-        result = yield future
+        result = await future
         return result
 
-    results = yield c.run(f)
+    results = await c.run(f)
     assert results == {a.address: 11, b.address: 11}
 
 
 def test_get_client_coroutine_sync(client, s, a, b):
-    def f():
-        client = yield get_client()
+    async def f():
+        client = await get_client()
         future = client.submit(inc, 10)
-        result = yield future
+        result = await future
         return result
 
     results = client.run(f)
@@ -980,7 +980,7 @@ def test_get_client_coroutine_sync(client, s, a, b):
 
 
 @gen_cluster()
-def test_global_workers(s, a, b):
+async def test_global_workers(s, a, b):
     n = len(Worker._instances)
     w = first(Worker._instances)
     assert w is a or w is b
@@ -988,24 +988,24 @@ def test_global_workers(s, a, b):
 
 @pytest.mark.skipif(WINDOWS, reason="file descriptors")
 @gen_cluster(nthreads=[])
-def test_worker_fds(s):
+async def test_worker_fds(s):
     psutil = pytest.importorskip("psutil")
-    yield gen.sleep(0.05)
+    await gen.sleep(0.05)
     start = psutil.Process().num_fds()
 
-    worker = yield Worker(s.address, loop=s.loop)
-    yield gen.sleep(0.1)
+    worker = await Worker(s.address, loop=s.loop)
+    await gen.sleep(0.1)
     middle = psutil.Process().num_fds()
     start = time()
     while middle > start:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 1
 
-    yield worker.close()
+    await worker.close()
 
     start = time()
     while psutil.Process().num_fds() > start:
-        yield gen.sleep(0.01)
+        await gen.sleep(0.01)
         assert time() < start + 0.5
 
 
@@ -1033,28 +1033,28 @@ async def test_start_services(s):
 
 
 @gen_test()
-def test_scheduler_file():
+async def test_scheduler_file():
     with tmpfile() as fn:
-        s = yield Scheduler(scheduler_file=fn, port=8009)
-        w = yield Worker(scheduler_file=fn)
+        s = await Scheduler(scheduler_file=fn, port=8009)
+        w = await Worker(scheduler_file=fn)
         assert set(s.workers) == {w.address}
-        yield w.close()
+        await w.close()
         s.stop()
 
 
 @gen_cluster(client=True)
-def test_scheduler_delay(c, s, a, b):
+async def test_scheduler_delay(c, s, a, b):
     old = a.scheduler_delay
     assert abs(a.scheduler_delay) < 0.3
     assert abs(b.scheduler_delay) < 0.3
-    yield gen.sleep(a.periodic_callbacks["heartbeat"].callback_time / 1000 + 0.3)
+    await gen.sleep(a.periodic_callbacks["heartbeat"].callback_time / 1000 + 0.3)
     assert a.scheduler_delay != old
 
 
 @gen_cluster(client=True)
-def test_statistical_profiling(c, s, a, b):
+async def test_statistical_profiling(c, s, a, b):
     futures = c.map(slowinc, range(10), delay=0.1)
-    yield wait(futures)
+    await wait(futures)
 
     profile = a.profile_keys["slowinc"]
     assert profile["count"]
@@ -1070,14 +1070,14 @@ def test_statistical_profiling(c, s, a, b):
         "distributed.worker.profile.cycle": "100ms",
     },
 )
-def test_statistical_profiling_2(c, s, a, b):
+async def test_statistical_profiling_2(c, s, a, b):
     da = pytest.importorskip("dask.array")
     while True:
         x = da.random.random(1000000, chunks=(10000,))
         y = (x + x * 2) - x.sum().persist()
-        yield wait(y)
+        await wait(y)
 
-        profile = yield a.get_profile()
+        profile = await a.get_profile()
         text = str(profile)
         if profile["count"] and "sum" in text and "random" in text:
             break
@@ -1088,7 +1088,7 @@ def test_statistical_profiling_2(c, s, a, b):
     client=True,
     worker_kwargs={"memory_monitor_interval": 10},
 )
-def test_robust_to_bad_sizeof_estimates(c, s, a):
+async def test_robust_to_bad_sizeof_estimates(c, s, a):
     np = pytest.importorskip("numpy")
     memory = psutil.Process().memory_info().rss
     a.memory_limit = memory / 0.7 + 400e6
@@ -1109,7 +1109,7 @@ def test_robust_to_bad_sizeof_estimates(c, s, a):
 
     start = time()
     while not a.data.disk:
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         assert time() < start + 5
 
 
@@ -1130,7 +1130,7 @@ def test_robust_to_bad_sizeof_estimates(c, s, a):
     },
     timeout=20,
 )
-def test_pause_executor(c, s, a):
+async def test_pause_executor(c, s, a):
     memory = psutil.Process().memory_info().rss
     a.memory_limit = memory / 0.5 + 200e6
     np = pytest.importorskip("numpy")
@@ -1145,7 +1145,7 @@ def test_pause_executor(c, s, a):
 
         start = time()
         while not a.paused:
-            yield gen.sleep(0.01)
+            await gen.sleep(0.01)
             assert time() < start + 4, (
                 format_bytes(psutil.Process().memory_info().rss),
                 format_bytes(a.memory_limit),
@@ -1157,41 +1157,41 @@ def test_pause_executor(c, s, a):
 
     assert sum(f.status == "finished" for f in futures) < 4
 
-    yield wait(futures)
+    await wait(futures)
 
 
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": "50 ms"})
-def test_statistical_profiling_cycle(c, s, a, b):
+async def test_statistical_profiling_cycle(c, s, a, b):
     futures = c.map(slowinc, range(20), delay=0.05)
-    yield wait(futures)
-    yield gen.sleep(0.01)
+    await wait(futures)
+    await gen.sleep(0.01)
     end = time()
     assert len(a.profile_history) > 3
 
-    x = yield a.get_profile(start=time() + 10, stop=time() + 20)
+    x = await a.get_profile(start=time() + 10, stop=time() + 20)
     assert not x["count"]
 
-    x = yield a.get_profile(start=0, stop=time() + 10)
+    x = await a.get_profile(start=0, stop=time() + 10)
     recent = a.profile_recent["count"]
     actual = sum(p["count"] for _, p in a.profile_history) + a.profile_recent["count"]
-    x2 = yield a.get_profile(start=0, stop=time() + 10)
+    x2 = await a.get_profile(start=0, stop=time() + 10)
     assert x["count"] <= actual <= x2["count"]
 
-    y = yield a.get_profile(start=end - 0.300, stop=time())
+    y = await a.get_profile(start=end - 0.300, stop=time())
     assert 0 < y["count"] <= x["count"]
 
 
 @gen_cluster(client=True)
-def test_get_current_task(c, s, a, b):
+async def test_get_current_task(c, s, a, b):
     def some_name():
         return get_worker().get_current_task()
 
-    result = yield c.submit(some_name)
+    result = await c.submit(some_name)
     assert result.startswith("some_name")
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_reschedule(c, s, a, b):
+async def test_reschedule(c, s, a, b):
     s.extensions["stealing"]._pc.stop()
     a_address = a.address
 
@@ -1202,7 +1202,7 @@ def test_reschedule(c, s, a, b):
 
     futures = c.map(f, range(4))
     futures2 = c.map(slowinc, range(10), delay=0.1, workers=a.address)
-    yield wait(futures)
+    await wait(futures)
 
     assert all(f.key in b.data for f in futures)
 
@@ -1222,20 +1222,20 @@ async def test_deque_handler(cleanup):
 
 
 @gen_cluster(nthreads=[], client=True)
-def test_avoid_memory_monitor_if_zero_limit(c, s):
-    worker = yield Worker(
+async def test_avoid_memory_monitor_if_zero_limit(c, s):
+    worker = await Worker(
         s.address, loop=s.loop, memory_limit=0, memory_monitor_interval=10
     )
     assert type(worker.data) is dict
     assert "memory" not in worker.periodic_callbacks
 
     future = c.submit(inc, 1)
-    assert (yield future) == 2
-    yield gen.sleep(worker.memory_monitor_interval / 1000)
+    assert (await future) == 2
+    await gen.sleep(worker.memory_monitor_interval / 1000)
 
-    yield c.submit(inc, 2)  # worker doesn't pause
+    await c.submit(inc, 2)  # worker doesn't pause
 
-    yield worker.close()
+    await worker.close()
 
 
 @gen_cluster(
@@ -1265,27 +1265,27 @@ def test_get_worker_name(client):
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], worker_kwargs={"memory_limit": "2e3 MB"})
-def test_parse_memory_limit(s, w):
+async def test_parse_memory_limit(s, w):
     assert w.memory_limit == 2e9
 
 
 @gen_cluster(nthreads=[], client=True)
-def test_scheduler_address_config(c, s):
+async def test_scheduler_address_config(c, s):
     with dask.config.set({"scheduler-address": s.address}):
-        worker = yield Worker(loop=s.loop)
+        worker = await Worker(loop=s.loop)
         assert worker.scheduler.address == s.address
-    yield worker.close()
+    await worker.close()
 
 
 @pytest.mark.slow
 @gen_cluster(client=True)
-def test_wait_for_outgoing(c, s, a, b):
+async def test_wait_for_outgoing(c, s, a, b):
     np = pytest.importorskip("numpy")
     x = np.random.random(10000000)
-    future = yield c.scatter(x, workers=a.address)
+    future = await c.scatter(x, workers=a.address)
 
     y = c.submit(inc, future, workers=b.address)
-    yield wait(y)
+    await wait(y)
 
     assert len(b.incoming_transfer_log) == len(a.outgoing_transfer_log) == 1
     bb = b.incoming_transfer_log[0]["duration"]
@@ -1301,11 +1301,11 @@ def test_wait_for_outgoing(c, s, a, b):
 @gen_cluster(
     nthreads=[("127.0.0.1", 1), ("127.0.0.1", 1), ("127.0.0.2", 1)], client=True
 )
-def test_prefer_gather_from_local_address(c, s, w1, w2, w3):
-    x = yield c.scatter(123, workers=[w1.address, w3.address], broadcast=True)
+async def test_prefer_gather_from_local_address(c, s, w1, w2, w3):
+    x = await c.scatter(123, workers=[w1.address, w3.address], broadcast=True)
 
     y = c.submit(inc, x, workers=[w2.address])
-    yield wait(y)
+    await wait(y)
 
     assert any(d["who"] == w2.address for d in w1.outgoing_transfer_log)
     assert not any(d["who"] == w2.address for d in w3.outgoing_transfer_log)
@@ -1317,14 +1317,14 @@ def test_prefer_gather_from_local_address(c, s, w1, w2, w3):
     timeout=30,
     config={"distributed.worker.connections.incoming": 1},
 )
-def test_avoid_oversubscription(c, s, *workers):
+async def test_avoid_oversubscription(c, s, *workers):
     np = pytest.importorskip("numpy")
     x = c.submit(np.random.random, 1000000, workers=[workers[0].address])
-    yield wait(x)
+    await wait(x)
 
     futures = [c.submit(len, x, pure=False, workers=[w.address]) for w in workers[1:]]
 
-    yield wait(futures)
+    await wait(futures)
 
     # Original worker not responsible for all transfers
     assert len(workers[0].outgoing_transfer_log) < len(workers) - 2
@@ -1334,13 +1334,13 @@ def test_avoid_oversubscription(c, s, *workers):
 
 
 @gen_cluster(client=True, worker_kwargs={"metrics": {"my_port": lambda w: w.port}})
-def test_custom_metrics(c, s, a, b):
+async def test_custom_metrics(c, s, a, b):
     assert s.workers[a.address].metrics["my_port"] == a.port
     assert s.workers[b.address].metrics["my_port"] == b.port
 
 
 @gen_cluster(client=True)
-def test_register_worker_callbacks(c, s, a, b):
+async def test_register_worker_callbacks(c, s, a, b):
     # preload function to run
     def mystartup(dask_worker):
         dask_worker.init_variable = 1
@@ -1362,81 +1362,81 @@ def test_register_worker_callbacks(c, s, a, b):
         return os.getenv("MY_ENV_VALUE", None) == "WORKER_ENV_VALUE"
 
     # Nothing has been run yet
-    result = yield c.run(test_import)
+    result = await c.run(test_import)
     assert list(result.values()) == [False] * 2
-    result = yield c.run(test_startup2)
+    result = await c.run(test_startup2)
     assert list(result.values()) == [False] * 2
 
     # Start a worker and check that startup is not run
-    worker = yield Worker(s.address, loop=s.loop)
-    result = yield c.run(test_import, workers=[worker.address])
+    worker = await Worker(s.address, loop=s.loop)
+    result = await c.run(test_import, workers=[worker.address])
     assert list(result.values()) == [False]
-    yield worker.close()
+    await worker.close()
 
     # Add a preload function
-    response = yield c.register_worker_callbacks(setup=mystartup)
+    response = await c.register_worker_callbacks(setup=mystartup)
     assert len(response) == 2
 
     # Check it has been ran on existing worker
-    result = yield c.run(test_import)
+    result = await c.run(test_import)
     assert list(result.values()) == [True] * 2
 
     # Start a worker and check it is ran on it
-    worker = yield Worker(s.address, loop=s.loop)
-    result = yield c.run(test_import, workers=[worker.address])
+    worker = await Worker(s.address, loop=s.loop)
+    result = await c.run(test_import, workers=[worker.address])
     assert list(result.values()) == [True]
-    yield worker.close()
+    await worker.close()
 
     # Register another preload function
-    response = yield c.register_worker_callbacks(setup=mystartup2)
+    response = await c.register_worker_callbacks(setup=mystartup2)
     assert len(response) == 2
 
     # Check it has been run
-    result = yield c.run(test_startup2)
+    result = await c.run(test_startup2)
     assert list(result.values()) == [True] * 2
 
     # Start a worker and check it is ran on it
-    worker = yield Worker(s.address, loop=s.loop)
-    result = yield c.run(test_import, workers=[worker.address])
+    worker = await Worker(s.address, loop=s.loop)
+    result = await c.run(test_import, workers=[worker.address])
     assert list(result.values()) == [True]
-    result = yield c.run(test_startup2, workers=[worker.address])
+    result = await c.run(test_startup2, workers=[worker.address])
     assert list(result.values()) == [True]
-    yield worker.close()
+    await worker.close()
 
 
 @gen_cluster(client=True)
-def test_register_worker_callbacks_err(c, s, a, b):
+async def test_register_worker_callbacks_err(c, s, a, b):
     with pytest.raises(ZeroDivisionError):
-        yield c.register_worker_callbacks(setup=lambda: 1 / 0)
+        await c.register_worker_callbacks(setup=lambda: 1 / 0)
 
 
 @gen_cluster(nthreads=[])
-def test_data_types(s):
-    w = yield Worker(s.address, data=dict)
+async def test_data_types(s):
+    w = await Worker(s.address, data=dict)
     assert isinstance(w.data, dict)
-    yield w.close()
+    await w.close()
 
     data = dict()
-    w = yield Worker(s.address, data=data)
+    w = await Worker(s.address, data=data)
     assert w.data is data
-    yield w.close()
+    await w.close()
 
     class Data(dict):
         def __init__(self, x, y):
             self.x = x
             self.y = y
 
-    w = yield Worker(s.address, data=(Data, {"x": 123, "y": 456}))
+    w = await Worker(s.address, data=(Data, {"x": 123, "y": 456}))
     assert w.data.x == 123
     assert w.data.y == 456
-    yield w.close()
+    await w.close()
 
 
 @gen_cluster(nthreads=[])
-def test_local_directory(s):
+async def test_local_directory(s):
     with tmpfile() as fn:
         with dask.config.set(temporary_directory=fn):
-            w = yield Worker(s.address)
+            w = await Worker(s.address)
             assert w.local_directory.startswith(fn)
             assert "dask-worker-space" in w.local_directory
 
@@ -1445,15 +1445,15 @@ def test_local_directory(s):
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )
 @gen_cluster(nthreads=[], client=True)
-def test_host_address(c, s):
-    w = yield Worker(s.address, host="127.0.0.2")
+async def test_host_address(c, s):
+    w = await Worker(s.address, host="127.0.0.2")
     assert "127.0.0.2" in w.address
-    yield w.close()
+    await w.close()
 
-    n = yield Nanny(s.address, host="127.0.0.3")
+    n = await Nanny(s.address, host="127.0.0.3")
     assert "127.0.0.3" in n.address
     assert "127.0.0.3" in n.worker_address
-    yield n.close()
+    await n.close()
 
 
 def test_resource_limit(monkeypatch):

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -22,7 +22,7 @@ from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
 
 
 @gen_cluster(client=True)
-def test_submit_from_worker(c, s, a, b):
+async def test_submit_from_worker(c, s, a, b):
     def func(x):
         with worker_client() as c:
             x = c.submit(inc, x)
@@ -31,7 +31,7 @@ def test_submit_from_worker(c, s, a, b):
             return result
 
     x, y = c.map(func, [10, 20])
-    xx, yy = yield c._gather([x, y])
+    xx, yy = await c._gather([x, y])
 
     assert xx == 10 + 1 + (10 + 1) * 2
     assert yy == 20 + 1 + (20 + 1) * 2
@@ -41,7 +41,7 @@ def test_submit_from_worker(c, s, a, b):
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_scatter_from_worker(c, s, a, b):
+async def test_scatter_from_worker(c, s, a, b):
     def func():
         with worker_client() as c:
             futures = c.scatter([1, 2, 3, 4, 5])
@@ -56,7 +56,7 @@ def test_scatter_from_worker(c, s, a, b):
             return total.result()
 
     future = c.submit(func)
-    result = yield future
+    result = await future
     assert result == sum([1, 2, 3, 4, 5])
 
     def func():
@@ -72,17 +72,17 @@ def test_scatter_from_worker(c, s, a, b):
             return correct
 
     future = c.submit(func)
-    result = yield future
+    result = await future
     assert result is True
 
     start = time()
     while not all(v == 1 for v in s.nthreads.values()):
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         assert time() < start + 5
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_scatter_singleton(c, s, a, b):
+async def test_scatter_singleton(c, s, a, b):
     np = pytest.importorskip("numpy")
 
     def func():
@@ -91,11 +91,11 @@ def test_scatter_singleton(c, s, a, b):
             future = c.scatter(x)
             assert future.type == np.ndarray
 
-    yield c.submit(func)
+    await c.submit(func)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
-def test_gather_multi_machine(c, s, a, b):
+async def test_gather_multi_machine(c, s, a, b):
     a_address = a.address
     b_address = b.address
     assert a_address != b_address
@@ -109,19 +109,19 @@ def test_gather_multi_machine(c, s, a, b):
         return xx, yy
 
     future = c.submit(func)
-    result = yield future
+    result = await future
 
     assert result == (2, 3)
 
 
 @gen_cluster(client=True)
-def test_same_loop(c, s, a, b):
+async def test_same_loop(c, s, a, b):
     def f():
         with worker_client() as lc:
             return lc.loop is get_worker().loop
 
     future = c.submit(f)
-    result = yield future
+    result = await future
     assert result
 
 
@@ -140,7 +140,7 @@ def test_sync(client):
 
 
 @gen_cluster(client=True)
-def test_async(c, s, a, b):
+async def test_async(c, s, a, b):
     def mysum():
         result = 0
         sub_tasks = [delayed(double)(i) for i in range(100)]
@@ -152,16 +152,16 @@ def test_async(c, s, a, b):
         return result
 
     future = c.compute(delayed(mysum)())
-    yield future
+    await future
 
     start = time()
     while len(a.data) + len(b.data) > 1:
-        yield gen.sleep(0.1)
+        await gen.sleep(0.1)
         assert time() < start + 3
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 3)])
-def test_separate_thread_false(c, s, a):
+async def test_separate_thread_false(c, s, a):
     a.count = 0
 
     def f(i):
@@ -174,19 +174,19 @@ def test_separate_thread_false(c, s, a):
         return i
 
     futures = c.map(f, range(20))
-    results = yield c._gather(futures)
+    results = await c._gather(futures)
     assert list(results) == list(range(20))
 
 
 @gen_cluster(client=True)
-def test_client_executor(c, s, a, b):
+async def test_client_executor(c, s, a, b):
     def mysum():
         with worker_client() as c:
             with c.get_executor() as e:
                 return sum(e.map(double, range(30)))
 
     future = c.submit(mysum)
-    result = yield future
+    result = await future
     assert result == 30 * 29
 
 
@@ -211,7 +211,7 @@ def test_dont_override_default_get(loop):
 
 
 @gen_cluster(client=True)
-def test_local_client_warning(c, s, a, b):
+async def test_local_client_warning(c, s, a, b):
     from distributed import local_client
 
     def func(x):
@@ -223,18 +223,18 @@ def test_local_client_warning(c, s, a, b):
             return result
 
     future = c.submit(func, 10)
-    result = yield future
+    result = await future
     assert result == 11
 
 
 @gen_cluster(client=True)
-def test_closing_worker_doesnt_close_client(c, s, a, b):
+async def test_closing_worker_doesnt_close_client(c, s, a, b):
     def func(x):
         get_client()
         return
 
-    yield wait(c.map(func, range(10)))
-    yield a.close()
+    await wait(c.map(func, range(10)))
+    await a.close()
     assert c.status == "running"
 
 
@@ -260,13 +260,13 @@ def test_secede_without_stealing_issue_1262():
     # run the loop as an inner function so all workers are closed
     # and exceptions can be examined
     @gen_cluster(client=True, scheduler_kwargs={"extensions": extensions})
-    def secede_test(c, s, a, b):
+    async def secede_test(c, s, a, b):
         def func(x):
             with worker_client() as wc:
                 y = wc.submit(lambda: 1 + x)
                 return wc.gather(y)
 
-        f = yield c.gather(c.submit(func, 1))
+        f = await c.gather(c.submit(func, 1))
 
         return c, s, a, b, f
 
@@ -278,40 +278,40 @@ def test_secede_without_stealing_issue_1262():
 
 
 @gen_cluster(client=True)
-def test_compute_within_worker_client(c, s, a, b):
+async def test_compute_within_worker_client(c, s, a, b):
     @dask.delayed
     def f():
         with worker_client():
             return dask.delayed(lambda x: x)(1).compute()
 
-    result = yield c.compute(f())
+    result = await c.compute(f())
     assert result == 1
 
 
 @gen_cluster(client=True)
-def test_worker_client_rejoins(c, s, a, b):
+async def test_worker_client_rejoins(c, s, a, b):
     def f():
         with worker_client():
             pass
 
         return threading.current_thread() in get_worker().executor._threads
 
-    result = yield c.submit(f)
+    result = await c.submit(f)
     assert result
 
 
 @gen_cluster()
-def test_submit_different_names(s, a, b):
+async def test_submit_different_names(s, a, b):
     # https://github.com/dask/distributed/issues/2058
     da = pytest.importorskip("dask.array")
-    c = yield Client(
+    c = await Client(
         "localhost:" + s.address.split(":")[-1], loop=s.loop, asynchronous=True
     )
     try:
         X = c.persist(da.random.uniform(size=(100, 10), chunks=50))
-        yield wait(X)
+        await wait(X)
 
-        fut = yield c.submit(lambda x: x.sum().compute(), X)
+        fut = await c.submit(lambda x: x.sum().compute(), X)
         assert fut > 0
     finally:
-        yield c.close()
+        await c.close()

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -268,7 +268,7 @@ def test_secede_without_stealing_issue_1262():
 
         f = yield c.gather(c.submit(func, 1))
 
-        raise gen.Return((c, s, a, b, f))
+        return c, s, a, b, f
 
     c, s, a, b, f = secede_test()
 

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import random
 import threading
 from time import sleep
@@ -6,7 +7,6 @@ import warnings
 import dask
 from dask import delayed
 import pytest
-from tornado import gen
 
 from distributed import (
     worker_client,
@@ -77,7 +77,7 @@ async def test_scatter_from_worker(c, s, a, b):
 
     start = time()
     while not all(v == 1 for v in s.nthreads.values()):
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 5
 
 
@@ -156,7 +156,7 @@ async def test_async(c, s, a, b):
 
     start = time()
     while len(a.data) + len(b.data) > 1:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 3
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -202,6 +202,7 @@ def ignoring(*exceptions):
         pass
 
 
+# FIXME: this breaks if changed to async def...
 @gen.coroutine
 def ignore_exceptions(coroutines, *exceptions):
     """ Process list of coroutines, ignoring certain exceptions

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -761,8 +761,8 @@ def gen_test(timeout=10):
     """ Coroutine test
 
     @gen_test(timeout=5)
-    def test_foo():
-        yield ...  # use tornado coroutines
+    async def test_foo():
+        await ...  # use tornado coroutines
     """
 
     def _(func):
@@ -862,8 +862,8 @@ def gen_cluster(
     """ Coroutine test with small cluster
 
     @gen_cluster()
-    def test_foo(scheduler, worker1, worker2):
-        yield ...  # use tornado coroutines
+    async def test_foo(scheduler, worker1, worker2):
+        await ...  # use tornado coroutines
 
     See also:
         start

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import gc
 from contextlib import contextmanager
 import copy
 import functools
@@ -33,7 +34,6 @@ import pytest
 
 import dask
 from tlz import merge, memoize, assoc
-from tornado import gen
 from tornado.ioloop import IOLoop
 
 from . import system
@@ -768,11 +768,9 @@ def gen_test(timeout=10):
     def _(func):
         def test_func():
             with clean() as loop:
-                if iscoroutinefunction(func):
-                    cor = func
-                else:
-                    cor = gen.coroutine(func)
-                loop.run_sync(cor, timeout=timeout)
+                if not iscoroutinefunction(func):
+                    raise ValueError("@gen_test should wrap async def functions")
+                loop.run_sync(func, timeout=timeout)
 
         return test_func
 
@@ -856,6 +854,7 @@ def gen_cluster(
     active_rpc_timeout=1,
     config={},
     clean_kwargs={},
+    allow_unclosed=False,
 ):
     from distributed import Client
 
@@ -878,10 +877,10 @@ def gen_cluster(
     )
 
     def _(func):
-        if not iscoroutinefunction(func):
-            func = gen.coroutine(func)
-
         def test_func():
+            if not iscoroutinefunction(func):
+                raise ValueError("@gen_cluster should wrap async def functions")
+
             result = None
             workers = []
             with clean(timeout=active_rpc_timeout, **clean_kwargs) as loop:
@@ -905,6 +904,7 @@ def gen_cluster(
                                     "Failed to start gen_cluster, retrying",
                                     exc_info=True,
                                 )
+                                await asyncio.sleep(1)
                             else:
                                 workers[:] = ws
                                 args = [s] + workers
@@ -940,16 +940,28 @@ def gen_cluster(
                         else:
                             await c._close(fast=True)
 
-                        for i in range(5):
-                            if all(c.closed() for c in Comm._instances):
-                                break
-                            else:
+                        def get_unclosed():
+                            return [c for c in Comm._instances if not c.closed()] + [
+                                c
+                                for c in _global_clients.values()
+                                if c.status != "closed"
+                            ]
+
+                        try:
+                            start = time()
+                            while time() < start + 5:
+                                gc.collect()
+                                if not get_unclosed():
+                                    break
                                 await asyncio.sleep(0.05)
-                        else:
-                            L = [c for c in Comm._instances if not c.closed()]
+                            else:
+                                if allow_unclosed:
+                                    print(f"Unclosed Comms: {get_unclosed()}")
+                                else:
+                                    raise RuntimeError("Unclosed Comms", get_unclosed())
+                        finally:
                             Comm._instances.clear()
-                            # raise ValueError("Unclosed Comms", L)
-                            print("Unclosed Comms", L)
+                            _global_clients.clear()
 
                         return result
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2310,6 +2310,7 @@ class Worker(ServerNode):
     # Execute Task #
     ################
 
+    # FIXME: this breaks if changed to async def...
     @gen.coroutine
     def executor_submit(self, key, function, args=(), kwargs=None, executor=None):
         """ Safely run function in thread pool executor

--- a/docs/source/asynchronous.rst
+++ b/docs/source/asynchronous.rst
@@ -64,18 +64,12 @@ function to run the asynchronous function:
    client.sync(f)
 
 
-Python 2 Compatibility
-----------------------
-
-Everything here works with Python 2 if you replace ``await`` with ``yield``.
-See more extensive comparison in the example below.
-
 Example
 -------
 
 This self-contained example starts an asynchronous client, submits a trivial
-job, waits on the result, and then shuts down the client.  You can see
-implementations for Python 2 and 3 and for Asyncio and Tornado.
+job, waits on the result, and then shuts down the client. You can see
+implementations for Asyncio and Tornado.
 
 Python 3 with Tornado or Asyncio
 ++++++++++++++++++++++++++++++++
@@ -99,25 +93,6 @@ Python 3 with Tornado or Asyncio
    import asyncio
    asyncio.get_event_loop().run_until_complete(f())
 
-
-Python 2/3 with Tornado
-+++++++++++++++++++++++
-
-.. code-block:: python
-
-   from dask.distributed import Client
-   from tornado import gen
-
-   @gen.coroutine
-   def f():
-       client = yield Client(asynchronous=True)
-       future = client.submit(lambda x: x + 1, 10)
-       result = yield future
-       yield client.close()
-       raise gen.Return(result)
-
-   from tornado.ioloop import IOLoop
-   IOLoop().run_sync(f)
 
 Use Cases
 ---------


### PR DESCRIPTION
- Update all tests to replace @gen.coroutine... yield with async... await
- Replace all gen.sleep with asyncio.sleep
- Clean up ``@skip`` markers for Python < 3.6
- Fix bug in ``Client(asynchronous=True).close()`` that, if invoked twice, on the second round would return ``None``; it now returns ``Awaitable[None]``.
- Decorators ``@gen_cluster`` and ``@gen_test`` now accept only async functions
- ``@gen_cluster`` now properly waits for all Comm and Client objects to be closed, and crashes in case some keep lingering
- Fix flaky tests