### PR TITLE
Test Pandas `Series` is writeable

### DIFF
--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -63,7 +63,7 @@ dfs = [
 
 
 @pytest.mark.parametrize("df", dfs)
-def test_dumps_serialize_numpy(df):
+def test_dumps_serialize_pandas(df):
     header, frames = serialize(df)
     if "compression" in header:
         frames = decompress(header, frames)

--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -4,7 +4,14 @@ import pytest
 
 from dask.dataframe.utils import assert_eq
 
-from distributed.protocol import serialize, deserialize, decompress
+from distributed.protocol import (
+    serialize,
+    deserialize,
+    decompress,
+    dumps,
+    loads,
+    to_serialize,
+)
 
 
 dfs = [
@@ -70,3 +77,12 @@ def test_dumps_serialize_pandas(df):
     df2 = deserialize(header, frames)
 
     assert_eq(df, df2)
+
+
+def test_dumps_pandas_writable():
+    a1 = np.arange(1000)
+    a1.flags.writeable = False
+    s1 = pd.Series(a1)
+    (s2,) = loads(dumps([to_serialize(s1)]))
+    assert (s1 == s2).all()
+    s2[...] = 0


### PR DESCRIPTION
Follow-up to PR ( https://github.com/dask/distributed/pull/3967 ) and issue ( https://github.com/dask/distributed/issues/3943 )

Includes a test to ensure a Pandas `Series` is writeable after round-trip serialization.