### PR TITLE
Ignore UCX errors when shutting down

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -296,7 +296,13 @@ class UCX(Comm):
 
     async def close(self):
         if self._ep is not None:
-            await self.ep.send(struct.pack("?Q", True, 0))
+            try:
+                await self.ep.send(struct.pack("?Q", True, 0))
+            except ucp.exceptions.UCXError:
+                # If the other end is in the process of closing,
+                # UCX will sometimes raise a `Input/output` error,
+                # which we can ignore.
+                pass
             self.abort()
             self._ep = None
 


### PR DESCRIPTION
If the other end is in the process of closing, UCX will sometimes raise a `Input/output` error, which will make the shutdown process hang.

I found the issue while developing an unrelated test in dask-cuda [ `test_communicating_proxy_objects()`](https://github.com/rapidsai/dask-cuda/blob/56f0546f3c492dc26bb11bf4cbae4deb5ce1bd27/dask_cuda/tests/test_proxy.py#L205), which hangs approx. every 10th run. I had to add a manual shutdown call to fix it.

This PR hopefully also fixes other hangs in dask-cuda: https://github.com/rapidsai/dask-cuda/issues/431

cc. @pentschev 
