### PR TITLE
Fix/task per key updates

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -591,31 +591,32 @@ class ComputePerKey(DashboardComponent):
             )
 
             # keep only time which are 2% of max or greater
-            max_time = compute_times[0][1] * 0.02
-            compute_times = [(n, t) for n, t in compute_times if t > max_time]
-            compute_colors = list()
-            compute_names = list()
-            compute_time = list()
-            total_time = 0
-            for name, t in compute_times:
-                compute_names.append(name)
-                compute_colors.append(ts_color_of(name))
-                compute_time.append(t)
-                total_time += t
+            if compute_times:
+                max_time = compute_times[0][1] * 0.02
+                compute_times = [(n, t) for n, t in compute_times if t > max_time]
+                compute_colors = list()
+                compute_names = list()
+                compute_time = list()
+                total_time = 0
+                for name, t in compute_times:
+                    compute_names.append(name)
+                    compute_colors.append(ts_color_of(name))
+                    compute_time.append(t)
+                    total_time += t
 
-            angles = [t / total_time * 2 * math.pi for t in compute_time]
+                angles = [t / total_time * 2 * math.pi for t in compute_time]
 
-            self.fig.x_range.factors = compute_names
+                self.fig.x_range.factors = compute_names
 
-            compute_result = dict(
-                angles=angles,
-                times=compute_time,
-                color=compute_colors,
-                names=compute_names,
-                formatted_time=[format_time(t) for t in compute_time],
-            )
+                compute_result = dict(
+                    angles=angles,
+                    times=compute_time,
+                    color=compute_colors,
+                    names=compute_names,
+                    formatted_time=[format_time(t) for t in compute_time],
+                )
 
-            update(self.compute_source, compute_result)
+                update(self.compute_source, compute_result)
 
 
 class AggregateAction(DashboardComponent):

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -456,6 +456,7 @@ class ComputePerKey(DashboardComponent):
 
             compute_data = {
                 "times": [0.2, 0.1],
+                "formatted_time": ["0.2 ms", "2.8 us"],
                 "color": [ts_color_lookup["transfer"], ts_color_lookup["compute"]],
                 "names": ["sum", "sum_partial"],
             }
@@ -498,7 +499,7 @@ class ComputePerKey(DashboardComponent):
             hover.tooltips = """
             <div>
                 <p><b>Name:</b> @names</p>
-                <p><b>Time:</b> @times s</p>
+                <p><b>Time:</b> @formatted_time</p>
             </div>
             """
             hover.point_policy = "follow_mouse"
@@ -534,7 +535,10 @@ class ComputePerKey(DashboardComponent):
             self.fig.title.text = "Compute Time Per Task"
 
             compute_result = dict(
-                times=compute_time, color=compute_colors, names=compute_names
+                times=compute_time,
+                color=compute_colors,
+                names=compute_names,
+                formatted_time=[format_time(t) for t in compute_time],
             )
 
             update(self.compute_source, compute_result)
@@ -658,6 +662,7 @@ class AggregateAction(DashboardComponent):
 
             action_data = {
                 "times": [0.2, 0.1],
+                "formatted_time": ["0.2 ms", "2.8 us"],
                 "color": [ts_color_lookup["transfer"], ts_color_lookup["compute"]],
                 "names": ["transfer", "compute"],
             }
@@ -701,7 +706,7 @@ class AggregateAction(DashboardComponent):
             hover.tooltips = """
             <div>
                 <p><b>Name:</b> @names</p>
-                <p><b>Time:</b> @times s</p>
+                <p><b>Time:</b> @formatted_time</p>
             </div>
             """
             hover.point_policy = "follow_mouse"
@@ -735,7 +740,12 @@ class AggregateAction(DashboardComponent):
             self.fig.x_range.factors = agg_names
             self.fig.title.text = "Aggregate Time Per Action"
 
-            action_result = dict(times=agg_time, color=agg_colors, names=agg_names)
+            action_result = dict(
+                times=agg_time,
+                color=agg_colors,
+                names=agg_names,
+                formatted_time=[format_time(t) for t in agg_time],
+            )
 
             update(self.action_source, action_result)
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -31,7 +31,7 @@ from bokeh.models.widgets import DataTable, TableColumn
 from bokeh.plotting import figure
 from bokeh.palettes import Viridis11
 from bokeh.themes import Theme
