### PR TITLE
Use PeriodicCallback class from tornado

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -37,7 +37,7 @@ try:
 except ImportError:
     single_key = first
 from tornado import gen
-from tornado.ioloop import IOLoop
+from tornado.ioloop import IOLoop, PeriodicCallback
 
 from .batched import BatchedSend
 from .utils_comm import (
@@ -72,7 +72,6 @@ from .utils import (
     key_split,
     thread_state,
     no_default,
-    PeriodicCallback,
     LoopRunner,
     parse_timedelta,
     shutting_down,
@@ -679,10 +678,10 @@ class Client(Node):
 
         self._periodic_callbacks = dict()
         self._periodic_callbacks["scheduler-info"] = PeriodicCallback(
-            self._update_scheduler_info, 2000, io_loop=self.loop
+            self._update_scheduler_info, 2000
         )
         self._periodic_callbacks["heartbeat"] = PeriodicCallback(
-            self._heartbeat, heartbeat_interval * 1000, io_loop=self.loop
+            self._heartbeat, heartbeat_interval * 1000
         )
 
         self._start_arg = address

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -12,7 +12,7 @@ import dask
 import tblib
 from tlz import merge
 from tornado import gen
-from tornado.ioloop import IOLoop
+from tornado.ioloop import IOLoop, PeriodicCallback
 
 from .comm import (
     connect,
@@ -31,7 +31,6 @@ from .utils import (
     truncate_exception,
     ignoring,
     shutting_down,
-    PeriodicCallback,
     parse_timedelta,
     has_keyword,
     CancelledError,
@@ -176,7 +175,7 @@ class Server:
 
         self.periodic_callbacks = dict()
 
-        pc = PeriodicCallback(self.monitor.update, 500, io_loop=self.io_loop)
+        pc = PeriodicCallback(self.monitor.update, 500)
         self.periodic_callbacks["monitor"] = pc
 
         self._last_tick = time()
@@ -186,7 +185,6 @@ class Server:
                 dask.config.get("distributed.admin.tick.interval"), default="ms"
             )
             * 1000,
-            io_loop=self.io_loop,
         )
         self.periodic_callbacks["tick"] = pc
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -179,13 +179,10 @@ class Server:
         self.periodic_callbacks["monitor"] = pc
 
         self._last_tick = time()
-        pc = PeriodicCallback(
-            self._measure_tick,
-            parse_timedelta(
-                dask.config.get("distributed.admin.tick.interval"), default="ms"
-            )
-            * 1000,
+        measure_tick_interval = parse_timedelta(
+            dask.config.get("distributed.admin.tick.interval"), default="ms"
         )
+        pc = PeriodicCallback(self._measure_tick, measure_tick_interval * 1000)
         self.periodic_callbacks["tick"] = pc
 
         self.thread_id = 0

--- a/distributed/counter.py
+++ b/distributed/counter.py
@@ -1,8 +1,6 @@
 from collections import defaultdict
 
-from tornado.ioloop import IOLoop
-
-from .utils import PeriodicCallback
+from tornado.ioloop import IOLoop, PeriodicCallback
 
 
 try:

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -1,11 +1,11 @@
 import collections
 import math
 
-from tornado.ioloop import IOLoop
+from tornado.ioloop import IOLoop, PeriodicCallback
 import tlz as toolz
 
 from ..metrics import time
-from ..utils import parse_timedelta, PeriodicCallback
+from ..utils import parse_timedelta
 
 
 class AdaptiveCore:

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -2,13 +2,13 @@ import asyncio
 import logging
 import threading
 import warnings
+from tornado.ioloop import PeriodicCallback
 
 from dask.utils import format_bytes
 
 from .adaptive import Adaptive
 
 from ..utils import (
-    PeriodicCallback,
     log_errors,
     ignoring,
     sync,
@@ -319,7 +319,7 @@ class Cluster:
         def update():
             status.value = self._widget_status()
 
-        pc = PeriodicCallback(update, 500, io_loop=self.loop)
+        pc = PeriodicCallback(update, 500)
         self.periodic_callbacks["cluster-repr"] = pc
         pc.start()
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -11,7 +11,7 @@ import weakref
 
 import dask
 from dask.system import CPU_COUNT
-from tornado.ioloop import IOLoop
+from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado import gen
 
 from .comm import get_address_host, unparse_host_port
@@ -28,7 +28,6 @@ from .utils import (
     mp_context,
     silence_logging,
     json_load_robust,
-    PeriodicCallback,
     parse_timedelta,
     ignoring,
     TimeoutError,
@@ -202,7 +201,7 @@ class Nanny(ServerNode):
         self.scheduler = self.rpc(self.scheduler_addr)
 
         if self.memory_limit:
-            pc = PeriodicCallback(self.memory_monitor, 100, io_loop=self.loop)
+            pc = PeriodicCallback(self.memory_monitor, 100)
             self.periodic_callbacks["memory"] = pc
 
         if (

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -32,7 +32,7 @@ from tlz import (
     groupby,
     concat,
 )
-from tornado.ioloop import IOLoop
+from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
 
@@ -64,7 +64,6 @@ from .utils import (
     no_default,
     parse_timedelta,
     parse_bytes,
-    PeriodicCallback,
     shutting_down,
     key_split_group,
     empty_context,
@@ -1357,11 +1356,11 @@ class Scheduler(ServerNode):
         )
 
         if self.worker_ttl:
-            pc = PeriodicCallback(self.check_worker_ttl, self.worker_ttl, io_loop=loop)
+            pc = PeriodicCallback(self.check_worker_ttl, self.worker_ttl)
             self.periodic_callbacks["worker-ttl"] = pc
 
         if self.idle_timeout:
-            pc = PeriodicCallback(self.check_idle, self.idle_timeout / 4, io_loop=loop)
+            pc = PeriodicCallback(self.check_idle, self.idle_timeout / 4)
             self.periodic_callbacks["idle-timeout"] = pc
 
         if extensions is None:

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -67,12 +67,12 @@ class SemaphoreExtension:
 
         self.scheduler.extensions["semaphores"] = self
 
-        validation_callback_time = 1000 * parse_timedelta(
+        validation_callback_time = parse_timedelta(
             dask.config.get("distributed.scheduler.locks.lease-validation-interval"),
             default="s",
         )
         self._pc_lease_timeout = PeriodicCallback(
-            self._check_lease_timeout, validation_callback_time,
+            self._check_lease_timeout, validation_callback_time * 1000,
         )
         self._pc_lease_timeout.start()
         self.lease_timeout = parse_timedelta(
@@ -343,7 +343,7 @@ class Semaphore:
         )
         self._refreshing_leases = False
         pc = PeriodicCallback(
-            self._refresh_leases, callback_time=1000 * refresh_leases_interval,
+            self._refresh_leases, callback_time=refresh_leases_interval * 1000
         )
         self.refresh_callback = pc
         # Registering the pc to the client here is important for proper cleanup

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -3,7 +3,8 @@ from collections import defaultdict, deque
 import asyncio
 import dask
 from asyncio import TimeoutError
-from .utils import PeriodicCallback, log_errors, parse_timedelta
+from tornado.ioloop import PeriodicCallback
+from .utils import log_errors, parse_timedelta
 from .worker import get_client
 from .metrics import time
 import warnings
@@ -70,9 +71,7 @@ class SemaphoreExtension:
             default="s",
         )
         self._pc_lease_timeout = PeriodicCallback(
-            self._check_lease_timeout,
-            validation_callback_time,
-            io_loop=self.scheduler.loop,
+            self._check_lease_timeout, validation_callback_time,
         )
         self._pc_lease_timeout.start()
         self.lease_timeout = parse_timedelta(
@@ -340,9 +339,7 @@ class Semaphore:
         )
         self._refreshing_leases = False
         pc = PeriodicCallback(
-            self._refresh_leases,
-            callback_time=1000 * refresh_leases_interval,
-            io_loop=self.client.io_loop,
+            self._refresh_leases, callback_time=1000 * refresh_leases_interval,
         )
         self.refresh_callback = pc
         # Registering the pc to the client here is important for proper cleanup

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -38,12 +38,12 @@ class WorkStealing(SchedulerPlugin):
         for worker in scheduler.workers:
             self.add_worker(worker=worker)
 
-        # `callback_time` is in milliseconds
-        callback_time = 1000 * parse_timedelta(
+        callback_time = parse_timedelta(
             dask.config.get("distributed.scheduler.work-stealing-interval"),
             default="ms",
         )
-        pc = PeriodicCallback(callback=self.balance, callback_time=callback_time,)
+        # `callback_time` is in milliseconds
+        pc = PeriodicCallback(callback=self.balance, callback_time=callback_time * 1000)
         self._pc = pc
         self.scheduler.periodic_callbacks["stealing"] = pc
         self.scheduler.plugins.append(self)

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -3,11 +3,13 @@ import logging
 from math import log
 from time import time
 
+from tornado.ioloop import PeriodicCallback
+
 import dask
 from .comm.addressing import get_address_host
 from .core import CommClosedError
 from .diagnostics.plugin import SchedulerPlugin
-from .utils import log_errors, parse_timedelta, PeriodicCallback
+from .utils import log_errors, parse_timedelta
 
 from tlz import topk
 
@@ -41,11 +43,7 @@ class WorkStealing(SchedulerPlugin):
             dask.config.get("distributed.scheduler.work-stealing-interval"),
             default="ms",
         )
-        pc = PeriodicCallback(
-            callback=self.balance,
-            callback_time=callback_time,
-            io_loop=self.scheduler.loop,
-        )
+        pc = PeriodicCallback(callback=self.balance, callback_time=callback_time,)
         self._pc = pc
         self.scheduler.periodic_callbacks["stealing"] = pc
         self.scheduler.plugins.append(self)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -48,7 +48,6 @@ from dask.utils import (  # noqa
 )
 
 import tlz as toolz
-import tornado
 from tornado import gen
 from tornado.ioloop import IOLoop
 
@@ -1117,17 +1116,6 @@ def nbytes(frame, _bytes_like=(bytes, bytearray)):
             return len(frame)
 
 
-def PeriodicCallback(callback, callback_time, io_loop=None):
-    """
-    Wrapper around tornado.IOLoop.PeriodicCallback, for compatibility
-    with removal of the `io_loop` parameter in Tornado 5.0.
-    """
-    if tornado.version_info >= (5,):
-        return tornado.ioloop.PeriodicCallback(callback, callback_time)
-    else:
-        return tornado.ioloop.PeriodicCallback(callback, callback_time, io_loop)
-
-
 @contextmanager
 def time_warn(duration, text):
     start = time()
@@ -1190,49 +1178,47 @@ def reset_logger_locks():
             handler.createLock()
 
 
-if tornado.version_info[0] >= 5:
+is_server_extension = False
 
-    is_server_extension = False
+if "notebook" in sys.modules:
+    import traitlets
+    from notebook.notebookapp import NotebookApp
 
-    if "notebook" in sys.modules:
-        import traitlets
-        from notebook.notebookapp import NotebookApp
+    is_server_extension = traitlets.config.Application.initialized() and isinstance(
+        traitlets.config.Application.instance(), NotebookApp
+    )
 
-        is_server_extension = traitlets.config.Application.initialized() and isinstance(
-            traitlets.config.Application.instance(), NotebookApp
-        )
+if not is_server_extension:
+    is_kernel_and_no_running_loop = False
 
-    if not is_server_extension:
-        is_kernel_and_no_running_loop = False
+    if is_kernel():
+        try:
+            get_running_loop()
+        except RuntimeError:
+            is_kernel_and_no_running_loop = True
 
-        if is_kernel():
-            try:
-                get_running_loop()
-            except RuntimeError:
-                is_kernel_and_no_running_loop = True
+    if not is_kernel_and_no_running_loop:
 
-        if not is_kernel_and_no_running_loop:
+        # TODO: Use tornado's AnyThreadEventLoopPolicy, instead of class below,
+        # once tornado > 6.0.3 is available.
+        if WINDOWS and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
+            # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+            # fallback to the pre-3.8 default of Selector
+            # https://github.com/tornadoweb/tornado/issues/2608
+            BaseEventLoopPolicy = asyncio.WindowsSelectorEventLoopPolicy
+        else:
+            BaseEventLoopPolicy = asyncio.DefaultEventLoopPolicy
 
-            # TODO: Use tornado's AnyThreadEventLoopPolicy, instead of class below,
-            # once tornado > 6.0.3 is available.
-            if WINDOWS and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
-                # WindowsProactorEventLoopPolicy is not compatible with tornado 6
-                # fallback to the pre-3.8 default of Selector
-                # https://github.com/tornadoweb/tornado/issues/2608
-                BaseEventLoopPolicy = asyncio.WindowsSelectorEventLoopPolicy
-            else:
-                BaseEventLoopPolicy = asyncio.DefaultEventLoopPolicy
+        class AnyThreadEventLoopPolicy(BaseEventLoopPolicy):
+            def get_event_loop(self):
+                try:
+                    return super().get_event_loop()
+                except (RuntimeError, AssertionError):
+                    loop = self.new_event_loop()
+                    self.set_event_loop(loop)
+                    return loop
 
-            class AnyThreadEventLoopPolicy(BaseEventLoopPolicy):
-                def get_event_loop(self):
-                    try:
-                        return super().get_event_loop()
-                    except (RuntimeError, AssertionError):
-                        loop = self.new_event_loop()
-                        self.set_event_loop(loop)
-                        return loop
-
-            asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
+        asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
 
 
 @functools.lru_cache(1000)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -473,9 +473,6 @@ class Worker(ServerNode):
         self.available_resources = (resources or {}).copy()
         self.death_timeout = parse_timedelta(death_timeout)
 
-        self.memory_monitor_interval = parse_timedelta(
-            memory_monitor_interval, default="ms"
-        )
         self.extensions = dict()
         if silence_logs:
             silence_logging(level=silence_logs)
@@ -667,6 +664,9 @@ class Worker(ServerNode):
 
         self._address = contact_address
 
+        self.memory_monitor_interval = parse_timedelta(
+            memory_monitor_interval, default="ms"
+        )
         if self.memory_limit:
             self._memory_monitoring = False
             pc = PeriodicCallback(
@@ -683,13 +683,10 @@ class Worker(ServerNode):
 
         setproctitle("dask-worker [not started]")
 
-        pc = PeriodicCallback(
-            self.trigger_profile,
-            parse_timedelta(
-                dask.config.get("distributed.worker.profile.interval"), default="ms"
-            )
-            * 1000,
+        profile_trigger_interval = parse_timedelta(
+            dask.config.get("distributed.worker.profile.interval"), default="ms"
         )
+        pc = PeriodicCallback(self.trigger_profile, profile_trigger_interval * 1000)
         self.periodic_callbacks["profile"] = pc
 
         pc = PeriodicCallback(self.cycle_profile, profile_cycle_interval * 1000)


### PR DESCRIPTION
We have a `PeriodicCallback` compatibility class which wraps tornado's `PeriodicCallback` and has some logic for dealing with tornado versions < 5

https://github.com/dask/distributed/blob/07b0cfeef4d2515361c1ee89222c18d30ad26a67/distributed/utils.py#L1120-L1128

Since today we require `tornado >= 5`, we can drop the compatibility class and just use `PeriodicCallback` from tornado