### PR TITLE
Coerce new `TaskState.nbytes` value to `int`

### DIFF
--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -493,7 +493,7 @@ async def assert_balanced(inp, expected, c, s, *workers):
                 ts = s.tasks[dat.key]
                 # Ensure scheduler state stays consistent
                 old_nbytes = ts.nbytes
-                ts.nbytes = s.bandwidth * t
+                ts.nbytes = int(s.bandwidth * t)
                 for ws in ts.who_has:
                     ws.nbytes += ts.nbytes - old_nbytes
             else:


### PR DESCRIPTION
Make sure that whatever value we assign to `nbytes` is an `int`. This is important as `Schedule.bandwidth` may be a `float`. So the value here could be a `float`. Though we only measure `nbytes` in whole values.