-from bokeh.transform import factor_cmap, linear_cmap
+from bokeh.transform import factor_cmap, linear_cmap, cumsum
 from bokeh.io import curdoc
 import dask
 from dask import config
@@ -535,6 +535,108 @@ class ComputePerKey(DashboardComponent):
 
             compute_result = dict(
                 times=compute_time, color=compute_colors, names=compute_names
+            )
+
+            update(self.compute_source, compute_result)
+
+
+class ComputePerKeyPie(DashboardComponent):
+    """ Pie!!!!! chart showing time spend in action by key prefix"""
+
+    def __init__(self, scheduler, **kwargs):
+        with log_errors():
+            self.last = 0
+            self.scheduler = scheduler
+
+            es = [p for p in self.scheduler.plugins if isinstance(p, TaskStreamPlugin)]
+            if not es:
+                self.plugin = TaskStreamPlugin(self.scheduler)
+            else:
+                self.plugin = es[0]
+
+            compute_data = {
+                "times": [0.2, 0.1],
+                "formatted_time": ["0.2 ms", "2.8 us"],
+                "angles": [1.4, 0.8],
+                "color": [ts_color_lookup["transfer"], ts_color_lookup["compute"]],
+                "names": ["sum", "sum_partial"],
+            }
+
+            self.compute_source = ColumnDataSource(data=compute_data)
+
+            fig = figure(
+                title="Compute Time Per Task",
+                tools="",
+                id="bk-Compute-by-key-pie",
+                name="compute_time_per_key-pie",
+                x_range=(-0.5, 1.0),
+                **kwargs,
+            )
+
+            wedge = fig.wedge(
+                x=0,
+                y=1,
+                radius=0.4,
+                start_angle=cumsum("angles", include_zero=True),
+                end_angle=cumsum("angles"),
+                line_color="white",
+                fill_color="color",
+                legend_field="names",
+                source=self.compute_source,
+            )
+
+            fig.axis.axis_label = None
+            fig.axis.visible = False
+            fig.grid.grid_line_color = None
+
+            hover = HoverTool()
+            hover.tooltips = """
+            <div>
+                <p><b>Name:</b> @names</p>
+                <p><b>Time:</b> @formatted_time</p>
+            </div>
+            """
+            hover.point_policy = "follow_mouse"
+            fig.add_tools(hover)
+
+            self.fig = fig
+
+    @without_property_validation
+    def update(self):
+        with log_errors():
+            compute_times = defaultdict(float)
+
+            for key, ts in self.scheduler.task_prefixes.items():
+                name = key_split(key)
+                for action, t in ts.all_durations.items():
+                    if action == "compute":
+                        compute_times[name] += t
+
+            # order by largest time first
+            compute_times = sorted(
+                compute_times.items(), key=lambda x: x[1], reverse=True
+            )
+
+            compute_colors = list()
+            compute_names = list()
+            compute_time = list()
+            total_time = 0
+            for name, t in compute_times:
+                compute_names.append(name)
+                compute_colors.append(ts_color_of(name))
+                compute_time.append(t)
+                total_time += t
+
+            angles = [t / total_time * 2 * math.pi for t in compute_time]
+
+            self.fig.title.text = "Compute Time Per Task"
+
+            compute_result = dict(
+                times=compute_time,
+                color=compute_colors,
+                names=compute_names,
+                angles=angles,
+                formatted_time=[format_time(t) for t in compute_time],
             )
 
             update(self.compute_source, compute_result)
@@ -2128,6 +2230,15 @@ def individual_memory_by_key_doc(scheduler, extra, doc):
 def individual_compute_time_per_key_doc(scheduler, extra, doc):
     with log_errors():
         component = ComputePerKey(scheduler, sizing_mode="stretch_both")
