### PR TITLE
WIP cancel stresstest

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3645,7 +3645,12 @@ class Scheduler(SchedulerState, ServerNode):
         ws._last_seen = local_now
         if executing is not None:
             ws._executing = {
-                parent._tasks[key]: duration for key, duration in executing.items()
+                parent._tasks[key]: duration
+                for key, duration in executing.items()
+                # key might've been already released and forgotten but the
+                # worker issued the hearbeat before it was made aware of
+                # this
+                if key in parent._tasks
             }
 
         ws._metrics = metrics


### PR DESCRIPTION
This adds another stress test which exposes at least two more race conditions in our worker state machine. I don't have a fix for it, yet, but wanted to preserve the WIP

I was not able to reproduce the failures in an async context so I'm guessing it is somehow relating to scheduler<->worker delay. It also only shows up as a log message which is why I needed to introduce the queue loghandling stuff but I can imagine this becoming useful in other places as well.

There are already sync and async stress tests available using dask.array a few lines up but they are not successfully triggering this. We can probably remove them if this plays out

Closes #4587 / ref #4663
Maybe #4510 (haven't investigated the memory leak there but the cancel stress test originates from there)