### PR TITLE
Serialize builtin array

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -1,3 +1,4 @@
+from array import array
 from functools import partial
 import traceback
 
@@ -594,6 +595,25 @@ def _deserialize_bytearray(header, frames):
         return frames[0]
     else:
         return bytearray().join(frames)
+
+
+@dask_serialize.register(array)
+def _serialize_array(obj):
+    header = {"typecode": obj.typecode}
+    frames = [memoryview(obj)]
+    return header, frames
+
+
+@dask_deserialize.register(array)
+def _deserialize_array(header, frames):
+    a = array(header["typecode"])
+    for f in map(memoryview, frames):
+        try:
+            f = f.cast("B")
+        except TypeError:
+            f = f.tobytes()
+        a.frombytes(f)
+    return a
 
 
 @dask_serialize.register(memoryview)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -1,3 +1,4 @@
+from array import array
 import copy
 import pickle
 
@@ -77,6 +78,20 @@ def test_serialize_bytestrings():
         bb = deserialize(header, [b"", *frames])
         assert type(bb) == type(b)
         assert bb == b
+
+
+@pytest.mark.parametrize(
+    "typecode", ["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d"],
+)
+def test_serialize_arrays(typecode):
+    a = array(typecode)
+    a.extend(range(5))
+    header, frames = serialize(a)
+    assert frames[0] == memoryview(a)
+    a2 = deserialize(header, frames)
+    assert type(a2) == type(a)
+    assert a2.typecode == a.typecode
+    assert a2 == a
 
 
 def test_Serialize():


### PR DESCRIPTION
Implements `"dask"` serialization for Python builtin `array`s.