### PR TITLE
Add iterate_collection argument to serialize

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -48,20 +48,14 @@ def dumps(msg, serializers=None, on_error="message", context=None) -> list:
         def _encode_default(obj):
             typ = type(obj)
             if typ is Serialize or typ is Serialized:
-                iterate_collection = None
                 if typ is Serialize:
-                    iterate_collection = obj.iterate_collection
                     obj = obj.data
                 offset = len(frames)
                 if typ is Serialized:
                     sub_header, sub_frames = obj.header, obj.frames
                 else:
                     sub_header, sub_frames = serialize_and_split(
-                        obj,
-                        serializers=serializers,
-                        on_error=on_error,
-                        context=context,
-                        iterate_collection=iterate_collection,
+                        obj, serializers=serializers, on_error=on_error, context=context
                     )
                     _inplace_compress_frames(sub_header, sub_frames)
                 sub_header["num-sub-frames"] = len(sub_frames)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -48,11 +48,17 @@ def dumps(msg, serializers=None, on_error="message", context=None) -> list:
         def _encode_default(obj):
             typ = type(obj)
             if typ is Serialize or typ is Serialized:
+                iterate_collection = None
                 if typ is Serialize:
+                    iterate_collection = obj.iterate_collection
                     obj = obj.data
                 offset = len(frames)
                 sub_header, sub_frames = serialize_and_split(
-                    obj, serializers=serializers, on_error=on_error, context=context
+                    obj,
+                    serializers=serializers,
+                    on_error=on_error,
+                    context=context,
+                    iterate_collection=iterate_collection,
                 )
                 sub_header["num-sub-frames"] = len(sub_frames)
                 _inplace_compress_frames(sub_header, sub_frames)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -48,8 +48,6 @@ def dumps(msg, serializers=None, on_error="message", context=None) -> list:
         def _encode_default(obj):
             typ = type(obj)
             if typ is Serialize or typ is Serialized:
-                if typ is Serialize:
-                    obj = obj.data
                 offset = len(frames)
                 if typ is Serialized:
                     sub_header, sub_frames = obj.header, obj.frames

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -195,7 +195,7 @@ def check_dask_serializable(x):
     return False
 
 
-def serialize(x, serializers=None, on_error="message", context=None):
+def serialize(x, serializers=None, on_error="message", context=None, iterate_collection=None):
     r"""
     Convert object to a header and list of bytestrings
 
@@ -238,7 +238,7 @@ def serialize(x, serializers=None, on_error="message", context=None):
         return x.header, x.frames
 
     if type(x) in (list, set, tuple, dict):
-        iterate_collection = False
+        iterate_collection = iterate_collection or False
         if type(x) is list and "msgpack" in serializers:
             # Note: "msgpack" will always convert lists to tuples
             #       (see GitHub #3716), so we should iterate

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -211,6 +211,12 @@ def serialize(
     per-class serialization methods. ``None`` gives the default list
     ``['dask', 'pickle']``.
 
+    Notes on the ``iterate_collection`` argument (only relevant when
+    ``x`` is a collection):
+    - ``iterate_collection=True``: Serialize collection elements separately.
+    - ``iterate_collection=False``: Serialize collection elements together.
+    - ``iterate_collection=None`` (default): Infer the best setting.
+
     Examples
     --------
     >>> serialize(1)
@@ -239,8 +245,7 @@ def serialize(
     if isinstance(x, Serialized):
         return x.header, x.frames
 
-    if type(x) in (list, set, tuple, dict):
-        iterate_collection = iterate_collection or False
+    if iterate_collection is None and type(x) in (list, set, tuple, dict):
         if type(x) is list and "msgpack" in serializers:
             # Note: "msgpack" will always convert lists to tuples
             #       (see GitHub #3716), so we should iterate

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -395,7 +395,9 @@ def deserialize(header, frames, deserializers=None):
     return loads(header, frames)
 
 
-def serialize_and_split(x, serializers=None, on_error="message", context=None):
+def serialize_and_split(
+    x, serializers=None, on_error="message", context=None, iterate_collection=None
+):
     """Serialize and split compressable frames
 
     This function is a drop-in replacement of `serialize()` that calls `serialize()`
