### PR TITLE
Bump pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ repos:
       - id: isort
         language_version: python3
   -   repo: https://github.com/psf/black
-      rev: 20.8b1
+      rev: 21.5b1
       hooks:
       - id: black
         language_version: python3
         exclude: versioneer.py
   -   repo: https://gitlab.com/pycqa/flake8
-      rev: 3.8.3
+      rev: 3.9.2
       hooks:
       - id: flake8
         language_version: python3

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -201,7 +201,7 @@ class Future(WrappedKey):
         return self._state.status
 
     def done(self):
-        """ Is the computation complete? """
+        """Is the computation complete?"""
         return self._state.done()
 
     def result(self, timeout=None):
@@ -309,7 +309,7 @@ class Future(WrappedKey):
         return self.client.retry([self], **kwargs)
 
     def cancelled(self):
-        """ Returns True if the future has been cancelled """
+        """Returns True if the future has been cancelled"""
         return self._state.status == "cancelled"
 
     async def _traceback(self):
@@ -491,7 +491,7 @@ class FutureState:
 
 
 async def done_callback(future, callback):
-    """ Coroutine that waits on future, then calls callback """
+    """Coroutine that waits on future, then calls callback"""
     while future.status == "pending":
         await future._state.wait()
     callback(future)
@@ -953,7 +953,7 @@ class Client:
             return text
 
     def start(self, **kwargs):
-        """ Start scheduler running in separate thread """
+        """Start scheduler running in separate thread"""
         if self.status != "newly-created":
             return
 
@@ -1221,7 +1221,7 @@ class Client:
                 self._release_key(key)
 
     def _release_key(self, key):
-        """ Release key from distributed memory """
+        """Release key from distributed memory"""
         logger.debug("Release key %s", key)
         st = self.futures.pop(key, None)
         if st is not None:
@@ -1232,7 +1232,7 @@ class Client:
             )
 
     async def _handle_report(self):
-        """ Listen to scheduler """
+        """Listen to scheduler"""
         with log_errors():
             try:
                 while True:
@@ -1325,7 +1325,7 @@ class Client:
         logger.exception(exception)
 
     async def _close(self, fast=False):
-        """ Send close signal and wait until scheduler completes """
+        """Send close signal and wait until scheduler completes"""
         if self.status == "closed":
             return
 
@@ -1815,7 +1815,7 @@ class Client:
                     direct = True
 
         async def wait(k):
-            """ Want to stop the All(...) early if we find an error """
+            """Want to stop the All(...) early if we find an error"""
             st = self.futures[k]
             await st.wait()
             if st.status != "finished" and errors == "raise":
@@ -4116,7 +4116,7 @@ class Client:
 
 
 class _WorkerSetupPlugin(WorkerPlugin):
-    """ This is used to support older setup functions as callbacks """
+    """This is used to support older setup functions as callbacks"""
 
     def __init__(self, setup):
         self._setup = setup
@@ -4129,7 +4129,7 @@ class _WorkerSetupPlugin(WorkerPlugin):
 
 
 class Executor(Client):
-    """ Deprecated: see Client """
+    """Deprecated: see Client"""
 
     def __init__(self, *args, **kwargs):
         warnings.warn("Executor has been renamed to Client")
@@ -4463,7 +4463,7 @@ class as_completed:
                 return
 
     def clear(self):
-        """ Clear out all submitted futures """
+        """Clear out all submitted futures"""
         with self.lock:
             self.futures.clear()
             while not self.queue.empty():
@@ -4475,7 +4475,7 @@ def AsCompleted(*args, **kwargs):
 
 
 def default_client(c=None):
-    """ Return a client if one has started """
+    """Return a client if one has started"""
     c = c or _get_global_client()
     if c:
         return c

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -264,7 +264,7 @@ def address_from_user_args(
     security=None,
     default_port=0,
 ) -> str:
-    """ Get an address to listen on from common user provided arguments """
+    """Get an address to listen on from common user provided arguments"""
 
     if security and security.require_encryption and not protocol:
         protocol = "tls"

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -261,7 +261,7 @@ class Server:
             raise TypeError(f"expected Status or str, got {new_status}")
 
     async def finished(self):
-        """ Wait until the server has finished """
+        """Wait until the server has finished"""
         await self._event_finished.wait()
 
     def __await__(self):
@@ -969,7 +969,7 @@ class ConnectionPool:
         )
 
     def __call__(self, addr=None, ip=None, port=None):
