### PR TITLE
Streamline `pack_frames`/`unpack_frames` frames

### DIFF
--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -105,12 +105,9 @@ def pack_frames(frames):
     --------
     unpack_frames
     """
-    prelude = [pack_frames_prelude(frames)]
-
-    if not isinstance(frames, list):
-        frames = list(frames)
-
-    return b"".join(prelude + frames)
+    data = [pack_frames_prelude(frames)]
+    data.extend(frames)
+    return b"".join(data)
 
 
 def unpack_frames(b):

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -123,11 +123,11 @@ def unpack_frames(b):
     fmt = "Q"
     fmt_size = struct.calcsize(fmt)
     (n_frames,) = struct.unpack_from(fmt, b)
+    lengths = struct.unpack_from(f"{n_frames}{fmt}", b, fmt_size)
 
     frames = []
     start = fmt_size * (1 + n_frames)
-    for i in range(n_frames):
-        (length,) = struct.unpack(fmt, b[(i + 1) * fmt_size : (i + 2) * fmt_size])
+    for length in lengths:
         frame = b[start : start + length]
         frames.append(frame)
         start += length

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -122,7 +122,7 @@ def unpack_frames(b):
     """
     fmt = "Q"
     fmt_size = struct.calcsize(fmt)
-    (n_frames,) = struct.unpack(fmt, b[:fmt_size])
+    (n_frames,) = struct.unpack_from(fmt, b)
 
     frames = []
     start = fmt_size * (1 + n_frames)

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -124,7 +124,7 @@ def unpack_frames(b):
     (n_frames,) = struct.unpack(fmt, b[:8])
 
     frames = []
-    start = 8 + n_frames * 8
+    start = 8 * (1 + n_frames)
     for i in range(n_frames):
         (length,) = struct.unpack(fmt, b[(i + 1) * 8 : (i + 2) * 8])
         frame = b[start : start + length]

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -121,12 +121,13 @@ def unpack_frames(b):
     pack_frames
     """
     fmt = "Q"
-    (n_frames,) = struct.unpack(fmt, b[:8])
+    fmt_size = struct.calcsize(fmt)
+    (n_frames,) = struct.unpack(fmt, b[:fmt_size])
 
     frames = []
-    start = 8 * (1 + n_frames)
+    start = fmt_size * (1 + n_frames)
     for i in range(n_frames):
-        (length,) = struct.unpack(fmt, b[(i + 1) * 8 : (i + 2) * 8])
+        (length,) = struct.unpack(fmt, b[(i + 1) * fmt_size : (i + 2) * fmt_size])
         frame = b[start : start + length]
         frames.append(frame)
         start += length

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -128,8 +128,9 @@ def unpack_frames(b):
     frames = []
     start = fmt_size * (1 + n_frames)
     for length in lengths:
-        frame = b[start : start + length]
+        end = start + length
+        frame = b[start : end]
         frames.append(frame)
-        start += length
+        start = end
 
     return frames

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -129,7 +129,7 @@ def unpack_frames(b):
     start = fmt_size * (1 + n_frames)
     for length in lengths:
         end = start + length
-        frame = b[start : end]
+        frame = b[start:end]
         frames.append(frame)
         start = end
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -120,12 +120,13 @@ def unpack_frames(b):
     --------
     pack_frames
     """
-    (n_frames,) = struct.unpack("Q", b[:8])
+    fmt = "Q"
+    (n_frames,) = struct.unpack(fmt, b[:8])
 
     frames = []
     start = 8 + n_frames * 8
     for i in range(n_frames):
-        (length,) = struct.unpack("Q", b[(i + 1) * 8 : (i + 2) * 8])
+        (length,) = struct.unpack(fmt, b[(i + 1) * 8 : (i + 2) * 8])
         frame = b[start : start + length]
         frames.append(frame)
         start += length


### PR DESCRIPTION
Handle prelude extraction in `unpack_frames` before extracting individual frames. Also collects prelude and frames in a single `list` in `pack_frames`.

Should add this can make a difference in how long it takes to pack/unpack frames (particularly when there are a lot of frames). This can be seen below.

Before:

```python
In [1]: from distributed.protocol.utils import pack_frames, unpack_frames

In [2]: frames = 1_000 * [1_000 * b"abc"] + 2_000 * [1_000 * b"de"] + 500 * [1_000 * b"fghi"]

In [3]: %timeit unpack_frames(pack_frames(frames))
5.25 ms ± 109 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

After:

```python
In [1]: from distributed.protocol.utils import pack_frames, unpack_frames

In [2]: frames = 1_000 * [1_000 * b"abc"] + 2_000 * [1_000 * b"de"] + 500 * [1_000 * b"fghi"]                                                           

In [3]: %timeit unpack_frames(pack_frames(frames))
3.98 ms ± 84.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```