### PR TITLE
Track mutable frames

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -7,7 +7,7 @@ import msgpack
 from .compression import compressions, maybe_compress, decompress
 from .serialize import serialize, deserialize, Serialize, Serialized, extract_serialize
 from .utils import frame_split_size, merge_frames, msgpack_opts
-from ..utils import nbytes
+from ..utils import is_writeable, nbytes
 
 _deserialize = deserialize
 
@@ -47,9 +47,7 @@ def dumps(msg, serializers=None, on_error="message", context=None):
 
         for key, (head, frames) in data.items():
             if "writeable" not in head:
-                head["writeable"] = tuple(
-                    not f.readonly for f in map(memoryview, frames)
-                )
+                head["writeable"] = tuple(map(is_writeable, frames))
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
 
@@ -76,9 +74,7 @@ def dumps(msg, serializers=None, on_error="message", context=None):
 
         for key, (head, frames) in pre.items():
             if "writeable" not in head:
-                head["writeable"] = tuple(
-                    not f.readonly for f in map(memoryview, frames)
-                )
+                head["writeable"] = tuple(map(is_writeable, frames))
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
             head["count"] = len(frames)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -46,7 +46,10 @@ def dumps(msg, serializers=None, on_error="message", context=None):
         out_frames = []
 
         for key, (head, frames) in data.items():
-            head["writeable"] = tuple(not f.readonly for f in map(memoryview, frames))
+            if "writeable" not in head:
+                head["writeable"] = tuple(
+                    not f.readonly for f in map(memoryview, frames)
+                )
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
 
@@ -72,7 +75,10 @@ def dumps(msg, serializers=None, on_error="message", context=None):
             out_frames.extend(_out_frames)
 
         for key, (head, frames) in pre.items():
-            head["writeable"] = tuple(not f.readonly for f in map(memoryview, frames))
+            if "writeable" not in head:
+                head["writeable"] = tuple(
+                    not f.readonly for f in map(memoryview, frames)
+                )
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
             head["count"] = len(frames)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -46,6 +46,7 @@ def dumps(msg, serializers=None, on_error="message", context=None):
         out_frames = []
 
         for key, (head, frames) in data.items():
+            head["writeable"] = tuple(not f.readonly for f in map(memoryview, frames))
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
 
@@ -71,6 +72,7 @@ def dumps(msg, serializers=None, on_error="message", context=None):
             out_frames.extend(_out_frames)
 
         for key, (head, frames) in pre.items():
+            head["writeable"] = tuple(not f.readonly for f in map(memoryview, frames))
             if "lengths" not in head:
                 head["lengths"] = tuple(map(nbytes, frames))
             head["count"] = len(frames)

--- a/distributed/protocol/cuda.py
+++ b/distributed/protocol/cuda.py
@@ -19,7 +19,6 @@ def cuda_dumps(x):
     header["type-serialized"] = pickle.dumps(type(x))
     header["serializer"] = "cuda"
     header["compression"] = (False,) * len(frames)  # no compression for gpu data
-    header["writeable"] = (False,) * len(frames)  # no need to enforce writeable frames
     return header, frames
 
 

--- a/distributed/protocol/cuda.py
+++ b/distributed/protocol/cuda.py
@@ -19,6 +19,7 @@ def cuda_dumps(x):
     header["type-serialized"] = pickle.dumps(type(x))
     header["serializer"] = "cuda"
     header["compression"] = (False,) * len(frames)  # no compression for gpu data
+    header["writeable"] = (False,) * len(frames)  # no need to enforce writeable frames
     return header, frames
 
 

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -23,7 +23,6 @@ def cuda_serialize_cupy_ndarray(x):
     header = x.__cuda_array_interface__.copy()
     header["strides"] = tuple(x.strides)
     header["lengths"] = [x.nbytes]
