### PR TITLE
[NO MRG] Use line_profiler to measure time in transitions

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -8,6 +8,7 @@ from tornado import gen, locks
 from tornado.ioloop import IOLoop
 
 from .core import CommClosedError
+from .scheduler import profiler
 from .utils import parse_timedelta
 
 
@@ -75,71 +76,73 @@ class BatchedSend:
 
     @gen.coroutine
     def _background_send(self):
-        from .scheduler import profiler
-        with profiler:
-            while not self.please_stop:
-                try:
-                    yield self.waker.wait(self.next_deadline)
-                    self.waker.clear()
-                except gen.TimeoutError:
-                    pass
-                if not self.buffer:
-                    # Nothing to send
-                    self.next_deadline = None
-                    continue
-                if self.next_deadline is not None and self.loop.time() < self.next_deadline:
-                    # Send interval not expired yet
-                    continue
-                payload, self.buffer = self.buffer, []
-                self.batch_count += 1
-                self.next_deadline = self.loop.time() + self.interval
-                try:
-                    nbytes = yield self.comm.write(
-                        payload, serializers=self.serializers, on_error="raise"
-                    )
-                    if nbytes < 1e6:
-                        self.recent_message_log.append(payload)
-                    else:
-                        self.recent_message_log.append("large-message")
-                    self.byte_count += nbytes
-                except CommClosedError as e:
-                    # If the comm is known to be closed, we'll immediately
-                    # give up.
-                    logger.info("Batched Comm Closed: %s", e)
-                    break
-                except Exception:
-                    # In other cases we'll retry a few times.
-                    # https://github.com/pangeo-data/pangeo/issues/788
-                    if self._consecutive_failures <= 5:
-                        logger.warning("Error in batched write, retrying")
-                        yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
-                        self._consecutive_failures += 1
-                        # Exponential backoff for retries.
-                        # Ensure we don't drop any messages.
-                        if self.buffer:
-                            # Someone could call send while we yielded above?
-                            self.buffer = payload + self.buffer
-                        else:
-                            self.buffer = payload
-                        continue
-                    else:
-                        logger.exception("Error in batched write")
-                        break
-                finally:
-                    payload = None  # lose ref
-            else:
-                # nobreak. We've been gracefully closed.
-                self.stopped.set()
-                return
+        yield self._background_send2()
 
-            # If we've reached here, it means our comm is known to be closed or
-            # we've repeatedly failed to send a message. We can't close gracefully
-            # via `.close()` since we can't send messages. So we just abort.
-            # This means that any messages in our buffer our lost.
-            # To propagate exceptions, we rely on subsequent `BatchedSend.send`
-            # calls to raise CommClosedErrors.
+    @profiler
+    def _background_send2(self):
+        while not self.please_stop:
+            try:
+                yield self.waker.wait(self.next_deadline)
+                self.waker.clear()
+            except gen.TimeoutError:
+                pass
+            if not self.buffer:
+                # Nothing to send
+                self.next_deadline = None
+                continue
+            if self.next_deadline is not None and self.loop.time() < self.next_deadline:
+                # Send interval not expired yet
+                continue
+            payload, self.buffer = self.buffer, []
+            self.batch_count += 1
+            self.next_deadline = self.loop.time() + self.interval
+            try:
+                nbytes = yield self.comm.write(
+                    payload, serializers=self.serializers, on_error="raise"
+                )
+                if nbytes < 1e6:
+                    self.recent_message_log.append(payload)
+                else:
+                    self.recent_message_log.append("large-message")
+                self.byte_count += nbytes
+            except CommClosedError as e:
+                # If the comm is known to be closed, we'll immediately
+                # give up.
+                logger.info("Batched Comm Closed: %s", e)
+                break
+            except Exception:
+                # In other cases we'll retry a few times.
+                # https://github.com/pangeo-data/pangeo/issues/788
+                if self._consecutive_failures <= 5:
+                    logger.warning("Error in batched write, retrying")
+                    yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
+                    self._consecutive_failures += 1
+                    # Exponential backoff for retries.
+                    # Ensure we don't drop any messages.
+                    if self.buffer:
+                        # Someone could call send while we yielded above?
+                        self.buffer = payload + self.buffer
+                    else:
+                        self.buffer = payload
+                    continue
+                else:
+                    logger.exception("Error in batched write")
+                    break
+            finally:
+                payload = None  # lose ref
+        else:
+            # nobreak. We've been gracefully closed.
             self.stopped.set()
-            self.abort()
+            return
+
+        # If we've reached here, it means our comm is known to be closed or
+        # we've repeatedly failed to send a message. We can't close gracefully
+        # via `.close()` since we can't send messages. So we just abort.
+        # This means that any messages in our buffer our lost.
+        # To propagate exceptions, we rely on subsequent `BatchedSend.send`
+        # calls to raise CommClosedErrors.
+        self.stopped.set()
+        self.abort()
 
     def send(self, msg):
         """Schedule a message for sending to the other side

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -10,6 +10,21 @@ from tornado.ioloop import IOLoop
 from .core import CommClosedError
 from .utils import parse_timedelta
 
+try:
+    import line_profiler
+
+    profiler = line_profiler.LineProfiler()
+
+    def dump_stats(p):
+        s = p.get_stats()
+        if any(s.timings.values()):
+            profiler.dump_stats(f"prof_{os.getpid()}.lstat")
+
+    atexit.register(dump_stats, profiler)
+except ImportError:
+    def profile(func):
+        return func
+
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +90,6 @@ class BatchedSend:
 
     @gen.coroutine
     def _background_send(self):
-        from .scheduler import profiler
         with profiler:
             while not self.please_stop:
                 try:

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -10,20 +10,7 @@ from tornado.ioloop import IOLoop
 from .core import CommClosedError
 from .utils import parse_timedelta
 
-try:
-    import line_profiler
-
-    profile = line_profiler.LineProfiler()
-
-    def dump_stats(p):
-        s = p.get_stats()
-        if any(s.timings.values()):
-            profile.dump_stats(f"prof_batched_{os.getpid()}.lstat")
-
-    atexit.register(dump_stats, profile)
-except ImportError:
-    def profile(func):
-        return func
+from .scheduler import profile
 
 
 logger = logging.getLogger(__name__)

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -10,8 +10,6 @@ from tornado.ioloop import IOLoop
 from .core import CommClosedError
 from .utils import parse_timedelta
 
-from .scheduler import profile
-
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +75,7 @@ class BatchedSend:
 
     @gen.coroutine
     def _background_send(self):
+        from .scheduler import profile
         with profile:
             while not self.please_stop:
                 try:
@@ -142,7 +141,6 @@ class BatchedSend:
             self.stopped.set()
             self.abort()
 
-    @profile
     def send(self, msg):
         """Schedule a message for sending to the other side
 

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -90,70 +90,73 @@ class BatchedSend:
 
     @gen.coroutine
     def _background_send(self):
