### PR TITLE
Move `nbytes` from `WorkerState` to `TaskState`

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -573,7 +573,6 @@ async def test_clean(c, s, a, b):
     collections = [
         a.tasks,
         a.data,
-        a.nbytes,
         a.threads,
     ]
     for c in collections:
@@ -667,7 +666,11 @@ async def test_clean_nbytes(c, s, a, b):
     await wait(future)
 
     await asyncio.sleep(1)
-    assert len(a.nbytes) + len(b.nbytes) == 1
+    assert (
+        len(list(filter(None, [ts.nbytes for ts in a.tasks.values()])))
+        + len(list(filter(None, [ts.nbytes for ts in b.tasks.values()])))
+        == 1
+    )
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 20)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1330,7 +1330,7 @@ class Worker(ServerNode):
                     data[k] = Actor(type(self.actors[k]), self.address, k)
 
         msg = {"status": "OK", "data": {k: to_serialize(v) for k, v in data.items()}}
-        nbytes = {k: self.tasks[k].nbytes for k in data}
+        nbytes = {k: self.tasks[k].nbytes for k in data if k in self.tasks}
         stop = time()
         if self.digests is not None:
             self.digests["get-data-load-duration"].add(stop - start)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -88,6 +88,10 @@ DEFAULT_METRICS = {}
 
 DEFAULT_STARTUP_INFORMATION = {}
 
+DEFAULT_DATA_SIZE = parse_bytes(
+    dask.config.get("distributed.scheduler.default-data-size")
+)
+
 SerializedTask = namedtuple("SerializedTask", ["function", "args", "kwargs", "task"])
 
 
@@ -132,6 +136,8 @@ class TaskState:
     * **metadata**: ``dict``
         Metadata related to task. Stored metadata should be msgpack
         serializable (e.g. int, string, list, dict).
+    * **nbytes**: ``int``
+        The size of a particular piece of data
 
     Parameters
     ----------
@@ -165,9 +171,14 @@ class TaskState:
         self.start_time = None
         self.stop_time = None
         self.metadata = {}
+        self.nbytes = None
 
     def __repr__(self):
         return "<Task %r %s>" % (self.key, self.state)
+
+    def get_nbytes(self) -> int:
+        nbytes = self.nbytes
+        return nbytes if nbytes is not None else DEFAULT_DATA_SIZE
 
 
 class Worker(ServerNode):
@@ -267,8 +278,6 @@ class Worker(ServerNode):
         dependencies we expect from those connections
     * **comm_bytes**: ``int``
         The total number of bytes in flight
-    * **nbytes**: ``{key: int}``
-        The size of a particular piece of data
     * **threads**: ``{key: int}``
         The ID of the thread on which the task ran
     * **active_threads**: ``{int: key}``
@@ -403,7 +412,6 @@ class Worker(ServerNode):
         self.comm_nbytes = 0
         self._missing_dep_flight = set()
 
-        self.nbytes = dict()
         self.threads = dict()
 
         self.active_threads_lock = threading.Lock()
@@ -856,7 +864,7 @@ class Worker(ServerNode):
                         keys=list(self.data),
                         nthreads=self.nthreads,
                         name=self.name,
-                        nbytes=self.nbytes,
+                        nbytes={ts.key: ts.get_nbytes() for ts in self.tasks.values()},
                         types={k: typename(v) for k, v in self.data.items()},
                         now=time(),
                         resources=self.total_resources,
@@ -1322,7 +1330,7 @@ class Worker(ServerNode):
                     data[k] = Actor(type(self.actors[k]), self.address, k)
 
         msg = {"status": "OK", "data": {k: to_serialize(v) for k, v in data.items()}}
-        nbytes = {k: self.nbytes.get(k) for k in data}
+        nbytes = {k: self.tasks[k].nbytes for k in data}
         stop = time()
         if self.digests is not None:
             self.digests["get-data-load-duration"].add(stop - start)
@@ -1464,9 +1472,6 @@ class Worker(ServerNode):
             if resource_restrictions:
                 ts.resource_restrictions = resource_restrictions
 
-            if nbytes is not None:
-                self.nbytes.update(nbytes)
-
             who_has = who_has or {}
 
             for dependency, workers in who_has.items():
@@ -1494,6 +1499,10 @@ class Worker(ServerNode):
                     if dep_ts.state != "memory":
                         self.pending_data_per_worker[worker].append(dep_ts.key)
 
+            if nbytes is not None:
+                for key, value in nbytes.items():
+                    self.tasks[key].nbytes = value
+
             if ts.waiting_for_data:
                 self.data_needed.append(ts.key)
             else:
@@ -1501,7 +1510,6 @@ class Worker(ServerNode):
             if self.validate:
                 if who_has:
                     assert all(self.tasks[dep] in ts.dependencies for dep in who_has)
