### PR TITLE
Dask internal inherit config

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -170,7 +170,7 @@ def main(
     if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
         config = deserialize_for_cli(os.environ["DASK_INTERNAL_INHERIT_CONFIG"])
         # Update the global config given priority to the existing global config
-        dask.config.update(dask.config.global_config, config, priority="old")
+        dask.config.update(dask.config.global_config, config)
 
     if not host and (tls_ca_file or tls_cert or tls_key):
         host = "tls://"

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -169,7 +169,6 @@ def main(
 
     if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
         config = deserialize_for_cli(os.environ["DASK_INTERNAL_INHERIT_CONFIG"])
-        # Update the global config given priority to the existing global config
         dask.config.update(dask.config.global_config, config)
 
     if not host and (tls_ca_file or tls_cert or tls_key):

--- a/distributed/cli/dask_spec.py
+++ b/distributed/cli/dask_spec.py
@@ -1,10 +1,13 @@
 import asyncio
 import click
 import json
+import os
 import sys
 import yaml
 
+import dask.config
 from distributed.deploy.spec import run_spec
+from distributed.utils import deserialize_for_cli
 
 
 @click.command(context_settings=dict(ignore_unknown_options=True))
@@ -13,6 +16,11 @@ from distributed.deploy.spec import run_spec
 @click.option("--spec-file", type=str, default=None, help="")
 @click.version_option()
 def main(args, spec: str, spec_file: str):
+
+    if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
+        config = deserialize_for_cli(os.environ["DASK_INTERNAL_INHERIT_CONFIG"])
+        dask.config.update(dask.config.global_config, config)
+
     if spec and spec_file or not spec and not spec_file:
         print("Must specify exactly one of --spec and --spec-file")
         sys.exit(1)

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -397,7 +397,6 @@ def main(
 
     if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
         config = deserialize_for_cli(os.environ["DASK_INTERNAL_INHERIT_CONFIG"])
-        # Update the global config given priority to the existing global config
         dask.config.update(dask.config.global_config, config)
 
     nannies = [

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -398,7 +398,7 @@ def main(
     if "DASK_INTERNAL_INHERIT_CONFIG" in os.environ:
         config = deserialize_for_cli(os.environ["DASK_INTERNAL_INHERIT_CONFIG"])
         # Update the global config given priority to the existing global config
-        dask.config.update(dask.config.global_config, config, priority="old")
+        dask.config.update(dask.config.global_config, config)
 
     nannies = [
         t(


### PR DESCRIPTION
Setting `priority="old"` when updating config with `DASK_INTERNAL_INHERIT_CONFIG` means that default config options can never be overridden.

When used in [`SSHCluster` to package up the local config](https://github.com/dask/distributed/blob/c2d87738828ddad421e4766cc9521b9e2c471857/distributed/deploy/ssh.py#L178-L180) to send to the scheduler and workers any value which has a [default set in `distributed.yaml`](https://github.com/dask/distributed/blob/master/distributed/distributed.yaml) will be returned to the default.

This change resolved my issue, however I'm guessing this option was included for a reason. @madsbk do you know why this was added?

Closes #4363 

---

I also added a test for the serialization as I ended up writing one as part of putting together the MVRE for #4363.