### PR TITLE
[WIP] Add minimum dependencies CI build

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -41,12 +41,9 @@ jobs:
         shell: bash -l {0}
         env:
           PYTHONFAULTHANDLER: 1
+          # FIXME ipv6-related failures on Ubuntu github actions CI
+          # https://github.com/dask/distributed/issues/4514
+          DISABLE_IPV6: 1
         run: |
-          if [[ "${{ matrix.os }}" = "ubuntu-latest" ]]; then
-              # FIXME ipv6-related failures on Ubuntu github actions CI
-              # https://github.com/dask/distributed/issues/4514
-              export DISABLE_IPV6=1
-          fi
-
           source continuous_integration/scripts/set_ulimit.sh
           pytest distributed -m "not avoid_ci" --runslow

--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -18,6 +18,7 @@ jobs:
           use-mamba: true
           channels: conda-forge,defaults
           channel-priority: true
+          python-version: 3.7
           environment-file: continuous_integration/environment-mindeps.yaml
           activate-environment: dask-distributed
           auto-activate-base: false

--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -1,0 +1,47 @@
+name: Additional
+
+on: [push, pull_request]
+
+jobs:
+  mindeps:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Setup Conda Environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          channels: conda-forge,defaults
+          channel-priority: true
+          environment-file: continuous_integration/environment-mindeps.yaml
+          activate-environment: dask-distributed
+          auto-activate-base: false
+
+      - name: mamba list
+        shell: bash -l {0}
+        run: mamba list
+
+      - name: mamba env export
+        shell: bash -l {0}
+        run: |
+          echo -e "--\n--Conda Environment (re-create this with \`mamba env create --name <name> -f <output_file>\`)\n--"
+          mamba env export | grep -E -v '^prefix:.*$'
+
+      - name: Test
+        shell: bash -l {0}
+        env:
+          PYTHONFAULTHANDLER: 1
+        run: |
+          if [[ "${{ matrix.os }}" = "ubuntu-latest" ]]; then
+              # FIXME ipv6-related failures on Ubuntu github actions CI
+              # https://github.com/dask/distributed/issues/4514
+              export DISABLE_IPV6=1
+          fi
+
+          source continuous_integration/scripts/set_ulimit.sh
+          pytest distributed -m "not avoid_ci" --runslow

--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -23,6 +23,10 @@ jobs:
           activate-environment: dask-distributed
           auto-activate-base: false
 
+      - name: Install
+        shell: bash -l {0}
+        run: python -m pip install --no-deps -e .
+
       - name: mamba list
         shell: bash -l {0}
         run: mamba list

--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -16,3 +16,10 @@ dependencies:
   - zict=0.1.3
   - pyyaml
   - setuptools
+  # test dependencies
+  - pytest
+  - pytest-asyncio<0.14.0
+  - pytest-faulthandler
+  - pytest-repeat
+  - pytest-rerunfailures
+  - pytest-timeout

--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7
   - click=6.7
   - cloudpickle=1.5.0
-  - dask=2021.03.0
+  - dask=2021.04.1
   - msgpack-python=0.6.0
   - psutil=5.4.7
   - sortedcontainers=2.0.4

--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -8,7 +8,7 @@ dependencies:
   - cloudpickle=1.5.0
   - dask=2021.03.0
   - msgpack-python=0.6.0
-  - psutil=5.0
+  - psutil=5.4.7
   - sortedcontainers=2.0.4
   - tblib=1.6.0
   - toolz=0.8.2

--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -11,7 +11,7 @@ dependencies:
   - psutil=5.4.7
   - sortedcontainers=2.0.4
   - tblib=1.6.0
-  - toolz=0.8.2
+  - toolz=0.10.0
   - tornado=5
   - zict=0.1.3
   - pyyaml

--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -7,9 +7,9 @@ dependencies:
   - click=6.6
   - cloudpickle=1.5.0
   - dask=2021.03.0
-  - msgpack=0.6.0
+  - msgpack-python=0.6.0
   - psutil=5.0
-  - sortedcontainers=2.0.2
+  - sortedcontainers=2.0.4
   - tblib=1.6.0
   - toolz=0.8.2
   - tornado=5

--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -1,0 +1,18 @@
+name: dask-distributed
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - click=6.6
+  - cloudpickle=1.5.0
+  - dask=2021.03.0
+  - msgpack=0.6.0
+  - psutil=5.0
+  - sortedcontainers=2.0.2
+  - tblib=1.6.0
+  - toolz=0.8.2
+  - tornado=5
+  - zict=0.1.3
+  - pyyaml
+  - setuptools

--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.7
-  - click=6.6
+  - click=6.7
   - cloudpickle=1.5.0
   - dask=2021.03.0
   - msgpack-python=0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-click >= 6.6
+click >= 6.7
 cloudpickle >= 1.5.0
-dask >= 2021.03.0
+dask >= 2021.04.1
 msgpack >= 0.6.0
-psutil >= 5.0
-sortedcontainers !=2.0.0, !=2.0.1
+psutil >= 5.4.7
+sortedcontainers >= 2.0.4
 tblib >= 1.6.0
-toolz >= 0.8.2
+toolz >= 0.10.0
 tornado >= 5;python_version<'3.8'
 tornado >= 6.0.3;python_version>='3.8'
 zict >= 0.1.3


### PR DESCRIPTION
This PR adds a new CI build which runs the test suite against the minimum version of `distributed`s dependencies (similar to what we already do over in `dask/dask`). This will allow us to test, to the best of our ability, that our specified minimum versions are valid.