### PR TITLE
Support Pickle's protocol 5

### DIFF
--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -36,18 +36,18 @@ def dumps(x, *, buffer_callback=None):
     if HIGHEST_PROTOCOL >= 5 and buffer_callback is not None:
         dump_kwargs["buffer_callback"] = buffers.append
     try:
-        del buffers[:]
+        buffers.clear()
         result = pickle.dumps(x, **dump_kwargs)
         if len(result) < 1000:
             if b"__main__" in result:
-                del buffers[:]
+                buffers.clear()
                 result = cloudpickle.dumps(x, **dump_kwargs)
         elif not _always_use_pickle_for(x) and b"__main__" in result:
-            del buffers[:]
+            buffers.clear()
             result = cloudpickle.dumps(x, **dump_kwargs)
     except Exception:
         try:
-            del buffers[:]
+            buffers.clear()
             result = cloudpickle.dumps(x, **dump_kwargs)
         except Exception as e:
             logger.info("Failed to serialize %s. Exception: %s", x, e)

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -31,21 +31,22 @@ def dumps(x):
     2.  If it is short then check if it contains __main__
     3.  If it is long, then first check type, then check __main__
     """
+    dump_kwargs = {"protocol": HIGHEST_PROTOCOL}
     try:
-        result = pickle.dumps(x, protocol=HIGHEST_PROTOCOL)
+        result = pickle.dumps(x, **dump_kwargs)
         if len(result) < 1000:
             if b"__main__" in result:
-                return cloudpickle.dumps(x, protocol=HIGHEST_PROTOCOL)
+                return cloudpickle.dumps(x, **dump_kwargs)
             else:
                 return result
         else:
             if _always_use_pickle_for(x) or b"__main__" not in result:
                 return result
             else:
-                return cloudpickle.dumps(x, protocol=HIGHEST_PROTOCOL)
+                return cloudpickle.dumps(x, **dump_kwargs)
     except Exception:
         try:
-            return cloudpickle.dumps(x, protocol=HIGHEST_PROTOCOL)
+            return cloudpickle.dumps(x, **dump_kwargs)
         except Exception as e:
             logger.info("Failed to serialize %s. Exception: %s", x, e)
             raise

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -33,7 +33,7 @@ def dumps(x, *, buffer_callback=None):
     """
     buffers = []
     dump_kwargs = {"protocol": HIGHEST_PROTOCOL}
-    if HIGHEST_PROTOCOL >= 5:
+    if HIGHEST_PROTOCOL >= 5 and buffer_callback is not None:
         dump_kwargs["buffer_callback"] = buffers.append
     try:
         del buffers[:]

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -52,8 +52,9 @@ def dumps(x, *, buffer_callback=None):
         except Exception as e:
             logger.info("Failed to serialize %s. Exception: %s", x, e)
             raise
-    for b in buffers:
-        buffer_callback(b)
+    if buffer_callback is not None:
+        for b in buffers:
+            buffer_callback(b)
     return result
 
 

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -32,6 +32,8 @@ def dumps(x, *, buffer_callback=None):
     3.  If it is long, then first check type, then check __main__
     """
     dump_kwargs = {"protocol": HIGHEST_PROTOCOL}
+    if HIGHEST_PROTOCOL >= 5:
+        dump_kwargs["buffer_callback"] = buffer_callback
     try:
         result = pickle.dumps(x, **dump_kwargs)
         if len(result) < 1000:

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -42,7 +42,7 @@ def dumps(x, *, buffer_callback=None):
             if b"__main__" in result:
                 del buffers[:]
                 result = cloudpickle.dumps(x, **dump_kwargs)
-        elif not (_always_use_pickle_for(x) or b"__main__" not in result):
+        elif not _always_use_pickle_for(x) and b"__main__" in result:
             del buffers[:]
             result = cloudpickle.dumps(x, **dump_kwargs)
     except Exception:

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -42,10 +42,9 @@ def dumps(x, *, buffer_callback=None):
             if b"__main__" in result:
                 del buffers[:]
                 result = cloudpickle.dumps(x, **dump_kwargs)
-        else:
-            if not (_always_use_pickle_for(x) or b"__main__" not in result):
-                del buffers[:]
-                result = cloudpickle.dumps(x, **dump_kwargs)
+        elif not (_always_use_pickle_for(x) or b"__main__" not in result):
+            del buffers[:]
+            result = cloudpickle.dumps(x, **dump_kwargs)
     except Exception:
         try:
             del buffers[:]

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -1,5 +1,6 @@
 import logging
 import pickle
+from pickle import HIGHEST_PROTOCOL
 
 import cloudpickle
 
@@ -31,20 +32,20 @@ def dumps(x):
     3.  If it is long, then first check type, then check __main__
     """
     try:
