### PR TITLE
Remove hostname check in test_dashboard

### DIFF
--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -4,7 +4,6 @@ pytest.importorskip("requests")
 
 import os
 import shutil
-import socket
 import sys
 import tempfile
 from time import sleep
@@ -77,9 +76,6 @@ def test_dashboard(loop):
             pass
 
         names = ["localhost", "127.0.0.1", get_ip()]
-        if "linux" in sys.platform:
-            names.append(socket.gethostname())
-
         start = time()
         while True:
             try:


### PR DESCRIPTION
This PR removes the hostname check in `test_dashboard` as proposed in https://github.com/dask/distributed/issues/4697#issuecomment-819436238

cc @fjetter 

Closes https://github.com/dask/distributed/issues/4697
