### PR TITLE
WIP - Optionally use offload executor in worker

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -586,7 +586,10 @@ class Server:
                     await asyncio.sleep(0)
 
                 for func in every_cycle:
-                    func()
+                    if is_coroutine_function(func):
+                        self.loop.add_callback(func)
+                    else:
+                        func()
 
         except (CommClosedError, EnvironmentError) as e:
             io_error = e

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -7,6 +7,7 @@ import os
 import psutil
 import sys
 from time import sleep
+import threading
 import traceback
 from unittest import mock
 import asyncio
@@ -1755,3 +1756,29 @@ async def test_taskstate_metadata(cleanup):
 
                 # Check that Scheduler TaskState.metadata was also updated
                 assert s.tasks[f.key].metadata == ts.metadata
+
+
+@pytest.mark.asyncio
+async def test_executor_offload(cleanup):
+    class SameThreadClass:
+        def __getstate__(self):
+            return ()
+
+        def __setstate__(self, state):
+            self._thread_ident = threading.get_ident()
+            return self
+
+    with dask.config.set(distributed__comm__offload=1):
+        async with Scheduler() as s:
+            async with Worker(s.address, executor="offload") as w:
+                from distributed.utils import _offload_executor
+
+                assert w.executor is _offload_executor
+
+                async with Client(s.address, asynchronous=True) as c:
+                    x = SameThreadClass()
+
+                    def f(x):
+                        return threading.get_ident() == x._thread_ident
+
+                    assert await c.submit(f, x)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -32,7 +32,7 @@ from . import profile, comm, system
 from .batched import BatchedSend
 from .comm import get_address_host, connect
 from .comm.addressing import address_from_user_args
-from .comm.utils import get_offload_threshold
+from .comm.utils import OFFLOAD_THRESHOLD
 from .core import error_message, CommClosedError, send_recv, pingpong, coerce_to_address
 from .diskutils import WorkSpace
 from .http import get_handlers
@@ -2453,8 +2453,7 @@ class Worker(ServerNode):
         try:
             start = time()
             # Offload deserializing large tasks
-            offload_threshold = get_offload_threshold()
-            if sizeof(ts.runspec) > offload_threshold:
+            if sizeof(ts.runspec) > OFFLOAD_THRESHOLD:
                 from distributed.utils import _offload_executor
 
                 function, args, kwargs = _offload_executor.submit(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -755,20 +755,17 @@ class Worker(ServerNode):
     ##################
 
     def __repr__(self):
-        return (
-            "<%s: %r, %s, %s, stored: %d, running: %d/%d, ready: %d, comm: %d, waiting: %d>"
-            % (
-                self.__class__.__name__,
-                self.address,
-                self.name,
-                self.status,
-                len(self.data),
-                self.executing_count,
-                self.nthreads,
-                len(self.ready),
-                self.in_flight_tasks,
-                self.waiting_for_data_count,
-            )
+        return "<%s: %r, %s, %s, stored: %d, running: %d/%d, ready: %d, comm: %d, waiting: %d>" % (
+            self.__class__.__name__,
+            self.address,
+            self.name,
+            self.status,
+            len(self.data),
+            self.executing_count,
+            self.nthreads,
+            len(self.ready),
+            self.in_flight_tasks,
+            self.waiting_for_data_count,
         )
 
     @property
@@ -777,7 +774,11 @@ class Worker(ServerNode):
 
     def log_event(self, topic, msg):
         self.batched_stream.send(
-            {"op": "log-event", "topic": topic, "msg": msg,}
+            {
+                "op": "log-event",
+                "topic": topic,
+                "msg": msg,
+            }
         )
 
     @property

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2482,11 +2482,8 @@ class Worker(ServerNode):
         try:
             while self.constrained and self.executing_count < self.nthreads:
                 key = self.constrained[0]
-                try:
-                    ts = self.tasks[key]
-                except KeyError:
-                    continue
-                if ts.state != "constrained":
+                ts = self.tasks.get(key, None)
+                if ts is None or ts.state != "constrained":
                     self.constrained.popleft()
                     continue
                 if self.meets_resource_constraints(key):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -214,6 +214,9 @@ class Worker(ServerNode):
         Number of nthreads used by this worker process
     * **executor:** ``concurrent.futures.ThreadPoolExecutor``:
         Executor used to perform computation
+        This can also be the string "offload" in which case this uses the same
+        thread pool used for offloading communications.  This results in the
+        same thread being used for deserialization and computation.
     * **local_directory:** ``path``:
         Path on local machine to store temporary files
     * **scheduler:** ``rpc``:
@@ -752,17 +755,20 @@ class Worker(ServerNode):
     ##################
 
     def __repr__(self):
-        return "<%s: %r, %s, %s, stored: %d, running: %d/%d, ready: %d, comm: %d, waiting: %d>" % (
-            self.__class__.__name__,
-            self.address,
-            self.name,
-            self.status,
-            len(self.data),
-            self.executing_count,
-            self.nthreads,
-            len(self.ready),
-            self.in_flight_tasks,
-            self.waiting_for_data_count,
+        return (
+            "<%s: %r, %s, %s, stored: %d, running: %d/%d, ready: %d, comm: %d, waiting: %d>"
+            % (
+                self.__class__.__name__,
+                self.address,
+                self.name,
+                self.status,
+                len(self.data),
+                self.executing_count,
+                self.nthreads,
+                len(self.ready),
+                self.in_flight_tasks,
+                self.waiting_for_data_count,
+            )
         )
 
     @property
@@ -771,11 +777,7 @@ class Worker(ServerNode):
 
     def log_event(self, topic, msg):
         self.batched_stream.send(
-            {
-                "op": "log-event",
-                "topic": topic,
-                "msg": msg,
-            }
+            {"op": "log-event", "topic": topic, "msg": msg,}
         )
 
     @property

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -610,6 +610,8 @@ class Worker(ServerNode):
         self.actors = {}
         self.loop = loop or IOLoop.current()
         self.reconnect = reconnect
+        if executor == "offload":
+            from distributed.utils import _offload_executor as executor
         self.executor = executor or ThreadPoolExecutor(
             self.nthreads, thread_name_prefix="Dask-Worker-Threads'"
         )


### PR DESCRIPTION
Normally we have one separate thread pool executor for deserializing data
and another thread pool executor in a worker for execution.
Sometimes this presents a problem because some data types want to be
used in the thread in which they were created.  One example of this is
TensorFlow graphs, but there are others.

One way to resolve this is to reuse the same executor in both
situations, and ensure that it has only one thread.  This means that
execution and deserialization will block each other (not great) but that
user data will always be operated on in one thread only.

This commit implements that, and drafts up a small test.  However, it is
still broken because Dask can be clever in some situations and
deserialize directly on the event loop.  This happens for a few reasons
today:

1.  For small messages we deserialize on the event loop for performance
    reasons.  The user can control this with the
    distributed.comm.offload configuration value.

    I recommend the value of 1, meaning a single byte

2.  The scheduler-client comms intentionally do not offload today
    (grep for the `allow_offload=False`)