### PR TITLE
MPI4Dask - MVAPICH2-GDR based Communication Backend for the Dask Distributed Library

### DIFF
--- a/dask-apps/cudf_merge_mpi.py
+++ b/dask-apps/cudf_merge_mpi.py
@@ -1,0 +1,594 @@
+"""
+
+Taken from: https://github.com/rapidsai/dask-cuda/blob/branch-0.18/dask_cuda/benchmarks/local_cudf_merge.py
+
+This is the cuDF merge benchmarking application. It has been 
+modified to work for the MVAPICH2-based (http://mvapich.cse.ohio-state.edu) 
+communication backend for the Dask Distributed library using the 
+dask-mpi package.
+
+"""
+
+import math
+from collections import defaultdict
+from time import perf_counter as clock
+
+import numpy
+
+from dask.base import tokenize
+from dask.dataframe.core import new_dd_object
+from dask.distributed import Client, performance_report, wait
+from dask.utils import format_bytes, format_time, parse_bytes
+from dask_mpi import initialize
+
+import argparse
+import os
+
+from dask.distributed import SSHCluster
+
+#adjust as per compute system
+GPUS_PER_NODE       =   1    # number of GPUs in the system  
+DASK_INTERFACE      = 'ib0'  # interface to use for communication
+THREADS_PER_NODE    =  28    # number of threads per node.
+
+rank = os.environ['MV2_COMM_WORLD_LOCAL_RANK']
+device_id = int(rank) % GPUS_PER_NODE
+os.environ["CUDA_VISIBLE_DEVICES"]=str(device_id)
+
+#from dask_cuda.local_cuda_cluster import LocalCUDACluster
+
+#from dask_cuda import explicit_comms
+#from utils import (
+#    get_cluster_options,
+#    get_scheduler_workers,
+#    parse_benchmark_args,
+#    setup_memory_pool,
+#)
+
+# Benchmarking cuDF merge operation based on
+# <https://gist.github.com/rjzamora/0ffc35c19b5180ab04bbf7c793c45955>
+
+def generate_chunk(i_chunk, local_size, num_chunks, chunk_type, frac_match, gpu):
+    #print("generate_chunk")
+    # Setting a seed that triggers max amount of comm in the two-GPU case.
+    if gpu:
+        import cupy as xp
+
+        import cudf as xdf
+    else:
+        import numpy as xp
+        import pandas as xdf
+
+    xp.random.seed(2 ** 32 - 1)
+
+    chunk_type = chunk_type or "build"
+    frac_match = frac_match or 1.0
+    if chunk_type == "build":
+        # Build dataframe
+        #
+        # "key" column is a unique sample within [0, local_size * num_chunks)
+        #
+        # "shuffle" column is a random selection of partitions (used for shuffle)
+        #
+        # "payload" column is a random permutation of the chunk_size
+
+        start = local_size * i_chunk
+        stop = start + local_size
+
+        parts_array = xp.arange(num_chunks, dtype="int64")
+        suffle_array = xp.repeat(parts_array, math.ceil(local_size / num_chunks))
+        
+        df = xdf.DataFrame(
+            {
+                "key": xp.arange(start, stop=stop, dtype="int64"),
+                "shuffle": xp.random.permutation(suffle_array)[:local_size],
+                "payload": xp.random.permutation(xp.arange(local_size, dtype="int64")),
+            }
+        )
+    else:
+        #print("chunk type is other")
+        # Other dataframe
+        #
+        # "key" column matches values from the build dataframe
+        # for a fraction (`frac_match`) of the entries. The matching
+        # entries are perfectly balanced across each partition of the
+        # "base" dataframe.
+        #
+        # "payload" column is a random permutation of the chunk_size
+
+        # Step 1. Choose values that DO match
+        sub_local_size = local_size // num_chunks
+        sub_local_size_use = max(int(sub_local_size * frac_match), 1)
+        arrays = []
+        for i in range(num_chunks):
+            bgn = (local_size * i) + (sub_local_size * i_chunk)
+            end = bgn + sub_local_size
+            ar = xp.arange(bgn, stop=end, dtype="int64")
+            arrays.append(xp.random.permutation(ar)[:sub_local_size_use])
+        key_array_match = xp.concatenate(tuple(arrays), axis=0)
+
+        # Step 2. Add values that DON'T match
+        missing_size = local_size - key_array_match.shape[0]
+        start = local_size * num_chunks + local_size * i_chunk
+        stop = start + missing_size
+        key_array_no_match = xp.arange(start, stop=stop, dtype="int64")
+
+        # Step 3. Combine and create the final dataframe chunk (dask_cudf partition)
+        key_array_combine = xp.concatenate(
+            (key_array_match, key_array_no_match), axis=0
+        )
+
+        df = xdf.DataFrame(
+            {
+                "key": xp.random.permutation(key_array_combine),
+                "payload": xp.random.permutation(xp.arange(local_size, dtype="int64")),
+            }
+        )
+    return df
+
+
+def get_random_ddf(chunk_size, num_chunks, frac_match, chunk_type, args):
+
+    parts = [chunk_size for i in range(num_chunks)]
+    device_type = True if args.type == "gpu" else False
+    meta = generate_chunk(0, 4, 1, chunk_type, None, device_type)
+    divisions = [None] * (len(parts) + 1)
+
+    name = "generate-data-" + tokenize(chunk_size, num_chunks, frac_match, chunk_type)
+
+    graph = {
+        (name, i): (
+            generate_chunk,
+            i,
+            part,
+            len(parts),
+            chunk_type,
+            frac_match,
+            device_type,
+        )
+        for i, part in enumerate(parts)
+    }
+
+    ddf = new_dd_object(graph, name, meta, divisions)
+
+    if chunk_type == "build":
+        if not args.no_shuffle:
+            divisions = [i for i in range(num_chunks)] + [num_chunks]
+            return ddf.set_index("shuffle", divisions=tuple(divisions))
+        else:
+            del ddf["shuffle"]
+
+    return ddf
+
+
+def merge(args, ddf1, ddf2, write_profile):
+    #print("merge called")
+    # Lazy merge/join operation
+    ddf_join = ddf1.merge(ddf2, on=["key"], how="inner")
+    if args.set_index:
+        ddf_join = ddf_join.set_index("key")
+
+    # Execute the operations to benchmark
+    if write_profile is not None:
+        with performance_report(filename=args.profile):
+            t1 = clock()
+            wait(ddf_join.persist())
+            took = clock() - t1
+    else:
+        t1 = clock()
+        wait(ddf_join.persist())
+        took = clock() - t1
+    return took
+
+
+#def merge_explicit_comms(args, ddf1, ddf2):
+#    t1 = clock()
+#    wait(explicit_comms.dataframe_merge(ddf1, ddf2, on="key").persist())
+#    took = clock() - t1
+#    return took
+
+
+def run(client, args, n_workers, write_profile=None):
+    # Generate random Dask dataframes
+    ddf_base = get_random_ddf(
+        args.chunk_size, n_workers, args.frac_match, "build", args
+    ).persist()
+
+    ddf_other = get_random_ddf(
+        args.chunk_size, n_workers, args.frac_match, "other", args
+    ).persist()
+
+    wait(ddf_base)
+    wait(ddf_other)
+    client.wait_for_workers(n_workers)
+
+    assert len(ddf_base.dtypes) == 2
+    assert len(ddf_other.dtypes) == 2
+    data_processed = len(ddf_base) * sum([t.itemsize for t in ddf_base.dtypes])
+    data_processed += len(ddf_other) * sum([t.itemsize for t in ddf_other.dtypes])
+
+    if args.backend == "dask":
+        took = merge(args, ddf_base, ddf_other, write_profile)
+    else:
+        took = None#merge_explicit_comms(args, ddf_base, ddf_other)
+
+    return (data_processed, took)
+
+
+def main(args):
+    cluster_options = get_cluster_options(args)
+    Cluster = cluster_options["class"]
+    cluster_args = cluster_options["args"]
+    cluster_kwargs = cluster_options["kwargs"]
+    scheduler_addr = cluster_options["scheduler_addr"]
+
+    if args.sched_addr:
+        initialize(
+            interface=DASK_INTERFACE,
+            protocol=args.protocol,
+            nanny=False,
+            nthreads=THREADS_PER_NODE
+        )
+        import time
+        time.sleep(5)
+
+        client = Client()
+        print(client)
+    else:
+        cluster = Cluster(*cluster_args, **cluster_kwargs)
+        if args.multi_node:
+            import time
+
+            # Allow some time for workers to start and connect to scheduler
+            # TODO: make this a command-line argument?
+            time.sleep(15)
+
+        client = Client(scheduler_addr if args.multi_node else cluster)
+
+    if args.type == "gpu":
+        client.run(setup_memory_pool, disable_pool=args.no_rmm_pool)
+        # Create an RMM pool on the scheduler due to occasional deserialization
+        # of CUDA objects. May cause issues with InfiniBand otherwise.
+        client.run_on_scheduler(setup_memory_pool, 1e9, disable_pool=args.no_rmm_pool)
+
+    scheduler_workers = client.run_on_scheduler(get_scheduler_workers)
+    n_workers = len(scheduler_workers)
+
+    took_list = []
+    for _ in range(args.runs - 1):
+        took_list.append(run(client, args, n_workers, write_profile=None))
+    took_list.append(
+        run(client, args, n_workers, write_profile=args.profile)
+    )  # Only profiling the last run
+
+    # Collect, aggregate, and print peer-to-peer bandwidths
+    incoming_logs = client.run(lambda dask_worker: dask_worker.incoming_transfer_log)
+    bandwidths = defaultdict(list)
+    total_nbytes = defaultdict(list)
+    for k, L in incoming_logs.items():
+        for d in L:
+            if d["total"] >= args.ignore_size:
+                bandwidths[k, d["who"]].append(d["bandwidth"])
+                total_nbytes[k, d["who"]].append(d["total"])
+    bandwidths = {
+        (scheduler_workers[w1].name, scheduler_workers[w2].name): [
+            "%s/s" % format_bytes(x) for x in numpy.quantile(v, [0.25, 0.50, 0.75])
+        ]
+        for (w1, w2), v in bandwidths.items()
+    }
+    total_nbytes = {
+        (scheduler_workers[w1].name, scheduler_workers[w2].name,): format_bytes(sum(nb))
+        for (w1, w2), nb in total_nbytes.items()
+    }
+
+    t_runs = numpy.empty(len(took_list))
+    if args.markdown:
+        print("```")
+    print("Merge benchmark")
+    print("-------------------------------")
+    print(f"backend        | {args.backend}")
+    print(f"merge type     | {args.type}")
+    print(f"rows-per-chunk | {args.chunk_size}")
+    print(f"protocol       | {args.protocol}")
+    print(f"device(s)      | {args.devs}")
+    print(f"rmm-pool       | {(not args.no_rmm_pool)}")
+    print(f"frac-match     | {args.frac_match}")
+    if args.protocol == "ucx":
+        print(f"tcp            | {args.enable_tcp_over_ucx}")
+        print(f"ib             | {args.enable_infiniband}")
+        print(f"nvlink         | {args.enable_nvlink}")
+    print(f"data-processed | {format_bytes(took_list[0][0])}")
+    print("===============================")
+    print("Wall-clock     | Throughput")
+    print("-------------------------------")
+    for idx, (data_processed, took) in enumerate(took_list):
+        throughput = int(data_processed / took)
+        m = format_time(took)
+        m += " " * (15 - len(m))
+        print(f"{m}| {format_bytes(throughput)}/s")
+        t_runs[idx] = float(format_bytes(throughput).split(" ")[0])
+    print("===============================")
+    if args.markdown:
+        print("\n```")
+
+    #if args.plot is not None:
+    #    plot_benchmark(t_runs, args.plot, historical=True)
+
+    if args.backend == "dask":
+        if args.markdown:
+            print("<details>\n<summary>Worker-Worker Transfer Rates</summary>\n\n```")
+        print("(w1,w2)     | 25% 50% 75% (total nbytes)")
+        print("-------------------------------")
+        for (d1, d2), bw in sorted(bandwidths.items()):
+            fmt = (
+                "(%s,%s)     | %s %s %s (%s)"
+                if args.multi_node or args.sched_addr
+                else "(%02d,%02d)     | %s %s %s (%s)"
+            )
+            print(fmt % (d1, d2, bw[0], bw[1], bw[2], total_nbytes[(d1, d2)]))
+        if args.markdown:
+            print("```\n</details>\n")
+
+    if args.multi_node:
+        client.shutdown()
+        client.close()
+
+
+def parse_args():
+    special_args = [
+        {
+            "name": ["-b", "--backend",],
+            "choices": ["dask", "explicit-comms"],
+            "default": "dask",
+            "type": str,
+            "help": "The backend to use.",
+        },
+        {
+            "name": ["-t", "--type",],
+            "choices": ["cpu", "gpu"],
+            "default": "gpu",
+            "type": str,
+            "help": "Do merge with GPU or CPU dataframes",
+        },
+        {
+            "name": ["-c", "--chunk-size",],
+            "default": 1_000_000,
+            "metavar": "n",
+            "type": int,
+            "help": "Chunk size (default 1_000_000)",
+        },
+        {
+            "name": "--ignore-size",
+            "default": "1 MiB",
+            "metavar": "nbytes",
+            "type": parse_bytes,
+            "help": "Ignore messages smaller than this (default '1 MB')",
+        },
+        {
+            "name": "--frac-match",
+            "default": 0.3,
+            "type": float,
+            "help": "Fraction of rows that matches (default 0.3)",
+        },
+        {
+            "name": "--no-shuffle",
+            "action": "store_true",
+            "help": "Don't shuffle the keys of the left (base) dataframe.",
+        },
+        {
+            "name": "--markdown",
+            "action": "store_true",
+            "help": "Write output as markdown",
+        },
+        {"name": "--runs", "default": 3, "type": int, "help": "Number of runs",},
+        {
+            "name": ["-s", "--set-index",],
+            "action": "store_true",
+            "help": "Call set_index on the key column to sort the joined dataframe.",
+        },
+    ]
+
+    return parse_benchmark_args(
+        description="Distributed merge (dask/cudf) benchmark", args_list=special_args
+    )
+
+def parse_benchmark_args(description="Generic dask-cuda Benchmark", args_list=[]):
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "-d", "--devs", default="0", type=str, help='GPU devices to use (default "0").'
+    )
+    parser.add_argument(
+        "-p",
+        "--protocol",
+        choices=["tcp", "ucx", "mpi"],
+        default="tcp",
+        type=str,
+        help="The communication protocol to use.",
+    )
+    parser.add_argument(
+        "--profile",
+        metavar="PATH",
+        default=None,
+        type=str,
+        help="Write dask profile report (E.g. dask-report.html)",
+    )
+    parser.add_argument(
+        "--no-rmm-pool", action="store_true", help="Disable the RMM memory pool"
+    )
+    parser.add_argument(
+        "--enable-tcp-over-ucx",
+        action="store_true",
+        dest="enable_tcp_over_ucx",
+        help="Enable tcp over ucx.",
+    )
+    parser.add_argument(
+        "--enable-infiniband",
+        action="store_true",
+        dest="enable_infiniband",
+        help="Enable infiniband over ucx.",
+    )
+    parser.add_argument(
+        "--enable-nvlink",
+        action="store_true",
+        dest="enable_nvlink",
+        help="Enable NVLink over ucx.",
+    )
+    parser.add_argument(
+        "--disable-tcp-over-ucx",
+        action="store_false",
+        dest="enable_tcp_over_ucx",
+        help="Disable tcp over ucx.",
+    )
+    parser.add_argument(
+        "--disable-infiniband",
+        action="store_false",
+        dest="enable_infiniband",
+        help="Disable infiniband over ucx.",
+    )
+    parser.add_argument(
+        "--disable-nvlink",
+        action="store_false",
+        dest="enable_nvlink",
+        help="Disable NVLink over ucx.",
+    )
+    parser.add_argument(
+        "--ucx-net-devices",
+        default=None,
+        type=str,
+        help="The device to be used for UCX communication, or 'auto'. "
+        "Ignored if protocol is 'tcp'",
+    )
+    parser.add_argument(
+        "--single-node",
+        action="store_true",
+        dest="multi_node",
+        help="Runs a single-node cluster on the current host.",
+    )
+    parser.add_argument(
+        "--multi-node",
+        action="store_true",
+        dest="multi_node",
+        help="Runs a multi-node cluster on the hosts specified by --hosts.",
+    )
+    parser.add_argument(
+        "--scheduler-address",
+        default="Not Needed", # MPI4Dask related modification
+        type=str,
+        dest="sched_addr",
+        help="Scheduler Address -- assumes cluster is created outside of benchmark.",
+    )
+    parser.add_argument(
+        "--hosts",
+        default=None,
+        type=str,
+        help="Specifies a comma-separated list of IP addresses or hostnames. "
+        "The list begins with the host where the scheduler will be launched "
+        "followed by any number of workers, with a minimum of 1 worker. "
+        "Requires --multi-node, ignored otherwise. "
+        "Usage example: --multi-node --hosts 'dgx12,dgx12,10.10.10.10,dgx13' . "
+        "In the example, the benchmark is launched with scheduler on host "
+        "'dgx12' (first in the list), and workers on three hosts being 'dgx12', "
+        "'10.10.10.10', and 'dgx13'. "
+        "Note: --devs is currently ignored in multi-node mode and for each host "
+        "one worker per GPU will be launched.",
+    )
+
+    for args in args_list:
+        name = args.pop("name")
+        if not isinstance(name, list):
+            name = [name]
+        parser.add_argument(*name, **args)
+
+    parser.set_defaults(
+        enable_tcp_over_ucx=True, enable_infiniband=True, enable_nvlink=True
+    )
+    args = parser.parse_args()
+
+    if args.protocol == "tcp":
+        args.enable_tcp_over_ucx = False
+        args.enable_infiniband = False
+        args.enable_nvlink = False
+
+    if args.multi_node and len(args.hosts.split(",")) < 2:
+        raise ValueError("--multi-node requires at least 2 hosts")
+
+    return args
+
+
+def get_cluster_options(args):
+    #print("get_cluster_options")
+
+    if args.multi_node is True:
+
+        #print("get_cluster_options: args.multi_node")
+        
+        Cluster = SSHCluster
+        cluster_args = [args.hosts.split(",")]
+        scheduler_addr = args.protocol + "://" + cluster_args[0][0] + ":8786"
+
+        worker_options = {}
+
+        # This looks counterintuitive but adding the variable name with
+        # an empty string is how we can enable CLI booleans currently,
+        # note that SSHCluster uses the dask-cuda-worker CLI.
+        if args.enable_tcp_over_ucx:
+            worker_options["enable_tcp_over_ucx"] = ""
+        if args.enable_nvlink:
+            worker_options["enable_nvlink"] = ""
+        if args.enable_infiniband:
+            worker_options["enable_infiniband"] = ""
+
+        if args.ucx_net_devices:
+            worker_options["ucx_net_devices"] = args.ucx_net_devices
+
+        cluster_kwargs = {
+            "connect_options": {"known_hosts": None},
+            "scheduler_options": {"protocol": args.protocol},
+            "worker_module": "dask_cuda.dask_cuda_worker",
+            "worker_options": worker_options,
+            # "n_workers": len(args.devs.split(",")),
+            # "CUDA_VISIBLE_DEVICES": args.devs,
+        }
+    else:
+        #print("get_cluster_options: else")
+        #Cluster = LocalCUDACluster
+        Cluster = None
+        scheduler_addr = None
+        cluster_args = []
+        cluster_kwargs = {
+            "protocol": args.protocol,
+            "n_workers": len(args.devs.split(",")),
+            "CUDA_VISIBLE_DEVICES": args.devs,
+            "ucx_net_devices": args.ucx_net_devices,
+            "enable_tcp_over_ucx": args.enable_tcp_over_ucx,
+            "enable_infiniband": args.enable_infiniband,
+            "enable_nvlink": args.enable_nvlink,
+        }
+
+    #print("returning cluster object")
+    return {
+        "class": Cluster,
+        "args": cluster_args,
+        "kwargs": cluster_kwargs,
+        "scheduler_addr": scheduler_addr,
+    }
+
+
+def get_scheduler_workers(dask_scheduler=None):
+    return dask_scheduler.workers
+
+
+def setup_memory_pool(pool_size=None, disable_pool=False):
+    import cupy
+
+    os.environ['RMM_NO_INITIALIZE'] = 'True'
+    import rmm
+
+    rmm.reinitialize(
+        pool_allocator=not disable_pool, devices=0, initial_pool_size=pool_size,
+    )
+    cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+
+if __name__ == "__main__":
+    main(parse_args())
+

