### PR TITLE
Support web addresses in preload

### DIFF
--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -133,18 +133,21 @@ def _import_module(name, file_dir=None):
 
 class Preload:
     """
+    Manage state for setup/teardown of a preload module
 
     Parameters
     ----------
     dask_server: dask.distributed.Server
         The Worker or Scheduler
+    name: str
+        module name, file name, or web address to load
     argv: [string]
         List of string arguments passed to click-configurable `dask_setup`.
     file_dir: string
         Path of a directory where files should be copied
     """
 
-    def __init__(self, dask_server, name, argv, file_dir):
+    def __init__(self, dask_server, name: str, argv: List[str], file_dir: str):
         self.dask_server = dask_server
         self.name = name
         self.argv = argv

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -37,9 +37,9 @@ def validate_preload_argv(ctx, param, value):
     preload_modules = {name: _import_module(name) for name in ctx.params.get("preload")}
 
     preload_commands = [
-        m["dask_setup"]
+        getattr(m, "dask_setup", None)
         for m in preload_modules.values()
-        if isinstance(m["dask_setup"], click.Command)
+        if isinstance(getattr(m, "dask_setup", None), click.Command)
     ]
 
     if len(preload_commands) > 1:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1109,9 +1109,7 @@ class Scheduler(ServerNode):
             preload = dask.config.get("distributed.scheduler.preload")
         if not preload_argv:
             preload_argv = dask.config.get("distributed.scheduler.preload-argv")
-        self.preload = preload
-        self.preload_argv = preload_argv
-        self._preload_modules = preloading.on_creation(self.preload)
+        self.preloads = preloading.process_preloads(self, preload, preload_argv)
 
         self.security = security or Security()
         assert isinstance(self.security, Security)
@@ -1474,7 +1472,8 @@ class Scheduler(ServerNode):
 
             weakref.finalize(self, del_scheduler_file)
 
-        await preloading.on_start(self._preload_modules, self, argv=self.preload_argv)
+        for preload in self.preloads:
+            await preload.start()
 
         await asyncio.gather(*[plugin.start(self) for plugin in self.plugins])
 
@@ -1498,7 +1497,8 @@ class Scheduler(ServerNode):
         logger.info("Scheduler closing...")
         setproctitle("dask-scheduler [closing]")
 
-        await preloading.on_teardown(self._preload_modules, self)
+        for preload in self.preloads:
+            await preload.teardown()
 
         if close_workers:
             await self.broadcast(msg={"op": "close_gracefully"}, nanny=True)


### PR DESCRIPTION
This commit does two things:

1.  We support passing web addresses as preloads,
    allowing for for functionality like the following:

    dask-scheduler --preload http://my-web-address/myfile.py

2.  We refactor preloads into a class structure.
    I'm usually against this, but I think that in this case it cleans
    things up.
    I think that it will also make it easier to rewrite how we handle
    preload and preload_argv in configuration later

cc @jcrist I think that this might interest you for Dask-Gateway work