### PR TITLE
Always set RMM's strides in the `header`

### DIFF
--- a/distributed/protocol/rmm.py
+++ b/distributed/protocol/rmm.py
@@ -12,6 +12,7 @@ if hasattr(rmm, "DeviceBuffer"):
     @cuda_serialize.register(rmm.DeviceBuffer)
     def cuda_serialize_rmm_device_buffer(x):
         header = x.__cuda_array_interface__.copy()
+        header["strides"] = (1,)
         header["lengths"] = [x.nbytes]
         frames = [x]
         return header, frames

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -21,8 +21,10 @@ def test_serialize_rmm_device_buffer(size, serializers):
     y_np = y.copy_to_host()
 
     if serializers[0] == "cuda":
+        assert header["strides"] == (1,)
         assert all(hasattr(f, "__cuda_array_interface__") for f in frames)
     elif serializers[0] == "dask":
+        assert header["strides"] == (1,)
         assert all(isinstance(f, memoryview) for f in frames)
 
     assert (x_np == y_np).all()


### PR DESCRIPTION
Follow-up to PR ( https://github.com/rapidsai/rmm/pull/477 )
Fixes this test failure ( https://github.com/rapidsai/ucx-py/pull/575#issuecomment-672359289 )

As newer versions of RMM have `DeviceBuffer` setting `strides` in `__cuda_array_interface__` to `None` (as they are C-contiguous) and some deserializers rely on this to be a non-`None` value, make sure to just explicitly set `strides` to a non-`None` value.