### PR TITLE
Use `str` for `Worker` `address` in tests

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -598,7 +598,7 @@ async def test_coerce_address():
         assert s.coerce_address(a.address) == a.address
         # Aliases
         assert s.coerce_address("alice") == a.address
-        assert s.coerce_address(123) == b.address
+        assert s.coerce_address("123") == b.address
         assert s.coerce_address("charlie") == c.address
 
         assert s.coerce_hostname("127.0.0.1") == "127.0.0.1"


### PR DESCRIPTION
Broken out from PR ( https://github.com/dask/distributed/pull/4296 )
Following up on this comment ( https://github.com/dask/distributed/pull/4294#pullrequestreview-544353865 )

This test uses an `int` address though we would expect it to be a `str`. So here we change it to a `str` to fix that issue.