### PR TITLE
Expose system monitor dashboard as individual plot for use in lab extension

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2184,6 +2184,16 @@ def individual_graph_doc(scheduler, extra, doc):
         doc.theme = BOKEH_THEME
 
 
+def individual_systemmonitor_doc(scheduler, extra, doc):
+    with log_errors():
+        sysmon = SystemMonitor(scheduler, sizing_mode="stretch_both")
+        doc.title = "Dask: Scheduler System Monitor"
+        add_periodic_callback(doc, sysmon, 500)
+
+        doc.add_root(sysmon.root)
+        doc.theme = BOKEH_THEME
+
+
 def individual_profile_doc(scheduler, extra, doc):
     with log_errors():
         prof = ProfileTimePlot(scheduler, sizing_mode="scale_width", doc=doc)

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -34,6 +34,7 @@ from .components.scheduler import (
     individual_memory_by_key_doc,
     individual_compute_time_per_key_doc,
     individual_aggregate_time_per_action_doc,
+    individual_systemmonitor_doc,
 )
 from .worker import counters_doc
 from .components.nvml import gpu_memory_doc, gpu_utilization_doc  # noqa: 1708
@@ -90,4 +91,5 @@ applications = {
     "/individual-aggregate-time-per-action": individual_aggregate_time_per_action_doc,
     "/individual-gpu-memory": gpu_memory_doc,
     "/individual-gpu-utilization": gpu_utilization_doc,
+    "/individual-scheduler-system": individual_systemmonitor_doc,
 }


### PR DESCRIPTION
- [x] Closes #4539
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`

![image](https://user-images.githubusercontent.com/1610850/108866785-6d373b80-75ec-11eb-9568-ac8759203a42.png)
