### PR TITLE
Add support for extra conn args for HTTP protocols

### DIFF
--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -176,6 +176,7 @@ async def test_connection_made_with_extra_conn_args(cleanup, protocol, security)
         connection_args = security.get_connection_args("worker")
         comm = await connect(s.address, **connection_args)
         assert comm.sock.request.headers.get("Authorization") == "Token abcd"
+        await comm.close()
 
 
 @pytest.mark.asyncio

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -380,7 +380,7 @@ class WSConnector(Connector):
         return self.comm_class(sock, deserialize=deserialize)
 
     def _get_connect_args(self, **connection_args):
-        return {}
+        return {**connection_args.get("extra_conn_args", {})}
 
 
 class WSSConnector(WSConnector):
@@ -389,7 +389,7 @@ class WSSConnector(WSConnector):
 
     def _get_connect_args(self, **connection_args):
         ctx = _expect_tls_context(connection_args)
-        return {"ssl_options": ctx}
+        return {"ssl_options": ctx, **connection_args.get("extra_conn_args", {})}
 
 
 class WSBackend(BaseTCPBackend):

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -45,6 +45,8 @@ class Security:
         Path to a key file for a worker, encoded in PEM format.
         Alternatively, the key may be appended to the cert file, and this
         parameter be omitted.
+    extra_conn_args : mapping, optional
+        Mapping with keyword arguments to pass down to connections.
     """
 
     __slots__ = (
@@ -57,12 +59,14 @@ class Security:
         "tls_scheduler_cert",
         "tls_worker_key",
         "tls_worker_cert",
+        "extra_conn_args",
     )
 
     def __init__(self, require_encryption=None, **kwargs):
         extra = set(kwargs).difference(self.__slots__)
         if extra:
             raise TypeError("Unknown parameters: %r" % sorted(extra))
+        self.extra_conn_args = kwargs.pop("extra_conn_args", {})
         if require_encryption is None:
             require_encryption = dask.config.get("distributed.comm.require-encryption")
         if require_encryption is None:
@@ -82,7 +86,7 @@ class Security:
         self._set_field(kwargs, "tls_worker_cert", "distributed.comm.tls.worker.cert")
 
     @classmethod
-    def temporary(cls):
+    def temporary(cls, **kwargs):
         """Create a new temporary Security object.
 
         This creates a new self-signed key/cert pair suitable for securing
@@ -139,6 +143,7 @@ class Security:
             tls_scheduler_cert=cert_contents,
             tls_worker_key=key_contents,
             tls_worker_cert=cert_contents,
+            **kwargs,
         )
 
     def _set_field(self, kwargs, field, config_name):
@@ -150,6 +155,7 @@ class Security:
 
     def __repr__(self):
         keys = sorted(self.__slots__)
+        keys.remove("extra_conn_args")
         items = []
         for k in keys:
             val = getattr(self, k)
@@ -221,6 +227,7 @@ class Security:
         return {
             "ssl_context": self._get_tls_context(tls, ssl.Purpose.SERVER_AUTH),
             "require_encryption": self.require_encryption,
+            "extra_conn_args": self.extra_conn_args,
         }
 
     def get_listen_args(self, role):

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -42,6 +42,7 @@ def test_defaults():
     assert sec.tls_scheduler_cert is None
     assert sec.tls_worker_key is None
     assert sec.tls_worker_cert is None
+    assert sec.extra_conn_args == {}
 
 
 def test_constructor_errors():
@@ -92,7 +93,10 @@ def test_kwargs():
     }
     with dask.config.set(c):
         sec = Security(
-            tls_scheduler_cert="newcert.pem", require_encryption=True, tls_ca_file=None
+            tls_scheduler_cert="newcert.pem",
+            require_encryption=True,
+            tls_ca_file=None,
+            extra_conn_args={"headers": {"Auth": "Token abc"}},
         )
     assert sec.require_encryption is True
     assert sec.tls_ca_file is None
@@ -103,6 +107,7 @@ def test_kwargs():
     assert sec.tls_scheduler_cert == "newcert.pem"
     assert sec.tls_worker_key is None
     assert sec.tls_worker_cert is None
+    assert sec.extra_conn_args == {"headers": {"Auth": "Token abc"}}
 
 
 def test_repr():
@@ -198,6 +203,30 @@ def test_connection_args():
     assert len(tls_12_ciphers) == 1
     tls_13_ciphers = [c for c in supported_ciphers if "TLSv1.3" in c["description"]]
     assert len(tls_13_ciphers) in (0, 3)
+
+
+def test_extra_conn_args_connection_args():
+    c = {
+        "distributed.comm.tls.ca-file": ca_file,
+        "distributed.comm.tls.scheduler.key": key1,
+        "distributed.comm.tls.scheduler.cert": cert1,
+        "distributed.comm.tls.worker.cert": keycert1,
+    }
+    with dask.config.set(c):
+        sec = Security(extra_conn_args={"headers": {"Authorization": "Token abcd"}})
+
+    d = sec.get_connection_args("scheduler")
+    assert not d["require_encryption"]
+    assert d["extra_conn_args"]["headers"] == {"Authorization": "Token abcd"}
+    ctx = d["ssl_context"]
+
+    d = sec.get_connection_args("worker")
+    assert d["extra_conn_args"]["headers"] == {"Authorization": "Token abcd"}
+
+    # No cert defined => no TLS
+    d = sec.get_connection_args("client")
+    assert d.get("ssl_context") is None
+    assert d["extra_conn_args"]["headers"] == {"Authorization": "Token abcd"}
 
 
 def test_listen_args():
@@ -374,6 +403,13 @@ def test_temporary_credentials():
         val = getattr(sec, f)
         assert "\n" in val
         assert val not in sec_repr
+
+
+def test_extra_conn_args_in_temporary_credentials():
+    pytest.importorskip("cryptography")
+
+    sec = Security.temporary(extra_conn_args={"headers": {"X-Request-ID": "abcd"}})
+    assert sec.extra_conn_args == {"headers": {"X-Request-ID": "abcd"}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Support sending extra connection information to
websockets comms, ie: headers but can map to any
init argument of tornado.httpclient.HTTPRequest

This allows me to authenticate, identify and track calls to a running Dask cluster with websockets behind a proxy, from the proxy itself.

General thoughts: 
* Couldn't find a better place for this than the Security class. That said, it place nicely with `get_connection_args`. Curious to see what other people thing about this.
* We could do something similar for `get_listener_args` if we want to add extra args to `tornado.httpserver.HTTPServer` than `ssl_options`. Is that something worth exploring? Shouldn't be too hard

/cc @mrocklin @jacobtomlinson @jcrist 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
