### PR TITLE
dask-worker --nprocs accepts negative values

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -127,7 +127,8 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     type=int,
     default=1,
     show_default=True,
-    help="Number of worker processes to launch.",
+    help="Number of worker processes to launch. "
+    "If negative, then (CPU_COUNT + 1 + nprocs) is used.",
 )
 @click.option(
     "--name",
@@ -287,6 +288,15 @@ def main(
         ]
         if v is not None
     }
+
+    if nprocs < 0:
+        nprocs = CPU_COUNT + 1 + nprocs
+
+    if nprocs <= 0:
+        logger.error(
+            "Failed to launch worker. Must specify --nprocs so that there's at least one process."
+        )
+        sys.exit(1)
 
     if nprocs > 1 and not nanny:
         logger.error(

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -243,11 +243,7 @@ def test_nprocs_negative(loop):
     with popen(["dask-scheduler", "--no-dashboard"]) as sched:
         with popen(["dask-worker", "127.0.0.1:8786", "--nprocs=-1"]) as worker:
             with Client("tcp://127.0.0.1:8786", loop=loop) as c:
-                start = time()
-                cpus = cpu_count()
-                while len(c.scheduler_info()["workers"]) != cpus:
-                    sleep(0.2)
-                    assert time() < start + 10
+                c.wait_for_workers(cpu_count(), timeout="10 seconds")
 
 
 def test_nprocs_expands_name(loop):

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -8,6 +8,7 @@ import requests
 import sys
 import os
 from time import sleep
+from multiprocessing import cpu_count
 
 import distributed.cli.dask_worker
 from distributed import Client, Scheduler
@@ -236,6 +237,17 @@ def test_nprocs_requires_nanny(loop):
                 b"Failed to launch worker" in worker.stderr.readline()
                 for i in range(15)
             )
+
+
+def test_nprocs_negative(loop):
+    with popen(["dask-scheduler", "--no-dashboard"]) as sched:
+        with popen(["dask-worker", "127.0.0.1:8786", "--nprocs=-1"]) as worker:
+            with Client("tcp://127.0.0.1:8786", loop=loop) as c:
+                start = time()
+                cpus = cpu_count()
+                while len(c.scheduler_info()["workers"]) != cpus:
+                    sleep(0.2)
+                    assert time() < start + 10
 
 
 def test_nprocs_expands_name(loop):


### PR DESCRIPTION
This pull request addresses #4088 .

dask-worker cli script now accepts negative --nprocs values, which are then converted using the formula `CPU_COUNT + 1 + nprocs`. This is similar to joblib.Parallel's n_jobs argument.

The help string for the --nprocs argument was also updated accordingly.