-        with profiler:
-            while not self.please_stop:
-                try:
-                    yield self.waker.wait(self.next_deadline)
-                    self.waker.clear()
-                except gen.TimeoutError:
-                    pass
-                if not self.buffer:
-                    # Nothing to send
-                    self.next_deadline = None
-                    continue
-                if self.next_deadline is not None and self.loop.time() < self.next_deadline:
-                    # Send interval not expired yet
-                    continue
-                payload, self.buffer = self.buffer, []
-                self.batch_count += 1
-                self.next_deadline = self.loop.time() + self.interval
-                try:
-                    nbytes = yield self.comm.write(
-                        payload, serializers=self.serializers, on_error="raise"
-                    )
-                    if nbytes < 1e6:
-                        self.recent_message_log.append(payload)
-                    else:
-                        self.recent_message_log.append("large-message")
-                    self.byte_count += nbytes
-                except CommClosedError as e:
-                    # If the comm is known to be closed, we'll immediately
-                    # give up.
-                    logger.info("Batched Comm Closed: %s", e)
-                    break
-                except Exception:
-                    # In other cases we'll retry a few times.
-                    # https://github.com/pangeo-data/pangeo/issues/788
-                    if self._consecutive_failures <= 5:
-                        logger.warning("Error in batched write, retrying")
-                        yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
-                        self._consecutive_failures += 1
-                        # Exponential backoff for retries.
-                        # Ensure we don't drop any messages.
-                        if self.buffer:
-                            # Someone could call send while we yielded above?
-                            self.buffer = payload + self.buffer
-                        else:
-                            self.buffer = payload
-                        continue
-                    else:
-                        logger.exception("Error in batched write")
-                        break
-                finally:
-                    payload = None  # lose ref
-            else:
-                # nobreak. We've been gracefully closed.
-                self.stopped.set()
-                return
+        yield self._background_send2()
 
-            # If we've reached here, it means our comm is known to be closed or
-            # we've repeatedly failed to send a message. We can't close gracefully
-            # via `.close()` since we can't send messages. So we just abort.
-            # This means that any messages in our buffer our lost.
-            # To propagate exceptions, we rely on subsequent `BatchedSend.send`
-            # calls to raise CommClosedErrors.
+    @profiler
+    def _background_send2(self):
+        while not self.please_stop:
+            try:
+                yield self.waker.wait(self.next_deadline)
+                self.waker.clear()
+            except gen.TimeoutError:
+                pass
+            if not self.buffer:
+                # Nothing to send
+                self.next_deadline = None
+                continue
+            if self.next_deadline is not None and self.loop.time() < self.next_deadline:
+                # Send interval not expired yet
+                continue
+            payload, self.buffer = self.buffer, []
+            self.batch_count += 1
+            self.next_deadline = self.loop.time() + self.interval
+            try:
+                nbytes = yield self.comm.write(
+                    payload, serializers=self.serializers, on_error="raise"
+                )
+                if nbytes < 1e6:
+                    self.recent_message_log.append(payload)
+                else:
+                    self.recent_message_log.append("large-message")
+                self.byte_count += nbytes
+            except CommClosedError as e:
+                # If the comm is known to be closed, we'll immediately
+                # give up.
+                logger.info("Batched Comm Closed: %s", e)
+                break
+            except Exception:
+                # In other cases we'll retry a few times.
+                # https://github.com/pangeo-data/pangeo/issues/788
+                if self._consecutive_failures <= 5:
+                    logger.warning("Error in batched write, retrying")
+                    yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
+                    self._consecutive_failures += 1
+                    # Exponential backoff for retries.
+                    # Ensure we don't drop any messages.
+                    if self.buffer:
+                        # Someone could call send while we yielded above?
+                        self.buffer = payload + self.buffer
+                    else:
+                        self.buffer = payload
+                    continue
+                else:
+                    logger.exception("Error in batched write")
+                    break
+            finally:
+                payload = None  # lose ref
+        else:
+            # nobreak. We've been gracefully closed.
             self.stopped.set()
