### PR TITLE
Relax NumPy requirement in UCX

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -239,9 +239,7 @@ class UCX(Comm):
             else:
                 # Recv frames
                 frames = [
-                    device_array(each_size)
-                    if is_cuda
-                    else host_array(each_size)
+                    device_array(each_size) if is_cuda else host_array(each_size)
                     for is_cuda, each_size in zip(cuda_frames, sizes)
                 ]
                 recv_frames = [

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -182,6 +182,7 @@ class UCX(Comm):
                 cuda_frames = tuple(
                     hasattr(f, "__cuda_array_interface__") for f in frames
                 )
+                sizes = tuple(nbytes(f) for f in frames)
                 send_frames = [
                     each_frame for each_frame in frames if len(each_frame) > 0
                 ]
@@ -189,9 +190,7 @@ class UCX(Comm):
                 # Send meta data
                 await self.ep.send(struct.pack("Q", nframes))
                 await self.ep.send(struct.pack(nframes * "?", *cuda_frames))
-                await self.ep.send(
-                    struct.pack(nframes * "Q", *(nbytes(f) for f in frames))
-                )
+                await self.ep.send(struct.pack(nframes * "Q", *sizes))
 
                 # Send frames
 

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -69,7 +69,7 @@ def init_once():
             import numba.cuda
 
             def rmm_cuda_array(n):
-                a = rmm.device_array(n, dtype=np.uint8)
+                a = rmm.device_array((n,), dtype=np.uint8)
                 weakref.finalize(a, numba.cuda.current_context)
                 return a
 

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -184,7 +184,9 @@ class UCX(Comm):
                 )
                 sizes = tuple(nbytes(f) for f in frames)
                 send_frames = [
-                    each_frame for each_frame in frames if len(each_frame) > 0
+                    each_frame
+                    for each_frame, each_size in zip(frames, sizes)
+                    if each_size
                 ]
 
                 # Send meta data

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -206,7 +206,7 @@ class UCX(Comm):
 
                 for each_frame in send_frames:
                     await self.ep.send(each_frame)
-                return sum(map(nbytes, send_frames))
+                return sum(sizes)
             except (ucp.exceptions.UCXBaseException):
                 self.abort()
                 raise CommClosedError("While writing, the connection was closed")

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -222,17 +222,17 @@ class UCX(Comm):
             try:
                 # Recv meta data
                 nframes_fmt = "Q"
-                nframes = bytearray(struct.calcsize(nframes_fmt))
+                nframes = host_array(struct.calcsize(nframes_fmt))
                 await self.ep.recv(nframes)
                 (nframes,) = struct.unpack(nframes_fmt, nframes)
 
                 cuda_frames_fmt = nframes * "?"
-                cuda_frames = bytearray(struct.calcsize(cuda_frames_fmt))
+                cuda_frames = host_array(struct.calcsize(cuda_frames_fmt))
                 await self.ep.recv(cuda_frames)
                 cuda_frames = struct.unpack(cuda_frames_fmt, cuda_frames)
 
                 sizes_fmt = nframes * "Q"
-                sizes = bytearray(struct.calcsize(sizes_fmt))
+                sizes = host_array(struct.calcsize(sizes_fmt))
                 await self.ep.recv(sizes)
                 sizes = struct.unpack(sizes_fmt, sizes)
             except (ucp.exceptions.UCXBaseException, CancelledError):

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -178,6 +178,7 @@ class UCX(Comm):
                 frames = await to_frames(
                     msg, serializers=serializers, on_error=on_error
                 )
+                nframes = len(frames)
                 cuda_frames = tuple(
                     hasattr(f, "__cuda_array_interface__") for f in frames
                 )
@@ -186,10 +187,10 @@ class UCX(Comm):
                 ]
 
                 # Send meta data
-                await self.ep.send(struct.pack("Q", len(frames)))
-                await self.ep.send(struct.pack(len(cuda_frames) * "?", *cuda_frames))
+                await self.ep.send(struct.pack("Q", nframes))
+                await self.ep.send(struct.pack(nframes * "?", *cuda_frames))
                 await self.ep.send(
-                    struct.pack(len(frames) * "Q", *(nbytes(f) for f in frames))
+                    struct.pack(nframes * "Q", *(nbytes(f) for f in frames))
                 )
 
                 # Send frames

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -178,14 +178,14 @@ class UCX(Comm):
                 frames = await to_frames(
                     msg, serializers=serializers, on_error=on_error
                 )
