### PR TITLE
Reinstate support for legacy @gen_cluster functions

### DIFF
--- a/distributed/_version.py
+++ b/distributed/_version.py
@@ -96,9 +96,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
         if verbose:
             print("unable to find command, tried %s" % (commands,))
         return None, None
-    stdout = p.communicate()[0].strip()
-    if sys.version_info[0] >= 3:
-        stdout = stdout.decode()
+    stdout = p.communicate()[0].strip().decode()
     if p.returncode != 0:
         if verbose:
             print("unable to run %s (error)" % dispcmd)

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -646,8 +646,7 @@ async def test_tls_reject_certificate():
         )
         await comm.write({"x": "foo"})  # TODO: why is this necessary in Tornado 6 ?
 
-    # The wrong error is reported on Python 2, see https://github.com/tornadoweb/tornado/pull/2028
-    if sys.version_info >= (3,) and os.name != "nt":
+    if os.name != "nt":
         try:
             # See https://serverfault.com/questions/793260/what-does-tlsv1-alert-unknown-ca-mean
             assert "unknown ca" in str(excinfo.value)
@@ -670,9 +669,7 @@ async def test_tls_reject_certificate():
         await connect(
             listener.contact_address, timeout=2, ssl_context=cli_ctx,
         )
-    # The wrong error is reported on Python 2, see https://github.com/tornadoweb/tornado/pull/2028
-    if sys.version_info >= (3,):
-        assert "certificate verify failed" in str(excinfo.value)
+    assert "certificate verify failed" in str(excinfo.value)
 
 
 #

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -67,7 +67,6 @@ def test_local_cluster_supports_blocked_handlers(loop):
     )
 
 
-@pytest.mark.skipif("sys.version_info[0] == 2", reason="fork issues")
 def test_close_twice():
     with LocalCluster() as cluster:
         with Client(cluster.scheduler_address) as client:
@@ -81,7 +80,6 @@ def test_close_twice():
         assert not log
 
 
-@pytest.mark.skipif("sys.version_info[0] == 2", reason="multi-loop")
 def test_procs():
     with LocalCluster(
         2,
@@ -173,13 +171,11 @@ def test_transports_tcp_port():
             assert e.submit(inc, 4).result() == 5
 
 
-@pytest.mark.skipif("sys.version_info[0] == 2", reason="")
 class LocalTest(ClusterTest, unittest.TestCase):
     Cluster = partial(LocalCluster, silence_logs=False, dashboard_address=None)
     kwargs = {"dashboard_address": None, "processes": False}
 
 
-@pytest.mark.skipif("sys.version_info[0] == 2", reason="")
 def test_Client_with_local(loop):
     with LocalCluster(
         1, scheduler_port=0, silence_logs=False, dashboard_address=None, loop=loop
@@ -429,7 +425,6 @@ def test_bokeh(loop, processes):
         requests.get(url, timeout=0.2)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason="Unknown")
 def test_blocks_until_full(loop):
     with Client(loop=loop) as c:
         assert len(c.nthreads()) > 0
@@ -462,7 +457,8 @@ async def test_scale_up_and_down():
 
 @pytest.mark.xfail(
     sys.version_info >= (3, 8) and LooseVersion(tornado.version) < "6.0.3",
-    reason="Known issue with Python 3.8 and Tornado < 6.0.3. See https://github.com/tornadoweb/tornado/pull/2683.",
+    reason="Known issue with Python 3.8 and Tornado < 6.0.3. "
+    "See https://github.com/tornadoweb/tornado/pull/2683.",
     strict=True,
 )
 def test_silent_startup():
@@ -549,7 +545,6 @@ def test_death_timeout_raises(loop):
     LocalCluster._instances.clear()  # ignore test hygiene checks
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason="Unknown")
 @pytest.mark.asyncio
 async def test_bokeh_kwargs(cleanup):
     pytest.importorskip("bokeh")

--- a/distributed/metrics.py
+++ b/distributed/metrics.py
@@ -49,10 +49,7 @@ class _WindowsTime:
         self.delta = None
         self.last_resync = float("-inf")
 
-    if sys.version_info >= (3,):
-        perf_counter = timemod.perf_counter
-    else:
-        perf_counter = timemod.clock
+    perf_counter = timemod.perf_counter
 
     def time(self):
         delta = self.delta

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -1,12 +1,8 @@
 import logging
-import sys
+import pickle
 
 import cloudpickle
 
-if sys.version_info.major == 2:
-    import cPickle as pickle
-else:
-    import pickle
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -1,4 +1,3 @@
-import sys
 from zlib import crc32
 
 import numpy as np
@@ -189,7 +188,6 @@ def test_itemsize(dt, size):
     assert itemsize(np.dtype(dt)) == size
 
 
