### PR TITLE
Multiple worker executors

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7366,6 +7366,8 @@ def _task_to_msg(state: SchedulerState, ts: TaskState, duration: double = -1) ->
     else:
         msg["task"] = task
 
+    if ts._annotations:
+        msg["annotations"] = ts._annotations
     return msg
 
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -61,7 +61,7 @@ from distributed.worker import Worker, error_message, logger, parse_memory_limit
 async def test_worker_nthreads(cleanup):
     async with Scheduler() as s:
         async with Worker(s.address) as w:
-            assert w.executors["default"]._max_workers == CPU_COUNT
+            assert w.executor._max_workers == CPU_COUNT
 
 
 @gen_cluster()
@@ -492,7 +492,7 @@ async def test_run_coroutine_dask_worker(c, s, a, b):
 async def test_Executor(c, s):
     with ThreadPoolExecutor(2) as e:
         w = Worker(s.address, executor=e)
-        assert w.executors["default"] is e
+        assert w.executor is e
         w = await w
 
         future = c.submit(inc, 1)
@@ -1769,7 +1769,7 @@ async def test_executor_offload(cleanup, monkeypatch):
         async with Worker(s.address, executor="offload") as w:
             from distributed.utils import _offload_executor
 
-            assert w.executors["default"] is _offload_executor
+            assert w.executor is _offload_executor
 
             async with Client(s.address, asynchronous=True) as c:
                 x = SameThreadClass()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -61,7 +61,7 @@ from distributed.worker import Worker, error_message, logger, parse_memory_limit
 async def test_worker_nthreads(cleanup):
     async with Scheduler() as s:
         async with Worker(s.address) as w:
-            assert w.executor._max_workers == CPU_COUNT
+            assert w.executors["default"]._max_workers == CPU_COUNT
 
 
 @gen_cluster()
@@ -492,7 +492,7 @@ async def test_run_coroutine_dask_worker(c, s, a, b):
 async def test_Executor(c, s):
     with ThreadPoolExecutor(2) as e:
         w = Worker(s.address, executor=e)
-        assert w.executor is e
+        assert w.executors["default"] is e
         w = await w
 
         future = c.submit(inc, 1)
@@ -1769,7 +1769,7 @@ async def test_executor_offload(cleanup, monkeypatch):
         async with Worker(s.address, executor="offload") as w:
             from distributed.utils import _offload_executor
 
-            assert w.executor is _offload_executor
+            assert w.executors["default"] is _offload_executor
 
             async with Client(s.address, asynchronous=True) as c:
                 x = SameThreadClass()

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -301,7 +301,7 @@ async def test_worker_client_rejoins(c, s, a, b):
         with worker_client():
             pass
 
-        return threading.current_thread() in get_worker().executors["default"]._threads
+        return threading.current_thread() in get_worker().executor._threads
 
     result = await c.submit(f)
     assert result

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -301,7 +301,7 @@ async def test_worker_client_rejoins(c, s, a, b):
         with worker_client():
             pass
 
-        return threading.current_thread() in get_worker().executor._threads
+        return threading.current_thread() in get_worker().executors["default"]._threads
 
     result = await c.submit(f)
     assert result

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -230,7 +230,7 @@ class Worker(ServerNode):
 
     * **nthreads:** ``int``:
         Number of nthreads used by this worker process
-    * **executors:** ``Dict[str, concurrent.futures.ThreadPoolExecutor]``:
+    * **executors:** ``Dict[str, concurrent.futures.Executor]``:
         Executors used to perform computation. Always contains the default
         executor.
     * **local_directory:** ``path``:
@@ -329,10 +329,15 @@ class Worker(ServerNode):
         Fraction of memory at which we start spilling to disk
     memory_pause_fraction: float
         Fraction of memory at which we stop running new tasks
