### PR TITLE
Drop usage of `WhoHas` & `WhatHas` from `Client`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -53,7 +53,6 @@ from .core import (
 )
 from .diagnostics.plugin import UploadFile, WorkerPlugin, _get_worker_plugin_name
 from .metrics import time
-from .objects import HasWhat, WhoHas
 from .protocol import to_serialize
 from .protocol.pickle import dumps, loads
 from .publish import Datasets
@@ -3203,12 +3202,7 @@ class Client:
             keys = list(map(stringify, {f.key for f in futures}))
         else:
             keys = None
-
-        result = self.sync(self.scheduler.who_has, keys=keys, **kwargs)
-        if self.asynchronous:
-            return result
-
-        return WhoHas(result)
+        return self.sync(self.scheduler.who_has, keys=keys, **kwargs)
 
     def has_what(self, workers=None, **kwargs):
         """Which keys are held by which workers
@@ -3242,12 +3236,7 @@ class Client:
             workers = list(workers)
         if workers is not None and not isinstance(workers, (tuple, list, set)):
             workers = [workers]
-        result = self.sync(self.scheduler.has_what, workers=workers, **kwargs)
-
-        if self.asynchronous:
-            return result
-
-        return HasWhat(result)
+        return self.sync(self.scheduler.has_what, workers=workers, **kwargs)
 
     def processing(self, workers=None):
         """The tasks currently running on each worker

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3625,7 +3625,7 @@ async def test_async_whowhat(c, s, a, b):
     assert has_what == {a.address: (x.key,), b.address: ()}
 
 
-@pytest.mark.xfail("Want to fix to use `WhoHas` + `WhatHas`")
+@pytest.mark.xfail(reason="Want to fix to use `WhoHas` + `WhatHas`")
 def test_client_repr(c):
     x = c.submit(inc, 1)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3625,6 +3625,7 @@ async def test_async_whowhat(c, s, a, b):
     assert has_what == {a.address: (x.key,), b.address: ()}
 
 
+@pytest.mark.xfail("Want to fix to use `WhoHas` + `WhatHas`")
 def test_client_repr(c):
     x = c.submit(inc, 1)
 


### PR DESCRIPTION
PR ( https://github.com/dask/distributed/pull/4853 ) ran into some issues, which was largely reverted by PR ( https://github.com/dask/distributed/pull/4860 ). However there are some lingering issues, this tries to revert the remaining pieces.

cc @dantegd @quasiben @jrbourbeau

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`

