### PR TITLE
Use annotations machinery for workers/priority/...

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2279,9 +2279,10 @@ class Scheduler(ServerNode):
         user_priority=0,
         actors=None,
         fifo_timeout=0,
+        annotations=None,
     ):
 
-        dsk, dependencies, annotations = highlevelgraph_unpack(hlg)
+        dsk, dependencies, annotations = highlevelgraph_unpack(hlg, annotations)
 
         # Remove any self-dependencies (happens on test_publish_bag() and others)
         for k, v in dependencies.items():

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6397,3 +6397,12 @@ async def test_annotations_loose_restrictions(c, s, a, b):
             for ts in s.tasks.values()
         ]
     )
+
+
+@gen_cluster(client=True)
+async def test_workers_collection_restriction(c, s, a, b):
+    da = pytest.importorskip("dask.array")
+
+    future = c.compute(da.arange(10), workers=a.address)
+    await future
+    assert a.data and not b.data


### PR DESCRIPTION
Previously we had two systems to send per-task metadata like retries or
workers or priorities to the scheduler.

1.  Older system with explicit workers= keywords and expand_foo functions
2.  Newer system with annotations

The annotations system is nicer for a few reasons:

1.  It's more generic
2.  It's more consistent (there were some bugs in the expand foo
    functions, especially when dealing with collections)
3.  We ship values up on a per-layer basis rather than a per-key basis

This work-in-progress commit rips out the old system and uses the new system,
but it still missing a lot:

1.  It only implements this for the Client.compute method.
    We need to repeat this for persist, submit, and map
2.  It doesn't handle the allow_other_workers -> loose_restrictions
    conversion anywhere yet.  (this will need to be added to the
    scheduler)

cc @sjperkins if you have time I'd love your thoughts on this approach.  Also, if you agree with this approach and want to take over this PR that would also be welcome :)  