### PR TITLE
Cast any `frame` to `uint8` (same type as `bytes`)

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -81,7 +81,7 @@ def dumps(msg, serializers=None, on_error="message", context=None):
         for i, frame in enumerate(out_frames):
             if type(frame) is memoryview and frame.strides != (1,):
                 try:
-                    frame = frame.cast("b")
+                    frame = frame.cast("B")
                 except TypeError:
                     frame = frame.tobytes()
                 out_frames[i] = frame


### PR DESCRIPTION
Cast all frames to `uint8` when casting. This matches the type of `bytes` and `bytearray` (please see example below), which is used in the fallback case below and for receiving the frames.

```python
In [1]: memoryview(b"abc").format                                               
Out[1]: 'B'
```