### PR TITLE
ignore oserror exception when scaling down (dask#4591)

### DIFF
--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -202,7 +202,8 @@ class AdaptiveCore:
             if status == "down":
                 await self.scale_down(**recommendations)
         except OSError as e:
-            logger.error("Adaptive stopping due to error %s", str(e))
-            self.stop()
+            if status != "down":
+                logger.error("Adaptive stopping due to error %s", str(e))
+                self.stop()
         finally:
             self._adapting = False


### PR DESCRIPTION
Adaptive stop() is called if workers are preempted. From the discussion #4591 with @jacobtomlinson , it's reasonable to ignore the exception and carry on with adaptive when scaling down