### PR TITLE
Correctly tear down LoopRunner in Client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -684,7 +684,6 @@ class Client:
 
         self._connecting_to_scheduler = False
         self._asynchronous = asynchronous
-        self._should_close_loop = not loop
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
         self.io_loop = self.loop = self._loop_runner.loop
 
@@ -1433,7 +1432,7 @@ class Client:
 
         assert self.status == "closed"
 
-        if self._should_close_loop and not shutting_down():
+        if not shutting_down():
             self._loop_runner.stop()
 
     async def _shutdown(self):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5403,10 +5403,10 @@ async def test_client_name(s, a, b):
     await c.close()
 
 
-def test_client_doesnt_close_given_loop(loop, s, a, b):
-    with Client(s["address"], loop=loop) as c:
+def test_client_doesnt_close_given_loop(loop_in_thread, s, a, b):
+    with Client(s["address"], loop=loop_in_thread) as c:
         assert c.submit(inc, 1).result() == 2
-    with Client(s["address"], loop=loop) as c:
+    with Client(s["address"], loop=loop_in_thread) as c:
         assert c.submit(inc, 2).result() == 3
 
 

--- a/distributed/tests/test_client_loop.py
+++ b/distributed/tests/test_client_loop.py
@@ -1,49 +1,34 @@
 import pytest
-import threading
-from time import sleep
 from distributed import LocalCluster, Client
 from distributed.utils import LoopRunner
 
 
-def run_client(loop):
-    with LocalCluster(loop=loop, asynchronous=False) as cluster:
-        client = Client(cluster, loop=loop, asynchronous=False)
-        sleep(1)  # Allow IO loop process events.
-        client.close()
-
-
-# Test if Client correctly tears down LoopRunner on close.
+# Test if Client stops LoopRunner on close.
 @pytest.mark.parametrize("with_own_loop", [True, False])
 def test_close_loop_sync(with_own_loop):
     loop_runner = loop = None
 
-    # Number of threads before and after the Cluster running.
-    threads_before = []
-    threads_after = []
+    # Setup simple cluster with one threaded worker.
+    # Complex setup is not required here since we test only IO loop teardown.
+    cluster_params = dict(n_workers=1, dashboard_address=None, processes=False)
 
-    for i in range(3):
-        threads_before.append(threading.enumerate())
+    loops_before = LoopRunner._all_loops.copy()
 
-        if with_own_loop:
-            loop_runner = LoopRunner(asynchronous=False)
-            loop_runner.start()
-            loop = loop_runner.loop
+    # Start own loop or use current thread's one.
+    if with_own_loop:
+        loop_runner = LoopRunner()
+        loop_runner.start()
+        loop = loop_runner.loop
 
-        run_client(loop)
+    with LocalCluster(loop=loop, **cluster_params) as cluster:
+        with Client(cluster, loop=loop) as client:
+            client.run(max, 1, 2)
 
-        if with_own_loop:
-            loop_runner.stop()
+    # own loop must be explicitly stopped.
+    if with_own_loop:
+        loop_runner.stop()
 
-        # Allow IO loop process events and wait until daemon threads finished.
-        sleep(1)
-        threads_after.append(threading.enumerate())
-
-    # TCP backend starts globally and runs few own threads on demand.
-    # 'threads_before' populates before that and contains less threads on first
-    # iteration. That's why we drop first values.
-    threads_before = threads_before[1:]
-    threads_after = threads_after[1:]
-
-    # In all other iterations there must be same number of threads before and
-    # after the Client running.
-    assert all([x == y for (x, y) in zip(threads_before, threads_after)])
+    # Internal loops registry must the same as before cluster running.
+    # This means loop runners in LocalCluster and Client correctly stopped.
+    # See LoopRunner._stop_unlocked().
+    assert loops_before == LoopRunner._all_loops

--- a/distributed/tests/test_client_loop.py
+++ b/distributed/tests/test_client_loop.py
@@ -1,0 +1,49 @@
+import pytest
+import threading
+from time import sleep
+from distributed import LocalCluster, Client
+from distributed.utils import LoopRunner
+
+
+def run_client(loop):
+    with LocalCluster(loop=loop, asynchronous=False) as cluster:
+        client = Client(cluster, loop=loop, asynchronous=False)
+        sleep(1)  # Allow IO loop process events.
+        client.close()
+
+
+# Test if Client correctly tears down LoopRunner on close.
+@pytest.mark.parametrize('with_own_loop', [True, False])
+def test_close_loop_sync(with_own_loop):
+    loop_runner = loop = None
+
+    # Number of threads before and after the Cluster running.
+    threads_before = []
+    threads_after = []
+
+    for i in range(3):
+        threads_before.append(threading.enumerate())
+
+        if with_own_loop:
+            loop_runner = LoopRunner(asynchronous=False)
+            loop_runner.start()
+            loop = loop_runner.loop
+
+        run_client(loop)
+
+        if with_own_loop:
+            loop_runner.stop()
+
+        # Allow IO loop process events and wait until daemon threads finished.
+        sleep(1)
+        threads_after.append(threading.enumerate())
+
+    # TCP backend starts globally and runs few own threads on demand.
+    # 'threads_before' populates before that and contains less threads on first
+    # iteration. That's why we drop first values.
+    threads_before = threads_before[1:]
+    threads_after = threads_after[1:]
+
+    # In all other iterations there must be same number of threads before and
+    # after the Client running.
+    assert all([x == y for (x, y) in zip(threads_before, threads_after)])

--- a/distributed/tests/test_client_loop.py
+++ b/distributed/tests/test_client_loop.py
@@ -13,7 +13,7 @@ def run_client(loop):
 
 
 # Test if Client correctly tears down LoopRunner on close.
-@pytest.mark.parametrize('with_own_loop', [True, False])
+@pytest.mark.parametrize("with_own_loop", [True, False])
 def test_close_loop_sync(with_own_loop):
     loop_runner = loop = None
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -371,10 +371,8 @@ class LoopRunner:
                 # We're expecting the loop to run in another thread,
                 # avoid re-using this thread's assigned loop
                 self._loop = IOLoop()
-            self._should_close_loop = True
         else:
             self._loop = loop
-            self._should_close_loop = False
         self._asynchronous = asynchronous
         self._loop_thread = None
         self._started = False


### PR DESCRIPTION
This PR partially fixes #4072 and adds a tests for the fix.

`SpecCluster` requires few changes to fully fix the issue. They will be provided in a separate PR since I'm not sure about impact on other parts.