### PR TITLE
Move scheduler_comm into Cluster.__init__

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -55,6 +55,7 @@ class Cluster:
         self._asynchronous = asynchronous
         self._watch_worker_status_comm = None
         self._watch_worker_status_task = None
+        self.scheduler_comm = None
 
         self.status = "created"
 

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -233,7 +233,6 @@ class SpecCluster(Cluster):
         self.workers = {}
         self._i = 0
         self.security = security or Security()
-        self.scheduler_comm = None
         self._futures = set()
 
         if silence_logs:


### PR DESCRIPTION
Following on from https://github.com/dask/distributed/pull/3935
This makes sure that not-yet-started clusters close quietly, even if
they are not SpecClusters