### PR TITLE
Simplify _graph_to_futures()

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2593,7 +2593,9 @@ class Client:
                     raise ValueError(msg)
 
             future_dependencies = {
-                tokey(k): {tokey(f.key) for f in v[1]} for k, v in d.items()
+                tokey(k): {tokey(f.key) for f in v[1]}
+                for k, v in d.items()
+                if len(v[1])
             }
 
             for s in future_dependencies.values():

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2627,6 +2627,8 @@ class Client:
             if isinstance(retries, Number) and retries > 0:
                 retries = {k: retries for k in dsk}
 
+            # Create futures before sending graph (helps avoid contention)
+            futures = {key: Future(key, self, inform=False) for key in keyset}
             self._send_to_scheduler(
                 {
                     "op": "update-graph",
@@ -2644,7 +2646,7 @@ class Client:
                     "actors": actors,
                 }
             )
-            return {key: Future(key, self, inform=False) for key in keyset}
+            return futures
 
     def get(
         self,

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -298,7 +298,7 @@ async def test_adapt_down():
             start = time()
             while len(cluster.scheduler.workers) != 2:
                 await asyncio.sleep(0.1)
-                assert time() < start + 1
+                assert time() < start + 3
 
 
 @gen_test(timeout=30)


### PR DESCRIPTION
This PR simplifies the implementation of `_graph_to_futures()` in order to make the [transition to `HighLevelGraph` easier](https://github.com/dask/distributed/issues/4119).

#### Removed `extra_keys`, which is redundant:
`extra_keys` is only used by `str_graph()` to find keys to tokenize but since `extra_keys` are already tokenized, it is redundant to tokenize the keys it finds!


