### PR TITLE
Use `memoryview` in `unpack_frames`

### DIFF
--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -120,6 +120,8 @@ def unpack_frames(b):
     --------
     pack_frames
     """
+    b = memoryview(b)
+
     fmt = "Q"
     fmt_size = struct.calcsize(fmt)
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -122,6 +122,7 @@ def unpack_frames(b):
     """
     fmt = "Q"
     fmt_size = struct.calcsize(fmt)
+
     (n_frames,) = struct.unpack_from(fmt, b)
     lengths = struct.unpack_from(f"{n_frames}{fmt}", b, fmt_size)
 


### PR DESCRIPTION
As part of `unpack_frames`, we slice out each frame we'd like to extract (see code snippet below).

https://github.com/dask/distributed/blob/8a0e4b6a8e4ac4c64ddb7b628af1f5b269b0f3aa/distributed/protocol/utils.py#L135

However this causes a copy, which increases memory usage and creates a notable bottleneck when unpacking frames. Closer inspection of `unpack_frames` shows this dominates the time of that function and takes up roughly half of the time in `deserialize_bytes`. Also as `deserialize_bytes` typically works with a `bytes` object, these frames end up being `bytes` objects, which we wind up needing to [copy later to produce mutable frames]( https://github.com/dask/distributed/blob/8a0e4b6a8e4ac4c64ddb7b628af1f5b269b0f3aa/distributed/protocol/utils.py#L88 ) ( see PR https://github.com/dask/distributed/pull/3967 and related context ). IOW performing a copy in `unpack_frames` is wasted effort.

To fix this issue, we coerce the input of `unpack_frames` to a `memoryview`. This means slicing later merely produces views onto the data, which is essentially free. This avoids the copy and alleviates this bottleneck. Also this just works in most Python calls (like `struct.unpack_from`) as they are `bytes`-like compatible so work on `memoryview`s. The details can be seen in the benchmark below using `deserialize_bytes` [part of the unspilling code path]( https://github.com/dask/distributed/blob/8a0e4b6a8e4ac4c64ddb7b628af1f5b269b0f3aa/distributed/worker.py#L557 ), which calls into `unpack_frames`. This speeds up the unspilling code path by ~50%.

<hr>

<br>

Before:

```python
In [1]: import numpy 
   ...: import pandas 
   ...: from distributed.protocol import serialize_bytelist, deserialize_bytes                                                 

In [2]: df = pandas.DataFrame({ 
   ...:     k: numpy.random.random(1_000_000) 
   ...:     for i, k in enumerate(map(chr, range(ord("A"), ord("K")))) 
   ...: })                                                                                                                     

In [3]: b = b"".join(serialize_bytelist(df))                                                                                   

In [4]: %timeit deserialize_bytes(b)                                                                                           
37.5 ms ± 243 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

After:

```python
In [1]: import numpy 
   ...: import pandas 
   ...: from distributed.protocol import serialize_bytelist, deserialize_bytes                                                 

In [2]: df = pandas.DataFrame({ 
   ...:     k: numpy.random.random(1_000_000) 
   ...:     for i, k in enumerate(map(chr, range(ord("A"), ord("K")))) 
   ...: })                                                                                                                     

In [3]: b = b"".join(serialize_bytelist(df))                                                                                   

In [4]: %timeit deserialize_bytes(b)                                                                                           
19.2 ms ± 188 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```