### PR TITLE
Refactor out `deserialize_bytelist`

### DIFF
--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -18,6 +18,7 @@ from .serialize import (
     serialize_bytes,
     deserialize_bytes,
     serialize_bytelist,
+    deserialize_bytelist,
     register_serialization_family,
     register_generic,
 )

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -520,18 +520,11 @@ def serialize_bytelist(x, **kwargs):
 
     header = msgpack.dumps(header, use_bin_type=True)
     frames2 = [header, *frames]
-    frames2.insert(0, pack_frames_prelude(frames2))
     return frames2
 
 
-def serialize_bytes(x, **kwargs):
-    L = serialize_bytelist(x, **kwargs)
-    return b"".join(L)
-
-
-def deserialize_bytes(b):
-    frames = unpack_frames(b)
-    header, frames = frames[0], frames[1:]
+def deserialize_bytelist(L):
+    header, frames = L[0], L[1:]
     if header:
         header = msgpack.loads(header, raw=False, use_list=False)
     else:
@@ -539,6 +532,16 @@ def deserialize_bytes(b):
     frames = decompress(header, frames)
     frames = merge_frames(header, frames)
     return deserialize(header, frames)
+
+
+def serialize_bytes(x, **kwargs):
+    L = serialize_bytelist(x, **kwargs)
+    return b"".join([pack_frames_prelude(L), *L])
+
+
+def deserialize_bytes(b):
+    L = unpack_frames(b)
+    return deserialize_bytelist(L)
 
 
 ################################

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -19,6 +19,7 @@ from distributed.protocol import (
     serialize_bytes,
     deserialize_bytes,
     serialize_bytelist,
+    deserialize_bytelist,
     register_serialization_family,
     dask_serialize,
 )
@@ -236,8 +237,7 @@ def test_serialize_list_compress():
     L = serialize_bytelist(x)
     assert sum(map(nbytes, L)) < x.nbytes / 2
 
-    b = b"".join(L)
-    y = deserialize_bytes(b)
+    y = deserialize_bytelist(L)
     assert (x == y).all()
 
 


### PR DESCRIPTION
Extracts the `deserialize_bytelist` function from `deserialize_bytes`. Under-the-hood `deserialize_bytes` does a minimal amount of prep work before calling into `deserialize_bytelist`. Thus maintaining the same code path.

This can be a useful place to hook into this part of serialization pipeline for things like in-memory compressed spilling in combination with `serialize_bytelist`. Also this avoids unnecessary copying in this case (unlike `deserialize_bytes`).