-        """ Cached rpc objects """
+        """Cached rpc objects"""
         addr = addr_from_args(addr=addr, ip=ip, port=port)
         return PooledRPCCall(
             addr, self, serializers=self.serializers, deserializers=self.deserializers

--- a/distributed/dashboard/components/__init__.py
+++ b/distributed/dashboard/components/__init__.py
@@ -59,7 +59,7 @@ class DashboardComponent:
         self.root = None
 
     def update(self, messages):
-        """ Reads from bokeh.distributed.messages and updates self.source """
+        """Reads from bokeh.distributed.messages and updates self.source"""
 
 
 def add_periodic_callback(doc, component, interval):

--- a/distributed/dashboard/components/nvml.py
+++ b/distributed/dashboard/components/nvml.py
@@ -29,7 +29,7 @@ except Exception:
 
 
 class GPUCurrentLoad(DashboardComponent):
-    """ How many tasks are on each worker """
+    """How many tasks are on each worker"""
 
     def __init__(self, scheduler, width=600, **kwargs):
         with log_errors():

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -92,7 +92,7 @@ XLABEL_ORIENTATION = -math.pi / 12  # slanted downwards 15 degrees
 
 
 class Occupancy(DashboardComponent):
-    """ Occupancy (in time) per worker """
+    """Occupancy (in time) per worker"""
 
     def __init__(self, scheduler, **kwargs):
         with log_errors():
@@ -176,7 +176,7 @@ class Occupancy(DashboardComponent):
 
 
 class ProcessingHistogram(DashboardComponent):
-    """ How many tasks are on each worker """
+    """How many tasks are on each worker"""
 
     def __init__(self, scheduler, **kwargs):
         with log_errors():
@@ -501,7 +501,7 @@ class NBytesHistogram(DashboardComponent):
 
 
 class BandwidthTypes(DashboardComponent):
-    """ Bar chart showing bandwidth per type """
+    """Bar chart showing bandwidth per type"""
 
     def __init__(self, scheduler, **kwargs):
         with log_errors():
@@ -567,7 +567,7 @@ class BandwidthTypes(DashboardComponent):
 
 
 class BandwidthWorkers(DashboardComponent):
-    """ How many tasks are on each worker """
+    """How many tasks are on each worker"""
 
     def __init__(self, scheduler, **kwargs):
         with log_errors():
@@ -672,7 +672,7 @@ class BandwidthWorkers(DashboardComponent):
 
 
 class ComputePerKey(DashboardComponent):
-    """ Bar chart showing time spend in action by key prefix"""
+    """Bar chart showing time spend in action by key prefix"""
 
     def __init__(self, scheduler, **kwargs):
         with log_errors():
@@ -840,7 +840,7 @@ class ComputePerKey(DashboardComponent):
 
 
 class AggregateAction(DashboardComponent):
-    """ Bar chart showing time spend in action by key prefix"""
+    """Bar chart showing time spend in action by key prefix"""
 
     def __init__(self, scheduler, **kwargs):
         with log_errors():
@@ -942,7 +942,7 @@ class AggregateAction(DashboardComponent):
 
 
 class MemoryByKey(DashboardComponent):
-    """ Bar chart showing memory use by key prefix"""
+    """Bar chart showing memory use by key prefix"""
 
     def __init__(self, scheduler, **kwargs):
         with log_errors():
@@ -1234,7 +1234,7 @@ class StealingEvents(DashboardComponent):
         )
 
     def convert(self, msgs):
-        """ Convert a log message to a glyph """
+        """Convert a log message to a glyph"""
         total_duration = 0
         for msg in msgs:
             time, level, key, duration, sat, occ_sat, idl, occ_idl = msg
@@ -1723,7 +1723,7 @@ class TaskGraph(DashboardComponent):
 
 
 class TaskProgress(DashboardComponent):
-    """ Progress bars per task type """
+    """Progress bars per task type"""
 
     def __init__(self, scheduler, **kwargs):
         self.scheduler = scheduler

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -50,7 +50,7 @@ template_variables = {"pages": ["status", "system", "profile", "crossfilter"]}
 
 
 class StateTable(DashboardComponent):
-    """ Currently running tasks """
+    """Currently running tasks"""
 
     def __init__(self, worker):
         self.worker = worker

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -113,7 +113,7 @@ class AdaptiveCore:
             self.periodic_callback = None
 
     async def target(self) -> int:
-        """ The target number of workers that should exist """
+        """The target number of workers that should exist"""
         raise NotImplementedError()
 
     async def workers_to_close(self, target: int) -> list:
@@ -124,7 +124,7 @@ class AdaptiveCore:
         return list(self.observed)[target:]
 
     async def safe_target(self) -> int:
-        """ Used internally, like target, but respects minimum/maximum """
+        """Used internally, like target, but respects minimum/maximum"""
         n = await self.target()
         if n > self.maximum:
             n = self.maximum

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -114,7 +114,7 @@ class Cluster:
                 self.loop.add_callback(self.close)
 
     async def _watch_worker_status(self, comm):
-        """ Listen to scheduler for updates on adding and removing workers """
+        """Listen to scheduler for updates on adding and removing workers"""
         while True:
             try:
                 msgs = await comm.read()
@@ -302,7 +302,7 @@ class Cluster:
         return text
 
     def _widget(self):
-        """ Create IPython widget for display within a notebook """
+        """Create IPython widget for display within a notebook"""
         try:
             return self._cached_widget
         except AttributeError:

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -98,7 +98,7 @@ class ProcessInterface:
         self._event_finished.set()
 
     async def finished(self):
