### PR TITLE
When closing Server, close all listeners

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -611,7 +611,7 @@ class Server:
         for cb in self._ongoing_coroutines:
             cb.cancel()
         for i in range(10):
-            if all(cb.cancelled() for c in self._ongoing_coroutines):
+            if all(c.cancelled() for c in self._ongoing_coroutines):
                 break
             else:
                 yield asyncio.sleep(0.01)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -599,7 +599,7 @@ class Server:
         for pc in self.periodic_callbacks.values():
             pc.stop()
         for listener in self.listeners:
-            future = self.listener.stop()
+            future = listener.stop()
             if inspect.isawaitable(future):
                 yield future
         for i in range(20):  # let comms close naturally for a second

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -831,3 +831,50 @@ async def test_connection_pool_detects_remote_close():
     # while creating conn2:
     p._validate()
     await p.close()
+
+
+@pytest.mark.asyncio
+async def test_close_properly():
+    """
+    If the server is closed we should cancel all still ongoing coros and close
+    all listeners.
+    GH4704
+    """
+
+    async def sleep(comm=None):
+        # We want to ensure this is actually canceled therefore don't give it a
+        # chance to actually complete
+        await asyncio.sleep(2000000)
+
+    server = await Server({"sleep": sleep})
+    assert server.status == Status.running
+    ports = [8881, 8882, 8883]
+
+    # Previously we close *one* listener, therefore ensure we always use more
+    # than one for this test
+    assert len(ports) > 1
+    for port in ports:
+        await server.listen(port)
+    # We use TCP here for simplicity. If they are closed we should expect other
+    # backends to close properly as well
+    ip = get_ip()
+    rpc_addr = f"tcp://{ip}:{ports[-1]}"
+    async with rpc(rpc_addr) as remote:
+
+        comm = await remote.live_comm()
+        await comm.write({"op": "sleep"})
+        await asyncio.sleep(0.05)
+        assert len(server._ongoing_coroutines)
+        listeners = server.listeners
+        assert len(listeners) == len(ports)
+
+        for port in ports:
+            await assert_can_connect(f"tcp://{ip}:{port}")
+
+        await server.close()
+
+        for port in ports:
+            await assert_cannot_connect(f"tcp://{ip}:{port}")
+
+        # weakref set/dict should be cleaned up
+        assert not len(server._ongoing_coroutines)

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -32,6 +32,7 @@ from distributed.utils_test import (
     assert_can_connect_locally_4,
     assert_can_connect_locally_6,
     assert_cannot_connect,
+    async_wait_for,
     captured_logger,
     gen_cluster,
     has_ipv6,
@@ -863,8 +864,9 @@ async def test_close_properly():
 
         comm = await remote.live_comm()
         await comm.write({"op": "sleep"})
-        await asyncio.sleep(0.05)
-        assert len(server._ongoing_coroutines)
+
+        await async_wait_for(lambda: not server._ongoing_coroutines, 10)
+
         listeners = server.listeners
         assert len(listeners) == len(ports)
 


### PR DESCRIPTION
The current implementation only stops _one_ of potentially many listeners when closing a server. 


I only stumbled over this and have no idea if this has any implications