--- a/dask-apps/cupy_sum_mpi.py
+++ b/dask-apps/cupy_sum_mpi.py
@@ -1,0 +1,91 @@
+"""
+This is the sum of cuPy array and its transpose application. It has been 
+modified to work for the MVAPICH2-based (http://mvapich.cse.ohio-state.edu) 
+communication backend for the Dask Distributed library using the 
+dask-mpi package.
+
+"""
+
+import os
+import asyncio
+from collections import defaultdict
+from time import perf_counter as clock
+
+import dask.array as da
+from dask.distributed import Client, performance_report, wait
+from dask.utils import format_bytes, format_time, parse_bytes
+from dask_mpi import initialize
+
+import cupy
+import numpy
+import time
+import sys
+
+#adjust as per compute system
+GPUS_PER_NODE      =   1    # number of GPUs in the system
+RUNS               =  20    # repititions for the benchmark
+DASK_INTERFACE     = 'ib0'  # interface to use for communication
+DASK_PROTOCOL      = 'mpi'  # protocol for Dask Distributed. Options include ['mpi', 'tcp']
+THREADS_PER_NODE   =  28    # number of threads per node.
+
+rank = os.environ['MV2_COMM_WORLD_LOCAL_RANK']
+device_id = int(rank) % GPUS_PER_NODE
+os.environ["CUDA_VISIBLE_DEVICES"]=str(device_id)
+
+async def run():
+    async with Client(asynchronous=True) as client:
+
+        print(client)
+
+        scheduler_workers = await client.run_on_scheduler(get_scheduler_workers)
+
+        took_list = []
+
+        for i in range(RUNS):
+            start = time.time()
+            rs = da.random.RandomState(RandomState=cupy.random.RandomState)
+            a = rs.normal(100, 1, (int(30000), int(30000)), \
+                          chunks=(int(1000), int(1000)))
+            x = a + a.T
+
+            xx = await client.compute(x)
+
+            duration = time.time() - start
+            took_list.append( (duration, a.npartitions) )
+            print("Time for iteration", i, ":", duration)
+            sys.stdout.flush()
+
+        sums = []
+
+        for (took, npartitions) in took_list:
+            sums.append(took)  
+            t = format_time(took)
+            t += " " * (11 - len(t))
+        
+        print ("Average Wall-clock Time: ", format_time(sum(sums)/len(sums)))
+
+        # Collect, aggregate, and print peer-to-peer bandwidths
+        incoming_logs = await client.run(
+            lambda dask_worker: dask_worker.incoming_transfer_log
+        )
+
+        outgoing_logs = await client.run(
+            lambda dask_worker: dask_worker.outgoing_transfer_log
+        )
+
+
+def get_scheduler_workers(dask_scheduler=None):
+    return dask_scheduler.workers
+
+if __name__ == "__main__":
+  
+    initialize(
+        interface=DASK_INTERFACE,
+        protocol=DASK_PROTOCOL,
+        nanny=False,
+        nthreads=THREADS_PER_NODE
+    )
+
+    time.sleep(5)
+
+    asyncio.run(run())

