### PR TITLE
Add "ready->memory" to transitions in worker

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1840,7 +1840,7 @@ class Worker(ServerNode):
         self.send_task_state_to_scheduler(ts)
 
     def transition_ready_memory(self, ts, value=no_value):
-        if value:
+        if value is not no_value:
             self.put_key_in_memory(ts, value=value)
         self.send_task_state_to_scheduler(ts)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1839,7 +1839,7 @@ class Worker(ServerNode):
             assert ts.traceback is not None
         self.send_task_state_to_scheduler(ts)
 
-    def transition_ready_memory(self, ts, value=None):
+    def transition_ready_memory(self, ts, value=no_value):
         if value:
             self.put_key_in_memory(ts, value=value)
         self.send_task_state_to_scheduler(ts)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -466,6 +466,8 @@ class Worker(ServerNode):
             ("executing", "memory"): self.transition_executing_done,
             ("flight", "memory"): self.transition_flight_memory,
             ("flight", "fetch"): self.transition_flight_fetch,
+            # Shouldn't be a valid transition but happens nonetheless
+            ("ready", "memory"): self.transition_ready_memory,
             # Scheduler intercession (re-assignment)
             ("fetch", "waiting"): self.transition_fetch_waiting,
             ("flight", "waiting"): self.transition_flight_waiting,


### PR DESCRIPTION
This should remove the error message in #4721 but is more of a band-aid
than a fix.  Ready->memory transitions shouldn't happen, but since they
do occassionally crop up, we might as well dispatch them appropriately
until the worker state machine is ready.

- [ ] Closes https://github.com/dask/distributed/issues/4721
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
