### PR TITLE
Use task annotation priotities for user-level priorities

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2448,7 +2448,7 @@ class Scheduler(ServerNode):
         # Override existing taxonomy with per task annotations
         if annotations:
             if "priority" in annotations:
-                priority.update(annotations["priority"])
+                user_priority.update(annotations["priority"])
 
             if "workers" in annotations:
                 restrictions.update(annotations["workers"])

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6325,6 +6325,7 @@ async def test_annotations_priorities(c, s, a, b):
         x = await x.persist()
 
     assert all("15" in str(ts.priority) for ts in s.tasks.values())
+    assert all(ts.priority[0] == -15 for ts in s.tasks.values())
     assert all({"priority": 15} == ts.annotations for ts in s.tasks.values())
 
 


### PR DESCRIPTION
I noticed our (awesome) new ability to assign task priority using `dask.annotate` is updating the graph-level priority for tasks and not the user-level priority.

For reference, there are three different types of priorities which we use to determine how tasks should be scheduled:

1. Priorities given directly from the user through the `priority=` keyword in `client.submit`, `client.persist`, etc.
2. Time-based priorities where older tasks are assigned a higher priority than newly submitted tasks (i.e. FIFO priority)
3. Graph structure related priorities which are assigned via `dask.order.order`

My understanding is the priority specified with `dask.annotate(priority=...)` should have the same affect as those specified with `client.submit(priority=...)`, which are used to assign the user-level type of priority:

https://github.com/dask/distributed/blob/e5e2c55b14d734c023dba1b50c8dcaa22f8825c9/distributed/client.py#L1589

not the graph-level type of priority:

https://github.com/dask/distributed/blob/e5e2c55b14d734c023dba1b50c8dcaa22f8825c9/distributed/scheduler.py#L2479-L2481

This PR updates our handling of task annotations to align which flavor of priority is updated with those given via `client.submit(priority=...)`.

cc @sjperkins 
 