### PR TITLE
Pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,3 @@ repos:
       hooks:
       - id: flake8
         language_version: python3
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.13.0
-    hooks:
-    -   id: pyupgrade
-        exclude: versioneer.py
-        args:
-          - "--py37-plus"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
       - id: black
         language_version: python3
         exclude: versioneer.py
+        args:
+          - --target-version=py37
   -   repo: https://gitlab.com/pycqa/flake8
       rev: 3.9.2
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,10 @@ repos:
       hooks:
       - id: flake8
         language_version: python3
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.13.0
+    hooks:
+    -   id: pyupgrade
+        exclude: versioneer.py
+        args:
+          - "--py37-plus"

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -69,7 +69,7 @@ class Actor(WrappedKey):
                 self._client = None
 
     def __repr__(self):
-        return "<Actor: %s, key=%s>" % (self._cls.__name__, self.key)
+        return f"<Actor: {self._cls.__name__}, key={self.key}>"
 
     def __reduce__(self):
         return (Actor, (self._cls, self._address, self.key))

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -130,7 +130,7 @@ def main(
     tls_cert,
     tls_key,
     dashboard_address,
-    **kwargs
+    **kwargs,
 ):
     g0, g1, g2 = gc.get_threshold()  # https://github.com/dask/distributed/issues/1653
     gc.set_threshold(g0 * 3, g1 * 3, g2 * 3)
@@ -194,7 +194,7 @@ def main(
         dashboard=dashboard,
         dashboard_address=dashboard_address,
         http_prefix=dashboard_prefix,
-        **kwargs
+        **kwargs,
     )
     logger.info("-" * 47)
 

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -175,10 +175,10 @@ def main(
             version=distributed.__version__
         )
     )
-    print("Worker nodes: {n}".format(n=len(hostnames)))
+    print(f"Worker nodes: {len(hostnames)}")
     for i, host in enumerate(hostnames):
-        print("  {num}: {host}".format(num=i, host=host))
-    print("\nscheduler node: {addr}:{port}".format(addr=scheduler, port=scheduler_port))
+        print(f"  {i}: {host}")
+    print(f"\nscheduler node: {scheduler}:{scheduler_port}")
     print("---------------------------------------------------------------\n\n")
 
     # Monitor the output of remote processes.  This blocks until the user issues a KeyboardInterrupt.

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -265,7 +265,7 @@ def main(
     dashboard_address,
     worker_class,
     preload_nanny,
-    **kwargs
+    **kwargs,
 ):
     g0, g1, g2 = gc.get_threshold()  # https://github.com/dask/distributed/issues/1653
     gc.set_threshold(g0 * 3, g1 * 3, g2 * 3)
