### PR TITLE
Allow RuntimeErrors when closing global clients

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4818,7 +4818,7 @@ def _close_global_client():
     if c is not None:
         c._should_close_loop = False
         with suppress(TimeoutError, RuntimeError):
-            c.close(timeout=2)
+            c.close(timeout=3)
 
 
 atexit.register(_close_global_client)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4817,7 +4817,7 @@ def _close_global_client():
     c = _get_global_client()
     if c is not None:
         c._should_close_loop = False
-        with suppress(TimeoutError):
+        with suppress(TimeoutError, RuntimeError):
             c.close(timeout=2)
 
 


### PR DESCRIPTION
These tend to be due to the event loop being closed.