### PR TITLE
Collect `report`'s `client_key`s in a `list`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2590,13 +2590,13 @@ class Scheduler(ServerNode):
         if ts is None:
             # Notify all clients
             client_keys = list(self.client_comms)
-        elif client is not None:
+        elif client is None:
+            # Notify clients interested in key
+            client_keys = [c.client_key for c in ts.who_wants]
+        else:
             # Notify clients interested in key (including `client`)
             client_keys = [c.client_key for c in ts.who_wants if c.client_key != client]
             client_keys.append(client)
-        else:
-            # Notify clients interested in key
-            client_keys = [c.client_key for c in ts.who_wants]
 
         for k in client_keys:
             try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2590,15 +2590,15 @@ class Scheduler(ServerNode):
         if ts is None:
             # Notify all clients
             client_keys = list(self.client_comms)
+        elif client is not None:
+            # Notify clients interested in key (including `client`)
+            client_keys = [
+                c.client_key for c in ts.who_wants if c.client_key != client
+            ]
+            client_keys.append(client)
         else:
             # Notify clients interested in key
-            if client is not None:
-                client_keys = [
-                    c.client_key for c in ts.who_wants if c.client_key != client
-                ]
-                client_keys.append(client)
-            else:
-                client_keys = [c.client_key for c in ts.who_wants]
+            client_keys = [c.client_key for c in ts.who_wants]
 
         for k in client_keys:
             try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2592,9 +2592,16 @@ class Scheduler(ServerNode):
             client_keys = list(self.client_comms)
         else:
             # Notify clients interested in key
-            client_keys = [c.client_key for c in ts.who_wants]
-            if client is not None and client not in client_keys:
+            client_keys = []
+            if client is not None:
                 client_keys.append(client)
+                for c in ts.who_wants:
+                    k = c.client_key
+                    if k != client:
+                        client_keys.append(k)
+            else:
+                for c in ts.who_wants:
+                    client_keys.append(c.client_key)
 
         for k in client_keys:
             try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2584,18 +2584,19 @@ class Scheduler(ServerNode):
         If the message contains a key then we only send the message to those
         comms that care about the key.
         """
-        client_keys = set()
-        if client is not None:
-            client_keys.add(client)
+        client_keys = []
 
         if ts is None and "key" in msg:
             ts = self.tasks.get(msg["key"])
         if ts is None:
             # Notify all clients
-            client_keys.update(self.client_comms)
+            client_keys.extend(self.client_comms)
         else:
             # Notify clients interested in key
-            client_keys.update(c.client_key for c in ts.who_wants)
+            client_keys.extend(c.client_key for c in ts.who_wants)
+
+        if client is not None and client not in client_keys:
+            client_keys.append(client)
 
         for k in client_keys:
             try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2598,13 +2598,9 @@ class Scheduler(ServerNode):
             comms.update(self.client_comms)
         else:
             # Notify clients interested in key
-            comms.update(
-                {
-                    c.client_key: self.client_comms[c.client_key]
-                    for c in ts.who_wants
-                    if c.client_key in self.client_comms
-                }
-            )
+            for c in ts.who_wants:
+                with suppress(KeyError):
+                    comms[c.client_key] = self.client_comms[c.client_key]
         for c in comms.values():
             try:
                 c.send(msg)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2588,6 +2588,7 @@ class Scheduler(ServerNode):
 
         if ts is None and "key" in msg:
             ts = self.tasks.get(msg["key"])
+
         if ts is None:
             # Notify all clients
             client_keys.extend(self.client_comms)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2593,9 +2593,8 @@ class Scheduler(ServerNode):
         else:
             # Notify clients interested in key
             client_keys = [c.client_key for c in ts.who_wants]
-
-        if client is not None and client not in client_keys:
-            client_keys.append(client)
+            if client is not None and client not in client_keys:
+                client_keys.append(client)
 
         for k in client_keys:
             try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2601,6 +2601,7 @@ class Scheduler(ServerNode):
             for c in ts.who_wants:
                 with suppress(KeyError):
                     comms[c.client_key] = self.client_comms[c.client_key]
+
         for c in comms.values():
             try:
                 c.send(msg)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2592,9 +2592,7 @@ class Scheduler(ServerNode):
             client_keys = list(self.client_comms)
         elif client is not None:
             # Notify clients interested in key (including `client`)
-            client_keys = [
-                c.client_key for c in ts.who_wants if c.client_key != client
-            ]
+            client_keys = [c.client_key for c in ts.who_wants if c.client_key != client]
             client_keys.append(client)
         else:
             # Notify clients interested in key

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2592,16 +2592,13 @@ class Scheduler(ServerNode):
             client_keys = list(self.client_comms)
         else:
             # Notify clients interested in key
-            client_keys = []
             if client is not None:
+                client_keys = [
+                    c.client_key for c in ts.who_wants if c.client_key != client
+                ]
                 client_keys.append(client)
-                for c in ts.who_wants:
-                    k = c.client_key
-                    if k != client:
-                        client_keys.append(k)
             else:
-                for c in ts.who_wants:
-                    client_keys.append(c.client_key)
+                client_keys = [c.client_key for c in ts.who_wants]
 
         for k in client_keys:
             try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2584,17 +2584,15 @@ class Scheduler(ServerNode):
         If the message contains a key then we only send the message to those
         comms that care about the key.
         """
-        client_keys = []
-
         if ts is None and "key" in msg:
             ts = self.tasks.get(msg["key"])
 
         if ts is None:
             # Notify all clients
-            client_keys.extend(self.client_comms)
+            client_keys = list(self.client_comms)
         else:
             # Notify clients interested in key
-            client_keys.extend(c.client_key for c in ts.who_wants)
+            client_keys = [c.client_key for c in ts.who_wants]
 
         if client is not None and client not in client_keys:
             client_keys.append(client)


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/4273

Instead of collecting a `set` of `comms` where `BatchedSend` objects will need to be `hash`ed, use a `dict` with keys based on `Client` IDs and their `BatchedSend` object as values.  This should still ensure that we only pick up each `Client`'s `BatchedSend` object once. Though this will hash the `Client` IDs (`str`s) instead of `BatchedSend` objects, which should be more performant.