### PR TITLE
Implementation of `Event` using `asyncio.Event`

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -24,6 +24,7 @@ from .pubsub import Pub, Sub
 from .queues import Queue
 from .security import Security
 from .semaphore import Semaphore
+from .event import Event
 from .scheduler import Scheduler
 from .threadpoolexecutor import rejoin
 from .utils import sync, TimeoutError, CancelledError

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -47,12 +47,14 @@ class EventExtension:
         # we can remove the event
         self._waiter_count = defaultdict(int)
 
-        self.scheduler.handlers.update({
-            "event_wait": self.event_wait,
-            "event_set": self.event_set,
-            "event_clear": self.event_clear,
-            "event_is_set": self.event_is_set
-        })
+        self.scheduler.handlers.update(
+            {
+                "event_wait": self.event_wait,
+                "event_set": self.event_set,
+                "event_clear": self.event_clear,
+                "event_is_set": self.event_is_set,
+            }
+        )
 
         self.scheduler.extensions["events"] = self
 
@@ -122,7 +124,7 @@ class EventExtension:
         with log_errors():
             name = self._normalize_name(name)
             # the default flag value is false
-            if not name in self._events:
+            if name not in self._events:
                 return False
 
             return self._events[name].is_set()
@@ -178,6 +180,7 @@ class Event:
     >>> event_2.set() # doctest: +SKIP
     >>> # now event_1 will stop waiting
     """
+
     def __init__(self, name=None, client=None):
         try:
             self.client = client or Client.current()
@@ -205,9 +208,7 @@ class Event:
         True if the event was set of false, if a timeout happend
         """
         result = self.client.sync(
-            self.client.scheduler.event_wait,
-            name=self.name,
-            timeout=timeout,
+            self.client.scheduler.event_wait, name=self.name, timeout=timeout,
         )
         return result
 
@@ -216,9 +217,7 @@ class Event:
 
         All waiters will now block.
         """
-        result = self.client.sync(
-            self.client.scheduler.event_clear, name=self.name,
-        )
+        result = self.client.sync(self.client.scheduler.event_clear, name=self.name,)
         return result
 
     def set(self):
@@ -226,16 +225,12 @@ class Event:
 
         All waiters will now be released.
         """
-        result = self.client.sync(
-            self.client.scheduler.event_set, name=self.name,
-        )
+        result = self.client.sync(self.client.scheduler.event_set, name=self.name,)
         return result
 
     def is_set(self):
         """ Check if the event is set """
-        result = self.client.sync(
-            self.client.scheduler.event_is_set, name=self.name,
-        )
+        result = self.client.sync(self.client.scheduler.event_is_set, name=self.name,)
         return result
 
     def __enter__(self):

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -165,11 +165,11 @@ class Event:
     ----------
     name: string (optional)
         Name of the event.  Choosing the same name allows two
-        disconnected processes to coordinate an event.  If not given, a random
-        name will be generated.
+        disconnected processes to coordinate an event.  
+        If not given, a random name will be generated.
     client: Client (optional)
-        Client to use for communication with the scheduler.  If not given, the
-        default global client will be used.
+        Client to use for communication with the scheduler.  
+        If not given, the default global client will be used.
 
     Examples
     --------

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -241,19 +241,5 @@ class Event:
         result = self.client.sync(self.client.scheduler.event_is_set, name=self.name,)
         return result
 
-    def __enter__(self):
-        self.set()
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        self.clear()
-
-    async def __aenter__(self):
-        await self.set()
-        return self
-
-    async def __aexit__(self, *args, **kwargs):
-        await self.clear()
-
     def __reduce__(self):
         return (Event, (self.name,))

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -87,7 +87,7 @@ class EventExtension:
 
             return True
 
