### PR TITLE
Simplify frame encoding

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -11,8 +11,41 @@ from ..utils import nbytes
 
 _deserialize = deserialize
 
-
 logger = logging.getLogger(__name__)
+
+"""
+Some values are sent in a serialized form, which does not need to be understood by the central server.
+These values are offloaded to separate MessagePack frames which are sent after the main message.
+The offloaded values in the main message are replaced by a placeholder object:
+key: {
+    [OFFLOAD_HEADER_KEY]: <message-pack encoded header of this offloaded value>,
+    [OFFLOAD_FINDEX_KEY]: <frames of this value start at this index in the frames array>,
+    [OFFLOAD_FCOUNT_KEY]: <number of frames of this offloaded value> 
+}
+
+The frames for a specific offloaded value can be found at frames[OFFLOAD_FINDEX_KEY:OFFLOAD_FINDEX_KEY+OFFLOAD_FCOUNT_KEY].
+"""
+
+OFFLOAD_HEADER_KEY = "_$header"
+OFFLOAD_FINDEX_KEY = "_$findex"
+OFFLOAD_FCOUNT_KEY = "_$fcount"
+
+
+def _make_offload_value(header, frame_index, frame_count):
+    return {OFFLOAD_HEADER_KEY: header, OFFLOAD_FINDEX_KEY: frame_index,
+            OFFLOAD_FCOUNT_KEY: frame_count}
+
+
+def _extract_offload_value(value):
+    if not isinstance(value, dict) or len(value) != 3:
+        return None
+    frame_index = value.get(OFFLOAD_FINDEX_KEY)
+    if frame_index is None:
+        return None
+    header = value.get(OFFLOAD_HEADER_KEY)
+    if header is None:
+        return None
+    return (header, frame_index)
 
 
 def dumps(msg, serializers=None, on_error="message", context=None):
@@ -22,10 +55,9 @@ def dumps(msg, serializers=None, on_error="message", context=None):
         # Only lists and dicts can contain serialized values
         if isinstance(msg, (list, dict)):
             msg, data, bytestrings = extract_serialize(msg)
-        small_header, small_payload = dumps_msgpack(msg)
 
         if not data:  # fast path without serialized data
-            return small_header, small_payload
+            return dumps_msgpack(msg)
 
         pre = {
             key: (value.header, value.frames)
@@ -41,14 +73,17 @@ def dumps(msg, serializers=None, on_error="message", context=None):
             if type(value) is Serialize
         }
 
-        header = {"headers": {}, "keys": [], "bytestrings": list(bytestrings)}
-
         out_frames = []
+
+        def patch_offload_header(path, header, frame_index, frame_count, context):
+            accessor, key = path[:-1], path[-1]
+            holder = reduce(operator.getitem, accessor, context)
+            header["deserialize"] = path in bytestrings
+            holder[key] = _make_offload_value(header, frame_index, frame_count)
 
         for key, (head, frames) in data.items():
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
-
             # Compress frames that are not yet compressed
             out_compression = []
             _out_frames = []
@@ -63,19 +98,16 @@ def dumps(msg, serializers=None, on_error="message", context=None):
                 else:  # already specified, so pass
                     out_compression.append(compression)
                     _out_frames.append(frame)
-
             head["compression"] = out_compression
             head["count"] = len(_out_frames)
-            header["headers"][key] = head
-            header["keys"].append(key)
+            patch_offload_header(key, head, len(out_frames), len(_out_frames), msg)
             out_frames.extend(_out_frames)
 
         for key, (head, frames) in pre.items():
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
             head["count"] = len(frames)
-            header["headers"][key] = head
-            header["keys"].append(key)
+            patch_offload_header(key, head, len(out_frames), len(frames), msg)
             out_frames.extend(frames)
 
         for i, frame in enumerate(out_frames):
@@ -86,11 +118,7 @@ def dumps(msg, serializers=None, on_error="message", context=None):
                     frame = frame.tobytes()
                 out_frames[i] = frame
 
-        return [
-            small_header,
-            small_payload,
-            msgpack.dumps(header, use_bin_type=True),
-        ] + out_frames
+        return dumps_msgpack(msg) + out_frames
     except Exception:
         logger.critical("Failed to Serialize", exc_info=True)
         raise
@@ -98,54 +126,51 @@ def dumps(msg, serializers=None, on_error="message", context=None):
 
 def loads(frames, deserialize=True, deserializers=None):
     """ Transform bytestream back into Python value """
-    frames = frames[::-1]  # reverse order to improve pop efficiency
     if not isinstance(frames, list):
         frames = list(frames)
     try:
-        small_header = frames.pop()
-        small_payload = frames.pop()
+        small_header = frames[0]
+        small_payload = frames[1]
         msg = loads_msgpack(small_header, small_payload)
-        if not frames:
+        if len(frames) < 3:
             return msg
 
-        header = frames.pop()
-        header = msgpack.loads(header, use_list=False, **msgpack_opts)
-        keys = header["keys"]
-        headers = header["headers"]
-        bytestrings = set(header["bytestrings"])
+        out_frames_start = 2
 
