### PR TITLE
[REVIEW] tcp.write(): cast memoryview to "B"

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -261,6 +261,12 @@ class TCP(Comm):
                 if each_frame_nbytes:
                     if stream._write_buffer is None:
                         raise StreamClosedError()
+
+                    if isinstance(each_frame, memoryview):
+                        # Make sure that len(data) == data.nbytes`
+                        # See <https://github.com/tornadoweb/tornado/pull/2996>
+                        each_frame = memoryview(each_frame).cast("B")
+
                     stream._write_buffer.append(each_frame)
                     stream._total_write_index += each_frame_nbytes
 


### PR DESCRIPTION
This PR makes sure that memoryview given to Tornado's TCP stream have an item size of one. See https://github.com/tornadoweb/tornado/pull/2996

Notice, since we are calling `stream._write_buffer.append()` directly, we still need this PR even when https://github.com/tornadoweb/tornado/pull/2996 get merged.

- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`
