### PR TITLE
Drop no longer needed local `import pickle`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3612,7 +3612,6 @@ class Scheduler(ServerNode):
                 "commonly used with progress bars)"
             )
             return
-        import pickle
 
         interval = parse_timedelta(interval)
         with log_errors():


### PR DESCRIPTION
We already [`import pickle` at the top of the module]( https://github.com/dask/distributed/blob/8480b4fde57d16b27b3079f25b95e61b862b79ae/distributed/scheduler.py#L15 ). So there is no need to import it locally here as well. So drop the local `import pickle`.