### PR TITLE
Ensure repr and eq for cluster always works

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -422,7 +422,9 @@ class Cluster:
         await self.close()
 
     @property
-    def scheduler_address(self):
+    def scheduler_address(self) -> str:
+        if not self.scheduler_comm:
+            return "<Not Connected>"
         return self.scheduler_comm.address
 
     @property
@@ -458,7 +460,7 @@ class Cluster:
         return {d["name"] for d in self.scheduler_info["workers"].values()}
 
     def __eq__(self, other):
-        return self.name == other.name
+        return type(other) == type(self) and self.name == other.name
 
     def __hash__(self):
         return id(self)

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -1,6 +1,7 @@
 import pytest
 
 from distributed.deploy.cluster import Cluster
+from distributed.utils_test import cleanup  # noqa: F401
 
 
 @pytest.mark.asyncio

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -4,7 +4,7 @@ from distributed.deploy.cluster import Cluster
 
 
 @pytest.mark.asyncio
-async def test_eq():
+async def test_eq(cleanup):
     clusterA = Cluster(asynchronous=True, name="A")
     clusterA2 = Cluster(asynchronous=True, name="A2")
     clusterB = Cluster(asynchronous=True, name="B")
@@ -19,7 +19,7 @@ async def test_eq():
 
 
 @pytest.mark.asyncio
-async def test_repr():
+async def test_repr(cleanup):
     cluster = Cluster(asynchronous=True, name="A")
     assert cluster.scheduler_address == "<Not Connected>"
     res = repr(cluster)

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -1,0 +1,27 @@
+import pytest
+
+from distributed.deploy.cluster import Cluster
+
+
+@pytest.mark.asyncio
+async def test_eq():
+    clusterA = Cluster(asynchronous=True, name="A")
+    clusterA2 = Cluster(asynchronous=True, name="A2")
+    clusterB = Cluster(asynchronous=True, name="B")
+    assert clusterA != "A"
+    assert not (clusterA == "A")
+    assert clusterA == clusterA
+    assert not (clusterA != clusterA)
+    assert clusterA != clusterA2
+    assert not (clusterA == clusterA2)
+    assert clusterA != clusterB
+    assert not (clusterA == clusterB)
+
+
+@pytest.mark.asyncio
+async def test_repr():
+    cluster = Cluster(asynchronous=True, name="A")
+    assert cluster.scheduler_address == "<Not Connected>"
+    res = repr(cluster)
+    expected = "Cluster(A, '<Not Connected>', workers=0, threads=0, memory=0 B)"
+    assert res == expected

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -73,7 +73,6 @@ from distributed.utils_test import (  # noqa: F401
     asyncinc,
     b,
     captured_logger,
-    check_dangling_tasks,
     cleanup,
 )
 from distributed.utils_test import client as c  # noqa: F401
@@ -6609,28 +6608,26 @@ async def test_workers_collection_restriction(c, s, a, b):
 async def test_get_client_functions_spawn_clusters(c, s, a):
     # see gh4565
 
-    with check_dangling_tasks():
+    scheduler_addr = c.scheduler.address
 
-        scheduler_addr = c.scheduler.address
+    def f(x):
+        ref = None
+        with LocalCluster(
+            n_workers=1,
+            processes=False,
+            dashboard_address=False,
+            worker_dashboard_address=False,
+        ) as cluster2:
+            with Client(cluster2) as c1:
+                c2 = get_client()
 
-        def f(x):
-            ref = None
-            with LocalCluster(
-                n_workers=1,
-                processes=False,
-                dashboard_address=False,
-                worker_dashboard_address=False,
-            ) as cluster2:
-                with Client(cluster2) as c1:
-                    c2 = get_client()
+                c1_scheduler = c1.scheduler.address
+                c2_scheduler = c2.scheduler.address
+                assert c1_scheduler != c2_scheduler
+                assert c2_scheduler == scheduler_addr
 
-                    c1_scheduler = c1.scheduler.address
-                    c2_scheduler = c2.scheduler.address
-                    assert c1_scheduler != c2_scheduler
-                    assert c2_scheduler == scheduler_addr
+    await c.gather(c.map(f, range(2)))
+    await a.close()
 
