### PR TITLE
Avoid too aggressive retry of connections.

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -219,7 +219,7 @@ async def connect(addr, timeout=None, deserialize=True, **connection_args):
     if timeout and timeout / 20 < backoff:
         backoff = timeout / 20
 
-    retry_timeout_backoff = 1
+    retry_timeout_backoff = random.randrange(140, 160) / 100
 
     # This starts a thread
     while True:

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -3,6 +3,7 @@ import asyncio
 from contextlib import suppress
 import inspect
 import logging
+import random
 import weakref
 
 import dask
@@ -218,6 +219,8 @@ async def connect(addr, timeout=None, deserialize=True, **connection_args):
     if timeout and timeout / 20 < backoff:
         backoff = timeout / 20
 
+    retry_timeout_backoff = 1
+
     # This starts a thread
     while True:
         try:
@@ -227,7 +230,7 @@ async def connect(addr, timeout=None, deserialize=True, **connection_args):
                 )
                 with suppress(TimeoutError):
                     comm = await asyncio.wait_for(
-                        future, timeout=min(deadline - time(), 1)
+                        future, timeout=min(deadline - time(), retry_timeout_backoff)
                     )
                     break
             if not comm:
@@ -239,7 +242,8 @@ async def connect(addr, timeout=None, deserialize=True, **connection_args):
             if time() < deadline:
                 logger.debug("Could not connect, waiting before retrying")
                 await asyncio.sleep(backoff)
-                backoff *= 1.5
+                backoff *= random.randrange(140, 160) / 100
+                retry_timeout_backoff *= random.randrange(140, 160) / 100
                 backoff = min(backoff, 1)  # wait at most one second
             else:
                 _raise(error)


### PR DESCRIPTION
Originally retrying was implemented to avoid timeout expiring for
addresses not yet existing (#3084). Though giving up after 1 second
maximum can be annoying for slow system and can trigger a thundering
herd-like problem.

Here progressively increase the inner timeout to give a chance to a slow
systems on th other side to respond especially when they are slow.

Here also jitter a bit when we are going to retry, and for how long
before we give up in the inner timeout to try-to again mitigate teh
thundering herd.

This is relatively difficult to test; so no tests are included.