### PR TITLE
Unregister worker plugin

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4055,6 +4055,21 @@ class Client:
 
         return self.sync(self._register_worker_plugin, plugin=plugin, name=name)
 
+    async def _unregister_worker_plugin(self, name):
+        responses = await self.scheduler.unregister_worker_plugin(name=name)
+
+        for response in responses.values():
+            if response["status"] == "error":
+                exc = response["exception"]
+                typ = type(exc)
+                tb = response["traceback"]
+                raise exc.with_traceback(tb)
+        return responses
+
+    def unregister_worker_plugin(self, name):
+        """Unregisters a lifecycle worker plugin"""
+        return self.sync(self._unregister_worker_plugin, name=name)
+
 
 class _WorkerSetupPlugin(WorkerPlugin):
     """ This is used to support older setup functions as callbacks """

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4050,6 +4050,7 @@ class Client:
         See Also
         --------
         distributed.WorkerPlugin
+        unregister_worker_plugin
         """
         if isinstance(plugin, type):
             plugin = plugin(**kwargs)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4078,7 +4078,7 @@ class Client:
 
         Parameters
         ----------
-        name: str
+        name : str
             Name of the plugin as it was registered.
             See ``register_worker_plugin`` docstrings for more reference.
             If there was not a name assigned when the plugin was added, it will

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4013,6 +4013,7 @@ class Client:
         name : str, optional
             A name for the plugin.
             Registering a plugin with the same name will have no effect.
+            If there is no name assigned it automatically assign ``name = funcname(plugin) + "-" + str(uuid.uuid4())``
         **kwargs : optional
             If you pass a class as the plugin, instead of a class instance, then the
             class will be instantiated with any extra keyword arguments.

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4067,7 +4067,44 @@ class Client:
         return responses
 
     def unregister_worker_plugin(self, name):
-        """Unregisters a lifecycle worker plugin"""
+        """Unregisters a lifecycle worker plugin
+
+        This unregister a worker plugin using its name attribute by calling
+        the plugin's teardown method. (See the ``dask.distributed.WorkerPlugin``
+        class or the examples below for the interface and docstrings.)
+
+        Parameters
+        ----------
+        name: str
+            Name of the plugin as it was registered.
+            See ``register_worker_plugin`` docstrings for more reference.
+            If there was not a name assigned when the plugin was added, it will
+            automatically assign ``name = funcname(plugin) + "-" + str(uuid.uuid4())``
+
+        Examples
+        --------
+        >>> class MyPlugin(WorkerPlugin):
+        ...     def __init__(self, *args, **kwargs):
+        ...         pass  # the constructor is up to you
+        ...     def setup(self, worker: dask.distributed.Worker):
+        ...         pass
+        ...     def teardown(self, worker: dask.distributed.Worker):
+        ...         pass
+        ...     def transition(self, key: str, start: str, finish: str, **kwargs):
+        ...         pass
+        ...     def release_key(self, key: str, state: str, cause: Optional[str], reason: None, report: bool):
+        ...         pass
+        ...     def release_dep(self, dep: str, state: str, report: bool):
+        ...         pass
+
+        >>> plugin = MyPlugin(1, 2, 3)
+        >>> client.register_worker_plugin(plugin, name='foo')
+        >>> client.unregister_worker_plugin(name='foo')
+
+        See Also
+        --------
+        register_worker_plugin
+        """
         return self.sync(self._unregister_worker_plugin, name=name)
 
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4073,9 +4073,8 @@ class Client:
     def unregister_worker_plugin(self, name):
         """Unregisters a lifecycle worker plugin
 
-        This unregister a worker plugin using its name attribute by calling
-        the plugin's teardown method. (See the ``dask.distributed.WorkerPlugin``
-        class or the examples below for the interface and docstrings.)
+        This unregisters an existing worker plugin. As part of the unregistration process
+        the plugin's ``teardown`` method will be called.
 
         Parameters
         ----------

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4061,7 +4061,6 @@ class Client:
         for response in responses.values():
             if response["status"] == "error":
                 exc = response["exception"]
-                typ = type(exc)
                 tb = response["traceback"]
                 raise exc.with_traceback(tb)
         return responses

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4013,7 +4013,7 @@ class Client:
         name : str, optional
             A name for the plugin.
             Registering a plugin with the same name will have no effect.
-            If there is no name assigned it automatically assign ``name = funcname(plugin) + "-" + str(uuid.uuid4())``
+            If plugin has no name attribute a random name is used.
         **kwargs : optional
             If you pass a class as the plugin, instead of a class instance, then the
             class will be instantiated with any extra keyword arguments.

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4079,10 +4079,8 @@ class Client:
         Parameters
         ----------
         name : str
