### PR TITLE
Treat falsey local directory as None

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -867,8 +867,11 @@ def test_worker_dir(worker):
 
 @gen_cluster(nthreads=[])
 async def test_false_worker_dir(s):
-    async with Worker(s.address, loop=s.loop, local_directory=""):
-        pass
+    async with Worker(s.address, local_directory="") as w:
+        local_directory = w.local_directory
+
+    cwd = os.getcwd()
+    assert os.path.dirname(local_directory) == os.path.join(cwd, "dask-worker-space")
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -865,6 +865,12 @@ def test_worker_dir(worker):
         test_worker_dir()
 
 
+@gen_cluster(nthreads=[])
+async def test_false_worker_dir(s):
+    async with Worker(s.address, loop=s.loop, local_directory=""):
+        pass
+
+
 @gen_cluster(client=True)
 async def test_dataframe_attribute_error(c, s, a, b):
     class BadSize:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -482,7 +482,7 @@ class Worker(ServerNode):
             warnings.warn("The local_dir keyword has moved to local_directory")
             local_directory = local_dir
 
-        if local_directory is None:
+        if not local_directory:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
 
         if not os.path.exists(local_directory):


### PR DESCRIPTION
Closes https://github.com/pangeo-data/pangeo-cloud-federation/issues/655

Dask-Gateway uses local-directory="" to launch workers. I think the
intent is that it's interpreted as False, and should fall back to the
config / current directory.