### PR TITLE
comm: close comm on low-level errors

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -472,9 +472,12 @@ class Server:
                         )
                     break
                 except Exception as e:
-                    logger.exception(e)
-                    await comm.write(error_message(e, status="uncaught-error"))
-                    continue
+                    logger.exception("Exception while reading from %s", address)
+                    if comm.closed():
+                        raise
+                    else:
+                        await comm.write(error_message(e, status="uncaught-error"))
+                        continue
                 if not isinstance(msg, dict):
                     raise TypeError(
                         "Bad message type.  Expected dict, got\n  " + str(msg)
@@ -531,8 +534,11 @@ class Server:
                             logger.info("Lost connection to %r: %s", address, e)
                         break
                     except Exception as e:
-                        logger.exception(e)
-                        result = error_message(e, status="uncaught-error")
+                        logger.exception("Exception while handling op %s", op)
+                        if comm.closed():
+                            raise
+                        else:
+                            result = error_message(e, status="uncaught-error")
 
                 # result is not type stable:
                 # when LHS is not Status then RHS must not be Status or it raises.

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -297,11 +297,5 @@ async def test_handles_exceptions():
             b.send("hello")
             b.send("world")
             await asyncio.sleep(0.020)
-            result = await comm.read()
-            assert result == ("hello", "hello", "world")
-
-            b.send("raises when flushed")
-            await asyncio.sleep(0.020)  # CommClosedError hit in callback
-
             with pytest.raises(CommClosedError):
-                b.send("raises when sent")
+                await comm.read()

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -1,6 +1,5 @@
 import asyncio
 import random
-from unittest import mock
 
 import pytest
 from tlz import assoc
@@ -8,10 +7,9 @@ from tlz import assoc
 from distributed.batched import BatchedSend
 from distributed.core import listen, connect, CommClosedError
 from distributed.metrics import time
-from distributed.utils import All, TimeoutError
+from distributed.utils import All
 from distributed.utils_test import captured_logger
 from distributed.protocol import to_serialize
-from distributed.compatibility import WINDOWS, TORNADO6
 
 
 class EchoServer:
@@ -250,52 +248,4 @@ async def test_serializers():
         assert "type" in value
         assert "function" in value
 
-        msg = await comm.read()
-        assert list(msg) == [{"x": 123}, {"x": "hello"}]
-
-        with pytest.raises(TimeoutError):
-            msg = await asyncio.wait_for(comm.read(), 0.1)
-
-
-@pytest.mark.asyncio
-@pytest.mark.skipif(WINDOWS and not TORNADO6, reason="failing on windows, tornado 5.")
-async def test_handles_exceptions():
-    # Ensure that we properly handle exceptions in BatchedSend.
-    # https://github.com/pangeo-data/pangeo/issues/788
-    # mentioned in https://github.com/dask/distributed/issues/4080, but
-    # possibly distinct.
-    #
-    # The reported issues (https://github.com/tornadoweb/tornado/pull/2008)
-    # claim that the BufferError *should* only happen when the application
-    # is incorrectly using threads. I haven't been able to construct an
-    # actual example, so we mock IOStream.write to raise and ensure that
-    # BufferedSend handles things correctly. We don't (yet) test that
-    # any *users* of BatchedSend correctly handle BatchedSend dropping
-    # messages.
-    async with EchoServer() as e:
-        comm = await connect(e.address)
-        b = BatchedSend(interval=10)
-        b.start(comm)
-        await asyncio.sleep(0.020)
-        orig = comm.stream.write
-
-        n = 0
-
-        def raise_buffererror(*args, **kwargs):
-            nonlocal n
-            n += 1
-
-            if n == 1:
-                raise BufferError("bad!")
-            elif n == 2:
-                orig(*args, **kwargs)
-            else:
-                raise CommClosedError
-
-        with mock.patch.object(comm.stream, "write", wraps=raise_buffererror):
-            b.send("hello")
-            b.send("hello")
-            b.send("world")
-            await asyncio.sleep(0.020)
-            with pytest.raises(CommClosedError):
-                await comm.read()
+        assert comm.closed()


### PR DESCRIPTION
Close `comm.stream` on low-level errors, such as BufferErrors. In such cases, we do not really know what was written to / read from the underlying socket, so the only safe way forward is to immediately close the connection.
See also #4133 