### PR TITLE
Remove passing of kwargs to super in Server

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -167,6 +167,10 @@ class Server:
         self.io_loop = io_loop or IOLoop.current()
         self.loop = self.io_loop
 
+        if kwargs:
+            for key in kwargs:
+                raise NameError(f"{self.__class__.__name__} has no such option {key}.")
+
         if not hasattr(self.io_loop, "profile"):
             ref = weakref.ref(self.io_loop)
 
@@ -238,7 +242,7 @@ class Server:
 
         self.__stopped = False
 
-        super().__init__(**kwargs)
+        super().__init__()
 
     @property
     def status(self):


### PR DESCRIPTION
- [x] Closes #4788
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`

The `super()` of `distributed.core.Server` is `object` which doesn't take any kwargs. So if there are any kwargs left over in `Server` it raises an unhelpful error.

This PR raises more helpful exceptions, but we may want to consider just removing  the `**kwargs` from the `Server.__init__` all together.