### PR TITLE
Optimize `get_comm_cost`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4376,10 +4376,11 @@ class Scheduler(ServerNode):
         on the given worker.
         """
         dts: TaskState
-        return (
-            sum([dts._nbytes for dts in ts._dependencies - ws._has_what])
-            / self.bandwidth
-        )
+        deps: set = ts._dependencies - ws._has_what
+        nbytes: Py_ssize_t = 0
+        for dts in deps:
+            nbytes += dts._nbytes
+        return nbytes / self.bandwidth
 
     def get_task_duration(self, ts: TaskState, default=None):
         """


### PR DESCRIPTION
Instead of using a generator expression to build out a `list` and `sum` it, simply iterate through each object and accumulate the total ourselves. In Cython this works out to be a `for`-loop roughly with the addition itself occurring just the same in C.