### PR TITLE
[docs] expand documentation on pure functions

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1512,6 +1512,7 @@ class Client:
         pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
+            See "Pure Functions by Default" in :doc:`client` for more details.
         workers : string or iterable of strings
             A set of worker addresses or hostnames on which computations may be
             performed. Leave empty to default to all workers (common case)
@@ -1631,6 +1632,7 @@ class Client:
         pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
+            See "Pure Functions by Default" in :doc:`client` for more details.
         workers : string or iterable of strings
             A set of worker hostnames on which computations may be performed.
             Leave empty to default to all workers (common case)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1512,7 +1512,7 @@ class Client:
         pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-            See "Pure Functions by Default" in :doc:`client` for more details.
+            See :ref:`pure functions` for more details.
         workers : string or iterable of strings
             A set of worker addresses or hostnames on which computations may be
             performed. Leave empty to default to all workers (common case)
@@ -1632,7 +1632,7 @@ class Client:
         pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-            See "Pure Functions by Default" in :doc:`client` for more details.
+            See :ref:`pure functions` for more details.
         workers : string or iterable of strings
             A set of worker hostnames on which computations may be performed.
             Leave empty to default to all workers (common case)

--- a/docs/source/client.rst
+++ b/docs/source/client.rst
@@ -108,6 +108,7 @@ which are used for larger and smaller result sets respectively.
 
 For more information see the page on :doc:`Managing Computation <manage-computation>`.
 
+.. _pure functions:
 
 Pure Functions by Default
 -------------------------
@@ -119,7 +120,7 @@ Pure functions:
 * always return the same output for a given set of inputs
 * do not have side effects, like modifying global state or creating files
 
-If this is not the case, you should use the ``pure=False`` keyword argument.
+If this is not the case, you should use the ``pure=False`` keyword argument in methods like ``Client.map()`` and ``Client.submit()``.
 
 The client associates a key to all computations.  This key is accessible on
 the Future object.

--- a/docs/source/client.rst
+++ b/docs/source/client.rst
@@ -112,8 +112,14 @@ For more information see the page on :doc:`Managing Computation <manage-computat
 Pure Functions by Default
 -------------------------
 
-By default we assume that all functions are pure_.  If this is not the case we
-should use the ``pure=False`` keyword argument.
+By default, ``distributed`` assumes that all functions are pure_.
+
+Pure functions:
+
+* always return the same output for a given set of inputs
+* do not have side effects, like modifying global state or creating files
+
+If this is not the case, you should use the ``pure=False`` keyword argument.
 
 The client associates a key to all computations.  This key is accessible on
 the Future object.


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed`

## Changes in this PR

* adds plain-language definition of "pure function" to the Client documentation
    - ![image](https://user-images.githubusercontent.com/7608904/112788524-b1b95b00-9020-11eb-82aa-966195af23df.png)

* links to the expanded doc on pure functions from the API docs on `Client.submit()` and `Client.map()`
    - ![image](https://user-images.githubusercontent.com/7608904/112788490-a23a1200-9020-11eb-98d0-cc9020bfb4b0.png)

## Background

I found myself working on a problem tonight that involved carefully controlling the behavior of `Client.submit()`, so I was reading the API docs for that method (https://distributed.dask.org/en/latest/api.html#distributed.Client.submit) to understand what could be controlled.

The documentation for `pure` doesn't provide any information about what "pure" actually means.

> Whether or not the function is pure. Set pure=False for impure functions like np.random.random.

I think that relies on users already being familiar with the concept of "pure functions". I personally was not familiar with that phrase, so I was left wondering "...is my function pure?".

Searching the rest of the documentation, I did find https://distributed.dask.org/en/latest/client.html#pure-functions-by-default which expands on this concept. But in my opinion, that section also doesn't define what "pure" is and is written for an audience that already understands that phrase. I didn't notice, until I looked at the raw `.rst` file for that page, that the word "pure" in the first sentence is a link out to [the `toolz` documentation](https://toolz.readthedocs.io/en/latest/purity.html).

![image](https://user-images.githubusercontent.com/7608904/112788309-3657a980-9020-11eb-8907-a832d069b66b.png)

I suspect that other people using `distributed` might not be familiar with the phrase "pure function".

I believe this PR's proposed changes make the documentation for the argument `pure` a bit more approachable, and make it easier to find the expanded docs about pure functions from the API docs for `Client.submit()`.

## Notes for reviewers

I tested the documentation locally with the following code, and didn't noticed any new warnings introduced by this change.

```shell
python setup.py install
cd docs
pip install -r requirements.txt
make clean html
```

Thanks for your time and consideration!