### PR TITLE
Unpin `numpydoc` now that 1.1 is released

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
-# We pin numpydoc to avoid doubly-escaped *args and **kwargs in rendered docs
-numpydoc==0.8.0
+numpydoc
 tornado
 toolz
 cloudpickle


### PR DESCRIPTION
Fix for errant backslashes was fixed upstream and released.
https://numpydoc.readthedocs.io/en/latest/release_notes.html#fixed-bugs
numpy/numpydoc#218