### PR TITLE
Annotation of some comm related methods in the Scheduler

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4200,7 +4200,7 @@ class Scheduler(ServerNode):
             if client:
                 self.client_desires_keys(keys=list(who_has), client=client)
 
-    def report_on_key(self, key=None, ts: TaskState = None, client=None):
+    def report_on_key(self, key: str = None, ts: TaskState = None, client: str = None):
         assert (key is None) + (ts is None) == 1, (key, ts)
         if ts is None:
             try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3097,9 +3097,8 @@ class Scheduler(ServerNode):
 
         k: str
         for k in client_keys:
-            try:
-                c = client_comms[k]
-            except KeyError:
+            c = client_comms.get(k)
+            if c is None:
                 continue
             try:
                 c.send(msg)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3066,7 +3066,7 @@ class Scheduler(ServerNode):
     # Manage Messages #
     ###################
 
-    def report(self, msg, ts: TaskState = None, client=None):
+    def report(self, msg: dict, ts: TaskState = None, client: str = None):
         """
         Publish updates to all listening Queues and Comms
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4203,8 +4203,9 @@ class Scheduler(ServerNode):
     def report_on_key(self, key: str = None, ts: TaskState = None, client: str = None):
         assert (key is None) != (ts is None), (key, ts)
         if ts is None:
+            tasks: dict = self.tasks
             try:
-                ts = self.tasks[key]
+                ts = tasks[key]
             except KeyError:
                 self.report({"op": "cancelled-key", "key": key}, client=client)
                 return

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3095,6 +3095,7 @@ class Scheduler(ServerNode):
             ]
             client_keys.append(client)
 
+        k: str
         for k in client_keys:
             try:
                 c = client_comms[k]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3073,8 +3073,10 @@ class Scheduler(ServerNode):
         If the message contains a key then we only send the message to those
         comms that care about the key.
         """
-        if ts is None and "key" in msg:
-            ts = self.tasks.get(msg["key"])
+        if ts is None:
+            msg_key = msg.get("key")
+            if msg_key is not None:
+                ts = self.tasks.get(msg_key)
 
         cs: ClientState
         if ts is None:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3080,6 +3080,7 @@ class Scheduler(ServerNode):
                 ts = tasks.get(msg_key)
 
         cs: ClientState
+        client_keys: list
         if ts is None:
             # Notify all clients
             client_keys = list(self.client_comms)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3363,8 +3363,9 @@ class Scheduler(ServerNode):
         This also handles connection failures by adding a callback to remove
         the worker on the next cycle.
         """
+        stream_comms: dict = self.stream_comms
         try:
-            self.stream_comms[worker].send(msg)
+            stream_comms[worker].send(msg)
         except (CommClosedError, AttributeError):
             self.loop.add_callback(self.remove_worker, address=worker)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4204,9 +4204,8 @@ class Scheduler(ServerNode):
         assert (key is None) != (ts is None), (key, ts)
         if ts is None:
             tasks: dict = self.tasks
-            try:
-                ts = tasks[key]
-            except KeyError:
+            ts = tasks.get(key)
+            if ts is None:
                 self.report({"op": "cancelled-key", "key": key}, client=client)
                 return
         else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3080,10 +3080,11 @@ class Scheduler(ServerNode):
                 ts = tasks.get(msg_key)
 
         cs: ClientState
+        client_comms: dict = self.client_comms
         client_keys: list
         if ts is None:
             # Notify all clients
-            client_keys = list(self.client_comms)
+            client_keys = list(client_comms)
         elif client is None:
             # Notify clients interested in key
             client_keys = [cs._client_key for cs in ts._who_wants]
@@ -3096,7 +3097,7 @@ class Scheduler(ServerNode):
 
         for k in client_keys:
             try:
-                c = self.client_comms[k]
+                c = client_comms[k]
             except KeyError:
                 continue
             try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3076,7 +3076,8 @@ class Scheduler(ServerNode):
         if ts is None:
             msg_key = msg.get("key")
             if msg_key is not None:
-                ts = self.tasks.get(msg_key)
+                tasks: dict = self.tasks
+                ts = tasks.get(msg_key)
 
         cs: ClientState
         if ts is None:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4201,7 +4201,7 @@ class Scheduler(ServerNode):
                 self.client_desires_keys(keys=list(who_has), client=client)
 
     def report_on_key(self, key: str = None, ts: TaskState = None, client: str = None):
-        assert (key is None) + (ts is None) == 1, (key, ts)
+        assert (key is None) != (ts is None), (key, ts)
         if ts is None:
             try:
                 ts = self.tasks[key]


### PR DESCRIPTION
This does some annotation around comm related methods in the scheduler: `report_on_key`, `report`, and `worker_send`. Should help speed through the intermediate code needed to send out a message.