-            self.abort()
+            return
+
+        # If we've reached here, it means our comm is known to be closed or
+        # we've repeatedly failed to send a message. We can't close gracefully
+        # via `.close()` since we can't send messages. So we just abort.
+        # This means that any messages in our buffer our lost.
+        # To propagate exceptions, we rely on subsequent `BatchedSend.send`
+        # calls to raise CommClosedErrors.
+        self.stopped.set()
+        self.abort()
 
     def send(self, msg):
         """Schedule a message for sending to the other side

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -18,7 +18,7 @@ try:
     def dump_stats(p):
         s = p.get_stats()
         if any(s.timings.values()):
-            profile.dump_stats(f"prof_{os.getpid()}.lstat")
+            profile.dump_stats(f"prof_batched_{os.getpid()}.lstat")
 
     atexit.register(dump_stats, profile)
 except ImportError:

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -90,6 +90,7 @@ class BatchedSend:
 
     @gen.coroutine
     def _background_send(self):
+        global profiler
         with profiler:
             while not self.please_stop:
                 try:

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -90,73 +90,70 @@ class BatchedSend:
 
     @gen.coroutine
     def _background_send(self):
-        yield self._background_send2()
-
-    @profiler
-    def _background_send2(self):
-        while not self.please_stop:
-            try:
-                yield self.waker.wait(self.next_deadline)
-                self.waker.clear()
-            except gen.TimeoutError:
-                pass
-            if not self.buffer:
-                # Nothing to send
-                self.next_deadline = None
-                continue
-            if self.next_deadline is not None and self.loop.time() < self.next_deadline:
-                # Send interval not expired yet
-                continue
-            payload, self.buffer = self.buffer, []
-            self.batch_count += 1
-            self.next_deadline = self.loop.time() + self.interval
-            try:
-                nbytes = yield self.comm.write(
-                    payload, serializers=self.serializers, on_error="raise"
-                )
-                if nbytes < 1e6:
-                    self.recent_message_log.append(payload)
-                else:
-                    self.recent_message_log.append("large-message")
-                self.byte_count += nbytes
-            except CommClosedError as e:
-                # If the comm is known to be closed, we'll immediately
-                # give up.
-                logger.info("Batched Comm Closed: %s", e)
-                break
-            except Exception:
-                # In other cases we'll retry a few times.
-                # https://github.com/pangeo-data/pangeo/issues/788
-                if self._consecutive_failures <= 5:
-                    logger.warning("Error in batched write, retrying")
-                    yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
-                    self._consecutive_failures += 1
-                    # Exponential backoff for retries.
-                    # Ensure we don't drop any messages.
-                    if self.buffer:
-                        # Someone could call send while we yielded above?
-                        self.buffer = payload + self.buffer
-                    else:
-                        self.buffer = payload
+        with profiler:
+            while not self.please_stop:
+                try:
+                    yield self.waker.wait(self.next_deadline)
+                    self.waker.clear()
+                except gen.TimeoutError:
+                    pass
+                if not self.buffer:
+                    # Nothing to send
+                    self.next_deadline = None
                     continue
-                else:
-                    logger.exception("Error in batched write")
+                if self.next_deadline is not None and self.loop.time() < self.next_deadline:
+                    # Send interval not expired yet
+                    continue
+                payload, self.buffer = self.buffer, []
+                self.batch_count += 1
+                self.next_deadline = self.loop.time() + self.interval
+                try:
+                    nbytes = yield self.comm.write(
+                        payload, serializers=self.serializers, on_error="raise"
+                    )
+                    if nbytes < 1e6:
+                        self.recent_message_log.append(payload)
+                    else:
+                        self.recent_message_log.append("large-message")
+                    self.byte_count += nbytes
+                except CommClosedError as e:
+                    # If the comm is known to be closed, we'll immediately
+                    # give up.
+                    logger.info("Batched Comm Closed: %s", e)
                     break
-            finally:
-                payload = None  # lose ref
-        else:
-            # nobreak. We've been gracefully closed.
-            self.stopped.set()
-            return
+                except Exception:
+                    # In other cases we'll retry a few times.
+                    # https://github.com/pangeo-data/pangeo/issues/788
+                    if self._consecutive_failures <= 5:
+                        logger.warning("Error in batched write, retrying")
+                        yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
+                        self._consecutive_failures += 1
+                        # Exponential backoff for retries.
+                        # Ensure we don't drop any messages.
+                        if self.buffer:
+                            # Someone could call send while we yielded above?
+                            self.buffer = payload + self.buffer
+                        else:
+                            self.buffer = payload
+                        continue
+                    else:
+                        logger.exception("Error in batched write")
+                        break
+                finally:
+                    payload = None  # lose ref
+            else:
+                # nobreak. We've been gracefully closed.
+                self.stopped.set()
+                return
 
-        # If we've reached here, it means our comm is known to be closed or
-        # we've repeatedly failed to send a message. We can't close gracefully
-        # via `.close()` since we can't send messages. So we just abort.
-        # This means that any messages in our buffer our lost.
-        # To propagate exceptions, we rely on subsequent `BatchedSend.send`
-        # calls to raise CommClosedErrors.
-        self.stopped.set()
-        self.abort()
+            # If we've reached here, it means our comm is known to be closed or
+            # we've repeatedly failed to send a message. We can't close gracefully
+            # via `.close()` since we can't send messages. So we just abort.
+            # This means that any messages in our buffer our lost.
+            # To propagate exceptions, we rely on subsequent `BatchedSend.send`
+            # calls to raise CommClosedErrors.
+            self.stopped.set()
+            self.abort()
 
     def send(self, msg):
         """Schedule a message for sending to the other side

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -75,8 +75,8 @@ class BatchedSend:
 
     @gen.coroutine
     def _background_send(self):
-        from .scheduler import profile
-        with profile:
+        from .scheduler import profiler
+        with profiler:
             while not self.please_stop:
                 try:
                     yield self.waker.wait(self.next_deadline)

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -8,7 +8,6 @@ from tornado import gen, locks
 from tornado.ioloop import IOLoop
 
 from .core import CommClosedError
-from .scheduler import profiler
 from .utils import parse_timedelta
 
 
@@ -76,73 +75,71 @@ class BatchedSend:
 
     @gen.coroutine
     def _background_send(self):
-        yield self._background_send2()
-
-    @profiler
-    def _background_send2(self):
-        while not self.please_stop:
-            try:
-                yield self.waker.wait(self.next_deadline)
-                self.waker.clear()
-            except gen.TimeoutError:
-                pass
-            if not self.buffer:
-                # Nothing to send
-                self.next_deadline = None
-                continue
-            if self.next_deadline is not None and self.loop.time() < self.next_deadline:
-                # Send interval not expired yet
-                continue
-            payload, self.buffer = self.buffer, []
-            self.batch_count += 1
-            self.next_deadline = self.loop.time() + self.interval
-            try:
-                nbytes = yield self.comm.write(
-                    payload, serializers=self.serializers, on_error="raise"
-                )
-                if nbytes < 1e6:
-                    self.recent_message_log.append(payload)
-                else:
-                    self.recent_message_log.append("large-message")
-                self.byte_count += nbytes
-            except CommClosedError as e:
-                # If the comm is known to be closed, we'll immediately
-                # give up.
-                logger.info("Batched Comm Closed: %s", e)
-                break
-            except Exception:
-                # In other cases we'll retry a few times.
-                # https://github.com/pangeo-data/pangeo/issues/788
-                if self._consecutive_failures <= 5:
-                    logger.warning("Error in batched write, retrying")
-                    yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
-                    self._consecutive_failures += 1
-                    # Exponential backoff for retries.
-                    # Ensure we don't drop any messages.
-                    if self.buffer:
-                        # Someone could call send while we yielded above?
-                        self.buffer = payload + self.buffer
-                    else:
-                        self.buffer = payload
+        from .scheduler import profiler
+        with profiler:
+            while not self.please_stop:
+                try:
+                    yield self.waker.wait(self.next_deadline)
+                    self.waker.clear()
+                except gen.TimeoutError:
+                    pass
+                if not self.buffer:
+                    # Nothing to send
+                    self.next_deadline = None
                     continue
