### PR TITLE
Use `.pop(...)` to remove `key`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5212,9 +5212,7 @@ class Scheduler(ServerNode):
         ts._who_wants.clear()
         ts._processing_on = None
         ts._exception_blame = ts._exception = ts._traceback = None
-
-        if key in self.task_metadata:
-            del self.task_metadata[key]
+        self.task_metadata.pop(key, None)
 
     def _propagate_forgotten(self, ts: TaskState, recommendations):
         ts.state = "forgotten"


### PR DESCRIPTION
Instead of checking for the `key` and then using `del` to remove it, simply do it in one operation with `.pop(...)`. If the key exists, it will be removed. If not, nothing happens.