### PR TITLE
Fix key check in rebalance missing keys

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3125,7 +3125,7 @@ class Scheduler(ServerNode):
                     return {
                         "status": "missing-data",
                         "keys": tuple(
-                            concat(r["keys"].keys() for r in result if "keys" in r)
+                            concat(r["keys"].keys() for r in result if r["status"] == "missing-data")
                         ),
                     }
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3125,7 +3125,11 @@ class Scheduler(ServerNode):
                     return {
                         "status": "missing-data",
                         "keys": tuple(
-                            concat(r["keys"].keys() for r in result if r["status"] == "missing-data")
+                            concat(
+                                r["keys"].keys()
+                                for r in result
+                                if r["status"] == "missing-data"
+                            )
                         ),
                     }
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3124,7 +3124,9 @@ class Scheduler(ServerNode):
                 if not all(r["status"] == "OK" for r in result):
                     return {
                         "status": "missing-data",
-                        "keys": tuple(concat(r["keys"].keys() for r in result)),
+                        "keys": tuple(
+                            concat(r["keys"].keys() for r in result if "keys" in r)
+                        ),
                     }
 
                 for sender, recipient, ts in msgs:
@@ -4976,7 +4978,7 @@ class Scheduler(ServerNode):
                 self.rpc(w).profile(start=start, stop=stop, key=key, server=server)
                 for w in workers
             ),
-            return_exceptions=True
+            return_exceptions=True,
         )
 
         results = [r for r in results if not isinstance(r, Exception)]
@@ -5007,7 +5009,7 @@ class Scheduler(ServerNode):
             workers = set(self.workers) & set(workers)
         results = await asyncio.gather(
             *(self.rpc(w).profile_metadata(start=start, stop=stop) for w in workers),
-            return_exceptions=True
+            return_exceptions=True,
         )
 
         results = [r for r in results if not isinstance(r, Exception)]


### PR DESCRIPTION
This check was removed in #3670 and seemed to be causing the exception in #3833.

There still seems to be a problem with rebalancing keys so #3833 is not fixed, but now the error message comes back with more useful information.

```python-traceback
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-d4d2d986b89e> in <module>
----> 1 client.rebalance()

~/Projects/dask/distributed/distributed/client.py in rebalance(self, futures, workers, **kwargs)
   3117             A list of workers on which to balance, defaults to all workers
   3118         """
-> 3119         return self.sync(self._rebalance, futures, workers, **kwargs)
   3120 
   3121     async def _replicate(self, futures, n=None, workers=None, branching_factor=2):

~/Projects/dask/distributed/distributed/client.py in sync(self, func, asynchronous, callback_timeout, *args, **kwargs)
    822         else:
    823             return sync(
--> 824                 self.loop, func, *args, callback_timeout=callback_timeout, **kwargs
    825             )
    826 

~/Projects/dask/distributed/distributed/utils.py in sync(loop, func, callback_timeout, *args, **kwargs)
    337     if error[0]:
    338         typ, exc, tb = error[0]
--> 339         raise exc.with_traceback(tb)
    340     else:
    341         return result[0]

~/Projects/dask/distributed/distributed/utils.py in f()
    321             if callback_timeout is not None:
    322                 future = asyncio.wait_for(future, callback_timeout)
--> 323             result[0] = yield future
    324         except Exception as exc:
    325             error[0] = sys.exc_info()

~/miniconda3/envs/dask/lib/python3.7/site-packages/tornado/gen.py in run(self)
    733 
    734                     try:
--> 735                         value = future.result()
    736                     except Exception:
    737                         exc_info = sys.exc_info()

~/Projects/dask/distributed/distributed/client.py in _rebalance(self, futures, workers)
   3095         if result["status"] == "missing-data":
   3096             raise ValueError(
-> 3097                 f"During rebalance {len(result['keys'])} keys were found to be missing"
   3098             )
   3099         assert result["status"] == "OK"

ValueError: During rebalance 1 keys were found to be missing
```