### PR TITLE
Optimizations of `*State` and `Task*` objects and stealing

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -145,11 +145,12 @@ logger = logging.getLogger(__name__)
 
 
 LOG_PDB = dask.config.get("distributed.admin.pdb-on-err")
-DEFAULT_DATA_SIZE = parse_bytes(
-    dask.config.get("distributed.scheduler.default-data-size")
+DEFAULT_DATA_SIZE = declare(
+    Py_ssize_t, parse_bytes(dask.config.get("distributed.scheduler.default-data-size"))
 )
-UNKNOWN_TASK_DURATION = parse_timedelta(
-    dask.config.get("distributed.scheduler.unknown-task-duration")
+UNKNOWN_TASK_DURATION = declare(
+    double,
+    parse_timedelta(dask.config.get("distributed.scheduler.unknown-task-duration")),
 )
 
 DEFAULT_EXTENSIONS = [

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -86,7 +86,7 @@ from .variable import VariableExtension
 from .protocol.highlevelgraph import highlevelgraph_unpack
 
 try:
-    from cython import bint, cast, cclass, double, Py_hash_t, Py_ssize_t
+    from cython import bint, cast, ccall, cclass, double, Py_hash_t, Py_ssize_t
 except ImportError:
     from ctypes import (
         c_double as double,
@@ -98,6 +98,9 @@ except ImportError:
 
     def cast(T, v, *a, **k):
         return v
+
+    def ccall(func):
+        return func
 
     def cclass(cls):
         return cls

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4419,8 +4419,9 @@ class Scheduler(ServerNode):
             s: set = self.unknown_durations[ts._prefix._name]
             s.add(ts)
             if default < 0:
-                default = UNKNOWN_TASK_DURATION
-            return default
+                duration = UNKNOWN_TASK_DURATION
+            else:
+                duration = default
 
         return duration
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2621,7 +2621,8 @@ class Scheduler(ServerNode):
         """ Mark that a task has finished execution on a particular worker """
         logger.debug("Stimulus task finished %s, %s", key, worker)
 
-        ts: TaskState = self.tasks.get(key)
+        tasks: dict = self.tasks
+        ts: TaskState = tasks.get(key)
         if ts is None:
             return {}
         workers: dict = cast(dict, self.workers)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5556,7 +5556,7 @@ class Scheduler(ServerNode):
 
         idle = self.idle
         saturated: set = self.saturated
-        if p < nc or occ / nc < avg / 2:
+        if p < nc or occ < nc * avg / 2:
             idle[ws._address] = ws
             saturated.discard(ws)
         else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -531,7 +531,7 @@ class WorkerState:
             len(self._processing),
         )
 
-    def identity(self):
+    def identity(self) -> dict:
         return {
             "type": "Worker",
             "id": self._name,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4401,9 +4401,10 @@ class Scheduler(ServerNode):
         dts: TaskState
         deps: set = ts._dependencies - ws._has_what
         nbytes: Py_ssize_t = 0
+        bandwidth: double = self.bandwidth
         for dts in deps:
             nbytes += dts._nbytes
-        return nbytes / self.bandwidth
+        return nbytes / bandwidth
 
     def get_task_duration(self, ts: TaskState, default=None):
         """

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -86,7 +86,16 @@ from .variable import VariableExtension
 from .protocol.highlevelgraph import highlevelgraph_unpack
 
 try:
-    from cython import bint, cast, ccall, cclass, double, Py_hash_t, Py_ssize_t
+    from cython import (
+        bint,
+        cast,
+        ccall,
+        cclass,
+        double,
+        exceptval,
+        Py_hash_t,
+        Py_ssize_t,
+    )
 except ImportError:
     from ctypes import (
         c_double as double,
@@ -104,6 +113,12 @@ except ImportError:
 
     def cclass(cls):
         return cls
+
+    def exceptval(*a, **k):
+        def wrapper(func):
+            return func
+
+        return wrapper
 
 
 if sys.version_info < (3, 8):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -91,6 +91,7 @@ try:
         cast,
         ccall,
         cclass,
+        declare,
         double,
         exceptval,
         final,
@@ -114,6 +115,12 @@ except ImportError:
 
     def cclass(cls):
         return cls
+
+    def declare(*a, **k):
+        if len(a) == 2:
+            return a[1]
+        else:
+            pass
 
     def exceptval(*a, **k):
         def wrapper(func):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4413,7 +4413,8 @@ class Scheduler(ServerNode):
         """
         duration: double = ts._prefix._duration_average
         if duration < 0:
-            self.unknown_durations[ts._prefix._name].add(ts)
+            s: set = self.unknown_durations[ts._prefix._name]
+            s.add(ts)
             if default is None:
                 default = parse_timedelta(
                     dask.config.get("distributed.scheduler.unknown-task-duration")

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1384,6 +1384,13 @@ class TaskState:
 
                 pdb.set_trace()
 
+    def get_nbytes_deps(self):
+        nbytes: Py_ssize_t = 0
+        ts: TaskState
+        for ts in self._dependencies:
+            nbytes += ts.get_nbytes()
+        return nbytes
+
 
 class _StateLegacyMapping(Mapping):
     """

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4411,7 +4411,7 @@ class Scheduler(ServerNode):
         Get the estimated computation cost of the given task
         (not including any communication cost).
         """
-        duration = ts._prefix._duration_average
+        duration: double = ts._prefix._duration_average
         if duration < 0:
             self.unknown_durations[ts._prefix._name].add(ts)
             if default is None:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -159,6 +159,7 @@ DEFAULT_EXTENSIONS = [
 ALL_TASK_STATES = {"released", "waiting", "no-worker", "processing", "erred", "memory"}
 
 
+@final
 @cclass
 class ClientState:
     """
@@ -231,6 +232,7 @@ class ClientState:
         return self._versions
 
 
+@final
 @cclass
 class WorkerState:
     """
@@ -579,6 +581,7 @@ class WorkerState:
         return self._nthreads
 
 
+@final
 @cclass
 class TaskPrefix:
     """Collection tracking all tasks within a group
@@ -703,6 +706,7 @@ class TaskPrefix:
         return set().union(*[tg._types for tg in self._groups])
 
 
+@final
 @cclass
 class TaskGroup:
     """Collection tracking all tasks within a group
@@ -818,6 +822,7 @@ class TaskGroup:
         return sum(self._states.values())
 
 
+@final
 @cclass
 class TaskState:
     """

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5564,7 +5564,7 @@ class Scheduler(ServerNode):
 
             if p > nc:
                 pending: double = occ * (p - nc) / (p * nc)
-                if pending > 0.4 and pending > 1.9 * avg:
+                if 0.4 < pending > 1.9 * avg:
                     saturated.add(ws)
                 else:
                     saturated.discard(ws)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -95,6 +95,7 @@ try:
         double,
         exceptval,
         final,
+        inline,
         Py_hash_t,
         Py_ssize_t,
     )
@@ -130,6 +131,9 @@ except ImportError:
 
     def final(cls):
         return cls
+
+    def inline(func):
+        return func
 
 
 if sys.version_info < (3, 8):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5566,10 +5566,9 @@ class Scheduler(ServerNode):
                 pending: double = occ * (p - nc) / (p * nc)
                 if 0.4 < pending > 1.9 * avg:
                     saturated.add(ws)
-                else:
-                    saturated.discard(ws)
-            else:
-                saturated.discard(ws)
+                    return
+
+            saturated.discard(ws)
 
     def valid_workers(self, ts: TaskState) -> set:
         """Return set of currently valid workers for key

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -119,6 +119,9 @@ LOG_PDB = dask.config.get("distributed.admin.pdb-on-err")
 DEFAULT_DATA_SIZE = parse_bytes(
     dask.config.get("distributed.scheduler.default-data-size")
 )
+UNKNOWN_TASK_DURATION = parse_timedelta(
+    dask.config.get("distributed.scheduler.unknown-task-duration")
+)
 
 DEFAULT_EXTENSIONS = [
     LockExtension,
@@ -4416,9 +4419,7 @@ class Scheduler(ServerNode):
             s: set = self.unknown_durations[ts._prefix._name]
             s.add(ts)
             if default < 0:
-                default = parse_timedelta(
-                    dask.config.get("distributed.scheduler.unknown-task-duration")
-                )
+                default = UNKNOWN_TASK_DURATION
             return default
 
         return duration

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1295,7 +1295,7 @@ class TaskState:
         self._group._dependencies.add(other._group)
         other._dependents.add(self)
 
-    def get_nbytes(self) -> int:
+    def get_nbytes(self) -> Py_ssize_t:
         return self._nbytes if self._nbytes >= 0 else DEFAULT_DATA_SIZE
 
     def set_nbytes(self, nbytes: Py_ssize_t):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -96,6 +96,7 @@ try:
         exceptval,
         final,
         inline,
+        nogil,
         Py_hash_t,
         Py_ssize_t,
     )
@@ -133,6 +134,9 @@ except ImportError:
         return cls
 
     def inline(func):
+        return func
+
+    def nogil(func):
         return func
 
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -524,6 +524,7 @@ class WorkerState:
     def versions(self):
         return self._versions
 
+    @ccall
     def clean(self):
         """ Return a version of this object that is appropriate for serialization """
         ws: WorkerState = WorkerState(
@@ -549,6 +550,8 @@ class WorkerState:
             len(self._processing),
         )
 
+    @ccall
+    @exceptval(check=False)
     def identity(self) -> dict:
         return {
             "type": "Worker",
@@ -790,6 +793,7 @@ class TaskGroup:
     def types(self):
         return self._types
 
+    @ccall
     def add(self, o):
         ts: TaskState = o
         self._states[ts._state] += 1
@@ -1307,15 +1311,18 @@ class TaskState:
     def prefix_key(self):
         return self._prefix._name
 
+    @ccall
     def add_dependency(self, other: "TaskState"):
         """ Add another task as a dependency of this task """
         self._dependencies.add(other)
         self._group._dependencies.add(other._group)
         other._dependents.add(self)
 
+    @ccall
     def get_nbytes(self) -> Py_ssize_t:
         return self._nbytes if self._nbytes >= 0 else DEFAULT_DATA_SIZE
 
+    @ccall
     def set_nbytes(self, nbytes: Py_ssize_t):
         diff: Py_ssize_t = nbytes
         old_nbytes: Py_ssize_t = self._nbytes
@@ -1331,6 +1338,7 @@ class TaskState:
     def __repr__(self):
         return "<Task %r %s>" % (self._key, self._state)
 
+    @ccall
     def validate(self):
         try:
             for cs in self._who_wants:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5562,7 +5562,7 @@ class Scheduler(ServerNode):
         else:
             idle.pop(ws._address, None)
 
-            pending: double = occ * (p - nc) / p / nc
+            pending: double = occ * (p - nc) / (p * nc)
             if p > nc and pending > 0.4 and pending > 1.9 * avg:
                 saturated.add(ws)
             else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1340,6 +1340,7 @@ class TaskState:
         other._dependents.add(self)
 
     @ccall
+    @inline
     def get_nbytes(self) -> Py_ssize_t:
         return self._nbytes if self._nbytes >= 0 else DEFAULT_DATA_SIZE
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -93,6 +93,7 @@ try:
         cclass,
         double,
         exceptval,
+        final,
         Py_hash_t,
         Py_ssize_t,
     )
@@ -119,6 +120,9 @@ except ImportError:
             return func
 
         return wrapper
+
+    def final(cls):
+        return cls
 
 
 if sys.version_info < (3, 8):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3647,7 +3647,7 @@ class Scheduler(ServerNode):
 
         ws: WorkerState = self.workers[worker_address]
         ts: TaskState
-        tasks = {self.tasks[key] for key in keys}
+        tasks: set = {self.tasks[key] for key in keys}
         ws._has_what -= tasks
         for ts in tasks:
             ts._who_has.remove(ws)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5562,9 +5562,12 @@ class Scheduler(ServerNode):
         else:
             idle.pop(ws._address, None)
 
-            pending: double = occ * (p - nc) / (p * nc)
-            if p > nc and pending > 0.4 and pending > 1.9 * avg:
-                saturated.add(ws)
+            if p > nc:
+                pending: double = occ * (p - nc) / (p * nc)
+                if pending > 0.4 and pending > 1.9 * avg:
+                    saturated.add(ws)
+                else:
+                    saturated.discard(ws)
             else:
                 saturated.discard(ws)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4406,7 +4406,7 @@ class Scheduler(ServerNode):
             nbytes += dts._nbytes
         return nbytes / bandwidth
 
-    def get_task_duration(self, ts: TaskState, default=None):
+    def get_task_duration(self, ts: TaskState, default: double = -1):
         """
         Get the estimated computation cost of the given task
         (not including any communication cost).
@@ -4415,7 +4415,7 @@ class Scheduler(ServerNode):
         if duration < 0:
             s: set = self.unknown_durations[ts._prefix._name]
             s.add(ts)
-            if default is None:
+            if default < 0:
                 default = parse_timedelta(
                     dask.config.get("distributed.scheduler.unknown-task-duration")
                 )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2624,7 +2624,8 @@ class Scheduler(ServerNode):
         ts: TaskState = self.tasks.get(key)
         if ts is None:
             return {}
-        ws: WorkerState = self.workers[worker]
+        workers: dict = cast(dict, self.workers)
+        ws: WorkerState = workers[worker]
         ts._metadata.update(kwargs["metadata"])
 
         recommendations: dict

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1345,6 +1345,7 @@ class TaskState:
 
     @ccall
     @inline
+    @nogil
     def get_nbytes(self) -> Py_ssize_t:
         return self._nbytes if self._nbytes >= 0 else DEFAULT_DATA_SIZE
 

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -120,7 +120,7 @@ class WorkStealing(SchedulerPlugin):
         if not ts.dependencies:  # no dependencies fast path
             return 0, 0
 
-        nbytes = sum(dep.get_nbytes() for dep in ts.dependencies)
+        nbytes = ts.get_nbytes_deps()
 
         transfer_time = nbytes / self.scheduler.bandwidth + LATENCY
         split = ts.prefix.name


### PR DESCRIPTION
* Mark all `*State` and `Task*` `class`es as `final` (optimizes method class by disabling inheritance)
* Use `ccall` decorator  `*State` and `Task*` (provide C API functions that can be called quickly in Cython) 
* Use `declare` to type some module variables ( annotation doesn't work at the module level https://github.com/cython/cython/issues/3944 ) 
* Add `TaskState.get_nbytes_deps` to speed up computation in stealing
* Annotate `get_task_duration` used both to evaluate and steal (also used in `transition_waiting_processing`)
* Annotate `bandwidth` in `get_comm_cost`
* Some tweaks to `check_idle_saturated` to minimize zero division checks
* Optimize `get_nbytes` to work directly in C and inline itself when possible