### PR TITLE
Fix _graph_to_futures bug for futures-based dependencies

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2632,13 +2632,11 @@ class Client:
 
             # HACK: currently when submitting work to the scheduler, the client need to
             # send all key dependencies along with the task graph. Since `dsk` doesn't
-            # know about the unpacked futures, we add them manually to `dsk` before
-            # calculating dependencies. This hack shouldn't be necessary when the
-            # scheduler accepts high level graphs.
-            #dsk.keyset()
-            #dsk._keys.update({f.key for f in unpacked_futures})
+            # know about the unpacked futures, we add futures-related dependencies from
+            # `future_deps`. This hack shouldn't be necessary when the scheduler accepts
+            # high level graphs.
+            dsk.keyset()
             dependencies = dsk.get_all_dependencies()
-            # TODO: Adjust the above comment to explain the new approach below.
             if future_deps:
                 for key in dependencies.keys():
                     dependencies[key] |= future_deps.get(key, set())

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -210,3 +210,12 @@ async def test_delayed_none(c, s, w):
     [xx, yy] = c.compute([x, y])
     assert await xx is None
     assert await yy == 123
+
+
+@pytest.mark.parametrize("typ", [tuple, list])
+def test_tuple_futures_arg(client, typ):
+    x = client.submit(make_time_dataframe,)
+    df2 = client.submit(pd.concat, typ([x,]))
+    dd.assert_eq(
+        df2.result().iloc[:0], make_time_dataframe().iloc[:0]
+    )

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -214,8 +214,15 @@ async def test_delayed_none(c, s, w):
 
 @pytest.mark.parametrize("typ", [tuple, list])
 def test_tuple_futures_arg(client, typ):
-    x = client.submit(make_time_dataframe,)
-    df2 = client.submit(pd.concat, typ([x,]))
-    dd.assert_eq(
-        df2.result().iloc[:0], make_time_dataframe().iloc[:0]
+    x = client.submit(
+        make_time_dataframe,
     )
+    df2 = client.submit(
+        pd.concat,
+        typ(
+            [
+                x,
+            ]
+        ),
+    )
+    dd.assert_eq(df2.result().iloc[:0], make_time_dataframe().iloc[:0])


### PR DESCRIPTION
closes #4177 
~depends on [dask#6761](https://github.com/dask/dask/pull/6761)~

After an offline discussion with @madsbk and @jrbourbeau , I decided to revise this PR into a "standalone" fix (that does **not** depend on changes in dask/dask).  The new fix will address the problem, but will also materialize the underlying graph in cases with futures.  Therefore, this should be viewed as a **temporary** change, that will (hopefully) be replaced with ongoing HLG work relatively soon.