### PR TITLE
Add aggregated topic logs

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3579,15 +3579,16 @@ class Client:
         """
         return self.sync(self.scheduler.worker_logs, n=n, workers=workers, nanny=nanny)
 
-    def log_event(self, topic: str, msg):
+    def log_event(self, topic, msg):
         """Log an event under a given topic
 
         Parameters
         ----------
-        topic: str
-            Name of the topic under which to log an event
+        topic: str, list
+            Name of the topic under which to log an event. To log the same
+            event under multiple topics, pass a list of topic names.
         msg
-            Event to log. Note this must be a msgpack serializable.
+            Event message to log. Note this must be msgpack serializable.
 
         Examples
         --------
@@ -3597,12 +3598,13 @@ class Client:
         return self.sync(self.scheduler.log_event, topic=topic, msg=msg)
 
     def get_events(self, topic: str = None):
-        """Retrieve structured logs
+        """Retrieve structured topic logs
 
         Parameters
         ----------
-        topic: str
-            Name of topic log to retrieve events for
+        topic: str, optional
+            Name of topic log to retrieve events for. If no ``topic`` is
+            provided, then logs for all topics will be returned.
         """
         return self.sync(self.scheduler.events, topic=topic)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3579,10 +3579,20 @@ class Client:
         """
         return self.sync(self.scheduler.worker_logs, n=n, workers=workers, nanny=nanny)
 
-    def log_event(self, topic, msg):
+    def log_event(self, topic: str, msg: dict):
+        """Log an event under a given topic
+
+        Parameters
+        ----------
+        topic: str
+            Name of the topic under which to log an event
+        msg: dict
+            Event to log. Note that this must be a msgpack serializable dictionary.
+        """
         return self.sync(self.scheduler.log_event, topic=topic, msg=msg)
 
-    def get_events(self, topic=None):
+    def get_events(self, topic: str = None):
+        """Retrieve structured logs"""
         return self.sync(self.scheduler.events, topic=topic)
 
     def retire_workers(self, workers=None, close_workers=True, **kwargs):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3579,20 +3579,31 @@ class Client:
         """
         return self.sync(self.scheduler.worker_logs, n=n, workers=workers, nanny=nanny)
 
-    def log_event(self, topic: str, msg: dict):
+    def log_event(self, topic: str, msg):
         """Log an event under a given topic
 
         Parameters
         ----------
         topic: str
             Name of the topic under which to log an event
-        msg: dict
-            Event to log. Note that this must be a msgpack serializable dictionary.
+        msg
+            Event to log. Note this must be a msgpack serializable.
+
+        Examples
+        --------
+        >>> from time import time
+        >>> client.log_event("current-time", time())
         """
         return self.sync(self.scheduler.log_event, topic=topic, msg=msg)
 
     def get_events(self, topic: str = None):
-        """Retrieve structured logs"""
+        """Retrieve structured logs
+
+        Parameters
+        ----------
+        topic: str
+            Name of topic log to retrieve events for
+        """
         return self.sync(self.scheduler.events, topic=topic)
 
     def retire_workers(self, workers=None, close_workers=True, **kwargs):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3579,6 +3579,12 @@ class Client:
         """
         return self.sync(self.scheduler.worker_logs, n=n, workers=workers, nanny=nanny)
 
