### PR TITLE
Remove `utils.shutting_down` in favor of `sys.is_finalizing`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -77,7 +77,6 @@ from .utils import (
     no_default,
     LoopRunner,
     parse_timedelta,
-    shutting_down,
     Any,
     has_keyword,
     format_dashboard_link,
@@ -383,7 +382,7 @@ class Future(WrappedKey):
         except AttributeError:
             # Ocassionally we see this error when shutting down the client
             # https://github.com/dask/distributed/issues/4305
-            if not shutting_down():
+            if not sys.is_finalizing():
                 raise
         except RuntimeError:  # closed event loop
             pass
@@ -1445,7 +1444,7 @@ class Client:
 
         assert self.status == "closed"
 
-        if not shutting_down():
+        if not sys.is_finalizing():
             self._loop_runner.stop()
 
     async def _shutdown(self):

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -21,7 +21,7 @@ from tornado.tcpserver import TCPServer
 
 from ..system import MEMORY_LIMIT
 from ..threadpoolexecutor import ThreadPoolExecutor
-from ..utils import ensure_ip, get_ip, get_ipv6, nbytes, parse_timedelta, shutting_down
+from ..utils import ensure_ip, get_ip, get_ipv6, nbytes, parse_timedelta
 
 from .registry import Backend, backends
 from .addressing import parse_host_port, unparse_host_port
@@ -201,7 +201,7 @@ class TCP(Comm):
         except StreamClosedError as e:
             self.stream = None
             self._closed = True
-            if not shutting_down():
+            if not sys.is_finalizing():
                 convert_stream_closed_error(self, e)
         except Exception:
             # Some OSError or a another "low-level" exception. We do not really know what
@@ -277,7 +277,7 @@ class TCP(Comm):
         except StreamClosedError as e:
             self.stream = None
             self._closed = True
-            if not shutting_down():
+            if not sys.is_finalizing():
                 convert_stream_closed_error(self, e)
         except Exception:
             # Some OSError or a another "low-level" exception. We do not really know

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -64,7 +64,6 @@ from .utils import (
     no_default,
     parse_timedelta,
     parse_bytes,
-    shutting_down,
     key_split_group,
     empty_context,
     tmpfile,
@@ -4738,7 +4737,7 @@ class Scheduler(SchedulerState, ServerNode):
             if not comm.closed():
                 self.client_comms[client].send({"op": "stream-closed"})
             try:
-                if not shutting_down():
+                if not sys.is_finalizing():
                     await self.client_comms[client].close()
                     del self.client_comms[client]
                     if self.status == Status.running:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -943,16 +943,6 @@ def mean(seq):
     return sum(seq) / len(seq)
 
 
-def shutting_down(is_finalizing=sys.is_finalizing):
-    """Whether the interpreter is currently shutting down.
-
-    For use in finalizers, __del__ methods, and similar; it is advised
-    to early bind this function rather than look it up when calling it,
-    since at shutdown module globals may be cleared.
-    """
-    return is_finalizing()
-
-
 def open_port(host=""):
     """Return a probably-open port
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1,6 +1,5 @@
 import asyncio
 from asyncio import TimeoutError
-import atexit
 import click
 from collections import deque, OrderedDict, UserDict
 from concurrent.futures import ThreadPoolExecutor, CancelledError  # noqa: F401
@@ -944,30 +943,14 @@ def mean(seq):
     return sum(seq) / len(seq)
 
 
-if hasattr(sys, "is_finalizing"):
+def shutting_down(is_finalizing=sys.is_finalizing):
+    """Whether the interpreter is currently shutting down.
 
-    def shutting_down(is_finalizing=sys.is_finalizing):
-        return is_finalizing()
-
-
-else:
-    _shutting_down = [False]
-
-    def _at_shutdown(l=_shutting_down):
-        l[0] = True
-
-    def shutting_down(l=_shutting_down):
-        return l[0]
-
-    atexit.register(_at_shutdown)
-
-
-shutting_down.__doc__ = """
-    Whether the interpreter is currently shutting down.
     For use in finalizers, __del__ methods, and similar; it is advised
     to early bind this function rather than look it up when calling it,
     since at shutdown module globals may be cleared.
     """
+    return is_finalizing()
 
 
 def open_port(host=""):


### PR DESCRIPTION
This PR removes our `utils.shutting_down` utility in favor of using [`sys.is_finalizing`](https://docs.python.org/3/library/sys.html#sys.is_finalizing) directly throughout the codebase. IIUC `shutting_down` is a compatibility utility to support versions of Python that don't have `sys.if_finalizing`, which was introduced in Python 3.5 (our current minimum is 3.7).