### PR TITLE
Cython fixes for `MemoryState`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -327,7 +327,7 @@ class MemoryState:
 
     @classmethod
     def sum(cls, *infos: "MemoryState") -> "MemoryState":
-        out = object.__new__(cls)
+        out = MemoryState.__new__(MemoryState)
         for k in cls.__slots__:
             setattr(out, k, sum(getattr(i, k) for i in infos))
         return out

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -343,9 +343,13 @@ class MemoryState:
 
     @classmethod
     def sum(cls, *infos: "MemoryState") -> "MemoryState":
-        out = MemoryState.__new__(MemoryState)
-        for k in cls.__slots__:
-            setattr(out, k, sum(getattr(i, k) for i in infos))
+        out = MemoryState(process=0, unmanaged_old=0, managed=0, managed_spilled=0)
+        ms: MemoryState
+        for ms in infos:
+            out._process += ms._process
+            out._managed_spilled += ms._managed_spilled
+            out._managed_in_memory += ms._managed_in_memory
+            out._unmanaged_old += ms._unmanaged_old
         return out
 
     @property

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -353,32 +353,20 @@ class MemoryState:
         return out
 
     @property
-    @ccall
-    @inline
-    @nogil
     def managed(self) -> Py_ssize_t:
         return self._managed_in_memory + self._managed_spilled
 
     @property
-    @ccall
-    @inline
-    @nogil
     def unmanaged(self) -> Py_ssize_t:
         # This is never negative thanks to __init__
         return self._process - self._managed_in_memory
 
     @property
-    @ccall
-    @inline
-    @nogil
     def unmanaged_recent(self) -> Py_ssize_t:
         # This is never negative thanks to __init__
         return self._process - self._managed_in_memory - self._unmanaged_old
 
     @property
-    @ccall
-    @inline
-    @nogil
     def optimistic(self) -> Py_ssize_t:
         return self._managed_in_memory + self._unmanaged_old
 


### PR DESCRIPTION
- [ ] Closes https://github.com/dask/distributed/issues/4760
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

There were some issues that surfaced when using the Cythonized Scheduler's dashboard with the recently added `MemoryState` class. One issue was around the use of `object.__new__`. However fixing that led to other issues. This fixes them basically until the reproducer in the issue linked above is able to render the dashboard.

cc @crusaderky @jrbourbeau @quasiben