### PR TITLE
Add missing options to dask-ssh cli

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -26,100 +26,125 @@ logger = logging.getLogger("distributed.scheduler")
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 
-@click.command(context_settings=dict(ignore_unknown_options=True))
-@click.option("--host", type=str, default="", help="URI, IP or hostname of this server")
-@click.option("--port", type=int, default=None, help="Serving port")
-@click.option(
-    "--interface",
-    type=str,
-    default=None,
-    help="Preferred network interface like 'eth0' or 'ib0'",
-)
-@click.option(
-    "--protocol", type=str, default=None, help="Protocol like tcp, tls, or ucx"
-)
-@click.option(
-    "--tls-ca-file",
-    type=pem_file_option_type,
-    default=None,
-    help="CA cert(s) file for TLS (in PEM format)",
-)
-@click.option(
-    "--tls-cert",
-    type=pem_file_option_type,
-    default=None,
-    help="certificate file for TLS (in PEM format)",
-)
-@click.option(
-    "--tls-key",
-    type=pem_file_option_type,
-    default=None,
-    help="private key file for TLS (in PEM format)",
-)
-# XXX default port (or URI) values should be centralized somewhere
-@click.option(
-    "--bokeh-port", type=int, default=None, help="Deprecated.  See --dashboard-address"
-)
-@click.option(
-    "--dashboard-address",
-    type=str,
-    default=":8787",
-    show_default=True,
-    help="Address on which to listen for diagnostics dashboard",
-)
-@click.option(
-    "--dashboard/--no-dashboard",
-    "dashboard",
-    default=True,
-    required=False,
-    help="Launch the Dashboard [default: --dashboard]",
-)
-@click.option(
-    "--bokeh/--no-bokeh",
-    "bokeh",
-    default=None,
-    required=False,
-    help="Deprecated.  See --dashboard/--no-dashboard.",
-)
-@click.option("--show/--no-show", default=False, help="Show web UI [default: --show]")
-@click.option(
-    "--dashboard-prefix", type=str, default="", help="Prefix for the dashboard app"
-)
-@click.option(
-    "--use-xheaders",
-    type=bool,
-    default=False,
-    show_default=True,
-    help="User xheaders in dashboard app for ssl termination in header",
-)
-@click.option("--pid-file", type=str, default="", help="File to write the process PID")
-@click.option(
-    "--scheduler-file",
-    type=str,
-    default="",
-    help="File to write connection information. "
-    "This may be a good way to share connection information if your "
-    "cluster is on a shared network file system.",
-)
-@click.option(
-    "--preload",
-    type=str,
-    multiple=True,
-    is_eager=True,
-    default="",
-    help="Module that should be loaded by the scheduler process  "
-    'like "foo.bar" or "/path/to/foo.py".',
-)
-@click.argument(
-    "preload_argv", nargs=-1, type=click.UNPROCESSED, callback=validate_preload_argv
-)
-@click.option(
-    "--idle-timeout",
-    default=None,
-    type=str,
-    help="Time of inactivity after which to kill the scheduler",
-)
+scheduler_options = [
+    click.Option(
+        ["--host"], type=str, default="", help="URI, IP or hostname of this server"
+    ),
+    click.Option(["--port"], type=int, default=None, help="Serving port"),
+    click.Option(
+        ["--interface"],
+        type=str,
+        default=None,
+        help="Preferred network interface like 'eth0' or 'ib0'",
+    ),
+    click.Option(
+        ["--protocol"], type=str, default=None, help="Protocol like tcp, tls, or ucx"
+    ),
+    click.Option(
+        ["--tls-ca-file"],
+        type=pem_file_option_type,
+        default=None,
+        help="CA cert(s) file for TLS (in PEM format)",
+    ),
+    click.Option(
+        ["--tls-cert"],
+        type=pem_file_option_type,
+        default=None,
+        help="certificate file for TLS (in PEM format)",
+    ),
+    click.Option(
+        ["--tls-key"],
+        type=pem_file_option_type,
+        default=None,
+        help="private key file for TLS (in PEM format)",
+    ),
+    # XXX default port (or URI) values should be centralized somewhere
+    click.Option(
+        ["--bokeh-port"],
+        type=int,
+        default=None,
+        help="Deprecated.  See --dashboard-address",
+    ),
+    click.Option(
+        ["--dashboard-address"],
+        type=str,
+        default=":8787",
+        show_default=True,
+        help="Address on which to listen for diagnostics dashboard",
+    ),
+    click.Option(
+        ["--dashboard/--no-dashboard"],
+        default=True,
+        required=False,
+        help="Launch the Dashboard [default: --dashboard]",
+    ),
+    click.Option(
+        ["--bokeh/--no-bokeh"],
+        "bokeh",
+        default=None,
+        required=False,
+        help="Deprecated.  See --dashboard/--no-dashboard.",
+    ),
+    click.Option(
+        ["--show/--no-show"], default=False, help="Show web UI [default: --show]"
+    ),
+    click.Option(
+        ["--dashboard-prefix"],
+        type=str,
+        default="",
+        help="Prefix for the dashboard app",
+    ),
+    click.Option(
+        ["--use-xheaders"],
+        type=bool,
+        default=False,
+        show_default=True,
+        help="User xheaders in dashboard app for ssl termination in header",
+    ),
+    click.Option(
+        ["--pid-file"], type=str, default="", help="File to write the process PID"
+    ),
+    click.Option(
+        ["--scheduler-file"],
+        type=str,
+        default="",
+        help="File to write connection information. "
+        "This may be a good way to share connection information if your "
+        "cluster is on a shared network file system.",
+    ),
+    click.Option(
+        ["--preload"],
+        type=str,
+        multiple=True,
+        is_eager=True,
+        default="",
+        help="Module that should be loaded by the scheduler process  "
+        'like "foo.bar" or "/path/to/foo.py".',
+    ),
+    click.Option(
+        ["--idle-timeout"],
+        default=None,
+        type=str,
+        help="Time of inactivity after which to kill the scheduler",
+    ),
+    click.Argument(
+        ["preload_argv"],
+        nargs=-1,
+        type=click.UNPROCESSED,
+        callback=validate_preload_argv,
+    ),
+]
+
+
+class SchedulerCommand(click.Command):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params = scheduler_options
+        self.context_settings = dict(ignore_unknown_options=True)
+
+
 @click.version_option()
