### PR TITLE
Use `set.update` to include other `comms`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2589,14 +2589,14 @@ class Scheduler(ServerNode):
             ts = self.tasks.get(msg["key"])
         if ts is None:
             # Notify all clients
-            comms |= set(self.client_comms.values())
+            comms.update(self.client_comms.values())
         else:
             # Notify clients interested in key
-            comms |= {
+            comms.update(
                 self.client_comms[c.client_key]
                 for c in ts.who_wants
                 if c.client_key in self.client_comms
-            }
+            )
         for c in comms:
             try:
                 c.send(msg)


### PR DESCRIPTION
Instead of coercing other collections to `set`s before performing a union with the `set` of `comms`, which can take a bit longer, simply call `comms.update(...)` on the provided collection. This avoids the need to build a separate `set` before performing the union and still has the same effect of including new values in `comms` where relevant.

Included a link to relevant Python docs for this method (for those unfamiliar). Note that both `frozenset` and `set` are documented together hence the reference to `frozenset` in the link even though it applies to `set` also.

https://docs.python.org/3/library/stdtypes.html#frozenset.update