### PR TITLE
use `tobytes` instead of decode in serialization example

### DIFF
--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -168,7 +168,7 @@ register them with Dask.
 
     @dask_deserialize.register(Human)
     def deserialize(header: Dict, frames: List[bytes]) -> Human:
-        return Human(frames[0].decode())
+        return Human(frames[0].tobytes())
 
 
 Traverse attributes


### PR DESCRIPTION
- [x] Closes #4562
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed`

Now that we are passing memoryviews we should use `tobytes` in the serialization example instead of `decode`

cc @jakirkham 