### PR TITLE
Use more informative default name for `WorkerPlugin`s

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -181,7 +181,7 @@ def _get_worker_plugin_name(plugin) -> str:
     if hasattr(plugin, "name"):
         return plugin.name
     else:
-        return funcname(plugin) + "-" + str(uuid.uuid4())
+        return funcname(type(plugin)) + "-" + str(uuid.uuid4())
 
 
 class PipInstall(WorkerPlugin):

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -208,3 +208,13 @@ async def test_empty_plugin(c, s, w):
         pass
 
     await c.register_worker_plugin(EmptyPlugin())
+
+
+@gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)
+async def test_default_name(c, s, w):
+    class MyCustomPlugin(WorkerPlugin):
+        pass
+
+    await c.register_worker_plugin(MyCustomPlugin())
+    assert len(w.plugins) == 1
+    assert next(iter(w.plugins)).startswith("MyCustomPlugin-")


### PR DESCRIPTION
This PR updates the default name we assign to `WorkerPlugin` to be more informative. For example, today on `main` the following snippet which prints the default name for a custom `MyPlugin` plugin:

```python
from distributed import Client, WorkerPlugin

class MyPlugin(WorkerPlugin):
    pass

with Client() as client:
    # Register custom plugin without explicit name
    client.register_worker_plugin(MyPlugin())
    # Get default generated names
    results = client.run(lambda dask_worker: list(dask_worker.plugins))
    print(next(iter(results.values())))
```

outputs

```
['<__main__.MyPlugin object at 0x11c055910>-f19cb51e-ef48-43d6-a6af-1236414fb719']
```

With the changes in this PR, the default name is more readable

```
['MyPlugin-e1458274-e471-42ab-a72e-2f1131a55521']
```