-        await c.gather(c.map(f, range(2)))
-        await a.close()
-
-        c_default = default_client()
-        assert c is c_default
+    c_default = default_client()
+    assert c is c_default

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -73,6 +73,7 @@ from distributed.utils_test import (  # noqa: F401
     asyncinc,
     b,
     captured_logger,
+    check_dangling_tasks,
     cleanup,
 )
 from distributed.utils_test import client as c  # noqa: F401
@@ -6605,23 +6606,31 @@ async def test_workers_collection_restriction(c, s, a, b):
 
 
 @pytest.mark.slow
-@gen_cluster(client=True)
-async def test_get_client_functions_spawn_clusters(c, s, a, b):
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 0)])
+async def test_get_client_functions_spawn_clusters(c, s, a):
     # see gh4565
+
+    # FIXME: There are dangling tasks, see
+    # https://github.com/dask/distributed/pull/3921
+    # with check_dangling_tasks():
+
     scheduler_addr = c.scheduler.address
 
     def f(x):
+        ref = None
         with LocalCluster(
             n_workers=1, processes=False, dashboard_address=False
         ) as cluster2:
             with Client(cluster2) as c1:
-                nonlocal scheduler_addr
                 c2 = get_client()
-                # Sometimes the default is closed and we get None for the
-                # scheduler attribute. Prefer robust test case over rigor
-                if c2.status != "closed":
-                    assert c1.scheduler.address != c2.scheduler.address
-                    assert c2.scheduler.address == scheduler_addr
-                    c2.close()
 
