### PR TITLE
Additional optimizations to stealing

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6106,7 +6106,6 @@ class Scheduler(ServerNode):
         lets us avoid this fringe optimization when we have better things to
         think about.
         """
-        DELAY = 0.1
         try:
             if self.status == Status.closed:
                 return
@@ -6131,7 +6130,7 @@ class Scheduler(ServerNode):
                         next_time = timedelta(seconds=duration * 5)  # 25ms gap
                         break
             else:
-                next_time = timedelta(seconds=DELAY)
+                next_time = timedelta(seconds=0.1)
 
             self.loop.add_timeout(
                 next_time, self.reevaluate_occupancy, worker_index=worker_index

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4831,10 +4831,9 @@ class Scheduler(ServerNode):
         duration: double = self.get_task_duration(ts)
         comm: double = self.get_comm_cost(ts, ws)
         total_duration: double = duration + comm
-        if ts in ws._executing:
-            exec_time: double = ws._executing[ts]
-            if exec_time > 2 * duration:
-                total_duration = 2 * exec_time
+        exec_time: double = ws._executing.get(ts, 0)
+        if exec_time > 2 * duration:
+            total_duration = 2 * exec_time
         ws._processing[ts] = total_duration
         return total_duration
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6111,9 +6111,8 @@ class Scheduler(ServerNode):
             if self.status == Status.closed:
                 return
 
-            last = time()
-
             if self.proc.cpu_percent() < 50:
+                last = time()
                 workers = list(self.workers.values())
                 for i in range(len(workers)):
                     ws: WorkerState = workers[worker_index % len(workers)]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4830,10 +4830,12 @@ class Scheduler(ServerNode):
         """
         duration: double = self.get_task_duration(ts)
         comm: double = self.get_comm_cost(ts, ws)
-        total_duration: double = duration + comm
+        total_duration: double
         exec_time: double = ws._executing.get(ts, 0)
         if exec_time > 2 * duration:
             total_duration = 2 * exec_time
+        else:
+            total_duration = duration + comm
         ws._processing[ts] = total_duration
         return total_duration
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4830,8 +4830,8 @@ class Scheduler(ServerNode):
         """
         duration: double = self.get_task_duration(ts)
         comm: double = self.get_comm_cost(ts, ws)
-        total_duration: double
         exec_time: double = ws._executing.get(ts, 0)
+        total_duration: double
         if exec_time > 2 * duration:
             total_duration = 2 * exec_time
         else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4828,8 +4828,8 @@ class Scheduler(ServerNode):
         estimate the task duration to be 2x current-runtime, otherwise we set it
         to be the average duration.
         """
-        duration: double = self.get_task_duration(ts)
         exec_time: double = ws._executing.get(ts, 0)
+        duration: double = self.get_task_duration(ts)
         total_duration: double
         if exec_time > 2 * duration:
             total_duration = 2 * exec_time

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4829,12 +4829,12 @@ class Scheduler(ServerNode):
         to be the average duration.
         """
         duration: double = self.get_task_duration(ts)
-        comm: double = self.get_comm_cost(ts, ws)
         exec_time: double = ws._executing.get(ts, 0)
         total_duration: double
         if exec_time > 2 * duration:
             total_duration = 2 * exec_time
         else:
+            comm: double = self.get_comm_cost(ts, ws)
             total_duration = duration + comm
         ws._processing[ts] = total_duration
         return total_duration

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6110,8 +6110,10 @@ class Scheduler(ServerNode):
             if self.status == Status.closed:
                 return
 
+            last = time()
+            next_time = timedelta(seconds=0.1)
+
             if self.proc.cpu_percent() < 50:
-                last = time()
                 workers: list = list(self.workers.values())
                 nworkers: Py_ssize_t = len(workers)
                 i: Py_ssize_t
@@ -6129,8 +6131,6 @@ class Scheduler(ServerNode):
                     if duration > 0.005:  # 5ms since last release
                         next_time = timedelta(seconds=duration * 5)  # 25ms gap
                         break
-            else:
-                next_time = timedelta(seconds=0.1)
 
             self.loop.add_timeout(
                 next_time, self.reevaluate_occupancy, worker_index=worker_index

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6091,7 +6091,7 @@ class Scheduler(ServerNode):
     # Cleanup #
     ###########
 
-    def reevaluate_occupancy(self, worker_index=0):
+    def reevaluate_occupancy(self, worker_index: Py_ssize_t = 0):
         """Periodically reassess task duration time
 
         The expected duration of a task can change over time.  Unfortunately we
