### PR TITLE
Fuse steps in `extract_serialize`

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -447,17 +447,12 @@ def extract_serialize(x):
     """
     x2 = type(x)()
     ser = {}
-    _extract_serialize(x, x2, ser)
-
     bytestrings = set()
-    for k, v in ser.items():
-        if type(v) in (bytes, bytearray):
-            ser[k] = to_serialize(v)
-            bytestrings.add(k)
+    _extract_serialize(x, x2, ser, bytestrings)
     return x2, ser, bytestrings
 
 
-def _extract_serialize(x, x2, ser, path=()):
+def _extract_serialize(x, x2, ser, bytestrings, path=()):
     typ_x = type(x)
     if typ_x is dict:
         x_items = x.items()
@@ -470,14 +465,12 @@ def _extract_serialize(x, x2, ser, path=()):
         typ_v = type(v)
         if typ_v is dict or typ_v is list:
             x2[k] = v2 = typ_v()
-            _extract_serialize(v, v2, ser, path_k)
-        elif (
-            typ_v is Serialize
-            or typ_v is Serialized
-            or (typ_v is bytes or typ_v is bytearray)
-            and len(v) > 2 ** 16
-        ):
+            _extract_serialize(v, v2, ser, bytestrings, path_k)
+        elif typ_v is Serialize or typ_v is Serialized:
             ser[path_k] = v
+        elif (typ_v is bytes or typ_v is bytearray) and len(v) > 2 ** 16:
+            ser[path_k] = to_serialize(v)
+            bytestrings.add(path_k)
         else:
             x2[k] = v
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -476,29 +476,21 @@ def extract_serialize(x):
 
 def _extract_serialize(x, ser, path=()):
     if type(x) is dict:
-        for k, v in x.items():
-            typ = type(v)
-            if typ is list or typ is dict:
-                _extract_serialize(v, ser, path + (k,))
-            elif (
-                typ is Serialize
-                or typ is Serialized
-                or typ in (bytes, bytearray)
-                and len(v) > 2 ** 16
-            ):
-                ser[path + (k,)] = v
+        x_items = x.items()
     elif type(x) is list:
-        for k, v in enumerate(x):
-            typ = type(v)
-            if typ is list or typ is dict:
-                _extract_serialize(v, ser, path + (k,))
-            elif (
-                typ is Serialize
-                or typ is Serialized
-                or typ in (bytes, bytearray)
-                and len(v) > 2 ** 16
-            ):
-                ser[path + (k,)] = v
+        x_items = enumerate(x)
+
+    for k, v in x_items:
+        typ = type(v)
+        if typ is list or typ is dict:
+            _extract_serialize(v, ser, path + (k,))
+        elif (
+            typ is Serialize
+            or typ is Serialized
+            or typ in (bytes, bytearray)
+            and len(v) > 2 ** 16
+        ):
+            ser[path + (k,)] = v
 
 
 def nested_deserialize(x):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -489,7 +489,7 @@ def _extract_serialize(x, ser, path=()):
         elif (
             typ_v is Serialize
             or typ_v is Serialized
-            or typ_v in (bytes, bytearray)
+            or (typ_v is bytes or typ_v is bytearray)
             and len(v) > 2 ** 16
         ):
             ser[path_k] = v

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -483,13 +483,13 @@ def _extract_serialize(x, ser, path=()):
 
     for k, v in x_items:
         path_k = path + (k,)
-        typ = type(v)
-        if typ is dict or typ is list:
+        typ_v = type(v)
+        if typ_v is dict or typ_v is list:
             _extract_serialize(v, ser, path_k)
         elif (
-            typ is Serialize
-            or typ is Serialized
-            or typ in (bytes, bytearray)
+            typ_v is Serialize
+            or typ_v is Serialized
+            or typ_v in (bytes, bytearray)
             and len(v) > 2 ** 16
         ):
             ser[path_k] = v

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -482,16 +482,17 @@ def _extract_serialize(x, ser, path=()):
         x_items = enumerate(x)
 
     for k, v in x_items:
+        path_k = path + (k,)
         typ = type(v)
         if typ is dict or typ is list:
-            _extract_serialize(v, ser, path + (k,))
+            _extract_serialize(v, ser, path_k)
         elif (
             typ is Serialize
             or typ is Serialized
             or typ in (bytes, bytearray)
             and len(v) > 2 ** 16
         ):
-            ser[path + (k,)] = v
+            ser[path_k] = v
 
 
 def nested_deserialize(x):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -475,9 +475,10 @@ def extract_serialize(x):
 
 
 def _extract_serialize(x, ser, path=()):
-    if type(x) is dict:
+    typ_x = type(x)
+    if typ_x is dict:
         x_items = x.items()
-    elif type(x) is list:
+    elif typ_x is list:
         x_items = enumerate(x)
 
     for k, v in x_items:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -1,13 +1,12 @@
 from array import array
 from functools import partial
+from itertools import repeat
 import traceback
 import importlib
 from enum import Enum
 
 import dask
 from dask.base import normalize_token
-
-from tlz import valmap, get_in
 
 import msgpack
 
@@ -433,15 +432,6 @@ class Serialized:
         return not (self == other)
 
 
-def container_copy(c):
-    typ = type(c)
-    if typ is list:
-        return list(map(container_copy, c))
-    if typ is dict:
-        return valmap(container_copy, c)
-    return c
-
-
 def extract_serialize(x):
     """Pull out Serialize objects from message
 
