### PR TITLE
Fixes #3978, enabling ActorFuture to work with `as_completed()`

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -63,6 +63,7 @@ class Actor(WrappedKey):
                 self._worker = None
             try:
                 from .client import Future, default_client
+
                 self._client = default_client()
                 self._future = Future(key)
             except ValueError:

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -3,7 +3,6 @@ import functools
 import threading
 from queue import Queue
 
-from .client import Future, default_client
 from .protocol import to_serialize
 from .utils import sync
 from .utils_comm import WrappedKey
@@ -63,6 +62,7 @@ class Actor(WrappedKey):
             except ValueError:
                 self._worker = None
             try:
+                from .client import Future, default_client
                 self._client = default_client()
                 self._future = Future(key)
             except ValueError:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -40,6 +40,7 @@ except ImportError:
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 
+from.actor import ActorFuture
 from .batched import BatchedSend
 from .utils_comm import (
     WrappedKey,
@@ -4379,8 +4380,8 @@ class as_completed:
         The added futures will emit from the iterator once they finish"""
         with self.lock:
             for f in futures:
-                if not isinstance(f, Future):
-                    raise TypeError("Input must be a future, got %s" % f)
+                if not isinstance(f, Future) and not isinstance(f, ActorFuture):
+                    raise TypeError("Input must be a Future or ActorFuture, got %s" % f)
                 self.futures[f] += 1
                 self.loop.add_callback(self._track_future, f)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -40,7 +40,7 @@ except ImportError:
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 
-from.actor import ActorFuture
+from .actor import ActorFuture
 from .batched import BatchedSend
 from .utils_comm import (
     WrappedKey,

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -293,11 +293,11 @@ def test_as_completed_with_actor(client):
     counter = future.result()
 
     futures = []
-    for num in [0, 1, 2]:
-        futures.append(counter.add(num))
+    for _ in range(3):
+        futures.append(counter.increment())
 
     results = []
     for future in as_completed(futures):
         results.append(future.result())
 
-    assert sum(results) == 4  # i.e. future.result() returns 0, 1, 3
+    assert sum(results) == 6  # i.e. future.result() returns 1, 2, 3

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -288,10 +288,12 @@ def test_as_completed_with_actor(client):
 
     futures = []
     for _ in range(3):
+        sleep(0.1)
         futures.append(counter.increment())
 
     results = []
     for future in as_completed(futures):
+        sleep(0.1)
         results.append(future.result())
 
     assert sum(results) == 6  # i.e. future.result() returns 1, 2, 3

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -276,17 +276,11 @@ async def test_clear(c, s, a, b):
 
 def test_as_completed_with_actor(client):
     class Counter:
-        n = 0
-
         def __init__(self):
             self.n = 0
 
         def increment(self):
             self.n += 1
-            return self.n
-
-        def add(self, x):
-            self.n += x
             return self.n
 
     future = client.submit(Counter, actor=True)


### PR DESCRIPTION
* Add test.
* Move import in actor.py (to prevent circular import - wasn't sure if this is the best way to achieve this, all feedback welcome :)).