-    executor: concurrent.futures.Executor, str
-        The default executor. This can also be the string "offload" in which
-        case this uses the same thread pool used for offloading communications.
-        This results in the same thread being used for deserialization and computation.
+    executor: concurrent.futures.Executor, dict[str, concurrent.futures.Executor], str
+        The executor(s) to use. Depending on the type, it has the following meanings:
+            - Executor instance: The default executor.
+            - Dict[str, Executor]: mapping names to Executor instances. If the
+              "default" key isn't in the dict, a "default" executor will be created
+              ``ThreadPoolExecutor(nthreads)``.
+            - Str: The string "offload", which refer to the same thread pool used for
+              offloading communications. This results in the same thread being used for
+              deserialization and computation.
     resources: dict
         Resources that this worker has like ``{'GPU': 2}``
     nanny: str

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -650,7 +650,7 @@ class Worker(ServerNode):
             self.executors["default"] = executor
         if "default" not in self.executors:
             self.executors["default"] = ThreadPoolExecutor(
-                self.nthreads, thread_name_prefix="Dask-Default-Threads'"
+                self.nthreads, thread_name_prefix="Dask-Default-Threads"
             )
 
         self.batched_stream = BatchedSend(interval="2ms", loop=self.loop)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -154,6 +154,8 @@ class TaskState:
         serializable (e.g. int, string, list, dict).
     * **nbytes**: ``int``
         The size of a particular piece of data
+    * **annotations**: ``dict``
+        Task annotations
 
     Parameters
     ----------
@@ -188,6 +190,7 @@ class TaskState:
         self.stop_time = None
         self.metadata = {}
         self.nbytes = None
+        self.annotations = None
 
     def __repr__(self):
         return "<Task %r %s>" % (self.key, self.state)
@@ -1503,6 +1506,7 @@ class Worker(ServerNode):
         duration=None,
         resource_restrictions=None,
         actor=False,
+        annotations=None,
         **kwargs2,
     ):
         try:
@@ -1549,6 +1553,7 @@ class Worker(ServerNode):
             ts.duration = duration
             if resource_restrictions:
                 ts.resource_restrictions = resource_restrictions
+            ts.annotations = annotations
 
             who_has = who_has or {}
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2812,7 +2812,10 @@ class Worker(ServerNode):
                 if self.digests is not None:
                     self.digests["disk-load-duration"].add(stop - start)
 
-            executor = ts.annotations.get("executor", "default")
+            if ts.annotations is not None and "executor" in ts.annotations:
+                executor = ts.annotations["executor"]
+            else:
+                executor = "default"
             assert executor in self.executors
 
             logger.debug(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -827,6 +827,10 @@ class Worker(ServerNode):
         )
         return self.local_directory
 
+    @property
+    def executor(self):
+        return self.executors["default"]
+
     async def get_metrics(self):
         out = dict(
             executing=self.executing_count,


### PR DESCRIPTION
This is the first iteration of implementing multiple worker executors as discussed in #4655

- [x] Closes #4655
- [x] Closes #4560
- [x] Closes #4598
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

The idea is to send task annotations to the workers and let workers have a dict of executors `name -> ThreadPoolExecutor`. The default value of this dict is:
```python
        self.executors = {
            "offload": utils._offload_executor,
            "actor": ThreadPoolExecutor(1, thread_name_prefix="Dask-Actor-Threads"),
            "default": ThreadPoolExecutor(self.nthreads, thread_name_prefix="Dask-Default-Threads'"),
        }
```
If nothing is specified through the `executor` annotation, the worker will use the `"default"` executor. 

**NB:** this doesn't control the number of concurrent tasks running on a worker. For now, use the already available `resource` management.

Example of running CPU tasks in the default `ThreadPoolExecutor` and GPU tasks in an dedicated `ThreadPoolExecutor`:
```python
import asyncio
import threading
import dask
from dask.distributed import Client, Scheduler, Worker
from distributed.threadpoolexecutor import ThreadPoolExecutor

def get_thread_name(prefix):
    return prefix + threading.current_thread().name

async def main():
    async with Scheduler() as s:
        async with Worker(
            s.address,
            nthreads=5,
            executor={
                "GPU": ThreadPoolExecutor(1, thread_name_prefix="Dask-GPU-Threads")
            },
            resources={"GPU": 1, "CPU": 4},
        ) as w:
            async with Client(s.address, asynchronous=True) as c:
                with dask.annotate(resources={"CPU": 1}, executor="default"):
                    print(await c.submit(get_thread_name, "CPU-"))
                with dask.annotate(resources={"GPU": 1}, executor="GPU"):
                    print(await c.submit(get_thread_name, "GPU-"))

if __name__ == "__main__":
    asyncio.get_event_loop().run_until_complete(main())
```
Output
```
CPU-Dask-Default-Threads'-29802-2
GPU-Dask-GPU-Threads-29802-3
```
