### PR TITLE
Handle async clients when closing

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4726,7 +4726,10 @@ def _close_global_client():
     if c is not None:
         c._should_close_loop = False
         with suppress(TimeoutError, RuntimeError):
-            c.close(timeout=3)
+            if c.asynchronous:
+                c.loop.add_callback(c.close, timeout=3)
+            else:
+                c.close(timeout=3)
 
 
 atexit.register(_close_global_client)


### PR DESCRIPTION
Fixes #4620

This probably occurs because a client created on a worker has its event loop thread, which in the worker case happens to be the main thread.  So the atexit call ends up happening in a situation where client.asynchronous is true.  

The close call may not ever actually occur (the event loop may be toast at this point) but we're doing best effort here at least.