### PR TITLE
Use dumps_msgpack and loads_msgpack when packing high level graphs

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2585,8 +2585,6 @@ class Client:
             if not isinstance(dsk, HighLevelGraph):
                 dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
 
-            dsk = highlevelgraph_pack(dsk, self, keyset)
-
             if isinstance(retries, Number) and retries > 0:
                 retries = {k: retries for k in dsk}
 
@@ -2595,7 +2593,7 @@ class Client:
             self._send_to_scheduler(
                 {
                     "op": "update-graph-hlg",
-                    "hlg": dsk,
+                    "hlg": highlevelgraph_pack(dsk, self, keyset),
                     "keys": list(map(stringify, keys)),
                     "restrictions": restrictions or {},
                     "loose_restrictions": loose_restrictions,

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2588,12 +2588,14 @@ class Client:
             if isinstance(retries, Number) and retries > 0:
                 retries = {k: retries for k in dsk}
 
+            dsk = highlevelgraph_pack(dsk, self, keyset)
+
             # Create futures before sending graph (helps avoid contention)
             futures = {key: Future(key, self, inform=False) for key in keyset}
             self._send_to_scheduler(
                 {
                     "op": "update-graph-hlg",
-                    "hlg": highlevelgraph_pack(dsk, self, keyset),
+                    "hlg": dsk,
                     "keys": list(map(stringify, keys)),
                     "restrictions": restrictions or {},
                     "loose_restrictions": loose_restrictions,


### PR DESCRIPTION
Alternative to #4407 that make use of `dumps_msgpack` and `loads_msgpack`.

Closes #4407
Closes #4395