### PR TITLE
Delay deserialization of Data in workers until actual usage.

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -123,7 +123,12 @@ def loads(frames, deserialize=True, deserializers=None):
             else:
                 fs = []
 
-            if deserialize or key in bytestrings:
+            import inspect
+
+            stack = inspect.stack()
+            get_data = any([s.function == "get_data_from_worker" for s in stack])
+
+            if (deserialize or key in bytestrings) and not get_data:
                 if "compression" in head:
                     fs = decompress(head, fs)
                 if not any(hasattr(f, "__cuda_array_interface__") for f in fs):

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -12,6 +12,7 @@ from tlz import merge, concat, groupby, drop
 
 from .core import rpc
 from .utils import All, tokey
+from .protocol.serialize import Serialized
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +85,12 @@ async def gather_from_workers(who_has, rpc, close=True, serializers=None, who=No
                     )
                     missing_workers.add(worker)
                 else:
-                    response.update(r["data"])
+                    response.update(
+                        {
+                            k: (v.deserialize() if isinstance(v, Serialized) else v)
+                            for k, v in r["data"].items()
+                        }
+                    )
         finally:
             for r in rpcs.values():
                 await r.close_rpc()


### PR DESCRIPTION
In some case deserialization is not thread safe and it would be good to
only deserialize if no work is being done at the same time.

This is trying to achieve this in part by delaying until unpicking
until the data is actually needed to be sent to the Executor. In the
case of a single thread TPE that would mean non-thread safe code can be
unpickled. Maybe we even want to move unpicking into the Executor, but
then we need the executor to support this; and we might want to make
sure we don't unpickle many times.

This of course needs a gross hack by looking at frames, but at least I
hope this will get some conversation started.

This also screws up the computation of per-type bandwidth; unless we
delay the BW calculation per type.

There is also some issues as clients will also call indirectly `get_data_from_worker`, and for example `await client.submit(lambda x: x + 1, 10)` will return a `Serialized` object instead of expected result...