### PR TITLE
Add get_task_metadata context manager

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -17,6 +17,7 @@ from .client import (
     futures_of,
     get_task_stream,
     performance_report,
+    get_task_metadata,
 )
 from .lock import Lock
 from .nanny import Nanny

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4838,7 +4838,7 @@ class performance_report:
 
 
 class get_task_metadata:
-    """Collect task metadata
+    """Collect task metadata within a context block
 
     This gathers ``TaskState`` metadata from the scheduler for tasks which
     are submitted and finished within the scope of this context manager.
@@ -4847,7 +4847,7 @@ class get_task_metadata:
     --------
     >>> with get_task_metadata() as tasks:
     ...     x.compute()
-    >>> tasks.metdata
+    >>> tasks.metadata
     {...}
     """
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4837,6 +4837,39 @@ class performance_report:
         get_client().sync(self.__aexit__, type, value, traceback, code=code)
 
 
+class get_task_metadata:
+    """Collect task metadata
+
+    This gathers ``TaskState`` metadata from the scheduler for tasks which
+    are submitted and finished within the scope of this context manager.
+
+    Examples
+    --------
+    >>> with get_task_metadata() as tasks:
+    ...     x.compute()
+    >>> tasks.metdata
+    {...}
+    """
+
+    def __init__(self):
+        self.name = f"task-metadata-{uuid.uuid4().hex}"
+        self.keys = set()
+        self.metadata = None
+
+    async def __aenter__(self):
+        await get_client().scheduler.start_task_metadata(name=self.name)
+        return self
+
+    async def __aexit__(self, typ, value, traceback):
+        self.metadata = await get_client().scheduler.stop_task_metadata(name=self.name)
+
+    def __enter__(self):
+        return get_client().sync(self.__aenter__)
+
+    def __exit__(self, typ, value, traceback):
+        return get_client().sync(self.__aexit__, type, value, traceback)
+
+
 @contextmanager
 def temp_default_client(c):
     """Set the default client for the duration of the context

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3876,7 +3876,7 @@ class Scheduler(ServerNode):
 
         plugin = plugins[0]
         self.remove_plugin(plugin)
-        return plugin.metadata
+        return {"metadata": plugin.metadata, "state": plugin.state}
 
     async def register_worker_plugin(self, comm, plugin, name=None):
         """ Registers a setup function, and call it on every worker """
@@ -5667,6 +5667,7 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
         self.name = name
         self.keys = set()
         self.metadata = {}
+        self.state = {}
 
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         self.keys.update(keys)
@@ -5676,4 +5677,5 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
             ts = self.scheduler.tasks.get(key)
             if ts is not None and ts.key in self.keys:
                 self.metadata[key] = ts.metadata
