### PR TITLE
Use dask-spec in SSHCluster

### DIFF
--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -42,12 +42,7 @@ async def test_keywords():
         ["127.0.0.1"] * 3,
         connect_options=dict(known_hosts=None),
         asynchronous=True,
-        worker_options={
-            "nprocs": 2,  # nprocs checks custom arguments with cli_keywords
-            "nthreads": 2,
-            "memory_limit": "2 GiB",
-            "death_timeout": "5s",
-        },
+        worker_options={"nthreads": 2, "memory_limit": "2 GiB", "death_timeout": "5s",},
         scheduler_options={"idle_timeout": "10s", "port": 0},
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:


### PR DESCRIPTION
Fixes #3903

Previously we used to specify CLI commands like dask-worker.
Now we specify Python classes like Worker or Nanny.
This makes it more consistent to pass through keywords without having to
go from Python to CLI back to Python.

However, this will also probably force dask-cuda to push its logic
from a CLI command into a Python class.
This commit speculatively changes documentation here in order to suggest
a CUDAWorker class type.  

I *think* that using dask-spec is probably a clean way forward generally.
Most systems that have switched over to it tend to have fewer complaints.

cc @quasiben @pentschev @jacobtomlinson 