### PR TITLE
Annotate `check_idle_saturated` for Cythonization

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4961,17 +4961,19 @@ class Scheduler(ServerNode):
         total_occupancy: double = self.total_occupancy
         avg: double = total_occupancy / total_nthreads
 
+        idle: set = self.idle
+        saturated: set = self.saturated
         if p < nc or occ / nc < avg / 2:
-            self.idle.add(ws)
-            self.saturated.discard(ws)
+            idle.add(ws)
+            saturated.discard(ws)
         else:
-            self.idle.discard(ws)
+            idle.discard(ws)
 
             pending: double = occ * (p - nc) / p / nc
             if p > nc and pending > 0.4 and pending > 1.9 * avg:
-                self.saturated.add(ws)
+                saturated.add(ws)
             else:
-                self.saturated.discard(ws)
+                saturated.discard(ws)
 
     def valid_workers(self, ts):
         """Return set of currently valid workers for key

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4928,7 +4928,7 @@ class Scheduler(ServerNode):
     # Assigning Tasks to Workers #
     ##############################
 
-    def check_idle_saturated(self, ws, occ=None):
+    def check_idle_saturated(self, ws, occ=-1):
         """Update the status of the idle and saturated state
 
         The scheduler keeps track of workers that are ..
@@ -4944,7 +4944,7 @@ class Scheduler(ServerNode):
         """
         if self.total_nthreads == 0 or ws.status == Status.closed:
             return
-        if occ is None:
+        if occ < 0:
             occ = ws.occupancy
 
         nc = ws.nthreads

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4961,7 +4961,7 @@ class Scheduler(ServerNode):
         total_occupancy: double = self.total_occupancy
         avg: double = total_occupancy / total_nthreads
 
-        idle: set = self.idle
+        idle = self.idle
         saturated: set = self.saturated
         if p < nc or occ / nc < avg / 2:
             idle.add(ws)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4946,9 +4946,9 @@ class Scheduler(ServerNode):
             return
         if occ is None:
             occ = ws.occupancy
+
         nc = ws.nthreads
         p = len(ws.processing)
-
         avg = self.total_occupancy / self.total_nthreads
 
         if p < nc or occ / nc < avg / 2:


### PR DESCRIPTION
In our profiling of the scheduler, we identified to main transitions that took a good chunk of time. These are `transition_processing_memory` and `transition_waiting_processing`. The former takes slightly longer than the other, but both are easily 2x slower than any transition that follows them. Both of them directly or indirectly make a call to `check_idle_saturated`. While this is not necessarily the worst bottleneck for either of them, it does stick out on the callgraph and stands a good chance of improving both transitions runtimes at once. Additionally `check_idle_saturated` includes a fair bit of code that simply crunches numbers and does not touch Python objects as much. It also isn't as dependent on the Cythonization of other classes as other functions in the profile are. So this makes it easier to Cythonize this piece of code without needing to touch too much other code.

Here we go through and annotate the local variables with types. Also we assign non-local variables accessed through attributes to local variables, which we type. Additionally we changed default argument values to be more friendly with C-style types. Initially we tried to type `self.idle`. However as [`self.idle` is a `sortedcontainers.SortedSet`]( https://github.com/dask/distributed/blob/9460e3fe1e0bcdb2daf6ebafe5335d536fa4f492/distributed/scheduler.py#L1292 ), this didn't work (as we need an actual Python `set` to type it). So we left this as untyped.

Should add as a good chunk of the time in `check_idle_saturated` is just spent doing `ws.status == Status.closed`, we still need PR ( https://github.com/dask/distributed/pull/4270 ) to cutdown on the time spent in this method.