### PR TITLE
Update PipInstall plugin command

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -237,9 +237,8 @@ class PipInstall(WorkerPlugin):
         async with Lock(socket.gethostname()):  # don't clobber one installation
             logger.info("Pip installing the following packages: %s", self.packages)
             proc = subprocess.Popen(
-                [sys.executable, "-m", "pip"]
+                [sys.executable, "-m", "pip", "install"]
                 + self.pip_options
-                + ["install"]
                 + self.packages,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1641,7 +1641,7 @@ async def test_pip_install(c, s, a, b):
 
             args = p2.call_args[0][0]
             assert "python" in args[0]
-            assert args[1:] == ["-m", "pip", "--upgrade", "install", "requests"]
+            assert args[1:] == ["-m", "pip", "install", "--upgrade", "requests"]
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
I tried out our `PipInstall` plugin for the first time and it didn't install the package I requested. It turns out we were putting the `pip install` CLI options in the wrong place. Today, for example if `pip_options = ["--upgrade"]`, we do

```
pip --upgrade install <packages>
```

we when should be doing

```
pip install --upgrade <packages>
```