### PR TITLE
Handle `stream is None` case in TCP comm finalizer

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -169,8 +169,9 @@ class TCP(Comm):
 
     def _get_finalizer(self):
         def finalize(stream=self.stream, r=repr(self)):
-            if not stream.closed():
-                logger.warning("Closing dangling stream in %s" % (r,))
+            # stream is None if a StreamClosedError is raised during interpreter shutdown
+            if stream is not None and not stream.closed():
+                logger.warning(f"Closing dangling stream in {r}")
                 stream.close()
 
         return finalize


### PR DESCRIPTION
Some Dask users reported running into the following error coming from the `TCP` comm finalizer method

```python
Exception ignored in: <finalize object at 0x7fc093a9f1a0; dead>
Traceback (most recent call last):

  File "distributed/comm/tcp.py", line 172, in finalize
    if not stream.closed():
AttributeError: 'NoneType' object has no attribute 'closed'
```

Looking at the `TCP` comm, there are some code paths where we will set the stream to `None`:

https://github.com/dask/distributed/blob/8942856bb83781c50c1307a3c8e8ed75f43191db/distributed/comm/tcp.py#L201-L205

 In particular, when `sys.is_finalizing()` is `True` we don't raise an error and could end up with

```python
AttributeError: 'NoneType' object has no attribute 'closed'
```

when the finalizer for the comm is run during interpreter shutdown.

This PR adds a check to the corresponding `finalize` function to make sure `stream is not None` before attempting to call `stream.close()`