### PR TITLE
Add configuration to enable/disable NVML diagnostics

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -7,17 +7,15 @@ try:
 except ImportError:
     pynvml = None
 
-nvmlEnabled = True
 nvmlInitialized = False
 nvmlLibraryNotFound = False
 nvmlOwnerPID = None
 
 
 def init_once():
-    global nvmlEnabled, nvmlInitialized, nvmlLibraryNotFound, nvmlOwnerPID
+    global nvmlInitialized, nvmlLibraryNotFound, nvmlOwnerPID
 
-    nvmlEnabled = dask.config.get("distributed.diagnostics.nvml")
-    if nvmlEnabled is False:
+    if dask.config.get("distributed.diagnostics.nvml") is False:
         nvmlInitialized = False
         return
 

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -15,11 +15,13 @@ nvmlOwnerPID = None
 
 def init_once():
     global nvmlEnabled, nvmlInitialized, nvmlLibraryNotFound, nvmlOwnerPID
-    if pynvml is None or (nvmlInitialized is True and nvmlOwnerPID == os.getpid()):
-        return
 
     nvmlEnabled = dask.config.get("distributed.diagnostics.nvml")
     if nvmlEnabled is False:
+        nvmlInitialized = False
+        return
+
+    if pynvml is None or (nvmlInitialized is True and nvmlOwnerPID == os.getpid()):
         return
 
     nvmlInitialized = True

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -1,18 +1,25 @@
 import os
 
+import dask
+
 try:
     import pynvml
 except ImportError:
     pynvml = None
 
+nvmlEnabled = True
 nvmlInitialized = False
 nvmlLibraryNotFound = False
 nvmlOwnerPID = None
 
 
 def init_once():
-    global nvmlInitialized, nvmlLibraryNotFound, nvmlOwnerPID
+    global nvmlEnabled, nvmlInitialized, nvmlLibraryNotFound, nvmlOwnerPID
     if pynvml is None or (nvmlInitialized is True and nvmlOwnerPID == os.getpid()):
+        return
+
+    nvmlEnabled = dask.config.get("distributed.diagnostics.nvml")
+    if nvmlEnabled is False:
         return
 
     nvmlInitialized = True

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -31,12 +31,10 @@ def test_enable_disable_nvml():
 
     with dask.config.set({"distributed.diagnostics.nvml": False}):
         nvml.init_once()
-        assert nvml.nvmlEnabled is False
         assert nvml.nvmlInitialized is False
 
     with dask.config.set({"distributed.diagnostics.nvml": True}):
         nvml.init_once()
-        assert nvml.nvmlEnabled is True
         assert nvml.nvmlInitialized is True
 
 

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -4,6 +4,8 @@ import pytest
 
 pynvml = pytest.importorskip("pynvml")
 
+import dask
+
 from distributed.diagnostics import nvml
 from distributed.utils_test import gen_cluster
 
@@ -17,6 +19,25 @@ def test_one_time():
     assert "name" in output
 
     assert len(output["name"]) > 0
+
+
+def test_enable_disable_nvml():
+    try:
+        pynvml.nvmlShutdown()
+    except pynvml.NVMLError_Uninitialized:
+        pass
+    else:
+        nvml.nvmlInitialized = False
+
+    with dask.config.set({"distributed.diagnostics.nvml": False}):
+        nvml.init_once()
+        assert nvml.nvmlEnabled is False
+        assert nvml.nvmlInitialized is False
+
+    with dask.config.set({"distributed.diagnostics.nvml": True}):
+        nvml.init_once()
+        assert nvml.nvmlEnabled is True
+        assert nvml.nvmlInitialized is True
 
 
 def test_1_visible_devices():

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -750,6 +750,17 @@ properties:
                       Alternatively, the key can be appended to the cert file
                       above, and this field left blank
 
+      diagnostics:
+        type: object
+        properties:
+          nvml:
+            type: boolean
+            description: |
+              If ``True``, enables GPU diagnostics with NVML. Generally leaving it enabled is
+              not a problem and will be automatically disabled if no GPUs are found in the
+              system, but in certain cases it may be desirable to completely disable NVML
+              diagnostics.
+
       dashboard:
         type: object
         properties:

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -195,6 +195,8 @@ distributed:
         key: null
         cert: null
 
+  diagnostics:
+    nvml: True
 
   ###################
   # Bokeh dashboard #


### PR DESCRIPTION
- [ ] Closes #4885

In some cases, users may want or need to explicitly disable NVML diagnostics, this PR adds support for that via Dask config.