### PR TITLE
Use dask.utils.stringify() instead of distributed.utils.tokey()

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -29,7 +29,7 @@ from dask.base import tokenize, normalize_token, collections_to_dsk
 from dask.core import flatten
 from dask.optimization import SubgraphCallable
 from dask.compatibility import apply
-from dask.utils import ensure_dict, format_bytes, funcname
+from dask.utils import ensure_dict, format_bytes, funcname, stringify
 from dask.highlevelgraph import HighLevelGraph
 
 from tlz import first, groupby, merge, valmap, keymap, partition_all
@@ -73,7 +73,6 @@ from .diagnostics.plugin import UploadFile, WorkerPlugin
 from .utils import (
     All,
     sync,
-    tokey,
     log_errors,
     key_split,
     thread_state,
@@ -170,7 +169,7 @@ class Future(WrappedKey):
     def __init__(self, key, client=None, inform=True, state=None):
         self.key = key
         self._cleared = False
-        tkey = tokey(key)
+        tkey = stringify(key)
         self.client = client or Client.current()
         self.client._inc_ref(tkey)
         self._generation = self.client.generation
@@ -184,7 +183,7 @@ class Future(WrappedKey):
             self.client._send_to_scheduler(
                 {
                     "op": "client-desires-keys",
-                    "keys": [tokey(key)],
+                    "keys": [stringify(key)],
                     "client": self.client.id,
                 }
             )
@@ -357,7 +356,7 @@ class Future(WrappedKey):
         if not self._cleared and self.client.generation == self._generation:
             self._cleared = True
             try:
-                self.client.loop.add_callback(self.client._dec_ref, tokey(self.key))
+                self.client.loop.add_callback(self.client._dec_ref, stringify(self.key))
             except TypeError:
                 pass  # Shutting down, add_callback may be None
 
@@ -375,7 +374,7 @@ class Future(WrappedKey):
             {
                 "op": "update-graph",
                 "tasks": {},
-                "keys": [tokey(self.key)],
+                "keys": [stringify(self.key)],
                 "client": c.id,
             }
         )
@@ -1553,7 +1552,7 @@ class Client:
             else:
                 key = funcname(func) + "-" + str(uuid.uuid4())
 
-        skey = tokey(key)
+        skey = stringify(key)
 
         with self._refcount_lock:
             if skey in self.futures:
@@ -1798,11 +1797,11 @@ class Client:
         )
         logger.debug("map(%s, ...)", funcname(func))
 
-        return [futures[tokey(k)] for k in keys]
+        return [futures[stringify(k)] for k in keys]
 
     async def _gather(self, futures, errors="raise", direct=None, local_worker=None):
         unpacked, future_set = unpack_remotedata(futures, byte_keys=True)
-        keys = [tokey(future.key) for future in future_set]
+        keys = [stringify(future.key) for future in future_set]
         bad_data = dict()
         data = {}
 
@@ -2009,8 +2008,8 @@ class Client:
         if isinstance(data, dict) and not all(
             isinstance(k, (bytes, str)) for k in data
         ):
-            d = await self._scatter(keymap(tokey, data), workers, broadcast)
-            return {k: d[tokey(k)] for k in data}
+            d = await self._scatter(keymap(stringify, data), workers, broadcast)
+            return {k: d[stringify(k)] for k in data}
 
         if isinstance(data, type(range(0))):
             data = list(data)
@@ -2199,7 +2198,7 @@ class Client:
         )
 
     async def _cancel(self, futures, force=False):
-        keys = list({tokey(f.key) for f in futures_of(futures)})
+        keys = list({stringify(f.key) for f in futures_of(futures)})
         await self.scheduler.cancel(keys=keys, client=self.id, force=force)
         for k in keys:
             st = self.futures.pop(k, None)
@@ -2223,7 +2222,7 @@ class Client:
         return self.sync(self._cancel, futures, asynchronous=asynchronous, force=force)
 
     async def _retry(self, futures):
