### PR TITLE
If SpecCluster fails to start attempt to gracefully close out again.

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -43,8 +43,8 @@ from . import protocol
 
 class Status(Enum):
     """
-    This Enum contains the various states a worker, scheduler and nanny can be
-    in. Some of the status can only be observed in one of nanny, scheduler or
+    This Enum contains the various states a cluster, worker, scheduler and nanny can be
+    in. Some of the status can only be observed in one of cluster, nanny, scheduler or
     worker but we put them in the same Enum as they are compared with each
     other.
     """
@@ -52,6 +52,7 @@ class Status(Enum):
     closed = "closed"
     closing = "closing"
     closing_gracefully = "closing-gracefully"
+    failed = "failed"
     init = "init"
     created = "created"
     running = "running"

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -314,8 +314,8 @@ class SpecCluster(Cluster):
         try:
             await super()._start()
         except Exception as e:
-            await self._close()
             self.status = Status.failed
+            await self._close()
             raise RuntimeError(f"Cluster failed to start. {str(e)}") from e
 
     def _correct_state(self):
@@ -405,7 +405,7 @@ class SpecCluster(Cluster):
             await asyncio.sleep(0.1)
         if self.status == Status.closed:
             return
-        if self.status == Status.created or self.status == Status.running:
+        if self.status == Status.running or self.status == Status.failed:
             self.status = Status.closing
             self.scale(0)
             await self._correct_state()

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -315,6 +315,7 @@ class SpecCluster(Cluster):
             await super()._start()
         except Exception as e:
             await self._close()
+            self.status = Status.failed
             raise RuntimeError(f"Cluster failed to start. {str(e)}") from e
 
     def _correct_state(self):


### PR DESCRIPTION
This PR catches broad exceptions raised when starting a `SpecCluster` and attempts to gracefully shut down again. 

In #4589 we see that if it is not possible for the `Cluster` super object to open an RPC to the scheduler (due to network restrictions) an exception is raised and the scheduler is never deleted. This aims to address that.

I've also added a `Status.failed` property to the status enum. This is useful in this case to mark the `SpecCluster` as failed before cleanup. I can also see it being useful in other cases (such as `dask-ctl`) where we may discover broken clusters and need a way to represent them in order to tear them down.

- [x] Closes #4589 
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`
