### PR TITLE
Match pre-commit in dask

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -1,0 +1,15 @@
+name: pre-commit
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
-  -   repo: https://github.com/python/black
+  -   repo: https://github.com/psf/black
       rev: stable
       hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3
   -   repo: https://gitlab.com/pycqa/flake8
-      rev: 3.7.9
+      rev: 3.8.3
       hooks:
       - id: flake8
-        language_version: python3.7
+        language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
       hooks:
       - id: black
         language_version: python3
+        exclude: versioneer.py
   -   repo: https://gitlab.com/pycqa/flake8
       rev: 3.8.3
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: stable
-    hooks:
-    - id: black
-      language_version: python3.7
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-    - id: flake8
+  -   repo: https://github.com/python/black
+      rev: stable
+      hooks:
+      - id: black
+        language_version: python3.7
+  -   repo: https://gitlab.com/pycqa/flake8
+      rev: 3.7.9
+      hooks:
+      - id: flake8
+        language_version: python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ env:
 matrix:
   fast_finish: true
   include:
-  - os: linux
-    language: python
-    python: 3.6
   - os: osx
     env: PYTHON=3.7 TESTS=true PACKAGES="python-snappy python-blosc" TORNADO=6
     if: type != pull_request OR commit_message =~ test-osx  # Skip on PRs unless the commit message contains "test-osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
   - os: linux
     language: python
     python: 3.6
-    env: LINT=true
   - os: osx
     env: PYTHON=3.7 TESTS=true PACKAGES="python-snappy python-blosc" TORNADO=6
     if: type != pull_request OR commit_message =~ test-osx  # Skip on PRs unless the commit message contains "test-osx"
@@ -30,8 +29,6 @@ install:
 
 script:
   - if [[ $TESTS == true ]]; then source continuous_integration/travis/run_tests.sh ; fi
-  - if [[ $LINT == true ]]; then python -m pip install flake8 ; flake8 distributed ; fi
-  - if [[ $LINT == true ]]; then python -m pip install black ; black distributed --check; fi
 
 after_success:
   - if [[ $COVERAGE == true ]]; then coverage report; python -m pip install -q coveralls ; coveralls ; fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 # https://flake8.readthedocs.io/en/latest/user/error-codes.html
 
 # Note: there cannot be spaces after comma's here
-exclude = __init__.py,distributed/_concurrent_futures_thread.py
+exclude = __init__.py,versioneer.py,distributed/_concurrent_futures_thread.py
 ignore =
     E20,        # Extra space in brackets
     E231,E241,  # Multiple spaces around ","


### PR DESCRIPTION
This PR copies the pre-commit from dask which seems to work fine

### Motivation
After cleaning out my dev env, I was getting errors from the pre-commit in distributed. I think it has to do with my dev env being python 3.8.

The error looked like:

```
[INFO] Installing environment for https://github.com/ambv/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/julia/conda/envs/dask-dev/bin/python3.8', '-mvirtualenv', '/home/julia/.cache/pre-commit/repoyh1z3_q8/py_env-python3.7', '-p', 'python3.7')
return code: 1
expected return code: 0
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.7'
    
stderr: (none)
Check the log at /home/julia/.cache/pre-commit/pre-commit.log
```