### PR TITLE
Fix `test_as_current_is_thread_local`

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4035,7 +4035,7 @@ def test_as_current_is_thread_local(s):
                     l4.release()
 
     def run2():
-        with Client(s.address) as c:
+        with Client(s["address"]) as c:
             with c.as_current():
                 l1.release()
                 l2.acquire()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4011,6 +4011,7 @@ async def test_as_current(c, s, a, b):
     await c2.close()
 
 
+@gen_cluster(client=False)
 def test_as_current_is_thread_local(s):
     l1 = threading.Lock()
     l2 = threading.Lock()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4022,7 +4022,7 @@ def test_as_current_is_thread_local(s):
     l4.acquire()
 
     def run1():
-        with Client(s.address) as c:
+        with Client(s["address"]) as c:
             with c.as_current():
                 l1.acquire()
                 l2.release()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4011,7 +4011,6 @@ async def test_as_current(c, s, a, b):
     await c2.close()
 
 
-@gen_cluster(client=False)
 def test_as_current_is_thread_local(s):
     l1 = threading.Lock()
     l2 = threading.Lock()


### PR DESCRIPTION
`s` is a `dict`, but we were treating it as the `Scheduler` object. This fixes that.