-        keys = list({tokey(f.key) for f in futures_of(futures)})
+        keys = list({stringify(f.key) for f in futures_of(futures)})
         response = await self.scheduler.retry(keys=keys, client=self.id)
         for key in response:
             st = self.futures[key]
@@ -2244,7 +2243,7 @@ class Client:
             coroutines = []
 
             def add_coro(name, data):
-                keys = [tokey(f.key) for f in futures_of(data)]
+                keys = [stringify(f.key) for f in futures_of(data)]
                 coroutines.append(
                     self.scheduler.publish_put(
                         keys=keys,
@@ -2558,7 +2557,7 @@ class Client:
                 resources = self._expand_resources(
                     resources, all_keys=itertools.chain(dsk, keys)
                 )
-                resources = {tokey(k): v for k, v in resources.items()}
+                resources = {stringify(k): v for k, v in resources.items()}
 
             if retries:
                 retries = self._expand_retries(
@@ -2569,11 +2568,11 @@ class Client:
                 actors = list(self._expand_key(actors))
 
             if restrictions:
-                restrictions = keymap(tokey, restrictions)
+                restrictions = keymap(stringify, restrictions)
                 restrictions = valmap(list, restrictions)
 
             if loose_restrictions is not None:
-                loose_restrictions = list(map(tokey, loose_restrictions))
+                loose_restrictions = list(map(stringify, loose_restrictions))
 
             keyset = set(keys)
 
@@ -2592,7 +2591,7 @@ class Client:
                 {
                     "op": "update-graph-hlg",
                     "hlg": dsk,
-                    "keys": list(map(tokey, keys)),
+                    "keys": list(map(stringify, keys)),
                     "restrictions": restrictions or {},
                     "loose_restrictions": loose_restrictions,
                     "priority": priority,
@@ -2696,7 +2695,7 @@ class Client:
         with self._refcount_lock:
             changed = False
             for key in list(dsk):
-                if tokey(key) in self.futures:
+                if stringify(key) in self.futures:
                     if not changed:
                         changed = True
                         dsk = ensure_dict(dsk)
@@ -3084,7 +3083,7 @@ class Client:
 
     async def _rebalance(self, futures=None, workers=None):
         await _wait(futures)
-        keys = list({tokey(f.key) for f in self.futures_of(futures)})
+        keys = list({stringify(f.key) for f in self.futures_of(futures)})
         result = await self.scheduler.rebalance(keys=keys, workers=workers)
         if result["status"] == "missing-data":
             raise ValueError(
@@ -3115,7 +3114,7 @@ class Client:
     async def _replicate(self, futures, n=None, workers=None, branching_factor=2):
         futures = self.futures_of(futures)
         await _wait(futures)
-        keys = {tokey(f.key) for f in futures}
+        keys = {stringify(f.key) for f in futures}
         await self.scheduler.replicate(
             keys=list(keys), n=n, workers=workers, branching_factor=branching_factor
         )
@@ -3225,7 +3224,7 @@ class Client:
         """
         if futures is not None:
             futures = self.futures_of(futures)
-            keys = list(map(tokey, {f.key for f in futures}))
+            keys = list(map(stringify, {f.key for f in futures}))
         else:
             keys = None
         return self.sync(self.scheduler.who_has, keys=keys, **kwargs)
@@ -3349,7 +3348,7 @@ class Client:
         keys = keys or []
         if futures is not None:
             futures = self.futures_of(futures)
-            keys += list(map(tokey, {f.key for f in futures}))
+            keys += list(map(stringify, {f.key for f in futures}))
         return self.sync(self.scheduler.call_stack, keys=keys or None)
 
     def profile(
@@ -3841,9 +3840,9 @@ class Client:
         for kk in k:
             if dask.is_dask_collection(kk):
                 for kkk in kk.__dask_keys__():
-                    yield tokey(kkk)
+                    yield stringify(kkk)
             else:
-                yield tokey(kk)
+                yield stringify(kk)
 
     @classmethod
     def _expand_retries(cls, retries, all_keys):
@@ -3864,7 +3863,7 @@ class Client:
             raise TypeError(
                 "`retries` should be an integer or dict, got %r" % (type(retries))
             )
-        return keymap(tokey, result)
+        return keymap(stringify, result)
 
     def _expand_resources(cls, resources, all_keys):
         """
@@ -4606,7 +4605,7 @@ def fire_and_forget(obj):
         future.client._send_to_scheduler(
             {
                 "op": "client-desires-keys",
-                "keys": [tokey(future.key)],
+                "keys": [stringify(future.key)],
                 "client": "fire-and-forget",
             }
         )

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -14,7 +14,8 @@ from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 import dask
 from dask.core import flatten
-from distributed.utils import tokey, format_dashboard_link
+from dask.utils import stringify
+from distributed.utils import format_dashboard_link
 from distributed.client import wait
 from distributed.metrics import time
 from distributed.utils_test import gen_cluster, inc, dec, slowinc, div, get_cert
@@ -556,7 +557,7 @@ async def test_TaskGraph_complex(c, s, a, b):
     gp.update()
     assert set(gp.layout.index.values()) == set(range(len(gp.layout.index)))
     visible = gp.node_source.data["visible"]
-    keys = list(map(tokey, flatten(y.__dask_keys__())))
+    keys = list(map(stringify, flatten(y.__dask_keys__())))
     assert all(visible[gp.layout.index[key]] == "True" for key in keys)
 
 

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -5,8 +5,9 @@ from timeit import default_timer
 
 from tlz import groupby, valmap
 
+from dask.utils import stringify
 from .plugin import SchedulerPlugin
-from ..utils import key_split, key_split_group, log_errors, tokey
+from ..utils import key_split, key_split_group, log_errors
 
 
 logger = logging.getLogger(__name__)
@@ -61,7 +62,7 @@ class Progress(SchedulerPlugin):
 
     def __init__(self, keys, scheduler, minimum=0, dt=0.1, complete=False):
         self.keys = {k.key if hasattr(k, "key") else k for k in keys}
-        self.keys = {tokey(k) for k in self.keys}
+        self.keys = {stringify(k) for k in self.keys}
         self.scheduler = scheduler
         self.complete = complete
         self._minimum = minimum

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -1,6 +1,8 @@
 from collections.abc import MutableMapping
 
-from .utils import log_errors, tokey
+from dask.utils import stringify
+
+from .utils import log_errors
 
 
 class PublishExtension:
@@ -32,7 +34,7 @@ class PublishExtension:
         with log_errors():
             if not override and name in self.datasets:
                 raise KeyError("Dataset %s already exists" % name)
-            self.scheduler.client_desires_keys(keys, "published-%s" % tokey(name))
+            self.scheduler.client_desires_keys(keys, "published-%s" % stringify(name))
             self.datasets[name] = {"data": data, "keys": keys}
             return {"status": "OK", "name": name}
 
@@ -40,7 +42,7 @@ class PublishExtension:
         with log_errors():
             out = self.datasets.pop(name, {"keys": []})
             self.scheduler.client_releases_keys(
-                out["keys"], "published-%s" % tokey(name)
+                out["keys"], "published-%s" % stringify(name)
             )
 
     def list(self, *args):

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -3,8 +3,10 @@ from collections import defaultdict
 import logging
 import uuid
 
+from dask.utils import stringify
+
 from .client import Future, Client
-from .utils import tokey, sync, thread_state
+from .utils import sync, thread_state
 from .worker import get_client
 from .utils import parse_timedelta
 
@@ -201,7 +203,7 @@ class Queue:
     async def _put(self, value, timeout=None):
         if isinstance(value, Future):
             await self.client.scheduler.queue_put(
-                key=tokey(value.key), timeout=timeout, name=self.name
+                key=stringify(value.key), timeout=timeout, name=self.name
             )
         else:
             await self.client.scheduler.queue_put(

--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -1,6 +1,7 @@
 import logging
+from dask.utils import stringify
 from .client import futures_of, wait
-from .utils import sync, tokey
+from .utils import sync
 from .utils_comm import pack_data
 from .worker import _deserialize
 
@@ -38,7 +39,7 @@ class ReplayExceptionScheduler:
         for key in keys:
             if isinstance(key, list):
                 key = tuple(key)  # ensure not a list from msgpack
-            key = tokey(key)
+            key = stringify(key)
             ts = self.scheduler.tasks.get(key)
             if ts is not None and ts.exception_blame is not None:
                 cause = ts.exception_blame

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -25,6 +25,7 @@ from tlz import identity, isdistinct, concat, pluck, valmap, first, merge
 import dask
 from dask import delayed
 from dask.optimization import SubgraphCallable
+from dask.utils import stringify
 import dask.bag as db
 from distributed import (
     Worker,
@@ -59,7 +60,7 @@ from distributed.compatibility import WINDOWS
 from distributed.metrics import time
 from distributed.scheduler import Scheduler, KilledWorker, CollectTaskMetaDataPlugin
 from distributed.sizeof import sizeof
-from distributed.utils import mp_context, sync, tmp_text, tokey, tmpfile, is_valid_xml
+from distributed.utils import mp_context, sync, tmp_text, tmpfile, is_valid_xml
 from distributed.utils_test import (
     cluster,
     slowinc,
@@ -3574,7 +3575,7 @@ async def test_persist_optimize_graph(c, s, a, b):
         b4 = method(b3, optimize_graph=False)
         await wait(b4)
 
-        assert set(map(tokey, b3.__dask_keys__())).issubset(s.tasks)
+        assert set(map(stringify, b3.__dask_keys__())).issubset(s.tasks)
 
         b = db.range(i, npartitions=2)
         i += 1
@@ -3584,7 +3585,7 @@ async def test_persist_optimize_graph(c, s, a, b):
         b4 = method(b3, optimize_graph=True)
         await wait(b4)
 
-        assert not any(tokey(k) in s.tasks for k in b2.__dask_keys__())
+        assert not any(stringify(k) in s.tasks for k in b2.__dask_keys__())
 
 
 @gen_cluster(client=True, nthreads=[])
@@ -3965,7 +3966,7 @@ async def test_serialize_future(s, a, b):
             with ctxman():
                 future2 = pickle.loads(pickle.dumps(future))
                 assert future2.client is ci
-                assert tokey(future2.key) in ci.futures
+                assert stringify(future2.key) in ci.futures
                 result2 = await future2
                 assert result == result2
 
@@ -5601,7 +5602,7 @@ async def test_nested_prioritization(c, s, w):
     await wait([fx, fy])
 
     assert (o[x.key] < o[y.key]) == (
-        s.tasks[tokey(fx.key)].priority < s.tasks[tokey(fy.key)].priority
+        s.tasks[stringify(fx.key)].priority < s.tasks[stringify(fy.key)].priority
     )
 
 

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -5,10 +5,10 @@ import pytest
 from dask.core import flatten
 import dask
 from dask import delayed, persist
+from dask.utils import stringify
 
 from distributed.utils_test import gen_cluster, inc, slowinc, slowdec
 from distributed import wait, Worker
-from distributed.utils import tokey
 
 
 @gen_cluster(client=True, nthreads=[])
@@ -45,7 +45,7 @@ async def test_compute(c, s):
     async with Worker(s.address, nthreads=1):
         await wait(high)
         assert all(s.processing.values())
-        assert s.tasks[tokey(low.key)].state in ("processing", "waiting")
+        assert s.tasks[stringify(low.key)].state in ("processing", "waiting")
 
 
 @gen_cluster(client=True, nthreads=[])
@@ -61,7 +61,7 @@ async def test_persist(c, s):
         await wait(high)
         assert all(s.processing.values())
         assert all(
-            s.tasks[tokey(k)].state in ("processing", "waiting")
+            s.tasks[stringify(k)].state in ("processing", "waiting")
             for k in flatten(low.__dask_keys__())
         )
 

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -2,12 +2,12 @@ import asyncio
 from time import time
 
 from dask import delayed
+from dask.utils import stringify
 import pytest
 
 from distributed import Worker
 from distributed.client import wait
 from distributed.compatibility import WINDOWS
-from distributed.utils import tokey
 from distributed.utils_test import inc, gen_cluster, slowinc, slowadd
 from distributed.utils_test import client, cluster_fixture, loop, s, a, b  # noqa: F401
 
@@ -211,9 +211,9 @@ async def test_resources_str(c, s, a, b):
     yy = y.persist(resources={"MyRes": 1})
     await wait(yy)
 
-    ts_first = s.tasks[tokey(y.__dask_keys__()[0])]
+    ts_first = s.tasks[stringify(y.__dask_keys__()[0])]
     assert ts_first.resource_restrictions == {"MyRes": 1}
-    ts_last = s.tasks[tokey(y.__dask_keys__()[-1])]
+    ts_last = s.tasks[stringify(y.__dask_keys__()[-1])]
     assert ts_last.resource_restrictions == {"MyRes": 1}
 
 
@@ -316,7 +316,7 @@ async def test_persist_collections(c, s, a, b):
 
     await wait([ww, yy])
 
-    assert all(tokey(key) in a.data for key in y.__dask_keys__())
+    assert all(stringify(key) in a.data for key in y.__dask_keys__())
 
 
 @pytest.mark.skip(reason="Should protect resource keys from optimization")
@@ -336,7 +336,7 @@ async def test_dont_optimize_out(c, s, a, b):
 
     await c.compute(w, resources={tuple(y.__dask_keys__()): {"A": 1}})
 
-    for key in map(tokey, y.__dask_keys__()):
+    for key in map(stringify, y.__dask_keys__()):
         assert "executing" in str(a.story(key))
 
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -24,7 +24,6 @@ from distributed.utils import (
     is_kernel,
     is_valid_xml,
     ensure_ip,
-    str_graph,
     truncate_exception,
     get_traceback,
     _maybe_complex,
@@ -49,7 +48,6 @@ from distributed.utils import (
 )
 from distributed.utils_test import loop, loop_in_thread  # noqa: F401
 from distributed.utils_test import div, has_ipv6, inc, throws, gen_test, captured_logger
-from dask.optimization import SubgraphCallable
 
 
 def test_All(loop):
@@ -191,37 +189,6 @@ def test_get_traceback():
     except Exception as e:
         tb = get_traceback()
         assert type(tb).__name__ == "traceback"
-
-
-def test_str_graph():
-    dsk = {"x": 1}
-    assert str_graph(dsk) == dsk
-
-    dsk = {("x", 1): (inc, 1)}
-    assert str_graph(dsk) == {str(("x", 1)): (inc, 1)}
-
-    dsk = {("x", 1): (inc, 1), ("x", 2): (inc, ("x", 1))}
-    assert str_graph(dsk) == {
-        str(("x", 1)): (inc, 1),
-        str(("x", 2)): (inc, str(("x", 1))),
-    }
-
-    dsks = [
-        {"x": 1},
-        {("x", 1): (inc, 1), ("x", 2): (inc, ("x", 1))},
-        {("x", 1): (sum, [1, 2, 3]), ("x", 2): (sum, [("x", 1), ("x", 1)])},
-    ]
-    for dsk in dsks:
-        sdsk = str_graph(dsk)
-        keys = list(dsk)
-        skeys = [str(k) for k in keys]
-        assert all(isinstance(k, str) for k in sdsk)
-        assert dask.get(dsk, keys) == dask.get(sdsk, skeys)
-
-    dsk = {("y", 1): (SubgraphCallable({"x": ("y", 1)}, "x", (("y", 1),)), (("z", 1),))}
-    dsk = str_graph(dsk, extra_values=(("z", 1),))
-    assert dsk["('y', 1)"][0].dsk["x"] == "('y', 1)"
-    assert dsk["('y', 1)"][1][0] == "('z', 1)"
 
 
 def test_maybe_complex():

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -36,7 +36,6 @@ except ImportError:
 
 import dask
 from dask import istask
-from dask.optimization import SubgraphCallable
 
 # provide format_bytes here for backwards compatibility
 from dask.utils import (  # noqa
@@ -739,26 +738,6 @@ def truncate_exception(e, n=10000):
         return e
 
 
-def tokey(o):
-    """Convert an object to a string.
-
-    Examples
-    --------
-
-    >>> tokey(b'x')
-    b'x'
-    >>> tokey('x')
-    'x'
-    >>> tokey(1)
-    '1'
-    """
-    typ = type(o)
-    if typ is str or typ is bytes:
-        return o
-    else:
-        return str(o)
-
-
 def validate_key(k):
     """Validate a key as received on a stream."""
     typ = type(k)
@@ -775,39 +754,6 @@ def _maybe_complex(task):
         or type(task) is dict
         and any(map(_maybe_complex, task.values()))
     )
-
-
-def convert(task, dsk, extra_values):
-    typ = type(task)
-    if typ is tuple and task:
-        if type(task[0]) is SubgraphCallable:
-            sc = task[0]
-            return (
-                SubgraphCallable(
-                    convert(sc.dsk, dsk, extra_values),
-                    sc.outkey,
-                    convert(sc.inkeys, dsk, extra_values),
-                    sc.name,
-                ),
-            ) + tuple(convert(x, dsk, extra_values) for x in task[1:])
-        elif callable(task[0]):
-            return (task[0],) + tuple(convert(x, dsk, extra_values) for x in task[1:])
-    if typ is list:
-        return [convert(v, dsk, extra_values) for v in task]
-    if typ is dict:
-        return {k: convert(v, dsk, extra_values) for k, v in task.items()}
-    try:
-        if task in dsk or task in extra_values:
-            return tokey(task)
-    except TypeError:
-        pass
-    if typ is tuple:  # If the tuple itself isn't a key, check its elements
-        return tuple(convert(v, dsk, extra_values) for v in task)
-    return task
-
-
-def str_graph(dsk, extra_values=()):
-    return {tokey(k): convert(v, dsk, extra_values) for k, v in dsk.items()}
 
 
 def seek_delimiter(file, delimiter, blocksize):

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -7,11 +7,11 @@ import random
 
 from dask.optimization import SubgraphCallable
 import dask.config
-from dask.utils import parse_timedelta
+from dask.utils import parse_timedelta, stringify
 from tlz import merge, concat, groupby, drop
 
 from .core import rpc
-from .utils import All, tokey
+from .utils import All
 
 logger = logging.getLogger(__name__)
 
@@ -210,7 +210,7 @@ def unpack_remotedata(o, byte_keys=False, myset=None):
             if futures:
                 myset.update(futures)
                 futures = (
-                    tuple(tokey(f.key) for f in futures)
+                    tuple(stringify(f.key) for f in futures)
                     if byte_keys
                     else tuple(f.key for f in futures)
                 )
@@ -238,7 +238,7 @@ def unpack_remotedata(o, byte_keys=False, myset=None):
     elif issubclass(typ, WrappedKey):  # TODO use type is Future
         k = o.key
         if byte_keys:
-            k = tokey(k)
+            k = stringify(k)
         myset.add(o)
         return k
     else:

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -6,8 +6,9 @@ import uuid
 
 from tlz import merge
 
+from dask.utils import stringify
 from .client import Future, Client
-from .utils import tokey, log_errors, TimeoutError, parse_timedelta
+from .utils import log_errors, TimeoutError, parse_timedelta
 from .worker import get_client
 
 logger = logging.getLogger(__name__)
@@ -170,7 +171,7 @@ class Variable:
     async def _set(self, value):
         if isinstance(value, Future):
             await self.client.scheduler.variable_set(
-                key=tokey(value.key), name=self.name
+                key=stringify(value.key), name=self.name
             )
         else:
             await self.client.scheduler.variable_set(data=value, name=self.name)


### PR DESCRIPTION
Replace calls to `distributed.utils.tokey()` with `dask.utils.stringify()` and removes `utils.tokey()` and `utils.str_graph()`.

Since we have to pin the Dask version in the next release anyways, we might as well include this refactoring (depends on https://github.com/dask/dask/pull/6852)