### PR TITLE
Remove outdated macOS build badge from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,13 @@
 Distributed
 ===========
 
-|Linux/Windows Build Status| |MacOS Build Status| |Doc Status| |Gitter| |Version Status| |NumFOCUS|
+|Test Status| |Doc Status| |Gitter| |Version Status| |NumFOCUS|
 
 A library for distributed computation.  See documentation_ for more details.
 
 .. _documentation: https://distributed.dask.org
-.. |Linux/Windows Build Status| image:: https://github.com/dask/distributed/workflows/Tests/badge.svg?branch=main
+.. |Test Status| image:: https://github.com/dask/distributed/workflows/Tests/badge.svg?branch=main
    :target: https://github.com/dask/distributed/actions?query=workflow%3A%22Tests%22
-.. |MacOS Build Status| image:: https://github.com/dask/distributed/workflows/MacOS%20tests/badge.svg?branch=main
-   :target: https://github.com/dask/distributed/actions?query=workflow%3A%22MacOS+tests%22
 .. |Doc Status| image:: https://readthedocs.org/projects/distributed/badge/?version=latest
    :target: https://distributed.dask.org
    :alt: Documentation Status


### PR DESCRIPTION
We no longer run our macOS tests in a separate GitHub actions workflow

https://github.com/dask/distributed/blob/93bcc943bf380d7a774fd96ea64c2ba554e22301/.github/workflows/tests.yaml#L12

so we can remove the corresponding badge from our README