+@click.command(cls=SchedulerCommand)
 def main(
     host,
     port,

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -98,15 +98,21 @@ dask_ssh_options = [
     ),
     click.Option(
         ["--worker-port"],
-        type=int,
-        default=0,
-        help="Serving computation port, defaults to random",
+        default=None,
+        help="Serving computation port, defaults to random. "
+        "When creating multiple workers with --nprocs, a sequential range of "
+        "worker ports may be used by specifying the first and last available "
+        "ports like <first-port>:<last-port>. For example, --worker-port=3000:3026 "
+        "will use ports 3000, 3001, ..., 3025, 3026.",
     ),
     click.Option(
         ["--nanny-port"],
-        type=int,
-        default=0,
-        help="Serving nanny port, defaults to random",
+        default=None,
+        help="Serving nanny port, defaults to random. "
+        "When creating multiple nannies with --nprocs, a sequential range of "
+        "nanny ports may be used by specifying the first and last available "
+        "ports like <first-port>:<last-port>. For example, --nanny-port=3000:3026 "
+        "will use ports 3000, 3001, ..., 3025, 3026.",
     ),
     click.Option(
         ["--remote-dask-worker"],

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -1,119 +1,166 @@
 from distributed.deploy.old_ssh import SSHCluster
+from distributed.cli.dask_worker import worker_options
+from distributed.cli.dask_scheduler import scheduler_options
+from collections import defaultdict
 import click
 
 from distributed.cli.utils import check_python_3
 
+dask_ssh_options = [
+    click.Option(
+        ["--scheduler"],
+        default=None,
+        type=str,
+        help="Specify scheduler node.  Defaults to first address.",
+    ),
+    click.Option(
+        ["--scheduler-port"],
+        default=8786,
+        show_default=True,
+        type=int,
+        help="Specify scheduler port number.",
+    ),
+    click.Option(
+        ["--nthreads"],
+        default=0,
+        type=int,
+        help=(
+            "Number of threads per worker process. "
+            "Defaults to number of cores divided by the number of "
+            "processes per host."
+        ),
+    ),
+    click.Option(
+        ["--nprocs"],
+        default=1,
+        show_default=True,
+        type=int,
+        help="Number of worker processes per host.",
+    ),
+    click.Option(
+        ["--hostfile"],
+        default=None,
+        type=click.Path(exists=True),
+        help="Textfile with hostnames/IP addresses",
+    ),
+    click.Option(
+        ["--ssh-username"],
+        default=None,
+        type=str,
+        help="Username to use when establishing SSH connections.",
+    ),
+    click.Option(
+        ["--ssh-port"],
+        default=22,
+        type=int,
+        show_default=True,
+        help="Port to use for SSH connections.",
+    ),
+    click.Option(
+        ["--ssh-private-key"],
+        default=None,
+        type=str,
+        help="Private key file to use for SSH connections.",
+    ),
+    click.Option(
+        ["--nohost"], is_flag=True, help="Do not pass the hostname to the worker."
+    ),
+    click.Option(
+        ["--log-directory"],
+        default=None,
+        type=click.Path(exists=True),
+        help=(
+            "Directory to use on all cluster nodes for the output of "
+            "dask-scheduler and dask-worker commands."
+        ),
+    ),
+    click.Option(
+        ["--local-directory"],
+        default=None,
+        type=click.Path(exists=True),
+        help="Directory to use on all cluster nodes to place workers files.",
+    ),
+    click.Option(
+        ["--remote-python"],
+        default=None,
+        type=str,
+        help="Path to Python on remote nodes.",
+    ),
+    click.Option(
+        ["--memory-limit"],
+        default="auto",
+        show_default=True,
+        help="Bytes of memory that the worker can use. "
+        "This can be an integer (bytes), "
+        "float (fraction of total system memory), "
+        "string (like 5GB or 5000M), "
+        "'auto', or zero for no memory management",
+    ),
+    click.Option(
+        ["--worker-port"],
+        type=int,
+        default=0,
+        help="Serving computation port, defaults to random",
+    ),
+    click.Option(
+        ["--nanny-port"],
+        type=int,
+        default=0,
+        help="Serving nanny port, defaults to random",
+    ),
+    click.Option(
+        ["--remote-dask-worker"],
+        default="distributed.cli.dask_worker",
+        show_default=True,
+        type=str,
+        help="Worker to run.",
+    ),
+    click.Argument(["hostnames"], nargs=-1, type=str),
+]
 
-@click.command(
-    help="""Launch a distributed cluster over SSH. A 'dask-scheduler' process will run on the
-                         first host specified in [HOSTNAMES] or in the hostfile (unless --scheduler is specified
-                         explicitly). One or more 'dask-worker' processes will be run each host in [HOSTNAMES] or
-                         in the hostfile. Use command line flags to adjust how many dask-worker process are run on
-                         each host (--nprocs) and how many cpus are used by each dask-worker process (--nthreads)."""
-)
-@click.option(
-    "--scheduler",
-    default=None,
-    type=str,
-    help="Specify scheduler node.  Defaults to first address.",
-)
-@click.option(
-    "--scheduler-port",
-    default=8786,
-    show_default=True,
-    type=int,
-    help="Specify scheduler port number.",
-)
-@click.option(
-    "--nthreads",
-    default=0,
-    type=int,
-    help=(
-        "Number of threads per worker process. "
-        "Defaults to number of cores divided by the number of "
-        "processes per host."
-    ),
-)
-@click.option(
-    "--nprocs",
-    default=1,
-    show_default=True,
-    type=int,
-    help="Number of worker processes per host.",
-)
-@click.argument("hostnames", nargs=-1, type=str)
-@click.option(
-    "--hostfile",
-    default=None,
-    type=click.Path(exists=True),
-    help="Textfile with hostnames/IP addresses",
-)
-@click.option(
-    "--ssh-username",
-    default=None,
-    type=str,
-    help="Username to use when establishing SSH connections.",
-)
-@click.option(
-    "--ssh-port",
-    default=22,
-    type=int,
-    show_default=True,
-    help="Port to use for SSH connections.",
-)
-@click.option(
-    "--ssh-private-key",
-    default=None,
-    type=str,
-    help="Private key file to use for SSH connections.",
-)
-@click.option("--nohost", is_flag=True, help="Do not pass the hostname to the worker.")
-@click.option(
-    "--log-directory",
-    default=None,
-    type=click.Path(exists=True),
-    help=(
-        "Directory to use on all cluster nodes for the output of "
-        "dask-scheduler and dask-worker commands."
-    ),
-)
-@click.option(
-    "--local-directory",
-    default=None,
-    type=click.Path(exists=True),
-    help=("Directory to use on all cluster nodes to place workers files."),
-)
-@click.option(
-    "--remote-python", default=None, type=str, help="Path to Python on remote nodes."
-)
-@click.option(
-    "--memory-limit",
-    default="auto",
-    show_default=True,
-    help="Bytes of memory that the worker can use. "
-    "This can be an integer (bytes), "
-    "float (fraction of total system memory), "
-    "string (like 5GB or 5000M), "
-    "'auto', or zero for no memory management",
-)
-@click.option(
-    "--worker-port",
-    type=int,
-    default=0,
-    help="Serving computation port, defaults to random",
-)
-@click.option(
-    "--nanny-port", type=int, default=0, help="Serving nanny port, defaults to random"
-)
-@click.option(
-    "--remote-dask-worker",
-    default="distributed.cli.dask_worker",
-    show_default=True,
-    type=str,
-    help="Worker to run.",
-)
-@click.pass_context
+dask_ssh_opt_names = [
+    opt.name for opt in dask_ssh_options if opt.param_type_name == "option"
+]
+ignored_options = ["version", "worker_class", "pid_file", "port"]
+options_dict = defaultdict(list)
+
+for opt in worker_options:
+    if opt.name in ignored_options:
+        continue
+    if opt.param_type_name == "option" and opt.name not in dask_ssh_opt_names:
+        options_dict["worker"].append(opt)
+
+for opt in scheduler_options:
+    if opt.name in ignored_options:
+        continue
+    if opt.param_type_name == "option" and opt.name not in dask_ssh_opt_names:
+        options_dict["scheduler"].append(opt)
+
+# print('\n'.join([opt.name for opt in options_dict['scheduler']]))
+# print(' ')
+# print('\n'.join([opt.name for opt in options_dict['worker']]))
+
+
+class DaskSSHCommand(click.Command):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params = (
+            dask_ssh_options
+            + options_dict.get("scheduler", [])
+            + options_dict.get("worker", [])
+        )
+        self.help = (
+            "Launch a distributed cluster over SSH. A 'dask-scheduler' process will run on the"
+            "first host specified in [HOSTNAMES] or in the hostfile (unless --scheduler is specified"
+            "explicitly). One or more 'dask-worker' processes will be run each host in [HOSTNAMES] or"
+            "in the hostfile. Use command line flags to adjust how many dask-worker process are run on"
+            "each host (--nprocs) and how many cpus are used by each dask-worker process (--nthreads)."
+        )
+
+
 @click.version_option()
+@click.command(cls=DaskSSHCommand)
+@click.pass_context
 def main(
     ctx,
     scheduler,
@@ -133,6 +180,7 @@ def main(
     nanny_port,
     remote_dask_worker,
     local_directory,
+    **kwargs,
 ):
     try:
         hostnames = list(hostnames)
@@ -165,6 +213,7 @@ def main(
         nanny_port,
         remote_dask_worker,
         local_directory,
+        **kwargs,
     )
 
     import distributed

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -49,15 +49,21 @@ worker_options = [
     ),
     click.Option(
         ["--worker-port"],
-        type=int,
-        default=0,
-        help="Serving computation port, defaults to random",
+        default=None,
+        help="Serving computation port, defaults to random. "
+        "When creating multiple workers with --nprocs, a sequential range of "
+        "worker ports may be used by specifying the first and last available "
+        "ports like <first-port>:<last-port>. For example, --worker-port=3000:3026 "
+        "will use ports 3000, 3001, ..., 3025, 3026.",
     ),
     click.Option(
         ["--nanny-port"],
-        type=int,
-        default=0,
-        help="Serving nanny port, defaults to random",
+        default=None,
+        help="Serving nanny port, defaults to random. "
+        "When creating multiple nannies with --nprocs, a sequential range of "
+        "nanny ports may be used by specifying the first and last available "
+        "ports like <first-port>:<last-port>. For example, --nanny-port=3000:3026 "
+        "will use ports 3000, 3001, ..., 3025, 3026.",
     ),
     click.Option(
         ["--bokeh-port"],

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -26,205 +26,231 @@ from tornado.ioloop import IOLoop, TimeoutError
 
 logger = logging.getLogger("distributed.dask_worker")
 
-
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
+worker_options = [
+    click.Option(
+        ["--tls-ca-file"],
+        type=pem_file_option_type,
+        default=None,
+        help="CA cert(s) file for TLS (in PEM format)",
+    ),
+    click.Option(
+        ["--tls-cert"],
+        type=pem_file_option_type,
+        default=None,
+        help="certificate file for TLS (in PEM format)",
+    ),
+    click.Option(
+        ["--tls-key"],
+        type=pem_file_option_type,
+        default=None,
+        help="private key file for TLS (in PEM format)",
+    ),
+    click.Option(
+        ["--worker-port"],
+        type=int,
+        default=0,
+        help="Serving computation port, defaults to random",
+    ),
+    click.Option(
+        ["--nanny-port"],
+        type=int,
+        default=0,
+        help="Serving nanny port, defaults to random",
+    ),
+    click.Option(
+        ["--bokeh-port"],
+        type=int,
+        default=None,
+        help="Deprecated.  See --dashboard-address",
+    ),
+    click.Option(
+        ["--dashboard-address"],
+        type=str,
+        default=":0",
+        help="Address on which to listen for diagnostics dashboard",
+    ),
+    click.Option(
+        ["--dashboard/--no-dashboard"],
+        default=True,
+        required=False,
+        help="Launch the Dashboard [default: --dashboard]",
+    ),
+    click.Option(
+        ["--bokeh/--no-bokeh"],
+        "bokeh",
+        default=None,
+        help="Deprecated.  See --dashboard/--no-dashboard.",
+        required=False,
+    ),
+    click.Option(
+        ["--listen-address"],
+        type=str,
+        default=None,
+        help="The address to which the worker binds. Example: tcp://0.0.0.0:9000",
+    ),
+    click.Option(
+        ["--contact-address"],
+        type=str,
+        default=None,
+        help="The address the worker advertises to the scheduler for "
+        "communication with it and other workers. "
+        "Example: tcp://127.0.0.1:9000",
+    ),
+    click.Option(
+        ["--host"],
+        type=str,
+        default=None,
+        help="Serving host. Should be an ip address that is"
+        " visible to the scheduler and other workers. "
+        "See --listen-address and --contact-address if you "
+        "need different listen and contact addresses. "
+        "See --interface.",
+    ),
+    click.Option(
+        ["--interface"],
+        type=str,
+        default=None,
+        help="Network interface like 'eth0' or 'ib0'",
+    ),
+    click.Option(
+        ["--protocol"], type=str, default=None, help="Protocol like tcp, tls, or ucx"
+    ),
+    click.Option(
+        ["--nthreads"], type=int, default=0, help="Number of threads per process."
+    ),
+    click.Option(
+        ["--nprocs"],
+        type=int,
+        default=1,
+        show_default=True,
+        help="Number of worker processes to launch.",
+    ),
+    click.Option(
+        ["--name"],
+        type=str,
+        default=None,
+        help="A unique name for this worker like 'worker-1'. "
+        "If used with --nprocs then the process number "
+        "will be appended like name-0, name-1, name-2, ...",
+    ),
+    click.Option(
+        ["--memory-limit"],
+        default="auto",
+        show_default=True,
+        help="Bytes of memory per process that the worker can use. "
+        "This can be an integer (bytes), "
+        "float (fraction of total system memory), "
+        "string (like 5GB or 5000M), "
+        "'auto', or zero for no memory management",
+    ),
+    click.Option(
+        ["--reconnect/--no-reconnect"],
+        default=True,
+        help="Reconnect to scheduler if disconnected [default: --reconnect]",
+    ),
+    click.Option(
+        ["--nanny/--no-nanny"],
+        default=True,
+        help="Start workers in nanny process for management [default: --nanny]",
+    ),
+    click.Option(
+        ["--pid-file"], type=str, default="", help="File to write the process PID"
+    ),
+    click.Option(
+        ["--local-directory"],
+        default=None,
+        type=str,
+        help="Directory to place worker files",
+    ),
+    click.Option(
+        ["--resources"],
+        type=str,
+        default=None,
+        help='Resources for task constraints like "GPU=2 MEM=10e9". '
+        "Resources are applied separately to each worker process "
+        "(only relevant when starting multiple worker processes with '--nprocs').",
+    ),
+    click.Option(
+        ["--scheduler-file"],
+        type=str,
+        default=None,
+        help="Filename to JSON encoded scheduler information. "
+        "Use with dask-scheduler --scheduler-file",
+    ),
+    click.Option(
+        ["--death-timeout"],
+        type=str,
+        default=None,
+        help="Seconds to wait for a scheduler before closing",
+    ),
+    click.Option(
+        ["--dashboard-prefix"], type=str, default="", help="Prefix for the dashboard"
+    ),
+    click.Option(
+        ["--lifetime"],
+        type=str,
+        default=None,
+        help="If provided, shut down the worker after this duration.",
+    ),
+    click.Option(
+        ["--lifetime-stagger"],
+        type=str,
+        default="0 seconds",
+        show_default=True,
+        help="Random amount by which to stagger lifetime values",
+    ),
+    click.Option(
+        ["--worker-class"],
+        type=str,
+        default="dask.distributed.Worker",
+        show_default=True,
+        help="Worker class used to instantiate workers from.",
+    ),
+    click.Option(
+        ["--lifetime-restart/--no-lifetime-restart"],
+        default=False,
+        show_default=True,
+        required=False,
+        help="Whether or not to restart the worker after the lifetime lapses. "
+        "This assumes that you are using the --lifetime and --nanny keywords",
+    ),
+    click.Option(
+        ["--preload"],
+        type=str,
+        multiple=True,
+        is_eager=True,
+        help="Module that should be loaded by each worker process "
+        'like "foo.bar" or "/path/to/foo.py"',
+    ),
+    click.Option(
+        ["--preload-nanny"],
+        type=str,
+        multiple=True,
+        is_eager=True,
+        help="Module that should be loaded by each nanny "
+        'like "foo.bar" or "/path/to/foo.py"',
+    ),
+    click.Argument(["scheduler"], type=str, required=False),
+    click.Argument(
+        ["preload_argv"],
+        nargs=-1,
+        type=click.UNPROCESSED,
+        callback=validate_preload_argv,
+    ),
+]
 
-@click.command(context_settings=dict(ignore_unknown_options=True))
-@click.argument("scheduler", type=str, required=False)
-@click.option(
-    "--tls-ca-file",
-    type=pem_file_option_type,
-    default=None,
-    help="CA cert(s) file for TLS (in PEM format)",
-)
-@click.option(
-    "--tls-cert",
-    type=pem_file_option_type,
-    default=None,
-    help="certificate file for TLS (in PEM format)",
-)
-@click.option(
-    "--tls-key",
-    type=pem_file_option_type,
-    default=None,
-    help="private key file for TLS (in PEM format)",
-)
-@click.option(
-    "--worker-port",
-    type=int,
-    default=0,
-    help="Serving computation port, defaults to random",
-)
-@click.option(
-    "--nanny-port", type=int, default=0, help="Serving nanny port, defaults to random"
-)
-@click.option(
-    "--bokeh-port", type=int, default=None, help="Deprecated.  See --dashboard-address"
-)
-@click.option(
-    "--dashboard-address",
-    type=str,
-    default=":0",
-    help="Address on which to listen for diagnostics dashboard",
-)
-@click.option(
-    "--dashboard/--no-dashboard",
-    "dashboard",
-    default=True,
-    required=False,
-    help="Launch the Dashboard [default: --dashboard]",
-)
-@click.option(
-    "--bokeh/--no-bokeh",
-    "bokeh",
-    default=None,
-    help="Deprecated.  See --dashboard/--no-dashboard.",
-    required=False,
-)
-@click.option(
-    "--listen-address",
-    type=str,
-    default=None,
-    help="The address to which the worker binds. Example: tcp://0.0.0.0:9000",
-)
-@click.option(
-    "--contact-address",
-    type=str,
-    default=None,
-    help="The address the worker advertises to the scheduler for "
-    "communication with it and other workers. "
-    "Example: tcp://127.0.0.1:9000",
-)
-@click.option(
-    "--host",
-    type=str,
-    default=None,
-    help="Serving host. Should be an ip address that is"
-    " visible to the scheduler and other workers. "
-    "See --listen-address and --contact-address if you "
-    "need different listen and contact addresses. "
-    "See --interface.",
-)
-@click.option(
-    "--interface", type=str, default=None, help="Network interface like 'eth0' or 'ib0'"
-)
-@click.option(
-    "--protocol", type=str, default=None, help="Protocol like tcp, tls, or ucx"
-)
-@click.option("--nthreads", type=int, default=0, help="Number of threads per process.")
-@click.option(
-    "--nprocs",
-    type=int,
-    default=1,
-    show_default=True,
-    help="Number of worker processes to launch.",
-)
-@click.option(
-    "--name",
-    type=str,
-    default=None,
-    help="A unique name for this worker like 'worker-1'. "
-    "If used with --nprocs then the process number "
-    "will be appended like name-0, name-1, name-2, ...",
-)
-@click.option(
-    "--memory-limit",
-    default="auto",
-    show_default=True,
-    help="Bytes of memory per process that the worker can use. "
-    "This can be an integer (bytes), "
-    "float (fraction of total system memory), "
-    "string (like 5GB or 5000M), "
-    "'auto', or zero for no memory management",
-)
-@click.option(
-    "--reconnect/--no-reconnect",
-    default=True,
-    help="Reconnect to scheduler if disconnected [default: --reconnect]",
-)
-@click.option(
-    "--nanny/--no-nanny",
-    default=True,
-    help="Start workers in nanny process for management [default: --nanny]",
-)
-@click.option("--pid-file", type=str, default="", help="File to write the process PID")
-@click.option(
-    "--local-directory", default=None, type=str, help="Directory to place worker files"
-)
-@click.option(
-    "--resources",
-    type=str,
-    default=None,
-    help='Resources for task constraints like "GPU=2 MEM=10e9". '
-    "Resources are applied separately to each worker process "
-    "(only relevant when starting multiple worker processes with '--nprocs').",
-)
-@click.option(
-    "--scheduler-file",
-    type=str,
-    default=None,
-    help="Filename to JSON encoded scheduler information. "
-    "Use with dask-scheduler --scheduler-file",
-)
-@click.option(
-    "--death-timeout",
-    type=str,
-    default=None,
-    help="Seconds to wait for a scheduler before closing",
-)
-@click.option(
-    "--dashboard-prefix", type=str, default="", help="Prefix for the dashboard"
-)
-@click.option(
-    "--lifetime",
-    type=str,
-    default=None,
-    help="If provided, shut down the worker after this duration.",
-)
-@click.option(
-    "--lifetime-stagger",
-    type=str,
-    default="0 seconds",
-    show_default=True,
-    help="Random amount by which to stagger lifetime values",
-)
-@click.option(
-    "--worker-class",
-    type=str,
-    default="dask.distributed.Worker",
-    show_default=True,
-    help="Worker class used to instantiate workers from.",
-)
-@click.option(
-    "--lifetime-restart/--no-lifetime-restart",
-    "lifetime_restart",
-    default=False,
-    show_default=True,
-    required=False,
-    help="Whether or not to restart the worker after the lifetime lapses. "
-    "This assumes that you are using the --lifetime and --nanny keywords",
-)
-@click.option(
-    "--preload",
-    type=str,
-    multiple=True,
-    is_eager=True,
-    help="Module that should be loaded by each worker process "
-    'like "foo.bar" or "/path/to/foo.py"',
-)
-@click.argument(
-    "preload_argv", nargs=-1, type=click.UNPROCESSED, callback=validate_preload_argv
-)
-@click.option(
-    "--preload-nanny",
-    type=str,
-    multiple=True,
-    is_eager=True,
-    help="Module that should be loaded by each nanny "
-    'like "foo.bar" or "/path/to/foo.py"',
-)
+
+class WorkerCommand(click.Command):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.params = worker_options
+        self.context_settings = dict(ignore_unknown_options=True)
+
+
 @click.version_option()
+@click.command(cls=WorkerCommand)
 def main(
     scheduler,
     host,

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -225,7 +225,7 @@ def start_scheduler(
         python=remote_python or sys.executable, port=port, logdir=logdir
     )
 
-    cmd = prepare_additional_options(cmd, scheduler_options, **kwargs)
+    cmd = prepare_additional_options("scheduler", cmd, scheduler_options, **kwargs)
 
     # Optionally re-direct stdout and stderr to a logfile
     if logdir is not None:
@@ -322,7 +322,7 @@ def start_worker(
             local_directory=local_directory
         )
 
-    cmd = prepare_additional_options(cmd, worker_options, **kwargs)
+    cmd = prepare_additional_options("worker", cmd, worker_options, **kwargs)
 
     # Optionally redirect stdout and stderr to a logfile
     if logdir is not None:

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -16,6 +16,9 @@ from tlz import merge
 
 from tornado import gen
 
+from distributed.cli.dask_scheduler import scheduler_options
+from distributed.cli.dask_worker import worker_options
+from distributed.cli.utils import prepare_additional_options
 
 logger = logging.getLogger(__name__)
 
@@ -209,11 +212,20 @@ def async_ssh(cmd_dict):
 
 
 def start_scheduler(
-    logdir, addr, port, ssh_username, ssh_port, ssh_private_key, remote_python=None,
+    logdir,
+    addr,
+    port,
+    ssh_username,
+    ssh_port,
+    ssh_private_key,
+    remote_python=None,
+    **kwargs,
 ):
     cmd = "{python} -m distributed.cli.dask_scheduler --port {port}".format(
         python=remote_python or sys.executable, port=port, logdir=logdir
     )
+
+    cmd = prepare_additional_options(cmd, scheduler_options, **kwargs)
 
     # Optionally re-direct stdout and stderr to a logfile
     if logdir is not None:
@@ -271,6 +283,7 @@ def start_worker(
     remote_python=None,
     remote_dask_worker="distributed.cli.dask_worker",
     local_directory=None,
+    **kwargs,
 ):
 
     cmd = (
@@ -308,6 +321,8 @@ def start_worker(
         cmd += " --local-directory {local_directory}".format(
             local_directory=local_directory
         )
+
+    cmd = prepare_additional_options(cmd, worker_options, **kwargs)
 
     # Optionally redirect stdout and stderr to a logfile
     if logdir is not None:
@@ -360,6 +375,7 @@ class SSHCluster:
         nanny_port=None,
         remote_dask_worker="distributed.cli.dask_worker",
         local_directory=None,
+        **kwargs,
     ):
 
         self.scheduler_addr = scheduler_addr
@@ -410,12 +426,13 @@ class SSHCluster:
             ssh_port,
             ssh_private_key,
             remote_python,
+            **kwargs,
         )
 
         # Start worker nodes
         self.workers = []
         for i, addr in enumerate(worker_addrs):
-            self.add_worker(addr)
+            self.add_worker(addr, **kwargs)
 
     @gen.coroutine
     def _start(self):
@@ -445,7 +462,7 @@ class SSHCluster:
         except KeyboardInterrupt:
             pass  # Return execution to the calling process
 
-    def add_worker(self, address):
+    def add_worker(self, address, **kwargs):
         self.workers.append(
             start_worker(
                 self.logdir,
@@ -464,6 +481,7 @@ class SSHCluster:
                 self.remote_python,
                 self.remote_dask_worker,
                 self.local_directory,
+                **kwargs,
             )
         )
 


### PR DESCRIPTION
Closes #3763

This PR add missing options from `dask-scheduler` and `dask-worker` commands to `dask-ssh`.

Example:
<pre>
$ dask-ssh --nprocs 2 --nthreads 1 --worker-port 9000:9010  --hostfile ../nodes \
<b>--scheduler-dashboard-address :8989</b> <b>--scheduler-preload /path/to/foo.py</b>
</pre>
