### PR TITLE
Wrong variable name example.

### DIFF
--- a/docs/source/journey.rst
+++ b/docs/source/journey.rst
@@ -120,7 +120,7 @@ Nothing blocks.*
 Eventually the computation completes.  The Worker stores this result in its
 local memory::
 
-    data['x'] = ...
+    data['z'] = ...
 
 And transmits back a success, and the number of bytes of the result::
 


### PR DESCRIPTION
Spotted by James Bourbeau during a demo of dask/distributed.