### PR TITLE
Unify annotations

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2825,9 +2825,6 @@ class Client:
             else:
                 dsk2[name] = (func, keys) + extra_args
 
-        if not isinstance(priority, Number):
-            priority = {k: p for c, p in priority.items() for k in self._expand_key(c)}
-
         if not isinstance(dsk, HighLevelGraph):
             dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
 
@@ -2944,9 +2941,6 @@ class Client:
         dsk = self.collections_to_dsk(collections, optimize_graph, **kwargs)
 
         names = {k for c in collections for k in flatten(c.__dask_keys__())}
-
-        if not isinstance(priority, Number):
-            priority = {k: p for c, p in priority.items() for k in self._expand_key(c)}
 
         futures = self._graph_to_futures(
             dsk,

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2562,6 +2562,8 @@ class Client:
                 annotations["workers"] = workers
             if retries:
                 annotations["retries"] = retries
+            if allow_other_workers not in (True, False, None):
+                raise TypeError("allow_other_workers= must be True or False")
             if allow_other_workers:
                 annotations["allow_other_workers"] = allow_other_workers
             if resources:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -11,10 +11,9 @@ import errno
 from functools import partial
 import html
 import inspect
-import itertools
 import json
 import logging
-from numbers import Integral, Number
+from numbers import Number
 import os
 import sys
 import uuid
@@ -2537,11 +2536,6 @@ class Client:
         actors=None,
     ):
         with self._refcount_lock:
-            if retries:
-                retries = self._expand_retries(
-                    retries, all_keys=itertools.chain(dsk, keys)
-                )
-
             if actors is not None and actors is not True and actors is not False:
                 actors = list(self._expand_key(actors))
 
@@ -3846,28 +3840,6 @@ class Client:
                     yield stringify(kkk)
             else:
                 yield stringify(kk)
-
-    @classmethod
-    def _expand_retries(cls, retries, all_keys):
-        """
-        Expand the user-provided "retries" specification
-        to a {task key: Integral} dictionary.
-        """
-        if retries and isinstance(retries, dict):
-            result = {
-                name: value
-                for key, value in retries.items()
-                for name in cls._expand_key(key)
-            }
-            result["__expanded_annotations__"] = True
-        elif isinstance(retries, Integral):
-            # If a simple number, it can be expanded on the scheduler
-            return retries
-        else:
-            raise TypeError(
-                "`retries` should be an integer or dict, got %r" % (type(retries))
-            )
-        return keymap(stringify, result)
 
     @staticmethod
     def collections_to_dsk(collections, *args, **kwargs):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1522,9 +1522,8 @@ class Client:
         fifo_timeout: str timedelta (default '100ms')
             Allowed amount of time between calls to consider the same priority
         resources: dict (defaults to {})
-            Defines the `resources` these tasks require on the worker. Can
-            specify global resources (``{'GPU': 2}``), or per-task resources
-            (``{'x': {'GPU': 1}, 'y': {'SSD': 4}}``), but not both.
+            Defines the `resources` each instance of this mapped task requires
+            on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
         actor: bool (default False)
@@ -1641,8 +1640,8 @@ class Client:
             Allowed amount of time between calls to consider the same priority
         resources: dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
-            on the worker; e.g. ``{'GPU': 2}``. See
-            :doc:`worker resources <resources>` for details on defining
+            on the worker; e.g. ``{'GPU': 2}``.
+            See :doc:`worker resources <resources>` for details on defining
             resources.
         actor: bool (default False)
             Whether these tasks should exist on the worker as stateful actors.
@@ -2612,9 +2611,8 @@ class Client:
             Optional prioritization of task.  Zero is default.
             Higher priorities take precedence
         resources: dict (defaults to {})
-            Defines the `resources` these tasks require on the worker. Can
-            specify global resources (``{'GPU': 2}``), or per-task resources
-            (``{'x': {'GPU': 1}, 'y': {'SSD': 4}}``), but not both.
+            Defines the `resources` each instance of this mapped task requires
+            on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
         sync: bool (optional)
@@ -2763,9 +2761,8 @@ class Client:
             be expensive. If none of the arguments contain any dask objects,
             set ``traverse=False`` to avoid doing this traversal.
         resources: dict (defaults to {})
