### PR TITLE
Deadlocks and infinite loops connected to failed dependencies

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -638,7 +638,8 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
         # If an exception occured we will need to close the comm, if possible.
         # Otherwise the other end might wait for a reply while this end is
         # reusing the comm for something else.
-        comm.abort()
+        with suppress(Exception):
+            await comm.close()
         raise exc
     finally:
         if please_close:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2738,7 +2738,14 @@ class Scheduler(ServerNode):
                 ts._who_has,
             )
             if ws not in ts._who_has:
-                self.worker_send(worker, {"op": "release-task", "key": key})
+                self.worker_send(
+                    worker,
+                    {
+                        "op": "release-task",
+                        "key": key,
+                        "reason": "stimulus task finished",
+                    },
+                )
             recommendations = {}
 
         return recommendations
@@ -5223,7 +5230,12 @@ class Scheduler(ServerNode):
                 assert self.tasks[key].state == "processing"
 
             self._remove_from_processing(
-                ts, send_worker_msg={"op": "release-task", "key": key}
+                ts,
+                send_worker_msg={
+                    "op": "release-task",
+                    "key": key,
+                    "reason": "transition released",
+                },
             )
 
             ts.state = "released"

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1943,17 +1943,15 @@ class FatallySerializedObject:
 async def test_badly_serialized_input(c, s, a, b):
     o = BadlySerializedObject()
 
-    future = c.submit(inc, o)
+    future = c.submit(inc, o, key="broken")
     futures = c.map(inc, range(10))
 
     L = await c.gather(futures)
     assert list(L) == list(map(inc, range(10)))
     assert future.status == "error"
 
-    with pytest.raises(Exception) as info:
+    with pytest.raises(TypeError, match="hello!"):
         await future
-
-    assert "hello!" in str(info.value)
 
 
 @pytest.mark.skipif("True", reason="")

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -253,6 +253,7 @@ async def test_minimum_resource(c, s, a):
     client=True,
     nthreads=[("127.0.0.1", 2, {"resources": {"A": 1}})],
     active_rpc_timeout=10,
+    timeout=20,
 )
 async def test_prefer_constrained(c, s, a):
     futures = c.map(slowinc, range(1000), delay=0.1)

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -249,7 +249,11 @@ async def test_minimum_resource(c, s, a):
     assert a.total_resources == a.available_resources
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 2, {"resources": {"A": 1}})])
+@gen_cluster(
+    client=True,
+    nthreads=[("127.0.0.1", 2, {"resources": {"A": 1}})],
+    active_rpc_timeout=10,
+)
 async def test_prefer_constrained(c, s, a):
     futures = c.map(slowinc, range(1000), delay=0.1)
     constrained = c.map(inc, range(10), resources={"A": 1})

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -79,7 +79,7 @@ async def test_cancel_stress(c, s, *workers):
 def test_cancel_stress_sync(loop):
     da = pytest.importorskip("dask.array")
     x = da.random.random((50, 50), chunks=(2, 2))
-    with cluster(active_rpc_timeout=10) as (s, [a, b]):
+    with cluster(active_rpc_timeout=10, disconnect_timeout=10) as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
             x = c.persist(x)
             y = (x.sum(axis=0) + x.sum(axis=1) + 1).std()

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -228,6 +228,12 @@ async def test_close_connections(c, s, *workers):
         x = x.rechunk((1000, 1))
 
     future = c.compute(x.sum())
+
+    # need to wait to ensure the scheduler actually registered anything
+    # processing. Computation itself should take a few seconds so this should be
+    # a safe period to wait.
+    await asyncio.sleep(0.05)
+
     while any(s.processing.values()):
         await asyncio.sleep(0.5)
         worker = random.choice(list(workers))


### PR DESCRIPTION
Two fixes in here which are unfortunately a bit intertwined.

1. if `send_rcv` fails for whatever reason (e.g. deserialization error) but doesn't close the comm, the other end might still wait for a response. in the meantime this comm is resused, causing some weird behaviour, see also #4316 I'll still need to write a test capturing the behaviour described in there

2. If we are in the case of a bad_dep, the current implementation never detects this and we're stuck in an infinite loop since the condition `dep.suspicious_count > 5` is *never* hit. It is never hit because there are multiple calls to `release-keys`issued causing the worker to loose all its memory, therefore the suspicious count never climbs up but the task instance is reinitialized