@@ -419,7 +419,7 @@ def main(
             name=name
             if nprocs == 1 or name is None or name == ""
             else str(name) + "-" + str(i),
-            **kwargs
+            **kwargs,
         )
         for i in range(nprocs)
     ]

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -37,7 +37,7 @@ def unparse_address(scheme, loc):
     >>> unparse_address('tcp', '127.0.0.1')
     'tcp://127.0.0.1'
     """
-    return "%s://%s" % (scheme, loc)
+    return f"{scheme}://{loc}"
 
 
 def normalize_address(addr):
@@ -60,11 +60,11 @@ def parse_host_port(address, default_port=None):
         return address
 
     def _fail():
-        raise ValueError("invalid address %r" % (address,))
+        raise ValueError(f"invalid address {address!r}")
 
     def _default():
         if default_port is None:
-            raise ValueError("missing port number in address %r" % (address,))
+            raise ValueError(f"missing port number in address {address!r}")
         return default_port
 
     if "://" in address:
@@ -99,7 +99,7 @@ def unparse_host_port(host, port=None):
     if ":" in host and not host.startswith("["):
         host = "[%s]" % host
     if port is not None:
-        return "%s:%s" % (host, port)
+        return f"{host}:{port}"
     else:
         return host
 
@@ -120,7 +120,7 @@ def get_address_host_port(addr, strict=False):
         return backend.get_address_host_port(loc)
     except NotImplementedError:
         raise ValueError(
-            "don't know how to extract host and port for address %r" % (addr,)
+            f"don't know how to extract host and port for address {addr!r}"
         )
 
 

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -157,9 +157,9 @@ class Comm(ABC):
     def __repr__(self):
         clsname = self.__class__.__name__
         if self.closed():
-            return "<closed %s>" % (clsname,)
+            return f"<closed {clsname}>"
         else:
-            return "<%s %s local=%s remote=%s>" % (
+            return "<{} {} local={} remote={}>".format(
                 clsname,
                 self.name or "",
                 self.local_address,
@@ -307,7 +307,7 @@ async def connect(
             )
             await asyncio.sleep(backoff)
     else:
-        raise IOError(
+        raise OSError(
             f"Timed out trying to connect to {addr} after {timeout} s"
         ) from active_exception
 
@@ -323,7 +323,7 @@ async def connect(
     except Exception as exc:
         with suppress(Exception):
             await comm.close()
-        raise IOError(
+        raise OSError(
             f"Timed out during handshake while connecting to {addr} after {timeout} s"
         ) from exc
 

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -43,7 +43,7 @@ class Manager:
     def add_listener(self, addr, listener):
         with self.lock:
             if addr in self.listeners:
-                raise RuntimeError("already listening on %r" % (addr,))
+                raise RuntimeError(f"already listening on {addr!r}")
             self.listeners[addr] = listener
 
     def remove_listener(self, addr):
@@ -170,7 +170,7 @@ class InProc(Comm):
 
     def _get_finalizer(self):
         def finalize(write_q=self._write_q, write_loop=self._write_loop, r=repr(self)):
-            logger.warning("Closing dangling queue in %s" % (r,))
+            logger.warning(f"Closing dangling queue in {r}")
             write_loop.add_callback(write_q.put_nowait, _EOF)
 
         return finalize
@@ -296,7 +296,7 @@ class InProcConnector(Connector):
     async def connect(self, address, deserialize=True, **connection_args):
         listener = self.manager.get_listener_for(address)
         if listener is None:
-            raise IOError("no endpoint for inproc address %r" % (address,))
+            raise OSError(f"no endpoint for inproc address {address!r}")
 
         conn_req = ConnectionRequest(
             c2s_q=Queue(),

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -92,7 +92,7 @@ def set_tcp_timeout(comm):
             logger.debug("Setting TCP user timeout: %d ms", timeout * 1000)
             TCP_USER_TIMEOUT = 18  # since Linux 2.6.37
             sock.setsockopt(socket.SOL_TCP, TCP_USER_TIMEOUT, timeout * 1000)
-    except EnvironmentError as e:
+    except OSError as e:
         logger.warning("Could not set timeout on TCP stream: %s", e)
 
 
@@ -105,7 +105,7 @@ def get_stream_address(comm):
 
     try:
         return unparse_host_port(*comm.socket.getsockname()[:2])
-    except EnvironmentError:
+    except OSError:
         # Probably EBADF
         return "<closed>"
 
@@ -119,14 +119,10 @@ def convert_stream_closed_error(obj, exc):
         exc = exc.real_error
         if ssl and isinstance(exc, ssl.SSLError):
             if "UNKNOWN_CA" in exc.reason:
-                raise FatalCommClosedError(
-                    "in %s: %s: %s" % (obj, exc.__class__.__name__, exc)
-                )
-        raise CommClosedError(
-            "in %s: %s: %s" % (obj, exc.__class__.__name__, exc)
-        ) from exc
+                raise FatalCommClosedError(f"in {obj}: {exc.__class__.__name__}: {exc}")
+        raise CommClosedError(f"in {obj}: {exc.__class__.__name__}: {exc}") from exc
     else:
-        raise CommClosedError("in %s: %s" % (obj, exc)) from exc
+        raise CommClosedError(f"in {obj}: {exc}") from exc
 
 
 def _close_comm(ref):
@@ -304,7 +300,7 @@ class TCP(Comm):
                 if stream.writing():
                     yield stream.write(b"")
                 stream.socket.shutdown(socket.SHUT_RDWR)
-            except EnvironmentError:
+            except OSError:
                 pass
             finally:
                 self._finalizer.detach()
@@ -452,7 +448,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
                 sockets = netutil.bind_sockets(
                     self.port, address=self.ip, backlog=backlog
                 )
-            except EnvironmentError as e:
+            except OSError as e:
                 # EADDRINUSE can happen sporadically when trying to bind
                 # to an ephemeral port
                 if self.port != 0 or e.errno != errno.EADDRINUSE:
@@ -545,7 +541,7 @@ class TLSListener(BaseTCPListener):
     async def _prepare_stream(self, stream, address):
         try:
             await stream.wait_for_handshake()
-        except EnvironmentError as e:
+        except OSError as e:
             # The handshake went wrong, log and ignore
             logger.warning(
                 "Listener on %r: TLS handshake failed with remote %r: %s",

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -862,7 +862,7 @@ async def test_retry_connect(monkeypatch):
                 return await super().connect(address, deserialize, **connection_args)
             else:
                 self.failures += 1
-                raise IOError()
+                raise OSError()
 
     class UnreliableBackend(TCPBackend):
         _connector_class = UnreliableConnector
@@ -950,8 +950,8 @@ async def check_many_listeners(addr):
         listener = await listen(addr, handle_comm)
         listeners.append(listener)
 
-    assert len(set(l.listen_address for l in listeners)) == N
-    assert len(set(l.contact_address for l in listeners)) == N
+    assert len({l.listen_address for l in listeners}) == N
+    assert len({l.contact_address for l in listeners}) == N
 
     for listener in listeners:
         listener.stop()

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -79,7 +79,7 @@ def test_ucx_specific():
     # 3. Test peer_address
     # 4. Test cleanup
     async def f():
-        address = "ucx://{}:{}".format(HOST, 0)
+        address = f"ucx://{HOST}:{0}"
 
         async def handle_comm(comm):
             msg = await comm.read()

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -76,7 +76,7 @@ def test_ucx_config_w_env_var(cleanup, loop, monkeypatch):
     dask.config.refresh()
 
     port = "13339"
-    sched_addr = "ucx://%s:%s" % (HOST, port)
+    sched_addr = f"ucx://{HOST}:{port}"
 
     with popen(
         ["dask-scheduler", "--no-dashboard", "--protocol", "ucx", "--port", port]

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -373,7 +373,7 @@ class UCXListener(Listener):
         comm_handler: None,
         deserialize=False,
         allow_offload=True,
-        **connection_args
+        **connection_args,
     ):
         if not address.startswith("ucx"):
             address = "ucx://" + address
@@ -525,7 +525,7 @@ def _scrub_ucx_config():
     for k, v in options.items():
         if k not in valid_ucx_vars:
             logger.debug(
-                "Key: %s with value: %s not a valid UCX configuration option" % (k, v)
+                f"Key: {k} with value: {v} not a valid UCX configuration option"
             )
 
     return options

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -87,7 +87,7 @@ def get_tcp_server_addresses(tcp_server):
     """
     sockets = list(tcp_server._sockets.values())
     if not sockets:
-        raise RuntimeError("TCP Server %r not started yet?" % (tcp_server,))
+        raise RuntimeError(f"TCP Server {tcp_server!r} not started yet?")
 
     def _look_for_family(fam):
         socks = []

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -428,7 +428,7 @@ class Server:
                 try:
                     msg = await comm.read()
                     logger.debug("Message from %r: %s", address, msg)
