### PR TITLE
Display priority values as specified by user (removing the negative sign)

### DIFF
--- a/distributed/http/templates/task.html
+++ b/distributed/http/templates/task.html
@@ -41,7 +41,7 @@
           {% end %}
           <tr>
               <th> Priority </th>
-              <td>{{ts.priority}}</td>
+              <td>{{(-ts.priority[0],*ts.priority[1:])}}</td>
           </tr>
           {% for attr in ['has_lost_dependencies', 'host_restrictions', 'worker_restrictions', 'resource_restrictions', 'loose_restrictions', 'suspicious', 'retries', 'metadata'] %}
           {% if getattr(ts, attr) %}

--- a/distributed/http/templates/worker.html
+++ b/distributed/http/templates/worker.html
@@ -36,7 +36,7 @@
             {% for ts in sorted(ws.processing, key=lambda ts: ts.priority) %}
             <tr>
                 <td> <a href="../task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></td>
-                <td> {{ts.priority }} </td>
+                <td> {{(-ts.priority[0],*ts.priority[1:])}} </td>
             </tr>
             {% end %}
           </table>


### PR DESCRIPTION
Only the first element in the tuple is negated (it contains the user-specified priority), other components are unchanged.

This is a follow-up from https://github.com/dask/distributed/pull/4185