### PR TITLE
Use powers-of-two when displaying RAM

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1817,10 +1817,10 @@ class WorkerTable(DashboardComponent):
         formatters = {
             "cpu": NumberFormatter(format="0.0 %"),
             "memory_percent": NumberFormatter(format="0.0 %"),
-            "memory": NumberFormatter(format="0 b"),
-            "memory_limit": NumberFormatter(format="0 b"),
-            "read_bytes": NumberFormatter(format="0 b"),
-            "write_bytes": NumberFormatter(format="0 b"),
+            "memory": NumberFormatter(format="0.00 b"),
+            "memory_limit": NumberFormatter(format="0.00 b"),
+            "read_bytes": NumberFormatter(format="0.00 b"),
+            "write_bytes": NumberFormatter(format="0.00 b"),
             "num_fds": NumberFormatter(format="0"),
             "nthreads": NumberFormatter(format="0"),
         }

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1819,8 +1819,8 @@ class WorkerTable(DashboardComponent):
             "memory_percent": NumberFormatter(format="0.0 %"),
             "memory": NumberFormatter(format="0.00 b"),
             "memory_limit": NumberFormatter(format="0.00 b"),
-            "read_bytes": NumberFormatter(format="0.00 b"),
-            "write_bytes": NumberFormatter(format="0.00 b"),
+            "read_bytes": NumberFormatter(format="0 b"),
+            "write_bytes": NumberFormatter(format="0 b"),
             "num_fds": NumberFormatter(format="0"),
             "nthreads": NumberFormatter(format="0"),
         }

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -979,7 +979,7 @@ async def test_repr(cleanup):
         assert "workers=2" in text
         assert cluster.scheduler_address in text
         assert "cores=4" in text or "threads=4" in text
-        assert "GB" in text and "4" in text
+        assert "4.00 GB" in text or "3.73 GiB" in text
 
     async with LocalCluster(
         n_workers=2, processes=False, memory_limit=None, asynchronous=True

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -361,8 +361,9 @@ async def test_widget(cleanup):
             await asyncio.sleep(0.01)
             assert time() < start + 1
 
-        assert "3" in cluster._widget_status()
-        assert "GB" in cluster._widget_status()
+        text = cluster._widget_status()
+        assert "3" in text
+        assert "GB" in text or "GiB" in text
 
         cluster.scale(5)
         assert "3 / 5" in cluster._widget_status()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1989,9 +1989,8 @@ def test_repr(loop):
             for func in funcs:
                 text = func(c)
                 assert c.scheduler.address in text
-                assert "3" in text
-                assert "6" in text
-                assert "GB" in text
+                assert "threads=3" in text or "Cores: </b>3" in text
+                assert "6.00 GB" in text or "5.59 GiB" in text
                 if "<table" not in text:
                     assert len(text) < 80
 
@@ -5417,7 +5416,7 @@ async def test_warn_when_submitting_large_values(c, s, a, b):
         future = c.submit(lambda x: x + 1, b"0" * 2000000)
 
     text = str(record[0].message)
-    assert "2.00 MB" in text
+    assert "2.00 MB" in text or "1.91 MiB" in text
     assert "large" in text
     assert "..." in text
     assert "'000" in text


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/3818
Twin of https://github.com/dask/dask/pull/7484

- Add two decimals to memory and memory_limit in the workers tab
- Fix failing tests downstream of https://github.com/dask/dask/pull/7484