### PR TITLE
`transition_processing_memory` optimizations, etc.

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6559,7 +6559,7 @@ def _remove_from_processing(state: SchedulerState, ts: TaskState) -> str:
     ts._processing_on = None
     w: str = ws._address
     if w in state._workers_dv:  # may have been removed
-        duration = ws._processing.pop(ts)
+        duration: double = ws._processing.pop(ts)
         if not ws._processing:
             state._total_occupancy -= ws._occupancy
             ws._occupancy = 0

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4623,8 +4623,9 @@ class Scheduler(SchedulerState, ServerNode):
             return
 
         if compute_duration:
-            old_duration = ts._prefix._duration_average
-            new_duration = compute_duration
+            old_duration: double = ts._prefix._duration_average
+            new_duration: double = compute_duration
+            avg_duration: double
             if old_duration < 0:
                 avg_duration = new_duration
             else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6781,13 +6781,15 @@ def _task_to_report_msg(state: SchedulerState, ts: TaskState) -> dict:
 @exceptval(check=False)
 def _task_to_client_msgs(state: SchedulerState, ts: TaskState) -> dict:
     report_msg: dict = _task_to_report_msg(state, ts)
+    client_msgs: dict
     if ts is None:
         # Notify all clients
-        return {k: [report_msg] for k in state._clients}
+        client_msgs = {k: [report_msg] for k in state._clients}
     else:
         # Notify clients interested in key
         cs: ClientState
-        return {cs._client_key: [report_msg] for cs in ts._who_wants}
+        client_msgs = {cs._client_key: [report_msg] for cs in ts._who_wants}
+    return client_msgs
 
 
 @cfunc

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2732,7 +2732,8 @@ class SchedulerState:
         """
         alias = self._aliases.get(host)
         if alias is not None:
-            return self._workers_dv[alias].host
+            ws: WorkerState = self._workers_dv[alias]
+            return ws.host
         else:
             return host
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4637,8 +4637,9 @@ class Scheduler(SchedulerState, ServerNode):
 
             ts._prefix._duration_average = avg_duration
 
-        ws._occupancy -= ws._processing[ts]
-        parent._total_occupancy -= ws._processing[ts]
+        occ: double = ws._processing[ts]
+        ws._occupancy -= occ
+        parent._total_occupancy -= occ
         ws._processing[ts] = 0
         self.check_idle_saturated(ws)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2308,7 +2308,7 @@ class SchedulerState:
 
             dts: TaskState
             for dts in ts._dependencies:
-                s = dts._waiters
+                s: set = dts._waiters
                 if ts in s:
                     s.discard(ts)
                     if not s and not dts._who_wants:
@@ -2362,7 +2362,7 @@ class SchedulerState:
             if recommendations.get(key) != "waiting":
                 for dts in ts._dependencies:
                     if dts._state != "released":
-                        s = dts._waiters
+                        s: set = dts._waiters
                         s.discard(ts)
                         if not s and not dts._who_wants:
                             recommendations[dts._key] = "released"
@@ -2420,7 +2420,7 @@ class SchedulerState:
                 recommendations[dts._key] = "erred"
 
             for dts in ts._dependencies:
-                s = dts._waiters
+                s: set = dts._waiters
                 s.discard(ts)
                 if not s and not dts._who_wants:
                     recommendations[dts._key] = "released"

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4580,12 +4580,11 @@ class Scheduler(SchedulerState, ServerNode):
         ts: TaskState = parent._tasks.get(key)
         if ts is None or not ts._who_has:
             return
-        if errant_worker in parent._workers_dv:
-            ws: WorkerState = parent._workers_dv[errant_worker]
-            if ws in ts._who_has:
-                ts._who_has.remove(ws)
-                ws._has_what.remove(ts)
-                ws._nbytes -= ts.get_nbytes()
+        ws: WorkerState = parent._workers_dv.get(errant_worker)
+        if ws is not None and ws in ts._who_has:
+            ts._who_has.remove(ws)
+            ws._has_what.remove(ts)
+            ws._nbytes -= ts.get_nbytes()
         if not ts._who_has:
             if ts._run_spec:
                 self.transitions({key: "released"})

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6772,20 +6772,14 @@ def _task_to_report_msg(state: SchedulerState, ts: TaskState) -> dict:
 @cfunc
 @exceptval(check=False)
 def _task_to_client_msgs(state: SchedulerState, ts: TaskState) -> dict:
-    client_keys: list
+    report_msg: dict = _task_to_report_msg(state, ts)
     if ts is None:
         # Notify all clients
-        client_keys = list(state._clients)
+        return {k: [report_msg] for k in state._clients}
     else:
         # Notify clients interested in key
         cs: ClientState
-        client_keys = [cs._client_key for cs in ts._who_wants]
-
-    report_msg: dict = _task_to_report_msg(state, ts)
-
-    client_msgs: dict = {k: [report_msg] for k in client_keys}
-
-    return client_msgs
+        return {cs._client_key: [report_msg] for cs in ts._who_wants}
 
 
 @cfunc

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4594,15 +4594,15 @@ class Scheduler(SchedulerState, ServerNode):
     def release_worker_data(self, comm=None, keys=None, worker=None):
         parent: SchedulerState = cast(SchedulerState, self)
         ws: WorkerState = parent._workers_dv[worker]
-        tasks = {parent._tasks[k] for k in keys}
-        removed_tasks = tasks & ws._has_what
+        tasks: set = {parent._tasks[k] for k in keys}
+        removed_tasks: set = tasks & ws._has_what
         ws._has_what -= removed_tasks
 
         ts: TaskState
         recommendations: dict = {}
         for ts in removed_tasks:
             ws._nbytes -= ts.get_nbytes()
-            wh = ts._who_has
+            wh: set = ts._who_has
             wh.remove(ws)
             if not wh:
                 recommendations[ts._key] = "released"

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6783,9 +6783,7 @@ def _task_to_client_msgs(state: SchedulerState, ts: TaskState) -> dict:
 
     report_msg: dict = _task_to_report_msg(state, ts)
 
-    client_msgs: dict = {}
-    for k in client_keys:
-        client_msgs[k] = [report_msg]
+    client_msgs: dict = {k: [report_msg] for k in client_keys}
 
     return client_msgs
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1593,7 +1593,7 @@ class SchedulerState:
     _task_metadata: dict
     _total_nthreads: Py_ssize_t
     _total_occupancy: double
-    _unknown_durations: object
+    _unknown_durations: dict
     _unrunnable: set
     _validate: bint
     _workers: object
@@ -1645,7 +1645,7 @@ class SchedulerState:
         self._task_metadata = dict()
         self._total_nthreads = 0
         self._total_occupancy = 0
-        self._unknown_durations = defaultdict(set)
+        self._unknown_durations = dict()
         if unrunnable is not None:
             self._unrunnable = unrunnable
         else:
@@ -2645,8 +2645,11 @@ class SchedulerState:
         """
         duration: double = ts._prefix._duration_average
         if duration < 0:
-            s: set = self._unknown_durations[ts._prefix._name]
+            s: set = self._unknown_durations.get(ts._prefix._name)
+            if s is None:
+                self._unknown_durations[ts._prefix._name] = s = set()
             s.add(ts)
