### PR TITLE
Cast `SortedDict`s to `dict`s in a few key places & other minor changes

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4710,7 +4710,7 @@ class Scheduler(ServerNode):
                 type(ws),
                 ws,
             )
-            assert ws.address in self.workers
+            assert ws._address in self.workers
 
         return ws
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4699,11 +4699,12 @@ class Scheduler(ServerNode):
             )
         else:
             worker_pool = self.idle or self.workers.values()
-            n_workers = len(worker_pool)
+            n_workers: Py_ssize_t = len(worker_pool)
             if n_workers < 20:  # smart but linear in small case
                 ws = min(worker_pool, key=operator.attrgetter("occupancy"))
             else:  # dumb but fast in large case
-                ws = worker_pool[self.n_tasks % n_workers]
+                n_tasks: Py_ssize_t = self.n_tasks
+                ws = worker_pool[n_tasks % n_workers]
 
         if self.validate:
             assert ws is None or isinstance(ws, WorkerState), (

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -303,7 +303,7 @@ class WorkStealing(SchedulerPlugin):
 
         with log_errors():
             i = 0
-            idle = s.idle
+            idle = s.idle.values()
             saturated = s.saturated
             if not idle or len(idle) == len(s.workers):
                 return


### PR DESCRIPTION
* Use a `SortedDict` for `self.idle` (can handle keys faster ourselves; plus leads to the next thing)
* Cast `SortedDict`s to `dict`s when viewing them (allows for the Python C API to be used on them)
* Type some variables containing integers for faster checks and mathematical operations
* Use `WorkerState` C-level attribute for faster access (missed previously)