### PR TITLE
Set port 8786 as default port for scheduler

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -101,7 +101,7 @@ class LocalCluster(SpecCluster):
         start=None,
         host=None,
         ip=None,
-        scheduler_port=0,
+        scheduler_port=8786,
         silence_logs=logging.WARN,
         dashboard_address=":8787",
         worker_dashboard_address=None,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -169,10 +169,10 @@ class LocalCluster(SpecCluster):
         if not protocol.endswith("://"):
             protocol = protocol + "://"
 
-        if protocol.startswith("inproc"):
-            scheduler_port = 0
-        else:
+        if protocol.startswith("tcp"):
             scheduler_port = 8786
+        else:
+            scheduler_port = 0
 
         if host is None and not protocol.startswith("inproc") and not interface:
             host = "127.0.0.1"

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -101,7 +101,7 @@ class LocalCluster(SpecCluster):
         start=None,
         host=None,
         ip=None,
-        scheduler_port=8786,
+        scheduler_port=None,
         silence_logs=logging.WARN,
         dashboard_address=":8787",
         worker_dashboard_address=None,
@@ -167,6 +167,11 @@ class LocalCluster(SpecCluster):
                 protocol = "tcp://"
         if not protocol.endswith("://"):
             protocol = protocol + "://"
+
+        if protocol.startswith("inproc"):
+            scheduler_port = 0
+        else:
+            scheduler_port = 8786
 
         if host is None and not protocol.startswith("inproc") and not interface:
             host = "127.0.0.1"

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1045,3 +1045,10 @@ async def test_no_workers(cleanup):
         n_workers=0, silence_logs=False, dashboard_address=None, asynchronous=True
     ) as c:
         pass
+
+
+@pytest.mark.asyncio
+async def test__default_scheduler_port():
+    async with LocalCluster(n_workers=2, processes=False, asynchronous=True) as cluster:
+
+        assert cluster.scheduler_port == 8786

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -16,6 +16,7 @@ import pytest
 
 from dask.system import CPU_COUNT
 from distributed import Client, Worker, Nanny, get_client
+from distributed.comm.addressing import parse_host_port
 from distributed.core import Status
 from distributed.deploy.local import LocalCluster
 from distributed.metrics import time
@@ -1048,7 +1049,8 @@ async def test_no_workers(cleanup):
 
 
 @pytest.mark.asyncio
-async def test__default_scheduler_port():
+async def test_default_scheduler_port():
     async with LocalCluster(n_workers=2, processes=False, asynchronous=True) as cluster:
 
-        assert "8786" in cluster.scheduler_address
+        _, port = parse_host_port(cluster.scheduler_adress)
+        assert port == 8786

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1052,5 +1052,5 @@ async def test_no_workers(cleanup):
 async def test_default_scheduler_port():
     async with LocalCluster(n_workers=2, processes=False, asynchronous=True) as cluster:
 
-        _, port = parse_host_port(cluster.scheduler_adress)
+        _, port = parse_host_port(cluster.scheduler_address)
         assert port == 8786

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -122,7 +122,7 @@ def test_move_unserializable_data():
     transports.
     """
     with LocalCluster(
-        processes=False, silence_logs=False, dashboard_address=None, scheduler_port=0
+        processes=False, silence_logs=False, dashboard_address=None
     ) as cluster:
         assert cluster.scheduler_address.startswith("inproc://")
         assert cluster.workers[0].address.startswith("inproc://")
@@ -138,7 +138,7 @@ def test_transports_inproc():
     Test the transport chosen by LocalCluster depending on arguments.
     """
     with LocalCluster(
-        1, processes=False, silence_logs=False, dashboard_address=None, scheduler_port=0
+        1, processes=False, silence_logs=False, dashboard_address=None
     ) as c:
         assert c.scheduler_address.startswith("inproc://")
         assert c.workers[0].address.startswith("inproc://")
@@ -833,9 +833,7 @@ def test_asynchronous_property(loop):
 
 
 def test_protocol_inproc(loop):
-    with LocalCluster(
-        protocol="inproc://", loop=loop, processes=False, scheduler_port=0
-    ) as cluster:
+    with LocalCluster(protocol="inproc://", loop=loop, processes=False) as cluster:
         assert cluster.scheduler.address.startswith("inproc://")
 
 

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1051,4 +1051,4 @@ async def test_no_workers(cleanup):
 async def test__default_scheduler_port():
     async with LocalCluster(n_workers=2, processes=False, asynchronous=True) as cluster:
 
-        assert cluster.scheduler_port == 8786
+        assert "8786" in cluster.scheduler_address

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -122,7 +122,7 @@ def test_move_unserializable_data():
     transports.
     """
     with LocalCluster(
-        processes=False, silence_logs=False, dashboard_address=None
+        processes=False, silence_logs=False, dashboard_address=None, scheduler_port=0
     ) as cluster:
         assert cluster.scheduler_address.startswith("inproc://")
         assert cluster.workers[0].address.startswith("inproc://")
@@ -138,7 +138,7 @@ def test_transports_inproc():
     Test the transport chosen by LocalCluster depending on arguments.
     """
     with LocalCluster(
-        1, processes=False, silence_logs=False, dashboard_address=None
+        1, processes=False, silence_logs=False, dashboard_address=None, scheduler_port=0
     ) as c:
         assert c.scheduler_address.startswith("inproc://")
         assert c.workers[0].address.startswith("inproc://")
@@ -833,7 +833,9 @@ def test_asynchronous_property(loop):
 
 
 def test_protocol_inproc(loop):
-    with LocalCluster(protocol="inproc://", loop=loop, processes=False) as cluster:
+    with LocalCluster(
+        protocol="inproc://", loop=loop, processes=False, scheduler_port=0
+    ) as cluster:
         assert cluster.scheduler.address.startswith("inproc://")
 
 


### PR DESCRIPTION
Hello,

This is my attempt at a fix #4429.  I followed Benjamin suggestion and changed the port number in the constructor, I've also added a tiny (silly) test to check if the port is the right one 😄 

Let me know if you would like me to change something 🤔 