### PR TITLE
Add context manager to check for dangling tasks

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -12,6 +12,7 @@ from distributed.core import rpc
 from distributed.metrics import time
 from distributed.utils import get_ip
 from distributed.utils_test import (  # noqa: F401
+    check_dangling_tasks,
     cleanup,
     cluster,
     gen_cluster,
@@ -230,3 +231,47 @@ def test_tls_cluster(tls_client):
 async def test_tls_scheduler(security, cleanup):
     async with Scheduler(security=security, host="localhost") as s:
         assert s.address.startswith("tls")
+
+
+@pytest.mark.asyncio()
+async def test_check_dangling_tasks(event_loop):
+    # Note: event loop fixture is managed by pytest-asyncio
+
+    from tornado.ioloop import IOLoop
+
+    assert not isinstance(event_loop, IOLoop)
+    tornado_loop = IOLoop.current()
+    assert event_loop is tornado_loop.asyncio_loop
+
+    start = asyncio.all_tasks()
+
+    async def foo():
+        await asyncio.sleep(100000)
+
+    for loop_ in [None, event_loop, tornado_loop]:
+        # Verify that our ctx manager catches all tasks created by plain asyncio
+        with pytest.raises(AssertionError):
+            with check_dangling_tasks(loop_):
+                task = event_loop.create_task(foo())
+
+        task.cancel()
+
+        before = asyncio.all_tasks()
+        # Tornado has slightly different semantics but also uses the asyncio
+        # event loop beneath. Ensure this is also caught
+        with pytest.raises(AssertionError):
+            with check_dangling_tasks(loop_):
+                tornado_loop.add_callback(foo)
+                await asyncio.sleep(0)
+        # We cannot cancel tornado callbacks but should close tasks to avoid
+        # warnings (i.e. this is what this test should cover in the first place)
+        after = asyncio.all_tasks()
+        assert len(after - before) == 1
+        for task in after - before:
+            task.cancel()
+        await asyncio.sleep(0)
+        after = asyncio.all_tasks()
+        assert len(after - before) == 0
+
+    end = asyncio.all_tasks()
+    assert not end - start

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1522,6 +1522,27 @@ def check_instances():
 
 
 @contextmanager
+def check_dangling_tasks(loop=None):
+    from tornado.platform.asyncio import BaseAsyncIOLoop
+
+    if loop is None:
+        asyncio_loop = asyncio.get_running_loop()
+    elif isinstance(loop, BaseAsyncIOLoop):
+        asyncio_loop = loop.asyncio_loop
+    else:
+        asyncio_loop = loop
+    start = asyncio.all_tasks()
+    start_loop = asyncio.all_tasks(asyncio_loop)
+    # If this is not true we're on the wrong loop
+    assert start == start_loop
+    yield
+    end = asyncio.all_tasks()
+    end_loop = asyncio.all_tasks(asyncio_loop)
+    assert end == end_loop
+    assert end == start
+
+
+@contextmanager
 def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
     @contextmanager
     def null():


### PR DESCRIPTION
This adds a context manager to `utils_test` which is there to ensure that there are no dangling tasks. The logic is a bit more complex since it ensure that it is actually using the correct loop, i.e. it ensures that there are also not any tasks added to _other_ loops (check for `all_tasks` w/ and w/out loop).
In particular with `pytest-asyncio`, which creates the loop itself, we're sometimes not using the correct loop in our tests and certain assertions are not working. For instance, the `pristine_loop` ctx mgr doesn't work properly with `pytest-asyncio` and therefore the clean/cleanup fixture is not working as intended. One step at a time...

