### PR TITLE
Add prometheus metrics for semaphore

### DIFF
--- a/distributed/http/scheduler/prometheus/semaphore.py
+++ b/distributed/http/scheduler/prometheus/semaphore.py
@@ -1,0 +1,76 @@
+class SemaphoreMetricExtension:
+    def __init__(self, dask_server):
+        self.server = dask_server
+
+    def collect(self):
+        from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily
+
+        sem_ext = self.server.extensions["semaphores"]
+
+        semaphore_max_leases_family = GaugeMetricFamily(
+            "semaphore_max_leases",
+            "Maximum leases allowed per semaphore, this will be constant for each semaphore during its lifetime.",
+            labels=["name"],
+        )
+        semaphore_active_leases_family = GaugeMetricFamily(
+            "semaphore_active_leases",
+            "Amount of currently active leases per semaphore.",
+            labels=["name"],
+        )
+        semaphore_pending_leases = GaugeMetricFamily(
+            "semaphore_pending_leases",
+            "Amount of currently pending leases per semaphore.",
+            labels=["name"],
+        )
+
+        semaphore_acquire_total = CounterMetricFamily(
+            "semaphore_acquire_total",
+            "Total number of leases acquired per semaphore.",
+            labels=["name"],
+        )
+
+        semaphore_release_total = CounterMetricFamily(
+            "semaphore_release_total",
+            "Total number of leases released per semaphore.\n"
+            "Note: if a semaphore is closed while there are still leases active, this count will not equal "
+            "`semaphore_acquired_total` after execution.",
+            labels=["name"],
+        )
+
+        semaphore_average_pending_lease_time = GaugeMetricFamily(
+            "semaphore_average_pending_lease_time",
+            "Exponential moving average of the time it took to acquire a lease per semaphore.\n"
+            "Note: this only includes time spent on scheduler side, "
+            "it does"
+            " not include time spent on communication.\n"
+            "Note: this average is calculated based on order of leases instead of time of lease acquisition.",
+            labels=["name"],
+            unit="s",
+        )
+
+        for semaphore_name, semaphore_max_leases in sem_ext.max_leases.items():
+            semaphore_max_leases_family.add_metric(
+                [semaphore_name], semaphore_max_leases
+            )
+            semaphore_active_leases_family.add_metric(
+                [semaphore_name], len(sem_ext.leases[semaphore_name])
+            )
+            semaphore_pending_leases.add_metric(
+                [semaphore_name], sem_ext.metrics["pending"][semaphore_name]
+            )
+            semaphore_acquire_total.add_metric(
+                [semaphore_name], sem_ext.metrics["acquire_total"][semaphore_name]
+            )
+            semaphore_release_total.add_metric(
+                [semaphore_name], sem_ext.metrics["release_total"][semaphore_name]
+            )
+            semaphore_average_pending_lease_time.add_metric(
+                [semaphore_name],
+                sem_ext.metrics["average_pending_lease_time"][semaphore_name],
+            )
+        yield semaphore_max_leases_family
+        yield semaphore_active_leases_family
+        yield semaphore_pending_leases
+        yield semaphore_acquire_total
+        yield semaphore_release_total
+        yield semaphore_average_pending_lease_time

--- a/distributed/http/scheduler/tests/test_semaphore_http.py
+++ b/distributed/http/scheduler/tests/test_semaphore_http.py
@@ -1,0 +1,79 @@
+import pytest
+
+from tornado.httpclient import AsyncHTTPClient
+
+from distributed.utils_test import gen_cluster
+from distributed import Semaphore
+
+
+@gen_cluster(client=True, clean_kwargs={"threads": False})
+async def test_prometheus_collect_task_states(c, s, a, b):
+    pytest.importorskip("prometheus_client")
+    from prometheus_client.parser import text_string_to_metric_families
+
+    http_client = AsyncHTTPClient()
+
+    async def fetch_metrics():
+        port = s.http_server.port
+        response = await http_client.fetch(f"http://localhost:{port}/metrics")
+        txt = response.body.decode("utf8")
+        families = {
+            family.name: family
+            for family in text_string_to_metric_families(txt)
+            if family.name.startswith("semaphore_")
+        }
+        return families
+
+    active_metrics = await fetch_metrics()
+
+    expected_metrics = {
+        "semaphore_max_leases",
+        "semaphore_active_leases",
+        "semaphore_pending_leases",
+        "semaphore_acquire",
+        "semaphore_release",
+        "semaphore_average_pending_lease_time_s",
+    }
+
+    assert active_metrics.keys() == expected_metrics
+    for v in active_metrics.values():  # Not yet any semaphore created
+        assert v.samples == []
+
+    sem = await Semaphore(name="test", max_leases=2)
+
+    active_metrics = await fetch_metrics()
+    assert active_metrics.keys() == expected_metrics
+    # Assert values are set upon intialization
+    for name, v in active_metrics.items():
+        samples = v.samples
+        assert len(samples) == 1
+        sample = samples.pop()
+        assert sample.labels["name"] == "test"
+        if name == "semaphore_max_leases":
+            assert sample.value == 2
+        else:
+            assert sample.value == 0
+
+    assert await sem.acquire()
+    active_metrics = await fetch_metrics()
+    assert active_metrics["semaphore_max_leases"].samples[0].value == 2
+    assert active_metrics["semaphore_active_leases"].samples[0].value == 1
+    assert active_metrics["semaphore_average_pending_lease_time_s"].samples[0].value > 0
+    assert active_metrics["semaphore_acquire"].samples[0].value == 1
+    assert active_metrics["semaphore_release"].samples[0].value == 0
+    assert active_metrics["semaphore_pending_leases"].samples[0].value == 0
+
+    await sem.release()
+    active_metrics = await fetch_metrics()
+    assert active_metrics["semaphore_max_leases"].samples[0].value == 2
+    assert active_metrics["semaphore_active_leases"].samples[0].value == 0
+    assert active_metrics["semaphore_average_pending_lease_time_s"].samples[0].value > 0
+    assert active_metrics["semaphore_acquire"].samples[0].value == 1
+    assert active_metrics["semaphore_release"].samples[0].value == 1
+    assert active_metrics["semaphore_pending_leases"].samples[0].value == 0
+
+    await sem.close()
+    active_metrics = await fetch_metrics()
+    assert active_metrics.keys() == expected_metrics
+    for v in active_metrics.values():
+        assert v.samples == []


### PR DESCRIPTION
This introduces two new data structures at the scheduler side: `metrics`, and `pending_leases`.

For `http/semaphore/prometheus.py` I copied the `PrometheusHandler` and the basics of `_PrometheusCollector` from `http/scheduler/prometheus.py`, I'd be happy to change this if there is a more correct way of doing so.