### PR TITLE
Add support for `click` 8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,12 @@ jobs:
               python -c "from distributed.scheduler import COMPILED; assert not COMPILED"
           fi
 
+        # TODO: Try click=8 on one CI build. Remove before merging.
+      - name: Install click
+        shell: bash -l {0}
+        if: ${{ matrix.python-version != '3.7' }}
+        run: python -m pip install click==8
+
       - name: mamba list
         shell: bash -l {0}
         run: mamba list

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,12 +60,6 @@ jobs:
               python -c "from distributed.scheduler import COMPILED; assert not COMPILED"
           fi
 
-        # TODO: Try click=8 on one CI build. Remove before merging.
-      - name: Install click
-        shell: bash -l {0}
-        if: ${{ matrix.python-version != '3.7' }}
-        run: python -m pip install click==8
-
       - name: mamba list
         shell: bash -l {0}
         run: mamba list

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -103,7 +103,6 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     type=str,
     multiple=True,
     is_eager=True,
-    default="",
     help="Module that should be loaded by the scheduler process  "
     'like "foo.bar" or "/path/to/foo.py".',
 )

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -1,4 +1,9 @@
+from distutils.version import LooseVersion
+
+import click
 from tornado.ioloop import IOLoop
+
+CLICK_VERSION = LooseVersion(click.__version__)
 
 py3_err_msg = """
 Warning: Your terminal does not set locales.
@@ -24,12 +29,19 @@ def check_python_3():
     # https://github.com/pallets/click/issues/448#issuecomment-246029304
     import click.core
 
-    click.core._verify_python3_env = lambda: None
+    # TODO: Remove use of internal click functions
+    if CLICK_VERSION < "8.0.0":
+        click.core._verify_python3_env = lambda: None
+    else:
+        click.core._verify_python_env = lambda: None
 
     try:
         from click import _unicodefun
 
-        _unicodefun._verify_python3_env()
+        if CLICK_VERSION < "8.0.0":
+            _unicodefun._verify_python3_env()
+        else:
+            _unicodefun._verify_python_env()
     except (TypeError, RuntimeError) as e:
         import click
 


### PR DESCRIPTION
This PR adds some compatibility code needed for the recent `click=8` release. Specifically:

- The name of internal `click` function we were using changed
- What constituents a valid default value when using `multiple=True` changed. Though, we should be able to just drop the existing default we're using and maintain the current behavior. 

cc @quasiben 

Closes https://github.com/dask/distributed/issues/4809