### PR TITLE
UCX: explicit shutdown message

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -136,7 +136,7 @@ class UCX(Comm):
 
     The expected read cycle is
 
-    1. Read the frame describing number of frames or if the connection is closing
+    1. Read the frame describing if connection is closing and number of frames
     2. Read the frame describing whether each data frame is gpu-bound
     3. Read the frame describing whether each data frame is sized
     4. Read all the data frames.


### PR DESCRIPTION
This PR makes the shutdown procedure of UCX-Py connections more robust by sending an explicit shutdown message instead of relying on UCX-Py close.

This is motivated by the challenging of UCX-Py to close endpoints cleanly. It works most of the time but occasionally UCX will fail or hang. Using `UCP_ERR_HANDLING_MODE_PEER` can fix this issue but it is not always available and comes with a performance penalty: https://github.com/rapidsai/ucx-py/pull/538.