-    async def event_set(self, comm=None, name=None):
+    def event_set(self, comm=None, name=None):
         """ Set the event with the given name to true.
 
         All waiters on this event will be notified.
@@ -97,9 +97,9 @@ class EventExtension:
             # No matter if someone is listening or not,
             # we set the event to true
             event = self._get_or_create_event(name)
-            self.scheduler.loop.add_callback(event.set)
+            event.set()
 
-    async def event_clear(self, comm=None, name=None):
+    def event_clear(self, comm=None, name=None):
         """Set the event with the given name to false."""
         with log_errors():
             name = self._normalize_name(name)
@@ -115,12 +115,12 @@ class EventExtension:
                 # In principle, the event should be unset at this point
                 # (because if it is set, all waiters should have been
                 # notified). But to prevent race conditions
-                # do to unlucky timing, we clear anyways
+                # due to unlucky timing, we clear anyways
                 assert name in self._events
                 event = self._events[name]
-                self.scheduler.loop.add_callback(event.clear)
+                event.clear()
 
-    async def event_is_set(self, comm=None, name=None):
+    def event_is_set(self, comm=None, name=None):
         with log_errors():
             name = self._normalize_name(name)
             # the default flag value is false

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -193,6 +193,7 @@ class Event:
 
         even though no waiting is implied
         """
