### PR TITLE
Allow scheduler to preserve worker hostnames

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -128,6 +128,16 @@ properties:
 
               See https://docs.dask.org/en/latest/setup/custom-startup.html for more information
 
+          resolve-worker-hostname:
+            type: boolean
+            description: |
+              Whether the scheduler should resolve the worker hostname when joining.
+
+              If true, the worker's contact string is resolved to an IP address when it connects
+              (and the IP address is used to identify the worker internally).  Otherwise, the
+              resolution is only done when a socket is connected.  Disabling hostname resolution
+              may be advantageous when using TLS security.
+
           unknown-task-duration:
             type: string
             description: |

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -24,6 +24,7 @@ distributed:
     pickle: True            # Is the scheduler allowed to deserialize arbitrary bytestrings
     preload: []             # Run custom modules with Scheduler
     preload-argv: []        # See https://docs.dask.org/en/latest/setup/custom-startup.html
+    resolve-worker-hostname: true # Whether or not the worker hostname is resolved to an IP address at connection time
     unknown-task-duration: 500ms  # Default duration for all tasks with unknown durations ("15m", "2h")
     default-task-durations:  # How long we expect function names to run ("1h", "1s") (helps for long tasks)
       rechunk-split: 1us

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -102,6 +102,8 @@ DEFAULT_DATA_SIZE = parse_bytes(
     dask.config.get("distributed.scheduler.default-data-size")
 )
 
+RESOLVE_WORKER_HOSTNAME = dask.config.get("distributed.scheduler.resolve-worker-hostname")
+
 DEFAULT_EXTENSIONS = [
     LockExtension,
     PublishExtension,
@@ -1609,7 +1611,7 @@ class Scheduler(ServerNode):
         self,
         comm=None,
         address=None,
-        resolve_address=True,
+        resolve_address=RESOLVE_WORKER_HOSTNAME,
         now=None,
         resources=None,
         host_info=None,
@@ -1679,7 +1681,7 @@ class Scheduler(ServerNode):
         keys=(),
         nthreads=None,
         name=None,
-        resolve_address=True,
+        resolve_address=RESOLVE_WORKER_HOSTNAME,
         nbytes=None,
         types=None,
         now=None,
@@ -4934,7 +4936,7 @@ class Scheduler(ServerNode):
         for resource, quantity in ws.resources.items():
             del self.resources[resource][worker]
 
-    def coerce_address(self, addr, resolve=True):
+    def coerce_address(self, addr, resolve=RESOLVE_WORKER_HOSTNAME):
         """
         Coerce possible input addresses to canonical form.
         *resolve* can be disabled for testing with fake hostnames.


### PR DESCRIPTION
This provides a configuration option allowing the scheduler to preserve worker hostnames (as opposed to the current & default behavior of resolving hostnames immediately to IP address).

Preserving the hostname should convey advantages in two situations:

1. Dual-network setups where some hosts have IPv4-only or IPv6-only. This allows the host that wants to communicate with the worker to determine the best network to route over (as opposed to the scheduler).
2. Clusters that route TLS connections based on SNI.  If the hostname is kept internally, it will be pased to OpenSSL when making a connection.  This allows the OpenSSL client to embed the desired hostname in a SNI header in the TLS handshake.  If the worker is behind a TLS-router (not entirely uncommon in a Kubernetes setup), then this SNI is required to successfully route the request.

Closes #4070 