### PR TITLE
Provide `setup.py` option to profile Cython code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,18 +21,26 @@ for r in requires:
     else:
         install_requires.append(r)
 
-try:
-    sys.argv.remove("--with-cython")
-    cython = True
-except ValueError:
-    cython = False
+cython_arg = None
+for i in range(len(sys.argv)):
+    if sys.argv[i].startswith("--with-cython"):
+        cython_arg = sys.argv[i]
+        del sys.argv[i]
+        break
 
 ext_modules = []
-if cython:
+if cython_arg:
     try:
-        import cython
+        import cython  # noqa: F401
     except ImportError:
         setup_requires.append("cython")
+
+    profile = False
+    try:
+        _, param = cython_arg.split("=")
+        profile = param == "profile"
+    except ValueError:
+        pass
 
     cyext_modules = [
         Extension(
@@ -46,6 +54,7 @@ if cython:
             "binding": False,
             "embedsignature": True,
             "language_level": 3,
+            "profile": profile,
         }
     ext_modules.extend(cyext_modules)
 


### PR DESCRIPTION
As it can be useful for development to profile the Cythonized code and this requires an argument be provided to the extensions to enable, go ahead and add some logic to `setup.py` to parse this option if provided. If it is not provided, profiling is turned off, which is preferable as this would impact the performance of the compiled code.

cc @quasiben