### PR TITLE
Avoid repeatedly using the same worker on first task with quiet cluster.

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2127,7 +2127,17 @@ class SchedulerState:
             if n_workers < 20:  # smart but linear in small case
                 ws = min(worker_pool.values(), key=operator.attrgetter("occupancy"))
                 if ws.occupancy == 0:  # special case to use round-robin
-                    ws = worker_pool.values()[self._n_tasks % n_workers]
+                    wp_vals = worker_pool.values()
+                    start = self._n_tasks % n_workers
+                    for i in range(start, n_workers):
+                        if wp_vals[i].occupancy == 0:
+                            ws = wp_vals[i]
+                            break
+                    else:
+                        for i in range(start):
+                            if wp_vals[i].occupancy == 0:
+                                ws = wp_vals[i]
+                                break
             else:  # dumb but fast in large case
                 ws = worker_pool.values()[self._n_tasks % n_workers]
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2134,7 +2134,7 @@ class SchedulerState:
                     wp_i: WorkerState
                     start: Py_ssize_t = self._n_tasks % n_workers
                     i: Py_ssize_t
-                    for i in range(0, n_workers):
+                    for i in range(n_workers):
                         wp_i = wp_vals[i + start % n_workers]
                         if wp_i._occupancy == 0:
                             ws = wp_i

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2138,8 +2138,9 @@ class SchedulerState:
                             break
                     else:
                         for i in range(start):
-                            if wp_vals[i].occupancy == 0:
-                                ws = wp_vals[i]
+                            wp_i = wp_vals[i]
+                            if wp_i._occupancy == 0:
+                                ws = wp_i
                                 break
             else:  # dumb but fast in large case
                 ws = worker_pool.values()[self._n_tasks % n_workers]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2124,9 +2124,9 @@ class SchedulerState:
             worker_pool = self._idle or self._workers
             worker_pool_dv = cast(dict, worker_pool)
             n_workers: Py_ssize_t = len(worker_pool_dv)
-            if n_workers < 20:
+            if n_workers < 20:  # smart but linear in small case
                 ws = min(worker_pool.values(), key=operator.attrgetter("occupancy"))
-                if ws.occupancy == 0:
+                if ws.occupancy == 0:  # special case to use round-robin
                     ws = worker_pool.values()[self._n_tasks % n_workers]
             else:  # dumb but fast in large case
                 ws = worker_pool.values()[self._n_tasks % n_workers]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2128,6 +2128,7 @@ class SchedulerState:
                 ws = min(worker_pool.values(), key=operator.attrgetter("occupancy"))
                 if ws._occupancy == 0:  # special case to use round-robin
                     wp_vals = worker_pool.values()
+                    wp_i: WorkerState
                     start: Py_ssize_t = self._n_tasks % n_workers
                     i: Py_ssize_t
                     for i in range(start, n_workers):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2126,7 +2126,7 @@ class SchedulerState:
             n_workers: Py_ssize_t = len(worker_pool_dv)
             if n_workers < 20:  # smart but linear in small case
                 ws = min(worker_pool.values(), key=operator.attrgetter("occupancy"))
-                if ws.occupancy == 0:  # special case to use round-robin
+                if ws._occupancy == 0:  # special case to use round-robin
                     wp_vals = worker_pool.values()
                     start = self._n_tasks % n_workers
                     for i in range(start, n_workers):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2124,14 +2124,10 @@ class SchedulerState:
             worker_pool = self._idle or self._workers
             worker_pool_dv = cast(dict, worker_pool)
             n_workers: Py_ssize_t = len(worker_pool_dv)
-            # if all occupancies in worker pool of size less than 20
-            # sum to under 0.1 of 1ms; go to the else branch (a round
-            # robin) because the cluster is considered quiet.
-            if (
-                n_workers < 20
-                and sum(w.occupancy for w in worker_pool.values()) > 1.0e-04
-            ):  # smart but linear in small case
+            if n_workers < 20:
                 ws = min(worker_pool.values(), key=operator.attrgetter("occupancy"))
+                if ws.occupancy == 0:
+                    ws = worker_pool.values()[self._n_tasks % n_workers]
             else:  # dumb but fast in large case
                 ws = worker_pool.values()[self._n_tasks % n_workers]
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2135,7 +2135,7 @@ class SchedulerState:
                     start: Py_ssize_t = self._n_tasks % n_workers
                     i: Py_ssize_t
                     for i in range(n_workers):
-                        wp_i = wp_vals[i + start % n_workers]
+                        wp_i = wp_vals[(i + start) % n_workers]
                         if wp_i._occupancy == 0:
                             ws = wp_i
                             break

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2128,7 +2128,8 @@ class SchedulerState:
                 ws = min(worker_pool.values(), key=operator.attrgetter("occupancy"))
                 if ws._occupancy == 0:  # special case to use round-robin
                     wp_vals = worker_pool.values()
-                    start = self._n_tasks % n_workers
+                    start: Py_ssize_t = self._n_tasks % n_workers
+                    i: Py_ssize_t
                     for i in range(start, n_workers):
                         if wp_vals[i].occupancy == 0:
                             ws = wp_vals[i]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2132,8 +2132,9 @@ class SchedulerState:
                     start: Py_ssize_t = self._n_tasks % n_workers
                     i: Py_ssize_t
                     for i in range(start, n_workers):
