### PR TITLE
Add GPU monitor to dashboard

### DIFF
--- a/distributed/dashboard/components/nvml.py
+++ b/distributed/dashboard/components/nvml.py
@@ -47,7 +47,6 @@ class GPUMonitor(DashboardComponent):
         data = {f"{ws}_{metric}": [] for ws in workers for metric in ["mem", "util"]}
         data.update({"time": []})
         self.source = ColumnDataSource(data)
-        self.update()
 
         x_range = DataRange1d(follow="end", follow_interval=20000, range_padding=0)
 
@@ -107,6 +106,7 @@ class GPUMonitor(DashboardComponent):
         now = time()
         workers = list(self.scheduler.workers.values())
         d = {"time": [now * 1000]}
+        memory_used = 0
         memory_total = 0
 
         for ws in workers:
@@ -118,10 +118,11 @@ class GPUMonitor(DashboardComponent):
             metrics = ws.metrics["gpu"]
             d[f"{ws.address}_mem"] = [metrics["memory-used"]]
             d[f"{ws.address}_util"] = [metrics["utilization"]]
+            memory_used += d[f"{ws.address}_mem"][0]
             memory_total += mem_total
             
         self.memory_figure.title.text = "GPU Memory: %s / %s" % (
-                format_bytes(sum(memory)),
+                format_bytes(memory_used),
                 format_bytes(memory_total),
             )
         self.source.stream(d, 1000)

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -37,7 +37,11 @@ from .components.scheduler import (
     individual_systemmonitor_doc,
 )
 from .worker import counters_doc
-from .components.nvml import gpu_memory_doc, gpu_utilization_doc  # noqa: 1708
+from .components.nvml import (
+    gpu_memory_doc,
+    gpu_utilization_doc,
+    gpu_monitor_doc,
+)
 
 
 template_variables = {
@@ -91,5 +95,6 @@ applications = {
     "/individual-aggregate-time-per-action": individual_aggregate_time_per_action_doc,
     "/individual-gpu-memory": gpu_memory_doc,
     "/individual-gpu-utilization": gpu_utilization_doc,
+    "/individual-gpu-monitor": gpu_monitor_doc,
     "/individual-scheduler-system": individual_systemmonitor_doc,
 }


### PR DESCRIPTION
In an attempt to address #4494, this PR adds a time series view of GPU memory and utilization to the dashboard, similar to the System tab:

![image](https://user-images.githubusercontent.com/20627856/112216139-8b965400-8bf7-11eb-97fa-7af8cbc31485.png)

Some things that could be improved:

- I'd like to add a hover tool with the worker name + current value of the metric; this seemingly requires this to be a Bokeh `multi_line` plot, which I tried out but wasn't able to get working just yet.
- Right now, the colors of the lines are generated by iterating through a 256-color Bokeh palette - this caps the number of lines to 256, which could cause problems for cases using more GPUs than this.

A plot like this would be nice in the performance reports, but I don't think this is possible right now as there isn't a way (accessible to the scheduler, at least) to collect logs for the workers outside of the dashboard component itself.

cc @quasiben 

- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed`
