### PR TITLE
Serialize `memoryview`s with `shape` and `format`

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -578,7 +578,7 @@ def _deserialize_bytes(header, frames):
 
 @dask_serialize.register(memoryview)
 def _serialize_memoryview(obj):
-    header = {}  # no special metadata
+    header = {"format": obj.format, "shape": obj.shape}
     frames = [obj]
     return header, frames
 
@@ -589,6 +589,7 @@ def _deserialize_memoryview(header, frames):
         out = memoryview(frames[0]).cast("B")
     else:
         out = memoryview(b"".join(frames))
+    out = out.cast(header["format"], header["shape"])
     return out
 
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -564,7 +564,7 @@ def normalize_Serialized(o):
 
 
 # Teach serialize how to handle bytestrings
-@dask_serialize.register((bytes, bytearray, memoryview))
+@dask_serialize.register((bytes, bytearray))
 def _serialize_bytes(obj):
     header = {}  # no special metadata
     frames = [obj]
@@ -574,6 +574,13 @@ def _serialize_bytes(obj):
 @dask_deserialize.register((bytes, bytearray))
 def _deserialize_bytes(header, frames):
     return b"".join(frames)
+
+
+@dask_serialize.register(memoryview)
+def _serialize_memoryview(obj):
+    header = {}  # no special metadata
+    frames = [obj]
+    return header, frames
 
 
 @dask_deserialize.register(memoryview)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -586,10 +586,10 @@ def _serialize_memoryview(obj):
 @dask_deserialize.register(memoryview)
 def _deserialize_memoryview(header, frames):
     if len(frames) == 1:
-        out = frames[0]
+        out = memoryview(frames[0]).cast("B")
     else:
-        out = b"".join(frames)
-    return memoryview(out)
+        out = memoryview(b"".join(frames))
+    return out
 
 
 #########################

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -578,6 +578,8 @@ def _deserialize_bytes(header, frames):
 
 @dask_serialize.register(memoryview)
 def _serialize_memoryview(obj):
+    if obj.format == "O":
+        raise ValueError("Cannot serialize `memoryview` containing Python objects")
     header = {"format": obj.format, "shape": obj.shape}
     frames = [obj]
     return header, frames

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -577,7 +577,7 @@ def _deserialize_bytes(header, frames):
 
 
 @dask_deserialize.register(memoryview)
-def _serialize_memoryview(header, frames):
+def _deserialize_memoryview(header, frames):
     if len(frames) == 1:
         out = frames[0]
     else:

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -451,3 +451,9 @@ def test_deser_memoryview(data_in):
     assert frames[0] is data_in
     data_out = deserialize(header, frames)
     assert data_in == data_out
+
+
+def test_ser_memoryview_object():
+    data_in = memoryview(np.array(["hello"], dtype=object))
+    with pytest.raises(TypeError):
+        serialize(data_in, on_error="raise")

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -441,8 +441,10 @@ def test_serialize_lists(serializers):
     assert data_in == data_out
 
 
-def test_deser_memoryview():
-    data_in = memoryview(b"hello")
+@pytest.mark.parametrize(
+    "data_in", [memoryview(b"hello")],
+)
+def test_deser_memoryview(data_in):
     header, frames = serialize(data_in)
     assert header["type"] == "builtins.memoryview"
     assert frames[0] is data_in

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -420,6 +420,7 @@ def test_compression_numpy_list():
         (tuple([MyObj(None)]), True),
         ({("x", i): MyObj(5) for i in range(100)}, True),
         (memoryview(b"hello"), True),
+        (memoryview(np.random.random((3, 4))), True),
     ],
 )
 def test_check_dask_serializable(data, is_serializable):
@@ -442,7 +443,7 @@ def test_serialize_lists(serializers):
 
 
 @pytest.mark.parametrize(
-    "data_in", [memoryview(b"hello")],
+    "data_in", [memoryview(b"hello"), memoryview(np.random.random((3, 4)))],
 )
 def test_deser_memoryview(data_in):
     header, frames = serialize(data_in)


### PR DESCRIPTION
Extends `memoryview` serialization to handle `shape` and `format` metadata. Also makes sure to error if a `memoryview` of `object`s is encountered.