### PR TITLE
Improve `bytes` and `bytearray` serialization

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -564,17 +564,30 @@ def normalize_Serialized(o):
     return [o.header] + o.frames  # for dask.base.tokenize
 
 
-# Teach serialize how to handle bytestrings
-@dask_serialize.register((bytes, bytearray))
+# Teach serialize how to handle bytes
+@dask_serialize.register(bytes)
 def _serialize_bytes(obj):
     header = {}  # no special metadata
     frames = [obj]
     return header, frames
 
 
-@dask_deserialize.register((bytes, bytearray))
+# Teach serialize how to handle bytestrings
+@dask_serialize.register(bytearray)
+def _serialize_bytearray(obj):
+    header = {}  # no special metadata
+    frames = [obj]
+    return header, frames
+
+
+@dask_deserialize.register(bytes)
 def _deserialize_bytes(header, frames):
     return bytes().join(frames)
+
+
+@dask_deserialize.register(bytearray)
+def _deserialize_bytearray(header, frames):
+    return bytearray().join(frames)
 
 
 @dask_serialize.register(memoryview)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -574,7 +574,7 @@ def _serialize_bytes(obj):
 
 @dask_deserialize.register((bytes, bytearray))
 def _deserialize_bytes(header, frames):
-    return b"".join(frames)
+    return bytes().join(frames)
 
 
 @dask_serialize.register(memoryview)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -582,12 +582,18 @@ def _serialize_bytearray(obj):
 
 @dask_deserialize.register(bytes)
 def _deserialize_bytes(header, frames):
-    return bytes().join(frames)
+    if len(frames) == 1 and isinstance(frames[0], bytes):
+        return frames[0]
+    else:
+        return bytes().join(frames)
 
 
 @dask_deserialize.register(bytearray)
 def _deserialize_bytearray(header, frames):
-    return bytearray().join(frames)
+    if len(frames) == 1 and isinstance(frames[0], bytearray):
+        return frames[0]
+    else:
+        return bytearray().join(frames)
 
 
 @dask_serialize.register(memoryview)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -69,6 +69,7 @@ def test_serialize_bytestrings():
         header, frames = serialize(b)
         assert frames[0] is b
         bb = deserialize(header, frames)
+        assert type(bb) == type(b)
         assert bb == b
 
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -71,6 +71,12 @@ def test_serialize_bytestrings():
         bb = deserialize(header, frames)
         assert type(bb) == type(b)
         assert bb == b
+        bb = deserialize(header, list(map(memoryview, frames)))
+        assert type(bb) == type(b)
+        assert bb == b
+        bb = deserialize(header, [b"", *frames])
+        assert type(bb) == type(b)
+        assert bb == b
 
 
 def test_Serialize():


### PR DESCRIPTION
Ensure `bytes` and `bytearray` serialization are handled correctly for each type respectively. Also adds a fast path for the common case where only a single frame of the right type is provided. This will also nicely build off of the work in PR ( https://github.com/dask/distributed/pull/4004 ) to improve serialization further. This results in more efficient serialization for these types as result. For example take this case of `bytearray` serialization before and after this change.

Before:

```python
In [1]: from distributed.protocol import serialize, deserialize

In [2]: b = 1_000_000 * bytearray(b"abc")

In [3]: %timeit deserialize(*serialize(b))
137 µs ± 1.5 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

After:

```python
In [1]: from distributed.protocol import serialize, deserialize

In [2]: b = 1_000_000 * bytearray(b"abc")

In [3]: %timeit deserialize(*serialize(b))
6.37 µs ± 51 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```