-                else:
-                    logger.exception("Error in batched write")
+                if self.next_deadline is not None and self.loop.time() < self.next_deadline:
+                    # Send interval not expired yet
+                    continue
+                payload, self.buffer = self.buffer, []
+                self.batch_count += 1
+                self.next_deadline = self.loop.time() + self.interval
+                try:
+                    nbytes = yield self.comm.write(
+                        payload, serializers=self.serializers, on_error="raise"
+                    )
+                    if nbytes < 1e6:
+                        self.recent_message_log.append(payload)
+                    else:
+                        self.recent_message_log.append("large-message")
+                    self.byte_count += nbytes
+                except CommClosedError as e:
+                    # If the comm is known to be closed, we'll immediately
+                    # give up.
+                    logger.info("Batched Comm Closed: %s", e)
                     break
-            finally:
-                payload = None  # lose ref
-        else:
-            # nobreak. We've been gracefully closed.
-            self.stopped.set()
-            return
+                except Exception:
+                    # In other cases we'll retry a few times.
+                    # https://github.com/pangeo-data/pangeo/issues/788
+                    if self._consecutive_failures <= 5:
+                        logger.warning("Error in batched write, retrying")
+                        yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
+                        self._consecutive_failures += 1
+                        # Exponential backoff for retries.
+                        # Ensure we don't drop any messages.
+                        if self.buffer:
+                            # Someone could call send while we yielded above?
+                            self.buffer = payload + self.buffer
+                        else:
+                            self.buffer = payload
+                        continue
+                    else:
+                        logger.exception("Error in batched write")
+                        break
+                finally:
+                    payload = None  # lose ref
+            else:
+                # nobreak. We've been gracefully closed.
+                self.stopped.set()
+                return
 
-        # If we've reached here, it means our comm is known to be closed or
-        # we've repeatedly failed to send a message. We can't close gracefully
-        # via `.close()` since we can't send messages. So we just abort.
-        # This means that any messages in our buffer our lost.
-        # To propagate exceptions, we rely on subsequent `BatchedSend.send`
-        # calls to raise CommClosedErrors.
-        self.stopped.set()
-        self.abort()
+            # If we've reached here, it means our comm is known to be closed or
+            # we've repeatedly failed to send a message. We can't close gracefully
+            # via `.close()` since we can't send messages. So we just abort.
+            # This means that any messages in our buffer our lost.
+            # To propagate exceptions, we rely on subsequent `BatchedSend.send`
+            # calls to raise CommClosedErrors.
+            self.stopped.set()
+            self.abort()
 
     def send(self, msg):
         """Schedule a message for sending to the other side

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -88,72 +88,72 @@ class BatchedSend:
 
     __str__ = __repr__
 
-    @profile
     @gen.coroutine
     def _background_send(self):
-        while not self.please_stop:
-            try:
-                yield self.waker.wait(self.next_deadline)
-                self.waker.clear()
-            except gen.TimeoutError:
-                pass
-            if not self.buffer:
-                # Nothing to send
-                self.next_deadline = None
-                continue
-            if self.next_deadline is not None and self.loop.time() < self.next_deadline:
-                # Send interval not expired yet
-                continue
-            payload, self.buffer = self.buffer, []
-            self.batch_count += 1
-            self.next_deadline = self.loop.time() + self.interval
-            try:
-                nbytes = yield self.comm.write(
-                    payload, serializers=self.serializers, on_error="raise"
-                )
-                if nbytes < 1e6:
-                    self.recent_message_log.append(payload)
-                else:
-                    self.recent_message_log.append("large-message")
-                self.byte_count += nbytes
-            except CommClosedError as e:
-                # If the comm is known to be closed, we'll immediately
-                # give up.
-                logger.info("Batched Comm Closed: %s", e)
-                break
-            except Exception:
-                # In other cases we'll retry a few times.
-                # https://github.com/pangeo-data/pangeo/issues/788
-                if self._consecutive_failures <= 5:
-                    logger.warning("Error in batched write, retrying")
-                    yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
-                    self._consecutive_failures += 1
-                    # Exponential backoff for retries.
-                    # Ensure we don't drop any messages.
-                    if self.buffer:
-                        # Someone could call send while we yielded above?
-                        self.buffer = payload + self.buffer
-                    else:
-                        self.buffer = payload
+        with profile:
+            while not self.please_stop:
+                try:
+                    yield self.waker.wait(self.next_deadline)
+                    self.waker.clear()
+                except gen.TimeoutError:
+                    pass
+                if not self.buffer:
+                    # Nothing to send
+                    self.next_deadline = None
                     continue
-                else:
-                    logger.exception("Error in batched write")
+                if self.next_deadline is not None and self.loop.time() < self.next_deadline:
+                    # Send interval not expired yet
+                    continue
+                payload, self.buffer = self.buffer, []
+                self.batch_count += 1
+                self.next_deadline = self.loop.time() + self.interval
+                try:
+                    nbytes = yield self.comm.write(
+                        payload, serializers=self.serializers, on_error="raise"
+                    )
+                    if nbytes < 1e6:
+                        self.recent_message_log.append(payload)
+                    else:
+                        self.recent_message_log.append("large-message")
+                    self.byte_count += nbytes
+                except CommClosedError as e:
+                    # If the comm is known to be closed, we'll immediately
+                    # give up.
+                    logger.info("Batched Comm Closed: %s", e)
                     break
-            finally:
-                payload = None  # lose ref
-        else:
-            # nobreak. We've been gracefully closed.
-            self.stopped.set()
-            return
+                except Exception:
+                    # In other cases we'll retry a few times.
+                    # https://github.com/pangeo-data/pangeo/issues/788
+                    if self._consecutive_failures <= 5:
+                        logger.warning("Error in batched write, retrying")
+                        yield gen.sleep(0.100 * 1.5 ** self._consecutive_failures)
+                        self._consecutive_failures += 1
+                        # Exponential backoff for retries.
+                        # Ensure we don't drop any messages.
+                        if self.buffer:
+                            # Someone could call send while we yielded above?
+                            self.buffer = payload + self.buffer
+                        else:
+                            self.buffer = payload
+                        continue
+                    else:
+                        logger.exception("Error in batched write")
+                        break
+                finally:
+                    payload = None  # lose ref
+            else:
+                # nobreak. We've been gracefully closed.
+                self.stopped.set()
+                return
 
-        # If we've reached here, it means our comm is known to be closed or
-        # we've repeatedly failed to send a message. We can't close gracefully
-        # via `.close()` since we can't send messages. So we just abort.
-        # This means that any messages in our buffer our lost.
-        # To propagate exceptions, we rely on subsequent `BatchedSend.send`
-        # calls to raise CommClosedErrors.
-        self.stopped.set()
-        self.abort()
+            # If we've reached here, it means our comm is known to be closed or
+            # we've repeatedly failed to send a message. We can't close gracefully
+            # via `.close()` since we can't send messages. So we just abort.
+            # This means that any messages in our buffer our lost.
+            # To propagate exceptions, we rely on subsequent `BatchedSend.send`
+            # calls to raise CommClosedErrors.
+            self.stopped.set()
+            self.abort()
 
     @profile
     def send(self, msg):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5799,7 +5799,6 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         self.keys.update(keys)
 
-    @profiler
     def transition(self, key, start, finish, *args, **kwargs):
         if finish == "memory" or finish == "erred":
             ts = self.scheduler.tasks.get(key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -102,7 +102,7 @@ try:
     def dump_stats(p):
         s = p.get_stats()
         if any(s.timings.values()):
-            profile.dump_stats(f"prof_sched_{os.getpid()}.lstat")
+            profile.dump_stats(f"prof_{os.getpid()}.lstat")
 
     atexit.register(dump_stats, profile)
 except ImportError:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4093,7 +4093,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_no_worker_waiting(self, key):
         try:
             ts = self.tasks[key]
@@ -4226,7 +4225,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_waiting_memory(self, key, nbytes=None, worker=None, **kwargs):
         try:
             ws = self.workers[worker]
@@ -4430,7 +4428,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_released_erred(self, key):
         try:
             ts = self.tasks[key]
@@ -4472,7 +4469,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_erred_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4507,7 +4503,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_waiting_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4544,7 +4539,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_processing_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4589,7 +4583,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_processing_erred(
         self, key, cause=None, exception=None, traceback=None, **kwargs
     ):
@@ -4659,7 +4652,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_no_worker_released(self, key):
         try:
             ts = self.tasks[key]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,5 +1,4 @@
 import asyncio
-import atexit
 from collections import defaultdict, deque
 from collections.abc import Mapping, Set
 from contextlib import suppress
@@ -94,20 +93,6 @@ if sys.version_info < (3, 8):
 else:
     import pickle
 
-try:
-    import line_profiler
-
-    profiler = line_profiler.LineProfiler()
-
-    def dump_stats(p):
-        s = p.get_stats()
-        if any(s.timings.values()):
-            profiler.dump_stats(f"prof_{os.getpid()}.lstat")
-
-    atexit.register(dump_stats, profiler)
-except ImportError:
-    def profile(func):
-        return func
 
 logger = logging.getLogger(__name__)
 
@@ -2590,7 +2575,6 @@ class Scheduler(ServerNode):
     # Manage Messages #
     ###################
 
-    @profiler
     def report(self, msg, ts=None, client=None):
         """
         Publish updates to all listening Queues and Comms
