### PR TITLE
Cleanup hlg annotation api

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4087,6 +4087,9 @@ class Scheduler(SchedulerState, ServerNode):
                     continue
                 ts._host_restrictions = set()
                 ts._worker_restrictions = set()
+                # Make sure `v` is a collection and not a single worker name / address
+                if not isinstance(v, (list, tuple, set)):
+                    v = [v]
                 for w in v:
                     try:
                         w = self.coerce_address(w)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3845,9 +3845,8 @@ class Scheduler(SchedulerState, ServerNode):
         user_priority=0,
         actors=None,
         fifo_timeout=0,
-        annotations=None,
     ):
-        unpacked_graph = HighLevelGraph.__dask_distributed_unpack__(hlg, annotations)
+        unpacked_graph = HighLevelGraph.__dask_distributed_unpack__(hlg)
         dsk = unpacked_graph["dsk"]
         dependencies = unpacked_graph["deps"]
         annotations = unpacked_graph["annotations"]

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4132,6 +4132,21 @@ async def test_persist_workers_annotate(e, s, a, b, c):
 
 @nodebug  # test timing is fragile
 @gen_cluster(nthreads=[("127.0.0.1", 1)] * 3, client=True)
+async def test_persist_workers_annotate2(e, s, a, b, c):
+    def key_to_worker(key):
+        return a.address
+
+    L1 = [delayed(inc)(i) for i in range(4)]
+    with dask.annotate(workers=key_to_worker):
+        out = e.persist(L1, optimize_graph=False)
+        await wait(out)
+
+    for v in L1:
+        assert s.worker_restrictions[v.key] == {a.address}
+
+
+@nodebug  # test timing is fragile
+@gen_cluster(nthreads=[("127.0.0.1", 1)] * 3, client=True)
 async def test_persist_workers(e, s, a, b, c):
     L1 = [delayed(inc)(i) for i in range(4)]
     total = delayed(sum)(L1)


### PR DESCRIPTION
Remove unused annotation argument from `Scheduler.update_graph_hlg()`

This PR depends on https://github.com/dask/distributed/pull/4691 and should be merged **together with** https://github.com/dask/dask/pull/7542

- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
