### PR TITLE
Wrap the parameter timeout with parse_timedelta

### DIFF
--- a/distributed/event.py
+++ b/distributed/event.py
@@ -7,6 +7,7 @@ import uuid
 from .client import Client
 from .utils import log_errors, TimeoutError
 from .worker import get_worker
+from .utils import parse_timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -204,19 +205,23 @@ class Event:
 
         Parameters
         ----------
-        timeout : number, optional
+        timeout : number or string or timedelta, optional
             Seconds to wait on the event in the scheduler.  This does not
             include local coroutine time, network transfer time, etc..
+            Instead of number of seconds, it is also possible to specify
+            a timedelta in string format, e.g. "200ms".
 
         Examples
         --------
         >>> event = Event('a')  # doctest: +SKIP
-        >>> event.wait(timeout=1)  # doctest: +SKIP
+        >>> event.wait(timeout="1s")  # doctest: +SKIP
 
         Returns
         -------
         True if the event was set of false, if a timeout happend
         """
+        timeout = parse_timedelta(timeout)
+
         result = self.client.sync(
             self.client.scheduler.event_wait, name=self.name, timeout=timeout,
         )

--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -6,6 +6,7 @@ import uuid
 from .client import Client
 from .utils import log_errors, TimeoutError
 from .worker import get_worker
+from .utils import parse_timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -109,20 +110,24 @@ class Lock:
         ----------
         blocking : bool, optional
             If false, don't wait on the lock in the scheduler at all.
-        timeout : number, optional
+        timeout : string or number or timedelta, optional
             Seconds to wait on the lock in the scheduler.  This does not
             include local coroutine time, network transfer time, etc..
             It is forbidden to specify a timeout when blocking is false.
+            Instead of number of seconds, it is also possible to specify
+            a timedelta in string format, e.g. "200ms".
 
         Examples
         --------
         >>> lock = Lock('x')  # doctest: +SKIP
-        >>> lock.acquire(timeout=1)  # doctest: +SKIP
+        >>> lock.acquire(timeout="1s")  # doctest: +SKIP
 
         Returns
         -------
         True or False whether or not it sucessfully acquired the lock
         """
+        timeout = parse_timedelta(timeout)
+
         if not blocking:
             if timeout is not None:
                 raise ValueError("can't specify a timeout for a non-blocking call")

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -7,7 +7,7 @@ import weakref
 
 from .core import CommClosedError
 from .metrics import time
-from .utils import sync, TimeoutError
+from .utils import sync, TimeoutError, parse_timedelta
 from .protocol.serialize import to_serialize
 
 logger = logging.getLogger(__name__)
@@ -429,7 +429,16 @@ class Sub:
     __anext__ = _get
 
     def get(self, timeout=None):
-        """ Get a single message """
+        """ Get a single message
+
+        Parameters
+        ----------
+        timeout: number or string or timedelta, optional
+            Time in seconds to wait before timing out.
+            Instead of number of seconds, it is also possible to specify
+            a timedelta in string format, e.g. "200ms".
+        """
+        timeout = parse_timedelta(timeout)
         if self.client:
             return self.client.sync(self._get, timeout=timeout)
         elif self.worker.thread_id == threading.get_ident():

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -6,6 +6,7 @@ import uuid
 from .client import Future, Client
 from .utils import tokey, sync, thread_state
 from .worker import get_client
+from .utils import parse_timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -208,7 +209,16 @@ class Queue:
             )
 
     def put(self, value, timeout=None, **kwargs):
-        """ Put data into the queue """
+        """ Put data into the queue
+
+        Parameters
+        ----------
+        timeout: number or string or timedelta, optional
+            Time in seconds to wait before timing out.
+            Instead of number of seconds, it is also possible to specify
+            a timedelta in string format, e.g. "200ms".
+        """
+        timeout = parse_timedelta(timeout)
         return self.client.sync(self._put, value, timeout=timeout, **kwargs)
 
     def get(self, timeout=None, batch=False, **kwargs):
@@ -216,13 +226,16 @@ class Queue:
 
         Parameters
         ----------
-        timeout: Number (optional)
-            Time in seconds to wait before timing out
+        timeout: number or string or timedelta, optional
+            Time in seconds to wait before timing out.
+            Instead of number of seconds, it is also possible to specify
+            a timedelta in string format, e.g. "200ms".
         batch: boolean, int (optional)
             If True then return all elements currently waiting in the queue.
             If an integer than return that many elements from the queue
             If False (default) then return one item at a time
          """
+        timeout = parse_timedelta(timeout)
         return self.client.sync(self._get, timeout=timeout, batch=batch, **kwargs)
 
     def qsize(self, **kwargs):

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -445,7 +445,16 @@ class Semaphore:
 
         If the internal counter is greater than zero, decrement it by one and return True immediately.
         If it is zero, wait until a release() is called and return True.
+
+        Parameters
+        ----------
+        timeout : number or string or timedelta, optional
+            Seconds to wait on acquiring the semaphore.  This does not
+            include local coroutine time, network transfer time, etc..
+            Instead of number of seconds, it is also possible to specify
+            a timedelta in string format, e.g. "200ms".
         """
+        timeout = parse_timedelta(timeout)
         return self.client.sync(self._acquire, timeout=timeout)
 
     def release(self):

