### PR TITLE
Include LIST_PICKLE in NumPy array serialization

### DIFF
--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -20,7 +20,7 @@ def itemsize(dt):
 
 @dask_serialize.register(np.ndarray)
 def serialize_numpy_ndarray(x, context=None):
-    if x.dtype.hasobject:
+    if x.dtype.hasobject or (x.dtype.flags & np.core.multiarray.LIST_PICKLE):
         header = {"pickle": True}
         frames = [None]
         buffer_callback = lambda f: frames.append(memoryview(f))


### PR DESCRIPTION
Some NumPy arrays [must be converted to a list before pickling](https://numpy.org/devdocs/reference/c-api/types-and-structures.html#c.PyArray_Descr.flags.NPY_LIST_PICKLE). This is indicated by whether or not the `dtype` for the array has its `LIST_PICKLE` flag set. You can see [here](https://github.com/numpy/numpy/blob/267d49fe43b0757183cb49f52053a21a339f5b7e/numpy/core/src/multiarray/methods.c#L1772-L1774) where the `__reduce__` method for a NumPy array checks for this flag and converts it to a list accordingly.

This PR expands the class of arrays we pass directly to `pickle` to include those which have their `LIST_PICKLE` flag set to ensure they are serialized correctly. 

Unfortunately it's difficult to write a test for this as, from what I can tell, constructing a `dtype` with `LIST_PICKLE` set in pure Python (without using NumPy's C-API) requires including object `dtype`s (see the example below). However, since we're already passing arrays with an object `dtype` directly to `pickle`, we're not isolating the new code path. 

```python
In [1]: import numpy as np

In [2]: dt = np.dtype([('obj', 'O'), ('int', 'i')])    # This dtype has LIST_PICKLE set

In [3]: a = np.empty(1, dtype=dt)

In [4]: a.dtype.flags
Out[4]: 27

In [5]: a.dtype.flags & np.core.multiarray.LIST_PICKLE   # This checks that LIST_PICKLE is set
Out[5]: 2

In [6]: a.dtype.hasobject   # Note it's also an object `dtype`
Out[6]: True
```

cc @jakirkham @madsbk, who have been thinking about our serialization code recently, in case you have any thoughts on this