### PR TITLE
Let servers close faster if there are no active handlers

### DIFF
--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -886,3 +886,70 @@ async def test_close_properly():
 async def test_server_redundant_kwarg():
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         await Server({}, typo_kwarg="foo")
+
+
+async def test_server_comms_mark_active_handlers():
+    """Whether handlers are active can be read off of the self._comms values.
+    ensure this is properly reflected and released. The sentinel for
+    "open comm but no active handler" is `None`
+    """
+
+    async def long_handler(comm):
+        await asyncio.sleep(0.2)
+        return "done"
+
+    server = await Server({"wait": long_handler})
+    await server.listen(0)
+    assert server._comms == {}
+
+    comm = await connect(server.address)
+    await comm.write({"op": "wait"})
+    while not server._comms:
+        await asyncio.sleep(0.05)
+    assert set(server._comms.values()) == {"wait"}
+    assert await comm.read() == "done"
+    assert set(server._comms.values()) == {None}
+    await comm.close()
+    while server._comms:
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_close_fast_without_active_handlers():
+    async def very_fast(comm):
+        return "done"
+
+    server = await Server({"do_stuff": very_fast})
+    await server.listen(0)
+    assert server._comms == {}
+
+    comm = await connect(server.address)
+    await comm.write({"op": "do_stuff"})
+    while not server._comms:
+        await asyncio.sleep(0.05)
+    fut = server.close()
+
+    await asyncio.wait_for(fut, 0.1)
+
+
+@pytest.mark.asyncio
+async def test_close_grace_period_for_handlers():
+    async def long_handler(comm, delay=10):
+        await asyncio.sleep(delay)
+        return "done"
+
+    server = await Server({"wait": long_handler})
+    await server.listen(0)
+    assert server._comms == {}
+
+    comm = await connect(server.address)
+    await comm.write({"op": "wait"})
+    while not server._comms:
+        await asyncio.sleep(0.05)
+    fut = server.close()
+    # since the handler is running for a while, the close will not immediately
+    # go through. We'll give the comm about a second to close itself
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(fut, 0.5)
+    await comm.close()
+    await server.close()


### PR DESCRIPTION
This is another marginal fix for test runtimes.

we have a hard coded grace period allowing incoming connections to finish on their own in case we want to close before we pull out the hammer.
A few things are a bit off here
1. If there is a remote Connectionpool, these comms will always remain open and they will not close themselves unless the remote closes as well. Therefore, this will *always* wait no matter what
2. If there are a bunch of comms just waiting for the remote to do stuff, there is frankly no big point in waiting. There is the edge case where we might be just in the process of reading an incoming stream but chances are very high that we will need to close something like that off anyhow
3. The only valid reason I can see for this is that if there are active handlers still running (if that is even sensible) we'll give them a chance.

This hard coded wait period causes effectively every single `await Worker.close()` to block for a second if the worker has had any incoming connections before. For some tests this makes the difference between subsecond and multi second runtime.

I think we should kick this waiting time out completely but either way, this give the entire process tests and a bit of a bigger purpose than before.