### PR TITLE
Batch more Scheduler sends

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1769,8 +1769,8 @@ class SchedulerState:
             ts: TaskState = self._tasks[key]
             dts: TaskState
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert ts._run_spec
@@ -1781,7 +1781,7 @@ class SchedulerState:
 
             if ts._has_lost_dependencies:
                 recommendations[key] = "forgotten"
-                return recommendations, worker_msgs, client_msgs
+                return recommendations, client_msgs, worker_msgs
 
             ts.state = "waiting"
 
@@ -1790,7 +1790,7 @@ class SchedulerState:
                 if dts._exception_blame:
                     ts._exception_blame = dts._exception_blame
                     recommendations[key] = "erred"
-                    return recommendations, worker_msgs, client_msgs
+                    return recommendations, client_msgs, worker_msgs
 
             for dts in ts._dependencies:
                 dep = dts._key
@@ -1810,7 +1810,7 @@ class SchedulerState:
                     self._unrunnable.add(ts)
                     ts.state = "no-worker"
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -1824,8 +1824,8 @@ class SchedulerState:
             ts: TaskState = self._tasks[key]
             dts: TaskState
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert ts in self._unrunnable
@@ -1837,7 +1837,7 @@ class SchedulerState:
 
             if ts._has_lost_dependencies:
                 recommendations[key] = "forgotten"
-                return recommendations, worker_msgs, client_msgs
+                return recommendations, client_msgs, worker_msgs
 
             for dts in ts._dependencies:
                 dep = dts._key
@@ -1857,7 +1857,7 @@ class SchedulerState:
                     self._unrunnable.add(ts)
                     ts.state = "no-worker"
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -1934,8 +1934,8 @@ class SchedulerState:
             ts: TaskState = self._tasks[key]
             dts: TaskState
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert not ts._waiting_on
@@ -1948,7 +1948,7 @@ class SchedulerState:
 
             ws: WorkerState = self.decide_worker(ts)
             if ws is None:
-                return recommendations, worker_msgs, client_msgs
+                return recommendations, client_msgs, worker_msgs
             worker = ws._address
 
             duration_estimate = self.set_duration_estimate(ts, ws)
@@ -1967,7 +1967,7 @@ class SchedulerState:
 
             worker_msgs[worker] = [_task_to_msg(self, ts)]
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -1983,8 +1983,8 @@ class SchedulerState:
             ws: WorkerState = self._workers_dv[worker]
             ts: TaskState = self._tasks[key]
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert not ts._processing_on
@@ -2007,7 +2007,7 @@ class SchedulerState:
                 assert not ts._waiting_on
                 assert ts._who_has
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2029,8 +2029,8 @@ class SchedulerState:
         ws: WorkerState
         wws: WorkerState
         recommendations: dict = {}
-        worker_msgs: dict = {}
         client_msgs: dict = {}
+        worker_msgs: dict = {}
         try:
             ts: TaskState = self._tasks[key]
             assert worker
@@ -2048,7 +2048,7 @@ class SchedulerState:
             ws = self._workers_dv.get(worker)
             if ws is None:
                 recommendations[key] = "released"
-                return recommendations, worker_msgs, client_msgs
+                return recommendations, client_msgs, worker_msgs
 
             if ws != ts._processing_on:  # someone else has this task
                 logger.info(
@@ -2058,7 +2058,7 @@ class SchedulerState:
                     ws,
                     key,
                 )
-                return recommendations, worker_msgs, client_msgs
+                return recommendations, client_msgs, worker_msgs
 
             has_compute_startstop: bool = False
             compute_start: double
@@ -2124,7 +2124,7 @@ class SchedulerState:
                 assert not ts._processing_on
                 assert not ts._waiting_on
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2139,8 +2139,8 @@ class SchedulerState:
             ts: TaskState = self._tasks[key]
             dts: TaskState
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert not ts._waiting_on
@@ -2157,8 +2157,8 @@ class SchedulerState:
                     recommendations[ts._key] = "erred"
                     return (
                         recommendations,
-                        worker_msgs,
                         client_msgs,
+                        worker_msgs,
                     )  # don't try to recreate
 
             for dts in ts._waiters:
