### PR TITLE
Remove tests for `process_time` and `thread_time`

### DIFF
--- a/distributed/tests/test_metrics.py
+++ b/distributed/tests/test_metrics.py
@@ -1,9 +1,6 @@
-import sys
-import threading
 import time
 
 from distributed import metrics
-from distributed.utils_test import run_for
 
 
 def test_wall_clock():
@@ -18,46 +15,3 @@ def test_wall_clock():
         assert any(lambda d: 0.0 < d < 0.0001 for d in deltas), deltas
         # Close to time.time()
         assert t - 0.5 < samples[0] < t + 0.5
-
-
-def test_process_time():
-    start = metrics.process_time()
-    run_for(0.05)
-    dt = metrics.process_time() - start
-    assert 0.03 <= dt <= 0.2
-
-    # All threads counted
-    t = threading.Thread(target=run_for, args=(0.1,))
-    start = metrics.process_time()
-    t.start()
-    t.join()
-    dt = metrics.process_time() - start
-    assert dt >= 0.05
-
-    # Sleep time not counted
-    start = metrics.process_time()
-    time.sleep(0.1)
-    dt = metrics.process_time() - start
-    assert dt <= 0.05
-
-
-def test_thread_time():
-    start = metrics.thread_time()
-    run_for(0.05)
-    dt = metrics.thread_time() - start
-    assert 0.03 <= dt <= 0.2
-
-    # Sleep time not counted
-    start = metrics.thread_time()
-    time.sleep(0.1)
-    dt = metrics.thread_time() - start
-    assert dt <= 0.05
-
-    if sys.platform == "linux":
-        # Always per-thread on Linux
-        t = threading.Thread(target=run_for, args=(0.1,))
-        start = metrics.thread_time()
-        t.start()
-        t.join()
-        dt = metrics.thread_time() - start
-        assert dt <= 0.05


### PR DESCRIPTION
Following up on https://github.com/dask/distributed/issues/4790#issuecomment-851529086, this PR removes tests for `metrics.thread_time` and `metrics.process_time` as today these are variables are aliases for methods in the standard library which we don't need dedicated tests for. 

https://github.com/dask/distributed/blob/ee06a44cc4b43270b5ae6ee102481f3bbc9daf27/distributed/metrics.py#L3
https://github.com/dask/distributed/blob/ee06a44cc4b43270b5ae6ee102481f3bbc9daf27/distributed/metrics.py#L86-L95

Closes https://github.com/dask/distributed/issues/4790
Closes https://github.com/dask/distributed/issues/4839