### PR TITLE
Refactor `SchedulerState` from `Scheduler`

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -135,6 +135,7 @@ class Server:
         connection_args=None,
         timeout=None,
         io_loop=None,
+        **kwargs,
     ):
         self.handlers = {
             "identity": self.identity,
@@ -229,6 +230,8 @@ class Server:
         )
 
         self.__stopped = False
+
+        super().__init__(**kwargs)
 
     @property
     def status(self):

--- a/distributed/http/scheduler/info.py
+++ b/distributed/http/scheduler/info.py
@@ -33,7 +33,13 @@ class Workers(RequestHandler):
                 "workers.html",
                 title="Workers",
                 scheduler=self.server,
-                **merge(self.server.__dict__, ns, self.extra, rel_path_statics),
+                **merge(
+                    self.server.__dict__,
+                    self.server.__pdict__,
+                    ns,
+                    self.extra,
+                    rel_path_statics,
+                ),
             )
 
 
@@ -49,7 +55,13 @@ class Worker(RequestHandler):
                 title="Worker: " + worker,
                 scheduler=self.server,
                 Worker=worker,
-                **merge(self.server.__dict__, ns, self.extra, rel_path_statics),
+                **merge(
+                    self.server.__dict__,
+                    self.server.__pdict__,
+                    ns,
+                    self.extra,
+                    rel_path_statics,
+                ),
             )
 
 
@@ -65,7 +77,13 @@ class Task(RequestHandler):
                 title="Task: " + task,
                 Task=task,
                 scheduler=self.server,
-                **merge(self.server.__dict__, ns, self.extra, rel_path_statics),
+                **merge(
+                    self.server.__dict__,
+                    self.server.__pdict__,
+                    ns,
+                    self.extra,
+                    rel_path_statics,
+                ),
             )
 
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1642,6 +1642,74 @@ class SchedulerState:
         self._workers_dv: dict = cast(dict, self._workers)
         super().__init__(**kwargs)
 
+    @property
+    def bandwidth(self):
+        return self._bandwidth
+
+    @property
+    def clients(self):
+        return self._clients
+
+    @property
+    def extensions(self):
+        return self._extensions
+
+    @property
+    def host_info(self):
+        return self._host_info
+
+    @property
+    def idle(self):
+        return self._idle
+
+    @property
+    def n_tasks(self):
+        return self._n_tasks
+
+    @property
+    def resources(self):
+        return self._resources
+
+    @property
+    def saturated(self):
+        return self._saturated
+
+    @property
+    def tasks(self):
+        return self._tasks
+
+    @property
+    def total_nthreads(self):
+        return self._total_nthreads
+
+    @property
+    def total_occupancy(self):
+        return self._total_occupancy
+
+    @total_occupancy.setter
+    def total_occupancy(self, v: double):
+        self._total_occupancy = v
+
+    @property
+    def unknown_durations(self):
+        return self._unknown_durations
+
+    @property
+    def unrunnable(self):
+        return self._unrunnable
+
+    @property
+    def validate(self):
+        return self._validate
+
+    @validate.setter
+    def validate(self, v: bint):
+        self._validate = v
+
+    @property
+    def workers(self):
+        return self._workers
+
     def _remove_from_processing(self, ts: TaskState) -> str:
         """
         Remove *ts* from the set of processing tasks.

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1547,7 +1547,49 @@ class SchedulerState:
     ``Scheduler`` affecting different transitions here under-the-hood. In
     the background ``Worker``s also engage with the ``Scheduler``
     affecting these state transitions as well.
+
+    **State**
+
+    The ``Transitions`` object contains the following state variables.
+    Each variable is listed along with what it stores and a brief
+    description.
+
+    * **tasks:** ``{task key: TaskState}``
+        Tasks currently known to the scheduler
+    * **unrunnable:** ``{TaskState}``
+        Tasks in the "no-worker" state
+
+    * **workers:** ``{worker key: WorkerState}``
+        Workers currently connected to the scheduler
+    * **idle:** ``{WorkerState}``:
+        Set of workers that are not fully utilized
+    * **saturated:** ``{WorkerState}``:
+        Set of workers that are not over-utilized
+
+    * **clients:** ``{client key: ClientState}``
+        Clients currently connected to the scheduler
+
+    * **task_duration:** ``{key-prefix: time}``
+        Time we expect certain functions to take, e.g. ``{'sum': 0.25}``
     """
