### PR TITLE
Remove WSSConnector TLS presence check

### DIFF
--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -9,8 +9,8 @@ import dask
 
 from distributed import Client, Scheduler, Worker
 from distributed.comm import connect, listen, ws
-from distributed.comm.registry import backends, get_backend
 from distributed.comm.core import FatalCommClosedError
+from distributed.comm.registry import backends, get_backend
 from distributed.security import Security
 from distributed.utils_test import (  # noqa: F401
     cleanup,

--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -10,6 +10,7 @@ import dask
 from distributed import Client, Scheduler, Worker
 from distributed.comm import connect, listen, ws
 from distributed.comm.registry import backends, get_backend
+from distributed.comm.core import FatalCommClosedError
 from distributed.security import Security
 from distributed.utils_test import (  # noqa: F401
     cleanup,
@@ -71,7 +72,7 @@ async def test_expect_ssl_context(cleanup):
     server_ctx = get_server_ssl_context()
 
     async with listen("wss://", lambda comm: comm, ssl_context=server_ctx) as listener:
-        with pytest.raises(TypeError):
+        with pytest.raises(FatalCommClosedError, match="TLS expects a `ssl_context` *"):
             comm = await connect(listener.contact_address)
 
 

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -376,7 +376,10 @@ class WSConnector(Connector):
         except StreamClosedError as e:
             convert_stream_closed_error(self, e)
         except SSLError as err:
-            raise FatalCommClosedError() from err
+            raise FatalCommClosedError(
+                "TLS expects a `ssl_context` argument of type "
+                "ssl.SSLContext (perhaps check your TLS configuration?)"
+            ) from err
         return self.comm_class(sock, deserialize=deserialize)
 
     def _get_connect_args(self, **connection_args):
@@ -388,7 +391,7 @@ class WSSConnector(WSConnector):
     comm_class = WSS
 
     def _get_connect_args(self, **connection_args):
-        ctx = _expect_tls_context(connection_args)
+        ctx = connection_args.get("ssl_context")
         return {"ssl_options": ctx, **connection_args.get("extra_conn_args", {})}
 
 


### PR DESCRIPTION
Let it fail at connection time if TLS is not properly configured

This allows me to authenticate against a proxy using other techniques like http headers but still use `wss`. The proxy has access to the set of TLS certs and can, based upon authentication, send them along.

/cc @mrocklin @jacobtomlinson 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
