### PR TITLE
Just extend `frames2` by `frames`

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -514,7 +514,7 @@ def serialize_bytelist(x, **kwargs):
     header["count"] = len(frames)
 
     header = msgpack.dumps(header, use_bin_type=True)
-    frames2 = [header] + list(frames)
+    frames2 = [header, *frames]
     return [pack_frames_prelude(frames2)] + frames2
 
 


### PR DESCRIPTION
Instead of coercing `frames` to a `list` to then later copy it again, just include `frames` in whatever iterable form it may be in `frames2`. This avoids the extra copy with the same net effect.