### PR TITLE
UCX: use nbytes instead of len

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -205,7 +205,7 @@ class UCX(Comm):
                     *(
                         (is_cuda, each_frame)
                         for is_cuda, each_frame in zip(cuda_frames, frames)
-                        if len(each_frame) > 0
+                        if nbytes(each_frame) > 0
                     )
                 )
 
@@ -275,7 +275,7 @@ class UCX(Comm):
                     *(
                         (is_cuda, each_frame)
                         for is_cuda, each_frame in zip(cuda_frames, frames)
-                        if len(each_frame) > 0
+                        if nbytes(each_frame) > 0
                     )
                 )
 


### PR DESCRIPTION
Use `nbytes()` to check for empty buffer objects since `nbytes() != len()`. 
This fixes the first part of https://github.com/rapidsai/dask-cuda/issues/549 where the send and recv got _out of sync_ because they didn't agree on which empty frames to skip.
```
10:58:40   File "/opt/conda/envs/rapids/lib/python3.7/site-packages/ucp/core.py", line 628, in recv
10:58:40     ret = await comm.tag_recv(self._ep, buffer, nbytes, tag, name=log)
10:58:40 ucp.exceptions.UCXMsgTruncated: <[Recv #112] ep: 0x7f0e25cde0d8, tag: 0xfa85496d273cdec2, nbytes: 260, type: <class 'numpy.ndarray'>>: length mismatch: 16 (got) != 260 (expected)
```

- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`

cc. @jakirkham 