-            Defines the `resources` these tasks require on the worker. Can
-            specify global resources (``{'GPU': 2}``), or per-task resources
-            (``{'x': {'GPU': 1}, 'y': {'SSD': 4}}``), but not both.
+            Defines the `resources` each instance of this mapped task requires
+            on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
         actors: bool or dict (default None)
@@ -2912,9 +2909,8 @@ class Client:
         fifo_timeout: timedelta str (defaults to '60s')
             Allowed amount of time between calls to consider the same priority
         resources: dict (defaults to {})
-            Defines the `resources` these tasks require on the worker. Can
-            specify global resources (``{'GPU': 2}``), or per-task resources
-            (``{'x': {'GPU': 1}, 'y': {'SSD': 4}}``), but not both.
+            Defines the `resources` each instance of this mapped task requires
+            on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
         actors: bool or dict (default None)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -11,10 +11,9 @@ import errno
 from functools import partial
 import html
 import inspect
-import itertools
 import json
 import logging
-from numbers import Number, Integral
+from numbers import Number
 import os
 import sys
 import uuid
@@ -2551,8 +2550,8 @@ class Client:
         self,
         dsk,
         keys,
-        restrictions=None,
-        loose_restrictions=None,
+        workers=None,
+        allow_other_workers=None,
         priority=None,
         user_priority=0,
         resources=None,
@@ -2561,26 +2560,8 @@ class Client:
         actors=None,
     ):
         with self._refcount_lock:
-            if resources:
-                resources = self._expand_resources(
-                    resources, all_keys=itertools.chain(dsk, keys)
-                )
-                resources = {stringify(k): v for k, v in resources.items()}
-
-            if retries:
-                retries = self._expand_retries(
-                    retries, all_keys=itertools.chain(dsk, keys)
-                )
-
             if actors is not None and actors is not True and actors is not False:
                 actors = list(self._expand_key(actors))
-
-            if restrictions:
-                restrictions = keymap(stringify, restrictions)
-                restrictions = valmap(list, restrictions)
-
-            if loose_restrictions is not None:
-                loose_restrictions = list(map(stringify, loose_restrictions))
 
             keyset = set(keys)
 
@@ -2588,8 +2569,19 @@ class Client:
             if not isinstance(dsk, HighLevelGraph):
                 dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
 
-            if isinstance(retries, Number) and retries > 0:
-                retries = {k: retries for k in dsk}
+            annotations = {}
+            if user_priority:
+                annotations["priority"] = user_priority
+            if workers:
+                if not isinstance(workers, (list, tuple, set)):
+                    workers = [workers]
+                annotations["workers"] = workers
+            if retries:
+                annotations["retries"] = retries
+            if allow_other_workers:
+                annotations["allow_other_workers"] = allow_other_workers
+            if resources:
+                annotations["resources"] = resources
 
             dsk = highlevelgraph_pack(dsk, self, keyset)
 
@@ -2600,14 +2592,10 @@ class Client:
                     "op": "update-graph-hlg",
                     "hlg": dsk,
                     "keys": list(map(stringify, keys)),
-                    "restrictions": restrictions or {},
-                    "loose_restrictions": loose_restrictions,
                     "priority": priority,
-                    "user_priority": user_priority,
-                    "resources": resources,
                     "submitting_task": getattr(thread_state, "key", None),
-                    "retries": retries,
                     "fifo_timeout": fifo_timeout,
+                    "annotations": annotations,
                     "actors": actors,
                 }
             )
@@ -2857,10 +2845,6 @@ class Client:
             else:
                 dsk2[name] = (func, keys) + extra_args
 
-        restrictions, loose_restrictions = self.get_restrictions(
-            collections, workers, allow_other_workers
-        )
-
         if not isinstance(priority, Number):
             priority = {k: p for c, p in priority.items() for k in self._expand_key(c)}
 
