### PR TITLE
Synchronize on non-trivial CUDA frame transmission

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -187,9 +187,7 @@ class UCX(Comm):
                 )
                 sizes = tuple(nbytes(f) for f in frames)
                 send_frames = [
-                    each_frame
-                    for each_frame, each_size in zip(frames, sizes)
-                    if each_size
+                    each_frame for each_frame in frames if len(each_frame) > 0
                 ]
 
                 # Send meta data

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -186,9 +186,13 @@ class UCX(Comm):
                     hasattr(f, "__cuda_array_interface__") for f in frames
                 )
                 sizes = tuple(nbytes(f) for f in frames)
-                send_frames = [
-                    each_frame for each_frame in frames if len(each_frame) > 0
-                ]
+                cuda_send_frames, send_frames = zip(
+                    *(
+                        (is_cuda, each_frame)
+                        for is_cuda, each_frame in zip(cuda_frames, frames)
+                        if len(each_frame) > 0
+                    )
+                )
 
                 # Send meta data
 
@@ -207,7 +211,7 @@ class UCX(Comm):
                 #  syncing the default stream will wait for other non-blocking CUDA streams.
                 # Note this is only sufficient if the memory being sent is not currently in use on
                 # non-blocking CUDA streams.
-                if any(cuda_frames):
+                if any(cuda_send_frames):
                     synchronize_stream(0)
 
                 for each_frame in send_frames:
@@ -250,13 +254,17 @@ class UCX(Comm):
                     device_array(each_size) if is_cuda else host_array(each_size)
                     for is_cuda, each_size in zip(cuda_frames, sizes)
                 ]
-                recv_frames = [
-                    each_frame for each_frame in frames if len(each_frame) > 0
-                ]
+                cuda_recv_frames, recv_frames = zip(
+                    *(
+                        (is_cuda, each_frame)
+                        for is_cuda, each_frame in zip(cuda_frames, frames)
+                        if len(each_frame) > 0
+                    )
+                )
 
                 # It is necessary to first populate `frames` with CUDA arrays and synchronize
                 # the default stream before starting receiving to ensure buffers have been allocated
-                if any(cuda_frames):
+                if any(cuda_recv_frames):
                     synchronize_stream(0)
 
                 for each_frame in recv_frames:


### PR DESCRIPTION
Further restrict when CUDA synchronization occurs by checking when non-trivial (non-zero length) CUDA frames are being transmitted and only synchronize in that case. Should avoid synchronization when only meta objects or objects with primarily host frames are involved.

cc @pentschev @quasiben