@@ -2704,7 +2688,6 @@ class Scheduler(ServerNode):
         )
         self.loop.call_later(cleanup_delay, remove_client_from_events)
 
-    @profiler
     def send_task_to_worker(self, worker, key):
         """ Send a single computational task to a worker """
         try:
@@ -2874,7 +2857,6 @@ class Scheduler(ServerNode):
         """ Remove external plugin from scheduler """
         self.plugins.remove(plugin)
 
-    @profiler
     def worker_send(self, worker, msg):
         """Send message to worker
 
@@ -3688,7 +3670,6 @@ class Scheduler(ServerNode):
             if client:
                 self.client_desires_keys(keys=list(who_has), client=client)
 
-    @profiler
     def report_on_key(self, key=None, ts=None, client=None):
         assert (key is None) + (ts is None) == 1, (key, ts)
         if ts is None:
@@ -3964,7 +3945,6 @@ class Scheduler(ServerNode):
     # State Transitions #
     #####################
 
-    @profiler
     def _remove_from_processing(self, ts, send_worker_msg=None):
         """
         Remove *ts* from the set of processing tasks.
@@ -3985,7 +3965,6 @@ class Scheduler(ServerNode):
             if send_worker_msg:
                 self.worker_send(w, send_worker_msg)
 
-    @profiler
     def _add_to_memory(
         self, ts, ws, recommendations, type=None, typename=None, **kwargs
     ):
@@ -4031,7 +4010,6 @@ class Scheduler(ServerNode):
         if ts in cs.wants_what:
             self.client_releases_keys(client="fire-and-forget", keys=[ts.key])
 
-    @profiler
     def transition_released_waiting(self, key):
         try:
             ts = self.tasks[key]
@@ -4083,7 +4061,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_no_worker_waiting(self, key):
         try:
             ts = self.tasks[key]
@@ -4128,7 +4105,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def decide_worker(self, ts):
         """
         Decide on a worker for task *ts*.  Return a WorkerState.
@@ -4169,7 +4145,6 @@ class Scheduler(ServerNode):
 
         return worker
 
-    @profiler
     def transition_waiting_processing(self, key):
         try:
             ts = self.tasks[key]
@@ -4216,7 +4191,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_waiting_memory(self, key, nbytes=None, worker=None, **kwargs):
         try:
             ws = self.workers[worker]
@@ -4252,7 +4226,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_processing_memory(
         self,
         key,
@@ -4360,7 +4333,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_memory_released(self, key, safe=False):
         try:
             ts = self.tasks[key]
@@ -4420,7 +4392,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_released_erred(self, key):
         try:
             ts = self.tasks[key]
@@ -4462,7 +4433,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_erred_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4497,7 +4467,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_waiting_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4534,7 +4503,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_processing_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4579,7 +4547,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_processing_erred(
         self, key, cause=None, exception=None, traceback=None, **kwargs
     ):
@@ -4649,7 +4616,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_no_worker_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4676,7 +4642,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def remove_key(self, key):
         ts = self.tasks.pop(key)
         assert ts.state == "forgotten"
@@ -4690,7 +4655,6 @@ class Scheduler(ServerNode):
         if key in self.task_metadata:
             del self.task_metadata[key]
 
-    @profiler
     def _propagate_forgotten(self, ts, recommendations):
         ts.state = "forgotten"
         key = ts.key
@@ -4728,7 +4692,6 @@ class Scheduler(ServerNode):
                 )
         ts.who_has.clear()
 
-    @profiler
     def transition_memory_forgotten(self, key):
         try:
             ts = self.tasks[key]
@@ -4769,7 +4732,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition_released_forgotten(self, key):
         try:
             ts = self.tasks[key]
@@ -4806,7 +4768,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transition(self, key, finish, *args, **kwargs):
         """Transition a key from its current state to the finish state
 
