### PR TITLE
Add a default argument to the datasets and a possibility to override datasets

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2342,24 +2342,28 @@ class Client:
         """
         return self.sync(self.scheduler.publish_list, **kwargs)
 
-    async def _get_dataset(self, name):
+    async def _get_dataset(self, name, default):
         with self.as_current():
             out = await self.scheduler.publish_get(name=name, client=self.id)
 
         if out is None:
-            raise KeyError(f"Dataset '{name}' not found")
+            if default is None:
+                raise KeyError(f"Dataset '{name}' not found")
+            else:
+                return default
         return out["data"]
 
-    def get_dataset(self, name, **kwargs):
+    def get_dataset(self, name, default=None, **kwargs):
         """
-        Get named dataset from the scheduler
+        Get named dataset from the scheduler if present.
+        Return the default or raise a KeyError if not present.
 
         See Also
         --------
         Client.publish_dataset
         Client.list_datasets
         """
-        return self.sync(self._get_dataset, name, **kwargs)
+        return self.sync(self._get_dataset, name, default=default, **kwargs)
 
     async def _run_on_scheduler(self, function, *args, wait=True, **kwargs):
         response = await self.scheduler.run_function(

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -98,6 +98,8 @@ _global_client_index = [0]
 _current_client = ContextVar("_current_client", default=None)
 
 DEFAULT_EXTENSIONS = [PubSubClientExtension]
+# Placeholder used in the get_dataset function(s)
+NO_DEFAULT_PLACEHOLDER = "_no_default_"
 
 
 def _get_global_client():
@@ -2281,7 +2283,8 @@ class Client:
         ----------
         args : list of objects to publish as name
         name : optional name of the dataset to publish
-        override : if true, override any already present dataset with the same name
+        override : bool (optional, default False)
+            if true, override any already present dataset with the same name
         kwargs: dict
             named collections to publish on the scheduler
 
@@ -2344,21 +2347,29 @@ class Client:
         """
         return self.sync(self.scheduler.publish_list, **kwargs)
 
-    async def _get_dataset(self, name, default):
+    async def _get_dataset(self, name, default=NO_DEFAULT_PLACEHOLDER):
         with self.as_current():
             out = await self.scheduler.publish_get(name=name, client=self.id)
 
         if out is None:
-            if default is None:
+            if default is NO_DEFAULT_PLACEHOLDER:
                 raise KeyError(f"Dataset '{name}' not found")
             else:
                 return default
         return out["data"]
 
-    def get_dataset(self, name, default=None, **kwargs):
+    def get_dataset(self, name, default=NO_DEFAULT_PLACEHOLDER, **kwargs):
         """
         Get named dataset from the scheduler if present.
         Return the default or raise a KeyError if not present.
+
+        Parameters
+        ----------
+        name : name of the dataset to retrieve
+        default : optional, not set by default
+            If set, do not raise a KeyError if the name is not present but return this default
+        kwargs: dict
+            additional arguments to _get_dataset
 
         See Also
         --------

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2237,7 +2237,7 @@ class Client:
         """
         return self.sync(self._retry, futures, asynchronous=asynchronous)
 
-    async def _publish_dataset(self, *args, name=None, **kwargs):
+    async def _publish_dataset(self, *args, name=None, override=False, **kwargs):
         with log_errors():
             coroutines = []
 
@@ -2245,7 +2245,8 @@ class Client:
                 keys = [tokey(f.key) for f in futures_of(data)]
                 coroutines.append(
                     self.scheduler.publish_put(
-                        keys=keys, name=name, data=to_serialize(data), client=self.id
+                        keys=keys, name=name, data=to_serialize(data),
+                        override=override, client=self.id
                     )
                 )
 
@@ -2280,6 +2281,7 @@ class Client:
         ----------
         args : list of objects to publish as name
         name : optional name of the dataset to publish
+        override : if true, override any already present dataset with the same name
         kwargs: dict
             named collections to publish on the scheduler
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2247,8 +2247,11 @@ class Client:
                 keys = [tokey(f.key) for f in futures_of(data)]
                 coroutines.append(
                     self.scheduler.publish_put(
-                        keys=keys, name=name, data=to_serialize(data),
-                        override=override, client=self.id
+                        keys=keys,
+                        name=name,
+                        data=to_serialize(data),
+                        override=override,
+                        client=self.id,
                     )
                 )
 

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -116,3 +116,7 @@ class Datasets(MutableMapping):
                 "please use 'len(await client.list_datasets())' instead"
             )
         return len(self._client.list_datasets())
