### PR TITLE
Type annotation of `_reevaluate_occupancy_worker`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6138,11 +6138,14 @@ class Scheduler(ServerNode):
 
     def _reevaluate_occupancy_worker(self, ws: WorkerState):
         """ See reevaluate_occupancy """
-        old = ws._occupancy
-        new = 0
+        old: double = ws._occupancy
+        new: double = 0
+        diff: double
         ts: TaskState
+        est: double
         for ts in ws._processing:
-            new += self.set_duration_estimate(ts, ws)
+            est = self.set_duration_estimate(ts, ws)
+            new += est
 
         ws._occupancy = new
         diff = new - old

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6140,6 +6140,7 @@ class Scheduler(ServerNode):
         """ See reevaluate_occupancy """
         old = ws._occupancy
         new = 0
+        ts: TaskState
         for ts in ws._processing:
             new += self.set_duration_estimate(ts, ws)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6148,11 +6148,12 @@ class Scheduler(ServerNode):
         self.check_idle_saturated(ws)
 
         # significant increase in duration
-        if (new > old * 1.3) and ("stealing" in self.extensions):
-            steal = self.extensions["stealing"]
-            for ts in ws._processing:
-                steal.remove_key_from_stealable(ts)
-                steal.put_key_in_stealable(ts)
+        if new > old * 1.3:
+            steal = self.extensions.get("stealing")
+            if steal is not None:
+                for ts in ws._processing:
+                    steal.remove_key_from_stealable(ts)
+                    steal.put_key_in_stealable(ts)
 
     async def check_worker_ttl(self):
         ws: WorkerState

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6140,7 +6140,6 @@ class Scheduler(ServerNode):
         """ See reevaluate_occupancy """
         old = ws._occupancy
         new = 0
-        nbytes = 0
         for ts in ws._processing:
             new += self.set_duration_estimate(ts, ws)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4833,7 +4833,7 @@ class Scheduler(ServerNode):
             if exec_time > 2 * duration:
                 total_duration = 2 * exec_time
         ws._processing[ts] = total_duration
-        return ws._processing[ts]
+        return total_duration
 
     def transition_waiting_processing(self, key):
         try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6145,7 +6145,8 @@ class Scheduler(ServerNode):
             new += self.set_duration_estimate(ts, ws)
 
         ws._occupancy = new
-        self.total_occupancy += new - old
+        diff = new - old
+        self.total_occupancy += diff
         self.check_idle_saturated(ws)
 
         # significant increase in duration

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6139,7 +6139,6 @@ class Scheduler(ServerNode):
     def _reevaluate_occupancy_worker(self, ws: WorkerState):
         """ See reevaluate_occupancy """
         old = ws._occupancy
-
         new = 0
         nbytes = 0
         for ts in ws._processing:


### PR DESCRIPTION
Does some light type annotation of `_reevaluate_occupancy_worker` to improve the Cython code generated for this function. This cuts down on the amount of time spent in this method when determining what tasks to steal.