@@ -4899,7 +4860,6 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profiler
     def transitions(self, recommendations):
         """Process transitions until none are left
 
@@ -4951,7 +4911,6 @@ class Scheduler(ServerNode):
     # Assigning Tasks to Workers #
     ##############################
 
-    @profiler
     def check_idle_saturated(self, ws, occ=None):
         """Update the status of the idle and saturated state
 
@@ -5542,7 +5501,6 @@ class Scheduler(ServerNode):
             return len(self.workers) - len(to_close)
 
 
-@profiler
 def decide_worker(ts, all_workers, valid_workers, objective):
     """
     Decide which worker should take task *ts*.
@@ -5789,7 +5747,6 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         self.keys.update(keys)
 
-    @profiler
     def transition(self, key, start, finish, *args, **kwargs):
         if finish == "memory" or finish == "erred":
             ts = self.scheduler.tasks.get(key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -97,14 +97,14 @@ else:
 try:
     import line_profiler
 
-    profile = line_profiler.LineProfiler()
+    profiler = line_profiler.LineProfiler()
 
     def dump_stats(p):
         s = p.get_stats()
         if any(s.timings.values()):
-            profile.dump_stats(f"prof_{os.getpid()}.lstat")
+            profiler.dump_stats(f"prof_{os.getpid()}.lstat")
 
-    atexit.register(dump_stats, profile)
+    atexit.register(dump_stats, profiler)
 except ImportError:
     def profile(func):
         return func
@@ -2585,7 +2585,7 @@ class Scheduler(ServerNode):
     # Manage Messages #
     ###################
 
-    @profile
+    @profiler
     def report(self, msg, ts=None, client=None):
         """
         Publish updates to all listening Queues and Comms
@@ -2699,7 +2699,7 @@ class Scheduler(ServerNode):
         )
         self.loop.call_later(cleanup_delay, remove_client_from_events)
 
-    @profile
+    @profiler
     def send_task_to_worker(self, worker, key):
         """ Send a single computational task to a worker """
         try:
@@ -2869,7 +2869,7 @@ class Scheduler(ServerNode):
         """ Remove external plugin from scheduler """
         self.plugins.remove(plugin)
 
-    @profile
+    @profiler
     def worker_send(self, worker, msg):
         """Send message to worker
 
@@ -3683,7 +3683,7 @@ class Scheduler(ServerNode):
             if client:
                 self.client_desires_keys(keys=list(who_has), client=client)
 
-    @profile
+    @profiler
     def report_on_key(self, key=None, ts=None, client=None):
         assert (key is None) + (ts is None) == 1, (key, ts)
         if ts is None:
@@ -3956,7 +3956,7 @@ class Scheduler(ServerNode):
     # State Transitions #
     #####################
 
-    @profile
+    @profiler
     def _remove_from_processing(self, ts, send_worker_msg=None):
         """
         Remove *ts* from the set of processing tasks.
@@ -3977,7 +3977,7 @@ class Scheduler(ServerNode):
             if send_worker_msg:
                 self.worker_send(w, send_worker_msg)
 
-    @profile
+    @profiler
     def _add_to_memory(
         self, ts, ws, recommendations, type=None, typename=None, **kwargs
     ):
@@ -4023,7 +4023,7 @@ class Scheduler(ServerNode):
         if ts in cs.wants_what:
             self.client_releases_keys(client="fire-and-forget", keys=[ts.key])
 
-    @profile
+    @profiler
     def transition_released_waiting(self, key):
         try:
             ts = self.tasks[key]
@@ -4075,7 +4075,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_no_worker_waiting(self, key):
         try:
             ts = self.tasks[key]
@@ -4120,7 +4120,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def decide_worker(self, ts):
         """
         Decide on a worker for task *ts*.  Return a WorkerState.
@@ -4161,7 +4161,7 @@ class Scheduler(ServerNode):
 
         return worker
 
-    @profile
+    @profiler
     def transition_waiting_processing(self, key):
         try:
             ts = self.tasks[key]
@@ -4208,7 +4208,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_waiting_memory(self, key, nbytes=None, worker=None, **kwargs):
         try:
             ws = self.workers[worker]
@@ -4244,7 +4244,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_processing_memory(
         self,
         key,
@@ -4352,7 +4352,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_memory_released(self, key, safe=False):
         try:
             ts = self.tasks[key]
@@ -4412,7 +4412,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_released_erred(self, key):
         try:
             ts = self.tasks[key]
@@ -4454,7 +4454,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_erred_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4489,7 +4489,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_waiting_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4526,7 +4526,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_processing_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4571,7 +4571,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_processing_erred(
         self, key, cause=None, exception=None, traceback=None, **kwargs
     ):
@@ -4641,7 +4641,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_no_worker_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4668,7 +4668,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def remove_key(self, key):
         ts = self.tasks.pop(key)
         assert ts.state == "forgotten"
@@ -4682,7 +4682,7 @@ class Scheduler(ServerNode):
         if key in self.task_metadata:
             del self.task_metadata[key]
 
-    @profile
+    @profiler
     def _propagate_forgotten(self, ts, recommendations):
         ts.state = "forgotten"
         key = ts.key
@@ -4720,7 +4720,7 @@ class Scheduler(ServerNode):
                 )
         ts.who_has.clear()
 
-    @profile
+    @profiler
     def transition_memory_forgotten(self, key):
         try:
             ts = self.tasks[key]
@@ -4761,7 +4761,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition_released_forgotten(self, key):
         try:
             ts = self.tasks[key]
@@ -4798,7 +4798,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transition(self, key, finish, *args, **kwargs):
         """Transition a key from its current state to the finish state
 
@@ -4891,7 +4891,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    @profile
+    @profiler
     def transitions(self, recommendations):
         """Process transitions until none are left
 
@@ -4943,7 +4943,7 @@ class Scheduler(ServerNode):
     # Assigning Tasks to Workers #
     ##############################
 
-    @profile
+    @profiler
     def check_idle_saturated(self, ws, occ=None):
         """Update the status of the idle and saturated state
 
@@ -5518,7 +5518,7 @@ class Scheduler(ServerNode):
             return len(self.workers) - len(to_close)
 
 
