### PR TITLE
Check `distributed.scheduler.pickle` in `Scheduler.run_function`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6278,6 +6278,13 @@ class Scheduler(SchedulerState, ServerNode):
         """
         from .worker import run
 
+        if not dask.config.get("distributed.scheduler.pickle"):
+            raise ValueError(
+                "Cannot run function as the scheduler has been explicitly disallowed from "
+                "deserializing arbitrary bytestrings using pickle via the "
+                "'distributed.scheduler.pickle' configuration setting."
+            )
+
         self.log_event("all", {"action": "run-function", "function": function})
         return run(self, stream, function=function, args=args, kwargs=kwargs, wait=wait)
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1100,6 +1100,15 @@ async def test_run_on_scheduler(c, s, a, b):
     assert response == s.address
 
 
+@gen_cluster(client=True, config={"distributed.scheduler.pickle": False})
+async def test_run_on_scheduler_disabled(c, s, a, b):
+    def f(dask_scheduler=None):
+        return dask_scheduler.address
+
+    with pytest.raises(ValueError, match="disallowed from deserializing"):
+        await c._run_on_scheduler(f)
+
+
 @gen_cluster(client=True)
 async def test_close_worker(c, s, a, b):
     assert len(s.workers) == 2


### PR DESCRIPTION
This PR update `Scheduler.run_function` to first check the `distributed.scheduler.pickle` configuration value before attempting to deserialize anything with `pickle`. Note we already to this today in `Scheduler.feed` -- another place where `pickle.loads` is called. 

Closes https://github.com/dask/distributed/issues/1621