### PR TITLE
Ensure exceptions in handlers are handled equally for sync and async

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -489,7 +489,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         try:
             await self.on_connection(comm)
         except CommClosedError:
-            logger.info("Connection closed before handshake completed")
+            logger.info("Connection from %s closed before handshake completed", address)
             return
 
         await self.comm_handler(comm)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -293,9 +293,12 @@ class Server:
 
         return _().__await__()
 
+    async def _start(self):
+        self.status = Status.running
+
     async def start(self):
         await self.rpc.start()
-        self.status = Status.running
+        await self._start()
 
     async def __aenter__(self):
         await self

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -438,6 +438,10 @@ class Server:
         logger.debug("Connection from %r to %s", address, type(self).__name__)
         self._comms[comm] = op
 
+        # The server might already be listening even though it is not properly
+        # started, yet. (e.g. preload modules not done)
+        await self
+
         try:
             while True:
                 try:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -280,7 +280,6 @@ class Server:
                 if timeout:
                     try:
                         await asyncio.wait_for(self.start(), timeout=timeout)
-                        self.status = Status.running
                     except Exception:
                         await self.close(timeout=1)
                         raise TimeoutError(
@@ -290,13 +289,13 @@ class Server:
                         )
                 else:
                     await self.start()
-                    self.status = Status.running
             return self
 
         return _().__await__()
 
     async def start(self):
         await self.rpc.start()
+        self.status = Status.running
 
     async def __aenter__(self):
         await self

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -439,11 +439,8 @@ async def test_scale_needs_to_be_awaited(cleanup):
 
     class RequiresAwaitCluster(LocalCluster):
         def scale(self, n):
-            # super invocation in the nested function scope is messy
-            method = super().scale
-
             async def _():
-                return method(n)
+                return LocalCluster.scale(self, n)
 
             return self.sync(_)
 
@@ -451,7 +448,7 @@ async def test_scale_needs_to_be_awaited(cleanup):
         async with Client(cluster, asynchronous=True) as client:
             futures = client.map(slowinc, range(5), delay=0.05)
             assert len(cluster.workers) == 0
-            cluster.adapt()
+            cluster.adapt(interval="10ms")
 
             await client.gather(futures)
 

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1068,12 +1068,12 @@ async def test_local_cluster_redundant_kwarg(nanny):
         # Extra arguments are forwarded to the worker class. Depending on
         # whether we use the nanny or not, the error treatment is quite
         # different and we should assert that an exception is raised
