### PR TITLE
Default threads_per_worker value causes test failure on large CPUs

### DIFF
--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -1,3 +1,4 @@
+import gc
 import math
 from time import sleep
 
@@ -151,6 +152,7 @@ def test_min_max():
         processes=False,
         dashboard_address=None,
         asynchronous=True,
+        threads_per_worker=1,
     )
     try:
         adapt = cluster.adapt(minimum=1, maximum=2, interval="20 ms", wait_count=10)
@@ -179,6 +181,7 @@ def test_min_max():
         assert len(adapt.log) == 2 and all(d["status"] == "up" for _, d in adapt.log)
 
         del futures
+        gc.collect()
 
         start = time()
         while len(cluster.scheduler.workers) != 1:


### PR DESCRIPTION
On my Linux dev box mounting a 16 cores / 32 threads CPU, ``LocalCluster(0)`` defaults to threads_per_worker=2, while on Travis it defaults to 1. This caused a test to fail on my box.