### PR TITLE
Store occupancy in `_reevaluate_occupancy_worker`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5986,8 +5986,9 @@ class Scheduler(ServerNode):
         for ts in ws._processing:
             duration = self.get_task_duration(ts)
             comm = self.get_comm_cost(ts, ws)
-            ws._processing[ts] = duration + comm
-            new += duration + comm
+            occupancy = duration + comm
+            ws._processing[ts] = occupancy
+            new += occupancy
 
         ws._occupancy = new
         self.total_occupancy += new - old


### PR DESCRIPTION
Instead of computing the sum of the task duration and communication cost repeatedly, simply compute it once and assign it to a variable. Then reuse it in later steps.