### PR TITLE
Fix state check in test_close_gracefully

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1571,7 +1571,7 @@ async def test_close_gracefully(c, s, a, b):
     assert b.address not in s.workers
     assert mem.issubset(set(a.data))
     for ts in proc:
-        assert ts.state in ("processing", "memory")
+        assert ts.state in ("executing", "memory")
 
 
 @pytest.mark.slow

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -105,8 +105,7 @@ class TaskState:
         The priority this task given by the scheduler.  Determines run order.
     * **state**: ``str``
         The current state of the task. One of ["waiting", "ready", "executing",
-        "memory", "flight", "executing", "error", "long-running",
-        "rescheduled", "error"]
+        "memory", "flight", "long-running", "rescheduled", "error"]
     * **who_has**: ``set(worker)``
         Workers that we believe have this data
     * **coming_from**: ``str``
@@ -1425,6 +1424,8 @@ class Worker(ServerNode):
                 if ts.state == "erred":
                     ts.exception = None
                     ts.traceback = None
+                else:
+                    ts.state = "waiting"
             else:
                 self.log.append((key, "new"))
                 self.tasks[key] = ts = TaskState(
@@ -1443,7 +1444,6 @@ class Worker(ServerNode):
             ts.duration = duration
             if resource_restrictions:
                 ts.resource_restrictions = resource_restrictions
-            ts.state = "waiting"
 
             if nbytes is not None:
                 self.nbytes.update(nbytes)


### PR DESCRIPTION
Also adding a typo fix (I had two duplicate states in the `TaskState`
docstring) and a very small change to the way state is assigned in
`add_task` that has been bugging me for a few days.

This should fix #4201 