@@ -6113,8 +6113,9 @@ class Scheduler(ServerNode):
 
             if self.proc.cpu_percent() < 50:
                 last = time()
-                workers = list(self.workers.values())
-                nworkers = len(workers)
+                workers: list = list(self.workers.values())
+                nworkers: Py_ssize_t = len(workers)
+                i: Py_ssize_t
                 for i in range(nworkers):
                     ws: WorkerState = workers[worker_index % nworkers]
                     worker_index += 1

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6112,7 +6112,6 @@ class Scheduler(ServerNode):
                 return
 
             last = time()
-            next_time = timedelta(seconds=DELAY)
 
             if self.proc.cpu_percent() < 50:
                 workers = list(self.workers.values())
@@ -6130,6 +6129,8 @@ class Scheduler(ServerNode):
                     if duration > 0.005:  # 5ms since last release
                         next_time = timedelta(seconds=duration * 5)  # 25ms gap
                         break
+            else:
+                next_time = timedelta(seconds=DELAY)
 
             self.loop.add_timeout(
                 next_time, self.reevaluate_occupancy, worker_index=worker_index

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6114,8 +6114,9 @@ class Scheduler(ServerNode):
             if self.proc.cpu_percent() < 50:
                 last = time()
                 workers = list(self.workers.values())
-                for i in range(len(workers)):
-                    ws: WorkerState = workers[worker_index % len(workers)]
+                nworkers = len(workers)
+                for i in range(nworkers):
+                    ws: WorkerState = workers[worker_index % nworkers]
                     worker_index += 1
                     try:
                         if ws is None or not ws._processing:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -81,10 +81,10 @@ class WorkStealing(SchedulerPlugin):
                 self.in_flight.pop(ts, None)
 
     def put_key_in_stealable(self, ts):
-        ws = ts.processing_on
-        worker = ws.address
         cost_multiplier, level = self.steal_time_ratio(ts)
         if cost_multiplier is not None:
+            ws = ts.processing_on
+            worker = ws.address
             self.stealable_all[level].add(ts)
             self.stealable[worker][level].add(ts)
             self.key_stealable[ts] = (worker, level)

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -74,8 +74,7 @@ class WorkStealing(SchedulerPlugin):
         ts = self.scheduler.tasks[key]
         if finish == "processing":
             self.put_key_in_stealable(ts)
-
-        if start == "processing":
+        elif start == "processing":
             self.remove_key_from_stealable(ts)
             if finish != "memory":
                 self.in_flight.pop(ts, None)

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -71,10 +71,11 @@ class WorkStealing(SchedulerPlugin):
     def transition(
         self, key, start, finish, compute_start=None, compute_stop=None, *args, **kwargs
     ):
-        ts = self.scheduler.tasks[key]
         if finish == "processing":
+            ts = self.scheduler.tasks[key]
             self.put_key_in_stealable(ts)
         elif start == "processing":
+            ts = self.scheduler.tasks[key]
             self.remove_key_from_stealable(ts)
             if finish != "memory":
                 self.in_flight.pop(ts, None)


### PR DESCRIPTION
Annotates variables in `reevaluate_occupancy` to improve efficiency there. As well as delaying construction of values that may not be needed.

Further optimizes `put_key_in_stealable` by only retrieving `ws` and `worker` if `cost_multiplier` is not `None`, which is the only case where they are used. Avoiding grabbing them otherwise.

Finally simplify check for executing task in `set_duration_estimate` by just using `.get(...)` instead of checking for the key and then getting the value. 