### PR TITLE
Use `main` branch for zict

### DIFF
--- a/continuous_integration/environment-windows.yml
+++ b/continuous_integration/environment-windows.yml
@@ -32,4 +32,4 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask.git@master
       - git+https://github.com/joblib/joblib.git@master
-      - git+https://github.com/dask/zict.git@master
+      - git+https://github.com/dask/zict.git@main

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -91,7 +91,7 @@ python -m pip install -q git+https://github.com/dask/dask.git --upgrade --no-dep
 python -m pip install -q git+https://github.com/joblib/joblib.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/intake/filesystem_spec.git --upgrade --no-deps
 python -m pip install -q git+https://github.com/dask/s3fs.git --upgrade --no-deps
-python -m pip install -q git+https://github.com/dask/zict.git --upgrade --no-deps
+python -m pip install -q git+https://github.com/dask/zict.git@main --upgrade --no-deps
 python -m pip install -q keras --upgrade --no-deps
 
 if [[ $CRICK == true ]]; then


### PR DESCRIPTION
This was recently changed from `master`. Though it appears `pip` uses `master` by default. So code it as `main` where it is not specified and fix the branch name where `master` is still used.

cc @jrbourbeau

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed`
