### PR TITLE
Add informative error message to install uvloop

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,6 +1,7 @@
 from . import config  # isort:skip; load distributed configuration first
 import dask
 from dask.config import config
+from dask.utils import import_required
 
 from ._version import get_versions
 from .actor import Actor, ActorFuture
@@ -45,6 +46,15 @@ del get_versions, versions
 if dask.config.get("distributed.admin.event-loop") in ("asyncio", "tornado"):
     pass
 elif dask.config.get("distributed.admin.event-loop") == "uvloop":
+    import_required(
+        "uvloop",
+        "The distributed.admin.event-loop configuration value "
+        "is set to 'uvloop' but the uvloop module is not installed"
+        "\n\n"
+        "Please either change the config value or install one of the following\n"
+        "    conda install uvloop\n"
+        "    pip install uvloop",
+    )
     import uvloop
 
     uvloop.install()


### PR DESCRIPTION
If you have a config value set to use uvloop but don't have uvloop
installed then things end badly, with a non-informative error message

This provides a more informative error message

```
RuntimeError: The distributed.admin.event-loop configuration value is set to 'uvloop' but the uvloop module is not installed

Please either change the config value or install one of the following
    conda install uvloop
    pip install uvloop
```

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
