### PR TITLE
Read & write all frames in one pass

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -254,7 +254,8 @@ class TCP(Comm):
 
             if sum(lengths) < 2 ** 17:  # 128kiB
                 # small enough, send in one go
-                stream.write(b"".join(frames))
+                frames = b"".join(frames)
+                stream.write(frames)
             else:
                 # avoid large memcpy, send in many
                 for frame, frame_bytes in zip(frames, lengths):

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -188,9 +188,12 @@ class TCP(Comm):
         if stream is None:
             raise CommClosedError
 
+        fmt = "Q"
+        fmt_size = struct.calcsize(fmt)
+
         try:
-            frames_nbytes = await stream.read_bytes(8)
-            (frames_nbytes,) = struct.unpack("Q", frames_nbytes)
+            frames_nbytes = await stream.read_bytes(fmt_size)
+            (frames_nbytes,) = struct.unpack(fmt, frames_nbytes)
 
             frames = bytearray(frames_nbytes)
             n = await stream.read_into(frames)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -240,13 +240,13 @@ class TCP(Comm):
                 **self.handshake_options,
             },
         )
+        frames_nbytes = sum(map(nbytes, frames))
 
         header = pack_frames_prelude(frames)
-        frames_nbytes = nbytes(header) + sum(map(nbytes, frames))
+        header = struct.pack("Q", nbytes(header) + frames_nbytes) + header
 
-        header = struct.pack("Q", frames_nbytes) + header
-        frames_nbytes += 8
         frames = [header, *frames]
+        frames_nbytes += nbytes(header)
 
         try:
             if frames_nbytes < 2 ** 17:  # 128kiB

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -125,8 +125,7 @@ def unpack_frames(b):
     start = fmt_size * (1 + n_frames)
     for length in lengths:
         end = start + length
-        frame = b[start:end]
-        frames.append(frame)
+        frames.append(b[start:end])
         start = end
 
     return frames


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`

Instead of doing multiple reads with `async`, just allocate one big chunk of memory for all of the frames and read into it. Should cutdown on the number of passes through Tornado needed to fill these frames.

Also knowing that `IOStream` has an internal queue of buffers for writing, we are able to push all of the frames into that queue beforehand. Then ask Tornado to `write` after they are in the queue. This also cuts down on the number of passes through Tornado by simply entering the write handling code once and writing all the buffers.