### PR TITLE
ipython causes test_profile_nested_sizeof crash on windows

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,13 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version < '3.8' }}
         run: mamba install -c conda-forge -c defaults -c numba libunwind stacktrace
 
+      - name: Hack around https://github.com/ipython/ipython/issues/12197
+        # This upstream issue causes an interpreter crash when running
+        # distributed/protocol/tests/test_serialize.py::test_profile_nested_sizeof
+        shell: bash -l {0}
+        if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.9' }}
+        run: mamba uninstall ipython
+
       - name: Cythonize
         shell: bash -l {0}
         if: ${{ matrix.python-version == '3.7' }}


### PR DESCRIPTION
test_profile_nested_sizeof has started crashing again on Windows 3.9.
Previous discussion at #4585

CC @jrbourbeau