-                    assert all(dep in self.nbytes for dep in who_has)
                     assert all(self.tasks[dep.key] for dep in ts.dependencies)
                     for dependency in ts.dependencies:
                         self.validate_task(dependency)
@@ -1887,14 +1895,13 @@ class Worker(ServerNode):
 
     def send_task_state_to_scheduler(self, ts):
         if ts.key in self.data or self.actors.get(ts.key):
-            nbytes = self.nbytes.get(ts.key)
             typ = ts.type
-            if nbytes is None or typ is None:
+            if ts.nbytes is None or typ is None:
                 try:
                     value = self.data[ts.key]
                 except KeyError:
                     value = self.actors[ts.key]
-                nbytes = self.nbytes[ts.key] = sizeof(value)
+                nbytes = ts.nbytes = sizeof(value)
                 typ = ts.type = type(value)
                 del value
             try:
@@ -1907,7 +1914,7 @@ class Worker(ServerNode):
                 "op": "task-finished",
                 "status": "OK",
                 "key": ts.key,
-                "nbytes": nbytes,
+                "nbytes": ts.nbytes,
                 "thread": self.threads.get(ts.key),
                 "type": typ_serialized,
                 "typename": typename(typ),
@@ -1948,8 +1955,8 @@ class Worker(ServerNode):
                     {"action": "disk-write", "start": start, "stop": stop}
                 )
 
-        if ts.key not in self.nbytes:
-            self.nbytes[ts.key] = sizeof(value)
+        if ts.nbytes is None:
+            ts.nbytes = sizeof(value)
 
         ts.type = type(value)
 
@@ -1968,7 +1975,7 @@ class Worker(ServerNode):
         assert isinstance(dep, str)
         deps = {dep}
 
-        total_bytes = self.nbytes[dep]
+        total_bytes = self.tasks[dep].get_nbytes()
         L = self.pending_data_per_worker[worker]
 
         while L:
@@ -1976,10 +1983,10 @@ class Worker(ServerNode):
             ts = self.tasks.get(d)
             if ts is None or ts.state != "waiting":
                 continue
-            if total_bytes + self.nbytes[d] > self.target_message_size:
+            if total_bytes + ts.get_nbytes() > self.target_message_size:
                 break
             deps.add(d)
-            total_bytes += self.nbytes[d]
+            total_bytes += ts.get_nbytes()
 
         return deps, total_bytes
 
@@ -2038,7 +2045,9 @@ class Worker(ServerNode):
                         }
                     )
 
-                total_bytes = sum(self.nbytes.get(key, 0) for key in response["data"])
+                total_bytes = sum(
+                    self.tasks[key].nbytes or 0 for key in response["data"]
+                )
                 duration = (stop - start) or 0.010
                 bandwidth = total_bytes / duration
                 self.incoming_transfer_log.append(
@@ -2048,7 +2057,7 @@ class Worker(ServerNode):
                         "middle": (start + stop) / 2.0 + self.scheduler_delay,
                         "duration": duration,
                         "keys": {
-                            key: self.nbytes.get(key, None) for key in response["data"]
+                            key: self.tasks[key].nbytes for key in response["data"]
                         },
                         "total": total_bytes,
                         "bandwidth": bandwidth,
@@ -2243,10 +2252,8 @@ class Worker(ServerNode):
                     del self.data[key]
                 except FileNotFoundError:
                     logger.error("Tried to delete %s but no file found", exc_info=True)
-                del self.nbytes[key]
             if key in self.actors and not ts.dependents:
                 del self.actors[key]
-                del self.nbytes[key]
 
             # for any dependencies of key we are releasing remove task as dependent
             for dependency in ts.dependencies:
@@ -2569,7 +2576,7 @@ class Worker(ServerNode):
             self.threads[ts.key] = result["thread"]
 
             if result["op"] == "task-finished":
-                self.nbytes[ts.key] = result["nbytes"]
+                ts.nbytes = result["nbytes"]
                 ts.type = result["type"]
                 self.transition(ts, "memory", value=value)
                 if self.digests is not None:
@@ -2851,7 +2858,7 @@ class Worker(ServerNode):
 
     def validate_task_memory(self, ts):
         assert ts.key in self.data or ts.key in self.actors
-        assert ts.key in self.nbytes
+        assert ts.nbytes is not None
         assert not ts.waiting_for_data
         assert ts.key not in self.ready
         assert ts.state == "memory"
@@ -2931,7 +2938,7 @@ class Worker(ServerNode):
                         or ts_wait.who_has.issubset(self.in_flight_workers)
                     )
                 if ts.state == "memory":
-                    assert isinstance(self.nbytes[ts.key], int)
+                    assert isinstance(ts.nbytes, int)
                     assert not ts.waiting_for_data
                     assert ts.key in self.data or ts.key in self.actors
 


### PR DESCRIPTION
Removing one less extra dictionary to track -- this was the source of
some tricky-to-debug issues over in #4264 and I thought I'd break it out
into a separate PR instead of jamming everything into one enormous PR.