### PR TITLE
Catch `OSError` in `Scheduler.restart`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5432,7 +5432,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
             try:
                 resps = await asyncio.wait_for(resps, timeout)
-            except TimeoutError:
+            except (TimeoutError, OSError):
                 logger.error(
                     "Nannies didn't report back restarted within "
                     "timeout.  Continuuing with restart process"


### PR DESCRIPTION
- [x] Closes #4783
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

It seems reasonable to catch `OSError` here, so the restart can continue. This looks similar to the fix in #4567.

Would you accept this without a test? I'm not sure how to simulate a (realistic) `OSError` in this case.