### PR TITLE
[WIP] Build `serialize` with Cython

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -157,14 +157,16 @@ def serialization_error_loads(header, frames):
 families = {}
 
 
-def register_serialization_family(name, dumps, loads):
-    families[name] = (dumps, loads, dumps and has_keyword(dumps, "context"))
+def register_serialization_family(name, dumps, loads, context=None):
+    if context is None:
+        context = has_keyword(dumps, "context")
+    families[name] = (dumps, loads, dumps and context)
 
 
-register_serialization_family("dask", dask_dumps, dask_loads)
-register_serialization_family("pickle", pickle_dumps, pickle_loads)
-register_serialization_family("msgpack", msgpack_dumps, msgpack_loads)
-register_serialization_family("error", None, serialization_error_loads)
+register_serialization_family("dask", dask_dumps, dask_loads, True)
+register_serialization_family("pickle", pickle_dumps, pickle_loads, True)
+register_serialization_family("msgpack", msgpack_dumps, msgpack_loads, False)
+register_serialization_family("error", None, serialization_error_loads, False)
 
 
 def check_dask_serializable(x):

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,10 @@ if cython_arg:
             "distributed.scheduler",
             sources=["distributed/scheduler.py"],
         ),
+        Extension(
+            "distributed.protocol.serialize",
+            sources=["distributed/protocol/serialize.py"],
+        ),
     ]
     for e in cyext_modules:
         e.cython_directives = {


### PR DESCRIPTION
Enables Cythonization of `serialize`, this should improve functions like `extract_serialize`, which have already been annotated for this purpose.

Note: Have sometimes encountered `ImportError`s locally when doing this. Plus we've only done the work to annotate `extract_serialize` and nothing else. Hence why this is disabled. In the end we may end up optimizing Scheduler communication to bypass this function ( https://github.com/dask/distributed/issues/4376 ). So this may not be needed in the end.

cc @quasiben @mrocklin @madsbk