-@profile
+@profiler
 def decide_worker(ts, all_workers, valid_workers, objective):
     """
     Decide which worker should take task *ts*.
@@ -5765,7 +5765,7 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         self.keys.update(keys)
 
-    @profile
+    @profiler
     def transition(self, key, start, finish, *args, **kwargs):
         if finish == "memory" or finish == "erred":
             ts = self.scheduler.tasks.get(key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -106,8 +106,10 @@ try:
 
     atexit.register(dump_stats, profiler)
 except ImportError:
+
     def profile(func):
         return func
+
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2586,6 +2586,7 @@ class Scheduler(ServerNode):
     # Manage Messages #
     ###################
 
+    @profile
     def report(self, msg, ts=None, client=None):
         """
         Publish updates to all listening Queues and Comms
@@ -2699,6 +2700,7 @@ class Scheduler(ServerNode):
         )
         self.loop.call_later(cleanup_delay, remove_client_from_events)
 
+    @profile
     def send_task_to_worker(self, worker, key):
         """ Send a single computational task to a worker """
         try:
@@ -2868,6 +2870,7 @@ class Scheduler(ServerNode):
         """ Remove external plugin from scheduler """
         self.plugins.remove(plugin)
 
+    @profile
     def worker_send(self, worker, msg):
         """Send message to worker
 
@@ -3681,6 +3684,7 @@ class Scheduler(ServerNode):
             if client:
                 self.client_desires_keys(keys=list(who_has), client=client)
 
+    @profile
     def report_on_key(self, key=None, ts=None, client=None):
         assert (key is None) + (ts is None) == 1, (key, ts)
         if ts is None:
@@ -3953,6 +3957,7 @@ class Scheduler(ServerNode):
     # State Transitions #
     #####################
 
+    @profile
     def _remove_from_processing(self, ts, send_worker_msg=None):
         """
         Remove *ts* from the set of processing tasks.
@@ -3973,6 +3978,7 @@ class Scheduler(ServerNode):
             if send_worker_msg:
                 self.worker_send(w, send_worker_msg)
 
+    @profile
     def _add_to_memory(
         self, ts, ws, recommendations, type=None, typename=None, **kwargs
     ):
@@ -4115,6 +4121,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def decide_worker(self, ts):
         """
         Decide on a worker for task *ts*.  Return a WorkerState.
@@ -4662,6 +4669,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def remove_key(self, key):
         ts = self.tasks.pop(key)
         assert ts.state == "forgotten"
@@ -4675,6 +4683,7 @@ class Scheduler(ServerNode):
         if key in self.task_metadata:
             del self.task_metadata[key]
 
+    @profile
     def _propagate_forgotten(self, ts, recommendations):
         ts.state = "forgotten"
         key = ts.key
@@ -4935,6 +4944,7 @@ class Scheduler(ServerNode):
     # Assigning Tasks to Workers #
     ##############################
 
+    @profile
     def check_idle_saturated(self, ws, occ=None):
         """Update the status of the idle and saturated state
 
@@ -5509,6 +5519,7 @@ class Scheduler(ServerNode):
             return len(self.workers) - len(to_close)
 
 
+@profile
 def decide_worker(ts, all_workers, valid_workers, objective):
     """
     Decide which worker should take task *ts*.

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import atexit
 from collections import defaultdict, deque
 from collections.abc import Mapping, Set
 from contextlib import suppress
@@ -94,6 +95,13 @@ if sys.version_info < (3, 8):
 else:
     import pickle
 
+try:
+    import line_profiler
+    profile = line_profiler.LineProfiler()
+    atexit.register(profile.dump_stats, f"prof_{os.getpid()}.lstat")
+except ImportError:
+    def profile(func):
+        return func
 
 logger = logging.getLogger(__name__)
 
@@ -4003,6 +4011,7 @@ class Scheduler(ServerNode):
         if ts in cs.wants_what:
             self.client_releases_keys(client="fire-and-forget", keys=[ts.key])
 
+    @profile
     def transition_released_waiting(self, key):
         try:
             ts = self.tasks[key]
@@ -4054,6 +4063,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_no_worker_waiting(self, key):
         try:
             ts = self.tasks[key]
@@ -4138,6 +4148,7 @@ class Scheduler(ServerNode):
 
         return worker
 
+    @profile
     def transition_waiting_processing(self, key):
         try:
             ts = self.tasks[key]
@@ -4184,6 +4195,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_waiting_memory(self, key, nbytes=None, worker=None, **kwargs):
         try:
             ws = self.workers[worker]
@@ -4219,6 +4231,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_processing_memory(
         self,
         key,
@@ -4326,6 +4339,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_memory_released(self, key, safe=False):
         try:
             ts = self.tasks[key]
@@ -4385,6 +4399,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_released_erred(self, key):
         try:
             ts = self.tasks[key]
@@ -4426,6 +4441,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_erred_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4460,6 +4476,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_waiting_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4496,6 +4513,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_processing_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4540,6 +4558,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_processing_erred(
         self, key, cause=None, exception=None, traceback=None, **kwargs
     ):
@@ -4609,6 +4628,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_no_worker_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4685,6 +4705,7 @@ class Scheduler(ServerNode):
                 )
         ts.who_has.clear()
 
+    @profile
     def transition_memory_forgotten(self, key):
         try:
             ts = self.tasks[key]
@@ -4725,6 +4746,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition_released_forgotten(self, key):
         try:
             ts = self.tasks[key]
@@ -4761,6 +4783,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transition(self, key, finish, *args, **kwargs):
         """Transition a key from its current state to the finish state
 
@@ -4853,6 +4876,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profile
     def transitions(self, recommendations):
         """Process transitions until none are left
 
@@ -5724,6 +5748,7 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         self.keys.update(keys)
 
+    @profile
     def transition(self, key, start, finish, *args, **kwargs):
         if finish == "memory" or finish == "erred":
             ts = self.scheduler.tasks.get(key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -97,8 +97,15 @@ else:
 
 try:
     import line_profiler
+
     profile = line_profiler.LineProfiler()
-    atexit.register(profile.dump_stats, f"prof_{os.getpid()}.lstat")
+
+    def dump_stats(p):
+        s = p.get_stats()
+        if any(s.timings.values()):
+            profile.dump_stats(f"prof_{os.getpid()}.lstat")
+
+    atexit.register(dump_stats, profile)
 except ImportError:
     def profile(func):
         return func

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -102,7 +102,7 @@ try:
     def dump_stats(p):
         s = p.get_stats()
         if any(s.timings.values()):
-            profile.dump_stats(f"prof_{os.getpid()}.lstat")
+            profile.dump_stats(f"prof_sched_{os.getpid()}.lstat")
 
     atexit.register(dump_stats, profile)
 except ImportError:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import atexit
 from collections import defaultdict, deque
 from collections.abc import Mapping, Set
 from contextlib import suppress
@@ -93,6 +94,20 @@ if sys.version_info < (3, 8):
 else:
     import pickle
 
+try:
+    import line_profiler
+
+    profiler = line_profiler.LineProfiler()
+
+    def dump_stats(p):
+        s = p.get_stats()
+        if any(s.timings.values()):
+            profiler.dump_stats(f"prof_{os.getpid()}.lstat")
+
+    atexit.register(dump_stats, profiler)
+except ImportError:
+    def profile(func):
+        return func
 
 logger = logging.getLogger(__name__)
 
@@ -2577,6 +2592,7 @@ class Scheduler(ServerNode):
     # Manage Messages #
     ###################
 
+    @profiler
     def report(self, msg, ts=None, client=None):
         """
         Publish updates to all listening Queues and Comms
