### PR TITLE
Suppress OSError on SpecCluster shutdown

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -407,7 +407,7 @@ class SpecCluster(Cluster):
             for future in self._futures:
                 await future
             async with self._lock:
-                with suppress(CommClosedError):
+                with suppress(CommClosedError, OSError):
                     if self.scheduler_comm:
                         await self.scheduler_comm.close(close_workers=True)
                     else:


### PR DESCRIPTION
In #4566 it seems that when the scheduler has exited on its own an `OSError` is raised by the comm during `SpecCluster` shutdown and shutdown stops. 

In `SpecCluster` we suppress `CommClosedError`s and continue the shutdown. I assume this suppression was intended to avoid issues like these. 

I'm not sure whether the comm should be raising a `CommClusterError` instead of an `OSError`, or whether we should also suppress `OSError`s. I've opted for the latter in this PR but happy either way.

- [x] Closes #4566
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`

