### PR TITLE
Only update TaskGraph if graphs are small

### DIFF
--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -526,8 +526,9 @@ async def test_TaskGraph_limit(c, s, a, b):
     assert len(gp.node_source.data["x"]) == 2
     f3 = c.submit(func, 3)
     await wait(f3)
+    # Breached task limit, clearing graph
     gp.update()
-    assert len(gp.node_source.data["x"]) == 2
+    assert len(gp.node_source.data["x"]) == 0
 
 
 @gen_cluster(client=True, timeout=30)


### PR DESCRIPTION
This is a practical fix for #4055 which updates the entire graph structure only if we're below the limit. Otherwise, setting the `invisible_count` will retrigger a reset_index on every iteration causing an extremely large load.

If there are ideas for more elegant fixes I'm happy to look into something else as well.