### PR TITLE
Add GPU metrics to SystemMonitor

### DIFF
--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -54,3 +54,14 @@ async def test_gpu_metrics(s, a, b):
         s.workers[a.address].extra["gpu"]["name"]
         == pynvml.nvmlDeviceGetName(h).decode()
     )
+
+
+@gen_cluster()
+async def test_gpu_monitoring(s, a, b):
+    h = nvml._pynvml_handles()
+    res = a.monitor.recent()
+
+    assert res["gpu_utilization"] == pynvml.nvmlDeviceGetUtilizationRates(h).gpu
+    assert res["gpu_memory_used"] == pynvml.nvmlDeviceGetMemoryInfo(h).used
+    assert a.monitor.gpu_name == pynvml.nvmlDeviceGetName(h).decode()
+    assert a.monitor.gpu_memory_total == pynvml.nvmlDeviceGetMemoryInfo(h).total

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -61,7 +61,13 @@ async def test_gpu_monitoring(s, a, b):
     h = nvml._pynvml_handles()
     res = await s.get_worker_monitor_info(recent=True)
 
-    assert res[a.address]["range_query"]["gpu_utilization"] == pynvml.nvmlDeviceGetUtilizationRates(h).gpu
-    assert res[a.address]["range_query"]["gpu_memory_used"] == pynvml.nvmlDeviceGetMemoryInfo(h).used
+    assert (
+        res[a.address]["range_query"]["gpu_utilization"]
+        == pynvml.nvmlDeviceGetUtilizationRates(h).gpu
+    )
+    assert (
+        res[a.address]["range_query"]["gpu_memory_used"]
+        == pynvml.nvmlDeviceGetMemoryInfo(h).used
+    )
     assert res[a.address]["gpu_name"] == pynvml.nvmlDeviceGetName(h).decode()
     assert res[a.address]["gpu_memory_total"] == pynvml.nvmlDeviceGetMemoryInfo(h).total

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -59,9 +59,9 @@ async def test_gpu_metrics(s, a, b):
 @gen_cluster()
 async def test_gpu_monitoring(s, a, b):
     h = nvml._pynvml_handles()
-    res = a.monitor.recent()
+    res = await s.get_worker_monitor_info(recent=True)
 
-    assert res["gpu_utilization"] == pynvml.nvmlDeviceGetUtilizationRates(h).gpu
-    assert res["gpu_memory_used"] == pynvml.nvmlDeviceGetMemoryInfo(h).used
-    assert a.monitor.gpu_name == pynvml.nvmlDeviceGetName(h).decode()
-    assert a.monitor.gpu_memory_total == pynvml.nvmlDeviceGetMemoryInfo(h).total
+    assert res[a.address]["range_query"]["gpu_utilization"] == pynvml.nvmlDeviceGetUtilizationRates(h).gpu
+    assert res[a.address]["range_query"]["gpu_memory_used"] == pynvml.nvmlDeviceGetMemoryInfo(h).used
+    assert res[a.address]["gpu_name"] == pynvml.nvmlDeviceGetName(h).decode()
+    assert res[a.address]["gpu_memory_total"] == pynvml.nvmlDeviceGetMemoryInfo(h).total


### PR DESCRIPTION
This PR adds the GPU metrics available in `WorkerState.metrics` and `WorkerState.extra` to the `SystemMonitor`; coupled with #4657, this should make it easier to generate time series of (GPU) workers in the dashboard / performance report.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
