### PR TITLE
DOC: missing backtick in inline directive.

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -262,7 +262,7 @@ def SSHCluster(
         List of hostnames or addresses on which to launch our cluster.
         The first will be used for the scheduler and the rest for workers.
     connect_options: dict or list of dict, optional
-        Keywords to pass through to :func:asyncssh.connect`.
+        Keywords to pass through to :func:`asyncssh.connect`.
         This could include things such as ``port``, ``username``, ``password``
         or ``known_hosts``. See docs for :func:`asyncssh.connect` and
         :class:`asyncssh.SSHClientConnectionOptions` for full information.


### PR DESCRIPTION
This messes-up rst parsing.