### PR TITLE
Set `WorkerState.processing` w/`dict` in `clean`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -386,7 +386,7 @@ class WorkerState:
             nanny=self.nanny,
             extra=self.extra,
         )
-        ws.processing = {ts.key for ts in self.processing}
+        ws.processing = {ts.key: cost for ts, cost in self.processing.items()}
         return ws
 
     def __repr__(self):


### PR DESCRIPTION
Based on [the documentation about `WorkerState.processing`]( https://github.com/dask/distributed/blob/a192b22dece37b9e151b71aaaa129a409f5bc630/distributed/scheduler.py#L213-L226 ), this should be a `dict`. However here we are assigning it a `set`. This replaces it with a copy of the `dict`.