### PR TITLE
Update task duration estimates for unknown tasks while executing

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3422,9 +3422,20 @@ class Scheduler(SchedulerState, ServerNode):
         ws._last_seen = time()
 
         if executing is not None:
-            ws._executing = {
-                parent._tasks[key]: duration for key, duration in executing.items()
-            }
+            ws._executing = {}
+            for key, duration in executing.items():
+                ts = parent.tasks[key]
+                ws._executing[ts] = duration
+                if ts._prefix._name in self.unknown_durations:
+                    old_duration = ts._prefix._duration_average
+                    new_duration = duration
+                    if old_duration < 0:
+                        avg_duration = new_duration
+                    else:
+                        avg_duration = 0.5 * old_duration + 0.5 * new_duration
+
+                    ts._prefix._duration_average = avg_duration
+                    ts._group._duration = new_duration
 
         if metrics:
             ws._metrics = metrics


### PR DESCRIPTION
Since the workers submit their currently running tasks duration, we can update the estimated average for unknown tasks, allowing for fast upscaling and work stealing in case of long running unknown tasks. I opted for not including any measurements anymore if the task is known since any intermediate measurement would skew the average.

I'm a bit on the fence regarding the exponential average for this application but I kept it since this is the way we update this average in other places. I don't think we need something formally correct for this, rather something which updates the value and converges to the true value reasonably fast.

Closes #3516
