### PR TITLE
Add TaskState to worker.py

### DIFF
--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -72,7 +72,7 @@ class StateTable(DashboardComponent):
             w = self.worker
             d = {
                 "Stored": [len(w.data)],
-                "Executing": ["%d / %d" % (len(w.executing), w.nthreads)],
+                "Executing": ["%d / %d" % (w.executing_count, w.nthreads)],
                 "Ready": [len(w.ready)],
                 "Waiting": [w.waiting_for_data_count],
                 "Connections": [len(w.in_flight_workers)],
@@ -265,7 +265,7 @@ class ExecutingTimeSeries(DashboardComponent):
     def update(self):
         with log_errors():
             self.source.stream(
-                {"x": [time() * 1000], "y": [len(self.worker.executing)]}, 1000
+                {"x": [time() * 1000], "y": [self.worker.executing_count]}, 1000
             )
 
 

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -74,7 +74,7 @@ class StateTable(DashboardComponent):
                 "Stored": [len(w.data)],
                 "Executing": ["%d / %d" % (len(w.executing), w.nthreads)],
                 "Ready": [len(w.ready)],
-                "Waiting": [len(w.waiting_for_data)],
+                "Waiting": [w.waiting_for_data],
                 "Connections": [len(w.in_flight_workers)],
                 "Serving": [len(w._comms)],
             }

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -74,7 +74,7 @@ class StateTable(DashboardComponent):
                 "Stored": [len(w.data)],
                 "Executing": ["%d / %d" % (len(w.executing), w.nthreads)],
                 "Ready": [len(w.ready)],
-                "Waiting": [w.waiting_for_data],
+                "Waiting": [w.waiting_for_data_count],
                 "Connections": [len(w.in_flight_workers)],
                 "Serving": [len(w._comms)],
             }

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -127,7 +127,7 @@ async def test_release_dep_called(c, s, w):
         {"key": "dep", "state": "memory"},
         # There is no more release_dep
         # Need to think about how to rework this test.
-        #{"dep": "dep", "state": "memory"},
+        # {"dep": "dep", "state": "memory"},
         {"key": "task", "state": "memory"},
     ]
 

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -125,7 +125,9 @@ async def test_release_dep_called(c, s, w):
         {"key": "task", "start": "ready", "finish": "executing"},
         {"key": "task", "start": "executing", "finish": "memory"},
         {"key": "dep", "state": "memory"},
-        {"dep": "dep", "state": "memory"},
+        # There is no more release_dep
+        # Need to think about how to rework this test.
+        #{"dep": "dep", "state": "memory"},
         {"key": "task", "state": "memory"},
     ]
 
@@ -133,7 +135,7 @@ async def test_release_dep_called(c, s, w):
 
     await c.register_worker_plugin(plugin)
     await c.get(dsk, "task", sync=False)
-    await async_wait_for(lambda: not (w.tasks or w.dep_state), timeout=10)
+    await async_wait_for(lambda: not w.tasks, timeout=10)
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -125,9 +125,6 @@ async def test_release_dep_called(c, s, w):
         {"key": "task", "start": "ready", "finish": "executing"},
         {"key": "task", "start": "executing", "finish": "memory"},
         {"key": "dep", "state": "memory"},
-        # There is no more release_dep
-        # Need to think about how to rework this test.
-        # {"dep": "dep", "state": "memory"},
         {"key": "task", "state": "memory"},
     ]
 

--- a/distributed/http/worker/prometheus.py
+++ b/distributed/http/worker/prometheus.py
@@ -25,7 +25,7 @@ class _PrometheusCollector:
         tasks.add_metric(["stored"], len(self.worker.data))
         tasks.add_metric(["executing"], len(self.worker.executing))
         tasks.add_metric(["ready"], len(self.worker.ready))
-        tasks.add_metric(["waiting"], self.worker.waiting_for_data)
+        tasks.add_metric(["waiting"], self.worker.waiting_for_data_count)
         tasks.add_metric(["serving"], len(self.worker._comms))
         yield tasks
 

--- a/distributed/http/worker/prometheus.py
+++ b/distributed/http/worker/prometheus.py
@@ -23,7 +23,7 @@ class _PrometheusCollector:
             "dask_worker_tasks", "Number of tasks at worker.", labels=["state"]
         )
         tasks.add_metric(["stored"], len(self.worker.data))
