### PR TITLE
DOC: Update PendingDeprecationWarning with correct version number.

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -73,7 +73,7 @@ class Status(Enum):
             return self.value == other.value
         elif isinstance(other, str) or (other is None):
             warnings.warn(
-                f"Since distributed 2.19 `.status` is now an Enum, please compare with `Status.{other}`",
+                f"Since distributed 2.23 `.status` is now an Enum, please compare with `Status.{other}`",
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
@@ -270,7 +270,7 @@ class Server:
             self._status = new_status
         elif isinstance(new_status, str) or new_status is None:
             warnings.warn(
-                f"Since distributed 2.19 `.status` is now an Enum, please assign `Status.{new_status}`",
+                f"Since distributed 2.23 `.status` is now an Enum, please assign `Status.{new_status}`",
                 PendingDeprecationWarning,
                 stacklevel=1,
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ parentdir_prefix = distributed-
 [tool:pytest]
 addopts = -rsx --durations=10
 filterwarnings =
-    error:Since distributed 2.19.*:PendingDeprecationWarning
+    error:Since distributed.*:PendingDeprecationWarning
 minversion = 3.2
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
It does not matter much as those warnings are silent by default,
but it might still be good to give the right version number.