### PR TITLE
Simplify transition `func` retrieval for `finish` case

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1876,16 +1876,15 @@ class SchedulerState:
                 a: tuple = func(key, *args, **kwargs)
                 recommendations, client_msgs, worker_msgs = a
             elif "released" not in start_finish:
-                func = self._transitions_table["released", finish]
                 assert not args and not kwargs
                 a_recs: dict
                 a_cmsgs: dict
                 a_wmsgs: dict
                 a: tuple = self._transition(key, "released")
                 a_recs, a_cmsgs, a_wmsgs = a
-                v = a_recs.get(key)
-                if v is not None:
-                    func = self._transitions_table["released", v]
+
+                v = a_recs.get(key, finish)
+                func = self._transitions_table["released", v]
                 b_recs: dict
                 b_cmsgs: dict
                 b_wmsgs: dict


### PR DESCRIPTION
The transition `func` that was being grabbed depended on whether `key` was found in the recommendations from the last transition. If `key` was found, one function based on `v` was called. If not, `finish` was used in place of `v`. To make this a bit more explicit, simple, and efficient, assign `finish` to `v` if `key` is not found. This way `v` can be used in all cases with one call to retrieve the `func`.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
