### PR TITLE
Allow dictionaries in security= keywords

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -11,7 +11,7 @@ import dask
 
 from tornado.ioloop import IOLoop
 
-from distributed import Scheduler, Security
+from distributed import Scheduler
 from distributed.preloading import validate_preload_argv
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.utils import deserialize_for_cli
@@ -157,17 +157,15 @@ def main(
     if port is None and (not host or not re.search(r":\d", host)):
         port = 8786
 
-    sec = Security(
-        **{
-            k: v
-            for k, v in [
-                ("tls_ca_file", tls_ca_file),
-                ("tls_scheduler_cert", tls_cert),
-                ("tls_scheduler_key", tls_key),
-            ]
-            if v is not None
-        }
-    )
+    sec = {
+        k: v
+        for k, v in [
+            ("tls_ca_file", tls_ca_file),
+            ("tls_scheduler_cert", tls_cert),
+            ("tls_scheduler_key", tls_key),
+        ]
+        if v is not None
+    }
 
     if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
         config = deserialize_for_cli(os.environ["DASK_INTERNAL_INHERIT_CONFIG"])

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -11,7 +11,7 @@ import warnings
 import click
 import dask
 from dask.system import CPU_COUNT
-from distributed import Nanny, Security
+from distributed import Nanny
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.comm import get_address_host_port
 from distributed.preloading import validate_preload_argv
@@ -278,17 +278,15 @@ def main(
         )
         dashboard = bokeh
 
-    sec = Security(
-        **{
-            k: v
-            for k, v in [
-                ("tls_ca_file", tls_ca_file),
-                ("tls_worker_cert", tls_cert),
-                ("tls_worker_key", tls_key),
-            ]
-            if v is not None
-        }
-    )
+    sec = {
+        k: v
+        for k, v in [
+            ("tls_ca_file", tls_ca_file),
+            ("tls_worker_cert", tls_cert),
+            ("tls_worker_key", tls_key),
+        ]
+        if v is not None
+    }
 
     if nprocs > 1 and not nanny:
         logger.error(

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -666,6 +666,8 @@ class Client:
 
         if security is None:
             security = Security()
+        elif isinstance(security, dict):
+            security = Security(**security)
         elif security is True:
             security = Security.temporary()
             self._startup_kwargs["security"] = security

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -97,6 +97,9 @@ class Nanny(ServerNode):
     ):
         self._setup_logging(logger)
         self.loop = loop or IOLoop.current()
+
+        if isinstance(security, dict):
+            security = Security(**security)
         self.security = security or Security()
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args("worker")

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1128,6 +1128,8 @@ class Scheduler(ServerNode):
             preload_argv = dask.config.get("distributed.scheduler.preload-argv")
         self.preloads = preloading.process_preloads(self, preload, preload_argv)
 
+        if isinstance(security, dict):
+            security = Security(**security)
         self.security = security or Security()
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args("scheduler")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -507,6 +507,8 @@ class Worker(ServerNode):
             self, preload, preload_argv, file_dir=self.local_directory
         )
 
+        if isinstance(security, dict):
+            security = Security(**security)
         self.security = security or Security()
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args("worker")


### PR DESCRIPTION
Previously Dask Server and Client objects had to be instantiated with a
Security object for security.  Now we also allow for dictionary inputs
that will be splatted out to the Security object.  This helps when using
systems like dask-spec with Security.

cc @jcrist if you have a moment