### PR TITLE
Ignore existing local directory when booting worker

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -485,8 +485,7 @@ class Worker(ServerNode):
         if not local_directory:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
 
-        if not os.path.exists(local_directory):
-            os.makedirs(local_directory)
+        os.makedirs(local_directory, exist_ok=True)
         local_directory = os.path.join(local_directory, "dask-worker-space")
 
         with warn_on_duration(


### PR DESCRIPTION
This PR addresses #3969. 
It resolves an issue where concurrently booting workers could try to create a folder at the same time with one of the two failing because the folder already exists. It resolves that issue, by simply trying to create the local_directory `dask-worker-space` on each workers boot time. If the folder already exists, it simply proceeds without raising an error. This way folder creation is ensured while avoiding concurrency issues. I as well removed the `if` statement, as that is essentially what `os.makedirs` does internally, so it seemed redundant to me. I can add it back in though 😉 

I did not add a test to reproduce the error either. It is really hard to reproduce the state of two processes trying to create the same folder at the same time and I really just found the bug after launching a lot of scripts running dask. I could take a shot at it, but it would probably end up being a for loop with a really large number of loops and non-deterministic nonetheless 😉 