### PR TITLE
Allow worker and scheduler to read logs from file

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -119,6 +119,12 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     type=str,
     help="Time of inactivity after which to kill the scheduler",
 )
+@click.option(
+    "--log-file",
+    default=None,
+    type=str,
+    help="Path to log file",
+)
 @click.version_option()
 def main(
     host,

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -237,6 +237,12 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     help="Module that should be loaded by each nanny "
     'like "foo.bar" or "/path/to/foo.py"',
 )
+@click.option(
+    "--log-file",
+    default=None,
+    type=str,
+    help="Path to log file",
+)
 @click.version_option()
 def main(
     scheduler,

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -208,12 +208,12 @@ class Cluster:
 
         if scheduler:
             L = await self.scheduler_comm.get_logs()
-            logs["Scheduler"] = Log("\n".join(line for level, line in L))
+            logs["Scheduler"] = Log("\n".join(line for line in L))
 
         if workers:
             d = await self.scheduler_comm.worker_logs(workers=workers)
             for k, v in d.items():
-                logs[k] = Log("\n".join(line for level, line in v))
+                logs[k] = Log("\n".join(line for line in v))
 
         return logs
 

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -45,6 +45,7 @@ distributed:
     locks:
       lease-validation-interval: 10s  # The interval in which the scheduler validates staleness of all acquired leases. Must always be smaller than the lease-timeout itself.
       lease-timeout: 30s  # Maximum interval to wait for a Client refresh before a lease is invalidated and released.
+    log-file: null
 
     http:
       routes:
@@ -94,10 +95,12 @@ distributed:
         - distributed.http.worker.prometheus
         - distributed.http.health
         - distributed.http.statics
+    log-file: null
 
   nanny:
     preload: []             # Run custom modules with Nanny
     preload-argv: []        # See https://docs.dask.org/en/latest/setup/custom-startup.html
+    log-file: null
 
   client:
     heartbeat: 5s  # Interval between client heartbeats

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -93,9 +93,11 @@ class Nanny(ServerNode):
         port=None,
         protocol=None,
         config=None,
+        log_file=None,
         **worker_kwargs,
     ):
-        self._setup_logging(logger)
+        self.log_file = log_file or dask.config.get("distributed.nanny.log-file")
+        self._setup_logging(logger, self.log_file)
         self.loop = loop or IOLoop.current()
 
         if isinstance(security, dict):
@@ -347,6 +349,7 @@ class Nanny(ServerNode):
                 preload_argv=self.preload_argv,
                 security=self.security,
                 contact_address=self.contact_address,
+                log_file=self.log_file,
             )
             worker_kwargs.update(self.worker_kwargs)
             self.process = WorkerProcess(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1101,9 +1101,12 @@ class Scheduler(ServerNode):
         preload=None,
         preload_argv=(),
         plugins=(),
+        log_file=None,
         **kwargs,
     ):
-        self._setup_logging(logger)
+        if log_file is None:
+            log_file = dask.config.get("distributed.scheduler.log-file")
+        self._setup_logging(logger, log_file)
 
         # Attributes
         if allowed_failures is None:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -380,6 +380,7 @@ class Worker(ServerNode):
         lifetime=None,
         lifetime_stagger=None,
         lifetime_restart=None,
+        log_file=None,
         **kwargs,
     ):
         self.tasks = dict()
@@ -469,7 +470,9 @@ class Worker(ServerNode):
             profile_cycle_interval = dask.config.get("distributed.worker.profile.cycle")
         profile_cycle_interval = parse_timedelta(profile_cycle_interval, default="ms")
 
-        self._setup_logging(logger)
+        if log_file is None:
+            log_file = dask.config.get("distributed.worker.log-file")
+        self._setup_logging(logger, log_file)
 
         if scheduler_file:
             cfg = json_load_robust(scheduler_file)


### PR DESCRIPTION
Currently all node subclasses (`Scheduler`, `Nanny` and `Worker`) log to an internal dequeue which can be queried from a `Cluster` or `Client` object via `get_logs` or `worker_logs` methods.

One downside of this is that not everything which would typically end up in stdout/stderr is logged by Dask. Some tracebacks and other startup output is not available.

In many deployment scenarios the output from the processes will be written to a file. This PR adds the ability to configure the scheduler, nanny and worker with the location of this file. So when a client or cluster queries the logs it will be read back from the file instead of the logging queue.

#### Toy example

```bash
dask-scheduler --log-file /tmp/scheduler.log 2>&1 | tee /tmp/scheduler.log
```

```bash
echo "hello world" >> /tmp/scheduler.log
```

```python
>>> from dask.distributed import Client

>>> client = Client("tcp://localhost:8786", asynchronous=True)

>>> print("".join(list(await client.scheduler.get_logs())))                               
distributed.scheduler - INFO - -----------------------------------------------
distributed.scheduler - INFO - -----------------------------------------------
distributed.scheduler - INFO - Clear task state
distributed.scheduler - INFO -   Scheduler at:   tcp://10.51.100.15:8786
distributed.scheduler - INFO -   dashboard at:                     :8787
distributed.scheduler - INFO - Receive client connection: Client-91f8da1e-1ebc-11eb-b114-acde48001122
distributed.core - INFO - Starting established connection
distributed.scheduler - INFO - Register worker <Worker 'tcp://127.0.0.1:50186', name: tcp://127.0.0.1:50186, memory: 0, processing: 0>
distributed.scheduler - INFO - Starting worker compute stream, tcp://127.0.0.1:50186
distributed.core - INFO - Starting established connection
hello world
```

#### Real world usage

In `dask-cloudprovider` we have a new set of VM based cluster managers. Schedulers and workers are created via [cloud-init](https://cloudinit.readthedocs.io/en/latest/topics/format.html) which is a common configuration format for cloud VMs and is often passed as a field called `user_data`.

For example on AWS [you can specify commands for your EC2 instance to run on launch](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html). This is how the components in `dask_cloudprovider.aws.EC2Cluster` are run.

Cloud init logs to a file called `/var/log/cloud-init-output.log` which contains all the startup information about the VM followed by the stdout/stderr of the custom commands, in this case the Dask component.

With this change we can configure the `log_file` to `/var/log/cloud-init-output.log` which means that calling `cluster.get_logs()` will return the full contents of the cloud init output log instead of just the logging calls made by Dask.