### PR TITLE
Flake8 config cleanup

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,9 @@ else:
     except Exception:
         pass
 
+# Make all fixtures available
+from distributed.utils_test import *  # noqa
+
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", help="run slow tests")

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -16,7 +16,6 @@ import distributed.cli.dask_scheduler
 from distributed import Client, Scheduler
 from distributed.metrics import time
 from distributed.utils import get_ip, get_ip_interface, tmpfile
-from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import (
     assert_can_connect_from_everywhere_4_6,
     assert_can_connect_locally_4,
@@ -142,17 +141,6 @@ def test_dashboard_whitelist(loop):
                 print(f)
                 sleep(0.1)
                 assert time() < start + 20
-
-
-def test_multiple_workers(loop):
-    with popen(["dask-scheduler", "--no-dashboard"]) as s:
-        with popen(["dask-worker", "localhost:8786", "--no-dashboard"]) as a:
-            with popen(["dask-worker", "localhost:8786", "--no-dashboard"]) as b:
-                with Client("127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
-                    start = time()
-                    while len(c.nthreads()) < 2:
-                        sleep(0.1)
-                        assert time() < start + 10
 
 
 def test_interface(loop):
@@ -418,7 +406,7 @@ def test_idle_timeout(loop):
     assert 1 < stop - start < 10
 
 
-def test_multiple_workers(loop):
+def test_multiple_workers_2(loop):
     text = """
 def dask_setup(worker):
     worker.foo = 'setup'
@@ -441,3 +429,14 @@ def dask_setup(worker):
                 assert foo == "setup"
                 [foo] = c.run(lambda dask_worker: dask_worker.foo, nanny=True).values()
                 assert foo == "setup"
+
+
+def test_multiple_workers(loop):
+    with popen(["dask-scheduler", "--no-dashboard"]) as s:
+        with popen(["dask-worker", "localhost:8786", "--no-dashboard"]) as a:
+            with popen(["dask-worker", "localhost:8786", "--no-dashboard"]) as b:
+                with Client("127.0.0.1:%d" % Scheduler.default_port, loop=loop) as c:
+                    start = time()
+                    while len(c.nthreads()) < 2:
+                        sleep(0.1)
+                        assert time() < start + 10

--- a/distributed/cli/tests/test_dask_spec.py
+++ b/distributed/cli/tests/test_dask_spec.py
@@ -5,7 +5,6 @@ import yaml
 
 from distributed import Client
 from distributed.scheduler import COMPILED
-from distributed.utils_test import cleanup  # noqa: F401
 from distributed.utils_test import popen
 
 

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -17,13 +17,7 @@ from distributed import Client, Scheduler
 from distributed.deploy.utils import nprocesses_nthreads
 from distributed.metrics import time
 from distributed.utils import parse_ports, sync, tmpfile
-from distributed.utils_test import (  # noqa: F401
-    cleanup,
-    loop,
-    popen,
-    terminate_process,
-    wait_for_port,
-)
+from distributed.utils_test import popen, terminate_process, wait_for_port
 
 
 def test_nanny_worker_ports(loop):

--- a/distributed/cli/tests/test_tls_cli.py
+++ b/distributed/cli/tests/test_tls_cli.py
@@ -2,7 +2,6 @@ from time import sleep
 
 from distributed import Client
 from distributed.metrics import time
-from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import (
     get_cert,
     new_config_file,

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -42,7 +42,7 @@ def check_python_3():
             _unicodefun._verify_python3_env()
         else:
             _unicodefun._verify_python_env()
-    except (TypeError, RuntimeError) as e:
+    except (TypeError, RuntimeError):
         import click
 
         click.echo(py3_err_msg, err=True)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1127,7 +1127,7 @@ class Client:
                     "versions": version_module.get_versions(),
                 }
             )
-        except Exception as e:
+        except Exception:
             if self.status == "closed":
                 return
             else:
@@ -3997,7 +3997,6 @@ class Client:
         for response in responses.values():
             if response["status"] == "error":
                 exc = response["exception"]
-                typ = type(exc)
                 tb = response["traceback"]
                 raise exc.with_traceback(tb)
         return responses

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -219,7 +219,7 @@ class Listener(ABC):
             # Timeout is to ensure that we'll terminate connections eventually.
             # Connector side will employ smaller timeouts and we should only
             # reach this if the comm is dead anyhow.
-            write = await asyncio.wait_for(comm.write(local_info), timeout=timeout)
+            await asyncio.wait_for(comm.write(local_info), timeout=timeout)
             handshake = await asyncio.wait_for(comm.read(), timeout=timeout)
             # This would be better, but connections leak if worker is closed quickly
             # write, handshake = await asyncio.gather(comm.write(local_info), comm.read())

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -33,7 +33,6 @@ from distributed.compatibility import WINDOWS
 from distributed.metrics import time
 from distributed.protocol import Serialized, deserialize, serialize, to_serialize
 from distributed.utils import get_ip, get_ipv6
-from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import (
     get_cert,
     get_client_ssl_context,

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -9,7 +9,7 @@ from distributed.comm import connect, listen, parse_address, ucx
 from distributed.comm.registry import backends, get_backend
 from distributed.deploy.local import LocalCluster
 from distributed.protocol import to_serialize
-from distributed.utils_test import cleanup, gen_test, inc, loop, popen  # noqa: 401
+from distributed.utils_test import gen_test, inc
 
 try:
     HOST = ucp.get_address()

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -8,7 +8,7 @@ from dask.utils import format_bytes
 from distributed import Client
 from distributed.comm.ucx import _scrub_ucx_config
 from distributed.utils import get_ip
-from distributed.utils_test import cleanup, gen_test, inc, loop, popen  # noqa: 401
+from distributed.utils_test import popen
 
 try:
     HOST = get_ip()

--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -12,8 +12,7 @@ from distributed.comm import connect, listen, ws
 from distributed.comm.core import FatalCommClosedError
 from distributed.comm.registry import backends, get_backend
 from distributed.security import Security
-from distributed.utils_test import (  # noqa: F401
-    cleanup,
+from distributed.utils_test import (
     gen_cluster,
     get_client_ssl_context,
     get_server_ssl_context,

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -547,7 +547,6 @@ class Server:
         extra = extra or {}
         logger.info("Starting established connection")
 
-        io_error = None
         closed = False
         try:
             while not closed:
@@ -580,8 +579,9 @@ class Server:
                     else:
                         func()
 
-        except (CommClosedError, EnvironmentError) as e:
-            io_error = e
+        except (CommClosedError, EnvironmentError):
+            # FIXME: This is silently ignored, is this intentional?
+            pass
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -217,7 +217,7 @@ class AdaptiveCore:
                 await self.scale_up(**recommendations)
             if status == "down":
                 await self.scale_down(**recommendations)
-        except OSError as e:
+        except OSError:
             if status != "down":
                 logger.error("Adaptive stopping due to error", exc_info=True)
                 self.stop()

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -334,7 +334,6 @@ class SpecCluster(Cluster):
         async with self._lock:
             self._correct_state_waiting = None
 
-            pre = list(set(self.workers))
             to_close = set(self.workers) - set(self.worker_spec)
             if to_close:
                 if self.scheduler.status == Status.running:

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -9,15 +9,7 @@ import dask
 
 from distributed import Adaptive, Client, LocalCluster, SpecCluster, Worker, wait
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa: F401
-    async_wait_for,
-    clean,
-    cleanup,
-    gen_test,
-    loop,
-    nodebug,
-    slowinc,
-)
+from distributed.utils_test import async_wait_for, clean, gen_test, slowinc
 
 
 def test_adaptive_local_cluster(loop):

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -1,7 +1,6 @@
 import pytest
 
 from distributed.deploy.cluster import Cluster
-from distributed.utils_test import cleanup  # noqa: F401
 
 
 @pytest.mark.asyncio

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -24,17 +24,15 @@ from distributed.metrics import time
 from distributed.scheduler import COMPILED
 from distributed.system import MEMORY_LIMIT
 from distributed.utils import TimeoutError, sync
-from distributed.utils_test import (  # noqa: F401
+from distributed.utils_test import (
     assert_can_connect_from_everywhere_4,
     assert_can_connect_from_everywhere_4_6,
     assert_can_connect_locally_4,
     assert_cannot_connect,
     captured_logger,
     clean,
-    cleanup,
     gen_test,
     inc,
-    loop,
     slowinc,
     tls_only_security,
 )

--- a/distributed/deploy/tests/test_old_ssh.py
+++ b/distributed/deploy/tests/test_old_ssh.py
@@ -7,7 +7,6 @@ pytest.importorskip("paramiko")
 from distributed import Client
 from distributed.deploy.old_ssh import SSHCluster
 from distributed.metrics import time
-from distributed.utils_test import loop  # noqa: F401
 
 
 @pytest.mark.avoid_ci

--- a/distributed/deploy/tests/test_slow_adaptive.py
+++ b/distributed/deploy/tests/test_slow_adaptive.py
@@ -5,7 +5,7 @@ import pytest
 from dask.distributed import Client, Scheduler, SpecCluster, Worker
 
 from distributed.metrics import time
-from distributed.utils_test import cleanup, slowinc  # noqa: F401
+from distributed.utils_test import slowinc
 
 
 class SlowWorker:

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -14,7 +14,6 @@ from distributed.core import Status
 from distributed.deploy.spec import ProcessInterface, close_clusters, run_spec
 from distributed.metrics import time
 from distributed.utils import is_valid_xml
-from distributed.utils_test import cleanup, loop  # noqa: F401
 
 
 class MyWorker(Worker):

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -9,7 +9,6 @@ import dask
 from distributed import Client
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.deploy.ssh import SSHCluster
-from distributed.utils_test import loop  # noqa: F401
 
 pytestmark = [
     pytest.mark.xfail(MACOS, reason="very high flakiness; see distributed/issues/4543"),

--- a/distributed/deploy/utils_test.py
+++ b/distributed/deploy/utils_test.py
@@ -17,7 +17,7 @@ class ClusterTest:
 
     @pytest.mark.xfail()
     def test_cores(self):
-        info = self.client.scheduler_info()
+        self.client.scheduler_info()
         assert len(self.client.nthreads()) == 2
 
     def test_submit(self):

--- a/distributed/diagnostics/graph_layout.py
+++ b/distributed/diagnostics/graph_layout.py
@@ -99,9 +99,7 @@ class GraphLayout(SchedulerPlugin):
             task = self.scheduler.tasks[key]
             for dep in task.dependents:
                 edge = (key, dep.key)
-                self.visible_edge_updates.append(
-                    (self.index_edge.pop((key, dep.key)), "False")
-                )
+                self.visible_edge_updates.append((self.index_edge.pop(edge), "False"))
             for dep in task.dependencies:
                 self.visible_edge_updates.append(
                     (self.index_edge.pop((dep.key, key)), "False")

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -5,14 +5,7 @@ import pytest
 from distributed import Scheduler, Worker
 from distributed.diagnostics.progressbar import TextProgressBar, progress
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa: F401
-    client,
-    cluster_fixture,
-    div,
-    gen_cluster,
-    inc,
-    loop,
-)
+from distributed.utils_test import div, gen_cluster, inc
 
 
 def test_text_progressbar(capsys, client):
@@ -49,8 +42,8 @@ async def test_TextProgressBar_error(c, s, a, b):
 @pytest.mark.asyncio
 async def test_TextProgressBar_empty(capsys):
     async with Scheduler(port=0) as s:
-        async with Worker(s.address, nthreads=1) as a:
-            async with Worker(s.address, nthreads=1) as b:
+        async with Worker(s.address, nthreads=1):
+            async with Worker(s.address, nthreads=1):
                 progress = TextProgressBar(
                     [], scheduler=s.address, start=False, interval=0.01
                 )

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -1,7 +1,7 @@
 import pytest
 
 from distributed import Scheduler, SchedulerPlugin, Worker
-from distributed.utils_test import cleanup, gen_cluster, inc  # noqa: F401
+from distributed.utils_test import gen_cluster, inc
 
 
 @gen_cluster(client=True)

--- a/distributed/diagnostics/tests/test_task_stream.py
+++ b/distributed/diagnostics/tests/test_task_stream.py
@@ -8,15 +8,7 @@ from distributed import get_task_stream
 from distributed.client import wait
 from distributed.diagnostics.task_stream import TaskStreamPlugin
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa: F401
-    client,
-    cluster_fixture,
-    div,
-    gen_cluster,
-    inc,
-    loop,
-    slowinc,
-)
+from distributed.utils_test import div, gen_cluster, inc, slowinc
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -84,16 +84,7 @@ from distributed.diagnostics.progressbar import (
     ProgressWidget,
     progress,
 )
-from distributed.utils_test import (  # noqa: F401
-    client,
-    cluster_fixture,
-    dec,
-    gen_cluster,
-    gen_tls_cluster,
-    inc,
-    loop,
-    throws,
-)
+from distributed.utils_test import dec, gen_cluster, gen_tls_cluster, inc, throws
 from distributed.worker import dumps_task
 
 

--- a/distributed/diskutils.py
+++ b/distributed/diskutils.py
@@ -54,7 +54,7 @@ class WorkDir:
                     with workspace._global_lock():
                         self._lock_file = locket.lock_file(self._lock_path)
                         self._lock_file.acquire()
-                except OSError as e:
+                except OSError:
                     logger.exception(
                         "Could not acquire workspace lock on "
                         "path: %s ."

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -22,7 +22,6 @@ from . import preloading
 from .comm import get_address_host, unparse_host_port
 from .comm.addressing import address_from_user_args
 from .core import CommClosedError, RPCClosed, Status, coerce_to_address
-from .metrics import time
 from .node import ServerNode
 from .process import AsyncProcess
 from .proctitle import enable_proctitle_on_children
@@ -386,8 +385,6 @@ class Nanny(ServerNode):
         return result
 
     async def restart(self, comm=None, timeout=2, executor_wait=True):
-        start = time()
-
         async def _():
             if self.process is not None:
                 await self.kill()
@@ -405,7 +402,7 @@ class Nanny(ServerNode):
     def _psutil_process(self):
         pid = self.process.process.pid
         try:
-            proc = self._psutil_process_obj
+            self._psutil_process_obj
         except AttributeError:
             self._psutil_process_obj = psutil.Process(pid)
 

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -208,8 +208,6 @@ def plot_data(state, profile_interval=0.010):
         line_numbers.append(desc["line_number"])
         names.append(desc["name"])
 
-        ident = state["identifier"]
-
         try:
             fn = desc["filename"]
         except IndexError:
@@ -224,7 +222,7 @@ def plot_data(state, profile_interval=0.010):
 
         x = start
 
-        for name, child in state["children"].items():
+        for _, child in state["children"].items():
             width = child["count"] * delta
             traverse(child, x, x + width, height + 1)
             x += width
@@ -335,7 +333,6 @@ def get_profile(history, recent=None, start=None, stop=None, key=None):
     start : time
     stop : time
     """
-    now = time()
     if start is None:
         istart = 0
     else:

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -73,6 +73,6 @@ def loads(x, *, buffers=()):
             return pickle.loads(x, buffers=buffers)
         else:
             return pickle.loads(x)
-    except Exception as e:
+    except Exception:
         logger.info("Failed to deserialize %s", x[:10000], exc_info=True)
         raise

--- a/distributed/protocol/scipy.py
+++ b/distributed/protocol/scipy.py
@@ -10,7 +10,6 @@ register_generic(scipy.sparse.spmatrix, "dask", dask_serialize, dask_deserialize
 
 @dask_serialize.register(scipy.sparse.dok.dok_matrix)
 def serialize_scipy_sparse_dok(x):
-    x_coo = x.tocoo()
     coo_header, coo_frames = dask_serialize(x.tocoo())
 
     header = {"coo_header": coo_header}

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -324,14 +324,14 @@ def serialize(
     tb = ""
 
     for name in serializers:
-        dumps, loads, wants_context = families[name]
+        dumps, _, wants_context = families[name]
         try:
             header, frames = dumps(x, context=context) if wants_context else dumps(x)
             header["serializer"] = name
             return header, frames
         except NotImplementedError:
             continue
-        except Exception as e:
+        except Exception:
             tb = traceback.format_exc()
             break
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -11,8 +11,6 @@ try:
 except ImportError:
     np = None
 
-from dask.utils_test import inc
-
 from distributed import Nanny, wait
 from distributed.comm.utils import from_frames, to_frames
 from distributed.protocol import (

--- a/distributed/pytest_resourceleaks.py
+++ b/distributed/pytest_resourceleaks.py
@@ -345,7 +345,7 @@ class LeakChecker:
             from _pytest.runner import runtestprotocol
 
             item._initrequest()  # Re-init fixtures
-            reports = runtestprotocol(item, nextitem=nextitem, log=False)
+            runtestprotocol(item, nextitem=nextitem, log=False)
 
         nodeid = item.nodeid
         leaks = self.leaks.get(nodeid)
@@ -354,7 +354,7 @@ class LeakChecker:
             try:
                 for i in range(self.max_retries):
                     run_test_again()
-            except Exception as e:
+            except Exception:
                 print("--- Exception when re-running test ---")
                 import traceback
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2158,7 +2158,7 @@ class SchedulerState:
                     del parent._task_groups[tg._name]
 
             return recommendations, client_msgs, worker_msgs
-        except Exception as e:
+        except Exception:
             logger.exception("Error transitioning %r from %r to %r", key, start, finish)
             if LOG_PDB:
                 import pdb
@@ -3817,14 +3817,10 @@ class Scheduler(SchedulerState, ServerNode):
         signal to the worker to shut down.  This works regardless of whether or
         not the worker has a nanny process restarting it
         """
-        parent: SchedulerState = cast(SchedulerState, self)
         logger.info("Closing worker %s", worker)
         with log_errors():
             self.log_event(worker, {"action": "close-worker"})
-            ws: WorkerState = parent._workers_dv[worker]
-            nanny_addr = ws._nanny
-            address = nanny_addr or worker
-
+            # FIXME: This does not handly nannys
             self.worker_send(worker, {"op": "close", "report": False})
             await self.remove_worker(address=worker, safe=safe)
 
@@ -5405,7 +5401,7 @@ class Scheduler(SchedulerState, ServerNode):
                     # Ask the worker to close if it doesn't have a nanny,
                     # otherwise the nanny will kill it anyway
                     await self.remove_worker(address=addr, close=addr not in nannies)
-                except Exception as e:
+                except Exception:
                     logger.info(
                         "Exception while restarting.  This is normal", exc_info=True
                     )
@@ -6539,7 +6535,7 @@ class Scheduler(SchedulerState, ServerNode):
                     metadata[key] = dict()
                 metadata = metadata[key]
             metadata[keys[-1]] = value
-        except Exception as e:
+        except Exception:
             import pdb
 
             pdb.set_trace()
@@ -6604,7 +6600,7 @@ class Scheduler(SchedulerState, ServerNode):
     async def unregister_worker_plugin(self, comm, name):
         """Unregisters a worker plugin"""
         try:
-            worker_plugins = self.worker_plugins.pop(name)
+            self.worker_plugins.pop(name)
         except KeyError:
             raise ValueError(f"The worker plugin {name} does not exists")
 

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -8,13 +8,7 @@ import dask
 
 from distributed import Actor, ActorFuture, Client, Future, Nanny, wait
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa: F401
-    client,
-    cluster,
-    cluster_fixture,
-    gen_cluster,
-    loop,
-)
+from distributed.utils_test import cluster, gen_cluster
 
 
 class Counter:

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -10,14 +10,7 @@ import pytest
 from distributed.client import _as_completed, _first_completed, as_completed, wait
 from distributed.metrics import time
 from distributed.utils import CancelledError
-from distributed.utils_test import (  # noqa: F401
-    client,
-    cluster_fixture,
-    gen_cluster,
-    inc,
-    loop,
-    throws,
-)
+from distributed.utils_test import gen_cluster, inc, throws
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -14,15 +14,9 @@ from tlz import take
 
 from distributed import Client
 from distributed.utils import CancelledError
-from distributed.utils_test import (  # noqa: F401
-    a,
-    b,
-    client,
+from distributed.utils_test import (
     cluster,
-    cluster_fixture,
     inc,
-    loop,
-    s,
     slowadd,
     slowdec,
     slowinc,

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -10,12 +10,7 @@ import dask.bag as db
 import dask.dataframe as dd
 
 from distributed.client import wait
-from distributed.utils_test import (  # noqa F401
-    client,
-    cluster_fixture,
-    gen_cluster,
-    loop,
-)
+from distributed.utils_test import gen_cluster
 
 PANDAS_VERSION = LooseVersion(pd.__version__)
 PANDAS_GT_100 = PANDAS_VERSION >= LooseVersion("1.0.0")

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -23,7 +23,6 @@ from distributed.metrics import time
 from distributed.protocol import to_serialize
 from distributed.protocol.compression import compressions
 from distributed.utils import get_ip, get_ipv6
-from distributed.utils_test import loop  # noqa F401
 from distributed.utils_test import (
     assert_can_connect,
     assert_can_connect_from_everywhere_4,

--- a/distributed/tests/test_counter.py
+++ b/distributed/tests/test_counter.py
@@ -1,7 +1,6 @@
 import pytest
 
 from distributed.counter import Counter
-from distributed.utils_test import loop  # noqa F401
 
 try:
     from distributed.counter import Digest

--- a/distributed/tests/test_events.py
+++ b/distributed/tests/test_events.py
@@ -2,12 +2,7 @@ import pickle
 from datetime import timedelta
 
 from distributed import Event
-from distributed.utils_test import (  # noqa F401
-    client,
-    cluster_fixture,
-    gen_cluster,
-    loop,
-)
+from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -15,7 +15,6 @@ from distributed.compatibility import MACOS
 from distributed.metrics import time
 from distributed.scheduler import COMPILED
 from distributed.utils import CancelledError, sync
-from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import (
     captured_logger,
     cluster,

--- a/distributed/tests/test_ipython.py
+++ b/distributed/tests/test_ipython.py
@@ -4,7 +4,7 @@ import pytest
 from tlz import first
 
 from distributed import Client
-from distributed.utils_test import cluster, loop, mock_ipython, zmq_ctx  # noqa F401
+from distributed.utils_test import cluster, mock_ipython
 
 
 def need_functional_ipython(func):

--- a/distributed/tests/test_locks.py
+++ b/distributed/tests/test_locks.py
@@ -6,12 +6,7 @@ import pytest
 
 from distributed import Client, Lock, get_client
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa F401
-    client,
-    cluster_fixture,
-    gen_cluster,
-    loop,
-)
+from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)

--- a/distributed/tests/test_multi_locks.py
+++ b/distributed/tests/test_multi_locks.py
@@ -4,12 +4,7 @@ from time import sleep
 from distributed import MultiLock, get_client
 from distributed.metrics import time
 from distributed.multi_lock import MultiLockExtension
-from distributed.utils_test import (  # noqa F401
-    client,
-    cluster_fixture,
-    gen_cluster,
-    loop,
-)
+from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 8)] * 2)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -19,7 +19,6 @@ from distributed.diagnostics import SchedulerPlugin
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps
 from distributed.utils import TimeoutError, parse_ports, tmpfile
-from distributed.utils_test import cleanup  # noqa: F401
 from distributed.utils_test import captured_logger, gen_cluster, gen_test, inc
 
 
@@ -478,7 +477,7 @@ async def test_lifetime(cleanup):
 
 
 @pytest.mark.asyncio
-async def test_nanny_closes_cleanly(cleanup):
+async def test_nanny_closes_cleanly_2(cleanup):
     async with Scheduler() as s:
         async with Nanny(s.address) as n:
             async with Client(s.address, asynchronous=True) as client:

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -9,7 +9,7 @@ from tornado import web
 import dask
 
 from distributed import Client, Nanny, Scheduler, Worker
-from distributed.utils_test import captured_logger, cleanup, cluster, loop  # noqa F401
+from distributed.utils_test import captured_logger, cluster
 
 PRELOAD_TEXT = """
 _worker_info = {}

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -8,13 +8,7 @@ from distributed import Client
 from distributed.client import futures_of
 from distributed.metrics import time
 from distributed.protocol import Serialized
-from distributed.utils_test import (  # noqa F401
-    client,
-    cluster_fixture,
-    gen_cluster,
-    inc,
-    loop,
-)
+from distributed.utils_test import gen_cluster, inc
 
 
 @gen_cluster(client=False)

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -6,15 +6,7 @@ import pytest
 
 from distributed import Client, Nanny, Queue, TimeoutError, wait, worker_client
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa: F401
-    client,
-    cluster_fixture,
-    div,
-    gen_cluster,
-    inc,
-    loop,
-    popen,
-)
+from distributed.utils_test import div, gen_cluster, inc, popen
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -10,18 +10,7 @@ from dask.utils import stringify
 from distributed import Worker
 from distributed.client import wait
 from distributed.compatibility import WINDOWS
-from distributed.utils_test import (  # noqa: F401
-    a,
-    b,
-    client,
-    cluster_fixture,
-    gen_cluster,
-    inc,
-    loop,
-    s,
-    slowadd,
-    slowinc,
-)
+from distributed.utils_test import gen_cluster, inc, slowadd, slowinc
 
 
 @gen_cluster(client=True, nthreads=[])
@@ -85,6 +74,26 @@ async def test_submit_many_non_overlapping(c, s, a, b):
 
     assert len(a.data) == 5
     assert len(b.data) == 0
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[
+        ("127.0.0.1", 4, {"resources": {"A": 2}}),
+        ("127.0.0.1", 4, {"resources": {"A": 1}}),
+    ],
+)
+async def test_submit_many_non_overlapping_2(c, s, a, b):
+    futures = c.map(slowinc, range(100), resources={"A": 1}, delay=0.02)
+
+    while len(a.data) + len(b.data) < 100:
+        await asyncio.sleep(0.01)
+        assert a.executing_count <= 2
+        assert b.executing_count <= 1
+
+    await wait(futures)
+    assert a.total_resources == a.available_resources
+    assert b.total_resources == b.available_resources
 
 
 @gen_cluster(
@@ -234,26 +243,6 @@ async def test_resources_str(c, s, a, b):
     assert ts_first.resource_restrictions == {"MyRes": 1}
     ts_last = s.tasks[stringify(y.__dask_keys__()[-1])]
     assert ts_last.resource_restrictions == {"MyRes": 1}
-
-
-@gen_cluster(
-    client=True,
-    nthreads=[
-        ("127.0.0.1", 4, {"resources": {"A": 2}}),
-        ("127.0.0.1", 4, {"resources": {"A": 1}}),
-    ],
-)
-async def test_submit_many_non_overlapping(c, s, a, b):
-    futures = c.map(slowinc, range(100), resources={"A": 1}, delay=0.02)
-
-    while len(a.data) + len(b.data) < 100:
-        await asyncio.sleep(0.01)
-        assert a.executing_count <= 2
-        assert b.executing_count <= 1
-
-    await wait(futures)
-    assert a.total_resources == a.available_resources
-    assert b.total_resources == b.available_resources
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 4, {"resources": {"A": 2, "B": 1}})])

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -20,7 +20,6 @@ from dask import delayed
 from dask.compatibility import apply
 
 from distributed import Client, Nanny, Worker, fire_and_forget, wait
-from distributed.client import wait
 from distributed.comm import Comm
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.core import ConnectionPool, Status, connect, rpc
@@ -28,16 +27,14 @@ from distributed.metrics import time
 from distributed.protocol.pickle import dumps
 from distributed.scheduler import MemoryState, Scheduler
 from distributed.utils import TimeoutError, tmpfile, typename
-from distributed.utils_test import (  # noqa: F401
+from distributed.utils_test import (
     captured_logger,
-    cleanup,
     cluster,
     dec,
     div,
     gen_cluster,
     gen_test,
     inc,
-    loop,
     nodebug,
     slowadd,
     slowdec,
@@ -2214,7 +2211,7 @@ async def test_unknown_task_duration_config(client, s, a, b):
 
 
 @gen_cluster()
-async def test_unknown_task_duration_config(s, a, b):
+async def test_unknown_task_duration_config_2(s, a, b):
     assert s.idle_since == s.time_started
 
 

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -14,17 +14,7 @@ from distributed.comm import Comm
 from distributed.compatibility import WINDOWS
 from distributed.core import ConnectionPool
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa: F401
-    async_wait_for,
-    captured_logger,
-    cleanup,
-    client,
-    cluster,
-    cluster_fixture,
-    gen_cluster,
-    loop,
-    slowidentity,
-)
+from distributed.utils_test import captured_logger, cluster, gen_cluster, slowidentity
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -11,16 +11,14 @@ from tlz import concat, sliding_window
 from dask import delayed
 
 from distributed import Client, Nanny, wait
-from distributed.client import wait
 from distributed.config import config
 from distributed.metrics import time
 from distributed.utils import All, CancelledError
-from distributed.utils_test import (  # noqa: F401
+from distributed.utils_test import (
     bump_rlimit,
     cluster,
     gen_cluster,
     inc,
-    loop,
     nodebug_setup_module,
     nodebug_teardown_module,
     slowadd,

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -9,8 +9,7 @@ import pytest
 from distributed import Client, Nanny, Queue, Scheduler, Worker, wait, worker_client
 from distributed.core import Status
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa: F401
-    cleanup,
+from distributed.utils_test import (
     double,
     gen_tls_cluster,
     inc,

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -47,16 +47,7 @@ from distributed.utils import (
     truncate_exception,
     warn_on_duration,
 )
-from distributed.utils_test import (  # noqa: F401
-    captured_logger,
-    div,
-    gen_test,
-    has_ipv6,
-    inc,
-    loop,
-    loop_in_thread,
-    throws,
-)
+from distributed.utils_test import captured_logger, div, gen_test, has_ipv6, inc, throws
 
 
 def test_All(loop):

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -5,7 +5,7 @@ import pytest
 from distributed.comm import Comm
 from distributed.core import ConnectionPool
 from distributed.utils_comm import gather_from_workers, pack_data, retry, subs_multiple
-from distributed.utils_test import gen_cluster, loop  # noqa: F401
+from distributed.utils_test import gen_cluster
 
 
 def test_pack_data():

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -11,17 +11,12 @@ from distributed import Client, Nanny, Scheduler, Worker, config, default_client
 from distributed.core import rpc
 from distributed.metrics import time
 from distributed.utils import get_ip
-from distributed.utils_test import (  # noqa: F401
-    cleanup,
+from distributed.utils_test import (
     cluster,
     gen_cluster,
     gen_test,
     inc,
-    loop,
     new_config,
-    security,
-    tls_client,
-    tls_cluster,
     tls_only_security,
     wait_for_port,
 )
@@ -216,7 +211,7 @@ def test_lingering_client():
         default_client()
 
 
-def test_lingering_client(loop):
+def test_lingering_client_2(loop):
     with cluster() as (s, [a, b]):
         client = Client(s["address"], loop=loop)
 

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -10,16 +10,7 @@ from tornado.ioloop import IOLoop
 from distributed import Client, Nanny, TimeoutError, Variable, wait, worker_client
 from distributed.compatibility import WINDOWS
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa: F401
-    captured_logger,
-    client,
-    cluster_fixture,
-    div,
-    gen_cluster,
-    inc,
-    loop,
-    popen,
-)
+from distributed.utils_test import captured_logger, div, gen_cluster, inc, popen
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 from distributed import Client, Worker
-from distributed.utils_test import gen_cluster, loop  # noqa: F401
+from distributed.utils_test import gen_cluster
 from distributed.versions import error_message, get_versions
 
 # if one of the nodes reports this version, there's a mismatch

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -35,23 +35,16 @@ from distributed.diagnostics.plugin import PipInstall
 from distributed.metrics import time
 from distributed.scheduler import Scheduler
 from distributed.utils import TimeoutError, tmpfile
-from distributed.utils_test import (  # noqa: F401
+from distributed.utils_test import (
     TaskStateMetadataPlugin,
-    a,
-    b,
     captured_logger,
-    cleanup,
-    client,
-    cluster_fixture,
     dec,
     div,
     gen_cluster,
     gen_test,
     inc,
-    loop,
     mul,
     nodebug,
-    s,
     slowinc,
 )
 from distributed.worker import Worker, error_message, logger, parse_memory_limit, weight

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -18,14 +18,7 @@ from distributed import (
     worker_client,
 )
 from distributed.metrics import time
-from distributed.utils_test import (  # noqa: F401
-    client,
-    cluster_fixture,
-    double,
-    gen_cluster,
-    inc,
-    loop,
-)
+from distributed.utils_test import double, gen_cluster, inc
 
 
 @gen_cluster(client=True)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -335,7 +335,7 @@ def sync(loop, func, *args, callback_timeout=None, **kwargs):
             if callback_timeout is not None:
                 future = asyncio.wait_for(future, callback_timeout)
             result[0] = yield future
-        except Exception as exc:
+        except Exception:
             error[0] = sys.exc_info()
         finally:
             assert thread_state.asynchronous > 0

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -24,7 +24,8 @@ from contextlib import contextmanager, suppress
 from hashlib import md5
 from importlib.util import cache_from_source
 from time import sleep
-from typing import Any, Dict, List
+from typing import Any as AnyType
+from typing import Dict, List
 
 import click
 import tblib.pickling_support
@@ -1507,7 +1508,7 @@ class LRU(UserDict):
         super().__setitem__(key, value)
 
 
-def clean_dashboard_address(addrs: Any, default_listen_ip: str = "") -> List[Dict]:
+def clean_dashboard_address(addrs: AnyType, default_listen_ip: str = "") -> List[Dict]:
     """
     Examples
     --------

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -24,6 +24,8 @@ from contextlib import contextmanager, nullcontext, suppress
 from glob import glob
 from time import sleep
 
+from distributed.scheduler import Scheduler
+
 try:
     import ssl
 except ImportError:
@@ -770,10 +772,6 @@ def gen_test(timeout=_TEST_TIMEOUT):
         return test_func
 
     return _
-
-
-from .scheduler import Scheduler
-from .worker import Worker
 
 
 async def start_cluster(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -553,6 +553,10 @@ def client(loop, cluster_fixture):
         yield client
 
 
+# Compatibility. A lot of tests simply use `c` as fixture name
+c = client
+
+
 @pytest.fixture
 def client_secondary(loop, cluster_fixture):
     scheduler, workers = cluster_fixture

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2127,7 +2127,7 @@ class Worker(ServerNode):
                     value = self.data[ts.key]
                 except KeyError:
                     value = self.actors[ts.key]
-                nbytes = ts.nbytes = sizeof(value)
+                ts.nbytes = sizeof(value)
                 typ = ts.type = type(value)
                 del value
             try:
@@ -2319,7 +2319,7 @@ class Worker(ServerNode):
                 self.incoming_count += 1
 
                 self.log.append(("receive-dep", worker, list(response["data"])))
-            except EnvironmentError as e:
+            except EnvironmentError:
                 logger.exception("Worker stream died during communication: %s", worker)
                 self.log.append(("receive-dep-failed", worker))
                 for d in self.has_what.pop(worker):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3882,8 +3882,6 @@ async def run(server, comm, function, args=(), kwargs=None, is_coro=None, wait=T
 _global_workers = Worker._instances
 
 try:
-    from .diagnostics import nvml
-
     if nvml.device_get_count() < 1:
         raise RuntimeError
 except (Exception, RuntimeError):

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ ignore =
     E129,       # visually indented line with same indent as next logical line
     E116,       # unexpected indentation
 
-    W504,       # line break after binary operator
 
 per-file-ignores =
     **/tests/*:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,6 @@ per-file-ignores =
         F841,
         # Ambiguous variable name
         E741,
-        # redefinition of unused variable
-        F811,
 
 
 max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,6 @@ ignore =
     E128,       # E128 continuation line under-indented for visual indent
     E702,       # multiple statements on one line (semicolon)
     W503,       # line break before binary operator
-    E129,       # visually indented line with same indent as next logical line
-    E116,       # unexpected indentation
 
 
 per-file-ignores =

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,6 @@ parentdir_prefix = distributed-
 addopts = -v -rsxfE --durations=20
 filterwarnings =
     error:Since distributed.*:PendingDeprecationWarning
-    ignore:Port
 minversion = 4
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,14 +20,18 @@ ignore =
     W503,       # line break before binary operator
     E129,       # visually indented line with same indent as next logical line
     E116,       # unexpected indentation
-    F811,       # redefinition of unused 'loop' from line 10
 
-    E741        # Ambiguous variable names
     W504,       # line break after binary operator
 
 per-file-ignores =
-    # local variable is assigned to but never used
-    **/tests/*: F841
+    **/tests/*:
+        # local variable is assigned to but never used
+        F841,
+        # Ambiguous variable name
+        E741,
+        # redefinition of unused variable
+        F811,
+
 
 max-line-length = 120
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,20 +3,14 @@
 # https://flake8.readthedocs.io/en/latest/user/configuration.html
 # https://flake8.readthedocs.io/en/latest/user/error-codes.html
 
+# Aligned with black https://github.com/psf/black/blob/main/.flake8
+extend-ignore = E203, E266, E501
 # Note: there cannot be spaces after comma's here
 exclude = __init__.py,versioneer.py,distributed/_concurrent_futures_thread.py
 ignore =
-    E20,        # Extra space in brackets
-    E231,E241,  # Multiple spaces around ","
     E26,        # Comments
     E4,         # Import formatting
-    E721,       # Comparing types instead of isinstance
     E731,       # Assigning lambda expression
-    E121,       # continuation line under-indented for hanging indent
-    E126,       # continuation line over-indented for hanging indent
-    E127,       # continuation line over-indented for visual indent
-    E128,       # E128 continuation line under-indented for visual indent
-    E702,       # multiple statements on one line (semicolon)
     W503,       # line break before binary operator
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,13 @@ ignore =
     E129,       # visually indented line with same indent as next logical line
     E116,       # unexpected indentation
     F811,       # redefinition of unused 'loop' from line 10
-    F841,       # local variable is assigned to but never used
+
     E741        # Ambiguous variable names
     W504,       # line break after binary operator
+
+per-file-ignores =
+    # local variable is assigned to but never used
+    **/tests/*: F841
 
 max-line-length = 120
 
@@ -48,6 +52,7 @@ parentdir_prefix = distributed-
 addopts = -v -rsxfE --durations=20
 filterwarnings =
     error:Since distributed.*:PendingDeprecationWarning
+    ignore:Port
 minversion = 4
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
This shrinks our flake8 error ignore config to a more reasonable level. Most error codes are irrelevant since they concern formatting which is handled by black, nowadays. However, there are two error codes in particular which triggered me doing this.

## F841: local variable is assigned to but never used

This is an error code which detects assigned variables if they are unused. While this is _usually_ not a big deal for tests (although not desired), this can be a frequent source for bugs in the actual code.

An example in this PR are changes in distributed/profile.py which likely indicates that we lost _something_ at some point in time or distributed/scheduler.py l 3820ff which is definitely a bug (not fixed, yet)

We can still ignore this for tests, which is now reflected in the setup.cfg

## F811 Redefinition of unused name from line n

This warning is raised if we are redefining symbols, e.g. functions or global variables, etc. Mostly, this is harmless. However, for test suites in particular this causes the problem of allowing duplicate test function names. I found 5-10 tests which were duplicated and therefore the first definition was ignored. These are typically cases where the definition of the two functions is hundreds or thousands of lines apart and it is impossible for reviewers to detect something like this. All instances where I found something like this, I simply appended a `_2` to the function name or similar.

Enabling this error code in particular caused most of the change in this PR since every fixture import we were doing would trigger this, e.g. the following would raise a warning in line 3 because loop was redefined in the local scope although it was already defined in global scope but remains unused.

The _easy_ solution to this is to use pytests fixture collection system via `conftest.py` which is why I added one import there to make all fixtures available to all functions. pytest will figure out the rest.

```python
from distributed.utils_test import loop

def test_loop(loop):
    pass
```

