### PR TITLE
Log

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -286,7 +286,7 @@ async def connect(
             while deadline - time() > 0:
 
                 async def _():
-                    logger.info('Connect start')
+                    logger.info(f'Connect start: {loc}')
                     comm = await connector.connect(
                         loc, deserialize=deserialize, **connection_args
                     )

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -286,6 +286,7 @@ async def connect(
             while deadline - time() > 0:
 
                 async def _():
+                    logger.info('Connect start')
                     comm = await connector.connect(
                         loc, deserialize=deserialize, **connection_args
                     )
@@ -293,9 +294,12 @@ async def connect(
                         **comm.handshake_info(),
                         **(handshake_overrides or {}),
                     }
+                    logger.info('Connect done')
                     try:
                         handshake = await asyncio.wait_for(comm.read(), 1)
+                        logger.info(f"Handshake: {handshake}")
                         write = await asyncio.wait_for(comm.write(local_info), 1)
+                        logger.info(f"Write: {write}")
                         # This would be better, but connections leak if worker is closed quickly
                         # write, handshake = await asyncio.gather(comm.write(local_info), comm.read())
                     except Exception as e:
@@ -314,8 +318,9 @@ async def connect(
                     return comm
 
                 with suppress(TimeoutError):
+                    timeout_ = min(deadline - time(), retry_timeout_backoff)
                     comm = await asyncio.wait_for(
-                        _(), timeout=min(deadline - time(), retry_timeout_backoff)
+                        _(), timeout=timeout_
                     )
                     break
             if not comm:

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -214,8 +214,11 @@ class Listener(ABC):
     async def on_connection(self, comm: Comm, handshake_overrides=None):
         local_info = {**comm.handshake_info(), **(handshake_overrides or {})}
         try:
+            logger.info('On connection')
             write = await asyncio.wait_for(comm.write(local_info), 1)
+            logger.info('Write')
             handshake = await asyncio.wait_for(comm.read(), 1)
+            logger.info('handshake')
             # This would be better, but connections leak if worker is closed quickly
             # write, handshake = await asyncio.gather(comm.write(local_info), comm.read())
         except Exception as e:


### PR DESCRIPTION
#4080 

did more digging with the reproducer and identified the failure mode, which is causing connection timeouts and failed tasks on a 50 worker cluster.

```python
b = bag.from_sequence([1]*100_000, partition_size=1)
bb = b.map_partitions(lambda *_, **__: [b'1'*2**20]*5).persist()
bc = bb.repartition(1000).persist()
```

1. For the repartition step, the workers will hit the scheduler with `100_000` `who_has` requests in a quite short period in time. 
2. The hits will go through the `ConnectionPool` of `Worker.scheduler`, which has the default connection limit of 512. This will result in ~25,000 concurrent connection attempts and saturate the scheduler listener socket.
Logs would typically output, and first tasks start to fail / worker start to crash
`Connect start: <SCHEDULER>` 170,000 events - Worker side
`Connect done` 16,000 events - Worker side
`On connection` 13,000 events - Scheduler side
`handshake:` 6,000 events - Successful handshakes
``
3. Setting a limit of 8 concurrent connections to the scheduler per worker resolved the issue

I doubt that this is a good solution and do not intend to do further work on this PR. Nevertheless, I believe that this 'fix' is helps to shed light on the root-cause of the issue.