### PR TITLE
Some common optimizations across transitions

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6221,7 +6221,7 @@ def validate_task_state(ts: TaskState):
         assert dts.state != "forgotten"
 
     assert (ts._processing_on is not None) == (ts.state == "processing")
-    assert bool(ts._who_has) == (ts.state == "memory"), (ts, ts._who_has)
+    assert (not not ts._who_has) == (ts.state == "memory"), (ts, ts._who_has)
 
     if ts.state == "processing":
         assert all([dts._who_has for dts in ts._dependencies]), (

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2218,7 +2218,8 @@ class Scheduler(ServerNode):
             recommendations: dict
             if nbytes:
                 for key in nbytes:
-                    ts: TaskState = self.tasks.get(key)
+                    tasks: dict = self.tasks
+                    ts: TaskState = tasks.get(key)
                     if ts is not None and ts.state in ("processing", "waiting"):
                         recommendations = self.transition(
                             key,
@@ -4571,7 +4572,8 @@ class Scheduler(ServerNode):
 
     def transition_released_waiting(self, key):
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             dts: TaskState
 
             if self.validate:
@@ -4624,7 +4626,8 @@ class Scheduler(ServerNode):
 
     def transition_no_worker_waiting(self, key):
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             dts: TaskState
 
             if self.validate:
@@ -4710,7 +4713,8 @@ class Scheduler(ServerNode):
 
     def transition_waiting_processing(self, key):
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             dts: TaskState
 
             if self.validate:
@@ -4759,7 +4763,8 @@ class Scheduler(ServerNode):
     def transition_waiting_memory(self, key, nbytes=None, worker=None, **kwargs):
         try:
             ws: WorkerState = self.workers[worker]
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
 
             if self.validate:
                 assert not ts._processing_on
@@ -4804,7 +4809,8 @@ class Scheduler(ServerNode):
         ws: WorkerState
         wws: WorkerState
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             assert worker
             assert isinstance(worker, str)
 
@@ -4904,7 +4910,8 @@ class Scheduler(ServerNode):
     def transition_memory_released(self, key, safe=False):
         ws: WorkerState
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             dts: TaskState
 
             if self.validate:
@@ -4964,7 +4971,8 @@ class Scheduler(ServerNode):
 
     def transition_released_erred(self, key):
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             dts: TaskState
             failing_ts: TaskState
 
@@ -5007,7 +5015,8 @@ class Scheduler(ServerNode):
 
     def transition_erred_released(self, key):
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             dts: TaskState
 
             if self.validate:
@@ -5042,7 +5051,8 @@ class Scheduler(ServerNode):
 
     def transition_waiting_released(self, key):
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
 
             if self.validate:
                 assert not ts._who_has
@@ -5079,7 +5089,8 @@ class Scheduler(ServerNode):
 
     def transition_processing_released(self, key):
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             dts: TaskState
 
             if self.validate:
@@ -5127,7 +5138,8 @@ class Scheduler(ServerNode):
     ):
         ws: WorkerState
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             dts: TaskState
             failing_ts: TaskState
 
@@ -5196,7 +5208,8 @@ class Scheduler(ServerNode):
 
     def transition_no_worker_released(self, key):
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
             dts: TaskState
 
             if self.validate:
@@ -5222,7 +5235,8 @@ class Scheduler(ServerNode):
             raise
 
     def remove_key(self, key):
-        ts: TaskState = self.tasks.pop(key)
+        tasks: dict = self.tasks
+        ts: TaskState = tasks.pop(key)
         assert ts.state == "forgotten"
         self.unrunnable.discard(ts)
         cs: ClientState
@@ -5273,9 +5287,11 @@ class Scheduler(ServerNode):
         ts._who_has.clear()
 
     def transition_memory_forgotten(self, key):
+        tasks: dict
         ws: WorkerState
         try:
-            ts: TaskState = self.tasks[key]
+            tasks = self.tasks
+            ts: TaskState = tasks[key]
 
             if self.validate:
                 assert ts.state == "memory"
@@ -5315,7 +5331,8 @@ class Scheduler(ServerNode):
 
     def transition_released_forgotten(self, key):
         try:
-            ts: TaskState = self.tasks[key]
+            tasks: dict = self.tasks
+            ts: TaskState = tasks[key]
 
             if self.validate:
                 assert ts.state in ("released", "erred")

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4541,6 +4541,7 @@ class Scheduler(ServerNode):
         if len(deps) > 1:
             deps = sorted(deps, key=operator.attrgetter("priority"), reverse=True)
         dts: TaskState
+        s: set
         for dts in deps:
             s = dts._waiting_on
             if ts in s:
@@ -4557,7 +4558,7 @@ class Scheduler(ServerNode):
         if not ts._waiters and not ts._who_wants:
             recommendations[ts._key] = "released"
         else:
-            msg = {"op": "key-in-memory", "key": ts._key}
+            msg: dict = {"op": "key-in-memory", "key": ts._key}
             if type is not None:
                 msg["type"] = type
             self.report(msg)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2215,6 +2215,7 @@ class Scheduler(ServerNode):
                 except Exception as e:
                     logger.exception(e)
 
+            recommendations: dict
             if nbytes:
                 for key in nbytes:
                     ts: TaskState = self.tasks.get(key)
@@ -2547,7 +2548,7 @@ class Scheduler(ServerNode):
                 ts._retries = v
 
         # Compute recommendations
-        recommendations = {}
+        recommendations: dict = {}
 
         for ts in sorted(runnables, key=operator.attrgetter("priority"), reverse=True):
             if ts.state == "released" and ts._run_spec:
@@ -2623,6 +2624,7 @@ class Scheduler(ServerNode):
         ws: WorkerState = self.workers[worker]
         ts._metadata.update(kwargs["metadata"])
 
+        recommendations: dict
         if ts.state == "processing":
             recommendations = self.transition(key, "memory", worker=worker, **kwargs)
 
@@ -2653,6 +2655,7 @@ class Scheduler(ServerNode):
         if ts is None:
             return {}
 
+        recommendations: dict
         if ts.state == "processing":
             retries = ts._retries
             if retries > 0:
@@ -2685,7 +2688,7 @@ class Scheduler(ServerNode):
                 return {}
             cts: TaskState = self.tasks.get(cause)
 
-            recommendations = {}
+            recommendations: dict = {}
 
             if cts is not None and cts.state == "memory":  # couldn't find this
                 ws: WorkerState
@@ -2725,7 +2728,7 @@ class Scheduler(ServerNode):
             else:
                 roots.append(key)
 
-        recommendations = {key: "waiting" for key in roots}
+        recommendations: dict = {key: "waiting" for key in roots}
         self.transitions(recommendations)
 
         if self.validate:
@@ -2786,7 +2789,7 @@ class Scheduler(ServerNode):
             ws.status = Status.closed
             self.total_occupancy -= ws._occupancy
 
-            recommendations = {}
+            recommendations: dict = {}
 
             ts: TaskState
             for ts in list(ws._processing):
@@ -2914,7 +2917,7 @@ class Scheduler(ServerNode):
                 if not s:
                     tasks2.add(ts)
 
-        recommendations = {}
+        recommendations: dict = {}
         for ts in tasks2:
             if not ts._dependents:
                 # No live dependents, can forget
@@ -3286,7 +3289,7 @@ class Scheduler(ServerNode):
         ws._has_what -= removed_tasks
 
         ts: TaskState
-        recommendations = {}
+        recommendations: dict = {}
         for ts in removed_tasks:
             ws._nbytes -= ts.get_nbytes()
             wh = ts._who_has
@@ -4518,7 +4521,7 @@ class Scheduler(ServerNode):
         self,
         ts: TaskState,
         ws: WorkerState,
-        recommendations,
+        recommendations: dict,
         type=None,
         typename=None,
         **kwargs,
@@ -4583,7 +4586,7 @@ class Scheduler(ServerNode):
 
             ts.state = "waiting"
 
-            recommendations = {}
+            recommendations: dict = {}
 
             dts: TaskState
             for dts in ts._dependencies:
@@ -4635,7 +4638,7 @@ class Scheduler(ServerNode):
             if ts._has_lost_dependencies:
                 return {key: "forgotten"}
 
-            recommendations = {}
+            recommendations: dict = {}
 
             for dts in ts._dependencies:
                 dep = dts._key
@@ -4770,7 +4773,7 @@ class Scheduler(ServerNode):
 
             self.check_idle_saturated(ws)
 
-            recommendations = {}
+            recommendations: dict = {}
 
             self._add_to_memory(ts, ws, recommendations, **kwargs)
 
@@ -4879,7 +4882,7 @@ class Scheduler(ServerNode):
             if nbytes is not None:
                 ts.set_nbytes(nbytes)
 
-            recommendations = {}
+            recommendations: dict = {}
 
             self._remove_from_processing(ts)
 
@@ -4918,7 +4921,7 @@ class Scheduler(ServerNode):
                     ts._exception = "Worker holding Actor was lost"
                     return {ts._key: "erred"}  # don't try to recreate
 
-            recommendations = {}
+            recommendations: dict = {}
 
             for dts in ts._waiters:
                 if dts.state in ("no-worker", "processing"):
@@ -4972,7 +4975,7 @@ class Scheduler(ServerNode):
                     assert not ts._waiting_on
                     assert not ts._waiters
 
-            recommendations = {}
+            recommendations: dict = {}
 
             failing_ts = ts._exception_blame
 
@@ -5015,7 +5018,7 @@ class Scheduler(ServerNode):
                     assert not ts._waiting_on
                     assert not ts._waiters
 
-            recommendations = {}
+            recommendations: dict = {}
 
             ts._exception = None
             ts._exception_blame = None
@@ -5045,7 +5048,7 @@ class Scheduler(ServerNode):
                 assert not ts._who_has
                 assert not ts._processing_on
 
-            recommendations = {}
+            recommendations: dict = {}
 
             dts: TaskState
             for dts in ts._dependencies:
@@ -5091,7 +5094,7 @@ class Scheduler(ServerNode):
 
             ts.state = "released"
 
-            recommendations = {}
+            recommendations: dict = {}
 
             if ts._has_lost_dependencies:
                 recommendations[key] = "forgotten"
@@ -5150,7 +5153,7 @@ class Scheduler(ServerNode):
             else:
                 failing_ts = ts._exception_blame
 
-            recommendations = {}
+            recommendations: dict = {}
 
             for dts in ts._dependents:
                 dts._exception_blame = failing_ts
@@ -5230,7 +5233,7 @@ class Scheduler(ServerNode):
         ts._exception_blame = ts._exception = ts._traceback = None
         self.task_metadata.pop(key, None)
 
-    def _propagate_forgotten(self, ts: TaskState, recommendations):
+    def _propagate_forgotten(self, ts: TaskState, recommendations: dict):
         ts.state = "forgotten"
         key: str = ts._key
         dts: TaskState
@@ -5290,7 +5293,7 @@ class Scheduler(ServerNode):
                 else:
                     assert 0, (ts,)
 
-            recommendations = {}
+            recommendations: dict = {}
 
             if ts._actor:
                 for ws in ts._who_has:
@@ -5331,7 +5334,7 @@ class Scheduler(ServerNode):
                 else:
                     assert 0, (ts,)
 
-            recommendations = {}
+            recommendations: dict = {}
             self._propagate_forgotten(ts, recommendations)
 
             self.report_on_key(ts=ts)
@@ -5376,6 +5379,7 @@ class Scheduler(ServerNode):
                 dependents = set(ts._dependents)
                 dependencies = set(ts._dependencies)
 
+            recommendations: dict = {}
             if (start, finish) in self._transitions:
                 func = self._transitions[start, finish]
                 recommendations = func(key, *args, **kwargs)
@@ -5439,7 +5443,7 @@ class Scheduler(ServerNode):
                 pdb.set_trace()
             raise
 
-    def transitions(self, recommendations):
+    def transitions(self, recommendations: dict):
         """Process transitions until none are left
 
         This includes feedback from previous transitions and continues until we

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4537,9 +4537,10 @@ class Scheduler(ServerNode):
         ws._has_what.add(ts)
         ws._nbytes += ts.get_nbytes()
 
-        deps = ts._dependents
+        deps: list = list(ts._dependents)
         if len(deps) > 1:
-            deps = sorted(deps, key=operator.attrgetter("priority"), reverse=True)
+            deps.sort(key=operator.attrgetter("priority"), reverse=True)
+
         dts: TaskState
         s: set
         for dts in deps:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5232,7 +5232,7 @@ class Scheduler(ServerNode):
 
     def _propagate_forgotten(self, ts: TaskState, recommendations):
         ts.state = "forgotten"
-        key = ts._key
+        key: str = ts._key
         dts: TaskState
         for dts in ts._dependents:
             dts._has_lost_dependencies = True
@@ -5246,7 +5246,7 @@ class Scheduler(ServerNode):
 
         for dts in ts._dependencies:
             dts._dependents.remove(ts)
-            s = dts._waiters
+            s: set = dts._waiters
             s.discard(ts)
             if not dts._dependents and not dts._who_wants:
                 # Task not needed anymore
@@ -5262,7 +5262,7 @@ class Scheduler(ServerNode):
         for ws in ts._who_has:
             ws._has_what.remove(ts)
             ws._nbytes -= ts.get_nbytes()
-            w = ws._address
+            w: str = ws._address
             if w in self.workers:  # in case worker has died
                 self.worker_send(
                     w, {"op": "delete-data", "keys": [key], "report": False}

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5575,10 +5575,10 @@ class Scheduler(ServerNode):
             else:
                 s &= ww
 
-        if s is None:
-            return s
-        else:
-            return {self.workers[w] for w in s}
+        if s is not None:
+            s = {self.workers[w] for w in s}
+
+        return s
 
     def consume_resources(self, ts: TaskState, ws: WorkerState):
         if ts._resource_restrictions:


### PR DESCRIPTION
Makes sure `self.tasks` is treated as a `dict` by assigning to a locally typed variable. Similarly type `recommendations` as a `dict` throughout since that is commonly what it is. This allows Cython to use the Python C API for `dict`s with these objects.

Also uses `TaskState`'s `_state` attribute for faster access when just getting it and not setting it.

Annotate variables (both in arguments and locally) of the private methods used by various transitions.

Finally make a few other minor arrangements to favorably affect the C generated by Cython.