### PR TITLE
Fix confusing error if compression not available

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -211,14 +211,12 @@ def maybe_compress(payload, min_size=1e4, sample_size=1e4, nsamples=5):
 
 def decompress(header, frames):
     """ Decompress frames according to information in the header """
-    return [
-        _decompress_frame(c, frame) for c, frame in zip(header["compression"], frames)
-    ]
-
-
-def _decompress_frame(method, frame):
-    """Decompress a single frame"""
-    compressor = compressions.get(method, None)
-    if compressor is None:
-        raise ValueError("Invalid compression method: %s" % method)
-    return compressor["decompress"](frame)
+    try:
+        return [
+            compressions[c]["decompress"](c, frame)
+            for c, frame in zip(header["compression"], frames)
+        ]
+    except KeyError as e:
+        # while it's not documented behavior, the presence of the offending key
+        # at `e.args[0]` is pretty consistent across versions of Python
+        raise ValueError("Invalid compression method: %s" % e.args[0])

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -218,8 +218,7 @@ def maybe_compress(payload, min_size=1e4, sample_size=1e4, nsamples=5):
 def decompress(header, frames):
     """ Decompress frames according to information in the header """
     return [
-        _decompress_frame(c, frame)
-        for c, frame in zip(header["compression"], frames)
+        _decompress_frame(c, frame) for c, frame in zip(header["compression"], frames)
     ]
 
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -213,7 +213,7 @@ def decompress(header, frames):
     """ Decompress frames according to information in the header """
     try:
         return [
-            compressions[c]["decompress"](c, frame)
+            compressions[c]["decompress"](frame)
             for c, frame in zip(header["compression"], frames)
         ]
     except KeyError as e:

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -11,12 +11,6 @@ import dask
 from tlz import identity
 
 
-class InvalidCompressionMethodError(ValueError):
-    def __init__(self, method):
-        self.method = method
-        super().__init__("Invalid compression method: %s" % method)
-
-
 try:
     import blosc
 
@@ -226,5 +220,5 @@ def _decompress_frame(method, frame):
     """Decompress a single frame"""
     compressor = compressions.get(method, None)
     if compressor is None:
-        raise InvalidCompressionMethodError(method)
+        raise ValueError("Invalid compression method: %s" % method)
     return compressor["decompress"](frame)


### PR DESCRIPTION
Currently, if a compression method isn't available on the client, it raises a `KeyError` with the name of the method used (e.g. `lz4`). This updates the decompress function to raise `InvalidCompressionMethodError` when that happens, which should be easier to interpret.

It also adds an obtrusive "Danger!" warning when connecting to a scheduler if the client doesn't support the scheduler's default compression method. 

I would appreciate some pointers as to how to make this configurable to throw an error ([see note in the diff](https://github.com/dask/distributed/pull/3742/files#diff-6a3108098afcddf88b38652ae1e383b5R2532)) which I think might be a good better-safe-than-sorry behavior. I'm also not sure how best to test this -- thanks in advance for the help!