### PR TITLE
Pass on original temp dir from nanny to worker

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -333,7 +333,9 @@ class Nanny(ServerNode):
             worker_kwargs = dict(
                 scheduler_ip=self.scheduler_addr,
                 nthreads=self.nthreads,
-                local_directory=self.local_directory,
+                # on the line below we undo the following in init
+                # os.path.join(local_directory, "dask-worker-space")
+                local_directory=os.path.dirname(self.local_directory),
                 services=self.services,
                 nanny=self.address,
                 name=self.name,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -168,7 +168,10 @@ class Nanny(ServerNode):
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
             if not os.path.exists(local_directory):
                 os.makedirs(local_directory)
+            self._original_local_dir = local_directory
             local_directory = os.path.join(local_directory, "dask-worker-space")
+        else:
+            self._original_local_dir = local_directory
 
         self.local_directory = local_directory
 
@@ -333,9 +336,7 @@ class Nanny(ServerNode):
             worker_kwargs = dict(
                 scheduler_ip=self.scheduler_addr,
                 nthreads=self.nthreads,
-                # on the line below we undo the following in init
-                # os.path.join(local_directory, "dask-worker-space")
-                local_directory=os.path.dirname(self.local_directory),
+                local_directory=self._original_local_dir,
                 services=self.services,
                 nanny=self.address,
                 name=self.name,

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -410,6 +410,7 @@ async def test_local_directory(s):
             w = await Nanny(s.address)
             assert w.local_directory.startswith(fn)
             assert "dask-worker-space" in w.local_directory
+            assert w.process.worker_dir.count("dask-worker-space") == 1
             await w.close()
 
 


### PR DESCRIPTION
- [x] Closes #4547
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`

~This is the simplest approach - since the nanny explicitly adds "dask-worker-space", we can just remove it before passing to the worker. The nanny does potentially make use of the dir, so it does need handling. We could store the original input as yet another attribute and pass that, but I think this works fine.~

OK, decided to just save the input temp directory after all.