### PR TITLE
Add check to scheduler creation in SpecCluster

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -252,6 +252,7 @@ class SpecCluster(Cluster):
         self.scheduler_spec = copy.copy(scheduler)
         self.worker_spec = copy.copy(workers) or {}
         self.new_spec = copy.copy(worker)
+        self.scheduler = None
         self.workers = {}
         self._i = 0
         self.security = security or Security()
@@ -290,6 +291,7 @@ class SpecCluster(Cluster):
             raise ValueError("Cluster is closed")
 
         self._lock = asyncio.Lock()
+        self.status = Status.starting
 
         if self.scheduler_spec is None:
             try:
@@ -300,13 +302,12 @@ class SpecCluster(Cluster):
                 options = {"dashboard": True}
             self.scheduler_spec = {"cls": Scheduler, "options": options}
 
-        cls = self.scheduler_spec["cls"]
-        if isinstance(cls, str):
-            cls = import_term(cls)
-        self.scheduler = cls(**self.scheduler_spec.get("options", {}))
-
-        self.status = Status.starting
-        self.scheduler = await self.scheduler
+        if self.scheduler is None:
+            cls = self.scheduler_spec["cls"]
+            if isinstance(cls, str):
+                cls = import_term(cls)
+            self.scheduler = cls(**self.scheduler_spec.get("options", {}))
+            self.scheduler = await self.scheduler
         self.scheduler_comm = rpc(
             getattr(self.scheduler, "external_address", None) or self.scheduler.address,
             connection_args=self.security.get_connection_args("client"),

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -302,6 +302,7 @@ class SpecCluster(Cluster):
                 options = {"dashboard": True}
             self.scheduler_spec = {"cls": Scheduler, "options": options}
 
+        # Check if scheduler has already been created by a subclass
         if self.scheduler is None:
             cls = self.scheduler_spec["cls"]
             if isinstance(cls, str):


### PR DESCRIPTION
While working on cluster discovery support I found that when reconstructing a cluster scheduler and worker objects may have already been created before start is called.

This small PR adds a check and only creates the scheduler if it doesn't already exist.

This is the first step towards making `SpecCluster` declarative rather than imperative.

- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`
