### PR TITLE
Reintroduce `weight` function

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -24,6 +24,7 @@ from distributed.utils import (
     LoopRunner,
     TimeoutError,
     _maybe_complex,
+    deprecated,
     ensure_bytes,
     ensure_ip,
     format_dashboard_link,
@@ -617,3 +618,20 @@ def test_lru():
 async def test_offload():
     assert (await offload(inc, 1)) == 2
     assert (await offload(lambda x, y: x + y, 1, y=2)) == 3
+
+
+def test_deprecated():
+    @deprecated()
+    def foo():
+        return "bar"
+
+    with pytest.warns(DeprecationWarning, match="foo is deprecated"):
+        assert foo() == "bar"
+
+    # Explicit version specified
+    @deprecated(version_removed="1.2.3")
+    def foo():
+        return "bar"
+
+    with pytest.warns(DeprecationWarning, match="removed in version 1.2.3"):
+        assert foo() == "bar"

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -54,7 +54,7 @@ from distributed.utils_test import (  # noqa: F401
     s,
     slowinc,
 )
-from distributed.worker import Worker, error_message, logger, parse_memory_limit
+from distributed.worker import Worker, error_message, logger, parse_memory_limit, weight
 
 
 @pytest.mark.asyncio
@@ -1787,3 +1787,8 @@ async def test_story(c, s, w):
     ts = w.tasks[future.key]
     assert ts.state in str(w.story(ts))
     assert w.story(ts) == w.story(ts.key)
+
+
+def test_weight_deprecated():
+    with pytest.warns(DeprecationWarning):
+        weight("foo", "bar")

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1073,6 +1073,34 @@ def time_warn(duration, text):
         print("TIME WARNING", text, end - start)
 
 
+def deprecated(*, version_removed: str = None):
+    """Decorator to mark a function as deprecated
+
+    Parameters
+    ----------
+    version_removed : str, optional
+        If specified, include the version in which the deprecated function
+        will be removed. Defaults to "a future release".
+    """
+
+    def decorator(func):
+        nonlocal version_removed
+        msg = f"{funcname(func)} is deprecated and will be removed in"
+        if version_removed is not None:
+            msg += f" version {version_removed}"
+        else:
+            msg += " a future release"
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 def json_load_robust(fn, load=json.load):
     """ Reads a JSON file from disk that may be being written as we read """
     while not os.path.exists(fn):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -56,6 +56,7 @@ from .utils import (
     LRU,
     TimeoutError,
     _maybe_complex,
+    deprecated,
     get_ip,
     has_arg,
     import_file,
@@ -3718,7 +3719,7 @@ def convert_kwargs_to_str(kwargs, max_len=None):
         return "{{{}}}".format(", ".join(strs))
 
 
-# Keep `weight` for backwards compatibility
+@deprecated(version_removed="2021.06.0")
 def weight(k, v):
     return sizeof(v)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3718,7 +3718,13 @@ def convert_kwargs_to_str(kwargs, max_len=None):
         return "{{{}}}".format(", ".join(strs))
 
 
+# Keep `weight` for backwards compatibility
+def weight(k, v):
+    return sizeof(v)
+
+
 async def run(server, comm, function, args=(), kwargs=None, is_coro=None, wait=True):
+
     kwargs = kwargs or {}
     function = pickle.loads(function)
     if is_coro is None:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3724,7 +3724,6 @@ def weight(k, v):
 
 
 async def run(server, comm, function, args=(), kwargs=None, is_coro=None, wait=True):
-
     kwargs = kwargs or {}
     function = pickle.loads(function)
     if is_coro is None:


### PR DESCRIPTION
This PR adds the `weight` function (which was recently removed) back into `distributed/worker.py`. I heard this was being used by RAPIDS so it'd be good to keep it around for a bit before removing it in a future release. 

cc @quasiben @kkraus14 