-        for key in keys:
-            head = headers[key]
-            count = head["count"]
-            if count:
-                fs = frames[-count::][::-1]
-                del frames[-count:]
-            else:
-                fs = []
-
-            if deserialize or key in bytestrings:
-                if "compression" in head:
-                    fs = decompress(head, fs)
-                fs = merge_frames(head, fs)
-                value = _deserialize(head, fs, deserializers=deserializers)
-            else:
-                value = Serialized(head, fs)
-
-            def put_in(keys, coll, val):
-                """Inverse of get_in, but does type promotion in the case of lists"""
-                if keys:
-                    holder = reduce(operator.getitem, keys[:-1], coll)
-                    if isinstance(holder, tuple):
-                        holder = list(holder)
-                        coll = put_in(keys[:-1], coll, holder)
-                    holder[keys[-1]] = val
+        def _traverse(item):
+            placeholder = _extract_offload_value(item)
+            if placeholder is not None:
+                header, frame_index = placeholder
+                deserialize_key = header["deserialize"]
+                count = header["count"]
+                if count:
+                    start_index = out_frames_start + frame_index
+                    end_index = start_index + count
+                    fs = frames[start_index:end_index]
+                    frames[start_index:end_index] = [None] * count  # free memory
                 else:
-                    coll = val
-                return coll
+                    fs = []
 
-            msg = put_in(key, msg, value)
+                if deserialize or deserialize_key:
+                    if "compression" in header:
+                        fs = decompress(header, fs)
+                    fs = merge_frames(header, fs)
+                    value = _deserialize(header, fs, deserializers=deserializers)
+                else:
+                    value = Serialized(header, fs)
+                return value
 
-        return msg
+            if isinstance(item, (list, tuple)):
+                return tuple(_traverse(i) for i in item)
+            elif isinstance(item, dict):
+                return {
+                    key: _traverse(val)
+                    for (key, val) in item.items()
+                }
+            else:
+                return item
+
+        return _traverse(msg)
     except Exception:
         logger.critical("Failed to deserialize", exc_info=True)
         raise


### PR DESCRIPTION
This PR attempts to simplify the low-level encoding of Dask protocol messages into frames to make it easier to implement handling of the protocol in a statically typed language (like Rust). There are of course multiple ways of solving this issue, in this PR I'll attempt to describe the issue and offer a possible solution that we have used for our Rust scheduler.

### The issue
The current implementation of the `dumps` function in `protocol/cores.py` takes a Python message (usually a dictionary), extracts serialized/serializable values out of the message, puts them into a series of frames and creates headers that describe how to reconstruct the original message from the frame stream. For example, if the input message has a "function" attribute which contains serialized data, Dask will remove the attribute, create a frame with its serialized data and describe how to put the "function" attribute back into the message in a header which is stored into a separate frame. This is displayed here in the top right corner:
![image](https://user-images.githubusercontent.com/4539057/82203672-e38f6a80-9903-11ea-9167-a4712b03ef0c.png)

The problematic part is message reconstruction during deserialization. A natural representation of Dask message types in a statically typed language is to use data structures which strictly describe the various message types, as opposed to loosely typed dictionaries with arbitrary types inside. An example from Rust (simplified):
```rust
struct DaskUpdateGraphTask {
   function: FunctionDefinition,
   arguments: ArgumentsDefinition,
   ...
}
```
If Dask clients/workers can remove arbitrary attributes from these messages and we have to support arbitrary data structure modification queries like `put <something> into "key1" field of the 0th element of the "key2" field of the input message`, we are pretty much left with no choice than to go back to untyped dictionaries, which defeats one of the benefits of statically typed languages, especially for such critical component of the scheduler. It's trivial to support these queries in a dynamic language, but in e.g. Rust it's incredibly painful.

### Proposed solution
Instead of removing the attributes of the Dask protocol messages and then putting them back in, we propose to keep the original message structure, but replace the attribute values with placeholders (see example image above, bottom right corner). A value which has to be offloaded will be replaced with a placeholder dictionary on the wire, which describes from which frames should the value be reconstructed (frame index + frame count) and how (header). With this approach we can model the original message structure and use a generic enumeration (like `InPlace`/`Offloaded`) type for attributes that can be offloaded (potentially for all attributes). Most importantly, we don't have to implement arbitrary data structure modification queries. In our specific implementation, we have two versions of message types that can contain offloadable attributes which can be converted between each other if you provide them a frame array. Here's a pseudocode of how that could look like:
```rust
struct TaskDefinitionOffloaded {
     function: Offloadable<FunctionDefinition>
}
struct TaskDefinition {
     function: FunctionDefinition
}

impl TaskDefinitionOffloaded {
     fn to_task_def(frames: &[Frame]) {
         // reconstruct TaskDefinition from TaskDefinitionOffloaded by reading data
         // from `frames`
    }
}
```

### Implementation
In our implementation, the placeholder is a dictionary with three "magic" keys, the number of frames of the offloaded value, the index of the first frame in the resulting frame stream and the Dask header containing information about compression and other stuff.

During serialization, we replace each offloaded value with this placeholder.
During deserialization, we check if a value if offloaded (by looking for these magic keys) and if yes, we read the corresponding frame range and reconstruct the original value.

The names of the magic keys are rather arbitrary, they can be probably improved. In our implementation, we send one frame less than in the current encoding, because we do not need the intermediate frame with headers describing how to reconstruct offloaded values. The headers are stored directly in the placeholders. This should not increase message size by itself, as all of the headers are also present in the current encoding, just in a different location. I'm not sure about the frame size limitations though. So far in our experiments it has not caused problems.

Even though our changes were motivated by our inability to implement the old protocol encoding elegantly and performantly in Rust, I'm certain that potential implementations in other statically typed languages (like C++) would face identical problems. I am not sure if our proposed solution is the right one, but I think that in order to make implementations of the scheduler (or other Dask parts) easier in statically typed languages, Dask should use a less "hostile" encoding. It would also help in documenting and understanding of the protocol itself. 

In an (slightly unrelated, but still relevant) attempt to unify what comes out of deserialization, the code in this PR also normalizes both lists and tuples to tuple (https://github.com/dask/distributed/issues/3716).