### PR TITLE
High level graph dumps/loads support

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -224,10 +224,11 @@ properties:
                   These modules will have a ``routes`` keyword that gets added to the main HTTP Server.
                   This is also a list that can be extended with user defined modules.
 
-          whitelist:
+          allowed-imports:
             type: array
             description: |
-              Whitelisted modules the schedular is allowed to import
+              A list of trusted modules the schedular is allowed to import. For security reasons, the
+              scheduler does not import arbitrary Python modules.
 
 
       worker:

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -227,7 +227,7 @@ properties:
           allowed-imports:
             type: array
             description: |
-              A list of trusted modules the schedular is allowed to import. For security reasons, the
+              A list of trusted root modules the schedular is allowed to import (incl. submodules). For security reasons, the
               scheduler does not import arbitrary Python modules.
 
 

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -224,6 +224,11 @@ properties:
                   These modules will have a ``routes`` keyword that gets added to the main HTTP Server.
                   This is also a list that can be extended with user defined modules.
 
+          whitelist:
+            type: array
+            description: |
+              Whitelisted modules the schedular is allowed to import
+
 
       worker:
         type: object

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -56,11 +56,8 @@ distributed:
         - distributed.http.statics
 
     allowed-imports:
-      - dask.highlevelgraph
-      - dask.optimization
-      - dask.blockwise
-      - dask.optimization
-      - dask.dataframe.io.parquet.core
+      - dask
+      - distributed
 
   worker:
     blocked-handlers: []

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -55,6 +55,13 @@ distributed:
         - distributed.http.proxy
         - distributed.http.statics
 
+    whitelist:
+      - dask.highlevelgraph
+      - dask.optimization
+      - dask.blockwise
+      - dask.optimization
+      - dask.dataframe.io.parquet.core
+
   worker:
     blocked-handlers: []
     multiprocessing-method: spawn

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -55,7 +55,7 @@ distributed:
         - distributed.http.proxy
         - distributed.http.statics
 
-    whitelist:
+    allowed-imports:
       - dask.highlevelgraph
       - dask.optimization
       - dask.blockwise

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -219,4 +219,6 @@ def loads_msgpack(header, payload):
                 " installed" % str(header["compression"])
             )
 
-    return msgpack.loads(payload, use_list=False, **msgpack_opts)
+    return msgpack.loads(
+        payload, object_hook=msgpack_decode_default, use_list=False, **msgpack_opts
+    )

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 import dask
 from dask.base import normalize_token
-from dask.highlevelgraph import HighLevelGraph, Layer
+from dask.highlevelgraph import HighLevelGraph, Layer, BasicLayer
 from dask.optimization import SubgraphCallable
 
 from tlz import valmap, get_in
@@ -92,7 +92,13 @@ def msgpack_decode_default(obj):
 
     if "__Layer__" in obj:
         mod = importlib.import_module(obj["__module__"])
-        layer_type = getattr(mod, obj["__name__"])
+        obj_name = obj["__name__"]
+        if obj_name == "BasicLayer":
+            # The default implemention of Layer returns a BasicLayer, which might
+            # not be defined in `mod` therefore we import it explicitly here
+            layer_type = BasicLayer
+        else:
+            layer_type = getattr(mod, obj["__name__"])
         return layer_type(*obj["args"])
 
     if "__HighLevelGraph__" in obj:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -97,7 +97,7 @@ def import_allowed_module(name):
 
 def msgpack_decode_default(obj):
     """
-    Custom packer/unpacker for msgpack to support Enums
+    Custom packer/unpacker for msgpack
     """
     if "__Enum__" in obj:
         mod = import_allowed_module(obj["__module__"])
@@ -129,13 +129,19 @@ def msgpack_decode_default(obj):
             obj["dependencies"],
         )
 
+    if "__Serialized__" in obj:
+        return Serialized(*obj["data"])
+
     return obj
 
 
 def msgpack_encode_default(obj):
     """
-    Custom packer/unpacker for msgpack to support Enums
+    Custom packer/unpacker for msgpack
     """
+
+    if isinstance(obj, Serialize):
+        return {"__Serialized__": True, "data": serialize(obj.data)}
 
     if isinstance(obj, Enum):
         return {

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -130,6 +130,11 @@ def msgpack_decode_default(obj):
         )
 
     if "__Serialized__" in obj:
