### PR TITLE
Handle exceptions in BatchedSend

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -123,6 +123,10 @@ class BatchedSend:
                     break
             finally:
                 payload = None  # lose ref
+        else:
+            # nobreak. We've been gracefully closed.
+            self.stopped.set()
+            return
 
         # If we've reached here, it means our comm is known to be closed or
         # we've repeatedly failed to send a message. We can't close gracefully
@@ -130,6 +134,7 @@ class BatchedSend:
         # This means that any messages in our buffer our lost.
         # To propagate exceptions, we rely on subsequent `BatchedSend.send`
         # calls to raise CommClosedErrors.
+        self.stopped.set()
         self.abort()
 
     def send(self, msg):

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -54,6 +54,7 @@ class BatchedSend:
             maxlen=dask.config.get("distributed.comm.recent-messages-log-length")
         )
         self.serializers = serializers
+        self._consecutive_failures = 0
 
     def start(self, comm):
         self.comm = comm
@@ -98,15 +99,38 @@ class BatchedSend:
                     self.recent_message_log.append("large-message")
                 self.byte_count += nbytes
             except CommClosedError as e:
+                # If the comm is known to be closed, we'll immediately
+                # give up.
                 logger.info("Batched Comm Closed: %s", e)
                 break
             except Exception:
-                logger.exception("Error in batched write")
-                break
+                # In other cases we'll retry a few times.
+                # https://github.com/pangeo-data/pangeo/issues/788
+                if self._consecutive_failures <= 5:
+                    logger.warning("Error in batched write, retrying")
+                    yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
+                    self._consecutive_failures += 1
+                    # Exponential backoff for retries.
+                    # Ensure we don't drop any messages.
+                    if self.buffer:
+                        # Someone could call send while we yielded above?
+                        self.buffer = payload + self.buffer
+                    else:
+                        self.buffer = payload
+                    continue
+                else:
+                    logger.exception("Error in batched write")
+                    break
             finally:
                 payload = None  # lose ref
 
-        self.stopped.set()
+        # If we've reached here, it means our comm is known to be closed or
+        # we've repeatedly failed to send a message. We can't close gracefully
+        # via `.close()` since we can't send messages. So we just abort.
+        # This means that any messages in our buffer our lost.
+        # To propagate exceptions, we rely on subsequent `BatchedSend.send`
+        # calls to raise CommClosedErrors.
+        self.abort()
 
     def send(self, msg):
         """Schedule a message for sending to the other side

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -2,11 +2,15 @@ import logging
 import platform
 import sys
 
+import tornado
+
 logging_names = logging._levelToName.copy()
 logging_names.update(logging._nameToLevel)
 
 PYPY = platform.python_implementation().lower() == "pypy"
 WINDOWS = sys.platform.startswith("win")
+TORNADO6 = tornado.version_info[0] >= 6
+PY37 = sys.version_info[:2] >= (3, 7)
 
 if sys.version_info[:2] >= (3, 7):
     from asyncio import get_running_loop

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -11,6 +11,7 @@ from distributed.metrics import time
 from distributed.utils import All, TimeoutError
 from distributed.utils_test import captured_logger
 from distributed.protocol import to_serialize
+from distributed.compatibility import WINDOWS, PY37, TORNADO6
 
 
 class EchoServer:
@@ -257,6 +258,9 @@ async def test_serializers():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    WINDOWS and not PY37 and not TORNADO6, reason="failing on windows, py36, tornado 5."
+)
 async def test_handles_exceptions():
     # Ensure that we properly handle exceptions in BatchedSend.
     # https://github.com/pangeo-data/pangeo/issues/788


### PR DESCRIPTION
This changes exception handling in BatchedSend.

The problem: BatchedSend.send is a regular function. What happens if we
add a message to be sent, but that send fails at a later time? In the
current structure, that exception is logged and then lost to the void.

This PR makes things a bit more robust in two ways:

1. For unexpected errors, we retry a few times. In
   https://github.com/pangeo-data/pangeo/issues/788 manual retries did
   fix the issue, so we try that here automatically.
2. For CommClosedErrors or repeated unexpected errors, we close the
   BatchedSend object. By closing the BatchedSend after an exception,
   *subsequent* `BatchedSend.send` calls will fail.

We still face the issue with a potential exception happening in the
background that *aren't* followed by another `BatchedSend.send` failing.
But I think that's unavoidable given the current design.

I think this better addresses the root problem than https://github.com/dask/distributed/pull/4128. https://github.com/dask/distributed/pull/4128 may still be useful, but I'll revisit it after testing this out.