@@ -2199,7 +2199,7 @@ class SchedulerState:
             if self._validate:
                 assert not ts._waiting_on
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2214,8 +2214,8 @@ class SchedulerState:
             dts: TaskState
             failing_ts: TaskState
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 with log_errors(pdb=LOG_PDB):
@@ -2244,7 +2244,7 @@ class SchedulerState:
             ts.state = "erred"
 
             # TODO: waiting data?
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2258,8 +2258,8 @@ class SchedulerState:
             ts: TaskState = self._tasks[key]
             dts: TaskState
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 with log_errors(pdb=LOG_PDB):
@@ -2284,7 +2284,7 @@ class SchedulerState:
 
             ts.state = "released"
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2297,8 +2297,8 @@ class SchedulerState:
         try:
             ts: TaskState = self._tasks[key]
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert not ts._who_has
@@ -2322,7 +2322,7 @@ class SchedulerState:
             else:
                 ts._waiters.clear()
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2336,8 +2336,8 @@ class SchedulerState:
             ts: TaskState = self._tasks[key]
             dts: TaskState
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert ts._processing_on
@@ -2368,7 +2368,7 @@ class SchedulerState:
             if self._validate:
                 assert not ts._processing_on
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2386,8 +2386,8 @@ class SchedulerState:
             dts: TaskState
             failing_ts: TaskState
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert cause or ts._exception_blame
@@ -2447,7 +2447,7 @@ class SchedulerState:
             if self._validate:
                 assert not ts._processing_on
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2461,8 +2461,8 @@ class SchedulerState:
             ts: TaskState = self._tasks[key]
             dts: TaskState
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert self._tasks[key].state == "no-worker"
@@ -2477,7 +2477,7 @@ class SchedulerState:
 
             ts._waiters.clear()
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2504,8 +2504,8 @@ class SchedulerState:
         try:
             ts: TaskState = self._tasks[key]
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert ts._state == "memory"
@@ -2532,7 +2532,7 @@ class SchedulerState:
             client_msgs = _task_to_client_msgs(self, ts)
             self.remove_key(key)
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2545,8 +2545,8 @@ class SchedulerState:
         try:
             ts: TaskState = self._tasks[key]
             recommendations: dict = {}
-            worker_msgs: dict = {}
             client_msgs: dict = {}
+            worker_msgs: dict = {}
 
             if self._validate:
                 assert ts._state in ("released", "erred")
@@ -2570,7 +2570,7 @@ class SchedulerState:
             client_msgs = _task_to_client_msgs(self, ts)
             self.remove_key(key)
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -3986,7 +3986,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         recommendations: dict
         if ts._state == "processing":
-            recommendations = self.transition(key, "memory", worker=worker, **kwargs)
+            recommendations = self._transition(key, "memory", worker=worker, **kwargs)
 
             if ts._state == "memory":
                 assert ws in ts._who_has
@@ -4743,16 +4743,9 @@ class Scheduler(SchedulerState, ServerNode):
 
     def send_all(self, client_msgs: dict, worker_msgs: dict):
         """Send messages to client and workers"""
-        stream_comms: dict = self.stream_comms
         client_comms: dict = self.client_comms
+        stream_comms: dict = self.stream_comms
         msgs: list
-
-        for worker, msgs in worker_msgs.items():
-            try:
-                w = stream_comms[worker]
-                w.send(*msgs)
-            except (CommClosedError, AttributeError):
-                self.loop.add_callback(self.remove_worker, address=worker)
 
         for client, msgs in client_msgs.items():
             c = client_comms.get(client)
@@ -4763,6 +4756,13 @@ class Scheduler(SchedulerState, ServerNode):
             except CommClosedError:
                 if self.status == Status.running:
                     logger.critical("Tried writing to closed comm: %s", msgs)
