### PR TITLE
Use SpecCluster name in worker names

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -462,6 +462,14 @@ class SpecCluster(Cluster):
         if self.asynchronous:
             return NoOpAwaitable()
 
+    def _new_worker_name(self, worker_number):
+        """ Returns new worker name.
+
+        This can be overriden in SpecCluster derived classes to customise the
+        worker names.
+        """
+        return worker_number
+
     def new_worker_spec(self):
         """ Return name and spec for the next worker
 
@@ -473,13 +481,12 @@ class SpecCluster(Cluster):
         --------
         scale
         """
-        worker_name_template = f"{self._name}-{{}}"
-        worker_name = worker_name_template.format(self._i)
-        while worker_name in self.worker_spec:
+        new_worker_name = self._new_worker_name(self._i)
+        while new_worker_name in self.worker_spec:
             self._i += 1
-            worker_name = worker_name_template.format(self._i)
+            new_worker_name = self._new_worker_name(self._i)
 
-        return {worker_name: self.new_spec}
+        return {new_worker_name: self.new_spec}
 
     @property
     def _supports_scaling(self):

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -473,10 +473,13 @@ class SpecCluster(Cluster):
         --------
         scale
         """
-        while self._i in self.worker_spec:
+        worker_name_template = f'{self._name}-{{}}'
+        worker_name = worker_name_template.format(self._i)
+        while worker_name in self.worker_spec:
             self._i += 1
+            worker_name = worker_name_template.format(self._i)
 
-        return {self._i: self.new_spec}
+        return {worker_name: self.new_spec}
 
     @property
     def _supports_scaling(self):

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -538,7 +538,7 @@ class SpecCluster(Cluster):
         maximum_cores: int = None,
         minimum_memory: str = None,
         maximum_memory: str = None,
-        **kwargs
+        **kwargs,
     ) -> Adaptive:
         """ Turn on adaptivity
 

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -473,7 +473,7 @@ class SpecCluster(Cluster):
         --------
         scale
         """
-        worker_name_template = f'{self._name}-{{}}'
+        worker_name_template = f"{self._name}-{{}}"
         worker_name = worker_name_template.format(self._i)
         while worker_name in self.worker_spec:
             self._i += 1

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1447,7 +1447,7 @@ def check_process_leak(check=True):
     yield
 
     if check:
-        for i in range(100):
+        for i in range(200):
             if not set(mp_context.active_children()):
                 break
             else:


### PR DESCRIPTION
So this comes from a long discussion about using job arrays in Dask-Jobqueue iin https://github.com/dask/dask-jobqueue/issues/196.

I'll try to summarise it:
- the emphasis is for now to provide a work-around to people who have a strong constraint to use job arrays
- when using a job array the job submission script looks like this (SGE here but would be similar for other job schedulers):
```bash
#!/usr/bin/env bash
# some other header things
# job array option
#$ -t 1-3

# 0 comes from `self._i` in SpecCluster
dask-worker <scheduler-address> --name 0
```
the problem is that this script will be run 3 times (the size of the job array) and workers will have the same name causing an error
- we would like to do:
```py
cluster = SGECluster(name='whatever_$SGE_TASK_ID', cores=1, memory='1GB')
```

so that the job submission script would look like this:
```bash
#!/usr/bin/env bash
# some other header things
# job array option
#$ -t 1-3

# 0 comes from `self._i` in SpecCluster
dask-worker <scheduler-address> --name whatever_$SGE_TASK_ID-0
```

This PR is an attempt at doing this. Suggestions on how to improve it would be more than welcome!

This modification is only motivated by Dask-Jobqueue so it could be argued that it should stay in Dask-Jobqueue. My feeling is that:
- having the SpecCluster name be used in the worker names is a rather limited change (to be fair I am not sure what SpecCluster name is used for outside of the `__repr__`)
- I have to say that my general approach is to keep as little tricky code in Dask-Jobqueue so this PR feels a better thing to do than overriding `new_worker_spec` in Dask-Jobqueue to do what we want. The latter approach feels more fragile and could break if some of the SpecCluster internals changed.

If I am being honest the Dask-Jobqueue use case feels a little bit kludgy because the key of the spec would be `wathever_$SGE_TASK_ID-0`, `wathever_$SGE_TASK_ID-1` and the worker names would be `whatever_1-0`, `whatever_2-0`, `whatever_3-0`, `whatever_1-1`, etc ... not sure it that could cause a problem later down the line.