### PR TITLE
Add support for a list of keys when using batch_size in client.map

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1693,7 +1693,7 @@ class Client:
             batches = list(
                 zip(*[partition_all(batch_size, iterable) for iterable in iterables])
             )
-            if type(key) == list:
+            if isinstance(key, list):
                 keys = [list(element) for element in partition_all(batch_size, key)]
             else:
                 keys = [key for _ in range(len(batches))]

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1693,12 +1693,10 @@ class Client:
             batches = list(
                 zip(*[partition_all(batch_size, iterable) for iterable in iterables])
             )
-            
             if type(key) == list:
                 keys = [list(element) for element in partition_all(batch_size, key)]
             else:
                 keys = [key for _ in range(len(batches))]
-            
             return sum(
                 [
                     self.map(

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1693,6 +1693,12 @@ class Client:
             batches = list(
                 zip(*[partition_all(batch_size, iterable) for iterable in iterables])
             )
+            
+            if type(key) == list:
+                keys = [list(element) for element in partition_all(batch_size, key)]
+            else:
+                keys = [key for _ in range(len(batches))]
+            
             return sum(
                 [
                     self.map(
@@ -1710,7 +1716,7 @@ class Client:
                         pure=pure,
                         **kwargs,
                     )
-                    for batch in batches
+                    for key, batch in zip(keys, batches)
                 ],
                 [],
             )

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6530,3 +6530,4 @@ async def test_workers_collection_restriction(c, s, a, b):
     await future
     assert a.data and not b.data
 
+

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6529,5 +6529,3 @@ async def test_workers_collection_restriction(c, s, a, b):
     future = c.compute(da.arange(10), workers=a.address)
     await future
     assert a.data and not b.data
-
-

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -230,6 +230,20 @@ async def test_map_batch_size(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_custom_key_with_batches(c, s, a, b):
+    """ Test of <https://github.com/dask/distributed/issues/4588>"""
+
+    futs = c.map(
+        lambda x: x ** 2,
+        range(10),
+        batch_size=5,
+        key=[str(x) for x in range(10)],
+    )
+    assert len(futs) == 10
+    await wait(futs)
+
+
+@gen_cluster(client=True)
 async def test_compute_retries(c, s, a, b):
     args = [ZeroDivisionError("one"), ZeroDivisionError("two"), 3]
 
@@ -6516,24 +6530,3 @@ async def test_workers_collection_restriction(c, s, a, b):
     await future
     assert a.data and not b.data
 
-
-@gen_cluster(client=True)
-async def test_custom_key_with_batches(c, s, a, b):
-    """ Test of <https://github.com/dask/distributed/issues/4588>"""
-
-    futs = c.map(
-        lambda x: x ** 2,
-        range(10),
-        batch_size=5,
-        key=[f"{x}" for x in range(10)],
-    )
-    assert len(futs) == 10
-    await wait(futs)
-
-
-    futs = c.map(
-        lambda x: x ** 2, list(range(10)), key=[f"{x}" for x in list(range(10))]
-    )
-    assert len(futs) == 10
-    res = c.gather(futs)  # this is to ensure that the futures are computed
-    assert len(res) == 10

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6523,7 +6523,7 @@ async def test_custom_key_with_batches(c, s, a, b):
 
     futs = c.map(
         lambda x: x ** 2,
-        list(range(10)),
+        range(10),
         batch_size=5,
         key=[f"{x}" for x in range(10)],
     )

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6528,8 +6528,7 @@ async def test_custom_key_with_batches(c, s, a, b):
         key=[f"{x}" for x in list(range(10))],
     )
     assert len(futs) == 10
-    res = c.gather(futs)  # this is to ensure that the futures are computed
-    assert len(res) == 10
+    await wait(futs)
 
     futs = c.map(lambda x: x ** 2, list(range(10)), batch_size=5)
     assert len(futs) == 10

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6530,10 +6530,6 @@ async def test_custom_key_with_batches(c, s, a, b):
     assert len(futs) == 10
     await wait(futs)
 
-    futs = c.map(lambda x: x ** 2, list(range(10)), batch_size=5)
-    assert len(futs) == 10
-    res = c.gather(futs)  # this is to ensure that the futures are computed
-    assert len(res) == 10
 
     futs = c.map(
         lambda x: x ** 2, list(range(10)), key=[f"{x}" for x in list(range(10))]

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6525,7 +6525,7 @@ async def test_custom_key_with_batches(c, s, a, b):
         lambda x: x ** 2,
         list(range(10)),
         batch_size=5,
-        key=[f"{x}" for x in list(range(10))],
+        key=[f"{x}" for x in range(10)],
     )
     assert len(futs) == 10
     await wait(futs)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6515,3 +6515,30 @@ async def test_workers_collection_restriction(c, s, a, b):
     future = c.compute(da.arange(10), workers=a.address)
     await future
     assert a.data and not b.data
+
+
+@gen_cluster(client=True)
+async def test_custom_key_with_batches(c, s, a, b):
+    """ Test of <https://github.com/dask/distributed/issues/4588>"""
+
+    futs = c.map(
+        lambda x: x ** 2,
+        list(range(10)),
+        batch_size=5,
+        key=[f"{x}" for x in list(range(10))],
+    )
+    assert len(futs) == 10
+    res = c.gather(futs)  # this is to ensure that the futures are computed
+    assert len(res) == 10
+
+    futs = c.map(lambda x: x ** 2, list(range(10)), batch_size=5)
+    assert len(futs) == 10
+    res = c.gather(futs)  # this is to ensure that the futures are computed
+    assert len(res) == 10
+
+    futs = c.map(
+        lambda x: x ** 2, list(range(10)), key=[f"{x}" for x in list(range(10))]
+    )
+    assert len(futs) == 10
+    res = c.gather(futs)  # this is to ensure that the futures are computed
+    assert len(res) == 10


### PR DESCRIPTION
This addresses issue #4588

- [x] Closes #4588
- [x] Tests passed (no new tests added)
- [x] Passes `black distributed` / `flake8 distributed` (flake8 finds some existing violations, but not related to changes in this PR)