-        tasks.add_metric(["executing"], len(self.worker.executing))
+        tasks.add_metric(["executing"], self.worker.executing_count)
         tasks.add_metric(["ready"], len(self.worker.ready))
         tasks.add_metric(["waiting"], self.worker.waiting_for_data_count)
         tasks.add_metric(["serving"], len(self.worker._comms))

--- a/distributed/http/worker/prometheus.py
+++ b/distributed/http/worker/prometheus.py
@@ -25,7 +25,7 @@ class _PrometheusCollector:
         tasks.add_metric(["stored"], len(self.worker.data))
         tasks.add_metric(["executing"], len(self.worker.executing))
         tasks.add_metric(["ready"], len(self.worker.ready))
-        tasks.add_metric(["waiting"], len(self.worker.waiting_for_data))
+        tasks.add_metric(["waiting"], self.worker.waiting_for_data)
         tasks.add_metric(["serving"], len(self.worker._comms))
         yield tasks
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5123,7 +5123,7 @@ async def test_call_stack_future(c, s, a, b):
     assert all(list(first(result.values())) == [future.key] for result in results)
     assert results[0] == results[1]
     result = results[0]
-    w = a if future.key in a.executing else b
+    w = a if future.key in a.executing_count else b
     assert list(result) == [w.address]
     assert list(result[w.address]) == [future.key]
     assert "slowinc" in str(result)
@@ -5133,10 +5133,10 @@ async def test_call_stack_future(c, s, a, b):
 @gen_cluster([("127.0.0.1", 4)] * 2, client=True)
 async def test_call_stack_all(c, s, a, b):
     future = c.submit(slowinc, 1, delay=0.8)
-    while not a.executing and not b.executing:
+    while not a.executing_count and not b.executing_count:
         await asyncio.sleep(0.01)
     result = await c.call_stack()
-    w = a if a.executing else b
+    w = a if a.executing_count else b
     assert list(result) == [w.address]
     assert list(result[w.address]) == [future.key]
     assert "slowinc" in str(result)
