### PR TITLE
Automatically cancel previous CI builds

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,15 @@
+name: Cancel
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - requested
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
This PR adds a new GitHub actions workflow for canceling previous CI builds when rapidly pushing commits. We recently adding something similar over in `dask/dask` which has helped reduce our CI queue wait time (xref https://github.com/dask/dask/pull/7348)

cc @jakirkham 