### PR TITLE
Add HTML reprs for Client.who_has and Client.has_what

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -53,6 +53,7 @@ from .core import (
 )
 from .diagnostics.plugin import UploadFile, WorkerPlugin, _get_worker_plugin_name
 from .metrics import time
+from .objects import HasWhat, WhoHas
 from .protocol import to_serialize
 from .protocol.pickle import dumps, loads
 from .publish import Datasets
@@ -3205,7 +3206,7 @@ class Client:
             keys = list(map(stringify, {f.key for f in futures}))
         else:
             keys = None
-        return self.sync(self.scheduler.who_has, keys=keys, **kwargs)
+        return WhoHas(self.sync(self.scheduler.who_has, keys=keys, **kwargs))
 
     def has_what(self, workers=None, **kwargs):
         """Which keys are held by which workers
@@ -3239,7 +3240,7 @@ class Client:
             workers = list(workers)
         if workers is not None and not isinstance(workers, (tuple, list, set)):
             workers = [workers]
-        return self.sync(self.scheduler.has_what, workers=workers, **kwargs)
+        return HasWhat(self.sync(self.scheduler.has_what, workers=workers, **kwargs))
 
     def processing(self, workers=None):
         """The tasks currently running on each worker

--- a/distributed/objects.py
+++ b/distributed/objects.py
@@ -1,0 +1,67 @@
+"""This file contains custom objects.
+These are mostly regular objects with more useful _repr_ and _repr_html_ methods."""
+
+
+class HasWhat(dict):
+    """A dictionary of all workers and which keys that worker has."""
+
+    def _repr_html_(self):
+        rows = ""
+
+        for worker, keys in sorted(self.items()):
+            summary = ""
+            for key in keys:
+                summary += f"""<tr><td>{key}</td></tr>"""
+
+            rows += f"""<tr>
+            <td>{worker}</td>
+            <td>{len(keys)}</td>
+            <td>
+                <details>
+                <summary style='display:list-item'>Expand</summary>
+                <table>
+                {summary}
+                </table>
+                </details>
+            </td>
+        </tr>"""
+
+        output = f"""
+        <table>
+        <tr>
+            <th>Worker</th>
+            <th>Key count</th>
+            <th>Key list</th>
+        </tr>
+        {rows}
+        </table>
+        """
+
+        return output
+
+
+class WhoHas(dict):
+    """A dictionary of all keys and which workers have that key."""
+
+    def _repr_html_(self):
+        rows = ""
+
+        for title, keys in sorted(self.items()):
+            rows += f"""<tr>
+            <td>{title}</td>
+            <td>{len(keys)}</td>
+            <td>{", ".join(keys)}</td>
+        </tr>"""
+
+        output = f"""
+        <table>
+        <tr>
+            <th>Key</th>
+            <th>Copies</th>
+            <th>Workers</th>
+        </tr>
+        {rows}
+        </table>
+        """
+
+        return output


### PR DESCRIPTION
@quasiben mentioned folks are regularly asking about how to better understand what workers have what keys.

Threw together some quick HTML reprs for `Client.who_has` and `Client.has_what` to try and make things more understandable.

I followed the same approach as `distributed.utils.Logs` by subclassing a `dict` and adding an HTML repr to it. I wasn't sure if `distributed.utils` was the right place for this though, so I started `distributed.objects` for a place to put custom objects with fancy reprs. I expect this to grow and contain more variations on `dict`, `str`, etc with fancy reprs.

Happy to move `Log` and `Logs` there if that makes sense.

**has_what**
![image](https://user-images.githubusercontent.com/1610850/119679859-9c9e5400-be38-11eb-8e23-6186469672c2.png)

**who_has**
![image](https://user-images.githubusercontent.com/1610850/119679971-b475d800-be38-11eb-805a-7137fdcfce34.png)
