### PR TITLE
Add isort to pre-commit hooks, package resorting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 - [ ] Closes #xxxx
 - [ ] Tests added / passed
-- [ ] Passes `black distributed` / `flake8 distributed`
+- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  -   repo: https://github.com/pycqa/isort
+      rev: 5.7.0
+      hooks:
+      - id: isort
+        language_version: python3
   -   repo: https://github.com/psf/black
       rev: 20.8b1
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/pycqa/isort
-      rev: 5.7.0
+      rev: 5.8.0
       hooks:
       - id: isort
         language_version: python3

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 # https://pytest.org/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
 import pytest
 
-
 # Uncomment to enable more logging and checks
 # (https://docs.python.org/3/library/asyncio-dev.html)
 # Note this makes things slower and might consume much memory.

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,4 +1,4 @@
-from . import config  # isort:skip
+from . import config  # isort:skip; load distributed configuration first
 import dask
 from dask.config import config
 

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,41 +1,41 @@
-from . import config
+from . import config  # isort:skip
 import dask
 from dask.config import config
+
+from ._version import get_versions
 from .actor import Actor, ActorFuture
-from .core import connect, rpc, Status
-from .deploy import LocalCluster, Adaptive, SpecCluster, SSHCluster
-from .diagnostics.progressbar import progress
-from .diagnostics.plugin import WorkerPlugin, SchedulerPlugin, PipInstall
 from .client import (
     Client,
-    Executor,
     CompatibleExecutor,
-    wait,
+    Executor,
+    Future,
     as_completed,
     default_client,
     fire_and_forget,
-    Future,
     futures_of,
+    get_task_metadata,
     get_task_stream,
     performance_report,
-    get_task_metadata,
+    wait,
 )
+from .core import Status, connect, rpc
+from .deploy import Adaptive, LocalCluster, SpecCluster, SSHCluster
+from .diagnostics.plugin import PipInstall, SchedulerPlugin, WorkerPlugin
+from .diagnostics.progressbar import progress
+from .event import Event
 from .lock import Lock
 from .multi_lock import MultiLock
 from .nanny import Nanny
 from .pubsub import Pub, Sub
 from .queues import Queue
+from .scheduler import Scheduler
 from .security import Security
 from .semaphore import Semaphore
-from .event import Event
-from .scheduler import Scheduler
 from .threadpoolexecutor import rejoin
-from .utils import sync, TimeoutError, CancelledError
+from .utils import CancelledError, TimeoutError, sync
 from .variable import Variable
-from .worker import Worker, get_worker, get_client, secede, Reschedule
+from .worker import Reschedule, Worker, get_client, get_worker, secede
 from .worker_client import local_client, worker_client
-
-from ._version import get_versions
 
 versions = get_versions()
 __version__ = versions["version"]

--- a/distributed/_concurrent_futures_thread.py
+++ b/distributed/_concurrent_futures_thread.py
@@ -8,16 +8,17 @@
 __author__ = "Brian Quinlan (brian@sweetapp.com)"
 
 import atexit
-from concurrent.futures import _base
 import itertools
+from concurrent.futures import _base
 
 try:
     import queue
 except ImportError:
     import Queue as queue
+
+import os
 import threading
 import weakref
-import os
 
 # Workers are created as daemon threads. This is done to allow the interpreter
 # to exit when there are still idle threads in a ThreadPoolExecutor's thread

--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -12,19 +12,17 @@ try:
 except ImportError:
     # Python 2
     import Queue as queue
-from subprocess import Popen
-import sys
-from threading import Thread
-from uuid import uuid4
 
-from tornado.gen import TimeoutError
-from tornado.ioloop import IOLoop
-from threading import Event
+import sys
+from subprocess import Popen
+from threading import Event, Thread
+from uuid import uuid4
 
 from IPython import get_ipython
 from jupyter_client import BlockingKernelClient, write_connection_file
 from jupyter_core.paths import jupyter_runtime_dir
-
+from tornado.gen import TimeoutError
+from tornado.ioloop import IOLoop
 
 OUTPUT_TIMEOUT = 10
 

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -5,7 +5,7 @@ from queue import Queue
 
 from .client import Future, default_client
 from .protocol import to_serialize
-from .utils import iscoroutinefunction, thread_state, sync
+from .utils import iscoroutinefunction, sync, thread_state
 from .utils_comm import WrappedKey
 from .worker import get_worker
 

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -1,9 +1,10 @@
 import logging
 from collections import deque
 
-import dask
 from tornado import gen, locks
 from tornado.ioloop import IOLoop
+
+import dask
 
 from .core import CommClosedError
 from .utils import parse_timedelta

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -1,5 +1,5 @@
-from collections import deque
 import logging
+from collections import deque
 
 import dask
 from tornado import gen, locks
@@ -7,7 +7,6 @@ from tornado.ioloop import IOLoop
 
 from .core import CommClosedError
 from .utils import parse_timedelta
-
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/cfexecutor.py
+++ b/distributed/cfexecutor.py
@@ -2,11 +2,10 @@ import concurrent.futures as cf
 import weakref
 
 from tlz import merge
-
 from tornado import gen
 
 from .metrics import time
-from .utils import sync, TimeoutError
+from .utils import TimeoutError, sync
 
 
 @gen.coroutine

--- a/distributed/cfexecutor.py
+++ b/distributed/cfexecutor.py
@@ -5,7 +5,7 @@ from tlz import merge
 from tornado import gen
 
 from .metrics import time
-from .utils import sync, TimeoutError, parse_timedelta
+from .utils import TimeoutError, parse_timedelta, sync
 
 
 @gen.coroutine

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -1,18 +1,17 @@
 import atexit
-import logging
 import gc
+import logging
 import os
 import re
 import sys
 import warnings
 
 import click
-
 from tornado.ioloop import IOLoop
 
 from distributed import Scheduler
-from distributed.preloading import validate_preload_argv
 from distributed.cli.utils import check_python_3, install_signal_handlers
