### PR TITLE
Support for UCX 1.10+

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -476,8 +476,8 @@ def _scrub_ucx_config():
             tls = "tcp,rdmacm"
             tls_priority = "rdmacm"
         else:
-            tls = "tcp,sockcm"
-            tls_priority = "sockcm"
+            tls = "tcp"
+            tls_priority = "tcp"
 
         # CUDA COPY can optionally be used with ucx -- we rely on the user
         # to define when messages will include CUDA objects.  Note:

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -53,12 +53,15 @@ def init_once():
     if ucp is not None:
         return
 
+    # remove/process dask.ucx flags for valid ucx options
+    ucx_config = _scrub_ucx_config()
+    if "TLS" in ucx_config and "cuda_copy" in ucx_config["TLS"]:
+        import numba.cuda
+        numba.cuda.current_context()
+
     import ucp as _ucp
 
     ucp = _ucp
-
-    # remove/process dask.ucx flags for valid ucx options
-    ucx_config = _scrub_ucx_config()
 
     ucp.init(options=ucx_config, env_takes_precedence=True)
 

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -473,7 +473,7 @@ def _scrub_ucx_config():
         ]
     ):
         if dask.config.get("ucx.rdmacm"):
-            tls = "tcp,rdmacm"
+            tls = "tcp"
             tls_priority = "rdmacm"
         else:
             tls = "tcp"

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -56,7 +56,11 @@ def init_once():
     # remove/process dask.ucx flags for valid ucx options
     ucx_config = _scrub_ucx_config()
     if "TLS" in ucx_config and "cuda_copy" in ucx_config["TLS"]:
-        import numba.cuda
+        try:
+            import numba.cuda
+        except ImportError:
+            raise ImportError("CUDA support with UCX requires Numba for context management")
+
         numba.cuda.current_context()
 
     import ucp as _ucp

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -392,7 +392,12 @@ class UCXListener(Listener):
                 await self.comm_handler(ucx)
 
         init_once()
-        self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
+        try:
+            self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
+        except ucp.exceptions.UCXError as e:
+            print("Error %s, retrying" % str(e))
+            self.ip, self._input_port = parse_host_port(self.ip, default_port=0)
+            self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
 
     def stop(self):
         self.ucp_server = None

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -466,7 +466,9 @@ def _scrub_ucx_config():
     # 2) explicitly defined UCX configuration flags
 
     # import does not initialize ucp -- this will occur outside this function
-    from ucp import get_config
+    from ucp import get_config, get_ucx_version
+
+    ucx_110 = get_ucx_version() >= (1, 10, 0)
 
     options = {}
 
@@ -481,11 +483,11 @@ def _scrub_ucx_config():
         ]
     ):
         if dask.config.get("ucx.rdmacm"):
-            tls = "tcp"
+            tls = "tcp" if ucx_110 else "tcp,rdmacm"
             tls_priority = "rdmacm"
         else:
-            tls = "tcp"
-            tls_priority = "tcp"
+            tls = "tcp" if ucx_110 else "tcp,sockcm"
+            tls_priority = "tcp" if ucx_110 else "sockcm"
 
         # CUDA COPY can optionally be used with ucx -- we rely on the user
         # to define when messages will include CUDA objects.  Note:

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -59,7 +59,9 @@ def init_once():
         try:
             import numba.cuda
         except ImportError:
-            raise ImportError("CUDA support with UCX requires Numba for context management")
+            raise ImportError(
+                "CUDA support with UCX requires Numba for context management"
+            )
 
         numba.cuda.current_context()
 
@@ -396,12 +398,7 @@ class UCXListener(Listener):
                 await self.comm_handler(ucx)
 
         init_once()
-        try:
-            self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
-        except ucp.exceptions.UCXError as e:
-            print("Error %s, retrying" % str(e))
-            self.ip, self._input_port = parse_host_port(self.ip, default_port=0)
-            self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
+        self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
 
     def stop(self):
         self.ucp_server = None

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -55,6 +55,10 @@ def init_once():
 
     # remove/process dask.ucx flags for valid ucx options
     ucx_config = _scrub_ucx_config()
+
+    # We ensure the CUDA context is created before initializing UCX. This can't
+    # be safely handled externally because communications in Dask start before
+    # preload scripts run.
     if "TLS" in ucx_config and "cuda_copy" in ucx_config["TLS"]:
         try:
             import numba.cuda


### PR DESCRIPTION
Select correct transports for UCX 1.10+ and ensure the CUDA context is created before initializing UCX when support for that is requested.