### PR TITLE
Don't require network to inspect tests

### DIFF
--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -42,11 +42,6 @@ from distributed.utils_test import (
 from distributed.utils_test import loop  # noqa F401
 
 
-EXTERNAL_IP4 = get_ip()
-if has_ipv6():
-    EXTERNAL_IP6 = get_ipv6()
-
-
 def echo(comm, x):
     return x
 
@@ -194,6 +189,15 @@ async def test_server_listen():
     """
     Test various Server.listen() arguments and their effect.
     """
+    import socket
+
+    try:
+        EXTERNAL_IP4 = get_ip()
+        if has_ipv6():
+            EXTERNAL_IP6 = get_ipv6()
+    except socket.gaierror:
+        raise pytest.skip(reason="no network access")
+
     from contextlib import asynccontextmanager
 
     @asynccontextmanager


### PR DESCRIPTION
Previously the get_ipv6 function was called at import time in test_core.py
This stopped any tests from running if a network adapter was not
attached

The results of this function were used only in one test,
so we move this call within that test and skip if it fails