### PR TITLE
Increase default for connect timeout

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -131,7 +131,7 @@ distributed:
       threads: 0    # Threads to use. 0 for single-threaded, -1 to infer from cpu count.
 
     timeouts:
-      connect: 10s          # time before connecting fails
+      connect: 30s          # time before connecting fails
       tcp: 30s              # time before calling an unresponsive connection dead
 
     require-encryption: null # Whether to require encryption on non-local comms


### PR DESCRIPTION
Disclaimer: I don't have data to back this up, only a gut feeling.

We're still seeing connection timeouts (#4080), even after the removal of the fixed handshake timeouts in #4176. There we already discussed the increase of the default timeout since the `connect` no longer just needs to accommodate for the actual TCP (or whatever) connect but also for the handshake.

What's made this worse is that due to DNS instabilities it was requested to split up to favour multiple small attempts instead of one large attempt (#3104)

Putting everything together, I believe the initial default of 10s should be increased to counteract the added complexity of this operation. I don't have a good feeling about an appropriate value here, in #4176 there was a suggestion to increase it to 30s but I could also see higher values to make sense.

cc @jcrist 