### PR TITLE
Add table of metric statistics to Workers tab

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6408,6 +6408,12 @@ class Scheduler(SchedulerState, ServerNode):
         bandwidth_types = BandwidthTypes(self, sizing_mode="stretch_both")
         bandwidth_types.update()
 
+        # Workers table
+        from distributed.dashboard.components.scheduler import WorkerTable
+
+        table = WorkerTable(self, report=True, sizing_mode="stretch_width")
+        table.update()
+
         from bokeh.models import Panel, Tabs, Div
         import distributed
 
@@ -6456,10 +6462,11 @@ class Scheduler(SchedulerState, ServerNode):
         html = Div(text=html)
 
         html = Panel(child=html, title="Summary")
+        table = Panel(child=table.root, title="Workers")
+        task_stream = Panel(child=task_stream, title="Task Stream")
         compute = Panel(child=compute, title="Worker Profile (compute)")
         workers = Panel(child=workers, title="Worker Profile (administrative)")
         scheduler = Panel(child=scheduler, title="Scheduler Profile (administrative)")
-        task_stream = Panel(child=task_stream, title="Task Stream")
         bandwidth_workers = Panel(
             child=bandwidth_workers.fig, title="Bandwidth (Workers)"
         )
@@ -6468,6 +6475,7 @@ class Scheduler(SchedulerState, ServerNode):
         tabs = Tabs(
             tabs=[
                 html,
+                table,
                 task_stream,
                 compute,
                 workers,


### PR DESCRIPTION
This PR adds a table of basic statistics (max, min, mean) for the worker metrics (CPU, memory, # of file descriptors, etc.) to the Workers tab of the dashboard:

![image](https://user-images.githubusercontent.com/20627856/111846916-2d5b2f80-88de-11eb-8461-03aedd195741.png)

It also adds a Workers tab to the performance report containing this table, attempting to tackle some of the resource tracking desired in #4494:

![image](https://user-images.githubusercontent.com/20627856/111847047-6f847100-88de-11eb-9cc4-18763a6e257a.png)

Some questions:

- This table is pretty crowded since I've included (to my knowledge) all dynamic metrics that could be aggregated; are there any metrics or statistics we don't really need to see in this table?
- Are there any statistics we *would* like to see here, maybe for specific metrics?


- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed`
