### PR TITLE
Worker dashboard clean up

### DIFF
--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -2,7 +2,7 @@ import logging
 import math
 import os
 
-from bokeh.layouts import row, column, widgetbox
+from bokeh.layouts import row, column
 from bokeh.models import (
     ColumnDataSource,
     DataRange1d,
@@ -309,7 +309,7 @@ class CrossFilter(DashboardComponent):
             else:
                 kw = {}
 
-            self.control = widgetbox(
+            self.control = column(
                 [self.x, self.y, self.color], width=200, **kw
             )
 

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -299,11 +299,6 @@ class CrossFilter(DashboardComponent):
             self.y = Select(title="Y-Axis", value="bandwidth", options=quantities)
             self.y.on_change("value", self.update_figure)
 
-            self.size = Select(
-                title="Size", value="None", options=["None"] + quantities
-            )
-            self.size.on_change("value", self.update_figure)
-
             self.color = Select(
                 title="Color", value="inout-color", options=["black"] + colors
             )
@@ -315,7 +310,7 @@ class CrossFilter(DashboardComponent):
                 kw = {}
 
             self.control = widgetbox(
-                [self.x, self.y, self.size, self.color], width=200, **kw
+                [self.x, self.y, self.color], width=200, **kw
             )
 
             self.last_outgoing = 0
@@ -368,11 +363,6 @@ class CrossFilter(DashboardComponent):
     def create_figure(self, **kwargs):
         with log_errors():
             fig = figure(title="", tools="", **kwargs)
-
-            size = self.size.value
-            if size == "None":
-                size = 1
-
             fig.circle(
                 source=self.source,
                 x=self.x.value,

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -309,9 +309,7 @@ class CrossFilter(DashboardComponent):
             else:
                 kw = {}
 
-            self.control = column(
-                [self.x, self.y, self.color], width=200, **kw
-            )
+            self.control = column([self.x, self.y, self.color], width=200, **kw)
 
             self.last_outgoing = 0
             self.last_incoming = 0


### PR DESCRIPTION
I got rid of the size option on the CrossFilter view since it was hardcoded to not do anything and it was tricky to make it have the desired behavior. To get it working properly I think we'd want to use radius, but then the axes might not match so it gets odd.

I also moved off widgetbox since it is raising a deprecated warning. 

Before:
![image](https://user-images.githubusercontent.com/4806877/90292894-d6294400-de50-11ea-88f8-fd23f5840514.png)
`BokehDeprecationWarning: 'WidgetBox' is deprecated and will be removed in Bokeh 3.0, use 'bokeh.models.Column' instead`

After:
![image](https://user-images.githubusercontent.com/4806877/90293045-31f3cd00-de51-11ea-80d1-f69afb5dd019.png)
