### PR TITLE
WIP Proper handling of application errors during get_data

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -649,9 +649,15 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
     try:
         await comm.write(msg, serializers=serializers, on_error="raise")
         if reply:
+            # XXX 1 This raises an exception
             response = await comm.read(deserializers=deserializers)
         else:
             response = None
+    except Exception as exc:
+        # XXX 2 The exception is not handled and bubbles up. Therefore no
+        # response is ever sent (yes the other end expects a response,
+        # surprise!)
+        raise exc
     except EnvironmentError:
         # On communication errors, we should simply close the communication
         force_close = True

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1339,6 +1339,10 @@ class Worker(ServerNode):
 
         try:
             compressed = await comm.write(msg, serializers=serializers)
+            # XXX 4 This never receives its actual response but is waiting... in
+            # the meantime the other end is recycling this comm and sends
+            # another request which is supposed to be handled by the handler...
+            # still not sure why and how
             response = await comm.read(deserializers=serializers)
             assert response == "OK", response
         except EnvironmentError:
@@ -3250,6 +3254,9 @@ async def get_data_from_worker(
             except KeyError:
                 raise ValueError("Unexpected response", response)
             else:
+                # XXX 3 Since the above send_recv raises an exception which is
+                # not handled here, this never returns, even though the other
+                # end waits for an answer
                 if status == "OK":
                     await comm.write("OK")
             return response


### PR DESCRIPTION
TL;DR If we encounter application errors during `get_data` (e.g. custom deserializer) we are somehow reusing comm objects and are swallowing handler calls which might drive the cluster into a corrupt state (sometimes self healing)

This is a funny one, again. It is not a fix, yet, but an analysis of the problem with a semi-complete test (not sure, yet, what the outcome of the test should be exactly but it is reproducing it simply)

A tiny bit of context: We had some more or less deterministic deserialization issues connected to custom (de-)serialization code. We fixed this one so I'm not sure how critical this problem actually is but from my understanding it could put the cluster in a corrupt state, at least for a while. I've seen retries eventually recovering it so I guess this is just weird but not critical.

On top of the "Failed to deserialize" messages (which are obviously expected) we got things like

```
  File "/mnt/mesos/sandbox/venv/lib/python3.6/site-packages/distributed/worker.py", line 1283, in get_data
    assert response == "OK", response

AssertionError: {'op': 'get_data', 'keys': ("('shuffle-split-7371cf941c2c38490c6b2db8b38e4e98', 2, 1, (6, 2))", "('shuffle-split-7371cf941c2c38490c6b2db8b38e4e98', 2, 1, (6, 1))"), 'who': 'tls://10.3.136.133:31114', 'max_connections': None, 'reply': True}
```

If you follow the XXX comments from 1 to 4 this leads through the code sequentially as the events happen to produce this issue.