--- a/distributed/comm/__init__.py
+++ b/distributed/comm/__init__.py
@@ -14,6 +14,7 @@ from .utils import get_tcp_server_address
 
 
 def _register_transports():
+    from . import mpi
     from . import inproc
     from . import tcp
 

--- a/distributed/comm/mpi.py
+++ b/distributed/comm/mpi.py
@@ -1,0 +1,781 @@
+"""
+This is an MVAPICH2-based (http://mvapich.cse.ohio-state.edu) communication 
+backend for the Dask Distributed library.
+
+This is based on the UCX device. UCX: https://github.com/openucx/ucx
+"""
+
+import logging
+import struct
+import weakref
+
+import collections
+import dask
+import asyncio
+import socket
+
+import random
+import time
+import sys
+
+import rmm
+
+from .addressing import parse_host_port, unparse_host_port
+from .core import Comm, Connector, Listener, CommClosedError
+from .registry import Backend, backends
+from .utils import ensure_concrete_host, to_frames, from_frames
+from ..utils import (
+    ensure_ip,
+    get_ip,
+    get_ipv6,
+    nbytes,
+    log_errors,
+    CancelledError,
+    parse_bytes,
+)
+
+from mpi4py import MPI
+
+logger = logging.getLogger(__name__)
+
+host_array = None
+device_array = None
+INITIAL_TAG_OFFSET = 100
+TAG_QUOTA_PER_CONNECTION = 200
+
+# workers and the scheduler randomly select ports for listening to 
+# incoming connections between this range
+LOWER_PORT_RANGE=30000 
+UPPER_PORT_RANGE=40000
+
+# This constant is used to split large message into chunks of this size
+CHUNK_SIZE = 2 ** 30 
+
+initialized = False
+
+# The tag_table dictionary is used to maintain 'tag offset' for a pair of 
+# processes. Imagine a Dask program executing with 4 MPI processes - a scheduler,
+# a client, and 2 workers. The MPI.COMM_WORLD communicator is used by all for
+# exchanging messages. However, during the connection establishment, all processes
+# need to make sure that they have a unique tag range to use with MPI.COMM_WORLD
+# for a pair of processes. Otherwise there is a possibility of message interference 
+# because processes connect with one another dynamically and also there are 
+# control and data channels. This situation is avoided using this dictionary
+# of tags.
+tag_table = dict()
+
+def synchronize_stream(stream=0):
+    import numba.cuda
+
+    ctx = numba.cuda.current_context()
+    cu_stream = numba.cuda.driver.drvapi.cu_stream(stream)
+    stream = numba.cuda.driver.Stream(ctx, cu_stream, None)
+    stream.synchronize()
+
+def init_tag_table():
+    """ this function initializes tag_table dictionary."""
+    global tag_table, INITIAL_TAG_OFFSET
+    rank = MPI.COMM_WORLD.Get_rank()
+    size = MPI.COMM_WORLD.Get_size()
+
+    # each process maintains an entry for every other process in the tag_table
+    for peer in range(size):
+        if rank != peer: 
+            tag_table.update({peer : INITIAL_TAG_OFFSET})
+
+    logger.debug(tag_table)
+
+def init_once():
+    global initialized, host_array, device_array
+
+    if initialized is True:
+        return
+     
+    initialized = True
+
+    random.seed(random.randrange(sys.maxsize))
+
+    name = MPI.Get_processor_name()
+    init_tag_table()
+    logger.debug("rank=%s, name=%s", MPI.COMM_WORLD.Get_rank(), name)
+
+    # Find the function, `host_array()`, to use when allocating new host arrays
+    try:
+        import numpy
+
+        host_array = lambda n: numpy.empty((n,), dtype="u1")
+    except ImportError:
+        host_array = lambda n: bytearray(n)
+
+    # Find the function, `cuda_array()`, to use when allocating new CUDA arrays
+    try:
+        import rmm
+
+        if hasattr(rmm, "DeviceBuffer"):
+            device_array = lambda n: rmm.DeviceBuffer(size=n)
+        else:  # pre-0.11.0
+            import numba.cuda
+
+            def rmm_device_array(n):
+                a = rmm.device_array(n, dtype="u1")
+                weakref.finalize(a, numba.cuda.current_context)
+                return a
+
+            device_array = rmm_device_array
+    except ImportError:
+        try:
+            import numba.cuda
+
+            def numba_device_array(n):
+                a = numba.cuda.device_array((n,), dtype="u1")
+                weakref.finalize(a, numba.cuda.current_context)
+                return a
+
+            device_array = numba_device_array
+        except ImportError:
+
+            def device_array(n):
+                raise RuntimeError(
+                    "In order to send/recv CUDA arrays, Numba or RMM is required"
+                )
+
+    pool_size_str = dask.config.get("rmm.pool-size")
+    if pool_size_str is not None:
+        pool_size = parse_bytes(pool_size_str)
+        rmm.reinitialize(
+            pool_allocator=True, managed_memory=False, initial_pool_size=pool_size
+        )
+
+class MPI4Dask(Comm):
+    """Comm object using MPI.
+
+    Parameters
+    ----------
+    peer_rank : int
+        The MPI rank of the peer process
+    suggested_tag : int
+        The suggested tag offet to avoid message interference
+    local_addr : str
+        The local address, prefixed with `mpi://`
+    peer_addr : str
+        The peer address, prefixed with `mpi://`
+    p_addr : str
+        The peer address, prefixed with `mpi://`
+    deserialize : bool, default True
+        Whether to deserialize data in :meth:`distributed.protocol.loads`
+
+    Notes
+    -----
+    The read-write cycle uses the following pattern:
+
+    Each msg is serialized into a number of "data" frames. We prepend these
+    real frames with two additional frames
+
+        1. is_gpus: Boolean indicator for whether the frame should be
+           received into GPU memory. Packed in '?' format. Unpack with
+           ``<n_frames>?`` format.
+        2. frame_size : Unsigned int describing the size of frame (in bytes)
+           to receive. Packed in 'Q' format, so a length-0 frame is equivalent
+           to an unsized frame. Unpacked with ``<n_frames>Q``.
+
+    The expected read cycle is
+
+    1. Read the frame describing if connection is closing and number of frames
+    2. Read the frame describing whether each data frame is gpu-bound
+    3. Read the frame describing whether each data frame is sized
+    4. Read all the data frames.
+    """
+
+    def __init__(self, peer_rank: int, suggested_tag: int, local_addr: str, \
+                                           peer_addr: str, p_addr: str, deserialize=True):
+                                                    
+        Comm.__init__(self)
+        self._suggested_tag = suggested_tag
+        self._peer_rank = peer_rank
+        if local_addr:
+            assert local_addr.startswith("mpi")
+        assert peer_addr.startswith("mpi")
+        self._local_addr = local_addr
+        self._peer_addr = peer_addr
+        self._p_addr = p_addr
+        self.deserialize = deserialize
+        self._closed = False
+        logger.debug("MPI4Dask.__init__ %s", self)
+
+    @property
+    def suggested_tag(self) -> int:
+        return self._suggested_tag
+
+    @property
+    def peer_rank(self) -> int:
+        return self._peer_rank
+
+    @property
+    def local_address(self) -> str:
+        return self._local_addr
+
+    @property
+    def peer_address(self) -> str:
+        return self._peer_addr
+
+    async def write(
+        self,
+        msg: dict,
+        serializers=("cuda", "dask", "pickle", "error"),
+        on_error: str = "message",
+    ):
+        logger.debug("write() function is called")
+        with log_errors():
+            if self.closed():
+                raise CommClosedError("Endpoint is closed -- unable to send message")
+            try:
+                if serializers is None:
+                    serializers = ("cuda", "dask", "pickle", "error")
+                # msg can also be a list of dicts when sending batched messages
+                frames = await to_frames(
+                    msg,
+                    serializers=serializers,
+                    on_error=on_error,
+                    allow_offload=self.allow_offload,
+                )
+                nframes = len(frames)
+                cuda_frames = tuple(
+                    hasattr(f, "__cuda_array_interface__") for f in frames
+                )
+                sizes = tuple(nbytes(f) for f in frames)
+                cuda_send_frames, send_frames = zip(
+                    *(
+                        (is_cuda, each_frame)
+                        for is_cuda, each_frame in zip(cuda_frames, frames)
+                        if len(each_frame) > 0
+                    )
+                )
+
+                # Send meta data
+
+                # Send close flag and number of frames (_Bool, int64)
+                #await self.ep.send(struct.pack("?Q", False, nframes))
+                #initialize tag with the assigned tag range
+                tag = self.suggested_tag 
+                packed_msg = struct.pack("?Q", False, nframes)
+                s_size = struct.calcsize("?Q")
+                logger.debug("write_1: me=%s, you=%s, tag=%s", MPI.COMM_WORLD.Get_rank(), self.peer_rank, tag)
+
+                await self.mpi_send(packed_msg, s_size, tag)
+                tag = tag + 1
+
+                # Send which frames are CUDA (bool) and
+                # how large each frame is (uint64)
+                #await self.ep.send(
+                #    struct.pack(nframes * "?" + nframes * "Q", *cuda_frames, *sizes)
+                #)
+                packed_msg = struct.pack(nframes * "?" + nframes * "Q", \
+                                                         *cuda_frames, *sizes)
+                s_size = struct.calcsize(nframes * "?" + nframes * "Q")
+
+                await self.mpi_send(packed_msg, s_size, tag)
+                tag = tag + 1
+                logger.debug("write_2: me=%s, you=%s, tag=%s", MPI.COMM_WORLD.Get_rank(), self.peer_rank, tag)
+
+                # Send frames
+
+                # It is necessary to first synchronize the default stream 
+                # before start sending. 
+
+                # non-blocking CUDA streams.
+                if any(cuda_send_frames):
+                    synchronize_stream(0)
+
+                sizes_new = tuple(i for i in sizes if i != 0) # remove all 0's from this list
+                read_counter = 0
+
+                for each_frame in send_frames:
+                    #await self.ep.send(each_frame)
+                    s_size = sizes_new[read_counter]
+                    await self.mpi_send(each_frame, s_size, tag)
+                    tag = tag + 1
+                    read_counter = read_counter + 1
+                logger.debug("write_3: me=%s, you=%s, tag=%s, sizes=%s, sizes_new=%s", MPI.COMM_WORLD.Get_rank(), self.peer_rank, tag, sizes, sizes_new)
+                return sum(sizes_new)
+            except (Exception):
+                self.abort()
+                raise CommClosedError("While writing, the connection was closed")
+
+    # a utility function for sending messages larger than CHUNK_SIZE data
+    async def mpi_send_large(self, buf, size, _tag):
+
+        me = MPI.COMM_WORLD.Get_rank()
+        you = self.peer_rank
+         
+        logger.debug("mpi_send_large: host=%s, me=%s, you=%s, tag=%s, size=%s, type(buf)=%s", \
+                                               socket.gethostname(), me, you, _tag, size, type(buf))
+
+        blk_size = CHUNK_SIZE
+        num_of_blks   = int(size / blk_size)
+        last_blk_size =     size % blk_size
+
+        logger.debug("mpi_send_large: blk_size=%s, num_of_blks=%s, last_blk_size=%s", \
+                                                          blk_size, num_of_blks, last_blk_size)
+
+        num_of_reqs = num_of_blks
+
+        if last_blk_size is not 0:
+            num_of_reqs = num_of_reqs + 1
+
+        reqs = []        
+
+        for i in range(num_of_blks):
+            s_idx = (i)   * blk_size
+            e_idx = (i+1) * blk_size
+
+            if type(buf) == rmm._lib.device_buffer.DeviceBuffer:
+                # need this if because rmm.DeviceBuffer is not subscriptable
+                shadow_buf = rmm.DeviceBuffer(ptr=(buf.ptr+s_idx), \
+                                                           size=blk_size)
+                r = MPI.COMM_WORLD.Isend([shadow_buf, MPI.BYTE], dest=you, tag=_tag)
+            else:
+                r = MPI.COMM_WORLD.Isend([buf[s_idx:e_idx], blk_size], dest=you, tag=_tag)
+            _tag = _tag + 1
+            reqs.append(r)
+
+        if last_blk_size is not 0:
+            s_idx = num_of_blks*blk_size
+            e_idx = s_idx+last_blk_size
+
+            if type(buf) == rmm._lib.device_buffer.DeviceBuffer:
+                # need this if because rmm.DeviceBuffer is not subscriptable
+                shadow_buf = rmm.DeviceBuffer(ptr=(buf.ptr+s_idx), \
+                                                           size=last_blk_size)
+                r = MPI.COMM_WORLD.Isend([shadow_buf, MPI.BYTE], dest=you, tag=_tag)
+            else:
+                r = MPI.COMM_WORLD.Isend([buf[s_idx:e_idx], last_blk_size], \
+                                                           dest=you, tag=_tag)
+
+            _tag = _tag + 1
+            reqs.append(r)
+
+        assert len(reqs) == num_of_reqs
+
+        flag = MPI.Request.Testall(reqs)
+
+        while flag is False:
+            await asyncio.sleep(0)
+            flag = MPI.Request.Testall(reqs)
+
+    # a utility function for sending messages through MPI
+    async def mpi_send(self, buf, size, _tag):
+
+        me = MPI.COMM_WORLD.Get_rank()
+        you = self.peer_rank
+        rank = MPI.COMM_WORLD.Get_rank()
+
+        if me == 0:
+            logger.debug("mpi_send: host=%s, suggested_tag=%s, peer_rank=%s, me=%s, you=%s, rank=%s, tag=%s, size=%s, type(buf)=%s", \
+                                             socket.gethostname(), self.suggested_tag, self.peer_rank, me, you, rank, _tag, size, type(buf))
+
+        if size > CHUNK_SIZE:
+            # if message size is larger than CHUNK_SIZE, split it into chunks and communicate
+            logger.debug("mpi_send: host=%s, comm=%s, me=%s, you=%s, rank=%s, tag=%s, size=%s, type(buf)=%s", \
+                                         socket.gethostname(), MPI.COMM_WORLD, me, you, rank, _tag, size, type(buf))
+            #if type(buf) == cupy.core.core.ndarray:
+            #h_buf = numpy.empty((size,), dtype="u1")
+            #h_buf = numpy.frombuffer(buf.tobytes(), dtype="u1")
+            await self.mpi_send_large(buf, size, _tag)
+            return
+    
+        req = MPI.COMM_WORLD.Isend([buf, size], dest=you, tag=_tag)
+
+        status = req.Test()
+
+        while status is False:
+            await asyncio.sleep(0)
+            status = req.Test()
+
+    # a utility function for receiving messages larger than CHUNK_SIZE data
+    async def mpi_recv_large(self, buf, size, _tag):
+
+        me = MPI.COMM_WORLD.Get_rank()
+        you = self.peer_rank
+
+        logger.debug("mpi_recv_large: host=%s, me=%s, you=%s, tag=%s, size=%s, type(buf)=%s", \
+                                                socket.gethostname(), me, you, _tag, size, type(buf))
+
+        blk_size = CHUNK_SIZE
+        num_of_blks   = int(size / blk_size)
+        last_blk_size =     size % blk_size
+
+        logger.debug("mpi_recv_large: blk_size=%s, num_of_blks=%s, last_blk_size=%s", \
+                                                        blk_size, num_of_blks, last_blk_size)
+
+        num_of_reqs = num_of_blks
+
+        if last_blk_size is not 0:
+            num_of_reqs = num_of_reqs + 1
+
+        reqs = []        
+
+        for i in range(num_of_blks):
+            s_idx = (i)   * blk_size
+            e_idx = (i+1) * blk_size
+
+            if type(buf) == rmm._lib.device_buffer.DeviceBuffer:
+                # need this if because rmm.DeviceBuffer is not subscriptable
+                shadow_buf = rmm.DeviceBuffer(ptr=(buf.ptr+s_idx), \
+                                                           size=blk_size)
+                r = MPI.COMM_WORLD.Irecv([shadow_buf, MPI.BYTE], source=you, tag=_tag)
+            else:
+                r = MPI.COMM_WORLD.Irecv([buf[s_idx:e_idx], blk_size], source=you, \
+                                                                   tag=_tag)
+            _tag = _tag + 1
+            reqs.append(r)
+
+        if last_blk_size is not 0:
+            s_idx = num_of_blks*blk_size
+            e_idx = s_idx+last_blk_size
+
+            if type(buf) == rmm._lib.device_buffer.DeviceBuffer:
+                # need this if because rmm.DeviceBuffer is not subscriptable
+                shadow_buf = rmm.DeviceBuffer(ptr=(buf.ptr+s_idx), \
+                                                           size=last_blk_size)
+                r = MPI.COMM_WORLD.Irecv([shadow_buf, MPI.BYTE], source=you, tag=_tag)
+            else:
+                r = MPI.COMM_WORLD.Irecv([buf[s_idx:e_idx], last_blk_size], \
+                                                    source=you, tag=_tag)
+            _tag = _tag + 1
+            reqs.append(r)
+
+        assert len(reqs) == num_of_reqs
+
+        flag = MPI.Request.Testall(reqs)
+
+        while flag is False:
+            await asyncio.sleep(0)
+            flag = MPI.Request.Testall(reqs)
+
+    # a utility function for receiving messages through MPI
+    async def mpi_recv(self, buf, size, _tag):
+
+        import numpy as np
+        rank = MPI.COMM_WORLD.Get_rank()
+        me = rank
+        you = self.peer_rank
+
+        if size > CHUNK_SIZE:
+            
+            logger.debug("mpi_recv: me=%s, you=%s, tag=%s, size=%s, type(buf)=%s", \
+                                                        me, you, _tag, size, type(buf))
+            await self.mpi_recv_large(buf, size, _tag)
+            return
+
+        req = MPI.COMM_WORLD.Irecv([buf, size], source=you, tag=_tag)
+
+        status = req.Test()
+
+        while status is False:
+            await asyncio.sleep(0)
+            status = req.Test()
+
+        if you == 0 and isinstance(buf, np.ndarray):
+            logger.debug("mpi_recv: me=%s, you=%s, tag=%s, size=%s, type(buf)=%s, buf[:10]=%s", \
+                                                        me, you, _tag, size, type(buf), bytearray(buf[:10]))
+
+    async def read(self, deserializers=("cuda", "dask", "pickle", "error")):
+        logger.debug("read() function is called")
+        with log_errors():
+            if self.closed():
+                #logger.debug("inside self.closed()")
+                raise CommClosedError("Endpoint is closed -- unable to read message")
+
+            if deserializers is None:
+                deserializers = ("cuda", "dask", "pickle", "error")
+
+            try:
+                # Recv meta data
+
+                # Recv close flag and number of frames (_Bool, int64)
+                buf_size = struct.calcsize("?Q")
+                msg = host_array(struct.calcsize("?Q"))
+                tag = self.suggested_tag
+                await self.mpi_recv(msg, buf_size, tag)
+                tag = tag + 1
+                (shutdown, nframes) = struct.unpack("?Q", msg)
+                logger.debug("read_1: me=%s, you=%s, tag=%s", MPI.COMM_WORLD.Get_rank(), self.peer_rank, tag)
+
+                if shutdown:  # The writer is closing the connection
+                    raise CancelledError("Connection closed by writer")
+
+                # Recv which frames are CUDA (bool) and
+                # how large each frame is (uint64)
+                header_fmt = nframes * "?" + nframes * "Q"
+                buf_size = struct.calcsize(header_fmt)
+                header = host_array(struct.calcsize(header_fmt))
+                #await self.ep.recv(header)
+                await self.mpi_recv(header, buf_size, tag)
+                tag = tag + 1
+                logger.debug("read_2: me=%s, you=%s, tag=%s", MPI.COMM_WORLD.Get_rank(), self.peer_rank, tag)
+                header = struct.unpack(header_fmt, header)
+                cuda_frames, sizes = header[:nframes], header[nframes:]
+            except (Exception, CancelledError):
+                self.abort()
+                raise CommClosedError("While reading, the connection was closed")
+            else:
+                # Recv frames
+                frames = [
+                    device_array(each_size) if is_cuda else host_array(each_size)
+                    for is_cuda, each_size in zip(cuda_frames, sizes)
+                ]
+                cuda_recv_frames, recv_frames = zip(
+                    *(
+                        (is_cuda, each_frame)
+                        for is_cuda, each_frame in zip(cuda_frames, frames)
+                        if len(each_frame) > 0
+                    )
+                )
+
+                # It is necessary to first populate `frames` with CUDA arrays 
+                # and synchronize the default stream before starting receiving 
+                # to ensure buffers have been allocated
+                if any(cuda_recv_frames):
+                    synchronize_stream(0)
+
+
+                sizes_new = tuple(i for i in sizes if i != 0) # remove all 0's from this list
+                assert len(sizes_new) < TAG_QUOTA_PER_CONNECTION - 2
+
+                logger.debug("read_3: me=%s, you=%s, tag=%s, sizes=%s, sizes_new=%s, rf_len=%s, crf_len=%s", \
+                                         MPI.COMM_WORLD.Get_rank(), self.peer_rank, tag, sizes, sizes_new, len(recv_frames), len(cuda_recv_frames))
+
+                read_counter = 0
+                for each_frame in recv_frames:
+                    #await self.ep.recv(each_frame)
+                    await self.mpi_recv(each_frame, sizes_new[read_counter], tag)
+                    tag = tag + 1
+                    read_counter = read_counter + 1
+
+                logger.debug("read_4: me=%s, you=%s, tag=%s", MPI.COMM_WORLD.Get_rank(), self.peer_rank, tag)
+
+                msg = await from_frames(
+                    frames,
+                    deserialize=self.deserialize,
+                    deserializers=deserializers,
+                    allow_offload=self.allow_offload,
+                )
+                logger.debug("read_5: me=%s, you=%s, tag=%s", MPI.COMM_WORLD.Get_rank(), self.peer_rank, tag)
+                return msg
+
+    async def close(self):
+        if self._closed is False:
+            self._closed = True
+
+    def abort(self):
+        if self._closed is False:
+            self._closed = True
+
+    def closed(self):
+        return self._closed
+
+
+class MPI4DaskConnector(Connector):
+    prefix = "mpi://"
+    comm_class = MPI4Dask
+    encrypted = False
+
+    async def connect(self, address: str, \
+                      deserialize=True, \
+                      **connection_args) -> MPI4Dask:
+
+        rand_num = 0.001 * random.randint(0, 1000)
+        await asyncio.sleep(rand_num)
+        logger.debug("%s: connecting to address=%s with delay=%s", \
+                             socket.gethostname(), address, rand_num)
+        init_once()
+
+        ip, port = parse_host_port(address)
+        reader, writer = await asyncio.open_connection(ip, port)
+
+        peer_addr = writer.get_extra_info('peername')
+        local_addr = writer.get_extra_info('sockname')
+        local_rank = MPI.COMM_WORLD.Get_rank()
+
+        logger.debug("%s: connect: local_addr=%s, peer_addr=%s", \
+                        socket.gethostname(), local_addr[0], peer_addr[0])
+
+        assert reader.at_eof() == False 
+        data = await reader.read(4)
+        logger.debug("data: %s", data)
+        peer_rank = int(data.decode())
+
+        data = str(local_rank).encode()
+        writer.write(data)
+        await writer.drain()
+
+        suggested_tag = tag_table.get(peer_rank)
+        #new_suggested_tag = suggested_tag + TAG_QUOTA_PER_CONNECTION 
+        tag_table.update({peer_rank : + (suggested_tag+TAG_QUOTA_PER_CONNECTION)})
+        logger.debug("%s: connect: data=%s, rank=%s, peer_rank=%s, suggested_tag=%s", \
+                        socket.gethostname(), data, local_rank, peer_rank, suggested_tag)
+
+        return self.comm_class(
+            peer_rank,
+            suggested_tag,
+            local_addr = self.prefix + local_addr[0] + ":" + \
+                                                str(local_addr[1]),
+            peer_addr = self.prefix + peer_addr[0] + ":" + \
+                                                str(peer_addr[1]),
+            p_addr = peer_addr[0],
+            deserialize=deserialize,
+        )
+
+class MPI4DaskListener(Listener):
+    prefix = MPI4DaskConnector.prefix
+    comm_class = MPI4DaskConnector.comm_class
+    encrypted = MPI4DaskConnector.encrypted
+
+    def __init__(
+        self,
+        address: str,
+        comm_handler: None,
+        deserialize=False,
+        allow_offload=True,
+        **connection_args
+    ):
+        global LOWER_PORT_RANGE, UPPER_PORT_RANGE
+
+        if not address.startswith("mpi"):
+            address = "mpi://" + address
+
+        logger.debug("%s: MPI4DaskListener.__init__ %s", \
+                                              socket.gethostname(), address)
+        self.ip, self._input_port = parse_host_port(address, default_port=0)
+        # choose a random port between LOWER_PORT_RANGE and UPPER_PORT_RANGE
+        self._input_port = random.randint(LOWER_PORT_RANGE, UPPER_PORT_RANGE)
+        self.comm_handler = comm_handler
+        self.deserialize = deserialize
+        self.allow_offload = allow_offload
+        self.mpi_server = None
+        self.connection_args = connection_args
+
+    @property
+    def port(self):
+        return self._input_port
+
+    @property
+    def address(self):
+        return "mpi://" + self.ip + ":" + str(self.port)
+
+    async def start(self):
+
+        async def serve_forever(reader, writer):
+
+            peer_addr = writer.get_extra_info('peername')
+            local_addr = writer.get_extra_info('sockname')
+            logger.debug("%s: listen(): local=%s, peer=%s", \
+                        socket.gethostname(), local_addr[0], peer_addr[0])
+
+            local_rank = MPI.COMM_WORLD.Get_rank()
+
+            data = str(local_rank).encode()
+            writer.write(data)
+            await writer.drain()
+            logger.debug("listen(): wrote data")
+
+            assert reader.at_eof() == False 
+            data = await reader.read(4)
+            peer_rank = int(data.decode())
+            logger.debug("listen(): read data")
+
+            suggested_tag = tag_table.get(peer_rank)
+            #new_suggested_tag = suggested_tag + TAG_QUOTA_PER_CONNECTION
+            tag_table.update({peer_rank : (suggested_tag + TAG_QUOTA_PER_CONNECTION)})
+            logger.debug("%s: listen(): data=%s, rank=%s, peer_rank=%s, suggested_tag=%s", \
+                                                      socket.gethostname(), data, local_rank, peer_rank, suggested_tag)
+
+            mpi = MPI4Dask(
+                peer_rank,
+                suggested_tag,
+                local_addr = self.prefix + local_addr[0] + ":" + \
+                                                   str(local_addr[1]),
+                peer_addr = self.prefix + peer_addr[0] + ":" + \
+                                                   str(peer_addr[1]),
+                p_addr = peer_addr[0],
+                deserialize=self.deserialize,
+            )
+
+            mpi.allow_offload = self.allow_offload
+
+            try:
+                await self.on_connection(mpi)
+            except CommClosedError:
+                logger.debug("Connection closed before handshake completed")
+                return
+
+            if self.comm_handler:
+                logger.debug("%s: calling comm_handler(mpi)", socket.gethostname())
+                await self.comm_handler(mpi)
+
+        init_once()
+        logger.debug("asyncio.start_server()")
+        coro = asyncio.start_server(serve_forever, \
+                                    None, \
+                                    port=self._input_port, \
+                                    backlog=1024)
+        task = asyncio.create_task(coro)
+        self.mpi_server = await task
+        addr = self.mpi_server.sockets[0].getsockname()
+        logger.debug(f'Serving on {addr}')
+
+    def stop(self):
+        self.mpi_server = None
+
+    def get_host_port(self):
+        # TODO: TCP raises if this hasn't started yet.
+        return self.ip, self.port
+
+    @property
+    def listen_address(self):
+        return self.prefix + unparse_host_port(*self.get_host_port())
+
+    @property
+    def contact_address(self):
+        host, port = self.get_host_port()
+        host = ensure_concrete_host(host)  # TODO: ensure_concrete_host
+        return self.prefix + unparse_host_port(host, port)
+
+    @property
+    def bound_address(self):
+        # TODO: Does this become part of the base API? Kinda hazy, since
+        # we exclude in for inproc.
+        return self.get_host_port()
+
+class MPI4DaskBackend(Backend):
+    # I / O
+
+    def get_connector(self):
+        return MPI4DaskConnector()
+
+    def get_listener(self, loc, handle_comm, deserialize, **connection_args):
+        return MPI4DaskListener(loc, handle_comm, deserialize, **connection_args)
+
+    # Address handling
+    # This duplicates BaseTCPBackend
+
+    def get_address_host(self, loc):
+        return parse_host_port(loc)[0]
+
+    def get_address_host_port(self, loc):
+        return parse_host_port(loc)
+
+    def resolve_address(self, loc):
+        host, port = parse_host_port(loc)
+        return unparse_host_port(ensure_ip(host), port)
+
+    def get_local_address_for(self, loc):
+        host, port = parse_host_port(loc)
+        host = ensure_ip(host)
+        if ":" in host:
+            local_host = get_ipv6(host)
+        else:
+            local_host = get_ip(host)
+        return unparse_host_port(local_host, None)
+
+backends["mpi"] = MPI4DaskBackend()


