### PR TITLE
Fix profile thread leakage during test teardown on some platforms

### DIFF
--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -175,7 +175,7 @@ def main(
             version=distributed.__version__
         )
     )
-    print("Worker nodes:".format(n=len(hostnames)))
+    print("Worker nodes: {n}".format(n=len(hostnames)))
     for i, host in enumerate(hostnames):
         print("  {num}: {host}".format(num=i, host=host))
     print("\nscheduler node: {addr}:{port}".format(addr=scheduler, port=scheduler_port))

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -212,7 +212,7 @@ def start_scheduler(
     logdir, addr, port, ssh_username, ssh_port, ssh_private_key, remote_python=None,
 ):
     cmd = "{python} -m distributed.cli.dask_scheduler --port {port}".format(
-        python=remote_python or sys.executable, port=port, logdir=logdir
+        python=remote_python or sys.executable, port=port
     )
 
     # Optionally re-direct stdout and stderr to a logfile

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2889,7 +2889,7 @@ async def test_rebalance_unprepared(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_rebalance_raises_missing_data(c, s, a, b):
-    with pytest.raises(ValueError, match=f"keys were found to be missing"):
+    with pytest.raises(ValueError, match="keys were found to be missing"):
         futures = await c.scatter(range(100))
         keys = [f.key for f in futures]
         del futures

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1542,12 +1542,5 @@ def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
 
 @pytest.fixture
 def cleanup():
-    with check_thread_leak():
-        with check_process_leak():
-            with check_instances():
-                reset_config()
-                dask.config.set({"distributed.comm.timeouts.connect": "5s"})
-                for name, level in logging_levels.items():
-                    logging.getLogger(name).setLevel(level)
-
-                yield
+    with clean():
+        yield


### PR DESCRIPTION
When running tests locally (in a debian9 docker container; docker on osx) I receive errors during test cleanup like

```
AssertionError: (<Thread(Profile, started daemon 139685301057280)>, ['  File "/home/fjetter/miniconda/envs/dask-distributed/lib/python...*self._kwargs)
E                 ', '  File "/workspace/distributed/distributed/profile.py", line 269, in _watch
```

Tracking this down, the profile watch thread has a termination condition which is coupled to the `ioloop` being alive. Therefore, this fixture needed another `pristine_loop` context manager for me to succeed. Ultimately, the construct looks incredibly similar to the contextmanager `clean` and I replaced it with this.

Apparently, the build failures can be reproduced when running on travis.**com** instead of travis.**org**. I didn't try to determine what the differences of the environment are.

Looks like this is one of the errors reported in #3356