### PR TITLE
[WIP] Use `str` for `Worker` `name` & `address` in tests

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -579,7 +579,7 @@ async def test_coerce_address():
         s = await Scheduler(validate=True, port=0)
         print("scheduler:", s.address, s.listen_address)
         a = Worker(s.address, name="alice")
-        b = Worker(s.address, name=123)
+        b = Worker(s.address, name="123")
         c = Worker("127.0.0.1", s.port, name="charlie")
         await asyncio.gather(a, b, c)
 
@@ -598,12 +598,12 @@ async def test_coerce_address():
         assert s.coerce_address(a.address) == a.address
         # Aliases
         assert s.coerce_address("alice") == a.address
-        assert s.coerce_address(123) == b.address
+        assert s.coerce_address("123") == b.address
         assert s.coerce_address("charlie") == c.address
 
         assert s.coerce_hostname("127.0.0.1") == "127.0.0.1"
         assert s.coerce_hostname("alice") == a.ip
-        assert s.coerce_hostname(123) == b.ip
+        assert s.coerce_hostname("123") == b.ip
         assert s.coerce_hostname("charlie") == c.ip
         assert s.coerce_hostname("jimmy") == "jimmy"
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -787,7 +787,7 @@ async def start_cluster(
         Worker(
             s.address,
             nthreads=ncore[1],
-            name=i,
+            name=str(i),
             security=security,
             loop=loop,
             validate=True,


### PR DESCRIPTION
It seems a few tests specified the `Worker`'s `name` and `address` with `int`s. However `Scheduler.coerce_address` (used in the tests) [doesn't actually allow `int`s]( https://github.com/dask/distributed/blob/a192b22dece37b9e151b71aaaa129a409f5bc630/distributed/scheduler.py#L5113 ). Also [the `WorkerState`'s docs for `address` imply it is a `str`]( https://github.com/dask/distributed/blob/a192b22dece37b9e151b71aaaa129a409f5bc630/distributed/scheduler.py#L208-L211 ), which is [also said of the `nanny` address]( https://github.com/dask/distributed/blob/a192b22dece37b9e151b71aaaa129a409f5bc630/distributed/scheduler.py#L266-L268 ). Here we attempt to resolve this discrepancy by fixing these tests to use `str`s instead of `int`s.