### PR TITLE
AutoRestrictor scheduler plugin

### DIFF
--- a/distributed/plugins/autorestrictor.py
+++ b/distributed/plugins/autorestrictor.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from distributed import SchedulerPlugin
-from dask.core import reverse_dict, get_dependencies
+from dask.core import reverse_dict
 from dask.base import tokenize
 from dask.order import graph_metrics, ndependencies
 
@@ -121,13 +121,16 @@ class AutoRestrictor(SchedulerPlugin):
                 hash_map[k] = \
                     set().union(*[hash_map[kk] for kk in shared_roots.keys()])
 
-        for k, deps in terminal_dependencies.items():
+        for k in terminal_dependencies.keys():
+
+            tdp = terminal_dependencies[k]
+            tdn = terminal_dependents[k] if terminal_dependents[k] else set()
 
             # TODO: This can likely be improved.
             group = hash_map[tokenize(*sorted(roots_per_terminal[k]))]
 
             # Set restrictions on a terminal node and its dependencies.
-            for tn in [k, *deps]:
+            for tn in [k, *tdp, *tdn]:
                 try:
                     task = tasks[tn]
                 except KeyError:  # Keys may not have an assosciated task.

--- a/distributed/plugins/autorestrictor.py
+++ b/distributed/plugins/autorestrictor.py
@@ -1,0 +1,139 @@
+from collections import defaultdict
+
+from distributed import SchedulerPlugin
+from dask.core import reverse_dict, get_dependencies
+from dask.base import tokenize
+from dask.order import graph_metrics, ndependencies
+
+
+def install_plugin(dask_scheduler=None, **kwargs):
+    dask_scheduler.add_plugin(AutoRestrictor(**kwargs), idempotent=True)
+
+
+def unravel_deps(hlg_deps, name, unravelled_deps=None):
+    """Recursively construct a set of all dependencies for a specific task."""
+
+    if unravelled_deps is None:
+        unravelled_deps = set()
+
+    for dep in hlg_deps[name]:
+        unravelled_deps |= {dep}
+        unravel_deps(hlg_deps, dep, unravelled_deps)
+
+    return unravelled_deps
+
+
+def get_node_depths(dependencies, root_nodes, metrics):
+
+    node_depths = {}
+
+    for k in dependencies.keys():
+        # Get dependencies per node.
+        deps = unravel_deps(dependencies, k)
+        # Associate nodes with root nodes.
+        roots = root_nodes & deps
+        offset = metrics[k][-1]
+        node_depths[k] = \
+            max(metrics[r][-1] - offset for r in roots) if roots else 0
+
+    return node_depths
+
+
+class AutoRestrictor(SchedulerPlugin):
+
+    def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None,
+                     **kw):
+        """Processes dependencies to assign tasks to specific workers."""
+
+        workers = list(scheduler.workers.keys())
+        n_worker = len(workers)
+
+        tasks = scheduler.tasks
+        dependencies = kw["dependencies"]
+        dependents = reverse_dict(dependencies)
+
+        _, total_dependencies = ndependencies(dependencies, dependents)
+        metrics = graph_metrics(dependencies, dependents, total_dependencies)
+
+        # Terminal nodes have no dependents, root nodes have no dependencies.
+        terminal_nodes = {k for (k, v) in dependents.items() if not v}
+        root_nodes = {k for (k, v) in dependencies.items() if not v}
+
+        # Figure out the depth of every task. Depth is defined as maximum
+        # distance from a root node.
+        node_depths = get_node_depths(dependencies, root_nodes, metrics)
+        max_depth = max(node_depths.values())
+
+        # If we have fewer terminal nodes than workers, we cannot utilise all
+        # the workers and are likely dealing with a reduction. We work our way
+        # back through the graph, starting at the deepest terminal nodes, and
+        # try to find a depth at which there was enough work to utilise all
+        # workers.
+        while len(terminal_nodes) < n_worker:
+            _terminal_nodes = terminal_nodes.copy()
+            for tn in _terminal_nodes:
+                if node_depths[tn] == max_depth:
+                    terminal_nodes ^= set((tn,))
+                    terminal_nodes |= dependencies[tn]
+            max_depth -= 1
+            if max_depth == -1:
+                raise ValueError("AutoRestrictor cannot determine a sensible "
+                                 "work assignment pattern. Falling back to "
+                                 "default behaviour.")
+
+        roots_per_terminal = {}
+        terminal_dependencies = {}
+        terminal_dependents = {}
+
+        for tn in terminal_nodes:
+            # Get dependencies per terminal node.
+            terminal_dependencies[tn] = unravel_deps(dependencies, tn)
+            # Get dependents per terminal node. TODO: This terminology is
+            # confusing - the terminal nodes are not necessarily the last.
+            terminal_dependents[tn] = unravel_deps(dependents, tn)
+            # Associate terminal nodes with root nodes.
+            roots_per_terminal[tn] = root_nodes & terminal_dependencies[tn]
+
+        # Create a unique token for each set of terminal roots. TODO: This is
+        # very strict. What about nodes with very similar roots? Tokenization
+        # may be overkill too.
+        root_tokens = \
+            {tokenize(*sorted(v)): v for v in roots_per_terminal.values()}
+
+        hash_map = defaultdict(set)
+        group_offset = 0
+
+        # Associate terminal roots with a specific group if they are not a
+        # subset of another larger root set. TODO: This can likely be improved.
+        for k, v in root_tokens.items():
+            if any([v < vv for vv in root_tokens.values()]):  # Strict subset.
+                continue
+            else:
+                hash_map[k] |= set([group_offset])
+                group_offset += 1
+
+        # If roots were a subset, they should share the annotation of their
+        # superset/s.
+        for k, v in root_tokens.items():
+            shared_roots = \
+                {kk: None for kk, vv in root_tokens.items() if v < vv}
+            if shared_roots:
+                hash_map[k] = \
+                    set().union(*[hash_map[kk] for kk in shared_roots.keys()])
+
+        for k, deps in terminal_dependencies.items():
+
+            # TODO: This can likely be improved.
+            group = hash_map[tokenize(*sorted(roots_per_terminal[k]))]
+
+            # Set restrictions on a terminal node and its dependencies.
+            for tn in [k, *deps]:
+                try:
+                    task = tasks[tn]
+                except KeyError:  # Keys may not have an assosciated task.
+                    continue
+                if task._worker_restrictions is None:
+                    task._worker_restrictions = set()
+                task._worker_restrictions |= \
+                    {workers[g % n_worker] for g in group}
+                task._loose_restrictions = False


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Hi all! I have taken the time to slightly refine the scheduler plugin which I described in my contribution to the Dask Summit (the final talk in the Radio Astronomy Applications with Dask workshop). Whilst it may not yet be ready to merge, I believe that it is now in a state for people to start playing with it and offering feedback.

