### PR TITLE
[DO NOT MERGE] Apply cleanup fixture to all tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -29,6 +29,8 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+        if "distributed_cleanup" not in item.keywords:
+            item.fixturenames.append("cleanup")
 
 
 pytest_plugins = ["distributed.pytest_resourceleaks"]

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -759,6 +759,7 @@ def gen_test(timeout=10):
     """
 
     def _(func):
+        @pytest.mark.distributed_cleanup
         def test_func():
             with clean() as loop:
                 if iscoroutinefunction(func):
@@ -875,6 +876,7 @@ def gen_cluster(
         if not iscoroutinefunction(func):
             func = gen.coroutine(func)
 
+        @pytest.mark.distributed_cleanup
         def test_func():
             result = None
             workers = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,5 +53,6 @@ markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     avoid_ci: marks tests as flaky on CI on all OSs
     ipython: marks tests as exercising IPython
+    distributed_cleanup: marks tests to check for leaked processes, threads, etc.
 timeout_method = thread
 timeout = 300


### PR DESCRIPTION
This PR is an experiment to see which of our existing tests leave behind dangling processes, threads, and other resources by automatically applying our `cleanup` fixture to tests which don't use `gen_cluster` / `gen_test` (which already perform the same checks as the `cleanup` fixture).

xref https://github.com/dask/distributed/issues/4806