### PR TITLE
Ensure exceptions are raised if workers are incorrectly started

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -136,7 +136,6 @@ class Server:
         connection_args=None,
         timeout=None,
         io_loop=None,
-        **kwargs,
     ):
         self.handlers = {
             "identity": self.identity,
@@ -237,8 +236,6 @@ class Server:
         )
 
         self.__stopped = False
-
-        super().__init__(**kwargs)
 
     @property
     def status(self):

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1063,3 +1063,21 @@ async def test_cluster_names():
 
         async with LocalCluster(processes=False, asynchronous=True) as unnamed_cluster2:
             assert unnamed_cluster2 != unnamed_cluster
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("nanny", [True, False])
+async def test_local_cluster_redundant_kwarg(nanny):
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        # Extra arguments are forwarded to the worker class. Depending on
+        # whether we use the nanny or not, the error treatment is quite
+        # different and we should assert that an exception is raised
+        async with await LocalCluster(
+            typo_kwarg="foo", processes=nanny, n_workers=1
+        ) as cluster:
+
+            # This will never work but is a reliable way to block without hard
+            # coding any sleep values
+            async with Client(cluster) as c:
+                f = c.submit(sleep, 0)
+                await f

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -880,3 +880,9 @@ async def test_close_properly():
 
         # weakref set/dict should be cleaned up
         assert not len(server._ongoing_coroutines)
+
+
+@pytest.mark.asyncio
+async def test_server_redundant_kwarg():
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        await Server({}, typo_kwarg="foo")

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -572,3 +572,11 @@ async def test_worker_start_exception(cleanup):
     with pytest.raises(StartException):
         async with Nanny("tcp://localhost:1", worker_class=BrokenWorker) as n:
             await n.start()
+
+
+@pytest.mark.asyncio
+async def test_failure_during_worker_initialization():
+    async with Scheduler() as s:
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            async with Nanny(s.address, foo="bar") as n:
+                await n

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -14,7 +14,6 @@ from tornado.ioloop import IOLoop
 import dask
 
 from distributed import Client, Nanny, Scheduler, Worker, rpc, wait, worker
-from distributed.compatibility import MACOS
 from distributed.core import CommClosedError, Status
 from distributed.diagnostics import SchedulerPlugin
 from distributed.metrics import time
@@ -565,7 +564,6 @@ class BrokenWorker(worker.Worker):
         raise StartException("broken")
 
 
-@pytest.mark.flaky(reruns=10, reruns_delay=5, condition=MACOS)
 @pytest.mark.asyncio
 async def test_worker_start_exception(cleanup):
     # make sure this raises the right Exception:
@@ -575,8 +573,10 @@ async def test_worker_start_exception(cleanup):
 
 
 @pytest.mark.asyncio
-async def test_failure_during_worker_initialization():
-    async with Scheduler() as s:
-        with pytest.raises(TypeError, match="unexpected keyword argument"):
-            async with Nanny(s.address, foo="bar") as n:
-                await n
+async def test_failure_during_worker_initialization(cleanup):
+    with captured_logger(logger="distributed.nanny", level=logging.WARNING) as logs:
+        async with Scheduler() as s:
+            with pytest.raises(Exception):
+                async with Nanny(s.address, foo="bar") as n:
+                    await n
+        assert "Restarting worker" not in logs.getvalue()


### PR DESCRIPTION
`Server` inherits from `object` which has no sensible initialiser. In particular, when provided with kwargs, it raises an obscure `TypeError`

`TypeError: object.__init__() takes exactly one argument (the instance to initialize)`

Instead of raising, this would issue a warning indicating that some arguments were not used