-    await c.gather(c.map(f, range(10)))
+                c1_scheduler = c1.scheduler.address
+                c2_scheduler = c2.scheduler.address
+                assert c1_scheduler != c2_scheduler
+                assert c2_scheduler == scheduler_addr
+
+    await c.gather(c.map(f, range(2)))
+    # FIXME: There are still worker clients around although they should be
+    # closed, see https://github.com/dask/distributed/pull/3921
+    # c2 = default_client()
+    # assert c is c2

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -12,6 +12,7 @@ from distributed.core import rpc
 from distributed.metrics import time
 from distributed.utils import get_ip
 from distributed.utils_test import (  # noqa: F401
+    check_dangling_tasks,
     cleanup,
     cluster,
     gen_cluster,
@@ -230,3 +231,47 @@ def test_tls_cluster(tls_client):
 async def test_tls_scheduler(security, cleanup):
     async with Scheduler(security=security, host="localhost") as s:
         assert s.address.startswith("tls")
+
+
+@pytest.mark.asyncio()
+async def test_check_dangling_tasks(event_loop):
+    # Note: event loop fixture is managed by pytest-asyncio
+
+    from tornado.ioloop import IOLoop
+
+    assert not isinstance(event_loop, IOLoop)
+    tornado_loop = IOLoop.current()
+    assert event_loop is tornado_loop.asyncio_loop
+
+    start = asyncio.all_tasks()
+
+    async def foo():
+        await asyncio.sleep(100000)
+
+    for loop_ in [None, event_loop, tornado_loop]:
+        # Verify that our ctx manager catches all tasks created by plain asyncio
+        with pytest.raises(AssertionError):
+            with check_dangling_tasks(loop_):
+                task = event_loop.create_task(foo())
+
+        task.cancel()
+
+        before = asyncio.all_tasks()
+        # Tornado has slightly different semantics but also uses the asyncio
+        # event loop beneath. Ensure this is also caught
+        with pytest.raises(AssertionError):
+            with check_dangling_tasks(loop_):
+                tornado_loop.add_callback(foo)
+                await asyncio.sleep(0)
+        # We cannot cancel tornado callbacks but should close tasks to avoid
+        # warnings (i.e. this is what this test should cover in the first place)
+        after = asyncio.all_tasks()
+        assert len(after - before) == 1
+        for task in after - before:
+            task.cancel()
+        await asyncio.sleep(0)
+        after = asyncio.all_tasks()
+        assert len(after - before) == 0
+
+    end = asyncio.all_tasks()
+    assert not end - start

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1958,7 +1958,7 @@ async def test_worker_client_closes_if_created_on_worker_one_worker(s, a):
             default_client()
 
 
-@gen_cluster(timeout=3600)
+@gen_cluster()
 async def test_worker_client_closes_if_created_on_worker_last_worker_alive(s, a, b):
     async with Client(s.address, set_as_default=False, asynchronous=True) as c:
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1905,6 +1905,7 @@ async def test_worker_client_uses_default_no_close(c, s, a):
     If a default client is available in the process, the worker will pick this
     one and will not close it if it is closed
     """
+    assert not Worker._initialized_clients
     assert default_client() is c
     existing_client = c.id
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1545,7 +1545,7 @@ def check_dangling_tasks(loop=None):
     end = asyncio.all_tasks()
     end_loop = asyncio.all_tasks(asyncio_loop)
     assert end == end_loop
-    assert end == start
+    assert end.issubset(start), end - start
 
 
 @contextmanager

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1528,6 +1528,27 @@ def check_instances():
 
 
 @contextmanager
+def check_dangling_tasks(loop=None):
+    from tornado.platform.asyncio import BaseAsyncIOLoop
+
+    if loop is None:
+        asyncio_loop = asyncio.get_running_loop()
+    elif isinstance(loop, BaseAsyncIOLoop):
+        asyncio_loop = loop.asyncio_loop
+    else:
+        asyncio_loop = loop
+    start = asyncio.all_tasks()
+    start_loop = asyncio.all_tasks(asyncio_loop)
+    # If this is not true we're on the wrong loop
+    assert start == start_loop
+    yield
+    end = asyncio.all_tasks()
+    end_loop = asyncio.all_tasks(asyncio_loop)
+    assert end == end_loop
+    assert end == start
+
+
+@contextmanager
 def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
     with check_thread_leak() if threads else nullcontext():
         with pristine_loop() as loop:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1528,27 +1528,6 @@ def check_instances():
 
 
 @contextmanager
-def check_dangling_tasks(loop=None):
-    from tornado.platform.asyncio import BaseAsyncIOLoop
-
-    if loop is None:
-        asyncio_loop = asyncio.get_running_loop()
-    elif isinstance(loop, BaseAsyncIOLoop):
-        asyncio_loop = loop.asyncio_loop
-    else:
-        asyncio_loop = loop
-    start = asyncio.all_tasks()
-    start_loop = asyncio.all_tasks(asyncio_loop)
-    # If this is not true we're on the wrong loop
-    assert start == start_loop
-    yield
-    end = asyncio.all_tasks()
-    end_loop = asyncio.all_tasks(asyncio_loop)
-    assert end == end_loop
-    assert end.issubset(start), end - start
-
-
-@contextmanager
 def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
     with check_thread_leak() if threads else nullcontext():
         with pristine_loop() as loop:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1479,6 +1479,7 @@ def check_instances():
     Worker._instances.clear()
     Scheduler._instances.clear()
     SpecCluster._instances.clear()
+    Worker._initialized_clients.clear()
     # assert all(n.status == "closed" for n in Nanny._instances), {
     #     n: n.status for n in Nanny._instances
     # }
@@ -1501,6 +1502,12 @@ def check_instances():
             if w.status == Status.running:
                 w.loop.add_callback(w.close)
     Worker._instances.clear()
+
+    start = time()
+    while any(c.status != "closed" for c in Worker._initialized_clients):
+        sleep(0.1)
+        assert time() < start + 10
+    Worker._initialized_clients.clear()
 
     for i in range(5):
         if all(c.closed() for c in Comm._instances):


### PR DESCRIPTION
If the scheduler_comm was None, e.g. because the cluster is not connected, yet, there would be an attribute error during `repr`
Also, the equality should verify types since this otherwise also raises unclear exceptions

Closes #4565

I would consider the spawning of a localcluster within a task as highly unorthodox but this has been reported in #4565 and it appears to work. Anyhow, this triggered a weird edge case in the worker connected to the scheduler address and equality which is fixed in this