### PR TITLE
Skip test_pid_file in older versions of Python

### DIFF
--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -185,6 +185,9 @@ def test_interface(loop):
                 assert all("127.0.0.1" == d["host"] for d in info["workers"].values())
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Intermittent failure on old Python version"
+)
 def test_pid_file(loop):
     def check_pidfile(proc, pidfile):
         start = time()


### PR DESCRIPTION
This has been intermittent for a while, but only seems to be on Python
3.6 .  I'm inclined to ignore it for now.  It's an infrequently used
feature and seems to be fixed in recent Python versions.