### PR TITLE
Only call `frame_split_size` when there are frames

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -475,8 +475,8 @@ def serialize_bytelist(x, **kwargs):
     header, frames = serialize(x, **kwargs)
     if "lengths" not in header:
         header["lengths"] = tuple(map(nbytes, frames))
-    frames = sum(map(frame_split_size, frames), [])
     if frames:
+        frames = sum(map(frame_split_size, frames), [])
         compression, frames = zip(*map(maybe_compress, frames))
     else:
         compression = []


### PR DESCRIPTION
This just becomes a no-op if an empty list is given (returning an empty list). However there is no need to do this work if we don't need it. So simply restrict calling `frame_split_size` to the case where frames are present and compression will occur.