### PR TITLE
make re-creating conda environments from the CI output easier

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -96,8 +96,8 @@ fi
 python -m pip install --no-deps -e .
 
 # For debugging
-echo -e "--\n--Conda Environment\n--"
-conda list
+echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
+conda env export | grep -E -v '^prefix:.*$'
 
 echo -e "--\n--Pip Environment\n--"
 python -m pip list --format=columns


### PR DESCRIPTION
This change makes it more straightforward to precisely re-create the conda environment used in the CI, which makes debugging easier