+        component.update()
+        add_periodic_callback(doc, component, 500)
+        doc.add_root(component.fig)
+        doc.theme = BOKEH_THEME
+
+
+def individual_compute_time_per_key_pie_doc(scheduler, extra, doc):
+    with log_errors():
+        component = ComputePerKeyPie(scheduler, sizing_mode="stretch_both")
         component.update()
         add_periodic_callback(doc, component, 500)
         doc.add_root(component.fig)

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -440,7 +440,7 @@ class BandwidthWorkers(DashboardComponent):
             update(self.source, result)
 
 
-class ComputerPerKey(DashboardComponent):
+class ComputePerKey(DashboardComponent):
     """ Bar chart showing time spend in action by key prefix"""
 
     def __init__(self, scheduler, **kwargs):
@@ -477,14 +477,13 @@ class ComputerPerKey(DashboardComponent):
                 top="times",
                 width=0.7,
                 color="color",
-                legend_field="names",
             )
 
             fig.y_range.start = 0
             fig.min_border_right = 20
             fig.min_border_bottom = 60
             fig.yaxis.axis_label = "Time (s)"
-            fig.yaxis[0].formatter = NumeralTickFormatter(format="0.0s")
+            fig.yaxis[0].formatter = NumeralTickFormatter(format="0")
             fig.yaxis.ticker = AdaptiveTicker(**TICKS_1024)
             fig.xaxis.major_label_orientation = -math.pi / 12
             rect.nonselection_glyph = None
@@ -578,13 +577,12 @@ class AggregateAction(DashboardComponent):
                 top="times",
                 width=0.7,
                 color="color",
-                legend_field="names",
             )
 
             fig.y_range.start = 0
             fig.min_border_right = 20
             fig.min_border_bottom = 60
-            fig.yaxis[0].formatter = NumeralTickFormatter(format="0.0s")
+            fig.yaxis[0].formatter = NumeralTickFormatter(format="0")
             fig.yaxis.axis_label = "Time (s)"
             fig.yaxis.ticker = AdaptiveTicker(**TICKS_1024)
             fig.xaxis.major_label_orientation = -math.pi / 12
@@ -2129,7 +2127,7 @@ def individual_memory_by_key_doc(scheduler, extra, doc):
 
 def individual_compute_time_per_key_doc(scheduler, extra, doc):
     with log_errors():
-        component = ComputerPerKey(scheduler, sizing_mode="stretch_both")
+        component = ComputePerKey(scheduler, sizing_mode="stretch_both")
         component.update()
         add_periodic_callback(doc, component, 500)
         doc.add_root(component.fig)

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -459,6 +459,7 @@ class ComputePerKey(DashboardComponent):
             compute_data = {
                 "times": [0.2, 0.1],
                 "formatted_time": ["0.2 ms", "2.8 us"],
+                "angles": [3.14, 0.785],
                 "color": [ts_color_lookup["transfer"], ts_color_lookup["compute"]],
                 "names": ["sum", "sum_partial"],
             }
@@ -518,8 +519,6 @@ class ComputePerKey(DashboardComponent):
                 "names": ["sum", "sum_partial"],
             }
 
-            self.compute_wedge_data = ColumnDataSource(data=compute_wedge_data)
-
             fig2 = figure(
                 title="Compute Time Per Task",
                 tools="",
@@ -538,7 +537,7 @@ class ComputePerKey(DashboardComponent):
                 line_color="white",
                 fill_color="color",
                 legend_field="names",
-                source=self.compute_wedge_data,
+                source=self.compute_source,
             )
 
             fig2.axis.axis_label = None
@@ -575,6 +574,9 @@ class ComputePerKey(DashboardComponent):
                 compute_times.items(), key=lambda x: x[1], reverse=True
             )
 
+            # keep only time which are 2% of max or greater
+            max_time = compute_times[0][1] * 0.02
+            compute_times = [(n, t) for n, t in compute_times if t > max_time]
             compute_colors = list()
             compute_names = list()
             compute_time = list()
@@ -587,25 +589,10 @@ class ComputePerKey(DashboardComponent):
 
             angles = [t / total_time * 2 * math.pi for t in compute_time]
 
