### PR TITLE
Remove `release_dep` from `WorkerPlugin` API

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3994,7 +3994,7 @@ class Client:
         that connects in the future.
 
         The plugin may include methods ``setup``, ``teardown``, ``transition``,
-        ``release_key``, and ``release_dep``.  See the
+        and ``release_key``.  See the
         ``dask.distributed.WorkerPlugin`` class or the examples below for the
         interface and docstrings.  It must be serializable with the pickle or
         cloudpickle modules.
@@ -4030,8 +4030,6 @@ class Client:
         ...     def transition(self, key: str, start: str, finish: str, **kwargs):
         ...         pass
         ...     def release_key(self, key: str, state: str, cause: Optional[str], reason: None, report: bool):
-        ...         pass
-        ...     def release_dep(self, dep: str, state: str, report: bool):
         ...         pass
 
         >>> plugin = MyPlugin(1, 2, 3)
@@ -4096,8 +4094,6 @@ class Client:
         ...     def transition(self, key: str, start: str, finish: str, **kwargs):
         ...         pass
         ...     def release_key(self, key: str, state: str, cause: Optional[str], reason: None, report: bool):
-        ...         pass
-        ...     def release_dep(self, dep: str, state: str, report: bool):
         ...         pass
 
         >>> plugin = MyPlugin(1, 2, 3)

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -174,20 +174,6 @@ class WorkerPlugin:
             Whether the worker should report the released task to the scheduler.
         """
 
-    def release_dep(self, dep, state, report):
-        """
-        Called when the worker releases a dependency.
-
-        Parameters
-        ----------
-        dep : string
-        state : string
-            State of the released dependency.
-            One of waiting, flight, memory.
-        report : bool
-            Whether the worker should report the released dependency to the scheduler.
-        """
-
 
 def _get_worker_plugin_name(plugin) -> str:
     """Returns the worker plugin name. If plugin has no name attribute

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -37,9 +37,6 @@ class MyPlugin(WorkerPlugin):
     def release_key(self, key, state, cause, reason, report):
         self.observed_notifications.append({"key": key, "state": state})
 
-    def release_dep(self, dep, state, report):
-        self.observed_notifications.append({"dep": dep, "state": state})
-
 
 @gen_cluster(client=True, nthreads=[])
 async def test_create_with_client(c, s):
@@ -164,7 +161,7 @@ async def test_superseding_task_transitions_called(c, s, w):
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)
-async def test_release_dep_called(c, s, w):
+async def test_dependent_tasks(c, s, w):
     dsk = {"dep": 1, "task": (inc, "dep")}
 
     expected_notifications = [


### PR DESCRIPTION
I noticed our `WorkerPlugin` docs still list `release_dep` as one of the available methods users can define. However after https://github.com/dask/distributed/pull/4107 we no longer differentiate between tasks and dependencies. This PR removes `release_dep` from the `WorkerPlugin` API as it's not longer being called today. 

cc @gforsyth 