### PR TITLE
Return right away in Cluster.close if cluster is already closed

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -91,6 +91,15 @@ class Cluster:
         self.status = Status.closed
 
     def close(self, timeout=None):
+        # If the cluster is already closed, we're already done
+        if self.status == Status.closed:
+            if self.asynchronous:
+                future = asyncio.Future()
+                future.set_result(None)
+                return future
+            else:
+                return
+
         with suppress(RuntimeError):  # loop closed during process shutdown
             return self.sync(self._close, callback_timeout=timeout)
 


### PR DESCRIPTION
If the cluster encountered an exception for example it may already
be closed. Calling close again should not at this point do anything.

I have a test suite (other project) where I call `cluster.close()` in an object that contains both a client and a LocalCluster.

Here's a simplified version.

```
class Scheduler:
    def __init__():
        self.cluster = None
        self.client = None

    def __del__():
        if self.cluster is not None:
            self.cluster.close()

        if self.client is not None:
            self.client.close()

    def submit(....):
        if self.cluster is None:
            self.cluster = LocalCluster()
            self.client = Client(self.cluster)
```

While this code has worked great, for some reason after an exception has been raised and we should have excited the program, the `self.cluster.close()` call is stuck in the `while not e.is_set():` loop of `distributed.utils.sync`.

One simple fix appears to be to not go through the async system when calling `self.cluster.close()` if the cluster is already closed due to the exception. I'm open to receiving more guidance on how to write a test case that would identify such case if it is pertinent.