@@ -5146,7 +5146,7 @@ async def test_call_stack_all(c, s, a, b):
 async def test_call_stack_collections(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.random.random(100, chunks=(10,)).map_blocks(slowinc, delay=0.5).persist()
-    while not a.executing and not b.executing:
+    while not a.executing_count and not b.executing_count:
         await asyncio.sleep(0.001)
     result = await c.call_stack(x)
     assert result
@@ -5156,7 +5156,7 @@ async def test_call_stack_collections(c, s, a, b):
 async def test_call_stack_collections_all(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.random.random(100, chunks=(10,)).map_blocks(slowinc, delay=0.5).persist()
-    while not a.executing and not b.executing:
+    while not a.executing_count and not b.executing_count:
         await asyncio.sleep(0.001)
     result = await c.call_stack()
     assert result

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5123,7 +5123,12 @@ async def test_call_stack_future(c, s, a, b):
     assert all(list(first(result.values())) == [future.key] for result in results)
     assert results[0] == results[1]
     result = results[0]
-    w = a if a.tasks[future.key].state == "executing" else b
+    ts = a.tasks.get(future.key)
+    if ts is not None and ts.state == "executing":
+        w = a
+    else:
+        w = b
+
     assert list(result) == [w.address]
     assert list(result[w.address]) == [future.key]
     assert "slowinc" in str(result)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5123,7 +5123,7 @@ async def test_call_stack_future(c, s, a, b):
     assert all(list(first(result.values())) == [future.key] for result in results)
     assert results[0] == results[1]
     result = results[0]
-    w = a if future.key in a.executing_count else b
+    w = a if a.tasks[future.key].state == "executing" else b
     assert list(result) == [w.address]
     assert list(result[w.address]) == [future.key]
     assert "slowinc" in str(result)

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -384,8 +384,9 @@ async def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
     await wait(futures)
 
     result = await c.submit(sum, futures, workers=a.address)
-    for dep in set(a.dep_state) - set(a.tasks):
-        a.release_dep(dep, report=True)
+    deps = [dep for dep in a.tasks.values() if dep.key not in a.data_needed]
+    for dep in deps:
+        a.release_key(dep.key, report=True)
 
     n_worker_address = n.worker_address
     with suppress(CommClosedError):
@@ -398,7 +399,7 @@ async def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
     await total
 
     assert not a.has_what.get(n_worker_address)
-    assert not any(n_worker_address in s for s in a.who_has.values())
+    assert not any(n_worker_address in s for ts in a.tasks.values() for s in ts.who_has)
 
     await n.close()
 

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -229,8 +229,8 @@ async def test_submit_many_non_overlapping(c, s, a, b):
 
     while len(a.data) + len(b.data) < 100:
         await asyncio.sleep(0.01)
-        assert len(a.executing) <= 2
-        assert len(b.executing) <= 1
+        assert a.executing_count <= 2
+        assert b.executing_count <= 1
 
     await wait(futures)
     assert a.total_resources == a.available_resources
@@ -243,7 +243,7 @@ async def test_minimum_resource(c, s, a):
 
     while len(a.data) < 30:
         await asyncio.sleep(0.01)
-        assert len(a.executing) <= 1
+        assert a.executing_count <= 1
 
     await wait(futures)
     assert a.total_resources == a.available_resources

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1554,12 +1554,12 @@ async def test_closing_scheduler_closes_workers(s, a, b):
 async def test_resources_reset_after_cancelled_task(c, s, w):
     future = c.submit(sleep, 0.2, resources={"A": 1})
 
-    while not w.executing:
+    while not w.executing_count:
         await asyncio.sleep(0.01)
 
     await future.cancel()
 
-    while w.executing:
+    while w.executing_count:
         await asyncio.sleep(0.01)
 
     assert not s.workers[w.address].used_resources["A"]

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -965,7 +965,7 @@ async def test_worker_arrives_with_processing_data(c, s, a, b):
         await asyncio.sleep(0.01)
 
     w = Worker(s.address, nthreads=1)
-    w.put_key_in_memory(y.key, 3)
+    w.update_data(data={y.key: 3})
 
     await w
 
@@ -1017,7 +1017,7 @@ async def test_no_workers_to_memory(c, s):
         await asyncio.sleep(0.01)
 
     w = Worker(s.address, nthreads=1)
-    w.put_key_in_memory(y.key, 3)
+    w.update_data(data={y.key: 3})
 
     await w
 
@@ -1047,7 +1047,7 @@ async def test_no_worker_to_memory_restrictions(c, s, a, b):
         await asyncio.sleep(0.01)
 
     w = Worker(s.address, nthreads=1, name="alice")
-    w.put_key_in_memory(y.key, 3)
+    w.update_data(data={y.key: 3})
 
     await w
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -604,16 +604,16 @@ async def test_message_breakup(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_types(c, s, a, b):
-    assert all(ts.type_ is None for ts in a.tasks.values())
-    assert all(ts.type_ is None for ts in b.tasks.values())
+    assert all(ts.type is None for ts in a.tasks.values())
+    assert all(ts.type is None for ts in b.tasks.values())
     x = c.submit(inc, 1, workers=a.address)
     await wait(x)
-    assert a.tasks[x.key].type_ == int
+    assert a.tasks[x.key].type == int
 
     y = c.submit(inc, x, workers=b.address)
     await wait(y)
-    assert b.tasks[x.key].type_ == int
-    assert b.tasks[y.key].type_ == int
+    assert b.tasks[x.key].type == int
+    assert b.tasks[y.key].type == int
 
     await c._cancel(y)
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -606,15 +606,16 @@ async def test_message_breakup(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_types(c, s, a, b):
-    assert not a.types
-    assert not b.types
+    assert all(ts.type_ is None for ts in a.tasks.values())
+    assert all(ts.type_ is None for ts in b.tasks.values())
     x = c.submit(inc, 1, workers=a.address)
     await wait(x)
-    assert a.types[x.key] == int
+    assert a.tasks[x.key].type_ == int
 
     y = c.submit(inc, x, workers=b.address)
     await wait(y)
-    assert b.types == {x.key: int, y.key: int}
+    assert b.tasks[x.key].type_ == int
+    assert b.tasks[y.key].type_ == int
 
     await c._cancel(y)
 
@@ -623,7 +624,7 @@ async def test_types(c, s, a, b):
         await asyncio.sleep(0.01)
         assert time() < start + 5
 
-    assert y.key not in b.types
+    assert y.key not in b.tasks
 
 
 @gen_cluster()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -654,7 +654,6 @@ async def test_restrictions(c, s, a, b):
     assert a.available_resources["A"] == 1
 
 
-@pytest.mark.xfail
 @gen_cluster(client=True)
 async def test_clean_nbytes(c, s, a, b):
     L = [delayed(inc)(i) for i in range(10)]

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -572,7 +572,6 @@ async def test_clean(c, s, a, b):
         a.startstops,
         a.data,
         a.nbytes,
-        a.types,
         a.threads,
     ]
     for c in collections:

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -569,7 +569,6 @@ async def test_clean(c, s, a, b):
 
     collections = [
         a.tasks,
-        a.startstops,
         a.data,
         a.nbytes,
         a.threads,
@@ -697,7 +696,7 @@ async def test_multiple_transfers(c, s, w1, w2, w3):
 
     await wait(z)
 
-    r = w3.startstops[z.key]
+    r = w3.tasks[z.key].startstops
     transfers = [t for t in r if t["action"] == "transfer"]
     assert len(transfers) == 2
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1546,7 +1546,6 @@ async def test_protocol_from_scheduler_address(Worker):
                 assert info["address"].startswith("ucx://")
 
 
-@pytest.mark.skip(reason="broken on Arch")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("Worker", [Worker, Nanny])
 async def test_worker_listens_on_same_interface_by_default(Worker):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1937,11 +1937,18 @@ class Worker(ServerNode):
         return deps, total_bytes
 
     async def gather_dep(self, worker, dep, deps, total_nbytes, cause=None):
-        """
-        worker: str
-        dep: TaskState object
-        deps: list of keys of dependencies to gather
+        """Gather dependencies for a task from a worker who has them
 
+        Parameters
+        ----------
+        worker : str
+            address of worker to gather dependency from
+        dep : TaskState
+            task we want to gather dependencies for
+        deps : list
+            keys of dependencies to gather from worker -- this is not
+            necessarily equivalent to the full list of dependencies of ``dep``
+            as some dependencies may already be present on this worker.
         """
         if self.status != Status.running:
             return

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -435,6 +435,7 @@ class Worker(ServerNode):
             ("long-running", "memory"): self.transition_executing_done,
             ("long-running", "rescheduled"): self.transition_executing_done,
             ("flight", "memory"): self.transition_flight_memory,
+            ("flight", "ready"): self.transition_flight_memory,
             ("flight", "waiting"): self.transition_flight_waiting,
         }
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1358,8 +1358,6 @@ class Worker(ServerNode):
         if keys:
             for key in list(keys):
                 self.log.append((key, "delete"))
-                # TODO: make sure this doesn't blow anything up but I think this check is redundant
-                # if key in self.tasks:
                 self.release_key(key)
 
             logger.debug("Worker %s -- Deleted %d keys", self.name, len(keys))
@@ -1932,7 +1930,7 @@ class Worker(ServerNode):
             if not dep.waiting_for_data:
                 self.transition(dep, "ready")
 
-        #if transition and ts.state is not None:
+        # if transition and ts.state is not None:
         #    self.transition(ts, "memory")
 
         self.log.append((ts.key, "put-in-memory"))

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2858,8 +2858,6 @@ class Worker(ServerNode):
                         key in self.in_flight_tasks
                         or key in self._missing_dep_flight
                         or self.tasks[key].who_has.issubset(self.in_flight_workers)
-                        # TODO: this prevents other test failures and seems like a
-                        # legitimate check -- a dependency might itself be waiting
                         or self.tasks[key].state == "waiting"
                     )
                 if ts.state == "memory":

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1500,7 +1500,10 @@ class Worker(ServerNode):
     def transition_waiting_flight(self, ts, worker=None):
         try:
             if self.validate:
-                assert ts.key not in self.in_flight_tasks
+                # TODO: This needs to be commented out for
+                # test_failed_workers.py::test_broken_worker_during_computation
+                # to pass.  Need to sort that out.
+                #assert ts.key not in self.in_flight_tasks
                 assert self.tasks[ts.key].dependents
 
             self.in_flight_tasks[ts.key] = worker

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1547,7 +1547,6 @@ class Worker(ServerNode):
             del self.in_flight_tasks[ts.key]
             if ts.dependents:
                 self.put_key_in_memory(ts, value)
-                assert ts.key in self.data
                 for dependent in ts.dependents:
                     dependent.waiting_for_data.discard(ts.key)
                     self.waiting_for_data -= 1

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1508,7 +1508,7 @@ class Worker(ServerNode):
                 # test_failed_workers.py::test_broken_worker_during_computation
                 # to pass.  Need to sort that out.
                 # assert ts.key not in self.in_flight_tasks
-                assert self.tasks[ts.key].dependents
+                assert ts.dependents
 
             self.in_flight_tasks[ts.key] = worker
         except Exception as e:
@@ -1536,7 +1536,7 @@ class Worker(ServerNode):
                 if ts.key not in self._missing_dep_flight:
                     self.loop.add_callback(self.handle_missing_dep, ts)
             for dependent in ts.dependents:
-                if self.tasks[dependent.key].state == "waiting":
+                if dependent.state == "waiting":
                     if remove:  # try a new worker immediately
                         self.data_needed.appendleft(dependent.key)
                     else:  # worker was probably busy, wait a while
@@ -2068,7 +2068,7 @@ class Worker(ServerNode):
                     elif ts.state not in ("ready", "memory"):
                         self.transition(ts, "waiting", worker=worker, remove=not busy)
 
-                    if not busy and d not in data and self.tasks[d].dependents:
+                    if not busy and d not in data and ts.dependents:
                         self.log.append(("missing-dep", d))
                         self.batched_stream.send(
                             {"op": "missing-data", "errant_worker": worker, "key": d}

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1493,10 +1493,6 @@ class Worker(ServerNode):
     def transition_waiting_flight(self, ts, worker=None):
         try:
             if self.validate:
-                # TODO: This needs to be commented out for
-                # test_failed_workers.py::test_broken_worker_during_computation
-                # to pass.  Need to sort that out.
-                # assert ts.key not in self.in_flight_tasks
                 assert ts.dependents
 
             self.in_flight_tasks[ts.key] = worker
@@ -1650,8 +1646,6 @@ class Worker(ServerNode):
     def transition_executing_done(self, ts, value=no_value, report=True):
         try:
             if self.validate:
-                # TODO: restore this (maybe?)
-                # assert ts.key in self.executing or ts.key in self.long_running
                 assert not ts.waiting_for_data
                 assert ts.key not in self.ready
 
@@ -1677,7 +1671,6 @@ class Worker(ServerNode):
                     ts.state = "error"
                     out = "error"
 
-                # TODO: should this be here
                 # Don't release the dependency keys, but do remove them from `dependents`
                 for dependency in ts.dependencies:
                     dependency.dependents.discard(ts)
@@ -2113,7 +2106,6 @@ class Worker(ServerNode):
                 self.scheduler.who_has, keys=list(dep.key for dep in deps)
             )
             who_has = {k: v for k, v in who_has.items() if v}
-            # TODO: fixup `update_who_has`
             self.update_who_has(who_has)
             for dep in deps:
                 dep.suspicious_count += 1
@@ -2194,9 +2186,8 @@ class Worker(ServerNode):
                 del self.actors[key]
                 del self.nbytes[key]
 
-            # for any dependencies of key we are releasing
+            # for any dependencies of key we are releasing remove task as dependent
             for dependency in ts.dependencies:
-                # remove task as dependent
                 dependency.dependents.discard(ts)
                 if not dependency.dependents and dependency.state in (
                     "waiting",

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2530,7 +2530,7 @@ class Worker(ServerNode):
             kwargs2 = pack_data(kwargs, data, key_types=(bytes, str))
             stop = time()
             if stop - start > 0.005:
-                self.startstops[key].append(
+                self.startstops[ts.key].append(
                     {"action": "disk-read", "start": start, "stop": stop}
                 )
                 if self.digests is not None:
@@ -2539,16 +2539,17 @@ class Worker(ServerNode):
             logger.debug(
                 "Execute key: %s worker: %s", ts.key, self.address
             )  # TODO: comment out?
+            assert key == ts.key
             try:
                 result = await self.executor_submit(
-                    key,
+                    ts.key,
                     apply_function,
                     args=(
                         function,
                         args2,
                         kwargs2,
                         self.execution_state,
-                        key,
+                        ts.key,
                         self.active_threads,
                         self.active_threads_lock,
                         self.scheduler_delay,
@@ -2571,7 +2572,7 @@ class Worker(ServerNode):
             if result["op"] == "task-finished":
                 self.nbytes[ts.key] = result["nbytes"]
                 self.types[ts.key] = result["type"]
-                self.transition(key, "memory", value=value)
+                self.transition(ts.key, "memory", value=value)
                 if self.digests is not None:
                     self.digests["task-duration"].add(result["stop"] - result["start"])
             else:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1479,9 +1479,6 @@ class Worker(ServerNode):
             raise
 
     def transition(self, ts, finish, **kwargs):
-        # TODO: check if this is needed
-        if ts is None:
-            return
         start = ts.state
         if start == finish:
             return
@@ -2225,9 +2222,6 @@ class Worker(ServerNode):
                         self.available_resources[resource] += quantity
 
             if report and ts.state in PROCESSING:  # not finished
-                # If not finished, restore TaskState to tasks dict
-                # TODO: need this?
-                # self.tasks[key] = ts
                 self.batched_stream.send({"op": "release", "key": key, "cause": cause})
 
             self._notify_plugins("release_key", key, ts.state, cause, reason, report)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1479,6 +1479,8 @@ class Worker(ServerNode):
             raise
 
     def transition(self, ts, finish, **kwargs):
+        if ts is None:
+            return
         start = ts.state
         if start == finish:
             return
@@ -1971,7 +1973,8 @@ class Worker(ServerNode):
                     return
 
                 if cause:
-                    self.tasks[cause].startstops.append(
+                    cause_ts = self.tasks.get(cause, TaskState(key=cause))
+                    cause_ts.startstops.append(
                         {
                             "action": "transfer",
                             "start": start + self.scheduler_delay,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1932,8 +1932,8 @@ class Worker(ServerNode):
             if not dep.waiting_for_data:
                 self.transition(dep, "ready")
 
-        if transition and ts.state is not None:
-            self.transition(ts, "memory")
+        #if transition and ts.state is not None:
+        #    self.transition(ts, "memory")
 
         self.log.append((ts.key, "put-in-memory"))
 
@@ -2065,6 +2065,7 @@ class Worker(ServerNode):
                         self.transition(ts, "memory", value=data[d])
                     elif ts is None or ts.state == "executing":
                         self.release_key(d)
+                        continue
                     elif ts.state not in ("ready", "memory"):
                         self.transition(ts, "waiting", worker=worker, remove=not busy)
 
@@ -2497,7 +2498,9 @@ class Worker(ServerNode):
                     # The scheduler might have re-routed to a new worker and told this worker
                     # to release.  If the task has "disappeared" just continue through the heap
                     continue
-                if ts.state in READY:
+                elif ts.key in self.data:
+                    self.transition(ts, "memory")
+                elif ts.state in READY:
                     try:
                         # Ensure task is deserialized prior to execution
                         ts.runspec = self._maybe_deserialize_task(ts)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2506,9 +2506,6 @@ class Worker(ServerNode):
                         self.scheduler_delay,
                     ),
                 )
-                # TODO: it seems insane that this needs to be here
-                # but it is occasionally cleared by something in executor_submit
-                self.executing.add(ts.key)
             except RuntimeError as e:
                 executor_error = e
                 raise

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1430,6 +1430,7 @@ class Worker(ServerNode):
             ts.duration = duration
             if resource_restrictions:
                 ts.resource_restrictions = resource_restrictions
+            ts.state = "waiting"
 
             if nbytes is not None:
                 self.nbytes.update(nbytes)
@@ -1897,7 +1898,10 @@ class Worker(ServerNode):
         if key in self.data:
             return
 
-        ts = self.tasks[key]
+        ts = self.tasks.get(key)
+        if ts is None:
+            # If `put_key_in_memory` is called directly...
+            self.tasks[key] = ts = TaskState(key=key)
 
         if key in self.actors:
             self.actors[key] = value

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1776,7 +1776,7 @@ class Worker(ServerNode):
 
                 deps = ts.dependencies
                 if self.validate:
-                    assert all(hasattr(dep, "state") for dep in deps)
+                    assert all(dep.key in self.tasks for dep in deps)
 
                 deps = [dep for dep in deps if dep.state == "waiting"]
 
@@ -2030,8 +2030,6 @@ class Worker(ServerNode):
                 self.log.append(("receive-dep-failed", worker))
                 for d in self.has_what.pop(worker):
                     self.tasks[d].who_has.remove(worker)
-                # If the worker has died, `return` here so we don't hit `finally`
-                return
 
             except Exception as e:
                 logger.exception(e)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1466,7 +1466,10 @@ class Worker(ServerNode):
             if ts.waiting_for_data:
                 self.data_needed.append(ts.key)
             elif ts.key in self.data:
-                # This seems like it shouldn't happen, and yet...
+                # This seems like it shouldn't happen, but during worker failures
+                # it is possible for the data to not be in `self.data` when the task
+                # is received from the scheduler (as a repeat) and then land
+                # in `self.data` before we get here.
                 self.transition(ts, "memory")
             else:
                 self.transition(ts, "ready")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1729,6 +1729,7 @@ class Worker(ServerNode):
                 # Don't release the dependency keys, but do remove them from `dependents`
                 for dependency in ts.dependencies:
                     dependency.dependents.discard(ts)
+                ts.dependencies = set()
 
             if report and self.batched_stream and self.status == Status.running:
                 self.send_task_state_to_scheduler(ts)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2829,6 +2829,12 @@ class Worker(ServerNode):
         if ts.dependencies:
             assert not all(dep.key in self.data for dep in ts.dependencies)
 
+    def validate_task_flight(self, ts):
+        assert ts.key not in self.data
+        assert not any(dep.key in self.ready for dep in ts.dependents)
+        peer = self.in_flight_tasks[ts.key]
+        assert ts.key in self.in_flight_workers[peer]
+
     def validate_task(self, ts):
         try:
             if ts.state == "memory":
@@ -2839,6 +2845,8 @@ class Worker(ServerNode):
                 self.validate_task_ready(ts)
             elif ts.state == "executing":
                 self.validate_task_executing(ts)
+            elif ts.state == "flight":
+                self.validate_task_flight(ts)
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2126,9 +2126,9 @@ class Worker(ServerNode):
                     self.release_key(dep.key)
                 else:
                     self.log.append((dep.key, "new workers found"))
-                    for depdep in dep.dependents:
-                        if depdep.key in dep.waiting_for_data:
-                            self.data_needed.append(depdep.key)
+                    for dependent in dep.dependents:
+                        if dependent.key in dep.waiting_for_data:
+                            self.data_needed.append(dependent.key)
 
         except Exception:
             logger.error("Handle missing dep failed, retrying", exc_info=True)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1825,7 +1825,7 @@ class Worker(ServerNode):
                     self.comm_nbytes += total_nbytes
                     self.in_flight_workers[worker] = to_gather
                     for d in to_gather:
-                        self.transition(self.tasks.get(d), "flight", worker=worker)
+                        self.transition(self.tasks[d], "flight", worker=worker)
                     self.loop.add_callback(
                         self.gather_dep, worker, dep, to_gather, total_nbytes, cause=key
                     )
@@ -1926,7 +1926,8 @@ class Worker(ServerNode):
 
         while L:
             d = L.popleft()
-            if getattr(self.tasks.get(d), "state", None) != "waiting":
+            ts = self.tasks.get(d)
+            if ts is None or ts.state != "waiting":
                 continue
             if total_bytes + self.nbytes[d] > self.target_message_size:
                 break

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1648,6 +1648,7 @@ class Worker(ServerNode):
     def transition_executing_done(self, ts, value=no_value, report=True):
         try:
             if self.validate:
+                assert ts.key in self.executing or ts.key in self.long_running
                 assert not ts.waiting_for_data
                 assert ts.key not in self.ready
 
@@ -2490,6 +2491,9 @@ class Worker(ServerNode):
                         self.scheduler_delay,
                     ),
                 )
+                # TODO: it seems insane that this needs to be here
+                # but it is occasionally cleared by something in executor_submit
+                self.executing.add(ts.key)
             except RuntimeError as e:
                 executor_error = e
                 raise

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1503,7 +1503,7 @@ class Worker(ServerNode):
                 # TODO: This needs to be commented out for
                 # test_failed_workers.py::test_broken_worker_during_computation
                 # to pass.  Need to sort that out.
-                #assert ts.key not in self.in_flight_tasks
+                # assert ts.key not in self.in_flight_tasks
                 assert self.tasks[ts.key].dependents
 
             self.in_flight_tasks[ts.key] = worker
@@ -2930,14 +2930,18 @@ class Worker(ServerNode):
                     # so we may have popped the key out of `self.tasks` but the
                     # dependency can still be in `memory` before GC grabs it...?
                     # Might need better bookkeeping
-                    assert dep.state == "memory" or dep.key in self.tasks
+                    assert dep.key in self.tasks
+                    assert dep.state is not None
                     self.validate_key(dep.key)
-                # for depkey in ts.waiting_for_data:
-                #    assert (
-                #        depkey in self.in_flight_tasks
-                #        or depkey in self._missing_dep_flight
-                #        or self.tasks[depkey].who_has.issubset(self.in_flight_workers)
-                #        )
+                for depkey in ts.waiting_for_data:
+                    assert (
+                        depkey in self.in_flight_tasks
+                        or depkey in self._missing_dep_flight
+                        or self.tasks[depkey].who_has.issubset(self.in_flight_workers)
+                        # TODO: this prevents other test failures and seems like a
+                        # legitimate check -- a dependency might itself be waiting
+                        or self.tasks[depkey].state == "waiting"
+                    )
                 if ts.state == "memory":
                     assert isinstance(self.nbytes[ts.key], int)
                     assert not ts.waiting_for_data

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1677,7 +1677,7 @@ class Worker(ServerNode):
                 # Don't release the dependency keys, but do remove them from `dependents`
                 for dependency in ts.dependencies:
                     dependency.dependents.discard(ts)
-                ts.dependencies = set()
+                ts.dependencies.clear()
 
             if report and self.batched_stream and self.status == Status.running:
                 self.send_task_state_to_scheduler(ts)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1901,10 +1901,7 @@ class Worker(ServerNode):
         if key in self.data:
             return
 
-        ts = self.tasks.get(key)
-        if ts is None:
-            # If `put_key_in_memory` is called directly...
-            self.tasks[key] = ts = TaskState(key=key)
+        ts = self.tasks[key]
 
         if key in self.actors:
             self.actors[key] = value

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1457,7 +1457,7 @@ class Worker(ServerNode):
                 self.log.append((dependency, "new-dep", dep_ts.state))
 
                 if dep_ts.state != "memory":
-                    ts.waiting_for_data.add(dependency)
+                    ts.waiting_for_data.add(dep_ts.key)
 
                 dep_ts.who_has.update(workers)
 
@@ -1465,9 +1465,9 @@ class Worker(ServerNode):
                 dep_ts.dependents.add(ts)
 
                 for worker in workers:
-                    self.has_what[worker].add(dependency)
+                    self.has_what[worker].add(dep_ts.key)
                     if dep_ts.state != "memory":
-                        self.pending_data_per_worker[worker].append(dependency)
+                        self.pending_data_per_worker[worker].append(dep_ts.key)
 
             if ts.waiting_for_data:
                 self.data_needed.append(ts.key)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2166,15 +2166,10 @@ class Worker(ServerNode):
     def update_who_has(self, who_has):
         try:
             for dep, workers in who_has.items():
-                assert isinstance(dep, str)
                 if not workers:
                     continue
 
-                if dep in self.tasks:
-                    self.tasks[dep].who_has.update(workers)
-                else:
-                    self.tasks[dep] = ts = TaskState(key=dep)
-                    ts.who_has = set(workers)
+                self.tasks[dep].who_has.update(workers)
 
                 for worker in workers:
                     self.has_what[worker].add(dep)
@@ -2187,7 +2182,7 @@ class Worker(ServerNode):
             raise
 
     def steal_request(self, key):
-        state = getattr(self.tasks.get(key, None), "state", None)
+        state = self.tasks[key].state
 
         response = {"op": "steal-response", "key": key, "state": state}
         self.batched_stream.send(response)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2248,6 +2248,7 @@ class Worker(ServerNode):
                 self.batched_stream.send({"op": "release", "key": key, "cause": cause})
 
             self._notify_plugins("release_key", key, ts.state, cause, reason, report)
+            del ts
         except CommClosedError:
             pass
         except Exception as e:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2521,8 +2521,6 @@ class Worker(ServerNode):
                 assert not ts.waiting_for_data
                 assert ts.state == "executing"
 
-            if ts.runspec is None:
-                breakpoint()
             function, args, kwargs = ts.runspec
 
             start = time()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -211,13 +211,13 @@ class Worker(ServerNode):
 
     **Volatile State**
 
-    This attributes track the progress of tasks that this worker is trying to
+    These attributes track the progress of tasks that this worker is trying to
     complete.  In the descriptions below a ``key`` is the name of a task that
     we want to compute and ``dep`` is the name of a piece of dependent data
     that we want to collect from others.
 
-    * **tasks**: ``{key: dict}``
-        The function, args, kwargs of a task.  We run this when appropriate
+    * **tasks**: ``{key: TaskState}``
+        The tasks currently executing on this worker (and any dependencies of those tasks)
     * **data:** ``{key: object}``:
         Prefer using the **host** attribute instead of this, unless
         memory_limit and at least one of memory_target_fraction or

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -42,7 +42,9 @@ def worker_client(timeout=3, separate_thread=True):
     client = get_client(timeout=timeout)
     if separate_thread:
         secede()  # have this thread secede from the thread pool
-        worker.loop.add_callback(worker.transition, thread_state.key, "long-running")
+        worker.loop.add_callback(
+            worker.transition, worker.tasks[thread_state.key], "long-running"
+        )
 
     yield client
 

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -246,4 +246,5 @@ process.
 API Documentation
 -----------------
 
+.. autoclass:: distributed.worker.TaskState
 .. autoclass:: distributed.worker.Worker


### PR DESCRIPTION
This is some initial progress towards #4097 -- dependents, dependencies and dep_state are still being tracked in a single dict on the Worker class but those come next.

Still lots to do on this, so no need for anyone to review just yet.