### PR TITLE
Add info tooltips to Dashboard plots

### DIFF
--- a/distributed/dashboard/components/nvml.py
+++ b/distributed/dashboard/components/nvml.py
@@ -3,6 +3,7 @@ import math
 from bokeh.models import (
     BasicTicker,
     ColumnDataSource,
+    HelpTool,
     HoverTool,
     NumeralTickFormatter,
     OpenURL,
@@ -101,18 +102,30 @@ class GPUCurrentLoad(DashboardComponent):
                 fig.add_tools(tap)
 
                 fig.toolbar.logo = None
-                fig.toolbar_location = None
+                fig.toolbar_location = "below"
                 fig.yaxis.visible = False
 
             hover = HoverTool()
             hover.tooltips = "@worker : @utilization %"
             hover.point_policy = "follow_mouse"
-            utilization.add_tools(hover)
+            utilization.add_tools(
+                hover,
+                HelpTool(
+                    description="TODO",
+                    redirect="https://distributed.dask.org/en/latest/",
+                ),
+            )
 
             hover = HoverTool()
             hover.tooltips = "@worker : @memory_text"
             hover.point_policy = "follow_mouse"
-            memory.add_tools(hover)
+            memory.add_tools(
+                hover,
+                HelpTool(
+                    description="TODO",
+                    redirect="https://distributed.dask.org/en/latest/",
+                ),
+            )
 
             self.memory_figure = memory
             self.utilization_figure = utilization

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -17,6 +17,7 @@ from bokeh.models import (
     ColumnDataSource,
     DataRange1d,
     GroupFilter,
+    HelpTool,
     HoverTool,
     NumberFormatter,
     NumeralTickFormatter,
@@ -132,7 +133,14 @@ class Occupancy(DashboardComponent):
             hover = HoverTool()
             hover.tooltips = "@worker : @occupancy s."
             hover.point_policy = "follow_mouse"
-            self.root.add_tools(hover, tap)
+            self.root.add_tools(
+                hover,
+                tap,
+                HelpTool(
+                    description="TODO",
+                    redirect="https://distributed.dask.org/en/latest/",
+                ),
+            )
 
     @without_property_validation
     def update(self):
@@ -1164,7 +1172,14 @@ class StealingTimeSeries(DashboardComponent):
         self.root.yaxis.minor_tick_line_color = None
 
         self.root.add_tools(
-            ResetTool(), PanTool(dimensions="width"), WheelZoomTool(dimensions="width")
+            ResetTool(),
+            PanTool(dimensions="width"),
+            WheelZoomTool(dimensions="width"),
+            HelpTool(
+                description="Time series of the number of idle/saturated workers; the red line represents number of "
+                "idle workers and the green line represents number of saturated workers",
+                redirect="https://distributed.dask.org/en/latest/",
+            ),
         )
 
     @without_property_validation
@@ -1231,6 +1246,9 @@ class StealingEvents(DashboardComponent):
             ResetTool(),
             PanTool(dimensions="width"),
             WheelZoomTool(dimensions="width"),
+            HelpTool(
+                description="TODO", redirect="https://distributed.dask.org/en/latest/"
+            ),
         )
 
     def convert(self, msgs):
@@ -1327,6 +1345,9 @@ class Events(DashboardComponent):
             ResetTool(),
             PanTool(dimensions="width"),
             WheelZoomTool(dimensions="width"),
+            HelpTool(
+                description="TODO", redirect="https://distributed.dask.org/en/latest/"
+            ),
         )
 
     @without_property_validation
@@ -1529,6 +1550,9 @@ def task_stream_figure(clear_interval="20s", **kwargs):
         ResetTool(),
         PanTool(dimensions="width"),
         WheelZoomTool(dimensions="width"),
+        HelpTool(
+            description="TODO", redirect="https://distributed.dask.org/en/latest/"
+        ),
     )
     if ExportTool:
         export = ExportTool()
@@ -1571,7 +1595,9 @@ class TaskGraph(DashboardComponent):
             palette=["gray", "green", "red", "blue", "black"],
         )
 
-        self.root = figure(title="Task Graph", **kwargs)
+        self.root = figure(
+            title="Task Graph", tools="box_zoom,xwheel_zoom,reset", **kwargs
+        )
         self.subtitle = Title(text=" ", text_font_style="italic")
         self.root.add_layout(self.subtitle, "above")
 
@@ -1603,7 +1629,13 @@ class TaskGraph(DashboardComponent):
         )
         tap = TapTool(callback=OpenURL(url="info/task/@key.html"), renderers=[rect])
         rect.nonselection_glyph = None
-        self.root.add_tools(hover, tap)
+        self.root.add_tools(
+            hover,
+            tap,
+            HelpTool(
+                description="TODO", redirect="https://distributed.dask.org/en/latest/"
+            ),
+        )
         self.max_items = config.get("distributed.dashboard.graph-max-items", 5000)
 
     @without_property_validation

--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -7,6 +7,7 @@ from bokeh.models import (
     Button,
     ColumnDataSource,
     DataRange1d,
+    HelpTool,
     HoverTool,
     NumeralTickFormatter,
     Range1d,
@@ -249,6 +250,11 @@ class ProfileTimePlot(DashboardComponent):
         )
         self.ts_plot.yaxis.visible = False
         self.ts_plot.grid.visible = False
+        self.ts_plot.add_tools(
+            HelpTool(
+                description="TODO", redirect="https://distributed.dask.org/en/latest/"
+            )
+        )
 
         def ts_change(attr, old, new):
             with log_errors():
@@ -402,6 +408,11 @@ class ProfileServer(DashboardComponent):
         )
         self.ts_plot.yaxis.visible = False
         self.ts_plot.grid.visible = False
+        self.ts_plot.add_tools(
+            HelpTool(
+                description="TODO", redirect="https://distributed.dask.org/en/latest/"
+            )
+        )
 
         def ts_change(attr, old, new):
             with log_errors():
@@ -455,7 +466,7 @@ class ProfileServer(DashboardComponent):
 
 
 class SystemMonitor(DashboardComponent):
-    def __init__(self, worker, height=150, **kwargs):
+    def __init__(self, worker, height=200, **kwargs):
         self.worker = worker
 
         names = worker.monitor.quantities
@@ -477,6 +488,13 @@ class SystemMonitor(DashboardComponent):
         )
         self.cpu.line(source=self.source, x="time", y="cpu")
         self.cpu.yaxis.axis_label = "Percentage"
+        self.cpu.add_tools(
+            HelpTool(
+                description="Time series of the total CPU utilization of the Dask scheduler",
+                redirect="https://distributed.dask.org/en/latest/",
+            )
+        )
+
         self.mem = figure(
             title="Memory",
             x_axis_type="datetime",
@@ -487,6 +505,13 @@ class SystemMonitor(DashboardComponent):
         )
         self.mem.line(source=self.source, x="time", y="memory")
         self.mem.yaxis.axis_label = "Bytes"
+        self.mem.add_tools(
+            HelpTool(
+                description="Time series of the memory utilization of the Dask scheduler",
+                redirect="https://distributed.dask.org/en/latest/",
+            )
+        )
+
         self.bandwidth = figure(
             title="Bandwidth",
             x_axis_type="datetime",
@@ -498,6 +523,13 @@ class SystemMonitor(DashboardComponent):
         self.bandwidth.line(source=self.source, x="time", y="read_bytes", color="red")
         self.bandwidth.line(source=self.source, x="time", y="write_bytes", color="blue")
         self.bandwidth.yaxis.axis_label = "Bytes / second"
+        self.bandwidth.add_tools(
+            HelpTool(
+                description="Time series of the read/write bandwidth of the Dask scheduler; the red line represents "
+                "read bandwidth and the blue line represents write bandwidth",
+                redirect="https://distributed.dask.org/en/latest/",
+            )
+        )
 
         # self.cpu.yaxis[0].formatter = NumeralTickFormatter(format='0%')
         self.bandwidth.yaxis[0].formatter = NumeralTickFormatter(format="0.0b")
@@ -516,6 +548,12 @@ class SystemMonitor(DashboardComponent):
             )
 
             self.num_fds.line(source=self.source, x="time", y="num_fds")
+            self.num_fds.add_tools(
+                HelpTool(
+                    description="Time series of the number of file descriptors used by the Dask scheduler",
+                    redirect="https://distributed.dask.org/en/latest/",
+                )
+            )
             plots.append(self.num_fds)
 
         if "sizing_mode" in kwargs:

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -375,7 +375,7 @@ def plot_figure(data, **kwargs):
     --------
     plot_data
     """
-    from bokeh.models import HoverTool
+    from bokeh.models import HelpTool, HoverTool
     from bokeh.plotting import ColumnDataSource, figure
 
     if "states" in data:
@@ -427,7 +427,12 @@ def plot_figure(data, **kwargs):
             </div>
             """,
     )
-    fig.add_tools(hover)
+    fig.add_tools(
+        hover,
+        HelpTool(
+            description="TODO", redirect="https://distributed.dask.org/en/latest/"
+        ),
+    )
 
     fig.xaxis.visible = False
     fig.yaxis.visible = False


### PR DESCRIPTION
Adds a Bokeh `HelpTool` to most plots with a visible toolbar, allowing users to hover over it for a brief explanation of the plot. Several of these still need to be filled in (marked with `description="TODO"`), but I figured that might be something easier to hash out with members of the community.

- [ ] Closes #4746
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
