### PR TITLE
Add retries to server listen

### DIFF
--- a/distributed/node.py
+++ b/distributed/node.py
@@ -96,11 +96,11 @@ class ServerNode(Server):
         return [(msg.levelname, deque_handler.format(msg)) for msg in L]
 
     def start_http_server(
-        self, routes, dashboard_address, default_port=0, ssl_options=None,
+        self, routes, dashboard_address, default_port=0, ssl_options=None
     ):
         """ This creates an HTTP Server running on this node """
 
-        self.http_application = RoutingApplication(routes,)
+        self.http_application = RoutingApplication(routes)
 
         # TLS configuration
         tls_key = dask.config.get("distributed.scheduler.dashboard.tls.key")
@@ -127,16 +127,26 @@ class ServerNode(Server):
             if address:
                 with ignoring(ValueError):
                     http_address["address"] = get_address_host(address)
-        changed_port = False
-        try:
-            self.http_server.listen(**http_address)
-        except Exception:
-            changed_port = True
-            self.http_server.listen(**tlz.merge(http_address, {"port": 0}))
+
+        change_port = False
+        retries_left = 3
+        while True:
+            try:
+                if not change_port:
+                    self.http_server.listen(**http_address)
+                else:
+                    self.http_server.listen(**tlz.merge(http_address, {"port": 0}))
+                break
+            except Exception:
+                change_port = True
+                retries_left = retries_left - 1
+                if retries_left < 1:
+                    raise
+
         self.http_server.port = get_tcp_server_address(self.http_server)[1]
         self.services["dashboard"] = self.http_server
 
-        if changed_port and dashboard_address:
+        if change_port and dashboard_address:
             warnings.warn(
                 "Port {} is already in use.\n"
                 "Perhaps you already have a cluster running?\n"


### PR DESCRIPTION
I thought I'd have a go at adding a little retry logic to the server listen.

As raised in #3800 we occasionally see issues with ports not being available even if they are a random high port. This is likely to be some quirk of the CI system environment, but I thought it wouldn't hurt to retry a couple of times.

There may be a more elegant way of writing this, I'm a little tired 😅.

cc @fjetter 