### PR TITLE
Increase timeout of gen_test to 30s

### DIFF
--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -312,7 +312,7 @@ async def test_adapt_down():
                 assert time() < start + 60
 
 
-@gen_test(timeout=30)
+@gen_test()
 async def test_no_more_workers_than_tasks():
     with dask.config.set(
         {"distributed.scheduler.default-task-durations": {"slowinc": 1000}}

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -367,7 +367,7 @@ async def test_scheduler_address_config(c, s):
 
 
 @pytest.mark.slow
-@gen_test(timeout=20)
+@gen_test()
 async def test_wait_for_scheduler():
     with captured_logger("distributed") as log:
         w = Nanny("127.0.0.1:44737")

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -78,7 +78,7 @@ logging_levels = {
     if isinstance(logger, logging.Logger)
 }
 
-
+_TEST_TIMEOUT = 30
 _offload_executor.submit(lambda: None).result()  # create thread during import
 
 
@@ -750,7 +750,7 @@ async def disconnect_all(addresses, timeout=3, rpc_kwargs=None):
     await asyncio.gather(*[disconnect(addr, timeout, rpc_kwargs) for addr in addresses])
 
 
-def gen_test(timeout=30):
+def gen_test(timeout=_TEST_TIMEOUT):
     """Coroutine test
 
     @gen_test(timeout=5)
@@ -839,7 +839,7 @@ def gen_cluster(
     nthreads=[("127.0.0.1", 1), ("127.0.0.1", 2)],
     ncores=None,
     scheduler="127.0.0.1",
-    timeout=30,
+    timeout=_TEST_TIMEOUT,
     security=None,
     Worker=Worker,
     client=False,

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -750,7 +750,7 @@ async def disconnect_all(addresses, timeout=3, rpc_kwargs=None):
     await asyncio.gather(*[disconnect(addr, timeout, rpc_kwargs) for addr in addresses])
 
 
-def gen_test(timeout=10):
+def gen_test(timeout=30):
     """Coroutine test
 
     @gen_test(timeout=5)


### PR DESCRIPTION
I've noticed some tests using `gen_test` are running into timeouts. We're using a timeout of 30s for all gen_cluster tests by default and think we should align here. Hopefully this helps with some flakiness
