### PR TITLE
Give clusters names

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -51,7 +51,7 @@ class Cluster:
     """
 
     _supports_scaling = True
-    name = str(uuid.uuid4())[:8]
+    name = None
 
     def __init__(self, asynchronous, quiet=False, name=None):
         self.scheduler_info = {"workers": {}}
@@ -65,6 +65,8 @@ class Cluster:
 
         if name is not None:
             self.name = name
+        elif self.name is None:
+            self.name = str(uuid.uuid4())[:8]
         self.status = Status.created
 
     async def _start(self):

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -94,6 +94,7 @@ class LocalCluster(SpecCluster):
 
     def __init__(
         self,
+        name=None,
         n_workers=None,
         threads_per_worker=None,
         processes=True,
@@ -227,6 +228,7 @@ class LocalCluster(SpecCluster):
         workers = {i: worker for i in range(n_workers)}
 
         super().__init__(
+            name=name,
             scheduler=scheduler,
             workers=workers,
             worker=worker,

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -269,7 +269,10 @@ class SpecCluster(Cluster):
         self._correct_state_waiting = None
         self._name = name or type(self).__name__
 
-        super().__init__(asynchronous=asynchronous)
+        super().__init__(
+            asynchronous=asynchronous,
+            name=name,
+        )
 
         if not self.asynchronous:
             self._loop_runner.start()
@@ -616,6 +619,11 @@ class SpecCluster(Cluster):
             )
 
         return super().adapt(*args, minimum=minimum, maximum=maximum, **kwargs)
+
+    @classmethod
+    def from_name(cls, name: str):
+        """Create an instance of this class to represent an existing cluster by name."""
+        raise NotImplementedError()
 
 
 async def run_spec(spec: dict, *args):

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -51,7 +51,11 @@ async def test_simultaneous_scale_up_and_down(cleanup):
 
 def test_adaptive_local_cluster(loop):
     with LocalCluster(
-        0, scheduler_port=0, silence_logs=False, dashboard_address=None, loop=loop
+        n_workers=0,
+        scheduler_port=0,
+        silence_logs=False,
+        dashboard_address=None,
+        loop=loop,
     ) as cluster:
         alc = cluster.adapt(interval="100 ms")
         with Client(cluster, loop=loop) as c:
@@ -76,7 +80,7 @@ def test_adaptive_local_cluster(loop):
 @pytest.mark.asyncio
 async def test_adaptive_local_cluster_multi_workers(cleanup):
     async with LocalCluster(
-        0,
+        n_workers=0,
         scheduler_port=0,
         silence_logs=False,
         processes=False,
@@ -146,7 +150,7 @@ async def test_adaptive_scale_down_override(cleanup):
 @gen_test()
 async def test_min_max():
     cluster = await LocalCluster(
-        0,
+        n_workers=0,
         scheduler_port=0,
         silence_logs=False,
         processes=False,
@@ -201,7 +205,7 @@ async def test_avoid_churn(cleanup):
     user is taking a brief pause between work
     """
     async with LocalCluster(
-        0,
+        n_workers=0,
         asynchronous=True,
         processes=False,
         scheduler_port=0,
@@ -226,7 +230,7 @@ async def test_adapt_quickly():
     user is taking a brief pause between work
     """
     cluster = await LocalCluster(
-        0,
+        n_workers=0,
         asynchronous=True,
         processes=False,
         scheduler_port=0,

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1059,3 +1059,6 @@ async def test_cluster_names():
             assert unnamed_cluster == unnamed_cluster
             assert named_cluster == named_cluster
             assert unnamed_cluster != named_cluster
+
+        async with LocalCluster(processes=False, asynchronous=True) as unnamed_cluster2:
+            assert unnamed_cluster2 != unnamed_cluster

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -98,7 +98,7 @@ def test_procs():
         repr(c)
 
     with LocalCluster(
-        2,
+        n_workers=2,
         scheduler_port=0,
         processes=True,
         threads_per_worker=3,

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -83,7 +83,7 @@ def test_close_twice():
 
 def test_procs():
     with LocalCluster(
-        2,
+        n_workers=2,
         scheduler_port=0,
         processes=False,
         threads_per_worker=3,
@@ -434,7 +434,7 @@ def test_blocks_until_full(loop):
 @pytest.mark.asyncio
 async def test_scale_up_and_down():
     async with LocalCluster(
-        0,
+        n_workers=0,
         scheduler_port=0,
         processes=False,
         silence_logs=False,
@@ -763,7 +763,7 @@ async def test_scale_retires_workers():
 
     loop = IOLoop.current()
     cluster = await MyCluster(
-        0,
+        n_workers=0,
         scheduler_port=0,
         processes=False,
         silence_logs=False,

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1045,3 +1045,17 @@ async def test_no_workers(cleanup):
         n_workers=0, silence_logs=False, dashboard_address=None, asynchronous=True
     ) as c:
         pass
+
+
+@pytest.mark.asyncio
+async def test_cluster_names():
+    async with LocalCluster(processes=False, asynchronous=True) as unnamed_cluster:
+        async with LocalCluster(
+            processes=False, asynchronous=True, name="mycluster"
+        ) as named_cluster:
+            assert isinstance(unnamed_cluster.name, str)
+            assert isinstance(named_cluster.name, str)
+            assert named_cluster.name == "mycluster"
+            assert unnamed_cluster == unnamed_cluster
+            assert named_cluster == named_cluster
+            assert unnamed_cluster != named_cluster

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -494,7 +494,7 @@ async def test_run_spec_cluster_worker_names(cleanup):
 
     class MyCluster(SpecCluster):
         def _new_worker_name(self, worker_number):
-            return f"prefix-{self._name }-{worker_number}-suffix"
+            return f"prefix-{self.name}-{worker_number}-suffix"
 
     async with SpecCluster(
         asynchronous=True, scheduler=scheduler, worker=worker


### PR DESCRIPTION
This PR gives all `Cluster` objects and subclasses a unique name.

This name can be provided with the `name` kwarg, if this is omitted it will default to a UUID.

I have also stubbed out a `from_name` class method in `SpecCluster` with the intention that cluster objects that can be reconstructed by name (Cloud, Kubernetes, etc) should implement this method.

I've also added the `shutdown_on_close` argument to `SpecCluster` as proposed by @mrocklin as creating a cluster from name requires the ability to detach from the cluster in the first place.