### PR TITLE
Add time started to scheduler info

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1963,6 +1963,7 @@ class Scheduler(ServerNode):
             "id": str(self.id),
             "address": self.address,
             "services": {key: v.port for (key, v) in self.services.items()},
+            "time_started": self.time_started,
             "workers": {
                 worker.address: worker.identity() for worker in self.workers.values()
             },

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1963,7 +1963,7 @@ class Scheduler(ServerNode):
             "id": str(self.id),
             "address": self.address,
             "services": {key: v.port for (key, v) in self.services.items()},
-            "time_started": self.time_started,
+            "started": self.time_started,
             "workers": {
                 worker.address: worker.identity() for worker in self.workers.values()
             },

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3789,7 +3789,7 @@ def test_scheduler_info(c):
     info = c.scheduler_info()
     assert isinstance(info, dict)
     assert len(info["workers"]) == 2
-    assert "time_started" in info
+    assert isinstance(info["started"], float)
 
 
 def test_write_scheduler_file(c):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3789,6 +3789,7 @@ def test_scheduler_info(c):
     info = c.scheduler_info()
     assert isinstance(info, dict)
     assert len(info["workers"]) == 2
+    assert "time_started" in info
 
 
 def test_write_scheduler_file(c):


### PR DESCRIPTION
It is useful from a cluster lifecycle management perspective to include the scheduler start time in the scheduler info.

Extracted from #4291