### PR TITLE
Mark `test_server_comms_mark_active_handlers` with `pytest.mark.asyncio`

### DIFF
--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -888,6 +888,7 @@ async def test_server_redundant_kwarg():
         await Server({}, typo_kwarg="foo")
 
 
+@pytest.mark.asyncio
 async def test_server_comms_mark_active_handlers():
     """Whether handlers are active can be read off of the self._comms values.
     ensure this is properly reflected and released. The sentinel for


### PR DESCRIPTION
I noticed `distributed/tests/test_core.py::test_server_comms_mark_active_handlers` is currently being unintentionally skipped because it's an `async def` tests which isn't marked with `pytest.mark.asyncio`. This PR ensures the test is run 