-    header["compression"] = (False,) * len(frames)
     frames = [
         cupy.ndarray(
             shape=(x.nbytes,), dtype=cupy.dtype("u1"), memptr=x.data, strides=(1,)

--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -23,6 +23,7 @@ def cuda_serialize_cupy_ndarray(x):
     header = x.__cuda_array_interface__.copy()
     header["strides"] = tuple(x.strides)
     header["lengths"] = [x.nbytes]
+    header["compression"] = (False,) * len(frames)
     frames = [
         cupy.ndarray(
             shape=(x.nbytes,), dtype=cupy.dtype("u1"), memptr=x.data, strides=(1,)
@@ -47,6 +48,7 @@ def cuda_deserialize_cupy_ndarray(header, frames):
 @dask_serialize.register(cupy.ndarray)
 def dask_serialize_cupy_ndarray(x):
     header, frames = cuda_serialize_cupy_ndarray(x)
+    header["writeable"] = (None,) * len(frames)
     frames = [memoryview(cupy.asnumpy(f)) for f in frames]
     return header, frames
 

--- a/distributed/protocol/numba.py
+++ b/distributed/protocol/numba.py
@@ -51,6 +51,7 @@ def cuda_deserialize_numba_ndarray(header, frames):
 @dask_serialize.register(numba.cuda.devicearray.DeviceNDArray)
 def dask_serialize_numba_ndarray(x):
     header, frames = cuda_serialize_numba_ndarray(x)
+    header["writeable"] = (None,) * len(frames)
     frames = [memoryview(f.copy_to_host()) for f in frames]
     return header, frames
 

--- a/distributed/protocol/rmm.py
+++ b/distributed/protocol/rmm.py
@@ -30,6 +30,7 @@ if hasattr(rmm, "DeviceBuffer"):
     @dask_serialize.register(rmm.DeviceBuffer)
     def dask_serialize_rmm_device_buffer(x):
         header, frames = cuda_serialize_rmm_device_buffer(x)
+        header["writeable"] = (None,) * len(frames)
         frames = [numba.cuda.as_cuda_array(f).copy_to_host().data for f in frames]
         return header, frames
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -9,7 +9,7 @@ from tlz import valmap, get_in
 import msgpack
 
 from . import pickle
-from ..utils import has_keyword, nbytes, typename, ensure_bytes
+from ..utils import has_keyword, nbytes, typename, ensure_bytes, is_writeable
 from .compression import maybe_compress, decompress
 from .utils import (
     unpack_frames,
@@ -474,7 +474,7 @@ def nested_deserialize(x):
 def serialize_bytelist(x, **kwargs):
     header, frames = serialize(x, **kwargs)
     if "writeable" not in header:
-        header["writeable"] = tuple(not f.readonly for f in map(memoryview, frames))
+        header["writeable"] = tuple(map(is_writeable, frames))
     if "lengths" not in header:
         header["lengths"] = tuple(map(nbytes, frames))
     if frames:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -503,8 +503,7 @@ def deserialize_bytes(b):
     else:
         header = {}
     frames = decompress(header, frames)
-    if not any(hasattr(f, "__cuda_array_interface__") for f in frames):
-        frames = merge_frames(header, frames)
+    frames = merge_frames(header, frames)
     return deserialize(header, frames)
 
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -473,7 +473,8 @@ def nested_deserialize(x):
 
 def serialize_bytelist(x, **kwargs):
     header, frames = serialize(x, **kwargs)
-    header["writeable"] = tuple(not f.readonly for f in map(memoryview, frames))
+    if "writeable" not in header:
+        header["writeable"] = tuple(not f.readonly for f in map(memoryview, frames))
     if "lengths" not in header:
         header["lengths"] = tuple(map(nbytes, frames))
     if frames:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -473,6 +473,7 @@ def nested_deserialize(x):
 
 def serialize_bytelist(x, **kwargs):
     header, frames = serialize(x, **kwargs)
+    header["writeable"] = tuple(not f.readonly for f in map(memoryview, frames))
     if "lengths" not in header:
         header["lengths"] = tuple(map(nbytes, frames))
     if frames:

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -17,7 +17,7 @@ from distributed.protocol.numpy import itemsize
 from distributed.protocol.pickle import HIGHEST_PROTOCOL
 from distributed.protocol.compression import maybe_compress
 from distributed.system import MEMORY_LIMIT
-from distributed.utils import tmpfile, nbytes
+from distributed.utils import ensure_bytes, tmpfile, nbytes
 from distributed.utils_test import gen_cluster
 
 
@@ -104,7 +104,10 @@ def test_dumps_serialize_numpy(x):
 def test_dumps_numpy_writable(writeable):
     a1 = np.arange(1000)
     a1.flags.writeable = writeable
-    (a2,) = loads(dumps([to_serialize(a1)]))
+    fs = dumps([to_serialize(a1)])
+    # Make all frames read-only
+    fs = list(map(ensure_bytes, fs))
+    (a2,) = loads(fs)
     assert (a1 == a2).all()
     assert a2.flags.writeable == a1.flags.writeable
 

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -100,12 +100,13 @@ def test_dumps_serialize_numpy(x):
         np.testing.assert_equal(x, y)
 
 
-def test_dumps_numpy_writable():
+@pytest.mark.parametrize("writeable", [True, False])
+def test_dumps_numpy_writable(writeable):
     a1 = np.arange(1000)
-    a1.flags.writeable = False
+    a1.flags.writeable = writeable
     (a2,) = loads(dumps([to_serialize(a1)]))
     assert (a1 == a2).all()
-    assert a2.flags.writeable
+    assert a2.flags.writeable == a1.flags.writeable
 
 
 @pytest.mark.parametrize(

--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -63,7 +63,7 @@ dfs = [
 
 
 @pytest.mark.parametrize("df", dfs)
-def test_dumps_serialize_numpy(df):
+def test_dumps_serialize_pandas(df):
     header, frames = serialize(df)
     if "compression" in header:
         frames = decompress(header, frames)

--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -12,6 +12,7 @@ from distributed.protocol import (
     loads,
     to_serialize,
 )
+from distributed.utils import ensure_bytes
 
 
 dfs = [
@@ -82,6 +83,9 @@ def test_dumps_serialize_pandas(df):
 def test_dumps_pandas_writable():
     a1 = np.arange(1000)
     s1 = pd.Series(a1)
-    (s2,) = loads(dumps([to_serialize(s1)]))
+    fs = dumps([to_serialize(s1)])
+    # Make all frames read-only
+    fs = list(map(ensure_bytes, fs))
+    (s2,) = loads(fs)
     assert (s1 == s2).all()
     s2[...] = 0

--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -4,7 +4,14 @@ import pytest
 
 from dask.dataframe.utils import assert_eq
 
-from distributed.protocol import serialize, deserialize, decompress
+from distributed.protocol import (
+    serialize,
+    deserialize,
+    decompress,
+    dumps,
+    loads,
+    to_serialize,
+)
 
 
 dfs = [
@@ -70,3 +77,11 @@ def test_dumps_serialize_pandas(df):
     df2 = deserialize(header, frames)
 
     assert_eq(df, df2)
+
+
+def test_dumps_pandas_writable():
+    a1 = np.arange(1000)
+    s1 = pd.Series(a1)
+    (s2,) = loads(dumps([to_serialize(s1)]))
+    assert (s1 == s2).all()
+    s2[...] = 0

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from distributed.protocol.utils import merge_frames, pack_frames, unpack_frames
-from distributed.utils import ensure_bytes
+from distributed.utils import ensure_bytes, is_writeable
 
 
 @pytest.mark.parametrize(
@@ -33,8 +33,8 @@ def test_merge_frames(lengths, writeable, frames):
         expected.append(data[:i])
         data = data[i:]
 
-    is_writeable = list(not memoryview(f).readonly for f in result)
-    assert (r == e for r, e in zip(is_writeable, header["writeable"]) if e is not None)
+    writeables = list(map(is_writeable, result))
+    assert (r == e for r, e in zip(writeables, header["writeable"]) if e is not None)
     assert list(map(ensure_bytes, result)) == expected
 
 

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -28,7 +28,7 @@ def test_merge_frames(lengths, writeable, frames):
         expected.append(data[:i])
         data = data[i:]
 
-    assert tuple(not memoryview(f).readonly for f in result) == header["writeable"]
+    assert list(not memoryview(f).readonly for f in result) == header["writeable"]
     assert list(map(ensure_bytes, result)) == expected
 
 

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -27,8 +27,7 @@ def test_merge_frames(lengths, frames):
         expected.append(data[:i])
         data = data[i:]
 
-    assert all(isinstance(f, memoryview) for f in result)
-    assert tuple(not f.readonly for f in result) == header["writeable"]
+    assert tuple(not memoryview(f).readonly for f in result) == header["writeable"]
     assert list(map(ensure_bytes, result)) == expected
 
 

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -15,7 +15,10 @@ from distributed.utils import ensure_bytes
     ],
 )
 def test_merge_frames(lengths, frames):
-    header = {"lengths": lengths}
+    header = {
+        "lengths": lengths,
+        "writeable": len(lengths) * (False,),
+    }
     result = merge_frames(header, frames)
 
     data = b"".join(frames)
@@ -25,7 +28,7 @@ def test_merge_frames(lengths, frames):
         data = data[i:]
 
     assert all(isinstance(f, memoryview) for f in result)
-    assert all(not f.readonly for f in result)
+    assert tuple(not f.readonly for f in result) == header["writeable"]
     assert list(map(ensure_bytes, result)) == expected
 
 

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -9,10 +9,14 @@ from distributed.utils import ensure_bytes
     [
         ([3], [False], [b"123"]),
         ([3], [True], [b"123"]),
+        ([3], [None], [b"123"]),
+        ([3], [False], [bytearray(b"123")]),
+        ([3], [True], [bytearray(b"123")]),
+        ([3], [None], [bytearray(b"123")]),
         ([3, 3], [False, False], [b"123", b"456"]),
-        ([2, 3, 2], [False, True, False], [b"12345", b"67"]),
+        ([2, 3, 2], [False, True, None], [b"12345", b"67"]),
         ([5, 2], [False, True], [b"123", b"45", b"67"]),
-        ([3, 4], [False, False], [b"12", b"34", b"567"]),
+        ([3, 4], [None, False], [b"12", b"34", b"567"]),
     ],
 )
 def test_merge_frames(lengths, writeable, frames):
@@ -28,7 +32,8 @@ def test_merge_frames(lengths, writeable, frames):
         expected.append(data[:i])
         data = data[i:]
 
-    assert list(not memoryview(f).readonly for f in result) == header["writeable"]
+    is_writeable = list(not memoryview(f).readonly for f in result)
+    assert (r == e for r, e in zip(is_writeable, header["writeable"]) if e is not None)
     assert list(map(ensure_bytes, result)) == expected
 
 

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -5,19 +5,20 @@ from distributed.utils import ensure_bytes
 
 
 @pytest.mark.parametrize(
-    "lengths,frames",
+    "lengths,writeable,frames",
     [
-        ([3], [b"123"]),
-        ([3, 3], [b"123", b"456"]),
-        ([2, 3, 2], [b"12345", b"67"]),
-        ([5, 2], [b"123", b"45", b"67"]),
-        ([3, 4], [b"12", b"34", b"567"]),
+        ([3], [False], [b"123"]),
+        ([3], [True], [b"123"]),
+        ([3, 3], [False, False], [b"123", b"456"]),
+        ([2, 3, 2], [False, True, False], [b"12345", b"67"]),
+        ([5, 2], [False, True], [b"123", b"45", b"67"]),
+        ([3, 4], [False, False], [b"12", b"34", b"567"]),
     ],
 )
-def test_merge_frames(lengths, frames):
+def test_merge_frames(lengths, writeable, frames):
     header = {
         "lengths": lengths,
-        "writeable": len(lengths) * (False,),
+        "writeable": writeable,
     }
     result = merge_frames(header, frames)
 

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -15,6 +15,7 @@ from distributed.utils import ensure_bytes
         ([3], [None], [bytearray(b"123")]),
         ([3, 3], [False, False], [b"123", b"456"]),
         ([2, 3, 2], [False, True, None], [b"12345", b"67"]),
+        ([2, 3, 2], [False, True, None], [bytearray(b"12345"), bytearray(b"67")]),
         ([5, 2], [False, True], [b"123", b"45", b"67"]),
         ([3, 4], [None, False], [b"12", b"34", b"567"]),
     ],

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -75,7 +75,7 @@ def merge_frames(header, frames):
             if len(L) == 1:  # no work necessary
                 out.append(L[0])
             else:
-                out.append(memoryview(bytearray().join(L)))
+                out.append(memoryview(bytes().join(L)))
         frames = out
 
     frames = [memoryview(bytearray(f)) if f.readonly else f for f in frames]

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -84,9 +84,7 @@ def merge_frames(header, frames):
         if len(L) == 1:  # no work necessary
             frame = L[0]
             if w == memoryview(frame).readonly:
-                frame = bytearray(frame)
-            else:
-                frame = bytes(frame)
+                frame = bytearray(frame) if w else bytes(frame)
             out.append(frame)
         elif w:
             out.append(bytearray().join(L))

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -80,8 +80,8 @@ def merge_frames(header, frames):
         frames = out
 
     frames = [
-        bytearray(f) if m and memoryview(f).readonly else f
-        for m, f in zip(header["writeable"], frames)
+        bytearray(f) if w and memoryview(f).readonly else f
+        for w, f in zip(header["writeable"], frames)
     ]
 
     return frames

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -52,6 +52,7 @@ def merge_frames(header, frames):
     """
     lengths = list(header["lengths"])
 
+    assert len(lengths) == len(header["writeable"])
     assert sum(lengths) == sum(map(nbytes, frames))
 
     if not all(len(f) == l for f, l in zip(frames, lengths)):

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -58,7 +58,7 @@ def merge_frames(header, frames):
 
     if all(len(f) == l for f, l in zip(frames, lengths)):
         return [
-            bytearray(f) if w and memoryview(f).readonly else f
+            (bytearray(f) if w else bytes(f)) if w == memoryview(f).readonly else f
             for w, f in zip(header["writeable"], frames)
         ]
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -82,7 +82,7 @@ def merge_frames(header, frames):
                 frames.append(frame[l:])
                 l = 0
         if len(L) == 1 and w != memoryview(L[0]).readonly:  # no work necessary
-            out.append(L[0])
+            out.extend(L)
         elif w:
             out.append(bytearray().join(L))
         else:

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -78,7 +78,10 @@ def merge_frames(header, frames):
                 out.append(memoryview(bytes().join(L)))
         frames = out
 
-    frames = [memoryview(bytearray(f)) if f.readonly else f for f in frames]
+    frames = [
+        memoryview(bytearray(f)) if m and f.readonly else f
+        for m, f in zip(header["writeable"], frames)
+    ]
 
     return frames
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -77,7 +77,12 @@ def merge_frames(header, frames):
                     frames.append(frame[l:])
                     l = 0
             if len(L) == 1:  # no work necessary
-                out.append(L[0])
+                frame = L[0]
+                if w == memoryview(frame).readonly:
+                    frame = bytearray(frame)
+                else:
+                    frame = bytes(frame)
+                out.append(frame)
             elif w:
                 out.append(bytearray().join(L))
             else:

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -87,9 +87,8 @@ def merge_frames(header, frames):
             out.append(bytearray().join(L))
         else:
             out.append(bytes().join(L))
-    frames = out
 
-    return frames
+    return out
 
 
 def pack_frames_prelude(frames):

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -51,17 +51,20 @@ def merge_frames(header, frames):
     [b'123456']
     """
     lengths = list(header["lengths"])
+    writeables = list(header["writeable"])
 
-    assert len(lengths) == len(header["writeable"])
+    assert len(lengths) == len(writeables)
     assert sum(lengths) == sum(map(nbytes, frames))
 
     if not all(len(f) == l for f, l in zip(frames, lengths)):
         frames = frames[::-1]
         lengths = lengths[::-1]
+        writeables = writeables[::-1]
 
         out = []
         while lengths:
             l = lengths.pop()
+            w = writeables.pop()
             L = []
             while l:
                 frame = frames.pop()
@@ -75,6 +78,8 @@ def merge_frames(header, frames):
                     l = 0
             if len(L) == 1:  # no work necessary
                 out.append(L[0])
+            elif w:
+                out.append(bytearray().join(L))
             else:
                 out.append(bytes().join(L))
         frames = out

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -81,11 +81,8 @@ def merge_frames(header, frames):
                 L.append(frame[:l])
                 frames.append(frame[l:])
                 l = 0
-        if len(L) == 1:  # no work necessary
-            frame = L[0]
-            if w == memoryview(frame).readonly:
-                frame = bytearray(frame) if w else bytes(frame)
-            out.append(frame)
+        if len(L) == 1 and w != memoryview(L[0]).readonly:  # no work necessary
+            out.append(L[0])
         elif w:
             out.append(bytearray().join(L))
         else:

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -51,7 +51,6 @@ def merge_frames(header, frames):
     [b'123456']
     """
     lengths = list(header["lengths"])
-    frames = list(map(memoryview, frames))
 
     assert sum(lengths) == sum(map(nbytes, frames))
 
@@ -69,17 +68,18 @@ def merge_frames(header, frames):
                     L.append(frame)
                     l -= nbytes(frame)
                 else:
+                    frame = memoryview(frame)
                     L.append(frame[:l])
                     frames.append(frame[l:])
                     l = 0
             if len(L) == 1:  # no work necessary
                 out.append(L[0])
             else:
-                out.append(memoryview(bytes().join(L)))
+                out.append(bytes().join(L))
         frames = out
 
     frames = [
-        memoryview(bytearray(f)) if m and f.readonly else f
+        bytearray(f) if m and memoryview(f).readonly else f
         for m, f in zip(header["writeable"], frames)
     ]
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1108,7 +1108,12 @@ def nbytes(frame, _bytes_like=(bytes, bytearray)):
 
 
 def is_writeable(frame):
-    """ Check whether frame is writeable """
+    """
+    Check whether frame is writeable
+
+    Will return ``True`` if writeable, ``False`` if readonly, and
+    ``None`` if undetermined.
+    """
     try:
         return not memoryview(frame).readonly
     except TypeError:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1107,6 +1107,14 @@ def nbytes(frame, _bytes_like=(bytes, bytearray)):
             return len(frame)
 
 
+def is_writeable(frame):
+    """ Check whether frame is writeable """
+    try:
+        return not memoryview(frame).readonly
+    except TypeError:
+        return None
+
+
 @contextmanager
 def time_warn(duration, text):
     start = time()


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/3994
Closes https://github.com/dask/distributed/pull/3995 (as it's included)

Instead of making all frames writeable as was done in PR ( https://github.com/dask/distributed/pull/3967 ), this tracks which frames were writeable and only makes sure those are writeable. This also fixes a performance regression. Thanks @jsignell for the suggestion 🙂

```python
In [1]: import cupy
   ...: import cudf
   ...: import rmm
   ...: 
   ...: from distributed.protocol import serialize_bytes, deserialize_bytes

In [2]: rmm.reinitialize(pool_allocator=True,
   ...:                  initial_pool_size=int(30 * 2**30))

In [3]: df = cudf.DataFrame({
   ...:     k: cupy.random.random(1_000_000)
   ...:     for i, k in enumerate(map(chr, range(ord("A"), ord("K"))))
   ...: })

In [4]: b = serialize_bytes(df)

In [5]: %timeit deserialize_bytes(b)
10.1 ms ± 50.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Edit: Had a typo in my benchmark before. It has been updated.

Note: The `merge_frames` code in this PR is now closer to what it looked like in `2.21.0` (thanks to some simplifications :). So it may be easier to compare what is here against the code in that version for a cleaner diff.

cc @quasiben