### PR TITLE
DOC: Autoreformat all functions docstrings.

### DIFF
--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -187,12 +187,11 @@ def start_ipython(ip=None, ns=None, log=None):
 
     Parameters
     ----------
-
-    ip: str
+    ip : str
         The IP address to listen on (likely the parent object's ip).
-    ns: dict
+    ns : dict
         Any names that should be injected into the IPython namespace.
-    log: logger instance
+    log : logger instance
         Hook up IPython's logging to an existing logger instead of the default.
     """
     from IPython import get_ipython

--- a/distributed/cfexecutor.py
+++ b/distributed/cfexecutor.py
@@ -98,12 +98,12 @@ class ClientExecutor(cf.Executor):
 
         Parameters
         ----------
-        fn: A callable that will take as many arguments as there are
+        fn : A callable that will take as many arguments as there are
             passed iterables.
-        iterables: One iterable for each parameter to *fn*.
-        timeout: The maximum number of seconds to wait. If None, then there
+        iterables : One iterable for each parameter to *fn*.
+        timeout : The maximum number of seconds to wait. If None, then there
             is no limit on the wait time.
-        chunksize: ignored.
+        chunksize : ignored.
 
         Returns
         -------
@@ -155,7 +155,7 @@ class ClientExecutor(cf.Executor):
 
         Parameters
         ----------
-        wait: If True then shutdown will not return until all running
+        wait : If True then shutdown will not return until all running
             futures have finished executing.  If False then all running
             futures are cancelled immediately.
         """

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1456,9 +1456,9 @@ class Client:
         Note, this may disrupt other clients that may be using the same
         scheduler and workers.
 
-        See also
+        See Also
         --------
-        Client.close: close only this client
+        Client.close : close only this client
         """
         return self.sync(self._shutdown)
 
@@ -1468,7 +1468,7 @@ class Client:
 
         Parameters
         ----------
-        **kwargs:
+        **kwargs
             Any submit()- or map()- compatible arguments, such as
             `workers` or `resources`.
 
@@ -1500,36 +1500,36 @@ class Client:
 
         Parameters
         ----------
-        func: callable
-        *args:
-        **kwargs:
-        pure: bool (defaults to True)
+        func : callable
+        *args
+        **kwargs
+        pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-        workers: string or iterable of strings
+        workers : string or iterable of strings
             A set of worker addresses or hostnames on which computations may be
             performed. Leave empty to default to all workers (common case)
-        key: str
+        key : str
             Unique identifier for the task.  Defaults to function-name and hash
-        allow_other_workers: bool (defaults to False)
+        allow_other_workers : bool (defaults to False)
             Used with ``workers``. Indicates whether or not the computations
             may be performed on workers that are not in the `workers` set(s).
-        retries: int (default to 0)
+        retries : int (default to 0)
             Number of allowed automatic retries if the task fails
-        priority: Number
+        priority : Number
             Optional prioritization of task.  Zero is default.
             Higher priorities take precedence
-        fifo_timeout: str timedelta (default '100ms')
+        fifo_timeout : str timedelta (default '100ms')
             Allowed amount of time between calls to consider the same priority
-        resources: dict (defaults to {})
+        resources : dict (defaults to {})
             Defines the ``resources`` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
-        actor: bool (default False)
+        actor : bool (default False)
             Whether this task should exist on the worker as a stateful actor.
             See :doc:`actors` for additional details.
-        actors: bool (default False)
+        actors : bool (default False)
             Alias for `actor`
 
         Examples
@@ -1542,7 +1542,7 @@ class Client:
 
         See Also
         --------
-        Client.map: Submit on many arguments at once
+        Client.map : Submit on many arguments at once
         """
         if not callable(func):
             raise TypeError("First input to submit must be a callable function")
@@ -1617,43 +1617,43 @@ class Client:
 
         Parameters
         ----------
-        func: callable
-        iterables: Iterables
+        func : callable
+        iterables : Iterables
             List-like objects to map over.  They should have the same length.
-        key: str, list
+        key : str, list
             Prefix for task names if string.  Explicit names if list.
-        pure: bool (defaults to True)
+        pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-        workers: string or iterable of strings
+        workers : string or iterable of strings
             A set of worker hostnames on which computations may be performed.
             Leave empty to default to all workers (common case)
-        allow_other_workers: bool (defaults to False)
+        allow_other_workers : bool (defaults to False)
             Used with `workers`. Indicates whether or not the computations
             may be performed on workers that are not in the `workers` set(s).
-        retries: int (default to 0)
+        retries : int (default to 0)
             Number of allowed automatic retries if a task fails
-        priority: Number
+        priority : Number
             Optional prioritization of task.  Zero is default.
             Higher priorities take precedence
-        fifo_timeout: str timedelta (default '100ms')
+        fifo_timeout : str timedelta (default '100ms')
             Allowed amount of time between calls to consider the same priority
-        resources: dict (defaults to {})
+        resources : dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
-        actor: bool (default False)
+        actor : bool (default False)
             Whether these tasks should exist on the worker as stateful actors.
             See :doc:`actors` for additional details.
-        actors: bool (default False)
+        actors : bool (default False)
             Alias for `actor`
         batch_size : int, optional
             Submit tasks to the scheduler in batches of (at most) ``batch_size``.
             Larger batch sizes can be useful for very large ``iterables``,
             as the cluster can start processing tasks while later ones are
             submitted asynchronously.
-        **kwargs: dict
+        **kwargs : dict
             Extra keywords to send to the function.
             Large values will be included explicitly in the task graph.
 
@@ -1666,9 +1666,9 @@ class Client:
         List, iterator, or Queue of futures, depending on the type of the
         inputs.
 
-        See also
+        See Also
         --------
-        Client.submit: Submit a single function
+        Client.submit : Submit a single function
         """
         if not callable(func):
             raise TypeError("First input to map must be a callable function")
@@ -1918,13 +1918,13 @@ class Client:
 
         Parameters
         ----------
-        futures: Collection of futures
+        futures : Collection of futures
             This can be a possibly nested collection of Future objects.
             Collections can be lists, sets, or dictionaries
-        errors: string
+        errors : string
             Either 'raise' or 'skip' if we should raise if a future has erred
             or skip its inclusion in the output collection
-        direct: boolean
+        direct : boolean
             Whether or not to connect directly to the workers, or to ask
             the scheduler to serve as intermediary.  This can also be set when
             creating the Client.
@@ -1946,7 +1946,7 @@ class Client:
 
         See Also
         --------
-        Client.scatter: Send data out to cluster
+        Client.scatter : Send data out to cluster
         """
         if isinstance(futures, pyQueue):
             raise TypeError(
@@ -2098,19 +2098,19 @@ class Client:
 
         Parameters
         ----------
-        data: list, dict, or object
+        data : list, dict, or object
             Data to scatter out to workers.  Output type matches input type.
-        workers: list of tuples (optional)
+        workers : list of tuples (optional)
             Optionally constrain locations of data.
             Specify workers as hostname/port pairs, e.g. ``('127.0.0.1', 8787)``.
-        broadcast: bool (defaults to False)
+        broadcast : bool (defaults to False)
             Whether to send each data element to all workers.
             By default we round-robin based on number of cores.
-        direct: bool (defaults to automatically check)
+        direct : bool (defaults to automatically check)
             Whether or not to connect directly to the workers, or to ask
             the scheduler to serve as intermediary.  This can also be set when
             creating the Client.
-        hash: bool (optional)
+        hash : bool (optional)
             Whether or not to hash data to determine key.
             If False then this uses a random key
 
@@ -2150,7 +2150,7 @@ class Client:
 
         See Also
         --------
-        Client.gather: Gather data back to local process
+        Client.gather : Gather data back to local process
         """
         if timeout == no_default:
             timeout = self._timeout
@@ -2194,8 +2194,8 @@ class Client:
 
         Parameters
         ----------
-        futures: list of Futures
-        force: boolean (False)
+        futures : list of Futures
+        force : boolean (False)
             Cancel this future even if other clients desire it
         """
         return self.sync(self._cancel, futures, asynchronous=asynchronous, force=force)
@@ -2213,7 +2213,7 @@ class Client:
 
         Parameters
         ----------
-        futures: list of Futures
+        futures : list of Futures
         """
         return self.sync(self._retry, futures, asynchronous=asynchronous)
 
@@ -2266,7 +2266,7 @@ class Client:
         name : optional name of the dataset to publish
         override : bool (optional, default False)
             if true, override any already present dataset with the same name
-        kwargs: dict
+        kwargs : dict
             named collections to publish on the scheduler
 
         Examples
@@ -2349,7 +2349,7 @@ class Client:
         name : name of the dataset to retrieve
         default : optional, not set by default
             If set, do not raise a KeyError if the name is not present but return this default
-        kwargs: dict
+        kwargs : dict
             additional arguments to _get_dataset
 
         See Also
@@ -2381,7 +2381,6 @@ class Client:
 
         Examples
         --------
-
         >>> def get_number_of_tasks(dask_scheduler=None):
         ...     return len(dask_scheduler.tasks)
 
@@ -2399,8 +2398,8 @@ class Client:
 
         See Also
         --------
-        Client.run: Run a function on all workers
-        Client.start_ipython_scheduler: Start an IPython session on scheduler
+        Client.run : Run a function on all workers
+        Client.start_ipython_scheduler : Start an IPython session on scheduler
         """
         return self.sync(self._run_on_scheduler, function, *args, **kwargs)
 
@@ -2443,12 +2442,12 @@ class Client:
 
         Parameters
         ----------
-        function: callable
-        *args: arguments for remote function
-        **kwargs: keyword arguments for remote function
-        workers: list
+        function : callable
+        *args : arguments for remote function
+        **kwargs : keyword arguments for remote function
+        workers : list
             Workers on which to run the function. Defaults to all known workers.
-        wait: boolean (optional)
+        wait : boolean (optional)
             If the function is asynchronous whether or not to wait until that
             function finishes.
         nanny : bool, defualt False
@@ -2499,14 +2498,14 @@ class Client:
 
         Parameters
         ----------
-        function: a coroutine function
+        function : a coroutine function
             (typically a function wrapped in gen.coroutine or
              a Python 3.5+ async function)
-        *args: arguments for remote function
-        **kwargs: keyword arguments for remote function
-        wait: boolean (default True)
+        *args : arguments for remote function
+        **kwargs : keyword arguments for remote function
+        wait : boolean (default True)
             Whether to wait for coroutines to end.
-        workers: list
+        workers : list
             Workers on which to run the function. Defaults to all known workers.
 
         """
@@ -2597,27 +2596,27 @@ class Client:
 
         Parameters
         ----------
-        dsk: dict
-        keys: object, or nested lists of objects
-        workers: string or iterable of strings
+        dsk : dict
+        keys : object, or nested lists of objects
+        workers : string or iterable of strings
             A set of worker addresses or hostnames on which computations may be
             performed. Leave empty to default to all workers (common case)
-        allow_other_workers: bool (defaults to False)
+        allow_other_workers : bool (defaults to False)
             Used with ``workers``. Indicates whether or not the computations
             may be performed on workers that are not in the `workers` set(s).
-        retries: int (default to 0)
+        retries : int (default to 0)
             Number of allowed automatic retries if computing a result fails
-        priority: Number
+        priority : Number
             Optional prioritization of task.  Zero is default.
             Higher priorities take precedence
-        resources: dict (defaults to {})
+        resources : dict (defaults to {})
             Defines the ``resources`` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
-        sync: bool (optional)
+        sync : bool (optional)
             Returns Futures if False or concrete values if True (default).
-        direct: bool
+        direct : bool
             Whether or not to connect directly to the workers, or to ask
             the scheduler to serve as intermediary.  This can also be set when
             creating the Client.
@@ -2631,7 +2630,7 @@ class Client:
 
         See Also
         --------
-        Client.compute: Compute asynchronous collections
+        Client.compute : Compute asynchronous collections
         """
         futures = self._graph_to_futures(
             dsk,
@@ -2707,7 +2706,7 @@ class Client:
 
         See Also
         --------
-        Client.persist: trigger computation of collection's tasks
+        Client.persist : trigger computation of collection's tasks
         """
         dsk_orig = collection.__dask_graph__()
         dsk = self._optimize_insert_futures(dsk_orig, collection.__dask_keys__())
@@ -2736,40 +2735,40 @@ class Client:
 
         Parameters
         ----------
-        collections: iterable of dask objects or single dask object
+        collections : iterable of dask objects or single dask object
             Collections like dask.array or dataframe or dask.value objects
-        sync: bool (optional)
+        sync : bool (optional)
             Returns Futures if False (default) or concrete values if True
-        optimize_graph: bool
+        optimize_graph : bool
             Whether or not to optimize the underlying graphs
-        workers: string or iterable of strings
+        workers : string or iterable of strings
             A set of worker hostnames on which computations may be performed.
             Leave empty to default to all workers (common case)
-        allow_other_workers: bool (defaults to False)
+        allow_other_workers : bool (defaults to False)
             Used with `workers`. Indicates whether or not the computations
             may be performed on workers that are not in the `workers` set(s).
-        retries: int (default to 0)
+        retries : int (default to 0)
             Number of allowed automatic retries if computing a result fails
-        priority: Number
+        priority : Number
             Optional prioritization of task.  Zero is default.
             Higher priorities take precedence
-        fifo_timeout: timedelta str (defaults to '60s')
+        fifo_timeout : timedelta str (defaults to '60s')
             Allowed amount of time between calls to consider the same priority
-        traverse: bool (defaults to True)
+        traverse : bool (defaults to True)
             By default dask traverses builtin python collections looking for
             dask objects passed to ``compute``. For large collections this can
             be expensive. If none of the arguments contain any dask objects,
             set ``traverse=False`` to avoid doing this traversal.
-        resources: dict (defaults to {})
+        resources : dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
-        actors: bool or dict (default None)
+        actors : bool or dict (default None)
             Whether these tasks should exist on the worker as stateful actors.
             Specified on a global (True/False) or per-task (``{'x': True,
             'y': False}``) basis. See :doc:`actors` for additional details.
-        **kwargs:
+        **kwargs
             Options to pass to the graph optimize calls
 
         Returns
@@ -2796,7 +2795,7 @@ class Client:
 
         See Also
         --------
-        Client.get: Normal synchronous dask.get function
+        Client.get : Normal synchronous dask.get function
         """
         if isinstance(collections, (list, tuple, set, frozenset)):
             singleton = False
@@ -2888,33 +2887,33 @@ class Client:
 
         Parameters
         ----------
-        collections: sequence or single dask object
+        collections : sequence or single dask object
             Collections like dask.array or dataframe or dask.value objects
-        optimize_graph: bool
+        optimize_graph : bool
             Whether or not to optimize the underlying graphs
-        workers: string or iterable of strings
+        workers : string or iterable of strings
             A set of worker hostnames on which computations may be performed.
             Leave empty to default to all workers (common case)
-        allow_other_workers: bool (defaults to False)
+        allow_other_workers : bool (defaults to False)
             Used with `workers`. Indicates whether or not the computations
             may be performed on workers that are not in the `workers` set(s).
-        retries: int (default to 0)
+        retries : int (default to 0)
             Number of allowed automatic retries if computing a result fails
-        priority: Number
+        priority : Number
             Optional prioritization of task.  Zero is default.
             Higher priorities take precedence
-        fifo_timeout: timedelta str (defaults to '60s')
+        fifo_timeout : timedelta str (defaults to '60s')
             Allowed amount of time between calls to consider the same priority
-        resources: dict (defaults to {})
+        resources : dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
             See :doc:`worker resources <resources>` for details on defining
             resources.
-        actors: bool or dict (default None)
+        actors : bool or dict (default None)
             Whether these tasks should exist on the worker as stateful actors.
             Specified on a global (True/False) or per-task (``{'x': True,
             'y': False}``) basis. See :doc:`actors` for additional details.
-        **kwargs:
+        **kwargs
             Options to pass to the graph optimize calls
 
         Returns
@@ -3025,7 +3024,7 @@ class Client:
 
         Parameters
         ----------
-        filename: string
+        filename : string
             Filename of .py, .egg or .zip file to send to workers
 
         Examples
@@ -3062,9 +3061,9 @@ class Client:
 
         Parameters
         ----------
-        futures: list, optional
+        futures : list, optional
             A list of futures to balance, defaults all data
-        workers: list, optional
+        workers : list, optional
             A list of workers on which to balance, defaults to all workers
         """
         return self.sync(self._rebalance, futures, workers, **kwargs)
@@ -3089,15 +3088,15 @@ class Client:
 
         Parameters
         ----------
-        futures: list of futures
+        futures : list of futures
             Futures we wish to replicate
-        n: int, optional
+        n : int, optional
             Number of processes on the cluster on which to replicate the data.
             Defaults to all.
-        workers: list of worker addresses
+        workers : list of worker addresses
             Workers on which we want to restrict the replication.
             Defaults to all.
-        branching_factor: int, optional
+        branching_factor : int, optional
             The number of workers that can copy data in each generation
 
         Examples
@@ -3109,7 +3108,7 @@ class Client:
         >>> c.replicate([x], n=1, workers=['alice', 'bob'])  # send to one of specific workers  # doctest: +SKIP
         >>> c.replicate([x], n=1)  # reduce replications # doctest: +SKIP
 
-        See also
+        See Also
         --------
         Client.rebalance
         """
@@ -3127,7 +3126,7 @@ class Client:
 
         Parameters
         ----------
-        workers: list (optional)
+        workers : list (optional)
             A list of workers that we care about specifically.
             Leave empty to receive information about all workers.
 
@@ -3159,7 +3158,7 @@ class Client:
 
         Parameters
         ----------
-        futures: list (optional)
+        futures : list (optional)
             A list of futures, defaults to all data
 
         Examples
@@ -3195,7 +3194,7 @@ class Client:
 
         Parameters
         ----------
-        workers: list (optional)
+        workers : list (optional)
             A list of worker addresses, defaults to all
 
         Examples
@@ -3226,7 +3225,7 @@ class Client:
 
         Parameters
         ----------
-        workers: list (optional)
+        workers : list (optional)
             A list of worker addresses, defaults to all
 
         Examples
@@ -3259,9 +3258,9 @@ class Client:
 
         Parameters
         ----------
-        keys: list (optional)
+        keys : list (optional)
             A list of keys, defaults to all keys
-        summary: boolean, (optional)
+        summary : boolean, (optional)
             Summarize keys into key types
 
         Examples
@@ -3291,9 +3290,9 @@ class Client:
 
         Parameters
         ----------
-        futures: list (optional)
+        futures : list (optional)
             List of futures, defaults to all data
-        keys: list (optional)
+        keys : list (optional)
             List of key names, defaults to all data
 
         Examples
@@ -3325,24 +3324,24 @@ class Client:
 
         Parameters
         ----------
-        key: str
+        key : str
             Key prefix to select, this is typically a function name like 'inc'
             Leave as None to collect all data
-        start: time
-        stop: time
-        workers: list
+        start : time
+        stop : time
+        workers : list
             List of workers to restrict profile information
         server : bool
             If true, return the profile of the worker's administrative thread
             rather than the worker threads.
             This is useful when profiling Dask itself, rather than user code.
-        scheduler: bool
+        scheduler : bool
             If true, return the profile information from the scheduler's
             administrative thread rather than the workers.
             This is useful when profiling Dask's scheduling itself.
-        plot: boolean or string
+        plot : boolean or string
             Whether or not to return a plot object
-        filename: str
+        filename : str
             Filename to save the plot
 
         Examples
@@ -3439,7 +3438,7 @@ class Client:
 
         Parameters
         ----------
-        scheduler_file: str
+        scheduler_file : str
             Path to a write the scheduler file.
 
         Examples
@@ -3464,14 +3463,14 @@ class Client:
 
         Parameters
         ----------
-        keys: key or list
+        keys : key or list
             Key to access.  If a list then gets within a nested collection
-        default: optional
+        default : optional
             If the key does not exist then return this value instead.
             If not provided then this raises a KeyError if the key is not
             present
 
-        See also
+        See Also
         --------
         Client.set_metadata
         """
@@ -3521,7 +3520,7 @@ class Client:
 
         Parameters
         ----------
-        topic: str, list
+        topic : str, list
             Name of the topic under which to log an event. To log the same
             event under multiple topics, pass a list of topic names.
         msg
@@ -3539,7 +3538,7 @@ class Client:
 
         Parameters
         ----------
-        topic: str, optional
+        topic : str, optional
             Name of topic log to retrieve events for. If no ``topic`` is
             provided, then logs for all topics will be returned.
         """
@@ -3682,18 +3681,15 @@ class Client:
 
         Parameters
         ----------
-        workers: list (optional)
+        workers : list (optional)
             A list of worker addresses, defaults to all
-
-        magic_names: str or list(str) (optional)
+        magic_names : str or list(str) (optional)
             If defined, register IPython magics with these names for
             executing code on the workers.  If string has asterix then expand
             asterix into 0, 1, ..., n for n workers
-
-        qtconsole: bool (optional)
+        qtconsole : bool (optional)
             If True, launch a Jupyter QtConsole connected to the worker(s).
-
-        qtconsole_args: list(str) (optional)
+        qtconsole_args : list(str) (optional)
             Additional arguments to pass to the qtconsole on startup.
 
         Examples
@@ -3724,7 +3720,7 @@ class Client:
 
         See Also
         --------
-        Client.start_ipython_scheduler: start ipython on the scheduler
+        Client.start_ipython_scheduler : start ipython on the scheduler
         """
         if isinstance(workers, (str, Number)):
             workers = [workers]
@@ -3764,15 +3760,13 @@ class Client:
 
         Parameters
         ----------
-        magic_name: str or None (optional)
+        magic_name : str or None (optional)
             If defined, register IPython magic with this name for
             executing code on the scheduler.
             If not defined, register %scheduler magic if IPython is running.
-
-        qtconsole: bool (optional)
+        qtconsole : bool (optional)
             If True, launch a Jupyter QtConsole connected to the worker(s).
-
-        qtconsole_args: list(str) (optional)
+        qtconsole_args : list(str) (optional)
             Additional arguments to pass to the qtconsole on startup.
 
         Examples
@@ -3792,7 +3786,7 @@ class Client:
 
         See Also
         --------
-        Client.start_ipython_workers: Start IPython on the workers
+        Client.start_ipython_workers : Start IPython on the workers
         """
         info = sync(self.loop, self.scheduler.start_ipython)
         if magic_name == "scheduler_if_ipython":
@@ -3856,22 +3850,22 @@ class Client:
 
         Parameters
         ----------
-        start: Number or string
+        start : Number or string
             When you want to start recording
             If a number it should be the result of calling time()
             If a string then it should be a time difference before now,
             like '60s' or '500 ms'
-        stop: Number or string
+        stop : Number or string
             When you want to stop recording
-        count: int
+        count : int
             The number of desired records, ignored if both start and stop are
             specified
-        plot: boolean, str
+        plot : boolean, str
             If true then also return a Bokeh figure
             If plot == 'save' then save the figure to a file
-        filename: str (optional)
+        filename : str (optional)
             The filename to save to if you set ``plot='save'``
-        bokeh_resources: bokeh.resources.Resources (optional)
+        bokeh_resources : bokeh.resources.Resources (optional)
             Specifies if the resource component is INLINE or CDN
 
         Examples
@@ -3903,7 +3897,7 @@ class Client:
 
         See Also
         --------
-        get_task_stream: a context manager version of this method
+        get_task_stream : a context manager version of this method
         """
         return self.sync(
             self._get_task_stream,
@@ -3998,12 +3992,12 @@ class Client:
 
         Parameters
         ----------
-        plugin: WorkerPlugin
+        plugin : WorkerPlugin
             The plugin object to pass to the workers
-        name: str, optional
+        name : str, optional
             A name for the plugin.
             Registering a plugin with the same name will have no effect.
-        **kwargs: optional
+        **kwargs : optional
             If you pass a class as the plugin, instead of a class instance, then the
             class will be instantiated with any extra keyword arguments.
 
@@ -4114,10 +4108,10 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
 
     Parameters
     ----------
-    fs: list of futures
-    timeout: number, optional
+    fs : list of futures
+    timeout : number, optional
         Time in seconds after which to raise a ``dask.distributed.TimeoutError``
-    return_when: str, optional
+    return_when : str, optional
         One of `ALL_COMPLETED` or `FIRST_COMPLETED`
 
     Returns
@@ -4343,7 +4337,7 @@ class as_completed:
 
         Parameters
         ----------
-        block: bool, optional
+        block : bool, optional
             If True then wait until we have some result, otherwise return
             immediately, even with an empty list.  Defaults to True.
 
@@ -4440,7 +4434,7 @@ def futures_of(o, client=None):
 
     Parameters
     ----------
-    o: collection
+    o : collection
         A possibly nested collection of Dask objects
 
     Examples
@@ -4496,7 +4490,7 @@ def fire_and_forget(obj):
 
     Parameters
     ----------
-    obj: Future, list, dict, dask collection
+    obj : Future, list, dict, dask collection
         The futures that you want to run at least once
 
     Examples

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -75,7 +75,7 @@ class Comm(ABC):
 
         Parameters
         ----------
-        msg :
+        msg
         on_error : Optional[str]
             The behavior when serialization fails. See
             ``distributed.protocol.core.dumps`` for valid values.

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1119,7 +1119,7 @@ def error_message(e, status="error"):
 
     See Also
     --------
-    clean_exception: deserialize and unpack message into exception/traceback
+    clean_exception : deserialize and unpack message into exception/traceback
     """
     MAX_ERROR_LEN = dask.config.get("distributed.admin.max-error-length")
     tblib.pickling_support.install(e, *collect_causes(e))
@@ -1150,7 +1150,7 @@ def clean_exception(exception, traceback, **kwargs):
 
     See Also
     --------
-    error_message: create and serialize errors into message
+    error_message : create and serialize errors into message
     """
     if isinstance(exception, bytes) or isinstance(exception, bytearray):
         try:

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -160,7 +160,7 @@ class Cluster:
 
         Parameters
         ----------
-        n: int
+        n : int
             Target number of workers
 
         Examples

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -265,22 +265,22 @@ def SSHCluster(
 
     Parameters
     ----------
-    hosts: List[str]
+    hosts : List[str]
         List of hostnames or addresses on which to launch our cluster.
         The first will be used for the scheduler and the rest for workers.
-    connect_options: dict or list of dict, optional
+    connect_options : dict or list of dict, optional
         Keywords to pass through to :func:`asyncssh.connect`.
         This could include things such as ``port``, ``username``, ``password``
         or ``known_hosts``. See docs for :func:`asyncssh.connect` and
         :class:`asyncssh.SSHClientConnectionOptions` for full information.
         If a list it must have the same length as ``hosts``.
-    worker_options: dict, optional
+    worker_options : dict, optional
         Keywords to pass on to workers.
-    scheduler_options: dict, optional
+    scheduler_options : dict, optional
         Keywords to pass on to scheduler.
-    worker_module: str, optional
+    worker_module : str, optional
         Python module to call to start the worker.
-    remote_python: str or list of str, optional
+    remote_python : str or list of str, optional
         Path to Python on remote nodes.
 
     Examples

--- a/distributed/deploy/utils.py
+++ b/distributed/deploy/utils.py
@@ -10,7 +10,7 @@ def nprocesses_nthreads(n=CPU_COUNT):
 
     Parameters
     ----------
-    n: int
+    n : int
         Number of available cores
 
     Examples

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -67,13 +67,13 @@ class SchedulerPlugin:
 
         Parameters
         ----------
-        key: string
-        start: string
+        key : string
+        start : string
             Start state of the transition.
             One of released, waiting, processing, memory, error.
-        finish: string
+        finish : string
             Final state of the transition.
-        *args, **kwargs: More options passed when transitioning
+        *args, **kwargs : More options passed when transitioning
             This may include worker ID, compute time, etc.
         """
 
@@ -144,13 +144,13 @@ class WorkerPlugin:
 
         Parameters
         ----------
-        key: string
-        start: string
+        key : string
+        start : string
             Start state of the transition.
             One of waiting, ready, executing, long-running, memory, error.
-        finish: string
+        finish : string
             Final state of the transition.
-        kwargs: More options passed when transitioning
+        kwargs : More options passed when transitioning
         """
 
     def release_key(self, key, state, cause, reason, report):
@@ -159,15 +159,15 @@ class WorkerPlugin:
 
         Parameters
         ----------
-        key: string
-        state: string
+        key : string
+        state : string
             State of the released task.
             One of waiting, ready, executing, long-running, memory, error.
-        cause: string or None
+        cause : string or None
             Additional information on what triggered the release of the task.
-        reason: None
+        reason : None
             Not used.
-        report: bool
+        report : bool
             Whether the worker should report the released task to the scheduler.
         """
 
@@ -177,11 +177,11 @@ class WorkerPlugin:
 
         Parameters
         ----------
-        dep: string
-        state: string
+        dep : string
+        state : string
             State of the released dependency.
             One of waiting, flight, memory.
-        report: bool
+        report : bool
             Whether the worker should report the released dependency to the scheduler.
         """
 

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -57,7 +57,6 @@ async def progress_stream(address, interval):
 
 def progress_quads(msg, nrows=8, ncols=3):
     """
-
     >>> msg = {'all': {'inc': 5, 'dec': 1, 'add': 4},
     ...        'memory': {'inc': 2, 'dec': 0, 'add': 1},
     ...        'erred': {'inc': 0, 'dec': 1, 'add': 0},

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -405,13 +405,13 @@ def progress(*futures, notebook=None, multi=True, complete=True, **kwargs):
 
     Parameters
     ----------
-    futures: Futures
+    futures : Futures
         A list of futures or keys to track
-    notebook: bool (optional)
+    notebook : bool (optional)
         Running in the notebook or not (defaults to guess)
-    multi: bool (optional)
+    multi : bool (optional)
         Track different functions independently (defaults to True)
-    complete: bool (optional)
+    complete : bool (optional)
         Track all keys (True) or only keys that have not yet run (False)
         (defaults to True)
 

--- a/distributed/diagnostics/websocket.py
+++ b/distributed/diagnostics/websocket.py
@@ -37,13 +37,13 @@ class WebsocketPlugin(SchedulerPlugin):
 
         Parameters
         ----------
-        key: string
-        start: string
+        key : string
+        start : string
             Start state of the transition.
             One of released, waiting, processing, memory, error.
-        finish: string
+        finish : string
             Final state of the transition.
-        *args, **kwargs: More options passed when transitioning
+        *args, **kwargs : More options passed when transitioning
             This may include worker ID, compute time, etc.
         """
         if key not in self.scheduler.tasks:

--- a/distributed/diskutils.py
+++ b/distributed/diskutils.py
@@ -228,9 +228,9 @@ class WorkSpace:
 
         Parameters
         ----------
-        prefix: str (optional)
+        prefix : str (optional)
             The prefix of the temporary subdirectory name for the workdir
-        name: str (optional)
+        name : str (optional)
             The subdirectory name for the workdir
         """
         try:

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -79,9 +79,9 @@ def _import_module(name, file_dir=None) -> ModuleType:
 
     Parameters
     ----------
-    name: str
+    name : str
         Module name, file path, or text of module or script
-    file_dir: string
+    file_dir : string
         Path of a directory where files should be copied
 
     Returns

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -284,16 +284,16 @@ def watch(
 
     Parameters
     ----------
-    thread_id: int
-    interval: str
+    thread_id : int
+    interval : str
         Time per sample
-    cycle: str
+    cycle : str
         Time per refreshing to a new profile state
-    maxlen: int
+    maxlen : int
         Passed onto deque, maximum number of periods
-    omit: str
+    omit : str
         Don't include entries that start with this filename
-    stop: callable
+    stop : callable
         Function to call to see if we should stop
 
     Returns
@@ -328,12 +328,12 @@ def get_profile(history, recent=None, start=None, stop=None, key=None):
 
     Parameters
     ----------
-    history: Sequence[Tuple[time, Dict]]
+    history : Sequence[Tuple[time, Dict]]
         A list or deque of profile states
-    recent: dict
+    recent : dict
         The most recent accumulating state
-    start: time
-    stop: time
+    start : time
+    stop : time
     """
     now = time()
     if start is None:

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -433,7 +433,7 @@ class Sub:
 
         Parameters
         ----------
-        timeout: number or string or timedelta, optional
+        timeout : number or string or timedelta, optional
             Time in seconds to wait before timing out.
             Instead of number of seconds, it is also possible to specify
             a timedelta in string format, e.g. "200ms".

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -215,7 +215,7 @@ class Queue:
 
         Parameters
         ----------
-        timeout: number or string or timedelta, optional
+        timeout : number or string or timedelta, optional
             Time in seconds to wait before timing out.
             Instead of number of seconds, it is also possible to specify
             a timedelta in string format, e.g. "200ms".
@@ -228,11 +228,11 @@ class Queue:
 
         Parameters
         ----------
-        timeout: number or string or timedelta, optional
+        timeout : number or string or timedelta, optional
             Time in seconds to wait before timing out.
             Instead of number of seconds, it is also possible to specify
             a timedelta in string format, e.g. "200ms".
-        batch: boolean, int (optional)
+        batch : boolean, int (optional)
             If True then return all elements currently waiting in the queue.
             If an integer than return that many elements from the queue
             If False (default) then return one item at a time

--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -27,7 +27,7 @@ class ReplayExceptionScheduler:
 
         Parameters
         ----------
-        keys: list of keys known to the scheduler
+        keys : list of keys known to the scheduler
 
         Returns
         -------
@@ -106,7 +106,6 @@ class ReplayExceptionClient:
 
         Returns
         -------
-
         Tuple:
         - the function that raised an exception
         - argument list (a tuple), may include values and keys

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5254,19 +5254,19 @@ class Scheduler(SchedulerState, ServerNode):
 
         Parameters
         ----------
-        memory_factor: Number
+        memory_factor : Number
             Amount of extra space we want to have for our stored data.
             Defaults two 2, or that we want to have twice as much memory as we
             currently have data.
-        n: int
+        n : int
             Number of workers to close
-        minimum: int
+        minimum : int
             Minimum number of workers to keep around
-        key: Callable(WorkerState)
+        key : Callable(WorkerState)
             An optional callable mapping a WorkerState object to a group
             affiliation.  Groups will be closed together.  This is useful when
             closing workers must be done collectively, such as by hostname.
-        target: int
+        target : int
             Target number of workers to have after we close
         attribute : str
             The attribute of the WorkerState object to return, like "address"
@@ -5732,7 +5732,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         See Also
         --------
-        Client.run_on_scheduler:
+        Client.run_on_scheduler
         """
         from .worker import run
 
@@ -5828,7 +5828,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         See Also
         --------
-        Scheduler.transitions: transitive version of this function
+        Scheduler.transitions : transitive version of this function
         """
         parent: SchedulerState = cast(SchedulerState, self)
         ts: TaskState
@@ -6386,7 +6386,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         Parameters
         ----------
-        target_duration: str
+        target_duration : str
             A desired duration of time for computations to take.  This affects
             how rapidly the scheduler will ask to scale.
 

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -110,7 +110,6 @@ class WorkStealing(SchedulerPlugin):
 
         Returns
         -------
-
         cost_multiplier: The increased cost from moving this task as a factor.
         For example a result of zero implies a task without dependencies.
         level: The location within a stealable list to place this value

--- a/distributed/threadpoolexecutor.py
+++ b/distributed/threadpoolexecutor.py
@@ -110,7 +110,7 @@ def secede(adjust=True):
 
     See Also
     --------
-    rejoin: rejoin the thread pool
+    rejoin : rejoin the thread pool
     """
     thread_state.proceed = False
     with threads_lock:
@@ -127,7 +127,7 @@ def rejoin():
 
     See Also
     --------
-    secede: leave the thread pool
+    secede : leave the thread pool
     """
     thread = threading.current_thread()
     event = threading.Event()

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -884,7 +884,6 @@ def ensure_bytes(s):
 
     Examples
     --------
-
     >>> ensure_bytes('123')
     b'123'
     >>> ensure_bytes(b'123')
@@ -905,7 +904,6 @@ def ensure_bytes(s):
 
 def divide_n_among_bins(n, bins):
     """
-
     >>> divide_n_among_bins(12, [1, 1])
     [6, 6]
     >>> divide_n_among_bins(12, [1, 2])
@@ -1375,11 +1373,11 @@ def cli_keywords(d: dict, cls=None, cmd=None):
 
     Parameters
     ----------
-    d: dict
+    d : dict
         The keywords to convert
-    cls: callable
+    cls : callable
         The callable that consumes these terms to check them for validity
-    cmd: string or object
+    cmd : string or object
         A string with the name of a module, or the module containing a
         click-generated command with a "main" function, or the function itself.
         It may be used to parse a module's custom arguments (i.e., arguments that
@@ -1460,11 +1458,11 @@ def serialize_for_cli(data):
 
     Parameters
     ----------
-    data: json-serializable object
+    data : json-serializable object
         The data to serialize
     Returns
     -------
-    serialized_data: str
+    serialized_data : str
         The serialized data as a string
     """
     return base64.urlsafe_b64encode(json.dumps(data).encode()).decode()
@@ -1475,11 +1473,11 @@ def deserialize_for_cli(data):
 
     Parameters
     ----------
-    data: str
+    data : str
         String serialied by serialize_for_cli()
     Returns
     -------
-    deserialized_data: obj
+    deserialized_data : obj
         The de-serialized data
     """
     return json.loads(base64.urlsafe_b64decode(data.encode()).decode())
@@ -1523,7 +1521,6 @@ class LRU(UserDict):
 
 def clean_dashboard_address(addr, default_listen_ip=""):
     """
-
     Examples
     --------
     >>> clean_dashboard_address(8787)

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -249,9 +249,9 @@ def pack_data(o, d, key_types=object):
 
     Parameters
     ----------
-    o:
+    o
         core data structures containing literals and keys
-    d: dict
+    d : dict
         mapping of keys to data
 
     Examples
@@ -284,9 +284,9 @@ def subs_multiple(o, d):
 
     Parameters
     ----------
-    o:
+    o
         Core data structures containing literals and keys
-    d: dict
+    d : dict
         Mapping of keys to values
 
     Examples

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -181,7 +181,7 @@ class Variable:
 
         Parameters
         ----------
-        value: Future or object
+        value : Future or object
             Must be either a Future or a msgpack-encodable value
         """
         return self.client.sync(self._set, value, **kwargs)
@@ -211,7 +211,7 @@ class Variable:
 
         Parameters
         ----------
-        timeout: number or string or timedelta, optional
+        timeout : number or string or timedelta, optional
             Time in seconds to wait before timing out.
             Instead of number of seconds, it is also possible to specify
             a timedelta in string format, e.g. "200ms".

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -17,10 +17,10 @@ def worker_client(timeout=None, separate_thread=True):
 
     Parameters
     ----------
-    timeout: Number or String
+    timeout : Number or String
         Timeout after which to error out. Defaults to the
         ``distributed.comm.timeouts.connect`` configuration value.
-    separate_thread: bool, optional
+    separate_thread : bool, optional
         Whether to run this function outside of the normal thread pool
         defaults to True
 


### PR DESCRIPTION
Prompted by comment in #4473

This uses my prototype package `velin` to auto format all the functions
docstrings, from the root of the repo:

        $ velin distributed/ --write

This should fix some common issues/mistakes with numpydoc format often
around the presence/absence of space and/or colon, that can have
semantic implications.

Note that this easy to redo per-file / folder; so let me know if this is
too big