### PR TITLE
Expose worker SystemMonitors to scheduler via RPC

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6505,13 +6505,16 @@ class Scheduler(SchedulerState, ServerNode):
         else:
             return valmap(tuple, self.events)
 
-    async def worker_monitors(self, start=0):
+    async def worker_monitors(self, starts=dict()):
         parent: SchedulerState = cast(SchedulerState, self)
         return dict(
             zip(
                 parent._workers_dv,
                 await asyncio.gather(
-                    *(self.rpc(w).get_monitor(start=start) for w in parent._workers_dv)
+                    *(
+                        self.rpc(w).get_monitor(start=starts.get(w, 0))
+                        for w in parent._workers_dv
+                    )
                 ),
             )
         )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6500,30 +6500,40 @@ class Scheduler(SchedulerState, ServerNode):
         else:
             return valmap(tuple, self.events)
 
-    async def worker_monitors(self, starts=dict()):
+    async def get_worker_monitor_info(self, starts=dict(), recent=False):
         parent: SchedulerState = cast(SchedulerState, self)
-        return dict(
-            zip(
-                parent._workers_dv,
-                await asyncio.gather(
-                    *(
-                        self.rpc(w).get_monitor(start=starts.get(w, 0))
-                        for w in parent._workers_dv
-                    )
-                ),
+        query = asyncio.gather(
+            *(
+                self.rpc(w).get_monitor_range(start=starts.get(w, 0))
+                for w in parent._workers_dv
             )
         )
-
-    async def worker_counts(self):
-        parent: SchedulerState = cast(SchedulerState, self)
-        return dict(
-            zip(
-                parent._workers_dv,
-                await asyncio.gather(
-                    *(self.rpc(w).get_monitor_count() for w in parent._workers_dv)
-                ),
+        if recent:
+            query = asyncio.gather(
+                *(self.rpc(w).get_monitor_recent() for w in parent._workers_dv)
             )
-        )
+        return {
+            "range_query": dict(zip(parent._workers_dv, await query)),
+            "count": dict(
+                zip(
+                    parent._workers_dv,
+                    await asyncio.gather(
+                        *(self.rpc(w).get_monitor_count() for w in parent._workers_dv)
+                    ),
+                )
+            ),
+            "last_time": dict(
+                zip(
+                    parent._workers_dv,
+                    await asyncio.gather(
+                        *(
+                            self.rpc(w).get_monitor_last_time()
+                            for w in parent._workers_dv
+                        )
+                    ),
+                )
+            ),
+        }
 
     ###########
     # Cleanup #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6502,31 +6502,15 @@ class Scheduler(SchedulerState, ServerNode):
 
     async def get_worker_monitor_info(self, recent=False, starts=None):
         parent: SchedulerState = cast(SchedulerState, self)
-        if starts is not None:
-            return dict(
-                zip(
-                    parent._workers_dv,
-                    await asyncio.gather(
-                        *(
-                            self.rpc(w).get_monitor_info(
-                                recent=recent, start=starts.get(w, 0)
-                            )
-                            for w in parent._workers_dv
-                        )
-                    ),
-                )
-            )
-        return dict(
-            zip(
-                parent._workers_dv,
-                await asyncio.gather(
-                    *(
-                        self.rpc(w).get_monitor_info(recent=recent, start=0)
-                        for w in parent._workers_dv
-                    )
-                ),
+        if starts is None:
+            starts = {}
+        results = await asyncio.gather(
+            *(
+                self.rpc(w).get_monitor_info(recent=recent, start=starts.get(w, 0))
+                for w in parent._workers_dv
             )
         )
+        return dict(zip(parent._workers_dv, results))
 
     ###########
     # Cleanup #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6505,6 +6505,28 @@ class Scheduler(SchedulerState, ServerNode):
         else:
             return valmap(tuple, self.events)
 
+    async def worker_monitors(self, start=0):
+        parent: SchedulerState = cast(SchedulerState, self)
+        return dict(
+            zip(
+                parent._workers_dv,
+                await asyncio.gather(
+                    *(self.rpc(w).get_monitor(start=start) for w in parent._workers_dv)
+                ),
+            )
+        )
+
+    async def worker_counts(self):
+        parent: SchedulerState = cast(SchedulerState, self)
+        return dict(
+            zip(
+                parent._workers_dv,
+                await asyncio.gather(
+                    *(self.rpc(w).get_monitor_count() for w in parent._workers_dv)
+                ),
+            )
+        )
+
     ###########
     # Cleanup #
     ###########

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2211,6 +2211,6 @@ async def test_get_worker_monitor_info(s, a, b):
         ms = ("cpu", "time", "read_bytes", "write_bytes")
     for w in (a, b):
         for m in ms:
-            assert res["range_query"][w.address][m] is not None
-        assert res["count"][w.address] is not None
-        assert res["last_time"][w.address] is not None
+            assert res[w.address]["range_query"][m] is not None
+        assert res[w.address]["count"] is not None
+        assert res[w.address]["last_time"] is not None

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2206,11 +2206,10 @@ async def test_configurable_events_log_length(c, s, a, b):
 @gen_cluster()
 async def test_get_worker_monitor_info(s, a, b):
     res = await s.get_worker_monitor_info()
-    ms = ("cpu", "time", "read_bytes", "write_bytes", "num_fds")
-    if WINDOWS:
-        ms = ("cpu", "time", "read_bytes", "write_bytes")
+    ms = ["cpu", "time", "read_bytes", "write_bytes"]
+    if not WINDOWS:
+        ms += ["num_fds"]
     for w in (a, b):
-        for m in ms:
-            assert res[w.address]["range_query"][m] is not None
+        assert all(res[w.address]["range_query"][m] is not None for m in ms)
         assert res[w.address]["count"] is not None
         assert res[w.address]["last_time"] is not None

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1073,7 +1073,9 @@ class Worker(ServerNode):
     def get_monitor_info(self, comm=None, recent=False, start=0):
         return dict(
             range_query=(
-                self.monitor.recent() if recent else self.monitor.range_query(start=0)
+                self.monitor.recent()
+                if recent
+                else self.monitor.range_query(start=start)
             ),
             count=self.monitor.count,
             last_time=self.monitor.last_time,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -677,6 +677,8 @@ class Worker(ServerNode):
             "actor_execute": self.actor_execute,
             "actor_attribute": self.actor_attribute,
             "plugin-add": self.plugin_add,
+            "get_monitor": self.get_monitor,
+            "get_monitor_count": self.get_monitor_count,
         }
 
         stream_handlers = {
@@ -1064,6 +1066,12 @@ class Worker(ServerNode):
         else:
             self.update_data(data=result, report=False)
             return {"status": "OK"}
+
+    def get_monitor(self, comm=None, start=0):
+        return self.monitor.range_query(start=start)
+
+    def get_monitor_count(self, comm=None):
+        return self.monitor.count
 
     #############
     # Lifecycle #

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -681,10 +681,7 @@ class Worker(ServerNode):
             "actor_execute": self.actor_execute,
             "actor_attribute": self.actor_attribute,
             "plugin-add": self.plugin_add,
-            "get_monitor_range": self.get_monitor_range,
-            "get_monitor_recent": self.get_monitor_recent,
-            "get_monitor_count": self.get_monitor_count,
-            "get_monitor_last_time": self.get_monitor_last_time,
+            "get_monitor_info": self.get_monitor_info,
         }
 
         stream_handlers = {
@@ -1073,17 +1070,14 @@ class Worker(ServerNode):
             self.update_data(data=result, report=False)
             return {"status": "OK"}
 
-    def get_monitor_range(self, comm=None, start=0):
-        return self.monitor.range_query(start=start)
-
-    def get_monitor_recent(self, comm=None):
-        return self.monitor.recent()
-
-    def get_monitor_count(self, comm=None):
-        return self.monitor.count
-
-    def get_monitor_last_time(self, comm=None):
-        return self.monitor.last_time
+    def get_monitor_info(self, comm=None, recent=False, start=0):
+        return dict(
+            range_query=(
+                self.monitor.recent() if recent else self.monitor.range_query(start=0)
+            ),
+            count=self.monitor.count,
+            last_time=self.monitor.last_time,
+        )
 
     #############
     # Lifecycle #

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -681,8 +681,10 @@ class Worker(ServerNode):
             "actor_execute": self.actor_execute,
             "actor_attribute": self.actor_attribute,
             "plugin-add": self.plugin_add,
-            "get_monitor": self.get_monitor,
+            "get_monitor_range": self.get_monitor_range,
+            "get_monitor_recent": self.get_monitor_recent,
             "get_monitor_count": self.get_monitor_count,
+            "get_monitor_last_time": self.get_monitor_last_time,
         }
 
         stream_handlers = {
@@ -1071,11 +1073,17 @@ class Worker(ServerNode):
             self.update_data(data=result, report=False)
             return {"status": "OK"}
 
-    def get_monitor(self, comm=None, start=0):
+    def get_monitor_range(self, comm=None, start=0):
         return self.monitor.range_query(start=start)
+
+    def get_monitor_recent(self, comm=None):
+        return self.monitor.recent()
 
     def get_monitor_count(self, comm=None):
         return self.monitor.count
+
+    def get_monitor_last_time(self, comm=None):
+        return self.monitor.last_time
 
     #############
     # Lifecycle #


### PR DESCRIPTION
This PR adds handler methods to the worker to return the values of:

- `worker.monitor.range_query(start=i)`
- `worker.monitor.count`

And scheduler utility functions `worker_monitors()` and `worker_counts()` to gather these values for all workers. The aim of this is to make it easier to generate time series of worker metrics in the dashboard / performance reports; as of now this can only be done by collecting fixed-point `WorkerStates`, which has some limitations (#4627 for example).

- [ ] Closes #4630
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`

cc @jacobtomlinson 