### PR TITLE
Protect profile against very large stacks

### DIFF
--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -73,7 +73,7 @@ def info_frame(frame):
     }
 
 
-def process(frame, child, state, stop=None, omit=None):
+def process(frame, child, state, stop=None, omit=None, depth=0):
     """ Add counts from a frame stack onto existing state
 
     This recursively adds counts to the existing state dictionary and creates
@@ -97,10 +97,12 @@ def process(frame, child, state, stop=None, omit=None):
         return False
 
     prev = frame.f_back
-    if prev is not None and (
-        stop is None or not prev.f_code.co_filename.endswith(stop)
+    if (
+        prev is not None
+        and (stop is None or not prev.f_code.co_filename.endswith(stop))
+        and depth < 200
     ):
-        state = process(prev, frame, state, stop=stop)
+        state = process(prev, frame, state, stop=stop, depth=depth + 1)
         if state is False:
             return False
 

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -199,3 +199,32 @@ def test_watch():
     while threading.active_count() > start_threads:
         assert metrics.time() < start + 2
         time.sleep(0.01)
+
+
+def test_deep_stack():
+    import time
+
+    def f(n):
+        if n == 0:
+            time.sleep(0.2)
+        else:
+            return f(n - 1)
+
+    thread = threading.Thread(target=f, args=(400,))
+    thread.daemon = True
+    thread.start()
+
+    state = create()
+
+    for i in range(10):
+        time.sleep(0.02)
+        try:
+            frame = sys._current_frames()[thread.ident]
+        except KeyError:
+            break
+        else:
+            process(frame, None, state)
+
+    import msgpack
+
+    msgpack.loads(msgpack.dumps(state))


### PR DESCRIPTION
This can come up in tracebacks when exporting profiles.

This isn't quite right.  We're chopping off the calling functions of the
call stack rather than the called functions, but it's easiest to do it
this way given how we've arranged our profile processing function.  So
the top of the call stack will appear somewhat disassociated, but will
still be around.

Mostly I don't care too much about pathological cases like these, as
long as they don't ruin communication of the rest of the system.