@@ -455,37 +445,32 @@ def extract_serialize(x):
     >>> extract_serialize(msg)
     ({'op': 'update'}, {('data',): <Serialize: 123>}, set())
     """
+    x2 = type(x)()
     ser = {}
-    _extract_serialize(x, ser)
-    if ser:
-        x = container_copy(x)
-        for path in ser:
-            t = get_in(path[:-1], x)
-            if isinstance(t, dict):
-                del t[path[-1]]
-            else:
-                t[path[-1]] = None
+    _extract_serialize(x, x2, ser)
 
     bytestrings = set()
     for k, v in ser.items():
         if type(v) in (bytes, bytearray):
             ser[k] = to_serialize(v)
             bytestrings.add(k)
-    return x, ser, bytestrings
+    return x2, ser, bytestrings
 
 
-def _extract_serialize(x, ser, path=()):
+def _extract_serialize(x, x2, ser, path=()):
     typ_x = type(x)
     if typ_x is dict:
         x_items = x.items()
     elif typ_x is list:
         x_items = enumerate(x)
+        x2.extend(repeat(None, len(x)))
 
     for k, v in x_items:
         path_k = path + (k,)
         typ_v = type(v)
         if typ_v is dict or typ_v is list:
-            _extract_serialize(v, ser, path_k)
+            x2[k] = v2 = typ_v()
+            _extract_serialize(v, v2, ser, path_k)
         elif (
             typ_v is Serialize
             or typ_v is Serialized
@@ -493,6 +478,8 @@ def _extract_serialize(x, ser, path=()):
             and len(v) > 2 ** 16
         ):
             ser[path_k] = v
+        else:
+            x2[k] = v
 
 
 def nested_deserialize(x):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -482,7 +482,7 @@ def _extract_serialize(x, ser, path=()):
 
     for k, v in x_items:
         typ = type(v)
-        if typ is list or typ is dict:
+        if typ is dict or typ is list:
             _extract_serialize(v, ser, path + (k,))
         elif (
             typ is Serialize


### PR DESCRIPTION
When Distributed prepares a message with [`dumps`]( https://github.com/dask/distributed/blob/18fff8b0ca0297e100695519931c78e579cb55a6/distributed/protocol/core.py#L26 ), it makes a call to [`extract_serialize`]( https://github.com/dask/distributed/blob/18fff8b0ca0297e100695519931c78e579cb55a6/distributed/protocol/core.py#L38 ), which in turn [extracted all of the binary objects to serialize alongside]( https://github.com/dask/distributed/blob/09d9799e401da695981600fe98ab4d4de4ec419e/distributed/protocol/serialize.py#L459 ), [took a copy of the message with binary objects removed]( https://github.com/dask/distributed/blob/09d9799e401da695981600fe98ab4d4de4ec419e/distributed/protocol/serialize.py#L460-L467 ), and [then extracted all of the `bytes` and `bytearray` objects]( https://github.com/dask/distributed/blob/09d9799e401da695981600fe98ab4d4de4ec419e/distributed/protocol/serialize.py#L469-L473 ). This resulted in a full copy of the message along with a few passes over the message and it contents to refine it. As a result `extract_serialize` and notably `container_copy` showed up when profiling a shuffle workload with Dask.

To improve the performance of `extract_serialize`, we handle all of these steps in one pass of the recursive function `_extract_serialize` avoiding the need for copying of the data or later mutation. While we are collecting the objects to serialize, we flag any `bytes` or `bytearray` objects for special handling as well. In addition we construct a new message from elements in the old message that don't require special handling. Finally `_extract_serialize` had two code paths depending on whether a `list` or `dict` was involved, which varied slightly between the two cases. With a small amount of prep work at the beginning of `_extract_serialize`, we were able to fuse these two blocks of code together. Thus cutting a bunch of lines of code in the process.

With these changes, we are able to cut the runtime of this function roughly in half as demonstrated by the simple example below.

<details>
<summary>Before:</summary>


```python
In [1]: from distributed.protocol.serialize import extract_serialize

In [2]: data = 1_000_000 * b"abc"
   ...: msg = 1_000 * [data]

In [3]: %timeit extract_serialize(msg)
1.1 ms ± 7.05 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

</details>

<details>
<summary>After:</summary>

```python
In [1]: from distributed.protocol.serialize import extract_serialize

In [2]: data = 1_000_000 * b"abc"
   ...: msg = 1_000 * [data]

In [3]: %timeit extract_serialize(msg)
612 µs ± 14.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

</details>