### PR TITLE
Fix exception handling in `_wait_until_connected`

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -693,7 +693,7 @@ class WorkerProcess:
                     "Failed while trying to start worker process: %s", msg["exception"]
                 )
                 await self.process.join()
-                raise msg
+                raise msg["exception"]
             else:
                 return msg
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -557,3 +557,20 @@ async def test_nanny_closed_by_keyboard_interrupt(cleanup, protocol):
             await n.process.stopped.wait()
             # Check that the scheduler has been notified about the closed worker
             assert len(s.workers) == 0
+
+
+class StartException(Exception):
+    pass
+
+
+class BrokenWorker(worker.Worker):
+    async def start(self):
+        raise StartException("broken")
+
+
+@pytest.mark.asyncio
+async def test_worker_start_exception(cleanup):
+    # make sure this raises the right Exception:
+    with pytest.raises(StartException):
+        async with Nanny("tcp://localhost:1", worker_class=BrokenWorker) as n:
+            await n.start()


### PR DESCRIPTION
In the nanny, if there is an exception in the `init_result_q`, the dict was raised, instead of only the exception, leading to a `TypeError: exceptions must derive from BaseException`