### PR TITLE
TST: Fix typo and remove unused `time.time` import

### DIFF
--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import pickle
 from datetime import timedelta
-from time import sleep, time
+from time import sleep
 
 import pytest
 
@@ -514,7 +514,7 @@ def test_threadpoolworkers_pick_correct_ioloop(cleanup):
     # * `lease-timeout` should be smaller than the sleep time. This is what the
     #   test builds on. assuming the leases cannot be refreshed, e.g. wrong
     #   event loop picked / PeriodicCallback never scheduled, the semaphore
-    #   would become oversubscribed and the len(protected_ressources) becomes
+    #   would become oversubscribed and the len(protected_resources) becomes
     #   non zero. This should also trigger a log message about "unknown leases"
     #   and fails the test.
     # * `lease-validation-interval` interval should be the smallest quantity.
@@ -530,17 +530,17 @@ def test_threadpoolworkers_pick_correct_ioloop(cleanup):
     ):
         with Client(processes=False, threads_per_worker=4) as client:
             sem = Semaphore(max_leases=1, name="database")
-            protected_ressource = []
+            protected_resource = []
 
             def access_limited(val, sem):
                 import time
 
                 with sem:
-                    assert len(protected_ressource) == 0
-                    protected_ressource.append(val)
+                    assert len(protected_resource) == 0
+                    protected_resource.append(val)
                     # Interact with the DB
                     time.sleep(0.2)
-                    protected_ressource.remove(val)
+                    protected_resource.remove(val)
 
             client.gather(client.map(access_limited, range(10), sem=sem))
 


### PR DESCRIPTION
- [ ] ~~Closes #xxxx~~ N/A
- [x] Tests ~~added~~ / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Suggested typo fix in https://github.com/dask/distributed/issues/4680#issuecomment-815369247 by @jrbourbeau - thanks!

**Summary:**
- Fix typo in `protected_resources`.
- Remove unused `time.time` import.