@@ -408,7 +410,9 @@ def serialize_and_split(x, serializers=None, on_error="message", context=None):
     serialize
     merge_and_deserialize
     """
-    header, frames = serialize(x, serializers, on_error, context)
+    header, frames = serialize(
+        x, serializers, on_error, context, iterate_collection=iterate_collection
+    )
     num_sub_frames = []
     offsets = []
     out_frames = []
@@ -475,8 +479,11 @@ class Serialize:
     distributed.protocol.dumps
     """
 
-    def __init__(self, data):
+    def __init__(self, data, iterate_collection=None):
         self.data = data
+        # Optional `iterate_collection` argument will
+        # be passed down to `serialize` function.
+        self.iterate_collection = iterate_collection
 
     def __repr__(self):
         return "<Serialize: %s>" % str(self.data)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -195,7 +195,9 @@ def check_dask_serializable(x):
     return False
 
 
-def serialize(x, serializers=None, on_error="message", context=None, iterate_collection=None):
+def serialize(
+    x, serializers=None, on_error="message", context=None, iterate_collection=None
+):
     r"""
     Convert object to a header and list of bytestrings
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -243,8 +243,18 @@ def serialize(
     if serializers is None:
         serializers = ("dask", "pickle")  # TODO: get from configuration
 
+    # Handle obects that are marked as `Serialize`, or that are
+    # already `Serialized` objects (don't want to serialize them twice)
     if isinstance(x, Serialized):
         return x.header, x.frames
+    if isinstance(x, Serialize):
+        return serialize(
+            x.data,
+            serializers=serializers,
+            on_error=on_error,
+            context=context,
+            iterate_collection=iterate_collection,
+        )
 
     if iterate_collection is None and type(x) in (list, set, tuple, dict):
         if type(x) is list and "msgpack" in serializers:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -253,7 +253,7 @@ def serialize(
             serializers=serializers,
             on_error=on_error,
             context=context,
-            iterate_collection=iterate_collection,
+            iterate_collection=True,
         )
 
     if iterate_collection is None and type(x) in (list, set, tuple, dict):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -406,9 +406,7 @@ def deserialize(header, frames, deserializers=None):
     return loads(header, frames)
 
 
-def serialize_and_split(
-    x, serializers=None, on_error="message", context=None, iterate_collection=None
-):
+def serialize_and_split(x, serializers=None, on_error="message", context=None):
     """Serialize and split compressable frames
 
     This function is a drop-in replacement of `serialize()` that calls `serialize()`
