### PR TITLE
Optionally use pickle5

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -71,9 +71,11 @@ if [[ $PYTHON == 3.6 ]]; then
   conda install -c conda-forge -c defaults contextvars
 fi
 
-# stacktrace is not currently avaiable for Python 3.8.
-# Remove the version check block below when it is avaiable.
 if [[ $PYTHON != 3.8 ]]; then
+    # Install backport package for pickle protocol 5 support
+    conda install -c conda-forge -c defaults 'pickle5>=0.0.10'
+    # stacktrace is not currently avaiable for Python 3.8.
+    # Remove the version check block below when it is avaiable.
     # For low-level profiler, install libunwind and stacktrace from conda-forge
     # For stacktrace we use --no-deps to avoid upgrade of python
     conda install -c conda-forge -c defaults libunwind

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -73,8 +73,7 @@ fi
 
 if [[ $PYTHON != 3.8 ]]; then
     # Install backport package for pickle protocol 5 support
-    conda install -c conda-forge -c defaults 'pickle5>=0.0.10'
-    pip install git+https://github.com/jakirkham/cloudpickle.git@opt_use_pickle5_redux
+    conda install -c conda-forge -c defaults 'pickle5>=0.0.11'
     # stacktrace is not currently avaiable for Python 3.8.
     # Remove the version check block below when it is avaiable.
     # For low-level profiler, install libunwind and stacktrace from conda-forge

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -74,6 +74,7 @@ fi
 if [[ $PYTHON != 3.8 ]]; then
     # Install backport package for pickle protocol 5 support
     conda install -c conda-forge -c defaults 'pickle5>=0.0.10'
+    pip install git+https://github.com/jakirkham/cloudpickle.git@opt_use_pickle5_redux
     # stacktrace is not currently avaiable for Python 3.8.
     # Remove the version check block below when it is avaiable.
     # For low-level profiler, install libunwind and stacktrace from conda-forge

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -1,7 +1,15 @@
 import logging
-import pickle
+import sys
 
 import cloudpickle
+
+if sys.version_info < (3, 8):
+    try:
+        import pickle5 as pickle
+    except ImportError:
+        import pickle
+else:
+    import pickle
 
 
 HIGHEST_PROTOCOL = pickle.HIGHEST_PROTOCOL

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -1,7 +1,6 @@
 from functools import partial
 import gc
 from operator import add
-import pickle
 import weakref
 import sys
 
@@ -9,6 +8,14 @@ import pytest
 
 from distributed.protocol import deserialize, serialize
 from distributed.protocol.pickle import HIGHEST_PROTOCOL, dumps, loads
+
+if sys.version_info < (3, 8):
+    try:
+        import pickle5 as pickle
+    except ImportError:
+        import pickle
+else:
+    import pickle
 
 
 def test_pickle_data():

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -12,7 +12,7 @@ import math
 from numbers import Number
 import operator
 import os
-import pickle
+import sys
 import random
 import warnings
 import weakref
@@ -85,6 +85,14 @@ from .event import EventExtension
 from .pubsub import PubSubSchedulerExtension
 from .stealing import WorkStealing
 from .variable import VariableExtension
+
+if sys.version_info < (3, 8):
+    try:
+        import pickle5 as pickle
+    except ImportError:
+        import pickle
+else:
+    import pickle
 
 
 logger = logging.getLogger(__name__)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import pickle
 import operator
 import re
 import sys
@@ -41,6 +40,14 @@ from distributed.utils_test import (  # noqa: F401
 )
 from distributed.utils_test import loop, nodebug  # noqa: F401
 from dask.compatibility import apply
+
+if sys.version_info < (3, 8):
+    try:
+        import pickle5 as pickle
+    except ImportError:
+        import pickle
+else:
+    import pickle
 
 
 alice = "alice:1234"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click >= 6.6
-cloudpickle >= 1.3.0
+cloudpickle >= 1.5.0
 contextvars;python_version<'3.7'
 dask >= 2.9.0
 msgpack >= 0.6.0


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/2495

This extends the changes in PR ( https://github.com/dask/distributed/pull/3784 ) to also support using `pickle5` (when available). Depends on PR ( https://github.com/cloudpipe/cloudpickle/pull/370 ), which is in `cloudpickle` version `1.5.0`.
cc @pierreglaser @pitrou