### PR TITLE
Optimize transitions

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -127,7 +127,7 @@ class BatchedSend:
         self.stopped.set()
         self.abort()
 
-    def send(self, msg):
+    def send(self, *msgs):
         """Schedule a message for sending to the other side
 
         This completes quickly and synchronously
@@ -135,8 +135,8 @@ class BatchedSend:
         if self.comm is not None and self.comm.closed():
             raise CommClosedError
 
-        self.message_count += 1
-        self.buffer.append(msg)
+        self.message_count += len(msgs)
+        self.buffer.extend(msgs)
         # Avoid spurious wakeups if possible
         if self.next_deadline is None:
             self.waker.set()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -182,7 +182,10 @@ DEFAULT_EXTENSIONS = [
     EventExtension,
 ]
 
-ALL_TASK_STATES = {"released", "waiting", "no-worker", "processing", "erred", "memory"}
+ALL_TASK_STATES = declare(
+    set, {"released", "waiting", "no-worker", "processing", "erred", "memory"}
+)
+globals()["ALL_TASK_STATES"] = ALL_TASK_STATES
 
 
 @final

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5892,11 +5892,8 @@ class Scheduler(SchedulerState, ServerNode):
             if self.plugins:
                 # Temporarily put back forgotten key for plugin to retrieve it
                 if ts._state == "forgotten":
-                    try:
-                        ts._dependents = dependents
-                        ts._dependencies = dependencies
-                    except KeyError:
-                        pass
+                    ts._dependents = dependents
+                    ts._dependencies = dependencies
                     parent._tasks[ts._key] = ts
                 for plugin in list(self.plugins):
                     try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5839,19 +5839,19 @@ class Scheduler(SchedulerState, ServerNode):
         dependents: set
         dependencies: set
         try:
+            recommendations = {}
             try:
                 ts = parent._tasks[key]
             except KeyError:
-                return {}
+                return recommendations
             start = ts._state
             if start == finish:
-                return {}
+                return recommendations
 
             if self.plugins:
                 dependents = set(ts._dependents)
                 dependencies = set(ts._dependencies)
 
-            recommendations = {}
             worker_msgs = {}
             client_msgs = {}
             if (start, finish) in self._transitions:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5858,7 +5858,8 @@ class Scheduler(SchedulerState, ServerNode):
             client_msgs = {}
             func = self._transitions.get(start_finish)
             if func is not None:
-                recommendations, worker_msgs, client_msgs = func(key, *args, **kwargs)
+                t: tuple = func(key, *args, **kwargs)
+                recommendations, worker_msgs, client_msgs = t
             elif "released" not in start_finish:
                 func = self._transitions["released", finish]
                 assert not args and not kwargs
@@ -5867,7 +5868,8 @@ class Scheduler(SchedulerState, ServerNode):
                 if v is not None:
                     func = self._transitions["released", v]
                 b: dict
-                b, worker_msgs, client_msgs = func(key)
+                t: tuple = func(key)
+                b, worker_msgs, client_msgs = t
                 recommendations.update(a)
                 recommendations.update(b)
                 start = "released"

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5839,12 +5839,12 @@ class Scheduler(SchedulerState, ServerNode):
     # State Transitions #
     #####################
 
-    def transition(self, key, finish: str, *args, **kwargs):
+    def _transition(self, key, finish: str, *args, **kwargs):
         """Transition a key from its current state to the finish state
 
         Examples
         --------
-        >>> self.transition('x', 'waiting')
+        >>> self._transition('x', 'waiting')
         {'x': 'processing'}
 
         Returns
@@ -5889,7 +5889,7 @@ class Scheduler(SchedulerState, ServerNode):
             elif "released" not in start_finish:
                 func = self._transitions["released", finish]
                 assert not args and not kwargs
-                a: dict = self.transition(key, "released")
+                a: dict = self._transition(key, "released")
                 v = a.get(key)
                 if v is not None:
                     func = self._transitions["released", v]
@@ -5950,6 +5950,24 @@ class Scheduler(SchedulerState, ServerNode):
                 pdb.set_trace()
             raise
 