-        """ Wait until the server has finished """
+        """Wait until the server has finished"""
         await self._event_finished.wait()
 
     def __repr__(self):
@@ -446,7 +446,7 @@ class SpecCluster(Cluster):
         self._loop_runner.stop()
 
     def _threads_per_worker(self) -> int:
-        """ Return the number of threads per worker for new workers """
+        """Return the number of threads per worker for new workers"""
         if not self.new_spec:
             raise ValueError("To scale by cores= you must specify cores per worker")
 
@@ -458,7 +458,7 @@ class SpecCluster(Cluster):
             raise ValueError("To scale by cores= you must specify cores per worker")
 
     def _memory_per_worker(self) -> int:
-        """ Return the memory limit per worker for new workers """
+        """Return the memory limit per worker for new workers"""
         if not self.new_spec:
             raise ValueError(
                 "to scale by memory= your worker definition must include a memory_limit definition"

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -288,7 +288,7 @@ async def test_adapt_quickly():
 
 @gen_test(timeout=None)
 async def test_adapt_down():
-    """ Ensure that redefining adapt with a lower maximum removes workers """
+    """Ensure that redefining adapt with a lower maximum removes workers"""
     async with LocalCluster(
         0,
         asynchronous=True,
@@ -348,7 +348,7 @@ def test_basic_no_loop(loop):
 
 @pytest.mark.asyncio
 async def test_target_duration():
-    """ Ensure that redefining adapt with a lower maximum removes workers """
+    """Ensure that redefining adapt with a lower maximum removes workers"""
     with dask.config.set(
         {"distributed.scheduler.default-task-durations": {"slowinc": 1}}
     ):
@@ -376,7 +376,7 @@ async def test_target_duration():
 
 @pytest.mark.asyncio
 async def test_worker_keys(cleanup):
-    """ Ensure that redefining adapt with a lower maximum removes workers """
+    """Ensure that redefining adapt with a lower maximum removes workers"""
     async with SpecCluster(
         workers={
             "a-1": {"cls": Worker},

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -627,7 +627,7 @@ def test_no_ipywidgets(loop, monkeypatch):
 
 
 def test_scale(loop):
-    """ Directly calling scale both up and down works as expected """
+    """Directly calling scale both up and down works as expected"""
     with LocalCluster(
         scheduler_port=0,
         silence_logs=False,
@@ -686,7 +686,7 @@ def test_adapt(loop):
 
 
 def test_adapt_then_manual(loop):
-    """ We can revert from adaptive, back to manual """
+    """We can revert from adaptive, back to manual"""
     with LocalCluster(
         scheduler_port=0,
         silence_logs=False,

--- a/distributed/diagnostics/eventstream.py
+++ b/distributed/diagnostics/eventstream.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class EventStream(SchedulerPlugin):
-    """ Maintain a copy of worker events """
+    """Maintain a copy of worker events"""
 
     def __init__(self, scheduler=None):
         self.buffer = []

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -60,10 +60,10 @@ class SchedulerPlugin:
         pass
 
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
-        """ Run when a new graph / tasks enter the scheduler """
+        """Run when a new graph / tasks enter the scheduler"""
 
     def restart(self, scheduler, **kwargs):
-        """ Run when the scheduler restarts itself """
+        """Run when the scheduler restarts itself"""
 
     def transition(self, key, start, finish, *args, **kwargs):
         """Run whenever a task changes state
@@ -81,16 +81,16 @@ class SchedulerPlugin:
         """
 
     def add_worker(self, scheduler=None, worker=None, **kwargs):
-        """ Run when a new worker enters the cluster """
+        """Run when a new worker enters the cluster"""
 
     def remove_worker(self, scheduler=None, worker=None, **kwargs):
-        """ Run when a worker leaves the cluster """
+        """Run when a worker leaves the cluster"""
 
     def add_client(self, scheduler=None, client=None, **kwargs):
-        """ Run when a new client connects """
+        """Run when a new client connects"""
 
     def remove_client(self, scheduler=None, client=None, **kwargs):
-        """ Run when a client disconnects """
+        """Run when a client disconnects"""
 
 
 class WorkerPlugin:
@@ -134,7 +134,7 @@ class WorkerPlugin:
         """
 
     def teardown(self, worker):
-        """ Run when the worker to which the plugin is attached to is closed """
+        """Run when the worker to which the plugin is attached to is closed"""
 
     def transition(self, key, start, finish, **kwargs):
         """

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -237,7 +237,7 @@ def format_time(t):
 
 
 class AllProgress(SchedulerPlugin):
-    """ Keep track of all keys, grouped by key_split """
+    """Keep track of all keys, grouped by key_split"""
 
     def __init__(self, scheduler):
         self.all = defaultdict(set)
@@ -287,7 +287,7 @@ class AllProgress(SchedulerPlugin):
 
 
 class GroupProgress(SchedulerPlugin):
-    """ Keep track of all keys, grouped by key_split """
+    """Keep track of all keys, grouped by key_split"""
 
     def __init__(self, scheduler):
         self.scheduler = scheduler

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -334,7 +334,7 @@ class MultiProgressWidget(MultiProgressBar):
         }
 
         def keyfunc(kv):
-            """ Order keys by most numerous, then by string name """
+            """Order keys by most numerous, then by string name"""
             return kv[::-1]
 
         key_order = [k for k, v in sorted(all.items(), key=keyfunc, reverse=True)]

--- a/distributed/diagnostics/websocket.py
+++ b/distributed/diagnostics/websocket.py
@@ -9,27 +9,27 @@ class WebsocketPlugin(SchedulerPlugin):
         self.scheduler = scheduler
 
     def restart(self, scheduler, **kwargs):
-        """ Run when the scheduler restarts itself """
+        """Run when the scheduler restarts itself"""
         self.socket.send("restart", {})
 
     def add_worker(self, scheduler=None, worker=None, **kwargs):
-        """ Run when a new worker enters the cluster """
+        """Run when a new worker enters the cluster"""
         self.socket.send("add_worker", {"worker": worker})
 
     def remove_worker(self, scheduler=None, worker=None, **kwargs):
-        """ Run when a worker leaves the cluster"""
+        """Run when a worker leaves the cluster"""
         self.socket.send("remove_worker", {"worker": worker})
 
     def add_client(self, scheduler=None, client=None, **kwargs):
-        """ Run when a new client connects """
+        """Run when a new client connects"""
         self.socket.send("add_client", {"client": client})
 
     def remove_client(self, scheduler=None, client=None, **kwargs):
-        """ Run when a client disconnects """
+        """Run when a client disconnects"""
         self.socket.send("remove_client", {"client": client})
 
     def update_graph(self, scheduler, client=None, **kwargs):
-        """ Run when a new graph / tasks enter the scheduler """
+        """Run when a new graph / tasks enter the scheduler"""
         self.socket.send("update_graph", {"client": client})
 
     def transition(self, key, start, finish, *args, **kwargs):

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -132,14 +132,14 @@ class EventExtension:
             return self._events[name].is_set()
 
     def _normalize_name(self, name):
-        """ Helper function to normalize an event name """
+        """Helper function to normalize an event name"""
         if isinstance(name, list):
             name = tuple(name)
 
         return name
 
     def _delete_event(self, name):
-        """ Helper function to delete an event """
+        """Helper function to delete an event"""
         # suppress key errors to make calling this method
         # also possible if we do not even have such an event
         with suppress(KeyError):
@@ -242,7 +242,7 @@ class Event:
         return result
 
     def is_set(self):
-        """ Check if the event is set """
+        """Check if the event is set"""
         result = self.client.sync(self.client.scheduler.event_is_set, name=self.name)
         return result
 

--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -142,7 +142,7 @@ class Lock:
         return result
 
     def release(self):
-        """ Release the lock if already acquired """
+        """Release the lock if already acquired"""
         if not self.locked():
             raise ValueError("Lock is not yet acquired")
         result = self.client.sync(

--- a/distributed/multi_lock.py
+++ b/distributed/multi_lock.py
@@ -209,7 +209,7 @@ class MultiLock:
         return result
 
     def release(self):
-        """ Release the lock if already acquired """
+        """Release the lock if already acquired"""
         if not self.locked():
             raise ValueError("Lock is not yet acquired")
         ret = self.client.sync(self.client.scheduler.multi_lock_release, id=self.id)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -253,12 +253,12 @@ class Nanny(ServerNode):
 
     @property
     def local_dir(self):
-        """ For API compatibility with Nanny """
+        """For API compatibility with Nanny"""
         warnings.warn("The local_dir attribute has moved to local_directory")
         return self.local_directory
 
     async def start(self):
-        """ Start nanny, start local process, start watching """
+        """Start nanny, start local process, start watching"""
 
         await super().start()
 
@@ -411,7 +411,7 @@ class Nanny(ServerNode):
         return self._psutil_process_obj
 
     def memory_monitor(self):
-        """ Track worker's memory.  Restart if it goes above terminate fraction """
+        """Track worker's memory.  Restart if it goes above terminate fraction"""
         if self.status != Status.running:
             return
         process = self.process.process

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -99,7 +99,7 @@ class ServerNode(Server):
     def start_http_server(
         self, routes, dashboard_address, default_port=0, ssl_options=None
     ):
-        """ This creates an HTTP Server running on this node """
+        """This creates an HTTP Server running on this node"""
 
         self.http_application = RoutingApplication(routes)
 

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -161,7 +161,7 @@ class Preload:
             self.module = None
 
     async def start(self):
-        """ Run when the server finishes its start method """
+        """Run when the server finishes its start method"""
         if is_webaddress(self.name):
             self.module = await _download_module(self.name)
 
@@ -185,7 +185,7 @@ class Preload:
                 logger.info("Run preload setup function: %s", self.name)
 
     async def teardown(self):
-        """ Run when the server starts its close method """
+        """Run when the server starts its close method"""
         dask_teardown = getattr(self.module, "dask_teardown", None)
         if dask_teardown:
             future = dask_teardown(self.dask_server)

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -55,7 +55,7 @@ def identifier(frame):
 
 
 def repr_frame(frame):
-    """ Render a frame as a line for inclusion into a text traceback """
+    """Render a frame as a line for inclusion into a text traceback"""
     co = frame.f_code
     text = '  File "%s", line %s, in %s' % (co.co_filename, frame.f_lineno, co.co_name)
     line = linecache.getline(co.co_filename, frame.f_lineno, frame.f_globals).lstrip()
@@ -126,7 +126,7 @@ def process(frame, child, state, stop=None, omit=None):
 
 
 def merge(*args):
-    """ Merge multiple frame states together """
+    """Merge multiple frame states together"""
     if not args:
         return create()
     s = {arg["identifier"] for arg in args}
@@ -490,7 +490,7 @@ def llprocess(frames, child, state):
 
 
 def ll_get_stack(tid):
-    """ Collect low level stack information from thread id """
+    """Collect low level stack information from thread id"""
     from stacktrace import get_thread_stack
 
     frames = get_thread_stack(tid, show_python=False)

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -221,7 +221,7 @@ def maybe_compress(
 
 
 def decompress(header, frames):
-    """ Decompress frames according to information in the header """
+    """Decompress frames according to information in the header"""
     return [
         compressions[c]["decompress"](frame)
         for c, frame in zip(header["compression"], frames)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -76,7 +76,7 @@ def dumps(msg, serializers=None, on_error="message", context=None) -> list:
 
 
 def loads(frames, deserialize=True, deserializers=None):
-    """ Transform bytestream back into Python value """
+    """Transform bytestream back into Python value"""
 
     try:
 

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class PubSubSchedulerExtension:
-    """ Extend Dask's scheduler with routes to handle PubSub machinery """
+    """Extend Dask's scheduler with routes to handle PubSub machinery"""
 
     def __init__(self, scheduler):
         self.scheduler = scheduler
@@ -116,7 +116,7 @@ class PubSubSchedulerExtension:
 
 
 class PubSubWorkerExtension:
-    """ Extend Dask's Worker with routes to handle PubSub machinery """
+    """Extend Dask's Worker with routes to handle PubSub machinery"""
 
     def __init__(self, worker):
         self.worker = worker
@@ -169,7 +169,7 @@ class PubSubWorkerExtension:
 
 
 class PubSubClientExtension:
-    """ Extend Dask's Client with handlers to handle PubSub machinery """
+    """Extend Dask's Client with handlers to handle PubSub machinery"""
 
     def __init__(self, client):
         self.client = client
@@ -344,7 +344,7 @@ class Pub:
             self.client.scheduler_comm.send(data)
 
     def put(self, msg):
-        """ Publish a message to all subscribers of this topic """
+        """Publish a message to all subscribers of this topic"""
         self.loop.add_callback(self._put, msg)
 
     def __repr__(self):

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -85,7 +85,7 @@ class QueueExtension:
 
     async def get(self, comm=None, name=None, client=None, timeout=None, batch=False):
         def process(record):
-            """ Add task status if known """
+            """Add task status if known"""
             if record["type"] == "Future":
                 record = record.copy()
                 key = record["value"]
@@ -244,7 +244,7 @@ class Queue:
         return self.client.sync(self._get, timeout=timeout, batch=batch, **kwargs)
 
     def qsize(self, **kwargs):
-        """ Current number of elements in the queue """
+        """Current number of elements in the queue"""
         return self.client.sync(self._qsize, **kwargs)
 
     async def _get(self, timeout=None, batch=False):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -715,7 +715,7 @@ class WorkerState:
 
     @ccall
     def clean(self):
-        """ Return a version of this object that is appropriate for serialization """
+        """Return a version of this object that is appropriate for serialization"""
         ws: WorkerState = WorkerState(
             address=self._address,
             pid=self._pid,
@@ -1534,7 +1534,7 @@ class TaskState:
 
     @ccall
     def add_dependency(self, other: "TaskState"):
-        """ Add another task as a dependency of this task """
+        """Add another task as a dependency of this task"""
         self._dependencies.add(other)
         self._group._dependencies.add(other._group)
         other._dependents.add(self)
@@ -1969,7 +1969,7 @@ class SchedulerState:
     @ccall
     @exceptval(check=False)
     def new_task(self, key: str, spec: object, state: str) -> TaskState:
-        """ Create a new task, and associated states """
+        """Create a new task, and associated states"""
         ts: TaskState = TaskState(key, spec)
         ts._state = state
 
@@ -3619,7 +3619,7 @@ class Scheduler(SchedulerState, ServerNode):
         return text
 
     def identity(self, comm=None):
-        """ Basic information about ourselves and our cluster """
+        """Basic information about ourselves and our cluster"""
         parent: SchedulerState = cast(SchedulerState, self)
         d = {
             "type": type(self).__name__,
@@ -3662,7 +3662,7 @@ class Scheduler(SchedulerState, ServerNode):
             return ws.host, port
 
     async def start(self):
-        """ Clear out old state and restart all running coroutines """
+        """Clear out old state and restart all running coroutines"""
         await super().start()
         assert self.status != Status.running
 
@@ -3932,7 +3932,7 @@ class Scheduler(SchedulerState, ServerNode):
         nanny=None,
         extra=None,
     ):
-        """ Add a new worker to the cluster """
+        """Add a new worker to the cluster"""
         parent: SchedulerState = cast(SchedulerState, self)
         with log_errors():
             address = self.coerce_address(address, resolve_address)
@@ -4407,7 +4407,7 @@ class Scheduler(SchedulerState, ServerNode):
         # TODO: balance workers
 
     def stimulus_task_finished(self, key=None, worker=None, **kwargs):
-        """ Mark that a task has finished execution on a particular worker """
+        """Mark that a task has finished execution on a particular worker"""
         parent: SchedulerState = cast(SchedulerState, self)
         logger.debug("Stimulus task finished %s, %s", key, worker)
 
@@ -4444,7 +4444,7 @@ class Scheduler(SchedulerState, ServerNode):
     def stimulus_task_erred(
         self, key=None, worker=None, exception=None, traceback=None, **kwargs
     ):
-        """ Mark that a task has erred on a particular worker """
+        """Mark that a task has erred on a particular worker"""
         parent: SchedulerState = cast(SchedulerState, self)
         logger.debug("Stimulus task erred %s, %s", key, worker)
 
@@ -4479,7 +4479,7 @@ class Scheduler(SchedulerState, ServerNode):
     def stimulus_missing_data(
         self, cause=None, key=None, worker=None, ensure=True, **kwargs
     ):
-        """ Mark that certain keys have gone missing.  Recover. """
+        """Mark that certain keys have gone missing.  Recover."""
         parent: SchedulerState = cast(SchedulerState, self)
         with log_errors():
             logger.debug("Stimulus missing data %s, %s", key, worker)
@@ -4666,7 +4666,7 @@ class Scheduler(SchedulerState, ServerNode):
         return "OK"
 
     def stimulus_cancel(self, comm, keys=None, client=None, force=False):
-        """ Stop execution on a list of keys """
+        """Stop execution on a list of keys"""
         logger.info("Client %s requests to cancel %d keys", client, len(keys))
         if client:
             self.log_event(
@@ -4676,7 +4676,7 @@ class Scheduler(SchedulerState, ServerNode):
             self.cancel_key(key, client, force=force)
 
     def cancel_key(self, key, client, retries=5, force=False):
-        """ Cancel a particular key and all dependents """
+        """Cancel a particular key and all dependents"""
         # TODO: this should be converted to use the transition mechanism
         parent: SchedulerState = cast(SchedulerState, self)
         ts: TaskState = parent._tasks.get(key)
@@ -4719,7 +4719,7 @@ class Scheduler(SchedulerState, ServerNode):
                 self.report_on_key(ts=ts, client=client)
 
     def client_releases_keys(self, keys=None, client=None):
-        """ Remove keys from client desired list """
+        """Remove keys from client desired list"""
 
         parent: SchedulerState = cast(SchedulerState, self)
         if not isinstance(keys, list):
@@ -4731,7 +4731,7 @@ class Scheduler(SchedulerState, ServerNode):
         self.transitions(recommendations)
 
     def client_heartbeat(self, client=None):
-        """ Handle heartbeats from Client """
+        """Handle heartbeats from Client"""
         parent: SchedulerState = cast(SchedulerState, self)
         cs: ClientState = parent._clients[client]
         cs._last_seen = time()
@@ -4976,7 +4976,7 @@ class Scheduler(SchedulerState, ServerNode):
                 pass
 
     def remove_client(self, client=None):
-        """ Remove client from network """
+        """Remove client from network"""
         parent: SchedulerState = cast(SchedulerState, self)
         if self.status == Status.running:
             logger.info("Remove client %s", client)
@@ -5010,7 +5010,7 @@ class Scheduler(SchedulerState, ServerNode):
         self.loop.call_later(cleanup_delay, remove_client_from_events)
 
     def send_task_to_worker(self, worker, ts: TaskState, duration: double = -1):
-        """ Send a single computational task to a worker """
+        """Send a single computational task to a worker"""
         parent: SchedulerState = cast(SchedulerState, self)
         try:
             msg: dict = _task_to_msg(parent, ts, duration)
@@ -5179,7 +5179,7 @@ class Scheduler(SchedulerState, ServerNode):
         self.plugins.append(plugin)
 
     def remove_plugin(self, plugin):
-        """ Remove external plugin from scheduler """
+        """Remove external plugin from scheduler"""
         self.plugins.remove(plugin)
 
     def worker_send(self, worker, msg):
@@ -5283,7 +5283,7 @@ class Scheduler(SchedulerState, ServerNode):
         return keys
 
     async def gather(self, comm=None, keys=None, serializers=None):
-        """ Collect data in from workers """
+        """Collect data in from workers"""
         parent: SchedulerState = cast(SchedulerState, self)
         ws: WorkerState
         keys = list(keys)
@@ -5360,7 +5360,7 @@ class Scheduler(SchedulerState, ServerNode):
             collection.clear()
 
     async def restart(self, client=None, timeout=3):
-        """ Restart all workers.  Reset local state. """
+        """Restart all workers.  Reset local state."""
         parent: SchedulerState = cast(SchedulerState, self)
         with log_errors():
 
@@ -5448,7 +5448,7 @@ class Scheduler(SchedulerState, ServerNode):
         nanny=False,
         serializers=None,
     ):
-        """ Broadcast message to workers, return all results """
+        """Broadcast message to workers, return all results"""
         parent: SchedulerState = cast(SchedulerState, self)
         if workers is None or workers is True:
             if hosts is None:
@@ -5483,7 +5483,7 @@ class Scheduler(SchedulerState, ServerNode):
         return dict(zip(workers, results))
 
     async def proxy(self, comm=None, msg=None, worker=None, serializers=None):
-        """ Proxy a communication through the scheduler to some other worker """
+        """Proxy a communication through the scheduler to some other worker"""
         d = await self.broadcast(
             comm=comm, msg=msg, workers=[worker], serializers=serializers
         )
@@ -6343,7 +6343,7 @@ class Scheduler(SchedulerState, ServerNode):
         return {"metadata": plugin.metadata, "state": plugin.state}
 
     async def register_worker_plugin(self, comm, plugin, name=None):
-        """ Registers a setup function, and call it on every worker """
+        """Registers a setup function, and call it on every worker"""
         self.worker_plugins[name] = plugin
 
         responses = await self.broadcast(
@@ -6352,7 +6352,7 @@ class Scheduler(SchedulerState, ServerNode):
         return responses
 
     async def unregister_worker_plugin(self, comm, name):
-        """ Unregisters a worker plugin"""
+        """Unregisters a worker plugin"""
         try:
             worker_plugins = self.worker_plugins.pop(name)
         except KeyError:
@@ -6399,7 +6399,7 @@ class Scheduler(SchedulerState, ServerNode):
         self.send_all(client_msgs, worker_msgs)
 
     def story(self, *keys):
-        """ Get all transitions that touch one of the input keys """
+        """Get all transitions that touch one of the input keys"""
         keys = {key.key if isinstance(key, TaskState) else key for key in keys}
         return [
             t for t in self.transition_log if t[0] in keys or keys.intersection(t[3])
@@ -7054,7 +7054,7 @@ def _propagate_forgotten(
 def _client_releases_keys(
     state: SchedulerState, keys: list, cs: ClientState, recommendations: dict
 ):
-    """ Remove keys from client desired list """
+    """Remove keys from client desired list"""
     logger.debug("Client %s releases keys: %s", cs._client_key, keys)
     ts: TaskState
     for key in keys:
@@ -7073,7 +7073,7 @@ def _client_releases_keys(
 @cfunc
 @exceptval(check=False)
 def _task_to_msg(state: SchedulerState, ts: TaskState, duration: double = -1) -> dict:
-    """ Convert a single computational task to a message """
+    """Convert a single computational task to a message"""
     ws: WorkerState
     dts: TaskState
 
@@ -7143,7 +7143,7 @@ def _task_to_client_msgs(state: SchedulerState, ts: TaskState) -> dict:
 @cfunc
 @exceptval(check=False)
 def _reevaluate_occupancy_worker(state: SchedulerState, ws: WorkerState):
-    """ See reevaluate_occupancy """
+    """See reevaluate_occupancy"""
     old: double = ws._occupancy
     new: double = 0
     diff: double

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -236,7 +236,7 @@ async def test_map_batch_size(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_custom_key_with_batches(c, s, a, b):
-    """ Test of <https://github.com/dask/distributed/issues/4588>"""
+    """Test of <https://github.com/dask/distributed/issues/4588>"""
 
     futs = c.map(
         lambda x: x ** 2,

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -442,7 +442,7 @@ async def test_rpc_with_many_connections_inproc():
 
 
 async def check_large_packets(listen_arg):
-    """ tornado has a 100MB cap by default """
+    """tornado has a 100MB cap by default"""
     server = Server({"echo": echo})
     await server.listen(listen_arg)
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -87,7 +87,7 @@ async def test_identity(cleanup):
 @gen_cluster(client=True)
 async def test_worker_bad_args(c, s, a, b):
     class NoReprObj:
-        """ This object cannot be properly represented as a string. """
+        """This object cannot be properly represented as a string."""
 
         def __str__(self):
             raise ValueError("I have no str representation.")

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -745,7 +745,7 @@ def get_traceback():
 
 
 def truncate_exception(e, n=10000):
-    """ Truncate exception to be about a certain length """
+    """Truncate exception to be about a certain length"""
     if len(str(e)) > n:
         try:
             return type(e)("Long error message", str(e)[:n])
@@ -763,7 +763,7 @@ def validate_key(k):
 
 
 def _maybe_complex(task):
-    """ Possibly contains a nested task """
+    """Possibly contains a nested task"""
     return (
         istask(task)
         or type(task) is list
@@ -962,7 +962,7 @@ def open_port(host=""):
 
 
 def import_file(path):
-    """ Loads modules for a file (.py, .zip, .egg) """
+    """Loads modules for a file (.py, .zip, .egg)"""
     directory, filename = os.path.split(path)
     name, ext = os.path.splitext(filename)
     names_to_import = []
@@ -1044,7 +1044,7 @@ def asciitable(columns, rows):
 
 
 def nbytes(frame, _bytes_like=(bytes, bytearray)):
-    """ Number of bytes of a frame or memoryview """
+    """Number of bytes of a frame or memoryview"""
     if isinstance(frame, _bytes_like):
         return len(frame)
     else:
@@ -1105,7 +1105,7 @@ def deprecated(*, version_removed: str = None):
 
 
 def json_load_robust(fn, load=json.load):
-    """ Reads a JSON file from disk that may be being written as we read """
+    """Reads a JSON file from disk that may be being written as we read"""
     while not os.path.exists(fn):
         sleep(0.01)
     for i in range(10):
@@ -1120,7 +1120,7 @@ def json_load_robust(fn, load=json.load):
 
 
 class DequeHandler(logging.Handler):
-    """ A logging.Handler that records records into a deque """
+    """A logging.Handler that records records into a deque"""
 
     _instances = weakref.WeakSet()
 
@@ -1364,7 +1364,7 @@ is_coroutine_function = iscoroutinefunction
 
 
 class Log(str):
-    """ A container for logs """
+    """A container for logs"""
 
     def _repr_html_(self):
         return "<pre><code>\n{log}\n</code></pre>".format(
@@ -1373,7 +1373,7 @@ class Log(str):
 
 
 class Logs(dict):
-    """ A container for multiple logs """
+    """A container for multiple logs"""
 
     def _repr_html_(self):
         summaries = [

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1422,7 +1422,7 @@ def save_sys_modules():
 
 @contextmanager
 def check_thread_leak():
-    """ Context manager to ensure we haven't leaked any threads """
+    """Context manager to ensure we haven't leaked any threads"""
     active_threads_start = threading.enumerate()
 
     yield

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -71,7 +71,7 @@ def get_system_info():
 
 
 def version_of_package(pkg):
-    """ Try a variety of common ways to get the version of a package """
+    """Try a variety of common ways to get the version of a package"""
     from contextlib import suppress
 
     with suppress(AttributeError):
@@ -84,7 +84,7 @@ def version_of_package(pkg):
 
 
 def get_package_info(pkgs):
-    """ get package versions for the passed required & optional packages """
+    """get package versions for the passed required & optional packages"""
 
     pversions = [("python", ".".join(map(str, sys.version_info)))]
     for pkg in pkgs:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -799,12 +799,12 @@ class Worker(ServerNode):
 
     @property
     def worker_address(self):
-        """ For API compatibility with Nanny """
+        """For API compatibility with Nanny"""
         return self.address
 
     @property
     def local_dir(self):
-        """ For API compatibility with Nanny """
+        """For API compatibility with Nanny"""
         warnings.warn(
             "The local_dir attribute has moved to local_directory", stacklevel=2
         )
@@ -3482,7 +3482,7 @@ cache_loads = LRU(maxsize=100)
 
 
 def loads_function(bytes_object):
-    """ Load a function from bytes, cache bytes """
+    """Load a function from bytes, cache bytes"""
     if len(bytes_object) < 100000:
         try:
             result = cache_loads[bytes_object]
@@ -3494,7 +3494,7 @@ def loads_function(bytes_object):
 
 
 def _deserialize(function=None, args=None, kwargs=None, task=no_value):
-    """ Deserialize task inputs and regularize to func, args, kwargs """
+    """Deserialize task inputs and regularize to func, args, kwargs"""
     if function is not None:
         function = loads_function(function)
     if args and isinstance(args, bytes):
@@ -3534,7 +3534,7 @@ _cache_lock = threading.Lock()
 
 
 def dumps_function(func):
-    """ Dump a function to bytes, cache functions """
+    """Dump a function to bytes, cache functions"""
     try:
         with _cache_lock:
             result = cache_dumps[func]
@@ -3583,7 +3583,7 @@ _warn_dumps_warned = [False]
 
 
 def warn_dumps(obj, dumps=pickle.dumps, limit=1e6):
-    """ Dump an object to bytes, warn if those bytes are large """
+    """Dump an object to bytes, warn if those bytes are large"""
     b = dumps(obj, protocol=4)
     if not _warn_dumps_warned[0] and len(b) > limit:
         _warn_dumps_warned[0] = True


### PR DESCRIPTION
This PR updates the version of `black` and `flake8` used in our pre-commit hooks. This will help avoid conflicts between running `black` manually and when `black` is run during our pre-commit hooks.

Similar to https://github.com/dask/dask/pull/7676