### PR TITLE
No longer cancel result future in async process when using timeouts

### DIFF
--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -49,7 +49,6 @@ def threads_info(q):
     q.put(threading.current_thread().name)
 
 
-@pytest.mark.xfail()
 @nodebug
 @gen_test()
 async def test_simple():
@@ -362,7 +361,7 @@ def _parent_process(child_pipe):
 
     with pristine_loop() as loop:
         try:
-            loop.run_sync(parent_process_coroutine(), timeout=10)
+            loop.run_sync(parent_process_coroutine, timeout=10)
         finally:
             loop.stop()
 


### PR DESCRIPTION
Minor fix I came across. From what I can see the async join is actually never used except for this test. Since the test was marked xfail it would still run, generate weird warnings, run into timeouts, etc.