+
             if default < 0:
                 duration = UNKNOWN_TASK_DURATION
             else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6891,10 +6891,10 @@ def decide_worker(
                 if ts._loose_restrictions:
                     ws = decide_worker(ts, all_workers, None, objective)
                 return ws
-    if not candidates:
-        return ws
 
-    if len(candidates) == 1:
+    if not candidates:
+        pass
+    elif len(candidates) == 1:
         for ws in candidates:
             break
     else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6871,6 +6871,7 @@ def decide_worker(
     *objective* function.
     """
     ws: WorkerState
+    wws: WorkerState
     dts: TaskState
     deps: set = ts._dependencies
     candidates: set
@@ -6878,7 +6879,7 @@ def decide_worker(
     if ts._actor:
         candidates = set(all_workers)
     else:
-        candidates = {ws for dts in deps for ws in dts._who_has}
+        candidates = {wws for dts in deps for wws in dts._who_has}
     if valid_workers is None:
         if not candidates:
             candidates = set(all_workers)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2023,7 +2023,7 @@ class SchedulerState:
         type=None,
         typename: str = None,
         worker=None,
-        startstops=None,
+        startstops: list = None,
         **kwargs,
     ):
         ws: WorkerState
@@ -2061,7 +2061,8 @@ class SchedulerState:
                 return recommendations, worker_msgs, client_msgs
 
             if startstops:
-                L = list()
+                L: list = list()
+                startstop: dict
                 for startstop in startstops:
                     stop = startstop["stop"]
                     start = startstop["start"]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6892,9 +6892,10 @@ def decide_worker(
                     ws = decide_worker(ts, all_workers, None, objective)
                 return ws
 
-    if not candidates:
+    ncandidates: Py_ssize_t = len(candidates)
+    if ncandidates == 0:
         pass
-    elif len(candidates) == 1:
+    elif ncandidates == 1:
         for ws in candidates:
             break
     else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4532,7 +4532,7 @@ class Scheduler(SchedulerState, ServerNode):
         )
         self.loop.call_later(cleanup_delay, remove_client_from_events)
 
-    def send_task_to_worker(self, worker, ts: TaskState, duration=None):
+    def send_task_to_worker(self, worker, ts: TaskState, duration: double = -1):
         """ Send a single computational task to a worker """
         parent: SchedulerState = cast(SchedulerState, self)
         try:
@@ -6710,12 +6710,12 @@ def _client_releases_keys(
 
 @cfunc
 @exceptval(check=False)
-def _task_to_msg(state: SchedulerState, ts: TaskState, duration=None) -> dict:
+def _task_to_msg(state: SchedulerState, ts: TaskState, duration: double = -1) -> dict:
     """ Convert a single computational task to a message """
     ws: WorkerState
     dts: TaskState
 
-    if duration is None:
+    if duration < 0:
         duration = state.get_task_duration(ts)
 
     msg: dict = {

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2637,10 +2637,9 @@ class SchedulerState:
         dts: TaskState
         deps: set = ts._dependencies - ws._has_what
         nbytes: Py_ssize_t = 0
-        bandwidth: double = self._bandwidth
         for dts in deps:
             nbytes += dts._nbytes
-        return nbytes / bandwidth
+        return nbytes / self._bandwidth
 
     @ccall
     def get_task_duration(self, ts: TaskState, default: double = -1) -> double:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6889,9 +6889,8 @@ def decide_worker(
             candidates = valid_workers
             if not candidates:
                 if ts._loose_restrictions:
-                    return decide_worker(ts, all_workers, None, objective)
-                else:
-                    return ws
+                    ws = decide_worker(ts, all_workers, None, objective)
+                return ws
     if not candidates:
         return ws
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4617,7 +4617,7 @@ class Scheduler(SchedulerState, ServerNode):
         """
         parent: SchedulerState = cast(SchedulerState, self)
         ts: TaskState = parent._tasks[key]
-        steal = self._extensions.get("stealing")
+        steal = parent._extensions.get("stealing")
         if steal is not None:
             steal.remove_key_from_stealable(ts)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2099,8 +2099,8 @@ class SchedulerState:
                 for tts in s:
                     if tts._processing_on is not None:
                         wws = tts._processing_on
-                        old: double = wws._processing[tts]
                         comm: double = self.get_comm_cost(tts, wws)
+                        old: double = wws._processing[tts]
                         new: double = avg_duration + comm
                         diff: double = new - old
                         wws._processing[tts] = new

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2077,9 +2077,9 @@ class SchedulerState:
                 if len(L) > 0:
                     compute_start, compute_stop = L[0]
                 else:  # This is very rare
-                    compute_start = compute_stop = None
+                    compute_start = compute_stop = 0
             else:
-                compute_start = compute_stop = None
+                compute_start = compute_stop = 0
 
             #############################
             # Update Timing Information #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2094,8 +2094,9 @@ class SchedulerState:
                 ts._prefix._duration_average = avg_duration
                 ts._group._duration += new_duration
 
+                s: set = self._unknown_durations.pop(ts._prefix._name, set())
                 tts: TaskState
-                for tts in self._unknown_durations.pop(ts._prefix._name, ()):
+                for tts in s:
                     if tts._processing_on:
                         wws = tts._processing_on
                         old: double = wws._processing[tts]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1997,7 +1997,6 @@ class SchedulerState:
             self.check_idle_saturated(ws)
 
             recommendations: dict = {}
-            client_msgs: dict = {}
 
             _add_to_memory(
                 self, ts, ws, recommendations, client_msgs, type=type, typename=typename
@@ -2111,7 +2110,6 @@ class SchedulerState:
                 ts.set_nbytes(nbytes)
 
             recommendations: dict = {}
-            client_msgs: dict = {}
 
             _remove_from_processing(self, ts)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2699,10 +2699,11 @@ class SchedulerState:
                     self._resources[resource] = dr = dict()
 
                 sw: set = set()
-                dw[resource] = sw
                 for w, supplied in dr.items():
                     if supplied >= required:
                         sw.add(w)
+
+                dw[resource] = sw
 
             ww: set = set.intersection(*dw.values())
             if s is None:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2753,9 +2753,8 @@ class SchedulerState:
                 nbytes = dts.get_nbytes()
                 comm_bytes += nbytes
 
-        bandwidth: double = self._bandwidth
         stack_time: double = ws._occupancy / ws._nthreads
-        start_time: double = stack_time + comm_bytes / bandwidth
+        start_time: double = stack_time + comm_bytes / self._bandwidth
 
         if ts._actor:
             return (len(ws._actors), start_time, ws._nbytes)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2100,9 +2100,11 @@ class SchedulerState:
                         wws = tts._processing_on
                         old: double = wws._processing[tts]
                         comm: double = self.get_comm_cost(tts, wws)
-                        wws._processing[tts] = avg_duration + comm
-                        wws._occupancy += avg_duration + comm - old
-                        self._total_occupancy += avg_duration + comm - old
+                        new: double = avg_duration + comm
+                        diff: double = new - old
+                        wws._processing[tts] = new
+                        wws._occupancy += diff
+                        self._total_occupancy += diff
 
             ############################
             # Update State Information #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3524,10 +3524,12 @@ class Scheduler(SchedulerState, ServerNode):
             if dh is None:
                 parent._host_info[host] = dh = dict()
 
-            if "addresses" not in dh:
-                dh.update({"addresses": set(), "nthreads": 0})
+            dh_addresses: set = dh.get("addresses")
+            if dh_addresses is None:
+                dh["addresses"] = dh_addresses = set()
+                dh["nthreads"] = 0
 
-            dh["addresses"].add(address)
+            dh_addresses.add(address)
             dh["nthreads"] += nthreads
 
             parent._total_nthreads += nthreads
@@ -4139,12 +4141,14 @@ class Scheduler(SchedulerState, ServerNode):
             if dh is None:
                 parent._host_info[host] = dh = dict()
 
+            dh_addresses: set = dh["addresses"]
+            dh_addresses.remove(address)
             dh["nthreads"] -= ws._nthreads
-            dh["addresses"].remove(address)
             parent._total_nthreads -= ws._nthreads
 
-            if not dh["addresses"]:
+            if not dh_addresses:
                 dh = None
+                dh_addresses = None
                 del parent._host_info[host]
 
             self.rpc.remove(address)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3922,7 +3922,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         # TODO: balance workers
 
-    def new_task(self, key, spec, state):
+    def new_task(self, key: str, spec: object, state: str):
         """ Create a new task, and associated states """
         parent: SchedulerState = cast(SchedulerState, self)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2097,7 +2097,7 @@ class SchedulerState:
                 s: set = self._unknown_durations.pop(ts._prefix._name, set())
                 tts: TaskState
                 for tts in s:
-                    if tts._processing_on:
+                    if tts._processing_on is not None:
                         wws = tts._processing_on
                         old: double = wws._processing[tts]
                         comm: double = self.get_comm_cost(tts, wws)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4617,8 +4617,9 @@ class Scheduler(SchedulerState, ServerNode):
         """
         parent: SchedulerState = cast(SchedulerState, self)
         ts: TaskState = parent._tasks[key]
-        if "stealing" in self._extensions:
-            self._extensions["stealing"].remove_key_from_stealable(ts)
+        steal = self._extensions.get("stealing")
+        if steal is not None:
+            steal.remove_key_from_stealable(ts)
 
         ws: WorkerState = ts._processing_on
         if ws is None:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6870,7 +6870,7 @@ def decide_worker(
     of bytes sent between workers.  This is determined by calling the
     *objective* function.
     """
-    ws: WorkerState
+    ws: WorkerState = None
     wws: WorkerState
     dts: TaskState
     deps: set = ts._dependencies
@@ -6891,9 +6891,9 @@ def decide_worker(
                 if ts._loose_restrictions:
                     return decide_worker(ts, all_workers, None, objective)
                 else:
-                    return None
+                    return ws
     if not candidates:
-        return None
+        return ws
 
     if len(candidates) == 1:
         for ws in candidates:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2610,8 +2610,7 @@ class SchedulerState:
 
         nc: Py_ssize_t = ws._nthreads
         p: Py_ssize_t = len(ws._processing)
-        total_occupancy: double = self._total_occupancy
-        avg: double = total_occupancy / self._total_nthreads
+        avg: double = self._total_occupancy / self._total_nthreads
 
         idle = self._idle
         saturated: set = self._saturated

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2094,7 +2094,10 @@ class SchedulerState:
                 ts._prefix._duration_average = avg_duration
                 ts._group._duration += new_duration
 
-                s: set = self._unknown_durations.pop(ts._prefix._name, set())
+                s: set = self._unknown_durations.pop(ts._prefix._name, None)
+                if s is None:
+                    s = set()
+
                 tts: TaskState
                 for tts in s:
                     if tts._processing_on is not None:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6558,19 +6558,22 @@ def _remove_from_processing(state: SchedulerState, ts: TaskState) -> str:
     ws: WorkerState = ts._processing_on
     ts._processing_on = None
     w: str = ws._address
-    if w in state._workers_dv:  # may have been removed
-        duration: double = ws._processing.pop(ts)
-        if not ws._processing:
-            state._total_occupancy -= ws._occupancy
-            ws._occupancy = 0
-        else:
-            state._total_occupancy -= duration
-            ws._occupancy -= duration
-        state.check_idle_saturated(ws)
-        state.release_resources(ts, ws)
-        return w
-    else:
+
+    if w not in state._workers_dv:  # may have been removed
         return None
+
+    duration: double = ws._processing.pop(ts)
+    if not ws._processing:
+        state._total_occupancy -= ws._occupancy
+        ws._occupancy = 0
+    else:
+        state._total_occupancy -= duration
+        ws._occupancy -= duration
+
+    state.check_idle_saturated(ws)
+    state.release_resources(ts, ws)
+
+    return w
 
 
 @cfunc

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2095,20 +2095,18 @@ class SchedulerState:
                 ts._group._duration += new_duration
 
                 s: set = self._unknown_durations.pop(ts._prefix._name, None)
-                if s is None:
-                    s = set()
-
                 tts: TaskState
-                for tts in s:
-                    if tts._processing_on is not None:
-                        wws = tts._processing_on
-                        comm: double = self.get_comm_cost(tts, wws)
-                        old: double = wws._processing[tts]
-                        new: double = avg_duration + comm
-                        diff: double = new - old
-                        wws._processing[tts] = new
-                        wws._occupancy += diff
-                        self._total_occupancy += diff
+                if s:
+                    for tts in s:
+                        if tts._processing_on is not None:
+                            wws = tts._processing_on
+                            comm: double = self.get_comm_cost(tts, wws)
+                            old: double = wws._processing[tts]
+                            new: double = avg_duration + comm
+                            diff: double = new - old
+                            wws._processing[tts] = new
+                            wws._occupancy += diff
+                            self._total_occupancy += diff
 
             ############################
             # Update State Information #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2083,8 +2083,9 @@ class SchedulerState:
             #############################
             if has_compute_startstop and ws._processing.get(ts, True):
                 # Update average task duration for worker
-                old_duration = ts._prefix._duration_average
-                new_duration = compute_stop - compute_start
+                old_duration: double = ts._prefix._duration_average
+                new_duration: double = compute_stop - compute_start
+                avg_duration: double
                 if old_duration < 0:
                     avg_duration = new_duration
                 else:
@@ -2097,8 +2098,8 @@ class SchedulerState:
                 for tts in self._unknown_durations.pop(ts._prefix._name, ()):
                     if tts._processing_on:
                         wws = tts._processing_on
-                        old = wws._processing[tts]
-                        comm = self.get_comm_cost(tts, wws)
+                        old: double = wws._processing[tts]
+                        comm: double = self.get_comm_cost(tts, wws)
                         wws._processing[tts] = avg_duration + comm
                         wws._occupancy += avg_duration + comm - old
                         self._total_occupancy += avg_duration + comm - old

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -483,7 +483,7 @@ class WorkerState:
 
     @property
     def host(self):
-        return get_address_host(self.address)
+        return get_address_host(self._address)
 
     @property
     def last_seen(self):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2023,7 +2023,7 @@ class SchedulerState:
         type=None,
         typename: str = None,
         worker=None,
-        startstops: list = None,
+        startstops=None,
         **kwargs,
     ):
         ws: WorkerState

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1518,7 +1518,7 @@ def _legacy_worker_key_set(workers):
     return {ws._address for ws in workers}
 
 
-def _legacy_task_key_dict(task_dict):
+def _legacy_task_key_dict(task_dict: dict):
     """
     Transform a dict of {task state: value} into a dict of {task key: value}.
     """
@@ -1526,8 +1526,8 @@ def _legacy_task_key_dict(task_dict):
     return {ts._key: value for ts, value in task_dict.items()}
 
 
-def _task_key_or_none(task):
-    return task.key if task is not None else None
+def _task_key_or_none(task: TaskState):
+    return task._key if task is not None else None
 
 
 @cclass

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2603,8 +2603,7 @@ class SchedulerState:
 
         This is useful for load balancing and adaptivity.
         """
-        total_nthreads: Py_ssize_t = self._total_nthreads
-        if total_nthreads == 0 or ws.status == Status.closed:
+        if self._total_nthreads == 0 or ws.status == Status.closed:
             return
         if occ < 0:
             occ = ws._occupancy
@@ -2612,7 +2611,7 @@ class SchedulerState:
         nc: Py_ssize_t = ws._nthreads
         p: Py_ssize_t = len(ws._processing)
         total_occupancy: double = self._total_occupancy
-        avg: double = total_occupancy / total_nthreads
+        avg: double = total_occupancy / self._total_nthreads
 
         idle = self._idle
         saturated: set = self._saturated

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2730,8 +2730,9 @@ class SchedulerState:
         """
         Coerce the hostname of a worker.
         """
-        if host in self._aliases:
-            return self._workers_dv[self._aliases[host]].host
+        alias = self._aliases.get(host)
+        if alias is not None:
+            return self._workers_dv[alias].host
         else:
             return host
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6693,7 +6693,6 @@ def _client_releases_keys(
     """ Remove keys from client desired list """
     logger.debug("Client %s releases keys: %s", cs._client_key, keys)
     ts: TaskState
-    tasks2: set = set()
     for key in keys:
         ts = state._tasks.get(key)
         if ts is not None and ts in cs._wants_what:
@@ -6701,14 +6700,11 @@ def _client_releases_keys(
             s: set = ts._who_wants
             s.remove(cs)
             if not s:
-                tasks2.add(ts)
-
-    for ts in tasks2:
-        if not ts._dependents:
-            # No live dependents, can forget
-            recommendations[ts._key] = "forgotten"
-        elif ts._state != "erred" and not ts._waiters:
-            recommendations[ts._key] = "released"
+                if not ts._dependents:
+                    # No live dependents, can forget
+                    recommendations[ts._key] = "forgotten"
+                elif ts._state != "erred" and not ts._waiters:
+                    recommendations[ts._key] = "released"
 
 
 @cfunc

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3567,8 +3567,7 @@ class Scheduler(SchedulerState, ServerNode):
             recommendations: dict
             if nbytes:
                 for key in nbytes:
-                    tasks: dict = parent._tasks
-                    ts: TaskState = tasks.get(key)
+                    ts: TaskState = parent._tasks.get(key)
                     if ts is not None and ts._state in ("processing", "waiting"):
                         recommendations = self.transition(
                             key,
@@ -3978,8 +3977,7 @@ class Scheduler(SchedulerState, ServerNode):
         parent: SchedulerState = cast(SchedulerState, self)
         logger.debug("Stimulus task finished %s, %s", key, worker)
 
-        tasks: dict = parent._tasks
-        ts: TaskState = tasks.get(key)
+        ts: TaskState = parent._tasks.get(key)
         if ts is None:
             return {}
         ws: WorkerState = parent._workers_dv[worker]
@@ -5607,8 +5605,7 @@ class Scheduler(SchedulerState, ServerNode):
     def report_on_key(self, key: str = None, ts: TaskState = None, client: str = None):
         parent: SchedulerState = cast(SchedulerState, self)
         if ts is None:
-            tasks: dict = parent._tasks
-            ts = tasks.get(key)
+            ts = parent._tasks.get(key)
         elif key is None:
             key = ts._key
         else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6772,13 +6772,13 @@ def _task_to_report_msg(state: SchedulerState, ts: TaskState) -> dict:
 @cfunc
 @exceptval(check=False)
 def _task_to_client_msgs(state: SchedulerState, ts: TaskState) -> dict:
-    cs: ClientState
     client_keys: list
     if ts is None:
         # Notify all clients
         client_keys = list(state._clients)
     else:
         # Notify clients interested in key
+        cs: ClientState
         client_keys = [cs._client_key for cs in ts._who_wants]
 
     report_msg: dict = _task_to_report_msg(state, ts)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3925,16 +3925,18 @@ class Scheduler(SchedulerState, ServerNode):
     def new_task(self, key, spec, state):
         """ Create a new task, and associated states """
         parent: SchedulerState = cast(SchedulerState, self)
+
         ts: TaskState = TaskState(key, spec)
-        tp: TaskPrefix
-        tg: TaskGroup
         ts._state = state
+
+        tp: TaskPrefix
         prefix_key = key_split(key)
         tp = parent._task_prefixes.get(prefix_key)
         if tp is None:
             parent._task_prefixes[prefix_key] = tp = TaskPrefix(prefix_key)
         ts._prefix = tp
 
+        tg: TaskGroup
         group_key = ts._group_key
         tg = parent._task_groups.get(group_key)
         if tg is None:
@@ -3942,7 +3944,9 @@ class Scheduler(SchedulerState, ServerNode):
             tg._prefix = tp
             tp._groups.append(tg)
         tg.add(ts)
+
         parent._tasks[key] = ts
+
         return ts
 
     def stimulus_task_finished(self, key=None, worker=None, **kwargs):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2060,6 +2060,8 @@ class SchedulerState:
                 )
                 return recommendations, worker_msgs, client_msgs
 
+            compute_start: double
+            compute_stop: double
             if startstops:
                 L: list = list()
                 startstop: dict


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`

Goes through `transition_processing_memory` and optimizes it more carefully. In particular simplifies the code around starts tops, durations, and occupancies. Also types variables to get more performant Cython code. Makes use of intermediate variables to group work and allow easier reuse in later expressions. Tries to simplify data generated and collected to cutdown on general overhead associated. Additionally really cuts down on the work needed to produce messages for clients and workers.

Also includes various small optimizations like using `.get(...)`, typing variables, dropping unneeded intermediate variables, constructing values once, using typed attributes, etc.