+
+    def get(self, key, default=None):
+        # just pass on to the client
+        return self._client.get_dataset(key, default=default)

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -26,7 +26,9 @@ class PublishExtension:
         self.scheduler.handlers.update(handlers)
         self.scheduler.extensions["publish"] = self
 
-    def put(self, comm=None, keys=None, data=None, name=None, override=False, client=None):
+    def put(
+        self, comm=None, keys=None, data=None, name=None, override=False, client=None
+    ):
         with log_errors():
             if not override and name in self.datasets:
                 raise KeyError("Dataset %s already exists" % name)

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -116,7 +116,3 @@ class Datasets(MutableMapping):
                 "please use 'len(await client.list_datasets())' instead"
             )
         return len(self._client.list_datasets())
-
-    def get(self, key, default=None):
-        # just pass on to the client
-        return self._client.get_dataset(key, default=default)

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -26,9 +26,9 @@ class PublishExtension:
         self.scheduler.handlers.update(handlers)
         self.scheduler.extensions["publish"] = self
 
-    def put(self, comm=None, keys=None, data=None, name=None, client=None):
+    def put(self, comm=None, keys=None, data=None, name=None, override=False, client=None):
         with log_errors():
-            if name in self.datasets:
+            if not override and name in self.datasets:
                 raise KeyError("Dataset %s already exists" % name)
             self.scheduler.client_desires_keys(keys, "published-%s" % tokey(name))
             self.datasets[name] = {"data": data, "keys": keys}

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -196,7 +196,7 @@ def test_datasets_getitem_default(client):
         client.get_dataset("key")
 
     assert client.datasets.get("key", default="value") == "value"
-    assert client.datasets.get("key", default=None) == None
+    assert client.datasets.get("key", default=None) is None
     assert client.get_dataset("key", default="value") == "value"
 
 

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -179,6 +179,7 @@ def test_datasets_setitem(client):
         value = "value"
         client.datasets[key] = value
         assert client.get_dataset(key) == value
+        assert client.get_dataset(key, default="something else") == value
 
 
 def test_datasets_getitem(client):
@@ -186,6 +187,19 @@ def test_datasets_getitem(client):
         value = "value"
         client.publish_dataset(value, name=key)
         assert client.datasets[key] == value
+        assert client.datasets.get(key) == value
+        assert client.datasets.get(key, default="something else") == value
+
+
+def test_datasets_getitem_default(client):
+    with pytest.raises(KeyError) as exc_info:
+        client.datasets.get("key")
+
+    with pytest.raises(KeyError) as exc_info:
+        client.get_dataset("key")
+
+    assert client.datasets.get("key", default="value") == "value"
+    assert client.get_dataset("key", default="value") == "value"
 
 
 def test_datasets_delitem(client):

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -222,6 +222,18 @@ def test_datasets_contains(client):
     assert key in client.datasets
 
 
+def test_datasets_republish(client):
+    key, value, value2 = "key", "value", "value2"
+    client.publish_dataset(key=value)
+    assert client.get_dataset(key) == value
+
+    with pytest.raises(KeyError) as exc_info:
+        client.publish_dataset(key=value)
+
+    client.publish_dataset(key=value2, override=True)
+    assert client.get_dataset(key) == value2
+
+
 def test_datasets_iter(client):
     keys = [n for n in range(10)]
     client.publish_dataset(**{str(key): key for key in keys})

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -193,12 +193,10 @@ def test_datasets_getitem(client):
 
 def test_datasets_getitem_default(client):
     with pytest.raises(KeyError) as exc_info:
-        client.datasets.get("key")
-
-    with pytest.raises(KeyError) as exc_info:
         client.get_dataset("key")
 
     assert client.datasets.get("key", default="value") == "value"
+    assert client.datasets.get("key", default=None) == None
     assert client.get_dataset("key", default="value") == "value"
 
 


### PR DESCRIPTION
Following the discussion in https://github.com/dask/dask/issues/6531, that PR adds two new features:
* if the get datasets method returns nothing, a new default keyword argument on the client can prevent the KeyError (similar to `dict.get`). I also added a `get` method to the `client.datasets`.
* A new keyword argument `override` in `publish_dataset` lets you also prevent the KeyError there on duplicated entries (server side)