### PR TITLE
Fix warning for attribute error when deleting a client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1419,7 +1419,7 @@ class Client:
         if timeout == no_default:
             timeout = self._timeout * 2
         # XXX handling of self.status here is not thread-safe
-        if self.status == "closed":
+        if self.status in ["closed", "newly-created"]:
             if self.asynchronous:
                 future = asyncio.Future()
                 future.set_result(None)


### PR DESCRIPTION
When running the tests, pytest usually prints a warning about an attribute error during `__del__` of Client while garbage collecting. This is since we're raising exceptions in the clients `__init__` and the `__del__` is then called on a partially initialised object. Since this is depending on the GC, I do not know how to reliably test this (other than converting all warnings to an error)

----

What I wanted to share is how I found this because this is fun and was surprisingly easy using [tracemalloc](https://docs.python.org/3/library/tracemalloc.html). At least it was surprising to me since I was using it for the first time :)

I put the `tracemalloc.start()` in the test files and wrapped the `close` in `__del__` with a try except block and a breakpoint. This seemed to fail reliably in the test `test_client.py::test_repr` but since its a GC issue the culprit is usually somewhere else.


```python
> /Users/fjetter/workspace/distributed-main/distributed/client.py(1215)__del__()
   1214             breakpoint()
-> 1215             raise
   1216

ipdb> import tracemalloc
ipdb> tracemalloc.get_object_traceback(self)
<Traceback (<Frame filename='/Users/fjetter/workspace/distributed-main/distributed/tests/test_client.py' lineno=1897>,)>
```

The line number points exactly to where the client object was created which was in another test case then where the exception occurred.

https://github.com/dask/distributed/blob/5e150aa6a3bd7decd38193a3d754497f8914d83c/distributed/tests/test_client.py#L1895-L1901


If somebody has an idea about how to test this, I'm all ears but otherwise this is maybe something we can justify without test?