### PR TITLE
Dont start http server in Scheduler.__init__

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2785,3 +2785,10 @@ async def test_rebalance_least_recently_inserted_sender_min(c, s, *_):
         a: (large_future.key,),
         b: tuple(f.key for f in small_futures),
     }
+
+
+def test_init_twice_no_warning():
+    with pytest.warns(None) as records:
+        for _ in range(2):
+            Scheduler()
+    assert not records


### PR DESCRIPTION
This refactors the scheduler init such that the HTTP server is only started once the server is actually up. Otherwise every init call starts an http server and binds sockets, etc.

I tried testing for leaking sockets but that's not easy. Depending on OS this requires root and even with root, I had trouble asserting this properly using psutil.

Closes https://github.com/dask/distributed/issues/4806