### PR TITLE
Fix failing `test_bandwidth`

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1635,7 +1635,7 @@ async def test_idle_timeout(c, s, a, b):
 @gen_cluster(client=True, config={"distributed.scheduler.bandwidth": "100 GB"})
 async def test_bandwidth(c, s, a, b):
     start = s.bandwidth
-    x = c.submit(operator.mul, b"0", 1000000, workers=a.address)
+    x = c.submit(operator.mul, b"0", 1000001, workers=a.address)
     y = c.submit(lambda x: x, x, workers=b.address)
     await y
     await b.heartbeat()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1639,7 +1639,7 @@ async def test_bandwidth(c, s, a, b):
     y = c.submit(lambda x: x, x, workers=b.address)
     await y
     await b.heartbeat()
-    assert s.bandwidth < start  # we've learned that we're slower
+    assert s.bandwidth <= start  # we've learned that we're slower
     assert b.latency
     assert typename(bytes) in s.bandwidth_types
     assert (b.address, a.address) in s.bandwidth_workers

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1639,7 +1639,7 @@ async def test_bandwidth(c, s, a, b):
     y = c.submit(lambda x: x, x, workers=b.address)
     await y
     await b.heartbeat()
-    assert s.bandwidth <= start  # we've learned that we're slower
+    assert s.bandwidth < start  # we've learned that we're slower
     assert b.latency
     assert typename(bytes) in s.bandwidth_types
     assert (b.address, a.address) in s.bandwidth_workers


### PR DESCRIPTION
It seems this test has been failing in a few places. Here's [one build]( https://travis-ci.org/github/dask/distributed/jobs/713023658#L3259 ) that failed. This tweaks the test to get it to pass again. Not sure if this is the right solution. So am open to other ideas.