+                cuda_frames = tuple(
+                    hasattr(f, "__cuda_array_interface__") for f in frames
+                )
                 send_frames = [
                     each_frame for each_frame in frames if len(each_frame) > 0
                 ]
 
                 # Send meta data
-                cuda_frames = tuple(
-                    hasattr(f, "__cuda_array_interface__") for f in frames
-                )
                 await self.ep.send(struct.pack("Q", len(frames)))
                 await self.ep.send(struct.pack(len(cuda_frames) * "?", *cuda_frames))
                 await self.ep.send(

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -190,7 +190,11 @@ class UCX(Comm):
                 ]
 
                 # Send meta data
+
+                # Send # of frames (uint64)
                 await self.ep.send(struct.pack("Q", nframes))
+                # Send which frames are CUDA (bool) and
+                # how large each frame is (uint64)
                 await self.ep.send(
                     struct.pack(nframes * "?" + nframes * "Q", *cuda_frames, *sizes)
                 )
@@ -222,11 +226,15 @@ class UCX(Comm):
 
             try:
                 # Recv meta data
+
+                # Recv # of frames (uint64)
                 nframes_fmt = "Q"
                 nframes = host_array(struct.calcsize(nframes_fmt))
                 await self.ep.recv(nframes)
                 (nframes,) = struct.unpack(nframes_fmt, nframes)
 
+                # Recv which frames are CUDA (bool) and
+                # how large each frame is (uint64)
                 header_fmt = nframes * "?" + nframes * "Q"
                 header = host_array(struct.calcsize(header_fmt))
                 await self.ep.recv(header)

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -69,7 +69,7 @@ def init_once():
             import numba.cuda
 
             def rmm_cuda_array(n):
-                a = rmm.device_array((n,), dtype=np.uint8)
+                a = rmm.device_array(n, dtype="u1")
                 weakref.finalize(a, numba.cuda.current_context)
                 return a
 
@@ -79,7 +79,7 @@ def init_once():
             import numba.cuda
 
             def numba_cuda_array(n):
-                a = numba.cuda.device_array((n,), dtype=np.uint8)
+                a = numba.cuda.device_array((n,), dtype="u1")
                 weakref.finalize(a, numba.cuda.current_context)
                 return a
 
@@ -225,7 +225,7 @@ class UCX(Comm):
                 frames = [
                     cuda_array(each_size)
                     if is_cuda
-                    else np.empty(each_size, dtype=np.uint8)
+                    else np.empty(each_size, dtype="u1")
                     for is_cuda, each_size in zip(is_cudas.tolist(), sizes.tolist())
                 ]
                 recv_frames = [

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -213,8 +213,8 @@ class UCX(Comm):
                 # Recv meta data
                 nframes = np.empty(1, dtype=np.uint64)
                 await self.ep.recv(nframes)
-                is_cudas = np.empty(nframes[0], dtype=np.bool)
-                await self.ep.recv(is_cudas)
+                cuda_frames = np.empty(nframes[0], dtype=np.bool)
+                await self.ep.recv(cuda_frames)
                 sizes = np.empty(nframes[0], dtype=np.uint64)
                 await self.ep.recv(sizes)
             except (ucp.exceptions.UCXBaseException, CancelledError):
@@ -226,7 +226,7 @@ class UCX(Comm):
                     cuda_array(each_size)
                     if is_cuda
                     else np.empty(each_size, dtype="u1")
-                    for is_cuda, each_size in zip(is_cudas.tolist(), sizes.tolist())
+                    for is_cuda, each_size in zip(cuda_frames.tolist(), sizes.tolist())
                 ]
                 recv_frames = [
                     each_frame for each_frame in frames if len(each_frame) > 0
@@ -234,7 +234,7 @@ class UCX(Comm):
 
                 # It is necessary to first populate `frames` with CUDA arrays and synchronize
                 # the default stream before starting receiving to ensure buffers have been allocated
-                if is_cudas.any():
+                if cuda_frames.any():
                     synchronize_stream(0)
 
                 for each_frame in recv_frames:


### PR DESCRIPTION
This relaxes the NumPy requirement in UCX communication. We do this by leveraging things like `struct.pack` and `struct.unpack` for metadata about the frames, which gives us simple `bytes` objects to send over the wire. Also we create a `host_array` function that will use NumPy when available, but will fallback to things like `bytearray` if not.