### PR TITLE
xfail test_preload_remote_module

### DIFF
--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -300,6 +300,9 @@ def test_preload_module(loop):
         shutil.rmtree(tmpdir)
 
 
+@pytest.mark.xfail(
+    reason="Known failure (see https://github.com/dask/distributed/issues/3774). This has been xfailed to unblock CI."
+)
 def test_preload_remote_module(loop, tmpdir):
     with open(tmpdir / "scheduler_info.py", "w") as f:
         f.write(PRELOAD_TEXT)


### PR DESCRIPTION
This PR `xfail`s `test_preload_remote_module` as a temporary patch until https://github.com/dask/distributed/issues/3774 is resolved (https://github.com/dask/distributed/pull/3775 is close)

cc @jcrist 