### PR TITLE
[WIP] Refactor communication out of transition functions

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2970,7 +2970,9 @@ class Scheduler(ServerNode):
             if ts._state in ("memory", "erred"):
                 self.report_on_key(ts=ts, client=client)
 
-    def client_releases_keys(self, keys=None, client=None):
+    def _client_releases_keys(
+        self, keys=None, client=None, recommendations: dict = None
+    ):
         """ Remove keys from client desired list """
         logger.debug("Client %s releases keys: %s", client, keys)
         cs: ClientState = self.clients[client]
@@ -2985,7 +2987,6 @@ class Scheduler(ServerNode):
                 if not s:
                     tasks2.add(ts)
 
-        recommendations: dict = {}
         for ts in tasks2:
             if not ts._dependents:
                 # No live dependents, can forget
@@ -2993,6 +2994,13 @@ class Scheduler(ServerNode):
             elif ts._state != "erred" and not ts._waiters:
                 recommendations[ts._key] = "released"
 
+    def client_releases_keys(self, keys=None, client=None):
+        """ Remove keys from client desired list """
+
+        recommendations: dict = {}
+        self._client_releases_keys(
+            keys=keys, client=client, recommendations=recommendations
+        )
         self.transitions(recommendations)
 
     def client_heartbeat(self, client=None):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4656,7 +4656,11 @@ class Scheduler(ServerNode):
 
         cs: ClientState = self.clients["fire-and-forget"]
         if ts in cs._wants_what:
-            self.client_releases_keys(client="fire-and-forget", keys=[ts._key])
+            self._client_releases_keys(
+                client="fire-and-forget",
+                keys=[ts._key],
+                recommendations=recommendations,
+            )
 
     def transition_released_waiting(self, key):
         try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4317,6 +4317,25 @@ class Scheduler(ServerNode):
         else:
             return None
 
+    def _task_to_client_msgs(self, ts: TaskState) -> dict:
+        cs: ClientState
+        clients: dict = self.clients
+        client_keys: list
+        if ts is None:
+            # Notify all clients
+            client_keys = list(clients)
+        else:
+            # Notify clients interested in key
+            client_keys = [cs._client_key for cs in ts._who_wants]
+
+        report_msg: dict = self._task_to_report_msg(ts)
+
+        client_msgs: dict = {}
+        for k in client_keys:
+            client_msgs[k] = report_msg
+
+        return client_msgs
+
     def report_on_key(self, key: str = None, ts: TaskState = None, client: str = None):
         if ts is None:
             tasks: dict = self.tasks

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5299,7 +5299,11 @@ class Scheduler(ServerNode):
 
             cs: ClientState = self.clients["fire-and-forget"]
             if ts in cs._wants_what:
-                self.client_releases_keys(client="fire-and-forget", keys=[key])
+                self._client_releases_keys(
+                    client="fire-and-forget",
+                    keys=[key],
+                    recommendations=recommendations,
+                )
 
             if self.validate:
                 assert not ts._processing_on

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3461,6 +3461,18 @@ class Scheduler(ServerNode):
         except (CommClosedError, AttributeError):
             self.loop.add_callback(self.remove_worker, address=worker)
 
+    def client_send(self, client, msg):
+        """Send message to client"""
+        client_comms: dict = self.client_comms
+        c = client_comms.get(client)
+        if c is None:
+            return
+        try:
+            c.send(msg)
+        except CommClosedError:
+            if self.status == Status.running:
+                logger.critical("Tried writing to closed comm: %s", msg)
+
     ############################
     # Less common interactions #
     ############################

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3262,42 +3262,47 @@ class Scheduler(ServerNode):
         )
         self.loop.call_later(cleanup_delay, remove_client_from_events)
 
+    def _task_to_msg(self, ts: TaskState, duration=None) -> dict:
+        """ Convert a single computational task to a message """
+        ws: WorkerState
+        dts: TaskState
+
+        if duration is None:
+            duration = self.get_task_duration(ts)
+
+        msg: dict = {
+            "op": "compute-task",
+            "key": ts._key,
+            "priority": ts._priority,
+            "duration": duration,
+        }
+        if ts._resource_restrictions:
+            msg["resource_restrictions"] = ts._resource_restrictions
+        if ts._actor:
+            msg["actor"] = True
+
+        deps: set = ts._dependencies
+        if deps:
+            msg["who_has"] = {
+                dts._key: [ws._address for ws in dts._who_has] for dts in deps
+            }
+            msg["nbytes"] = {dts._key: dts._nbytes for dts in deps}
+
+            if self.validate:
+                assert all(msg["who_has"].values())
+
+        task = ts._run_spec
+        if type(task) is dict:
+            msg.update(task)
+        else:
+            msg["task"] = task
+
+        return msg
+
     def send_task_to_worker(self, worker, ts: TaskState, duration=None):
         """ Send a single computational task to a worker """
         try:
-            ws: WorkerState
-            dts: TaskState
-
-            if duration is None:
-                duration = self.get_task_duration(ts)
-
-            msg: dict = {
-                "op": "compute-task",
-                "key": ts._key,
-                "priority": ts._priority,
-                "duration": duration,
-            }
-            if ts._resource_restrictions:
-                msg["resource_restrictions"] = ts._resource_restrictions
-            if ts._actor:
-                msg["actor"] = True
-
-            deps: set = ts._dependencies
-            if deps:
-                msg["who_has"] = {
-                    dts._key: [ws._address for ws in dts._who_has] for dts in deps
-                }
-                msg["nbytes"] = {dts._key: dts._nbytes for dts in deps}
-
-                if self.validate:
-                    assert all(msg["who_has"].values())
-
-            task = ts._run_spec
-            if type(task) is dict:
-                msg.update(task)
-            else:
-                msg["task"] = task
-
+            msg: dict = self._task_to_msg(ts, duration)
             self.worker_send(worker, msg)
         except Exception as e:
             logger.exception(e)


### PR DESCRIPTION
Currently transition functions alternate between working on the task graph a bit and communicate out to workers and clients. As it is, this is pretty interwoven. Sometimes going back and forth between these two modes of processing multiple times in the same function. This makes it a little tricky to optimize the transition functions further as often the communication is handled in high-level Python and doesn't improve much through Cythonization. Further this makes a bit tricky to pull apart the transitions functions and task graph state from the Scheduler as it is a bit too reliant on these communication steps.

To attempt to remedy this situation, this PR tries to move all of the communication out of the transition functions. It does this by trying to return all messages to be communicated and handling those in `transition` after each transition function completes. While transition functions and communication still effectively interleave at a higher level, this should make it easier to separate out the transition functions along with relevant state for further optimization.