### PR TITLE
Instantiate plugin if needed in register_worker_plugin

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4223,6 +4223,9 @@ class Client:
         --------
         distributed.WorkerPlugin
         """
+        if isinstance(plugin, type):
+            raise ValueError("Plugin should be an instantiated object.")
+
         return self.sync(self._register_worker_plugin, plugin=plugin, name=name)
 
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4160,7 +4160,7 @@ class Client:
                 raise exc.with_traceback(tb)
         return responses
 
-    def register_worker_plugin(self, plugin=None, name=None):
+    def register_worker_plugin(self, plugin=None, name=None, **kwargs):
         """
         Registers a lifecycle worker plugin for all current and future workers.
 
@@ -4176,7 +4176,7 @@ class Client:
         cloudpickle modules.
 
         If the plugin has a ``name`` attribute, or if the ``name=`` keyword is
-        used then that will control idempotency.  A a plugin with that name has
+        used then that will control idempotency.  If a plugin with that name has
         already registered then any future plugins will not run.
 
         For alternatives to plugins, you may also wish to look into preload
@@ -4189,6 +4189,9 @@ class Client:
         name: str, optional
             A name for the plugin.
             Registering a plugin with the same name will have no effect.
+        **kwargs: optional
+            If you do pass an class name as the plugin, it will be instantiated
+            with any extra keyword arguments.
 
         Examples
         --------
@@ -4224,7 +4227,7 @@ class Client:
         distributed.WorkerPlugin
         """
         if isinstance(plugin, type):
-            raise ValueError("Plugin should be an instantiated object.")
+            plugin = plugin(self, **kwargs)
 
         return self.sync(self._register_worker_plugin, plugin=plugin, name=name)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4227,7 +4227,7 @@ class Client:
         distributed.WorkerPlugin
         """
         if isinstance(plugin, type):
-            plugin = plugin(self, **kwargs)
+            plugin = plugin(**kwargs)
 
         return self.sync(self._register_worker_plugin, plugin=plugin, name=name)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4190,8 +4190,8 @@ class Client:
             A name for the plugin.
             Registering a plugin with the same name will have no effect.
         **kwargs: optional
-            If you do pass an class name as the plugin, it will be instantiated
-            with any extra keyword arguments.
+            If you pass a class as the plugin, instead of a class instance, then the
+            class will be instantiated with any extra keyword arguments.
 
         Examples
         --------

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -53,6 +53,19 @@ async def test_create_with_client(c, s):
     assert worker._my_plugin_status == "teardown"
 
 
+@gen_cluster(client=True, nthreads=[])
+async def test_create_with_client_and_plugin_from_class(c, s):
+    await c.register_worker_plugin(MyPlugin, data=456)
+
+    worker = await Worker(s.address, loop=s.loop)
+    assert worker._my_plugin_status == "setup"
+    assert worker._my_plugin_data == 456
+
+    # Give the plugin a new name so that it registers
+    await c.register_worker_plugin(MyPlugin, name="new", data=789)
+    assert worker._my_plugin_data == 789
+
+
 @gen_cluster(client=True, worker_kwargs={"plugins": [MyPlugin(5)]})
 async def test_create_on_construction(c, s, a, b):
     assert len(a.plugins) == len(b.plugins) == 1

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1628,6 +1628,11 @@ async def test_pip_install(c, s, a, b):
         ) as p2:
             p1.communicate.return_value = b"", b""
             p1.wait.return_value = 0
+
+            # if plugin class isn't instantiated, fail early
+            with pytest.raises(ValueError, "instantiated"):
+                await c.register_worker_plugin(PipInstall)
+
             await c.register_worker_plugin(
                 PipInstall(packages=["requests"], pip_options=["--upgrade"])
             )

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1628,11 +1628,6 @@ async def test_pip_install(c, s, a, b):
         ) as p2:
             p1.communicate.return_value = b"", b""
             p1.wait.return_value = 0
-
-            # if plugin class isn't instantiated, fail early
-            with pytest.raises(ValueError, "instantiated"):
-                await c.register_worker_plugin(PipInstall)
-
             await c.register_worker_plugin(
                 PipInstall(packages=["requests"], pip_options=["--upgrade"])
             )


### PR DESCRIPTION
From the conversation in #4197 I realized that if you register a plugin wrong then that name is used up and you cannot register another plugin with the same name. This PR is just a little earlier catch to try to protect people from that. If this seems like overkill that is fine and we can close, just wanted to propose it since it would have helped me figure out what was going on sooner.