### PR TITLE
Move test_gpu_metrics test

### DIFF
--- a/distributed/tests/test_gpu_metrics.py
+++ b/distributed/tests/test_gpu_metrics.py
@@ -6,10 +6,9 @@ pytest.importorskip("pynvml")
 
 @gen_cluster()
 async def test_gpu_metrics(s, a, b):
-from distributed.diagnostics.nvml import handles
+    from distributed.diagnostics.nvml import handles
 
     assert "gpu" in a.metrics
-len(s.workers[a.address].metrics["gpu"]["memory-used"]) == len(handles)
-
+    assert len(s.workers[a.address].metrics["gpu"]["memory-used"]) == len(handles)
     assert "gpu" in a.startup_information
-len(s.workers[a.address].extra["gpu"]["name"]) == len(handles)
+    assert len(s.workers[a.address].extra["gpu"]["name"]) == len(handles)

--- a/distributed/tests/test_gpu_metrics.py
+++ b/distributed/tests/test_gpu_metrics.py
@@ -6,10 +6,10 @@ pytest.importorskip("pynvml")
 
 @gen_cluster()
 async def test_gpu_metrics(s, a, b):
-    from distributed.diagnostics.nvml import count
+from distributed.diagnostics.nvml import handles
 
     assert "gpu" in a.metrics
-    assert len(s.workers[a.address].metrics["gpu"]["memory-used"]) == count
+len(s.workers[a.address].metrics["gpu"]["memory-used"]) == len(handles)
 
     assert "gpu" in a.startup_information
-    assert len(s.workers[a.address].extra["gpu"]["name"]) == count
+len(s.workers[a.address].extra["gpu"]["name"]) == len(handles)

--- a/distributed/tests/test_gpu_metrics.py
+++ b/distributed/tests/test_gpu_metrics.py
@@ -1,0 +1,15 @@
+import pytest
+from distributed.utils_test import gen_cluster
+
+pytest.importorskip("pynvml")
+
+
+@gen_cluster()
+async def test_gpu_metrics(s, a, b):
+    from distributed.diagnostics.nvml import count
+
+    assert "gpu" in a.metrics
+    assert len(s.workers[a.address].metrics["gpu"]["memory-used"]) == count
+
+    assert "gpu" in a.startup_information
+    assert len(s.workers[a.address].extra["gpu"]["name"]) == count

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -1,6 +1,6 @@
 import asyncio
 import random
-from time import sleep
+from time import sleep, monotonic
 import logging
 
 import pytest
@@ -96,10 +96,10 @@ async def test_hold_futures(s, a, b):
 async def test_timeout(c, s, a, b):
     v = Variable("v")
 
-    start = IOLoop.current().time()
+    start = monotonic()
     with pytest.raises(TimeoutError):
         await v.get(timeout=0.2)
-    stop = IOLoop.current().time()
+    stop = monotonic()
 
     if WINDOWS:  # timing is weird with asyncio and Windows
         assert 0.1 < stop - start < 2.0

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1572,18 +1572,6 @@ async def test_lifetime_stagger(c, s, a, b):
     assert 8 <= b.lifetime <= 12
 
 
-@gen_cluster()
-async def test_gpu_metrics(s, a, b):
-    pytest.importorskip("pynvml")
-    from distributed.diagnostics.nvml import count
-
-    assert "gpu" in a.metrics
-    assert len(s.workers[a.address].metrics["gpu"]["memory-used"]) == count
-
-    assert "gpu" in a.startup_information
-    assert len(s.workers[a.address].extra["gpu"]["name"]) == count
-
-
 @pytest.mark.asyncio
 async def test_bad_metrics(cleanup):
     def bad_metric(w):


### PR DESCRIPTION
gen_cluster doesn't cleanly handle pytest.importorskip. The test is still skipped correctly, but there's some noise in the output.

```
Task exception was never retrieved

future: <Task finished coro=<test_gpu_metrics() done, defined at
/home/travis/build/dask/distributed/distributed/tests/test_worker.py:1575>
exception=could not import 'pynvml': No module named 'pynvml'>

Traceback (most recent call last):

  File
  "/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/_pytest/runner.py",
  line 244, in from_call
```

This moves the importorskip outside the test.

Could someone with a GPU (@quasiben or @jakirkham) make sure I didn't break the test?