### PR TITLE
DOC: Proper numpydoc syntax for distributed/protocol/*.py

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -147,10 +147,10 @@ def byte_sample(b, size, n):
 
     Parameters
     ----------
-    b: bytes or memoryview
-    size: int
+    b : bytes or memoryview
+    size : int
         size of each sample to collect
-    n: int
+    n : int
         number of samples to collect
     """
     starts = [random.randint(0, len(b) - size) for j in range(n)]

--- a/distributed/protocol/highlevelgraph.py
+++ b/distributed/protocol/highlevelgraph.py
@@ -79,11 +79,11 @@ def highlevelgraph_pack(hlg: HighLevelGraph, client, client_keys):
 
     Parameters
     ----------
-    hlg: HighLevelGraph
+    hlg : HighLevelGraph
         The high level graph to pack
-    client: distributed.Client
+    client : distributed.Client
         The client calling this function.
-    client_keys: Iterable
+    client_keys : Iterable
         List of keys requested by the client.
 
     Returns
@@ -134,10 +134,9 @@ def highlevelgraph_unpack(dumped_hlg, annotations: dict):
 
     Parameters
     ----------
-    dumped_hlg: list of header and payload
+    dumped_hlg : list of header and payload
         Packed high level graph serialized by dumps_msgpack
-
-    annotations: dict
+    annotations : dict
         A top-level annotations object which may be partially populated,
         and which may be further filled by annotations from the layers
         of the dumped_hlg.

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -213,9 +213,9 @@ def serialize(x, serializers=None, on_error="message", context=None):
 
     See Also
     --------
-    deserialize: Convert header and frames back to object
-    to_serialize: Mark that data in a message should be serialized
-    register_serialization: Register custom serialization functions
+    deserialize : Convert header and frames back to object
+    to_serialize : Mark that data in a message should be serialized
+    register_serialization : Register custom serialization functions
     """
     if serializers is None:
         serializers = ("dask", "pickle")  # TODO: get from configuration
@@ -322,8 +322,8 @@ def deserialize(header, frames, deserializers=None):
 
     Parameters
     ----------
-    header: dict
-    frames: list of bytes
+    header : dict
+    frames : list of bytes
     deserializers : Optional[Dict[str, Tuple[Callable, Callable, bool]]]
         An optional dict mapping a name to a (de)serializer.
         See `dask_serialize` and `dask_deserialize` for more.
@@ -580,9 +580,9 @@ def register_serialization(cls, serialize, deserialize):
 
     Parameters
     ----------
-    cls: type
-    serialize: callable(cls) -> Tuple[Dict, List[bytes]]
-    deserialize: callable(header: Dict, frames: List[bytes]) -> cls
+    cls : type
+    serialize : callable(cls) -> Tuple[Dict, List[bytes]]
+    deserialize : callable(header: Dict, frames: List[bytes]) -> cls
 
     Examples
     --------


### PR DESCRIPTION
Numpydoc return semantically different informations when there is no
space in front of :, in particular it will put the whole line as the
name of the parameter.

This might not be visible in the sphinx theme depending on the theme
chosen.

-- 

Note that those changes have been automatically generated;  
I can easily send a PRs that add on top of this  about 250 other fixes, but don't want to send too big of an update; 