### PR TITLE
Show more in test summary

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ tag_prefix =
 parentdir_prefix = distributed-
 
 [tool:pytest]
-addopts = -v -r s --durations=20
+addopts = -v -rsxfE --durations=20
 filterwarnings =
     error:Since distributed.*:PendingDeprecationWarning
 minversion = 4


### PR DESCRIPTION
This PR updates our default `pytest` command to display more information (e.g. which tests failed) in the summary printed after running tests. This is particularly nice as it will help us avoid lots of scrolling in CI builds in light of https://github.com/dask/distributed/issues/4806

Companion PR to https://github.com/dask/dask/pull/7735