### PR TITLE
WIP co-assign related root-ish tasks

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2388,11 +2388,10 @@ class SchedulerState:
                 ws = wp_vals[self._n_tasks % n_workers]
 
             # TODO repeated logic from `decide_worker`
-            print("fastpath")
             ts._group._last_worker = ws
-            # ts._group._last_worker_tasks_left = math.floor(
-            #     len(ts._group) / self._total_nthreads
-            # )
+            ts._group._last_worker_tasks_left = math.floor(
+                len(ts._group) / self._total_nthreads
+            )
 
         if self._validate:
             assert ws is None or isinstance(ws, WorkerState), (
@@ -7546,9 +7545,7 @@ def decide_worker(
             break
     else:
         group: TaskGroup = ts._group
-        old: WorkerState = group._last_worker
-
-        ws = min(candidates, key=objective)
+        ws = group._last_worker
 
         total_nthreads = sum(
             wws._nthreads for wws in candidates
@@ -7559,41 +7556,20 @@ def decide_worker(
         # Try to schedule sibling root-like tasks on the same workers, so subsequent reduction tasks
         # don't require data transfer. Assumes `decide_worker` is being called in priority order.
         if (
-            old is not None  # there is a previous worker
+            ws is not None  # there is a previous worker
+            and group._last_worker_tasks_left > 0  # previous worker not fully assigned
             and ts._dependents  # task has dependents
             and group_tasks_per_worker > 1  # group is larger than cluster
-            # and group._last_worker_tasks_left > 0  # previous worker not fully assigned
-            and ts._prefix._duration_average + old.occupancy < ws.occupancy + math.ceil(group_tasks_per_worker) * ts._prefix._duration_average
             and (  # is a root-like task (task group depends on very few tasks)
                 sum(map(len, group._dependencies)) < 5  # TODO what number
             )
         ):
-            # group._last_worker_tasks_left -= 1
-            print("using last worker")
-            return old
+            group._last_worker_tasks_left -= 1
+            return ws
 
-        print(
-            f"{ts.prefix_key}",
-            f"{ts._prefix._duration_average=}",
-            f"{old.occupancy=}" if old else None,
-            f"{ws.occupancy=}",
-            f"{group_tasks_per_worker=}",
-        )
-        # print(
-        #     f"{old is not None=}",
-        #     f"{ts._dependents=}",
-        #     f"{group_tasks_per_worker > 1=}",
-        #     f"{ts._prefix._duration_average + old.occupancy}",
-        #     f"{ws.occupancy + math.ceil(group_tasks_per_worker) * ts._prefix._duration_average}",
-        #     f"{sum(map(len, group._dependencies))=}",
-        #     f"{group._dependencies=}",
-        #     f"{group=}",
-        #     f"{ts=}",
-        # )
-
-        # ws = min(candidates, key=objective)
+        ws = min(candidates, key=objective)
         group._last_worker = ws
-        # group._last_worker_tasks_left = math.floor(group_tasks_per_worker)
+        group._last_worker_tasks_left = math.floor(group_tasks_per_worker)
 
     return ws
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7609,9 +7609,12 @@ def decide_worker(
         if group._last_worker_tasks_left > 0:
             # Previous worker not fully assigned
             group._last_worker_tasks_left -= 1
-            if group._last_worker_priority < ts.priority:
+            if group._last_worker_priority < ts.priority and (
+                valid_workers is None or ws in valid_workers
+            ):
                 group._last_worker_priority = ts.priority
                 # print(f"reusing worker - {ts.group_key} -> {ws.name}")
+                assert ws in all_workers  # TODO just for tests right now; slow!
                 return ws
 
             # print(
@@ -7621,8 +7624,8 @@ def decide_worker(
             #     f"{group.last_worker_tasks_left=}\n"
             #     f"{group_tasks_per_worker=}\n"
             # )
-            # `decide_worker` called out of priority order---this is probably not actually a root-ish task;
-            # disable root-ish mode in the future.
+            # `decide_worker` called out of priority order, or the last used worker is not valid for this task.
+            # This is probably not actually a root-ish task; disable root-ish mode in the future.
             group._last_worker = None
             group._last_worker_tasks_left = 0
             group._last_worker_priority = None

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2399,7 +2399,7 @@ class SchedulerState:
                 ws = wp_vals[self._n_tasks % n_workers]
 
             # TODO repeated logic from `decide_worker`
-            print(f"nodeps / no last worker fastpah - {ts.group_key} -> {ws.name}")
+            # print(f"nodeps / no last worker fastpah - {ts.group_key} -> {ws.name}")
             ts._group._last_worker = ws
             if self._total_nthreads > 0:
                 group_tasks_per_thread = len(ts._group) / self._total_nthreads

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2401,8 +2401,8 @@ class SchedulerState:
             # TODO repeated logic from `decide_worker`
             print(f"nodeps / no last worker fastpah - {ts.group_key} -> {ws.name}")
             ts._group._last_worker = ws
-            ts._group._last_worker_tasks_left = math.floor(
-                len(ts._group) / self._total_nthreads
+            ts._group._last_worker_tasks_left = (
+                math.floor(len(ts._group) / self._total_nthreads) - 1
             )
             ts._group._last_worker_priority = ts._priority
 
@@ -7667,7 +7667,7 @@ def decide_worker(
 
     if group._last_worker_priority is not None:
         group._last_worker = ws
-        group._last_worker_tasks_left = math.floor(group_tasks_per_worker)
+        group._last_worker_tasks_left = math.floor(group_tasks_per_worker) - 1
         group._last_worker_priority = ts.priority
     return ws
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2399,6 +2399,7 @@ class SchedulerState:
                 ws = wp_vals[self._n_tasks % n_workers]
 
             # TODO repeated logic from `decide_worker`
+            print(f"nodeps / no last worker fastpah - {ts.group_key}")
             ts._group._last_worker = ws
             ts._group._last_worker_tasks_left = math.floor(
                 len(ts._group) / self._total_nthreads
@@ -7588,8 +7589,10 @@ def decide_worker(
                     f"{group_tasks_per_worker=}\n"
                 )
             group._last_worker_priority = ts.priority
+            print(f"reusing worker - {ts.group_key}")
             return ws
 
+        print(f"picking worker - {ts.group_key}")
         ws = min(candidates, key=objective)
         group._last_worker = ws
         group._last_worker_tasks_left = math.floor(group_tasks_per_worker)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7508,6 +7508,9 @@ def _reevaluate_occupancy_worker(state: SchedulerState, ws: WorkerState):
                 steal.put_key_in_stealable(ts)
 
 
+NOT_ROOT_ISH = WorkerState()
+
+
 @cfunc
 @exceptval(check=False)
 def decide_worker(
@@ -7537,54 +7540,67 @@ def decide_worker(
     group: TaskGroup = ts._group
     ws: WorkerState = group._last_worker
 
-    if valid_workers is not None:
-        total_nthreads = sum(wws._nthreads for wws in valid_workers)
+    group_tasks_per_worker: float
+    if ws is None or (ws is not NOT_ROOT_ISH and group._last_worker_tasks_left) == 0:
+        # Calculate the ratio of tasks in the task group to number of workers.
+        # We only need to do this computation when 1) seeing a task group for the first time,
+        # or 2) this is a root-ish task group, and we've just filled up the worker we were
+        # sending tasks to and need to pick a new one.
+        if valid_workers is not None:
+            total_nthreads = sum(wws._nthreads for wws in valid_workers)
 
-    group_tasks_per_worker = len(group) / total_nthreads
-    ignore_deps_while_picking: bool = False
+        group_tasks_per_worker = len(group) / total_nthreads
+    else:
+        group_tasks_per_worker = float("nan")
 
-    # Try to schedule sibling root-like tasks on the same workers, so subsequent reduction tasks
-    # don't require data transfer. Assumes `decide_worker` is being called in priority order.
-    if (
-        ws is not None  # there is a previous worker
-        and group_tasks_per_worker > 1  # group is larger than cluster
-        and (  # is a root-like task (task group is large, but depends on very few tasks)
-            sum(map(len, group._dependencies)) < 5  # TODO what number
-        )
-    ):
-        if group._last_worker_tasks_left > 0:
-            # Previous worker not fully assigned
-            group._last_worker_tasks_left -= 1
-            if group._last_worker_priority >= ts.priority:
-                print(
-                    f"decide_worker called out of priority order: {group._last_worker_priority} >= {ts.priority}.\n"
-                    f"{ts=}\n"
-                    f"{group.last_worker=}\n"
-                    f"{group.last_worker_tasks_left=}\n"
-                    f"{group_tasks_per_worker=}\n"
-                )
-            group._last_worker_priority = ts.priority
-            print(f"reusing worker - {ts.group_key} -> {ws.name}")
-            return ws
+    is_root_ish: bool
+    if ws is None:
+        # Very fist task in the group - we haven't determined yet whether it's a root-ish task group
+        if (
+            group_tasks_per_worker > 1  # group is larger than cluster
+            and (  # is a root-like task (task group is large, but depends on very few tasks)
+                sum(map(len, group._dependencies)) < 5  # TODO what number
+            )
+        ):
+            is_root_ish = True
+        else:
+            is_root_ish = False
+            group._last_worker = NOT_ROOT_ISH
+    else:
+        # We've seen this task group before and already made the above determination
+        is_root_ish = ws is not NOT_ROOT_ISH
 
-        # Previous worker is fully assigned, so pick a new worker.
+    if is_root_ish and ws is not None and group._last_worker_tasks_left > 0:
+        # Root-ish task and previous worker not fully assigned - reuse previous worker.
+        # (When the previous worker _is_ fully assigned, we fall through here to the pick-a-worker logic.)
+        if group._last_worker_priority >= ts.priority:
+            print(
+                f"decide_worker called out of priority order: {group._last_worker_priority} >= {ts.priority}.\n"
+                f"{ts=}\n"
+                f"{group.last_worker=}\n"
+                f"{group.last_worker_tasks_left=}\n"
+                f"{group_tasks_per_worker=}\n"
+            )
+        group._last_worker_priority = ts.priority
+        group._last_worker_tasks_left -= 1
+        print(f"reusing worker - {ts.group_key} -> {ws.name}")
+        return ws
+
+    # Pick a worker to run this task
+    deps: set = ts._dependencies
+    dts: TaskState
+    candidates: set
+    assert all([dts._who_has for dts in deps])
+    if is_root_ish:
+        # Previous worker is fully assigned (or unknown), so pick a new worker.
         # Since this is a root-like task, we should ignore the placement of its dependencies while selecting workers.
         # Every worker is going to end up running this type of task eventually, and any dependencies will have to be
         # transferred to all workers, so there's no gain from only considering workers where the dependencies already live.
         # Indeed, we _must_ consider all workers, otherwise we would keep picking the same "new" worker(s) every time,
         # since there are only N workers to choose from that actually have the dependency (where N <= n_deps).
-        ignore_deps_while_picking = True
-        print(f"{ts.group_key} is root-like but {ws.name} is full - picking a new worker")
-
-    # Not a root-like task; pick the best worker among the valid workers
-    # that hold at least one dependency of this task.
-    deps: set = ts._dependencies
-    dts: TaskState
-    candidates: set
-    assert all([dts._who_has for dts in deps])
-    if ignore_deps_while_picking:
         candidates = valid_workers if valid_workers is not None else set(all_workers)
     else:
+        # Restrict placement of this task to workers that hold its dependencies
         if ts._actor:
             candidates = set(all_workers)
         else:
@@ -7598,13 +7614,15 @@ def decide_worker(
                 candidates = valid_workers
                 if not candidates:
                     if ts._loose_restrictions:
-                        ws = decide_worker(ts, all_workers, None, objective, total_nthreads)
+                        ws = decide_worker(
+                            ts, all_workers, None, objective, total_nthreads
+                        )
                     return ws
 
     ncandidates: Py_ssize_t = len(candidates)
     if ncandidates == 0:
         print(f"no candidates - {ts.group_key}")
-        pass
+        return None
     elif ncandidates == 1:
         # NOTE: this is the ideal case: all the deps are already on the same worker.
         # We did a good job in previous `decide_worker`s!
@@ -7615,9 +7633,11 @@ def decide_worker(
         ws = min(candidates, key=objective)
         print(f"picked worker - {ts.group_key} -> {ws.name}")
 
-    group._last_worker = ws
-    group._last_worker_tasks_left = math.floor(group_tasks_per_worker)
-    group._last_worker_priority = ts.priority
+    if is_root_ish:
+        group._last_worker = ws
+        group._last_worker_tasks_left = math.floor(group_tasks_per_worker)
+        group._last_worker_priority = ts.priority
+
     return ws
 
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7558,7 +7558,6 @@ def decide_worker(
         if (
             ws is not None  # there is a previous worker
             and group._last_worker_tasks_left > 0  # previous worker not fully assigned
-            and ts._dependents  # task has dependents
             and group_tasks_per_worker > 1  # group is larger than cluster
             and (  # is a root-like task (task group depends on very few tasks)
                 sum(map(len, group._dependencies)) < 5  # TODO what number

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2398,17 +2398,13 @@ class SchedulerState:
             else:  # dumb but fast in large case
                 ws = wp_vals[self._n_tasks % n_workers]
 
-            # TODO repeated logic from `decide_worker`
-            # print(f"nodeps / no last worker fastpah - {ts.group_key} -> {ws.name}")
             ts._group._last_worker = ws
-            if self._total_nthreads > 0:
-                group_tasks_per_thread = len(ts._group) / self._total_nthreads
-                ts._group._last_worker_tasks_left = (
-                    math.floor(group_tasks_per_thread * ws._nthreads) - 1
-                )
-            else:
-                # Note: negative would have been fine, except if this ever becomes Py_ssize_t
-                ts._group._last_worker_tasks_left = 0
+            group_tasks_per_thread = (
+                len(ts._group) / self._total_nthreads if self._total_nthreads > 0 else 0
+            )
+            ts._group._last_worker_tasks_left = (
+                math.floor(group_tasks_per_thread * ws._nthreads) - 1
+            )
             ts._group._last_worker_priority = ts._priority
 
         if self._validate:
@@ -7594,36 +7590,22 @@ def decide_worker(
     group_tasks_per_thread = (len(group) / total_nthreads) if total_nthreads > 0 else 0
     ignore_deps_while_picking: bool = False
 
-    # Try to schedule sibling root-like tasks on the same workers, so subsequent reduction tasks
-    # don't require data transfer. Assumes `decide_worker` is being called in priority order.
+    # Try to schedule sibling root-like tasks on the same workers.
     if (
-        # there is a previous worker
         ws is not None
-        # `decide_worker` hasn't previously been called out of priority order
         and group._last_worker_priority is not None
-        # group is larger than cluster
+        # ^ `decide_worker` hasn't previously been called out of priority order
         and group_tasks_per_thread > 1
-        # is a root-like task (task group is large, but depends on very few tasks)
         and sum(map(len, group._dependencies)) < 5  # TODO what number
     ):
         if group._last_worker_tasks_left > 0:
-            # Previous worker not fully assigned
             group._last_worker_tasks_left -= 1
             if group._last_worker_priority < ts.priority and (
                 valid_workers is None or ws in valid_workers
             ):
                 group._last_worker_priority = ts.priority
-                # print(f"reusing worker - {ts.group_key} -> {ws.name}")
-                assert ws in all_workers  # TODO just for tests right now; slow!
                 return ws
 
-            # print(
-            #     f"decide_worker called out of priority order: {group._last_worker_priority} >= {ts.priority}.\n"
-            #     f"{ts=}\n"
-            #     f"{group.last_worker=}\n"
-            #     f"{group.last_worker_tasks_left=}\n"
-            #     f"{group_tasks_per_worker=}\n"
-            # )
             # `decide_worker` called out of priority order, or the last used worker is not valid for this task.
             # This is probably not actually a root-ish task; disable root-ish mode in the future.
             group._last_worker = None
@@ -7631,18 +7613,8 @@ def decide_worker(
             group._last_worker_priority = None
 
         # Previous worker is fully assigned, so pick a new worker.
-        # Since this is a root-like task, we should ignore the placement of its dependencies while selecting workers.
-        # Every worker is going to end up running this type of task eventually, and any dependencies will have to be
-        # transferred to all workers, so there's no gain from only considering workers where the dependencies already live.
-        # Indeed, we _must_ consider all workers, otherwise we would keep picking the same "new" worker(s) every time,
-        # since there are only N workers to choose from that actually have the dependency (where N <= n_deps).
         ignore_deps_while_picking = True
-        # print(
-        #     f"{ts.group_key} is root-like but {ws.name} is full - picking a new worker"
-        # )
 
-    # Not a root-like task; pick the best worker among the valid workers
-    # that hold at least one dependency of this task.
     deps: set = ts._dependencies
     dts: TaskState
     candidates: set
@@ -7670,24 +7642,18 @@ def decide_worker(
 
     ncandidates: Py_ssize_t = len(candidates)
     if ncandidates == 0:
-        # print(f"no candidates - {ts.group_key}")
         pass
     elif ncandidates == 1:
         # NOTE: this is the ideal case: all the deps are already on the same worker.
-        # We did a good job in previous `decide_worker`s!
         for ws in candidates:
             break
-        # print(f"1 candidate - {ts.group_key} -> {ws.name}")
     else:
         ws = min(candidates, key=objective)
-        # print(f"picked worker - {ts.group_key} -> {ws.name}")
 
     if group._last_worker_priority is not None:
         group._last_worker = ws
         group._last_worker_tasks_left = (
             math.floor(group_tasks_per_thread * ws._nthreads) - 1
-            if group_tasks_per_thread > 0
-            else 0
         )
         group._last_worker_priority = ts.priority
     return ws

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -17,7 +17,7 @@ from tlz import concat, first, frequencies, merge, valmap
 
 import dask
 from dask import delayed
-from dask.utils import apply
+from dask.utils import apply, stringify
 
 from distributed import Client, Nanny, Worker, fire_and_forget, wait
 from distributed.comm import Comm
@@ -124,6 +124,114 @@ async def test_decide_worker_with_restrictions(client, s, a, b, c):
     x = client.submit(inc, 1, workers=[a.address, b.address])
     await x
     assert x.key in a.data or x.key in b.data
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("127.0.0.1", 1)] * 3,
+    config={"distributed.scheduler.work-stealing": False},
+)
+async def test_decide_worker_select_candidate_holding_no_deps(client, s, a, b, c):
+    await client.submit(slowinc, 10, delay=0.1)  # learn that slowinc is slow
+    root = await client.scatter(1)
+    assert sum(root.key in worker.data for worker in [a, b, c]) == 1
+
+    start = time()
+    tasks = client.map(slowinc, [root] * 6, delay=0.1, pure=False)
+    await wait(tasks)
+    elapsed = time() - start
+
+    assert elapsed <= 4
+    assert all(root.key in worker.data for worker in [a, b, c]), [
+        list(worker.data.keys()) for worker in [a, b, c]
+    ]
+
+
+@pytest.mark.parametrize("ndeps", [0, 1, 4])
+@pytest.mark.parametrize(
+    "nthreads",
+    [
+        [("127.0.0.1", 1)] * 5,
+        [("127.0.0.1", 3), ("127.0.0.1", 2), ("127.0.0.1", 1)],
+    ],
+)
+def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
+    @gen_cluster(
+        client=True,
+        nthreads=nthreads,
+        config={"distributed.scheduler.work-stealing": False},
+    )
+    async def test(c, s, *workers):
+        """Ensure that related tasks end up on the same node"""
+        da = pytest.importorskip("dask.array")
+        np = pytest.importorskip("numpy")
+
+        if ndeps == 0:
+            x = da.random.random((100, 100), chunks=(10, 10))
+        else:
+
+            def random(**kwargs):
+                assert len(kwargs) == ndeps
+                return np.random.random((10, 10))
+
+            trivial_deps = {f"k{i}": delayed(object()) for i in range(ndeps)}
+
+            # TODO is there a simpler (non-blockwise) way to make this sort of graph?
+            x = da.blockwise(
+                random,
+                "yx",
+                new_axes={"y": (10,) * 10, "x": (10,) * 10},
+                dtype=float,
+                **trivial_deps,
+            )
+
+        xx, xsum = dask.persist(x, x.sum(axis=1, split_every=20))
+        await xsum
+
+        # Check that each chunk-row of the array is (mostly) stored on the same worker
+        primary_worker_key_fractions = []
+        secondary_worker_key_fractions = []
+        for i, keys in enumerate(x.__dask_keys__()):
+            # Iterate along rows of the array.
+            keys = set(stringify(k) for k in keys)
+
+            # No more than 2 workers should have any keys
+            assert sum(any(k in w.data for k in keys) for w in workers) <= 2
+
+            # What fraction of the keys for this row does each worker hold?
+            key_fractions = [
+                len(set(w.data).intersection(keys)) / len(keys) for w in workers
+            ]
+            key_fractions.sort()
+            # Primary worker: holds the highest percentage of keys
+            # Secondary worker: holds the second highest percentage of keys
+            primary_worker_key_fractions.append(key_fractions[-1])
+            secondary_worker_key_fractions.append(key_fractions[-2])
+
+        # There may be one or two rows that were poorly split across workers,
+        # but the vast majority of rows should only be on one worker.
+        assert np.mean(primary_worker_key_fractions) >= 0.9
+        assert np.median(primary_worker_key_fractions) == 1.0
+        assert np.mean(secondary_worker_key_fractions) <= 0.1
+        assert np.median(secondary_worker_key_fractions) == 0.0
+
+        # Check that there were few transfers
+        unexpected_transfers = []
+        for worker in workers:
+            for log in worker.incoming_transfer_log:
+                keys = log["keys"]
+                # The root-ish tasks should never be transferred
+                assert not any(k.startswith("random") for k in keys), keys
+                # `object-` keys (the trivial deps of the root random tasks) should be transferred
+                if any(not k.startswith("object") for k in keys):
+                    # But not many other things should be
+                    unexpected_transfers.append(list(keys))
+
+        # A transfer at the very end to move aggregated results is fine (necessary with unbalanced workers in fact),
+        # but generally there should be very very few transfers.
+        assert len(unexpected_transfers) <= 2, unexpected_transfers
+
+    test()
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)


### PR DESCRIPTION
In `decide_worker`, rather than spreading out root tasks as much as possible, schedule consecutive (by priority order) root(ish) tasks on the same worker. This ensures the dependencies of a reduction start out on the same worker, reducing future data transfer.

- [x] Closes #4892
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