-            Name of the plugin as it was registered.
-            See ``register_worker_plugin`` docstrings for more reference.
-            If there was not a name assigned when the plugin was added, it will
-            automatically assign ``name = funcname(plugin) + "-" + str(uuid.uuid4())``
+            Name of the plugin to unregister. See the :meth:`Client.register_worker_plugin`
+            docstring for more information.
 
         Examples
         --------

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -51,7 +51,7 @@ from .core import (
     connect,
     rpc,
 )
-from .diagnostics.plugin import UploadFile, WorkerPlugin
+from .diagnostics.plugin import UploadFile, WorkerPlugin, _get_worker_plugin_name
 from .metrics import time
 from .protocol import to_serialize
 from .protocol.pickle import dumps, loads
@@ -4052,6 +4052,11 @@ class Client:
         """
         if isinstance(plugin, type):
             plugin = plugin(**kwargs)
+
+        if name is None:
+            name = _get_worker_plugin_name(plugin)
+
+        assert name
 
         return self.sync(self._register_worker_plugin, plugin=plugin, name=name)
 

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -190,8 +190,8 @@ class WorkerPlugin:
 
 
 def _get_worker_plugin_name(plugin) -> str:
-    """Returns the worker plugin name. If plugin has no name
-    it assigns a random name using funcname and uuid"""
+    """Returns the worker plugin name. If plugin has no name attribute
+    a random name is used."""
     if hasattr(plugin, "name"):
         return plugin.name
     else:

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -188,13 +188,14 @@ class WorkerPlugin:
             Whether the worker should report the released dependency to the scheduler.
         """
 
-    def _get_worker_plugin_name(plugin) -> str:
-        """Returns the worker plugin name. If plugin has no name
-        it assigns a random name using funcname and uuid"""
-        if hasattr(plugin, "name"):
-            return plugin.name
-        else:
-            return funcname(plugin) + "-" + str(uuid.uuid4())
+
+def _get_worker_plugin_name(plugin) -> str:
+    """Returns the worker plugin name. If plugin has no name
+    it assigns a random name using funcname and uuid"""
+    if hasattr(plugin, "name"):
+        return plugin.name
+    else:
+        return funcname(plugin) + "-" + str(uuid.uuid4())
 
 
 class PipInstall(WorkerPlugin):

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -3,6 +3,9 @@ import os
 import socket
 import subprocess
 import sys
+import uuid
+
+from dask.utils import funcname
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +187,12 @@ class WorkerPlugin:
         report : bool
             Whether the worker should report the released dependency to the scheduler.
         """
+
+    def _get_worker_plugin_name(plugin) -> str:
+        if hasattr(plugin, "name"):
+            return plugin.name
+        else:
+            return funcname(plugin) + "-" + str(uuid.uuid4())
 
 
 class PipInstall(WorkerPlugin):

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -189,6 +189,8 @@ class WorkerPlugin:
         """
 
     def _get_worker_plugin_name(plugin) -> str:
+        """Returns the worker plugin name. If plugin has no name
+        it assigns a random name using funcname and uuid"""
         if hasattr(plugin, "name"):
             return plugin.name
         else:

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -54,6 +54,32 @@ async def test_create_with_client(c, s):
 
 
 @gen_cluster(client=True, nthreads=[])
+async def test_remove_with_client(c, s):
+    await c.register_worker_plugin(MyPlugin(123), name="foo")
+
+    worker = await Worker(s.address, loop=s.loop)
+    assert worker._my_plugin_status == "setup"
+    assert worker._my_plugin_data == 123
+
+    await c.unregister_worker_plugin("bar")
+    assert worker._my_plugin_status == "teardown"
+    assert not s.worker_plugins
+    assert not worker.plugins
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_remove_with_client_raises(c, s):
+    await c.register_worker_plugin(MyPlugin(123), name="foo")
+
+    worker = await Worker(s.address, loop=s.loop)
+    assert worker._my_plugin_status == "setup"
+    assert worker._my_plugin_data == 123
+
+    with pytest.raises(KeyError, match="bar"):
+        await c.unregister_worker_plugin("bar")
+
+
+@gen_cluster(client=True, nthreads=[])
 async def test_create_with_client_and_plugin_from_class(c, s):
     await c.register_worker_plugin(MyPlugin, data=456)
 

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -61,7 +61,7 @@ async def test_remove_with_client(c, s):
     assert worker._my_plugin_status == "setup"
     assert worker._my_plugin_data == 123
 
