### PR TITLE
Track frame sizes along with frames

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -263,7 +263,7 @@ class TCP(Comm):
                         raise StreamClosedError()
 
                     if isinstance(each_frame, memoryview):
-                        # Make sure that len(data) == data.nbytes`
+                        # Make sure that `len(data) == data.nbytes`
                         # See <https://github.com/tornadoweb/tornado/pull/2996>
                         each_frame = memoryview(each_frame).cast("B")
 


### PR DESCRIPTION
Should cutdown on the number of `nbytes` calls to 1 per frame as opposed to a couple as before.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`