### PR TITLE
Attempt to get client from worker in Queue and Variable

### DIFF
--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -9,6 +9,7 @@ from tornado.ioloop import IOLoop
 
 from distributed import Client, Variable, worker_client, Nanny, wait, TimeoutError
 from distributed.metrics import time
+from distributed.client import _del_global_client
 from distributed.compatibility import WINDOWS
 from distributed.utils_test import gen_cluster, inc, div
 from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
@@ -38,6 +39,23 @@ async def test_variable(c, s, a, b):
     while s.tasks:
         await asyncio.sleep(0.01)
         assert time() < start + 5
+
+
+@gen_cluster(client=True)
+async def test_variable_in_task(c, s, a, b):
+    x = Variable("x")
+    await x.set(123)
+
+    def foo():
+        y = Variable("x")
+        return y.get()
+
+    # We want to make sure Client.current() will not return c
+    # when called from inside a task
+    _del_global_client(c)
+
+    result = await c.submit(foo)
+    assert result == 123
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -9,11 +9,9 @@ from tornado.ioloop import IOLoop
 
 from distributed import Client, Variable, worker_client, Nanny, wait, TimeoutError
 from distributed.metrics import time
-from distributed.client import _del_global_client
 from distributed.compatibility import WINDOWS
-from distributed.utils_test import gen_cluster, inc, div
+from distributed.utils_test import gen_cluster, inc, div, captured_logger, popen
 from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
-from distributed.utils_test import captured_logger
 
 
 @gen_cluster(client=True)
@@ -41,21 +39,23 @@ async def test_variable(c, s, a, b):
         assert time() < start + 5
 
 
-@gen_cluster(client=True)
-async def test_variable_in_task(c, s, a, b):
-    x = Variable("x")
-    await x.set(123)
+def test_variable_in_task(loop):
+    # Ensure that we can create a Variable inside a task on a
+    # worker in a separate Python process than the client
+    with popen(["dask-scheduler", "--no-dashboard"]):
+        with popen(["dask-worker", "127.0.0.1:8786"]):
+            with Client("tcp://127.0.0.1:8786", loop=loop) as c:
+                c.wait_for_workers(1)
 
-    def foo():
-        y = Variable("x")
-        return y.get()
+                x = Variable("x")
+                x.set(123)
 
-    # We want to make sure Client.current() will not return c
-    # when called from inside a task
-    _del_global_client(c)
+                def foo():
+                    y = Variable("x")
+                    return y.get()
 
-    result = await c.submit(foo)
-    assert result == 123
+                result = c.submit(foo).result()
+                assert result == 123
 
 
 @gen_cluster(client=True)

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -9,13 +9,13 @@ from tlz import merge
 from dask.utils import stringify
 from .client import Future, Client
 from .utils import log_errors, TimeoutError, parse_timedelta
-from .worker import get_client
+from .worker import get_client, get_worker
 
 logger = logging.getLogger(__name__)
 
 
 class VariableExtension:
-    """An extension for the scheduler to manage queues
+    """An extension for the scheduler to manage Variables
 
     This adds the following routes to the scheduler
 
@@ -145,8 +145,8 @@ class Variable:
         Name used by other clients and the scheduler to identify the variable.
         If not given, a random name will be generated.
     client: Client (optional)
-        Client used for communication with the scheduler. Defaults to the
-        value of ``Client.current()``.
+        Client used for communication with the scheduler.
+        If not given, the default global client will be used.
 
     Examples
     --------
@@ -165,7 +165,11 @@ class Variable:
     """
 
     def __init__(self, name=None, client=None, maxsize=0):
-        self.client = client or Client.current()
+        try:
+            self.client = client or Client.current()
+        except ValueError:
+            # Initialise new client
+            self.client = get_worker().client
         self.name = name or "variable-" + uuid.uuid4().hex
 
     async def _set(self, value):


### PR DESCRIPTION
Today if a user attempts to create a `Variable` or `Queue` from within a task they will get the following error:

```python
ValueError: No clients found
Start a client and point it to the scheduler address
  from distributed import Client
  client = Client('ip-addr-of-scheduler:8786')
```

This PR adds additional fallback logic to attempt to get a `Client` from the worker running the task, which allows users to do the following

```python
In [6]: x = Variable("my-var")

In [7]: def bar():
   ...:     from distributed import Variable
   ...:     v = Variable("my-var")
   ...:     return v.get()
   ...:

In [8]: x.set(987)

In [9]: client.submit(bar).result()
987
```

This behavior is in line with how `Lock`s, `Event`s, and `Semaphore`s work today:

https://github.com/dask/distributed/blob/7d2a22f94332974825e599dd779b4d98f44dbca2/distributed/lock.py#L96-L101