### PR TITLE
Provide option to build Distributed with Cython

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -47,6 +47,13 @@ jobs:
         shell: bash -l {0}
         run: conda list
 
+      - name: Optionally Cythonize
+        shell: bash -l {0}
+        run: |
+          if [[ "${{ matrix.python-version }}" = "3.7" ]]; then
+            python setup.py build_ext --with-cython
+          fi
+
       - name: Run tests
         shell: bash -l {0}
         env:

--- a/continuous_integration/environment-windows.yml
+++ b/continuous_integration/environment-windows.yml
@@ -7,6 +7,7 @@ dependencies:
   - bokeh!=2.0.0
   - click
   - cloudpickle
+  - cython
   - dask
   - lz4
   - ipykernel

--- a/setup.py
+++ b/setup.py
@@ -34,18 +34,24 @@ if cython:
     except ImportError:
         setup_requires.append("cython")
 
-    ext_modules.extend(
-        [
-            Extension(
-                "distributed.scheduler",
-                sources=["distributed/scheduler.py"],
-            ),
-            Extension(
-                "distributed.protocol.serialize",
-                sources=["distributed/protocol/serialize.py"],
-            ),
-        ]
-    )
+    cyext_modules = [
+        Extension(
+            "distributed.scheduler",
+            sources=["distributed/scheduler.py"],
+        ),
+        Extension(
+            "distributed.protocol.serialize",
+            sources=["distributed/protocol/serialize.py"],
+        ),
+    ]
+    for e in cyext_modules:
+        e.cython_directives = {
+            "annotation_typing": True,
+            "binding": False,
+            "embedsignature": True,
+            "language_level": 3,
+        }
+    ext_modules.extend(cyext_modules)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
 import os
+import sys
 from setuptools import setup, find_packages
+from setuptools.extension import Extension
 import versioneer
 
 requires = open("requirements.txt").read().strip().split("\n")
+setup_requires = []
 install_requires = []
 extras_require = {}
 for r in requires:
@@ -17,6 +20,33 @@ for r in requires:
         cond_reqs.append(req)
     else:
         install_requires.append(r)
+
+try:
+    sys.argv.remove("--with-cython")
+    cython = True
+except ValueError:
+    cython = False
+
+ext_modules = []
+if cython:
+    try:
+        import cython
+    except ImportError:
+        setup_requires.append("cython")
+
+    ext_modules.extend(
+        [
+            Extension(
+                "distributed.scheduler",
+                sources=["distributed/scheduler.py"],
+            ),
+            Extension(
+                "distributed.protocol.serialize",
+                sources=["distributed/protocol/serialize.py"],
+            ),
+        ]
+    )
+
 
 setup(
     name="distributed",
@@ -33,9 +63,11 @@ setup(
         "distributed": ["http/templates/*.html"],
     },
     include_package_data=True,
+    setup_requires=setup_requires,
     install_requires=install_requires,
     extras_require=extras_require,
     packages=find_packages(exclude=["*tests*"]),
+    ext_modules=ext_modules,
     long_description=(
         open("README.rst").read() if os.path.exists("README.rst") else ""
     ),


### PR DESCRIPTION
This takes an initial pass at providing an option to build some portions of Distributed with Cython. Basically if we encounter `--with-cython` in `sys.argv`, we remove it and wrap the modules to compile in `Extension`s. If for whatever reason Cython isn't around, we add it `setup_requires` (though we could skip this and error instead if preferred). If we don't encounter `--with-cython`, we don't do anything.