### PR TITLE
Nanny closing worker on KeyboardInterrupt

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -762,4 +762,6 @@ class WorkerProcess:
             # Loop was stopped before wait_until_closed() returned, ignore
             pass
         except KeyboardInterrupt:
-            pass
+            # At this point the loop is not running thus we have to run
+            # do_stop() explicitly.
+            loop.run_sync(do_stop)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -506,6 +506,7 @@ async def test_config(cleanup):
 
 class KeyboardInterruptWorker(worker.Worker):
     """A Worker that raises KeyboardInterrupt almost immediately"""
+
     async def heartbeat(self):
         def raise_err():
             raise KeyboardInterrupt()

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -14,7 +14,7 @@ from tornado.ioloop import IOLoop
 
 import dask
 from distributed.diagnostics import SchedulerPlugin
-from distributed import Nanny, rpc, Scheduler, Worker, Client, wait
+from distributed import Nanny, rpc, Scheduler, Worker, Client, wait, worker
 from distributed.core import CommClosedError
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps
@@ -502,3 +502,28 @@ async def test_config(cleanup):
             async with Client(s.address, asynchronous=True) as client:
                 config = await client.run(dask.config.get, "foo")
                 assert config[n.worker_address] == "bar"
+
+
+class KeyboardInterruptWorker(worker.Worker):
+    """A Worker that raises KeyboardInterrupt almost immediately"""
+    async def heartbeat(self):
+        def raise_err():
+            raise KeyboardInterrupt()
+
+        self.loop.add_callback(raise_err)
+
+
+@pytest.mark.parametrize("protocol", ["tcp", "ucx"])
+@pytest.mark.asyncio
+async def test_nanny_closed_by_keyboard_interrupt(cleanup, protocol):
+    if protocol == "ucx":  # Skip if UCX isn't available
+        pytest.importorskip("ucp")
+
+    async with Scheduler(protocol=protocol) as s:
+        async with Nanny(
+            s.address, nthreads=1, worker_class=KeyboardInterruptWorker
+        ) as n:
+            n.auto_restart = False
+            await n.process.stopped.wait()
+            # Check that the scheduler has been notified about the closed worker
+            assert len(s.workers) == 0


### PR DESCRIPTION
Fix issue https://github.com/dask/distributed/issues/3576 by closing the worker on `KeyboardInterrupt`.