--- a/distributed/tests/test_events.py
+++ b/distributed/tests/test_events.py
@@ -1,4 +1,5 @@
 import pickle
+from datetime import timedelta
 
 from distributed import Event
 from distributed.utils_test import gen_cluster
@@ -119,10 +120,10 @@ async def test_timeout(c, s, a, b):
     assert not await Event("x").wait(timeout=0.1)
 
     await event.set()
-    assert await Event("x").wait(timeout=0.1)
+    assert await Event("x").wait(timeout="100ms")
 
     await event.clear()
-    assert not await Event("x").wait(timeout=0.1)
+    assert not await Event("x").wait(timeout=timedelta(seconds=0.1))
 
 
 def test_event_sync(client):

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -1,5 +1,6 @@
 import pickle
 from time import sleep
+from datetime import timedelta
 
 import pytest
 
@@ -57,9 +58,9 @@ async def test_acquires_with_zero_timeout(c, s, a, b):
     assert lock.locked()
     await lock.release()
 
-    await lock.acquire(timeout=1)
+    await lock.acquire(timeout="1s")
     await lock.release()
-    await lock.acquire(timeout=1)
+    await lock.acquire(timeout=timedelta(seconds=1))
     await lock.release()
 
 

--- a/distributed/tests/test_pubsub.py
+++ b/distributed/tests/test_pubsub.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import timedelta
 from time import sleep
 
 import pytest
@@ -120,11 +121,11 @@ async def test_timeouts(c, s, a, b):
     sub = Sub("a", client=c, worker=None)
     start = time()
     with pytest.raises(TimeoutError):
-        await sub.get(timeout=0.1)
+        await sub.get(timeout="100ms")
     stop = time()
     assert stop - start < 1
     with pytest.raises(TimeoutError):
-        await sub.get(timeout=0.01)
+        await sub.get(timeout=timedelta(milliseconds=10))
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import timedelta
 from time import sleep
 
 import pytest
@@ -248,7 +249,7 @@ async def test_timeout(c, s, a, b):
 
     start = time()
     with pytest.raises(TimeoutError):
-        await q.get(timeout=0.3)
+        await q.get(timeout="300ms")
     stop = time()
     assert 0.2 < stop - start < 2.0
 
@@ -256,7 +257,7 @@ async def test_timeout(c, s, a, b):
 
     start = time()
     with pytest.raises(TimeoutError):
-        await q.put(2, timeout=0.3)
+        await q.put(2, timeout=timedelta(seconds=0.3))
     stop = time()
     assert 0.1 < stop - start < 2.0
 

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import timedelta
 import pickle
 import dask
 import pytest
@@ -77,10 +78,10 @@ async def test_release_simple(c, s, a, b):
 @gen_cluster(client=True)
 async def test_acquires_with_timeout(c, s, a, b):
     sem = await Semaphore(1, "x")
-    assert await sem.acquire(timeout=0.025)
+    assert await sem.acquire(timeout="25ms")
     assert not await sem.acquire(timeout=0.025)
     await sem.release()
-    assert await sem.acquire(timeout=0.025)
+    assert await sem.acquire(timeout=timedelta(seconds=0.025))
     await sem.release()
 
 

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+from datetime import timedelta
 from time import sleep, monotonic
 import logging
 
@@ -98,7 +99,7 @@ async def test_timeout(c, s, a, b):
 
     start = monotonic()
     with pytest.raises(TimeoutError):
-        await v.get(timeout=0.2)
+        await v.get(timeout="200ms")
     stop = monotonic()
 
     if WINDOWS:  # timing is weird with asyncio and Windows
@@ -107,7 +108,7 @@ async def test_timeout(c, s, a, b):
         assert 0.2 < stop - start < 2.0
 
     with pytest.raises(TimeoutError):
-        await v.get(timeout=0.01)
+        await v.get(timeout=timedelta(milliseconds=10))
 
 
 def test_timeout_sync(client):

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -7,7 +7,7 @@ import uuid
 from tlz import merge
 
 from .client import Future, Client
-from .utils import tokey, log_errors, TimeoutError
+from .utils import tokey, log_errors, TimeoutError, parse_timedelta
 from .worker import get_client
 
 logger = logging.getLogger(__name__)
@@ -204,7 +204,16 @@ class Variable:
         return value
 
     def get(self, timeout=None, **kwargs):
-        """ Get the value of this variable """
+        """ Get the value of this variable
+
+        Parameters
+        ----------
+        timeout: number or string or timedelta, optional
+            Time in seconds to wait before timing out.
+            Instead of number of seconds, it is also possible to specify
+            a timedelta in string format, e.g. "200ms".
+        """
+        timeout = parse_timedelta(timeout)
         return self.client.sync(self._get, timeout=timeout, **kwargs)
 
     def delete(self):


### PR DESCRIPTION
All public-facing API parameters "timeout" are wrapped with utils.parse_timedelta before passing them on, to allow things like `timeout="42ms"`.

This fixes #3823.

I also put some test cases in the corresponding tests.
I only did the change for all communication primitives (lock, event, semaphore, etc.).
In principle there are many more "timeout" parameters through distributed - I am not sure if it is worth changing all of them.