### PR TITLE
Managing priorities manually

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1961,7 +1961,7 @@ class Scheduler(ServerNode):
         for key in set(priority) & touched_keys:
             ts = self.tasks[key]
             if ts.priority is None:
-                ts.priority = (-(user_priority.get(key, 0)), generation, priority[key])
+                ts.priority = ((user_priority.get(key, 0)), generation, priority[key])
 
         # Ensure all runnables have a priority
         runnables = [ts for ts in touched_tasks if ts.run_spec]


### PR DESCRIPTION
When defining priorities manually, somehow they are added with a negative sign. In the example below, last task should have the highest priority, but ends up with a lower priority (-4):

```python
from dask.distributed import Client, LocalCluster
cluster = LocalCluster()
client = Client(cluster)

def test_func(i):
    return

futures = [client.submit(test_func, i, priority=i) for i in range(5)]
```