### PR TITLE
Fix compilation warnings, `decide_worker` now a C func, stealing improvements

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -86,6 +86,11 @@ from .variable import VariableExtension
 from .protocol.highlevelgraph import highlevelgraph_unpack
 
 try:
+    from cython import compiled
+except ImportError:
+    compiled = False
+
+if compiled:
     from cython import (
         bint,
         cast,
@@ -100,7 +105,7 @@ try:
         Py_hash_t,
         Py_ssize_t,
     )
-except ImportError:
+else:
     from ctypes import (
         c_double as double,
         c_ssize_t as Py_hash_t,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6213,6 +6213,8 @@ class Scheduler(ServerNode):
             return len(self.workers) - len(to_close)
 
 
+@cfunc
+@exceptval(check=False)
 def decide_worker(
     ts: TaskState, all_workers, valid_workers: set, objective
 ) -> WorkerState:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -96,6 +96,7 @@ if compiled:
         cast,
         ccall,
         cclass,
+        cfunc,
         declare,
         double,
         exceptval,
@@ -122,6 +123,9 @@ else:
 
     def cclass(cls):
         return cls
+
+    def cfunc(func):
+        return func
 
     def declare(*a, **k):
         if len(a) == 2:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -122,6 +122,7 @@ class WorkStealing(SchedulerPlugin):
         split = ts.prefix.name
         if split in fast_tasks:
             return None, None
+
         ws = ts.processing_on
         compute_time = ws.processing[ts]
         if compute_time < 0.005:  # 5ms, just give up

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -84,7 +84,6 @@ class WorkStealing(SchedulerPlugin):
         ws = ts.processing_on
         worker = ws.address
         cost_multiplier, level = self.steal_time_ratio(ts)
-        self.log(("add-stealable", ts.key, worker, level))
         if cost_multiplier is not None:
             self.stealable_all[level].add(ts)
             self.stealable[worker][level].add(ts)

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -134,7 +134,9 @@ class WorkStealing(SchedulerPlugin):
             return None, None
 
         level = int(round(log2(cost_multiplier) + 6))
-        level = max(1, level)
+        if level < 1:
+            level = 1
+
         return cost_multiplier, level
 
     def move_task_request(self, ts, victim, thief):

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -119,9 +119,6 @@ class WorkStealing(SchedulerPlugin):
         if not ts.dependencies:  # no dependencies fast path
             return 0, 0
 
-        nbytes = ts.get_nbytes_deps()
-
-        transfer_time = nbytes / self.scheduler.bandwidth + LATENCY
         split = ts.prefix.name
         if split in fast_tasks:
             return None, None
@@ -129,6 +126,9 @@ class WorkStealing(SchedulerPlugin):
         compute_time = ws.processing[ts]
         if compute_time < 0.005:  # 5ms, just give up
             return None, None
+
+        nbytes = ts.get_nbytes_deps()
+        transfer_time = nbytes / self.scheduler.bandwidth + LATENCY
         cost_multiplier = transfer_time / compute_time
         if cost_multiplier > 100:
             return None, None

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -1,6 +1,6 @@
 from collections import defaultdict, deque
 import logging
-from math import log
+from math import log2
 from time import time
 
 from tornado.ioloop import PeriodicCallback
@@ -14,7 +14,6 @@ from .utils import log_errors, parse_timedelta
 from tlz import topk
 
 LATENCY = 10e-3
-log_2 = log(2)
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +133,7 @@ class WorkStealing(SchedulerPlugin):
         if cost_multiplier > 100:
             return None, None
 
-        level = int(round(log(cost_multiplier) / log_2 + 6, 0))
+        level = int(round(log2(cost_multiplier) + 6, 0))
         level = max(1, level)
         return cost_multiplier, level
 

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -133,7 +133,7 @@ class WorkStealing(SchedulerPlugin):
         if cost_multiplier > 100:
             return None, None
 
-        level = int(round(log2(cost_multiplier) + 6, 0))
+        level = int(round(log2(cost_multiplier) + 6))
         level = max(1, level)
         return cost_multiplier, level
 


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/4359

* Use `cython.compiled` to skip pure Python fallback functions in Cython case (fixes unused symbol warnings from C compiler)
* Move `decide_worker` function into C (removes overhead of Python API, which is unneeded)
* Some optimization to stealing math and other misc. stealing improvements

Note: There are still some warnings that predate this PR and are not handled currently. See issue ( https://github.com/cython/cython/issues/3474 ) for details.