### PR TITLE
Fix total aggregated metrics in dashboard

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1864,7 +1864,7 @@ class WorkerTable(DashboardComponent):
                     total_data = (
                         sum(ws.metrics["cpu"] for ws in self.scheduler.workers.values())
                         / 100
-                        / sum(1 for ws in self.scheduler.workers.values())
+                        / len(self.scheduler.workers.values())
                     )
                 elif name == "cpu_fraction":
                     total_data = (

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -535,7 +535,7 @@ class ComputerPerKey(DashboardComponent):
             self.fig.title.text = "Compute Time Per Task"
 
             compute_result = dict(
-                times=compute_time, color=compute_colors, names=compute_names,
+                times=compute_time, color=compute_colors, names=compute_names
             )
 
             update(self.compute_source, compute_result)
@@ -635,7 +635,7 @@ class AggregateAction(DashboardComponent):
             self.fig.x_range.factors = agg_names
             self.fig.title.text = "Aggregate Time Per Action"
 
-            action_result = dict(times=agg_time, color=agg_colors, names=agg_names,)
+            action_result = dict(times=agg_time, color=agg_colors, names=agg_names)
 
             update(self.action_source, action_result)
 
@@ -1856,9 +1856,25 @@ class WorkerTable(DashboardComponent):
                 )
                 continue
             try:
-                total_data = sum(data[name])
                 if name == "memory_percent":
-                    total_data /= len(data[name])
+                    total_data = sum(
+                        ws.metrics["memory"] for ws in self.scheduler.workers.values()
+                    ) / sum(ws.memory_limit for ws in self.scheduler.workers.values())
+                elif name == "cpu":
+                    total_data = (
+                        sum(ws.metrics["cpu"] for ws in self.scheduler.workers.values())
+                        / 100
+                        / sum(1 for ws in self.scheduler.workers.values())
+                    )
+                elif name == "cpu_fraction":
+                    total_data = (
+                        sum(ws.metrics["cpu"] for ws in self.scheduler.workers.values())
+                        / 100
+                        / sum(ws.nthreads for ws in self.scheduler.workers.values())
+                    )
+                else:
+                    total_data = sum(data[name])
+
                 data[name].insert(0, total_data)
             except TypeError:
                 data[name].insert(0, None)

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1856,7 +1856,10 @@ class WorkerTable(DashboardComponent):
                 )
                 continue
             try:
-                data[name].insert(0, sum(data[name]))
+                total_data = sum(data[name])
+                if name == "memory_percent":
+                    total_data /= len(data[name])
+                data[name].insert(0, total_data)
             except TypeError:
                 data[name].insert(0, None)
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1856,7 +1856,9 @@ class WorkerTable(DashboardComponent):
                 )
                 continue
             try:
-                if name == "memory_percent":
+                if len(self.scheduler.workers) == 0:
+                    total_data = None
+                elif name == "memory_percent":
                     total_data = sum(
                         ws.metrics["memory"] for ws in self.scheduler.workers.values()
                     ) / sum(ws.memory_limit for ws in self.scheduler.workers.values())


### PR DESCRIPTION
Originally reported in https://github.com/dask/dask-jobqueue/issues/440.

To reproduce:
```py
import webbrowser
from distributed import LocalCluster

cluster = LocalCluster(n_workers=4)
webbrowser.open(cluster.dashboard_link.replace("status", "workers"))
```
![image](https://user-images.githubusercontent.com/1680079/84684085-738ef700-af38-11ea-8c4f-722c91c10516.png)

The total memory usage is `250MiB`, the total memory limit is `16GiB`, so the total memory percentage should be `250/16e3 ~= 1.6%` and not `6.4%` (the memory percentage gets summed across all the workers rather than averaged).

I believe `memory_percent` is the only column affected by this.

Not sure how to add a test for this and I was not able to find some a good inspiration in the existing tests, but suggestions more than welcome!