### PR TITLE
Remove hard coded connect handshake timeouts

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -307,7 +307,7 @@ async def connect(
     except Exception as exc:
         comm.abort()
         raise IOError(
-            f"Timed out trying to connect to {addr} after {timeout} s"
+            f"Timed out during handshake while connecting to {addr} after {timeout} s"
         ) from exc
 
     comm.remote_info = handshake

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -1,5 +1,4 @@
 import asyncio
-from build.lib.distributed.comm.tcp import TCPConnector
 import os
 import sys
 import threading
@@ -24,7 +23,7 @@ from distributed.comm import (
     unparse_host_port,
 )
 from distributed.comm.registry import backends, get_backend
-from distributed.comm.tcp import TCP, TCPBackend
+from distributed.comm.tcp import TCP, TCPBackend, TCPConnector
 from distributed.metrics import time
 from distributed.protocol import Serialized, deserialize, serialize, to_serialize
 from distributed.utils import get_ip, get_ipv6

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -867,6 +867,14 @@ async def test_handshake_slow_comm(monkeypatch):
     msg = await comm.read()
     assert msg == b"test"
 
+    import dask
+
+    with dask.config.set({"distributed.comm.timeouts.connect": "100ms"}):
+        with pytest.raises(
+            TimeoutError, match="Timed out during handshake while connecting to"
+        ):
+            await connect(listener.contact_address)
+
 
 async def check_connect_timeout(addr):
     t1 = time()

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -1,4 +1,5 @@
 import asyncio
+from build.lib.distributed.comm.tcp import TCPConnector
 import os
 import sys
 import threading
@@ -23,6 +24,7 @@ from distributed.comm import (
     unparse_host_port,
 )
 from distributed.comm.registry import backends, get_backend
+from distributed.comm.tcp import TCP, TCPBackend
 from distributed.metrics import time
 from distributed.protocol import Serialized, deserialize, serialize, to_serialize
 from distributed.utils import get_ip, get_ipv6
@@ -661,7 +663,8 @@ async def test_tls_reject_certificate():
 
     with pytest.raises(EnvironmentError) as excinfo:
         await connect(listener.contact_address, timeout=2, ssl_context=cli_ctx)
-    assert "certificate verify failed" in str(excinfo.value)
+
+    assert "certificate verify failed" in str(excinfo.value.__cause__)
 
 
 #
@@ -793,99 +796,76 @@ async def test_inproc_comm_closed_explicit_2():
 #
 
 
-import random
-
-from distributed.comm.core import Comm, Connector
-from distributed.comm.registry import Backend, backends
-
-
-class BrokenComm(Comm):
-    peer_address = None
-    local_address = None
-
-    def close(self):
-        pass
-
-    def closed(self):
-        pass
-
-    def abort(self):
-        pass
-
-    def read(self, deserializers=None):
-        raise IOError
-
-    def write(self, msg, serializers=None, on_error=None):
-        raise IOError
-
-
-class UnreliableConnector(Connector):
-    prefix = "chaos"
-
-    def __init__(self, backend, success_rate=0.1):
-
-        self.max_failures = 4
-        self.failures = 0
-        self.connector = backend.get_connector()
-        self.success_rate = success_rate
-
-    async def connect(self, address, deserialize=True, **connection_args):
-        if self.failures >= self.max_failures or random.random() <= self.success_rate:
-            return await self.connector.connect(address, deserialize, **connection_args)
-        else:
-            self.failures += 1
-            # Sometimes the connect fails and sometimes the connection is closed/broken already
-            if random.random() <= self.success_rate:
-                raise IOError()
-            return BrokenComm()
-
-
-class UnreliableBackend(Backend):
-    """Don't try this at home"""
-
-    def __init__(self):
-        self.backend = get_backend("tcp")
-
-    def get_connector(self):
-        return UnreliableConnector(backend=self.backend)
-
-    def get_listener(self, loc, handle_comm, deserialize, **connection_args):
-        return self.backend.get_listener(
-            loc, handle_comm, deserialize, **connection_args
-        )
-
-    def get_address_host(self, loc):
-        return self.backend.get_address_host(loc)
-
-    def resolve_address(self, loc):
-        return self.backend.resolve_address(loc)
-
-    def get_address_host_port(self, loc):
-        return self.backend.get_address_host_port(loc)
-
-    def get_local_address_for(self, loc):
-        return self.backend.get_local_address_for(loc)
+async def echo(comm):
+    message = await comm.read()
+    await comm.write(message)
 
 
 @pytest.mark.asyncio
-async def test_retries():
+async def test_retry_connect(monkeypatch):
     async def echo(comm):
         message = await comm.read()
         await comm.write(message)
 
-    from distributed.comm.registry import backends
+    class UnreliableConnector(TCPConnector):
+        def __init__(self):
 
-    try:
+            self.num_failures = 2
+            self.failures = 0
+            super().__init__()
 
-        backends["chaos"] = UnreliableBackend()
-        listener = await listen("chaos://127.0.0.1:1234", echo)
-        comm = await connect(listener.contact_address.replace("tcp", "chaos"))
-        await comm.write(b"test")
-        msg = await comm.read()
-        assert msg == b"test"
+        async def connect(self, address, deserialize=True, **connection_args):
+            if self.failures > self.num_failures:
+                return await super().connect(address, deserialize, **connection_args)
+            else:
+                self.failures += 1
+                raise IOError()
 
-    finally:
-        del backends["chaos"]
+    class UnreliableBackend(TCPBackend):
+        """Don't try this at home"""
+
+        _connector_class = UnreliableConnector
+
+    monkeypatch.setitem(backends, "tcp", UnreliableBackend())
+
+    listener = await listen("tcp://127.0.0.1:1234", echo)
+    comm = await connect(listener.contact_address)
+    await comm.write(b"test")
+    msg = await comm.read()
+    assert msg == b"test"
+
+
+@pytest.mark.asyncio
+async def test_handshake_slow_comm(monkeypatch):
+    class SlowComm(TCP):
+        def __init__(self, *args, delay_in_comm=0.5, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.delay_in_comm = delay_in_comm
+
+        async def read(self, *args, **kwargs):
+            await asyncio.sleep(self.delay_in_comm)
+            return await super().read(*args, **kwargs)
+
+        async def write(self, *args, **kwargs):
+            await asyncio.sleep(self.delay_in_comm)
+            res = await super(type(self), self).write(*args, **kwargs)
+            return res
+
+    class SlowConnector(TCPConnector):
+        comm_class = SlowComm
+
+    class SlowBackend(TCPBackend):
+        """Don't try this at home"""
+
+        _connector_class = SlowConnector
+
+    monkeypatch.setitem(backends, "tcp", SlowBackend())
+
+    listener = await listen("tcp://127.0.0.1:1234", echo)
+    comm = await connect(listener.contact_address)
+    await comm.write(b"test")
+    msg = await comm.read()
+    assert msg == b"test"
 
 
 async def check_connect_timeout(addr):

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -891,7 +891,7 @@ async def test_retries():
 async def check_connect_timeout(addr):
     t1 = time()
     with pytest.raises(IOError):
-        await connect(addr, timeout=0.15)
+        await connect(addr, timeout=0.3)
     dt = time() - t1
     assert 1 >= dt >= 0.1
 


### PR DESCRIPTION
This code section, in particular the handshake (#4019), is causing issues for me in "high load" scenarios. I see broken connections popping up once I reach about ~200 workers and these errors tear down the entire system. From the exceptions I cannot infer whether the handshake runs into a timeout or whether it is completely broken (mostly because our internal user reports are not as thorough as I'd like them to be but I'm investigating).
Whenever the handshake fails, it is raised as a `CommClosedError` which is, unfortunately, not an `EnvironmentError`. Therefore, what I *wanted* to change is the exception type upon which we retry to be more inclusive.
Then I had a look at the code and was really confused about the retry behaviour and the individual timeouts and started to (subjectively) simplify this piece of code and write a test for it. The test is a bit messy, works but I'd appreciate suggestions on how this can be implemented cleaner.


W.r.t the implementation, I am open for suggestions and can revert anything/everything/nothing depending on the feedback here. 

Here a quick dump of my thoughts to this

* We should not only retry `EnvironmentError`s but rather more inclusive error classes (at least the `CommClosed` we raise ourselves)
* We should retry with (an exponential) backoff
* Ideally with a jitter
* I don't have a strong opinion about individual timeouts of the read/write/connect. Therefore I chose this approach, where every step may take time until the deadline is reached. I guess one could argue that this should somehow be split up but I want for the reduced complexity approach instead.
* I removed the backoff cap since I figured we wouldn't really need it here. This is just a gut feeling. Happy to introduce something
* I oriented the implementation on https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ and chose the FullJitter approach. Not sure if this applies 100% but it made me feel as if my choices where "data driven" and this sounded similar enough to our situation :)

In case anybody wonders, with the chosen base of 0.01 this results in (non randomised) backoffs

```python
In [1]: backoff_base = 0.01

In [2]: [backoff_base * 2 ** ix for ix in range(10)]
Out[2]: [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12]

In [3]: sum([backoff_base * 2 ** ix for ix in range(10)])
Out[3]: 10.23
```
With the jitter this likely adds up to a probably significantly larger number of max retries

There is currently an alternative fix for this section open, see https://github.com/dask/distributed/pull/4167 cc @jcrist 