-                except EnvironmentError as e:
+                except OSError as e:
                     if not sys.is_finalizing():
                         logger.debug(
                             "Lost connection to %r while reading message: %s."
@@ -517,7 +517,7 @@ class Server:
                 if reply and not is_dont_reply:
                     try:
                         await comm.write(result, serializers=serializers)
-                    except (EnvironmentError, TypeError) as e:
+                    except (OSError, TypeError) as e:
                         logger.debug(
                             "Lost connection to %r while sending result for op %r: %s",
                             address,
@@ -579,7 +579,7 @@ class Server:
                     else:
                         func()
 
-        except (CommClosedError, EnvironmentError):
+        except (CommClosedError, OSError):
             # FIXME: This is silently ignored, is this intentional?
             pass
         except Exception as e:
@@ -647,7 +647,7 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
             response = await comm.read(deserializers=deserializers)
         else:
             response = None
-    except (EnvironmentError, CommClosedError):
+    except (OSError, CommClosedError):
         # On communication errors, we should simply close the communication
         force_close = True
         raise
@@ -763,7 +763,7 @@ class rpc:
                 if not comm.closed():
                     await comm.write({"op": "close", "reply": False})
                     await comm.close()
-            except EnvironmentError:
+            except OSError:
                 comm.abort()
 
         tasks = []
@@ -792,9 +792,7 @@ class rpc:
                 comm.name = "rpc." + key
                 result = await send_recv(comm=comm, op=key, **kwargs)
             except (RPCClosed, CommClosedError) as e:
-                raise e.__class__(
-                    "%s: while trying to call remote method %r" % (e, key)
-                )
+                raise e.__class__(f"{e}: while trying to call remote method {key!r}")
 
             self.comms[comm] = True  # mark as open
             return result
@@ -881,7 +879,7 @@ class PooledRPCCall:
         pass
 
     def __repr__(self):
-        return "<pooled rpc to %r>" % (self.addr,)
+        return f"<pooled rpc to {self.addr!r}>"
 
 
 class ConnectionPool:

--- a/distributed/dashboard/components/nvml.py
+++ b/distributed/dashboard/components/nvml.py
@@ -49,7 +49,7 @@ class GPUCurrentLoad(DashboardComponent):
                 id="bk-gpu-memory-worker-plot",
                 width=int(width / 2),
                 name="gpu_memory_histogram",
-                **kwargs
+                **kwargs,
             )
             rect = memory.rect(
                 source=self.source,
@@ -67,7 +67,7 @@ class GPUCurrentLoad(DashboardComponent):
                 id="bk-gpu-utilization-worker-plot",
                 width=int(width / 2),
                 name="gpu_utilization_histogram",
-                **kwargs
+                **kwargs,
             )
             rect = utilization.rect(
                 source=self.source,
@@ -159,7 +159,7 @@ class GPUCurrentLoad(DashboardComponent):
                 "escaped_worker": [escape.url_escape(w) for w in worker],
             }
 
-            self.memory_figure.title.text = "GPU Memory: %s / %s" % (
+            self.memory_figure.title.text = "GPU Memory: {} / {}".format(
                 format_bytes(sum(memory)),
                 format_bytes(memory_total),
             )

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -164,9 +164,11 @@ class Occupancy(DashboardComponent):
                     color.append("blue")
 
             if total:
-                self.root.title.text = "Occupancy -- total time: %s  wall time: %s" % (
-                    format_time(total),
-                    format_time(total / self.scheduler.total_nthreads),
+                self.root.title.text = (
+                    "Occupancy -- total time: {}  wall time: {}".format(
+                        format_time(total),
+                        format_time(total / self.scheduler.total_nthreads),
+                    )
                 )
             else:
                 self.root.title.text = "Occupancy"
@@ -2640,9 +2642,7 @@ class WorkerTable(DashboardComponent):
 
         for name in self.names + self.extra_names:
             if name == "name":
-                data[name].insert(
-                    0, "Total ({nworkers})".format(nworkers=len(data[name]))
-                )
+                data[name].insert(0, f"Total ({len(data[name])})")
                 continue
             try:
                 if len(self.scheduler.workers) == 0:

--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -57,7 +57,7 @@ class Processing(DashboardComponent):
             tools="",
             x_range=x_range,
             id="bk-processing-stacks-plot",
-            **kwargs
+            **kwargs,
         )
         fig.quad(
             source=self.source,
@@ -297,7 +297,7 @@ class ProfileTimePlot(DashboardComponent):
             ),
             self.profile_plot,
             self.ts_plot,
-            **kwargs
+            **kwargs,
         )
 
     @without_property_validation
@@ -434,7 +434,7 @@ class ProfileServer(DashboardComponent):
             row(self.reset_button, self.update_button, sizing_mode="scale_width"),
             self.profile_plot,
             self.ts_plot,
-            **kwargs
+            **kwargs,
         )
 
     @without_property_validation
@@ -486,7 +486,7 @@ class SystemMonitor(DashboardComponent):
             height=height,
             tools=tools,
             x_range=x_range,
-            **kwargs
+            **kwargs,
         )
         self.cpu.line(source=self.source, x="time", y="cpu")
         self.cpu.yaxis.axis_label = "Percentage"
@@ -508,7 +508,7 @@ class SystemMonitor(DashboardComponent):
             height=height,
             tools=tools,
             x_range=x_range,
-            **kwargs
+            **kwargs,
         )
         self.mem.line(source=self.source, x="time", y="memory")
         self.mem.yaxis.axis_label = "Bytes"
@@ -530,7 +530,7 @@ class SystemMonitor(DashboardComponent):
             height=height,
             x_range=x_range,
             tools=tools,
-            **kwargs
+            **kwargs,
         )
         self.bandwidth.line(source=self.source, x="time", y="read_bytes", color="red")
         self.bandwidth.line(source=self.source, x="time", y="write_bytes", color="blue")
@@ -549,7 +549,7 @@ class SystemMonitor(DashboardComponent):
                 height=height,
                 x_range=x_range,
                 tools=tools,
-                **kwargs
+                **kwargs,
             )
 
             self.num_fds.line(source=self.source, x="time", y="num_fds")

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -110,7 +110,7 @@ class CommunicatingStream(DashboardComponent):
                 y_range=y_range,
                 height=height,
                 tools="",
-                **kwargs
+                **kwargs,
             )
 
             fig.rect(
@@ -178,7 +178,7 @@ class CommunicatingStream(DashboardComponent):
                         self.who[msg["who"]] = len(self.who)
                         msg["y"] = self.who[msg["who"]]
 
-                    msg["hover"] = "%s / %s = %s/s" % (
+                    msg["hover"] = "{} / {} = {}/s".format(
                         format_bytes(msg["total"]),
                         format_time(msg["duration"]),
                         format_bytes(msg["total"] / msg["duration"]),
@@ -212,7 +212,7 @@ class CommunicatingTimeSeries(DashboardComponent):
             height=150,
             tools="",
             x_range=x_range,
-            **kwargs
+            **kwargs,
         )
         fig.line(source=self.source, x="x", y="in", color="red")
         fig.line(source=self.source, x="x", y="out", color="blue")
@@ -250,7 +250,7 @@ class ExecutingTimeSeries(DashboardComponent):
             height=150,
             tools="",
             x_range=x_range,
-            **kwargs
+            **kwargs,
         )
         fig.line(source=self.source, x="x", y="y")
 
@@ -440,7 +440,7 @@ class Counters(DashboardComponent):
                     row(*pair, sizing_mode=sizing_mode)
                     for pair in partition_all(2, figures)
                 ],
-                sizing_mode=sizing_mode
+                sizing_mode=sizing_mode,
             )
 
     def add_digest_figure(self, name):

--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -86,7 +86,7 @@ class Adaptive(AdaptiveCore):
         wait_count=None,
         target_duration=None,
         worker_key=None,
-        **kwargs
+        **kwargs,
     ):
         self.cluster = cluster
         self.worker_key = worker_key
@@ -178,7 +178,7 @@ class Adaptive(AdaptiveCore):
             target=target,
             key=pickle.dumps(self.worker_key) if self.worker_key else None,
             attribute="name",
-            **self._workers_to_close_kwargs
+            **self._workers_to_close_kwargs,
         )
 
     async def scale_down(self, workers):

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -171,7 +171,7 @@ class AdaptiveCore:
             not_yet_arrived = requested - observed
             to_close = set()
             if not_yet_arrived:
-                to_close.update((toolz.take(len(plan) - target, not_yet_arrived)))
+                to_close.update(toolz.take(len(plan) - target, not_yet_arrived))
 
             if target < len(plan) - len(to_close):
                 L = await self.workers_to_close(target=target)

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -100,7 +100,7 @@ def async_ssh(cmd_dict):
             print(
                 "               "
                 + bcolors.FAIL
-                + "Retrying... (attempt {n}/{total})".format(n=retries, total=3)
+                + f"Retrying... (attempt {retries}/{3})"
                 + bcolors.ENDC
             )
 
@@ -152,7 +152,7 @@ def async_ssh(cmd_dict):
                 cmd_dict["output_queue"].put(
                     "[ {label} ] : ".format(label=cmd_dict["label"])
                     + bcolors.FAIL
-                    + "{output}".format(output=line)
+                    + f"{line}"
                     + bcolors.ENDC
                 )
                 line = stderr.readline()
@@ -215,18 +215,14 @@ def start_scheduler(
 
     # Optionally re-direct stdout and stderr to a logfile
     if logdir is not None:
-        cmd = "mkdir -p {logdir} && ".format(logdir=logdir) + cmd
+        cmd = f"mkdir -p {logdir} && " + cmd
         cmd += "&> {logdir}/dask_scheduler_{addr}:{port}.log".format(
             addr=addr, port=port, logdir=logdir
         )
 
     # Format output labels we can prepend to each line of output, and create
     # a 'status' key to keep track of jobs that terminate prematurely.
-    label = (
-        bcolors.BOLD
-        + "scheduler {addr}:{port}".format(addr=addr, port=port)
-        + bcolors.ENDC
-    )
+    label = bcolors.BOLD + f"scheduler {addr}:{port}" + bcolors.ENDC
 
     # Create a command dictionary, which contains everything we need to run and
     # interact with this command.
@@ -309,12 +305,12 @@ def start_worker(
 
     # Optionally redirect stdout and stderr to a logfile
     if logdir is not None:
-        cmd = "mkdir -p {logdir} && ".format(logdir=logdir) + cmd
+        cmd = f"mkdir -p {logdir} && " + cmd
         cmd += "&> {logdir}/dask_scheduler_{addr}.log".format(
             addr=worker_addr, logdir=logdir
         )
 
-    label = "worker {addr}".format(addr=worker_addr)
+    label = f"worker {worker_addr}"
 
     # Create a command dictionary, which contains everything we need to run and
     # interact with this command.

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -97,7 +97,7 @@ class ProcessInterface:
         await self._event_finished.wait()
 
     def __repr__(self):
-        return "<%s: status=%s>" % (type(self).__name__, self.status)
+        return f"<{type(self).__name__}: status={self.status}>"
 
     async def __aenter__(self):
         await self

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -43,7 +43,7 @@ class Process(ProcessInterface):
         await super().close()
 
     def __repr__(self):
-        return "<SSH %s: status=%s>" % (type(self).__name__, self.status)
+        return f"<SSH {type(self).__name__}: status={self.status}>"
 
 
 class Worker(Process):

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -558,7 +558,7 @@ async def test_bokeh_kwargs(cleanup):
     ) as c:
         client = AsyncHTTPClient()
         response = await client.fetch(
-            "http://localhost:{}/foo/status".format(c.scheduler.http_server.port)
+            f"http://localhost:{c.scheduler.http_server.port}/foo/status"
         )
         assert "bokeh" in response.body.decode()
 

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -229,11 +229,11 @@ def format_time(t):
     m, s = divmod(t, 60)
     h, m = divmod(m, 60)
     if h:
-        return "{0:2.0f}hr {1:2.0f}min {2:4.1f}s".format(h, m, s)
+        return f"{h:2.0f}hr {m:2.0f}min {s:4.1f}s"
     elif m:
-        return "{0:2.0f}min {1:4.1f}s".format(m, s)
+        return f"{m:2.0f}min {s:4.1f}s"
     else:
-        return "{0:4.1f}s".format(s)
+        return f"{s:4.1f}s"
 
 
 class AllProgress(SchedulerPlugin):

--- a/distributed/diskutils.py
+++ b/distributed/diskutils.py
@@ -23,7 +23,7 @@ def is_locking_enabled():
 def safe_unlink(path):
     try:
         os.unlink(path)
-    except EnvironmentError as e:
+    except OSError as e:
         # Perhaps it was removed by someone else?
         if e.errno != errno.ENOENT:
             logger.error("Failed to remove %r", str(e))
@@ -121,7 +121,7 @@ class WorkSpace:
     def _init_workspace(self):
         try:
             os.mkdir(self.base_dir)
-        except EnvironmentError as e:
+        except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
 
@@ -174,7 +174,7 @@ class WorkSpace:
         for p in glob.glob(os.path.join(self.base_dir, "*" + DIR_LOCK_EXT)):
             try:
                 st = os.stat(p)
-            except EnvironmentError:
+            except OSError:
                 # May have been removed in the meantime
                 pass
             else:

--- a/distributed/http/proxy.py
+++ b/distributed/http/proxy.py
@@ -24,13 +24,13 @@ try:
             self.host = host
 
             # rewrite uri for jupyter-server-proxy handling
-            uri = "/proxy/%s/%s" % (str(port), proxied_path)
+            uri = f"/proxy/{str(port)}/{proxied_path}"
             self.request.uri = uri
 
             # slash is removed during regex in handler
             proxied_path = "/%s" % proxied_path
 
-            worker = "%s:%s" % (self.host, str(port))
+            worker = f"{self.host}:{str(port)}"
             if not check_worker_dashboard_exits(self.scheduler, worker):
                 msg = "Worker <%s> does not exist" % worker
                 self.set_status(400)
@@ -81,9 +81,9 @@ except ImportError:
             self.extra = extra or {}
 
         def get(self, port, host, proxied_path):
-            worker_url = "%s:%s/%s" % (host, str(port), proxied_path)
+            worker_url = f"{host}:{str(port)}/{proxied_path}"
             msg = """
-                <p> Try navigating to <a href=http://%s>%s</a> for your worker dashboard </p>
+                <p> Try navigating to <a href=http://{}>{}</a> for your worker dashboard </p>
 
                 <p>
                 Dask tried to proxy you to that page through your
@@ -101,7 +101,7 @@ except ImportError:
                 but less common in production clusters.  Your IT administrators
                 will know more
                 </p>
-            """ % (
+            """.format(
                 worker_url,
                 worker_url,
             )

--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -6,7 +6,5 @@ from distributed.utils_test import gen_cluster
 @gen_cluster(client=True)
 async def test_scheduler(c, s, a, b):
     client = AsyncHTTPClient()
-    response = await client.fetch(
-        "http://localhost:{}/health".format(s.http_server.port)
-    )
+    response = await client.fetch(f"http://localhost:{s.http_server.port}/health")
     assert response.code == 200

--- a/distributed/locket.py
+++ b/distributed/locket.py
@@ -63,7 +63,7 @@ else:
         try:
             fcntl.flock(file_.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             return True
-        except IOError as error:
+        except OSError as error:
             if error.errno in [errno.EACCES, errno.EAGAIN]:
                 return False
             else:
@@ -109,7 +109,7 @@ def _acquire_non_blocking(acquire, timeout, retry_period, path):
         if success:
             return
         elif timeout is not None and time.time() - start_time > timeout:
-            raise LockError("Couldn't lock {0}".format(path))
+            raise LockError(f"Couldn't lock {path}")
         else:
             time.sleep(retry_period)
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -451,7 +451,7 @@ class Nanny(ServerNode):
         ):
             try:
                 await self._unregister()
-            except (EnvironmentError, CommClosedError):
+            except (OSError, CommClosedError):
                 if not self.reconnect:
                     await self.close()
                     return

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -63,7 +63,7 @@ class ServerNode(Server):
                 self.services[k] = service
             except Exception as e:
                 warnings.warn(
-                    "\nCould not launch service '%s' on port %s. " % (k, port)
+                    f"\nCould not launch service '{k}' on port {port}. "
                     + "Got the following message:\n\n"
                     + str(e),
                     stacklevel=3,

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -52,7 +52,7 @@ class AsyncProcess:
 
     def __init__(self, loop=None, target=None, name=None, args=(), kwargs={}):
         if not callable(target):
-            raise TypeError("`target` needs to be callable, not %r" % (type(target),))
+            raise TypeError(f"`target` needs to be callable, not {type(target)!r}")
         self._state = _ProcessState()
         self._loop = loop or IOLoop.current(instance=False)
 
@@ -91,7 +91,7 @@ class AsyncProcess:
         self._start_threads()
 
     def __repr__(self):
-        return "<%s %s>" % (self.__class__.__name__, self._name)
+        return f"<{self.__class__.__name__} {self._name}>"
 
     def _check_closed(self):
         if self._closed:
@@ -211,11 +211,11 @@ class AsyncProcess:
 
             state.is_alive = True
             state.pid = process.pid
-            logger.debug("[%s] created process with pid %r" % (r, state.pid))
+            logger.debug(f"[{r}] created process with pid {state.pid!r}")
 
         while True:
             msg = q.get()
-            logger.debug("[%s] got message %r" % (r, msg))
+            logger.debug(f"[{r}] got message {msg!r}")
             op = msg["op"]
             if op == "start":
                 _call_and_set_future(loop, msg["future"], _start)
@@ -338,7 +338,7 @@ class AsyncProcess:
 def _asyncprocess_finalizer(proc):
     if proc.is_alive():
         try:
-            logger.info("reaping stray process %s" % (proc,))
+            logger.info(f"reaping stray process {proc}")
             proc.terminate()
         except OSError:
             pass

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -59,7 +59,7 @@ def identifier(frame):
 def repr_frame(frame):
     """Render a frame as a line for inclusion into a text traceback"""
     co = frame.f_code
-    text = '  File "%s", line %s, in %s' % (co.co_filename, frame.f_lineno, co.co_name)
+    text = f'  File "{co.co_filename}", line {frame.f_lineno}, in {co.co_name}'
     line = linecache.getline(co.co_filename, frame.f_lineno, frame.f_globals).lstrip()
     return text + "\n\t" + line
 
@@ -230,7 +230,7 @@ def plot_data(state, profile_interval=0.010):
             x += width
 
     traverse(state, 0, 1, 0)
-    percentages = ["{:.1f}%".format(100 * w) for w in widths]
+    percentages = [f"{100 * w:.1f}%" for w in widths]
     return {
         "left": starts,
         "right": stops,

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -87,7 +87,7 @@ def loads(frames, deserialize=True, deserializers=None):
                     frames[offset],
                     object_hook=msgpack_decode_default,
                     use_list=False,
-                    **msgpack_opts
+                    **msgpack_opts,
                 )
                 offset += 1
                 sub_frames = frames[offset : offset + sub_header["num-sub-frames"]]

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -96,8 +96,7 @@ class Datasets(MutableMapping):
                 "Can't invoke iter() or 'for' on client.datasets when client is "
                 "asynchronous; use 'async for' instead"
             )
-        for key in self._client.list_datasets():
-            yield key
+        yield from self._client.list_datasets()
 
     def __aiter__(self):
         if not self._client.asynchronous:

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -350,7 +350,7 @@ class Pub:
         self.loop.add_callback(self._put, msg)
 
     def __repr__(self):
-        return "<Pub: {}>".format(self.name)
+        return f"<Pub: {self.name}>"
 
     __str__ = __repr__
 
@@ -462,6 +462,6 @@ class Sub:
             self.condition.notify()
 
     def __repr__(self):
-        return "<Sub: {}>".format(self.name)
+        return f"<Sub: {self.name}>"
 
     __str__ = __repr__

--- a/distributed/pytest_resourceleaks.py
+++ b/distributed/pytest_resourceleaks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 A pytest plugin to trace resource leaks.
 """
@@ -67,7 +66,7 @@ def pytest_configure(config):
             leaks = leaks.split(",")
         unknown = sorted(set(leaks) - set(all_checkers))
         if unknown:
-            raise ValueError("unknown resources: %r" % (unknown,))
+            raise ValueError(f"unknown resources: {unknown!r}")
 
         checkers = [all_checkers[leak]() for leak in leaks]
         checker = LeakChecker(
@@ -389,7 +388,7 @@ class LeakChecker:
                 unknown = sorted(set(leaking.args) - set(all_checkers))
                 if unknown:
                     raise ValueError(
-                        "pytest.mark.leaking: unknown resources %r" % (unknown,)
+                        f"pytest.mark.leaking: unknown resources {unknown!r}"
                     )
                 classes = tuple(all_checkers[a] for a in leaking.args)
                 self.skip_checkers[nodeid] = {
@@ -428,7 +427,7 @@ class LeakChecker:
                         report.outcome = "failed"
                         report.longrepr = "\n".join(
                             [
-                                "%s %s" % (nodeid, checker.format(before, after))
+                                f"{nodeid} {checker.format(before, after)}"
                                 for checker, before, after in leaks
                             ]
                         )
@@ -447,4 +446,4 @@ class LeakChecker:
             for rep in leaked:
                 nodeid = rep.nodeid
                 for checker, before, after in self.leaks[nodeid]:
-                    tr.line("%s %s" % (rep.nodeid, checker.format(before, after)))
+                    tr.line(f"{rep.nodeid} {checker.format(before, after)}")

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -46,7 +46,7 @@ class QueueExtension:
         self.scheduler.extensions["queues"] = self
 
     def create(self, comm=None, name=None, client=None, maxsize=0):
-        logger.debug("Queue name: {}".format(name))
+        logger.debug(f"Queue name: {name}")
         if name not in self.queues:
             self.queues[name] = asyncio.Queue(maxsize=maxsize)
             self.client_refcount[name] = 1

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1546,7 +1546,7 @@ class TaskState:
         self._nbytes = nbytes
 
     def __repr__(self):
-        return "<TaskState %r %s>" % (self._key, self._state)
+        return f"<TaskState {self._key!r} {self._state}>"
 
     def _repr_html_(self):
         color = (
@@ -1606,7 +1606,7 @@ class _StateLegacyMapping(Mapping):
         return self._accessor(self._states[key])
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__, dict(self))
+        return f"{self.__class__}({dict(self)})"
 
 
 class _OptionalStateLegacyMapping(_StateLegacyMapping):
@@ -1658,7 +1658,7 @@ class _StateLegacySet(Set):
         return st is not None and bool(self._accessor(st))
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__, set(self))
+        return f"{self.__class__}({set(self)})"
 
 
 def _legacy_task_key_set(tasks):
@@ -3746,7 +3746,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         self.start_periodic_callbacks()
 
-        setproctitle("dask-scheduler [%s]" % (self.address,))
+        setproctitle(f"dask-scheduler [{self.address}]")
         return self
 
     async def close(self, comm=None, fast=False, close_workers=False):
@@ -6420,7 +6420,7 @@ class Scheduler(SchedulerState, ServerNode):
                         response = function(self, state)
                     await comm.write(response)
                     await asyncio.sleep(interval)
-            except (EnvironmentError, CommClosedError):
+            except (OSError, CommClosedError):
                 pass
             finally:
                 if teardown:
@@ -6759,7 +6759,7 @@ class Scheduler(SchedulerState, ServerNode):
         if isinstance(addr, tuple):
             addr = unparse_host_port(*addr)
         if not isinstance(addr, str):
-            raise TypeError("addresses should be strings or tuples, got %r" % (addr,))
+            raise TypeError(f"addresses should be strings or tuples, got {addr!r}")
 
         if resolve:
             addr = resolve_address(addr)

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -164,14 +164,14 @@ class Security:
                     items.append((k, "..."))
                 else:
                     items.append((k, repr(val)))
-        return "Security(" + ", ".join("%s=%s" % (k, v) for k, v in items) + ")"
+        return "Security(" + ", ".join(f"{k}={v}" for k, v in items) + ")"
 
     def get_tls_config_for_role(self, role):
         """
         Return the TLS configuration for the given role, as a flat dict.
         """
         if role not in {"client", "scheduler", "worker"}:
-            raise ValueError("unknown role %r" % (role,))
+            raise ValueError(f"unknown role {role!r}")
         return {
             "ca_file": self.tls_ca_file,
             "ciphers": self.tls_ciphers,

--- a/distributed/tests/make_tls_certs.py
+++ b/distributed/tests/make_tls_certs.py
@@ -120,9 +120,9 @@ def make_cert_key(hostname, sign=False):
             ]
             subprocess.check_call(["openssl"] + args)
 
-        with open(cert_file, "r") as f:
+        with open(cert_file) as f:
             cert = f.read()
-        with open(key_file, "r") as f:
+        with open(key_file) as f:
             key = f.read()
         return cert, key
     finally:
@@ -203,7 +203,7 @@ if __name__ == "__main__":
 
     # For certificate matching tests
     make_ca()
-    with open("tls-ca-cert.pem", "r") as f:
+    with open("tls-ca-cert.pem") as f:
         ca_cert = f.read()
 
     cert, key = make_cert_key("localhost", sign=True)

--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -406,7 +406,7 @@ def test_asyncprocess_child_teardown_on_parent_exit():
         # test failure.
         try:
             readable = children_alive.poll(short_timeout)
-        except EnvironmentError:
+        except OSError:
             # Windows can raise BrokenPipeError. EnvironmentError is caught for
             # Python2/3 portability.
             assert sys.platform.startswith("win"), "should only raise on windows"
@@ -423,7 +423,7 @@ def test_asyncprocess_child_teardown_on_parent_exit():
             result = children_alive.recv()
         except EOFError:
             pass  # Test passes.
-        except EnvironmentError:
+        except OSError:
             # Windows can raise BrokenPipeError. EnvironmentError is caught for
             # Python2/3 portability.
             assert sys.platform.startswith("win"), "should only raise on windows"
@@ -432,7 +432,7 @@ def test_asyncprocess_child_teardown_on_parent_exit():
             # Oops, children_alive read something. It should be closed. If
             # something was read, it's a message from the child telling us they
             # are still alive!
-            raise RuntimeError("unreachable: {}".format(result))
+            raise RuntimeError(f"unreachable: {result}")
 
     finally:
         # Cleanup.

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1549,7 +1549,7 @@ async def test_upload_file(c, s, a, b):
 
     with save_sys_modules():
         for value in [123, 456]:
-            with tmp_text("myfile.py", "def f():\n    return {}".format(value)) as fn:
+            with tmp_text("myfile.py", f"def f():\n    return {value}") as fn:
                 await c.upload_file(fn)
 
             x = c.submit(g, pure=False)
@@ -1561,7 +1561,7 @@ async def test_upload_file(c, s, a, b):
 async def test_upload_file_refresh_delayed(c, s, a, b):
     with save_sys_modules():
         for value in [123, 456]:
-            with tmp_text("myfile.py", "def f():\n    return {}".format(value)) as fn:
+            with tmp_text("myfile.py", f"def f():\n    return {value}") as fn:
                 await c.upload_file(fn)
 
             sys.path.append(os.path.dirname(fn))
@@ -1590,7 +1590,7 @@ async def test_upload_file_zip(c, s, a, b):
         try:
             for value in [123, 456]:
                 with tmp_text(
-                    "myfile.py", "def f():\n    return {}".format(value)
+                    "myfile.py", f"def f():\n    return {value}"
                 ) as fn_my_file:
                     with zipfile.ZipFile("myfile.zip", "w") as z:
                         z.write(fn_my_file, arcname=os.path.basename(fn_my_file))
@@ -1635,13 +1635,13 @@ async def test_upload_file_egg(c, s, a, b):
                 package_1 = os.path.join(dirname, "package_1")
                 os.mkdir(package_1)
                 with open(os.path.join(package_1, "__init__.py"), "w") as f:
-                    f.write("a = {}\n".format(value))
+                    f.write(f"a = {value}\n")
 
                 # test multiple top-level packages
                 package_2 = os.path.join(dirname, "package_2")
                 os.mkdir(package_2)
                 with open(os.path.join(package_2, "__init__.py"), "w") as f:
-                    f.write("b = {}\n".format(value))
+                    f.write(f"b = {value}\n")
 
                 # compile these into an egg
                 subprocess.check_call(
@@ -1887,12 +1887,12 @@ async def test_allow_restrictions(c, s, a, b):
 def test_bad_address():
     try:
         Client("123.123.123.123:1234", timeout=0.1)
-    except (IOError, TimeoutError) as e:
+    except (OSError, TimeoutError) as e:
         assert "connect" in str(e).lower()
 
     try:
         Client("127.0.0.1:1234", timeout=0.1)
-    except (IOError, TimeoutError) as e:
+    except (OSError, TimeoutError) as e:
         assert "connect" in str(e).lower()
 
 
@@ -4637,7 +4637,7 @@ async def test_client_timeout():
     await asyncio.sleep(4)
     try:
         await s
-    except EnvironmentError:  # port in use
+    except OSError:  # port in use
         await c.close()
         return
 
@@ -5155,7 +5155,7 @@ def test_get_client_no_cluster():
     Worker._instances.clear()
 
     msg = "No global client found and no address provided"
-    with pytest.raises(ValueError, match=r"^{}$".format(msg)):
+    with pytest.raises(ValueError, match=fr"^{msg}$"):
         get_client()
 
 

--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -162,7 +162,7 @@ def test_workspace_rmtree_failure(tmpdir):
     # shutil.rmtree() may call its onerror callback several times
     assert lines
     for line in lines:
-        assert line.startswith("Failed to remove %r" % (a.dir_path,))
+        assert line.startswith(f"Failed to remove {a.dir_path!r}")
 
 
 def test_locking_disabled(tmpdir):

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -344,7 +344,7 @@ async def test_broken_worker_during_computation(c, s, a, b):
         L = c.map(
             slowadd,
             *zip(*partition_all(2, L)),
-            key=["add-%d-%d" % (i, j) for j in range(len(L) // 2)]
+            key=["add-%d-%d" % (i, j) for j in range(len(L) // 2)],
         )
 
     await asyncio.sleep(random.random() / 20)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -786,7 +786,7 @@ async def test_workers_to_close_grouped(c, s, *workers):
     def key(ws):
         return groups[ws.address]
 
-    assert set(s.workers_to_close(key=key)) == set(w.address for w in workers)
+    assert set(s.workers_to_close(key=key)) == {w.address for w in workers}
 
     # Assert that job in one worker blocks closure of group
     future = c.submit(slowinc, 1, delay=0.2, workers=workers[0].address)
@@ -2016,10 +2016,10 @@ class BrokenComm(Comm):
         pass
 
     def read(self, deserializers=None):
-        raise EnvironmentError
+        raise OSError
 
     def write(self, msg, serializers=None, on_error=None):
-        raise EnvironmentError
+        raise OSError
 
 
 class FlakyConnectionPool(ConnectionPool):

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -395,7 +395,7 @@ def test_temporary_credentials():
     sec_repr = repr(sec)
     fields = ["tls_ca_file"]
     fields.extend(
-        "tls_%s_%s" % (role, kind)
+        f"tls_{role}_{kind}"
         for role in ["client", "scheduler", "worker"]
         for kind in ["key", "cert"]
     )

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -283,10 +283,10 @@ class BrokenComm(Comm):
         pass
 
     def read(self, deserializers=None):
-        raise EnvironmentError
+        raise OSError
 
     def write(self, msg, serializers=None, on_error=None):
-        raise EnvironmentError
+        raise OSError
 
 
 class FlakyConnectionPool(ConnectionPool):

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -553,7 +553,7 @@ async def assert_balanced(inp, expected, c, s, *workers):
 
         if result2 == expected2:
             return
-    raise Exception("Expected: {}; got: {}".format(str(expected2), str(result2)))
+    raise Exception(f"Expected: {str(expected2)}; got: {str(result2)}")
 
 
 @pytest.mark.parametrize(

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -146,10 +146,10 @@ def test_get_ip_interface():
     elif sys.platform.startswith("linux"):
         assert get_ip_interface("lo") == "127.0.0.1"
     else:
-        pytest.skip("test needs to be enhanced for platform %r" % (sys.platform,))
+        pytest.skip(f"test needs to be enhanced for platform {sys.platform!r}")
 
     non_existent_interface = "__non-existent-interface"
-    expected_error_message = "{!r}.+network interface.+".format(non_existent_interface)
+    expected_error_message = f"{non_existent_interface!r}.+network interface.+"
 
     if sys.platform == "darwin":
         expected_error_message += "'lo0'"

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -56,10 +56,10 @@ class BrokenComm(Comm):
         pass
 
     def read(self, deserializers=None):
-        raise EnvironmentError
+        raise OSError
 
     def write(self, msg, serializers=None, on_error=None):
-        raise EnvironmentError
+        raise OSError
 
 
 class BrokenConnectionPool(ConnectionPool):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -134,7 +134,7 @@ def _get_ip(host, port, family):
         sock.connect((host, port))
         ip = sock.getsockname()[0]
         return ip
-    except EnvironmentError as e:
+    except OSError as e:
         warnings.warn(
             "Couldn't detect a suitable IP address for "
             "reaching %r, defaulting to hostname: %s" % (host, e),
@@ -187,7 +187,7 @@ def get_ip_interface(ifname):
     for info in net_if_addrs[ifname]:
         if info.family == socket.AF_INET:
             return info.address
-    raise ValueError("interface %r doesn't have an IPv4 address" % (ifname,))
+    raise ValueError(f"interface {ifname!r} doesn't have an IPv4 address")
 
 
 async def All(args, quiet_exceptions=()):
@@ -317,7 +317,7 @@ def sync(loop, func, *args, callback_timeout=None, **kwargs):
     loop.add_callback(f)
     if callback_timeout is not None:
         if not e.wait(callback_timeout):
-            raise TimeoutError("timed out after %s s." % (callback_timeout,))
+            raise TimeoutError(f"timed out after {callback_timeout} s.")
     else:
         while not e.is_set():
             e.wait(10)
@@ -726,7 +726,7 @@ def validate_key(k):
     """Validate a key as received on a stream."""
     typ = type(k)
     if typ is not str and typ is not bytes:
-        raise TypeError("Unexpected key type %s (value: %r)" % (typ, k))
+        raise TypeError(f"Unexpected key type {typ} (value: {k!r})")
 
 
 def _maybe_complex(task):
@@ -1085,13 +1085,11 @@ def command_has_keyword(cmd, k):
         if isinstance(getattr(cmd, "main"), click.core.Command):
             cmd = cmd.main
         if isinstance(cmd, click.core.Command):
-            cmd_params = set(
-                [
-                    p.human_readable_name
-                    for p in cmd.params
-                    if isinstance(p, click.core.Option)
-                ]
-            )
+            cmd_params = {
+                p.human_readable_name
+                for p in cmd.params
+                if isinstance(p, click.core.Option)
+            }
             return k in cmd_params
 
     return False
@@ -1308,11 +1306,11 @@ def cli_keywords(d: dict, cls=None, cmd=None):
                     )
                 elif cls:
                     raise ValueError(
-                        "Class %s does not support keyword %s" % (typename(cls), k)
+                        f"Class {typename(cls)} does not support keyword {k}"
                     )
                 else:
                     raise ValueError(
-                        "Module %s does not support keyword %s" % (typename(cmd), k)
+                        f"Module {typename(cmd)} does not support keyword {k}"
                     )
 
     def convert_value(v):

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -77,7 +77,7 @@ async def gather_from_workers(who_has, rpc, close=True, serializers=None, who=No
             for worker, c in coroutines.items():
                 try:
                     r = await c
-                except EnvironmentError:
+                except OSError:
                     missing_workers.add(worker)
                 except ValueError as e:
                     logger.info(
@@ -112,7 +112,7 @@ class WrappedKey:
         self.key = key
 
     def __repr__(self):
-        return "%s('%s')" % (type(self).__name__, self.key)
+        return f"{type(self).__name__}('{self.key}')"
 
 
 _round_robin_counter = [0]

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -981,7 +981,7 @@ def gen_cluster(
                 if getattr(w, "data", None):
                     try:
                         w.data.clear()
-                    except EnvironmentError:
+                    except OSError:
                         # zict backends can fail if their storage directory
                         # was already removed
                         pass
@@ -1075,10 +1075,10 @@ def wait_for_port(address, timeout=5):
     while True:
         timeout = deadline - time()
         if timeout < 0:
-            raise RuntimeError("Failed to connect to %s" % (address,))
+            raise RuntimeError(f"Failed to connect to {address}")
         try:
             sock = socket.create_connection(address, timeout=timeout)
-        except EnvironmentError:
+        except OSError:
             pass
         else:
             sock.close()
@@ -1092,7 +1092,7 @@ def wait_for(predicate, timeout, fail_func=None, period=0.001):
         if time() > deadline:
             if fail_func is not None:
                 fail_func()
-            pytest.fail("condition not reached until %s seconds" % (timeout,))
+            pytest.fail(f"condition not reached until {timeout} seconds")
 
 
 async def async_wait_for(predicate, timeout, fail_func=None, period=0.001):
@@ -1102,7 +1102,7 @@ async def async_wait_for(predicate, timeout, fail_func=None, period=0.001):
         if time() > deadline:
             if fail_func is not None:
                 fail_func()
-            pytest.fail("condition not reached until %s seconds" % (timeout,))
+            pytest.fail(f"condition not reached until {timeout} seconds")
 
 
 @memoize
@@ -1120,7 +1120,7 @@ def has_ipv6():
         serv.bind(("::", 0))
         serv.listen(5)
         cli = socket.create_connection(serv.getsockname()[:2])
-    except EnvironmentError:
+    except OSError:
         return False
     else:
         return True
@@ -1422,7 +1422,7 @@ def bump_rlimit(limit, desired):
         if soft < desired:
             resource.setrlimit(limit, (desired, max(hard, desired)))
     except Exception as e:
-        pytest.skip("rlimit too low (%s) and can't be increased: %s" % (soft, e))
+        pytest.skip(f"rlimit too low ({soft}) and can't be increased: {e}")
 
 
 def gen_tls_cluster(**kwargs):

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -1,6 +1,5 @@
 """ utilities for package version introspection """
 
-from __future__ import absolute_import, division, print_function
 
 import importlib
 import os
@@ -25,9 +24,7 @@ optional_packages = [
 
 
 # only these scheduler packages will be checked for version mismatch
-scheduler_relevant_packages = set(pkg for pkg, _ in required_packages) | set(
-    ["lz4", "blosc"]
-)
+scheduler_relevant_packages = {pkg for pkg, _ in required_packages} | {"lz4", "blosc"}
 
 
 # notes to be displayed for mismatch packages
@@ -135,12 +132,12 @@ def error_message(scheduler, workers, client, client_name="client"):
         )
         versions.add(client_version)
 
-        worker_versions = set(
+        worker_versions = {
             workers[w].get(pkg, "MISSING")
             if isinstance(workers[w], dict)
             else workers[w]
             for w in workers
-        )
+        }
         versions |= worker_versions
 
         if len(versions) <= 1:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Dask.distributed documentation build configuration file, created by
 # sphinx-quickstart on Tue Oct  6 14:42:44 2015.
@@ -471,16 +470,14 @@ class AutoAutoSummary(Autosummary):
         if "methods" in self.options:
             _, methods = self.get_members(app, c, ["method"], ["__init__"])
             self.content = [
-                "%s.%s" % (class_name, method)
+                f"{class_name}.{method}"
                 for method in methods
                 if not method.startswith("_")
             ]
         if "attributes" in self.options:
             _, attribs = self.get_members(app, c, ["attribute", "property"])
             self.content = [
-                "~%s.%s" % (clazz, attrib)
-                for attrib in attribs
-                if not attrib.startswith("_")
+                f"~{clazz}.{attrib}" for attrib in attribs if not attrib.startswith("_")
             ]
         return super().run()
 


### PR DESCRIPTION
I personally **love** automated formatting and I discovered this gem in the pandas pre-commit hooks. While deprecations are less common in py3 (opposed to the py2->py3 migration) they do happen. Often this boils down to slightly less verbose syntax, other times exception classes or functions are renamed, etc.

Some changes are merely for style while others, e.g. around exception classes, imho clarify things better, e.g. what's the distinction between `OSError`, `IOError`, `EnvironmentError`, `socket.error`? Nothing... since [py3.3](https://docs.python.org/3/library/exceptions.html#OSError)

Is this kind of thing something people would feel comfortable with or is this too much?