### PR TITLE
WIP: Use Dask serialization on `args` and `kwargs`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2355,7 +2355,10 @@ class Client:
 
     async def _run_on_scheduler(self, function, *args, wait=True, **kwargs):
         response = await self.scheduler.run_function(
-            function=dumps(function), args=dumps(args), kwargs=dumps(kwargs), wait=wait
+            function=dumps(function),
+            args=to_serialize(args),
+            kwargs=to_serialize(kwargs),
+            wait=wait,
         )
         if response["status"] == "error":
             typ, exc, tb = clean_exception(**response)
@@ -2402,9 +2405,9 @@ class Client:
             msg=dict(
                 op="run",
                 function=dumps(function),
-                args=dumps(args),
+                args=to_serialize(args),
                 wait=wait,
-                kwargs=dumps(kwargs),
+                kwargs=to_serialize(kwargs),
             ),
             workers=workers,
             nanny=nanny,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3535,10 +3535,6 @@ async def run(server, comm, function, args=(), kwargs=None, is_coro=None, wait=T
             "We now automatically detect coroutines/async functions"
         )
     assert wait or is_coro, "Combination not supported"
-    if args:
-        args = pickle.loads(args)
-    if kwargs:
-        kwargs = pickle.loads(kwargs)
     if has_arg(function, "dask_worker"):
         kwargs["dask_worker"] = server
     if has_arg(function, "dask_scheduler"):


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/3946

Instead of relying on pickling for function arguments and keyword arguments, wrap them with `to_serialize`. This should ensure Dask picks the most efficient way to serialize arguments and keyword arguments when writing/reading data with a `Comm`.