### PR TITLE
Fix regression in task stealing for already released keys

### DIFF
--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -142,7 +142,7 @@ class WorkStealing(SchedulerPlugin):
     def move_task_request(self, ts, victim, thief):
         try:
             if self.scheduler.validate:
-                if victim is not ts.processing_on:
+                if victim is not ts.processing_on and LOG_PDB:
                     import pdb
 
                     pdb.set_trace()


### PR DESCRIPTION
This fixes a regression introduced in #4107 

I believe this scenario can only be encountered in some race condition scenarios which is why I had a hard time constructing a test case which is less close to the implementation.