### PR TITLE
Restore Scheduler.time_started for Dask Gateway

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1117,6 +1117,7 @@ class Scheduler(ServerNode):
         else:
             self.idle_timeout = None
         self.idle_since = time()
+        self.time_started = self.idle_since  # compatibility for dask-gateway
         self._lock = asyncio.Lock()
         self.bandwidth = parse_bytes(dask.config.get("distributed.scheduler.bandwidth"))
         self.bandwidth_workers = defaultdict(float)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2147,3 +2147,8 @@ async def test_unknown_task_duration_config(client, s, a, b):
     assert len(s.unknown_durations) == 1
     await wait(future)
     assert len(s.unknown_durations) == 0
+
+
+@gen_cluster()
+async def test_unknown_task_duration_config(s, a, b):
+    assert s.idle_since == s.time_started


### PR DESCRIPTION
Removed in https://github.com/dask/distributed/pull/3830. Dask Gateway was using it. I'll make a PR to it to use the new name in the meantime.