### PR TITLE
Introduce events log length config option

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -80,6 +80,18 @@ properties:
               we will clear out old entries after a certain length.
               This is that length.
 
+          events-log-length:
+            type: integer
+            minimum: 0
+            description: |
+              How long should we keep the events log
+
+              All events (e.g. worker heartbeat) are stored in the events log.
+
+              To make sure that we don't run out of memory
+              we will clear out old entries after a certain length.
+              This is that length.
+
           work-stealing:
             type: boolean
             description: |

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -18,6 +18,7 @@ distributed:
     events-cleanup-delay: 1h
     idle-timeout: null      # Shut down after this duration, like "1h" or "30 minutes"
     transition-log-length: 100000
+    events-log-length: 100000
     work-stealing: True     # workers should steal tasks from each other
     work-stealing-interval: 100ms  # Callback time for work stealing
     worker-ttl: null        # like '60s'. Time to live for workers.  They must heartbeat faster than this

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3281,7 +3281,7 @@ class Scheduler(SchedulerState, ServerNode):
         )
         self.events = defaultdict(
             lambda: deque(
-                maxlen=dask.config.get("distributed.scheduler.transition-log-length")
+                maxlen=dask.config.get("distributed.scheduler.events-log-length")
             )
         )
         self.event_counts = defaultdict(int)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2186,7 +2186,7 @@ async def test_retire_state_change(c, s, a, b):
     await c.retire_workers(workers=[a.address])
 
 
-@gen_cluster(client=True, config={"distributed.scheduler.transition-log-length": 3})
+@gen_cluster(client=True, config={"distributed.scheduler.events-log-length": 3})
 async def test_configurable_events_log_length(c, s, a, b):
     s.log_event("test", "dummy message 1")
     assert len(s.events["test"]) == 1


### PR DESCRIPTION
Follow-up PR to #4604.

This adds the config parameter `distributed.scheduler.events-log-length` as a separate config option to accompany the existing `distributed.scheduler.transition-log-length` config option.

Note, that I also changed the default length of both `events-log-length` and `transition-log-length` to `5000` instead of `100000`, since it seems like a more reasonable default lengths to me. Let me know if you have any other suggestion for the default log length value.

~- [ ] Closes #xxxx~
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`
