### PR TITLE
Avoid DeprecationWarning from pandas

### DIFF
--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -1,5 +1,5 @@
+import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
 import pytest
 
 from dask.dataframe.utils import assert_eq
@@ -22,18 +22,43 @@ dfs = [
     pd.DataFrame({"x": [b"a", b"b", b"c"]}),
     pd.DataFrame({"x": pd.Categorical(["a", "b", "a"], ordered=True)}),
     pd.DataFrame({"x": pd.Categorical(["a", "b", "a"], ordered=False)}),
-    tm.makeCategoricalIndex(),
-    tm.makeCustomDataframe(5, 3),
-    tm.makeDataFrame(),
-    tm.makeDateIndex(),
-    tm.makeMissingDataframe(),
-    tm.makeMixedDataFrame(),
-    tm.makeObjectSeries(),
-    tm.makePeriodFrame(),
-    tm.makeRangeIndex(),
-    tm.makeTimeDataFrame(),
-    tm.makeTimeSeries(),
-    tm.makeUnicodeIndex(),
+    pd.Index(pd.Categorical(["a"], categories=["a", "b"], ordered=True)),
+    pd.date_range("2000", periods=12, freq="B"),
+    pd.RangeIndex(10),
+    pd.DataFrame(
+        "a",
+        index=pd.Index(["a", "b", "c", "d"], name="a"),
+        columns=pd.Index(["A", "B", "C", "D"], name="columns"),
+    ),
+    pd.DataFrame(
+        np.random.randn(10, 5), columns=list("ABCDE"), index=list("abcdefghij")
+    ),
+    pd.DataFrame(
+        np.random.randn(10, 5), columns=list("ABCDE"), index=list("abcdefghij")
+    ).where(lambda x: x > 0),
+    pd.DataFrame(
+        {
+            "a": [0.0, 0.1],
+            "B": [0.0, 1.0],
+            "C": ["a", "b"],
+            "D": pd.to_datetime(["2000", "2001"]),
+        }
+    ),
+    pd.Series(["a", "b", "c"], index=["a", "b", "c"]),
+    pd.DataFrame(
+        np.random.randn(10, 5),
+        columns=list("ABCDE"),
+        index=pd.period_range("2000", periods=10, freq="B"),
+    ),
+    pd.DataFrame(
+        np.random.randn(10, 5),
+        columns=list("ABCDE"),
+        index=pd.date_range("2000", periods=10, freq="B"),
+    ),
+    pd.Series(
+        np.random.randn(10), name="a", index=pd.date_range("2000", periods=10, freq="B")
+    ),
+    pd.Index(["סשםקה7ךשץא", "8טלכז6לרפל"]),
 ]
 
 

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -11,7 +11,7 @@ from distributed.utils_test import gen_cluster
 from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
 import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
+import pandas.testing as tm
 
 
 dfs = [
@@ -126,28 +126,37 @@ def test_dataframe_set_index_sync(wait, client):
     assert len(df2)
 
 
+def make_time_dataframe():
+    return pd.DataFrame(
+        np.random.randn(30, 4),
+        columns=list("ABCD"),
+        index=pd.date_range("2000", periods=30, freq="B"),
+    )
+
+
 def test_loc_sync(client):
-    df = pd.util.testing.makeTimeDataFrame()
+    df = make_time_dataframe()
     ddf = dd.from_pandas(df, npartitions=10)
     ddf.loc["2000-01-17":"2000-01-24"].compute()
 
 
 def test_rolling_sync(client):
-    df = pd.util.testing.makeTimeDataFrame()
+    df = make_time_dataframe()
     ddf = dd.from_pandas(df, npartitions=10)
     ddf.A.rolling(2).mean().compute()
 
 
 @gen_cluster(client=True)
 def test_loc(c, s, a, b):
-    df = pd.util.testing.makeTimeDataFrame()
+    df = make_time_dataframe()
     ddf = dd.from_pandas(df, npartitions=10)
     future = c.compute(ddf.loc["2000-01-17":"2000-01-24"])
     yield future
 
 
 def test_dataframe_groupby_tasks(client):
-    df = pd.util.testing.makeTimeDataFrame()
+    df = make_time_dataframe()
+
     df["A"] = df.A // 0.1
     df["B"] = df.B // 0.1
     ddf = dd.from_pandas(df, npartitions=10)


### PR DESCRIPTION
pandas.util.testing is deprecated in favor of `pandas.testing`.

The `make*` functions weren't given replacements, so we just make our own.