### PR TITLE
Add test for informative errors in serialization cases

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1939,6 +1939,11 @@ async def test_badly_serialized_input(c, s, a, b):
     assert list(L) == list(map(inc, range(10)))
     assert future.status == "error"
 
+    with pytest.raises(Exception) as info:
+        await future
+
+    assert "hello!" in str(info.value)
+
 
 @pytest.mark.skipif("True", reason="")
 async def test_badly_serialized_input_stderr(capsys, c):


### PR DESCRIPTION
I wanted to make sure that this worked, and then found that it did.  I
figured I'd push up the test enhancement anyway.