+    def transition(self, key, finish: str, *args, **kwargs):
+        """Transition a key from its current state to the finish state
+
+        Examples
+        --------
+        >>> self.transition('x', 'waiting')
+        {'x': 'processing'}
+
+        Returns
+        -------
+        Dictionary of recommendations for future transitions
+
+        See Also
+        --------
+        Scheduler.transitions: transitive version of this function
+        """
+        return self._transition(key, finish, *args, **kwargs)
+
     def transitions(self, recommendations: dict):
         """Process transitions until none are left
 
@@ -5963,7 +5981,7 @@ class Scheduler(SchedulerState, ServerNode):
         while recommendations:
             key, finish = recommendations.popitem()
             keys.add(key)
-            new = self.transition(key, finish)
+            new = self._transition(key, finish)
             recommendations.update(new)
 
         if parent._validate:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5834,6 +5834,7 @@ class Scheduler(SchedulerState, ServerNode):
         ts: TaskState
         start: str
         start_finish: tuple
+        finish2: str
         recommendations: dict
         worker_msgs: dict
         client_msgs: dict

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5840,9 +5840,8 @@ class Scheduler(SchedulerState, ServerNode):
         dependencies: set
         try:
             recommendations = {}
-            try:
-                ts = parent._tasks[key]
-            except KeyError:
+            ts = parent._tasks.get(key)
+            if ts is None:
                 return recommendations
             start = ts._state
             if start == finish:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5861,9 +5861,10 @@ class Scheduler(SchedulerState, ServerNode):
             elif "released" not in start_finish:
                 func = self._transitions["released", finish]
                 assert not args and not kwargs
-                a = self.transition(key, "released")
+                a: dict = self.transition(key, "released")
                 if key in a:
                     func = self._transitions["released", a[key]]
+                b: dict
                 b, worker_msgs, client_msgs = func(key)
                 a = a.copy()
                 a.update(b)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5862,8 +5862,9 @@ class Scheduler(SchedulerState, ServerNode):
                 func = self._transitions["released", finish]
                 assert not args and not kwargs
                 a: dict = self.transition(key, "released")
-                if key in a:
-                    func = self._transitions["released", a[key]]
+                v = a.get(key)
+                if v is not None:
+                    func = self._transitions["released", v]
                 b: dict
                 b, worker_msgs, client_msgs = func(key)
                 a = a.copy()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5907,7 +5907,12 @@ class Scheduler(SchedulerState, ServerNode):
             tg: TaskGroup = ts._group
             if ts._state == "forgotten" and tg._name in parent._task_groups:
                 # Remove TaskGroup if all tasks are in the forgotten state
-                if not any([tg._states.get(s) for s in ALL_TASK_STATES]):
+                all_forgotten: bint = True
+                for s in ALL_TASK_STATES:
+                    if tg._states.get(s):
+                        all_forgotten = False
+                        break
+                if all_forgotten:
                     ts._prefix._groups.remove(tg)
                     del parent._task_groups[tg._name]
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5925,8 +5925,9 @@ class Scheduler(SchedulerState, ServerNode):
         reach a steady state
         """
         parent: SchedulerState = cast(SchedulerState, self)
-        keys = set()
+        keys: set = set()
         recommendations = recommendations.copy()
