### PR TITLE
Optimize `valid_workers`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5544,7 +5544,7 @@ class Scheduler(ServerNode):
                 s |= ss
 
         if ts._resource_restrictions:
-            w = {
+            dw = {
                 resource: {
                     w
                     for w, supplied in self.resources[resource].items()
@@ -5553,7 +5553,7 @@ class Scheduler(ServerNode):
                 for resource, required in ts._resource_restrictions.items()
             }
 
-            ww = set.intersection(*w.values())
+            ww = set.intersection(*dw.values())
             if s is True:
                 s = ww
             else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5536,8 +5536,8 @@ class Scheduler(ServerNode):
             # may not be connected when host_restrictions is populated
             hr = [self.coerce_hostname(h) for h in ts._host_restrictions]
             # XXX need HostState?
-            ss = [self.host_info[h]["addresses"] for h in hr if h in self.host_info]
-            ss = set.union(*ss) if ss else set()
+            sl = [self.host_info[h]["addresses"] for h in hr if h in self.host_info]
+            ss = set.union(*sl) if sl else set()
             if s is True:
                 s = ss
             else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2225,7 +2225,7 @@ class Scheduler(ServerNode):
 
             recommendations = {}
             for ts in list(self.unrunnable):
-                valid = self.valid_workers(ts)
+                valid: set = self.valid_workers(ts)
                 if valid is None or ws in valid:
                     recommendations[ts._key] = "waiting"
 
@@ -4655,7 +4655,7 @@ class Scheduler(ServerNode):
         """
         Decide on a worker for task *ts*.  Return a WorkerState.
         """
-        valid_workers = self.valid_workers(ts)
+        valid_workers: set = self.valid_workers(ts)
 
         if (
             valid_workers is not None
@@ -5521,7 +5521,7 @@ class Scheduler(ServerNode):
             else:
                 saturated.discard(ws)
 
-    def valid_workers(self, ts: TaskState):
+    def valid_workers(self, ts: TaskState) -> set:
         """Return set of currently valid workers for key
 
         If all workers are valid then this returns ``None``.
@@ -5531,7 +5531,7 @@ class Scheduler(ServerNode):
         *  host_restrictions
         *  resource_restrictions
         """
-        s = None
+        s: set = None
 
         if ts._worker_restrictions:
             s = {w for w in ts._worker_restrictions if w in self.workers}
@@ -6084,7 +6084,7 @@ class Scheduler(ServerNode):
             return len(self.workers) - len(to_close)
 
 
-def decide_worker(ts: TaskState, all_workers, valid_workers, objective):
+def decide_worker(ts: TaskState, all_workers, valid_workers: set, objective):
     """
     Decide which worker should take task *ts*.
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5554,7 +5554,6 @@ class Scheduler(ServerNode):
             }
 
             ww = set.intersection(*w.values())
-
             if s is True:
                 s = ww
             else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5534,17 +5534,19 @@ class Scheduler(ServerNode):
         if ts._host_restrictions:
             # Resolve the alias here rather than early, for the worker
             # may not be connected when host_restrictions is populated
-            hr = [self.coerce_hostname(h) for h in ts._host_restrictions]
+            hr: list = [self.coerce_hostname(h) for h in ts._host_restrictions]
             # XXX need HostState?
-            sl = [self.host_info[h]["addresses"] for h in hr if h in self.host_info]
-            ss = set.union(*sl) if sl else set()
+            sl: list = [
+                self.host_info[h]["addresses"] for h in hr if h in self.host_info
+            ]
+            ss: set = set.union(*sl) if sl else set()
             if s is True:
                 s = ss
             else:
                 s |= ss
 
         if ts._resource_restrictions:
-            dw = {
+            dw: dict = {
                 resource: {
                     w
                     for w, supplied in self.resources[resource].items()
@@ -5553,7 +5555,7 @@ class Scheduler(ServerNode):
                 for resource, required in ts._resource_restrictions.items()
             }
 
-            ww = set.intersection(*dw.values())
+            ww: set = set.intersection(*dw.values())
             if s is True:
                 s = ww
             else:


### PR DESCRIPTION
Annotates `valid_workers` for Cython optimization. In particular ensure it always returns a `set` or `None` (in case all workers are viable instead of `True` as before). Also use unique variables when they have already been assigned or if new results may have different types than before. This makes it easier to annotate these variables and for Cython to then optimize usage thereof.