### PR TITLE
Drop custom `__eq__` from `Status`

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -61,32 +61,6 @@ class Status(Enum):
     undefined = None
     dont_reply = "dont-reply"
 
-    def __eq__(self, other):
-        """
-        Implement equality checking with backward compatibility.
-
-        If other object instance is string, we compare with the values, but we
-        actually want to make sure the value compared with is in the list of
-        possible Status, this avoid comparison with non-existing status.
-        """
-        if isinstance(other, type(self)):
-            return self.value == other.value
-        elif isinstance(other, str) or (other is None):
-            warnings.warn(
-                f"Since distributed 2.23 `.status` is now an Enum, please compare with `Status.{other}`",
-                PendingDeprecationWarning,
-                stacklevel=1,
-            )
-            assert other in [
-                s.value for s in type(self)
-            ], f"comparison with non-existing states {other}"
-            return other == self.value
-        raise TypeError(
-            f"'==' not supported between instances of"
-            f" {type(self).__module__+'.'+type(self).__qualname__!r} and"
-            f" {type(other).__module__+'.'+type(other).__qualname__!r}"
-        )
-
 
 class RPCClosed(IOError):
     pass

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -100,15 +100,6 @@ def test_server_status_assign_non_variant_raises():
             server.status = "I do not exists"
 
 
-def test_server_status_compare_non_variant_raises():
-    server = Server({})
-    # turn off warnings into error for assertion checking.
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("default")
-        with pytest.raises(AssertionError):
-            server.status == "You can't compare with me"
-
-
 def test_server_status_assign_with_variant_warns():
     server = Server({})
     with warnings.catch_warnings(record=True) as w:
@@ -117,26 +108,11 @@ def test_server_status_assign_with_variant_warns():
             server.status = "running"
 
 
-def test_server_status_compare_with_variant_warns():
-    server = Server({})
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("default")
-        with pytest.warns(PendingDeprecationWarning):
-            server.status == "running"
-
-
 def test_server_status_assign_with_variant_raises_in_tests():
     """That would be the default in user code"""
     server = Server({})
     with pytest.raises(PendingDeprecationWarning):
         server.status = "running"
-
-
-def test_server_status_compare_with_variant_raises_in_tests():
-    """That would be the default in user code"""
-    server = Server({})
-    with pytest.raises(PendingDeprecationWarning):
-        server.status == "running"
 
 
 def test_server_assign_assign_enum_is_quiet():


### PR DESCRIPTION
This appears to eat up a good chunk of time in places where the `Status` needs to be checked. So try dropping this method in favor of the default implementation.

That said, I'm sure this is here for some reason. So marking this as WIP so we can discuss whether removing is ok or if we need to figure out some alternative solution.