### PR TITLE
Forget erred tasks // Fix deadlocks on worker

### DIFF
--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -131,6 +131,7 @@ async def test_failing_task_transitions_called(c, s, w):
         {"key": "task", "start": "waiting", "finish": "ready"},
         {"key": "task", "start": "ready", "finish": "executing"},
         {"key": "task", "start": "executing", "finish": "error"},
+        {"key": "task", "state": "error"},
     ]
 
     plugin = MyPlugin(1, expected_notifications=expected_notifications)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2746,8 +2746,8 @@ class SchedulerState:
                     recommendations[dts._key] = "waiting"
 
             w_msg = {"op": "free-keys", "keys": [key], "reason": "Erred->Released"}
-            for w in ts._erred_on:
-                worker_msgs[w] = [w_msg]
+            for ws_addr in ts._erred_on:
+                worker_msgs[ws_addr] = [w_msg]
             ts._erred_on.clear()
 
             report_msg = {"op": "task-retried", "key": key}

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -406,7 +406,6 @@ class SlowTransmitData:
 @gen_cluster(client=True)
 async def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
     n = await Nanny(s.address, nthreads=2, loop=s.loop)
-    n.auto_restart = False
 
     start = time()
     while len(s.nthreads) < 3:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1916,7 +1916,7 @@ async def test_task_groups(c, s, a, b):
     assert s.task_groups[y.name].dependencies == {s.task_groups[x.name]}
 
     await c.replicate(y)
-    # TODO: Are we supposed to track repliacted memory here? See also Scheduelr.add_keys
+    # TODO: Are we supposed to track replicated memory here? See also Scheduler.add_keys
     assert tg.nbytes_in_memory == y.nbytes
     assert "array" in str(tg.types)
     assert "array" in str(tp.types)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -748,7 +748,6 @@ async def test_log_exception_on_failed_task(c, s, a, b):
             logger.removeHandler(fh)
 
 
-@pytest.mark.flaky(reruns=10, reruns_delay=5)
 @gen_cluster(client=True)
 async def test_clean_up_dependencies(c, s, a, b):
     x = delayed(inc)(1)
@@ -760,15 +759,12 @@ async def test_clean_up_dependencies(c, s, a, b):
     zz = c.persist(z)
     await wait(zz)
 
-    start = time()
     while len(a.data) + len(b.data) > 1:
         await asyncio.sleep(0.01)
-        assert time() < start + 2
 
     assert set(a.data) | set(b.data) == {zz.key}
 
 
-@pytest.mark.flaky(reruns=10, reruns_delay=5)
 @gen_cluster(client=True)
 async def test_hold_onto_dependents(c, s, a, b):
     x = c.submit(inc, 1, workers=a.address)
@@ -778,9 +774,8 @@ async def test_hold_onto_dependents(c, s, a, b):
     assert x.key in b.data
 
     await c._cancel(y)
-    await asyncio.sleep(0.1)
-
-    assert x.key in b.data
+    while x.key not in b.data:
+        await asyncio.sleep(0.1)
 
 
 @pytest.mark.slow
@@ -1840,8 +1835,8 @@ async def test_story_with_deps(c, s, a, b):
         ),
         (key, "waiting", "ready"),
         (key, "ready", "executing"),
-        (key, "put-in-memory"),
         (key, "executing", "memory"),
+        (key, "put-in-memory"),
     ]
     assert story == expected_story
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2171,7 +2171,6 @@ async def test_worker_state_error_release_error_first(c, s, a, b):
     f.release()
     g.release()
 
-    # We no longer hold any refs. Cluster should reset completely
     # This is not happening
     for server in [s, a, b]:
         while server.tasks:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2364,7 +2364,7 @@ class Worker(ServerNode):
                         self.release_key(d, cause="already executing at gather")
                         continue
                     elif ts.state not in ("ready", "memory"):
-                        self.transition(ts, "fetch", worker=worker)
+                        self.transition(ts, "fetch")
 
                     if not busy and d not in data and ts.dependents:
                         self.log.append(("missing-dep", d))

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -685,7 +685,7 @@ class Worker(ServerNode):
             "run_coroutine": self.run_coroutine,
             "get_data": self.get_data,
             "update_data": self.update_data,
-            "free_keys": self.free_keys_comm,
+            "free_keys": self.handle_free_keys,
             "terminate": self.close,
             "ping": pingpong,
             "upload_file": self.upload_file,
@@ -1490,13 +1490,9 @@ class Worker(ServerNode):
         info = {"nbytes": {k: sizeof(v) for k, v in data.items()}, "status": "OK"}
         return info
 
