### PR TITLE
Use `merge_frames` with host memory only

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -126,7 +126,8 @@ def loads(frames, deserialize=True, deserializers=None):
             if deserialize or key in bytestrings:
                 if "compression" in head:
                     fs = decompress(head, fs)
-                fs = merge_frames(head, fs)
+                if head["serializer"] in ("dask", "pickle"):
+                    fs = merge_frames(head, fs)
                 value = _deserialize(head, fs, deserializers=deserializers)
             else:
                 value = Serialized(head, fs)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -126,7 +126,7 @@ def loads(frames, deserialize=True, deserializers=None):
             if deserialize or key in bytestrings:
                 if "compression" in head:
                     fs = decompress(head, fs)
-                if head["serializer"] in ("dask", "pickle"):
+                if not any(hasattr(f, "__cuda_array_interface__") for f in fs):
                     fs = merge_frames(head, fs)
                 value = _deserialize(head, fs, deserializers=deserializers)
             else:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -501,7 +501,8 @@ def deserialize_bytes(b):
     else:
         header = {}
     frames = decompress(header, frames)
-    frames = merge_frames(header, frames)
+    if header["serializer"] in ("dask", "pickle"):
+        frames = merge_frames(header, frames)
     return deserialize(header, frames)
 
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -501,7 +501,7 @@ def deserialize_bytes(b):
     else:
         header = {}
     frames = decompress(header, frames)
-    if header["serializer"] in ("dask", "pickle"):
+    if not any(hasattr(f, "__cuda_array_interface__") for f in frames):
         frames = merge_frames(header, frames)
     return deserialize(header, frames)
 


### PR DESCRIPTION
Currently `merge_frames` is only really designed to work with memory on host. So limit calling `merge_frames` to cases where host memory is used (as opposed to cases with device memory).