### PR TITLE
Use `operator.attrgetter` on `WorkerState.address`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3696,7 +3696,7 @@ class Scheduler(ServerNode):
                 return []
 
             if key is None:
-                key = lambda ws: ws.address
+                key = operator.attrgetter("address")
             if isinstance(key, bytes) and dask.config.get(
                 "distributed.scheduler.pickle"
             ):


### PR DESCRIPTION
Make use of `operator.attrgetter` to get `WorkerState`'s `address` attribute instead of a `lambda`. This winds up being a bit faster. Also `operator.attrgetter` is honed for this purpose. Not too mention it is already used frequently for this purpose in this code.