### PR TITLE
Pin black pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/psf/black
-      rev: stable
+      rev: 20.8b1
       hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
This PR pings `black` to a specific version in our pre-commit hooks to silence the following warning which is now raised by pre-commit

```
[WARNING] The 'rev' field of repo 'https://github.com/psf/black' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.
```

Similar to https://github.com/dask/dask/pull/7256