### PR TITLE
Optimize `assert` in `validate_waiting`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2950,7 +2950,7 @@ class Scheduler(ServerNode):
         assert ts not in self.unrunnable
         for dts in ts._dependencies:
             # We are waiting on a dependency iff it's not stored
-            assert bool(dts._who_has) != (dts in ts._waiting_on)
+            assert (not not dts._who_has) != (dts in ts._waiting_on)
             assert ts in dts._waiters  # XXX even if dts._who_has?
 
     def validate_processing(self, key):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2950,7 +2950,7 @@ class Scheduler(ServerNode):
         assert ts not in self.unrunnable
         for dts in ts._dependencies:
             # We are waiting on a dependency iff it's not stored
-            assert bool(dts._who_has) + (dts in ts._waiting_on) == 1
+            assert bool(dts._who_has) != (dts in ts._waiting_on)
             assert ts in dts._waiters  # XXX even if dts._who_has?
 
     def validate_processing(self, key):


### PR DESCRIPTION
Makes a few tweaks to this `assert` in `validate_waiting`. First `not not` ends up being faster than `bool(...)` in Python and Cython. The latter because it can skip constructing a Python `bool` object and continue operating in straight C. Second `!=` behaves like `xor` between `bool`s, which Cython can also do directly in C.