### PR TITLE
Allow partial profile information in case of exceptions

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4970,8 +4970,11 @@ class Scheduler(ServerNode):
             *(
                 self.rpc(w).profile(start=start, stop=stop, key=key, server=server)
                 for w in workers
-            )
+            ),
+            return_exceptions=True
         )
+
+        results = [r for r in results if not isinstance(r, Exception)]
 
         if merge_workers:
             response = profile.merge(*results)
@@ -4998,9 +5001,11 @@ class Scheduler(ServerNode):
         else:
             workers = set(self.workers) & set(workers)
         results = await asyncio.gather(
-            *(self.rpc(w).profile_metadata(start=start, stop=stop) for w in workers)
+            *(self.rpc(w).profile_metadata(start=start, stop=stop) for w in workers),
+            return_exceptions=True
         )
 
+        results = [r for r in results if not isinstance(r, Exception)]
         counts = [v["counts"] for v in results]
         counts = itertools.groupby(merge_sorted(*counts), lambda t: t[0] // dt * dt)
         counts = [(time, sum(pluck(1, group))) for time, group in counts]

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5108,7 +5108,7 @@ async def test_call_stack_collections_all(c, s, a, b):
     assert result
 
 
-@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
+@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": "100ms"})
 async def test_profile(c, s, a, b):
     futures = c.map(slowinc, range(10), delay=0.05, workers=a.address)
     await wait(futures)
@@ -5130,7 +5130,7 @@ async def test_profile(c, s, a, b):
     assert not result["count"]
 
 
-@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
+@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": "100ms"})
 async def test_profile_keys(c, s, a, b):
     x = c.map(slowinc, range(10), delay=0.05, workers=a.address)
     y = c.map(slowdec, range(10), delay=0.05, workers=a.address)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1235,6 +1235,27 @@ async def test_profile_metadata(c, s, a, b):
 
 
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
+async def test_profile_metadata_timeout(c, s, a, b):
+    start = time() - 1
+
+    def raise_timeout(*args, **kwargs):
+        raise TimeoutError
+
+    b.handlers["profile_metadata"] = raise_timeout
+
+    futures = c.map(slowinc, range(10), delay=0.05, workers=a.address)
+    await wait(futures)
+    await asyncio.sleep(0.200)
+
+    meta = await s.get_profile_metadata(profile_cycle_interval=0.100)
+    now = time() + 1
+    assert meta
+    assert all(start < t < now for t, count in meta["counts"])
+    assert all(0 <= count < 30 for t, count in meta["counts"][:4])
+    assert not meta["counts"][-1][1]
+
+
+@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
 async def test_profile_metadata_keys(c, s, a, b):
     x = c.map(slowinc, range(10), delay=0.05)
     y = c.map(slowdec, range(10), delay=0.05)
@@ -1245,6 +1266,42 @@ async def test_profile_metadata_keys(c, s, a, b):
     assert (
         len(meta["counts"]) - 3 <= len(meta["keys"]["slowinc"]) <= len(meta["counts"])
     )
+
+
+@gen_cluster(
+    client=True,
+    config={
+        "distributed.worker.profile.interval": "1ms",
+        "distributed.worker.profile.cycle": "100ms",
+    },
+)
+async def test_statistical_profiling(c, s, a, b):
+    futures = c.map(slowinc, range(10), delay=0.1)
+
+    await wait(futures)
+
+    profile = await s.get_profile()
+    assert profile["count"]
+
+
+@gen_cluster(
+    client=True,
+    config={
+        "distributed.worker.profile.interval": "1ms",
+        "distributed.worker.profile.cycle": "100ms",
+    },
+)
+async def test_statistical_profiling_failure(c, s, a, b):
+    futures = c.map(slowinc, range(10), delay=0.1)
+
+    def raise_timeout(*args, **kwargs):
+        raise TimeoutError
+
+    b.handlers["profile"] = raise_timeout
+    await wait(futures)
+
+    profile = await s.get_profile()
+    assert profile["count"]
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1219,7 +1219,7 @@ async def test_service_hosts():
             assert sock.getsockname()[0] == "127.0.0.1"
 
 
-@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
+@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": "100ms"})
 async def test_profile_metadata(c, s, a, b):
     start = time() - 1
     futures = c.map(slowinc, range(10), delay=0.05, workers=a.address)
@@ -1234,7 +1234,7 @@ async def test_profile_metadata(c, s, a, b):
     assert not meta["counts"][-1][1]
 
 
-@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
+@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": "100ms"})
 async def test_profile_metadata_timeout(c, s, a, b):
     start = time() - 1
 
@@ -1255,7 +1255,7 @@ async def test_profile_metadata_timeout(c, s, a, b):
     assert not meta["counts"][-1][1]
 
 
-@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": 100})
+@gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": "100ms"})
 async def test_profile_metadata_keys(c, s, a, b):
     x = c.map(slowinc, range(10), delay=0.05)
     y = c.map(slowdec, range(10), delay=0.05)


### PR DESCRIPTION
I sometimes observe timeout errors when collecting the profile information on large, busy distributed clusters. Since it's a statistical profiling I would usually not care if a fraction of the workers timeout and think this should be handled a bit more gracefully. This implementation would still return a result even in case the individual profile fetches timeout.
