### PR TITLE
Use `contextlib.nullcontext`

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -20,7 +20,7 @@ import threading
 import uuid
 import warnings
 import weakref
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager, nullcontext, suppress
 from glob import glob
 from time import sleep
 
@@ -1524,14 +1524,10 @@ def check_instances():
 
 @contextmanager
 def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
-    @contextmanager
-    def null():
-        yield
-
-    with check_thread_leak() if threads else null():
+    with check_thread_leak() if threads else nullcontext():
         with pristine_loop() as loop:
             with check_process_leak(check=processes):
-                with check_instances() if instances else null():
+                with check_instances() if instances else nullcontext():
                     with check_active_rpc(loop, timeout):
                         reset_config()
 


### PR DESCRIPTION
Since our minimum support Python version is 3.7, we can now use Python's built in `contextlib.nullcontext` instead of defining something equivalent ourselves 