### PR TITLE
Show cpu_fraction on hover for dashboard workers circle plot

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1794,7 +1794,7 @@ class WorkerTable(DashboardComponent):
             tooltips="""
                 <div>
                   <span style="font-size: 10px; font-family: Monaco, monospace;">Worker (@name): </span>
-                  <span style="font-size: 10px; font-family: Monaco, monospace;">@cpu</span>
+                  <span style="font-size: 10px; font-family: Monaco, monospace;">@cpu_fraction</span>
                 </div>
                 """,
         )


### PR DESCRIPTION
A [few lines below](https://github.com/lesteve/distributed/blob/e696ec9ea356af9c48c44b5982dcb4a2c5e1bd2e/distributed/dashboard/components/scheduler.py#L1812) "cpu_fraction" is used to position the dot but "cpu" is shown rather than "cpu_fraction" on hover.

```py
cpu_plot.circle(
	source=self.source, x="cpu_fraction", y=0, size=10, fill_alpha=0.5
)
```