### PR TITLE
Fix UCX scrub config logging

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -512,11 +512,9 @@ def _scrub_ucx_config():
             options["NET_DEVICES"] = net_devices
 
     # ANY UCX options defined in config will overwrite high level dask.ucx flags
-    valid_ucx_keys = list(get_config().keys())
-    for k, v in dask.config.get("ucx").items():
-        if k in valid_ucx_keys:
-            options[k] = v
-        else:
+    valid_ucx_vars = list(get_config().keys())
+    for k, v in options.items():
+        if k not in valid_ucx_vars:
             logger.debug(
                 "Key: %s with value: %s not a valid UCX configuration option" % (k, v)
             )


### PR DESCRIPTION
- [x] Closes #4845 

I believe this check was originally intended to work as a map from `DASK_UCX__*` to the actual `UCX_*` configurations. Since the original implementation the UCX configurations in Dask have evolved to aliases, so the mapping doesn't match. However, the `options` variable is what is passed to UCX, so we should verify that we're not setting variables that don't match those that UCX exposes.