### PR TITLE
Locally rerun successfully completed futures

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -744,9 +744,9 @@ class Client:
         self.start(timeout=timeout)
         Client._instances.add(self)
 
-        from distributed.recreate_exceptions import ReplayExceptionClient
+        from distributed.recreate_tasks import ReplayTaskClient
 
-        ReplayExceptionClient(self)
+        ReplayTaskClient(self)
 
     @contextmanager
     def as_current(self):

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -184,6 +184,7 @@ class AdaptiveCore:
         if self._adapting:  # Semaphore to avoid overlapping adapt calls
             return
         self._adapting = True
+        status = None
 
         try:
 

--- a/distributed/deploy/tests/test_adaptive_core.py
+++ b/distributed/deploy/tests/test_adaptive_core.py
@@ -4,6 +4,7 @@ import pytest
 
 from distributed.deploy.adaptive_core import AdaptiveCore
 from distributed.metrics import time
+from distributed.utils_test import captured_logger
 
 
 class MyAdaptive(AdaptiveCore):
@@ -89,3 +90,24 @@ async def test_interval():
     adapt._target = 10
     await asyncio.sleep(0.020)
     assert len(adapt.plan) == 1  # last value from before, unchanged
+
+
+@pytest.mark.asyncio
+async def test_adapt_oserror():
+    class BadAdaptive(MyAdaptive):
+        """AdaptiveCore subclass which raises an OSError when attempting to adapt
+
+        We use this to check that error handling works properly
+        """
+
+        def safe_target(self):
+            raise OSError()
+
+    with captured_logger("distributed.deploy.adaptive_core") as log:
+        adapt = BadAdaptive(minimum=1, maximum=4)
+        await adapt.adapt()
+    text = log.getvalue()
+    assert "Adaptive stopping due to error" in text
+    assert "Adaptive stop" in text
+    assert not adapt._adapting
+    assert not adapt.periodic_callback

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -58,7 +58,7 @@ from .proctitle import setproctitle
 from .publish import PublishExtension
 from .pubsub import PubSubSchedulerExtension
 from .queues import QueueExtension
-from .recreate_exceptions import ReplayExceptionScheduler
+from .recreate_tasks import ReplayTaskScheduler
 from .security import Security
 from .semaphore import SemaphoreExtension
 from .stealing import WorkStealing