### PR DESCRIPTION
This document outlines installation and usage of MPI4Dask, which provides an MVAPICH2-GDR based MPI communication backend for the Dask Distributed library. MPI4Dask embodies enhancements to the Dask Distributed package. 

A paper titled ["Efficient MPI-based Communication for GPU-Accelerated Dask Applications"](https://arxiv.org/abs/2101.08878) describes MPI4Dask and its performance against existing communication devices in detail.

## Install MPI4Dask

We start off with the installation of MPI4Dask.

### Installation Pre-Requisites

Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html), which is a free minimal installer for the conda package manager. The following commands download and install latest version of Miniconda3 for Python 3.x.

```
wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
chmod a+x Miniconda3-latest-Linux-x86_64.sh
./Miniconda3-latest-Linux-x86_64.sh
```

After installing the conda package manager, create a new conda environment named mpi4dask (suggested name). 
```
conda create --name mpi4dask
conda activate mpi4dask
```

Make sure that relevant/required modules are loaded in the environment. One of the required module is the CUDA toolkit (10.2 in this case). A list of all installed modules on the system can be seen as follows. Obviously the version of CUDA toolkit might be different on the user system.

```
module list
Currently Loaded Modulefiles:
  1) cuda/10.2
```

Install pre-requisite libraries including build tools, Python (version 3.8 here), Cython, CUDA tookit (version 10.2 here), Dask packages, RAPIDS libraries, and array packages. Users may install specific versions of these packages. Also, these packages are installed from three conda channels, including conda-forge, rapidsai, and nvidia, as follows:

```
conda install -c conda-forge -c rapidsai -c nvidia automake make libtool pkg-config libhwloc psutil python=3.8 setuptools cython cudatoolkit=10.2 cupy dask-cudf dask distributed numpy rmm
```

### Install MVAPICH2-GDR 

Download [the MVAPICH2-GDR library](http://mvapich.cse.ohio-state.edu). Detailed installation instructions are 
available from [here](http://mvapich.cse.ohio-state.edu/userguide/gdr/). Please become familiar with advanced configurations of the MVAPICH2-GDR software --- this is important to get maximum performance from the hardware system. This guide assumes that an environment variable `$MPILIB` points to the installation directory of the MVAPICH2-GDR software.

```
export MPILIB=/path/to/MVAPICH2-GDR/install/directory
```

It is important to make sure that the MVAPICH2-GDR is the MPI library used with MPI4Dask. Multiple installations of MPI libraries can result in errors. In order to avoid such situations, it is important to make sure that the correct version of the MVAPICH2-GDR library is available on the `$PATH` variable. This can be checked as follows.

```
$MPILIB/bin/mpiname -a
```

If the `$PATH` is set correctly, the output of the following command should match the previous command output.

```
mpiname -a
```

### Install mpi4py

Download and install the mpi4py library. Details about mpi4py can be seen [here](https://mpi4py.readthedocs.io). Download the software as follows.

```
git clone https://github.com/mpi4py/mpi4py.git
cd mpi4py
```

As part of the installation, the configuration file (mpi.cfg) in the root directory of mpi4py software needs to be updated to point to the MVAPICH2-GDR library. It is recommended to make a new section---in the mpi.cfg file---for MVAPICH2-GDR as follows:

```
# ------------
[MVAPICH2-GDR]
mpi_dir              = /path/to/MVAPICH2-GDR/install/directory
mpicc                = %(mpi_dir)s/bin/mpicc
mpicxx               = %(mpi_dir)s/bin/mpicxx
include_dirs         = %(mpi_dir)s/include
library_dirs         = %(mpi_dir)s/lib
runtime_library_dirs = %(library_dirs)s
```

After updating the mpi.cfg configuration file, install mpi4py with following commands:

```
python setup.py build --mpi=MVAPICH2-GDR
pip install .
```
### Install Dask-MPI

Download and Install Dask-MPI package from the github repository. MPI4Dask relies on Dask-MPI to start execution of Dask scheduler, client, and workers. Details about Dask-MPI package can be seen [here](http://mpi.dask.org). It is recommended not to install Dask-MPI through the conda package manager as it installs some conflicting packages as dependencies.

```
git clone https://github.com/dask/dask-mpi.git
cd dask-mpi
python setup.py build
pip install .
```
## Download MPI4Dask

MPI4Dask has been shared as a pull request. Enhancements to the Dask Distributed library can be summarized as follows.

1. The main enhancement to the the distributed package is the `distributed/comm/mpi.py` file
2. The dask-apps folder that contains two representative Dask test/benchmarking applications to show the MPI backend

## Install MPI4Dask

MPI4Dask can be installed using the following commands:

```
python setup.py build
pip install .
```

At this time, MPI4Dask with all its dependencies should be installed. Verify this by running the following commands:
```
conda list
conda list | grep distributed
conda list | grep dask
```

## Basic Usage Instructions

The MPI4Dask package contains two sample applications that can be used to test and benchmark performance of the MPI backend. These applications include: 1) Sum of cuPy Array and its Transpose, and 2) cuDF Merge.

### Sum of cuPy Array and its Transpose

This benchmark creates a cuPy array and distributes its chunks across Dask workers. The benchmark adds these
distributed chunks to their transpose. This benchmark is originally taken from the [dask-cuda package repository](https://github.com/rapidsai/dask-cuda/tree/branch-0.18/dask_cuda/benchmarks).

The next step is to start execution of the Dask program using Dask-MPI.

Write the hosts files. This file contains names of the compute nodes, with GPUs, that will execute the parallel Dask program.

```
cd dask-apps
vim hosts
.. write name of the compute nodes ..
cat hosts
machine1
machine2
machine3
machine4
```

Note that users need to customize the hosts file as per their environment. This benchmark can be executed as follows:

```
LD_PRELOAD=$MPILIB/lib/libmpi.so $MPILIB/bin/mpirun_rsh -export-all -np 4 -hostfile hosts MV2_USE_CUDA=1 MV2_USE_GDRCOPY=1 MV2_GPUDIRECT_GDRCOPY_LIB=/opt/gdrcopy2.0/lib64/libgdrapi.so MV2_CPU_BINDING_LEVEL=SOCKET MV2_CPU_BINDING_POLICY=SCATTER python cupy_sum_mpi.py
```

This command is starting the execution of the Dask application using MPI --- this is enabled by the Dask-MPI package. A total of 4 MPI processes are started with process 0 and 1 assuming the role of Dask scheduler and client respectively. All other processes with ranks greater than 1 becoming Dask workers. Here processes 2 and 3 are Dask workers. The `LD_PRELOAD` environment variable is required for Python applications to run correctly with the MVAPICH2-GDR library.

Details on various options, passed to the MVAPICH2-GDR library, are as follows:

- `-np 4` --- specifies the total number of parallel processes started by the MPI library
- `-hostfile hosts` --- specifies the names of machines where to start parallel processes in the ``hosts'' file
- `MV2_USE_CUDA=1` --- ensures that MVAPICH2-GDR library supports GPU-to-GPU communication
- `MV2_USE_GDRCOPY=1` --- turns on the GDRCopy protocol
- `MV2_GPUDIRECT_GDRCOPY_LIB` --- specifies path to the GDRCopy dynamic library
- `MV2_CPU_BINDING_LEVEL=SOCKET MV2_CPU_BINDING_POLICY=SCATTER` --- selects a socket-level scatter process binding policy

This is not an exhaustive list of options that can be passed to the MVAPICH2-GDR library. Details on these --- and other flags for the MVAPICH2-GDR library --- can be seen [here](http://mvapich.cse.ohio-state.edu/userguide/gdr/). As mentioned earlier, it is important to configure the MVAPICH2-GDR installation correctly to ensure optimal performance.

The `cupy_sum_mpi.py` script has some configuration parameters that can be modified, in the source-code, by the users. These include:

- `DASK_PROTOCOL = 'mpi'` --- specifies the protocol used by the Dask Distributed library. Options include `mpi', `tcp', `ucx'
- `DASK_INTERFACE = 'ib0'` --- specifies the interface used by the Dask Distributed library
- `GPUS_PER_NODE = 1` --- specifies the number of GPUs in the system
- `THREADS_PER_NODE = 28` --- specifies the number of threads (cores) in the system

### cuDF Merge

cuDF DataFrames are table-like data-structure that are stored in the GPU memory. As part of this application, the merge operation is carried out for multiple cuDF data frames. This benchmark is originally taken from the
[dask-cuda package repository](https://github.com/rapidsai/dask-cuda/tree/branch-0.18/dask\_cuda/benchmarks).

This application can be executed as follows.

```
cd dask-apps
LD_PRELOAD=$MPILIB/lib/libmpi.so $MPILIB/bin/mpirun_rsh -export-all -np 4 -hostfile hosts MV2_USE_CUDA=1 MV2_USE_GDRCOPY=1 MV2_GPUDIRECT_GDRCOPY_LIB=/opt/gdrcopy2.0/lib64/libgdrapi.so MV2_CPU_BINDING_LEVEL=SOCKET MV2_CPU_BINDING_POLICY=SCATTER python cudf_merge_mpi.py --type gpu --protocol mpi --runs 20 --chunk-size 1_000_000_00
```

The `cudf_merge_mpi.py` script accepts some runtime arguments. Some of the important ones include:

- `--type gpu` --- specifies that the data frame is GPU-based. Currently only GPU has been tested
- `--protocol mpi` --- specifies the communication backend used by Dask Distributed. Options include `mpi', `tcp', `ucx'
- `--runs 20` --- specifies the number of repetitions for the experiment
- `--chunk-size 1_000_000_00` --- specifies the chunk size for the data frame

In addition, the `cudf_merge_mpi.py` script has some configuration parameters that can be modified by the users. These include:

- `DASK_INTERFACE = 'ib0'` --- specifies the interface used by the Dask Distributed library
- `GPUS_PER_NODE = 1` --- specifies the number of GPUs in the system
- `THREADS_PER_NODE = 28` --- specifies the number of threads (cores) in the system