@@ -421,9 +419,7 @@ def serialize_and_split(
     serialize
     merge_and_deserialize
     """
-    header, frames = serialize(
-        x, serializers, on_error, context, iterate_collection=iterate_collection
-    )
+    header, frames = serialize(x, serializers, on_error, context)
     num_sub_frames = []
     offsets = []
     out_frames = []
@@ -490,11 +486,8 @@ class Serialize:
     distributed.protocol.dumps
     """
 
-    def __init__(self, data, iterate_collection=None):
+    def __init__(self, data):
         self.data = data
-        # Optional `iterate_collection` argument will
-        # be passed down to `serialize` function.
-        self.iterate_collection = iterate_collection
 
     def __repr__(self):
         return "<Serialize: %s>" % str(self.data)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -151,15 +151,20 @@ def test_serialize_iterate_collection():
 
     arr = "special-data"
     sarr = Serialized(*serialize(arr))
+    sdarr = to_serialize(arr)
 
-    task = (0, sarr, "('fake-key', 3)", None)
+    task1 = (0, sarr, "('fake-key', 3)", None)
+    task2 = (0, sdarr, "('fake-key', 3)", None)
     expect = (0, arr, "('fake-key', 3)", None)
 
     # Check serialize/deserialize directly
-    assert deserialize(*serialize(task, iterate_collection=True)) == expect
+    assert deserialize(*serialize(task1, iterate_collection=True)) == expect
+    assert deserialize(*serialize(task2, iterate_collection=True)) == expect
 
     # Check to_serialize -> dumps -> loads
-    d = dumps(to_serialize(task, iterate_collection=True))
+    d = dumps(to_serialize(task1, iterate_collection=True))
+    assert loads(d) == expect
+    d = dumps(to_serialize(task2, iterate_collection=True))
     assert loads(d) == expect
 
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -161,12 +161,6 @@ def test_serialize_iterate_collection():
     assert deserialize(*serialize(task1, iterate_collection=True)) == expect
     assert deserialize(*serialize(task2, iterate_collection=True)) == expect
 
-    # Check to_serialize -> dumps -> loads
-    d = dumps(to_serialize(task1, iterate_collection=True))
-    assert loads(d) == expect
-    d = dumps(to_serialize(task2, iterate_collection=True))
-    assert loads(d) == expect
-
 
 from dask import delayed
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -145,6 +145,19 @@ def test_nested_deserialize():
     assert x == x_orig  # x wasn't mutated
 
 
+def test_serialize_iterate_collection():
+    # Use iterate_collection to ensure elements of
+    # a collection will be serialized seperately
+
+    arr = "special-data"
+    sarr = Serialized(*serialize(arr))
+
+    task = (0, sarr, "('fake-key', 3)", None)
+    expect = (0, arr, "('fake-key', 3)", None)
+
+    assert deserialize(*serialize(task, iterate_collection=True)) == expect
+
+
 from distributed.utils_test import gen_cluster
 from dask import delayed
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -155,7 +155,12 @@ def test_serialize_iterate_collection():
     task = (0, sarr, "('fake-key', 3)", None)
     expect = (0, arr, "('fake-key', 3)", None)
 
+    # Check serialize/deserialize directly
     assert deserialize(*serialize(task, iterate_collection=True)) == expect
+
+    # Check to_serialize -> dumps -> loads
+    d = dumps(to_serialize(task, iterate_collection=True))
+    assert loads(d) == expect
 
 
 from distributed.utils_test import gen_cluster

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -21,7 +21,6 @@ from distributed.comm import Comm
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.core import ConnectionPool, Status, connect, rpc
 from distributed.metrics import time
-from distributed.protocol import Serialized, deserialize, serialize
 from distributed.protocol.pickle import dumps
 from distributed.scheduler import Scheduler
 from distributed.utils import TimeoutError, tmpfile, typename
@@ -42,12 +41,7 @@ from distributed.utils_test import (  # noqa: F401
     tls_only_security,
     varying,
 )
-from distributed.worker import (
-    dumps_function,
-    dumps_task,
-    serialize_task,
-    warn_serialize,
-)
+from distributed.worker import dumps_function, dumps_task
 
 if sys.version_info < (3, 8):
     try:
@@ -496,48 +490,6 @@ def test_dumps_task():
     assert cloudpickle.loads(d["function"])(1, 2) == 3
     assert cloudpickle.loads(d["args"]) == (1,)
     assert set(d) == {"function", "args"}
-
-
-def test_serialize_task():
-    d = dumps_task((inc, 1))
-    assert set(d) == {"function", "args"}
-
-    f = lambda x, y=2: x + y
-    d = serialize_task((apply, f, (1,), {"y": 10}), dump_args=True, dump_kwargs=True)
-    assert cloudpickle.loads(d["function"])(1, 2) == 3
-    assert cloudpickle.loads(d["args"]) == (1,)
-    assert cloudpickle.loads(d["kwargs"]) == {"y": 10}
-
-    d = serialize_task((apply, f, (1,)), dump_args=True)
-    assert cloudpickle.loads(d["function"])(1, 2) == 3
-    assert cloudpickle.loads(d["args"]) == (1,)
-    assert set(d) == {"function", "args"}
-
-    # Check that dumps_task properly uses warn_serialize
-    arr = "special-data"
-    sarr = Serialized(*serialize(arr))
-    task = (dumps_function(f), sarr, "('fake-key', 3)", None)
-    expect = (arr, "('fake-key', 3)", None)
-    s = serialize_task(task)
-    assert cloudpickle.loads(s["function"])(1, 2) == 3
-    d = s["args"]
-    assert deserialize(d.header, d.frames) == expect
-    assert set(s) == {"function", "args"}
-
-
-def test_warn_serialize():
-
-    arr = "special-data"
-    sarr = Serialized(*serialize(arr))
-
-    task = (0, sarr, "('fake-key', 3)", None)
-    expect = (0, arr, "('fake-key', 3)", None)
-
-    with pytest.warns(UserWarning):
-        warn_serialize(task, limit=1)
-
-    d = warn_serialize(task)
-    assert deserialize(d.header, d.frames) == expect
 
 
 @gen_cluster()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -21,8 +21,8 @@ from distributed.comm import Comm
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.core import ConnectionPool, Status, connect, rpc
 from distributed.metrics import time
+from distributed.protocol import Serialized, dumps, loads, serialize
 from distributed.protocol.pickle import dumps
-from distributed.protocol import Serialized, serialize, dumps, loads
 from distributed.scheduler import Scheduler
 from distributed.utils import TimeoutError, tmpfile, typename
 from distributed.utils_test import (  # noqa: F401

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -470,11 +470,6 @@ def test_dumps_function():
     c = dumps_function(dec)
     assert a != c
 
-    a = dumps_function(inc)
-    a2 = dumps_function(a)
-    assert a is a2
-    assert cloudpickle.loads(a2)(10) == 11
-
 
 def test_dumps_task():
     d = dumps_task((inc, 1))

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3549,7 +3549,7 @@ def _serialized_task_arg(args):
     return any(isinstance(arg, Serialized) for arg in args)
 
 
-def dumps_task(task):
+def dumps_task(task, check_task=True):
     """Serialize a dask task
 
     Returns a dict of bytestrings that can each be loaded with ``loads``.
@@ -3571,7 +3571,7 @@ def dumps_task(task):
     >>> dumps_task(1)  # doctest: +SKIP
     {'task': b'\x80\x04\x95\x03\x00\x00\x00\x00\x00\x00\x00K\x01.'}
     """
-    if istask(task):
+    if not check_task or istask(task):
         if task[0] is apply and not any(map(_maybe_complex, task[2:])):
             # Use `warn_serialize` if any elements of `task` are `Serialized`.
             # Otherwise, we can just use warn_dumps (pickle)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -46,7 +46,14 @@ from .http import get_handlers
 from .metrics import time
 from .node import ServerNode
 from .proctitle import setproctitle
-from .protocol import deserialize_bytes, pickle, serialize_bytelist, to_serialize, serialize, Serialized
+from .protocol import (
+    Serialized,
+    deserialize_bytes,
+    pickle,
+    serialize,
+    serialize_bytelist,
+    to_serialize,
+)
 from .pubsub import PubSubWorkerExtension
 from .security import Security
 from .sizeof import safe_sizeof as sizeof
@@ -3545,7 +3552,9 @@ def _serialized_task_arg(args):
 def dumps_task(task):
     """Serialize a dask task
 
-    Returns a dict of bytestrings that can each be loaded with ``loads``
+    Returns a dict of bytestrings that can each be loaded with ``loads``.
+    If any elements of the task are ``Serialized`` objects, the returned
+    dict elements will contain ``Serialized`` objects instead.
 
     Examples
     --------
@@ -3579,6 +3588,7 @@ def dumps_task(task):
 
 _warn_dumps_warned = [False]
 
+
 def _large_object_msg(nbytes, obj):
     s = str(obj)
     if len(s) > 70:
@@ -3595,6 +3605,7 @@ def _large_object_msg(nbytes, obj):
         % (format_bytes(nbytes), s)
     )
 
+
 def warn_dumps(obj, dumps=pickle.dumps, limit=1e6):
     """ Dump an object to bytes, warn if those bytes are large """
     b = dumps(obj, protocol=4)
@@ -3603,7 +3614,9 @@ def warn_dumps(obj, dumps=pickle.dumps, limit=1e6):
         warnings.warn(_large_object_msg(len(b), obj))
     return b
 
+
 _warn_serialize_warned = [False]
+
 
 def warn_serialize(obj, limit=1e6):
     """ Serialize an object, warn if the result is too large """

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3544,7 +3544,7 @@ def dumps_function(func):
 def dumps_task(task):
     """Serialize a dask task
 
-    Returns a dict of bytestrings that can each be loaded with ``loads``.
+    Returns a dict of bytestrings that can each be loaded with ``loads``
 
     Examples
     --------

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3581,19 +3581,15 @@ def serialize_task(task, dump_args=False, dump_kwargs=False):
     objects, the ``dump_args`` and/or ``dumps_kwargs`` options can
     be used to avoid serializing the seperate elements of args/kwargs.
     """
+    _to_serialize = partial(to_serialize, iterate_collection=True)
     if task[0] is apply and not any(map(_maybe_complex, task[2:])):
-        # Use `warn_serialize` if any elements of `task` are `Serialized`.
-        # Otherwise, we can just use warn_dumps (pickle)
-        _dumps = warn_dumps if dump_args else warn_serialize
-        d = {"function": dumps_function(task[1]), "args": _dumps(task[2])}
+        d = {"function": dumps_function(task[1]), "args": _to_serialize(task[2])}
         if len(task) == 4:
-            _dumps = warn_dumps if dump_kwargs else warn_serialize
-            d["kwargs"] = _dumps(task[3])
+            d["kwargs"] = _to_serialize(task[3])
         return d
     elif not any(map(_maybe_complex, task[1:])):
-        _dumps = warn_dumps if dump_args else warn_serialize
-        return {"function": dumps_function(task[0]), "args": _dumps(task[1:])}
-    return to_serialize(task, iterate_collection=True)
+        return {"function": dumps_function(task[0]), "args": _to_serialize(task[1:])}
+    return _to_serialize(task)
 
 
 _warn_dumps_warned = [False]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3512,25 +3512,18 @@ cache_dumps = LRU(maxsize=100)
 _cache_lock = threading.Lock()
 
 
-def _pickle_non_bytes(func):
-    # Used by `dumps_function`.
-    # Assume that we only want to pickle an
-    # object that is not already `bytes`.
-    return func if isinstance(func, bytes) else pickle.dumps(func, protocol=4)
-
-
 def dumps_function(func):
     """ Dump a function to bytes, cache functions """
     try:
         with _cache_lock:
             result = cache_dumps[func]
     except KeyError:
-        result = _pickle_non_bytes(func)
+        result = pickle.dumps(func, protocol=4)
         if len(result) < 100000:
             with _cache_lock:
                 cache_dumps[func] = result
     except TypeError:  # Unhashable function
-        result = _pickle_non_bytes(func)
+        result = pickle.dumps(func, protocol=4)
     return result
 
 


### PR DESCRIPTION
This PR is motivated by serialization needs for the ongoing Blockwise-IO work in dask/dask (e.g [dask#7417](https://github.com/dask/dask/pull/7417), [dask#7415](https://github.com/dask/dask/pull/7415)).  One critical issue is that `serialize` is not guarenteed to iterate through the elements of a task (and generate seperate header/frames for each element).  This is a problem when one or more of those task elements are a `Serialized` object - We don't what these objects to be grouped together with the other elements in a single blob of bytes, otherwise the object will remain `Serialized` when it is passed to the actual function on the worker.

Note that I also think that we should **always** use `serialize(..., iterate_collection=True)` when the object is a task. However, I'll rather leave that work for a seperate PR.