+from distributed.preloading import validate_preload_argv
 from distributed.proctitle import (
     enable_proctitle_on_children,
     enable_proctitle_on_current,

--- a/distributed/cli/dask_spec.py
+++ b/distributed/cli/dask_spec.py
@@ -1,7 +1,8 @@
 import asyncio
-import click
 import json
 import sys
+
+import click
 import yaml
 
 from distributed.deploy.spec import run_spec

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -1,7 +1,7 @@
-from distributed.deploy.old_ssh import SSHCluster
 import click
 
 from distributed.cli.utils import check_python_3
+from distributed.deploy.old_ssh import SSHCluster
 
 
 @click.command(

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -9,10 +9,11 @@ import warnings
 from contextlib import suppress
 
 import click
-import dask
-from dask.system import CPU_COUNT
 from tlz import valmap
 from tornado.ioloop import IOLoop, TimeoutError
+
+import dask
+from dask.system import CPU_COUNT
 
 from distributed import Nanny
 from distributed.cli.utils import check_python_3, install_signal_handlers

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -1,16 +1,19 @@
 import asyncio
 import atexit
-from contextlib import suppress
-import logging
 import gc
+import logging
 import os
 import signal
 import sys
 import warnings
+from contextlib import suppress
 
 import click
 import dask
 from dask.system import CPU_COUNT
+from tlz import valmap
+from tornado.ioloop import IOLoop, TimeoutError
+
 from distributed import Nanny
 from distributed.cli.utils import check_python_3, install_signal_handlers
 from distributed.comm import get_address_host_port
@@ -21,9 +24,6 @@ from distributed.proctitle import (
     enable_proctitle_on_current,
 )
 from distributed.utils import import_term
-
-from tlz import valmap
-from tornado.ioloop import IOLoop, TimeoutError
 
 logger = logging.getLogger("distributed.dask_worker")
 

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -3,26 +3,26 @@ import pytest
 pytest.importorskip("requests")
 
 import os
-import requests
-import socket
 import shutil
+import socket
 import sys
 import tempfile
 from time import sleep
 
+import requests
 from click.testing import CliRunner
 
 import distributed
-from distributed import Scheduler, Client
+import distributed.cli.dask_scheduler
+from distributed import Client, Scheduler
+from distributed.metrics import time
 from distributed.utils import get_ip, get_ip_interface, tmpfile
+from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import (
-    popen,
     assert_can_connect_from_everywhere_4_6,
     assert_can_connect_locally_4,
+    popen,
 )
-from distributed.utils_test import loop  # noqa: F401
-from distributed.metrics import time
-import distributed.cli.dask_scheduler
 
 
 def test_defaults(loop):

--- a/distributed/cli/tests/test_dask_spec.py
+++ b/distributed/cli/tests/test_dask_spec.py
@@ -1,10 +1,11 @@
-import pytest
 import sys
+
+import pytest
 import yaml
 
 from distributed import Client
-from distributed.utils_test import popen
 from distributed.utils_test import cleanup  # noqa: F401
+from distributed.utils_test import popen
 
 
 @pytest.mark.asyncio

--- a/distributed/cli/tests/test_dask_ssh.py
+++ b/distributed/cli/tests/test_dask_ssh.py
@@ -1,4 +1,5 @@
 from click.testing import CliRunner
+
 from distributed.cli.dask_ssh import main
 
 

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -1,22 +1,29 @@
 import asyncio
+
 import pytest
 from click.testing import CliRunner
 
 pytest.importorskip("requests")
 
-import requests
-import sys
 import os
-from time import sleep
+import sys
 from multiprocessing import cpu_count
+from time import sleep
+
+import requests
 
 import distributed.cli.dask_worker
 from distributed import Client, Scheduler
 from distributed.deploy.utils import nprocesses_nthreads
 from distributed.metrics import time
-from distributed.utils import sync, tmpfile, parse_ports
-from distributed.utils_test import popen, terminate_process, wait_for_port
-from distributed.utils_test import loop, cleanup  # noqa: F401
+from distributed.utils import parse_ports, sync, tmpfile
+from distributed.utils_test import (  # noqa: F401
+    cleanup,
+    loop,
+    popen,
+    terminate_process,
+    wait_for_port,
+)
 
 
 def test_nanny_worker_ports(loop):

--- a/distributed/cli/tests/test_tls_cli.py
+++ b/distributed/cli/tests/test_tls_cli.py
@@ -1,16 +1,15 @@
 from time import sleep
 
 from distributed import Client
+from distributed.metrics import time
+from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import (
-    popen,
     get_cert,
     new_config_file,
-    tls_security,
+    popen,
     tls_only_config,
+    tls_security,
 )
-from distributed.utils_test import loop  # noqa: F401
-from distributed.metrics import time
-
 
 ca_file = get_cert("tls-ca-cert.pem")
 cert = get_cert("tls-cert.pem")

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -1,6 +1,5 @@
 from tornado.ioloop import IOLoop
 
-
 py3_err_msg = """
 Warning: Your terminal does not set locales.
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -23,6 +23,8 @@ from functools import partial
 from numbers import Number
 from queue import Queue as pyQueue
 
+from tlz import first, groupby, keymap, merge, partition_all, valmap
+
 import dask
 from dask.base import collections_to_dsk, normalize_token, tokenize
 from dask.compatibility import apply
@@ -30,7 +32,6 @@ from dask.core import flatten
 from dask.highlevelgraph import HighLevelGraph
 from dask.optimization import SubgraphCallable
 from dask.utils import ensure_dict, format_bytes, funcname, stringify
-from tlz import first, groupby, keymap, merge, partition_all, valmap
 
 try:
     from dask.delayed import single_key

--- a/distributed/comm/__init__.py
+++ b/distributed/comm/__init__.py
@@ -1,21 +1,20 @@
 from .addressing import (
-    parse_address,
-    unparse_address,
-    normalize_address,
-    parse_host_port,
-    unparse_host_port,
-    resolve_address,
-    get_address_host_port,
     get_address_host,
+    get_address_host_port,
     get_local_address_for,
+    normalize_address,
+    parse_address,
+    parse_host_port,
+    resolve_address,
+    unparse_address,
+    unparse_host_port,
 )
-from .core import connect, listen, Comm, CommClosedError
+from .core import Comm, CommClosedError, connect, listen
 from .utils import get_tcp_server_address
 
 
 def _register_transports():
-    from . import inproc
-    from . import tcp
+    from . import inproc, tcp
 
     try:
         from . import ucx

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -1,9 +1,9 @@
 import itertools
+
 import dask
 
-from . import registry
 from ..utils import get_ip_interface
-
+from . import registry
 
 DEFAULT_SCHEME = dask.config.get("distributed.comm.default-scheme")
 

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -1,21 +1,20 @@
-from abc import ABC, abstractmethod, abstractproperty
 import asyncio
-from contextlib import suppress
 import inspect
 import logging
 import random
 import sys
 import weakref
+from abc import ABC, abstractmethod, abstractproperty
+from contextlib import suppress
 
 import dask
 
 from ..metrics import time
-from ..utils import parse_timedelta, TimeoutError
+from ..protocol import pickle
+from ..protocol.compression import get_default_compression
+from ..utils import TimeoutError, parse_timedelta
 from . import registry
 from .addressing import parse_address
-from ..protocol.compression import get_default_compression
-from ..protocol import pickle
-
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -1,21 +1,19 @@
 import asyncio
-from collections import deque, namedtuple
 import itertools
 import logging
 import os
 import threading
-import weakref
 import warnings
+import weakref
+from collections import deque, namedtuple
 
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 
 from ..protocol import nested_deserialize
 from ..utils import get_ip
-
+from .core import Comm, CommClosedError, Connector, Listener
 from .registry import Backend, backends
-from .core import Comm, Connector, Listener, CommClosedError
-
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -14,11 +14,12 @@ try:
 except ImportError:
     ssl = None
 
-import dask
 from tornado import netutil
 from tornado.iostream import StreamClosedError
 from tornado.tcpclient import TCPClient
 from tornado.tcpserver import TCPServer
+
+import dask
 
 from ..protocol.utils import pack_frames_prelude, unpack_frames
 from ..system import MEMORY_LIMIT

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -2,11 +2,12 @@ import errno
 import functools
 import logging
 import socket
-from ssl import SSLError
 import struct
 import sys
-from tornado import gen
 import weakref
+from ssl import SSLError
+
+from tornado import gen
 
 try:
     import ssl
@@ -19,16 +20,14 @@ from tornado.iostream import StreamClosedError
 from tornado.tcpclient import TCPClient
 from tornado.tcpserver import TCPServer
 
+from ..protocol.utils import pack_frames_prelude, unpack_frames
 from ..system import MEMORY_LIMIT
 from ..threadpoolexecutor import ThreadPoolExecutor
 from ..utils import ensure_ip, get_ip, get_ipv6, nbytes, parse_timedelta
-
-from .registry import Backend, backends
 from .addressing import parse_host_port, unparse_host_port
-from .core import Comm, Connector, Listener, CommClosedError, FatalCommClosedError
-from .utils import to_frames, from_frames, get_tcp_server_address, ensure_concrete_host
-from ..protocol.utils import pack_frames_prelude, unpack_frames
-
+from .core import Comm, CommClosedError, Connector, FatalCommClosedError, Listener
+from .registry import Backend, backends
+from .utils import ensure_concrete_host, from_frames, get_tcp_server_address, to_frames
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -6,11 +6,12 @@ import types
 import warnings
 from functools import partial
 
-import dask
 import pkg_resources
 import pytest
 from tornado import ioloop
 from tornado.concurrent import Future
+
+import dask
 
 import distributed
 from distributed.comm import (

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -7,10 +7,12 @@ import warnings
 from functools import partial
 
 import dask
-
-import distributed
 import pkg_resources
 import pytest
+from tornado import ioloop
+from tornado.concurrent import Future
+
+import distributed
 from distributed.comm import (
     CommClosedError,
     connect,
@@ -38,8 +40,6 @@ from distributed.utils_test import (
     has_ipv6,
     requires_ipv6,
 )
-from tornado import ioloop
-from tornado.concurrent import Future
 
 EXTERNAL_IP4 = get_ip()
 if has_ipv6():

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -1,16 +1,15 @@
 import asyncio
+
 import pytest
 
 ucp = pytest.importorskip("ucp")
 
-from distributed import Client, Worker, Scheduler, wait
-from distributed.comm import ucx, listen, connect
+from distributed import Client, Scheduler, Worker, wait
+from distributed.comm import connect, listen, parse_address, ucx
 from distributed.comm.registry import backends, get_backend
-from distributed.comm import ucx, parse_address
-from distributed.protocol import to_serialize
 from distributed.deploy.local import LocalCluster
-from distributed.utils_test import gen_test, loop, inc, cleanup, popen  # noqa: 401
-
+from distributed.protocol import to_serialize
+from distributed.utils_test import cleanup, gen_test, inc, loop, popen  # noqa: 401
 
 try:
     HOST = ucp.get_address()

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -1,7 +1,8 @@
 from time import sleep
 
-import dask
 import pytest
+
+import dask
 from dask.utils import format_bytes
 
 from distributed import Client

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -1,12 +1,13 @@
-import pytest
 from time import sleep
 
 import dask
+import pytest
 from dask.utils import format_bytes
+
 from distributed import Client
-from distributed.utils_test import gen_test, loop, inc, cleanup, popen  # noqa: 401
-from distributed.utils import get_ip
 from distributed.comm.ucx import _scrub_ucx_config
+from distributed.utils import get_ip
+from distributed.utils_test import cleanup, gen_test, inc, loop, popen  # noqa: 401
 
 try:
     HOST = get_ip()

--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -2,9 +2,10 @@ import os
 import tempfile
 import warnings
 
-import dask
 import numpy as np
 import pytest
+
+import dask
 
 from distributed import Client, Scheduler, Worker
 from distributed.comm import connect, listen, ws

--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -1,20 +1,21 @@
 import os
-import warnings
-import pytest
 import tempfile
+import warnings
 
-import numpy as np
 import dask
+import numpy as np
+import pytest
+
 from distributed import Client, Scheduler, Worker
-from distributed.security import Security
+from distributed.comm import connect, listen, ws
 from distributed.comm.registry import backends, get_backend
-from distributed.comm import ws, listen, connect
+from distributed.security import Security
 from distributed.utils_test import (  # noqa: F401
+    cleanup,
+    gen_cluster,
     get_client_ssl_context,
     get_server_ssl_context,
-    cleanup,
     inc,
-    gen_cluster,
 )
 
 from .test_comms import check_tls_extra

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -11,19 +11,19 @@ import weakref
 
 import dask
 
-from .addressing import parse_host_port, unparse_host_port
-from .core import Comm, Connector, Listener, CommClosedError
-from .registry import Backend, backends
-from .utils import ensure_concrete_host, to_frames, from_frames
 from ..utils import (
+    CancelledError,
     ensure_ip,
     get_ip,
     get_ipv6,
-    nbytes,
     log_errors,
-    CancelledError,
+    nbytes,
     parse_bytes,
 )
+from .addressing import parse_host_port, unparse_host_port
+from .core import Comm, CommClosedError, Connector, Listener
+from .registry import Backend, backends
+from .utils import ensure_concrete_host, from_frames, to_frames
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -9,7 +9,6 @@ from dask.utils import parse_bytes
 from .. import protocol
 from ..utils import get_ip, get_ipv6, nbytes, offload
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -1,26 +1,23 @@
 import asyncio
 import logging
 import struct
-import weakref
 import warnings
-
-from typing import Callable
+import weakref
 from ssl import SSLError
+from typing import Callable
 
-from tornado.iostream import StreamClosedError
-from tornado.httpserver import HTTPServer
-from tornado.httpclient import HTTPRequest
 from tornado import web
-from tornado.websocket import WebSocketClosedError, websocket_connect, WebSocketHandler
+from tornado.httpclient import HTTPRequest
+from tornado.httpserver import HTTPServer
+from tornado.iostream import StreamClosedError
+from tornado.websocket import WebSocketClosedError, WebSocketHandler, websocket_connect
 
 from ..utils import ensure_bytes, nbytes
-
-from .registry import backends
 from .addressing import parse_host_port, unparse_host_port
-from .core import Comm, CommClosedError, Listener, Connector, FatalCommClosedError
+from .core import Comm, CommClosedError, Connector, FatalCommClosedError, Listener
+from .registry import backends
 from .tcp import BaseTCPBackend, _expect_tls_context, convert_stream_closed_error
-from .utils import ensure_concrete_host, to_frames, from_frames, get_tcp_server_address
-
+from .utils import ensure_concrete_host, from_frames, get_tcp_server_address, to_frames
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -3,8 +3,9 @@ import logging.config
 import os
 import sys
 
-import dask
 import yaml
+
+import dask
 
 from .compatibility import logging_names
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -12,11 +12,12 @@ from contextlib import suppress
 from enum import Enum
 from functools import partial
 
-import dask
 import tblib
 from tlz import merge
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
+
+import dask
 
 from . import profile, protocol
 from .comm import (

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1,16 +1,16 @@
 import asyncio
-from collections import defaultdict
-from contextlib import suppress
-from enum import Enum
-from functools import partial
 import inspect
 import logging
 import sys
 import threading
 import traceback
 import uuid
-import weakref
 import warnings
+import weakref
+from collections import defaultdict
+from contextlib import suppress
+from enum import Enum
+from functools import partial
 
 import dask
 import tblib
@@ -18,27 +18,26 @@ from tlz import merge
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 
+from . import profile, protocol
 from .comm import (
-    connect,
-    listen,
     CommClosedError,
+    connect,
+    get_address_host_port,
+    listen,
     normalize_address,
     unparse_host_port,
-    get_address_host_port,
 )
 from .metrics import time
-from . import profile
 from .system_monitor import SystemMonitor
 from .utils import (
-    is_coroutine_function,
-    get_traceback,
-    truncate_exception,
-    parse_timedelta,
-    has_keyword,
     CancelledError,
     TimeoutError,
+    get_traceback,
+    has_keyword,
+    is_coroutine_function,
+    parse_timedelta,
+    truncate_exception,
 )
-from . import protocol
 
 
 class Status(Enum):

--- a/distributed/counter.py
+++ b/distributed/counter.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 
 from tornado.ioloop import IOLoop, PeriodicCallback
 
-
 try:
     from crick import TDigest
 except ImportError:

--- a/distributed/dashboard/components/__init__.py
+++ b/distributed/dashboard/components/__init__.py
@@ -1,34 +1,34 @@
 import asyncio
+import weakref
 from bisect import bisect
 from operator import add
 from time import time
-import weakref
 
-from bokeh.layouts import row, column
+import dask
+from bokeh.layouts import column, row
 from bokeh.models import (
-    ColumnDataSource,
-    Plot,
-    DataRange1d,
-    LinearAxis,
-    HoverTool,
     BoxZoomTool,
-    ResetTool,
-    PanTool,
-    WheelZoomTool,
-    Range1d,
-    Quad,
-    TapTool,
-    OpenURL,
     Button,
+    ColumnDataSource,
+    DataRange1d,
+    HoverTool,
+    LinearAxis,
+    OpenURL,
+    PanTool,
+    Plot,
+    Quad,
+    Range1d,
+    ResetTool,
     Select,
+    TapTool,
+    WheelZoomTool,
 )
 from bokeh.palettes import Spectral9
 from bokeh.plotting import figure
-import dask
 from tornado import gen
 
-from distributed.dashboard.utils import without_property_validation, BOKEH_VERSION
 from distributed import profile
+from distributed.dashboard.utils import BOKEH_VERSION, without_property_validation
 from distributed.utils import log_errors, parse_timedelta
 
 if dask.config.get("distributed.dashboard.export-tool"):

--- a/distributed/dashboard/components/__init__.py
+++ b/distributed/dashboard/components/__init__.py
@@ -4,7 +4,6 @@ from bisect import bisect
 from operator import add
 from time import time
 
-import dask
 from bokeh.layouts import column, row
 from bokeh.models import (
     BoxZoomTool,
@@ -26,6 +25,8 @@ from bokeh.models import (
 from bokeh.palettes import Spectral9
 from bokeh.plotting import figure
 from tornado import gen
+
+import dask
 
 from distributed import profile
 from distributed.dashboard.utils import BOKEH_VERSION, without_property_validation

--- a/distributed/dashboard/components/nvml.py
+++ b/distributed/dashboard/components/nvml.py
@@ -1,22 +1,21 @@
 import math
 
-from distributed.dashboard.components import DashboardComponent, add_periodic_callback
-
-from bokeh.plotting import figure
 from bokeh.models import (
-    ColumnDataSource,
     BasicTicker,
-    NumeralTickFormatter,
-    TapTool,
-    OpenURL,
+    ColumnDataSource,
     HoverTool,
+    NumeralTickFormatter,
+    OpenURL,
+    TapTool,
 )
-from tornado import escape
+from bokeh.plotting import figure
 from dask.utils import format_bytes
-from distributed.utils import log_errors
-from distributed.dashboard.components.scheduler import BOKEH_THEME, TICKS_1024, env
-from distributed.dashboard.utils import without_property_validation, update
+from tornado import escape
 
+from distributed.dashboard.components import DashboardComponent, add_periodic_callback
+from distributed.dashboard.components.scheduler import BOKEH_THEME, TICKS_1024, env
+from distributed.dashboard.utils import update, without_property_validation
+from distributed.utils import log_errors
 
 try:
     import pynvml

--- a/distributed/dashboard/components/nvml.py
+++ b/distributed/dashboard/components/nvml.py
@@ -9,8 +9,9 @@ from bokeh.models import (
     TapTool,
 )
 from bokeh.plotting import figure
-from dask.utils import format_bytes
 from tornado import escape
+
+from dask.utils import format_bytes
 
 from distributed.dashboard.components import DashboardComponent, add_periodic_callback
 from distributed.dashboard.components.scheduler import BOKEH_THEME, TICKS_1024, env

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -5,7 +5,6 @@ import os
 from collections import defaultdict
 from numbers import Number
 
-import dask
 from bokeh.io import curdoc
 from bokeh.layouts import column, row
 from bokeh.models import (
@@ -37,11 +36,13 @@ from bokeh.palettes import Viridis11
 from bokeh.plotting import figure
 from bokeh.themes import Theme
 from bokeh.transform import cumsum, factor_cmap, linear_cmap
-from dask import config
-from dask.utils import format_bytes, key_split
 from tlz import pipe
 from tlz.curried import concat, groupby, map
 from tornado import escape
+
+import dask
+from dask import config
+from dask.utils import format_bytes, key_split
 
 try:
     import numpy as np

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1,46 +1,46 @@
-from collections import defaultdict
 import logging
 import math
-from numbers import Number
 import operator
 import os
+from collections import defaultdict
+from numbers import Number
 
+import dask
+from bokeh.io import curdoc
 from bokeh.layouts import column, row
 from bokeh.models import (
-    ColumnDataSource,
-    ColorBar,
-    DataRange1d,
-    HoverTool,
-    ResetTool,
-    PanTool,
-    WheelZoomTool,
-    TapTool,
-    OpenURL,
-    Range1d,
-    value,
-    NumeralTickFormatter,
-    BoxZoomTool,
     AdaptiveTicker,
     BasicTicker,
-    NumberFormatter,
     BoxSelectTool,
-    GroupFilter,
+    BoxZoomTool,
     CDSView,
-    Tabs,
+    ColorBar,
+    ColumnDataSource,
+    DataRange1d,
+    GroupFilter,
+    HoverTool,
+    NumberFormatter,
+    NumeralTickFormatter,
+    OpenURL,
     Panel,
+    PanTool,
+    Range1d,
+    ResetTool,
+    Tabs,
+    TapTool,
     Title,
+    WheelZoomTool,
+    value,
 )
 from bokeh.models.widgets import DataTable, TableColumn
-from bokeh.plotting import figure
 from bokeh.palettes import Viridis11
+from bokeh.plotting import figure
 from bokeh.themes import Theme
-from bokeh.transform import factor_cmap, linear_cmap, cumsum
-from bokeh.io import curdoc
-import dask
+from bokeh.transform import cumsum, factor_cmap, linear_cmap
 from dask import config
 from dask.utils import format_bytes, key_split
 from tlz import pipe
-from tlz.curried import map, concat, groupby
+from tlz.curried import concat, groupby, map
 from tornado import escape
 
 try:
@@ -51,24 +51,24 @@ except ImportError:
 from distributed.dashboard.components import add_periodic_callback
 from distributed.dashboard.components.shared import (
     DashboardComponent,
-    ProfileTimePlot,
     ProfileServer,
+    ProfileTimePlot,
     SystemMonitor,
 )
 from distributed.dashboard.utils import (
-    transpose,
     BOKEH_VERSION,
     PROFILING,
-    without_property_validation,
+    transpose,
     update,
+    without_property_validation,
 )
-from distributed.metrics import time
-from distributed.utils import log_errors, format_time, parse_timedelta
-from distributed.diagnostics.progress_stream import color_of, progress_quads
 from distributed.diagnostics.graph_layout import GraphLayout
+from distributed.diagnostics.progress_stream import color_of, progress_quads
 from distributed.diagnostics.task_stream import TaskStreamPlugin
 from distributed.diagnostics.task_stream import color_of as ts_color_of
 from distributed.diagnostics.task_stream import colors as ts_color_lookup
+from distributed.metrics import time
+from distributed.utils import format_time, log_errors, parse_timedelta
 
 if dask.config.get("distributed.dashboard.export-tool"):
     from distributed.dashboard.export_tool import ExportTool

--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -1,7 +1,6 @@
 import asyncio
 import weakref
 
-import dask
 import tlz as toolz
 from bokeh.layouts import column, row
 from bokeh.models import (
@@ -16,6 +15,8 @@ from bokeh.models import (
 from bokeh.palettes import Spectral9
 from bokeh.plotting import figure
 from tornado import gen
+
+import dask
 
 from distributed import profile
 from distributed.compatibility import WINDOWS

--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -1,31 +1,31 @@
 import asyncio
 import weakref
 
-from bokeh.layouts import row, column
+import dask
+import tlz as toolz
+from bokeh.layouts import column, row
 from bokeh.models import (
+    Button,
     ColumnDataSource,
     DataRange1d,
     HoverTool,
-    Range1d,
-    Button,
-    Select,
     NumeralTickFormatter,
+    Range1d,
+    Select,
 )
 from bokeh.palettes import Spectral9
 from bokeh.plotting import figure
-import dask
 from tornado import gen
-import tlz as toolz
 
+from distributed import profile
+from distributed.compatibility import WINDOWS
 from distributed.dashboard.components import DashboardComponent
 from distributed.dashboard.utils import (
-    without_property_validation,
     BOKEH_VERSION,
     update,
+    without_property_validation,
 )
-from distributed import profile
 from distributed.utils import log_errors, parse_timedelta
-from distributed.compatibility import WINDOWS
 
 if dask.config.get("distributed.dashboard.export-tool"):
     from distributed.dashboard.export_tool import ExportTool

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -2,22 +2,21 @@ import logging
 import math
 import os
 
-from bokeh.layouts import row, column
+from bokeh.layouts import column, row
 from bokeh.models import (
+    BoxZoomTool,
     ColumnDataSource,
     DataRange1d,
     HoverTool,
-    BoxZoomTool,
-    ResetTool,
-    PanTool,
-    WheelZoomTool,
     NumeralTickFormatter,
+    PanTool,
+    ResetTool,
     Select,
+    WheelZoomTool,
 )
-
 from bokeh.models.widgets import DataTable, TableColumn
-from bokeh.plotting import figure
 from bokeh.palettes import RdBu
+from bokeh.plotting import figure
 from bokeh.themes import Theme
 from dask.utils import format_bytes
 from tlz import merge, partition_all
@@ -25,15 +24,14 @@ from tlz import merge, partition_all
 from distributed.dashboard.components import add_periodic_callback
 from distributed.dashboard.components.shared import (
     DashboardComponent,
-    ProfileTimePlot,
     ProfileServer,
+    ProfileTimePlot,
     SystemMonitor,
 )
-from distributed.dashboard.utils import transpose, without_property_validation, update
+from distributed.dashboard.utils import transpose, update, without_property_validation
 from distributed.diagnostics.progress_stream import color_of
 from distributed.metrics import time
-from distributed.utils import log_errors, key_split, format_time
-
+from distributed.utils import format_time, key_split, log_errors
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -18,8 +18,9 @@ from bokeh.models.widgets import DataTable, TableColumn
 from bokeh.palettes import RdBu
 from bokeh.plotting import figure
 from bokeh.themes import Theme
-from dask.utils import format_bytes
 from tlz import merge, partition_all
+
+from dask.utils import format_bytes
 
 from distributed.dashboard.components import add_periodic_callback
 from distributed.dashboard.components.shared import (

--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -1,6 +1,6 @@
-from distutils.version import LooseVersion
 import functools
 import warnings
+from distutils.version import LooseVersion
 
 import bokeh
 from bokeh.server.server import BokehTornado
@@ -9,11 +9,11 @@ try:
     from bokeh.server.util import create_hosts_allowlist
 except ImportError:
     from bokeh.server.util import create_hosts_whitelist as create_hosts_allowlist
-from bokeh.application.handlers.function import FunctionHandler
-from bokeh.application import Application
+
 import dask
 import toolz
-
+from bokeh.application import Application
+from bokeh.application.handlers.function import FunctionHandler
 
 if LooseVersion(bokeh.__version__) < LooseVersion("0.13.0"):
     warnings.warn(

--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -10,10 +10,11 @@ try:
 except ImportError:
     from bokeh.server.util import create_hosts_whitelist as create_hosts_allowlist
 
-import dask
 import toolz
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
+
+import dask
 
 if LooseVersion(bokeh.__version__) < LooseVersion("0.13.0"):
     warnings.warn(

--- a/distributed/dashboard/export_tool.py
+++ b/distributed/dashboard/export_tool.py
@@ -6,7 +6,6 @@ from bokeh.models import Tool
 from bokeh.resources import CDN
 from bokeh.util.compiler import JavaScript
 
-
 fn = __file__
 fn = os.path.join(os.path.dirname(fn), "export_tool.js")
 with open(fn) as f:

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -1,49 +1,44 @@
 from urllib.parse import urljoin
 
-from tornado.ioloop import IOLoop
 from tornado import web
+from tornado.ioloop import IOLoop
 
 try:
     import numpy as np
 except ImportError:
     np = False
 
-from .core import BokehApplication
-from .components.worker import counters_doc
+from .components.nvml import gpu_doc  # noqa: 1708
+from .components.nvml import NVML_ENABLED, gpu_memory_doc, gpu_utilization_doc
 from .components.scheduler import (
-    systemmonitor_doc,
-    stealing_doc,
-    workers_doc,
     events_doc,
-    tasks_doc,
-    status_doc,
-    profile_doc,
-    profile_server_doc,
     graph_doc,
-    individual_task_stream_doc,
-    individual_progress_doc,
-    individual_graph_doc,
-    individual_profile_doc,
-    individual_profile_server_doc,
-    individual_nbytes_doc,
-    individual_cpu_doc,
-    individual_nprocessing_doc,
-    individual_workers_doc,
+    individual_aggregate_time_per_action_doc,
     individual_bandwidth_types_doc,
     individual_bandwidth_workers_doc,
-    individual_memory_by_key_doc,
     individual_compute_time_per_key_doc,
-    individual_aggregate_time_per_action_doc,
+    individual_cpu_doc,
+    individual_graph_doc,
+    individual_memory_by_key_doc,
+    individual_nbytes_doc,
+    individual_nprocessing_doc,
+    individual_profile_doc,
+    individual_profile_server_doc,
+    individual_progress_doc,
     individual_systemmonitor_doc,
+    individual_task_stream_doc,
+    individual_workers_doc,
+    profile_doc,
+    profile_server_doc,
+    status_doc,
+    stealing_doc,
+    systemmonitor_doc,
+    tasks_doc,
+    workers_doc,
 )
+from .components.worker import counters_doc
+from .core import BokehApplication
 from .worker import counters_doc
-from .components.nvml import (
-    NVML_ENABLED,
-    gpu_memory_doc,
-    gpu_utilization_doc,
-    gpu_doc,
-)  # noqa: 1708
-
 
 template_variables = {
     "pages": ["status", "workers", "tasks", "system", "profile", "graph", "info"]

--- a/distributed/dashboard/tests/test_components.py
+++ b/distributed/dashboard/tests/test_components.py
@@ -6,12 +6,12 @@ pytest.importorskip("bokeh")
 
 from bokeh.models import ColumnDataSource, Model
 
-from distributed.utils_test import slowinc, gen_cluster
 from distributed.dashboard.components.shared import (
     Processing,
     ProfilePlot,
     ProfileTimePlot,
 )
+from distributed.utils_test import gen_cluster, slowinc
 
 
 @pytest.mark.parametrize("Component", [Processing])

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -8,39 +8,39 @@ from time import sleep
 import pytest
 
 pytest.importorskip("bokeh")
+import dask
 from bokeh.server.server import BokehTornado
+from dask.core import flatten
+from dask.utils import stringify
 from tlz import first
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
-import dask
-from dask.core import flatten
-from dask.utils import stringify
 from distributed.client import wait
 from distributed.compatibility import MACOS
-from distributed.metrics import time
-from distributed.utils import format_dashboard_link
-from distributed.utils_test import gen_cluster, inc, dec, slowinc, div, get_cert
-from distributed.dashboard.components.worker import Counters
-from distributed.dashboard.scheduler import applications
+from distributed.dashboard import scheduler
 from distributed.dashboard.components.scheduler import (
-    SystemMonitor,
-    Occupancy,
-    StealingTimeSeries,
-    StealingEvents,
-    Events,
-    TaskStream,
-    TaskProgress,
-    CurrentLoad,
-    ProcessingHistogram,
-    NBytesHistogram,
-    WorkerTable,
-    TaskGraph,
-    ProfileServer,
-    MemoryByKey,
     AggregateAction,
     ComputePerKey,
+    CurrentLoad,
+    Events,
+    MemoryByKey,
+    NBytesHistogram,
+    Occupancy,
+    ProcessingHistogram,
+    ProfileServer,
+    StealingEvents,
+    StealingTimeSeries,
+    SystemMonitor,
+    TaskGraph,
+    TaskProgress,
+    TaskStream,
+    WorkerTable,
 )
-from distributed.dashboard import scheduler
+from distributed.dashboard.components.worker import Counters
+from distributed.dashboard.scheduler import applications
+from distributed.metrics import time
+from distributed.utils import format_dashboard_link
+from distributed.utils_test import dec, div, gen_cluster, get_cert, inc, slowinc
 
 scheduler.PROFILING = False
 

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -8,12 +8,13 @@ from time import sleep
 import pytest
 
 pytest.importorskip("bokeh")
-import dask
 from bokeh.server.server import BokehTornado
-from dask.core import flatten
-from dask.utils import stringify
 from tlz import first
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+
+import dask
+from dask.core import flatten
+from dask.utils import stringify
 
 from distributed.client import wait
 from distributed.compatibility import MACOS

--- a/distributed/dashboard/tests/test_worker_bokeh.py
+++ b/distributed/dashboard/tests/test_worker_bokeh.py
@@ -10,17 +10,17 @@ from tlz import first
 from tornado.httpclient import AsyncHTTPClient
 
 from distributed.client import wait
-from distributed.metrics import time
-from distributed.utils_test import gen_cluster, inc, dec
 from distributed.dashboard.components.worker import (
-    StateTable,
-    CrossFilter,
     CommunicatingStream,
-    ExecutingTimeSeries,
     CommunicatingTimeSeries,
-    SystemMonitor,
     Counters,
+    CrossFilter,
+    ExecutingTimeSeries,
+    StateTable,
+    SystemMonitor,
 )
+from distributed.metrics import time
+from distributed.utils_test import dec, gen_cluster, inc
 
 
 @gen_cluster(

--- a/distributed/dashboard/worker.py
+++ b/distributed/dashboard/worker.py
@@ -1,14 +1,14 @@
-from .components.worker import (
-    status_doc,
-    crossfilter_doc,
-    systemmonitor_doc,
-    counters_doc,
-    profile_doc,
-    profile_server_doc,
-)
-from .core import BokehApplication
 from tornado.ioloop import IOLoop
 
+from .components.worker import (
+    counters_doc,
+    crossfilter_doc,
+    profile_doc,
+    profile_server_doc,
+    status_doc,
+    systemmonitor_doc,
+)
+from .core import BokehApplication
 
 template_variables = {
     "pages": ["status", "system", "profile", "crossfilter", "profile-server"]

--- a/distributed/deploy/__init__.py
+++ b/distributed/deploy/__init__.py
@@ -1,10 +1,10 @@
 from contextlib import suppress
 
+from .adaptive import Adaptive
 from .cluster import Cluster
 from .local import LocalCluster
+from .spec import ProcessInterface, SpecCluster
 from .ssh import SSHCluster
-from .spec import SpecCluster, ProcessInterface
-from .adaptive import Adaptive
 
 with suppress(ImportError):
     from .ssh import SSHCluster

--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -1,10 +1,11 @@
-from inspect import isawaitable
 import logging
+from inspect import isawaitable
+
 import dask.config
 
-from .adaptive_core import AdaptiveCore
-from ..utils import log_errors, parse_timedelta
 from ..protocol import pickle
+from ..utils import log_errors, parse_timedelta
+from .adaptive_core import AdaptiveCore
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -2,12 +2,11 @@ import collections
 import logging
 import math
 
-from tornado.ioloop import IOLoop, PeriodicCallback
 import tlz as toolz
+from tornado.ioloop import IOLoop, PeriodicCallback
 
 from ..metrics import time
 from ..utils import parse_timedelta
-
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -6,9 +6,10 @@ import uuid
 import warnings
 from contextlib import suppress
 
+from tornado.ioloop import PeriodicCallback
+
 import dask.config
 from dask.utils import format_bytes
-from tornado.ioloop import PeriodicCallback
 
 from ..core import Status
 from ..utils import (

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -1,28 +1,26 @@
 import asyncio
 import datetime
-from contextlib import suppress
 import logging
 import threading
-import warnings
 import uuid
-from tornado.ioloop import PeriodicCallback
+import warnings
+from contextlib import suppress
 
 import dask.config
 from dask.utils import format_bytes
-
-from .adaptive import Adaptive
+from tornado.ioloop import PeriodicCallback
 
 from ..core import Status
 from ..utils import (
-    log_errors,
-    sync,
     Log,
     Logs,
-    thread_state,
     format_dashboard_link,
+    log_errors,
     parse_timedelta,
+    sync,
+    thread_state,
 )
-
+from .adaptive import Adaptive
 
 logger = logging.getLogger(__name__)
 
@@ -310,7 +308,7 @@ class Cluster:
             pass
 
         try:
-            from ipywidgets import Layout, VBox, HBox, IntText, Button, HTML, Accordion
+            from ipywidgets import HTML, Accordion, Button, HBox, IntText, Layout, VBox
         except ImportError:
             self._cached_widget = None
             return None

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -4,15 +4,15 @@ import math
 import warnings
 import weakref
 
-from dask.system import CPU_COUNT
 import toolz
+from dask.system import CPU_COUNT
 
-from .spec import SpecCluster
-from .utils import nprocesses_nthreads
 from ..nanny import Nanny
 from ..scheduler import Scheduler
 from ..security import Security
 from ..worker import Worker, parse_memory_limit
+from .spec import SpecCluster
+from .utils import nprocesses_nthreads
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -5,6 +5,7 @@ import warnings
 import weakref
 
 import toolz
+
 from dask.system import CPU_COUNT
 
 from ..nanny import Nanny

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -1,6 +1,6 @@
 import logging
-import socket
 import os
+import socket
 import sys
 import time
 import traceback
@@ -13,9 +13,7 @@ except ImportError:  # Python 2.7 fix
 from threading import Thread
 
 from tlz import merge
-
 from tornado import gen
-
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +34,7 @@ class bcolors:
 def async_ssh(cmd_dict):
     import paramiko
     from paramiko.buffered_pipe import PipeTimeout
-    from paramiko.ssh_exception import SSHException, PasswordRequiredException
+    from paramiko.ssh_exception import PasswordRequiredException, SSHException
 
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -7,8 +7,9 @@ import warnings
 import weakref
 from contextlib import suppress
 
-import dask
 from tornado import gen
+
+import dask
 
 from ..core import CommClosedError, Status, rpc
 from ..scheduler import Scheduler

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -1,29 +1,28 @@
 import asyncio
 import atexit
-from contextlib import suppress
 import copy
 import logging
 import math
-import weakref
 import warnings
+import weakref
+from contextlib import suppress
 
 import dask
 from tornado import gen
 
-from .adaptive import Adaptive
-from .cluster import Cluster
-from ..core import rpc, CommClosedError, Status
-from ..utils import (
-    LoopRunner,
-    silence_logging,
-    parse_bytes,
-    parse_timedelta,
-    import_term,
-    TimeoutError,
-)
+from ..core import CommClosedError, Status, rpc
 from ..scheduler import Scheduler
 from ..security import Security
-
+from ..utils import (
+    LoopRunner,
+    TimeoutError,
+    import_term,
+    parse_bytes,
+    parse_timedelta,
+    silence_logging,
+)
+from .adaptive import Adaptive
+from .cluster import Cluster
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -1,17 +1,17 @@
 import logging
 import sys
-from typing import List, Union
 import warnings
 import weakref
+from typing import List, Union
 
 import dask
 import dask.config
 
-from .spec import SpecCluster, ProcessInterface
 from ..core import Status
-from ..utils import cli_keywords
 from ..scheduler import Scheduler as _Scheduler
+from ..utils import cli_keywords
 from ..worker import Worker as _Worker
+from .spec import ProcessInterface, SpecCluster
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -6,10 +6,16 @@ from time import sleep
 import dask
 import pytest
 
-from distributed import Client, wait, Adaptive, LocalCluster, SpecCluster, Worker
-from distributed.utils_test import gen_test, slowinc, clean
-from distributed.utils_test import loop, nodebug, cleanup  # noqa: F401
+from distributed import Adaptive, Client, LocalCluster, SpecCluster, Worker, wait
 from distributed.metrics import time
+from distributed.utils_test import (  # noqa: F401
+    clean,
+    cleanup,
+    gen_test,
+    loop,
+    nodebug,
+    slowinc,
+)
 
 
 @pytest.mark.asyncio

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -3,8 +3,9 @@ import gc
 import math
 from time import sleep
 
-import dask
 import pytest
+
+import dask
 
 from distributed import Adaptive, Client, LocalCluster, SpecCluster, Worker, wait
 from distributed.metrics import time

--- a/distributed/deploy/tests/test_adaptive_core.py
+++ b/distributed/deploy/tests/test_adaptive_core.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import pytest
 
 from distributed.deploy.adaptive_core import AdaptiveCore

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -11,9 +11,10 @@ from time import sleep
 
 import pytest
 import tornado
-from dask.system import CPU_COUNT
 from tornado.httpclient import AsyncHTTPClient
 from tornado.ioloop import IOLoop
+
+from dask.system import CPU_COUNT
 
 from distributed import Client, Nanny, Worker, get_client
 from distributed.core import Status

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1,42 +1,41 @@
 import asyncio
-from functools import partial
 import gc
 import subprocess
 import sys
-from time import sleep
-from threading import Lock
 import unittest
 import weakref
 from distutils.version import LooseVersion
+from functools import partial
+from threading import Lock
+from time import sleep
 
-from tornado.ioloop import IOLoop
-import tornado
-from tornado.httpclient import AsyncHTTPClient
 import pytest
-
+import tornado
 from dask.system import CPU_COUNT
-from distributed import Client, Worker, Nanny, get_client
+from tornado.httpclient import AsyncHTTPClient
+from tornado.ioloop import IOLoop
+
+from distributed import Client, Nanny, Worker, get_client
 from distributed.core import Status
 from distributed.deploy.local import LocalCluster
+from distributed.deploy.utils_test import ClusterTest
 from distributed.metrics import time
 from distributed.system import MEMORY_LIMIT
+from distributed.utils import TimeoutError, sync
 from distributed.utils_test import (  # noqa: F401
-    clean,
-    cleanup,
-    inc,
-    gen_test,
-    slowinc,
-    assert_cannot_connect,
-    assert_can_connect_locally_4,
     assert_can_connect_from_everywhere_4,
     assert_can_connect_from_everywhere_4_6,
+    assert_can_connect_locally_4,
+    assert_cannot_connect,
     captured_logger,
+    clean,
+    cleanup,
+    gen_test,
+    inc,
+    loop,
+    slowinc,
     tls_only_security,
 )
-from distributed.utils_test import loop  # noqa: F401
-from distributed.utils import sync, TimeoutError
-
-from distributed.deploy.utils_test import ClusterTest
 
 
 def test_simple(loop):

--- a/distributed/deploy/tests/test_slow_adaptive.py
+++ b/distributed/deploy/tests/test_slow_adaptive.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+
 from dask.distributed import Client, Scheduler, SpecCluster, Worker
 
 from distributed.metrics import time

--- a/distributed/deploy/tests/test_slow_adaptive.py
+++ b/distributed/deploy/tests/test_slow_adaptive.py
@@ -1,9 +1,10 @@
 import asyncio
-import pytest
 
-from dask.distributed import Worker, Scheduler, SpecCluster, Client
-from distributed.utils_test import slowinc, cleanup  # noqa: F401
+import pytest
+from dask.distributed import Client, Scheduler, SpecCluster, Worker
+
 from distributed.metrics import time
+from distributed.utils_test import cleanup, slowinc  # noqa: F401
 
 
 class SlowWorker:

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -1,18 +1,19 @@
 import asyncio
 import re
-from time import sleep
 import warnings
+from time import sleep
 
 import dask
-from dask.distributed import SpecCluster, Worker, Client, Scheduler, Nanny
-from distributed.core import Status
-from distributed.compatibility import WINDOWS
-from distributed.deploy.spec import close_clusters, ProcessInterface, run_spec
-from distributed.metrics import time
-from distributed.utils_test import loop, cleanup  # noqa: F401
-from distributed.utils import is_valid_xml
-import tlz as toolz
 import pytest
+import tlz as toolz
+from dask.distributed import Client, Nanny, Scheduler, SpecCluster, Worker
+
+from distributed.compatibility import WINDOWS
+from distributed.core import Status
+from distributed.deploy.spec import ProcessInterface, close_clusters, run_spec
+from distributed.metrics import time
+from distributed.utils import is_valid_xml
+from distributed.utils_test import cleanup, loop  # noqa: F401
 
 
 class MyWorker(Worker):

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -3,9 +3,10 @@ import re
 import warnings
 from time import sleep
 
-import dask
 import pytest
 import tlz as toolz
+
+import dask
 from dask.distributed import Client, Nanny, Scheduler, SpecCluster, Worker
 
 from distributed.compatibility import WINDOWS

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -3,7 +3,9 @@ import pytest
 pytest.importorskip("asyncssh")
 
 import sys
+
 import dask
+
 from distributed import Client
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.deploy.ssh import SSHCluster

--- a/distributed/deploy/utils_test.py
+++ b/distributed/deploy/utils_test.py
@@ -1,6 +1,6 @@
-from ..client import Client
-
 import pytest
+
+from ..client import Client
 
 
 class ClusterTest:

--- a/distributed/diagnostics/eventstream.py
+++ b/distributed/diagnostics/eventstream.py
@@ -1,10 +1,8 @@
 import logging
 
-from .plugin import SchedulerPlugin
-
-from ..core import connect, coerce_to_address
+from ..core import coerce_to_address, connect
 from ..worker import dumps_function
-
+from .plugin import SchedulerPlugin
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -1,4 +1,5 @@
 import os
+
 import pynvml
 
 nvmlInit = None

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -1,14 +1,13 @@
 import asyncio
-from collections import defaultdict
 import logging
+from collections import defaultdict
 from timeit import default_timer
 
+from dask.utils import stringify
 from tlz import groupby, valmap
 
-from dask.utils import stringify
-from .plugin import SchedulerPlugin
 from ..utils import key_split, key_split_group, log_errors
-
+from .plugin import SchedulerPlugin
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -3,8 +3,9 @@ import logging
 from collections import defaultdict
 from timeit import default_timer
 
-from dask.utils import stringify
 from tlz import groupby, valmap
+
+from dask.utils import stringify
 
 from ..utils import key_split, key_split_group, log_errors
 from .plugin import SchedulerPlugin

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -1,14 +1,12 @@
 import logging
 
-from tlz import valmap, merge
+from tlz import merge, valmap
 
-from .progress import AllProgress
-
-from ..core import connect, coerce_to_address
+from ..core import coerce_to_address, connect
 from ..scheduler import Scheduler
-from ..utils import key_split, color_of
+from ..utils import color_of, key_split
 from ..worker import dumps_function
-
+from .progress import AllProgress
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -1,20 +1,18 @@
-from contextlib import suppress
-import logging
 import html
-from timeit import default_timer
+import logging
 import sys
 import weakref
+from contextlib import suppress
+from timeit import default_timer
 
 from tlz import valmap
 from tornado.ioloop import IOLoop
 
-from .progress import format_time, Progress, MultiProgress
-
-from ..core import connect, coerce_to_address, CommClosedError
 from ..client import default_client, futures_of
+from ..core import CommClosedError, coerce_to_address, connect
 from ..protocol.pickle import dumps
-from ..utils import key_split, is_kernel, LoopRunner, parse_timedelta
-
+from ..utils import LoopRunner, is_kernel, key_split, parse_timedelta
+from .progress import MultiProgress, Progress, format_time
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +158,7 @@ class ProgressWidget(ProgressBar):
     ):
         super().__init__(keys, scheduler, interval, complete)
 
-        from ipywidgets import FloatProgress, HBox, VBox, HTML
+        from ipywidgets import HTML, FloatProgress, HBox, VBox
 
         self.elapsed_time = HTML("")
         self.bar = FloatProgress(min=0, max=1, description="")
@@ -319,7 +317,7 @@ class MultiProgressWidget(MultiProgressBar):
         self.widget = VBox([])
 
     def make_widget(self, all):
-        from ipywidgets import FloatProgress, HBox, VBox, HTML
+        from ipywidgets import HTML, FloatProgress, HBox, VBox
 
         self.elapsed_time = HTML("")
         self.bars = {key: FloatProgress(min=0, max=1, description="") for key in all}

--- a/distributed/diagnostics/task_stream.py
+++ b/distributed/diagnostics/task_stream.py
@@ -1,12 +1,12 @@
-from collections import deque
 import logging
+from collections import deque
 
 import dask
-from .progress_stream import color_of
-from .plugin import SchedulerPlugin
-from ..utils import key_split, format_time, parse_timedelta
-from ..metrics import time
 
+from ..metrics import time
+from ..utils import format_time, key_split, parse_timedelta
+from .plugin import SchedulerPlugin
+from .progress_stream import color_of
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/diagnostics/tests/test_graph_layout.py
+++ b/distributed/diagnostics/tests/test_graph_layout.py
@@ -1,9 +1,9 @@
 import asyncio
 import operator
 
-from distributed.utils_test import gen_cluster, inc
-from distributed.diagnostics import GraphLayout
 from distributed import wait
+from distributed.diagnostics import GraphLayout
+from distributed.utils_test import gen_cluster, inc
 
 
 @gen_cluster(client=True)

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 
 pynvml = pytest.importorskip("pynvml")
 

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -4,15 +4,15 @@ import pytest
 
 from distributed import Nanny
 from distributed.client import wait
-from distributed.metrics import time
-from distributed.utils_test import gen_cluster, inc, dec, div, nodebug
 from distributed.diagnostics.progress import (
-    Progress,
-    SchedulerPlugin,
     AllProgress,
     GroupProgress,
     MultiProgress,
+    Progress,
+    SchedulerPlugin,
 )
+from distributed.metrics import time
+from distributed.utils_test import dec, div, gen_cluster, inc, nodebug
 
 
 def f(*args):

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -3,6 +3,7 @@ import pytest
 pytest.importorskip("bokeh")
 
 from dask import delayed
+
 from distributed.client import wait
 from distributed.diagnostics.progress_stream import progress_quads, progress_stream
 from distributed.utils_test import div, gen_cluster, inc

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -5,8 +5,14 @@ import pytest
 from distributed import Scheduler, Worker
 from distributed.diagnostics.progressbar import TextProgressBar, progress
 from distributed.metrics import time
-from distributed.utils_test import inc, div, gen_cluster
-from distributed.utils_test import client, loop, cluster_fixture  # noqa: F401
+from distributed.utils_test import (  # noqa: F401
+    client,
+    cluster_fixture,
+    div,
+    gen_cluster,
+    inc,
+    loop,
+)
 
 
 def test_text_progressbar(capsys, client):

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -1,6 +1,7 @@
 import pytest
-from distributed import Scheduler, Worker, SchedulerPlugin
-from distributed.utils_test import inc, gen_cluster, cleanup  # noqa: F401
+
+from distributed import Scheduler, SchedulerPlugin, Worker
+from distributed.utils_test import cleanup, gen_cluster, inc  # noqa: F401
 
 
 @gen_cluster(client=True)

--- a/distributed/diagnostics/tests/test_task_stream.py
+++ b/distributed/diagnostics/tests/test_task_stream.py
@@ -5,11 +5,18 @@ import pytest
 from tlz import frequencies
 
 from distributed import get_task_stream
-from distributed.utils_test import gen_cluster, div, inc, slowinc
-from distributed.utils_test import client, loop, cluster_fixture  # noqa: F401
 from distributed.client import wait
 from distributed.diagnostics.task_stream import TaskStreamPlugin
 from distributed.metrics import time
+from distributed.utils_test import (  # noqa: F401
+    client,
+    cluster_fixture,
+    div,
+    gen_cluster,
+    inc,
+    loop,
+    slowinc,
+)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -2,9 +2,10 @@ import pytest
 
 pytest.importorskip("ipywidgets")
 
-from distributed.compatibility import WINDOWS
 from ipykernel.comm import Comm
 from ipywidgets import Widget
+
+from distributed.compatibility import WINDOWS
 
 #################
 # Utility stuff #
@@ -72,20 +73,28 @@ def record_display(*args):
 # Distributed stuff #
 #####################
 
-from operator import add
 import re
+from operator import add
 
 from tlz import valmap
 
 from distributed.client import wait
-from distributed.worker import dumps_task
-from distributed.utils_test import inc, dec, throws, gen_cluster, gen_tls_cluster
-from distributed.utils_test import client, loop, cluster_fixture  # noqa: F401
 from distributed.diagnostics.progressbar import (
-    ProgressWidget,
     MultiProgressWidget,
+    ProgressWidget,
     progress,
 )
+from distributed.utils_test import (  # noqa: F401
+    client,
+    cluster_fixture,
+    dec,
+    gen_cluster,
+    gen_tls_cluster,
+    inc,
+    loop,
+    throws,
+)
+from distributed.worker import dumps_task
 
 
 @gen_cluster(client=True)

--- a/distributed/diagnostics/websocket.py
+++ b/distributed/diagnostics/websocket.py
@@ -1,5 +1,5 @@
-from .plugin import SchedulerPlugin
 from ..utils import key_split
+from .plugin import SchedulerPlugin
 from .task_stream import colors
 
 

--- a/distributed/diskutils.py
+++ b/distributed/diskutils.py
@@ -11,7 +11,6 @@ import dask
 
 from . import locket
 
-
 logger = logging.getLogger(__name__)
 
 DIR_LOCK_EXT = ".dirlock"

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -1,13 +1,12 @@
 import asyncio
-from collections import defaultdict
-from contextlib import suppress
 import logging
 import uuid
+from collections import defaultdict
+from contextlib import suppress
 
 from .client import Client
-from .utils import log_errors, TimeoutError
+from .utils import TimeoutError, log_errors, parse_timedelta
 from .worker import get_worker
-from .utils import parse_timedelta
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/http/routing.py
+++ b/distributed/http/routing.py
@@ -1,7 +1,8 @@
 import os
-from tornado import web
+
 import tornado.httputil
 import tornado.routing
+from tornado import web
 
 
 def _descend_routes(router, routers=set(), out=set()):

--- a/distributed/http/scheduler/info.py
+++ b/distributed/http/scheduler/info.py
@@ -4,10 +4,11 @@ import os
 import os.path
 from datetime import datetime
 
-from dask.utils import format_bytes
 from tlz import first, merge
 from tornado import escape
 from tornado.websocket import WebSocketHandler
+
+from dask.utils import format_bytes
 
 from ...diagnostics.websocket import WebsocketPlugin
 from ...metrics import time

--- a/distributed/http/scheduler/info.py
+++ b/distributed/http/scheduler/info.py
@@ -1,19 +1,18 @@
-from datetime import datetime
 import json
 import logging
 import os
 import os.path
+from datetime import datetime
 
 from dask.utils import format_bytes
-
+from tlz import first, merge
 from tornado import escape
 from tornado.websocket import WebSocketHandler
-from tlz import first, merge
 
-from ..utils import RequestHandler, redirect
 from ...diagnostics.websocket import WebsocketPlugin
 from ...metrics import time
-from ...utils import log_errors, format_time
+from ...utils import format_time, log_errors
+from ..utils import RequestHandler, redirect
 
 ns = {
     func.__name__: func

--- a/distributed/http/scheduler/json.py
+++ b/distributed/http/scheduler/json.py
@@ -1,5 +1,5 @@
-from ..utils import RequestHandler
 from ...utils import log_errors
+from ..utils import RequestHandler
 
 
 class CountsJSON(RequestHandler):

--- a/distributed/http/scheduler/missing_bokeh.py
+++ b/distributed/http/scheduler/missing_bokeh.py
@@ -1,5 +1,5 @@
-from ..utils import RequestHandler, redirect
 from ...utils import log_errors
+from ..utils import RequestHandler, redirect
 
 
 class MissingBokeh(RequestHandler):

--- a/distributed/http/scheduler/prometheus/__init__.py
+++ b/distributed/http/scheduler/prometheus/__init__.py
@@ -2,6 +2,7 @@ import toolz
 
 from distributed.http.utils import RequestHandler
 from distributed.scheduler import ALL_TASK_STATES
+
 from .semaphore import SemaphoreMetricExtension
 
 
@@ -10,7 +11,7 @@ class _PrometheusCollector:
         self.server = dask_server
 
     def collect(self):
-        from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily
+        from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
         yield GaugeMetricFamily(
             "dask_scheduler_clients",

--- a/distributed/http/scheduler/prometheus/semaphore.py
+++ b/distributed/http/scheduler/prometheus/semaphore.py
@@ -3,7 +3,7 @@ class SemaphoreMetricExtension:
         self.server = dask_server
 
     def collect(self):
-        from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily
+        from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
         sem_ext = self.server.extensions["semaphores"]
 

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -5,9 +5,10 @@ import pytest
 
 pytest.importorskip("bokeh")
 
-from dask.sizeof import sizeof
 from tornado.escape import url_escape
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError
+
+from dask.sizeof import sizeof
 
 from distributed.utils import is_valid_xml
 from distributed.utils_test import gen_cluster, inc, slowinc

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -5,12 +5,12 @@ import pytest
 
 pytest.importorskip("bokeh")
 
+from dask.sizeof import sizeof
 from tornado.escape import url_escape
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError
 
-from dask.sizeof import sizeof
 from distributed.utils import is_valid_xml
-from distributed.utils_test import gen_cluster, slowinc, inc
+from distributed.utils_test import gen_cluster, inc, slowinc
 
 
 @gen_cluster(client=True)

--- a/distributed/http/scheduler/tests/test_semaphore_http.py
+++ b/distributed/http/scheduler/tests/test_semaphore_http.py
@@ -1,9 +1,8 @@
 import pytest
-
 from tornado.httpclient import AsyncHTTPClient
 
-from distributed.utils_test import gen_cluster
 from distributed import Semaphore
+from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})

--- a/distributed/http/statics.py
+++ b/distributed/http/statics.py
@@ -1,5 +1,6 @@
-from tornado import web
 import os
+
+from tornado import web
 
 routes = [
     (

--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -1,5 +1,6 @@
-from distributed.utils_test import gen_cluster
 from tornado.httpclient import AsyncHTTPClient
+
+from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True)

--- a/distributed/http/tests/test_routing.py
+++ b/distributed/http/tests/test_routing.py
@@ -1,6 +1,6 @@
+import pytest
 from tornado import web
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError
-import pytest
 
 from distributed.http.routing import RoutingApplication
 

--- a/distributed/http/utils.py
+++ b/distributed/http/utils.py
@@ -2,11 +2,10 @@ import importlib
 import os
 from typing import List
 
-from tornado import web
 import toolz
+from tornado import web
 
 from ..utils import has_keyword
-
 
 dirname = os.path.dirname(__file__)
 

--- a/distributed/http/worker/prometheus.py
+++ b/distributed/http/worker/prometheus.py
@@ -1,6 +1,6 @@
-from ..utils import RequestHandler
-
 import logging
+
+from ..utils import RequestHandler
 
 
 class _PrometheusCollector:

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -1,6 +1,8 @@
-import pytest
 import json
+
+import pytest
 from tornado.httpclient import AsyncHTTPClient
+
 from distributed.utils_test import gen_cluster
 
 

--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -1,12 +1,11 @@
 import asyncio
-from collections import defaultdict, deque
 import logging
 import uuid
+from collections import defaultdict, deque
 
 from .client import Client
-from .utils import log_errors, TimeoutError
+from .utils import TimeoutError, log_errors, parse_timedelta
 from .worker import get_worker
-from .utils import parse_timedelta
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/locket.py
+++ b/distributed/locket.py
@@ -3,9 +3,9 @@
 
 # flake8: noqa
 
-import time
 import errno
 import threading
+import time
 import weakref
 
 __all__ = ["lock_file"]

--- a/distributed/metrics.py
+++ b/distributed/metrics.py
@@ -1,8 +1,7 @@
 import collections
-from functools import wraps
 import sys
 import time as timemod
-
+from functools import wraps
 
 _empty_namedtuple = collections.namedtuple("_empty_namedtuple", ())
 

--- a/distributed/multi_lock.py
+++ b/distributed/multi_lock.py
@@ -1,13 +1,12 @@
 import asyncio
-from collections import defaultdict
 import logging
-from typing import Hashable, List
 import uuid
+from collections import defaultdict
+from typing import Hashable, List
 
 from .client import Client
-from .utils import log_errors, TimeoutError
+from .utils import TimeoutError, log_errors, parse_timedelta
 from .worker import get_worker
-from .utils import parse_timedelta
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -1,41 +1,40 @@
 import asyncio
-from contextlib import suppress
 import errno
 import logging
-from multiprocessing.queues import Empty
 import os
-import psutil
 import shutil
 import threading
 import uuid
 import warnings
 import weakref
+from contextlib import suppress
+from multiprocessing.queues import Empty
 
 import dask
+import psutil
 from dask.system import CPU_COUNT
-from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado import gen
+from tornado.ioloop import IOLoop, PeriodicCallback
 
+from . import preloading
 from .comm import get_address_host, unparse_host_port
 from .comm.addressing import address_from_user_args
-from .core import RPCClosed, CommClosedError, coerce_to_address, Status
+from .core import CommClosedError, RPCClosed, Status, coerce_to_address
 from .metrics import time
 from .node import ServerNode
-from . import preloading
 from .process import AsyncProcess
 from .proctitle import enable_proctitle_on_children
 from .security import Security
 from .utils import (
-    get_ip,
-    mp_context,
-    silence_logging,
-    json_load_robust,
-    parse_timedelta,
-    parse_ports,
     TimeoutError,
+    get_ip,
+    json_load_robust,
+    mp_context,
+    parse_ports,
+    parse_timedelta,
+    silence_logging,
 )
-from .worker import run, parse_memory_limit, Worker
-
+from .worker import Worker, parse_memory_limit, run
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -10,11 +10,12 @@ import weakref
 from contextlib import suppress
 from multiprocessing.queues import Empty
 
-import dask
 import psutil
-from dask.system import CPU_COUNT
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
+
+import dask
+from dask.system import CPU_COUNT
 
 from . import preloading
 from .comm import get_address_host, unparse_host_port

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -3,9 +3,10 @@ import warnings
 import weakref
 from contextlib import suppress
 
-import dask
 import tlz
 from tornado.httpserver import HTTPServer
+
+import dask
 
 from .comm import get_address_host, get_tcp_server_address
 from .core import Server

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -1,18 +1,17 @@
-from contextlib import suppress
 import logging
 import warnings
 import weakref
+from contextlib import suppress
 
-from tornado.httpserver import HTTPServer
-import tlz
 import dask
+import tlz
+from tornado.httpserver import HTTPServer
 
-from .comm import get_tcp_server_address
-from .comm import get_address_host
+from .comm import get_address_host, get_tcp_server_address
 from .core import Server
 from .http.routing import RoutingApplication
-from .versions import get_versions
 from .utils import DequeHandler, clean_dashboard_address
+from .versions import get_versions
 
 
 class ServerNode(Server):

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -9,8 +9,9 @@ from types import ModuleType
 from typing import List
 
 import click
-from dask.utils import tmpfile
 from tornado.httpclient import AsyncHTTPClient
+
+from dask.utils import tmpfile
 
 from .utils import import_file
 

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -1,17 +1,16 @@
+import filecmp
 import inspect
 import logging
 import os
 import shutil
 import sys
-from typing import List
-from types import ModuleType
-import filecmp
 from importlib import import_module
+from types import ModuleType
+from typing import List
 
 import click
-from tornado.httpclient import AsyncHTTPClient
-
 from dask.utils import tmpfile
+from tornado.httpclient import AsyncHTTPClient
 
 from .utils import import_file
 

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -6,10 +6,11 @@ import threading
 import weakref
 from queue import Queue as PyQueue
 
-import dask
 from tornado import gen
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
+
+import dask
 
 from .utils import TimeoutError, mp_context
 

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -1,18 +1,17 @@
+import asyncio
 import logging
 import os
-from queue import Queue as PyQueue
 import re
 import threading
 import weakref
-import asyncio
+from queue import Queue as PyQueue
+
 import dask
-
-from .utils import mp_context, TimeoutError
-
 from tornado import gen
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 
+from .utils import TimeoutError, mp_context
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -25,16 +25,16 @@ We represent this tree as a nested dictionary with the following form:
     }
 """
 import bisect
-from collections import defaultdict, deque
 import linecache
 import sys
 import threading
+from collections import defaultdict, deque
 from time import sleep
 
 import tlz as toolz
 
 from .metrics import time
-from .utils import format_time, color_of, parse_timedelta
+from .utils import color_of, format_time, parse_timedelta
 
 
 def identifier(frame):
@@ -375,8 +375,8 @@ def plot_figure(data, **kwargs):
     --------
     plot_data
     """
-    from bokeh.plotting import ColumnDataSource, figure
     from bokeh.models import HoverTool
+    from bokeh.plotting import ColumnDataSource, figure
 
     if "states" in data:
         data = toolz.dissoc(data, "states")

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -1,25 +1,25 @@
 from contextlib import suppress
-from functools import partial
 from distutils.version import LooseVersion
+from functools import partial
 
 from .compression import compressions, default_compression
-from .core import dumps, loads, maybe_compress, decompress, msgpack
-from .cuda import cuda_serialize, cuda_deserialize
+from .core import decompress, dumps, loads, maybe_compress, msgpack
+from .cuda import cuda_deserialize, cuda_serialize
 from .serialize import (
-    serialize,
-    deserialize,
-    nested_deserialize,
     Serialize,
     Serialized,
-    to_serialize,
-    register_serialization,
-    dask_serialize,
     dask_deserialize,
-    serialize_bytes,
+    dask_serialize,
+    deserialize,
     deserialize_bytes,
-    serialize_bytelist,
-    register_serialization_family,
+    nested_deserialize,
     register_generic,
+    register_serialization,
+    register_serialization_family,
+    serialize,
+    serialize_bytelist,
+    serialize_bytes,
+    to_serialize,
 )
 
 

--- a/distributed/protocol/arrow.py
+++ b/distributed/protocol/arrow.py
@@ -1,6 +1,6 @@
-from .serialize import dask_serialize, dask_deserialize
-
 import pyarrow
+
+from .serialize import dask_deserialize, dask_serialize
 
 if pyarrow.__version__ < "0.10":
     raise ImportError(

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -3,10 +3,10 @@ Record known compressors
 
 Includes utilities for determining whether or not to compress
 """
-from contextlib import suppress
-from functools import partial
 import logging
 import random
+from contextlib import suppress
+from functools import partial
 
 import dask
 from tlz import identity
@@ -21,7 +21,6 @@ except ImportError:
     blosc = False
 
 from ..utils import ensure_bytes
-
 
 compressions = {None: {"compress": identity, "decompress": identity}}
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -8,8 +8,9 @@ import random
 from contextlib import suppress
 from functools import partial
 
-import dask
 from tlz import identity
+
+import dask
 
 try:
     import blosc

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -1,17 +1,17 @@
 import logging
+
 import msgpack
 
-from .compression import compressions, maybe_compress, decompress
+from .compression import compressions, decompress, maybe_compress
 from .serialize import (
     Serialize,
     Serialized,
+    merge_and_deserialize,
     msgpack_decode_default,
     msgpack_encode_default,
-    merge_and_deserialize,
     serialize_and_split,
 )
 from .utils import msgpack_opts
-
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/protocol/cuda.py
+++ b/distributed/protocol/cuda.py
@@ -1,8 +1,8 @@
 import dask
+from dask.utils import typename
 
 from . import pickle
 from .serialize import ObjectDictSerializer, register_serialization_family
-from dask.utils import typename
 
 cuda_serialize = dask.utils.Dispatch("cuda_serialize")
 cuda_deserialize = dask.utils.Dispatch("cuda_deserialize")

--- a/distributed/protocol/h5py.py
+++ b/distributed/protocol/h5py.py
@@ -1,6 +1,6 @@
-from .serialize import dask_serialize, dask_deserialize
-
 import h5py
+
+from .serialize import dask_deserialize, dask_serialize
 
 
 @dask_serialize.register(h5py.File)

--- a/distributed/protocol/keras.py
+++ b/distributed/protocol/keras.py
@@ -1,6 +1,6 @@
-from .serialize import dask_serialize, dask_deserialize, serialize, deserialize
-
 import keras
+
+from .serialize import dask_deserialize, dask_serialize, deserialize, serialize
 
 
 @dask_serialize.register(keras.Model)

--- a/distributed/protocol/netcdf4.py
+++ b/distributed/protocol/netcdf4.py
@@ -1,6 +1,6 @@
-from .serialize import dask_serialize, dask_deserialize, serialize, deserialize
-
 import netCDF4
+
+from .serialize import dask_deserialize, dask_serialize, deserialize, serialize
 
 
 @dask_serialize.register(netCDF4.Dataset)

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -1,10 +1,10 @@
 import math
+
 import numpy as np
 
-from .serialize import dask_serialize, dask_deserialize
-from . import pickle
-
 from ..utils import log_errors
+from . import pickle
+from .serialize import dask_deserialize, dask_serialize
 
 
 def itemsize(dt):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -1,24 +1,17 @@
-from array import array
-from functools import partial
-import traceback
 import importlib
+import traceback
+from array import array
 from enum import Enum
+from functools import partial
 
 import dask
+import msgpack
 from dask.base import normalize_token
 
-import msgpack
-
+from ..utils import ensure_bytes, has_keyword, typename
 from . import pickle
-from ..utils import has_keyword, typename, ensure_bytes
-from .compression import maybe_compress, decompress
-from .utils import (
-    unpack_frames,
-    pack_frames_prelude,
-    frame_split_size,
-    msgpack_opts,
-)
-
+from .compression import decompress, maybe_compress
+from .utils import frame_split_size, msgpack_opts, pack_frames_prelude, unpack_frames
 
 lazy_registrations = {}
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -4,8 +4,9 @@ from array import array
 from enum import Enum
 from functools import partial
 
-import dask
 import msgpack
+
+import dask
 from dask.base import normalize_token
 
 from ..utils import ensure_bytes, has_keyword, typename

--- a/distributed/protocol/sparse.py
+++ b/distributed/protocol/sparse.py
@@ -1,6 +1,6 @@
-from .serialize import dask_serialize, dask_deserialize, serialize, deserialize
-
 import sparse
+
+from .serialize import dask_deserialize, dask_serialize, deserialize, serialize
 
 
 @dask_serialize.register(sparse.COO)

--- a/distributed/protocol/tests/test_arrow.py
+++ b/distributed/protocol/tests/test_arrow.py
@@ -4,8 +4,8 @@ pa = pytest.importorskip("pyarrow")
 pd = pytest.importorskip("pandas")
 
 import distributed
-from distributed.utils_test import gen_cluster
 from distributed.protocol import deserialize, serialize, to_serialize
+from distributed.utils_test import gen_cluster
 
 df = pd.DataFrame({"A": list("abc"), "B": [1, 2, 3]})
 tbl = pa.Table.from_pandas(df, preserve_index=False)

--- a/distributed/protocol/tests/test_collection.py
+++ b/distributed/protocol/tests/test_collection.py
@@ -1,5 +1,6 @@
 import pytest
-from distributed.protocol import serialize, deserialize
+
+from distributed.protocol import deserialize, serialize
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")

--- a/distributed/protocol/tests/test_collection_cuda.py
+++ b/distributed/protocol/tests/test_collection_cuda.py
@@ -1,4 +1,5 @@
 import pytest
+
 from dask.dataframe.utils import assert_eq
 
 from distributed.protocol import deserialize, serialize

--- a/distributed/protocol/tests/test_collection_cuda.py
+++ b/distributed/protocol/tests/test_collection_cuda.py
@@ -1,7 +1,7 @@
 import pytest
-
-from distributed.protocol import serialize, deserialize
 from dask.dataframe.utils import assert_eq
+
+from distributed.protocol import deserialize, serialize
 
 
 @pytest.mark.parametrize("collection", [tuple, dict])

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -1,6 +1,7 @@
 import pickle
 
 import pytest
+
 from distributed.protocol import deserialize, serialize
 
 cupy = pytest.importorskip("cupy")

--- a/distributed/protocol/tests/test_h5py.py
+++ b/distributed/protocol/tests/test_h5py.py
@@ -6,7 +6,6 @@ import pytest
 h5py = pytest.importorskip("h5py")
 
 from distributed.protocol import deserialize, serialize
-
 from distributed.utils import tmpfile
 
 
@@ -82,10 +81,9 @@ def test_raise_error_on_serialize_write_permissions():
                 deserialize(*serialize(f))
 
 
-from distributed.utils_test import gen_cluster
-
-
 import dask.array as da
+
+from distributed.utils_test import gen_cluster
 
 
 @silence_h5py_issue775

--- a/distributed/protocol/tests/test_highlevelgraph.py
+++ b/distributed/protocol/tests/test_highlevelgraph.py
@@ -1,14 +1,12 @@
 import ast
 
 import dask
-
 import dask.array as da
 import dask.dataframe as dd
-
-from distributed.utils_test import gen_cluster
-from distributed.diagnostics import SchedulerPlugin
-
 import pytest
+
+from distributed.diagnostics import SchedulerPlugin
+from distributed.utils_test import gen_cluster
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")

--- a/distributed/protocol/tests/test_highlevelgraph.py
+++ b/distributed/protocol/tests/test_highlevelgraph.py
@@ -1,9 +1,10 @@
 import ast
 
+import pytest
+
 import dask
 import dask.array as da
 import dask.dataframe as dd
-import pytest
 
 from distributed.diagnostics import SchedulerPlugin
 from distributed.utils_test import gen_cluster

--- a/distributed/protocol/tests/test_keras.py
+++ b/distributed/protocol/tests/test_keras.py
@@ -3,7 +3,7 @@ import pytest
 keras = pytest.importorskip("keras")
 np = pytest.importorskip("numpy")
 
-from distributed.protocol import serialize, deserialize, dumps, loads, to_serialize
+from distributed.protocol import deserialize, dumps, loads, serialize, to_serialize
 
 
 def test_serialize_deserialize_model():

--- a/distributed/protocol/tests/test_netcdf4.py
+++ b/distributed/protocol/tests/test_netcdf4.py
@@ -4,7 +4,6 @@ netCDF4 = pytest.importorskip("netCDF4")
 np = pytest.importorskip("numpy")
 
 from distributed.protocol import deserialize, serialize
-
 from distributed.utils import tmpfile
 
 
@@ -75,10 +74,9 @@ def test_serialize_deserialize_group():
                 assert (x[:] == y[:]).all()
 
 
-from distributed.utils_test import gen_cluster
-
-
 import dask.array as da
+
+from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True)

--- a/distributed/protocol/tests/test_numba.py
+++ b/distributed/protocol/tests/test_numba.py
@@ -1,6 +1,8 @@
-from distributed.protocol import serialize, deserialize
 import pickle
+
 import pytest
+
+from distributed.protocol import deserialize, serialize
 
 cuda = pytest.importorskip("numba.cuda")
 np = pytest.importorskip("numpy")

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -5,20 +5,20 @@ import pytest
 np = pytest.importorskip("numpy")
 
 from distributed.protocol import (
-    serialize,
-    deserialize,
     decompress,
+    deserialize,
     dumps,
     loads,
-    to_serialize,
     msgpack,
+    serialize,
+    to_serialize,
 )
-from distributed.protocol.utils import BIG_BYTES_SHARD_SIZE
+from distributed.protocol.compression import maybe_compress
 from distributed.protocol.numpy import itemsize
 from distributed.protocol.pickle import HIGHEST_PROTOCOL
-from distributed.protocol.compression import maybe_compress
+from distributed.protocol.utils import BIG_BYTES_SHARD_SIZE
 from distributed.system import MEMORY_LIMIT
-from distributed.utils import ensure_bytes, tmpfile, nbytes
+from distributed.utils import ensure_bytes, nbytes, tmpfile
 from distributed.utils_test import gen_cluster
 
 

--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -6,15 +6,14 @@ np = pytest.importorskip("numpy")
 from dask.dataframe.utils import assert_eq
 
 from distributed.protocol import (
-    serialize,
-    deserialize,
     decompress,
+    deserialize,
     dumps,
     loads,
+    serialize,
     to_serialize,
 )
 from distributed.utils import ensure_bytes
-
 
 dfs = [
     pd.DataFrame({}),

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -1,8 +1,8 @@
-from functools import partial
 import gc
-from operator import add
-import weakref
 import sys
+import weakref
+from functools import partial
+from operator import add
 
 import pytest
 

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -1,8 +1,8 @@
 import pytest
 
-from distributed.protocol import loads, dumps, msgpack, maybe_compress, to_serialize
+from distributed.protocol import dumps, loads, maybe_compress, msgpack, to_serialize
 from distributed.protocol.compression import compressions
-from distributed.protocol.serialize import Serialize, Serialized, serialize, deserialize
+from distributed.protocol.serialize import Serialize, Serialized, deserialize, serialize
 from distributed.system import MEMORY_LIMIT
 from distributed.utils import nbytes
 

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -1,5 +1,6 @@
-from distributed.protocol import serialize, deserialize
 import pytest
+
+from distributed.protocol import deserialize, serialize
 
 numpy = pytest.importorskip("numpy")
 cuda = pytest.importorskip("numba.cuda")

--- a/distributed/protocol/tests/test_scipy.py
+++ b/distributed/protocol/tests/test_scipy.py
@@ -1,4 +1,5 @@
 import pytest
+
 from distributed.protocol import deserialize, serialize
 
 numpy = pytest.importorskip("numpy")

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -1,6 +1,6 @@
-from array import array
 import copy
 import pickle
+from array import array
 
 import msgpack
 import pytest
@@ -14,26 +14,26 @@ except ImportError:
 from dask.utils_test import inc
 
 from distributed import wait
+from distributed.comm.utils import from_frames, to_frames
 from distributed.protocol import (
-    register_serialization,
-    serialize,
-    deserialize,
-    nested_deserialize,
     Serialize,
     Serialized,
-    to_serialize,
-    serialize_bytes,
-    deserialize_bytes,
-    serialize_bytelist,
-    register_serialization_family,
     dask_serialize,
+    deserialize,
+    deserialize_bytes,
     dumps,
     loads,
+    nested_deserialize,
+    register_serialization,
+    register_serialization_family,
+    serialize,
+    serialize_bytelist,
+    serialize_bytes,
+    to_serialize,
 )
 from distributed.protocol.serialize import check_dask_serializable
 from distributed.utils import nbytes
-from distributed.utils_test import inc, gen_test
-from distributed.comm.utils import to_frames, from_frames
+from distributed.utils_test import gen_test, inc
 
 
 class MyObj:
@@ -145,8 +145,9 @@ def test_nested_deserialize():
     assert x == x_orig  # x wasn't mutated
 
 
-from distributed.utils_test import gen_cluster
 from dask import delayed
+
+from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True)

--- a/distributed/protocol/tests/test_torch.py
+++ b/distributed/protocol/tests/test_torch.py
@@ -1,5 +1,6 @@
-from distributed.protocol import serialize, deserialize
 import pytest
+
+from distributed.protocol import deserialize, serialize
 
 np = pytest.importorskip("numpy")
 torch = pytest.importorskip("torch")

--- a/distributed/protocol/torch.py
+++ b/distributed/protocol/torch.py
@@ -1,7 +1,7 @@
-from .serialize import serialize, dask_serialize, dask_deserialize, register_generic
-
-import torch
 import numpy as np
+import torch
+
+from .serialize import dask_deserialize, dask_serialize, register_generic, serialize
 
 
 @dask_serialize.register(torch.Tensor)

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -1,13 +1,13 @@
 import asyncio
-from collections import defaultdict, deque
 import logging
 import threading
 import weakref
+from collections import defaultdict, deque
 
 from .core import CommClosedError
 from .metrics import time
-from .utils import sync, TimeoutError, parse_timedelta
 from .protocol.serialize import to_serialize
+from .utils import TimeoutError, parse_timedelta, sync
 
 logger = logging.getLogger(__name__)
 
@@ -283,7 +283,7 @@ class Pub:
 
     def __init__(self, name, worker=None, client=None):
         if worker is None and client is None:
-            from distributed import get_worker, get_client
+            from distributed import get_client, get_worker
 
             try:
                 worker = get_worker()
@@ -363,7 +363,7 @@ class Sub:
 
     def __init__(self, name, worker=None, client=None):
         if worker is None and client is None:
-            from distributed.worker import get_worker, get_client
+            from distributed.worker import get_client, get_worker
 
             try:
                 worker = get_worker()

--- a/distributed/pytest_resourceleaks.py
+++ b/distributed/pytest_resourceleaks.py
@@ -4,10 +4,10 @@ A pytest plugin to trace resource leaks.
 """
 import collections
 import gc
-import time
 import os
 import sys
 import threading
+import time
 
 import pytest
 

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -1,14 +1,13 @@
 import asyncio
-from collections import defaultdict
 import logging
 import uuid
+from collections import defaultdict
 
 from dask.utils import stringify
 
-from .client import Future, Client
-from .utils import sync, thread_state
+from .client import Client, Future
+from .utils import parse_timedelta, sync, thread_state
 from .worker import get_client, get_worker
-from .utils import parse_timedelta
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/recreate_exceptions.py
+++ b/distributed/recreate_exceptions.py
@@ -1,5 +1,7 @@
 import logging
+
 from dask.utils import stringify
+
 from .client import futures_of, wait
 from .utils import sync
 from .utils_comm import pack_data

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -17,10 +17,8 @@ from datetime import timedelta
 from functools import partial
 from numbers import Number
 
-import dask
 import psutil
 import sortedcontainers
-from dask.highlevelgraph import HighLevelGraph
 from tlz import (
     compose,
     concat,
@@ -34,6 +32,9 @@ from tlz import (
     valmap,
 )
 from tornado.ioloop import IOLoop, PeriodicCallback
+
+import dask
+from dask.highlevelgraph import HighLevelGraph
 
 from . import preloading, profile
 from . import versions as version_module

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1,89 +1,84 @@
 import asyncio
-from collections import defaultdict, deque
-
-from collections.abc import Mapping, Set
-from contextlib import suppress
-from datetime import timedelta
-from functools import partial
 import inspect
 import itertools
 import json
 import logging
 import math
-from numbers import Number
 import operator
 import os
-import sys
 import random
+import sys
 import warnings
 import weakref
+from collections import defaultdict, deque
+from collections.abc import Mapping, Set
+from contextlib import suppress
+from datetime import timedelta
+from functools import partial
+from numbers import Number
+
+import dask
 import psutil
 import sortedcontainers
-
+from dask.highlevelgraph import HighLevelGraph
 from tlz import (
-    merge,
-    pluck,
-    merge_sorted,
-    first,
-    merge_with,
-    valmap,
-    second,
     compose,
-    groupby,
     concat,
+    first,
+    groupby,
+    merge,
+    merge_sorted,
+    merge_with,
+    pluck,
+    second,
+    valmap,
 )
 from tornado.ioloop import IOLoop, PeriodicCallback
 
-import dask
-from dask.highlevelgraph import HighLevelGraph
-
-from . import profile
+from . import preloading, profile
+from . import versions as version_module
 from .batched import BatchedSend
 from .comm import (
+    get_address_host,
     normalize_address,
     resolve_address,
-    get_address_host,
     unparse_host_port,
 )
 from .comm.addressing import addresses_from_user_args
-from .core import rpc, send_recv, clean_exception, CommClosedError, Status
+from .core import CommClosedError, Status, clean_exception, rpc, send_recv
 from .diagnostics.plugin import SchedulerPlugin
-
+from .event import EventExtension
 from .http import get_handlers
+from .lock import LockExtension
 from .metrics import time
+from .multi_lock import MultiLockExtension
 from .node import ServerNode
-from . import preloading
 from .proctitle import setproctitle
+from .publish import PublishExtension
+from .pubsub import PubSubSchedulerExtension
+from .queues import QueueExtension
+from .recreate_exceptions import ReplayExceptionScheduler
 from .security import Security
+from .semaphore import SemaphoreExtension
+from .stealing import WorkStealing
 from .utils import (
     All,
-    get_fileno_limit,
-    log_errors,
-    key_split,
-    validate_key,
-    no_default,
-    parse_timedelta,
-    parse_bytes,
-    key_split_group,
+    TimeoutError,
     empty_context,
-    tmpfile,
     format_bytes,
     format_time,
-    TimeoutError,
+    get_fileno_limit,
+    key_split,
+    key_split_group,
+    log_errors,
+    no_default,
+    parse_bytes,
+    parse_timedelta,
+    tmpfile,
+    validate_key,
 )
-from .utils_comm import scatter_to_workers, gather_from_workers, retry_operation
-from .utils_perf import enable_gc_diagnosis, disable_gc_diagnosis
-from . import versions as version_module
-
-from .publish import PublishExtension
-from .queues import QueueExtension
-from .semaphore import SemaphoreExtension
-from .recreate_exceptions import ReplayExceptionScheduler
-from .lock import LockExtension
-from .multi_lock import MultiLockExtension
-from .event import EventExtension
-from .pubsub import PubSubSchedulerExtension
-from .stealing import WorkStealing
+from .utils_comm import gather_from_workers, retry_operation, scatter_to_workers
+from .utils_perf import disable_gc_diagnosis, enable_gc_diagnosis
 from .variable import VariableExtension
 
 try:
@@ -93,6 +88,8 @@ except ImportError:
 
 if compiled:
     from cython import (
+        Py_hash_t,
+        Py_ssize_t,
         bint,
         cast,
         ccall,
@@ -104,15 +101,11 @@ if compiled:
         final,
         inline,
         nogil,
-        Py_hash_t,
-        Py_ssize_t,
     )
 else:
-    from ctypes import (
-        c_double as double,
-        c_ssize_t as Py_hash_t,
-        c_ssize_t as Py_ssize_t,
-    )
+    from ctypes import c_double as double
+    from ctypes import c_ssize_t as Py_hash_t
+    from ctypes import c_ssize_t as Py_ssize_t
 
     bint = bool
 
@@ -6390,16 +6383,16 @@ class Scheduler(SchedulerState, ServerNode):
         for k in sorted(timespent.keys()):
             tasks_timings += f"\n<li> {k} time: {format_time(timespent[k])} </li>"
 
-        from .diagnostics.task_stream import rectangles
         from .dashboard.components.scheduler import task_stream_figure
+        from .diagnostics.task_stream import rectangles
 
         rects = rectangles(task_stream)
         source, task_stream = task_stream_figure(sizing_mode="stretch_both")
         source.data.update(rects)
 
         from distributed.dashboard.components.scheduler import (
-            BandwidthWorkers,
             BandwidthTypes,
+            BandwidthWorkers,
         )
 
         bandwidth_workers = BandwidthWorkers(self, sizing_mode="stretch_both")
@@ -6407,7 +6400,8 @@ class Scheduler(SchedulerState, ServerNode):
         bandwidth_types = BandwidthTypes(self, sizing_mode="stretch_both")
         bandwidth_types.update()
 
-        from bokeh.models import Panel, Tabs, Div
+        from bokeh.models import Div, Panel, Tabs
+
         import distributed
 
         # HTML
@@ -6476,8 +6470,8 @@ class Scheduler(SchedulerState, ServerNode):
             ]
         )
 
-        from bokeh.plotting import save, output_file
         from bokeh.core.templates import get_env
+        from bokeh.plotting import output_file, save
 
         with tmpfile(extension=".html") as fn:
             output_file(filename=fn, title="Dask Performance Report")

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -1,6 +1,6 @@
 import datetime
-import tempfile
 import os
+import tempfile
 
 try:
     import ssl
@@ -8,7 +8,6 @@ except ImportError:
     ssl = None
 
 import dask
-
 
 __all__ = ("Security",)
 
@@ -95,8 +94,7 @@ class Security:
         try:
             from cryptography import x509
             from cryptography.hazmat.backends import default_backend
-            from cryptography.hazmat.primitives import hashes
-            from cryptography.hazmat.primitives import serialization
+            from cryptography.hazmat.primitives import hashes, serialization
             from cryptography.hazmat.primitives.asymmetric import rsa
             from cryptography.x509.oid import NameOID
         except ImportError:

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -5,8 +5,9 @@ import warnings
 from asyncio import TimeoutError
 from collections import defaultdict, deque
 
-import dask
 from tornado.ioloop import IOLoop, PeriodicCallback
+
+import dask
 
 from distributed.utils_comm import retry_operation
 

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -1,17 +1,16 @@
-from collections import defaultdict, deque
 import logging
+from collections import defaultdict, deque
 from math import log2
 from time import time
 
+import dask
+from tlz import topk
 from tornado.ioloop import PeriodicCallback
 
-import dask
 from .comm.addressing import get_address_host
 from .core import CommClosedError
 from .diagnostics.plugin import SchedulerPlugin
 from .utils import log_errors, parse_timedelta
-
-from tlz import topk
 
 LATENCY = 10e-3
 

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -3,9 +3,10 @@ from collections import defaultdict, deque
 from math import log2
 from time import time
 
-import dask
 from tlz import topk
 from tornado.ioloop import PeriodicCallback
+
+import dask
 
 from .comm.addressing import get_address_host
 from .core import CommClosedError

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -1,4 +1,5 @@
 from collections import deque
+
 import psutil
 
 from .compatibility import WINDOWS

--- a/distributed/tests/make_tls_certs.py
+++ b/distributed/tests/make_tls_certs.py
@@ -5,8 +5,8 @@ Code heavily borrowed from Lib/tests/make_ssl_certs.py in CPython.
 
 import os
 import shutil
-import tempfile
 import subprocess
+import tempfile
 
 req_template = """
     [req]

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -2,8 +2,9 @@ import asyncio
 import operator
 from time import sleep
 
-import dask
 import pytest
+
+import dask
 
 from distributed import Actor, ActorFuture, Client, Future, Nanny, wait
 from distributed.metrics import time

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -2,13 +2,18 @@ import asyncio
 import operator
 from time import sleep
 
+import dask
 import pytest
 
-import dask
-from distributed import Actor, ActorFuture, Client, Future, wait, Nanny
-from distributed.utils_test import cluster, gen_cluster
-from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
+from distributed import Actor, ActorFuture, Client, Future, Nanny, wait
 from distributed.metrics import time
+from distributed.utils_test import (  # noqa: F401
+    client,
+    cluster,
+    cluster_fixture,
+    gen_cluster,
+    loop,
+)
 
 
 class Counter:

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -1,17 +1,23 @@
 import asyncio
-from collections.abc import Iterator
-from operator import add
 import queue
 import random
+from collections.abc import Iterator
+from operator import add
 from time import sleep
 
 import pytest
 
-from distributed.client import _as_completed, as_completed, _first_completed, wait
+from distributed.client import _as_completed, _first_completed, as_completed, wait
 from distributed.metrics import time
 from distributed.utils import CancelledError
-from distributed.utils_test import gen_cluster, inc, throws
-from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
+from distributed.utils_test import (  # noqa: F401
+    client,
+    cluster_fixture,
+    gen_cluster,
+    inc,
+    loop,
+    throws,
+)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -16,7 +16,7 @@ from distributed.compatibility import WINDOWS
 from distributed.metrics import time
 from distributed.process import AsyncProcess
 from distributed.utils import mp_context
-from distributed.utils_test import gen_test, pristine_loop, nodebug
+from distributed.utils_test import gen_test, nodebug, pristine_loop
 
 
 def feed(in_q, out_q):

--- a/distributed/tests/test_batched.py
+++ b/distributed/tests/test_batched.py
@@ -5,11 +5,11 @@ import pytest
 from tlz import assoc
 
 from distributed.batched import BatchedSend
-from distributed.core import listen, connect, CommClosedError
+from distributed.core import CommClosedError, connect, listen
 from distributed.metrics import time
+from distributed.protocol import to_serialize
 from distributed.utils import All
 from distributed.utils_test import captured_logger
-from distributed.protocol import to_serialize
 
 
 class EchoServer:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -18,14 +18,15 @@ from operator import add
 from threading import Semaphore
 from time import sleep
 
-import dask
-import dask.bag as db
 import psutil
 import pytest
+from tlz import concat, first, identity, isdistinct, merge, pluck, valmap
+
+import dask
+import dask.bag as db
 from dask import delayed
 from dask.optimization import SubgraphCallable
 from dask.utils import stringify
-from tlz import concat, first, identity, isdistinct, merge, pluck, valmap
 
 from distributed import (
     CancelledError,

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1,102 +1,101 @@
 import asyncio
-from collections import deque
-from contextlib import suppress
-from functools import partial
 import gc
 import logging
-from operator import add
 import os
 import pickle
-import psutil
 import random
 import subprocess
 import sys
 import threading
-from threading import Semaphore
-from time import sleep
 import traceback
 import warnings
 import weakref
 import zipfile
-
-import pytest
-from tlz import identity, isdistinct, concat, pluck, valmap, first, merge
+from collections import deque
+from contextlib import suppress
+from functools import partial
+from operator import add
+from threading import Semaphore
+from time import sleep
 
 import dask
+import dask.bag as db
+import psutil
+import pytest
 from dask import delayed
 from dask.optimization import SubgraphCallable
 from dask.utils import stringify
-import dask.bag as db
+from tlz import concat, first, identity, isdistinct, merge, pluck, valmap
+
 from distributed import (
-    Worker,
-    Nanny,
-    fire_and_forget,
-    LocalCluster,
-    get_client,
-    secede,
-    get_worker,
-    Executor,
-    profile,
-    performance_report,
-    TimeoutError,
     CancelledError,
+    Executor,
+    LocalCluster,
+    Nanny,
+    TimeoutError,
+    Worker,
+    fire_and_forget,
+    get_client,
+    get_worker,
+    performance_report,
+    profile,
+    secede,
 )
-from distributed.core import Status
-from distributed.comm import CommClosedError
 from distributed.client import (
     Client,
     Future,
-    wait,
-    as_completed,
-    tokenize,
     _get_global_client,
+    as_completed,
     default_client,
     futures_of,
-    temp_default_client,
     get_task_metadata,
+    temp_default_client,
+    tokenize,
+    wait,
 )
+from distributed.comm import CommClosedError
 from distributed.compatibility import MACOS, WINDOWS
-
+from distributed.core import Status
 from distributed.metrics import time
-from distributed.scheduler import Scheduler, KilledWorker, CollectTaskMetaDataPlugin
+from distributed.scheduler import CollectTaskMetaDataPlugin, KilledWorker, Scheduler
 from distributed.sizeof import sizeof
-from distributed.utils import mp_context, sync, tmp_text, tmpfile, is_valid_xml
-from distributed.utils_test import (
+from distributed.utils import is_valid_xml, mp_context, sync, tmp_text, tmpfile
+from distributed.utils_test import (  # noqa: F401
+    TaskStateMetadataPlugin,
+    a,
+    async_wait_for,
+    asyncinc,
+    b,
+    captured_logger,
+    cleanup,
+)
+from distributed.utils_test import client as c  # noqa: F401
+from distributed.utils_test import client_secondary as c2  # noqa: F401
+from distributed.utils_test import (  # noqa: F401
     cluster,
-    slowinc,
-    slowadd,
-    slowdec,
-    randominc,
-    inc,
+    cluster_fixture,
     dec,
     div,
-    throws,
-    geninc,
-    asyncinc,
+    double,
     gen_cluster,
     gen_test,
-    double,
-    popen,
-    captured_logger,
-    varying,
-    map_varying,
-    wait_for,
-    async_wait_for,
-    pristine_loop,
-    save_sys_modules,
-    TaskStateMetadataPlugin,
-)
-from distributed.utils_test import (  # noqa: F401
-    client as c,
-    client_secondary as c2,
-    cleanup,
-    cluster_fixture,
+    geninc,
+    inc,
     loop,
     loop_in_thread,
+    map_varying,
     nodebug,
+    popen,
+    pristine_loop,
+    randominc,
     s,
-    a,
-    b,
+    save_sys_modules,
+    slowadd,
+    slowdec,
+    slowinc,
+    throws,
+    varying,
+    wait_for,
 )
 
 
@@ -1598,7 +1597,8 @@ async def test_upload_file_zip(c, s, a, b):
 @gen_cluster(client=True)
 async def test_upload_file_egg(c, s, a, b):
     def g():
-        import package_1, package_2
+        import package_1
+        import package_2
 
         return package_1.a, package_2.b
 
@@ -2451,7 +2451,7 @@ def test_Future_exception_sync_2(loop, capsys):
 
 @gen_cluster(timeout=60, client=True)
 async def test_async_persist(c, s, a, b):
-    from dask.delayed import delayed, Delayed
+    from dask.delayed import Delayed, delayed
 
     x = delayed(1)
     y = delayed(inc)(x)
@@ -5517,8 +5517,8 @@ async def test_client_timeout_2():
 
 @gen_test()
 async def test_client_active_bad_port():
-    import tornado.web
     import tornado.httpserver
+    import tornado.web
 
     application = tornado.web.Application([(r"/", tornado.web.RequestHandler)])
     http_server = tornado.httpserver.HTTPServer(application)

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -1,13 +1,12 @@
 import random
 import time
-
 from concurrent.futures import (
-    TimeoutError,
-    Future,
-    wait,
-    as_completed,
     FIRST_COMPLETED,
     FIRST_EXCEPTION,
+    Future,
+    TimeoutError,
+    as_completed,
+    wait,
 )
 
 import pytest
@@ -15,16 +14,21 @@ from tlz import take
 
 from distributed import Client
 from distributed.utils import CancelledError
-from distributed.utils_test import (
-    slowinc,
+from distributed.utils_test import (  # noqa: F401
+    a,
+    b,
+    client,
+    cluster,
+    cluster_fixture,
+    inc,
+    loop,
+    s,
     slowadd,
     slowdec,
-    inc,
+    slowinc,
     throws,
     varying,
-    cluster,
 )
-from distributed.utils_test import client, cluster_fixture, loop, s, a, b  # noqa: F401
 
 
 def number_of_processing_tasks(client):

--- a/distributed/tests/test_client_loop.py
+++ b/distributed/tests/test_client_loop.py
@@ -1,5 +1,6 @@
 import pytest
-from distributed import LocalCluster, Client
+
+from distributed import Client, LocalCluster
 from distributed.utils import LoopRunner
 
 

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -6,11 +6,16 @@ np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 
 import dask
-import dask.dataframe as dd
 import dask.bag as db
+import dask.dataframe as dd
+
 from distributed.client import wait
-from distributed.utils_test import gen_cluster
-from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
+from distributed.utils_test import (  # noqa F401
+    client,
+    cluster_fixture,
+    gen_cluster,
+    loop,
+)
 
 PANDAS_VERSION = LooseVersion(pd.__version__)
 PANDAS_GT_100 = PANDAS_VERSION >= LooseVersion("1.0.0")

--- a/distributed/tests/test_config.py
+++ b/distributed/tests/test_config.py
@@ -1,19 +1,19 @@
 import logging
+import os
 import subprocess
 import sys
 import tempfile
-import os
-import yaml
 
 import pytest
+import yaml
 
+from distributed.config import initialize_logging
 from distributed.utils_test import (
     captured_handler,
     captured_logger,
     new_config,
     new_config_file,
 )
-from distributed.config import initialize_logging
 
 
 def dump_logger_list():

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -2,43 +2,42 @@ import asyncio
 import os
 import socket
 import threading
-import weakref
 import warnings
-
-import pytest
+import weakref
 
 import dask
+import pytest
+
 from distributed.core import (
-    pingpong,
+    ConnectionPool,
     Server,
     Status,
-    rpc,
-    connect,
-    send_recv,
     coerce_to_address,
-    ConnectionPool,
+    connect,
+    pingpong,
+    rpc,
+    send_recv,
 )
-from distributed.protocol.compression import compressions
-
 from distributed.metrics import time
 from distributed.protocol import to_serialize
+from distributed.protocol.compression import compressions
 from distributed.utils import get_ip, get_ipv6
+from distributed.utils_test import loop  # noqa F401
 from distributed.utils_test import (
-    gen_cluster,
-    has_ipv6,
     assert_can_connect,
-    assert_cannot_connect,
     assert_can_connect_from_everywhere_4,
     assert_can_connect_from_everywhere_4_6,
     assert_can_connect_from_everywhere_6,
     assert_can_connect_locally_4,
     assert_can_connect_locally_6,
-    tls_security,
+    assert_cannot_connect,
     captured_logger,
+    gen_cluster,
+    has_ipv6,
     inc,
     throws,
+    tls_security,
 )
-from distributed.utils_test import loop  # noqa F401
 
 
 def echo(comm, x):

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -5,8 +5,9 @@ import threading
 import warnings
 import weakref
 
-import dask
 import pytest
+
+import dask
 
 from distributed.core import (
     ConnectionPool,

--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -8,9 +8,9 @@ import sys
 from time import sleep
 from unittest import mock
 
+import dask
 import pytest
 
-import dask
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.diskutils import WorkSpace
 from distributed.metrics import time

--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -8,8 +8,9 @@ import sys
 from time import sleep
 from unittest import mock
 
-import dask
 import pytest
+
+import dask
 
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.diskutils import WorkSpace

--- a/distributed/tests/test_events.py
+++ b/distributed/tests/test_events.py
@@ -2,8 +2,12 @@ import pickle
 from datetime import timedelta
 
 from distributed import Event
-from distributed.utils_test import gen_cluster
-from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
+from distributed.utils_test import (  # noqa F401
+    client,
+    cluster_fixture,
+    gen_cluster,
+    loop,
+)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -1,28 +1,28 @@
 import asyncio
-from contextlib import suppress
 import os
 import random
+from contextlib import suppress
 from time import sleep
 
 import pytest
-from tlz import partition_all, first
-
 from dask import delayed
+from tlz import first, partition_all
+
 from distributed import Client, Nanny, wait
 from distributed.comm import CommClosedError
 from distributed.compatibility import MACOS
 from distributed.metrics import time
-from distributed.utils import sync, CancelledError
-from distributed.utils_test import (
-    gen_cluster,
-    cluster,
-    inc,
-    div,
-    slowinc,
-    slowadd,
-    captured_logger,
-)
+from distributed.utils import CancelledError, sync
 from distributed.utils_test import loop  # noqa: F401
+from distributed.utils_test import (
+    captured_logger,
+    cluster,
+    div,
+    gen_cluster,
+    inc,
+    slowadd,
+    slowinc,
+)
 
 
 def test_submit_after_failed_worker_sync(loop):

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -5,8 +5,9 @@ from contextlib import suppress
 from time import sleep
 
 import pytest
-from dask import delayed
 from tlz import first, partition_all
+
+from dask import delayed
 
 from distributed import Client, Nanny, wait
 from distributed.comm import CommClosedError

--- a/distributed/tests/test_ipython.py
+++ b/distributed/tests/test_ipython.py
@@ -4,8 +4,7 @@ import pytest
 from tlz import first
 
 from distributed import Client
-from distributed.utils_test import cluster, mock_ipython
-from distributed.utils_test import loop, zmq_ctx  # noqa F401
+from distributed.utils_test import cluster, loop, mock_ipython, zmq_ctx  # noqa F401
 
 
 def need_functional_ipython(func):

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -1,13 +1,17 @@
 import pickle
-from time import sleep
 from datetime import timedelta
+from time import sleep
 
 import pytest
 
-from distributed import Lock, get_client, Client
+from distributed import Client, Lock, get_client
 from distributed.metrics import time
-from distributed.utils_test import gen_cluster
-from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
+from distributed.utils_test import (  # noqa F401
+    client,
+    cluster_fixture,
+    gen_cluster,
+    loop,
+)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)

--- a/distributed/tests/test_multi_locks.py
+++ b/distributed/tests/test_multi_locks.py
@@ -1,12 +1,15 @@
 import asyncio
-from distributed.multi_lock import MultiLockExtension
 from time import sleep
-
 
 from distributed import MultiLock, get_client
 from distributed.metrics import time
-from distributed.utils_test import gen_cluster
-from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
+from distributed.multi_lock import MultiLockExtension
+from distributed.utils_test import (  # noqa F401
+    client,
+    cluster_fixture,
+    gen_cluster,
+    loop,
+)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -7,10 +7,11 @@ import random
 import sys
 from contextlib import suppress
 
-import dask
 import pytest
 from tlz import first, valmap
 from tornado.ioloop import IOLoop
+
+import dask
 
 from distributed import Client, Nanny, Scheduler, Worker, rpc, wait, worker
 from distributed.compatibility import MACOS

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -1,31 +1,26 @@
 import asyncio
-from contextlib import suppress
 import gc
 import logging
+import multiprocessing as mp
 import os
 import random
 import sys
-import multiprocessing as mp
-
-import pytest
-from tlz import valmap, first
-from tornado.ioloop import IOLoop
+from contextlib import suppress
 
 import dask
-from distributed.diagnostics import SchedulerPlugin
-from distributed import Nanny, rpc, Scheduler, Worker, Client, wait, worker
+import pytest
+from tlz import first, valmap
+from tornado.ioloop import IOLoop
+
+from distributed import Client, Nanny, Scheduler, Worker, rpc, wait, worker
 from distributed.compatibility import MACOS
 from distributed.core import CommClosedError, Status
+from distributed.diagnostics import SchedulerPlugin
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps
-from distributed.utils import tmpfile, TimeoutError, parse_ports
-from distributed.utils_test import (  # noqa: F401
-    gen_cluster,
-    gen_test,
-    inc,
-    captured_logger,
-    cleanup,
-)
+from distributed.utils import TimeoutError, parse_ports, tmpfile
+from distributed.utils_test import cleanup  # noqa: F401
+from distributed.utils_test import captured_logger, gen_cluster, gen_test, inc
 
 
 # FIXME why does this leave behind unclosed Comm objects?

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -1,17 +1,14 @@
 import os
-import pytest
 import shutil
 import sys
 import tempfile
-import pytest
-
-from tornado import web
 
 import dask
-from distributed import Client, Scheduler, Worker, Nanny
-from distributed.utils_test import cluster, captured_logger
-from distributed.utils_test import loop, cleanup  # noqa F401
+import pytest
+from tornado import web
 
+from distributed import Client, Nanny, Scheduler, Worker
+from distributed.utils_test import captured_logger, cleanup, cluster, loop  # noqa F401
 
 PRELOAD_TEXT = """
 _worker_info = {}

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -3,9 +3,10 @@ import shutil
 import sys
 import tempfile
 
-import dask
 import pytest
 from tornado import web
+
+import dask
 
 from distributed import Client, Nanny, Scheduler, Worker
 from distributed.utils_test import captured_logger, cleanup, cluster, loop  # noqa F401

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -1,7 +1,8 @@
 import asyncio
 
-import dask
 import pytest
+
+import dask
 from dask import delayed, persist
 from dask.core import flatten
 from dask.utils import stringify

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -1,14 +1,13 @@
 import asyncio
 
-import pytest
-
-from dask.core import flatten
 import dask
+import pytest
 from dask import delayed, persist
+from dask.core import flatten
 from dask.utils import stringify
 
-from distributed.utils_test import gen_cluster, inc, slowinc, slowdec
-from distributed import wait, Worker
+from distributed import Worker, wait
+from distributed.utils_test import gen_cluster, inc, slowdec, slowinc
 
 
 @gen_cluster(client=True, nthreads=[])

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -1,21 +1,22 @@
-import pytest
 import sys
-import time
-from tlz import first
 import threading
+import time
 
-from distributed.compatibility import WINDOWS
+import pytest
+from tlz import first
+
 from distributed import metrics
+from distributed.compatibility import WINDOWS
 from distributed.profile import (
-    process,
-    merge,
-    create,
     call_stack,
+    create,
     identifier,
-    watch,
-    llprocess,
     ll_get_stack,
+    llprocess,
+    merge,
     plot_data,
+    process,
+    watch,
 )
 
 

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+
 from dask import delayed
 
 from distributed import Client

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -1,13 +1,19 @@
 import asyncio
-import pytest
 
+import pytest
 from dask import delayed
+
 from distributed import Client
 from distributed.client import futures_of
 from distributed.metrics import time
-from distributed.utils_test import gen_cluster, inc
-from distributed.utils_test import client, cluster_fixture, loop  # noqa F401
 from distributed.protocol import Serialized
+from distributed.utils_test import (  # noqa F401
+    client,
+    cluster_fixture,
+    gen_cluster,
+    inc,
+    loop,
+)
 
 
 @gen_cluster(client=False)

--- a/distributed/tests/test_pubsub.py
+++ b/distributed/tests/test_pubsub.py
@@ -5,9 +5,9 @@ from time import sleep
 import pytest
 import tlz as toolz
 
-from distributed import Pub, Sub, wait, get_worker, TimeoutError
-from distributed.utils_test import gen_cluster
+from distributed import Pub, Sub, TimeoutError, get_worker, wait
 from distributed.metrics import time
+from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True, timeout=None)

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -4,10 +4,17 @@ from time import sleep
 
 import pytest
 
-from distributed import Client, Queue, Nanny, worker_client, wait, TimeoutError
+from distributed import Client, Nanny, Queue, TimeoutError, wait, worker_client
 from distributed.metrics import time
-from distributed.utils_test import gen_cluster, inc, div, popen
-from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
+from distributed.utils_test import (  # noqa: F401
+    client,
+    cluster_fixture,
+    div,
+    gen_cluster,
+    inc,
+    loop,
+    popen,
+)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -2,15 +2,25 @@ import asyncio
 from time import time
 
 import dask
+import pytest
 from dask import delayed
 from dask.utils import stringify
-import pytest
 
 from distributed import Worker
 from distributed.client import wait
 from distributed.compatibility import WINDOWS
-from distributed.utils_test import inc, gen_cluster, slowinc, slowadd
-from distributed.utils_test import client, cluster_fixture, loop, s, a, b  # noqa: F401
+from distributed.utils_test import (  # noqa: F401
+    a,
+    b,
+    client,
+    cluster_fixture,
+    gen_cluster,
+    inc,
+    loop,
+    s,
+    slowadd,
+    slowinc,
+)
 
 
 @gen_cluster(client=True, nthreads=[])

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -1,8 +1,9 @@
 import asyncio
 from time import time
 
-import dask
 import pytest
+
+import dask
 from dask import delayed
 from dask.utils import stringify
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -8,11 +8,12 @@ from collections import defaultdict
 from time import sleep
 
 import cloudpickle
-import dask
 import pytest
+from tlz import concat, first, frequencies, merge, valmap
+
+import dask
 from dask import delayed
 from dask.compatibility import apply
-from tlz import concat, first, frequencies, merge, valmap
 
 from distributed import Client, Nanny, Worker, fire_and_forget, wait
 from distributed.client import wait

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -9,38 +9,38 @@ from time import sleep
 
 import cloudpickle
 import dask
-from dask import delayed
-from tlz import merge, concat, valmap, first, frequencies
-
 import pytest
+from dask import delayed
+from dask.compatibility import apply
+from tlz import concat, first, frequencies, merge, valmap
 
-from distributed import Nanny, Worker, Client, wait, fire_and_forget
+from distributed import Client, Nanny, Worker, fire_and_forget, wait
+from distributed.client import wait
 from distributed.comm import Comm
 from distributed.compatibility import MACOS
-from distributed.core import connect, rpc, ConnectionPool, Status
-from distributed.scheduler import Scheduler
-from distributed.client import wait
+from distributed.core import ConnectionPool, Status, connect, rpc
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps
-from distributed.worker import dumps_function, dumps_task
-from distributed.utils import tmpfile, typename, TimeoutError
+from distributed.scheduler import Scheduler
+from distributed.utils import TimeoutError, tmpfile, typename
 from distributed.utils_test import (  # noqa: F401
     captured_logger,
     cleanup,
-    inc,
+    cluster,
     dec,
+    div,
     gen_cluster,
     gen_test,
-    slowinc,
+    inc,
+    loop,
+    nodebug,
     slowadd,
     slowdec,
-    cluster,
-    div,
-    varying,
+    slowinc,
     tls_only_security,
+    varying,
 )
-from distributed.utils_test import loop, nodebug  # noqa: F401
-from dask.compatibility import apply
+from distributed.worker import dumps_function, dumps_task
 
 if sys.version_info < (3, 8):
     try:

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -5,8 +5,9 @@ try:
 except ImportError:
     ssl = None
 
-import dask
 import pytest
+
+import dask
 
 from distributed.comm import connect, listen
 from distributed.security import Security

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -5,13 +5,12 @@ try:
 except ImportError:
     ssl = None
 
+import dask
 import pytest
 
 from distributed.comm import connect, listen
 from distributed.security import Security
 from distributed.utils_test import get_cert
-
-import dask
 
 ca_file = get_cert("tls-ca-cert.pem")
 

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -4,8 +4,9 @@ import pickle
 from datetime import timedelta
 from time import sleep, time
 
-import dask
 import pytest
+
+import dask
 from dask.distributed import Client
 
 from distributed import Semaphore, fire_and_forget

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -1,27 +1,29 @@
 import asyncio
-from datetime import timedelta
+import logging
 import pickle
+from datetime import timedelta
+from time import sleep, time
+
 import dask
 import pytest
 from dask.distributed import Client
-from time import time, sleep
+
 from distributed import Semaphore, fire_and_forget
 from distributed.comm import Comm
 from distributed.compatibility import WINDOWS
 from distributed.core import ConnectionPool
 from distributed.metrics import time
 from distributed.utils_test import (  # noqa: F401
-    client,
-    cleanup,
-    cluster,
     async_wait_for,
     captured_logger,
+    cleanup,
+    client,
+    cluster,
     cluster_fixture,
     gen_cluster,
-    slowidentity,
     loop,
+    slowidentity,
 )
-import logging
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -1,5 +1,6 @@
-import pytest
 import logging
+
+import pytest
 from dask.sizeof import sizeof
 
 from distributed.sizeof import safe_sizeof

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+
 from dask.sizeof import sizeof
 
 from distributed.sizeof import safe_sizeof

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -9,6 +9,8 @@ from time import sleep
 
 import dask
 import pytest
+from tlz import concat, sliding_window
+
 from distributed import Nanny, Worker, wait, worker_client
 from distributed.config import config
 from distributed.metrics import time
@@ -24,7 +26,6 @@ from distributed.utils_test import (
     slowidentity,
     slowinc,
 )
-from tlz import concat, sliding_window
 
 # Most tests here are timing-dependent
 setup_module = nodebug_setup_module

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -7,9 +7,10 @@ import weakref
 from operator import mul
 from time import sleep
 
-import dask
 import pytest
 from tlz import concat, sliding_window
+
+import dask
 
 from distributed import Nanny, Worker, wait, worker_client
 from distributed.config import config

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -1,34 +1,31 @@
 import asyncio
-from contextlib import suppress
 import random
 import sys
+from contextlib import suppress
 from operator import add
 from time import sleep
 
-from dask import delayed
 import pytest
+from dask import delayed
 from tlz import concat, sliding_window
 
-from distributed import Client, wait, Nanny
+from distributed import Client, Nanny, wait
+from distributed.client import wait
 from distributed.config import config
 from distributed.metrics import time
 from distributed.utils import All, CancelledError
-from distributed.utils_test import (
-    gen_cluster,
-    cluster,
-    inc,
-    slowinc,
-    slowadd,
-    slowsum,
-    bump_rlimit,
-)
 from distributed.utils_test import (  # noqa: F401
+    bump_rlimit,
+    cluster,
+    gen_cluster,
+    inc,
     loop,
     nodebug_setup_module,
     nodebug_teardown_module,
+    slowadd,
+    slowinc,
+    slowsum,
 )
-from distributed.client import wait
-
 
 # All tests here are slow in some way
 setup_module = nodebug_setup_module
@@ -254,10 +251,12 @@ async def test_no_delay_during_large_transfer(c, s, w):
     x_nbytes = x.nbytes
 
     # Reset digests
-    from distributed.counter import Digest
     from collections import defaultdict
     from functools import partial
+
     from dask.diagnostics import ResourceProfiler
+
+    from distributed.counter import Digest
 
     for server in [s, w]:
         server.digests = defaultdict(partial(Digest, loop=server.io_loop))

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -6,8 +6,9 @@ from operator import add
 from time import sleep
 
 import pytest
-from dask import delayed
 from tlz import concat, sliding_window
+
+from dask import delayed
 
 from distributed import Client, Nanny, wait
 from distributed.client import wait

--- a/distributed/tests/test_threadpoolexecutor.py
+++ b/distributed/tests/test_threadpoolexecutor.py
@@ -1,8 +1,8 @@
-from time import sleep
 import threading
+from time import sleep
 
 from distributed.metrics import time
-from distributed.threadpoolexecutor import ThreadPoolExecutor, secede, rejoin
+from distributed.threadpoolexecutor import ThreadPoolExecutor, rejoin, secede
 
 
 def test_tpe():

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -3,21 +3,22 @@ Various functional tests for TLS networking.
 Most are taken from other test files and adapted.
 """
 import asyncio
+
 import pytest
 
-from distributed import Scheduler, Worker, Client, Nanny, worker_client, Queue
-from distributed.core import Status
+from distributed import Client, Nanny, Queue, Scheduler, Worker, worker_client
 from distributed.client import wait
+from distributed.core import Status
 from distributed.metrics import time
 from distributed.nanny import Nanny
 from distributed.utils_test import (  # noqa: F401
+    cleanup,
+    double,
     gen_tls_cluster,
     inc,
-    double,
-    slowinc,
     slowadd,
+    slowinc,
     tls_config,
-    cleanup,
 )
 
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,52 +1,60 @@
-import asyncio
 import array
+import asyncio
 import datetime
-from functools import partial
 import io
 import os
 import queue
 import socket
 import sys
-from time import sleep
 import traceback
+from functools import partial
+from time import sleep
 
+import dask
 import pytest
 from tornado.ioloop import IOLoop
 
-import dask
 from distributed.metrics import time
 from distributed.utils import (
+    LRU,
     All,
     Log,
     Logs,
-    sync,
+    LoopRunner,
+    TimeoutError,
+    _maybe_complex,
+    ensure_bytes,
+    ensure_ip,
+    format_dashboard_link,
+    funcname,
+    get_ip_interface,
+    get_traceback,
     is_kernel,
     is_valid_xml,
-    ensure_ip,
-    truncate_exception,
-    get_traceback,
-    _maybe_complex,
+    nbytes,
+    offload,
+    open_port,
+    parse_bytes,
+    parse_ports,
+    parse_timedelta,
     read_block,
     seek_delimiter,
-    funcname,
-    ensure_bytes,
-    open_port,
-    get_ip_interface,
-    nbytes,
     set_thread_state,
+    sync,
     thread_state,
-    LoopRunner,
-    parse_bytes,
-    parse_timedelta,
-    parse_ports,
+    truncate_exception,
     warn_on_duration,
-    format_dashboard_link,
-    LRU,
-    offload,
-    TimeoutError,
 )
-from distributed.utils_test import loop, loop_in_thread  # noqa: F401
-from distributed.utils_test import div, has_ipv6, inc, throws, gen_test, captured_logger
+from distributed.utils_test import (  # noqa: F401
+    captured_logger,
+    div,
+    gen_test,
+    has_ipv6,
+    inc,
+    loop,
+    loop_in_thread,
+    throws,
+)
 
 
 def test_All(loop):

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -10,9 +10,10 @@ import traceback
 from functools import partial
 from time import sleep
 
-import dask
 import pytest
 from tornado.ioloop import IOLoop
+
+import dask
 
 from distributed.metrics import time
 from distributed.utils import (

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -1,11 +1,11 @@
-from distributed.core import ConnectionPool
-from distributed.comm import Comm
-from distributed.utils_test import gen_cluster, loop  # noqa: F401
-from distributed.utils_comm import pack_data, subs_multiple, gather_from_workers, retry
-
 from unittest import mock
 
 import pytest
+
+from distributed.comm import Comm
+from distributed.core import ConnectionPool
+from distributed.utils_comm import gather_from_workers, pack_data, retry, subs_multiple
+from distributed.utils_test import gen_cluster, loop  # noqa: F401
 
 
 def test_pack_data():

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1,33 +1,30 @@
 import asyncio
-from contextlib import contextmanager
 import socket
 import threading
+from contextlib import contextmanager
 from time import sleep
 
 import pytest
 from tornado import gen
 
-from distributed import Scheduler, Worker, Nanny, Client, config, default_client
+from distributed import Client, Nanny, Scheduler, Worker, config, default_client
 from distributed.core import rpc
 from distributed.metrics import time
+from distributed.utils import get_ip
 from distributed.utils_test import (  # noqa: F401
     cleanup,
     cluster,
     gen_cluster,
-    inc,
     gen_test,
-    wait_for_port,
-    new_config,
-)
-
-from distributed.utils_test import (  # noqa: F401
+    inc,
     loop,
-    tls_only_security,
+    new_config,
     security,
     tls_client,
     tls_cluster,
+    tls_only_security,
+    wait_for_port,
 )
-from distributed.utils import get_ip
 
 
 def test_bare_cluster(loop):

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -1,17 +1,25 @@
 import asyncio
+import logging
 import random
 from datetime import timedelta
-from time import sleep, monotonic
-import logging
+from time import monotonic, sleep
 
 import pytest
 from tornado.ioloop import IOLoop
 
-from distributed import Client, Variable, worker_client, Nanny, wait, TimeoutError
-from distributed.metrics import time
+from distributed import Client, Nanny, TimeoutError, Variable, wait, worker_client
 from distributed.compatibility import WINDOWS
-from distributed.utils_test import gen_cluster, inc, div, captured_logger, popen
-from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
+from distributed.metrics import time
+from distributed.utils_test import (  # noqa: F401
+    captured_logger,
+    client,
+    cluster_fixture,
+    div,
+    gen_cluster,
+    inc,
+    loop,
+    popen,
+)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -3,10 +3,9 @@ import sys
 
 import pytest
 
-from distributed.versions import get_versions, error_message
 from distributed import Client, Worker
 from distributed.utils_test import gen_cluster, loop  # noqa: F401
-
+from distributed.versions import error_message, get_versions
 
 # if one of the nodes reports this version, there's a mismatch
 mismatched_version = get_versions()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -11,13 +11,14 @@ from operator import add
 from time import sleep
 from unittest import mock
 
-import dask
 import psutil
 import pytest
+from tlz import first, pluck, sliding_window
+
+import dask
 from dask import delayed
 from dask.system import CPU_COUNT
 from dask.utils import format_bytes
-from tlz import first, pluck, sliding_window
 
 from distributed import (
     Client,

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1,61 +1,59 @@
-from concurrent.futures import ThreadPoolExecutor
+import asyncio
 import importlib
 import logging
-from numbers import Number
-from operator import add
 import os
-import psutil
 import sys
-from time import sleep
 import threading
 import traceback
+from concurrent.futures import ThreadPoolExecutor
+from numbers import Number
+from operator import add
+from time import sleep
 from unittest import mock
-import asyncio
 
 import dask
-from dask import delayed
-from dask.utils import format_bytes
-from dask.system import CPU_COUNT
+import psutil
 import pytest
-from tlz import pluck, sliding_window, first
+from dask import delayed
+from dask.system import CPU_COUNT
+from dask.utils import format_bytes
+from tlz import first, pluck, sliding_window
 
 from distributed import (
     Client,
     Nanny,
-    get_client,
-    default_client,
-    get_worker,
     Reschedule,
+    default_client,
+    get_client,
+    get_worker,
     wait,
 )
-from distributed.diagnostics.plugin import PipInstall
 from distributed.compatibility import MACOS, WINDOWS
-from distributed.core import rpc, CommClosedError, Status
-from distributed.scheduler import Scheduler
+from distributed.core import CommClosedError, Status, rpc
+from distributed.diagnostics.plugin import PipInstall
 from distributed.metrics import time
-from distributed.worker import Worker, error_message, logger, parse_memory_limit
-from distributed.utils import tmpfile, TimeoutError
+from distributed.scheduler import Scheduler
+from distributed.utils import TimeoutError, tmpfile
 from distributed.utils_test import (  # noqa: F401
-    cleanup,
-    inc,
-    mul,
-    gen_cluster,
-    div,
-    dec,
-    slowinc,
-    gen_test,
-    captured_logger,
-)
-from distributed.utils_test import (  # noqa: F401
-    client,
-    loop,
-    nodebug,
-    cluster_fixture,
-    s,
+    TaskStateMetadataPlugin,
     a,
     b,
-    TaskStateMetadataPlugin,
+    captured_logger,
+    cleanup,
+    client,
+    cluster_fixture,
+    dec,
+    div,
+    gen_cluster,
+    gen_test,
+    inc,
+    loop,
+    mul,
+    nodebug,
+    s,
+    slowinc,
 )
+from distributed.worker import Worker, error_message, logger, parse_memory_limit
 
 
 @pytest.mark.asyncio

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -4,8 +4,9 @@ import threading
 import warnings
 from time import sleep
 
-import dask
 import pytest
+
+import dask
 from dask import delayed
 
 from distributed import (

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -1,24 +1,30 @@
 import asyncio
 import random
 import threading
-from time import sleep
 import warnings
+from time import sleep
 
 import dask
-from dask import delayed
 import pytest
+from dask import delayed
 
 from distributed import (
-    worker_client,
     Client,
     as_completed,
+    get_client,
     get_worker,
     wait,
-    get_client,
+    worker_client,
 )
 from distributed.metrics import time
-from distributed.utils_test import double, gen_cluster, inc
-from distributed.utils_test import client, cluster_fixture, loop  # noqa: F401
+from distributed.utils_test import (  # noqa: F401
+    client,
+    cluster_fixture,
+    double,
+    gen_cluster,
+    inc,
+    loop,
+)
 
 
 @gen_cluster(client=True)

--- a/distributed/threadpoolexecutor.py
+++ b/distributed/threadpoolexecutor.py
@@ -20,13 +20,13 @@ which is included as a comment at the end of this file:
 
    Copyright 2001-2016 Python Software Foundation; All Rights Reserved
 """
-from . import _concurrent_futures_thread as thread
-import os
+import itertools
 import logging
+import os
 import queue
 import threading
-import itertools
 
+from . import _concurrent_futures_thread as thread
 from .metrics import time
 
 logger = logging.getLogger(__name__)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1,31 +1,32 @@
 import asyncio
-from asyncio import TimeoutError
-import click
-from collections import deque, OrderedDict, UserDict
-from concurrent.futures import ThreadPoolExecutor, CancelledError  # noqa: F401
-from contextlib import contextmanager, suppress
 import functools
-from hashlib import md5
 import html
+import importlib
+import inspect
 import json
 import logging
 import multiprocessing
 import os
+import pkgutil
 import re
 import shutil
 import socket
-from time import sleep
-import importlib
-from importlib.util import cache_from_source
-import inspect
 import sys
 import tempfile
 import threading
 import warnings
 import weakref
-import pkgutil
-import tblib.pickling_support
 import xml.etree.ElementTree
+from asyncio import TimeoutError
+from collections import OrderedDict, UserDict, deque
+from concurrent.futures import CancelledError, ThreadPoolExecutor  # noqa: F401
+from contextlib import contextmanager, suppress
+from hashlib import md5
+from importlib.util import cache_from_source
+from time import sleep
+
+import click
+import tblib.pickling_support
 
 try:
     import resource
@@ -33,22 +34,21 @@ except ImportError:
     resource = None
 
 import dask
+import tlz as toolz
 from dask import istask
 
 # Import config serialization functions here for backward compatibility
-from dask.config import serialize as serialize_for_cli  # noqa
 from dask.config import deserialize as deserialize_for_cli  # noqa
+from dask.config import serialize as serialize_for_cli  # noqa
 
 # provide format_bytes here for backwards compatibility
-from dask.utils import (  # noqa
+from dask.utils import (  # noqa: F401
     format_bytes,
-    funcname,
     format_time,
+    funcname,
     parse_bytes,
     parse_timedelta,
 )
-
-import tlz as toolz
 from tornado import gen
 from tornado.ioloop import IOLoop
 
@@ -59,7 +59,6 @@ except ImportError:
 
 from .compatibility import PYPY, WINDOWS
 from .metrics import time
-
 
 try:
     from dask.context import thread_state
@@ -89,7 +88,7 @@ def _initialize_mp_context():
         if "pkg_resources" in sys.modules:
             preload.append("pkg_resources")
 
-        from .versions import required_packages, optional_packages
+        from .versions import optional_packages, required_packages
 
         for pkg, _ in required_packages + optional_packages:
             try:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -33,8 +33,11 @@ try:
 except ImportError:
     resource = None
 
-import dask
 import tlz as toolz
+from tornado import gen
+from tornado.ioloop import IOLoop
+
+import dask
 from dask import istask
 
 # Import config serialization functions here for backward compatibility
@@ -49,8 +52,6 @@ from dask.utils import (  # noqa: F401
     parse_bytes,
     parse_timedelta,
 )
-from tornado import gen
-from tornado.ioloop import IOLoop
 
 try:
     from tornado.ioloop import PollIOLoop

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -5,10 +5,11 @@ from collections import defaultdict
 from functools import partial
 from itertools import cycle
 
+from tlz import concat, drop, groupby, merge
+
 import dask.config
 from dask.optimization import SubgraphCallable
 from dask.utils import parse_timedelta, stringify
-from tlz import concat, drop, groupby, merge
 
 from .core import rpc
 from .utils import All

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -1,14 +1,14 @@
 import asyncio
+import logging
+import random
 from collections import defaultdict
 from functools import partial
 from itertools import cycle
-import logging
-import random
 
-from dask.optimization import SubgraphCallable
 import dask.config
+from dask.optimization import SubgraphCallable
 from dask.utils import parse_timedelta, stringify
-from tlz import merge, concat, groupby, drop
+from tlz import concat, drop, groupby, merge
 
 from .core import rpc
 from .utils import All

--- a/distributed/utils_perf.py
+++ b/distributed/utils_perf.py
@@ -1,13 +1,12 @@
-from collections import deque
 import gc
 import logging
 import threading
+from collections import deque
 
 from dask.utils import format_bytes
 
 from .compatibility import PYPY
 from .metrics import thread_time
-
 
 logger = _logger = logging.getLogger(__name__)
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -29,11 +29,12 @@ try:
 except ImportError:
     ssl = None
 
-import dask
 import pytest
 from tlz import assoc, memoize, merge
 from tornado import gen
 from tornado.ioloop import IOLoop
+
+import dask
 
 from . import system
 from .client import Client, _global_clients, default_client

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1,10 +1,8 @@
 import asyncio
 import collections
-import gc
-from contextlib import contextmanager, suppress
 import copy
 import functools
-from glob import glob
+import gc
 import io
 import itertools
 import logging
@@ -19,49 +17,50 @@ import subprocess
 import sys
 import tempfile
 import threading
-from time import sleep
 import uuid
 import warnings
 import weakref
+from contextlib import contextmanager, suppress
+from glob import glob
+from time import sleep
 
 try:
     import ssl
 except ImportError:
     ssl = None
 
-import pytest
-
 import dask
-from tlz import merge, memoize, assoc
+import pytest
+from tlz import assoc, memoize, merge
 from tornado import gen
 from tornado.ioloop import IOLoop
 
 from . import system
-from .client import default_client, _global_clients, Client
-from .compatibility import WINDOWS
+from .client import Client, _global_clients, default_client
 from .comm import Comm
+from .compatibility import WINDOWS
 from .config import initialize_logging
-from .core import connect, rpc, CommClosedError, Status
+from .core import CommClosedError, Status, connect, rpc
 from .deploy import SpecCluster
+from .diagnostics.plugin import WorkerPlugin
 from .metrics import time
+from .nanny import Nanny
 from .proctitle import enable_proctitle_on_children
 from .security import Security
 from .utils import (
-    log_errors,
-    mp_context,
+    DequeHandler,
+    TimeoutError,
+    _offload_executor,
     get_ip,
     get_ipv6,
-    DequeHandler,
+    iscoroutinefunction,
+    log_errors,
+    mp_context,
     reset_logger_locks,
     sync,
-    iscoroutinefunction,
     thread_state,
-    _offload_executor,
-    TimeoutError,
 )
 from .worker import Worker
-from .nanny import Nanny
-from .diagnostics.plugin import WorkerPlugin
 
 try:
     import dask.array  # register config
@@ -190,6 +189,7 @@ def pristine_loop():
 @contextmanager
 def mock_ipython():
     from unittest import mock
+
     from distributed._ipython_utils import remote_magic
 
     ip = mock.Mock()

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -1,14 +1,14 @@
 import asyncio
-from collections import defaultdict
-from contextlib import suppress
 import logging
 import uuid
-
-from tlz import merge
+from collections import defaultdict
+from contextlib import suppress
 
 from dask.utils import stringify
-from .client import Future, Client
-from .utils import log_errors, TimeoutError, parse_timedelta
+from tlz import merge
+
+from .client import Client, Future
+from .utils import TimeoutError, log_errors, parse_timedelta
 from .worker import get_client, get_worker
 
 logger = logging.getLogger(__name__)

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -4,8 +4,9 @@ import uuid
 from collections import defaultdict
 from contextlib import suppress
 
-from dask.utils import stringify
 from tlz import merge
+
+from dask.utils import stringify
 
 from .client import Client, Future
 from .utils import TimeoutError, log_errors, parse_timedelta

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -1,13 +1,12 @@
 """ utilities for package version introspection """
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
+import importlib
+import os
 import platform
 import struct
-import os
 import sys
-import importlib
-
 
 required_packages = [
     ("dask", lambda p: p.__version__),

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1,76 +1,79 @@
 import asyncio
 import bisect
-
+import errno
+import heapq
+import logging
+import os
+import random
+import sys
+import threading
+import uuid
+import warnings
+import weakref
 from collections import defaultdict, deque, namedtuple
 from collections.abc import MutableMapping
 from contextlib import suppress
 from datetime import timedelta
-import errno
 from functools import partial
-import heapq
 from inspect import isawaitable
-import logging
-import os
 from pickle import PicklingError
-import random
-import threading
-import sys
-import uuid
-import warnings
-import weakref
 
 import dask
-from dask.core import istask
 from dask.compatibility import apply
-from dask.utils import format_bytes, funcname
+from dask.core import istask
 from dask.system import CPU_COUNT
-
-from tlz import pluck, merge, first, keymap
+from dask.utils import format_bytes, funcname
+from tlz import first, keymap, merge, pluck
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 
-from . import profile, comm, system
+from . import comm, preloading, profile, system
 from .batched import BatchedSend
-from .comm import get_address_host, connect
+from .comm import connect, get_address_host
 from .comm.addressing import address_from_user_args
 from .comm.utils import OFFLOAD_THRESHOLD
-from .core import error_message, CommClosedError, send_recv, pingpong, coerce_to_address
+from .core import (
+    CommClosedError,
+    Status,
+    coerce_to_address,
+    error_message,
+    pingpong,
+    send_recv,
+)
 from .diskutils import WorkSpace
 from .http import get_handlers
 from .metrics import time
 from .node import ServerNode
-from . import preloading
 from .proctitle import setproctitle
-from .protocol import pickle, to_serialize, deserialize_bytes, serialize_bytelist
+from .protocol import deserialize_bytes, pickle, serialize_bytelist, to_serialize
 from .pubsub import PubSubWorkerExtension
 from .security import Security
 from .sizeof import safe_sizeof as sizeof
-from .threadpoolexecutor import ThreadPoolExecutor, secede as tpe_secede
+from .threadpoolexecutor import ThreadPoolExecutor
+from .threadpoolexecutor import secede as tpe_secede
 from .utils import (
-    get_ip,
-    typename,
-    has_arg,
-    _maybe_complex,
-    log_errors,
-    import_file,
-    silence_logging,
-    thread_state,
-    json_load_robust,
-    key_split,
-    offload,
-    parse_bytes,
-    parse_timedelta,
-    parse_ports,
-    iscoroutinefunction,
-    warn_on_duration,
     LRU,
     TimeoutError,
+    _maybe_complex,
+    get_ip,
+    has_arg,
+    import_file,
+    iscoroutinefunction,
+    json_load_robust,
+    key_split,
+    log_errors,
+    offload,
+    parse_bytes,
+    parse_ports,
+    parse_timedelta,
+    silence_logging,
+    thread_state,
+    typename,
+    warn_on_duration,
 )
-from .utils_comm import pack_data, gather_from_workers, retry_operation
-from .utils_perf import ThrottledGC, enable_gc_diagnosis, disable_gc_diagnosis
+from .utils_comm import gather_from_workers, pack_data, retry_operation
+from .utils_perf import ThrottledGC, disable_gc_diagnosis, enable_gc_diagnosis
 from .versions import get_versions
-
-from .core import Status
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -18,14 +18,15 @@ from functools import partial
 from inspect import isawaitable
 from pickle import PicklingError
 
+from tlz import first, keymap, merge, pluck  # noqa: F401
+from tornado import gen
+from tornado.ioloop import IOLoop, PeriodicCallback
+
 import dask
 from dask.compatibility import apply
 from dask.core import istask
 from dask.system import CPU_COUNT
 from dask.utils import format_bytes, funcname
-from tlz import first, keymap, merge, pluck  # noqa: F401
-from tornado import gen
-from tornado.ioloop import IOLoop, PeriodicCallback
 
 from . import comm, preloading, profile, system
 from .batched import BatchedSend

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -23,7 +23,7 @@ from dask.compatibility import apply
 from dask.core import istask
 from dask.system import CPU_COUNT
 from dask.utils import format_bytes, funcname
-from tlz import first, keymap, merge, pluck
+from tlz import first, keymap, merge, pluck  # noqa: F401
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -1,10 +1,11 @@
-from contextlib import contextmanager
 import warnings
+from contextlib import contextmanager
 
 import dask
-from .threadpoolexecutor import secede, rejoin
-from .worker import thread_state, get_client, get_worker
+
+from .threadpoolexecutor import rejoin, secede
 from .utils import parse_timedelta
+from .worker import get_client, get_worker, thread_state
 
 
 @contextmanager

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -425,12 +425,12 @@ def copy_legacy_redirects(app, docname):
                 f.write(page)
 
 
+from docutils.parsers.rst import directives
+
 # -- Configuration to keep autosummary in sync with autoclass::members ----------------------------------------------
 # Fixes issues/3693
 # See https://stackoverflow.com/questions/20569011/python-sphinx-autosummary-automated-listing-of-member-functions
-from sphinx.ext.autosummary import Autosummary
-from sphinx.ext.autosummary import get_documenter
-from docutils.parsers.rst import directives
+from sphinx.ext.autosummary import Autosummary, get_documenter
 from sphinx.util.inspect import safe_getattr
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,13 @@ ignore =
 
 max-line-length = 120
 
+[isort]
+profile = black
+skip_gitignore = true
+force_to_top = true
+default_section = THIRDPARTY
+known_first_party = distributed
+
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,13 @@ ignore =
 max-line-length = 120
 
 [isort]
+sections = FUTURE,STDLIB,THIRDPARTY,DISTRIBUTED,FIRSTPARTY,LOCALFOLDER
 profile = black
 skip_gitignore = true
 force_to_top = true
 default_section = THIRDPARTY
 known_first_party = distributed
+known_distributed = dask
 
 [versioneer]
 VCS = git

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@
 
 import os
 import sys
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 from setuptools.extension import Extension
+
 import versioneer
 
 requires = open("requirements.txt").read().strip().split("\n")

--- a/versioneer.py
+++ b/versioneer.py
@@ -277,10 +277,12 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 """
 
 from __future__ import print_function
+
 try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
+
 import errno
 import json
 import os
@@ -1557,6 +1559,7 @@ def get_cmdclass():
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
+
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{


### PR DESCRIPTION
Second pass at #4600, as there were a lot of merge conflicts piling up there. 

- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed`
