### PR TITLE
Enhance VersionMismatchWarning messages

### DIFF
--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -106,6 +106,20 @@ def test_scheduler_additional_irrelevant_package(kwargs_matching):
     assert error_message(**kwargs_matching) == ""
 
 
+def test_python_mismatch(kwargs_matching):
+    kwargs_matching["client"]["packages"]["python"] = "0.0.0"
+    msg = error_message(**kwargs_matching)
+    assert "Mismatched versions found" in msg
+    assert "python" in msg
+    assert (
+        "0.0.0"
+        in re.search(r"python\s+(?:(?:\|[^|\r\n]*)+\|(?:\r?\n|\r)?)+", msg)
+        .group(0)
+        .split("|")[1]
+        .strip()
+    )
+
+
 @gen_cluster()
 async def test_version_warning_in_cluster(s, a, b):
     s.workers[a.address].versions["packages"]["dask"] = "0.0.0"

--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -33,11 +33,6 @@ def kwargs_matching():
     )
 
 
-@pytest.fixture
-def column_matching():
-    return dict(scheduler=2, workers=3, client=1,)
-
-
 def test_versions_match(kwargs_matching):
     assert error_message(**kwargs_matching) == ""
 
@@ -81,7 +76,8 @@ def pattern(effect):
     }[effect]
 
 
-def test_version_mismatch(node, effect, kwargs_not_matching, column_matching, pattern):
+def test_version_mismatch(node, effect, kwargs_not_matching, pattern):
+    column_matching = {"client": 1, "scheduler": 2, "workers": 3}
     msg = error_message(**kwargs_not_matching)
     i = column_matching.get(node, 3)
     assert "Mismatched versions found" in msg

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -152,6 +152,11 @@ def error_message(scheduler, workers, client, client_name="client"):
             else:
                 workers_version.add(node_packages[node_name][pkg])
 
+        if len(workers_version) == 1:
+            workers_version = list(workers_version)[0]
+        elif len(workers_version) == 0:
+            workers_version = None
+
         errs.append((pkg, client_version, scheduler_version, workers_version))
         if pkg in notes_mismatch_package.keys():
             notes.append(f"-  {pkg}: {notes_mismatch_package[pkg]}")

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -163,7 +163,7 @@ def error_message(scheduler, workers, client, client_name="client"):
 
     if errs:
         err_table = asciitable(["Package", "client", "scheduler", "workers"], errs)
-        err_msg = "Mismatched versions found\n" "\n" f"{err_table}"
+        err_msg = f"Mismatched versions found\n\n{err_table}"
         if notes:
             err_msg += "\nNotes: \n{}".format("\n".join(notes))
         return err_msg


### PR DESCRIPTION
This PR closes #3767

```
/usr/local/lib/python3.7/site-packages/distributed/client.py:1079: VersionMismatchWarning: Mismatched versions found

+-------------+---------------+--------------------------+-----------------------------------------------------+
| Package     | client        | scheduler                | workers                                             |
+-------------+---------------+--------------------------+-----------------------------------------------------+
| cloudpickle | 0.7.0         | 1.4.0                    | {'1.4.0'}                                           |
| dask        | 2.15.0        | 2.15.0+17.g6d7ae70e      | {'2.15.0+17.g6d7ae70e'}                             |
| distributed | 2.15.2        | 2.15.2+9.g77f6c55f.dirty | {'2.15.2+9.g77f6c55f.dirty', '2.15.2+10.g1ad0ba3a'} |
| lz4         | None          | 3.0.2                    | {None, '3.0.2'}                                     |
| msgpack     | 0.6.1         | 1.0.0                    | {'1.0.0'}                                           |
| numpy       | 1.15.0        | 1.18.3                   | {'1.18.3'}                                          |
| python      | 3.7.6.final.0 | 3.7.6.final.0            | {'3.7.6.final.0', '3.7.5.final.0'}                  |
| toolz       | 0.9.0         | 0.10.0                   | {'0.10.0'}                                          |
| tornado     | 5.1.1         | 6.0.4                    | {'6.0.4'}                                           |
+-------------+---------------+--------------------------+-----------------------------------------------------+
Notes: 
-  lz4: Variation is ok, but missing libraries are not
-  msgpack: Variation is ok, as long as everything is above 0.6
-  python: Variation is sometimes ok, sometimes not.  It depends on your workloads
  warnings.warn(version_module.VersionMismatchWarning(msg[0]["warning"]))
```