### PR TITLE
Handle HTTPClientError in websocket connector

### DIFF
--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -7,7 +7,7 @@ from ssl import SSLError
 from typing import Callable
 
 from tornado import web
-from tornado.httpclient import HTTPRequest
+from tornado.httpclient import HTTPRequest, HTTPClientError
 from tornado.httpserver import HTTPServer
 from tornado.iostream import StreamClosedError
 from tornado.websocket import WebSocketClosedError, WebSocketHandler, websocket_connect
@@ -380,6 +380,8 @@ class WSConnector(Connector):
                 "TLS expects a `ssl_context` argument of type "
                 "ssl.SSLContext (perhaps check your TLS configuration?)"
             ) from err
+        except HTTPClientError as e:
+            raise CommClosedError(f"in {self}: {e}") from e
         return self.comm_class(sock, deserialize=deserialize)
 
     def _get_connect_args(self, **connection_args):

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -7,7 +7,7 @@ from ssl import SSLError
 from typing import Callable
 
 from tornado import web
-from tornado.httpclient import HTTPRequest, HTTPClientError
+from tornado.httpclient import HTTPClientError, HTTPRequest
 from tornado.httpserver import HTTPServer
 from tornado.iostream import StreamClosedError
 from tornado.websocket import WebSocketClosedError, WebSocketHandler, websocket_connect


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Catch websocket client connection errors and re-raise them as `CommClosedError` so that they are handled correctly by the Client.

Scenario:
A Client tries to reconnect to a closed Cluster behind a proxy. The proxy closes the connection back to the client since it can't connect to the Cluster which leads to a HTTPClientError that gets bubbled up.

Not exactly sure how to write an efficient test for this 🤔 . Thoughts?