### PR TITLE
Compress serialized config data with zlib

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -28,6 +28,7 @@ import pkgutil
 import base64
 import tblib.pickling_support
 import xml.etree.ElementTree
+import zlib
 
 try:
     import resource
@@ -1467,7 +1468,7 @@ def serialize_for_cli(data):
     serialized_data: str
         The serialized data as a string
     """
-    return base64.urlsafe_b64encode(json.dumps(data).encode()).decode()
+    return base64.urlsafe_b64encode(zlib.compress(json.dumps(data).encode())).decode()
 
 
 def deserialize_for_cli(data):
@@ -1482,7 +1483,7 @@ def deserialize_for_cli(data):
     deserialized_data: obj
         The de-serialized data
     """
-    return json.loads(base64.urlsafe_b64decode(data.encode()).decode())
+    return json.loads(zlib.decompress(base64.urlsafe_b64decode(data.encode())).decode())
 
 
 class EmptyContext:


### PR DESCRIPTION
While working on `dask-cloudprovider` I've noticed there is a limit to the amount of [user_data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) you can pass to AWS. Among other things, a serialized copy of the local Dask config is passed via the user_data and depending on how much config a user has can result in the AWS API rejecting the call.

dask/dask-cloudprovider#249

In an attempt to mitigate this I've added `zlib` compression to the config serialization utility methods. From the limited testing I've done locally I've seen a ~60% reduction in size.

```python
>>> from distributed.utils import serialize_for_cli
>>> import dask.config
>>> len(serialize_for_cli(dask.config.global_config))  # Before change
5452
>>> len(serialize_for_cli(dask.config.global_config))  # After change
2256
```
