### PR TITLE
Update TaskState documentation about dependents attribute

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -104,7 +104,10 @@ class TaskState:
     * **dependencies**: ``set(TaskState instances)``
         The data needed by this key to run
     * **dependents**: ``set(TaskState instances)``
-        The keys that use this dependency
+        The keys that use this dependency. Only keys which are not available
+        already are tracked in this structure and dependents made available are
+        actively removed. Only after all dependents have been removed, this task
+        is allowed to be forgotten
     * **duration**: ``float``
         Expected duration the a task
     * **priority**: ``tuple``


### PR DESCRIPTION
I think this mechanism should be refined but currently `dependents` is a dynamic data structure and this should be reflected in the docs.

For dependencies we have already a dynamic equivalent with `waiting_for_data` and I believe we should establish a similar mechanism for the dependents since this is primarily used to determine whether or not a key is allowed to be forgotten. In the meantime, a more accurate docstring should help

xref #4413 