### PR TITLE
Fixes some pickling issues in the Cythonized Scheduler

### DIFF
--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -22,6 +22,8 @@ def counts(scheduler, allprogress):
 
 
 def remove_plugin(*args, **kwargs):
+    # Wrapper function around `Scheduler.remove_plugin` to avoid raising a
+    # `PicklingError` when using a cythonized scheduler
     return Scheduler.remove_plugin(*args, **kwargs)
 
 

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -21,6 +21,10 @@ def counts(scheduler, allprogress):
     )
 
 
+def remove_plugin(*args, **kwargs):
+    return Scheduler.remove_plugin(*args, **kwargs)
+
+
 async def progress_stream(address, interval):
     """Open a TCP connection to scheduler, receive progress messages
 
@@ -47,7 +51,7 @@ async def progress_stream(address, interval):
             "setup": dumps_function(AllProgress),
             "function": dumps_function(counts),
             "interval": interval,
-            "teardown": dumps_function(Scheduler.remove_plugin),
+            "teardown": dumps_function(remove_plugin),
         }
     )
     return comm

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -6,7 +6,6 @@ from dask import delayed
 
 from distributed.client import wait
 from distributed.diagnostics.progress_stream import progress_quads, progress_stream
-from distributed.scheduler import COMPILED
 from distributed.utils_test import div, gen_cluster, inc
 
 
@@ -57,12 +56,6 @@ def test_progress_quads_too_many():
     assert len(d["name"]) == 6 * 3
 
 
-@pytest.mark.xfail(
-    COMPILED,
-    reason=(
-        "Fails due to Cython issue: https://github.com/cython/cython/issues/2972"
-    ),
-)
 @gen_cluster(client=True)
 async def test_progress_stream(c, s, a, b):
     futures = c.map(div, [1] * 10, range(10))

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -57,7 +57,12 @@ def test_progress_quads_too_many():
     assert len(d["name"]) == 6 * 3
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
+@pytest.mark.xfail(
+    COMPILED,
+    reason=(
+        "Fails due to Cython issue: https://github.com/cython/cython/issues/2972"
+    ),
+)
 @gen_cluster(client=True)
 async def test_progress_stream(c, s, a, b):
     futures = c.map(div, [1] * 10, range(10))

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3453,8 +3453,8 @@ class Scheduler(SchedulerState, ServerNode):
             maxlen=dask.config.get("distributed.scheduler.transition-log-length")
         )
         self.events = defaultdict(
-            lambda: deque(
-                maxlen=dask.config.get("distributed.scheduler.events-log-length")
+            partial(
+                deque, maxlen=dask.config.get("distributed.scheduler.events-log-length")
             )
         )
         self.event_counts = defaultdict(int)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5854,10 +5854,6 @@ async def test_get_mix_futures_and_SubgraphCallable_dask_dataframe(c, s, a, b):
     assert result.equals(df.astype("f8"))
 
 
-@pytest.mark.xfail(
-    COMPILED,
-    reason="Fails due to Cython issue: https://github.com/cython/cython/issues/3499",
-)
 def test_direct_to_workers(s, loop):
     with Client(s["address"], loop=loop, direct_to_workers=True) as client:
         future = client.scatter(1)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5854,7 +5854,10 @@ async def test_get_mix_futures_and_SubgraphCallable_dask_dataframe(c, s, a, b):
     assert result.equals(df.astype("f8"))
 
 
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
+@pytest.mark.xfail(
+    COMPILED,
+    reason="Fails due to Cython issue: https://github.com/cython/cython/issues/3499",
+)
 def test_direct_to_workers(s, loop):
     with Client(s["address"], loop=loop, direct_to_workers=True) as client:
         future = client.scatter(1)


### PR DESCRIPTION
A few of the test failures discovered in PR ( https://github.com/dask/distributed/pull/4764 ) were related to pickling issues. One relating to pickling unbound methods, which Cython has a fix for in a pending release ( https://github.com/cython/cython/issues/2972 ). Another related pickling to `lambda`s ( https://github.com/cython/cython/issues/3499 ).

Here we workaround these issues by using other techniques. This fixes a couple of test failures on the Cython Scheduler. So are now re-enabled in this PR.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
