### PR TITLE
Ensure that retire_workers returns a dict

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3616,7 +3616,7 @@ class Scheduler(ServerNode):
         names=None,
         lock=True,
         **kwargs,
-    ):
+    ) -> dict:
         """Gracefully retire workers from cluster
 
         Parameters
@@ -3673,7 +3673,7 @@ class Scheduler(ServerNode):
                             pass
                 workers = {self.workers[w] for w in workers if w in self.workers}
                 if not workers:
-                    return []
+                    return {}
                 logger.info("Retire workers %s", workers)
 
                 # Keys orphaned by retiring those workers
@@ -3692,7 +3692,7 @@ class Scheduler(ServerNode):
                             lock=False,
                         )
                     else:
-                        return []
+                        return {}
 
                 worker_keys = {ws.address: ws.identity() for ws in workers}
                 if close_workers and worker_keys:


### PR DESCRIPTION
A long while ago we changed retire_workers to return a dict, but didn't
change all of the cases, particularly those for empty results, which
still returned a list.  Now we reliably return a dict in all cases.