-        result = pickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
+        result = pickle.dumps(x, protocol=HIGHEST_PROTOCOL)
         if len(result) < 1000:
             if b"__main__" in result:
-                return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
+                return cloudpickle.dumps(x, protocol=HIGHEST_PROTOCOL)
             else:
                 return result
         else:
             if _always_use_pickle_for(x) or b"__main__" not in result:
                 return result
             else:
-                return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
+                return cloudpickle.dumps(x, protocol=HIGHEST_PROTOCOL)
     except Exception:
         try:
-            return cloudpickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
+            return cloudpickle.dumps(x, protocol=HIGHEST_PROTOCOL)
         except Exception as e:
             logger.info("Failed to serialize %s. Exception: %s", x, e)
             raise

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -53,12 +53,15 @@ def dask_loads(header, frames):
 
 def pickle_dumps(x):
     header = {"serializer": "pickle"}
-    frames = [pickle.dumps(x)]
+    frames = [None]
+    buffer_callback = lambda f: frames.append(memoryview(f))
+    frames[0] = pickle.dumps(x, buffer_callback=buffer_callback)
     return header, frames
 
 
 def pickle_loads(header, frames):
-    return pickle.loads(b"".join(frames))
+    x, buffers = frames[0], frames[1:]
+    return pickle.loads(x, buffers=buffers)
 
 
 def msgpack_dumps(x):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -52,7 +52,9 @@ def dask_loads(header, frames):
 
 
 def pickle_dumps(x):
-    return {"serializer": "pickle"}, [pickle.dumps(x)]
+    header = {"serializer": "pickle"}
+    frames = [pickle.dumps(x)]
+    return header, frames
 
 
 def pickle_loads(header, frames):

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -8,6 +8,11 @@ import pytest
 
 from distributed.protocol.pickle import HIGHEST_PROTOCOL, dumps, loads
 
+try:
+    from pickle import PickleBuffer
+except ImportError:
+    pass
+
 
 def test_pickle_data():
     data = [1, b"123", "123", [123], {}, set()]
@@ -16,11 +21,6 @@ def test_pickle_data():
 
 
 def test_pickle_out_of_band():
-    try:
-        from pickle import PickleBuffer
-    except ImportError:
-        pass
-
     class MemoryviewHolder:
         def __init__(self, mv):
             self.mv = memoryview(mv)

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -40,6 +40,10 @@ def test_pickle_out_of_band():
         l = []
         d = dumps(mvh, buffer_callback=l.append)
         mvh2 = loads(d, buffers=l)
+
+        assert len(l) == 1
+        assert isinstance(l[0], PickleBuffer)
+        assert l[0].raw() == mv
     else:
         mvh2 = loads(dumps(mvh))
 
@@ -81,6 +85,7 @@ def test_pickle_numpy():
         d = dumps(x, buffer_callback=l.append)
         assert len(l) == 1
         assert isinstance(l[0], PickleBuffer)
+        assert l[0].raw() == memoryview(x).cast("B")
         assert (loads(d, buffers=l) == x).all()
 
         h, f = serialize(x, serializers=("pickle",))

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -43,7 +43,7 @@ def test_pickle_out_of_band():
 
         assert len(l) == 1
         assert isinstance(l[0], PickleBuffer)
-        assert l[0].raw() == mv
+        assert memoryview(l[0]) == mv
     else:
         mvh2 = loads(dumps(mvh))
 
@@ -85,7 +85,7 @@ def test_pickle_numpy():
         d = dumps(x, buffer_callback=l.append)
         assert len(l) == 1
         assert isinstance(l[0], PickleBuffer)
-        assert l[0].raw() == memoryview(x).cast("B")
+        assert memoryview(l[0]) == memoryview(x)
         assert (loads(d, buffers=l) == x).all()
 
         h, f = serialize(x, serializers=("pickle",))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click >= 6.6
-cloudpickle >= 0.2.2
+cloudpickle >= 1.3.0
 contextvars;python_version<'3.7'
 dask >= 2.9.0
 msgpack >= 0.6.0


### PR DESCRIPTION
This ensures that objects that do support Pickle's protocol 5 go through out-of-band serialization of buffers. Should avoid some extra memory usage and memory copies that would otherwise be encountered when going through Pickle's older protocols without this feature. Requires Python 3.8+ to work (as that is when this protocol was introduced).

Had considered supporting `pickle5` as well to ensure users could get this functionality with earlier versions of Python. However this would involve supporting `pickle5` in `cloudpickle`, which hasn't been done yet ( https://github.com/cloudpipe/cloudpickle/issues/179 ). So am side stepping that for now. Could be handled in a follow-up once that is addressed.