@@ -173,7 +173,7 @@ DEFAULT_EXTENSIONS = [
     LockExtension,
     MultiLockExtension,
     PublishExtension,
-    ReplayExceptionScheduler,
+    ReplayTaskScheduler,
     QueueExtension,
     VariableExtension,
     PubSubSchedulerExtension,

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4591,36 +4591,6 @@ async def test_dont_clear_waiting_data(c, s, a, b):
 
 
 @gen_cluster(client=True)
-async def test_get_future_error_simple(c, s, a, b):
-    f = c.submit(div, 1, 0)
-    await wait(f)
-    assert f.status == "error"
-
-    function, args, kwargs, deps = await c._get_futures_error(f)
-    # args contains only solid values, not keys
-    assert function.__name__ == "div"
-    with pytest.raises(ZeroDivisionError):
-        function(*args, **kwargs)
-
-
-@gen_cluster(client=True)
-async def test_get_futures_error(c, s, a, b):
-    x0 = delayed(dec)(2, dask_key_name="x0")
-    y0 = delayed(dec)(1, dask_key_name="y0")
-    x = delayed(div)(1, x0, dask_key_name="x")
-    y = delayed(div)(1, y0, dask_key_name="y")
-    tot = delayed(sum)(x, y, dask_key_name="tot")
-
-    f = c.compute(tot)
-    await wait(f)
-    assert f.status == "error"
-
-    function, args, kwargs, deps = await c._get_futures_error(f)
-    assert function.__name__ == "div"
-    assert args == (1, y0.key)
-
-
-@gen_cluster(client=True)
 async def test_recreate_error_delayed(c, s, a, b):
     x0 = delayed(dec)(2)
     y0 = delayed(dec)(1)
@@ -4632,7 +4602,8 @@ async def test_recreate_error_delayed(c, s, a, b):
 
     assert f.status == "pending"
 
-    function, args, kwargs = await c._recreate_error_locally(f)
+    error_f = await c._get_errored_future(f)
+    function, args, kwargs = await c._get_components_from_future(error_f)
     assert f.status == "error"
     assert function.__name__ == "div"
     assert args == (1, 0)
@@ -4651,7 +4622,8 @@ async def test_recreate_error_futures(c, s, a, b):
 
     assert f.status == "pending"
 
-    function, args, kwargs = await c._recreate_error_locally(f)
+    error_f = await c._get_errored_future(f)
+    function, args, kwargs = await c._get_components_from_future(error_f)
     assert f.status == "error"
     assert function.__name__ == "div"
     assert args == (1, 0)
@@ -4666,7 +4638,8 @@ async def test_recreate_error_collection(c, s, a, b):
     b = b.persist()
     f = c.compute(b)
 
-    function, args, kwargs = await c._recreate_error_locally(f)
+    error_f = await c._get_errored_future(f)
+    function, args, kwargs = await c._get_components_from_future(error_f)
     with pytest.raises(ZeroDivisionError):
         function(*args, **kwargs)
 
@@ -4683,13 +4656,15 @@ async def test_recreate_error_collection(c, s, a, b):
 
     df2 = df.a.map(make_err)
     f = c.compute(df2)
-    function, args, kwargs = await c._recreate_error_locally(f)
+    error_f = await c._get_errored_future(f)
+    function, args, kwargs = await c._get_components_from_future(error_f)
     with pytest.raises(ValueError):
         function(*args, **kwargs)
 
     # with persist
     df3 = c.persist(df2)
-    function, args, kwargs = await c._recreate_error_locally(df3)
+    error_f = await c._get_errored_future(df3)
+    function, args, kwargs = await c._get_components_from_future(error_f)
     with pytest.raises(ValueError):
         function(*args, **kwargs)
 
@@ -4700,7 +4675,8 @@ async def test_recreate_error_array(c, s, a, b):
     pytest.importorskip("scipy")
     z = (da.linalg.inv(da.zeros((10, 10), chunks=10)) + 1).sum()
     zz = z.persist()
-    func, args, kwargs = await c._recreate_error_locally(zz)
+    error_f = await c._get_errored_future(zz)
+    function, args, kwargs = await c._get_components_from_future(error_f)
     assert "0.,0.,0." in str(args).replace(" ", "")  # args contain actual arrays
 
 
@@ -4721,6 +4697,98 @@ def test_recreate_error_not_error(c):
     f = c.submit(dec, 2)
     with pytest.raises(ValueError, match="No errored futures passed"):
         c.recreate_error_locally(f)
+
+
+@gen_cluster(client=True)
+async def test_recreate_task_delayed(c, s, a, b):
+    x0 = delayed(dec)(2)
+    y0 = delayed(dec)(2)
+    x = delayed(div)(1, x0)
+    y = delayed(div)(1, y0)
+    tot = delayed(sum)([x, y])
+
+    f = c.compute(tot)
+
+    assert f.status == "pending"
+
+    function, args, kwargs = await c._get_components_from_future(f)
+    assert f.status == "finished"
+    assert function.__name__ == "sum"
+    assert args == ([1, 1],)
+    assert function(*args, **kwargs) == 2
+
+
+@gen_cluster(client=True)
+async def test_recreate_task_futures(c, s, a, b):
+    x0 = c.submit(dec, 2)
+    y0 = c.submit(dec, 2)
+    x = c.submit(div, 1, x0)
+    y = c.submit(div, 1, y0)
+    tot = c.submit(sum, [x, y])
+    f = c.compute(tot)
+
+    assert f.status == "pending"
+
+    function, args, kwargs = await c._get_components_from_future(f)
+    assert f.status == "finished"
+    assert function.__name__ == "sum"
+    assert args == ([1, 1],)
+    assert function(*args, **kwargs) == 2
+
+
+@gen_cluster(client=True)
+async def test_recreate_task_collection(c, s, a, b):
+    b = db.range(10, npartitions=4)
+    b = b.map(lambda x: int(3628800 / (x + 1)))
+    b = b.persist()
+    f = c.compute(b)
+
+    function, args, kwargs = await c._get_components_from_future(f)
+    assert function(*args, **kwargs) == [3628800, 1814400, 1209600, 907200, 725760,
+                                         604800, 518400, 453600, 403200, 362880]
+
+    dd = pytest.importorskip("dask.dataframe")
+    import pandas as pd
+
+    df = dd.from_pandas(pd.DataFrame({"a": [0, 1, 2, 3, 4]}), chunksize=2)
+
+    df2 = df.a.map(lambda x: x + 1)
+    f = c.compute(df2)
+
+    function, args, kwargs = await c._get_components_from_future(f)
+    expected = pd.DataFrame({"a": [1, 2, 3, 4, 5]})['a']
+    assert function(*args, **kwargs).equals(expected)
+
+    # with persist
+    df3 = c.persist(df2)
+    # recreate_task_locally only works with futures
+    with pytest.raises(AttributeError):
+        function, args, kwargs = await c._get_components_from_future(df3)
+
+    f = c.compute(df3)
+    function, args, kwargs = await c._get_components_from_future(f)
+    assert function(*args, **kwargs).equals(expected)
+
+
+@gen_cluster(client=True)
+async def test_recreate_task_array(c, s, a, b):
+    da = pytest.importorskip("dask.array")
+    pytest.importorskip("scipy")
+    z = (da.zeros((10, 10), chunks=10) + 1).sum()
+    f = c.compute(z)
+    function, args, kwargs = await c._get_components_from_future(f)
+    assert function(*args, **kwargs) == 100
+
+
+def test_recreate_task_sync(c):
+    x0 = c.submit(dec, 2)
+    y0 = c.submit(dec, 2)
+    x = c.submit(div, 1, x0)
+    y = c.submit(div, 1, y0)
+    tot = c.submit(sum, [x, y])
+    f = c.compute(tot)
+
+    assert c.recreate_task_locally(f) == 2
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4744,8 +4744,18 @@ async def test_recreate_task_collection(c, s, a, b):
     f = c.compute(b)
 
     function, args, kwargs = await c._get_components_from_future(f)
-    assert function(*args, **kwargs) == [3628800, 1814400, 1209600, 907200, 725760,
-                                         604800, 518400, 453600, 403200, 362880]
+    assert function(*args, **kwargs) == [
+        3628800,
+        1814400,
+        1209600,
+        907200,
+        725760,
+        604800,
+        518400,
+        453600,
+        403200,
+        362880,
+    ]
 
     dd = pytest.importorskip("dask.dataframe")
     import pandas as pd
@@ -4756,7 +4766,7 @@ async def test_recreate_task_collection(c, s, a, b):
     f = c.compute(df2)
 
     function, args, kwargs = await c._get_components_from_future(f)
-    expected = pd.DataFrame({"a": [1, 2, 3, 4, 5]})['a']
+    expected = pd.DataFrame({"a": [1, 2, 3, 4, 5]})["a"]
     assert function(*args, **kwargs).equals(expected)
 
     # with persist

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4783,7 +4783,6 @@ async def test_recreate_task_collection(c, s, a, b):
 @gen_cluster(client=True)
 async def test_recreate_task_array(c, s, a, b):
     da = pytest.importorskip("dask.array")
-    pytest.importorskip("scipy")
     z = (da.zeros((10, 10), chunks=10) + 1).sum()
     f = c.compute(z)
     function, args, kwargs = await c._get_components_from_future(f)


### PR DESCRIPTION
- [ ] Closes #4804 
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Initial concept for locally rerunning a successfully completed future (rerunning failed futures functionality already exists). (Discussed in ticket #4804). Reason you'd want to do this is, for example, if the task completes successfully but is giving results you wouldn't expect. With this PR you can now do something like this:

```
>>> import pdb

>>> pdb.runcall(client.recreate_task_locally, future)
(Pdb) b path/to/file:<line no>
(Pdb) c
<etc.>
```

I believe this functionality is a superset of recreate_error_locally, but leaving that in place, in case you want to ensure the future you're calling actually did fail.

In the interest of reusing as much code as possible I reimplemented some of the existing methods with a more general version that takes a callback so the general recreate_tasks/error can pass in their relevant differences with the callback. Not married to this idea though.