### PR TITLE
Close a created cluster quietly

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -53,6 +53,8 @@ class Cluster:
         self.scheduler_info = {"workers": {}}
         self.periodic_callbacks = {}
         self._asynchronous = asynchronous
+        self._watch_worker_status_comm = None
+        self._watch_worker_status_task = None
 
         self.status = "created"
 
@@ -70,12 +72,16 @@ class Cluster:
         if self.status == "closed":
             return
 
-        await self._watch_worker_status_comm.close()
-        await self._watch_worker_status_task
+        if self._watch_worker_status_comm:
+            await self._watch_worker_status_comm.close()
+        if self._watch_worker_status_task:
+            await self._watch_worker_status_task
 
         for pc in self.periodic_callbacks.values():
             pc.stop()
-        await self.scheduler_comm.close_rpc()
+
+        if self.scheduler_comm:
+            await self.scheduler_comm.close_rpc()
 
         self.status = "closed"
 

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,6 +1,7 @@
 import asyncio
 import re
 from time import sleep
+import warnings
 
 import dask
 from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
@@ -508,3 +509,14 @@ async def test_run_spec_cluster_worker_names(cleanup):
         await cluster
         assert list(cluster.worker_spec) == worker_names
         assert sorted(list(cluster.workers)) == worker_names
+
+
+@pytest.mark.asyncio
+async def test_bad_close(cleanup):
+    with warnings.catch_warnings(record=True) as record:
+        cluster = SpecCluster(
+            workers=worker_spec, scheduler=scheduler, asynchronous=True
+        )
+        await cluster.close()
+
+    assert not record


### PR DESCRIPTION
Without this the user gets some scary warnings.

This happens when a cluster fails to start for some reason