# Motivation
I am developing QuartiCal, an application for calibrating radio interferometer data. Whilst testing this on an HPC system, I would regularly see dashboard output resembling the following:

![Screenshot from 2021-06-01 10-32-29](https://user-images.githubusercontent.com/6582745/120293997-0e0d5500-c2c6-11eb-9240-3746181cf4c6.png)

This includes a large number of transfers (red) as well as a large amount of time spent doing nothing (white-space). The transfers are particularly bothersome as the graph in question consists of many parallel, independent subgraphs i.e. each can be processed completely independently of its neighbours. I had previously assumed that the scheduler would realise this and avoid the unnecessary transfers. With the assistance of @sjperkins, I have attempted to design a scheduler plugin to coerce this behaviour by automatically restricting tasks to specific workers. The goal was to design something:
 - non-invasive
 - generic
 - low-overhead 

# How it works
1. Identify all root nodes (no dependencies).
2. Identify all terminal nodes (no dependents).
3. If the number of terminal nodes (outputs) is smaller than the number of available workers, replace terminal nodes with their dependencies (partition the graph horizontally) until there are enough nodes in the partitioning layer to ensure every worker gets work.
4. Associate each node in the partitioning layer with its roots (the root nodes on which it depends, directly or indirectly).
5. Associate each unique set of roots with an abstract group number (essentially an index), taking care to ensure that tasks which share roots are assigned to the same group.
6. Assign each group to a worker by setting the worker restrictions for all tasks in the group (tasks may be assigned to multiple workers if they are e.g. a shared dependency). Groups are iteratively assigned to the least subscribed worker.

# How to use it
This example uses a `LocalCluster`, but it should work regardless of cluster setup.
```python
from distributed import Client, LocalCluster
from distributed.plugins.autorestrictor import install_plugin

cluster = LocalCluster(...)  # Cluster setup.
client = Client(cluster)
client.run_on_scheduler(install_plugin)
```

# Example
The following example demonstrates how the plugin alters the scheduler's default behaviour. I have chosen a sum over a single axis of a chunked dask array as I feel it is a representative example of common use-cases (reduction, non-negligible transfer sizes).
```python
import dask.array as da
from distributed import Client, LocalCluster
from distributed.plugins.autorestrictor import install_plugin


def example():
    # Each chunk is 100MB of data. Entire array is 100GB.
    data = da.zeros((12500000, 1000), chunks=(12500000, 1))
    return da.sum(data, axis=1)


if __name__ == "__ main__":

    cluster = LocalCluster(processes=True,
                           n_workers=4,
                           threads_per_worker=1,
                           memory_limit=0)
    client = Client(cluster)
    #client.run_on_scheduler(install_plugin)  # Uncomment to enable.

    da.compute(example)
```

This is a screenshot of the task stream with the scheduler plugin disabled:

![Screenshot from 2021-06-01 10-44-35](https://user-images.githubusercontent.com/6582745/120294471-8116cb80-c2c6-11eb-81ca-f49cdb063d7e.png)

This takes just under 90s on my laptop. Note the huge number of transfers (red). Running the example again, this time with the plugin installed we see the following in the dashboard:

![Screenshot from 2021-06-01 10-44-43](https://user-images.githubusercontent.com/6582745/120294489-86741600-c2c6-11eb-8648-12b525792039.png)

This took just under 60s on my laptop. Transfers have been all but eliminated; those that remain are those which cannot be avoided due to distributing the problem (at some point during this type of reduction, one has to combine results from different workers.)

It is also interesting to look at memory usage with and without the plugin. The following results were obtained using `memory_profiler`. Without the plugin:

![Screenshot from 2021-06-01 10-18-38](https://user-images.githubusercontent.com/6582745/120294818-df43ae80-c2c6-11eb-82b2-4a8bb2c84399.png)
Here we see very inconsistent behaviour between workers and the peak memory usage is around 27GB. Note that every run will differ when using the default behaviour as the scheduling is non-deterministic (to the best of my knowledge).  

With the plugin:

![Screenshot from 2021-06-01 10-18-27](https://user-images.githubusercontent.com/6582745/120294835-e4086280-c2c6-11eb-81b9-103129c1ea6a.png)

Here the behaviour is very consistent between workers and we would expect multiple runs to produce very similar results. The peak memory usage is just under 7GB. This demonstrates a fairly dramatic improvement in memory footprint. This is due to the fact that the plugin discourages greediness (which may lead to many large tasks being in memory) in favour of minimizing transfers. 

# Real-world example
The following is the same problem shown in the motivation section but with the scheduler plugin enabled:

![Screenshot from 2021-06-01 10-32-32](https://user-images.githubusercontent.com/6582745/120295639-9e986500-c2c7-11eb-8071-4fa47d03f249.png)

Note how the transfers have been eliminated and that workers spend substantially less time idling (performance improved by approximately a factor of two).

# Caveats
 - I do not know where this should live inside distributed.
 - Behaviour may be poor for very small graphs.
 - `graph_metrics` and `get_node_depths` are expensive (plugin takes around 2s for around 100000 nodes), but I believe I can remove/improve them. I wanted to get other feedback before optimizing.
 - Heterogeneous compute is supported, `da.compute(a, b, c)`, but I have likely not considered every use case.
 - Failure should be graceful (revert to the default behaviour) but this could likely be improved. 
- I have not implemented proper tests, largely because I am unsure how to test something like this. Suggestions welcome.
