### PR TITLE
Fix registering a worker plugin with name arg

### DIFF
--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from distributed import Worker, WorkerPlugin
+from distributed import Client, LocalCluster, Worker, WorkerPlugin
 from distributed.utils_test import async_wait_for, gen_cluster, inc
 
 
@@ -134,6 +134,33 @@ async def test_release_dep_called(c, s, w):
     await c.register_worker_plugin(plugin)
     await c.get(dsk, "task", sync=False)
     await async_wait_for(lambda: not (w.task_state or w.dep_state), timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_registering_with_name_arg():
+    class FooWorkerPlugin:
+        def setup(self, worker):
+            if hasattr(worker, "foo"):
+                raise RuntimeError(f"Worker {worker.address} already has foo!")
+
+            worker.foo = True
+
+    async with LocalCluster(
+        1,
+        scheduler_port=0,
+        processes=False,
+        silence_logs=False,
+        dashboard_address=None,
+        asynchronous=True,
+    ) as cluster, Client(cluster, asynchronous=True) as c:
+        responses = await c.register_worker_plugin(FooWorkerPlugin(), name="foo")
+        assert list(responses.values()) == [{"status": "OK"}]
+
+        cluster.scale(2)
+        await cluster
+
+        responses = await c.register_worker_plugin(FooWorkerPlugin(), name="foo")
+        assert list(responses.values()) == [{"status": "repeat"}] * 2
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -57,6 +57,7 @@ from .security import Security
 from .utils import (
     All,
     get_fileno_limit,
+    get_plugin_name,
     log_errors,
     key_split,
     validate_key,
@@ -1291,7 +1292,7 @@ class Scheduler(ServerNode):
         self.log = deque(
             maxlen=dask.config.get("distributed.scheduler.transition-log-length")
         )
-        self.worker_plugins = []
+        self.worker_plugins = {}
 
         worker_handlers = {
             "task-finished": self.handle_task_finished,
@@ -3844,7 +3845,10 @@ class Scheduler(ServerNode):
 
     async def register_worker_plugin(self, comm, plugin, name=None):
         """ Registers a setup function, and call it on every worker """
-        self.worker_plugins.append(plugin)
+        if name is None:
+            name = get_plugin_name(plugin)
+
+        self.worker_plugins[name] = plugin
 
         responses = await self.broadcast(
             msg=dict(op="plugin-add", plugin=plugin, name=name)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -57,7 +57,6 @@ from .security import Security
 from .utils import (
     All,
     get_fileno_limit,
-    get_plugin_name,
     log_errors,
     key_split,
     validate_key,
@@ -1292,7 +1291,7 @@ class Scheduler(ServerNode):
         self.log = deque(
             maxlen=dask.config.get("distributed.scheduler.transition-log-length")
         )
-        self.worker_plugins = {}
+        self.worker_plugins = []
 
         worker_handlers = {
             "task-finished": self.handle_task_finished,
@@ -3845,10 +3844,7 @@ class Scheduler(ServerNode):
 
     async def register_worker_plugin(self, comm, plugin, name=None):
         """ Registers a setup function, and call it on every worker """
-        if name is None:
-            name = get_plugin_name(plugin)
-
-        self.worker_plugins[name] = plugin
+        self.worker_plugins.append({"plugin": plugin, "name": name})
 
         responses = await self.broadcast(
             msg=dict(op="plugin-add", plugin=plugin, name=name)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -22,7 +22,6 @@ import inspect
 import sys
 import tempfile
 import threading
-import uuid
 import warnings
 import weakref
 import pkgutil
@@ -1608,9 +1607,3 @@ def clean_dashboard_address(addr, default_listen_ip=""):
         port = addr
 
     return {"address": host, "port": port}
-
-
-def get_plugin_name(plugin):
-    if hasattr(plugin, "name"):
-        return plugin.name
-    return funcname(plugin) + "-" + str(uuid.uuid4())

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -22,6 +22,7 @@ import inspect
 import sys
 import tempfile
 import threading
+import uuid
 import warnings
 import weakref
 import pkgutil
@@ -1607,3 +1608,9 @@ def clean_dashboard_address(addr, default_listen_ip=""):
         port = addr
 
     return {"address": host, "port": port}
+
+
+def get_plugin_name(plugin):
+    if hasattr(plugin, "name"):
+        return plugin.name
+    return funcname(plugin) + "-" + str(uuid.uuid4())

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -14,7 +14,6 @@ from pickle import PicklingError
 import random
 import threading
 import sys
-import uuid
 import warnings
 import weakref
 
@@ -46,6 +45,7 @@ from .sizeof import safe_sizeof as sizeof
 from .threadpoolexecutor import ThreadPoolExecutor, secede as tpe_secede
 from .utils import (
     get_ip,
+    get_plugin_name,
     typename,
     has_arg,
     _maybe_complex,
@@ -845,8 +845,8 @@ class Worker(ServerNode):
         else:
             await asyncio.gather(
                 *[
-                    self.plugin_add(plugin=plugin)
-                    for plugin in response["worker-plugins"]
+                    self.plugin_add(plugin=plugin, name=name)
+                    for name, plugin in response["worker-plugins"].items()
                 ]
             )
 
@@ -2369,13 +2369,8 @@ class Worker(ServerNode):
         with log_errors(pdb=False):
             if isinstance(plugin, bytes):
                 plugin = pickle.loads(plugin)
-            if not name:
-                if hasattr(plugin, "name"):
-                    name = plugin.name
-                else:
-                    name = funcname(plugin) + "-" + str(uuid.uuid4())
-
-            assert name
+            if name is None:
+                name = get_plugin_name(plugin)
 
             if name in self.plugins:
                 return {"status": "repeat"}


### PR DESCRIPTION
Fixes #4100.

Please say if `utils` is not the best place for `get_plugin_name`, which is used by `scheduler` and `worker`.