### PR TITLE
Ensure deps are actually logged in worker

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2007,7 +2007,8 @@ class Worker(ServerNode):
 
                     deps = [dep for dep in deps if dep not in missing_deps]
 
-                self.log.append(("gather-dependencies", key, deps.copy()))
+                log_keys = {d.key for d in deps}
+                self.log.append(("gather-dependencies", key, log_keys))
 
                 in_flight = False
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2007,7 +2007,7 @@ class Worker(ServerNode):
 
                     deps = [dep for dep in deps if dep not in missing_deps]
 
-                self.log.append(("gather-dependencies", key, deps))
+                self.log.append(("gather-dependencies", key, deps.copy()))
 
                 in_flight = False
 


### PR DESCRIPTION
Ensure dependencies in our logs are actually logged. The set is popped a few lines below and we need to create a copy for the logs