+
+    _bandwidth: double
+    _clients: dict
+    _extensions: dict
+    _host_info: object
+    _idle: object
+    _idle_dv: dict
+    _n_tasks: Py_ssize_t
+    _resources: object
+    _saturated: set
+    _tasks: dict
+    _total_nthreads: Py_ssize_t
+    _total_occupancy: double
+    _unknown_durations: object
+    _unrunnable: set
+    _validate: bint
+    _workers: object
+    _workers_dv: dict
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1591,7 +1591,55 @@ class SchedulerState:
     _workers: object
     _workers_dv: dict
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        clients: dict = None,
+        workers=None,
+        host_info=None,
+        resources=None,
+        tasks: dict = None,
+        unrunnable: set = None,
+        validate: bint = False,
+        **kwargs,
+    ):
+        self._bandwidth = parse_bytes(
+            dask.config.get("distributed.scheduler.bandwidth")
+        )
+        if clients is not None:
+            self._clients = clients
+        else:
+            self._clients = dict()
+        self._clients["fire-and-forget"] = ClientState("fire-and-forget")
+        self._extensions = dict()
+        if host_info is not None:
+            self._host_info = host_info
+        else:
+            self._host_info = defaultdict(dict)
+        self._idle = sortedcontainers.SortedDict()
+        self._idle_dv: dict = cast(dict, self._idle)
+        self._n_tasks = 0
+        if resources is not None:
+            self._resources = resources
+        else:
+            self._resources = defaultdict(dict)
+        self._saturated = set()
+        if tasks is not None:
+            self._tasks = tasks
+        else:
+            self._tasks = dict()
+        self._total_nthreads = 0
+        self._total_occupancy = 0
+        self._unknown_durations = defaultdict(set)
+        if unrunnable is not None:
+            self._unrunnable = unrunnable
+        else:
+            self._unrunnable = set()
+        self._validate = validate
+        if workers is not None:
+            self._workers = workers
+        else:
+            self._workers = sortedcontainers.SortedDict()
+        self._workers_dv: dict = cast(dict, self._workers)
         super().__init__(**kwargs)
 
     def _remove_from_processing(self, ts: TaskState) -> str:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1733,6 +1733,8 @@ class SchedulerState:
         else:
             return None
 
+    @cfunc
+    @exceptval(check=False)
     def _add_to_memory(
         self,
         ts: TaskState,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4630,6 +4630,7 @@ class Scheduler(ServerNode):
         ts: TaskState,
         ws: WorkerState,
         recommendations: dict,
+        report_msg: dict,
         type=None,
         typename=None,
         **kwargs,
@@ -4666,10 +4667,10 @@ class Scheduler(ServerNode):
         if not ts._waiters and not ts._who_wants:
             recommendations[ts._key] = "released"
         else:
-            msg: dict = {"op": "key-in-memory", "key": ts._key}
+            report_msg["op"] = "key-in-memory"
+            report_msg["key"] = ts._key
             if type is not None:
-                msg["type"] = type
-            self.report(msg)
+                report_msg["type"] = type
 
         ts.state = "memory"
         ts._type = typename
@@ -4907,8 +4908,11 @@ class Scheduler(ServerNode):
             self.check_idle_saturated(ws)
 
             recommendations: dict = {}
+            report_msg: dict = {}
 
-            self._add_to_memory(ts, ws, recommendations, **kwargs)
+            self._add_to_memory(ts, ws, recommendations, report_msg, **kwargs)
+            if report_msg:
+                self.report(report_msg)
 
             if self.validate:
                 assert not ts._processing_on
@@ -5018,10 +5022,15 @@ class Scheduler(ServerNode):
                 ts.set_nbytes(nbytes)
 
             recommendations: dict = {}
+            report_msg: dict = {}
 
             self._remove_from_processing(ts)
 
-            self._add_to_memory(ts, ws, recommendations, type=type, typename=typename)
+            self._add_to_memory(
+                ts, ws, recommendations, report_msg, type=type, typename=typename
+            )
+            if report_msg:
+                self.report(report_msg)
 
             if self.validate:
                 assert not ts._processing_on

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3490,6 +3490,18 @@ class Scheduler(ServerNode):
         except (CommClosedError, AttributeError):
             self.loop.add_callback(self.remove_worker, address=worker)
 
+    def client_send(self, client, msg):
+        """Send message to client"""
+        client_comms: dict = self.client_comms
+        c = client_comms.get(client)
+        if c is None:
+            return
+        try:
+            c.send(msg)
+        except CommClosedError:
+            if self.status == Status.running:
+                logger.critical("Tried writing to closed comm: %s", msg)
+
     ############################
     # Less common interactions #
     ############################

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4686,7 +4686,7 @@ class Scheduler(ServerNode):
         cs: ClientState = self.clients["fire-and-forget"]
         if ts in cs._wants_what:
             self._client_releases_keys(
-                client="fire-and-forget",
+                cs=cs,
                 keys=[ts._key],
                 recommendations=recommendations,
             )
@@ -5341,7 +5341,11 @@ class Scheduler(ServerNode):
 
             cs: ClientState = self.clients["fire-and-forget"]
             if ts in cs._wants_what:
-                self.client_releases_keys(client="fire-and-forget", keys=[key])
+                self._client_releases_keys(
+                    cs=cs,
+                    keys=[key],
+                    recommendations=recommendations,
+                )
 
             if self.validate:
                 assert not ts._processing_on

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1741,7 +1741,6 @@ class SchedulerState:
         client_msgs: dict,
         type=None,
         typename: str = None,
-        **kwargs,
     ):
         """
         Add *ts* to the set of in-memory tasks.

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4598,7 +4598,7 @@ class Scheduler(ServerNode):
     # State Transitions #
     #####################
 
-    def _remove_from_processing(self, ts: TaskState, send_worker_msg=None):
+    def _remove_from_processing(self, ts: TaskState) -> str:
         """
         Remove *ts* from the set of processing tasks.
         """
@@ -4616,8 +4616,9 @@ class Scheduler(ServerNode):
                 ws._occupancy -= duration
             self.check_idle_saturated(ws)
             self.release_resources(ts, ws)
-            if send_worker_msg:
-                self.worker_send(w, send_worker_msg)
+            return w
+        else:
+            return None
 
     def _add_to_memory(
         self,
@@ -5222,9 +5223,9 @@ class Scheduler(ServerNode):
                 assert not ts._waiting_on
                 assert self.tasks[key].state == "processing"
 
-            self._remove_from_processing(
-                ts, send_worker_msg={"op": "release-task", "key": key}
-            )
+            w: str = self._remove_from_processing(ts)
+            if w:
+                self.worker_send(w, {"op": "release-task", "key": key})
 
             ts.state = "released"
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1899,6 +1899,8 @@ class SchedulerState:
                 pdb.set_trace()
             raise
 
+    @ccall
+    @exceptval(check=False)
     def decide_worker(self, ts: TaskState) -> WorkerState:
         """
         Decide on a worker for task *ts*.  Return a WorkerState.
@@ -1941,6 +1943,7 @@ class SchedulerState:
 
         return ws
 
+    @ccall
     def set_duration_estimate(self, ts: TaskState, ws: WorkerState) -> double:
         """Estimate task duration using worker state and task state.
 
@@ -2633,6 +2636,8 @@ class SchedulerState:
                 pdb.set_trace()
             raise
 
+    @ccall
+    @exceptval(check=False)
     def check_idle_saturated(self, ws: WorkerState, occ: double = -1.0):
         """Update the status of the idle and saturated state
 
@@ -2802,6 +2807,7 @@ class SchedulerState:
                     steal.remove_key_from_stealable(ts)
                     steal.put_key_in_stealable(ts)
 
+    @ccall
     def get_comm_cost(self, ts: TaskState, ws: WorkerState) -> double:
         """
         Get the estimated communication cost (in s.) to compute the task
@@ -2815,6 +2821,7 @@ class SchedulerState:
             nbytes += dts._nbytes
         return nbytes / bandwidth
 
+    @ccall
     def get_task_duration(self, ts: TaskState, default: double = -1) -> double:
         """
         Get the estimated computation cost of the given task
@@ -2831,6 +2838,8 @@ class SchedulerState:
 
         return duration
 
+    @ccall
+    @exceptval(check=False)
     def valid_workers(self, ts: TaskState) -> set:
         """Return set of currently valid workers for key
 
@@ -2881,6 +2890,8 @@ class SchedulerState:
 
         return s
 
+    @ccall
+    @exceptval(check=False)
     def worker_objective(self, ts: TaskState, ws: WorkerState) -> tuple:
         """
         Objective function to determine which worker should get the task

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1710,6 +1710,8 @@ class SchedulerState:
     def workers(self):
         return self._workers
 
+    @cfunc
+    @exceptval(check=False)
     def _remove_from_processing(self, ts: TaskState) -> str:
         """
         Remove *ts* from the set of processing tasks.
@@ -2509,6 +2511,8 @@ class SchedulerState:
                 pdb.set_trace()
             raise
 
+    @cfunc
+    @exceptval(check=False)
     def _propagate_forgotten(
         self, ts: TaskState, recommendations: dict, worker_msgs: dict
     ):
@@ -2670,6 +2674,8 @@ class SchedulerState:
 
             saturated.discard(ws)
 
+    @cfunc
+    @exceptval(check=False)
     def _client_releases_keys(self, keys: list, cs: ClientState, recommendations: dict):
         """ Remove keys from client desired list """
         logger.debug("Client %s releases keys: %s", cs._client_key, keys)
@@ -2691,6 +2697,8 @@ class SchedulerState:
             elif ts._state != "erred" and not ts._waiters:
                 recommendations[ts._key] = "released"
 
+    @cfunc
+    @exceptval(check=False)
     def _task_to_msg(self, ts: TaskState, duration=None) -> dict:
         """ Convert a single computational task to a message """
         ws: WorkerState
@@ -2728,6 +2736,8 @@ class SchedulerState:
 
         return msg
 
+    @cfunc
+    @exceptval(check=False)
     def _task_to_report_msg(self, ts: TaskState) -> dict:
         if ts is None:
             return {"op": "cancelled-key", "key": ts._key}
@@ -2746,6 +2756,8 @@ class SchedulerState:
         else:
             return None
 
+    @cfunc
+    @exceptval(check=False)
     def _task_to_client_msgs(self, ts: TaskState) -> dict:
         cs: ClientState
         client_keys: list
@@ -2764,6 +2776,8 @@ class SchedulerState:
 
         return client_msgs
 
+    @cfunc
+    @exceptval(check=False)
     def _reevaluate_occupancy_worker(self, ws: WorkerState):
         """ See reevaluate_occupancy """
         old: double = ws._occupancy

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1738,7 +1738,7 @@ class SchedulerState:
         recommendations: dict,
         client_msgs: dict,
         type=None,
-        typename=None,
+        typename: str = None,
         **kwargs,
     ):
         """
@@ -1939,7 +1939,7 @@ class SchedulerState:
 
         return ws
 
-    def set_duration_estimate(self, ts: TaskState, ws: WorkerState):
+    def set_duration_estimate(self, ts: TaskState, ws: WorkerState) -> double:
         """Estimate task duration using worker state and task state.
 
         If a task takes longer than twice the current average duration we
@@ -2045,7 +2045,7 @@ class SchedulerState:
         key,
         nbytes=None,
         type=None,
-        typename=None,
+        typename: str = None,
         worker=None,
         startstops=None,
         **kwargs,
@@ -2155,7 +2155,7 @@ class SchedulerState:
                 pdb.set_trace()
             raise
 
-    def transition_memory_released(self, key, safe=False):
+    def transition_memory_released(self, key, safe: bint = False):
         ws: WorkerState
         try:
             ts: TaskState = self._tasks[key]
@@ -2788,7 +2788,7 @@ class SchedulerState:
                     steal.remove_key_from_stealable(ts)
                     steal.put_key_in_stealable(ts)
 
-    def get_comm_cost(self, ts: TaskState, ws: WorkerState):
+    def get_comm_cost(self, ts: TaskState, ws: WorkerState) -> double:
         """
         Get the estimated communication cost (in s.) to compute the task
         on the given worker.
@@ -2801,7 +2801,7 @@ class SchedulerState:
             nbytes += dts._nbytes
         return nbytes / bandwidth
 
-    def get_task_duration(self, ts: TaskState, default: double = -1):
+    def get_task_duration(self, ts: TaskState, default: double = -1) -> double:
         """
         Get the estimated computation cost of the given task
         (not including any communication cost).
@@ -2867,7 +2867,7 @@ class SchedulerState:
 
         return s
 
-    def worker_objective(self, ts: TaskState, ws: WorkerState):
+    def worker_objective(self, ts: TaskState, ws: WorkerState) -> tuple:
         """
         Objective function to determine which worker should get the task
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1526,7 +1526,34 @@ def _task_key_or_none(task):
     return task.key if task is not None else None
 
 
-class Scheduler(ServerNode):
+@cclass
+class SchedulerState:
+    """Underlying task state of dynamic scheduler
+
+    Tracks the current state of workers, data, and computations.
+
+    Handles transitions between different task states. Notifies the
+    Scheduler of changes by messaging passing through Queues, which the
+    Scheduler listens to responds accordingly.
+
+    All events are handled quickly, in linear time with respect to their
+    input (which is often of constant size) and generally within a
+    millisecond. Additionally when Cythonized, this can be faster still.
+    To accomplish this the scheduler tracks a lot of state.  Every
+    operation maintains the consistency of this state.
+
+    Users typically do not interact with ``Transitions`` directly. Instead
+    users interact with the ``Client``, which in turn engages the
+    ``Scheduler`` affecting different transitions here under-the-hood. In
+    the background ``Worker``s also engage with the ``Scheduler``
+    affecting these state transitions as well.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Scheduler(SchedulerState, ServerNode):
     """Dynamic distributed task scheduler
 
     The scheduler tracks the current state of workers, data, and computations.

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2687,6 +2687,16 @@ class SchedulerState:
                 ws._used_resources[r] -= required
 
     @ccall
+    def coerce_hostname(self, host):
+        """
+        Coerce the hostname of a worker.
+        """
+        if host in self._aliases:
+            return self._workers_dv[self._aliases[host]].host
+        else:
+            return host
+
+    @ccall
     @exceptval(check=False)
     def worker_objective(self, ts: TaskState, ws: WorkerState) -> tuple:
         """
@@ -5983,16 +5993,6 @@ class Scheduler(SchedulerState, ServerNode):
             addr = normalize_address(addr)
 
         return addr
-
-    def coerce_hostname(self, host):
-        """
-        Coerce the hostname of a worker.
-        """
-        parent: SchedulerState = cast(SchedulerState, self)
-        if host in self.aliases:
-            return parent._workers_dv[self.aliases[host]].host
-        else:
-            return host
 
     def workers_list(self, workers):
         """

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2534,6 +2534,10 @@ class SchedulerState:
                 pdb.set_trace()
             raise
 
+    ##############################
+    # Assigning Tasks to Workers #
+    ##############################
+
     @ccall
     @exceptval(check=False)
     def check_idle_saturated(self, ws: WorkerState, occ: double = -1.0):
@@ -2659,6 +2663,18 @@ class SchedulerState:
             s = {self._workers_dv[w] for w in s}
 
         return s
+
+    @ccall
+    def consume_resources(self, ts: TaskState, ws: WorkerState):
+        if ts._resource_restrictions:
+            for r, required in ts._resource_restrictions.items():
+                ws._used_resources[r] += required
+
+    @ccall
+    def release_resources(self, ts: TaskState, ws: WorkerState):
+        if ts._resource_restrictions:
+            for r, required in ts._resource_restrictions.items():
+                ws._used_resources[r] -= required
 
     @ccall
     @exceptval(check=False)
@@ -5912,20 +5928,6 @@ class Scheduler(SchedulerState, ServerNode):
         if worker and ts._processing_on.address != worker:
             return
         self.transitions({key: "released"})
-
-    ##############################
-    # Assigning Tasks to Workers #
-    ##############################
-
-    def consume_resources(self, ts: TaskState, ws: WorkerState):
-        if ts._resource_restrictions:
-            for r, required in ts._resource_restrictions.items():
-                ws._used_resources[r] += required
-
-    def release_resources(self, ts: TaskState, ws: WorkerState):
-        if ts._resource_restrictions:
-            for r, required in ts._resource_restrictions.items():
-                ws._used_resources[r] -= required
 
     #####################
     # Utility functions #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4316,6 +4316,24 @@ class Scheduler(ServerNode):
             if client:
                 self.client_desires_keys(keys=list(who_has), client=client)
 
+    def _task_to_report_msg(self, ts: TaskState) -> dict:
+        if ts is None:
+            return {"op": "cancelled-key", "key": ts._key}
+        elif ts._state == "forgotten":
+            return {"op": "cancelled-key", "key": ts._key}
+        elif ts._state == "memory":
+            return {"op": "key-in-memory", "key": ts._key}
+        elif ts._state == "erred":
+            failing_ts: TaskState = ts._exception_blame
+            return {
+                "op": "task-erred",
+                "key": ts._key,
+                "exception": failing_ts._exception,
+                "traceback": failing_ts._traceback,
+            }
+        else:
+            return None
+
     def report_on_key(self, key: str = None, ts: TaskState = None, client: str = None):
         if ts is None:
             tasks: dict = self.tasks
@@ -4326,24 +4344,9 @@ class Scheduler(ServerNode):
             assert False, (key, ts)
             return
 
-        if ts is None:
-            self.report({"op": "cancelled-key", "key": key}, client=client)
-        elif ts._state == "forgotten":
-            self.report({"op": "cancelled-key", "key": key}, ts=ts, client=client)
-        elif ts._state == "memory":
-            self.report({"op": "key-in-memory", "key": key}, ts=ts, client=client)
-        elif ts._state == "erred":
-            failing_ts: TaskState = ts._exception_blame
-            self.report(
-                {
-                    "op": "task-erred",
-                    "key": key,
-                    "exception": failing_ts._exception,
-                    "traceback": failing_ts._traceback,
-                },
-                ts=ts,
-                client=client,
-            )
+        report_msg: dict = self._task_to_report_msg(ts)
+        if report_msg is not None:
+            self.report(report_msg, ts=ts, client=client)
 
     async def feed(
         self, comm, function=None, setup=None, teardown=None, interval="1s", **kwargs

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2007,7 +2007,9 @@ class SchedulerState:
                 pdb.set_trace()
             raise
 
-    def transition_waiting_memory(self, key, nbytes=None, worker=None, **kwargs):
+    def transition_waiting_memory(
+        self, key, nbytes=None, type=None, typename: str = None, worker=None, **kwargs
+    ):
         try:
             ws: WorkerState = self._workers_dv[worker]
             ts: TaskState = self._tasks[key]
@@ -2029,7 +2031,9 @@ class SchedulerState:
             recommendations: dict = {}
             client_msgs: dict = {}
 
-            self._add_to_memory(ts, ws, recommendations, client_msgs, **kwargs)
+            self._add_to_memory(
+                ts, ws, recommendations, client_msgs, type=type, typename=typename
+            )
 
             if self._validate:
                 assert not ts._processing_on

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4346,6 +4346,25 @@ class Scheduler(ServerNode):
         else:
             return None
 
+    def _task_to_client_msgs(self, ts: TaskState) -> dict:
+        cs: ClientState
+        clients: dict = self.clients
+        client_keys: list
+        if ts is None:
+            # Notify all clients
+            client_keys = list(clients)
+        else:
+            # Notify clients interested in key
+            client_keys = [cs._client_key for cs in ts._who_wants]
+
+        report_msg: dict = self._task_to_report_msg(ts)
+
+        client_msgs: dict = {}
+        for k in client_keys:
+            client_msgs[k] = report_msg
+
+        return client_msgs
+
     def report_on_key(self, key: str = None, ts: TaskState = None, client: str = None):
         if ts is None:
             tasks: dict = self.tasks

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1710,6 +1710,26 @@ class SchedulerState:
     def workers(self):
         return self._workers
 
+    @property
+    def __pdict__(self):
+        return {
+            "bandwidth": self._bandwidth,
+            "resources": self._resources,
+            "saturated": self._saturated,
+            "unrunnable": self._unrunnable,
+            "n_tasks": self._n_tasks,
+            "unknown_durations": self._unknown_durations,
+            "validate": self._validate,
+            "tasks": self._tasks,
+            "total_nthreads": self._total_nthreads,
+            "total_occupancy": self._total_occupancy,
+            "extensions": self._extensions,
+            "clients": self._clients,
+            "workers": self._workers,
+            "idle": self._idle,
+            "host_info": self._host_info,
+        }
+
     def transition_released_waiting(self, key):
         try:
             ts: TaskState = self._tasks[key]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4389,7 +4389,7 @@ class Scheduler(SchedulerState, ServerNode):
         cs: ClientState = parent._clients[client]
         recommendations: dict = {}
 
-        self._client_releases_keys(keys=keys, cs=cs, recommendations=recommendations)
+        parent._client_releases_keys(keys=keys, cs=cs, recommendations=recommendations)
         self.transitions(recommendations)
 
     def client_heartbeat(self, client=None):
@@ -5693,7 +5693,7 @@ class Scheduler(SchedulerState, ServerNode):
             assert False, (key, ts)
             return
 
-        report_msg: dict = self._task_to_report_msg(ts)
+        report_msg: dict = parent._task_to_report_msg(ts)
         if report_msg is not None:
             self.report(report_msg, ts=ts, client=client)
 
@@ -6498,7 +6498,7 @@ class Scheduler(SchedulerState, ServerNode):
                     try:
                         if ws is None or not ws._processing:
                             continue
-                        self._reevaluate_occupancy_worker(ws)
+                        parent._reevaluate_occupancy_worker(ws)
                     finally:
                         del ws  # lose ref
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3292,42 +3292,47 @@ class Scheduler(ServerNode):
         )
         self.loop.call_later(cleanup_delay, remove_client_from_events)
 
