### PR TITLE
Check traceback object can be unpickled

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1141,6 +1141,7 @@ def error_message(e, status="error"):
     e4 = protocol.to_serialize(e2)
     try:
         tb2 = protocol.pickle.dumps(tb, protocol=4)
+        protocol.pickle.loads(tb2)
     except Exception:
         tb = tb2 = "".join(traceback.format_tb(tb))
 


### PR DESCRIPTION
Just as we check if the exception can be round-tripped through pickle, check the traceback can as well. If that does, work proceed to fallback handling as before for the traceback.