### PR TITLE
Use pickle protocol 5 with NumPy object arrays

### DIFF
--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -81,9 +81,10 @@ def test_dumps_serialize_numpy(x):
         assert isinstance(frame, (bytes, memoryview))
     y = deserialize(header, frames)
 
-    np.testing.assert_equal(x, y)
     if x.flags.c_contiguous or x.flags.f_contiguous:
         assert x.strides == y.strides
+
+    np.testing.assert_equal(x, y)
 
 
 @pytest.mark.parametrize(

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -86,7 +86,11 @@ def test_dumps_serialize_numpy(x):
     if x.flags.c_contiguous or x.flags.f_contiguous:
         assert x.strides == y.strides
 
-    np.testing.assert_equal(x, y)
+    if x.dtype.char == "O":
+        for e_x, e_y in zip(x.flat, y.flat):
+            np.testing.assert_equal(e_x, e_y)
+    else:
+        np.testing.assert_equal(x, y)
 
 
 @pytest.mark.parametrize(

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -81,6 +81,8 @@ def test_dumps_serialize_numpy(x):
         assert isinstance(frame, (bytes, memoryview))
     y = deserialize(header, frames)
 
+    assert x.shape == y.shape
+    assert x.dtype == y.dtype
     if x.flags.c_contiguous or x.flags.f_contiguous:
         assert x.strides == y.strides
 

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -57,6 +57,7 @@ def test_serialize():
         np.array(["abc"], dtype="S3"),
         np.array(["abc"], dtype="U3"),
         np.array(["abc"], dtype=object),
+        np.array([np.arange(3), np.arange(4, 6)], dtype=object),
         np.ones(shape=(5,), dtype=("f8", 32)),
         np.ones(shape=(5,), dtype=[("x", "f8", 32)]),
         np.ones(shape=(5,), dtype=np.dtype([("a", "i1"), ("b", "f8")], align=False)),

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -14,6 +14,7 @@ from distributed.protocol import (
 )
 from distributed.protocol.utils import BIG_BYTES_SHARD_SIZE
 from distributed.protocol.numpy import itemsize
+from distributed.protocol.pickle import HIGHEST_PROTOCOL
 from distributed.protocol.compression import maybe_compress
 from distributed.system import MEMORY_LIMIT
 from distributed.utils import tmpfile, nbytes
@@ -80,6 +81,11 @@ def test_dumps_serialize_numpy(x):
         frames = decompress(header, frames)
     for frame in frames:
         assert isinstance(frame, (bytes, memoryview))
+    if x.dtype.char == "O" and any(isinstance(e, np.ndarray) for e in x.flat):
+        if HIGHEST_PROTOCOL >= 5:
+            assert len(frames) > 1
+        else:
+            assert len(frames) == 1
     y = deserialize(header, frames)
 
     assert x.shape == y.shape

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -74,6 +74,20 @@ def test_pickle_numpy():
     assert (loads(dumps(x)) == x).all()
     assert (deserialize(*serialize(x, serializers=("pickle",))) == x).all()
 
+    x = np.array([np.arange(3), np.arange(4, 6)], dtype=object)
+    x2 = loads(dumps(x))
+    assert x.shape == x2.shape
+    assert x.dtype == x2.dtype
+    assert x.strides == x2.strides
+    for e_x, e_x2 in zip(x.flat, x2.flat):
+        np.testing.assert_equal(e_x, e_x2)
+    x3 = deserialize(*serialize(x, serializers=("pickle",)))
+    assert x.shape == x3.shape
+    assert x.dtype == x3.dtype
+    assert x.strides == x3.strides
+    for e_x, e_x3 in zip(x.flat, x3.flat):
+        np.testing.assert_equal(e_x, e_x3)
+
     if HIGHEST_PROTOCOL >= 5:
         x = np.ones(5000)
 

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -81,7 +81,12 @@ def test_pickle_numpy():
     assert x.strides == x2.strides
     for e_x, e_x2 in zip(x.flat, x2.flat):
         np.testing.assert_equal(e_x, e_x2)
-    x3 = deserialize(*serialize(x, serializers=("pickle",)))
+    h, f = serialize(x, serializers=("pickle",))
+    if HIGHEST_PROTOCOL >= 5:
+        assert len(f) == 3
+    else:
+        assert len(f) == 1
+    x3 = deserialize(h, f)
     assert x.shape == x3.shape
     assert x.dtype == x3.dtype
     assert x.strides == x3.strides


### PR DESCRIPTION
Depends on PR ( https://github.com/dask/distributed/pull/3868 )

Builds off the work in PR ( https://github.com/dask/distributed/pull/3784 ) to support pickle protocol 5. Supports out-of-band pickling when serializing NumPy object arrays. This can be useful when serializing ragged arrays for example or really any NumPy object arrays containing data that supports out-of-band pickling.