### PR TITLE
Add runner

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -413,14 +413,6 @@ class Cluster:
     def __exit__(self, typ, value, traceback):
         return self.sync(self.__aexit__, typ, value, traceback)
 
-    def __await__(self):
-        async def _():
-            if self.status == Status.created:
-                await self._start()
-            return self
-
-        return _().__await__()
-
     async def __aenter__(self):
         await self
         return self

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -413,6 +413,14 @@ class Cluster:
     def __exit__(self, typ, value, traceback):
         return self.sync(self.__aexit__, typ, value, traceback)
 
+    def __await__(self):
+        async def _():
+            if self.status == Status.created:
+                await self._start()
+            return self
+
+        return _().__await__()
+
     async def __aenter__(self):
         await self
         return self

--- a/distributed/deploy/runner.py
+++ b/distributed/deploy/runner.py
@@ -1,0 +1,227 @@
+import asyncio
+import sys
+import threading
+from contextlib import suppress
+from enum import Enum
+from typing import Dict
+
+from ..core import CommClosedError, Status, rpc
+from ..scheduler import Scheduler
+from ..utils import LoopRunner, import_term, sync, thread_state
+from ..worker import Worker
+
+
+class Role(Enum):
+    """
+    This Enum contains the various roles processes can be.
+    """
+
+    worker = "worker"
+    scheduler = "scheduler"
+    client = "client"
+
+
+class Runner:
+    """Superclass for runner objects.
+
+    This class contains common functionality for Dask cluster runner classes.
+
+    To implement this class, you must provide
+
+    1.  A ``get_role`` method which returns a role from the ``Role`` enum.
+    2.  A ``set_scheduler_address`` method for the scheduler process to communicate its address.
+    3.  A ``get_scheduler_address`` method for all other processed to recieve the scheduler address.
+    4.  Optionally, a ``get_worker_name`` to provide a platform specific name to the workers.
+    5.  Optionally, a ``before_scheduler_start`` to perform any actions before the scheduler is created.
+    6.  Optionally, a ``before_worker_start`` to perform any actions before the worker is created.
+    7.  Optionally, a ``before_client_start`` to perform any actions before the client code continues.
+    8.  Optionally, a ``on_scheduler_start`` to perform anything on the scheduler once it has started.
+    9.  Optionally, a ``on_worker_start`` to perform anything on the worker once it has started.
+
+    For that, you should get the following:
+
+    A context manager and object which can be used within a script that is run in parallel to decide which processes
+    run the scheduler, workers and client code.
+
+    """
+
+    def __init__(
+        self,
+        scheduler: bool = True,
+        scheduler_options: Dict = None,
+        worker_class: str = None,
+        worker_options: Dict = None,
+        client: bool = True,
+        asynchronous: bool = False,
+        loop: asyncio.BaseEventLoop = None,
+    ):
+        self.status = Status.created
+        self.scheduler = scheduler
+        self.scheduler_address = None
+        self.scheduler_comm = None
+        self.client = client
+        self.scheduler_options = (
+            scheduler_options if scheduler_options is not None else {}
+        )
+        self.worker_class = (
+            Worker if worker_class is None else import_term(worker_class)
+        )
+        self.worker_options = worker_options if worker_options is not None else {}
+        self.role = None
+        self._asynchronous = asynchronous
+        self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
+        self.loop = self._loop_runner.loop
+
+        if not self.asynchronous:
+            self._loop_runner.start()
+            self.sync(self._start)
+
+    async def get_role(self) -> str:
+        raise NotImplementedError()
+
+    async def set_scheduler_address(self, scheduler: Scheduler) -> None:
+        raise NotImplementedError()
+
+    async def get_scheduler_address(self) -> str:
+        raise NotImplementedError()
+
+    async def get_worker_name(self) -> str:
+        return None
+
+    async def before_scheduler_start(self) -> None:
+        return None
+
+    async def before_worker_start(self) -> None:
+        return None
+
+    async def before_client_start(self) -> None:
+        return None
+
+    async def on_scheduler_start(self, scheduler: Scheduler) -> None:
+        return None
+
+    async def on_worker_start(self, worker: Worker) -> None:
+        return None
+
+    @property
+    def asynchronous(self):
+        return (
+            self._asynchronous
+            or getattr(thread_state, "asynchronous", False)
+            or hasattr(self.loop, "_thread_identity")
+            and self.loop._thread_identity == threading.get_ident()
+        )
+
+    def sync(self, func, *args, asynchronous=None, callback_timeout=None, **kwargs):
+        asynchronous = asynchronous or self.asynchronous
+        if asynchronous:
+            future = func(*args, **kwargs)
+            if callback_timeout is not None:
+                future = asyncio.wait_for(future, callback_timeout)
+            return future
+        else:
+            return sync(self.loop, func, *args, **kwargs)
+
+    def __await__(self):
+        async def _await():
+            if self.status != Status.running:
+                await self._start()
+            return self
+
+        return _await().__await__()
+
+    async def __aenter__(self):
+        await self
+        return self
+
+    async def __aexit__(self, *args):
+        await self._close()
+
+    def __enter__(self):
+        return self.sync(self.__aenter__)
+
+    def __exit__(self, typ, value, traceback):
+        return self.sync(self.__aexit__)
+
+    def __del__(self):
+        if self.status != Status.closed:
+            with suppress(AttributeError, RuntimeError):  # during closing
+                self.loop.add_callback(self.close)
+
+    async def _start(self) -> None:
+        self.role = await self.get_role()
+        if self.role == Role.scheduler:
+            await self.start_scheduler()
+            sys.exit(0)
+        elif self.role == Role.worker:
+            await self.start_worker()
+            sys.exit(0)
+        elif self.role == Role.client:
+            self.scheduler_address = await self.get_scheduler_address()
+            self.scheduler_comm = rpc(self.scheduler_address)
+            await self.before_client_start()
+        self.status = Status.running
+
+    async def start_scheduler(self) -> None:
+        await self.before_scheduler_start()
+        async with Scheduler(**self.scheduler_options, loop=self.loop) as scheduler:
+            await self.set_scheduler_address(scheduler)
+            await self.on_scheduler_start(scheduler)
+            await scheduler.finished()
+
+    async def start_worker(self) -> None:
+        if (
+            "scheduler_file" not in self.worker_options
+            and "scheduler_ip" not in self.worker_options
+        ):
+            self.worker_options["scheduler_ip"] = await self.get_scheduler_address()
+        worker_name = await self.get_worker_name()
+        await self.before_worker_start()
+        async with self.worker_class(
+            name=worker_name, **self.worker_options, loop=self.loop
+        ) as worker:
+            await self.on_worker_start(worker)
+            await worker.finished()
+
+    async def _close(self) -> None:
+        print(f"stopping {self.role}")
+        if self.status == Status.running:
+            with suppress(CommClosedError):
+                await self.scheduler_comm.terminate()
+            self.status = Status.closed
+
+    def close(self) -> None:
+        return self.sync(self._close)
+        self._loop_runner.stop()
+
+
+class AsyncCommWorld:
+    def __init__(self):
+        self.roles = {"scheduler": None, "client": None}
+        self.role_lock = asyncio.Lock()
+        self.scheduler_address = None
+
+
+class AsyncRunner(Runner):
+    def __init__(self, commworld: AsyncCommWorld, *args, **kwargs):
+        self.commworld = commworld
+        super().__init__(*args, **kwargs)
+
+    async def get_role(self) -> str:
+        async with self.commworld.role_lock:
+            if self.commworld.roles["scheduler"] is None and self.scheduler:
+                self.commworld.roles["scheduler"] = self
+                return Role.scheduler
+            elif self.commworld.roles["client"] is None and self.client:
+                self.commworld.roles["client"] = self
+                return Role.client
+            else:
+                return Role.worker
+
+    async def set_scheduler_address(self, scheduler: Scheduler) -> None:
+        self.commworld.scheduler_address = scheduler.address
+
+    async def get_scheduler_address(self) -> str:
+        while self.commworld.scheduler_address is None:
+            await asyncio.sleep(0.1)
+        return self.commworld.scheduler_address