-    def free_keys_comm(self, comm, keys, reason):
-        """This is a comm handler calling `free_keys`"""
-        return self.handle_free_keys(keys, reason)
-
-    def handle_free_keys(self, keys, reason):
+    def handle_free_keys(self, comm=None, keys=None, reason=None):
         """
-        Stream handler to be called by the scheduler.
+        Handler to be called by the scheduler.
 
         The given keys are no longer referred to and required by the scheduler.
         The worker is now allowed to release the key, if applicable.

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2329,7 +2329,12 @@ class Worker(ServerNode):
                 del to_gather, dependency_key, dependency_ts
 
                 self.log.append(("request-dep", cause.key, worker, to_gather_keys))
-                logger.debug("Request %d keys for task %s", len(to_gather_keys), cause)
+                logger.debug(
+                    "Request %d keys for task %s from %s",
+                    len(to_gather_keys),
+                    cause,
+                    worker,
+                )
 
                 start = time()
                 response = await get_data_from_worker(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -685,7 +685,7 @@ class Worker(ServerNode):
             "run_coroutine": self.run_coroutine,
             "get_data": self.get_data,
             "update_data": self.update_data,
-            "delete_data": self.delete_data,
+            "free_keys": self.free_keys_comm,
             "terminate": self.close,
             "ping": pingpong,
             "upload_file": self.upload_file,
@@ -706,8 +706,8 @@ class Worker(ServerNode):
         stream_handlers = {
             "close": self.close,
             "compute-task": self.add_task,
-            "release-task": self.release_task,
-            "delete-data": self.delete_data,
+            "free-keys": self.handle_free_keys,
+            "superfluous-data": self.handle_superfluous_data,
             "steal-request": self.steal_request,
         }
 
@@ -1482,26 +1482,61 @@ class Worker(ServerNode):
             self.log.append((key, "receive-from-scatter"))
 
         if report:
+
+            self.log.append(
+                ("Notifying scheduler about in-memory in update-data", list(data))
+            )
             self.batched_stream.send({"op": "add-keys", "keys": list(data)})
         info = {"nbytes": {k: sizeof(v) for k, v in data.items()}, "status": "OK"}
         return info
 
-    def release_task(self, key):
-        ts = self.tasks.get(key)
-        if ts:
-            ts.scheduler_holds_ref = False
-        self.release_key(key, report=False)
+    def free_keys_comm(self, comm, keys, reason):
+        """This is a comm handler calling `free_keys`"""
+        return self.handle_free_keys(keys, reason)
 
-    def delete_data(self, comm=None, keys=None, report=True):
-        if keys:
-            for key in list(keys):
-                ts = self.tasks.get(key)
-                if ts:
-                    ts.scheduler_holds_ref = False
-                self.log.append((key, "delete"))
-                self.release_key(key, reason="delete data")
+    def handle_free_keys(self, keys, reason):
+        """
+        Stream handler to be called by the scheduler.
 
