### PR TITLE
Drop serialize extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,6 @@ if cython:
             "distributed.scheduler",
             sources=["distributed/scheduler.py"],
         ),
-        Extension(
-            "distributed.protocol.serialize",
-            sources=["distributed/protocol/serialize.py"],
-        ),
     ]
     for e in cyext_modules:
         e.cython_directives = {


### PR DESCRIPTION
This disables Cythonizing `serialize`. While we have annotated one function in that module, most of `serialize` is not Cythonized. Additionally there are some `ImportError`s in development mode that have been getting in the way. So suggest we just drop this for now and revisit if this becomes more important in the future.