### PR TITLE
Warn if cluster closes before starting

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -383,7 +383,10 @@ class SpecCluster(Cluster):
             await future
         async with self._lock:
             with ignoring(CommClosedError):
-                await self.scheduler_comm.close(close_workers=True)
+                if self.scheduler_comm:
+                    await self.scheduler_comm.close(close_workers=True)
+                else:
+                    logger.warning("Cluster closed without starting up")
 
         await self.scheduler.close()
         for w in self._created:


### PR DESCRIPTION
Otherwise users get an odd message like the following:

```python-traceback
  File "/home/XXX/.local/lib/python3.6/site-packages/tornado/ioloop.py", line 743, in _run_callback
    ret = callback()
  File "/home/XXX/.local/lib/python3.6/site-packages/tornado/ioloop.py", line 767, in _discard_future_result
    future.result()
  File "/home/XXX/.local/lib/python3.6/site-packages/distributed/deploy/spec.py", line 386, in _close
    await self.scheduler_comm.close(close_workers=True)
AttributeError: 'NoneType' object has no attribute 'close'
```