### PR TITLE
Drop `Serialized.deserialize()` method

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -381,12 +381,6 @@ class Serialized:
         self.header = header
         self.frames = frames
 
-    def deserialize(self):
-        from .core import decompress
-
-        frames = decompress(self.header, self.frames)
-        return deserialize(self.header, frames)
-
     def __eq__(self, other):
         return (
             isinstance(other, Serialized)


### PR DESCRIPTION
This method was added in PR ( https://github.com/dask/distributed/pull/638 ). However it appears it wasn't used in that change and does not appear to be used today. So go ahead and drop it.