### PR TITLE
comm/tcp listener: do not pass comm with failed handshake to comm_handler

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -459,6 +459,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
             await self.on_connection(comm)
         except CommClosedError:
             logger.info("Connection closed before handshake completed")
+            return
 
         await self.comm_handler(comm)
 

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -216,11 +216,14 @@ async def test_tcp_listener_does_not_call_handler_on_handshake_error():
         host, port = listener.get_host_port()
         # connect without handshake:
         reader, writer = await asyncio.open_connection(host=host, port=port)
+        # wait a but to let the listener side hit the timeout on the handshake:
         await asyncio.sleep(0.02)
 
     assert not handle_comm_called
 
     writer.close()
+    if hasattr(writer, "wait_closed"):  # always true for python >= 3.7, but not for 3.6
+        await writer.wait_closed()
 
 
 @pytest.mark.asyncio

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -6,6 +6,8 @@ import types
 import warnings
 from functools import partial
 
+import dask
+
 import distributed
 import pkg_resources
 import pytest
@@ -199,6 +201,26 @@ def test_get_local_address_for():
 #
 # Test concrete transport APIs
 #
+
+
+@pytest.mark.asyncio
+async def test_tcp_listener_does_not_call_handler_on_handshake_error():
+    handle_comm_called = False
+
+    async def handle_comm(comm):
+        nonlocal handle_comm_called
+        handle_comm_called = True
+
+    with dask.config.set({"distributed.comm.timeouts.connect": 0.01}):
+        listener = await tcp.TCPListener("127.0.0.1", handle_comm)
+        host, port = listener.get_host_port()
+        # connect without handshake:
+        reader, writer = await asyncio.open_connection(host=host, port=port)
+        await asyncio.sleep(0.02)
+
+    assert not handle_comm_called
+
+    writer.close()
 
 
 @pytest.mark.asyncio

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -216,7 +216,7 @@ async def test_tcp_listener_does_not_call_handler_on_handshake_error():
         host, port = listener.get_host_port()
         # connect without handshake:
         reader, writer = await asyncio.open_connection(host=host, port=port)
-        # wait a but to let the listener side hit the timeout on the handshake:
+        # wait a bit to let the listener side hit the timeout on the handshake:
         await asyncio.sleep(0.02)
 
     assert not handle_comm_called


### PR DESCRIPTION
A return was missing here, which would pass on `comm` to the handler, even if the handshake had errors.