### PR TITLE
Semaphore: Ensure semaphore picks correct IOLoop for threadpool workers

### DIFF
--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -372,6 +372,10 @@ class Semaphore:
             / 5
         )
         self._refreshing_leases = False
+
+        # Ensure that the PC below takes the correct IOLoop
+        if not self.client.io_loop.is_current:
+            self.client.io_loop.make_current()
         pc = PeriodicCallback(
             self._refresh_leases, callback_time=refresh_leases_interval * 1000
         )

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -362,8 +362,6 @@ class Semaphore:
         self.id = uuid.uuid4().hex
         self._leases = deque()
 
-        self._refreshing_leases = False
-
         self.refresh_leases = True
 
         self._registered = None


### PR DESCRIPTION
When running workers in a threadpool the Tornado PC doesn't seem to pick the correct IOLoop instance. The PC is effectively never scheduled causing all semaphore leases to timeout.

Closes #4057 