### PR TITLE
Provide informative error when connecting an older version of Dask

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -134,9 +134,18 @@ class Comm(ABC):
 
     @staticmethod
     def handshake_configuration(local, remote):
-        out = {
-            "pickle-protocol": min(local["pickle-protocol"], remote["pickle-protocol"])
-        }
+        try:
+            out = {
+                "pickle-protocol": min(
+                    local["pickle-protocol"], remote["pickle-protocol"]
+                )
+            }
+        except KeyError:
+            raise ValueError(
+                "Your Dask versions may not be in sync. "
+                "Please ensure that you have the same version of dask "
+                "and distributed on your client, scheduler, and worker machines"
+            )
 
         if local["compression"] == remote["compression"]:
             out["compression"] = local["compression"]


### PR DESCRIPTION
This seems to be coming up with the new protocol changes.
In the future we'll know which versions are present and so will be able
to give better messages.  This should stop the bleeding short term
though.