### PR TITLE
Consider custom profile interval in performance_report

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6367,8 +6367,12 @@ class Scheduler(SchedulerState, ServerNode):
         )
         from . import profile
 
+        profile_interval = parse_timedelta(
+            dask.config.get("distributed.worker.profile.interval"), default="ms"
+        )
+
         def profile_to_figure(state):
-            data = profile.plot_data(state)
+            data = profile.plot_data(state, profile_interval=profile_interval)
             figure, source = profile.plot_figure(data, sizing_mode="stretch_both")
             return figure
 


### PR DESCRIPTION
`plot_data` assumes an interval of `0.010` seconds. When setting a custom `distributed.worker.profile.interval`, the plot would show incorrect time values.

- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`