@@ -2878,8 +2862,8 @@ class Client:
         futures_dict = self._graph_to_futures(
             dsk,
             names,
-            restrictions,
-            loose_restrictions,
+            workers=workers,
+            allow_other_workers=allow_other_workers,
             resources=resources,
             retries=retries,
             user_priority=priority,
@@ -3880,90 +3864,6 @@ class Client:
                     yield stringify(kkk)
             else:
                 yield stringify(kk)
-
-    @classmethod
-    def _expand_retries(cls, retries, all_keys):
-        """
-        Expand the user-provided "retries" specification
-        to a {task key: Integral} dictionary.
-        """
-        if retries and isinstance(retries, dict):
-            result = {
-                name: value
-                for key, value in retries.items()
-                for name in cls._expand_key(key)
-            }
-        elif isinstance(retries, Integral):
-            # Each task unit may potentially fail, allow retrying all of them
-            result = {name: retries for name in all_keys}
-        else:
-            raise TypeError(
-                "`retries` should be an integer or dict, got %r" % (type(retries))
-            )
-        return keymap(stringify, result)
-
-    def _expand_resources(cls, resources, all_keys):
-        """
-        Expand the user-provided "resources" specification
-        to a {task key: {resource name: Number}} dictionary.
-        """
-        # Resources can either be a single dict such as {'GPU': 2},
-        # indicating a requirement for all keys, or a nested dict
-        # such as {'x': {'GPU': 1}, 'y': {'SSD': 4}} indicating
-        # per-key requirements
-        if not isinstance(resources, dict):
-            raise TypeError("`resources` should be a dict, got %r" % (type(resources)))
-
-        per_key_reqs = {}
-        global_reqs = {}
-        all_keys = list(all_keys)
-        for k, v in resources.items():
-            if isinstance(v, dict):
-                # It's a per-key requirement
-                per_key_reqs.update((kk, v) for kk in cls._expand_key(k))
-            else:
-                # It's a global requirement
-                global_reqs.update((kk, {k: v}) for kk in all_keys)
-
-        if global_reqs and per_key_reqs:
-            raise ValueError(
-                "cannot have both per-key and all-key requirements "
-                "in resources dict %r" % (resources,)
-            )
-        return global_reqs or per_key_reqs
-
-    @classmethod
-    def get_restrictions(cls, collections, workers, allow_other_workers):
-        """ Get restrictions from inputs to compute/persist """
-        if isinstance(workers, (str, tuple, list)):
-            workers = {tuple(collections): workers}
-        if isinstance(workers, dict):
-            restrictions = {}
-            for colls, ws in workers.items():
-                if isinstance(ws, str):
-                    ws = [ws]
-                if dask.is_dask_collection(colls):
-                    keys = flatten(colls.__dask_keys__())
-                elif isinstance(colls, str):
-                    keys = [colls]
-                else:
-                    keys = list(
-                        {k for c in flatten(colls) for k in flatten(c.__dask_keys__())}
-                    )
-                restrictions.update({k: ws for k in keys})
-        else:
-            restrictions = {}
-
-        if allow_other_workers is True:
-            loose_restrictions = list(restrictions)
-        elif allow_other_workers:
-            loose_restrictions = list(
-                {k for c in flatten(allow_other_workers) for k in c.__dask_keys__()}
-            )
-        else:
-            loose_restrictions = []
-
-        return restrictions, loose_restrictions
 
     @staticmethod
     def collections_to_dsk(collections, *args, **kwargs):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1507,12 +1507,12 @@ class Client:
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
         workers: string or iterable of strings
-            A set of worker hostnames on which computations may be performed.
-            Leave empty to default to all workers (common case)
+            A set of worker addresses or hostnames on which computations may be
+            performed. Leave empty to default to all workers (common case)
         key: str
             Unique identifier for the task.  Defaults to function-name and hash
         allow_other_workers: bool (defaults to False)
-            Used with `workers`. Indicates whether or not the computations
+            Used with ``workers``. Indicates whether or not the computations
             may be performed on workers that are not in the `workers` set(s).
         retries: int (default to 0)
             Number of allowed automatic retries if the task fails
@@ -1522,7 +1522,7 @@ class Client:
         fifo_timeout: str timedelta (default '100ms')
             Allowed amount of time between calls to consider the same priority
         resources: dict (defaults to {})
-            Defines the `resources` each instance of this mapped task requires
+            Defines the ``resources`` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
@@ -2553,7 +2553,7 @@ class Client:
             if retries:
                 annotations["retries"] = retries
             if allow_other_workers not in (True, False, None):
-                raise TypeError("allow_other_workers= must be True or False")
+                raise TypeError("allow_other_workers= must be True, False, or None")
             if allow_other_workers:
                 annotations["allow_other_workers"] = allow_other_workers
             if resources:
@@ -2600,10 +2600,10 @@ class Client:
         dsk: dict
         keys: object, or nested lists of objects
         workers: string or iterable of strings
-            A set of worker hostnames on which computations may be performed.
-            Leave empty to default to all workers (common case)
+            A set of worker addresses or hostnames on which computations may be
+            performed. Leave empty to default to all workers (common case)
         allow_other_workers: bool (defaults to False)
-            Used with `workers`. Indicates whether or not the computations
+            Used with ``workers``. Indicates whether or not the computations
             may be performed on workers that are not in the `workers` set(s).
         retries: int (default to 0)
             Number of allowed automatic retries if computing a result fails
@@ -2611,7 +2611,7 @@ class Client:
             Optional prioritization of task.  Zero is default.
             Higher priorities take precedence
         resources: dict (defaults to {})
-            Defines the `resources` each instance of this mapped task requires
+            Defines the ``resources`` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1506,7 +1506,7 @@ class Client:
         pure: bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-        workers: set, iterable of sets
+        workers: string or iterable of strings
             A set of worker hostnames on which computations may be performed.
             Leave empty to default to all workers (common case)
         key: str
@@ -1522,9 +1522,11 @@ class Client:
         fifo_timeout: str timedelta (default '100ms')
             Allowed amount of time between calls to consider the same priority
         resources: dict (defaults to {})
-            Defines the `resources` this job requires on the worker; e.g.
-            ``{'GPU': 2}``. See :doc:`worker resources <resources>` for details
-            on defining resources.
+            Defines the `resources` these tasks require on the worker. Can
+            specify global resources (``{'GPU': 2}``), or per-task resources
+            (``{'x': {'GPU': 1}, 'y': {'SSD': 4}}``), but not both.
+            See :doc:`worker resources <resources>` for details on defining
+            resources.
         actor: bool (default False)
             Whether this task should exist on the worker as a stateful actor.
             See :doc:`actors` for additional details.
@@ -1624,7 +1626,7 @@ class Client:
         pure: bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-        workers: set, iterable of sets
+        workers: string or iterable of strings
             A set of worker hostnames on which computations may be performed.
             Leave empty to default to all workers (common case)
         allow_other_workers: bool (defaults to False)
@@ -2598,14 +2600,23 @@ class Client:
         ----------
         dsk: dict
         keys: object, or nested lists of objects
-        restrictions: dict (optional)
-            A mapping of {key: {set of worker hostnames}} that restricts where
-            jobs can take place
+        workers: string or iterable of strings
+            A set of worker hostnames on which computations may be performed.
+            Leave empty to default to all workers (common case)
+        allow_other_workers: bool (defaults to False)
+            Used with `workers`. Indicates whether or not the computations
+            may be performed on workers that are not in the `workers` set(s).
         retries: int (default to 0)
             Number of allowed automatic retries if computing a result fails
         priority: Number
             Optional prioritization of task.  Zero is default.
             Higher priorities take precedence
+        resources: dict (defaults to {})
+            Defines the `resources` these tasks require on the worker. Can
+            specify global resources (``{'GPU': 2}``), or per-task resources
+            (``{'x': {'GPU': 1}, 'y': {'SSD': 4}}``), but not both.
+            See :doc:`worker resources <resources>` for details on defining
+            resources.
         sync: bool (optional)
             Returns Futures if False or concrete values if True (default).
         direct: bool
@@ -2733,15 +2744,12 @@ class Client:
             Returns Futures if False (default) or concrete values if True
         optimize_graph: bool
             Whether or not to optimize the underlying graphs
-        workers: str, list, dict
-            Which workers can run which parts of the computation
-            If a string or list then the output collections will run on the listed
-            workers, but other sub-computations can run anywhere
-            If a dict then keys should be (tuples of) collections or
-            task keys and values should be addresses or lists.
-        allow_other_workers: bool, list
-            If True then all restrictions in workers= are considered loose
-            If a list then only the keys for the listed collections are loose
+        workers: string or iterable of strings
+            A set of worker hostnames on which computations may be performed.
+            Leave empty to default to all workers (common case)
+        allow_other_workers: bool (defaults to False)
+            Used with `workers`. Indicates whether or not the computations
+            may be performed on workers that are not in the `workers` set(s).
         retries: int (default to 0)
             Number of allowed automatic retries if computing a result fails
         priority: Number
@@ -2890,15 +2898,12 @@ class Client:
             Collections like dask.array or dataframe or dask.value objects
         optimize_graph: bool
             Whether or not to optimize the underlying graphs
-        workers: str, list, dict
-            Which workers can run which parts of the computation
-            If a string or list then the output collections will run on the listed
-            workers, but other sub-computations can run anywhere
-            If a dict then keys should be (tuples of) collections or
-            task keys and values should be addresses or lists.
-        allow_other_workers: bool, list
-            If True then all restrictions in workers= are considered loose
-            If a list then only the keys for the listed collections are loose
+        workers: string or iterable of strings
+            A set of worker hostnames on which computations may be performed.
+            Leave empty to default to all workers (common case)
+        allow_other_workers: bool (defaults to False)
+            Used with `workers`. Indicates whether or not the computations
+            may be performed on workers that are not in the `workers` set(s).
         retries: int (default to 0)
             Number of allowed automatic retries if computing a result fails
         priority: Number

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1583,7 +1583,7 @@ class Client:
             allow_other_workers=allow_other_workers,
             priority={skey: 0},
             user_priority=priority,
-            resources={skey: resources} if resources else None,
+            resources=resources,
             retries=retries,
             fifo_timeout=fifo_timeout,
             actors=actor,
@@ -1760,11 +1760,6 @@ class Client:
             raise TypeError("Workers must be a list or set of workers or None")
 
         internal_priority = dict(zip(keys, range(len(keys))))
-
-        if resources:
-            resources = {k: resources for k in keys}
-        else:
-            resources = None
 
         futures = self._graph_to_futures(
             dsk,

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2841,10 +2841,7 @@ class Client:
         layers.update(dsk.layers)
         dependencies = {finalize_name: set(dsk.layers.keys())}
         dependencies.update(dsk.dependencies)
-        print("A")
-        print(layers)
         dsk = HighLevelGraph(layers, dependencies)
-        print("B")
 
         futures_dict = self._graph_to_futures(
             dsk,

--- a/distributed/protocol/highlevelgraph.py
+++ b/distributed/protocol/highlevelgraph.py
@@ -1,4 +1,4 @@
-from tlz import merge, valmap
+from tlz import valmap
 
 from dask.core import keys_in_tasks
 from dask.highlevelgraph import HighLevelGraph, Layer
@@ -134,7 +134,7 @@ def _materialized_layer_unpack(state, dsk, dependencies, annotations):
         new_annotations = {}
         for k, v in expanded.items():
             if isinstance(v, dict) and k in annotations:
-                new_annotations[k] = merge(annotations[k], v)
+                new_annotations[k] = {**annotations[k], **v}
             else:
                 new_annotations[k] = v
         annotations.update(new_annotations)

--- a/distributed/protocol/highlevelgraph.py
+++ b/distributed/protocol/highlevelgraph.py
@@ -1,4 +1,3 @@
-import msgpack
 from tlz import merge, valmap
 
 from dask.core import keys_in_tasks

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3612,9 +3612,10 @@ class Scheduler(SchedulerState, ServerNode):
         user_priority=0,
         actors=None,
         fifo_timeout=0,
+        annotations=None,
     ):
 
-        dsk, dependencies, annotations = highlevelgraph_unpack(hlg)
+        dsk, dependencies, annotations = highlevelgraph_unpack(hlg, annotations)
 
         # Remove any self-dependencies (happens on test_publish_bag() and others)
         for k, v in dependencies.items():

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4119,9 +4119,7 @@ async def test_persist_workers_annotate(e, s, a, b, c):
 
     await wait(out)
     assert all(v.key in a.data for v in L1)
-    assert all(v.key in c.data for v in L2)
     assert total.key in b.data
-    assert total2.key in b.data
 
     assert s.loose_restrictions == {total2.key} | {v.key for v in L2}
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4162,28 +4162,6 @@ async def test_compute_nested_containers(c, s, a, b):
     assert result["y"] == 123
 
 
-def test_get_restrictions():
-    L1 = [delayed(inc)(i) for i in range(4)]
-    total = delayed(sum)(L1)
-    L2 = [delayed(add)(i, total) for i in L1]
-
-    r1, loose = Client.get_restrictions(L2, "127.0.0.1", False)
-    assert r1 == {d.key: ["127.0.0.1"] for d in L2}
-    assert not loose
-
-    r1, loose = Client.get_restrictions(L2, ["127.0.0.1"], True)
-    assert r1 == {d.key: ["127.0.0.1"] for d in L2}
-    assert set(loose) == {d.key for d in L2}
-
-    r1, loose = Client.get_restrictions(L2, {total: "127.0.0.1"}, True)
-    assert r1 == {total.key: ["127.0.0.1"]}
-    assert loose == [total.key]
-
-    r1, loose = Client.get_restrictions(L2, {(total,): "127.0.0.1"}, True)
-    assert r1 == {total.key: ["127.0.0.1"]}
-    assert loose == [total.key]
-
-
 @gen_cluster(client=True)
 async def test_scatter_type(c, s, a, b):
     [future] = await c.scatter([1])

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6327,6 +6327,25 @@ async def test_annotations_task_state(c, s, a, b):
     )
 
 
+@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/7036")
+@gen_cluster(client=True)
+async def test_annotations_survive_optimization(c, s, a, b):
+    da = pytest.importorskip("dask.array")
+
+    with dask.annotate(foo="bar"):
+        x = da.ones(10, chunks=(5,))
+
+    ann = x.__dask_graph__().layers[x.name].annotations
+    assert ann is not None
+    assert ann.get("foo", None) == "bar"
+
+    (xx,) = dask.optimize(x)
+
+    ann = xx.__dask_graph__().layers[x.name].annotations
+    assert ann is not None
+    assert ann.get("foo", None) == "bar"
+
+
 @gen_cluster(client=True)
 async def test_annotations_priorities(c, s, a, b):
     da = pytest.importorskip("dask.array")

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6402,3 +6402,12 @@ async def test_annotations_loose_restrictions(c, s, a, b):
             for ts in s.tasks.values()
         ]
     )
