### PR TITLE
Document task priority tie breaking

### DIFF
--- a/docs/source/priority.rst
+++ b/docs/source/priority.rst
@@ -57,3 +57,7 @@ Dask uses the following priorities, in order:
     call) Dask orders tasks in such a way as to minimize the memory-footprint
     of the computation.  This is discussed in more depth in the
     `task ordering documentation <https://github.com/dask/dask/blob/master/dask/order.py>`_.
+
+If multiple tasks each have exactly the same priorities outlined above, then
+the order in which tasks arrive at a worker, in a last in first out manner,
+is used to determine the order in which tasks run.


### PR DESCRIPTION
This PR has a small documentation addition which documents what happens in the case that multiple tasks have exactly the same priority. 

Closes https://github.com/dask/distributed/issues/4246