-@pytest.mark.skipif(sys.version_info[0] < 3, reason="numpy doesnt use memoryviews")
 def test_compress_numpy():
     pytest.importorskip("lz4")
     x = np.ones(10000000, dtype="i4")
@@ -238,7 +236,6 @@ async def test_dumps_large_blosc(c, s, a, b):
     await x
 
 
-@pytest.mark.skipif(sys.version_info[0] < 3, reason="numpy doesnt use memoryviews")
 def test_compression_takes_advantage_of_itemsize():
     pytest.importorskip("lz4")
     blosc = pytest.importorskip("blosc")

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -1,5 +1,3 @@
-import sys
-
 import dask
 import pytest
 
@@ -209,7 +207,6 @@ def test_dumps_loads_Serialized():
     assert result == result3
 
 
-@pytest.mark.skipif(sys.version_info[0] < 3, reason="NumPy doesnt use memoryviews")
 def test_maybe_compress_memoryviews():
     np = pytest.importorskip("numpy")
     pytest.importorskip("lz4")

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -106,6 +106,7 @@ async def test_worksteal_many_thieves(c, s, *workers):
     assert sum(map(len, s.has_what.values())) < 150
 
 
+@pytest.mark.xfail(reason="GH#3574")
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 async def test_dont_steal_unknown_functions(c, s, a, b):
     futures = c.map(inc, range(100), workers=a.address, allow_other_workers=True)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 import functools
 from hashlib import md5
 import html
-import inspect
 import json
 import logging
 import multiprocessing

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1039,10 +1039,7 @@ def import_file(path):
     if ext in (".egg", ".zip", ".pyz"):
         if path not in sys.path:
             sys.path.insert(0, path)
-        if sys.version_info >= (3, 6):
-            names = (mod_info.name for mod_info in pkgutil.iter_modules([path]))
-        else:
-            names = (mod_info[1] for mod_info in pkgutil.iter_modules([path]))
+        names = (mod_info.name for mod_info in pkgutil.iter_modules([path]))
         names_to_import.extend(names)
 
     loaded = []
@@ -1285,11 +1282,7 @@ def color_of(x, palette=palette):
 
 
 def iscoroutinefunction(f):
-    if gen.is_coroutine_function(f):
-        return True
-    if sys.version_info >= (3, 5) and inspect.iscoroutinefunction(f):
-        return True
-    return False
+    return inspect.iscoroutinefunction(f) or gen.is_coroutine_function(f)
 
 
 @contextmanager

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -18,7 +18,6 @@ import socket
 import subprocess
 import sys
 import tempfile
-import textwrap
 import threading
 from time import sleep
 import uuid

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -398,22 +398,9 @@ async def geninc(x, delay=0.02):
     return x + 1
 
 
-def compile_snippet(code, dedent=True):
-    if dedent:
-        code = textwrap.dedent(code)
-    code = compile(code, "<dynamic>", "exec")
-    ns = globals()
-    exec(code, ns, ns)
-
-
-compile_snippet(
-    """
-    async def asyncinc(x, delay=0.02):
-        await asyncio.sleep(delay)
-        return x + 1
-    """
-)
-assert asyncinc  # noqa: F821
+async def asyncinc(x, delay=0.02):
+    await asyncio.sleep(delay)
+    return x + 1
 
 
 _readone_queues = {}

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -406,17 +406,14 @@ def compile_snippet(code, dedent=True):
     exec(code, ns, ns)
 
 
-if sys.version_info >= (3, 5):
-    compile_snippet(
-        """
-        async def asyncinc(x, delay=0.02):
-            await asyncio.sleep(delay)
-            return x + 1
-        """
-    )
-    assert asyncinc  # noqa: F821
-else:
-    asyncinc = None
+compile_snippet(
+    """
+    async def asyncinc(x, delay=0.02):
+        await asyncio.sleep(delay)
+        return x + 1
+    """
+)
+assert asyncinc  # noqa: F821
 
 
 _readone_queues = {}
@@ -1004,12 +1001,7 @@ def terminate_process(proc):
         else:
             proc.send_signal(signal.SIGINT)
         try:
-            if sys.version_info[0] == 3:
-                proc.wait(10)
-            else:
-                start = time()
-                while proc.poll() is None and time() < start + 10:
-                    sleep(0.02)
+            proc.wait(10)
         finally:
             # Make sure we don't leave the process lingering around
             with ignoring(OSError):


### PR DESCRIPTION
Revert change in https://github.com/dask/distributed/pull/3706 that caused non-async functions decorated by ``@gen_cluster`` and ``@gen_test`` to break.

Clean up some more Python<3.6-specific code.