+
+        for worker, msgs in worker_msgs.items():
+            try:
+                w = stream_comms[worker]
+                w.send(*msgs)
+            except (CommClosedError, AttributeError):
+                self.loop.add_callback(self.remove_worker, address=worker)
 
     ############################
     # Less common interactions #
@@ -5916,10 +5916,10 @@ class Scheduler(SchedulerState, ServerNode):
 
             ts = parent._tasks.get(key)
             if ts is None:
-                return recommendations, worker_msgs, client_msgs
+                return recommendations, client_msgs, worker_msgs
             start = ts._state
             if start == finish:
-                return recommendations, worker_msgs, client_msgs
+                return recommendations, client_msgs, worker_msgs
 
             if self.plugins:
                 dependents = set(ts._dependents)
@@ -5929,51 +5929,51 @@ class Scheduler(SchedulerState, ServerNode):
             func = self._transitions_table.get(start_finish)
             if func is not None:
                 a: tuple = func(key, *args, **kwargs)
-                recommendations, worker_msgs, client_msgs = a
+                recommendations, client_msgs, worker_msgs = a
             elif "released" not in start_finish:
                 func = self._transitions_table["released", finish]
                 assert not args and not kwargs
                 a_recs: dict
-                a_wmsgs: dict
                 a_cmsgs: dict
+                a_wmsgs: dict
                 a: tuple = self._transition(key, "released")
-                a_recs, a_wmsgs, a_cmsgs = a
+                a_recs, a_cmsgs, a_wmsgs = a
                 v = a_recs.get(key)
                 if v is not None:
                     func = self._transitions_table["released", v]
                 b_recs: dict
-                b_wmsgs: dict
                 b_cmsgs: dict
+                b_wmsgs: dict
                 b: tuple = func(key)
-                b_recs, b_wmsgs, b_cmsgs = b
+                b_recs, b_cmsgs, b_wmsgs = b
 
                 recommendations.update(a_recs)
-                for w, new_msgs in a_wmsgs.items():
-                    msgs = worker_msgs.get(w)
-                    if msgs is not None:
-                        msgs.extend(new_msgs)
-                    else:
-                        worker_msgs[w] = new_msgs
                 for c, new_msgs in a_cmsgs.items():
                     msgs = client_msgs.get(c)
                     if msgs is not None:
                         msgs.extend(new_msgs)
                     else:
                         client_msgs[c] = new_msgs
-
-                recommendations.update(b_recs)
-                for w, new_msgs in b_wmsgs.items():
+                for w, new_msgs in a_wmsgs.items():
                     msgs = worker_msgs.get(w)
                     if msgs is not None:
                         msgs.extend(new_msgs)
                     else:
                         worker_msgs[w] = new_msgs
+
+                recommendations.update(b_recs)
                 for c, new_msgs in b_cmsgs.items():
                     msgs = client_msgs.get(c)
                     if msgs is not None:
                         msgs.extend(new_msgs)
                     else:
                         client_msgs[c] = new_msgs
+                for w, new_msgs in b_wmsgs.items():
+                    msgs = worker_msgs.get(w)
+                    if msgs is not None:
+                        msgs.extend(new_msgs)
+                    else:
+                        worker_msgs[w] = new_msgs
 
                 start = "released"
             else:
@@ -6016,7 +6016,7 @@ class Scheduler(SchedulerState, ServerNode):
                     ts._prefix._groups.remove(tg)
                     del parent._task_groups[tg._name]
 
-            return recommendations, worker_msgs, client_msgs
+            return recommendations, client_msgs, worker_msgs
         except Exception as e:
             logger.exception("Error transitioning %r from %r to %r", key, start, finish)
             if LOG_PDB:
@@ -6045,7 +6045,7 @@ class Scheduler(SchedulerState, ServerNode):
         worker_msgs: dict
         client_msgs: dict
         a: tuple = self._transition(key, finish, *args, **kwargs)
-        recommendations, worker_msgs, client_msgs = a
+        recommendations, client_msgs, worker_msgs = a
         self.send_all(client_msgs, worker_msgs)
         return recommendations
 
