### PR TITLE
[WIP] Fine grained serialization

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -5,6 +5,7 @@ from queue import Queue
 
 from .client import Future, default_client
 from .protocol import to_serialize
+from .protocol.serialize import nested_deserialize
 from .utils import iscoroutinefunction, sync, thread_state
 from .utils_comm import WrappedKey
 from .worker import get_worker
@@ -162,7 +163,7 @@ class Actor(WrappedKey):
                             await self._future
                         else:
                             raise OSError("Unable to contact Actor's worker")
-                    return result["result"]
+                    return nested_deserialize(result["result"])
 
                 if self._asynchronous:
                     return asyncio.ensure_future(run_actor_function_on_worker())
@@ -187,7 +188,7 @@ class Actor(WrappedKey):
                 x = await self._worker_rpc.actor_attribute(
                     attribute=key, actor=self.key
                 )
-                return x["result"]
+                return nested_deserialize(x["result"])
 
             return self._sync(get_actor_attribute_from_worker)
 

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -2,8 +2,8 @@ from contextlib import suppress
 from distutils.version import LooseVersion
 from functools import partial
 
-from .compression import compressions, default_compression
-from .core import decompress, dumps, loads, maybe_compress, msgpack
+from .compression import compressions, decompress, default_compression
+from .core import dumps, loads, maybe_compress, msgpack
 from .cuda import cuda_deserialize, cuda_serialize
 from .serialize import (
     Serialize,

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -2,11 +2,10 @@ import logging
 
 import msgpack
 
-from .compression import decompress, maybe_compress
+from .compression import maybe_compress
 from .serialize import (
     Serialize,
     Serialized,
-    merge_and_deserialize,
     msgpack_decode_default,
     msgpack_encode_default,
     serialize_and_split,
@@ -91,14 +90,10 @@ def loads(frames, deserialize=True, deserializers=None):
                 )
                 offset += 1
                 sub_frames = frames[offset : offset + sub_header["num-sub-frames"]]
+                ret = Serialized(sub_header, sub_frames, deserializers)
                 if deserialize:
-                    if "compression" in sub_header:
-                        sub_frames = decompress(sub_header, sub_frames)
-                    return merge_and_deserialize(
-                        sub_header, sub_frames, deserializers=deserializers
-                    )
-                else:
-                    return Serialized(sub_header, sub_frames)
+                    ret = ret.deserialize()
+                return ret
             else:
                 return msgpack_decode_default(obj, deserialize=deserialize)
 

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -15,6 +15,18 @@ from .utils import msgpack_opts
 logger = logging.getLogger(__name__)
 
 
+class DeserializeFlag:
+    def __init__(self, value: bool, *, raise_exception: bool = None):
+        self.value = value
+        if raise_exception is None:  # Defaults to `value`
+            self.raise_exception = value
+        else:
+            self.raise_exception = raise_exception
+
+    def __bool__(self):
+        return self.value
+
+
 def dumps(msg, serializers=None, on_error="message", context=None) -> list:
     """Transform Python message to bytestream suitable for communication
 

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -100,7 +100,7 @@ def loads(frames, deserialize=True, deserializers=None):
                 else:
                     return Serialized(sub_header, sub_frames)
             else:
-                return msgpack_decode_default(obj)
+                return msgpack_decode_default(obj, deserialize=deserialize)
 
         return msgpack.loads(
             frames[0], object_hook=_decode_default, use_list=False, **msgpack_opts

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -716,7 +716,7 @@ def nested_deserialize(obj):
     if typ is MsgpackList:
         return list(nested_deserialize(obj.data))
     if typ is Computations:
-        return obj.data
+        return nested_deserialize(obj.data)
     else:
         return obj
 


### PR DESCRIPTION
### Warning, this is very much work-in-progress


This PR implements fine grained serialization by only serializing none-msgpack-serializable objects. E.g.:
```python
task = (add, (add, 1, 2), 3)  # Nested task
ser = (SerializedCallable(add), (SerializedCallable(add), 1, 2), 3) # Serialized 
```

#### Motivation
In `main` we serialize:
 - **Nested tasks** using `to_serialize()` on both the function and all its arguments
 - **Non-nested tasks** using `dumps_function()` on the function and `pickle.dumps()` on its arguments.

This means that once serialized, we cannot access or modify the function arguments, which can be a problem: https://github.com/dask/distributed/issues/4673.
Also, this means that we have to separate code paths for nested and non-nested tasks in the Scheduler to the Worker.

#### The Protocol
 - Fined grained serialization -- only _none-msgpack-serializable_  objects are serialized
 - Never de-serialize on the Scheduler (other than the implicit msgpack de-serialization) 
 - Always de-serialize on the Client
 - Delay de-serialize on the Worker until task execution:
     - Except when receiving scattered data from the Scheduler or Client
     - or when receiving data from other Workers e.g. when gathering data dependencies.

#### Notice
- Since we do not serialize task arguments, we have to handle the implicit convert of lists to tuples by `msgpack` (see `msgpack_persist_lists()`)
- We do not necessarily serialize all [**Computations**](https://docs.dask.org/en/latest/spec.html#definitions) thus a task graph such as `{"x": None}` will result in a task just containing `None`. This is a potential problem for the Scheduler, which we have to handle. 
- The goal here is not performance, the goal is to simplify the serialization and make it clear what we need from the HLG pack and unpack functions. 
- This PR doesn't require any changes to Dask but in a follow up PR I will use this new clean serialization protocol to simplify the HLG pack and unpack functions.
- With this PR, it is my hope that we can improve performance by implementing _single pass serialization_.

---

- [ ] Closes #4673
- [ ] Closes #4890
- [ ] Closes #4575
- [ ] Closes #4699
- [ ] Closes https://github.com/dask/dask/issues/7777
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
