### PR TITLE
Grouped task stream

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1348,7 +1348,6 @@ class TaskStream(DashboardComponent):
                     this_worker_positions['nthreads']
                 ) / 2
                 this_worker_positions['threads_y_coord'][thread] = y
-                print(worker, thread, y)
 
     def _group_tasks_vetrically_by_workers(self, rects):
         # Modifies the 'y' field of the completed tasks data structure so that

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1266,6 +1266,9 @@ class TaskStream(DashboardComponent):
         boxes = {}
 
         def highlight_worker_band(event):
+            if event.x is None or event.y is None:
+                return
+
             # highlights the horizontal band corresponding to the tasks
             # completed by all threads of a given worker
             nonlocal last_box

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -542,6 +542,10 @@ class WorkerState:
         return self._time_delay
 
     @property
+    def uuid(self):
+        return self._uuid
+
+    @property
     def used_resources(self):
         return self._used_resources
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -19,6 +19,7 @@ import weakref
 import psutil
 import sortedcontainers
 
+from uuid import uuid4
 from tlz import (
     merge,
     pluck,
@@ -377,6 +378,7 @@ class WorkerState:
         "_services",
         "_status",
         "_time_delay",
+        "_uuid",
         "_used_resources",
         "_versions",
     )
@@ -403,8 +405,9 @@ class WorkerState:
         self._services = services or {}
         self._versions = versions or {}
         self._nanny = nanny
-
+        self._uuid = uuid4().hex
         self._hash = hash(address)
+
         self._status = Status.running
         self._nbytes = 0
         self._occupancy = 0


### PR DESCRIPTION
Fixes #4346 

Changes the tasks stream displaying logic:

- All bands related to the same workers are now placed one after the other
- The total band for a worker is computed statically at the beginning: if new threads are created from `secede` calls,
  tasks completed by such threads will all be allocated to the upper-most sub-band of their worker
- Added a slight hovering effect to know which sub-bands are associated with each worker

Screencasts to come, but @mrocklin or anyone else, feel free to check it out locally. 