### PR TITLE
Simplify `frame_split_size`

### DIFF
--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -28,9 +28,8 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     if frame.nbytes <= n:
         return [frame]
 
-    itemsize = frame.itemsize
-    nitems = frame.nbytes // itemsize
-    items_per_shard = n // itemsize
+    nitems = frame.nbytes // frame.itemsize
+    items_per_shard = n // frame.itemsize
 
     return [frame[i : i + items_per_shard] for i in range(0, nitems, items_per_shard)]
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -23,7 +23,9 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     >>> frame_split_size([b'12345', b'678'], n=3)  # doctest: +SKIP
     [b'123', b'45', b'678']
     """
-    if nbytes(frame) <= n:
+    nbytes_frames = nbytes(frame)
+
+    if nbytes_frames <= n:
         return [frame]
 
     if isinstance(frame, (bytes, bytearray)):
@@ -35,7 +37,7 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
 
     return [
         frame[i : i + n // itemsize]
-        for i in range(0, nbytes(frame) // itemsize, n // itemsize)
+        for i in range(0, nbytes_frames // itemsize, n // itemsize)
     ]
 
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -26,18 +26,17 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     if nbytes(frame) <= n:
         return [frame]
 
-    if nbytes(frame) > n:
-        if isinstance(frame, (bytes, bytearray)):
-            frame = memoryview(frame)
-        try:
-            itemsize = frame.itemsize
-        except AttributeError:
-            itemsize = 1
+    if isinstance(frame, (bytes, bytearray)):
+        frame = memoryview(frame)
+    try:
+        itemsize = frame.itemsize
+    except AttributeError:
+        itemsize = 1
 
-        return [
-            frame[i : i + n // itemsize]
-            for i in range(0, nbytes(frame) // itemsize, n // itemsize)
-        ]
+    return [
+        frame[i : i + n // itemsize]
+        for i in range(0, nbytes(frame) // itemsize, n // itemsize)
+    ]
 
 
 def merge_frames(header, frames):

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -35,9 +35,12 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     except AttributeError:
         itemsize = 1
 
+    nitems = nbytes_frames // itemsize
+    items_per_shard = n // itemsize
+
     return [
-        frame[i : i + n // itemsize]
-        for i in range(0, nbytes_frames // itemsize, n // itemsize)
+        frame[i : i + items_per_shard]
+        for i in range(0, nitems, items_per_shard)
     ]
 
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -23,15 +23,13 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     >>> frame_split_size([b'12345', b'678'], n=3)  # doctest: +SKIP
     [b'123', b'45', b'678']
     """
-    nbytes_frames = nbytes(frame)
-
-    if nbytes_frames <= n:
-        return [frame]
-
     frame = memoryview(frame)
 
+    if frame.nbytes <= n:
+        return [frame]
+
     itemsize = frame.itemsize
-    nitems = nbytes_frames // itemsize
+    nitems = frame.nbytes // itemsize
     items_per_shard = n // itemsize
 
     return [frame[i : i + items_per_shard] for i in range(0, nitems, items_per_shard)]

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -28,13 +28,9 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     if nbytes_frames <= n:
         return [frame]
 
-    if isinstance(frame, (bytes, bytearray)):
-        frame = memoryview(frame)
-    try:
-        itemsize = frame.itemsize
-    except AttributeError:
-        itemsize = 1
+    frame = memoryview(frame)
 
+    itemsize = frame.itemsize
     nitems = nbytes_frames // itemsize
     items_per_shard = n // itemsize
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -38,10 +38,7 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     nitems = nbytes_frames // itemsize
     items_per_shard = n // itemsize
 
-    return [
-        frame[i : i + items_per_shard]
-        for i in range(0, nitems, items_per_shard)
-    ]
+    return [frame[i : i + items_per_shard] for i in range(0, nitems, items_per_shard)]
 
 
 def merge_frames(header, frames):


### PR DESCRIPTION
As we already check `nbytes` and `return`ed if it was `<= n`, we already know `nbytes(frame) > n`. So there is no need to check it again. Thus we get rid of this second check. Also assign some repeatedly used values to variables to make things a little easier to follow. Finally just always use a `memoryview` to split frames as it views instead of copying data and has easy access to things like `itemsize` and `nbytes`.