### PR TITLE
Rename annotation plugin in test_highlevelgraph.py

### DIFF
--- a/distributed/protocol/tests/test_highlevelgraph.py
+++ b/distributed/protocol/tests/test_highlevelgraph.py
@@ -91,7 +91,7 @@ async def test_shuffle(c, s, a, b):
     assert (res == 10.0).all()
 
 
-class TestAnnotationPlugin(SchedulerPlugin):
+class ExampleAnnotationPlugin(SchedulerPlugin):
     def __init__(self, priority_fn=None, qux="", resource="", retries=0):
         self.priority_fn = priority_fn or (lambda k: 0)
         self.qux = qux
@@ -134,7 +134,7 @@ async def test_array_annotations(c, s, a, b):
     qux = "baz"
     resource = "widget"
 
-    plugin = TestAnnotationPlugin(priority_fn=fn, qux=qux, resource=resource)
+    plugin = ExampleAnnotationPlugin(priority_fn=fn, qux=qux, resource=resource)
     s.add_plugin(plugin)
 
     assert plugin in s.plugins
@@ -159,7 +159,7 @@ async def test_array_annotations(c, s, a, b):
 @gen_cluster(client=True)
 async def test_dataframe_annotations(c, s, a, b):
     retries = 5
-    plugin = TestAnnotationPlugin(retries=retries)
+    plugin = ExampleAnnotationPlugin(retries=retries)
     s.add_plugin(plugin)
 
     assert plugin in s.plugins


### PR DESCRIPTION
This avoids `pytest` logging this warning

```
distributed/protocol/tests/test_highlevelgraph.py:94
  /Users/james/projects/dask/distributed/distributed/protocol/tests/test_highlevelgraph.py:94: PytestCollectionWarning: cannot collect test class 'TestAnnotationPlugin' because it has a __init__ constructor (from: distributed/protocol/tests/test_highlevelgraph.py)
    class TestAnnotationPlugin(SchedulerPlugin):
```

because it thinks `TestAnnotationPlugin` is a `unittest`-style test class