### PR TITLE
Await self before handling comms

### DIFF
--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -317,16 +317,9 @@ def test_preload_remote_module(loop, tmp_path):
             with Client(
                 scheduler_file=tmp_path / "scheduler-file.json", loop=loop
             ) as c:
-                for i in range(10):
-                    val = c.run_on_scheduler(
-                        lambda dask_scheduler: getattr(dask_scheduler, "foo", None)
-                    )
-                    if val == "bar":
-                        break
-                    else:
-                        sleep(0.1)
-                else:
-                    raise ValueError(val)
+                assert c.run_on_scheduler(
+                    lambda dask_scheduler: getattr(dask_scheduler, "foo", None)
+                ) == "bar"
 
 
 PRELOAD_COMMAND_TEXT = """

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -66,6 +66,11 @@ def test_dashboard(loop):
     pytest.importorskip("bokeh")
 
     with popen(["dask-scheduler"]) as proc:
+        for line in proc.stderr:
+            if b"dashboard at" in line:
+                dashboard_port = int(line.decode().split(":")[-1].strip())
+                break
+
         with Client("127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
             pass
 
@@ -78,7 +83,7 @@ def test_dashboard(loop):
             try:
                 # All addresses should respond
                 for name in names:
-                    uri = "http://%s:8787/status/" % name
+                    uri = "http://%s:%d/status/" % (name, dashboard_port)
                     response = requests.get(uri)
                     assert response.ok
                 break
@@ -88,7 +93,7 @@ def test_dashboard(loop):
                 assert time() < start + 10
 
     with pytest.raises(Exception):
-        requests.get("http://127.0.0.1:8787/status/")
+        requests.get("http://127.0.0.1:%d/status/" % dashboard_port)
 
 
 def test_dashboard_non_standard_ports(loop):
@@ -317,9 +322,12 @@ def test_preload_remote_module(loop, tmp_path):
             with Client(
                 scheduler_file=tmp_path / "scheduler-file.json", loop=loop
             ) as c:
-                assert c.run_on_scheduler(
-                    lambda dask_scheduler: getattr(dask_scheduler, "foo", None)
-                ) == "bar"
+                assert (
+                    c.run_on_scheduler(
+                        lambda dask_scheduler: getattr(dask_scheduler, "foo", None)
+                    )
+                    == "bar"
+                )
 
 
 PRELOAD_COMMAND_TEXT = """

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -678,7 +678,7 @@ class Client:
         self._asynchronous = asynchronous
         self._should_close_loop = not loop
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
-        self.loop = self._loop_runner.loop
+        self.io_loop = self.loop = self._loop_runner.loop
 
         self._gather_keys = None
         self._gather_future = None

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -51,9 +51,15 @@ from .utils_comm import (
     retry_operation,
 )
 from .cfexecutor import ClientExecutor
-from .core import connect, rpc, clean_exception, CommClosedError, PooledRPCCall
+from .core import (
+    connect,
+    rpc,
+    clean_exception,
+    CommClosedError,
+    PooledRPCCall,
+    ConnectionPool,
+)
 from .metrics import time
-from .node import Node
 from .protocol import to_serialize
 from .protocol.pickle import dumps, loads
 from .publish import Datasets
@@ -492,7 +498,7 @@ class AllExit(Exception):
     """
 
 
-class Client(Node):
+class Client:
     """ Connect to and submit computation to a Dask cluster
 
     The Client connects users to a Dask cluster.  It provides an asynchronous
@@ -590,6 +596,7 @@ class Client(Node):
         deserializers=None,
         extensions=DEFAULT_EXTENSIONS,
         direct_to_workers=None,
+        connection_limit=512,
         **kwargs,
     ):
         if timeout == no_default:
@@ -714,12 +721,14 @@ class Client(Node):
             "erred": self._handle_task_erred,
         }
 
-        super(Client, self).__init__(
-            connection_args=self.connection_args,
-            io_loop=self.loop,
+        self.rpc = ConnectionPool(
+            limit=connection_limit,
             serializers=serializers,
             deserializers=deserializers,
+            deserialize=True,
+            connection_args=self.connection_args,
             timeout=timeout,
+            server=self,
         )
 
         for ext in extensions:
@@ -961,8 +970,7 @@ class Client(Node):
             )
 
     async def _start(self, timeout=no_default, **kwargs):
-
-        await super().start()
+        await self.rpc.start()
 
         if timeout == no_default:
             timeout = self._timeout

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -331,6 +331,7 @@ class Server:
 
         logger.debug("Connection from %r to %s", address, type(self).__name__)
         self._comms[comm] = op
+        await self
         try:
             while True:
                 try:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -34,6 +34,7 @@ from .utils import (
     parse_timedelta,
     has_keyword,
     CancelledError,
+    TimeoutError,
 )
 from . import protocol
 
@@ -106,6 +107,10 @@ class Server:
         stream_handlers=None,
         connection_limit=512,
         deserialize=True,