@@ -6058,34 +6058,34 @@ class Scheduler(SchedulerState, ServerNode):
         parent: SchedulerState = cast(SchedulerState, self)
         keys: set = set()
         recommendations = recommendations.copy()
-        worker_msgs: dict = {}
         client_msgs: dict = {}
+        worker_msgs: dict = {}
         msgs: list
         new_msgs: list
         new: tuple
         new_recs: dict
-        new_wmsgs: dict
         new_cmsgs: dict
+        new_wmsgs: dict
         while recommendations:
             key, finish = recommendations.popitem()
             keys.add(key)
 
             new = self._transition(key, finish)
-            new_recs, new_wmsgs, new_cmsgs = new
+            new_recs, new_cmsgs, new_wmsgs = new
 
             recommendations.update(new_recs)
-            for w, new_msgs in new_wmsgs.items():
-                msgs = worker_msgs.get(w)
-                if msgs is not None:
-                    msgs.extend(new_msgs)
-                else:
-                    worker_msgs[w] = new_msgs
             for c, new_msgs in new_cmsgs.items():
                 msgs = client_msgs.get(c)
                 if msgs is not None:
                     msgs.extend(new_msgs)
                 else:
                     client_msgs[c] = new_msgs
+            for w, new_msgs in new_wmsgs.items():
+                msgs = worker_msgs.get(w)
+                if msgs is not None:
+                    msgs.extend(new_msgs)
+                else:
+                    worker_msgs[w] = new_msgs
 
         if parent._validate:
             for key in keys:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3120,7 +3120,7 @@ class Scheduler(SchedulerState, ServerNode):
             "stop_task_metadata": self.stop_task_metadata,
         }
 
