### PR TITLE
[WIP] Use asyncio loop with `reevaluate_occupancy`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6453,8 +6453,10 @@ class Scheduler(SchedulerState, ServerNode):
                         next_time = timedelta(seconds=duration * 5)  # 25ms gap
                         break
 
-            self.loop.add_timeout(
-                next_time, self.reevaluate_occupancy, worker_index=worker_index
+            self.loop.call_later(
+                next_time.total_seconds(),
+                self.reevaluate_occupancy,
+                worker_index,
             )
 
         except Exception:


### PR DESCRIPTION
Leverages the asyncio API directly when scheduling `reevaluate_occupancy` calls. This has the benefit of using asyncio directly (without overhead from Tornado) or uvloop (if enabled), which doesn't happen otherwise.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed`
