### PR TITLE
Create dependency TaskState as needed in gather_dep

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1998,7 +1998,7 @@ class Worker(ServerNode):
 
                 # dep states may have changed before gather_dep runs
                 # if a dep is no longer in-flight then don't fetch it
-                deps_ts = [self.tasks[key] for key in deps]
+                deps_ts = [self.tasks.get(key, None) or TaskState(key) for key in deps]
                 deps_ts = tuple(ts for ts in deps_ts if ts.state == "flight")
                 deps = [d.key for d in deps_ts]
 


### PR DESCRIPTION
Fixes #4231

As raised in #4231 there are a few cases where we try to gather
dependencies that don't have a corresponding TaskState object -- I think
this is probably because those objects have been recently released (or
it may be due to work-stealing, still trying to work that out
definitively).

This prevents the worker from bailing out -- and in either of the cases
above, we'll still need to ask the scheduler for more information, so we
don't need to add this particular TaskState object to the tasks dict.