+
         async def _():
             return self
 

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -1,0 +1,246 @@
+import asyncio
+from collections import defaultdict
+from contextlib import suppress
+import logging
+import uuid
+
+from .client import Client
+from .utils import log_errors, TimeoutError
+from .worker import get_worker
+
+logger = logging.getLogger(__name__)
+
+
+class EventExtension:
+    """ An extension for the scheduler to manage Events
+
+    This adds the following routes to the scheduler
+
+    *  event_wait
+    *  event_set
+    *  event_clear
+    *  event_is_set
+
+    In principle, the implementation logic is quite simple
+    as we can reuse the asyncio.Event as much as possible:
+    we keep a mapping from name to an asyncio.Event and call
+    every function (wait, set, clear, is_set) directly on these
+    events.
+
+    However, this would cause a memory leak: created events in the
+    dictionary are never removed.
+    For this, we also keep a counter for the number of waiters on
+    a specific event.
+    If an event is set, we need to keep track of this state so
+    we can not remove it (the default flag is false).
+    If it is unset but there are waiters, we can also not remove
+    it, as those waiters would then have dangling futures.
+    Therefore the only time we can remove the event from our dict
+    is when the number of waiters is 0 and the event flag is cleared.
+    """
+
+    def __init__(self, scheduler):
+        self.scheduler = scheduler
+        # Keep track of all current events, identified by their name
+        self._events = dict()
+        # Keep track on how many waiters are present, so we know when
+        # we can remove the event
+        self._waiter_count = defaultdict(int)
+
+        self.scheduler.handlers.update({
+            "event_wait": self.event_wait,
+            "event_set": self.event_set,
+            "event_clear": self.event_clear,
+            "event_is_set": self.event_is_set
+        })
+
+        self.scheduler.extensions["events"] = self
+
+    async def event_wait(self, stream=None, name=None, timeout=None):
+        """ Wait until the event is set to true.
+        Returns false, when this did not happen in the given time
+        and true otherwise.
+        """
+        with log_errors():
+            name = self._normalize_name(name)
+
+            event = self._get_or_create_event(name)
+            future = event.wait()
+            if timeout is not None:
+                future = asyncio.wait_for(future, timeout)
+
+            self._waiter_count[name] += 1
+            try:
+                await future
+            except TimeoutError:
+                return False
+            finally:
+                self._waiter_count[name] -= 1
+
+            return True
+
+    async def event_set(self, stream=None, name=None):
+        """ Set the event with the given name to true.
+
+        All waiters on this event will be notified.
+        """
+        with log_errors():
+            name = self._normalize_name(name)
+            # No matter if someone is listening or not,
+            # we set the event to true
+            event = self._get_or_create_event(name)
+            self.scheduler.loop.add_callback(event.set)
+
+    async def event_clear(self, stream=None, name=None):
+        """Set the event with the given name to false."""
+        with log_errors():
+            name = self._normalize_name(name)
+            if not self._waiter_count[name]:
+                # No one is waiting for this
+                # and as the default flag for an event is false
+                # we can safely remove it
+                with suppress(KeyError):
+                    del self._waiter_count[name]
+                with suppress(KeyError):
+                    del self._events[name]
+
+            else:
+                # There are waiters
+                # This can happen if an event is "double-cleared"
+                # In principle, the event should be unset at this point
+                # (because if it is set, all waiters should have been
+                # notified). But to prevent race conditions
+                # do to unlucky timing, we clear anyways
+                assert name in self._events
+                event = self._events[name]
+                self.scheduler.loop.add_callback(event.clear)
+
+    async def event_is_set(self, stream=None, name=None):
+        with log_errors():
+            name = self._normalize_name(name)
+            # the default flag value is false
+            if not name in self._events:
+                return False
+
+            return self._events[name].is_set()
+
+    def _normalize_name(self, name):
+        """ Helper function to normalize an event name """
+        if isinstance(name, list):
+            name = tuple(name)
+
+        return name
+
+    def _get_or_create_event(self, name):
+        """ Helper function to return or create and return an event """
+        if name not in self._events:
+            # It seems we are the first one accessing it,
+            # so lets create a new event
+            self._events[name] = asyncio.Event()
+
+        return self._events[name]
+
+
+class Event:
+    """ Distributed Centralized Event equivalent to asyncio.Event
+
+    An event stores a single flag, which is set to false on start.
+    The flag can be set to true (using the set() call) or back to false
+    (with the clear() call).
+    Every call to wait() blocks until the event flag is set to true.
+
+    Parameters
+    ----------
+    name: string (optional)
+        Name of the event.  Choosing the same name allows two
+        disconnected processes to coordinate an event.  If not given, a random
+        name will be generated.
+    client: Client (optional)
+        Client to use for communication with the scheduler.  If not given, the
+        default global client will be used.
+
+    Examples
+    --------
+    >>> event_1 = Event('a')  # doctest: +SKIP
+    >>> event_1.wait(timeout=1)  # doctest: +SKIP
+    >>> # in another process
+    >>> event_2 = Event('a')  # doctest: +SKIP
+    >>> event_2.set() # doctest: +SKIP
+    >>> # now event_1 will stop waiting
+    """
+    def __init__(self, name=None, client=None):
+        try:
+            self.client = client or Client.current()
+        except ValueError:
+            # Initialise new client
+            self.client = get_worker().client
+        self.name = name or "event-" + uuid.uuid4().hex
+
+    def wait(self, timeout=None):
+        """ Wait until the event is set.
+
+        Parameters
+        ----------
+        timeout : number, optional
+            Seconds to wait on the event in the scheduler.  This does not
+            include local coroutine time, network transfer time, etc..
+
+        Examples
+        --------
+        >>> event = Event('a')  # doctest: +SKIP
+        >>> event.wait(timeout=1)  # doctest: +SKIP
+
+        Returns
+        -------
+        True if the event was set of false, if a timeout happend
+        """
+        result = self.client.sync(
+            self.client.scheduler.event_wait,
+            name=self.name,
+            timeout=timeout,
+        )
+        return result
+
+    def clear(self):
+        """ Clear the event (set its flag to false).
+
+        All waiters will now block.
+        """
+        result = self.client.sync(
+            self.client.scheduler.event_clear, name=self.name,
+        )
+        return result
+
+    def set(self):
+        """ Set the event (set its flag to false).
+
+        All waiters will now be released.
+        """
+        result = self.client.sync(
+            self.client.scheduler.event_set, name=self.name,
+        )
+        return result
+
+    def is_set(self):
+        """ Check if the event is set """
+        result = self.client.sync(
+            self.client.scheduler.event_is_set, name=self.name,
+        )
+        return result
+
+    def __enter__(self):
+        self.set()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.clear()
+
+    async def __aenter__(self):
+        await self.set()
+        return self
+
+    async def __aexit__(self, *args, **kwargs):
+        await self.clear()
+
+    def __reduce__(self):
+        return (Event, (self.name,))

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -217,8 +217,7 @@ class Event:
 
         All waiters will now block.
         """
-        result = self.client.sync(self.client.scheduler.event_clear, name=self.name,)
-        return result
+        return self.client.sync(self.client.scheduler.event_clear, name=self.name)
 
     def set(self):
         """ Set the event (set its flag to false).

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -160,10 +160,10 @@ class Event:
     ----------
     name: string (optional)
         Name of the event.  Choosing the same name allows two
