### PR TITLE
Check hosts for None value in SSH cluster.

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -235,7 +235,7 @@ def SSHCluster(
     scheduler_options: dict = {},
     worker_module: str = "distributed.cli.dask_worker",
     remote_python: str = None,
-    **kwargs
+    **kwargs,
 ):
     """ Deploy a Dask cluster using SSH
 
@@ -315,6 +315,10 @@ def SSHCluster(
         kwargs.setdefault("worker_addrs", hosts)
         return OldSSHCluster(**kwargs)
 
+    if not hosts:
+        raise ValueError(
+            f"`hosts` must be a non empty list, value {repr(hosts)!r} found."
+        )
     if isinstance(connect_options, list) and len(connect_options) != len(hosts):
         raise RuntimeError(
             "When specifying a list of connect_options you must provide a "

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -8,6 +8,16 @@ from distributed.deploy.ssh import SSHCluster
 from distributed.utils_test import loop  # noqa: F401
 
 
+def test_ssh_hosts_None():
+    with pytest.raises(ValueError):
+        SSHCluster(hosts=None)
+
+
+def test_ssh_hosts_empty_list():
+    with pytest.raises(ValueError):
+        SSHCluster(hosts=[])
+
+
 @pytest.mark.asyncio
 async def test_basic():
     async with SSHCluster(


### PR DESCRIPTION
Then mypy is happy and does not complain in the rest of the function.
If host was None or empty list it would fail anyway either on the next
line `len(None)`, or further down `host[0]`.