### PR TITLE
Task state logs and data fix

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1464,7 +1464,9 @@ class Worker(ServerNode):
                 assert workers
                 if dependency not in self.tasks:
                     self.tasks[dependency] = dep_ts = TaskState(key=dependency)
-                    dep_ts.state = "waiting"
+                    dep_ts.state = (
+                        "waiting" if dependency not in self.data else "memory"
+                    )
 
                 dep_ts = self.tasks[dependency]
                 self.log.append((dependency, "new-dep", dep_ts.state))

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2117,7 +2117,7 @@ class Worker(ServerNode):
 
     def bad_dep(self, dep):
         exc = ValueError(
-            "Could not find dependent %s.  Check worker logs" % str(dep.ts)
+            "Could not find dependent %s.  Check worker logs" % str(dep.key)
         )
         for ts in dep.dependents:
             msg = error_message(exc)
@@ -2169,7 +2169,7 @@ class Worker(ServerNode):
             retries = kwargs.get("retries", 5)
             self.log.append(("handle-missing-failed", retries, deps))
             if retries > 0:
-                await self.handle_missing_dep(self, *deps, retries=retries - 1)
+                await self.handle_missing_dep(*deps, retries=retries - 1)
             else:
                 raise
         finally:


### PR DESCRIPTION
I'm putting this in on top of @fjetter's fix in #4200 to try to track down the assertion errors in the `task_validate` that showed up in CI.

I can reproduce that failure locally one out of every 10 times or so, running `pytest test_failed_workers.py::test_worker_who_has_clears_after_failed_connection -s`

To try to track down what was happening, I've added in per-task logs.  
What I found from there is that @fjetter is almost certainly correct that there's an extra `release_key` call somewhere.  
The failure occurs consistently for me where the only task-level log entry is "new", indicating a newly created `TaskState` object, but the same key already exists in `self.data`, which would indicate that we've called `release_key` but that because there are `dependents` of that particular task, we don't clear out the entry in `self.data`.

I've "fixed" that here by just nuking the key if it's present in `self.data`, but I don't think that's the correct way to fix this.  I'm putting this up in case anyone else can make use of the task-level logs (and I'll also keep looking for the stray call)