### PR TITLE
Bump minimum Dask to 2021.02.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click >= 6.6
 cloudpickle >= 1.5.0
 contextvars;python_version<'3.7'
-dask>=2020.12.0
+dask>=2021.02.0
 msgpack >= 0.6.0
 psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1


### PR DESCRIPTION
In https://github.com/dask/distributed/pull/4406 and https://github.com/dask/dask/pull/7102 we moved some logic (what was a default `_materialized_layer_unpack` implementation) from `distributed` into `dask`. This is a follow-up PR to bump the minimum version of `dask` required for `distributed` to ensure we're working with a version of `dask` which has this updated logic. 

cc @ian-r-rose 