### PR TITLE
Allow to pass in task key strings in the worker restrictions

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2762,10 +2762,10 @@ class Client:
             Whether or not to optimize the underlying graphs
         workers: str, list, dict
             Which workers can run which parts of the computation
-            If a string a list then the output collections will run on the listed
+            If a string or list then the output collections will run on the listed
             workers, but other sub-computations can run anywhere
-            If a dict then keys should be (tuples of) collections and values
-            should be addresses or lists.
+            If a dict then keys should be (tuples of) collections or
+            task keys and values should be addresses or lists.
         allow_other_workers: bool, list
             If True then all restrictions in workers= are considered loose
             If a list then only the keys for the listed collections are loose
@@ -2912,10 +2912,10 @@ class Client:
             Whether or not to optimize the underlying graphs
         workers: str, list, dict
             Which workers can run which parts of the computation
-            If a string a list then the output collections will run on the listed
+            If a string or list then the output collections will run on the listed
             workers, but other sub-computations can run anywhere
-            If a dict then keys should be (tuples of) collections and values
-            should be addresses or lists.
+            If a dict then keys should be (tuples of) collections or
+            task keys and values should be addresses or lists.
         allow_other_workers: bool, list
             If True then all restrictions in workers= are considered loose
             If a list then only the keys for the listed collections are loose
@@ -3912,6 +3912,8 @@ class Client:
                     ws = [ws]
                 if dask.is_dask_collection(colls):
                     keys = flatten(colls.__dask_keys__())
+                elif isinstance(colls, str):
+                    keys = [colls]
                 else:
                     keys = list(
                         {k for c in flatten(colls) for k in flatten(c.__dask_keys__())}

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -923,9 +923,9 @@ async def test_restrictions_ip_port_task_key(c, s, a, b):
     last_task = tasks[-1]
 
     # calculate all dependency keys
-    all_dependencies = list(last_task.__dask_graph__())
+    all_tasks = list(last_task.__dask_graph__())
     # only restrict to a single worker
-    workers = {d: a.address for d in all_dependencies}
+    workers = {d: a.address for d in all_tasks}
     result = c.compute(last_task, workers=workers)
     await result
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -913,6 +913,31 @@ async def test_restrictions_ip_port(c, s, a, b):
     assert y.key in b.data
 
 
+@gen_cluster(client=True)
+async def test_restrictions_ip_port_task_key(c, s, a, b):
+    # Create a long dependency list
+    tasks = [delayed(inc)(1)]
+    for _ in range(100):
+        tasks.append(delayed(add)(tasks[-1], random.choice(tasks)))
+
+    last_task = tasks[-1]
+
+    # calculate all dependency keys
+    all_dependencies = list(last_task.dask.dependencies.keys())
+    # only restrict to a single worker
+    workers = {d: a.address for d in all_dependencies}
+    result = c.compute(last_task, workers=workers)
+    await result
+
+    # all tasks should have been calculated by the first worker
+    for task in tasks:
+        assert s.worker_restrictions[task.key] == {a.address}
+
+    # and the data should also be there
+    assert last_task.key in a.data
+    assert last_task.key not in b.data
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="Need 127.0.0.2 to mean localhost"
 )

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -923,7 +923,7 @@ async def test_restrictions_ip_port_task_key(c, s, a, b):
     last_task = tasks[-1]
 
     # calculate all dependency keys
-    all_dependencies = list(last_task.dask.dependencies.keys())
+    all_dependencies = list(last_task.__dask_graph__())
     # only restrict to a single worker
     workers = {d: a.address for d in all_dependencies}
     result = c.compute(last_task, workers=workers)


### PR DESCRIPTION
The `workers` parameter of `Client.compute` and `Client.persist` allows to restrict the workers where the calculations of the tasks should take place.

Advanced usages of this keyword (for example #3592) might need passing the task key
(string) instead of the dask collection or dask task. Internally, collections and task (lists) are turned into string keys anyways - so we just need to pass the key of the dict in this case.

This allows now to do things like:

```python
task = ... long dependencies ...
all_dependencies = task.dask.dependencies.keys()

workers = {d: worker_address for d in all_dependencies}
result = client.compute(last_task, workers=workers)
```

to have a task and all of its dependencies being calculated on a single worker.

This does not directly solve #3592, but at least makes it much easier to handle.