### PR TITLE
Remove incorrect comment regarding default LocalCluster creation

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -78,7 +78,7 @@ class LocalCluster(SpecCluster):
 
     Examples
     --------
-    >>> cluster = LocalCluster()  # Create a local cluster with as many workers as cores  # doctest: +SKIP
+    >>> cluster = LocalCluster()  # Create a local cluster  # doctest: +SKIP
     >>> cluster  # doctest: +SKIP
     LocalCluster("127.0.0.1:8786", workers=8, threads=8)
 


### PR DESCRIPTION
This PR resolves an erroneous comment describing the default behavior of the LocalCluster() class.

When the caller does not pass arguments to the LocalCluster() class, the number of workers created does not necessarily equal the number of cores. Specifically, if the machine has more than 4 cores, then the number of workers may not equal the number of cores.

The `nprocesses_nthreads` function determines the number of workers and number of threads, as shown here: https://github.com/dask/distributed/blob/main/distributed/deploy/local.py#L180

If the number of cores is greater than 4, then the `nprocesses_nthreads` may not set the number of cores equal to the number of workers. See the implementation of the `nprocesses_nthreads` function here: https://github.com/dask/distributed/blob/main/distributed/deploy/utils.py#L30
