### PR TITLE
Ensure adaptive scaling is properly awaited and closed

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1198,7 +1198,7 @@ class Client:
         return self
 
     async def __aenter__(self):
-        await self._started
+        await self
         return self
 
     async def __aexit__(self, typ, value, traceback):

--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -184,19 +184,23 @@ class Adaptive(AdaptiveCore):
         if not workers:
             return
         with log_errors():
+            logger.info("Retiring workers %s", workers)
             # Ask scheduler to cleanly retire workers
             await self.scheduler.retire_workers(
-                names=workers, remove=True, close_workers=True
+                names=workers,
+                remove=True,
+                close_workers=True,
             )
 
             # close workers more forcefully
-            logger.info("Retiring workers %s", workers)
             f = self.cluster.scale_down(workers)
             if isawaitable(f):
                 await f
 
     async def scale_up(self, n):
-        self.cluster.scale(n)
+        f = self.cluster.scale(n)
+        if isawaitable(f):
+            await f
 
     @property
     def loop(self):

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -107,6 +107,7 @@ class AdaptiveCore:
 
     def stop(self):
         logger.info("Adaptive stop")
+        assert not self._adapting
 
         if self.periodic_callback:
             self.periodic_callback.stop()

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 import math
+from typing import Iterable
 
 import tlz as toolz
 from tornado.ioloop import IOLoop, PeriodicCallback
@@ -107,7 +108,6 @@ class AdaptiveCore:
 
     def stop(self):
         logger.info("Adaptive stop")
-        assert not self._adapting
 
         if self.periodic_callback:
             self.periodic_callback.stop()
@@ -134,6 +134,12 @@ class AdaptiveCore:
             n = self.minimum
 
         return n
+
+    async def scale_down(self, n: int):
+        raise NotImplementedError()
+
+    async def scale_up(self, workers: Iterable):
+        raise NotImplementedError()
 
     async def recommendations(self, target: int) -> dict:
         """

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -481,17 +481,11 @@ async def test_adaptive_stopped():
     stops.
     """
     async with LocalCluster(n_workers=0, asynchronous=True) as cluster:
-        async with Client(cluster, asynchronous=True) as client:
-            instance = cluster.adapt(interval="10ms")
+        instance = cluster.adapt(interval="10ms")
+        assert instance.periodic_callback is not None
 
-            await async_wait_for(
-                lambda: instance.periodic_callback is not None, timeout=5
-            )
+        await async_wait_for(lambda: instance.periodic_callback.is_running(), timeout=5)
 
-            await async_wait_for(
-                lambda: instance.periodic_callback.is_running() is not None, timeout=5
-            )
+        pc = instance.periodic_callback
 
-            pc = instance.periodic_callback
-
-    await async_wait_for(lambda: pc.is_running() is not None, timeout=5)
+    await async_wait_for(lambda: not pc.is_running(), timeout=5)

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -10,6 +10,7 @@ import dask
 from distributed import Adaptive, Client, LocalCluster, SpecCluster, Worker, wait
 from distributed.metrics import time
 from distributed.utils_test import (  # noqa: F401
+    async_wait_for,
     clean,
     cleanup,
     gen_test,
@@ -17,43 +18,6 @@ from distributed.utils_test import (  # noqa: F401
     nodebug,
     slowinc,
 )
-
-
-@pytest.mark.asyncio
-async def test_simultaneous_scale_up_and_down(cleanup):
-    class TestAdaptive(Adaptive):
-        def get_scale_up_kwargs(self):
-            assert False
-
-        def _retire_workers(self):
-            assert False
-
-    class TestCluster(LocalCluster):
-        def scale_up(self, n, **kwargs):
-            assert False
-
-        def scale_down(self, workers):
-            assert False
-
-    with dask.config.set(
-        {"distributed.scheduler.default-task-durations": {"a": 4, "b": 4, "c": 1}}
-    ):
-        async with TestCluster(
-            n_workers=4, processes=False, asynchronous=True
-        ) as cluster:
-            async with Client(cluster, asynchronous=True) as c:
-                s = cluster.scheduler
-
-                future = c.map(slowinc, [1, 1, 1], key=["a-4", "b-4", "c-1"])
-
-                while len(s.rprocessing) < 3:
-                    await asyncio.sleep(0.001)
-
-                ta = cluster.adapt(
-                    interval="100 ms", scale_factor=2, Adaptive=TestAdaptive
-                )
-
-                await asyncio.sleep(0.3)
 
 
 def test_adaptive_local_cluster(loop):
@@ -479,3 +443,55 @@ async def test_adaptive_no_memory_limit(cleanup):
             )
             <= 5
         )
+
+
+@pytest.mark.asyncio
+async def test_scale_needs_to_be_awaited(cleanup):
+    """
+    This tests that the adaptive class works fine if the scale method uses the
+    `sync` method to schedule its task instead of loop.add_callback
+    """
+
+    class RequiresAwaitCluster(LocalCluster):
+        def scale(self, n):
+            # super invocation in the nested function scope is messy
+            method = super().scale
+
+            async def _():
+                return method(n)
+
+            return self.sync(_)
+
+    async with RequiresAwaitCluster(n_workers=0, asynchronous=True) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            futures = client.map(slowinc, range(5), delay=0.05)
+            assert len(cluster.workers) == 0
+            cluster.adapt()
+
+            await client.gather(futures)
+
+            del futures
+            await async_wait_for(lambda: not cluster.workers, 10)
+
+
+@pytest.mark.asyncio
+async def test_adaptive_stopped():
+    """
+    We should ensure that the adapt PC is actually stopped once the cluster
+    stops.
+    """
+    async with LocalCluster(n_workers=0, asynchronous=True) as cluster:
+        async with Client(cluster, asynchronous=True) as client:
+            instance = cluster.adapt(interval="10ms")
+
+            await async_wait_for(
+                lambda: instance.periodic_callback is not None, timeout=5
+            )
+
+            await async_wait_for(
+                lambda: instance.periodic_callback.is_running() is not None, timeout=5
+            )
+
+            pc = instance.periodic_callback
+
+    await async_wait_for(lambda: pc.is_running() is not None, timeout=5)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -722,7 +722,7 @@ async def test_scheduler_sees_memory_limits(s):
     await w.close()
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, timeout=1000)
 async def test_retire_workers(c, s, a, b):
     [x] = await c.scatter([1], workers=a.address)
     [y] = await c.scatter([list(range(1000))], workers=b.address)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -722,7 +722,7 @@ async def test_scheduler_sees_memory_limits(s):
     await w.close()
 
 
-@gen_cluster(client=True, timeout=1000)
+@gen_cluster(client=True)
 async def test_retire_workers(c, s, a, b):
     [x] = await c.scatter([1], workers=a.address)
     [y] = await c.scatter([list(range(1000))], workers=b.address)


### PR DESCRIPTION
* Primarily this ensures that scale_up/down is properly awaited in case the `sync` method is used which is more common than the `loop.add_callback`.
* It also ensures the adaptive PC is stopped properly once a cluster shuts down.
* A bit cleanup. There has been a test which raises error logs and I had issues figuring out what it actually was doing. It also was refactored a few times since its original inception.