### PR TITLE
800 times speedup: intersection of set vs dict_keys

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1850,8 +1850,11 @@ class Scheduler(ServerNode):
 
         if priority is None:
             # Removing all non-local keys before calling order()
+            dsk_keys = set(dsk)  # intersection() of a set is much faster than a dict_keys
             stripped_deps = {
-                k: v.intersection(dsk) for k, v in dependencies.items() if k in dsk
+                k: v.intersection(dsk_keys)
+                for k, v in dependencies.items()
+                if k in dsk_keys
             }
             priority = dask.order.order(dsk, dependencies=stripped_deps)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1850,7 +1850,7 @@ class Scheduler(ServerNode):
 
         if priority is None:
             # Removing all non-local keys before calling order()
-            dsk_keys = set(dsk)  # intersection() of a set is much faster than a dict_keys
+            dsk_keys = set(dsk)  # intersection() of sets is much faster than dict_keys
             stripped_deps = {
                 k: v.intersection(dsk_keys)
                 for k, v in dependencies.items()


### PR DESCRIPTION
I just discovered that calling `Set.intersection(x)` where `x` is a `dict_keys` is slow! 
Converting `x` to a `set` gives a 800x speedup in a 1000 partitioned shuffle :)
```
Calculation of `stripped_deps` in update_graph_hlg():
0.096s vs 77.373s
```

Notice, it is not enough to set `dsk_keys = dsk.keys()`. It has to be a `set`.
