### PR TITLE
Add timing information to TaskGroup

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -846,6 +846,18 @@ class TaskGroup:
     def types(self):
         return self._types
 
+    @property
+    def all_durations(self):
+        return self._all_durations
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def stop(self):
+        return self._stop
+
     @ccall
     def add(self, o):
         ts: TaskState = o

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -796,6 +796,9 @@ class TaskGroup:
     _nbytes_in_memory: Py_ssize_t
     _duration: double
     _types: set
+    _start: double
+    _stop: double
+    _all_durations: object
 
     def __init__(self, name: str):
         self._name = name
@@ -807,6 +810,9 @@ class TaskGroup:
         self._nbytes_in_memory = 0
         self._duration = 0
         self._types = set()
+        self._start = 0.0
+        self._stop = 0.0
+        self._all_durations = defaultdict(float)
 
     @property
     def name(self):
@@ -2305,6 +2311,7 @@ class SchedulerState:
                     # record timings of all actions -- a cheaper way of
                     # getting timing info compared with get_task_stream()
                     ts._prefix._all_durations[action] += stop - start
+                    ts._group._all_durations[action] += stop - start
 
             #############################
             # Update Timing Information #
@@ -2321,6 +2328,9 @@ class SchedulerState:
 
                 ts._prefix._duration_average = avg_duration
                 ts._group._duration += new_duration
+                ts._group._start = ts._group._start or compute_start
+                if ts._group._stop < compute_stop:
+                    ts._group._stop = compute_stop
 
                 s: set = self._unknown_durations.pop(ts._prefix._name, None)
                 tts: TaskState

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1830,7 +1830,23 @@ async def test_no_danglng_asyncio_tasks(cleanup):
     assert tasks == start
 
 
-@gen_cluster(client=True)
+class NoSchedulerDelayWorker(Worker):
+    """Custom worker class which does not update `scheduler_delay`.
+
+    This worker class is useful for some tests which make time
+    comparisons using times reported from workers.
+    """
+
+    @property
+    def scheduler_delay(self):
+        return 0
+
+    @scheduler_delay.setter
+    def scheduler_delay(self, value):
+        pass
+
+
+@gen_cluster(client=True, Worker=NoSchedulerDelayWorker)
 async def test_task_groups(c, s, a, b):
     start = time()
     da = pytest.importorskip("dask.array")

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1888,9 +1888,9 @@ async def test_task_groups(c, s, a, b):
     assert tg.states["forgotten"] == 5
     # Ensure TaskGroup is removed once all tasks are in forgotten state
     assert tg.name not in s.task_groups
-    assert tg._start > start
-    assert tg._stop < stop
-    assert "compute" in tg._all_durations
+    assert tg.start > start
+    assert tg.stop < stop
+    assert "compute" in tg.all_durations
     assert sys.getrefcount(tg) == 2
 
 


### PR DESCRIPTION
I would like for us to start thinking about visualizing TaskGroups as an alternative to the task stream.

This adds timeline information to those objects as a precursor to that work.

Example
-------

```python
from dask.distributed import Client, wait
client = Client()
client

import dask.array as da
x = da.random.random((10000, 10000))
y = x + x.T - x.mean(axis=0)
y = y.persist()
wait(y)

groups = client.cluster.scheduler.task_groups
tg = list(groups.values())[0]
tg.__dict__
```

```python
{'_name': 'sub-2005fd772a2da340e72f1de1df1ac06d',
 '_prefix': <sub: memory: 16>,
 '_states': {'waiting': 0,
  'erred': 0,
  'released': 0,
  'memory': 16,
  'no-worker': 0,
  'processing': 0,
  'forgotten': 0},
 '_dependencies': {<mean_agg-aggregate-3f80179c8a4d92eabf1c0046dbbabd74: released: 4>,
  <random_sample-87d33bde1d8da2f2c8edc106b69514a0: released: 16>},
 '_nbytes_total': 800000000,
 '_nbytes_in_memory': 800000000,
 '_duration': 4.233909368515015,
 '_types': {'numpy.ndarray'},
 '_start': 1617389525.5363212,
 '_stop': 1617389526.3259144,
 '_all_durations': defaultdict(float,
             {'compute': 4.233909368515015, 'transfer': 1.8818869590759277})}
```

This should be enough to give us information for a rich visual
