### PR TITLE
Make behavior clearer for how to get worker dashboard

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -45,6 +45,10 @@ class LocalCluster(SpecCluster):
         'localhost:8787' or '0.0.0.0:8787'.  Defaults to ':8787'.
         Set to ``None`` to disable the dashboard.
         Use ':0' for a random port.
+    worker_dashboard_address: str
+        Address on which to listen for the Bokeh worker diagnostics server like
+        'localhost:8787' or '0.0.0.0:8787'.  Defaults to None which disables the dashboard.
+        Use ':0' for a random port.
     diagnostics_port: int
         Deprecated.  See dashboard_address.
     asynchronous: bool (False by default)
@@ -132,6 +136,13 @@ class LocalCluster(SpecCluster):
                 "Please set to None or to a specific int to get best behavior."
             )
             threads_per_worker = None
+
+        if "dashboard" in worker_kwargs:
+            warnings.warn(
+                "Setting `dashboard` is discouraged. "
+                "Please set `worker_dashboard_address` or `dashboard_address` to "
+                "get best behavior."
+            )
 
         self.status = None
         self.processes = processes

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -140,8 +140,8 @@ class LocalCluster(SpecCluster):
         if "dashboard" in worker_kwargs:
             warnings.warn(
                 "Setting `dashboard` is discouraged. "
-                "Please set `dashboard_address` affect the scheduler (more common) "
-                "and `worker_dashboard_address` to affect the worker (less common)."
+                "Please set `dashboard_address` to affect the scheduler (more common) "
+                "and `worker_dashboard_address` for the worker (less common)."
             )
 
         self.status = None

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -140,8 +140,8 @@ class LocalCluster(SpecCluster):
         if "dashboard" in worker_kwargs:
             warnings.warn(
                 "Setting `dashboard` is discouraged. "
-                "Please set `worker_dashboard_address` or `dashboard_address` to "
-                "get best behavior."
+                "Please set `dashboard_address` affect the scheduler (more common) "
+                "and `worker_dashboard_address` to affect the worker (less common)."
             )
 
         self.status = None


### PR DESCRIPTION
I ran into this when smoke testing the dashboard. The docs say that all worker kwargs are passed along, but that isn't quite true. 