### PR TITLE
Activity timeseries plot: move toolbar to above and fix y axis

### DIFF
--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -238,9 +238,9 @@ class ProfileTimePlot(DashboardComponent):
             height=150,
             x_axis_type="datetime",
             active_drag="xbox_select",
-            y_range=[0, 1 / profile_interval],
             tools="xpan,xwheel_zoom,xbox_select,reset",
             sizing_mode="stretch_width",
+            toolbar_location="above",
         )
         self.ts_plot.line("time", "count", source=self.ts_source)
         self.ts_plot.circle(
@@ -391,9 +391,9 @@ class ProfileServer(DashboardComponent):
             height=150,
             x_axis_type="datetime",
             active_drag="xbox_select",
-            y_range=[0, 1 / profile_interval],
             tools="xpan,xwheel_zoom,xbox_select,reset",
             sizing_mode="stretch_width",
+            toolbar_location="above",
         )
         self.ts_plot.line("time", "count", source=self.ts_source)
         self.ts_plot.circle(


### PR DESCRIPTION
I noticed this when smoke testing latest bokeh but it's not a new issue, just a small fix up. 

Before:
![image](https://user-images.githubusercontent.com/4806877/90264909-d5c48500-de1f-11ea-9f18-49eee7b9d7f7.png)

After:

![image](https://user-images.githubusercontent.com/4806877/90265037-fdb3e880-de1f-11ea-8ece-59978326b5a9.png)
