### PR TITLE
Support string timeouts in sync

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -111,6 +111,9 @@ def test_sync_timeout(loop_in_thread):
     with pytest.raises(TimeoutError):
         sync(loop_in_thread, asyncio.sleep, 0.5, callback_timeout=0.05)
 
+    with pytest.raises(TimeoutError):
+        sync(loop_in_thread, asyncio.sleep, 0.5, callback_timeout="50ms")
+
 
 def test_sync_closed_loop():
     loop = IOLoop.current()

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -294,6 +294,7 @@ def sync(loop, func, *args, callback_timeout=None, **kwargs):
     """
     Run coroutine in loop running in separate thread.
     """
+    callback_timeout = parse_timedelta(callback_timeout, "s")
     # Tornado's PollIOLoop doesn't raise when using closed, do it ourselves
     if PollIOLoop and (
         (isinstance(loop, PollIOLoop) and getattr(loop, "_closing", False))


### PR DESCRIPTION
We support string timeouts (e.g. "10 minutes") in many places and I recently had a use case where it would have been convenient if `distributed.utils.sync` supported this too