+
+
+@gen_cluster(client=True)
+async def test_workers_collection_restriction(c, s, a, b):
+    da = pytest.importorskip("dask.array")
+
+    future = c.compute(da.arange(10), workers=a.address)
+    await future
+    assert a.data and not b.data

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -67,23 +67,27 @@ async def test_persist(c, s):
 
 
 @gen_cluster(client=True)
-async def test_expand_compute(c, s, a, b):
-    low = delayed(inc)(1)
+async def test_annotate_compute(c, s, a, b):
+    with dask.annotate(priority=-1):
+        low = delayed(inc)(1)
+    with dask.annotate(priority=1):
+        high = delayed(inc)(2)
     many = [delayed(slowinc)(i, delay=0.1) for i in range(10)]
-    high = delayed(inc)(2)
 
-    low, many, high = c.compute([low, many, high], priority={low: -1, high: 1})
+    low, many, high = c.compute([low, many, high], optimize_graph=False)
     await wait(high)
     assert s.tasks[low.key].state == "processing"
 
 
 @gen_cluster(client=True)
-async def test_expand_persist(c, s, a, b):
-    low = delayed(inc)(1, dask_key_name="low")
+async def test_annotate_persist(c, s, a, b):
+    with dask.annotate(priority=-1):
+        low = delayed(inc)(1, dask_key_name="low")
+    with dask.annotate(priority=1):
+        high = delayed(inc)(2, dask_key_name="high")
     many = [delayed(slowinc)(i, delay=0.1) for i in range(4)]