-                        if wp_vals[i].occupancy == 0:
-                            ws = wp_vals[i]
+                        wp_i = wp_vals[i]
+                        if wp_i._occupancy == 0:
+                            ws = wp_i
                             break
                     else:
                         for i in range(start):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2123,14 +2123,14 @@ class SchedulerState:
         else:
             worker_pool = self._idle or self._workers
             worker_pool_dv = cast(dict, worker_pool)
+            wp_vals = worker_pool.values()
             n_workers: Py_ssize_t = len(worker_pool_dv)
             if n_workers < 20:  # smart but linear in small case
-                ws = min(worker_pool.values(), key=operator.attrgetter("occupancy"))
+                ws = min(wp_vals, key=operator.attrgetter("occupancy"))
                 if ws._occupancy == 0:
                     # special case to use round-robin; linear search
                     # for next worker with zero occupancy (or just
                     # land back where we started).
-                    wp_vals = worker_pool.values()
                     wp_i: WorkerState
                     start: Py_ssize_t = self._n_tasks % n_workers
                     i: Py_ssize_t
@@ -2140,7 +2140,7 @@ class SchedulerState:
                             ws = wp_i
                             break
             else:  # dumb but fast in large case
-                ws = worker_pool.values()[self._n_tasks % n_workers]
+                ws = wp_vals[self._n_tasks % n_workers]
 
         if self._validate:
             assert ws is None or isinstance(ws, WorkerState), (

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -210,26 +210,24 @@ def test_unsupported_arguments(client, s, a, b):
 def test_retries(client):
     args = [ZeroDivisionError("one"), ZeroDivisionError("two"), 42]
 
-    with client.get_executor(retries=3, pure=False) as e:
+    with client.get_executor(retries=5, pure=False) as e:
         future = e.submit(varying(args))
         assert future.result() == 42
 
-    with client.get_executor(retries=2) as e:
+    with client.get_executor(retries=4) as e:
         future = e.submit(varying(args))
         result = future.result()
         assert result == 42
 
-    with client.get_executor(retries=1) as e:
+    with client.get_executor(retries=2) as e:
         future = e.submit(varying(args))
-        with pytest.raises(ZeroDivisionError) as exc_info:
+        with pytest.raises(ZeroDivisionError, match="two"):
             res = future.result()
-        exc_info.match("two")
 
     with client.get_executor(retries=0) as e:
         future = e.submit(varying(args))
-        with pytest.raises(ZeroDivisionError) as exc_info:
+        with pytest.raises(ZeroDivisionError, match="one"):
             res = future.result()
-        exc_info.match("one")
 
 
 def test_shutdown(loop):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1691,14 +1691,6 @@ async def test_result_type(c, s, a, b):
     assert "int" in s.tasks[x.key].type
 
 
-@gen_cluster(client=True)
-async def test_round_robin_dd(c, s, a, b):
-    await c.submit(inc, 1)
-    await c.submit(inc, 2)
-    await c.submit(inc, 3)
-    assert a.log and b.log
-
-
 @gen_cluster()
 async def test_close_workers(s, a, b):
     await s.close(close_workers=True)
@@ -2209,3 +2201,11 @@ async def test_configurable_events_log_length(c, s, a, b):
     assert s.events["test"][0][1] == "dummy message 2"
     assert s.events["test"][1][1] == "dummy message 3"
     assert s.events["test"][2][1] == "dummy message 4"
+
+
+@gen_cluster(client=True)
+async def test_quiet_cluster_round_robin(c, s, a, b):
+    await c.submit(inc, 1)
+    await c.submit(inc, 2)
+    await c.submit(inc, 3)
+    assert a.log and b.log

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2213,3 +2213,11 @@ async def test_get_worker_monitor_info(s, a, b):
         assert all(res[w.address]["range_query"][m] is not None for m in ms)
         assert res[w.address]["count"] is not None
         assert res[w.address]["last_time"] is not None
+
+
+@gen_cluster(client=True)
+async def test_quiet_cluster_round_robin(c, s, a, b):
+    await c.submit(inc, 1)
+    await c.submit(inc, 2)
+    await c.submit(inc, 3)
+    assert a.log and b.log

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1691,6 +1691,14 @@ async def test_result_type(c, s, a, b):
     assert "int" in s.tasks[x.key].type
 
 
+@gen_cluster(client=True)
+async def test_round_robin_dd(c, s, a, b):
+    await c.submit(inc, 1)
+    await c.submit(inc, 2)
+    await c.submit(inc, 3)
+    assert a.log and b.log
+
+
 @gen_cluster()
 async def test_close_workers(s, a, b):
     await s.close(close_workers=True)


### PR DESCRIPTION
This adds an additional check to avoid quiet clusters (as Matt describes in #4637) repeatedly using the same worker (the new test fails without the added sum of occupancies check). I understand this is a CPU sensitive area, and perhaps the sum of occupancies is too expensive a task to use here. Very happy to hear suggestions to try alternatives.

- [x] Closes #4637
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`
