### PR TITLE
Add notification of the origin of stack traces from other machines

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -602,6 +602,7 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
     if isinstance(response, dict) and response.get("status") == "uncaught-error":
         if comm.deserialize:
             typ, exc, tb = clean_exception(**response)
+            print("Error originated from", comm.peer_addr)
             raise exc.with_traceback(tb)
         else:
             raise Exception(response["text"])


### PR DESCRIPTION

fix #3828

The problem is that this notification is only readable by the a human user and should rather be an exception. I don't know if anything from https://docs.python.org/3.8/library/traceback.html could help.