### PR TITLE
Increase robustness of Semaphore.release

### DIFF
--- a/distributed/http/scheduler/tests/test_semaphore_http.py
+++ b/distributed/http/scheduler/tests/test_semaphore_http.py
@@ -63,7 +63,7 @@ async def test_prometheus_collect_task_states(c, s, a, b):
     assert active_metrics["semaphore_release"].samples[0].value == 0
     assert active_metrics["semaphore_pending_leases"].samples[0].value == 0
 
-    await sem.release()
+    assert await sem.release() is True
     active_metrics = await fetch_metrics()
     assert active_metrics["semaphore_max_leases"].samples[0].value == 2
     assert active_metrics["semaphore_active_leases"].samples[0].value == 0

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -486,12 +486,18 @@ class Semaphore:
 
     def release(self):
         """
-        Release a semaphore.
+        Release the semaphore.
 
-        Increment the internal counter by one.
+        This will increment the amount of available leases by one.
+
+        Returns
+        -------
+        bool
+            This value indicates whether a lease was released immediately or not. Note that a user should  *not* retry
+            this operation. Under certain circumstances (e.g. scheduler overload) the lease may not be released
+            immediately, but it will always be automatically released after a specific interval configured using
+            "distributed.scheduler.locks.lease-validation-interval" and "distributed.scheduler.locks.lease-timeout".
         """
