### PR TITLE
[WIP] Fix Cythonized Scheduler test failures

### DIFF
--- a/distributed/cli/tests/test_dask_spec.py
+++ b/distributed/cli/tests/test_dask_spec.py
@@ -4,12 +4,10 @@ import pytest
 import yaml
 
 from distributed import Client
-from distributed.scheduler import COMPILED
 from distributed.utils_test import cleanup  # noqa: F401
 from distributed.utils_test import popen
 
 
-@pytest.mark.skipif(COMPILED, reason="Fails with cythonized scheduler")
 @pytest.mark.asyncio
 async def test_text(cleanup):
     with popen(
@@ -39,7 +37,6 @@ async def test_text(cleanup):
                 assert w["nthreads"] == 3
 
 
-@pytest.mark.skipif(COMPILED, reason="Fails with cythonized scheduler")
 @pytest.mark.asyncio
 async def test_file(cleanup, tmp_path):
     fn = str(tmp_path / "foo.yaml")

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -21,7 +21,6 @@ from distributed.core import Status
 from distributed.deploy.local import LocalCluster
 from distributed.deploy.utils_test import ClusterTest
 from distributed.metrics import time
-from distributed.scheduler import COMPILED
 from distributed.system import MEMORY_LIMIT
 from distributed.utils import TimeoutError, sync
 from distributed.utils_test import (  # noqa: F401
@@ -794,7 +793,6 @@ async def test_scale_retires_workers():
     await cluster.close()
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 def test_local_tls_restart(loop):
     from distributed.utils_test import tls_only_security
 

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -12,7 +12,6 @@ from distributed.diagnostics.progress import (
     SchedulerPlugin,
 )
 from distributed.metrics import time
-from distributed.scheduler import COMPILED
 from distributed.utils_test import dec, div, gen_cluster, inc, nodebug
 
 
@@ -95,7 +94,6 @@ def check_bar_completed(capsys, width=40):
     assert percent == "100% Completed"
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(client=True, Worker=Nanny, timeout=None)
 async def test_AllProgress(c, s, a, b):
     x, y, z = c.map(inc, [1, 2, 3])

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -6,7 +6,6 @@ from dask import delayed
 
 from distributed.client import wait
 from distributed.diagnostics.progress_stream import progress_quads, progress_stream
-from distributed.scheduler import COMPILED
 from distributed.utils_test import div, gen_cluster, inc
 
 
@@ -57,7 +56,6 @@ def test_progress_quads_too_many():
     assert len(d["name"]) == 6 * 3
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(client=True)
 async def test_progress_stream(c, s, a, b):
     futures = c.map(div, [1] * 10, range(10))

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -58,12 +58,7 @@ from distributed.comm import CommClosedError
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.core import Status
 from distributed.metrics import time
-from distributed.scheduler import (
-    COMPILED,
-    CollectTaskMetaDataPlugin,
-    KilledWorker,
-    Scheduler,
-)
+from distributed.scheduler import CollectTaskMetaDataPlugin, KilledWorker, Scheduler
 from distributed.sizeof import sizeof
 from distributed.utils import is_valid_xml, mp_context, sync, tmp_text, tmpfile
 from distributed.utils_test import (  # noqa: F401
@@ -5101,7 +5096,6 @@ def test_dynamic_workloads_sync_random(c):
     _test_dynamic_workloads_sync(c, delay="random")
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(client=True)
 async def test_bytes_keys(c, s, a, b):
     key = b"inc-123"
@@ -5854,7 +5848,6 @@ async def test_get_mix_futures_and_SubgraphCallable_dask_dataframe(c, s, a, b):
     assert result.equals(df.astype("f8"))
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 def test_direct_to_workers(s, loop):
     with Client(s["address"], loop=loop, direct_to_workers=True) as client:
         future = client.scatter(1)

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -13,7 +13,6 @@ from distributed import Client, Nanny, wait
 from distributed.comm import CommClosedError
 from distributed.compatibility import MACOS
 from distributed.metrics import time
-from distributed.scheduler import COMPILED
 from distributed.utils import CancelledError, sync
 from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import (
@@ -100,7 +99,6 @@ async def test_gather_then_submit_after_failed_workers(c, s, w, x, y, z):
         assert result == [sum(map(inc, range(20)))]
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(Worker=Nanny, timeout=60, client=True)
 async def test_failed_worker_without_warning(c, s, a, b):
     L = c.map(inc, range(10))
@@ -137,7 +135,6 @@ async def test_failed_worker_without_warning(c, s, a, b):
     assert not (set(nthreads2) & set(s.nthreads))  # no overlap
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
 async def test_restart(c, s, a, b):
     assert s.nthreads == {a.worker_address: 1, b.worker_address: 2}
@@ -166,7 +163,6 @@ async def test_restart(c, s, a, b):
     assert not any(cs.wants_what for cs in s.clients.values())
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
 async def test_restart_cleared(c, s, a, b):
     x = 2 * delayed(1) + 1
@@ -179,7 +175,6 @@ async def test_restart_cleared(c, s, a, b):
         assert not coll
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 def test_restart_sync_no_center(loop):
     with cluster(nanny=True) as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
@@ -191,7 +186,6 @@ def test_restart_sync_no_center(loop):
             assert len(c.nthreads()) == 2
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 def test_restart_sync(loop):
     with cluster(nanny=True) as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
@@ -211,7 +205,6 @@ def test_restart_sync(loop):
             assert y.result() == 1 / 3
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
 async def test_restart_fast(c, s, a, b):
     L = c.map(sleep, range(10))
@@ -228,7 +221,6 @@ async def test_restart_fast(c, s, a, b):
     assert result == 2
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 def test_worker_doesnt_await_task_completion(loop):
     with cluster(nanny=True, nworkers=1) as (s, [w]):
         with Client(s["address"], loop=loop) as c:
@@ -240,7 +232,6 @@ def test_worker_doesnt_await_task_completion(loop):
             assert stop - start < 5
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 def test_restart_fast_sync(loop):
     with cluster(nanny=True) as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
@@ -257,7 +248,6 @@ def test_restart_fast_sync(loop):
             assert x.result() == 2
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
 async def test_fast_kill(c, s, a, b):
     L = c.map(sleep, range(10))
@@ -273,7 +263,6 @@ async def test_fast_kill(c, s, a, b):
     assert result == 2
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(Worker=Nanny, timeout=60)
 async def test_multiple_clients_restart(s, a, b):
     c1 = await Client(s.address, asynchronous=True)
@@ -367,7 +356,6 @@ async def test_broken_worker_during_computation(c, s, a, b):
     await n.close()
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(client=True, Worker=Nanny, timeout=60)
 async def test_restart_during_computation(c, s, a, b):
     xs = [delayed(slowinc)(i, delay=0.01) for i in range(50)]


### PR DESCRIPTION
Reverts the tests skipped/xfailed in PR ( https://github.com/dask/distributed/pull/4764 ) due to issues encountered with the Cythonized Scheduler. Doing this to fix those tests and get them passing in the Cythonized Scheduler case as well.

**Note:** This PR mainly exists for tracking purposes while we sort out the different tests failures.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