-        disconnected processes to coordinate an event.  
+        disconnected processes to coordinate an event.
         If not given, a random name will be generated.
     client: Client (optional)
-        Client to use for communication with the scheduler.  
+        Client to use for communication with the scheduler.
         If not given, the default global client will be used.
 
     Examples
@@ -183,6 +183,20 @@ class Event:
             # Initialise new client
             self.client = get_worker().client
         self.name = name or "event-" + uuid.uuid4().hex
+
+    def __await__(self):
+        """ async constructor
+
+        Make it possible to write
+
+        >>> event = await Event("x") # doctest: +SKIP
+
+        even though no waiting is implied
+        """
+        async def _():
+            return self
+
+        return _().__await__()
 
     def wait(self, timeout=None):
         """ Wait until the event is set.

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -58,7 +58,7 @@ class EventExtension:
 
         self.scheduler.extensions["events"] = self
 
-    async def event_wait(self, stream=None, name=None, timeout=None):
+    async def event_wait(self, comm=None, name=None, timeout=None):
         """ Wait until the event is set to true.
         Returns false, when this did not happen in the given time
         and true otherwise.
@@ -87,7 +87,7 @@ class EventExtension:
 
             return True
 
-    async def event_set(self, stream=None, name=None):
+    async def event_set(self, comm=None, name=None):
         """ Set the event with the given name to true.
 
         All waiters on this event will be notified.
@@ -99,7 +99,7 @@ class EventExtension:
             event = self._get_or_create_event(name)
             self.scheduler.loop.add_callback(event.set)
 
-    async def event_clear(self, stream=None, name=None):
+    async def event_clear(self, comm=None, name=None):
         """Set the event with the given name to false."""
         with log_errors():
             name = self._normalize_name(name)
@@ -120,7 +120,7 @@ class EventExtension:
                 event = self._events[name]
                 self.scheduler.loop.add_callback(event.clear)
 
-    async def event_is_set(self, stream=None, name=None):
+    async def event_is_set(self, comm=None, name=None):
         with log_errors():
             name = self._normalize_name(name)
             # the default flag value is false

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -140,6 +140,8 @@ class EventExtension:
 
     def _delete_event(self, name):
         """ Helper function to delete an event """
+        # suppress key errors to make calling this method
+        # also possible if we do not even have such an event
         with suppress(KeyError):
             del self._waiter_count[name]
         with suppress(KeyError):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -81,6 +81,7 @@ from .queues import QueueExtension
 from .semaphore import SemaphoreExtension
 from .recreate_exceptions import ReplayExceptionScheduler
 from .lock import LockExtension
+from .event import EventExtension
 from .pubsub import PubSubSchedulerExtension
 from .stealing import WorkStealing
 from .variable import VariableExtension
@@ -102,6 +103,7 @@ DEFAULT_EXTENSIONS = [
     VariableExtension,
     PubSubSchedulerExtension,
     SemaphoreExtension,
+    EventExtension,
 ]
 
 ALL_TASK_STATES = {"released", "waiting", "no-worker", "processing", "erred", "memory"}

--- a/distributed/tests/test_events.py
+++ b/distributed/tests/test_events.py
@@ -1,0 +1,169 @@
+import pickle
+from time import sleep
+
+import pytest
+
+from distributed import Event, get_client, Client
+from distributed.metrics import time
+from distributed.utils_test import gen_cluster
+from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
+
+
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)
+async def test_event(c, s, a, b):
+    def wait_for_it_failing(x):
+        event = Event("x")
+
+        # Event is not set in another task so far
+        assert not event.wait(timeout=0.05)
+        assert not event.is_set()
+
+    def wait_for_it_ok(x):
+        event = Event("x")
+
+        # Event is set in another task
+        assert event.wait(timeout=0.5)
+        assert event.is_set()
+
+    def set_it():
+        event = Event("x")
+        event.set()
+
+    def clear_it():
+        event = Event("x")
+        event.clear()
+
+    wait_futures = c.map(wait_for_it_failing, range(10))
+    await c.gather(wait_futures)
+
+    set_future = c.submit(set_it)
+    await c.gather(set_future)
+
+    wait_futures = c.map(wait_for_it_ok, range(10))
+    await c.gather(wait_futures)
+
+    clear_future = c.submit(clear_it)
+    await c.gather(clear_future)
+
+    wait_futures = c.map(wait_for_it_ok, range(10))
+    await c.gather(wait_futures)
+
+    assert not s.extensions["events"]._events
+    assert not s.extensions["events"]._waiter_count
+
+
+def test_default_event(client):
+    event = Event("x")
+    assert not event.is_set()
+
+
+def test_set_not_set(client):
+    event = Event("x")
+
+    event.clear()
+    assert not event.is_set()
+
+    event.set()
+    assert event.is_set()
+
+    event.set()
+    assert event.is_set()
+
+    event.clear()
+    assert not event.is_set()
+
+
+def test_timeout_sync(client):
+    event = Event("x")
+    assert Event("x").wait(timeout=0.1) is False
+
+
+def test_event_sync(client):
+    def wait_for_it_failing(x):
+        event = Event("x")
+
+        # Event is not set in another task so far
+        assert not event.wait(timeout=0.05)
+        assert not event.is_set()
+
+    def wait_for_it_ok(x):
+        event = Event("x")
+
+        # Event is set in another task
+        assert event.wait(timeout=0.5)
+        assert event.is_set()
+
+    def set_it():
+        event = Event("x")
+        event.set()
+
+    wait_futures = client.map(wait_for_it_failing, range(10))
+    client.gather(wait_futures)
+
+    set_future = client.submit(set_it)
+    client.gather(set_future)
+
+    wait_futures = client.map(wait_for_it_ok, range(10))
+    client.gather(wait_futures)
+
+
+@gen_cluster(client=True)
+async def test_event_types(c, s, a, b):
+    for name in [1, ("a", 1), ["a", 1], b"123", "123"]:
+        event = Event(name)
+        assert event.name == name
+
+        await event.set()
+        await event.clear()
+        result = await event.is_set()
+        assert not result
+
+    assert not s.extensions["events"]._events
+    assert not s.extensions["events"]._waiter_count
+
+
+@gen_cluster(client=True)
+async def test_serializable(c, s, a, b):
+    def f(x, event=None):
+        assert event.name == "x"
+        return x + 1
+
+    event = Event("x")
+    futures = c.map(f, range(10), event=event)
+    await c.gather(futures)
+
+    event2 = pickle.loads(pickle.dumps(event))
+    assert event2.name == event.name
+    assert event2.client is event.client
+
+
+@gen_cluster(client=True)
+async def test_two_events(c, s, a, b):
+    def event_not_set(event_name):
+        assert not Event(event_name).wait(timeout=0.05)
+
+    def event_is_set(event_name):
+        assert Event(event_name).wait(timeout=0.5)
+
+    await c.gather(c.submit(event_not_set, "first_event"))
+    await c.gather(c.submit(event_not_set, "second_event"))
+
+    await Event("first_event").set()
+
+    await c.gather(c.submit(event_is_set, "first_event"))
+    await c.gather(c.submit(event_not_set, "second_event"))
+
+    await Event("first_event").clear()
+    await Event("second_event").set()
+
+    await c.gather(c.submit(event_not_set, "first_event"))
+    await c.gather(c.submit(event_is_set, "second_event"))
+
+    await Event("first_event").clear()
+    await Event("second_event").clear()
+
+    await c.gather(c.submit(event_not_set, "first_event"))
+    await c.gather(c.submit(event_not_set, "second_event"))
+
+    assert not s.extensions["events"]._events
+    assert not s.extensions["events"]._waiter_count

--- a/distributed/tests/test_events.py
+++ b/distributed/tests/test_events.py
@@ -1,10 +1,6 @@
 import pickle
-from time import sleep
 
-import pytest
-
-from distributed import Event, get_client, Client
-from distributed.metrics import time
+from distributed import Event
 from distributed.utils_test import gen_cluster
 from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
 

--- a/distributed/tests/test_events.py
+++ b/distributed/tests/test_events.py
@@ -50,8 +50,8 @@ async def test_event_on_workers(c, s, a, b):
     assert not s.extensions["events"]._waiter_count
 
 
-@gen_cluster()
-async def test_default_event(s, a, b):
+@gen_cluster(client=True)
+async def test_default_event(c, s, a, b):
     # The default flag for events should be false
     event = Event("x")
     assert not await event.is_set()
@@ -63,8 +63,8 @@ async def test_default_event(s, a, b):
     assert not s.extensions["events"]._waiter_count
 
 
-@gen_cluster()
-async def test_set_not_set(s, a, b):
+@gen_cluster(client=True)
+async def test_set_not_set(c, s, a, b):
     # Set and unset the event and check if the flag is
     # propagated correctly
     event = Event("x")
@@ -86,8 +86,8 @@ async def test_set_not_set(s, a, b):
     assert not s.extensions["events"]._waiter_count
 
 
-@gen_cluster()
-async def test_set_not_set_many_events(s, a, b):
+@gen_cluster(client=True)
+async def test_set_not_set_many_events(c, s, a, b):
     # Set and unset the event and check if the flag is
     # propagated correctly with many events
     events = [Event(name) for name in range(100)]
@@ -112,8 +112,8 @@ async def test_set_not_set_many_events(s, a, b):
     assert not s.extensions["events"]._waiter_count
 
 
-@gen_cluster()
-async def test_timeout(s, a, b):
+@gen_cluster(client=True)
+async def test_timeout(c, s, a, b):
     # The event should not be set and the timeout should happen
     event = Event("x")
     assert not await Event("x").wait(timeout=0.1)
@@ -155,8 +155,8 @@ def test_event_sync(client):
     client.gather(wait_futures)
 
 
-@gen_cluster()
-async def test_event_types(s, a, b):
+@gen_cluster(client=True)
+async def test_event_types(c, s, a, b):
     # Event names could be strings, numbers or tuples
     for name in [1, ("a", 1), ["a", 1], b"123", "123"]:
         event = Event(name)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -83,6 +83,7 @@ API
 .. currentmodule:: distributed
 
 .. autosummary::
+   Event
    Lock
    Queue
    Variable
@@ -193,6 +194,8 @@ Other
 .. autoclass:: distributed.Reschedule
 .. autoclass:: get_task_stream
 
+.. autoclass:: Event
+   :members:
 .. autoclass:: Lock
    :members:
 .. autoclass:: Semaphore


### PR DESCRIPTION
This PR solves part of #2007 (I assumed no progress so far, since the last update was approx. half a year ago) . It adds a new class `Event` which has the same interface as the `asyncio.Event` and the needed scheduler extension.

Actually, the implementation would have been quite simple: just keeping a `dict` of events and forwarding everything to the `asyncio.Event`. However, this will never clean up the created events in the dictionary, so I added some kind of reference counter additionally.

I am very happy for suggestions - I do not know if this is the best way to do it.