### PR TITLE
test_performance_report: skip without bokeh

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6129,6 +6129,7 @@ async def test_run_scheduler_async_def_wait(c, s, a, b):
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 2)] * 2)
 async def test_performance_report(c, s, a, b):
+    pytest.importorskip("bokeh")
     da = pytest.importorskip("dask.array")
 
     async def f():


### PR DESCRIPTION
This test is failing if bokeh is not available:

```
___________________________ test_performance_report ____________________________

    def test_func():
        result = None
        workers = []
        with clean(timeout=active_rpc_timeout, **clean_kwargs) as loop:
    
            async def coro():
                with dask.config.set(config):
                    s = False
                    for i in range(5):
                        try:
                            s, ws = await start_cluster(
                                nthreads,
                                scheduler,
                                loop,
                                security=security,
                                Worker=Worker,
                                scheduler_kwargs=scheduler_kwargs,
                                worker_kwargs=worker_kwargs,
                            )
                        except Exception as e:
                            logger.error(
                                "Failed to start gen_cluster, retrying",
                                exc_info=True,
                            )
                            await asyncio.sleep(1)
                        else:
                            workers[:] = ws
                            args = [s] + workers
                            break
                    if s is False:
                        raise Exception("Could not start cluster")
                    if client:
                        c = await Client(
                            s.address,
                            loop=loop,
                            security=security,
                            asynchronous=True,
                            **client_kwargs,
                        )
                        args = [c] + args
                    try:
                        future = func(*args)
                        if timeout:
                            future = asyncio.wait_for(future, timeout)
                        result = await future
                        if s.validate:
                            s.validate_state()
                    finally:
                        if client and c.status not in ("closing", "closed"):
                            await c._close(fast=s.status == Status.closed)
                        await end_cluster(s, workers)
                        await asyncio.wait_for(cleanup_global_workers(), 1)
    
                    try:
                        c = await default_client()
                    except ValueError:
                        pass
                    else:
                        await c._close(fast=True)
    
                    def get_unclosed():
                        return [c for c in Comm._instances if not c.closed()] + [
                            c
                            for c in _global_clients.values()
                            if c.status != "closed"
                        ]
    
                    try:
                        start = time()
                        while time() < start + 5:
                            gc.collect()
                            if not get_unclosed():
                                break
                            await asyncio.sleep(0.05)
                        else:
                            if allow_unclosed:
                                print(f"Unclosed Comms: {get_unclosed()}")
                            else:
                                raise RuntimeError("Unclosed Comms", get_unclosed())
                    finally:
                        Comm._instances.clear()
                        _global_clients.clear()
    
                    return result
    
>           result = loop.run_sync(
                coro, timeout=timeout * 2 if timeout else timeout
            )

distributed/utils_test.py:953: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.9/site-packages/tornado/ioloop.py:530: in run_sync
    return future_cell[0].result()
distributed/utils_test.py:912: in coro
    result = await future
/usr/lib/python3.9/asyncio/tasks.py:478: in wait_for
    return fut.result()
distributed/tests/test_client.py:6150: in test_performance_report
    data = await f()
distributed/tests/test_client.py:6144: in f
    await c.compute((x + x.T).sum())
distributed/client.py:4757: in __aexit__
    data = await get_client().scheduler.performance_report(
distributed/core.py:878: in send_recv_from_rpc
    result = await send_recv(comm=comm, op=key, **kwargs)
distributed/core.py:677: in send_recv
    raise exc.with_traceback(tb)
distributed/core.py:517: in handle_comm
    result = await result
distributed/scheduler.py:5817: in performance_report
    compute, scheduler, workers = map(
distributed/scheduler.py:5814: in profile_to_figure
    figure, source = profile.plot_figure(data, sizing_mode="stretch_both")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   from bokeh.plotting import ColumnDataSource, figure
E   ModuleNotFoundError: No module named 'bokeh'

distributed/profile.py:378: ModuleNotFoundError
----------------------------- Captured stderr call -----------------------------
distributed.core - ERROR - Exception while handling op performance_report
Traceback (most recent call last):
  File "/build/python-distributed/src/distributed-2020.12.0/distributed/core.py", line 517, in handle_comm
    result = await result
  File "/build/python-distributed/src/distributed-2020.12.0/distributed/scheduler.py", line 5817, in performance_report
    compute, scheduler, workers = map(
  File "/build/python-distributed/src/distributed-2020.12.0/distributed/scheduler.py", line 5814, in profile_to_figure
    figure, source = profile.plot_figure(data, sizing_mode="stretch_both")
  File "/build/python-distributed/src/distributed-2020.12.0/distributed/profile.py", line 378, in plot_figure
    from bokeh.plotting import ColumnDataSource, figure
ModuleNotFoundError: No module named 'bokeh'
```