+                self.state[key] = finish
                 self.keys.discard(key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1363,6 +1363,8 @@ class Scheduler(ServerNode):
             "adaptive_target": self.adaptive_target,
             "workers_to_close": self.workers_to_close,
             "subscribe_worker_status": self.subscribe_worker_status,
+            "start_task_metadata": self.start_task_metadata,
+            "stop_task_metadata": self.stop_task_metadata,
         }
 
         self._transitions = {
@@ -3855,6 +3857,27 @@ class Scheduler(ServerNode):
         ts = [p for p in self.plugins if isinstance(p, TaskStreamPlugin)][0]
         return ts.collect(start=start, stop=stop, count=count)
 
+    def start_task_metadata(self, comm=None, name=None):
+        plugin = CollectTaskMetaDataPlugin(scheduler=self, name=name)
+
+        self.add_plugin(plugin)
+
+    def stop_task_metadata(self, comm=None, name=None):
+        plugins = [
+            p
+            for p in self.plugins
+            if isinstance(p, CollectTaskMetaDataPlugin) and p.name == name
+        ]
+        if len(plugins) != 1:
+            raise ValueError(
+                "Expected to find exactly one CollectTaskMetaDataPlugin "
+                f"with name {name} but found {len(plugins)}."
+            )
+
+        plugin = plugins[0]
+        self.remove_plugin(plugin)
+        return plugin.metadata
+
     async def register_worker_plugin(self, comm, plugin, name=None):
         """ Registers a setup function, and call it on every worker """
         self.worker_plugins.append({"plugin": plugin, "name": name})
@@ -5636,3 +5659,21 @@ class WorkerStatusPlugin(SchedulerPlugin):
 
     def teardown(self):
         self.bcomm.close()
+
+
+class CollectTaskMetaDataPlugin(SchedulerPlugin):
+    def __init__(self, scheduler, name):
+        self.scheduler = scheduler
+        self.name = name
+        self.keys = set()
+        self.metadata = {}
+
+    def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
+        self.keys.update(keys)
+
+    def transition(self, key, start, finish, *args, **kwargs):
+        if start == "processing" and (finish == "memory" or finish == "erred"):
+            ts = self.scheduler.tasks.get(key)
+            if ts is not None and ts.key in self.keys:
+                self.metadata[key] = ts.metadata
+                self.keys.discard(key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5672,7 +5672,7 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
         self.keys.update(keys)
 
     def transition(self, key, start, finish, *args, **kwargs):
-        if start == "processing" and (finish == "memory" or finish == "erred"):
+        if finish == "memory" or finish == "erred":
             ts = self.scheduler.tasks.get(key)
             if ts is not None and ts.key in self.keys:
                 self.metadata[key] = ts.metadata

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6214,9 +6214,12 @@ async def test_get_task_metadata(c, s, a, b):
         await f
 
     metadata = tasks.metadata
-    assert metadata
     assert f.key in metadata
     assert metadata[f.key] == s.tasks.get(f.key).metadata
+
+    state = tasks.state
+    assert f.key in state
+    assert state[f.key] == "memory"
 
     assert not any(isinstance(p, CollectTaskMetaDataPlugin) for p in s.plugins)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -52,11 +52,12 @@ from distributed.client import (
     default_client,
     futures_of,
     temp_default_client,
+    get_task_metadata,
 )
 from distributed.compatibility import WINDOWS
 
 from distributed.metrics import time
-from distributed.scheduler import Scheduler, KilledWorker
+from distributed.scheduler import Scheduler, KilledWorker, CollectTaskMetaDataPlugin
 from distributed.sizeof import sizeof
 from distributed.utils import mp_context, sync, tmp_text, tokey, tmpfile, is_valid_xml
 from distributed.utils_test import (
@@ -82,6 +83,7 @@ from distributed.utils_test import (
     async_wait_for,
     pristine_loop,
     save_sys_modules,
+    TaskStateMetadataPlugin,
 )
 from distributed.utils_test import (  # noqa: F401
     client as c,
@@ -6199,3 +6201,49 @@ async def test_futures_in_subgraphs(c, s, a, b):
     ddf["local_time"] = ddf.enter_time.dt.tz_convert("US/Central")
     ddf["day"] = ddf.enter_time.dt.day_name()
     ddf = await c.submit(dd.categorical.categorize, ddf, columns=["day"], index=False)
+
+
+@gen_cluster(client=True)
+async def test_get_task_metadata(c, s, a, b):
+
+    # Populate task metadata
+    await c.register_worker_plugin(TaskStateMetadataPlugin())
+
+    async with get_task_metadata() as tasks:
+        f = c.submit(slowinc, 1)
+        await f
+
+    metadata = tasks.metadata
+    assert metadata
+    assert f.key in metadata
+    assert metadata[f.key] == s.tasks.get(f.key).metadata
+
+    assert not any(isinstance(p, CollectTaskMetaDataPlugin) for p in s.plugins)
+
+
+@gen_cluster(client=True)
+async def test_get_task_metadata_multiple(c, s, a, b):
+
+    # Populate task metadata
+    await c.register_worker_plugin(TaskStateMetadataPlugin())
+
+    # Ensure that get_task_metadata only collects metadata for
+    # tasks which are submitted and completed within its context
+    async with get_task_metadata() as tasks1:
+        f1 = c.submit(slowinc, 1)
+        await f1
+        async with get_task_metadata() as tasks2:
+            f2 = c.submit(slowinc, 2)
+            await f2
+
+    metadata1 = tasks1.metadata
+    metadata2 = tasks2.metadata
+
+    assert len(metadata1) == 2
+    assert sorted(metadata1.keys()) == sorted([f1.key, f2.key])
+    assert metadata1[f1.key] == s.tasks.get(f1.key).metadata
+    assert metadata1[f2.key] == s.tasks.get(f2.key).metadata
+
+    assert len(metadata2) == 1
+    assert list(metadata2.keys()) == [f2.key]
+    assert metadata2[f2.key] == s.tasks.get(f2.key).metadata

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -98,6 +98,7 @@ API
    fire_and_forget
    futures_of
    get_task_stream
+   get_task_metadata
 
 
 Asynchronous methods
@@ -193,6 +194,7 @@ Other
 .. autofunction:: distributed.rejoin
 .. autoclass:: distributed.Reschedule
 .. autoclass:: get_task_stream
+.. autoclass:: get_task_metadata
 
 .. autoclass:: Event
    :members:


### PR DESCRIPTION
In https://github.com/dask/distributed/pull/4191 we added a new `.metadata` attribute to the `TaskState` classes used by the scheduler and workers. However, after a tasks have been computed and are no longer needed, the corresponding `TaskState` objects are removed from the scheduler / workers. This makes it difficult to collect custom task-level metadata in practice.

This PR adds a new `get_task_metadata` context manager to collect `TaskState` metadata within a given context (similar to our existing `get_task_stream` and `get_performance_report` context managers). This enables users to do something like:

```python
>>> from distributed import get_task_metadata
>>> with get_task_metadata() as tasks:
...     x.compute()
>>> tasks.metadata
{...}
```

to get a key-to-metadata mapping for all the tasks which were submitted and completed within the `get_task_metadata` context.