-        async with await LocalCluster(
-            typo_kwarg="foo", processes=nanny, n_workers=1
+        async with LocalCluster(
+            typo_kwarg="foo", processes=nanny, n_workers=1, asynchronous=True
         ) as cluster:
 
             # This will never work but is a reliable way to block without hard
             # coding any sleep values
-            async with Client(cluster) as c:
+            async with Client(cluster, asynchronous=True) as c:
                 f = c.submit(sleep, 0)
                 await f

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -409,6 +409,9 @@ class MultiWorker(Worker, ProcessInterface):
 
     __repr__ = __str__
 
+    def __await__(self):
+        return self.start().__await__()
+
     async def start(self):
         await asyncio.gather(*self.workers)
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -260,10 +260,8 @@ class Nanny(ServerNode):
         warnings.warn("The local_dir attribute has moved to local_directory")
         return self.local_directory
 
-    async def start(self):
+    async def _start(self):
         """Start nanny, start local process, start watching"""
-
-        await super().start()
 
         ports = parse_ports(self._start_port)
         for port in ports:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -286,7 +286,7 @@ class Nanny(ServerNode):
                 break
         else:
             raise ValueError(
-                f"Could not start Nanny on host {self._start_host}"
+                f"Could not start Nanny on host {self._start_host} "
                 f"with port {self._start_port}"
             )
 
@@ -504,7 +504,12 @@ class Nanny(ServerNode):
             return "OK"
 
         self.status = Status.closing
-        logger.info("Closing Nanny at %r", self.address)
+
+        # Not properly started servers don't have an address
+        addr = None
+        with suppress(ValueError):
+            addr = self.address
+        logger.info("Closing Nanny at %r", addr)
 
         for preload in self.preloads:
             await preload.teardown()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3749,9 +3749,8 @@ class Scheduler(SchedulerState, ServerNode):
         else:
             return ws.host, port
 
-    async def start(self):
+    async def _start(self):
         """Clear out old state and restart all running coroutines"""
-        await super().start()
 
         enable_gc_diagnosis()
 
@@ -3805,7 +3804,7 @@ class Scheduler(SchedulerState, ServerNode):
         await asyncio.gather(*[plugin.start(self) for plugin in self.plugins])
 
         self.start_periodic_callbacks()
-
+        self.status = Status.running
         setproctitle(f"dask-scheduler [{self.address}]")
         return self
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3752,7 +3752,6 @@ class Scheduler(SchedulerState, ServerNode):
     async def start(self):
         """Clear out old state and restart all running coroutines"""
         await super().start()
-        assert self.status != Status.running
 
         enable_gc_diagnosis()
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -541,7 +541,7 @@ class StartException(Exception):
 
 
 class BrokenWorker(worker.Worker):
-    async def start(self):
+    async def _start(self):
         raise StartException("broken")
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2962,3 +2962,15 @@ async def test_worker_heartbeat_after_cancel(c, s, *workers):
 
     while any(w.tasks for w in workers):
         await asyncio.gather(*[w.heartbeat() for w in workers])
+
+
+@gen_cluster(nthreads=[])
+async def test_scheduler_terminate(s):
+    s_rpc = rpc(s.address)
+    await s_rpc.terminate(reply=False)
+
+    while s.status != Status.closed:
+        await asyncio.sleep(0.05)
+
+    # already closed should be noop
+    await s.close()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2321,3 +2321,22 @@ async def test_hold_on_to_replicas(c, s, *workers):
 
     while len(workers[2].tasks) > 1:
         await asyncio.sleep(0.01)
+
+
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
+async def test_forget_dependents_after_release(c, s, a):
+
+    fut = c.submit(inc, 1, key="f-1")
+    fut2 = c.submit(inc, fut, key="f-2")
+
+    await asyncio.wait([fut, fut2])
+
+    assert fut.key in a.tasks
+    assert fut2.key in a.tasks
+    assert fut2.key in {d.key for d in a.tasks[fut.key].dependents}
+
+    fut2.release()
+
+    while fut2.key in a.tasks:
+        await asyncio.sleep(0.001)
+    assert fut2.key not in {d.key for d in a.tasks[fut.key].dependents}

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1552,7 +1552,8 @@ def check_instances():
         # raise ValueError("Unclosed Comms", L)
 
     assert all(
-        n.status == Status.closed or n.status == Status.init for n in Nanny._instances
+        n.status in [Status.closed, Status.init, Status.stopped]
+        for n in Nanny._instances
     ), {n: n.status for n in Nanny._instances}
 
     # assert not list(SpecCluster._instances)  # TODO

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1606,3 +1606,13 @@ class TaskStateMetadataPlugin(WorkerPlugin):
             ts.metadata["start_time"] = time()
         elif start == "executing" and finish == "memory":
             ts.metadata["stop_time"] = time()
+
+
+def get_unused_port(addr: str = "") -> int:
+    """Return a currently open port. Not thread safe!"""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind((addr, 0))
+    s.listen(1)
+    port = s.getsockname()[1]
+    s.close()
+    return port

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1226,7 +1226,7 @@ class Worker(ServerNode):
 
             if self.status not in (Status.running, Status.closing_gracefully):
                 logger.info(
-                    "Closed worker %s has not yet started: %s",
+                    "Closing worker %s has not yet started: %s",
                     self.name,
                     self.status,
                 )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1109,7 +1109,7 @@ class Worker(ServerNode):
     # Lifecycle #
     #############
 
-    async def start(self):
+    async def _start(self):
         if self.status and self.status in (
             Status.closed,
             Status.closing,
@@ -1117,8 +1117,6 @@ class Worker(ServerNode):
         ):
             return
         assert self.status is Status.undefined, self.status
-
-        await super().start()
 
         enable_gc_diagnosis()
         thread_state.on_event_loop_thread = True

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -66,6 +66,7 @@ from .utils import (
     log_errors,
     offload,
     parse_ports,
+    shielded,
     silence_logging,
     thread_state,
     typename,
@@ -1213,13 +1214,26 @@ class Worker(ServerNode):
         warnings.warn("Worker._close has moved to Worker.close", stacklevel=2)
         return self.close(*args, **kwargs)
 
+    @shielded
     async def close(
         self, report=True, timeout=30, nanny=True, executor_wait=True, safe=False
     ):
         with log_errors():
-            if self.status in (Status.closed, Status.closing):
+            if self.status in (
+                Status.closing,
+                Status.closed,
+            ):
                 await self.finished()
                 return
+
+            if self.status not in (Status.running, Status.closing_gracefully):
+                logger.info(
+                    "Closed worker %s has not yet started: %s",
+                    self.name,
+                    self.status,
+                )
+
+            self.status = Status.closing
 
             self.reconnect = False
             disable_gc_diagnosis()
@@ -1228,9 +1242,6 @@ class Worker(ServerNode):
                 logger.info("Stopping worker at %s", self.address)
             except ValueError:  # address not available if already closed
                 logger.info("Stopping worker")
-            if self.status not in (Status.running, Status.closing_gracefully):
-                logger.info("Closed worker has not yet started: %s", self.status)
-            self.status = Status.closing
 
             for preload in self.preloads:
                 await preload.teardown()
@@ -1307,11 +1318,7 @@ class Worker(ServerNode):
                 else:
                     executor.shutdown(wait=executor_wait)
 
-            self.stop()
-            await self.rpc.close()
-
-            self.status = Status.closed
-            await ServerNode.close(self)
+            await super().close()
 
             setproctitle("dask-worker [closed]")
         return "OK"


### PR DESCRIPTION
I do not have a strong opinion at the moment about what should happen if a handler raises an exception but regardless, I believe an async and sync handler should show the same behaviour. Everything else is pretty hard to distinguish for any developer.

One easy way to achieve this is to simply await the handler during handle_stream. I am not sure if it was implemented this way hoping that messages would be faster worked off or what the motivation behind this was.
If we want to stick to the old `add_callback` we need to implement exception handling on the returned future/task.