### PR TITLE
DOC: typo, directives ends with 2 colons `::`.

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1089,19 +1089,19 @@ class TaskState:
        into the "processing" state and be sent for execution to another
        connected worker.
 
-    .. attribute: metadata: dict
+    .. attribute:: metadata: dict
 
        Metadata related to task.
 
-    .. attribute: actor: bool
+    .. attribute:: actor: bool
 
        Whether or not this task is an Actor.
 
-    .. attribute: group: TaskGroup
+    .. attribute:: group: TaskGroup
 
         The group of tasks to which this one belongs.
 
-    .. attribute: annotations: dict
+    .. attribute:: annotations: dict
 
         Task annotations
     """


### PR DESCRIPTION
It's mischievous as those are interpreted as comments so perfectly valid syntax; but completely removed from the output. 

Side question, you seem to be using Numpy Doc format in many places, why not use the [Attributes](https://numpydoc.readthedocs.io/en/latest/format.html#class-docstring) section and maybe less prone to errors ?