### PR TITLE
Fix TypeError in broadcast when using TLS

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -37,6 +37,7 @@ from distributed.utils_test import (  # noqa: F401
     cluster,
     div,
     varying,
+    tls_only_security,
 )
 from distributed.utils_test import loop, nodebug  # noqa: F401
 from dask.compatibility import apply
@@ -513,6 +514,18 @@ async def test_restart(c, s, a, b):
 
 @gen_cluster()
 async def test_broadcast(s, a, b):
+    result = await s.broadcast(msg={"op": "ping"})
+    assert result == {a.address: b"pong", b.address: b"pong"}
+
+    result = await s.broadcast(msg={"op": "ping"}, workers=[a.address])
+    assert result == {a.address: b"pong"}
+
+    result = await s.broadcast(msg={"op": "ping"}, hosts=[a.ip])
+    assert result == {a.address: b"pong", b.address: b"pong"}
+
+
+@gen_cluster(security=tls_only_security(),)
+async def test_broadcast_tls(s, a, b):
     result = await s.broadcast(msg={"op": "ping"})
     assert result == {a.address: b"pong", b.address: b"pong"}
 


### PR DESCRIPTION
This fixes an issue where the broadcast fails if using TLS with

```
`TypeError: TLS expects a `ssl_context` argument of type ssl.SSLContext (perhaps check your TLS configuration?)  Instead got None`
```

The issue is that the connect passes the connection_args as one argument but it should pass it as kwargs. While fixing this, I realised that this is the only place where we connect without using the connection pool. I opted to use the connection pool instead but if there is a reason for having dedicated connections for the broadcast, I can revert this, of course.