### PR TITLE
Clean path prefix from filename in profile (WIP)

### DIFF
--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -66,7 +66,7 @@ def info_frame(frame):
     co = frame.f_code
     line = linecache.getline(co.co_filename, frame.f_lineno, frame.f_globals).lstrip()
     return {
-        "filename": co.co_filename,
+        "filename": co.co_filename.replace(sys.exec_prefix, ""),
         "name": co.co_name,
         "line_number": frame.f_lineno,
         "line": line,

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5298,6 +5298,15 @@ async def test_cleaned_filenames_in_profile(c, s, a, b):
     # #print('sys.platlibdir:', sys.platlibdir) #starts working on py3.9
 
 
+@gen_cluster(client=True)
+async def test_cleaned_filenames_in_profile_raises(c, s, a, b):
+    # no work done by the client, should give empty profile
+    profile = await c.profile()
+
+    with pytest.raises(AssertionError):
+        assert profile["children"] != {}
+
+
 @gen_cluster()
 async def test_client_with_name(s, a, b):
     with captured_logger("distributed.scheduler") as sio:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5270,6 +5270,34 @@ async def test_profile_keys(c, s, a, b):
     assert not out
 
 
+@gen_cluster(client=True)
+async def test_cleaned_filenames_in_profile(c, s, a, b):
+    # do some work with the client
+    x = await c.submit(sleep, 1)
+
+    # When doing something like this, the sys.exec_prefix is not
+    # in filename, probably need to handle this case differently
+    # y = await c.submit(slowdec, 2, delay=2)
+
+    profile = await c.profile()
+
+    # check that profile is non-empty profile
+    assert profile["children"] != {}
+
+    children = profile["children"]
+    children_vals = list(children.values())[0]
+    assert sys.exec_prefix not in children_vals["description"]["filename"]
+
+    # print('THE OUTPUT OF profile is:')
+    # from pprint import pprint
+    # pprint(profile)
+
+    # print('Some useful outputs:\n')
+    # print('sys.executable:', sys.executable)
+    # print('sys.exec_prefix:', sys.exec_prefix)
+    # #print('sys.platlibdir:', sys.platlibdir) #starts working on py3.9
+
+
 @gen_cluster()
 async def test_client_with_name(s, a, b):
     with captured_logger("distributed.scheduler") as sio:


### PR DESCRIPTION
We remove the `sys.exec_prefix` from the filename in the profile. I think we are still missing couple of cases where the filename won't have the `sys.exec_prefix` but some other information that we want to remove. 
For example in the current test, if instead of doing  `x = await c.submit(sleep, 1)`  we use a function like `slowinc` that lives in `distributed.utils_test` we will have a path of the form `/Users/username/Documents/distributed/distributed/utils_test.py.` we should see for cases like this one, what do we want to remove. 

- [x] Closes #4716
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
