### PR TITLE
Removing dumps_msgpack() and loads_msgpack()

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -2,7 +2,7 @@ import logging
 
 import msgpack
 
-from .compression import compressions, decompress, maybe_compress
+from .compression import decompress, maybe_compress
 from .serialize import (
     Serialize,
     Serialized,
@@ -111,55 +111,3 @@ def loads(frames, deserialize=True, deserializers=None):
     except Exception:
         logger.critical("Failed to deserialize", exc_info=True)
         raise
-
-
-def dumps_msgpack(msg, compression=None):
-    """Dump msg into header and payload, both bytestrings
-
-    All of the message must be msgpack encodable
-
-    See Also:
-        loads_msgpack
-    """
-    header = {}
-    payload = msgpack.dumps(msg, default=msgpack_encode_default, use_bin_type=True)
-
-    fmt, payload = maybe_compress(payload, compression=compression)
-    if fmt:
-        header["compression"] = fmt
-
-    if header:
-        header_bytes = msgpack.dumps(header, use_bin_type=True)
-    else:
-        header_bytes = b""
-
-    return [header_bytes, payload]
-
-
-def loads_msgpack(header, payload):
-    """Read msgpack header and payload back to Python object
-
-    See Also:
-        dumps_msgpack
-    """
-    header = bytes(header)
-    if header:
-        header = msgpack.loads(
-            header, object_hook=msgpack_decode_default, use_list=False, **msgpack_opts
-        )
-    else:
-        header = {}
-
-    if header.get("compression"):
-        try:
-            decompress = compressions[header["compression"]]["decompress"]
-            payload = decompress(payload)
-        except KeyError:
-            raise ValueError(
-                "Data is compressed as %s but we don't have this"
-                " installed" % str(header["compression"])
-            )
-
-    return msgpack.loads(
-        payload, object_hook=msgpack_decode_default, use_list=False, **msgpack_opts
-    )


### PR DESCRIPTION
Removing `dumps_msgpack()` and `loads_msgpack()` since https://github.com/dask/dask/pull/7525 makes them obsolete.

Depend on https://github.com/dask/dask/pull/7525

- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