+    def _task_to_msg(self, ts: TaskState, duration=None) -> dict:
+        """ Convert a single computational task to a message """
+        ws: WorkerState
+        dts: TaskState
+
+        if duration is None:
+            duration = self.get_task_duration(ts)
+
+        msg: dict = {
+            "op": "compute-task",
+            "key": ts._key,
+            "priority": ts._priority,
+            "duration": duration,
+        }
+        if ts._resource_restrictions:
+            msg["resource_restrictions"] = ts._resource_restrictions
+        if ts._actor:
+            msg["actor"] = True
+
+        deps: set = ts._dependencies
+        if deps:
+            msg["who_has"] = {
+                dts._key: [ws._address for ws in dts._who_has] for dts in deps
+            }
+            msg["nbytes"] = {dts._key: dts._nbytes for dts in deps}
+
+            if self.validate:
+                assert all(msg["who_has"].values())
+
+        task = ts._run_spec
+        if type(task) is dict:
+            msg.update(task)
+        else:
+            msg["task"] = task
+
+        return msg
+
     def send_task_to_worker(self, worker, ts: TaskState, duration=None):
         """ Send a single computational task to a worker """
         try:
-            ws: WorkerState
-            dts: TaskState
-
-            if duration is None:
-                duration = self.get_task_duration(ts)
-
-            msg: dict = {
-                "op": "compute-task",
-                "key": ts._key,
-                "priority": ts._priority,
-                "duration": duration,
-            }
-            if ts._resource_restrictions:
-                msg["resource_restrictions"] = ts._resource_restrictions
-            if ts._actor:
-                msg["actor"] = True
-
-            deps: set = ts._dependencies
-            if deps:
-                msg["who_has"] = {
-                    dts._key: [ws._address for ws in dts._who_has] for dts in deps
-                }
-                msg["nbytes"] = {dts._key: dts._nbytes for dts in deps}
-
-                if self.validate:
-                    assert all(msg["who_has"].values())
-
-            task = ts._run_spec
-            if type(task) is dict:
-                msg.update(task)
-            else:
-                msg["task"] = task
-
+            msg: dict = self._task_to_msg(ts, duration)
             self.worker_send(worker, msg)
         except Exception as e:
             logger.exception(e)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2509,8 +2509,9 @@ class SchedulerState:
                 pdb.set_trace()
             raise
 
-    def _propagate_forgotten(self, ts: TaskState, recommendations: dict):
-        worker_msgs: dict = {}
+    def _propagate_forgotten(
+        self, ts: TaskState, recommendations: dict, worker_msgs: dict
+    ):
         ts.state = "forgotten"
         key: str = ts._key
         dts: TaskState
@@ -2547,8 +2548,6 @@ class SchedulerState:
                 worker_msgs[w] = {"op": "delete-data", "keys": [key], "report": False}
         ts._who_has.clear()
 
-        return worker_msgs
-
     def transition_memory_forgotten(self, key):
         ws: WorkerState
         try:
@@ -2578,7 +2577,7 @@ class SchedulerState:
                 for ws in ts._who_has:
                     ws._actors.discard(ts)
 
-            worker_msgs = self._propagate_forgotten(ts, recommendations)
+            self._propagate_forgotten(ts, recommendations, worker_msgs)
 
             client_msgs = self._task_to_client_msgs(ts)
             self.remove_key(key)
@@ -2616,7 +2615,7 @@ class SchedulerState:
                     assert 0, (ts,)
 
             recommendations: dict = {}
-            self._propagate_forgotten(ts, recommendations)
+            self._propagate_forgotten(ts, recommendations, worker_msgs)
 
             client_msgs = self._task_to_client_msgs(ts)
             self.remove_key(key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4685,7 +4685,11 @@ class Scheduler(ServerNode):
 
         cs: ClientState = self.clients["fire-and-forget"]
         if ts in cs._wants_what:
-            self.client_releases_keys(client="fire-and-forget", keys=[ts._key])
+            self._client_releases_keys(
+                client="fire-and-forget",
+                keys=[ts._key],
+                recommendations=recommendations,
+            )
 
     def transition_released_waiting(self, key):
         try:


### PR DESCRIPTION
Requires PR ( https://github.com/dask/distributed/pull/4343 )

This refactors out the `SchedulerState` as `@cclass` including info about endpoints and tasks. Also includes the `transition_*` functions. This should make it easier to more thoroughly Cythonize these components.