### PR TITLE
Drop msgpack pre-0.5.2 compat code

### DIFF
--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -1,5 +1,4 @@
 import struct
-import msgpack
 
 from ..utils import nbytes
 
@@ -10,13 +9,7 @@ msgpack_opts = {
     ("max_%s_len" % x): 2 ** 31 - 1 for x in ["str", "bin", "array", "map", "ext"]
 }
 msgpack_opts["strict_map_key"] = False
-
-try:
-    msgpack.loads(msgpack.dumps(""), raw=False, **msgpack_opts)
-    msgpack_opts["raw"] = False
-except TypeError:
-    # Backward compat with old msgpack (prior to 0.5.2)
-    msgpack_opts["encoding"] = "utf-8"
+msgpack_opts["raw"] = False
 
 
 def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:


### PR DESCRIPTION
As we require msgpack 0.6.0+ ( https://github.com/dask/distributed/pull/3494 ), there is no need for msgpack compat code for versions prior to 0.6.0. So drop this compat code.

cc @jrbourbeau