### PR TITLE
Add `__hash__` and `__eq__` for `TaskState`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -620,6 +620,8 @@ class TaskState:
         "actor",
         # Key name
         "key",
+        # Hash of the key name
+        "_hash",
         # Key prefix (see key_split())
         "prefix",
         # How to run the task (None if pure data)
@@ -664,6 +666,7 @@ class TaskState:
 
     def __init__(self, key, run_spec):
         self.key = key
+        self._hash = hash(key)
         self.run_spec = run_spec
         self._state = None
         self.exception = self.traceback = self.exception_blame = None
@@ -687,6 +690,12 @@ class TaskState:
         self.group_key = key_split_group(key)
         self.group = None
         self.metadata = {}
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.key == other.key
 
     @property
     def state(self) -> str:


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/4277

Implemented to make `TaskState` objects hashable.