### PR TITLE
Skip `stream.write` call for empty frames

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -261,11 +261,12 @@ class TCP(Comm):
                     # Can't wait for the write() Future as it may be lost
                     # ("If write is called again before that Future has resolved,
                     #   the previous future will be orphaned and will never resolve")
-                    future = stream.write(frame)
-                    bytes_since_last_yield += frame_bytes
-                    if bytes_since_last_yield > 32e6:
-                        await future
-                        bytes_since_last_yield = 0
+                    if frame_bytes:
+                        future = stream.write(frame)
+                        bytes_since_last_yield += frame_bytes
+                        if bytes_since_last_yield > 32e6:
+                            await future
+                            bytes_since_last_yield = 0
         except StreamClosedError as e:
             self.stream = None
             self._closed = True


### PR DESCRIPTION
Sometimes a frame winds up have `0` bytes. In these cases, make sure to skip calling `stream.write` to avoid incurring the overhead. After all it is trivial to create an empty frame on the receiving end as long as we know it exists (the size of all frames are tracked) without involving IO.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed`