### PR TITLE
Handle missing `key` case in `report_on_key`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7082,15 +7082,9 @@ def _task_to_report_msg(state: SchedulerState, ts: TaskState) -> dict:
 @cfunc
 @exceptval(check=False)
 def _task_to_client_msgs(state: SchedulerState, ts: TaskState) -> dict:
+    cs: ClientState
     report_msg: dict = _task_to_report_msg(state, ts)
-    client_msgs: dict
-    if ts is None:
-        # Notify all clients
-        client_msgs = {k: [report_msg] for k in state._clients}
-    else:
-        # Notify clients interested in key
-        cs: ClientState
-        client_msgs = {cs._client_key: [report_msg] for cs in ts._who_wants}
+    client_msgs: dict = {cs._client_key: [report_msg] for cs in ts._who_wants}
     return client_msgs
 
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7063,9 +7063,7 @@ def _task_to_msg(state: SchedulerState, ts: TaskState, duration: double = -1) ->
 @cfunc
 @exceptval(check=False)
 def _task_to_report_msg(state: SchedulerState, ts: TaskState) -> dict:
-    if ts is None:
-        return {"op": "cancelled-key", "key": ts._key}
-    elif ts._state == "forgotten":
+    if ts._state == "forgotten":
         return {"op": "cancelled-key", "key": ts._key}
     elif ts._state == "memory":
         return {"op": "key-in-memory", "key": ts._key}

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6050,7 +6050,11 @@ class Scheduler(SchedulerState, ServerNode):
             assert False, (key, ts)
             return
 
-        report_msg: dict = _task_to_report_msg(parent, ts)
+        report_msg: dict
+        if ts is None:
+            report_msg = {"op": "cancelled-key", "key": key}
+        else:
+            report_msg = _task_to_report_msg(parent, ts)
         if report_msg is not None:
             self.report(report_msg, ts=ts, client=client)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7082,10 +7082,12 @@ def _task_to_report_msg(state: SchedulerState, ts: TaskState) -> dict:
 @cfunc
 @exceptval(check=False)
 def _task_to_client_msgs(state: SchedulerState, ts: TaskState) -> dict:
-    cs: ClientState
-    report_msg: dict = _task_to_report_msg(state, ts)
-    client_msgs: dict = {cs._client_key: [report_msg] for cs in ts._who_wants}
-    return client_msgs
+    if ts._who_wants:
+        report_msg: dict = _task_to_report_msg(state, ts)
+        if report_msg is not None:
+            cs: ClientState
+            return {cs._client_key: [report_msg] for cs in ts._who_wants}
+    return {}
 
 
 @cfunc

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -413,6 +413,7 @@ async def test_delete_data(c, s, a, b):
 async def test_delete(c, s, a):
     x = c.submit(inc, 1)
     await x
+    assert x.key in s.tasks
     assert x.key in a.data
 
     await c._cancel(x)
@@ -421,6 +422,10 @@ async def test_delete(c, s, a):
     while x.key in a.data:
         await asyncio.sleep(0.01)
         assert time() < start + 5
+
+    assert x.key not in s.tasks
+
+    s.report_on_key(key=x.key)
 
 
 @gen_cluster()


### PR DESCRIPTION
Handle missing `key` case in `report_on_key`. This [was previously handled]( https://github.com/dask/distributed/blob/dfbe171905b349fdd933424ae7af2b6217a28133/distributed/scheduler.py#L3672-L3676 ), but was accidentally dropped during refactoring. Here we add it back.

Some dead code was found in `_task_to_client_msgs` because of this change and was dropped as result. Also some unneeded code was dropped from `_task_to_report_msg`.

- [x] Closes https://github.com/dask/distributed/issues/4730
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
