### PR TITLE
Improve graceful shutdown if nanny is involved

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -301,7 +301,9 @@ async def connect(
             upper_cap = min(time_left(), backoff_base * (2 ** attempt))
             backoff = random.uniform(0, upper_cap)
             attempt += 1
-            logger.debug("Could not connect, waiting for %s before retrying", backoff)
+            logger.debug(
+                "Could not connect to %s, waiting for %s before retrying", loc, backoff
+            )
             await asyncio.sleep(backoff)
     else:
         raise IOError(

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -441,30 +441,35 @@ class Nanny(ServerNode):
         self.loop.add_callback(self._on_exit, exitcode)
 
     async def _on_exit(self, exitcode):
-        if self.status not in (Status.init, Status.closing, Status.closed):
+        if self.status not in (
+            Status.init,
+            Status.closing,
+            Status.closed,
+            Status.closing_gracefully,
+        ):
             try:
-                await self.scheduler.unregister(address=self.worker_address)
+                await self._unregister()
             except (EnvironmentError, CommClosedError):
                 if not self.reconnect:
                     await self.close()
                     return
 
-            try:
-                if self.status not in (
-                    Status.closing,
-                    Status.closed,
-                    Status.closing_gracefully,
-                ):
-                    if self.auto_restart:
-                        logger.warning("Restarting worker")
-                        await self.instantiate()
-                elif self.status == Status.closing_gracefully:
-                    await self.close()
+        try:
+            if self.status not in (
+                Status.closing,
+                Status.closed,
+                Status.closing_gracefully,
+            ):
+                if self.auto_restart:
+                    logger.warning("Restarting worker")
+                    await self.instantiate()
+            elif self.status == Status.closing_gracefully:
+                await self.close()
 
-            except Exception:
-                logger.error(
-                    "Failed to restart worker after its process exited", exc_info=True
-                )
+        except Exception:
+            logger.error(
+                "Failed to restart worker after its process exited", exc_info=True
+            )
 
     @property
     def pid(self):
@@ -733,8 +738,9 @@ class WorkerProcess:
         async def do_stop(timeout=5, executor_wait=True):
             try:
                 await worker.close(
-                    report=False,
+                    report=True,
                     nanny=False,
+                    safe=True,  # TODO: Graceful or not?
                     executor_wait=executor_wait,
                     timeout=timeout,
                 )

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2468,3 +2468,23 @@ async def test_memory_is_none(c, s):
             assert s.memory.unmanaged == 0
             assert s.memory.unmanaged_old == 0
             assert s.memory.unmanaged_recent == 0
+
+
+@gen_cluster()
+async def test_close_scheduler__close_workers_Worker(s, a, b):
+    with captured_logger("distributed.comm", level=logging.DEBUG) as log:
+        await s.close(close_workers=True)
+        while not a.status == Status.closed:
+            await asyncio.sleep(0.05)
+    log = log.getvalue()
+    assert "retry" not in log
+
+
+@gen_cluster(Worker=Nanny)
+async def test_close_scheduler__close_workers_Nanny(s, a, b):
+    with captured_logger("distributed.comm", level=logging.DEBUG) as log:
+        await s.close(close_workers=True)
+        while not a.status == Status.closed:
+            await asyncio.sleep(0.05)
+    log = log.getvalue()
+    assert "retry" not in log


### PR DESCRIPTION
These fixes affect test runtimes and general graceful downscaling performance if a Nanny is involved. There are two fixes in here

* When using the test fixture `cluster`, there are explicit calls to `disconnect`, i.e. close every individual worker. This call involves the `rpc` implementation which, by default, waits for the remote handler to reply. This reply always times out since the worker terminated already and closed it's comm. Therefore, waiting for a reply is useless. This timeout is not big but a few seconds which we always have to wait when this thing stops. By not waiting for the reply, this finishes almost immediately. For most tests using this fixture, this makes up almost the entire test runtime
* The second fix involves the nanny. The graceful shutdown of a nanny worker is a bit messy at the moment and happens in two stages (I won't address this right now since it requires changing a bunch of handlers with subtle side effects). See for example https://github.com/dask/distributed/blob/e4b534af5722a7aebb8d5b086081984e93e1784f/distributed/scheduler.py#L3702-L3704 . In the graceful scaledown event, the nanny tried to unregister the worker unnecessarily which also runs into a timeout and slows down the shutdown. this has real world impact, not only test runtime