### PR TITLE
Add TaskState metadata

### DIFF
--- a/distributed/http/templates/task.html
+++ b/distributed/http/templates/task.html
@@ -43,7 +43,7 @@
               <th> Priority </th>
               <td>{{ts.priority}}</td>
           </tr>
-          {% for attr in ['has_lost_dependencies', 'host_restrictions', 'worker_restrictions', 'resource_restrictions', 'loose_restrictions', 'suspicious', 'retries'] %}
+          {% for attr in ['has_lost_dependencies', 'host_restrictions', 'worker_restrictions', 'resource_restrictions', 'loose_restrictions', 'suspicious', 'retries', 'metadata'] %}
           {% if getattr(ts, attr) %}
           <tr>
               <th> {{attr.replace('_', ' ').title()}} </th>

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -593,6 +593,10 @@ class TaskState:
            into the "processing" state and be sent for execution to another
            connected worker.
 
+        .. attribute: metadata: dict
+
+           Metadata related to task.
+
         .. attribute: actor: bool
 
            Whether or not this task is an Actor.
@@ -646,6 +650,7 @@ class TaskState:
         "type",
         "group_key",
         "group",
+        "metadata",
     )
 
     def __init__(self, key, run_spec):
@@ -672,6 +677,7 @@ class TaskState:
         self.type = None
         self.group_key = key_split_group(key)
         self.group = None
+        self.metadata = {}
 
     @property
     def state(self) -> str:
@@ -2084,6 +2090,7 @@ class Scheduler(ServerNode):
         if ts is None:
             return {}
         ws = self.workers[worker]
+        ts.metadata.update(kwargs["metadata"])
 
         if ts.state == "processing":
             recommendations = self.transition(key, "memory", worker=worker, **kwargs)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -126,6 +126,9 @@ class TaskState:
         The number of times a dependency has not been where we expected it
     * **startstops**: ``[{startstop}]``
         Log of transfer, load, and compute times for a task
+    * **metadata**: ``dict``
+        Metadata related to task. Stored metadata should be msgpack
+        serializable (e.g. int, string, list, dict).
 
     Parameters
     ----------
@@ -156,6 +159,7 @@ class TaskState:
         self.type = None
         self.suspicious_count = 0
         self.startstops = list()
+        self.metadata = {}
 
     def __repr__(self):
         return "<Task %r %s>" % (self.key, self.state)
@@ -1886,6 +1890,7 @@ class Worker(ServerNode):
                 "thread": self.threads.get(ts.key),
                 "type": typ_serialized,
                 "typename": typename(typ),
+                "metadata": ts.metadata,
             }
         elif ts.exception is not None:
             d = {


### PR DESCRIPTION
This PR adds a new `.metadata` attribute to the `TaskState` classes used by the scheduler and workers. When a task is finished the metadata stored on worker `TaskState`s synchronized with the corresponding `TaskState` on the scheduler   

Closes https://github.com/dask/distributed/issues/4188