### PR TITLE
Memoryview serialisation

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -570,7 +570,11 @@ def _deserialize_bytes(header, frames):
 
 @dask_deserialize.register(memoryview)
 def _serialize_memoryview(header, frames):
-    return memoryview(b"".join(frames))
+    if len(frames) == 1:
+        out = frames[0]
+    else:
+        out = b"".join(frames)
+    return memoryview(out)
 
 
 #########################

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -556,7 +556,7 @@ def normalize_Serialized(o):
 
 
 # Teach serialize how to handle bytestrings
-@dask_serialize.register((bytes, bytearray))
+@dask_serialize.register((bytes, bytearray, memoryview))
 def _serialize_bytes(obj):
     header = {}  # no special metadata
     frames = [obj]
@@ -566,6 +566,11 @@ def _serialize_bytes(obj):
 @dask_deserialize.register((bytes, bytearray))
 def _deserialize_bytes(header, frames):
     return b"".join(frames)
+
+
+@dask_deserialize.register(memoryview)
+def _serialize_memoryview(header, frames):
+    return memoryview(b"".join(frames))
 
 
 #########################

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -409,6 +409,7 @@ def test_compression_numpy_list():
         ([MyObj([0, 1, 2]), 1], True),
         (tuple([MyObj(None)]), True),
         ({("x", i): MyObj(5) for i in range(100)}, True),
+        (memoryview(b'hello'), True)
     ],
 )
 def test_check_dask_serializable(data, is_serializable):
@@ -427,4 +428,13 @@ def test_serialize_lists(serializers):
     header, frames = serialize(data_in, serializers=serializers)
     data_out = deserialize(header, frames)
 
+    assert data_in == data_out
+
+
+def test_deser_memoryview():
+    data_in = memoryview(b'hello')
+    header, frames = serialize(data_in)
+    assert header['type'] == 'builtins.memoryview'
+    assert frames[0] is data_in
+    data_out = deserialize(header, frames)
     assert data_in == data_out

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -409,7 +409,7 @@ def test_compression_numpy_list():
         ([MyObj([0, 1, 2]), 1], True),
         (tuple([MyObj(None)]), True),
         ({("x", i): MyObj(5) for i in range(100)}, True),
-        (memoryview(b'hello'), True)
+        (memoryview(b"hello"), True),
     ],
 )
 def test_check_dask_serializable(data, is_serializable):
@@ -432,9 +432,9 @@ def test_serialize_lists(serializers):
 
 
 def test_deser_memoryview():
-    data_in = memoryview(b'hello')
+    data_in = memoryview(b"hello")
     header, frames = serialize(data_in)
-    assert header['type'] == 'builtins.memoryview'
+    assert header["type"] == "builtins.memoryview"
     assert frames[0] is data_in
     data_out = deserialize(header, frames)
     assert data_in == data_out


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/3640 (for discussion)

Does not create an intermediate bytes object for serialization, passes through the memoryview. That, of course, still gets sent as bytes on the wire, so for deserialization, we just wrap it.