### PR TITLE
Update handling of UCX exceptions on endpoint closing

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -476,8 +476,8 @@ def _scrub_ucx_config():
             tls = "tcp,rdmacm"
             tls_priority = "rdmacm"
         else:
-            tls = "tcp,sockcm"
-            tls_priority = "sockcm"
+            tls = "tcp"
+            tls_priority = "tcp"
 
         # CUDA COPY can optionally be used with ucx -- we rely on the user
         # to define when messages will include CUDA objects.  Note:

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -306,7 +306,11 @@ class UCX(Comm):
         if self._ep is not None:
             try:
                 await self.ep.send(struct.pack("?Q", True, 0))
-            except (ucp.exceptions.UCXError, ucp.exceptions.UCXCloseError):
+            except (
+                ucp.exceptions.UCXError,
+                ucp.exceptions.UCXCloseError,
+                ucp.exceptions.UCXCanceled,
+            ) + (getattr(ucp.exceptions, "UCXConnectionReset", ()),):
                 # If the other end is in the process of closing,
                 # UCX will sometimes raise a `Input/output` error,
                 # which we can ignore.

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -120,12 +120,15 @@ def init_once():
         ucx_create_endpoint = ucp.create_endpoint
         ucx_create_listener = ucp.create_listener
     else:
-        if dask.config.get("ucx.reuse-endpoints"):
-            ucx_create_endpoint = EndpointReuse.create_endpoint
-            ucx_create_listener = EndpointReuse.create_listener
-        else:
+        reuse_endpoints = dask.config.get("ucx.reuse-endpoints")
+        if (
+            reuse_endpoints is None and ucp.get_ucx_version() >= (1, 11, 0)
+        ) or reuse_endpoints is False:
             ucx_create_endpoint = ucp.create_endpoint
             ucx_create_listener = ucp.create_listener
+        else:
+            ucx_create_endpoint = EndpointReuse.create_endpoint
+            ucx_create_listener = EndpointReuse.create_listener
 
 
 class UCX(Comm):

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -53,12 +53,15 @@ def init_once():
     if ucp is not None:
         return
 
+    # remove/process dask.ucx flags for valid ucx options
+    ucx_config = _scrub_ucx_config()
+    if "TLS" in ucx_config and "cuda_copy" in ucx_config["TLS"]:
+        import numba.cuda
+        numba.cuda.current_context()
+
     import ucp as _ucp
 
     ucp = _ucp
-
-    # remove/process dask.ucx flags for valid ucx options
-    ucx_config = _scrub_ucx_config()
 
     ucp.init(options=ucx_config, env_takes_precedence=True)
 

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -473,7 +473,7 @@ def _scrub_ucx_config():
         ]
     ):
         if dask.config.get("ucx.rdmacm"):
-            tls = "tcp,rdmacm"
+            tls = "tcp"
             tls_priority = "rdmacm"
         else:
             tls = "tcp"

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -56,7 +56,11 @@ def init_once():
     # remove/process dask.ucx flags for valid ucx options
     ucx_config = _scrub_ucx_config()
     if "TLS" in ucx_config and "cuda_copy" in ucx_config["TLS"]:
-        import numba.cuda
+        try:
+            import numba.cuda
+        except ImportError:
+            raise ImportError("CUDA support with UCX requires Numba for context management")
+
         numba.cuda.current_context()
 
     import ucp as _ucp

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -392,7 +392,12 @@ class UCXListener(Listener):
                 await self.comm_handler(ucx)
 
         init_once()
-        self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
+        try:
+            self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
+        except ucp.exceptions.UCXError as e:
+            print("Error %s, retrying" % str(e))
+            self.ip, self._input_port = parse_host_port(self.ip, default_port=0)
+            self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
 
     def stop(self):
         self.ucp_server = None

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -466,7 +466,9 @@ def _scrub_ucx_config():
     # 2) explicitly defined UCX configuration flags
 
     # import does not initialize ucp -- this will occur outside this function
-    from ucp import get_config
+    from ucp import get_config, get_ucx_version
+
+    ucx_110 = get_ucx_version() >= (1, 10, 0)
 
     options = {}
 
@@ -481,11 +483,11 @@ def _scrub_ucx_config():
         ]
     ):
         if dask.config.get("ucx.rdmacm"):
-            tls = "tcp"
+            tls = "tcp" if ucx_110 else "tcp,rdmacm"
             tls_priority = "rdmacm"
         else:
-            tls = "tcp"
-            tls_priority = "tcp"
+            tls = "tcp" if ucx_110 else "tcp,sockcm"
+            tls_priority = "tcp" if ucx_110 else "sockcm"
 
         # CUDA COPY can optionally be used with ucx -- we rely on the user
         # to define when messages will include CUDA objects.  Note:

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -59,7 +59,9 @@ def init_once():
         try:
             import numba.cuda
         except ImportError:
-            raise ImportError("CUDA support with UCX requires Numba for context management")
+            raise ImportError(
+                "CUDA support with UCX requires Numba for context management"
+            )
 
         numba.cuda.current_context()
 
@@ -396,12 +398,7 @@ class UCXListener(Listener):
                 await self.comm_handler(ucx)
 
         init_once()
-        try:
-            self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
-        except ucp.exceptions.UCXError as e:
-            print("Error %s, retrying" % str(e))
-            self.ip, self._input_port = parse_host_port(self.ip, default_port=0)
-            self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
+        self.ucp_server = ucx_create_listener(serve_forever, port=self._input_port)
 
     def stop(self):
         self.ucp_server = None

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -270,7 +270,7 @@ class UCX(Comm):
             except (
                 ucp.exceptions.UCXCloseError,
                 ucp.exceptions.UCXCanceled,
-            ) + (getattr(ucp.exceptions, "UCXConnectionReset", ())):
+            ) + (getattr(ucp.exceptions, "UCXConnectionReset", ()),):
                 self.abort()
                 raise CommClosedError("Connection closed by writer")
             else:
@@ -344,7 +344,7 @@ class UCXConnector(Connector):
         except (
             ucp.exceptions.UCXCloseError,
             ucp.exceptions.UCXCanceled,
-        ) + (getattr(ucp.exceptions, "UCXConnectionReset", ())):
+        ) + (getattr(ucp.exceptions, "UCXConnectionReset", ()),):
             raise CommClosedError("Connection closed before handshake completed")
         return self.comm_class(
             ep,

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -645,7 +645,7 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
             response = await comm.read(deserializers=deserializers)
         else:
             response = None
-    except EnvironmentError:
+    except (EnvironmentError, CommClosedError):
         # On communication errors, we should simply close the communication
         force_close = True
         raise

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -860,5 +860,5 @@ properties:
           Enable UCX-Py reuse endpoints mechanism if ``True`` or if it's not specified and
           UCX < 1.11 is installed, otherwise disable reuse endpoints. This was primarily
           introduced to resolve an issue with CUDA IPC that has been fixed in UCX 1.10, but
-          can cause establishing endpoints to be very slow, particularly noticeable in
+          can cause establishing endpoints to be very slow, this is particularly noticeable in
           clusters of more than a few dozen workers.

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -855,11 +855,10 @@ properties:
           and compiled with hwloc support. Unexpected errors can occur when using
           ``"auto"`` if any interfaces are disconnected or improperly configured.
       reuse-endpoints:
+        type: [boolean, 'null']
+        description: |
           Enable UCX-Py reuse endpoints mechanism if ``True`` or if it's not specified and
           UCX < 1.11 is installed, otherwise disable reuse endpoints. This was primarily
           introduced to resolve an issue with CUDA IPC that has been fixed in UCX 1.10, but
           can cause establishing endpoints to be very slow, particularly noticeable in
           clusters of more than a few dozen workers.
-        type: [boolean, 'null']
-        description: |
-          Whether to reuse endpoints or not.

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -855,6 +855,6 @@ properties:
           and compiled with hwloc support. Unexpected errors can occur when using
           ``"auto"`` if any interfaces are disconnected or improperly configured.
       reuse-endpoints:
-        type: boolean
-        description: | 
+        type: [boolean, 'null']
+        description: |
           Whether to reuse endpoints or not.

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -855,6 +855,11 @@ properties:
           and compiled with hwloc support. Unexpected errors can occur when using
           ``"auto"`` if any interfaces are disconnected or improperly configured.
       reuse-endpoints:
+          Enable UCX-Py reuse endpoints mechanism if ``True`` or if it's not specified and
+          UCX < 1.11 is installed, otherwise disable reuse endpoints. This was primarily
+          introduced to resolve an issue with CUDA IPC that has been fixed in UCX 1.10, but
+          can cause establishing endpoints to be very slow, particularly noticeable in
+          clusters of more than a few dozen workers.
         type: [boolean, 'null']
         description: |
           Whether to reuse endpoints or not.

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -196,4 +196,4 @@ ucx:
   infiniband: False # enable Infiniband
   rdmacm: False # enable RDMACM
   net-devices: null  # define what interface to use for UCX comm
-  reuse-endpoints: True  # enable endpoint reuse
+  reuse-endpoints: null  # enable endpoint reuse


### PR DESCRIPTION
The changes in this PR provide an update for UCX 1.11, where we will enable endpoint error handling by default in UCX-Py. It's necessary to update exceptions raised in cases where endpoints disconnect.

The UCX-Py endpoint reuse is not anymore necessary, so we also disable that for UCX 1.11+. The primary reason it was introduced was to circumvent an issue with CUDA IPC that was resolved by https://github.com/openucx/ucx/pull/6360. Using the endpoint reuse class has also proven to be very slow, taking a long time to initialize for clusters with just a few dozen workers and pretty much unusable for a cluster in the order of 100 workers.