### PR TITLE
Use a callback to close TCP Comms, rather than check every time

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -128,7 +128,7 @@ def convert_stream_closed_error(obj, exc):
 
 
 def _close_comm(ref):
-    """ Callback to close Dask Comm when Tornado Stream closes
+    """Callback to close Dask Comm when Tornado Stream closes
 
     Parameters
     ----------


### PR DESCRIPTION
In a recent trace this relieves about 30ms of a 3s shuffle computation
resulting in around a 1% overall speedup

cc @jakirkham this might help a bit with the worker_send/client_send code in transition.  I think that the real solution is still to try to batch things there though.