### PR TITLE
Make `Worker.delete_data` sync

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1634,22 +1634,3 @@ async def test_heartbeat_comm_closed(cleanup, monkeypatch, reconnect):
                 else:
                     assert w.status == "closed"
     assert "Heartbeat to scheduler failed" in logger.getvalue()
-
-
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-async def test_delete_data(c, s, w):
-    df = dask.datasets.timeseries(dtypes={"x": int, "y": float}, freq="1s").reset_index(
-        drop=True
-    )
-
-    df2 = df.persist()
-    await df2
-
-    del df
-    assert len(w.data) > 0
-
-    del df2
-    start = time()
-    while w.data:
-        await asyncio.sleep(0.01)
-        assert time() < start + 2

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1638,9 +1638,8 @@ async def test_heartbeat_comm_closed(cleanup, monkeypatch, reconnect):
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 async def test_delete_data(client, s, w):
-    df = (
-        dask.datasets.timeseries(dtypes={"x": int, "y": float}, freq="1s")
-        .reset_index(drop=True)
+    df = dask.datasets.timeseries(dtypes={"x": int, "y": float}, freq="1s").reset_index(
+        drop=True
     )
 
     await client.compute(df.map_partitions(lambda df: df.__sizeof__()))

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1352,12 +1352,6 @@ class Worker(ServerNode):
                     self.release_dep(key)
 
             logger.debug("Deleted %d keys", len(keys))
-            if report:
-                logger.debug("Reporting loss of keys to scheduler")
-                # TODO: this route seems to not exist?
-                self.scheduler.remove_keys(
-                    address=self.contact_address, keys=list(keys)
-                )
         return "OK"
 
     async def set_resources(self, **resources):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1341,7 +1341,7 @@ class Worker(ServerNode):
         info = {"nbytes": {k: sizeof(v) for k, v in data.items()}, "status": "OK"}
         return info
 
-    async def delete_data(self, comm=None, keys=None, report=True):
+    def delete_data(self, comm=None, keys=None, report=True):
         if keys:
             for key in list(keys):
                 self.log.append((key, "delete"))
@@ -1355,7 +1355,7 @@ class Worker(ServerNode):
             if report:
                 logger.debug("Reporting loss of keys to scheduler")
                 # TODO: this route seems to not exist?
-                await self.scheduler.remove_keys(
+                self.scheduler.remove_keys(
                     address=self.contact_address, keys=list(keys)
                 )
         return "OK"


### PR DESCRIPTION
This should fix issues where `Worker.delete_data` isn't awaited.

Fixes #3920 