### PR TITLE
Allow workers to talk to multiple schedulers

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1659,3 +1659,20 @@ async def test_who_wants(c, s, w):
         await asyncio.sleep(0.01)
 
     assert not w.who_wants
+
+
+@pytest.mark.asyncio
+async def test_mulitple_schedulers(cleanup):
+    async with Scheduler() as s1, Scheduler() as s2:
+        async with Worker(s1.address) as w:
+            await w._register_with_scheduler(s2.address)
+            async with Client(s1.address, asynchronous=True) as c1, Client(
+                s2.address, asynchronous=True
+            ) as c2:
+                x = c1.submit(inc, 1)
+                y = c2.submit(inc, 2)
+                await x
+                await y
+
+                assert x.key in w.data
+                assert y.key in w.data

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1647,3 +1647,15 @@ async def test_heartbeat_comm_closed(cleanup, monkeypatch, reconnect):
                 else:
                     assert w.status == Status.closed
     assert "Heartbeat to scheduler failed" in logger.getvalue()
+
+
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
+async def test_who_wants(c, s, w):
+    x = c.submit(inc, 1)
+    await x
+    assert w.who_wants[x.key] == {s.address}
+    del x
+    while w.tasks:
+        await asyncio.sleep(0.01)
+
+    assert not w.who_wants


### PR DESCRIPTION
This is a proof of concept.  I was talking with a group last week who wanted to use Dask for production workloads where they had lots of smallish concurrent requests and cared pretty strongly about uptime.  They were reasonably concerned about being bottlenecked on a single Scheduler.  

For this kind of highly concurrent workload it might make sense to have a pool of workers and a smaller pool of schedulers to query them, possibly behind a traditional load balancer.  

![multi-scheduler architecture](https://user-images.githubusercontent.com/306380/92313987-acae9480-ef86-11ea-89d5-fd8a34702a51.png)

Today, Workers know about only one Scheduler.  It turns out not to be difficult to generalize this a bit, and let them talk to multiple Schedulers.  Actually that might not be true, I haven't gone through any tricky cases for this yet, but I thought that I'd post what I have here as a proof of concept and a conversation starter.  This was only about an hour's work.  This could be doable in a day, or maybe a week.  We might also choose to reject it for reasons of code complexity.