### PR TITLE
Connect to dashboard when address provided

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1133,14 +1133,14 @@ class Scheduler(ServerNode):
         )
         self.start_http_server(routes, dashboard_address, default_port=8787)
 
-        if dashboard:
+        if dashboard or (dashboard is None and dashboard_address):
             try:
                 import distributed.dashboard.scheduler
             except ImportError:
                 logger.debug("To start diagnostics web server please install Bokeh")
             else:
                 distributed.dashboard.scheduler.connect(
-                    self.http_application, self.http_server, self, prefix=http_prefix,
+                    self.http_application, self.http_server, self, prefix=http_prefix
                 )
 
         # Communication state


### PR DESCRIPTION
It seems like if the caller provides a `dashboard_address` then they
want the dashboard running. I'm not sure why `dashboard` is required,
looking for guidance on that if you recall the reason for the keyword @mrocklin.

Closes https://github.com/dask/dask-gateway/issues/261