### PR TITLE
Allow async add_worker remove_worker plugin methods

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -516,6 +516,7 @@ class Server:
                             handler = self.stream_handlers[op]
                             if is_coroutine_function(handler):
                                 self.loop.add_callback(handler, **merge(extra, msg))
+                                await gen.sleep(0)
                             else:
                                 handler(**merge(extra, msg))
                         else:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -187,7 +187,7 @@ class WorkStealing(SchedulerPlugin):
                 pdb.set_trace()
             raise
 
-    def move_task_confirm(self, key=None, worker=None, state=None):
+    async def move_task_confirm(self, key=None, worker=None, state=None):
         try:
             try:
                 ts = self.scheduler.tasks[key]
@@ -256,7 +256,7 @@ class WorkStealing(SchedulerPlugin):
                 try:
                     self.scheduler.send_task_to_worker(thief.address, key)
                 except CommClosedError:
-                    self.scheduler.remove_worker(thief.address)
+                    await self.scheduler.remove_worker(thief.address)
                 self.log.append(("confirm", key, victim.address, thief.address))
             else:
                 raise ValueError("Unexpected task state: %s" % state)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -208,7 +208,7 @@ async def test_remove_worker_from_scheduler(s, a, b):
     )
 
     assert a.address in s.stream_comms
-    s.remove_worker(address=a.address)
+    await s.remove_worker(address=a.address)
     assert a.address not in s.nthreads
     assert len(s.workers[b.address].processing) == len(dsk)  # b owns everything
     s.validate_state()
@@ -217,9 +217,9 @@ async def test_remove_worker_from_scheduler(s, a, b):
 @gen_cluster()
 async def test_remove_worker_by_name_from_scheduler(s, a, b):
     assert a.address in s.stream_comms
-    assert s.remove_worker(address=a.name) == "OK"
+    assert await s.remove_worker(address=a.name) == "OK"
     assert a.address not in s.nthreads
-    assert s.remove_worker(address=a.address) == "already-removed"
+    assert await s.remove_worker(address=a.address) == "already-removed"
     s.validate_state()
 
 
@@ -230,7 +230,7 @@ async def test_clear_events_worker_removal(s, a, b):
     assert b.address in s.events
     assert b.address in s.nthreads
 
-    s.remove_worker(address=a.address)
+    await s.remove_worker(address=a.address)
     # Shortly after removal, the events should still be there
     assert a.address in s.events
     assert a.address not in s.nthreads
@@ -489,7 +489,7 @@ async def test_ready_remove_worker(s, a, b):
 
     assert all(len(w.processing) > w.nthreads for w in s.workers.values())
 
-    s.remove_worker(address=a.address)
+    await s.remove_worker(address=a.address)
 
     assert set(s.workers) == {b.address}
     assert all(len(w.processing) > w.nthreads for w in s.workers.values())


### PR DESCRIPTION
This PR is to add support for asynchronous `SchedulerPlugin.add_worker` and `SchedulerPlugin.remove_worker` methods (which are currently supported for `start` and `close`)