### PR TITLE
Use `bytearray` for trivial frames too

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -200,7 +200,7 @@ class TCP(Comm):
                     else:
                         frame = await stream.read_bytes(length)
                 else:
-                    frame = b""
+                    frame = bytearray()
                 frames.append(frame)
         except StreamClosedError as e:
             self.stream = None


### PR DESCRIPTION
Related to issue ( https://github.com/dask/dask/issues/6071 )