### PR TITLE
Use `dict` comprehension in `unpack_remotedata`

### DIFF
--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -231,8 +231,7 @@ def unpack_remotedata(o, byte_keys=False, myset=None):
         return typ(outs)
     elif typ is dict:
         if o:
-            values = [unpack_remotedata(v, byte_keys, myset) for v in o.values()]
-            return dict(zip(o.keys(), values))
+            return {k: unpack_remotedata(v, byte_keys, myset) for k, v in o.items()}
         else:
             return o
     elif issubclass(typ, WrappedKey):  # TODO use type is Future


### PR DESCRIPTION
This code is likely some Python 2 holdover code from before one could use generator expressions in `dict`s. As we are Python 3 only (and 3.6+ at that), rewrite this to be a generator expression that populates the full `dict` in one pass.

Also this has a small but notable speedup on `dict` construction (as shown below). Since this function can be deeply recursive, this starts to add up.

```python
In [1]: def add2(i):
   ...:     return i + 2
   ...: 

In [2]: d = {"a": 0, "b": 1, "c": 2, "d": 3, "e": 4, "f": 5, "g": 6, "h": 7, "i": 8, "j": 9}

In [3]: %%timeit
   ...: v = [add2(i) for i in d.values()]
   ...: d2 = dict(zip(d.keys(), v))
   ...: 
   ...: 
1.73 µs ± 5.84 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: %%timeit
   ...: d2 = {k: add2(v) for k, v in d.items()}
   ...: 
   ...: 
1.28 µs ± 4.21 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```