### PR TITLE
Drop legacy `buffer_interface` assignment

### DIFF
--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -77,9 +77,8 @@ def test_dumps_serialize_numpy(x):
     header, frames = serialize(x)
     if "compression" in header:
         frames = decompress(header, frames)
-    buffer_interface = memoryview
     for frame in frames:
-        assert isinstance(frame, (bytes, buffer_interface))
+        assert isinstance(frame, (bytes, memoryview))
     y = deserialize(header, frames)
 
     np.testing.assert_equal(x, y)


### PR DESCRIPTION
This was part of some Python 2 compatibility code at one point. However as Python 2 has long since been dropped, we are safe to drop this as well.