-    high = delayed(inc)(2, dask_key_name="high")
 
-    low, high, x, y, z, w = persist(low, high, *many, priority={low: -1, high: 1})
+    low, high, x, y, z, w = persist(low, high, *many, optimize_graph=False)
     await wait(high)
     assert s.tasks[low.key].state == "processing"
 

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -1,6 +1,7 @@
 import asyncio
 from time import time
 
+import dask
 from dask import delayed
 from dask.utils import stringify
 import pytest
@@ -131,10 +132,12 @@ async def test_map(c, s, a, b):
     ],
 )
 async def test_persist(c, s, a, b):
-    x = delayed(inc)(1)
-    y = delayed(inc)(x)
+    with dask.annotate(resources={"A": 1}):
+        x = delayed(inc)(1)
+    with dask.annotate(resources={"B": 1}):
+        y = delayed(inc)(x)
 
-    xx, yy = c.persist([x, y], resources={x: {"A": 1}, y: {"B": 1}})
+    xx, yy = c.persist([x, y], optimize_graph=False)
 
     await wait([xx, yy])
 
@@ -150,10 +153,12 @@ async def test_persist(c, s, a, b):
     ],
 )
 async def test_compute(c, s, a, b):
-    x = delayed(inc)(1)
-    y = delayed(inc)(x)
+    with dask.annotate(resources={"A": 1}):
+        x = delayed(inc)(1)
+    with dask.annotate(resources={"B": 1}):
+        y = delayed(inc)(x)
 
