### PR TITLE
Fix `ensure_bytes` import location

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -9,14 +9,13 @@ from tlz import valmap, get_in
 import msgpack
 
 from . import pickle
-from ..utils import has_keyword, nbytes, typename
+from ..utils import has_keyword, nbytes, typename, ensure_bytes
 from .compression import maybe_compress, decompress
 from .utils import (
     unpack_frames,
     pack_frames_prelude,
     frame_split_size,
     merge_frames,
-    ensure_bytes,
     msgpack_opts,
 )
 


### PR DESCRIPTION
The `ensure_bytes` function is [defined in `distributed.utils`]( https://github.com/dask/distributed/blob/6144eb1a2f93274148cf84299f0eb0a2d93fc509/distributed/utils.py#L905 ). However here we are relying on the fact that it is [imported into other modules]( https://github.com/dask/distributed/blob/6144eb1a2f93274148cf84299f0eb0a2d93fc509/distributed/protocol/utils.py#L4 ). Fix this to import `ensure_bytes` from the correct place.