--- a/distributed/deploy/tests/test_runner.py
+++ b/distributed/deploy/tests/test_runner.py
@@ -1,0 +1,31 @@
+import asyncio
+from contextlib import suppress
+from time import time
+
+import pytest
+
+from dask.distributed import Client
+
+from distributed.deploy.runner import AsyncCommWorld, AsyncRunner
+from distributed.utils_test import loop  # noqa: F401
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(10)
+async def test_runner(loop):
+    commworld = AsyncCommWorld()
+
+    async def run_code(commworld):
+        with suppress(SystemExit):
+            async with AsyncRunner(commworld, asynchronous=True) as runner:
+                async with Client(runner, asynchronous=True) as c:
+
+                    start = time()
+                    while len(c.scheduler_info()["workers"]) != 2:
+                        assert time() < start + 10
+                        await asyncio.sleep(0.2)
+
+                    assert await c.submit(lambda x: x + 1, 10).result() == 11
+                    assert await c.submit(lambda x: x + 1, 20).result() == 21
+
+    await asyncio.gather(*[run_code(commworld) for _ in range(4)])


### PR DESCRIPTION
This PR adds a new `Runner` base class with a similar intention to `Cluster` in that it is for other projects to subclass and flesh out platform-specific implementation.

This work was inspired by [dask-mpi](https://github.com/dask/dask-mpi/) which has a deployment paradigm unlike any of the existing cluster management tooling.

Dask MPI assumes that the user wants to submit a single Python script to a parallel batch scheduler, resulting in all processes executing this script. Dask MPI then handles deciding which process will be the scheduler, which will be the workers and which will continue executing the user's client code. Negotiation between processes is done via the MPI ranking and comm.

This kind of functionality would also be useful on similar systems which do not use MPI. The concept of running a single script and having all but one invocations bootstrap a Dask cluster, leaving one to complete the client work, is appealing.

The new `Runner` class takes the concepts from Dask MPI and attempts to mix them with the structure of the `Cluster` object in terms of asyncio support and the use of context managers.

## Usage

The general usage for a runner should look like this.

```python
from dask_foo import FooRunner

from dask.distributed import Client

with FooRunner() as runner:
    with Client(runner) as c:
        # Do client work
```
This script should be submitted many time in parallel using an appropriate execution engine. 

When `FooRunner` is created each instance of the script will negotiate via some platform specific means to decide which role each process will take. All but the client will block here and run their components. Then when the client finishes and the runner context manager closes all components will be shut down via the Dask comm.

## Reference implementation

This PR also includes a reference implementation of the runner which uses asyncio to concurrently execute four instances of the `AsyncioRunner` concurrently. These instances will negotiate via an `asyncio.Lock` to decide who is the scheduler, who continues with client code and who are workers.

## Dask MPI

See dask/dask-mpi#69 for an implementation of this to replace the current code in dask-mpi.