### PR TITLE
Validate address parameter in client constructor

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -657,7 +657,7 @@ class Client:
                 loop = address.loop
             if security is None:
                 security = getattr(self.cluster, "security", None)
-        elif not isinstance(address, str):
+        elif address is not None and not isinstance(address, str):
             raise ValueError(
                 "Scheduler address must be a string or a Cluster instance, got {}".format(
                     address

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -660,7 +660,7 @@ class Client:
         elif address is not None and not isinstance(address, str):
             raise ValueError(
                 "Scheduler address must be a string or a Cluster instance, got {}".format(
-                    address
+                    type(address)
                 )
             )
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -648,24 +648,21 @@ class Client:
                 "Unexpected keyword arguments: {}".format(str(sorted(kwargs)))
             )
 
-        from .deploy import Cluster
-
         if isinstance(address, (rpc, PooledRPCCall)):
             self.scheduler = address
-        elif isinstance(address, Cluster):
+        elif isinstance(getattr(address, "scheduler_address", None), str):
             # It's a LocalCluster or LocalCluster-compatible object
             self.cluster = address
             with suppress(AttributeError):
                 loop = address.loop
             if security is None:
                 security = getattr(self.cluster, "security", None)
-        elif address is not None and not isinstance(address, str):
-            if issubclass(address, Cluster):
-                raise ValueError(
-                    "address is a subclass of Cluster rather than an instance.\n"
-                    "Did you forget to instantiate the cluster?"
+        elif not isinstance(address, str):
+            raise ValueError(
+                "Scheduler address must be a string or a Cluster instance, got {}".format(
+                    address
                 )
-            raise ValueError("address must be a string or Cluster instance.")
+            )
 
         if security is None:
             security = Security()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -648,15 +648,24 @@ class Client:
                 "Unexpected keyword arguments: {}".format(str(sorted(kwargs)))
             )
 
+        from .deploy import Cluster
+
         if isinstance(address, (rpc, PooledRPCCall)):
             self.scheduler = address
-        elif hasattr(address, "scheduler_address"):
+        elif isinstance(address, Cluster):
             # It's a LocalCluster or LocalCluster-compatible object
             self.cluster = address
             with suppress(AttributeError):
                 loop = address.loop
             if security is None:
                 security = getattr(self.cluster, "security", None)
+        elif address is not None and not isinstance(address, str):
+            if issubclass(address, Cluster):
+                raise ValueError(
+                    "address is a subclass of Cluster rather than an instance.\n"
+                    "Did you forget to instantiate the cluster?"
+                )
+            raise ValueError("address must be a string or Cluster instance.")
 
         if security is None:
             security = Security()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -658,7 +658,7 @@ class Client:
             if security is None:
                 security = getattr(self.cluster, "security", None)
         elif address is not None and not isinstance(address, str):
-            raise ValueError(
+            raise TypeError(
                 "Scheduler address must be a string or a Cluster instance, got {}".format(
                     type(address)
                 )

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1847,6 +1847,15 @@ def test_bad_address():
         assert "connect" in str(e).lower()
 
 
+def test_informative_error_on_cluster_type():
+    with pytest.raises(TypeError) as exc_info:
+        Client(LocalCluster)
+
+    assert "Scheduler address must be a string or a Cluster instance" in str(
+        exc_info.value
+    )
+
+
 @gen_cluster(client=True)
 async def test_long_error(c, s, a, b):
     def bad(x):


### PR DESCRIPTION
Closes #3839 

-Validate address parameter.
-Provide helpful error message if `address` is a `Cluster` class rather than an instance of the class. 