-            compute_wedge_data = dict(
-                times=compute_time,
-                color=compute_colors,
-                names=compute_names,
-                angles=angles,
-                formatted_time=[format_time(t) for t in compute_time],
-            )
-
-            update(self.compute_wedge_data, compute_wedge_data)
-
-            # keep only time which are 2% of max or greater
-            max_time = compute_time[0] * 0.02
-            compute_time = [t for t in compute_time if t >= max_time]
-            compute_names = compute_names[: len(compute_time)]
-            compute_colors = compute_colors[: len(compute_time)]
-
             self.fig.x_range.factors = compute_names
 
             compute_result = dict(
+                angles=angles,
                 times=compute_time,
                 color=compute_colors,
                 names=compute_names,

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -28,6 +28,7 @@ from bokeh.models import (
     CDSView,
     Tabs,
     Panel,
+    Title,
 )
 from bokeh.models.widgets import DataTable, TableColumn
 from bokeh.plotting import figure
@@ -508,6 +509,14 @@ class ComputePerKey(DashboardComponent):
             hover.point_policy = "follow_mouse"
             fig.add_tools(hover)
 
+            fig.add_layout(
+                Title(
+                    text="Note: tasks less than 2% of max are not displayed",
+                    text_font_style="italic",
+                ),
+                "below",
+            )
+
             self.fig = fig
             tab1 = Panel(child=fig, title="Bar Chart")
 
@@ -543,6 +552,13 @@ class ComputePerKey(DashboardComponent):
             fig2.axis.axis_label = None
             fig2.axis.visible = False
             fig2.grid.grid_line_color = None
+            fig2.add_layout(
+                Title(
+                    text="Note: tasks less than 2% of max are not displayed",
+                    text_font_style="italic",
+                ),
+                "below",
+            )
 
             hover = HoverTool()
             hover.tooltips = """

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -33,7 +33,6 @@ from .components.scheduler import (
     individual_bandwidth_workers_doc,
     individual_memory_by_key_doc,
     individual_compute_time_per_key_doc,
-    individual_compute_time_per_key_pie_doc,
     individual_aggregate_time_per_action_doc,
 )
 from .worker import counters_doc
@@ -87,7 +86,6 @@ applications = {
     "/individual-bandwidth-workers": individual_bandwidth_workers_doc,
     "/individual-memory-by-key": individual_memory_by_key_doc,
     "/individual-compute-time-per-key": individual_compute_time_per_key_doc,
-    "/individual-compute-time-per-key-pie": individual_compute_time_per_key_pie_doc,
     "/individual-aggregate-time-per-action": individual_aggregate_time_per_action_doc,
 }
 

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -33,6 +33,7 @@ from .components.scheduler import (
     individual_bandwidth_workers_doc,
     individual_memory_by_key_doc,
     individual_compute_time_per_key_doc,
+    individual_compute_time_per_key_pie_doc,
     individual_aggregate_time_per_action_doc,
 )
 from .worker import counters_doc
@@ -86,6 +87,7 @@ applications = {
     "/individual-bandwidth-workers": individual_bandwidth_workers_doc,
     "/individual-memory-by-key": individual_memory_by_key_doc,
     "/individual-compute-time-per-key": individual_compute_time_per_key_doc,
+    "/individual-compute-time-per-key-pie": individual_compute_time_per_key_pie_doc,
     "/individual-aggregate-time-per-action": individual_aggregate_time_per_action_doc,
 }
 

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -37,7 +37,6 @@ from distributed.dashboard.components.scheduler import (
     MemoryByKey,
     AggregateAction,
     ComputePerKey,
-    ComputePerKeyPie,
 )
 from distributed.dashboard import scheduler
 
@@ -760,19 +759,12 @@ async def test_compute_per_key(c, s, a, b):
     )
     assert response.code == 200
     assert ("sum-aggregate") in mbk.compute_source.data["names"]
-    assert ("inc") in mbk.compute_source.data["names"]
     assert ("add") in mbk.compute_source.data["names"]
 
-    mbkpie = ComputePerKeyPie(s)
-    mbkpie.update()
-    response = await http_client.fetch(
-        "http://localhost:%d/individual-compute-time-per-key-pie" % s.http_server.port
-    )
-    assert response.code == 200
-    assert ("sum-aggregate") in mbkpie.compute_source.data["names"]
-    assert ("inc") in mbkpie.compute_source.data["names"]
-    assert ("add") in mbkpie.compute_source.data["names"]
-    assert "angles" in mbkpie.compute_source.data.keys()
+    assert ("sum-aggregate") in mbk.compute_wedge_data.data["names"]
+    assert ("inc") in mbk.compute_wedge_data.data["names"]
+    assert ("add") in mbk.compute_wedge_data.data["names"]
+    assert "angles" in mbk.compute_wedge_data.data.keys()
 
 
 @gen_cluster(scheduler_kwargs={"http_prefix": "foo-bar", "dashboard": True})

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -37,6 +37,7 @@ from distributed.dashboard.components.scheduler import (
     MemoryByKey,
     AggregateAction,
     ComputePerKey,
+    ComputePerKeyPie,
 )
 from distributed.dashboard import scheduler
 
@@ -761,6 +762,17 @@ async def test_compute_per_key(c, s, a, b):
     assert ("sum-aggregate") in mbk.compute_source.data["names"]
     assert ("inc") in mbk.compute_source.data["names"]
     assert ("add") in mbk.compute_source.data["names"]
+
+    mbkpie = ComputePerKeyPie(s)
+    mbkpie.update()
+    response = await http_client.fetch(
+        "http://localhost:%d/individual-compute-time-per-key-pie" % s.http_server.port
+    )
+    assert response.code == 200
+    assert ("sum-aggregate") in mbkpie.compute_source.data["names"]
+    assert ("inc") in mbkpie.compute_source.data["names"]
+    assert ("add") in mbkpie.compute_source.data["names"]
+    assert "angles" in mbkpie.compute_source.data.keys()
 
 
 @gen_cluster(scheduler_kwargs={"http_prefix": "foo-bar", "dashboard": True})

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -760,11 +760,7 @@ async def test_compute_per_key(c, s, a, b):
     assert response.code == 200
     assert ("sum-aggregate") in mbk.compute_source.data["names"]
     assert ("add") in mbk.compute_source.data["names"]
-
-    assert ("sum-aggregate") in mbk.compute_wedge_data.data["names"]
-    assert ("inc") in mbk.compute_wedge_data.data["names"]
-    assert ("add") in mbk.compute_wedge_data.data["names"]
-    assert "angles" in mbk.compute_wedge_data.data.keys()
+    assert "angles" in mbk.compute_source.data.keys()
 
 
 @gen_cluster(scheduler_kwargs={"http_prefix": "foo-bar", "dashboard": True})

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -36,7 +36,7 @@ from distributed.dashboard.components.scheduler import (
     ProfileServer,
     MemoryByKey,
     AggregateAction,
-    ComputerPerKey,
+    ComputePerKey,
 )
 from distributed.dashboard import scheduler
 
@@ -741,8 +741,8 @@ async def test_aggregate_action(c, s, a, b):
 
 
 @gen_cluster(client=True, scheduler_kwargs={"dashboard": True})
-async def test_computer_per_key(c, s, a, b):
-    mbk = ComputerPerKey(s)
+async def test_compute_per_key(c, s, a, b):
+    mbk = ComputePerKey(s)
 
     da = pytest.importorskip("dask.array")
     x = (da.ones((20, 20), chunks=(10, 10)) + 1).persist(optimize_graph=False)


### PR DESCRIPTION
Attempt to resolve #3930

This PR _keeps_ the original compute-per-task bar chart (I am a bit partial to the bar chart but I can remove) but limits which tasks are displayed as @mrocklin suggested:

<img width="818" alt="Screen Shot 2020-06-29 at 12 29 02 PM" src="https://user-images.githubusercontent.com/1403768/86031960-99ba9980-ba04-11ea-91e6-13d4ec962ded.png">

While the removal of keys provides easier digestion of data I wonder if users would wonder where the other keys were.  If we keep the bar chart I'd like to address this some how -- maybe a note on the bottom of the page ?

I also added the pie chart which was pleasant to try out:
<img width="827" alt="Screen Shot 2020-06-29 at 12 16 54 PM" src="https://user-images.githubusercontent.com/1403768/86031945-94f5e580-ba04-11ea-9695-c53dc6a8ced4.png">

