### PR TITLE
Memory measures for LocalCluster(worker_class=Worker)

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -889,9 +889,15 @@ class Client:
                 nworkers,
                 nthreads,
             )
-            memory = [w["memory_limit"] for w in workers.values()]
-            if all(memory):
-                text += ", memory=" + format_bytes(sum(memory))
+
+            if self.cluster is not None:
+                memory = self.cluster.memory_limit
+            else:
+                memory = [w["memory_limit"] for w in workers.values()]
+                memory = sum(memory) if all(memory) else 0
+            if memory:
+                text += ", memory=" + format_bytes(memory)
+
             text += ">"
             return text
 
@@ -926,11 +932,13 @@ class Client:
         if info:
             workers = list(info["workers"].values())
             cores = sum(w["nthreads"] for w in workers)
-            if all(isinstance(w["memory_limit"], Number) for w in workers):
-                memory = sum(w["memory_limit"] for w in workers)
-                memory = format_bytes(memory)
+
+            if self.cluster is not None:
+                memory = self.cluster.memory_limit
             else:
-                memory = ""
+                memory = [w["memory_limit"] for w in workers]
+                memory = sum(memory) if all(memory) else 0
+            memory = format_bytes(memory) if memory else ""
 
             text2 = (
                 '<h3 style="text-align: left;">Cluster</h3>\n'

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -290,9 +290,7 @@ class NBytesCluster(DashboardComponent):
     @without_property_validation
     def update(self):
         with log_errors():
-            limit = sum(
-                getattr(ws, "memory_limit", 0) for ws in self.scheduler.workers.values()
-            )
+            limit = self.scheduler.memory_limit
             meminfo = self.scheduler.memory
             color = _nbytes_color(meminfo.process, limit)
 

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -259,6 +259,11 @@ class Cluster:
             host = self.scheduler_address.split("://")[1].split("/")[0].split(":")[0]
             return format_dashboard_link(host, port)
 
+    @property
+    def memory_limit(self):
+        memory = [w["memory_limit"] for w in self.scheduler_info["workers"].values()]
+        return sum(memory) if all(memory) else 0
+
     def _widget_status(self):
         workers = len(self.scheduler_info["workers"])
         if hasattr(self, "worker_spec"):
@@ -271,8 +276,7 @@ class Cluster:
         else:
             requested = workers
         cores = sum(v["nthreads"] for v in self.scheduler_info["workers"].values())
-        memory = sum(v["memory_limit"] for v in self.scheduler_info["workers"].values())
-        memory = format_bytes(memory)
+        memory = format_bytes(self.memory_limit)
         text = """
 <div>
   <style scoped>
@@ -438,9 +442,9 @@ class Cluster:
             sum(w["nthreads"] for w in self.scheduler_info["workers"].values()),
         )
 
-        memory = [w["memory_limit"] for w in self.scheduler_info["workers"].values()]
-        if all(memory):
-            text += ", memory=" + format_bytes(sum(memory))
+        memory = self.memory_limit
+        if memory:
+            text += ", memory=" + format_bytes(memory)
 
         text += ")"
         return text


### PR DESCRIPTION
Closes #4833

- ``LocalCluster(worker_class=Worker)`` will not split the max_memory by the number of CPUs anymore
- GUI top-left bar will now show the correct max_memory, unmanaged_old, and unmanaged_recent
- plain-text and html repr of Client and Cluster will now show the correct max_memory

DONE: implementation
TODO: unit tests

I wonder however how much we actually care about and want to support the use case of multiple Worker objects in the same process? Who would want to use it, other than unit tests? As opposed ``LocalCluster(worker_class=Worker, processes=False)``, which spawns a single worker with multiple threads and definitely has its merit.
I wonder if, instead of all this, we should just add a check to ``LocalCluster.__init__`` that sets processes=False if the user sets worker_class=Worker?