### PR TITLE
Add test for adaptive stop

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -77,6 +77,8 @@ class Cluster:
         if self.status == Status.closed:
             return
 
+        with suppress(AttributeError):
+            self._adaptive.stop()
         if self._watch_worker_status_comm:
             await self._watch_worker_status_comm.close()
         if self._watch_worker_status_task:

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -81,6 +81,16 @@ def test_close_twice():
         assert not log
 
 
+def test_adapt_coros():
+    import time
+    with LocalCluster(n_workers=0, threads_per_worker=1) as cluster:
+        cluster.adapt(minimum=1, maximum=4)
+        with Client(cluster) as client:
+            client.submit(lambda: time.sleep(1)).result()
+    pending = [t for t in asyncio.tasks._all_tasks if not t.done()]
+    assert not pending
+
+
 def test_procs():
     with LocalCluster(
         2,


### PR DESCRIPTION
Eventually fixes #4427

For now, the test shows the problem, but adding `adaptive.stop()` doesn't seem to be enough