### PR TITLE
Make dashboard server listens on all IPs by default even when interface is set explicitly.

### DIFF
--- a/distributed/node.py
+++ b/distributed/node.py
@@ -121,7 +121,7 @@ class ServerNode(Server):
         self.http_server = HTTPServer(self.http_application, ssl_options=ssl_options)
         http_address = clean_dashboard_address(dashboard_address or default_port)
 
-        if not http_address["address"]:
+        if http_address["address"] is None:
             address = self._start_address
             if isinstance(address, (list, tuple)):
                 address = address[0]

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1205,8 +1205,8 @@ async def test_service_hosts():
     port = 0
     for url, expected in [
         ("tcp://0.0.0.0", ("::", "0.0.0.0")),
-        ("tcp://127.0.0.1", "127.0.0.1"),
-        ("tcp://127.0.0.1:38275", "127.0.0.1"),
+        ("tcp://127.0.0.1", "0.0.0.0"),
+        ("tcp://127.0.0.1:38275", "0.0.0.0"),
     ]:
         async with Scheduler(host=url) as s:
             sock = first(s.http_server._sockets.values())

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1205,8 +1205,8 @@ async def test_service_hosts():
     port = 0
     for url, expected in [
         ("tcp://0.0.0.0", ("::", "0.0.0.0")),
-        ("tcp://127.0.0.1", "0.0.0.0"),
-        ("tcp://127.0.0.1:38275", "0.0.0.0"),
+        ("tcp://127.0.0.1", ("::", "0.0.0.0")),
+        ("tcp://127.0.0.1:38275", ("::", "0.0.0.0")),
     ]:
         async with Scheduler(host=url) as s:
             sock = first(s.http_server._sockets.values())

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1042,7 +1042,7 @@ async def test_service_hosts_match_worker(s):
 
     async with Worker(s.address, host="tcp://127.0.0.1") as w:
         sock = first(w.http_server._sockets.values())
-        assert sock.getsockname()[0] == "0.0.0.0"
+        assert sock.getsockname()[0] in ("::", "0.0.0.0")
 
 
 @gen_cluster(nthreads=[])

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1042,7 +1042,7 @@ async def test_service_hosts_match_worker(s):
 
     async with Worker(s.address, host="tcp://127.0.0.1") as w:
         sock = first(w.http_server._sockets.values())
-        assert sock.getsockname()[0] == "127.0.0.1"
+        assert sock.getsockname()[0] == "0.0.0.0"
 
 
 @gen_cluster(nthreads=[])


### PR DESCRIPTION
This is causing a HTTP 500 in the dashboard in a dask-jobqueue context (when interface is explicitly specified).

Hacky way to reproduce the problem:
```sh
dask-scheduler --interface lo&
sleep 2
ss -nlput | grep 8787
kill %
```

distributed 2.19 (useful par of the output)
```
tcp    LISTEN     0      128    127.0.0.1:8787                  *:*                   users:(("dask-sched
```

So my reading of this is that the dashboard is only listening on the IP address corresponding to the `lo` interface (i.e. the one specified for the scheduler).

distributed 2.14 (useful part of the output)
```
tcp    LISTEN     0      128       *:8787                  *:*                   users:(("dask-scheduler",pid=19693,fd=9))
tcp    LISTEN     0      128      :::8787                 :::*                   users:(("dask-scheduler",pid=19693,fd=10))
```

Very likely introduced by #3658.

When `dashboard_address` was `":8787"` `http_address` was `""` so the HTTP server was not listening on all IP interfaces.

Not sure if this is the right fix and how to test this. Feed-back more than welcome!