### PR TITLE
Semaphore uses worker comm pool

### DIFF
--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -432,7 +432,7 @@ async def test_oversubscribing_leases(c, s, a, b):
     )
     fut_observe = c.submit(observe_state, sem=sem, workers=[observer.address])
 
-    with captured_logger("distributed.semaphore") as caplog:
+    with captured_logger("distributed.semaphore", level=logging.DEBUG) as caplog:
         payload, observer = await c.gather([futures, fut_observe])
 
     logs = caplog.getvalue().split("\n")
@@ -581,7 +581,9 @@ async def test_release_failure(c, s, a, b):
             with captured_logger("distributed.utils_comm") as retry_log:
                 assert await semaphore.release() is False
 
-        with captured_logger("distributed.semaphore") as semaphore_cleanup_log:
+        with captured_logger(
+            "distributed.semaphore", level=logging.DEBUG
+        ) as semaphore_cleanup_log:
             pool.deactivate()  # comm chaos stops
             assert await semaphore.get_value() == 1  # lease is still registered
             await asyncio.sleep(0.2)  # Wait for lease to be cleaned up


### PR DESCRIPTION
This decouples the lifetime of a semaphore object completely from the Clients and reuses the worker connection pools, if available.

For largish clusters (>>100) I've observed the many worker clients we spawn here to put a lot of stress onto the scheduler. Haven't debugged this further, but generally speaking the system is not well tuned for having *many* clients (no adaptive heartbeats and a lot of administrative stuff via direct comms instead of streams).

Before this change my scheduler was effectively at twice the CPU utilisation when using semaphores opposed to not using any for the same amount of work being done. With this change, the scheduler is hardly impacted at all by using semaphores.

The coupling to the client instances was initially introduced since I wanted to align the implementation with the existing synchronization objects (e.g. Lock) but I guess they will share the same problem. On top of this, the initial implementation was using the client heartbeat itself for lease lifecycle management but we no longer need this coupling.

The downside of this approach is that we require a bit of code duplication w.r.t. the `Client.sync` method since we can no longer re-use this. I am not certain if this poses any issues (e.g. because it is a frequent source of bugs, etc.)