### PR TITLE
Automatically restart memory-leaking workers when they reach a critical limit

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2678,6 +2678,7 @@ class Worker(ServerNode):
                         if self.memory_limit is not None
                         else "None",
                     )
+                    await self.close_gracefully(restart=True)
                     break
                 k, v, weight = self.data.fast.evict()
                 del k, v


### PR DESCRIPTION
Attempt to fix https://github.com/dask/distributed/issues/4193.

This pull request successfully restarts memory-leaking workers.
However, some workers still keep freezing.

Minimal example to reproduce memory leak outside of the test suite:
```python
import dask
import dask.distributed
import numpy as np
import time

cluster = dask.distributed.LocalCluster(n_workers=4, threads_per_worker=1, memory_limit="512M")
client = dask.distributed.Client(cluster)

x = {}
def memory_leaking_fn(data):
    x[data] = np.random.randint(100, size=12 * 1024**2 // 8)
    
    time.sleep(0.1)
    return data

futures = client.map(memory_leaking_fn, range(1000))

for f in futures:
    print(f.result())
```