+    def log_event(self, topic, msg):
+        return self.sync(self.scheduler.log_event, topic=topic, msg=msg)
+
+    def get_events(self, topic=None):
+        return self.sync(self.scheduler.events, topic=topic)
+
     def retire_workers(self, workers=None, close_workers=True, **kwargs):
         """Retire certain workers on the scheduler
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections import defaultdict, deque
+from collections import defaultdict
 from contextlib import suppress
 from enum import Enum
 from functools import partial
@@ -184,8 +184,6 @@ class Server:
         self.monitor = SystemMonitor()
         self.counters = None
         self.digests = None
-        self.events = None
-        self.event_counts = None
         self._ongoing_coroutines = weakref.WeakSet()
         self._event_finished = asyncio.Event()
 
@@ -224,8 +222,6 @@ class Server:
         from .counter import Counter
 
         self.counters = defaultdict(partial(Counter, loop=self.io_loop))
-        self.events = defaultdict(lambda: deque(maxlen=10000))
-        self.event_counts = defaultdict(lambda: 0)
 
         self.periodic_callbacks = dict()
 
@@ -368,16 +364,6 @@ class Server:
             )
         if self.digests is not None:
             self.digests["tick-duration"].add(diff)
-
-    def log_event(self, name, msg):
-        msg["time"] = time()
-        if isinstance(name, list):
-            for n in name:
-                self.events[n].append(msg)
-                self.event_counts[n] += 1
-        else:
-            self.events[name].append(msg)
-            self.event_counts[name] += 1
 
     @property
     def address(self):

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1121,9 +1121,9 @@ class StealingEvents(DashboardComponent):
     @without_property_validation
     def update(self):
         with log_errors():
-            log = self.steal.log
+            log = self.scheduler.get_events(topic="stealing")
             n = self.steal.count - self.last
-            log = [log[-i] for i in range(1, n + 1) if isinstance(log[-i], list)]
+            log = [log[-i][1] for i in range(1, n + 1) if isinstance(log[-i][1], list)]
             self.last = self.steal.count
 
             if log:
@@ -1205,8 +1205,8 @@ class Events(DashboardComponent):
                 hovers = []
                 ys = []
                 colors = []
-                for msg in log:
-                    times.append(msg["time"] * 1000)
+                for msg_time, msg in log:
+                    times.append(msg_time * 1000)
                     action = msg["action"]
                     actions.append(action)
                     try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1299,7 +1299,7 @@ class Scheduler(ServerNode):
             maxlen=dask.config.get("distributed.scheduler.transition-log-length")
         )
         self.events = defaultdict(lambda: deque(maxlen=100000))
-        self.event_counts = defaultdict(lambda: 0)
+        self.event_counts = defaultdict(int)
         self.worker_plugins = []
 
         worker_handlers = {

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5324,13 +5324,13 @@ class Scheduler(ServerNode):
         return results
 
     def log_event(self, name, msg):
-        msg["time"] = time()
+        event = (time(), msg)
         if isinstance(name, list):
             for n in name:
-                self.events[n].append(msg)
+                self.events[n].append(event)
                 self.event_counts[n] += 1
         else:
-            self.events[name].append(msg)
+            self.events[name].append(event)
             self.event_counts[name] += 1
 
     def get_events(self, comm=None, topic=None):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6251,3 +6251,32 @@ async def test_get_task_metadata_multiple(c, s, a, b):
     assert len(metadata2) == 1
     assert list(metadata2.keys()) == [f2.key]
     assert metadata2[f2.key] == s.tasks.get(f2.key).metadata
+
+
+@gen_cluster(client=True)
+async def test_log_event(c, s, a, b):
+
+    # Log an event from inside a task
+    def foo():
+        get_worker().log_event("topic1", {"foo": "bar"})
+
+    assert not await c.get_events("topic1")
+    await c.submit(foo)
+    events = await c.get_events("topic1")
+    assert len(events) == 1
+    assert events[0]["foo"] == "bar"
+
+    # Log an event while on the scheduler
+    def log_scheduler(dask_scheduler):
+        dask_scheduler.log_event("topic2", {"woo": "hoo"})
+
+    await c.run_on_scheduler(log_scheduler)
+    events = await c.get_events("topic2")
+    assert len(events) == 1
+    assert events[0]["woo"] == "hoo"
+
+    # Log an event from the client process
+    await c.log_event("topic2", {"alice": "bob"})
+    events = await c.get_events("topic2")
+    assert len(events) == 2
+    assert events[1]["alice"] == "bob"

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6264,7 +6264,7 @@ async def test_log_event(c, s, a, b):
     await c.submit(foo)
     events = await c.get_events("topic1")
     assert len(events) == 1
-    assert events[0]["foo"] == "bar"
+    assert events[0][1] == {"foo": "bar"}
 
     # Log an event while on the scheduler
     def log_scheduler(dask_scheduler):
@@ -6273,10 +6273,10 @@ async def test_log_event(c, s, a, b):
     await c.run_on_scheduler(log_scheduler)
     events = await c.get_events("topic2")
     assert len(events) == 1
-    assert events[0]["woo"] == "hoo"
+    assert events[0][1] == {"woo": "hoo"}
 
     # Log an event from the client process
-    await c.log_event("topic2", {"alice": "bob"})
+    await c.log_event("topic2", ("alice", "bob"))
     events = await c.get_events("topic2")
     assert len(events) == 2
-    assert events[1]["alice"] == "bob"
+    assert events[1][1] == ("alice", "bob")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -758,6 +758,15 @@ class Worker(ServerNode):
     def logs(self):
         return self._deque_handler.deque
 
+    def log_event(self, topic, msg):
+        self.batched_stream.send(
+            {
+                "op": "log-event",
+                "topic": topic,
+                "msg": msg,
+            }
+        )
+
     @property
     def worker_address(self):
         """ For API compatibility with Nanny """

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -16,6 +16,7 @@ API
    Client.gather
    Client.get
    Client.get_dataset
+   Client.get_events
    Client.get_executor
    Client.get_metadata
    Client.get_scheduler_logs
@@ -23,6 +24,7 @@ API
    Client.get_task_stream
    Client.has_what
    Client.list_datasets
+   Client.log_event
    Client.map
    Client.nthreads
    Client.persist

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -91,6 +91,7 @@ Contents
    efficiency
    limitations
    locality
+   logging
    manage-computation
    memory
    priority

--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -1,0 +1,72 @@
+
+Logging
+=======
+
+.. currentmodule:: distributed
+
+There are several ways in which state and other activities are logged throughout
+a Dask cluster.
+
+
+Logs
+----
+
+The scheduler, workers, and client all log various administrative events using Python's standard
+logging module. Both the logging level and logging handlers are customizable.
+See the `Debugging docs <https://docs.dask.org/en/latest/debugging.html#logs>`_ for more information.
+
+
+Task transition logs
+--------------------
+
+The scheduler keeps track of all :ref:`state transitions <scheduler-task-state>` for each task.
+This gives insight into how tasks progressed through their computation and can be particularly
+valuable when debugging.
+To retrieve the transition logs for a given task, pass the task's key to the :meth:`Scheduler.story` method.
+
+.. code-block:: Python
+
+    >>> f = client.submit(inc, 123)
+    >>> f
+    <Future: finished, type: builtins.int, key: inc-aad7bbea25dc61c8e53d929c7ec50bed>
+    >>> s.story(f.key)
+    [('inc-aad7bbea25dc61c8e53d929c7ec50bed', 'released', 'waiting', {'inc-aad7bbea25dc61c8e53d929c7ec50bed': 'processing'}, 1605143345.7283862),
+     ('inc-aad7bbea25dc61c8e53d929c7ec50bed', 'waiting', 'processing', {}, 1605143345.7284858),
+     ('inc-aad7bbea25dc61c8e53d929c7ec50bed', 'processing', 'memory', {}, 1605143345.731495)]
+
+
+Structured logs
+---------------
+
+The scheduler, workers, and client all support logging structured events to a centralized ledger,
+which is indexed by topic. By default, Dask will log a few administrative events to this system
+(e.g. when workers enter and leave the cluster) but custom events can be logged using the
+:meth:`Scheduler.log_event`, :meth:`Worker.log_event`, or :meth:`Client.log_event` methods.
+
+For example, below we log start and stop times to the ``"runtimes"`` topic using the worker's
+``log_event`` method:
+
+.. code-block:: python
+
+    >>> def myfunc(x):
+    ...     start = time()
+    ...     ...
+    ...     stop = time()
+    ...     dask.distributed.get_worker().log_event("runtimes", {"start": start, "stop": stop})
+    >>> futures = client.map(myfunc, range(10))
+    >>> client.get_events("runtimes")
+    ({'start': 1605199867.613919,
+      'stop': 1605199867.613919,
+      'time': 1605199867.617635},
+     {'start': 1605199867.613919,
+      'stop': 1605199867.613919,
+      'time': 1605199867.617635},
+     ...
+    )
+
+Events for a given topic can be retrieved using the :meth:`Client.get_events` method.
+In the above example, we retrieved the logged start and stop times with
+``client.get_events("runtimes")``.
+
+When combined with scheduler and worker plugins, the structured events system can produce
+rich logging / diagnostic systems.

--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -55,18 +55,16 @@ For example, below we log start and stop times to the ``"runtimes"`` topic using
     ...     dask.distributed.get_worker().log_event("runtimes", {"start": start, "stop": stop})
     >>> futures = client.map(myfunc, range(10))
     >>> client.get_events("runtimes")
-    ({'start': 1605199867.613919,
-      'stop': 1605199867.613919,
-      'time': 1605199867.617635},
-     {'start': 1605199867.613919,
-      'stop': 1605199867.613919,
-      'time': 1605199867.617635},
+    ((1605207481.77175, {'start': 1605207481.769397, 'stop': 1605207481.769397}),
+     (1605207481.772021, {'start': 1605207481.770036, 'stop': 1605207481.770037}),
      ...
     )
 
 Events for a given topic can be retrieved using the :meth:`Client.get_events` method.
 In the above example, we retrieved the logged start and stop times with
-``client.get_events("runtimes")``.
+``client.get_events("runtimes")``. Note that ``Client.get_events`` returns a tuple for
+each logged event which contains the logged message along with a timestamp for when
+the event was logged.
 
 When combined with scheduler and worker plugins, the structured events system can produce
 rich logging / diagnostic systems.

--- a/docs/source/scheduling-state.rst
+++ b/docs/source/scheduling-state.rst
@@ -46,6 +46,8 @@ The scheduler keeps internal state about several kinds of entities:
    in user code (including on any APIs explained here).
 
 
+.. _scheduler-task-state:
+
 Task State
 ----------
 


### PR DESCRIPTION
This PR adds the ability to log events under a specified topic to a centralized ledger of events that lives on the scheduler. Currently the centralized ledger contains some administrative events which were previously logged using `Scheduler.log_event`. With the changes in this PR, the client and workers now also have a `log_event` method to add their own events to the ledger. Additionally, the client also has a `get_events` method which allows users to retrieve events from the ledger.

Closes https://github.com/dask/distributed/issues/4222