### PR TITLE
Update super usage

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4202,7 +4202,7 @@ class Executor(Client):
 
     def __init__(self, *args, **kwargs):
         warnings.warn("Executor has been renamed to Client")
-        super(Executor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 def CompatibleExecutor(*args, **kwargs):

--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -152,7 +152,7 @@ class Adaptive(AdaptiveCore):
             # are in sync before making recommendations.
             await self.cluster
 
-        return await super(Adaptive, self).recommendations(target)
+        return await super().recommendations(target)
 
     async def workers_to_close(self, target: int):
         """

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -226,7 +226,7 @@ class LocalCluster(SpecCluster):
 
         workers = {i: worker for i in range(n_workers)}
 
-        super(LocalCluster, self).__init__(
+        super().__init__(
             scheduler=scheduler,
             workers=workers,
             worker=worker,

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -115,7 +115,7 @@ class TextProgressBar(ProgressBar):
         start=True,
         **kwargs,
     ):
-        super(TextProgressBar, self).__init__(keys, scheduler, interval, complete)
+        super().__init__(keys, scheduler, interval, complete)
         self.width = width
         self.loop = loop or IOLoop()
 
@@ -158,7 +158,7 @@ class ProgressWidget(ProgressBar):
         loop=None,
         **kwargs,
     ):
-        super(ProgressWidget, self).__init__(keys, scheduler, interval, complete)
+        super().__init__(keys, scheduler, interval, complete)
 
         from ipywidgets import FloatProgress, HBox, VBox, HTML
 
@@ -314,7 +314,7 @@ class MultiProgressWidget(MultiProgressBar):
         complete=False,
         **kwargs,
     ):
-        super(MultiProgressWidget, self).__init__(
+        super().__init__(
             keys, scheduler, func, interval, complete
         )
         from ipywidgets import VBox

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -314,9 +314,7 @@ class MultiProgressWidget(MultiProgressBar):
         complete=False,
         **kwargs,
     ):
-        super().__init__(
-            keys, scheduler, func, interval, complete
-        )
+        super().__init__(keys, scheduler, func, interval, complete)
         from ipywidgets import VBox
 
         self.widget = VBox([])

--- a/distributed/http/scheduler/prometheus/__init__.py
+++ b/distributed/http/scheduler/prometheus/__init__.py
@@ -78,9 +78,7 @@ class PrometheusHandler(RequestHandler):
     def __init__(self, *args, dask_server=None, **kwargs):
         import prometheus_client
 
-        super(PrometheusHandler, self).__init__(
-            *args, dask_server=dask_server, **kwargs
-        )
+        super().__init__(*args, dask_server=dask_server, **kwargs)
 
         if PrometheusHandler._collectors:
             # Especially during testing, multiple schedulers are started

--- a/distributed/http/worker/prometheus.py
+++ b/distributed/http/worker/prometheus.py
@@ -77,7 +77,7 @@ class PrometheusHandler(RequestHandler):
     def __init__(self, *args, **kwargs):
         import prometheus_client
 
-        super(PrometheusHandler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         if PrometheusHandler._initialized:
             return

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -198,7 +198,7 @@ class Nanny(ServerNode):
             "run": self.run,
         }
 
-        super(Nanny, self).__init__(
+        super().__init__(
             handlers=handlers, io_loop=self.loop, connection_args=self.connection_args
         )
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1379,7 +1379,7 @@ class Scheduler(ServerNode):
 
         connection_limit = get_fileno_limit() / 2
 
-        super(Scheduler, self).__init__(
+        super().__init__(
             handlers=self.handlers,
             stream_handlers=merge(worker_handlers, client_handlers),
             io_loop=self.loop,
@@ -1580,7 +1580,7 @@ class Scheduler(ServerNode):
 
         self.status = Status.closed
         self.stop()
-        await super(Scheduler, self).close()
+        await super().close()
 
         setproctitle("dask-scheduler [closed]")
         disable_gc_diagnosis()
@@ -5586,7 +5586,7 @@ def heartbeat_interval(n):
 
 class KilledWorker(Exception):
     def __init__(self, task, last_worker):
-        super(KilledWorker, self).__init__(task, last_worker)
+        super().__init__(task, last_worker)
         self.task = task
         self.last_worker = last_worker
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1963,12 +1963,12 @@ class FlakyConnectionPool(ConnectionPool):
     def __init__(self, *args, failing_connections=0, **kwargs):
         self.cnn_count = 0
         self.failing_connections = failing_connections
-        super(FlakyConnectionPool, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     async def connect(self, *args, **kwargs):
         self.cnn_count += 1
         if self.cnn_count > self.failing_connections:
-            return await super(FlakyConnectionPool, self).connect(*args, **kwargs)
+            return await super().connect(*args, **kwargs)
         else:
             return BrokenComm()
 

--- a/distributed/threadpoolexecutor.py
+++ b/distributed/threadpoolexecutor.py
@@ -70,7 +70,7 @@ class ThreadPoolExecutor(thread.ThreadPoolExecutor):
     _counter = itertools.count()
 
     def __init__(self, *args, **kwargs):
-        super(ThreadPoolExecutor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._rejoin_list = []
         self._rejoin_lock = threading.Lock()
         self._thread_name_prefix = kwargs.get(

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1150,7 +1150,7 @@ class DequeHandler(logging.Handler):
 
     def __init__(self, *args, n=10000, **kwargs):
         self.deque = deque(maxlen=n)
-        super(DequeHandler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._instances.add(self)
 
     def emit(self, record):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -627,7 +627,7 @@ class Worker(ServerNode):
             "steal-request": self.steal_request,
         }
 
-        super(Worker, self).__init__(
+        super().__init__(
             handlers=handlers,
             stream_handlers=stream_handlers,
             io_loop=self.loop,


### PR DESCRIPTION
On Python 3, `super` can be called without any arguments where as on Python 2, `super` needs to be called with the class object and an instance e.g. `super(Executor, self)`. Given that distributed does not support Python 2 anymore on master, the `super` usage can be updated.

Additionally, it looks like a few uses of `super()` had already crept into the codebase so these changes also help with consistency in the codebase.

Note that this was an automated regex-based search and replace. The regex used was - `(super)+\(+(\w+)(,)+\s(self)+\)+`. After the automated search and replace happened, each change was individually checked and committed.

See also sister PR ins dask - https://github.com/dask/dask/pull/6630

Ref : https://docs.python.org/3/library/functions.html#super