### PR TITLE
Ensure `retire_workers` always `return`s a `dict`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3810,7 +3810,9 @@ class Scheduler(ServerNode):
                                     close_workers=close_workers,
                                     lock=False,
                                 )
-                            return workers
+                                return workers
+                            else:
+                                return {}
                         except KeyError:  # keys left during replicate
                             pass
                 workers = {self.workers[w] for w in workers if w in self.workers}


### PR DESCRIPTION
As `workers_to_close` actually `return`s a `list` and that `list` could be empty, we can wind up `return`ing an empty `list` instead of `return`ing a `dict`. To fix that, we only return the `workers` object when it is non-trivial (so will be replaced by a `dict`). In the trivial case we just `return` an empty `dict`. This ensures we only `return` a `dict` in this case, which fixes an issue that was cropping up when compiling the scheduler with Cython.