### PR TITLE
Re-introduce "logging" to the default config

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3494,8 +3494,8 @@ class Client:
         Parameters
         ----------
         n : int
-            Number of logs to retrive.  Maxes out at 10000 by default,
-            confiruable in config.yaml::log-length
+            Number of logs to retrive.  Maxes out at 100000 by default,
+            confiruable in distributed.yaml::transition-log-length
 
         Returns
         -------
@@ -3509,8 +3509,8 @@ class Client:
         Parameters
         ----------
         n : int
-            Number of logs to retrive.  Maxes out at 10000 by default,
-            confiruable in config.yaml::log-length
+            Number of logs to retrive.  Set to 0 by default,
+            confiruable in distributed.yaml::recent-messages-log-length
         workers : iterable
             List of worker addresses to retrieve.  Gets all workers by default.
         nanny : bool, default False

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -1,12 +1,12 @@
 distributed:
   version: 2
-  # logging:
-  #   distributed: info
-  #   distributed.client: warning
-  #   bokeh: critical
-  #   # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
-  #   tornado: critical
-  #   tornado.application: error
+  logging:
+    distributed: info
+    distributed.client: warning
+    bokeh: critical
+    # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
+    tornado: critical
+    tornado.application: error
 
   scheduler:
     allowed-failures: 3     # number of retries before a task is considered bad


### PR DESCRIPTION
- [ ] ~~Closes #xxxx~~ N/A
- [ ] ~~Tests added / passed~~ N/A
- [ ] ~~Passes `black distributed` / `flake8 distributed`~~ N/A (locally, `black==19.10b0` suggests that there should be an unrelated update elsewhere in `distributed/client.py`, but I'm not convinced that's an actual issue, because it would've been addressed beforehand, otherwise)

I've marked the latter two as "N/A" as well, because the proposed PR doesn't update the docstring style. It only updates docstring contents in two instances, as well as re-enables the `logging` section of `distributed/distributed.yaml`.

Some further details: 
- `logging` was removed from the config in 399522b95 (#1948), and the assumption made in the present commit is that
    it was done unintentionally, since [docs/source/configuration.rst](https://github.com/dask/dask/blob/main/docs/source/configuration.rst) (dask) wasn't updated around the same time as 399522b95.
- Later down the line, in response to https://stackoverflow.com/questions/57829474/dask-config-get-cannot-get-anything,
    (https://github.com/dask/dask/pull/5374) was merged, which didn't update the documentation either.
- The above two facts, combined together, suggest that `logging` must've been removed unintentionally from the config.

Please, feel free to reject or propose changes (the documentation will probably need to be updated) to this PR, if the `logging` section _was_ intentionally removed from `distributed.yaml`.
