### PR TITLE
[WIP] Fix-up Cython build

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -43,9 +43,9 @@ jobs:
         shell: bash -l {0}
         run: |
           if [[ "${{ matrix.python-version }}" = "3.7" ]]; then
-            python -m pip install -q --no-deps --install-option="--with-cython" -e .
+            python -m pip install -q --no-deps --install-option="--with-cython" .
           else
-            python -m pip install -q --no-deps -e .
+            python -m pip install -q --no-deps .
           fi
 
       - name: List packages in environment

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install distributed from source
         shell: bash -l {0}
-        run: python -m pip install -q --no-deps -e .
+        run: python -m pip install -q --no-deps .
 
       - name: List packages in environment
         shell: bash -l {0}

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -43,9 +43,9 @@ jobs:
         shell: bash -l {0}
         run: |
           if [[ "${{ matrix.python-version }}" = "3.7" ]]; then
-            python -m pip install -q --no-deps --install-option="--with-cython" .
+            python -m pip install -q --no-deps --install-option="--with-cython" -e .
           else
-            python -m pip install -q --no-deps .
+            python -m pip install -q --no-deps -e .
           fi
 
       - name: List packages in environment

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -41,18 +41,16 @@ jobs:
 
       - name: Install distributed from source
         shell: bash -l {0}
-        run: python -m pip install -q --no-deps .
+        run: |
+          if [[ "${{ matrix.python-version }}" = "3.7" ]]; then
+            python -m pip install -q --no-deps --install-option="--with-cython" .
+          else
+            python -m pip install -q --no-deps .
+          fi
 
       - name: List packages in environment
         shell: bash -l {0}
         run: conda list
-
-      - name: Optionally Cythonize
-        shell: bash -l {0}
-        run: |
-          if [[ "${{ matrix.python-version }}" = "3.7" ]]; then
-            python setup.py build_ext --with-cython
-          fi
 
       - name: Run tests
         shell: bash -l {0}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,6 @@ recursive-include distributed *.yaml
 recursive-include docs *.rst
 
 recursive-exclude distributed *.c
-recursive-exclude distributed *.pxd
 recursive-exclude distributed *.pyx
 
 include setup.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ recursive-include distributed *.yaml
 recursive-include docs *.rst
 
 recursive-exclude distributed *.c
+recursive-exclude distributed *.pxd
 recursive-exclude distributed *.pyx
 
 include setup.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,9 @@ recursive-include distributed *.ico
 recursive-include distributed *.yaml
 recursive-include docs *.rst
 
+recursive-exclude distributed *.c
+recursive-exclude distributed *.pyx
+
 include setup.py
 include README.rst
 include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import atexit
 import os
 import sys
 from setuptools import setup, find_packages
@@ -45,7 +44,6 @@ if cython:
         p_pyx = p_py + "x"
         m = ".".join(m)
         os.replace(p_py, p_pyx)
-        atexit.register(os.replace, p_pyx, p_py)
         e = Extension(m, sources=[p_pyx])
         e.cython_directives = {
             "annotation_typing": True,

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,20 @@ if cython:
         print("Please install Cython to build extensions.")
         sys.exit(1)
 
+    to_remove = set()
     modules = [
         ("distributed", "scheduler"),
         ("distributed", "protocol", "serialize"),
     ]
     cyext_modules = []
     for m in modules:
+        d = "."
+        for e in m[:-1]:
+            d = os.path.join(d, e)
+            fn = os.path.join(d, "__init__.pxd")
+            to_remove.add(fn)
+            with open(fn, "w+") as fh:
+                fh.write("")
         p_py = os.path.join(*m) + os.extsep + "py"
         p_pyx = p_py + "x"
         m = ".".join(m)
@@ -55,6 +63,8 @@ if cython:
             "language_level": 3,
         }
         cyext_modules.append(e)
+    for fn in to_remove:
+        atexit.register(os.remove, fn)
     ext_modules.extend(cyext_modules)
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import atexit
 import os
 import sys
 from setuptools import setup, find_packages
@@ -41,9 +42,12 @@ if cython:
     ]
     cyext_modules = []
     for m in modules:
-        p = os.path.join(*m) + os.extsep + "py"
+        p_py = os.path.join(*m) + os.extsep + "py"
+        p_pyx = p_py + "x"
         m = ".".join(m)
