### PR TITLE
SSHCluster send kill signal

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -33,11 +33,11 @@ class Process(ProcessInterface):
         assert self.connection
         weakref.finalize(
             self, self.proc.stdin.write, "\x03"
-        )  # https://github.com/ronf/asyncssh/issues/112
+        )  # Workaround from https://github.com/ronf/asyncssh/issues/112
         await super().start()
 
     async def close(self):
-        # https://github.com/ronf/asyncssh/issues/112
+        # Workaround from https://github.com/ronf/asyncssh/issues/112
         await self.proc.stdin.write("\x03")
         await self.proc.wait_closed()
 


### PR DESCRIPTION
There is a discussion in #3420 around older versions of OpenSSH not respecting the kill command, which results in SSH connections being left open after `SSHCluster` is done.

This issue (ronf/asyncssh#112) discusses the problem and explains that upgrading your OpenSSH version will resolve it. However as not all users are able to do this is also explains a workaround which involves sending a keyboard interrupt character to stdin on the process to manually kill it.

This PR implements that workaround.