### PR TITLE
DOC: Update out-of-date references to `config.yaml`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3495,7 +3495,8 @@ class Client:
         ----------
         n : int
             Number of logs to retrive.  Maxes out at 10000 by default,
-            confiruable in config.yaml::log-length
+            configurable via the ``distributed.admin.log-length``
+            configuration value.
 
         Returns
         -------
@@ -3510,7 +3511,8 @@ class Client:
         ----------
         n : int
             Number of logs to retrive.  Maxes out at 10000 by default,
-            confiruable in config.yaml::log-length
+            configurable via the ``distributed.admin.log-length``
+            configuration value.
         workers : iterable
             List of worker addresses to retrieve.  Gets all workers by default.
         nanny : bool, default False


### PR DESCRIPTION
- [ ] ~~Closes #xxxx~~ N/A
- [ ] ~~Tests added / passed~~ N/A
- [ ] ~~Passes `black distributed` / `flake8 distributed`~~ N/A (locally, `black==19.10b0` suggests that there should be an unrelated update elsewhere in `distributed/client.py`, but I'm not convinced that's an actual issue, because it would've been addressed beforehand, otherwise)

Extracted out of https://github.com/dask/distributed/pull/4642.
The proposed PR updates docstring contents (outdated references to config file and associated config items) in two instances in `distributed/client.py`.