-        e = Extension(m, sources=[p])
+        os.replace(p_py, p_pyx)
+        atexit.register(os.replace, p_pyx, p_py)
+        e = Extension(m, sources=[p_pyx])
         e.cython_directives = {
             "annotation_typing": True,
             "binding": False,

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ for r in requires:
     else:
         install_requires.append(r)
 
+
 try:
     sys.argv.remove("--with-cython")
     cython = True

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ if cython:
 
     modules = [
         ("distributed", "scheduler"),
-        ("distributed", "protocol", "serialize"),
     ]
     cyext_modules = []
     for m in modules:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ from setuptools.extension import Extension
 import versioneer
 
 requires = open("requirements.txt").read().strip().split("\n")
-setup_requires = []
 install_requires = []
 extras_require = {}
 for r in requires:
@@ -33,7 +32,8 @@ if cython:
     try:
         import cython
     except ImportError:
-        setup_requires.append("cython")
+        print("Please install Cython to build extensions.")
+        sys.exit(1)
 
     cyext_modules = [
         Extension(
@@ -70,7 +70,6 @@ setup(
         "distributed": ["http/templates/*.html"],
     },
     include_package_data=True,
-    setup_requires=setup_requires,
     install_requires=install_requires,
     extras_require=extras_require,
     packages=find_packages(exclude=["*tests*"]),

--- a/setup.py
+++ b/setup.py
@@ -35,23 +35,22 @@ if cython:
         print("Please install Cython to build extensions.")
         sys.exit(1)
 
-    cyext_modules = [
-        Extension(
-            "distributed.scheduler",
-            sources=["distributed/scheduler.py"],
-        ),
-        Extension(
-            "distributed.protocol.serialize",
-            sources=["distributed/protocol/serialize.py"],
-        ),
+    modules = [
+        ("distributed", "scheduler"),
+        ("distributed", "protocol", "serialize"),
     ]
-    for e in cyext_modules:
+    cyext_modules = []
+    for m in modules:
+        p = os.path.join(*m) + os.extsep + "py"
+        m = ".".join(m)
+        e = Extension(m, sources=[p])
         e.cython_directives = {
             "annotation_typing": True,
             "binding": False,
             "embedsignature": True,
             "language_level": 3,
         }
+        cyext_modules.append(e)
     ext_modules.extend(cyext_modules)
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import atexit
 import os
 import sys
 from setuptools import setup, find_packages
@@ -44,6 +45,7 @@ if cython:
         p_pyx = p_py + "x"
         m = ".".join(m)
         os.replace(p_py, p_pyx)
+        atexit.register(os.replace, p_pyx, p_py)
         e = Extension(m, sources=[p_pyx])
         e.cython_directives = {
             "annotation_typing": True,

--- a/setup.py
+++ b/setup.py
@@ -36,20 +36,12 @@ if cython:
         print("Please install Cython to build extensions.")
         sys.exit(1)
 
-    to_remove = set()
     modules = [
         ("distributed", "scheduler"),
         ("distributed", "protocol", "serialize"),
     ]
     cyext_modules = []
     for m in modules:
-        d = "."
-        for e in m[:-1]:
-            d = os.path.join(d, e)
-            fn = os.path.join(d, "__init__.pxd")
-            to_remove.add(fn)
-            with open(fn, "w+") as fh:
-                fh.write("")
         p_py = os.path.join(*m) + os.extsep + "py"
         p_pyx = p_py + "x"
         m = ".".join(m)
@@ -63,8 +55,6 @@ if cython:
             "language_level": 3,
         }
         cyext_modules.append(e)
-    for fn in to_remove:
-        atexit.register(os.remove, fn)
     ext_modules.extend(cyext_modules)
 
 


### PR DESCRIPTION
As the modules we Cythonize are `.py` file, both the compiled extension and the `.py` file get installed. On macOS and Linux, this doesn't appear to present an issue as the `.so` will be loaded before the `.py` file. So the `.py` files are effectively ignored on these platforms. However it seems Windows loads the `.py` file before the `.pyd` (Windows compiled extension).

To fix this, we make some tweaks to the build process. Namely we rename the `.py` file to a `.pyx` file, which exclude from packaging (just as we exclude the `.c` file Cython generates). Thus we avoid having two files with the same name and different file extensions, which may be loaded in arbitrary order. We make sure to return the source directory to the original state by reverting the renaming when we are done.

For this to work effectively on CI, we start installing into the Conda environment instead of doing an editable install. This way we know only the compiled extension was installed.