### PR TITLE
Fix for missing `:` in autosummary docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ toolz
 cloudpickle
 dask
 sphinx
-dask-sphinx-theme>=1.3.3
+dask-sphinx-theme>=1.3.4
 sphinx-click

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ toolz
 cloudpickle
 dask
 sphinx
-dask-sphinx-theme>=1.3.4
+dask-sphinx-theme>=1.3.5
 sphinx-click

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ toolz
 cloudpickle
 dask
 sphinx
-dask_sphinx_theme
+dask-sphinx-theme>=1.3.3
 sphinx-click


### PR DESCRIPTION
Same fix as in dask/dask#6700

Shouldn't be merged until dask/dask-sphinx-theme#43 is merged and a
release is cut