### PR TITLE
Set use_bin_type=True in highlevelgraph_pack

### DIFF
--- a/distributed/protocol/highlevelgraph.py
+++ b/distributed/protocol/highlevelgraph.py
@@ -127,7 +127,9 @@ def highlevelgraph_pack(hlg: HighLevelGraph, client, client_keys):
             }
         )
 
-    return msgpack.dumps({"layers": layers}, default=msgpack_encode_default)
+    return msgpack.dumps(
+        {"layers": layers}, use_bin_type=True, default=msgpack_encode_default
+    )
 
 
 def _materialized_layer_unpack(state, dsk, dependencies, annotations):


### PR DESCRIPTION
This PR ensures we use `use_bin_type=True` in `highlevelgraph_pack`. For `msgpack` >= 1 this is the default behavior, so doesn't need to be explicitly specified. However older versions of `msgpack` use `use_bin_type=False` by default, which was causing serialization errors.

cc @haraldschilly @bnaul 

Closes https://github.com/dask/distributed/issues/4395