### PR TITLE
Support zero-worker clients

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1028,13 +1028,6 @@ class Client:
                     **self._startup_kwargs,
                 )
 
-            # Wait for all workers to be ready
-            # XXX should be a LocalCluster method instead
-            while not self.cluster.workers or len(self.cluster.scheduler.workers) < len(
-                self.cluster.workers
-            ):
-                await asyncio.sleep(0.01)
-
             address = self.cluster.scheduler_address
 
         self._gather_semaphore = asyncio.Semaphore(5)

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1050,3 +1050,11 @@ async def test_async_with():
         assert w
 
     assert not w
+
+
+@pytest.mark.asyncio
+async def test_no_workers(cleanup):
+    async with Client(
+        n_workers=0, silence_logs=False, dashboard_address=None, asynchronous=True
+    ) as c:
+        pass


### PR DESCRIPTION
Previously we used to wait until workers arrived before handing back
control.  However this stopped zero-worker clients from starting up

I don't think that we need this any more.  I'm guessing that SpecCluster
handles this now.