### PR TITLE
Don't inherit from WorkerPlugin class

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -185,7 +185,7 @@ class WorkerPlugin:
         """
 
 
-class PipInstall(WorkerPlugin):
+class PipInstall:
     """A Worker Plugin to pip install a set of packages
 
     This accepts a set of packages to install on all workers.

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -104,9 +104,12 @@ class WorkerPlugin:
     the plugin to your client in order to have it attached to every existing and
     future workers with ``Client.register_worker_plugin``.
 
+    Note: Do not inherit from this class. Just use it as a specification and implement
+    the methods that you need.
+
     Examples
     --------
-    >>> class ErrorLogger(WorkerPlugin):
+    >>> class ErrorLogger:
     ...     def __init__(self, logger):
     ...         self.logger = logger
     ...


### PR DESCRIPTION
It seems like WorkerPlugins should not inherit from the WorkerPlugin class, but just use it as a spec. Otherwise I don't think:

https://github.com/dask/distributed/blob/24007c2b81e12d98fb229504f858c8f28b6063ba/distributed/worker.py#L1158-L1162

can work if the user hasn't defined a teardown method.