### PR TITLE
Allow the dashboard to run on multiple ports

### DIFF
--- a/distributed/comm/__init__.py
+++ b/distributed/comm/__init__.py
@@ -10,7 +10,7 @@ from .addressing import (
     unparse_host_port,
 )
 from .core import Comm, CommClosedError, connect, listen
-from .utils import get_tcp_server_address
+from .utils import get_tcp_server_address, get_tcp_server_addresses
 
 
 def _register_transports():

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -81,29 +81,37 @@ async def from_frames(frames, deserialize=True, deserializers=None, allow_offloa
     return res
 
 
-def get_tcp_server_address(tcp_server):
+def get_tcp_server_addresses(tcp_server):
     """
-    Get the bound address of a started Tornado TCPServer.
+    Get all bound addresses of a started Tornado TCPServer.
     """
     sockets = list(tcp_server._sockets.values())
     if not sockets:
         raise RuntimeError("TCP Server %r not started yet?" % (tcp_server,))
 
     def _look_for_family(fam):
+        socks = []
         for sock in sockets:
             if sock.family == fam:
-                return sock
-        return None
+                socks.append(sock)
+        return socks
 
     # If listening on both IPv4 and IPv6, prefer IPv4 as defective IPv6
     # is common (e.g. Travis-CI).
-    sock = _look_for_family(socket.AF_INET)
-    if sock is None:
-        sock = _look_for_family(socket.AF_INET6)
-    if sock is None:
+    socks = _look_for_family(socket.AF_INET)
+    if not socks:
+        socks = _look_for_family(socket.AF_INET6)
+    if not socks:
         raise RuntimeError("No Internet socket found on TCPServer??")
 
-    return sock.getsockname()
+    return [sock.getsockname() for sock in socks]
+
+
+def get_tcp_server_address(tcp_server):
+    """
+    Get the first bound address of a started Tornado TCPServer.
+    """
+    return get_tcp_server_addresses(tcp_server)[0]
 
 
 def ensure_concrete_host(host):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1728,6 +1728,18 @@ async def test_dashboard_address():
     assert s.services["dashboard"].port
     await s.close()
 
+    s = await Scheduler(dashboard_address="127.0.0.1:8901,127.0.0.1:8902", port=0)
+    assert s.services["dashboard"].port == 8901
+    await s.close()
+
+    s = await Scheduler(dashboard_address=":8901,:8902", port=0)
+    assert s.services["dashboard"].port == 8901
+    await s.close()
+
+    s = await Scheduler(dashboard_address=[8901, 8902], port=0)
+    assert s.services["dashboard"].port == 8901
+    await s.close()
+
 
 @gen_cluster(client=True)
 async def test_adaptive_target(c, s, a, b):


### PR DESCRIPTION
- [ ] Closes #4782
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
