### PR TITLE
Type `TaskGroup` in `active_states`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -708,6 +708,7 @@ class TaskPrefix:
 
     @property
     def active_states(self):
+        tg: TaskGroup
         return merge_with(sum, [tg._states for tg in self.active])
 
     def __repr__(self):


### PR DESCRIPTION
This was missing a type annotation before, which results in issues when accessing `_states` when compiled. This fixes that issue.

cc @quasiben