### PR TITLE
Register `dask_cudf` serializers

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -105,6 +105,10 @@ def _register_rmm():
 @cuda_deserialize.register_lazy("cudf")
 @dask_serialize.register_lazy("cudf")
 @dask_deserialize.register_lazy("cudf")
+@cuda_serialize.register_lazy("dask_cudf")
+@cuda_deserialize.register_lazy("dask_cudf")
+@dask_serialize.register_lazy("dask_cudf")
+@dask_deserialize.register_lazy("dask_cudf")
 def _register_cudf():
     from cudf.comm import serialize
 


### PR DESCRIPTION
As `dask_cudf` simply relies on the same serialization machinery that is in `cudf` ( plus whatever is implemented by `dask_cudf` objects themselves, https://github.com/rapidsai/cudf/pull/5294 ), just reuse the `cudf` serialization import to handle `dask_cudf` object serialization for simplicity.