### PR TITLE
Add `performance_report` to API docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -62,6 +62,7 @@ API
    futures_of
    get_task_stream
    get_task_metadata
+   performance_report
 
 
 Asynchronous methods
@@ -158,6 +159,7 @@ Other
 .. autoclass:: distributed.Reschedule
 .. autoclass:: get_task_stream
 .. autoclass:: get_task_metadata
+.. autoclass:: performance_report
 
 .. autoclass:: Event
    :members:

--- a/docs/source/diagnosing-performance.rst
+++ b/docs/source/diagnosing-performance.rst
@@ -121,7 +121,8 @@ Performance Reports
 Often when benchmarking and/or profiling, users may want to record a
 particular computation or even a full workflow.  Dask can save the bokeh
 dashboards as static HTML plots including the task stream, worker profiles,
-bandwidths, etc. This is done wrapping a computation with the ``performance_report`` context manager:
+bandwidths, etc. This is done wrapping a computation with the
+:class:`distributed.performance_report` context manager:
 
 .. code-block:: python
 


### PR DESCRIPTION
This is comfortably in our public interface and let's us link to the corresponding API docs throughout our documentation 