### PR TITLE
Fix timeout in client.restart

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2980,13 +2980,14 @@ class Client:
             timeout = self._timeout * 2
         if timeout is not None:
             timeout = parse_timedelta(timeout, "s")
+
         self._send_to_scheduler({"op": "restart", "timeout": timeout})
         self._restart_event = asyncio.Event()
         try:
             await asyncio.wait_for(self._restart_event.wait(), timeout)
         except TimeoutError:
             logger.error("Restart timed out after %.2f seconds", timeout)
-            pass
+
         self.generation += 1
         with self._refcount_lock:
             self.refcount.clear()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2978,6 +2978,8 @@ class Client:
     async def _restart(self, timeout=no_default):
         if timeout == no_default:
             timeout = self._timeout * 2
+        if timeout is not None:
+            timeout = parse_timedelta(timeout, "s")
         self._send_to_scheduler({"op": "restart", "timeout": timeout})
         self._restart_event = asyncio.Event()
         try:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2981,9 +2981,7 @@ class Client:
         self._send_to_scheduler({"op": "restart", "timeout": timeout})
         self._restart_event = asyncio.Event()
         try:
-            await asyncio.wait_for(
-                self._restart_event.wait(), self.loop.time() + timeout
-            )
+            await asyncio.wait_for(self._restart_event.wait(), timeout)
         except TimeoutError:
             logger.error("Restart timed out after %f seconds", timeout)
             pass

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2985,7 +2985,7 @@ class Client:
         try:
             await asyncio.wait_for(self._restart_event.wait(), timeout)
         except TimeoutError:
-            logger.error("Restart timed out after %f seconds", timeout)
+            logger.error("Restart timed out after %.2f seconds", timeout)
             pass
         self.generation += 1
         with self._refcount_lock:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3511,7 +3511,7 @@ async def test_Client_clears_references_after_restart(c, s, a, b):
 @gen_cluster(Worker=Nanny, client=True)
 async def test_restart_timeout_is_logged(c, s, a, b):
     with captured_logger(logging.getLogger("distributed.client")) as logger:
-        await c.restart(timeout=0.5)
+        await c.restart(timeout="0.5s")
     text = logger.getvalue()
     assert "Restart timed out after 0.50 seconds" in text
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3513,7 +3513,7 @@ async def test_restart_timeout_is_logged(c, s, a, b):
     with captured_logger(logging.getLogger("distributed.client")) as logger:
         await c.restart(timeout=0.5)
     text = logger.getvalue()
-    assert "Restart timed out after 0.500000 seconds" in text
+    assert "Restart timed out after 0.50 seconds" in text
 
 
 def test_get_stops_work_after_error(c):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3508,6 +3508,14 @@ async def test_Client_clears_references_after_restart(c, s, a, b):
     assert key not in c.refcount
 
 
+@gen_cluster(Worker=Nanny, client=True)
+async def test_restart_timeout_is_logged(c, s, a, b):
+    with captured_logger(logging.getLogger("distributed.client")) as logger:
+        await c.restart(timeout=0.5)
+    text = logger.getvalue()
+    assert "Restart timed out after 0.500000 seconds" in text
+
+
 def test_get_stops_work_after_error(c):
     with pytest.raises(RuntimeError):
         c.get({"x": (throws, 1), "y": (sleep, 1.5)}, ["x", "y"])


### PR DESCRIPTION
I noticed `client.restart()` would hang sometimes, and then I discovered the timeout passed to `asyncio.wait_for` being expressed as a "deadline" instead. Am I correct in assuming this is wrong?