+        serializers=None,
+        deserializers=None,
+        connection_args=None,
+        timeout=None,
         io_loop=None,
     ):
         self.handlers = {
@@ -191,12 +196,58 @@ class Server:
             self.thread_id = threading.get_ident()
 
         self.io_loop.add_callback(set_thread_ident)
+        self._startup_lock = asyncio.Lock()
+        self.status = None
+
+        self.rpc = ConnectionPool(
+            limit=connection_limit,
+            deserialize=deserialize,
+            serializers=serializers,
+            deserializers=deserializers,
+            connection_args=connection_args,
+            timeout=timeout,
+            server=self,
+        )
 
         self.__stopped = False
 
     async def finished(self):
         """ Wait until the server has finished """
         await self._event_finished.wait()
+
+    def __await__(self):
+        async def _():
+            timeout = getattr(self, "death_timeout", 0)
+            async with self._startup_lock:
+                if self.status == "running":
+                    return self
+                if timeout:
+                    try:
+                        await asyncio.wait_for(self.start(), timeout=timeout)
+                        self.status = "running"
+                    except Exception:
+                        await self.close(timeout=1)
+                        raise TimeoutError(
+                            "{} failed to start in {} seconds".format(
+                                type(self).__name__, timeout
+                            )
+                        )
+                else:
+                    await self.start()
+                    self.status = "running"
+            return self
+
+        return _().__await__()
+
+    async def start(self):
+        await self.rpc.start()
+
+    async def __aenter__(self):
+        await self
+        return self
+
+    async def __aexit__(self, typ, value, traceback):
+        await self.close()
 
     def start_periodic_callbacks(self):
         """ Start Periodic Callbacks consistently

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -806,7 +806,6 @@ def test_local_tls_restart(loop):
         loop=loop,
     ) as c:
         with Client(c.scheduler.address, loop=loop, security=security) as client:
-            print(c.workers, c.workers[0].address)
             workers_before = set(client.scheduler_info()["workers"])
             assert client.submit(inc, 1).result() == 2
             client.restart()

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -399,6 +399,7 @@ class MultiWorker(Worker, ProcessInterface):
             )
             for i in range(n)
         ]
+        self._startup_lock = asyncio.Lock()
 
     @property
     def status(self):

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -1,53 +1,20 @@
-import asyncio
 import logging
 import warnings
 import weakref
 
-from tornado import gen
-from tornado.ioloop import IOLoop
 from tornado.httpserver import HTTPServer
 import tlz
 import dask
 
 from .comm import get_tcp_server_address
 from .comm import get_address_host
-from .core import Server, ConnectionPool
+from .core import Server
 from .http.routing import RoutingApplication
 from .versions import get_versions
-from .utils import DequeHandler, TimeoutError, clean_dashboard_address, ignoring
+from .utils import DequeHandler, clean_dashboard_address, ignoring
 
 
-class Node:
-    """
-    Base class for nodes in a distributed cluster.
-    """
-
-    def __init__(
-        self,
-        connection_limit=512,
-        deserialize=True,
-        connection_args=None,
-        io_loop=None,
-        serializers=None,
-        deserializers=None,
-        timeout=None,
-    ):
-        self.io_loop = io_loop or IOLoop.current()
-        self.rpc = ConnectionPool(
-            limit=connection_limit,
-            deserialize=deserialize,
-            serializers=serializers,
-            deserializers=deserializers,
-            connection_args=connection_args,
-            timeout=timeout,
-            server=self,
-        )
-
-    async def start(self):
-        await self.rpc.start()
-
-
-class ServerNode(Node, Server):
+class ServerNode(Server):
     """
     Base class for server nodes in a distributed cluster.
     """
@@ -56,40 +23,6 @@ class ServerNode(Node, Server):
 
     # XXX avoid inheriting from Server? there is some large potential for confusion
     # between base and derived attribute namespaces...
-
-    def __init__(
-        self,
-        handlers=None,
-        blocked_handlers=None,
-        stream_handlers=None,
-        connection_limit=512,
-        deserialize=True,
-        connection_args=None,
-        io_loop=None,
-        serializers=None,
-        deserializers=None,
-        timeout=None,
-    ):
-        Node.__init__(
-            self,
-            deserialize=deserialize,
-            connection_limit=connection_limit,
-            connection_args=connection_args,
-            io_loop=io_loop,
-            serializers=serializers,
-            deserializers=deserializers,
-            timeout=timeout,
-        )
-        Server.__init__(
-            self,
-            handlers=handlers,
-            blocked_handlers=blocked_handlers,
-            stream_handlers=stream_handlers,
-            connection_limit=connection_limit,
-            deserialize=deserialize,
-            io_loop=self.io_loop,
-        )
-        self._startup_lock = asyncio.Lock()
 
     def versions(self, comm=None, packages=None):
         return get_versions(packages=packages)
@@ -161,42 +94,6 @@ class ServerNode(Node, Server):
             L = deque_handler.deque
             L = [L[-i] for i in range(min(n, len(L)))]
         return [(msg.levelname, deque_handler.format(msg)) for msg in L]
-
-    async def __aenter__(self):
-        await self
-        return self
-
-    async def __aexit__(self, typ, value, traceback):
-        await self.close()
-
-    def __await__(self):
-        async def _():
-            timeout = getattr(self, "death_timeout", 0)
-            async with self._startup_lock:
-                if self.status == "running":
-                    return self
-                if timeout:
-                    try:
-                        await asyncio.wait_for(self.start(), timeout=timeout)
-                        self.status = "running"
-                    except Exception:
-                        await self.close(timeout=1)
-                        raise TimeoutError(
-                            "{} failed to start in {} seconds".format(
-                                type(self).__name__, timeout
-                            )
-                        )
-                else:
-                    await self.start()
-                    self.status = "running"
-            return self
-
-        return _().__await__()
-
-    async def start(self):
-        # subclasses should implement their own start method whichs calls super().start()
-        await Node.start(self)
-        return self
 
     def start_http_server(
         self, routes, dashboard_address, default_port=0, ssl_options=None,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1426,8 +1426,8 @@ class Scheduler(ServerNode):
 
     async def start(self):
         """ Clear out old state and restart all running coroutines """
-
         await super().start()
+        assert self.status != "running"
 
         enable_gc_diagnosis()
 
@@ -1437,28 +1437,26 @@ class Scheduler(ServerNode):
             for c in self._worker_coroutines:
                 c.cancel()
 
-        if self.status != "running":
-            for addr in self._start_address:
-                await self.listen(addr, **self.security.get_listen_args("scheduler"))
-                self.ip = get_address_host(self.listen_address)
-                listen_ip = self.ip
+        for addr in self._start_address:
+            await self.listen(addr, **self.security.get_listen_args("scheduler"))
+            self.ip = get_address_host(self.listen_address)
+            listen_ip = self.ip
 
-                if listen_ip == "0.0.0.0":
-                    listen_ip = ""
+            if listen_ip == "0.0.0.0":
+                listen_ip = ""
 
-            if self.address.startswith("inproc://"):
-                listen_ip = "localhost"
+        if self.address.startswith("inproc://"):
+            listen_ip = "localhost"
 
-            # Services listen on all addresses
-            self.start_services(listen_ip)
+        # Services listen on all addresses
+        self.start_services(listen_ip)
 
-            self.status = "running"
-            for listener in self.listeners:
-                logger.info("  Scheduler at: %25s", listener.contact_address)
-            for k, v in self.services.items():
-                logger.info("%11s at: %25s", k, "%s:%d" % (listen_ip, v.port))
+        for listener in self.listeners:
+            logger.info("  Scheduler at: %25s", listener.contact_address)
+        for k, v in self.services.items():
+            logger.info("%11s at: %25s", k, "%s:%d" % (listen_ip, v.port))
 
-            self.loop.add_callback(self.reevaluate_occupancy)
+        self.loop.add_callback(self.reevaluate_occupancy)
 
         if self.scheduler_file:
             with open(self.scheduler_file, "w") as f:
@@ -2937,7 +2935,8 @@ class Scheduler(ServerNode):
             finally:
                 await asyncio.gather(*[nanny.close_rpc() for nanny in nannies])
 
-            await self.start()
+            self.status = None
+            await self
 
             self.log_event([client, "all"], {"action": "restart", "client": client})
             start = time()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3620,8 +3620,8 @@ def test_open_close_many_workers(loop, worker, count, repeat):
                     return
                 w = worker(s["address"], loop=loop)
                 running[w] = None
-                workers.add(w)
                 await w
+                workers.add(w)
                 addr = w.worker_address
                 running[w] = addr
                 await asyncio.sleep(duration)
@@ -3648,6 +3648,9 @@ def test_open_close_many_workers(loop, worker, count, repeat):
             while c.nthreads():
                 sleep(0.2)
                 assert time() < start + 10
+
+            while len(workers) < count * repeat:
+                sleep(0.2)
 
             status = False
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -88,6 +88,7 @@ def test_server(loop):
         await server.listen(8881)
         assert server.port == 8881
         assert server.address == ("tcp://%s:8881" % get_ip())
+        await server
 
         for addr in ("127.0.0.1:8881", "tcp://127.0.0.1:8881", server.address):
             comm = await connect(addr)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -562,7 +562,6 @@ class Worker(ServerNode):
 
         self.actors = {}
         self.loop = loop or IOLoop.current()
-        self.status = None
         self.reconnect = reconnect
         self.executor = executor or ThreadPoolExecutor(
             self.nthreads, thread_name_prefix="Dask-Worker-Threads'"


### PR DESCRIPTION
This stops servers from handling messages until they are finished
starting.

Additionally, we centralize the status management to Server.__await__

Lots of things break currently, but I didn't want to lose this.