### PR TITLE
Ignore writeable frames with builtin `array`

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -628,7 +628,7 @@ def _deserialize_bytearray(header, frames):
 
 @dask_serialize.register(array)
 def _serialize_array(obj):
-    header = {"typecode": obj.typecode}
+    header = {"typecode": obj.typecode, "writeable": (None,)}
     frames = [memoryview(obj)]
     return header, frames
 


### PR DESCRIPTION
As the builtin `array` needs to own its data (meaning it will always copy), simply mark its frames to ignore tracking whether they are writeable. This avoids an unneeded copy during deserialization.

Before:

```python
In [1]: from array import array 
   ...:  
   ...: from distributed.protocol import serialize_bytes, deserialize_bytes     

In [2]: a = array("d", range(1_000_000))                                        

In [3]: %timeit deserialize_bytes(serialize_bytes(a))                           
9.27 ms ± 116 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

After:

```python
In [1]: from array import array 
   ...:  
   ...: from distributed.protocol import serialize_bytes, deserialize_bytes     

In [2]: a = array("d", range(1_000_000))                                        

In [3]: %timeit deserialize_bytes(serialize_bytes(a))                           
7.09 ms ± 475 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```