### PR TITLE
Cleanup more exception tracebacks

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -209,10 +209,10 @@ class Listener(ABC):
             handshake = await asyncio.wait_for(comm.read(), 1)
             # This would be better, but connections leak if worker is closed quickly
             # write, handshake = await asyncio.gather(comm.write(local_info), comm.read())
-        except Exception:
+        except Exception as e:
             with suppress(Exception):
                 await comm.close()
-            raise CommClosedError()
+            raise CommClosedError() from e
 
         comm.remote_info = handshake
         comm.remote_info["address"] = comm._peer_addr
@@ -263,7 +263,7 @@ async def connect(
             timeout,
             error,
         )
-        raise IOError(msg)
+        raise IOError(msg) from error
 
     backoff = 0.01
     if timeout and timeout / 20 < backoff:
@@ -289,10 +289,10 @@ async def connect(
                         write = await asyncio.wait_for(comm.write(local_info), 1)
                         # This would be better, but connections leak if worker is closed quickly
                         # write, handshake = await asyncio.gather(comm.write(local_info), comm.read())
-                    except Exception:
+                    except Exception as e:
                         with suppress(Exception):
                             await comm.close()
-                        raise CommClosedError()
+                        raise CommClosedError() from e
 
                     comm.remote_info = handshake
                     comm.remote_info["address"] = comm._peer_addr

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -482,10 +482,10 @@ class Server:
 
                 try:
                     op = msg.pop("op")
-                except KeyError:
+                except KeyError as e:
                     raise ValueError(
                         "Received unexpected message without 'op' key: " + str(msg)
-                    )
+                    ) from e
                 if self.counters is not None:
                     self.counters["op"].add(op)
                 self._comms[comm] = op


### PR DESCRIPTION
I've found a few more places where the error message could be confusing for users:

e.g.

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/krishan/.local/lib/python3.7/site-packages/distributed/comm/core.py", line 295, in _
    raise CommClosedError()
distributed.comm.core.CommClosedError
```

I've changed in places that look like they are correct, but I have not personally encountered errors for all of the diffs I have created.

If preferred, I'm happy to limit this PR to only the instances I have seen myself.