+        # Notice, the data here is marked a Serialized rather than deserialized. This
+        # is because deserialization requires Pickle which the Scheduler cannot run
+        # because of security reasons.
+        # By marking it Serialized, the data is passed through to the workers that
+        # eventually will deserialize it.
         return Serialized(*obj["data"])
 
     return obj

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -78,7 +78,13 @@ def import_allowed_module(name):
     if name in _cached_allowed_modules:
         return _cached_allowed_modules[name]
 
-    if name.split(".")[0] in dask.config.get("distributed.scheduler.allowed-imports"):
+    # Check for non-ASCII characters
+    name = name.encode("ascii").decode()
+    # We only compare the root module
+    name = name.split(".", 1)[0]
+
+    # Note, if an empty string creeps into allowed-imports it is disallowed explicitly
+    if name and name in dask.config.get("distributed.scheduler.allowed-imports"):
         _cached_allowed_modules[name] = importlib.import_module(name)
         return _cached_allowed_modules[name]
     else:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -78,12 +78,14 @@ def import_allowed_module(name):
     if name in _cached_allowed_modules:
         return _cached_allowed_modules[name]
 
-    if name in dask.config.get("distributed.scheduler.allowed-imports"):
+    if name.split(".")[0] in dask.config.get("distributed.scheduler.allowed-imports"):
         _cached_allowed_modules[name] = importlib.import_module(name)
         return _cached_allowed_modules[name]
     else:
         raise RuntimeError(
-            f"Importing {repr(name)} is not allowed, add it to the whitelist"
+            f"Importing {repr(name)} is not allowed, please add it to the list of "
+            "allowed modules the scheduler can import via the "
+            "distributed.scheduler.allowed-imports configuration setting."
         )
 
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from tlz import identity, valmap
 
+from dask.dataframe.io.parquet.core import ParquetSubgraph
 from dask.highlevelgraph import HighLevelGraph, BasicLayer
 from dask.blockwise import Blockwise
 from dask.utils_test import inc
@@ -495,6 +496,16 @@ def test_highlevelgraphs():
             numblocks={"x": (3,)},
             concatenate=False,
             new_axes=None,
+        ),
+        "parquet": ParquetSubgraph(
+            "",
+            None,
+            "",
+            None,
+            [],
+            [],
+            [],
+            {},
         ),
     }
     dependencies = {"basic": set(), "blockwise": {"basic"}}

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -507,6 +507,7 @@ def test_highlevelgraphs():
             [],
             {},
         ),
+        "Serialize": BasicLayer({"Serialize key": Serialize(42)}),
     }
     dependencies = {"basic": set(), "blockwise": {"basic"}}
     hlg = HighLevelGraph(layers, dependencies)
@@ -518,7 +519,11 @@ def test_highlevelgraphs():
     # Check the loaded result
     assert isinstance(res, HighLevelGraph)
     assert hlg.dependencies == res.dependencies
-    for l1, l2 in zip(hlg.layers, res.layers):
-        assert type(l1) == type(l2)
-        assert l1 == l2
-    assert dict(res) == dict(hlg)
+    assert hlg.layers.keys() == res.layers.keys()
+    for l1, l2 in zip(hlg.layers.values(), res.layers.values()):
+        if "Serialize key" in l1:
+            # `Serialize` wrapped values are not deserialized by `loads()`
+            ser = l2["Serialize key"]
+            assert deserialize(ser.header, ser.frames) == 42
+        else:
+            assert dict(l1) == dict(l2)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,9 @@ numpydoc
 tornado
 toolz
 cloudpickle
-dask
+# TODO: Update our dask version requirement to
+# the latest dask release before releasing distributed
+dask @ git+https://github.com/dask/dask.git@master
 sphinx
 dask-sphinx-theme>=1.3.5
 sphinx-click


### PR DESCRIPTION
This PR uses https://github.com/dask/dask/pull/6693 to support serialization and communication of HLGs to the scheduler.

- [x] Whitelist of allowed modules to import https://github.com/dask/distributed/pull/4140#discussion_r498847639
- [ ] Tests added / passed
- [x] Passes `black dask` / `flake8 dask`