-            logger.debug("Worker %s -- Deleted %d keys", self.name, len(keys))
+        The given keys are no longer referred to and required by the scheduler.
+        The worker is now allowed to release the key, if applicable.
+
+        This does not guarantee that the memory is released since the worker may
+        still decide to hold on to the data and task since it is required by an
+        upstream dependency.
+        """
+        self.log.append(("free-keys", keys, reason))
+        for key in keys:
+            ts = self.tasks.get(key)
+            if ts:
+                ts.scheduler_holds_ref = False
+            self.release_key(key, report=False, reason=reason)
+
+    def handle_superfluous_data(self, keys=(), reason=None):
+        """Stream handler notifying the worker that it might be holding unreferenced, superfluous data.
+
+        This should not actually happen during ordinary operations and is only
+        intended to correct any erroneous state. An example where this is
+        necessary is if a worker fetches data for a downstream task but that
+        task is released before the data arrives.
+        In this case, the scheduler will notify the worker that it may be
+        holding this unnecessary data, if the worker hasn't released the data itself, already.
+
+        This handler does not guarantee the task nor the data to be actually
+        released but only asks the worker to release the data on a best effort
+        guarantee. This protects from race conditions where the given keys may
+        already have been rescheduled for compute in which case the compute
+        would win and this handler is ignored.
+
+        For stronger guarantees, see handler free_keys
+        """
+        for key in list(keys):
+            ts = self.tasks.get(key)
+            self.log.append((key, "nofity superfluous data", reason))
+            if ts and not ts.scheduler_holds_ref:
+                self.release_key(key, reason=f"delete data: {reason}", report=False)
+
+                logger.debug("Worker %s -- Deleted %d keys", self.name, len(keys))
         return "OK"
 
     async def set_resources(self, **resources):
@@ -1604,10 +1639,23 @@ class Worker(ServerNode):
 
                     # transition from new -> fetch handles adding dependency
                     # to waiting_for_data
+                    discarded_self = False
+                    if self.address in workers and state == "fetch":
+                        discarded_self = True
+                        workers = set(workers)
+                        workers.discard(self.address)
+                        who_has[dependency] = tuple(workers)
+
                     self.transition(dep_ts, state, who_has=workers)
 
                     self.log.append(
-                        (dependency, "new-dep", dep_ts.state, f"requested by {ts.key}")
+                        (
+                            dependency,
+                            "new-dep",
+                            dep_ts.state,
+                            f"requested by {ts.key}",
+                            discarded_self,
+                        )
                     )
 
                 else:
@@ -1656,8 +1704,10 @@ class Worker(ServerNode):
         if start == finish:
             return
         func = self._transitions[start, finish]
+        self.log.append((ts.key, start, finish))
         state = func(ts, **kwargs)
-        self.log.append((ts.key, start, state or finish))
+        if state and finish != state:
+            self.log.append((ts.key, start, finish, state))
         ts.state = state or finish
         if self.validate:
             self.validate_task(ts)
@@ -1682,7 +1732,7 @@ class Worker(ServerNode):
             if self.validate:
                 assert ts.state == "new"
                 assert ts.runspec is None
-                assert who_has
+                # assert who_has
 
             for dependent in ts.dependents:
                 dependent.waiting_for_data.add(ts.key)
@@ -1791,6 +1841,7 @@ class Worker(ServerNode):
             if not ts.who_has:
                 if ts.key not in self._missing_dep_flight:
                     self._missing_dep_flight.add(ts.key)
+                    logger.info("Task %s does not know who has", ts)
                     self.loop.add_callback(self.handle_missing_dep, ts)
             for w in ts.who_has:
                 self.pending_data_per_worker[w].append(ts.key)
@@ -1822,6 +1873,7 @@ class Worker(ServerNode):
                 except KeyError:
                     pass
 
+            self.log.append(("Notifying scheduler about in-memory", ts.key))
             self.batched_stream.send({"op": "add-keys", "keys": [ts.key]})
 
         except Exception as e:
@@ -2064,10 +2116,9 @@ class Worker(ServerNode):
                         else:
                             dependencies_fetch.add(dependency_ts)
 
-                del dependencies
+                del dependencies, dependency_ts
 
                 if dependencies_missing:
-                    logger.info("Can't find dependencies for key %s", key)
                     missing_deps2 = {
                         dep
                         for dep in dependencies_missing
@@ -2075,8 +2126,13 @@ class Worker(ServerNode):
                     }
                     for dep in missing_deps2:
                         self._missing_dep_flight.add(dep.key)
-                    self.loop.add_callback(self.handle_missing_dep, *missing_deps2)
-
+                    if missing_deps2:
+                        logger.info(
+                            "Can't find dependencies %s for key %s",
+                            missing_deps2.copy(),
+                            key,
+                        )
+                        self.loop.add_callback(self.handle_missing_dep, *missing_deps2)
                     dependencies_fetch -= dependencies_missing
 
                 self.log.append(
@@ -2113,6 +2169,7 @@ class Worker(ServerNode):
                     for d in to_gather:
                         dependencies_fetch.discard(self.tasks.get(d))
                         self.transition(self.tasks[d], "flight", worker=worker)
+                    assert not worker == self.address
                     self.loop.add_callback(
                         self.gather_dep,
                         worker=worker,
@@ -2267,7 +2324,9 @@ class Worker(ServerNode):
                     dependency_ts = self.tasks.get(dependency_key)
                     if dependency_ts and dependency_ts.state == "flight":
                         to_gather_keys.add(dependency_key)
-                del to_gather
+                # Keep namespace clean since this func is long and has many
+                # dep*, *ts* variables
+                del to_gather, dependency_key, dependency_ts
 
                 self.log.append(("request-dep", cause.key, worker, to_gather_keys))
                 logger.debug("Request %d keys for task %s", len(to_gather_keys), cause)
@@ -2361,7 +2420,10 @@ class Worker(ServerNode):
                 busy = response.get("status", "") == "busy"
                 data = response.get("data", {})
 
-                assert to_gather_keys == self.in_flight_workers.get(worker)
+                # FIXME: We should not handle keys which were skipped by this coro. to_gather_keys is only a subset
+                assert set(to_gather_keys).issubset(
+                    set(self.in_flight_workers.get(worker))
+                )
                 for d in self.in_flight_workers.pop(worker):
 
                     ts = self.tasks.get(d)
@@ -2376,17 +2438,26 @@ class Worker(ServerNode):
                         self.release_key(
                             d, reason="In-flight task no longer has dependents."
                         )
-                    elif ts.state not in ("ready", "memory"):
-                        self.log.append(("busy?", d, busy))
-                        self.transition(ts, "fetch")
-                    elif not busy and d not in data and ts.dependents:
+                    elif (
+                        not busy
+                        and d not in data
+                        and ts.dependents
+                        and ts.state != "memory"
+                    ):
+                        # FIXME: Is this the correct behaviour in case we do not receive the data?
                         self.log.append(("missing-dep", d))
                         self.batched_stream.send(
                             {"op": "missing-data", "errant_worker": worker, "key": d}
                         )
+                        # TODO: What happens if we transition to fetch but the
+                        # task is in fact missing? and what is happening if it
+                        # is *not* missing?
+                        self.transition(ts, "fetch")
+                    elif ts.state not in ("ready", "memory"):
+                        self.transition(ts, "fetch")
                     else:
-                        raise RuntimeError(
-                            f"Unexpected state for {ts} encountered after gather_dep"
+                        logger.debug(
+                            "Unexpected task state encountered for %s after gather_dep"
                         )
 
                 if self.validate:
@@ -2442,18 +2513,38 @@ class Worker(ServerNode):
             )
             who_has = {k: v for k, v in who_has.items() if v}
             self.update_who_has(who_has)
+            still_missing = set()
             for dep in deps:
                 dep.suspicious_count += 1
 
                 if not who_has.get(dep.key):
+                    logger.info(
+                        "No workers found for %s",
+                        dep.key,
+                    )
                     self.log.append((dep.key, "no workers found", dep.dependents))
-                    self.release_key(dep.key)
+                    self.release_key(dep.key, reason="Handle missing no workers")
+                elif self.address in who_has and dep.state != "memory":
+
+                    still_missing.add(dep)
+                    self.batched_stream.send(
+                        {
+                            "op": "release-worker-data",
+                            "keys": [dep.key],
+                            "worker": self.address,
+                        }
+                    )
                 else:
+                    logger.debug("New workers found for %s", dep.key)
                     self.log.append((dep.key, "new workers found"))
                     for dependent in dep.dependents:
                         if dependent.key in dep.waiting_for_data:
                             self.data_needed.append(dependent.key)
-
+            if still_missing:
+                logger.critical(
+                    "Found self referencing who has response from scheduler. Trying again handle_missing"
+                )
+                await self.handle_missing_dep(*deps)
         except Exception:
             logger.error("Handle missing dep failed, retrying", exc_info=True)
             retries = kwargs.get("retries", 5)
@@ -2484,6 +2575,8 @@ class Worker(ServerNode):
                     continue
 
                 if dep in self.tasks:
+                    if self.address in workers and self.tasks[dep].state != "memory":
+                        workers = set(workers) - {self.address}
                     self.tasks[dep].who_has.update(workers)
 
                     for worker in workers:
@@ -2513,6 +2606,7 @@ class Worker(ServerNode):
             # If task is marked as "constrained" we haven't yet assigned it an
             # `available_resources` to run on, that happens in
             # `transition_constrained_executing`
+            ts.scheduler_holds_ref = False
             self.release_key(ts.key, reason="stolen")
             if self.validate:
                 assert ts.key not in self.tasks
@@ -2525,9 +2619,16 @@ class Worker(ServerNode):
         report: bool = True,
     ):
         try:
+
             if self.validate:
                 assert isinstance(key, str)
             ts = self.tasks.get(key, TaskState(key=key))
+            # If the scheduler holds a reference which is usually the
+            # case when it instructed the task to be computed here or if
+            # data was scattered we must not release it unless the
+            # scheduler allow us to. See also handle_delete_data and
+            if ts and ts.scheduler_holds_ref:
+                return
             logger.debug(
                 "Release key %s",
                 {
@@ -2537,9 +2638,9 @@ class Worker(ServerNode):
                 },
             )
             if cause:
-                self.log.append((key, "release-key", {"cause": cause}))
+                self.log.append((key, "release-key", {"cause": cause}, reason))
             else:
-                self.log.append((key, "release-key"))
+                self.log.append((key, "release-key", reason))
             if key in self.data and not ts.dependents:
                 try:
                     del self.data[key]
@@ -2552,22 +2653,13 @@ class Worker(ServerNode):
             for dependency in ts.dependencies:
                 dependency.dependents.discard(ts)
 
-                if (
-                    not dependency.dependents
-                    and dependency.state
-                    not in (
-                        # don't boot keys that are in flight
-                        # we don't know if they're already queued up for transit
-                        # in a gather_dep callback
-                        "flight",
-                        # The same is true for already executing keys.
-                        "executing",
-                    )
-                    # If the scheduler holds a reference which is usually the
-                    # case when it instructed the task to be computed here or if
-                    # data was scattered we must not release it unless the
-                    # scheduler allow us to. See also handle_delete_data and
-                    and not dependency.scheduler_holds_ref
+                if not dependency.dependents and dependency.state not in (
+                    # don't boot keys that are in flight
+                    # we don't know if they're already queued up for transit
+                    # in a gather_dep callback
+                    "flight",
+                    # The same is true for already executing keys.
+                    "executing",
                 ):
                     self.release_key(dependency.key, reason=f"Dependent {ts} released")
 
@@ -2586,10 +2678,18 @@ class Worker(ServerNode):
                     for resource, quantity in ts.resource_restrictions.items():
                         self.available_resources[resource] += quantity
 
-            # Inform the scheduler of keys which will have gone missing
-            # We are releasing them before they have completed
-            if report and ts.state in PROCESSING:
-                self.batched_stream.send({"op": "release", "key": key, "cause": cause})
+            if report:
+                # Inform the scheduler of keys which will have gone missing
+                # We are releasing them before they have completed
+                if ts.state in PROCESSING:
+                    msg = {"op": "release", "key": key, "cause": cause}
+                else:
+                    msg = {
+                        "op": "release-worker-data",
+                        "keys": [key],
+                        "worker": self.address,
+                    }
+                self.batched_stream.send(msg)
 
             self._notify_plugins("release_key", key, ts.state, cause, reason, report)
             if key in self.tasks and not ts.dependents:
@@ -2938,7 +3038,7 @@ class Worker(ServerNode):
             elif isinstance(result.pop("actual-exception"), Reschedule):
                 self.batched_stream.send({"op": "reschedule", "key": ts.key})
                 self.transition(ts, "rescheduled", report=False)
-                self.release_key(ts.key, report=False)
+                self.release_key(ts.key, report=False, reason="Reschedule")
             else:
                 ts.exception = result["exception"]
                 ts.traceback = result["traceback"]
@@ -3242,11 +3342,14 @@ class Worker(ServerNode):
     def validate_task_flight(self, ts):
         assert ts.key not in self.data
         assert not any(dep.key in self.ready for dep in ts.dependents)
+        assert ts.coming_from
+        assert ts.coming_from in self.in_flight_workers
         assert ts.key in self.in_flight_workers[ts.coming_from]
 
     def validate_task_fetch(self, ts):
         assert ts.runspec is None
         assert ts.key not in self.data
+        assert self.address not in ts.who_has  #!!!!!!!!
         # FIXME This is currently not an invariant since upon comm failure we
         # remove the erroneous worker from all who_has and correct the state
         # upon the next ensure_communicate
@@ -3306,7 +3409,7 @@ class Worker(ServerNode):
                     # dependency can still be in `memory` before GC grabs it...?
                     # Might need better bookkeeping
                     assert dep.state is not None
-                    assert ts in dep.dependents
+                    assert ts in dep.dependents, ts
                 for key in ts.waiting_for_data:
                     ts_wait = self.tasks[key]
                     assert (


### PR DESCRIPTION
I need some feedback because the cluster behaves differently than I would expect and I would like to know for sure what we expect to happen.

The test case constructs a very simple graph consisting of three tasks, F, G and Res where F and G are simple dependencies executed on different workers while Res is task which will fail. I pinned the workers down explicitly to ensure determinism but otherwise this is not relevant.

What happens is that the task errs which is expected. We keep all tasks in memory, still expected. Afterwards, two things happen which surprised me and I would like to know if those are bugs or expected behaviour I misunderstood

1. I release refs to `F` and `G` and would expect them to be _released_, i.e. the memory is freed because `Res` is done and we no longer hold a reference to the dependencies `F` and `G`. Instead, both stay in memory. Is this expected?
2. After I move on, I release refs to `Res` and would expect the cluster to reset, i.e. forget about all tasks. This isn't happening but instead `F` and `G` are released and `Res` stays erred. The tasks are never forgotten.

cc @jrbourbeau 

----

Edit:

While investigating the free error tasks, I found two deadlock situations which were more likely to be triggered in this branch than in others. This increased the scope of this PR