### PR TITLE
Changed the default scheduler_port in local.py to 8786 #4429

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -105,7 +105,7 @@ class LocalCluster(SpecCluster):
         start=None,
         host=None,
         ip=None,
-        scheduler_port=0,
+        scheduler_port=8786,
         silence_logs=logging.WARN,
         dashboard_address=":8787",
         worker_dashboard_address=None,


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