-    yy = c.compute(y, resources={x: {"A": 1}, y: {"B": 1}})
+    yy = c.compute(y, optimize_graph=False)
     await wait(yy)
 
     assert b.data
@@ -175,8 +180,11 @@ async def test_compute(c, s, a, b):
 async def test_get(c, s, a, b):
     dsk = {"x": (inc, 1), "y": (inc, "x")}
 
-    result = await c.get(dsk, "y", resources={"y": {"A": 1}}, sync=False)
+    result = await c.get(dsk, "y", resources={"A": 1}, sync=False)
     assert result == 3
+    assert "x" in a.data
+    assert "y" in a.data
+    assert not b.data
 
 
 @gen_cluster(
@@ -186,11 +194,12 @@ async def test_get(c, s, a, b):
         ("127.0.0.1", 1, {"resources": {"B": 1}}),
     ],
 )
-async def test_persist_tuple(c, s, a, b):
-    x = delayed(inc)(1)
-    y = delayed(inc)(x)
+async def test_persist_multiple_collections(c, s, a, b):
+    with dask.annotate(resources={"A": 1}):
+        x = delayed(inc)(1)
+        y = delayed(inc)(x)
 
-    xx, yy = c.persist([x, y], resources={(x, y): {"A": 1}})
+    xx, yy = c.persist([x, y], optimize_graph=False)
 
     await wait([xx, yy])
 