-        self._transitions = {
+        self._transitions_table = {
             ("released", "waiting"): self.transition_released_waiting,
             ("waiting", "released"): self.transition_waiting_released,
             ("waiting", "processing"): self.transition_waiting_processing,
@@ -5926,12 +5926,12 @@ class Scheduler(SchedulerState, ServerNode):
                 dependencies = set(ts._dependencies)
 
             start_finish = (start, finish)
-            func = self._transitions.get(start_finish)
+            func = self._transitions_table.get(start_finish)
             if func is not None:
                 a: tuple = func(key, *args, **kwargs)
                 recommendations, worker_msgs, client_msgs = a
             elif "released" not in start_finish:
-                func = self._transitions["released", finish]
+                func = self._transitions_table["released", finish]
                 assert not args and not kwargs
                 a_recs: dict
                 a_wmsgs: dict
@@ -5940,7 +5940,7 @@ class Scheduler(SchedulerState, ServerNode):
                 a_recs, a_wmsgs, a_cmsgs = a
                 v = a_recs.get(key)
                 if v is not None:
-                    func = self._transitions["released", v]
+                    func = self._transitions_table["released", v]
                 b_recs: dict
                 b_wmsgs: dict
                 b_cmsgs: dict

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3564,7 +3564,7 @@ class Scheduler(SchedulerState, ServerNode):
                 except Exception as e:
                     logger.exception(e)
 
-            recommendations: dict
+            recommendations: dict = {}
             if nbytes:
                 for key in nbytes:
                     ts: TaskState = parent._tasks.get(key)
@@ -3577,8 +3577,8 @@ class Scheduler(SchedulerState, ServerNode):
                             typename=types[key],
                         )
                         self.transitions(recommendations)
+                        recommendations = {}
 
-            recommendations = {}
             for ts in list(parent._unrunnable):
                 valid: set = self.valid_workers(ts)
                 if valid is None or ws in valid:
@@ -3586,6 +3586,7 @@ class Scheduler(SchedulerState, ServerNode):
 
             if recommendations:
                 self.transitions(recommendations)
+                recommendations = {}
 
             self.log_event(address, {"action": "add-worker"})
             self.log_event("all", {"action": "add-worker", "worker": address})

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4043,12 +4043,12 @@ class Scheduler(SchedulerState, ServerNode):
         with log_errors():
             logger.debug("Stimulus missing data %s, %s", key, worker)
 
+            recommendations: dict = {}
+
             ts: TaskState = parent._tasks.get(key)
             if ts is None or ts._state == "memory":
-                return {}
+                return recommendations
             cts: TaskState = parent._tasks.get(cause)
-
-            recommendations: dict = {}
 
             if cts is not None and cts._state == "memory":  # couldn't find this
                 ws: WorkerState
@@ -4063,11 +4063,12 @@ class Scheduler(SchedulerState, ServerNode):
                 recommendations[key] = "released"
 
             self.transitions(recommendations)
+            recommendations = {}
 
             if parent._validate:
                 assert cause not in self.who_has
 
-            return {}
+            return recommendations
 
     def stimulus_retry(self, comm=None, keys=None, client=None):
         parent: SchedulerState = cast(SchedulerState, self)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6086,11 +6086,11 @@ class Scheduler(SchedulerState, ServerNode):
                 else:
                     client_msgs[c] = new_msgs
 
-        self.send_all(client_msgs, worker_msgs)
-
         if parent._validate:
             for key in keys:
                 self.validate_key(key)
+
+        self.send_all(client_msgs, worker_msgs)
 
     def story(self, *keys):
         """ Get all transitions that touch one of the input keys """

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4017,7 +4017,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         recommendations: dict
         if ts._state == "processing":
-            retries = ts._retries
+            retries: Py_ssize_t = ts._retries
             if retries > 0:
                 ts._retries = retries - 1
                 recommendations = self.transition(key, "waiting")

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6049,7 +6049,7 @@ class Scheduler(SchedulerState, ServerNode):
         self.send_all(client_msgs, worker_msgs)
         return recommendations
 
-    def transitions(self, recommendations: dict):
+    def _transitions(self, recommendations: dict, client_msgs: dict, worker_msgs: dict):
         """Process transitions until none are left
 
         This includes feedback from previous transitions and continues until we
@@ -6058,8 +6058,6 @@ class Scheduler(SchedulerState, ServerNode):
         parent: SchedulerState = cast(SchedulerState, self)
         keys: set = set()
         recommendations = recommendations.copy()
-        client_msgs: dict = {}
-        worker_msgs: dict = {}
         msgs: list
         new_msgs: list
         new: tuple
@@ -6091,6 +6089,15 @@ class Scheduler(SchedulerState, ServerNode):
             for key in keys:
                 self.validate_key(key)
 
+    def transitions(self, recommendations: dict):
+        """Process transitions until none are left
+
+        This includes feedback from previous transitions and continues until we
+        reach a steady state
+        """
+        client_msgs: dict = {}
+        worker_msgs: dict = {}
+        self._transitions(recommendations, client_msgs, worker_msgs)
         self.send_all(client_msgs, worker_msgs)
 
     def story(self, *keys):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4011,11 +4011,12 @@ class Scheduler(SchedulerState, ServerNode):
         parent: SchedulerState = cast(SchedulerState, self)
         logger.debug("Stimulus task erred %s, %s", key, worker)
 
+        recommendations: dict = {}
+
         ts: TaskState = parent._tasks.get(key)
         if ts is None:
-            return {}
+            return recommendations
 
-        recommendations: dict
         if ts._state == "processing":
             retries: Py_ssize_t = ts._retries
             if retries > 0:
@@ -4031,8 +4032,6 @@ class Scheduler(SchedulerState, ServerNode):
                     worker=worker,
                     **kwargs,
                 )
-        else:
-            recommendations = {}
 
         return recommendations
 


### PR DESCRIPTION
Factors out `_transitions` from `transitions` to allow collecting of messages to send for the caller to handle as opposed to sending immediately. This then leveraged in a few stimulus and handle functions to collect all messages and send in one batch. Also this is leveraged in `add_worker` and `gather`. All of which makes a few calls to `transition` or `transitions`. The result is in these cases we should send fewer messages.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`