### PR TITLE
Make length of events deque configurable

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3279,7 +3279,11 @@ class Scheduler(SchedulerState, ServerNode):
         self.log = deque(
             maxlen=dask.config.get("distributed.scheduler.transition-log-length")
         )
-        self.events = defaultdict(lambda: deque(maxlen=100000))
+        self.events = defaultdict(
+            lambda: deque(
+                maxlen=dask.config.get("distributed.scheduler.transition-log-length")
+            )
+        )
         self.event_counts = defaultdict(int)
         self.worker_plugins = []
 


### PR DESCRIPTION
Hi there 👋 

this change fixes an OOM issue on the scheduler because of the increasing size of the events deque. The default value seems a bit too high. This issue can be avoided by making the value configurable.

~- [ ] Closes #xxxx~
- [x] Tests added / passed (Note: Some tests failed on my local machine with Timeout errors, but I assume this is related to my machine)
- [x] Passes `black distributed` / `flake8 distributed`