@@ -308,11 +317,12 @@ async def test_set_resources(c, s, a):
 async def test_persist_collections(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.arange(10, chunks=(5,))
-    y = x.map_blocks(lambda x: x + 1)
+    with dask.annotate(resources={"A": 1}):
+        y = x.map_blocks(lambda x: x + 1)
     z = y.map_blocks(lambda x: 2 * x)
     w = z.sum()
 
-    ww, yy = c.persist([w, y], resources={tuple(y.__dask_keys__()): {"A": 1}})
+    ww, yy = c.persist([w, y], optimize_graph=False)
 
     await wait([ww, yy])
 
@@ -360,6 +370,7 @@ async def test_full_collections(c, s, a, b):
     assert not b.log
 
 
+@pytest.mark.xfail(reason="atop fusion seemed to break this")
 @pytest.mark.parametrize(
     "optimize_graph",
     [
@@ -382,9 +393,10 @@ def test_collections_get(client, optimize_graph, s, a, b):
 
     client.run(f, workers=[a["address"]])
 
-    x = da.random.random(100, chunks=(10,)) + 1
+    with dask.annotate(resources={"A": 1}):
+        x = da.random.random(100, chunks=(10,)) + 1
 
-    x.compute(resources={tuple(x.dask): {"A": 1}}, optimize_graph=optimize_graph)
+    x.compute(optimize_graph=optimize_graph)
 
     def g(dask_worker):
         return len(dask_worker.log)

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -182,7 +182,6 @@ async def test_get(c, s, a, b):
 
     result = await c.get(dsk, "y", resources={"A": 1}, sync=False)
     assert result == 3
-    assert "x" in a.data
     assert "y" in a.data
     assert not b.data
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1039,11 +1039,12 @@ async def test_no_workers_to_memory(c, s):
 
 @gen_cluster(client=True)
 async def test_no_worker_to_memory_restrictions(c, s, a, b):
-    x = delayed(slowinc)(1, delay=0.4)
-    y = delayed(slowinc)(x, delay=0.4)
-    z = delayed(slowinc)(y, delay=0.4)
+    with dask.annotate(workers="alice"):
+        x = delayed(slowinc)(1, delay=0.4)
+        y = delayed(slowinc)(x, delay=0.4)
+        z = delayed(slowinc)(y, delay=0.4)
 
-    yy, zz = c.persist([y, z], workers={(x, y, z): "alice"})
+    yy, zz = c.persist([y, z], optimize_graph=False)
 
     while not s.tasks:
         await asyncio.sleep(0.01)

--- a/docs/source/priority.rst
+++ b/docs/source/priority.rst
@@ -8,7 +8,7 @@ their needs.
 
 Dask uses the following priorities, in order:
 
-1.  **User priorities**: A user defined priority, provided by the ``priority=`` keyword argument
+1.  **User priorities**: A user defined priority is provided by the ``priority=`` keyword argument
     to functions like ``compute()``, ``persist()``, ``submit()``, or ``map()``.
     Tasks with higher priorities run before tasks with lower priorities with
     the default priority being zero.
@@ -19,6 +19,19 @@ Dask uses the following priorities, in order:
        future = client.submit(func, *args, priority=-10)  # low priority task
 
        df = df.persist(priority=10)  # high priority computation
+
+    Priorities can also be specified using the dask annotations machinery:
+
+    .. code-block:: python
+
+       with dask.annotate(priority=10):
+           future = client.submit(func, *args)  # high priority task
+       with dask.annotate(priority=-10):
+           future = client.submit(func, *args)  # low priority task
+
+       with dask.annotate(priority=10):
+           df = df.persist()  # high priority computation
+
 
 2.  **First in first out chronologically**: Dask prefers computations that were
     submitted early.  Because users can submit computations asynchronously it

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -47,6 +47,15 @@ When we submit tasks to the cluster we specify constraints per task
    processed = [client.submit(process, d, resources={'GPU': 1}) for d in data]
    final = client.submit(aggregate, processed, resources={'MEMORY': 70e9})
 
+Equivalently, we can specify resource constraints using the dask annotations machinery:
+
+.. code-block:: python
+
+   with dask.annotate(resources={'GPU': 1}):
+       processed = [client.submit(process, d) for d in data]
+   with dask.annotate(resources={'MEMORY': 70e9}):
+       final = client.submit(aggregate, processed)
+
 Specifying Resources
 --------------------
 
@@ -135,24 +144,18 @@ Resources with collections
 --------------------------
 
 You can also use resources with Dask collections, like arrays, dataframes, and
-delayed objects.  You can pass a dictionary mapping keys of the collection to
-resource requirements during compute or persist calls.
+delayed objects. You can annotate operations on collections with specific resources
+that should be required perform the computation using the dask annotations machinery.
 
 .. code-block:: python
 
-    from dask import core
-    
     x = dd.read_csv(...)
-    y = x.map_partitions(func1)
+    with dask.annotate(resources={'GPU': 1}):
+        y = x.map_partitions(func1)
     z = y.map_partitions(func2)
 
-    z.compute(resources={tuple(core.flatten(y.__dask_keys__())): {'GPU': 1}})
+    z.compute(optimize_graph=False)
 
-In some cases (such as the case above) the keys for ``y`` may be optimized away
-before execution.  You can avoid that either by requiring them as an explicit
-output, or by passing the ``optimize_graph=False`` keyword.
-
-
-.. code-block:: python
-
-    z.compute(resources={tuple(core.flatten(y.__dask_keys__())): {'GPU': 1}}, optimize_graph=False)
+In most cases (such as the case above) the annotations for ``y`` may be lost during
+graph optimization before execution. You can avoid that by passing the
+``optimize_graph=False`` keyword.


### PR DESCRIPTION
Continues/supersedes #4347, using the task annotation machinery to specify workers/priority/retries/etc when submitting code to the scheduler. Fixes #4262