### PR TITLE
Log adaptive error

### DIFF
--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -201,7 +201,8 @@ class AdaptiveCore:
                 await self.scale_up(**recommendations)
             if status == "down":
                 await self.scale_down(**recommendations)
-        except OSError:
+        except OSError as e:
+            logger.error("Adaptive stopping due to error %s", str(e))
             self.stop()
         finally:
             self._adapting = False


### PR DESCRIPTION
Sometimes adaptive will stop due to an `OSError`.

This PR logs that error to help with debugging.