### PR TITLE
Avoid `active_threads` changing size during iteration

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -945,16 +945,16 @@ class Worker(ServerNode):
         logger.debug("Heartbeat: %s", self.address)
         try:
             start = time()
+            with self.active_threads_lock:
+                active_keys = list(self.active_threads.values())
             response = await retry_operation(
                 self.scheduler.heartbeat_worker,
                 address=self.contact_address,
                 now=start,
                 metrics=await self.get_metrics(),
-                # Create a copy of `self.active_threads.values()` to avoid
-                # `self.active_threads` changing size during iteration
                 executing={
                     key: start - self.tasks[key].start_time
-                    for key in list(self.active_threads.values())
+                    for key in active_keys
                     if key in self.tasks
                 },
             )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -950,9 +950,11 @@ class Worker(ServerNode):
                 address=self.contact_address,
                 now=start,
                 metrics=await self.get_metrics(),
+                # Create a copy of `self.active_threads.values()` to avoid
+                # `self.active_threads` changing size during iteration
                 executing={
                     key: start - self.tasks[key].start_time
-                    for key in self.active_threads.values()
+                    for key in list(self.active_threads.values())
                     if key in self.tasks
                 },
             )


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/7581. @bsesar would you mind trying this PR out to see if it resolves the error you were seeing?

Note that we could also acquire `active_threads_lock` during the heartbeat to avoid `self.active_threads` changing size during iteration. However since we acquire `active_threads_lock` during task execution and heartbeat often I opted to not acquire the lock here to avoid coupling task execution and heartbeating. Happy to acquire `active_threads_lock` instead if others prefer. 
