### PR TITLE
Support different remote_python paths on cluster nodes

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -247,7 +247,7 @@ def SSHCluster(
     worker_options: dict = {},
     scheduler_options: dict = {},
     worker_module: str = "distributed.cli.dask_worker",
-    remote_python: str = None,
+    remote_python: Union[str, dict] = None,
     **kwargs,
 ):
     """Deploy a Dask cluster using SSH

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -59,7 +59,7 @@ class Worker(Process):
         The python module to run to start the worker.
     connect_options: dict
         kwargs to be passed to asyncssh connections
-    remote_python: str
+    remote_python: str or dict
         Path to Python on remote node to run this worker.
     kwargs: dict
         These will be passed through the dask-worker CLI to the
@@ -108,10 +108,16 @@ class Worker(Process):
                     "Worker failed to set DASK_INTERNAL_INHERIT_CONFIG variable "
                 )
 
+        if not self.remote_python:
+            self.remote_python = sys.executable
+
+        elif type(self.remote_python) == dict:
+            self.remote_python = self.remote_python.get(self.address, sys.executable)
+
         cmd = " ".join(
             [
                 set_env,
-                self.remote_python or sys.executable,
+                self.remote_python,
                 "-m",
                 self.worker_module,
                 self.scheduler,
@@ -146,7 +152,7 @@ class Scheduler(Process):
         The hostname where we should run this worker
     connect_options: dict
         kwargs to be passed to asyncssh connections
-    remote_python: str
+    remote_python: str or dict
         Path to Python on remote node to run this scheduler.
     kwargs: dict
         These will be passed through the dask-scheduler CLI to the
@@ -186,10 +192,16 @@ class Scheduler(Process):
                     "Scheduler failed to set DASK_INTERNAL_INHERIT_CONFIG variable "
                 )
 
+        if not self.remote_python:
+            self.remote_python = sys.executable
+
+        elif type(self.remote_python) == dict:
+            self.remote_python = self.remote_python.get(self.address, sys.executable)
+
         cmd = " ".join(
             [
                 set_env,
-                self.remote_python or sys.executable,
+                self.remote_python,
                 "-m",
                 "distributed.cli.dask_scheduler",
             ]
@@ -274,7 +286,7 @@ def SSHCluster(
         Keywords to pass on to scheduler.
     worker_module: str, optional
         Python module to call to start the worker.
-    remote_python: str, optional
+    remote_python: str or dict, optional
         Path to Python on remote nodes.
 
     Examples

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -346,9 +346,9 @@ def SSHCluster(
             if isinstance(connect_options, dict)
             else connect_options[0],
             "kwargs": scheduler_options,
-            "remote_python": remote_python
-            if isinstance(remote_python, str)
-            else remote_python[0],
+            "remote_python": remote_python[0]
+            if isinstance(remote_python, list)
+            else remote_python,
         },
     }
     workers = {
@@ -361,9 +361,9 @@ def SSHCluster(
                 else connect_options[i + 1],
                 "kwargs": worker_options,
                 "worker_module": worker_module,
-                "remote_python": remote_python
-                if isinstance(remote_python, str)
-                else remote_python[i + 1],
+                "remote_python": remote_python[i + 1]
+                if isinstance(remote_python, list)
+                else remote_python,
             },
         }
         for i, host in enumerate(hosts[1:])

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -2,6 +2,7 @@ import pytest
 
 pytest.importorskip("asyncssh")
 
+import sys
 import dask
 from dask.distributed import Client
 from distributed.deploy.ssh import SSHCluster
@@ -156,3 +157,29 @@ async def test_list_of_connect_options_raises():
             worker_options={"death_timeout": "5s"},
         ) as _:
             pass
+
+
+@pytest.mark.asyncio
+async def test_remote_python():
+    async with SSHCluster(
+        ["127.0.0.1"] * 3,
+        connect_options=[dict(known_hosts=None)] * 3,
+        asynchronous=True,
+        scheduler_options={"port": 0, "idle_timeout": "5s"},
+        worker_options={"death_timeout": "5s"},
+        remote_python=sys.executable,
+    ) as cluster:
+        assert cluster.workers[0].remote_python == sys.executable
+
+
+@pytest.mark.asyncio
+async def test_remote_python_as_dict():
+    async with SSHCluster(
+        ["127.0.0.1"] * 3,
+        connect_options=[dict(known_hosts=None)] * 3,
+        asynchronous=True,
+        scheduler_options={"port": 0, "idle_timeout": "5s"},
+        worker_options={"death_timeout": "5s"},
+        remote_python={"127.0.0.1": sys.executable},
+    ) as cluster:
+        assert cluster.workers[0].remote_python == sys.executable

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -180,6 +180,20 @@ async def test_remote_python_as_dict():
         asynchronous=True,
         scheduler_options={"port": 0, "idle_timeout": "5s"},
         worker_options={"death_timeout": "5s"},
-        remote_python={"127.0.0.1": sys.executable},
+        remote_python=[sys.executable] * 3,
     ) as cluster:
         assert cluster.workers[0].remote_python == sys.executable
+
+
+@pytest.mark.asyncio
+async def test_list_of_remote_python_raises():
+    with pytest.raises(RuntimeError):
+        async with SSHCluster(
+            ["127.0.0.1"] * 3,
+            connect_options=[dict(known_hosts=None)] * 3,
+            asynchronous=True,
+            scheduler_options={"port": 0, "idle_timeout": "5s"},
+            worker_options={"death_timeout": "5s"},
+            remote_python=[sys.executable] * 4,  # Mismatch in length 4 != 3
+        ) as _:
+            pass


### PR DESCRIPTION
Trying to resolve #4063

```python
cluster = SSHCluster(["hostA", "hostA", "hostB"], 
                     remote_python={'hostA': '/tmp/condaA/bin/python', 
                                    'hostB': '/tmp/condaB/bin/python'}, 
                     connect_options={"known_hosts": None},
                     worker_options={"nthreads": 2},
                     scheduler_options={"port": 0, "dashboard_address": ":8797"})
```

```
> w = cluster.workers
> w[0].remote_python
/tmp/condaA/bin/python
> w[1].remote_python
/tmp/condaB/bin/python
```

@jacobtomlinson please let me know if more work is needed here. Thanks, 