### PR TITLE
Add cluster log method

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 from contextlib import suppress
 import logging
 import threading
@@ -50,12 +51,14 @@ class Cluster:
 
     _supports_scaling = True
 
-    def __init__(self, asynchronous):
+    def __init__(self, asynchronous, quiet=False):
         self.scheduler_info = {"workers": {}}
         self.periodic_callbacks = {}
         self._asynchronous = asynchronous
         self._watch_worker_status_comm = None
         self._watch_worker_status_task = None
+        self._cm_logs = []
+        self.quiet = quiet
         self.scheduler_comm = None
 
         self.status = Status.created
@@ -170,8 +173,26 @@ class Cluster:
         else:
             return sync(self.loop, func, *args, **kwargs)
 
+    def _log(self, log):
+        """Log a message.
+
+        Output a message to the user and also store for future retrieval.
+
+        For use in subclasses where initialisation may take a while and it would
+        be beneficial to feed back to the user.
+
+        Examples
+        --------
+        >>> self._log("Submitted job X to batch scheduler")
+        """
+        self._cm_logs.append((datetime.datetime.now(), log))
+        if not self.quiet:
+            print(log)
+
     async def _get_logs(self, scheduler=True, workers=True):
         logs = Logs()
+
+        logs["Cluster"] = Log("\n".join(line[1] for line in self._cm_logs))
 
         if scheduler:
             L = await self.scheduler_comm.get_logs()

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -57,7 +57,7 @@ class Cluster:
         self._asynchronous = asynchronous
         self._watch_worker_status_comm = None
         self._watch_worker_status_task = None
-        self._cm_logs = []
+        self._cluster_manager_logs = []
         self.quiet = quiet
         self.scheduler_comm = None
 
@@ -179,20 +179,23 @@ class Cluster:
         Output a message to the user and also store for future retrieval.
 
         For use in subclasses where initialisation may take a while and it would
-        be beneficial to feed back to the user.
+        # be beneficial to feed back to the user.
 
         Examples
         --------
         >>> self._log("Submitted job X to batch scheduler")
         """
-        self._cm_logs.append((datetime.datetime.now(), log))
+        self._cluster_manager_logs.append((datetime.datetime.now(), log))
         if not self.quiet:
             print(log)
 
-    async def _get_logs(self, scheduler=True, workers=True):
+    async def _get_logs(self, cluster=True, scheduler=True, workers=True):
         logs = Logs()
 
-        logs["Cluster"] = Log("\n".join(line[1] for line in self._cm_logs))
+        if cluster:
+            logs["Cluster"] = Log(
+                "\n".join(line[1] for line in self._cluster_manager_logs)
+            )
 
         if scheduler:
             L = await self.scheduler_comm.get_logs()
@@ -205,11 +208,13 @@ class Cluster:
 
         return logs
 
-    def get_logs(self, scheduler=True, workers=True):
-        """ Return logs for the scheduler and workers
+    def get_logs(self, cluster=True, scheduler=True, workers=True):
+        """ Return logs for the cluster, scheduler and workers
 
         Parameters
         ----------
+        cluster : boolean
+            Whether or not to collect logs for the cluster manager
         scheduler : boolean
             Whether or not to collect logs for the scheduler
         workers : boolean or Iterable[str], optional
@@ -222,7 +227,9 @@ class Cluster:
             A dictionary of logs, with one item for the scheduler and one for
             each worker
         """
-        return self.sync(self._get_logs, scheduler=scheduler, workers=workers)
+        return self.sync(
+            self._get_logs, cluster=cluster, scheduler=scheduler, workers=workers
+        )
 
     def logs(self, *args, **kwargs):
         warnings.warn("logs is deprecated, use get_logs instead", DeprecationWarning)

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -179,7 +179,7 @@ class Cluster:
         Output a message to the user and also store for future retrieval.
 
         For use in subclasses where initialisation may take a while and it would
-        # be beneficial to feed back to the user.
+        be beneficial to feed back to the user.
 
         Examples
         --------

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -292,17 +292,20 @@ async def test_logs(cleanup):
 
         assert "Registered" in str(logs)
 
-        logs = await cluster.get_logs(scheduler=True, workers=False)
+        logs = await cluster.get_logs(cluster=True, scheduler=False, workers=False)
+        assert list(logs) == ["Cluster"]
+
+        logs = await cluster.get_logs(cluster=False, scheduler=True, workers=False)
         assert list(logs) == ["Scheduler"]
 
-        logs = await cluster.get_logs(scheduler=False, workers=False)
+        logs = await cluster.get_logs(cluster=False, scheduler=False, workers=False)
         assert list(logs) == []
 
-        logs = await cluster.get_logs(scheduler=False, workers=True)
+        logs = await cluster.get_logs(cluster=False, scheduler=False, workers=True)
         assert set(logs) == set(cluster.scheduler.workers)
 
         w = toolz.first(cluster.scheduler.workers)
-        logs = await cluster.get_logs(scheduler=False, workers=[w])
+        logs = await cluster.get_logs(cluster=False, scheduler=False, workers=[w])
         assert set(logs) == {w}
 
 


### PR DESCRIPTION
In many downstream cluster managers it may take time for the cluster manager to be instantiated. Often this is because the scheduler needs to be spawned on some external resource like a batch system, and the cluster cannot be created until the scheduler exists.

In `dask-cloudprovider.AzureMLCluster` we have taken the approach to print output to the user to let them know where progress is, because it can take tens of minutes depending on the complexity of your environment.

This PR adds a standardised way to log messages to the user with the `Cluster._log` method which is intended for use by subclasses. It also adds a `quiet` kwarg which can be set to `True` to disable printing. And it stores all log messages in a list so that they can be included in the `Cluster.get_logs()` method if a user wished to retrieve all logs later.

I'm not 100% set on the design for this so would love some feedback, but I think the main thing I want to achieve is to standardise the way cluster managers print output to the user and provide options to silence it and retrieve that output later.