### PR TITLE
Set runspec on all new tasks to avoid deadlocks

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2316,6 +2316,7 @@ class Worker(ServerNode):
 
             for worker in ts.who_has:
                 self.has_what[worker].discard(ts.key)
+            ts.who_has.clear()
 
             if key in self.threads:
                 del self.threads[key]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2282,13 +2282,14 @@ class Worker(ServerNode):
         self.batched_stream.send(response)
 
         if state in ("ready", "waiting", "constrained"):
-            self.transition(ts, "waiting")
             ts.runspec = None
             self.release_key(key)
 
     def release_key(self, key, cause=None, reason=None, report=True):
         try:
             ts = self.tasks.get(key, TaskState(key=key))
+            if self.validate:
+                assert not ts.dependents
             if cause:
                 self.log.append((key, "release-key", {"cause": cause}))
             else:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1714,10 +1714,7 @@ class Worker(ServerNode):
         """
         This transition is common for work stealing
         """
-        ts.state = "waiting"
-        ts.runspec = None
-
-        return ts.state
+        pass
 
     def transition_constrained_executing(self, ts):
         self.transition_ready_executing(ts)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -453,6 +453,7 @@ class Worker(ServerNode):
             ("ready", "error"): self.transition_ready_error,
             ("ready", "waiting"): self.transition_ready_waiting,
             ("constrained", "waiting"): self.transition_ready_waiting,
+            ("constrained", "error"): self.transition_ready_error,
             ("constrained", "executing"): self.transition_constrained_executing,
             ("executing", "memory"): self.transition_executing_done,
             ("executing", "error"): self.transition_executing_done,


### PR DESCRIPTION
This is a more minimalistic version of #4360 with fixes I am pretty confident with. I still can see local issue, though and this is incomplete.