### PR TITLE
Use Enum for worker, scheduler and nanny status.

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -64,7 +64,7 @@ class Status(Enum):
         if isinstance(other, str) or (other is None):
             assert other in [s.value for s in type(self)]
             return other == self.value
-        elif isinstance(other, type(self)):
+        elif isinstance(other, Enum):
             return self.value == other.value
         raise TypeError(
             f"'==' not supported between instances of"

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -42,16 +42,21 @@ from . import protocol
 
 class Status(Enum):
     """
-    This Enum contains the various states a worker can be.
-    Those states can be observed and used in worker, scheduler and nanny.
-
+    This Enum contains the various states a worker, scheduler and nanny can be
+    in. Some of the status can only be observed in one of nanny, scheduler or
+    worker but we put them in the same Enum as they are compared with each
+    other.
     """
 
-    undefined = None
-    running = "running"
     closed = "closed"
     closing = "closing"
     closing_gracefully = "closing-gracefully"
+    init = "init"
+    running = "running"
+    starting = "starting"
+    stopped = "stopped"
+    stopping = "stopping"
+    undefined = None
 
     def __eq__(self, other):
         """
@@ -59,13 +64,15 @@ class Status(Enum):
 
         If other object instance is string, we compare with the values, but we
         actually want to make sure the value compared with is in the list of
-        possible Status.
+        possible Status, this avoid comparison with non-existing status.
         """
-        if isinstance(other, str) or (other is None):
-            assert other in [s.value for s in type(self)]
-            return other == self.value
-        elif isinstance(other, Enum):
+        if isinstance(other, type(self)):
             return self.value == other.value
+        elif isinstance(other, str) or (other is None):
+            assert other in [
+                s.value for s in type(self)
+            ], f"comparison with non-existing states {other}"
+            return other == self.value
         raise TypeError(
             f"'==' not supported between instances of"
             f" {type(self).__module__+'.'+type(self).__qualname__!r} and"

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -252,6 +252,19 @@ class Server:
 
         self.__stopped = False
 
+    @property
+    def status(self):
+        return self._status
+
+    @status.setter
+    def status(self, new_status):
+        if isinstance(new_status, Status):
+            self._status = new_status
+        elif isinstance(new_status, str) or new_status is None:
+            corresponding_enum_variants = [s for s in Status if s.value == new_status]
+            assert len(corresponding_enum_variants) == 1
+            self._status = corresponding_enum_variants[0]
+
     async def finished(self):
         """ Wait until the server has finished """
         await self._event_finished.wait()

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -11,7 +11,7 @@ from tornado import gen
 
 from .adaptive import Adaptive
 from .cluster import Cluster
-from ..core import rpc, CommClosedError, Status as WorkerStatus
+from ..core import rpc, CommClosedError, Status
 from ..utils import (
     LoopRunner,
     silence_logging,
@@ -20,7 +20,7 @@ from ..utils import (
     import_term,
     TimeoutError,
 )
-from ..scheduler import Scheduler, Status as SchedulerStatus
+from ..scheduler import Scheduler
 from ..security import Security
 
 
@@ -304,7 +304,7 @@ class SpecCluster(Cluster):
             pre = list(set(self.workers))
             to_close = set(self.workers) - set(self.worker_spec)
             if to_close:
-                if self.scheduler.status == SchedulerStatus.running:
+                if self.scheduler.status == Status.running:
                     await self.scheduler_comm.retire_workers(workers=list(to_close))
                 tasks = [self.workers[w].close() for w in to_close if w in self.workers]
                 await asyncio.wait(tasks)
@@ -390,7 +390,7 @@ class SpecCluster(Cluster):
 
         await self.scheduler.close()
         for w in self._created:
-            assert w.status == WorkerStatus.closed, w.status
+            assert w.status == Status.closed, w.status
 
         if hasattr(self, "_old_logging_level"):
             silence_logging(self._old_logging_level)

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -11,7 +11,7 @@ from tornado import gen
 
 from .adaptive import Adaptive
 from .cluster import Cluster
-from ..core import rpc, CommClosedError
+from ..core import rpc, CommClosedError, Status as WorkerStatus
 from ..utils import (
     LoopRunner,
     silence_logging,
@@ -20,7 +20,7 @@ from ..utils import (
     import_term,
     TimeoutError,
 )
-from ..scheduler import Scheduler
+from ..scheduler import Scheduler, Status as SchedulerStatus
 from ..security import Security
 
 
@@ -304,7 +304,7 @@ class SpecCluster(Cluster):
             pre = list(set(self.workers))
             to_close = set(self.workers) - set(self.worker_spec)
             if to_close:
-                if self.scheduler.status == "running":
+                if self.scheduler.status == SchedulerStatus.running:
                     await self.scheduler_comm.retire_workers(workers=list(to_close))
                 tasks = [self.workers[w].close() for w in to_close if w in self.workers]
                 await asyncio.wait(tasks)
@@ -390,7 +390,7 @@ class SpecCluster(Cluster):
 
         await self.scheduler.close()
         for w in self._created:
-            assert w.status == "closed", w.status
+            assert w.status == WorkerStatus.closed, w.status
 
         if hasattr(self, "_old_logging_level"):
             silence_logging(self._old_logging_level)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -1,5 +1,6 @@
 import asyncio
 from contextlib import suppress
+from enum import Enum
 import errno
 import logging
 from multiprocessing.queues import Empty
@@ -35,6 +36,43 @@ from .utils import (
     TimeoutError,
 )
 from .worker import run, parse_memory_limit, Worker
+
+
+class Status(Enum):
+    """
+    This Enum contains the various states a worker can be.
+    Those states can be observed and used in worker, scheduler and nanny.
+
+    """
+
+    init = "init"
+    starting = "starting"
+    running = "running"
+    stopped = "stopped"
+    stopping = "stopping"
+    closed = "closed"
+    closing = "closing"
+    closing_gracefully = "closing-gracefully"
+
+    def __eq__(self, other):
+        """
+        Implement equality checking with backward compatibility.
+
+        If other object instance is string, we compare with the values, but we
+        actually want to make sure the value compared with is in the list of
+        possible Status.
+        """
+        if isinstance(other, str):
+            assert other in [s.value for s in type(self)]
+            return other == self.value
+        elif isinstance(other, type(self)):
+            return self.value == other.value
+        raise TypeError(
+            f"'==' not supported between instances of"
+            f" {type(self).__module__+'.'+type(self).__qualname__!r} and"
+            f" {type(other).__module__+'.'+type(other).__qualname__!r}"
+        )
+
 
 logger = logging.getLogger(__name__)
 
@@ -218,7 +256,7 @@ class Nanny(ServerNode):
 
         self._listen_address = listen_address
         Nanny._instances.add(self)
-        self.status = "init"
+        self.status = Status.init
 
     def __repr__(self):
         return "<Nanny: %s, threads: %d>" % (self.worker_address, self.nthreads)
@@ -291,7 +329,7 @@ class Nanny(ServerNode):
         response = await self.instantiate()
         if response == "running":
             assert self.worker_address
-            self.status = "running"
+            self.status = Status.running
         else:
             await self.close()
 
@@ -405,7 +443,7 @@ class Nanny(ServerNode):
 
     def memory_monitor(self):
         """ Track worker's memory.  Restart if it goes above terminate fraction """
-        if self.status != "running":
+        if self.status != Status.running:
             return
         process = self.process.process
         if process is None:
@@ -434,7 +472,7 @@ class Nanny(ServerNode):
         self.loop.add_callback(self._on_exit, exitcode)
 
     async def _on_exit(self, exitcode):
-        if self.status not in ("closing", "closed"):
+        if self.status not in (Status.closing, Status.closed):
             try:
                 await self.scheduler.unregister(address=self.worker_address)
             except (EnvironmentError, CommClosedError):
@@ -443,11 +481,15 @@ class Nanny(ServerNode):
                     return
 
             try:
-                if self.status not in ("closing", "closed", "closing-gracefully"):
+                if self.status not in (
+                    Status.closing,
+                    Status.closed,
+                    Status.closing_gracefully,
+                ):
                     if self.auto_restart:
                         logger.warning("Restarting worker")
                         await self.instantiate()
-                elif self.status == "closing-gracefully":
+                elif self.status == Status.closing_gracefully:
                     await self.close()
 
             except Exception:
@@ -469,20 +511,20 @@ class Nanny(ServerNode):
 
         This is used as part of the cluster shutdown process.
         """
-        self.status = "closing-gracefully"
+        self.status = Status.closing_gracefully
 
     async def close(self, comm=None, timeout=5, report=None):
         """
         Close the worker process, stop all comms.
         """
-        if self.status == "closing":
+        if self.status == Status.closing:
             await self.finished()
-            assert self.status == "closed"
+            assert self.status == Status.closed
 
-        if self.status == "closed":
+        if self.status == Status.closed:
             return "OK"
 
-        self.status = "closing"
+        self.status = Status.closing
         logger.info("Closing Nanny at %r", self.address)
 
         for preload in self.preloads:
@@ -496,7 +538,7 @@ class Nanny(ServerNode):
             pass
         self.process = None
         await self.rpc.close()
-        self.status = "closed"
+        self.status = Status.closed
         if comm:
             await comm.write("OK")
         await ServerNode.close(self)
@@ -513,7 +555,7 @@ class WorkerProcess:
         env,
         config,
     ):
-        self.status = "init"
+        self.status = Status.init
         self.silence_logs = silence_logs
         self.worker_kwargs = worker_kwargs
         self.worker_start_args = worker_start_args
@@ -532,9 +574,9 @@ class WorkerProcess:
         Ensure the worker process is started.
         """
         enable_proctitle_on_children()
-        if self.status == "running":
+        if self.status == Status.running:
             return self.status
-        if self.status == "starting":
+        if self.status == Status.starting:
             await self.running.wait()
             return self.status
 
@@ -561,7 +603,7 @@ class WorkerProcess:
         self.process.set_exit_callback(self._on_exit)
         self.running = asyncio.Event()
         self.stopped = asyncio.Event()
-        self.status = "starting"
+        self.status = Status.starting
 
         try:
             await self.process.start()
@@ -606,13 +648,13 @@ class WorkerProcess:
         return self.process.pid if self.process and self.process.is_alive() else None
 
     def mark_stopped(self):
-        if self.status != "stopped":
+        if self.status != Status.stopped:
             r = self.process.exitcode
             assert r is not None
             if r != 0:
                 msg = self._death_message(self.process.pid, r)
                 logger.info(msg)
-            self.status = "stopped"
+            self.status = Status.stopped
             self.stopped.set()
             # Release resources
             self.process.close()
@@ -635,13 +677,13 @@ class WorkerProcess:
         loop = IOLoop.current()
         deadline = loop.time() + timeout
 
-        if self.status == "stopped":
+        if self.status == Status.stopped:
             return
-        if self.status == "stopping":
+        if self.status == Status.stopping:
             await self.stopped.wait()
             return
-        assert self.status in ("starting", "running")
-        self.status = "stopping"
+        assert self.status in (Status.starting, Status.running)
+        self.status = Status.stopping
 
         process = self.process
         self.child_stop_q.put(
@@ -669,7 +711,7 @@ class WorkerProcess:
     async def _wait_until_connected(self, uid):
         delay = 0.05
         while True:
-            if self.status != "starting":
+            if self.status != Status.starting:
                 return
             try:
                 msg = self.init_result_q.get_nowait()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -57,7 +57,7 @@ class Nanny(ServerNode):
 
     _instances = weakref.WeakSet()
     process = None
-    status = None
+    status = Status.undefined
 
     def __init__(
         self,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -1,6 +1,5 @@
 import asyncio
 from contextlib import suppress
-from enum import Enum
 import errno
 import logging
 from multiprocessing.queues import Empty

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -62,16 +62,17 @@ class Status(Enum):
         actually want to make sure the value compared with is in the list of
         possible Status.
         """
-        if isinstance(other, str):
+        if isinstance(other, str) or other is None:
             assert other in [s.value for s in type(self)]
             return other == self.value
-        elif isinstance(other, type(self)):
+        elif isinstance(other, Enum):
             return self.value == other.value
         raise TypeError(
             f"'==' not supported between instances of"
             f" {type(self).__module__+'.'+type(self).__qualname__!r} and"
             f" {type(other).__module__+'.'+type(other).__qualname__!r}"
         )
+
 
 
 logger = logging.getLogger(__name__)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -19,7 +19,7 @@ from tornado import gen
 
 from .comm import get_address_host, unparse_host_port
 from .comm.addressing import address_from_user_args
-from .core import RPCClosed, CommClosedError, coerce_to_address
+from .core import RPCClosed, CommClosedError, coerce_to_address, Status
 from .metrics import time
 from .node import ServerNode
 from . import preloading
@@ -36,43 +36,6 @@ from .utils import (
     TimeoutError,
 )
 from .worker import run, parse_memory_limit, Worker
-
-
-class Status(Enum):
-    """
-    This Enum contains the various states a worker can be.
-    Those states can be observed and used in worker, scheduler and nanny.
-
-    """
-
-    init = "init"
-    starting = "starting"
-    running = "running"
-    stopped = "stopped"
-    stopping = "stopping"
-    closed = "closed"
-    closing = "closing"
-    closing_gracefully = "closing-gracefully"
-
-    def __eq__(self, other):
-        """
-        Implement equality checking with backward compatibility.
-
-        If other object instance is string, we compare with the values, but we
-        actually want to make sure the value compared with is in the list of
-        possible Status.
-        """
-        if isinstance(other, str) or other is None:
-            assert other in [s.value for s in type(self)]
-            return other == self.value
-        elif isinstance(other, Enum):
-            return self.value == other.value
-        raise TypeError(
-            f"'==' not supported between instances of"
-            f" {type(self).__module__+'.'+type(self).__qualname__!r} and"
-            f" {type(other).__module__+'.'+type(other).__qualname__!r}"
-        )
-
 
 
 logger = logging.getLogger(__name__)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -47,7 +47,7 @@ from .comm import (
     unparse_host_port,
 )
 from .comm.addressing import addresses_from_user_args
-from .core import rpc, send_recv, clean_exception, CommClosedError
+from .core import rpc, send_recv, clean_exception, CommClosedError, Status
 from .diagnostics.plugin import SchedulerPlugin
 
 from .http import get_handlers
@@ -108,38 +108,6 @@ DEFAULT_EXTENSIONS = [
 ]
 
 ALL_TASK_STATES = {"released", "waiting", "no-worker", "processing", "erred", "memory"}
-
-
-class Status(Enum):
-    """
-    This Enum contains the various states a worker can be.
-    Those states can be observed and used in worker, scheduler and nanny.
-
-    """
-
-    running = "running"
-    closed = "closed"
-    closing = "closing"
-    closing_gracefully = "closing-gracefully"
-
-    def __eq__(self, other):
-        """
-        Implement equality checking with backward compatibility.
-
-        If other object instance is string, we compare with the values, but we
-        actually want to make sure the value compared with is in the list of
-        possible Status.
-        """
-        if isinstance(other, str) or other is None:
-            assert other in [s.value for s in type(self)]
-            return other == self.value
-        elif isinstance(other, Enum):
-            return self.value == other.value
-        raise TypeError(
-            f"'==' not supported between instances of"
-            f" {type(self).__module__+'.'+type(self).__qualname__!r} and"
-            f" {type(other).__module__+'.'+type(other).__qualname__!r}"
-        )
 
 
 class ClientState:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3,7 +3,6 @@ from collections import defaultdict, deque
 from collections.abc import Mapping, Set
 from contextlib import suppress
 from datetime import timedelta
-from enum import Enum
 from functools import partial
 import inspect
 import itertools

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -130,10 +130,10 @@ class Status(Enum):
         actually want to make sure the value compared with is in the list of
         possible Status.
         """
-        if isinstance(other, str):
+        if isinstance(other, str) or other is None:
             assert other in [s.value for s in type(self)]
             return other == self.value
-        elif isinstance(other, type(self)):
+        elif isinstance(other, Enum):
             return self.value == other.value
         raise TypeError(
             f"'==' not supported between instances of"

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -245,7 +245,7 @@ class WorkerState:
         "processing",
         "resources",
         "services",
-        "status",
+        "_status",
         "time_delay",
         "used_resources",
         "versions",
@@ -274,7 +274,7 @@ class WorkerState:
         self.versions = versions or {}
         self.nanny = nanny
 
-        self.status = Status.running
+        self._status = Status.running
         self.nbytes = 0
         self.occupancy = 0
         self.metrics = {}
@@ -295,6 +295,19 @@ class WorkerState:
 
     def __eq__(self, other):
         return type(self) == type(other) and self.address == other.address
+
+    @property
+    def status(self):
+        return self._status
+
+    @status.setter
+    def status(self, new_status):
+        if isinstance(new_status, Status):
+            self._status = new_status
+        elif isinstance(new_status, str) or new_status is None:
+            corresponding_enum_variants = [s for s in Status if s.value == new_status]
+            assert len(corresponding_enum_variants) == 1
+            self._status = corresponding_enum_variants[0]
 
     @property
     def host(self):
@@ -1373,6 +1386,20 @@ class Scheduler(ServerNode):
         setproctitle("dask-scheduler [not started]")
         Scheduler._instances.add(self)
         self.rpc.allow_offload = False
+        self.status = Status.undefined
+
+    @property
+    def status(self):
+        return self._status
+
+    @status.setter
+    def status(self, new_status):
+        if isinstance(new_status, Status):
+            self._status = new_status
+        elif isinstance(new_status, str) or new_status is None:
+            corresponding_enum_variants = [s for s in Status if s.value == new_status]
+            assert len(corresponding_enum_variants) == 1
+            self._status = corresponding_enum_variants[0]
 
     ##################
     # Administration #

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -17,7 +17,7 @@ import pytest
 
 from distributed import Nanny, Worker, Client, wait, fire_and_forget
 from distributed.comm import Comm
-from distributed.core import connect, rpc, ConnectionPool
+from distributed.core import connect, rpc, ConnectionPool, Status
 from distributed.scheduler import Scheduler
 from distributed.client import wait
 from distributed.metrics import time
@@ -736,7 +736,10 @@ async def test_retire_workers_n(c, s, a, b):
     await s.retire_workers(n=0, close_workers=True)
     assert len(s.workers) == 0
 
-    while not (a.status.startswith("clos") and b.status.startswith("clos")):
+    while not (
+        a.status in (Status.closed, Status.closing, Status.closing_gracefully)
+        and b.status in (Status.closed, Status.closing, Status.closing_gracefully)
+    ):
         await asyncio.sleep(0.01)
 
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -41,7 +41,7 @@ from .client import default_client, _global_clients, Client
 from .compatibility import WINDOWS
 from .comm import Comm
 from .config import initialize_logging
-from .core import connect, rpc, CommClosedError
+from .core import connect, rpc, CommClosedError, Status as WorkerStatus
 from .deploy import SpecCluster
 from .metrics import time
 from .process import _cleanup_dangling
@@ -61,7 +61,7 @@ from .utils import (
     TimeoutError,
 )
 from .worker import Worker
-from .nanny import Nanny
+from .nanny import Nanny, Status as NannyStatus
 
 try:
     import dask.array  # register config
@@ -1485,7 +1485,7 @@ def check_instances():
     for w in Worker._instances:
         with suppress(RuntimeError):  # closed IOLoop
             w.loop.add_callback(w.close, report=False, executor_wait=False)
-            if w.status == "running":
+            if w.status == WorkerStatus.running:
                 w.loop.add_callback(w.close)
     Worker._instances.clear()
 
@@ -1500,9 +1500,10 @@ def check_instances():
         print("Unclosed Comms", L)
         # raise ValueError("Unclosed Comms", L)
 
-    assert all(n.status == "closed" or n.status == "init" for n in Nanny._instances), {
-        n: n.status for n in Nanny._instances
-    }
+    assert all(
+        n.status == NannyStatus.closed or n.status == NannyStatus.init
+        for n in Nanny._instances
+    ), {n: n.status for n in Nanny._instances}
 
     # assert not list(SpecCluster._instances)  # TODO
     assert all(c.status == "closed" for c in SpecCluster._instances), list(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -41,7 +41,7 @@ from .client import default_client, _global_clients, Client
 from .compatibility import WINDOWS
 from .comm import Comm
 from .config import initialize_logging
-from .core import connect, rpc, CommClosedError, Status as WorkerStatus
+from .core import connect, rpc, CommClosedError, Status
 from .deploy import SpecCluster
 from .metrics import time
 from .process import _cleanup_dangling
@@ -61,7 +61,7 @@ from .utils import (
     TimeoutError,
 )
 from .worker import Worker
-from .nanny import Nanny, Status as NannyStatus
+from .nanny import Nanny
 
 try:
     import dask.array  # register config
@@ -1485,7 +1485,7 @@ def check_instances():
     for w in Worker._instances:
         with suppress(RuntimeError):  # closed IOLoop
             w.loop.add_callback(w.close, report=False, executor_wait=False)
-            if w.status == WorkerStatus.running:
+            if w.status == Status.running:
                 w.loop.add_callback(w.close)
     Worker._instances.clear()
 
@@ -1501,8 +1501,7 @@ def check_instances():
         # raise ValueError("Unclosed Comms", L)
 
     assert all(
-        n.status == NannyStatus.closed or n.status == NannyStatus.init
-        for n in Nanny._instances
+        n.status == Status.closed or n.status == Status.init for n in Nanny._instances
     ), {n: n.status for n in Nanny._instances}
 
     # assert not list(SpecCluster._instances)  # TODO


### PR DESCRIPTION
Looking at the code it was hard to find all the states a worker, nanny
scheduler could be
in, and in particular it is easy to forget 'closing_gracefully' for
example when skimming over a `self.status.startswith('clos')`, and it
also hard to fine that in some places the status can be "None", "init",
"starting" and "stopped"

So I just took a pass at seeing in how many places status was
assigned/compared in worker, nanny and scheduler and replace that by an
Enum I'm assuming the status each can see is not shared  so we end up

I thus tried to do separate Status Enums for Scheduler/Nanny/Worker.

Note that even if Enums have values for their variants, the variants _do
not_ compare equal to their values. That is to say `Status.running =!
'running'`, but `Status.running.value == 'running'`,

So I implemented a custom `__eq__` method that can compare with
strings/None for backward compatibility. It works both when the LHS or
RHS is str/None as the default impl of str/None forward to our
implementation. This also make sure the value you compare with is also
in the list of possible state.

The main other code changes were updating some of the comparisons to use
the enums instead of the strings directly, and replace the "startswith"
with the `in` operator, which is slightly more verbose.

I believe despite being a bit more verbose, it is a bit more explicit and
may help navigate the codebase and if you want to go this route you
probably want to remove the custom comparison but that would be an API
change that could break other project.