### PR TITLE
Exclude 'fire-and-forget' client from metrics

### DIFF
--- a/distributed/http/scheduler/prometheus/__init__.py
+++ b/distributed/http/scheduler/prometheus/__init__.py
@@ -12,9 +12,6 @@ class _PrometheusCollector:
     def collect(self):
         from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily
 
-        print("server", self.server)
-        print("clients", self.server.clients)
-
         yield GaugeMetricFamily(
             "dask_scheduler_clients",
             "Number of clients connected.",

--- a/distributed/http/scheduler/prometheus/__init__.py
+++ b/distributed/http/scheduler/prometheus/__init__.py
@@ -12,10 +12,13 @@ class _PrometheusCollector:
     def collect(self):
         from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily
 
+        print("server", self.server)
+        print("clients", self.server.clients)
+
         yield GaugeMetricFamily(
             "dask_scheduler_clients",
             "Number of clients connected.",
-            value=len(self.server.clients),
+            value=len([k for k in self.server.clients if k != "fire-and-forget"]),
         )
 
         yield GaugeMetricFamily(

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -92,8 +92,13 @@ async def test_prometheus(c, s, a, b):
         assert response.headers["Content-Type"] == "text/plain; version=0.0.4"
 
         txt = response.body.decode("utf8")
-        families = {familiy.name for familiy in text_string_to_metric_families(txt)}
+        families = {
+            family.name: family for family in text_string_to_metric_families(txt)
+        }
         assert "dask_scheduler_workers" in families
+
+        client = families["dask_scheduler_clients"]
+        assert client.samples[0].value == 1.0
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})


### PR DESCRIPTION
Right now we include the "fire-and-forget" client in our prometheus
metrics. So after connecting a `Client(scheduler)` prometheus will report 2
clients rather than 1. I think it's best to leave that one out, to only have "user"
clients in the reported metrics.