### PR TITLE
Fix race condition in repeated calls to cluster.adapt()

### DIFF
--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -75,11 +75,13 @@ class AdaptiveCore:
         self.maximum = maximum
         self.wait_count = wait_count
         self.interval = parse_timedelta(interval, "seconds") if interval else interval
-        self.periodic_callback = None
+        self.periodic_callback = PeriodicCallback(self.adapt, self.interval * 1000)
 
         def f():
-            self.periodic_callback = PeriodicCallback(self.adapt, self.interval * 1000)
-            self.periodic_callback.start()
+            try:
+                self.periodic_callback.start()
+            except AttributeError:
+                pass
 
         if self.interval:
             try:

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -75,7 +75,7 @@ class AdaptiveCore:
         self.maximum = maximum
         self.wait_count = wait_count
         self.interval = parse_timedelta(interval, "seconds") if interval else interval
-        self.periodic_callback = PeriodicCallback(self.adapt, self.interval * 1000)
+        self.periodic_callback = None
 
         def f():
             try:
@@ -84,6 +84,7 @@ class AdaptiveCore:
                 pass
 
         if self.interval:
+            self.periodic_callback = PeriodicCallback(self.adapt, self.interval * 1000)
             try:
                 self.loop.add_callback(f)
             except AttributeError:

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -430,3 +430,22 @@ def test_adaptive_config():
         assert adapt.maximum == math.inf
         assert adapt.interval == 5
         assert adapt.wait_count == 8
+
+
+@pytest.mark.asyncio
+async def test_update_adaptive(cleanup):
+    async with LocalCluster(
+        0,
+        threads_per_worker=2,
+        memory_limit="3 GB",
+        scheduler_port=0,
+        silence_logs=False,
+        processes=False,
+        dashboard_address=None,
+        asynchronous=True,
+    ) as cluster:
+        first = cluster.adapt(maxmimum=1)
+        second = cluster.adapt(maxmimum=2)
+        await asyncio.sleep(0.2)
+        assert first.periodic_callback is None
+        assert second.periodic_callback.is_running()


### PR DESCRIPTION
Closes #3863.

There was a race condition where an `Adaptive` periodic callback was being created and started in a deferred function. This meant that if `adapt` was called again in quick succession the `stop` method which removed the periodic callback would be called before the `start` method, resulting in multiple periodic callbacks being scheduled.

The reference to the old `Adaptive` object was being replaced so this bug was intermittent depending on how fast the old object was garbage collected.

This PR instantiates the `PeriodicCallback` sequentially and only defers the `start` call. We also catch when `start` raises an `AttributeError` due to the callback already being stopped and nullified.