### PR TITLE
Simplify frame length packing in TCP write

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -240,7 +240,8 @@ class TCP(Comm):
                 b = b"".join([length_bytes, *frames])  # small enough, send in one go
                 stream.write(b)
             else:
-                stream.write(length_bytes)  # avoid large memcpy, send in many
+                # avoid large memcpy, send in many
+                stream.write(length_bytes)
 
                 for frame, frame_bytes in zip(frames, lengths):
                     # Can't wait for the write() Future as it may be lost

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -235,14 +235,12 @@ class TCP(Comm):
         try:
             nframes = len(frames)
             lengths = [nbytes(frame) for frame in frames]
-            length_bytes = [struct.pack("Q", nframes)] + [
-                struct.pack("Q", x) for x in lengths
-            ]
+            length_bytes = struct.pack(f"Q{nframes}Q", nframes, *lengths)
             if sum(lengths) < 2 ** 17:  # 128kiB
-                b = b"".join(length_bytes + frames)  # small enough, send in one go
+                b = b"".join([length_bytes, *frames])  # small enough, send in one go
                 stream.write(b)
             else:
-                stream.write(b"".join(length_bytes))  # avoid large memcpy, send in many
+                stream.write(length_bytes)  # avoid large memcpy, send in many
 
                 for frame, frame_bytes in zip(frames, lengths):
                     # Can't wait for the write() Future as it may be lost

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -398,7 +398,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         deserialize=True,
         allow_offload=True,
         default_port=0,
-        **connection_args
+        **connection_args,
     ):
         self._check_encryption(address, connection_args)
         self.ip, self.port = parse_host_port(address, default_port)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -237,8 +237,8 @@ class TCP(Comm):
             lengths = [nbytes(frame) for frame in frames]
             length_bytes = struct.pack(f"Q{nframes}Q", nframes, *lengths)
             if sum(lengths) < 2 ** 17:  # 128kiB
-                b = b"".join([length_bytes, *frames])  # small enough, send in one go
-                stream.write(b)
+                # small enough, send in one go
+                stream.write(b"".join([length_bytes, *frames]))
             else:
                 # avoid large memcpy, send in many
                 stream.write(length_bytes)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -233,8 +233,9 @@ class TCP(Comm):
         )
 
         try:
+            nframes = len(frames)
             lengths = [nbytes(frame) for frame in frames]
-            length_bytes = [struct.pack("Q", len(frames))] + [
+            length_bytes = [struct.pack("Q", nframes)] + [
                 struct.pack("Q", x) for x in lengths
             ]
             if sum(lengths) < 2 ** 17:  # 128kiB


### PR DESCRIPTION
Noticed that TCP write was taking a while in the process of other benchmarking work. These `struct.pack` calls stuck out. Combined these into a single `struct.pack` call for simplicity. This results in a nearly 5x speed improvement.

Here's a simple benchmark to illustrate the effect of this change:

```python
In [1]: import struct

In [2]: %%timeit lengths = list(range(10))
   ...: 
   ...: length_bytes = [struct.pack("Q", len(lengths))] + [
   ...:     struct.pack("Q", x) for x in lengths
   ...: ]
   ...: length_bytes = b"".join(length_bytes)
   ...: 
   ...: 
3.45 µs ± 88.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [3]: %%timeit lengths = list(range(10))
   ...: 
   ...: nframes = len(lengths)
   ...: length_bytes = struct.pack(f"Q{nframes}Q", nframes, *lengths)
   ...: 
   ...: 
711 ns ± 2.05 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```