### PR TITLE
What to do when threads_per_worker is 0

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -161,8 +161,10 @@ class LocalCluster(SpecCluster):
             else:
                 n_workers = 1
                 threads_per_worker = CPU_COUNT
-        if n_workers is None and threads_per_worker is not None:
+        if n_workers is None and threads_per_worker:
             n_workers = max(1, CPU_COUNT // threads_per_worker)
+        if n_workers is None:
+            n_workers = 0
         if n_workers and threads_per_worker is None:
             # Overcommit threads per worker, rather than undercommit
             threads_per_worker = max(1, int(math.ceil(CPU_COUNT / n_workers)))

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -126,6 +126,13 @@ class LocalCluster(SpecCluster):
             )
             dashboard_address = diagnostics_port
 
+        if threads_per_worker == 0:
+            warnings.warn(
+                "Setting `threads_per_worker` to 0 is discouraged. "
+                "Please set to None or to a specific int to get best behavior."
+            )
+            threads_per_worker = None
+
         self.status = None
         self.processes = processes
 
@@ -161,10 +168,8 @@ class LocalCluster(SpecCluster):
             else:
                 n_workers = 1
                 threads_per_worker = CPU_COUNT
-        if n_workers is None and threads_per_worker:
+        if n_workers is None and threads_per_worker is not None:
             n_workers = max(1, CPU_COUNT // threads_per_worker)
-        if n_workers is None:
-            n_workers = 0
         if n_workers and threads_per_worker is None:
             # Overcommit threads per worker, rather than undercommit
             threads_per_worker = max(1, int(math.ceil(CPU_COUNT / n_workers)))

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -114,33 +114,6 @@ def test_procs():
         repr(c)
 
 
-def test_threads_per_worker_set_to_zero():
-    with LocalCluster(
-        None,
-        scheduler_port=0,
-        processes=False,
-        threads_per_worker=0,
-        dashboard_address=None,
-        silence_logs=False,
-    ) as c:
-        assert len(c.workers) == 0
-        repr(c)
-
-    with LocalCluster(
-        2,
-        scheduler_port=0,
-        processes=False,
-        threads_per_worker=0,
-        dashboard_address=None,
-        silence_logs=False,
-    ) as c:
-        assert len(c.workers) == 2
-        assert all(isinstance(w, Worker) for w in c.workers.values())
-        with Client(c.scheduler.address) as e:
-            assert all(w.nthreads == CPU_COUNT for w in c.workers.values())
-        repr(c)
-
-
 def test_move_unserializable_data():
     """
     Test that unserializable data is still fine to transfer over inproc
@@ -1022,6 +995,18 @@ async def test_repr(cleanup):
         n_workers=2, processes=False, memory_limit=None, asynchronous=True
     ) as cluster:
         assert "memory" not in repr(cluster)
+
+
+@pytest.mark.asyncio
+async def test_threads_per_worker_set_to_0(cleanup):
+    with pytest.warns(
+        Warning, match="Setting `threads_per_worker` to 0 is discouraged."
+    ):
+        async with LocalCluster(
+            n_workers=2, processes=False, threads_per_worker=0, asynchronous=True,
+        ) as cluster:
+            assert len(cluster.workers) == 2
+            assert all(w.nthreads < CPU_COUNT for w in cluster.workers.values())
 
 
 @pytest.mark.asyncio

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -114,6 +114,33 @@ def test_procs():
         repr(c)
 
 
+def test_threads_per_worker_set_to_zero():
+    with LocalCluster(
+        None,
+        scheduler_port=0,
+        processes=False,
+        threads_per_worker=0,
+        dashboard_address=None,
+        silence_logs=False,
+    ) as c:
+        assert len(c.workers) == 0
+        repr(c)
+
+    with LocalCluster(
+        2,
+        scheduler_port=0,
+        processes=False,
+        threads_per_worker=0,
+        dashboard_address=None,
+        silence_logs=False,
+    ) as c:
+        assert len(c.workers) == 2
+        assert all(isinstance(w, Worker) for w in c.workers.values())
+        with Client(c.scheduler.address) as e:
+            assert all(w.nthreads == CPU_COUNT for w in c.workers.values())
+        repr(c)
+
+
 def test_move_unserializable_data():
     """
     Test that unserializable data is still fine to transfer over inproc


### PR DESCRIPTION
*tl;dr Maybe `threads_per_worker` should throw an error if set to 0.*

While working on https://github.com/dask/distributed/pull/3984  I ran into some odd behaviors when `threads_per_worker` is set to 0 in `LocalCluster`. I am not sure what the intended behavior should be or if this PR makes things better. 

### Some examples:
On master the following results in a divide by 0 error. This PR sets n_workers to 0 which I think is a good solution:

```python
from distributed import LocalCluster, Client
cluster = LocalCluster(threads_per_worker=0)
client = Client(cluster)

client
# <Client: 'tcp://127.0.0.1:46121' processes=0 threads=0, memory=0 B> 
```

For the next case, I am not sure that the behavior should be. Here the `nthreads` is being passed int the `worker_kwargs` as 0. So we don't really have control over what happens after that. In this case it sets nthreads for each worker to `CPU_COUNT`

```python
from distributed import LocalCluster, Client

cluster = LocalCluster(n_workers=2, threads_per_worker=0)
client = Client(cluster)

client
# <Client: 'tcp://127.0.0.1:46509' processes=2 threads=24, memory=33.37 GB>
```