### PR TITLE
Fixed stuck BatchedSend comm

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -119,7 +119,7 @@ class BatchedSend:
         self.message_count += 1
         self.buffer.append(msg)
         # Avoid spurious wakeups if possible
-        if self.next_deadline is None:
+        if self.next_deadline is None or self.next_deadline < self.loop.time():
             self.waker.set()
 
     @gen.coroutine


### PR DESCRIPTION
As reported in https://github.com/pangeo-data/pangeo/issues/788, users
were seeing tasks just not completing. After some debugging, I
discovered that the scheduler had assigned the "stuck" tasks to a worker,
but the worker never received the message. A bit more digging showed
that

1. The message was stuck in the worker BatchedSend comm's buffer
2. The BatchedSend.waker event was clear (awaiting it would wait)
3. The BatchedSend.next_deadline was set

I couldn't determine *why*, but this state is consistent with us
"missing" a deadline, i.e. the `BatchedSend.next_deadline` is set, but
the `_background_send` is already `awaiting` the event (maybe with no timeout?).
So I'm very shaky on the cause, but I'm hoping that this fixes the issue. Doing
some more manual testing.

@mrocklin I'm extra confused here, since this code hasn't been touched in a while. I'd have thought we would have seen more reports of this, but I don't recall any.