### PR TITLE
pickle_loads(): Handle empty memoryview

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -74,9 +74,13 @@ def pickle_loads(header, frames):
         mv = memoryview(buffers[i])
         if writeable[i] == mv.readonly:
             if mv.readonly:
-                buffers[i] = memoryview(bytearray(mv)).cast(mv.format, mv.shape)
+                buf = memoryview(bytearray(mv))
             else:
-                buffers[i] = memoryview(bytes(mv)).cast(mv.format, mv.shape)
+                buf = memoryview(bytes(mv))
+            if buf.nbytes > 0:
+                buffers[i] = buf.cast(mv.format, mv.shape)
+            else:
+                buffers[i] = buf.cast(mv.format)
     return pickle.loads(x, buffers=buffers)
 
 

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -8,6 +8,7 @@ import pytest
 
 from distributed.protocol import deserialize, serialize
 from distributed.protocol.pickle import HIGHEST_PROTOCOL, dumps, loads
+from distributed.protocol.serialize import pickle_dumps
 
 if sys.version_info < (3, 8):
     try:
@@ -69,6 +70,16 @@ def test_pickle_out_of_band():
     else:
         assert len(f) == 1
         assert isinstance(f[0], bytes)
+
+
+def test_pickle_empty():
+    np = pytest.importorskip("numpy")
+    x = np.arange(2)[0:0]  # Empty view
+    header, frames = pickle_dumps(x)
+    header["writeable"] = [False] * len(frames)
+    y = deserialize(header, frames)
+    assert memoryview(y).nbytes == 0
+    assert memoryview(y).readonly
 
 
 def test_pickle_numpy():


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/4594

- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`