-
-        """ Release the lock if already acquired """
         if not self._leases:
             raise RuntimeError("Released too often")
 

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -488,8 +488,6 @@ class Semaphore:
         """
         Release the semaphore.
 
-        This will increment the amount of available leases by one.
-
         Returns
         -------
         bool

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -477,8 +477,9 @@ class Semaphore:
             )
         except OSError:  # Too many broken connections, release fails
             logger.error(
-                "Release failed for client=%s, lease_id=%s, name=%s. Cluster network might be unstable."
+                "Release failed for client=%s, lease_id=%s, name=%s. Cluster network might be unstable?"
                 % (self.client.id, lease_id, self.name),
+                exc_info=True,
             )
             return False
 

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -468,14 +468,15 @@ class Semaphore:
         logger.info("%s releases %s for %s", self.client.id, lease_id, self.name)
 
         try:
-            return await retry_operation(
+            await retry_operation(
                 self.client.scheduler.semaphore_release,
                 name=self.name,
                 lease_id=lease_id,
                 operation="semaphore release: client=%s, lease_id=%s, name=%s"
                 % (self.client.id, lease_id, self.name),
             )
-        except OSError:  # Too many broken connections, release fails
+            return True
+        except Exception:  # Release fails for whatever reason
             logger.error(
                 "Release failed for client=%s, lease_id=%s, name=%s. Cluster network might be unstable?"
                 % (self.client.id, lease_id, self.name),

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -539,7 +539,6 @@ async def test_release_retry(c, s, a, b):
         with captured_logger("distributed.utils_comm") as caplog:
             assert await semaphore.release() is True
         logs = caplog.getvalue().split("\n")
-        print(logs)
         log = logs[0]
         assert log.startswith("Retrying semaphore release:") and log.endswith(
             "after exception in attempt 0/1: "

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -591,7 +591,7 @@ async def test_release_failure(c, s, a, b):
         semaphore_log = semaphore_log.getvalue().split("\n")[0]
         assert semaphore_log.startswith(
             "Release failed for client="
-        ) and semaphore_log.endswith("Cluster network might be unstable.")
+        ) and semaphore_log.endswith("Cluster network might be unstable?")
 
         # Check lease has timed out
         assert any(

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -20,6 +20,7 @@ from distributed.utils_test import (  # noqa: F401
     slowidentity,
     loop,
 )
+import logging
 
 
 @gen_cluster(client=True)
@@ -301,6 +302,9 @@ class FlakyConnectionPool(ConnectionPool):
     def activate(self):
         self._flaky_active = True
 
+    def deactivate(self):
+        self._flaky_active = False
+
     async def connect(self, *args, **kwargs):
         if self.cnn_count >= self.failing_connections or not self._flaky_active:
             return await super().connect(*args, **kwargs)
@@ -518,3 +522,80 @@ def test_threadpoolworkers_pick_correct_ioloop(cleanup):
                     protected_ressource.remove(val)
 
             client.gather(client.map(access_limited, range(10), sem=sem))
+
+
+@gen_cluster(client=True)
+async def test_release_retry(c, s, a, b):
+    """Verify that we can properly retry a semaphore release operation"""
+    with dask.config.set({"distributed.comm.retry.count": 1}):
+        pool = await FlakyConnectionPool(failing_connections=1)
+        rpc = pool(s.address)
+        c.scheduler = rpc
+        semaphore = await Semaphore(
+            max_leases=2, name="resource_we_want_to_limit", client=c
+        )
+        await semaphore.acquire()
+        pool.activate()  # Comm chaos starts
+        with captured_logger("distributed.utils_comm") as caplog:
+            await semaphore.release()
+        logs = caplog.getvalue().split("\n")
+        print(logs)
+        log = logs[0]
+        assert log.startswith("Retrying semaphore release:") and log.endswith(
+            "after exception in attempt 0/1: "
+        )
+
+        assert await semaphore.acquire() is True
+        assert await semaphore.release() is not False
+
+
+@gen_cluster(
+    client=True,
+    config={
+        "distributed.scheduler.locks.lease-timeout": "100ms",
+        "distributed.scheduler.locks.lease-validation-interval": "100ms",
+    },
+)
+async def test_release_failure(c, s, a, b):
+    """Don't raise even if release fails: lease will be cleaned up by the lease-validation after
+    a specified interval anyways (see config parameters used)."""
+
+    with dask.config.set({"distributed.comm.retry.count": 1}):
+        pool = await FlakyConnectionPool(failing_connections=5)
+        rpc = pool(s.address)
+        c.scheduler = rpc
+        semaphore = await Semaphore(
+            max_leases=2, name="resource_we_want_to_limit", client=c
+        )
+        await semaphore.acquire()
+        pool.activate()  # Comm chaos starts
+
+        # Release fails (after a single retry) because of broken connections
+        with captured_logger(
+            "distributed.semaphore", level=logging.ERROR
+        ) as semaphore_log:
+            with captured_logger("distributed.utils_comm") as retry_log:
+                assert await semaphore.release() is False
+
+        with captured_logger("distributed.semaphore") as semaphore_cleanup_log:
+            pool.deactivate()  # comm chaos stops
+            assert await semaphore.get_value() == 1  # lease is still registered
+            await asyncio.sleep(0.2)  # Wait for lease to be cleaned up
+
+        # Check release was retried
+        retry_log = retry_log.getvalue().split("\n")[0]
+        assert retry_log.startswith(
+            "Retrying semaphore release:"
+        ) and retry_log.endswith("after exception in attempt 0/1: ")
+        # Check release failed
+        semaphore_log = semaphore_log.getvalue().split("\n")[0]
+        assert semaphore_log.startswith(
+            "Release failed for client="
+        ) and semaphore_log.endswith("Cluster network might be unstable.")
+
+        # Check lease has timed out
+        assert any(
+            log.startswith("Lease") and "timed out after" in log
+            for log in semaphore_cleanup_log.getvalue().split("\n")
+        )
+        assert await semaphore.get_value() == 0


### PR DESCRIPTION
The Semaphore.release method does not handle connection errors gracefully. If a connection error appears, the exception may cause a catastrophic failure of the computation.

This PR adds retries to the semaphore release method, which must be
configured using "distributed.comm.retry.count". This may come to
use when the scheduler is under high load and some release
calls may fail.
This PR also avoids raising an exception in case a release fails,
instead a warning is logged at ERROR level, and the Semaphore.release
method will return `False`. The lease will eventually be cleaned up
during the semaphore lease validation check, which may be configured using
"distributed.scheduler.locks.lease-validation-interval" and
"distributed.scheduler.locks.lease-timeout".

Wrt the "Released too often" RuntimeError that affects #4147, one may argue that exception could also be converted into a log message, but I have decided not to change that until we have some more clarity on the background of that issue.

cc @fjetter 