### PR TITLE
Use `list.insert` to add prelude up front

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -520,7 +520,8 @@ def serialize_bytelist(x, **kwargs):
 
     header = msgpack.dumps(header, use_bin_type=True)
     frames2 = [header, *frames]
-    return [pack_frames_prelude(frames2)] + frames2
+    frames2.insert(0, pack_frames_prelude(frames2))
+    return frames2
 
 
 def serialize_bytes(x, **kwargs):


### PR DESCRIPTION
Avoids creating a temporary `list` by simply modifying the existing `list` in-place. This can result in significant savings particularly for large `list`s.

```python
In [1]: %%timeit L = list(range(1_000_000))
   ...: L = [None] + L
   ...:
   ...:
7.1 ms ± 45.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [2]: %%timeit L = list(range(1_000_000))
   ...: L.insert(0, None)
   ...:
   ...:
634 µs ± 4.57 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```