@@ -2690,6 +2706,7 @@ class Scheduler(ServerNode):
         )
         self.loop.call_later(cleanup_delay, remove_client_from_events)
 
+    @profiler
     def send_task_to_worker(self, worker, key):
         """ Send a single computational task to a worker """
         try:
@@ -2859,6 +2876,7 @@ class Scheduler(ServerNode):
         """ Remove external plugin from scheduler """
         self.plugins.remove(plugin)
 
+    @profiler
     def worker_send(self, worker, msg):
         """Send message to worker
 
@@ -3672,6 +3690,7 @@ class Scheduler(ServerNode):
             if client:
                 self.client_desires_keys(keys=list(who_has), client=client)
 
+    @profiler
     def report_on_key(self, key=None, ts=None, client=None):
         assert (key is None) + (ts is None) == 1, (key, ts)
         if ts is None:
@@ -3947,6 +3966,7 @@ class Scheduler(ServerNode):
     # State Transitions #
     #####################
 
+    @profiler
     def _remove_from_processing(self, ts, send_worker_msg=None):
         """
         Remove *ts* from the set of processing tasks.
@@ -3967,6 +3987,7 @@ class Scheduler(ServerNode):
             if send_worker_msg:
                 self.worker_send(w, send_worker_msg)
 
+    @profiler
     def _add_to_memory(
         self, ts, ws, recommendations, type=None, typename=None, **kwargs
     ):
@@ -4012,6 +4033,7 @@ class Scheduler(ServerNode):
         if ts in cs.wants_what:
             self.client_releases_keys(client="fire-and-forget", keys=[ts.key])
 
+    @profiler
     def transition_released_waiting(self, key):
         try:
             ts = self.tasks[key]
@@ -4063,6 +4085,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_no_worker_waiting(self, key):
         try:
             ts = self.tasks[key]
@@ -4107,6 +4130,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def decide_worker(self, ts):
         """
         Decide on a worker for task *ts*.  Return a WorkerState.
@@ -4147,6 +4171,7 @@ class Scheduler(ServerNode):
 
         return worker
 
+    @profiler
     def transition_waiting_processing(self, key):
         try:
             ts = self.tasks[key]
@@ -4193,6 +4218,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_waiting_memory(self, key, nbytes=None, worker=None, **kwargs):
         try:
             ws = self.workers[worker]
@@ -4228,6 +4254,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_processing_memory(
         self,
         key,
@@ -4335,6 +4362,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_memory_released(self, key, safe=False):
         try:
             ts = self.tasks[key]
@@ -4394,6 +4422,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_released_erred(self, key):
         try:
             ts = self.tasks[key]
@@ -4435,6 +4464,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_erred_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4469,6 +4499,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_waiting_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4505,6 +4536,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_processing_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4549,6 +4581,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_processing_erred(
         self, key, cause=None, exception=None, traceback=None, **kwargs
     ):
@@ -4618,6 +4651,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_no_worker_released(self, key):
         try:
             ts = self.tasks[key]
@@ -4644,6 +4678,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def remove_key(self, key):
         ts = self.tasks.pop(key)
         assert ts.state == "forgotten"
@@ -4657,6 +4692,7 @@ class Scheduler(ServerNode):
         if key in self.task_metadata:
             del self.task_metadata[key]
 
+    @profiler
     def _propagate_forgotten(self, ts, recommendations):
         ts.state = "forgotten"
         key = ts.key
@@ -4694,6 +4730,7 @@ class Scheduler(ServerNode):
                 )
         ts.who_has.clear()
 
+    @profiler
     def transition_memory_forgotten(self, key):
         try:
             ts = self.tasks[key]
@@ -4734,6 +4771,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition_released_forgotten(self, key):
         try:
             ts = self.tasks[key]
@@ -4770,6 +4808,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transition(self, key, finish, *args, **kwargs):
         """Transition a key from its current state to the finish state
 
@@ -4862,6 +4901,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
+    @profiler
     def transitions(self, recommendations):
         """Process transitions until none are left
 
@@ -4913,6 +4953,7 @@ class Scheduler(ServerNode):
     # Assigning Tasks to Workers #
     ##############################
 
+    @profiler
     def check_idle_saturated(self, ws, occ=None):
         """Update the status of the idle and saturated state
 
@@ -5503,6 +5544,7 @@ class Scheduler(ServerNode):
             return len(self.workers) - len(to_close)
 
 
+@profiler
 def decide_worker(ts, all_workers, valid_workers, objective):
     """
     Decide which worker should take task *ts*.
@@ -5749,6 +5791,7 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         self.keys.update(keys)
 
+    @profiler
     def transition(self, key, start, finish, *args, **kwargs):
         if finish == "memory" or finish == "erred":
             ts = self.scheduler.tasks.get(key)

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,12 @@ if cython:
         Extension(
             "distributed.scheduler",
             sources=["distributed/scheduler.py"],
+            define_macros=[("CYTHON_TRACE", 1)],
         ),
         Extension(
             "distributed.protocol.serialize",
             sources=["distributed/protocol/serialize.py"],
+            define_macros=[("CYTHON_TRACE", 1)],
         ),
     ]
     for e in cyext_modules:
@@ -50,6 +52,8 @@ if cython:
             "binding": False,
             "embedsignature": True,
             "language_level": 3,
+            "profile": True,
+            "linetrace": True,
         }
     ext_modules.extend(cyext_modules)
 


### PR DESCRIPTION
In order to identify any slow parts within the transition methods themselves, this leverages line_profiler and decorates the relevant methods. Should help us get a better picture about what in these methods may take a long time and therefore where effort is best directed.