### PR TITLE
Simplify `pack_frames_prelude`

### DIFF
--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -89,7 +89,9 @@ def merge_frames(header, frames):
 
 
 def pack_frames_prelude(frames):
-    return struct.pack(f"Q{len(frames)}Q", len(frames), *map(nbytes, frames))
+    nframes = len(frames)
+    nbytes_frames = map(nbytes, frames)
+    return struct.pack(f"Q{nframes}Q", nframes, *nbytes_frames)
 
 
 def pack_frames(frames):

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -89,10 +89,7 @@ def merge_frames(header, frames):
 
 
 def pack_frames_prelude(frames):
-    lengths = [struct.pack("Q", len(frames))] + [
-        struct.pack("Q", nbytes(frame)) for frame in frames
-    ]
-    return b"".join(lengths)
+    return struct.pack(f"Q{len(frames)}Q", len(frames), *map(nbytes, frames))
 
 
 def pack_frames(frames):


### PR DESCRIPTION
Reduce to a single call of `struct.pack`.