-    await c.unregister_worker_plugin("bar")
+    await c.unregister_worker_plugin("foo")
     assert worker._my_plugin_status == "teardown"
     assert not s.worker_plugins
     assert not worker.plugins

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -56,12 +56,23 @@ async def test_create_with_client(c, s):
 @gen_cluster(client=True, nthreads=[])
 async def test_remove_with_client(c, s):
     await c.register_worker_plugin(MyPlugin(123), name="foo")
+    await c.register_worker_plugin(MyPlugin(546), name="bar")
 
     worker = await Worker(s.address, loop=s.loop)
-    assert worker._my_plugin_status == "setup"
-    assert worker._my_plugin_data == 123
-
+    # remove the 'foo' plugin
     await c.unregister_worker_plugin("foo")
+    assert worker._my_plugin_status == "teardown"
+
+    # check that on the scheduler regitered worker plugins we only have 'bar'
+    assert len(s.worker_plugins) == 1
+    assert s.worker_plugins[0]["name"] == "bar"
+
+    # check on the worker plugins that we only have 'bar'
+    assert "foo" not in worker.plugins
+    assert "bar" in worker.plugins
+
+    # let's remove 'bar' and we should have none worker plugins
+    await c.unregister_worker_plugin("bar")
     assert worker._my_plugin_status == "teardown"
     assert not s.worker_plugins
     assert not worker.plugins

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -58,14 +58,19 @@ async def test_remove_with_client(c, s):
     await c.register_worker_plugin(MyPlugin(123), name="foo")
     await c.register_worker_plugin(MyPlugin(546), name="bar")
 
+    from pprint import pprint
+
+    print("#### worker_plugins ####")
+    pprint(s.worker_plugins)
+
     worker = await Worker(s.address, loop=s.loop)
     # remove the 'foo' plugin
     await c.unregister_worker_plugin("foo")
     assert worker._my_plugin_status == "teardown"
 
-    # check that on the scheduler regitered worker plugins we only have 'bar'
+    # check that on the scheduler registered worker plugins we only have 'bar'
     assert len(s.worker_plugins) == 1
-    assert s.worker_plugins[0]["name"] == "bar"
+    assert "bar" in s.worker_plugins
 
     # check on the worker plugins that we only have 'bar'
     assert len(worker.plugins) == 1

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -58,11 +58,6 @@ async def test_remove_with_client(c, s):
     await c.register_worker_plugin(MyPlugin(123), name="foo")
     await c.register_worker_plugin(MyPlugin(546), name="bar")
 
-    from pprint import pprint
-
-    print("#### worker_plugins ####")
-    pprint(s.worker_plugins)
-
     worker = await Worker(s.address, loop=s.loop)
     # remove the 'foo' plugin
     await c.unregister_worker_plugin("foo")

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -83,9 +83,6 @@ async def test_remove_with_client_raises(c, s):
     await c.register_worker_plugin(MyPlugin(123), name="foo")
 
     worker = await Worker(s.address, loop=s.loop)
-    assert worker._my_plugin_status == "setup"
-    assert worker._my_plugin_data == 123
-
     with pytest.raises(KeyError, match="bar"):
         await c.unregister_worker_plugin("bar")
 

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -68,7 +68,7 @@ async def test_remove_with_client(c, s):
     assert s.worker_plugins[0]["name"] == "bar"
 
     # check on the worker plugins that we only have 'bar'
-    assert "foo" not in worker.plugins
+    assert len(worker.plugins) == 1
     assert "bar" in worker.plugins
 
     # let's remove 'bar' and we should have none worker plugins
@@ -83,7 +83,7 @@ async def test_remove_with_client_raises(c, s):
     await c.register_worker_plugin(MyPlugin(123), name="foo")
 
     worker = await Worker(s.address, loop=s.loop)
-    with pytest.raises(KeyError, match="bar"):
+    with pytest.raises(ValueError, match="bar"):
         await c.unregister_worker_plugin("bar")
 
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3518,6 +3518,7 @@ class Scheduler(SchedulerState, ServerNode):
             "get_task_status": self.get_task_status,
             "get_task_stream": self.get_task_stream,
             "register_worker_plugin": self.register_worker_plugin,
+            "unregister_worker_plugin": self.unregister_worker_plugin,
             "adaptive_target": self.adaptive_target,
             "workers_to_close": self.workers_to_close,
             "subscribe_worker_status": self.subscribe_worker_status,
@@ -6302,6 +6303,17 @@ class Scheduler(SchedulerState, ServerNode):
         responses = await self.broadcast(
             msg=dict(op="plugin-add", plugin=plugin, name=name)
         )