+        new: dict
         while recommendations:
             key, finish = recommendations.popitem()
             keys.add(key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4717,8 +4717,7 @@ class Scheduler(SchedulerState, ServerNode):
         for worker, msgs in worker_msgs.items():
             try:
                 w = stream_comms[worker]
-                for msg in msgs:
-                    w.send(msg)
+                w.send(*msgs)
             except (CommClosedError, AttributeError):
                 self.loop.add_callback(self.remove_worker, address=worker)
 
@@ -4726,12 +4725,11 @@ class Scheduler(SchedulerState, ServerNode):
             c = client_comms.get(client)
             if c is None:
                 continue
-            for msg in msgs:
-                try:
-                    c.send(msg)
-                except CommClosedError:
-                    if self.status == Status.running:
-                        logger.critical("Tried writing to closed comm: %s", msg)
+            try:
+                c.send(*msgs)
+            except CommClosedError:
+                if self.status == Status.running:
+                    logger.critical("Tried writing to closed comm: %s", msgs)
 
     ############################
     # Less common interactions #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5867,9 +5867,8 @@ class Scheduler(SchedulerState, ServerNode):
                     func = self._transitions["released", v]
                 b: dict
                 b, worker_msgs, client_msgs = func(key)
-                a = a.copy()
-                a.update(b)
-                recommendations = a
+                recommendations.update(a)
+                recommendations.update(b)
                 start = "released"
             else:
                 raise RuntimeError("Impossible transition from %r to %r" % start_finish)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5814,7 +5814,7 @@ class Scheduler(SchedulerState, ServerNode):
     # State Transitions #
     #####################
 
-    def transition(self, key, finish, *args, **kwargs):
+    def transition(self, key, finish: str, *args, **kwargs):
         """Transition a key from its current state to the finish state
 
         Examples
@@ -5832,6 +5832,7 @@ class Scheduler(SchedulerState, ServerNode):
         """
         parent: SchedulerState = cast(SchedulerState, self)
         ts: TaskState
+        start: str
         recommendations: dict
         worker_msgs: dict
         client_msgs: dict

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5832,6 +5832,7 @@ class Scheduler(SchedulerState, ServerNode):
         """
         parent: SchedulerState = cast(SchedulerState, self)
         ts: TaskState
+        recommendations: dict
         worker_msgs: dict
         client_msgs: dict
         try:
@@ -5847,7 +5848,7 @@ class Scheduler(SchedulerState, ServerNode):
                 dependents = set(ts._dependents)
                 dependencies = set(ts._dependencies)
 
-            recommendations: dict = {}
+            recommendations = {}
             worker_msgs = {}
             client_msgs = {}
             if (start, finish) in self._transitions:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5833,6 +5833,7 @@ class Scheduler(SchedulerState, ServerNode):
         parent: SchedulerState = cast(SchedulerState, self)
         ts: TaskState
         start: str
+        start_finish: tuple
         recommendations: dict
         worker_msgs: dict
         client_msgs: dict
@@ -5851,12 +5852,13 @@ class Scheduler(SchedulerState, ServerNode):
                 dependents = set(ts._dependents)
                 dependencies = set(ts._dependencies)
 
+            start_finish = (start, finish)
             worker_msgs = {}
             client_msgs = {}
-            if (start, finish) in self._transitions:
-                func = self._transitions[start, finish]
+            if start_finish in self._transitions:
+                func = self._transitions[start_finish]
                 recommendations, worker_msgs, client_msgs = func(key, *args, **kwargs)
-            elif "released" not in (start, finish):
+            elif "released" not in start_finish:
                 func = self._transitions["released", finish]
                 assert not args and not kwargs
                 a = self.transition(key, "released")
@@ -5868,9 +5870,7 @@ class Scheduler(SchedulerState, ServerNode):
                 recommendations = a
                 start = "released"
             else:
-                raise RuntimeError(
-                    "Impossible transition from %r to %r" % (start, finish)
-                )
+                raise RuntimeError("Impossible transition from %r to %r" % start_finish)
 
             for worker, msg in worker_msgs.items():
                 self.worker_send(worker, msg)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5855,8 +5855,8 @@ class Scheduler(SchedulerState, ServerNode):
             start_finish = (start, finish)
             worker_msgs = {}
             client_msgs = {}
-            if start_finish in self._transitions:
-                func = self._transitions[start_finish]
+            func = self._transitions.get(start_finish)
+            if func is not None:
                 recommendations, worker_msgs, client_msgs = func(key, *args, **kwargs)
             elif "released" not in start_finish:
                 func = self._transitions["released", finish]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5835,6 +5835,8 @@ class Scheduler(SchedulerState, ServerNode):
         recommendations: dict
         worker_msgs: dict
         client_msgs: dict
+        dependents: set
+        dependencies: set
         try:
             try:
                 ts = parent._tasks[key]


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/4454
~~Requires https://github.com/dask/distributed/pull/4452~~ (merged! 🎉)

This more thoroughly optimizes the higher-level `transition` and `transitions` functions. Does this by going through and annotating the variables used. Also avoids contains checks when it is possible to retrieve with a fallback (like with `dict.get(...)`). Tries to remove any unneeded copies where possible.

Also this collects all messages to send to workers and clients from transitions and waits to send them until the end of the transition where it lumps multiple messages together.

Note: Still need to move communication calls from `transition` to `transitions`.