### PR TITLE
Use `parent._tasks` in heartbeat

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3411,7 +3411,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         if executing is not None:
             ws._executing = {
-                self.tasks[key]: duration for key, duration in executing.items()
+                parent._tasks[key]: duration for key, duration in executing.items()
             }
 
         if metrics:


### PR DESCRIPTION
Make sure we grab the typed `parent._tasks` in heartbeat. This benefits from the type annotation of this attribute.