+        return responses
+
+    async def unregister_worker_plugin(self, comm, name):
+        """ Unregisters a worker plugin"""
+
+        for idx, entry in enumerate(self.worker_plugins):
+            if entry["name"] == name:
+                break
+        del self.worker_plugins[idx]
+
+        responses = await self.broadcast(msg=dict(op="plugin-remove", name=name))
         return responses
 
     def transition(self, key, finish: str, *args, **kwargs):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3451,7 +3451,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
         )
         self.event_counts = defaultdict(int)
-        self.worker_plugins = dict()  # []
+        self.worker_plugins = dict()
 
         worker_handlers = {
             "task-finished": self.handle_task_finished,
@@ -6298,9 +6298,6 @@ class Scheduler(SchedulerState, ServerNode):
 
     async def register_worker_plugin(self, comm, plugin, name=None):
         """ Registers a setup function, and call it on every worker """
-        # self.worker_plugins.append({"plugin": plugin, "name": name})
-        #####HOW DO WE SWITCH FOR DICT (this is not working,
-        # throwing error in worker.py line 926)
         self.worker_plugins[name] = plugin
 
         responses = await self.broadcast(
@@ -6310,22 +6307,10 @@ class Scheduler(SchedulerState, ServerNode):
 
     async def unregister_worker_plugin(self, comm, name):
         """ Unregisters a worker plugin"""
-
         try:
             worker_plugins = self.worker_plugins.pop(name)
         except KeyError:
             raise ValueError(f"The worker plugin {name} does not exists")
-
-        #   do we do a raise or we use the error messege(e), or this will be handfle at
-        # the worker level.
-
-        # for idx, entry in enumerate(self.worker_plugins):
-        #     if entry["name"] == name:
-        #         break
-        # else:
-        #     raise ValueError(f"The worker plugin {name} does not exist")
-
-        # del self.worker_plugins[idx]
 
         responses = await self.broadcast(msg=dict(op="plugin-remove", name=name))
         return responses

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6311,6 +6311,9 @@ class Scheduler(SchedulerState, ServerNode):
         for idx, entry in enumerate(self.worker_plugins):
             if entry["name"] == name:
                 break
+        else:
+            raise KeyError(f"The worker plugin {name} does not exists")
+
         del self.worker_plugins[idx]
 
         responses = await self.broadcast(msg=dict(op="plugin-remove", name=name))

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3451,7 +3451,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
         )
         self.event_counts = defaultdict(int)
-        self.worker_plugins = []  # dict()
+        self.worker_plugins = dict()  # []
 
         worker_handlers = {
             "task-finished": self.handle_task_finished,
@@ -6298,10 +6298,10 @@ class Scheduler(SchedulerState, ServerNode):
 
     async def register_worker_plugin(self, comm, plugin, name=None):
         """ Registers a setup function, and call it on every worker """
-        self.worker_plugins.append({"plugin": plugin, "name": name})
+        # self.worker_plugins.append({"plugin": plugin, "name": name})
         #####HOW DO WE SWITCH FOR DICT (this is not working,
         # throwing error in worker.py line 926)
-        # self.worker_plugins[name] = plugin
+        self.worker_plugins[name] = plugin
 
         responses = await self.broadcast(
             msg=dict(op="plugin-add", plugin=plugin, name=name)
@@ -6311,21 +6311,21 @@ class Scheduler(SchedulerState, ServerNode):
     async def unregister_worker_plugin(self, comm, name):
         """ Unregisters a worker plugin"""
 
-        # try:
-        #    worker_plugins =  self.worker_plugins.pop(name)
-        # except:
-        #   raise ValueError(f"The worker plugin {name} does not exists")
+        try:
+            worker_plugins = self.worker_plugins.pop(name)
+        except KeyError:
+            raise ValueError(f"The worker plugin {name} does not exists")
 
         #   do we do a raise or we use the error messege(e), or this will be handfle at
         # the worker level.
 
-        for idx, entry in enumerate(self.worker_plugins):
-            if entry["name"] == name:
-                break
-        else:
-            raise ValueError(f"The worker plugin {name} does not exist")
+        # for idx, entry in enumerate(self.worker_plugins):
+        #     if entry["name"] == name:
+        #         break
+        # else:
+        #     raise ValueError(f"The worker plugin {name} does not exist")
 
-        del self.worker_plugins[idx]
+        # del self.worker_plugins[idx]
 
         responses = await self.broadcast(msg=dict(op="plugin-remove", name=name))
         return responses

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3451,7 +3451,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
         )
         self.event_counts = defaultdict(int)
-        self.worker_plugins = []
+        self.worker_plugins = []  # dict()
 
         worker_handlers = {
             "task-finished": self.handle_task_finished,
@@ -6299,6 +6299,9 @@ class Scheduler(SchedulerState, ServerNode):
     async def register_worker_plugin(self, comm, plugin, name=None):
         """ Registers a setup function, and call it on every worker """
         self.worker_plugins.append({"plugin": plugin, "name": name})
+        #####HOW DO WE SWITCH FOR DICT (this is not working,
+        # throwing error in worker.py line 926)
+        # self.worker_plugins[name] = plugin
 
         responses = await self.broadcast(
             msg=dict(op="plugin-add", plugin=plugin, name=name)
@@ -6308,11 +6311,19 @@ class Scheduler(SchedulerState, ServerNode):
     async def unregister_worker_plugin(self, comm, name):
         """ Unregisters a worker plugin"""
 
+        # try:
+        #    worker_plugins =  self.worker_plugins.pop(name)
+        # except:
+        #   raise ValueError(f"The worker plugin {name} does not exists")
+
+        #   do we do a raise or we use the error messege(e), or this will be handfle at
+        # the worker level.
+
         for idx, entry in enumerate(self.worker_plugins):
             if entry["name"] == name:
                 break
         else:
-            raise KeyError(f"The worker plugin {name} does not exists")
+            raise ValueError(f"The worker plugin {name} does not exist")
 
         del self.worker_plugins[idx]
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -922,8 +922,10 @@ class Worker(ServerNode):
         else:
             await asyncio.gather(
                 *[
-                    self.plugin_add(**plugin_kwargs)
-                    for plugin_kwargs in response["worker-plugins"]
+                    # self.plugin_add(**plugin_kwargs)
+                    # for plugin_kwargs in response["worker-plugins"]
+                    self.plugin_add(name=name, plugin=plugin)
+                    for name, plugin in response["worker-plugins"].items()
                 ]
             )
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -680,6 +680,7 @@ class Worker(ServerNode):
             "actor_execute": self.actor_execute,
             "actor_attribute": self.actor_attribute,
             "plugin-add": self.plugin_add,
+            "plugin-remove": self.plugin_remove,
             "get_monitor_info": self.get_monitor_info,
         }
 
@@ -2573,6 +2574,21 @@ class Worker(ServerNode):
                         return msg
 
                 return {"status": "OK"}
+
+    async def plugin_remove(self, comm=None, name=None):
+        with log_errors(pdb=False):
+            logger.info(f"Removing Worker plugin {name}")
+            try:
+                plugin = self.plugins.pop(name)
+                if hasattr(plugin, "teardown"):
+                    result = plugin.teardown(worker=self)
+                    if isawaitable(result):
+                        result = await result
+            except Exception as e:
+                msg = error_message(e)
+                return msg
+
+            return {"status": "OK"}
 
     async def actor_execute(
         self, comm=None, actor=None, function=None, args=(), kwargs={}

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -922,8 +922,6 @@ class Worker(ServerNode):
         else:
             await asyncio.gather(
                 *[
-                    # self.plugin_add(**plugin_kwargs)
-                    # for plugin_kwargs in response["worker-plugins"]
                     self.plugin_add(name=name, plugin=plugin)
                     for name, plugin in response["worker-plugins"].items()
                 ]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -7,7 +7,6 @@ import os
 import random
 import sys
 import threading
-import uuid
 import warnings
 import weakref
 from collections import defaultdict, deque, namedtuple
@@ -41,6 +40,7 @@ from .core import (
     pingpong,
     send_recv,
 )
+from .diagnostics.plugin import _get_worker_plugin_name
 from .diskutils import WorkSpace
 from .http import get_handlers
 from .metrics import time
@@ -2550,11 +2550,9 @@ class Worker(ServerNode):
         with log_errors(pdb=False):
             if isinstance(plugin, bytes):
                 plugin = pickle.loads(plugin)
-            if not name:
-                if hasattr(plugin, "name"):
-                    name = plugin.name
-                else:
-                    name = funcname(plugin) + "-" + str(uuid.uuid4())
+
+            if name is None:
+                name = _get_worker_plugin_name(plugin)
 
             assert name
 


### PR DESCRIPTION
This PR adds the possibility to do `client.unregister_worker_plugin`. 
So far we added two tests:
- Given a register plugin it "unregisters" and checks there are no worker plugins (pass)
- Given a non-existing plugin raises KeyError (pass)

But I would like to add one more test that given two plugins we unregister one of them and check that case. 

- [x] Closes #4237
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
