### PR TITLE
Simplify `pack_frames`

### DIFF
--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -106,8 +106,7 @@ def pack_frames(frames):
     --------
     unpack_frames
     """
-    data = [pack_frames_prelude(frames)]
-    data.extend(frames)
+    data = [pack_frames_prelude(frames), *frames]
     return b"".join(data)
 
 

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -106,8 +106,7 @@ def pack_frames(frames):
     --------
     unpack_frames
     """
-    data = [pack_frames_prelude(frames), *frames]
-    return b"".join(data)
+    return b"".join([pack_frames_prelude(frames), *frames])
 
 
 def unpack_frames(b):


### PR DESCRIPTION
Drop some verbiage in `pack_frames` to communicate the behavior more succinctly.