### PR TITLE
Drop `log` from `remove_key_from_stealable`

### DIFF
--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -95,7 +95,6 @@ class WorkStealing(SchedulerPlugin):
             return
 
         worker, level = result
-        self.log(("remove-stealable", ts.key, worker, level))
         try:
             self.stealable[worker][level].remove(ts)
         except KeyError:


### PR DESCRIPTION
We already dropped the `log` line from `put_key_in_stealable` ( https://github.com/dask/distributed/pull/4375 ) because it was too granular of logging and was slowing things down there ( https://github.com/dask/distributed/issues/4359 ). This does the same thing for `remove_key_from_stealable` for the same reason.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed`