### PR TITLE
Don't strip scheduler protocol when determining host

### DIFF
--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -5,8 +5,6 @@ import dask
 from ..utils import get_ip_interface
 from . import registry
 
-DEFAULT_SCHEME = dask.config.get("distributed.comm.default-scheme")
-
 
 def parse_address(addr, strict=False):
     """
@@ -28,7 +26,7 @@ def parse_address(addr, strict=False):
         )
         raise ValueError(msg)
     if not sep:
-        scheme = DEFAULT_SCHEME
+        scheme = dask.config.get("distributed.comm.default-scheme")
     return scheme, loc
 
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -530,7 +530,7 @@ class Worker(ServerNode):
         # Target interface on which we contact the scheduler by default
         # TODO: it is unfortunate that we special-case inproc here
         if not host and not interface and not scheduler_addr.startswith("inproc://"):
-            host = get_ip(get_address_host(scheduler_addr.split("://")[-1]))
+            host = get_ip(get_address_host(scheduler_addr))
 
         self._start_port = port
         self._start_host = host


### PR DESCRIPTION
When determining the scheduler `host` on a worker we currently strip off the protocol used by the scheduler:

https://github.com/dask/distributed/blob/611923e2d718350b8e8443d0d94c853c18b91574/distributed/worker.py#L533

Since [`distributed.addressing.get_address_host` internally calls the corresponding comm backend `get_address_host` method](https://github.com/dask/distributed/blob/611923e2d718350b8e8443d0d94c853c18b91574/distributed/comm/addressing.py#L140-L142), I would have expected that if the scheduler is using a custom protocol, we would want to use the custom comm backend `get_address_host` method when determining the scheduler's host instead of whatever the default is on the worker (`tcp` by default). 

It looks like we began stripping the protocol intentionally in https://github.com/dask/distributed/pull/3678, though I'm not sure what the reasoning behind the change was (xref https://github.com/dask/distributed/pull/3678#discussion_r404941210). This PR proposes we keep the scheduler address protocol so we can use that information in `get_address_host`, though I certainly could be missing some logic behind why we began stripping the protocol in the first place.

cc @mrocklin 