### PR TITLE
DOC: Attempt at autoreformatting docstrings to conform to Numpydoc.

### DIFF
--- a/distributed/cfexecutor.py
+++ b/distributed/cfexecutor.py
@@ -99,7 +99,7 @@ class ClientExecutor(cf.Executor):
         ----------
         fn : A callable that will take as many arguments as there are
             passed iterables.
-        iterables : One iterable for each parameter to *fn*.
+        *iterables : One iterable for each parameter to *fn*.
         timeout : The maximum number of seconds to wait. If None, then there
             is no limit on the wait time.
         chunksize : ignored.

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1624,7 +1624,7 @@ class Client:
         Parameters
         ----------
         func : callable
-        iterables : Iterables
+        *iterables : Iterables
             List-like objects to map over.  They should have the same length.
         key : str, list
             Prefix for task names if string.  Explicit names if list.
@@ -2273,11 +2273,11 @@ class Client:
 
         Parameters
         ----------
-        args : list of objects to publish as name
+        *args : list of objects to publish as name
         name : optional name of the dataset to publish
         override : bool (optional, default False)
             if true, override any already present dataset with the same name
-        kwargs : dict
+        **kwargs : dict
             named collections to publish on the scheduler
 
         Examples
@@ -2360,7 +2360,7 @@ class Client:
         name : name of the dataset to retrieve
         default : optional, not set by default
             If set, do not raise a KeyError if the name is not present but return this default
-        kwargs : dict
+        **kwargs : dict
             additional arguments to _get_dataset
 
         See Also

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -133,7 +133,7 @@ def _close_comm(ref):
 
     Parameters
     ----------
-        ref: weak reference to a Dask comm
+    ref : weak reference to a Dask comm
     """
     comm = ref()
     if comm:

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -150,7 +150,7 @@ class WorkerPlugin:
             One of waiting, ready, executing, long-running, memory, error.
         finish : string
             Final state of the transition.
-        kwargs : More options passed when transitioning
+        **kwargs : More options passed when transitioning
         """
 
     def release_key(self, key, state, cause, reason, report):

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -403,7 +403,7 @@ def progress(*futures, notebook=None, multi=True, complete=True, **kwargs):
 
     Parameters
     ----------
-    futures : Futures
+    *futures : Futures
         A list of futures or keys to track
     notebook : bool (optional)
         Running in the notebook or not (defaults to guess)

--- a/distributed/multi_lock.py
+++ b/distributed/multi_lock.py
@@ -49,15 +49,15 @@ class MultiLockExtension:
 
         Parameters
         ----------
-        locks: List[str]
+        locks : List[str]
             Names of the locks to request.
-        id: Hashable
+        id : Hashable
             Identifier of the `MultiLock` instance requesting the locks.
-        num_locks: int
+        num_locks : int
             Number of locks in `locks` requesting
 
-        Return
-        ------
+        Returns
+        -------
         result: bool
             Whether `num_locks` requested locks are free immediately or not.
         """
@@ -82,9 +82,9 @@ class MultiLockExtension:
 
         Parameters
         ----------
-        locks: List[str]
+        locks : List[str]
             Names of the locks to refain.
-        id: Hashable
+        id : Hashable
             Identifier of the `MultiLock` instance refraining the locks.
         """
         waiters_ready = set()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6117,7 +6117,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         See Also
         --------
-        Scheduler.transitions: transitive version of this function
+        Scheduler.transitions : transitive version of this function
         """
         parent: SchedulerState = cast(SchedulerState, self)
         recommendations: dict


### PR DESCRIPTION
I'm still working on my reformatter, but as distributed in one of the
project using numpydoc, I gave it a shot.

Most of the spacing around colons slightly change the semantic and allow
sphix/NumpyDoc to properly find the parameter names and type.

The one contentious question is whether *args, **kwargs should have */**
in front of them in docstrings (or not), and wether those should be
escaped.

Numpydoc reference does not say so but provide an example where stars
are present; and escaping seem unnecessary to render properly in sphinx.
Plus \*\* looks bad when using `?` in IPython.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
