### PR TITLE
prevent KeyError when obtaining task durations

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3645,8 +3645,9 @@ class Scheduler(SchedulerState, ServerNode):
         ws._last_seen = local_now
         if executing is not None:
             ws._executing = {
-                parent._tasks[key]: duration for key, duration in executing.items()
+                parent._tasks.get(key): duration for key, duration in executing.items()
             }
+            del ws._executing[None]
 
         ws._metrics = metrics
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3647,7 +3647,8 @@ class Scheduler(SchedulerState, ServerNode):
             ws._executing = {
                 parent._tasks.get(key): duration for key, duration in executing.items()
             }
-            del ws._executing[None]
+            if None in ws._executing:
+                del ws._executing[None]
 
         ws._metrics = metrics
 


### PR DESCRIPTION

- [x] Closes #4587
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`


I was experiencing the KeyErrors being thrown by dask similar to the ones in #4587
```
tornado.application - ERROR - Exception in callback functools.partial(<bound method IOLoop._discard_future_result of <tornado.platform.asyncio.AsyncIOLoop object at 0x7fee0c5720d0>>, <Task finished name='Task-50395' coro=<Worker.heartbeat() done, defined at /home/skoposov/pyenv38/lib/python3.8/site-packages/distributed/worker.py:936> exception=KeyError('fit_specs-1fb90318b006face08a1eb5d25d683c0')>)
Traceback (most recent call last):
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/tornado/ioloop.py", line 741, in _run_callback
    ret = callback()
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/tornado/ioloop.py", line 765, in _discard_future_result
    future.result()
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/distributed/worker.py", line 942, in heartbeat
    response = await retry_operation(
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/distributed/utils_comm.py", line 384, in retry_operation
    return await retry(
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/distributed/utils_comm.py", line 369, in retry
    return await coro()
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/distributed/core.py", line 862, in send_recv_from_rpc
    result = await send_recv(comm=comm, op=key, **kwargs)
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/distributed/core.py", line 661, in send_recv
    raise exc.with_traceback(tb)
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/distributed/core.py", line 497, in handle_comm
    result = handler(comm, **msg)
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/distributed/scheduler.py", line 3658, in heartbeat_worker
    ws._executing = {
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/distributed/scheduler.py", line 3659, in <dictcomp>
    parent._tasks[key]: duration for key, duration in executing.items()
KeyError: 'fit_specs-1fb90318b006face08a1eb5d25d683c0'
```
I don't know internals of distributed  well enough, but it seems to me that by the time executing.items() is done, the _tasks may already not have a key. 
So it could be fixed either by with this  https://github.com/dask/distributed/issues/4510#issue-808721305
or with this PR.

