### PR TITLE
Fix `pip` install issue on CI

### DIFF
--- a/continuous_integration/environment-windows.yml
+++ b/continuous_integration/environment-windows.yml
@@ -30,6 +30,6 @@ dependencies:
   - fsspec
   - pip
   - pip:
-      - git+https://github.com/dask/dask.git
-      - git+https://github.com/joblib/joblib.git
-      - git+https://github.com/dask/zict
+      - git+https://github.com/dask/dask.git@master
+      - git+https://github.com/joblib/joblib.git@master
+      - git+https://github.com/dask/zict.git@master


### PR DESCRIPTION
Fixes an issue we are [seeing on CI]( https://github.com/dask/distributed/pull/4294/checks?check_run_id=1495023367 ). This came up for us in RAPIDS and this solved the issue there as well. Basically `pip`'s solver seems to be trying to get involved here even though we don't need it to. Specifying the repo branches seems to bypass the issue.

This also came up in dask-cloudprovider recently ( https://github.com/dask/dask-cloudprovider/pull/203 ).