### PR TITLE
Add scheduler log tab to performance reports

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -37,7 +37,6 @@ from bokeh.palettes import Viridis11
 from bokeh.plotting import figure
 from bokeh.themes import Theme
 from bokeh.transform import cumsum, factor_cmap, linear_cmap
-from jinja2.environment import Template
 from tlz import curry, pipe
 from tlz.curried import concat, groupby, map
 from tornado import escape
@@ -71,7 +70,7 @@ from distributed.diagnostics.task_stream import TaskStreamPlugin
 from distributed.diagnostics.task_stream import color_of as ts_color_of
 from distributed.diagnostics.task_stream import colors as ts_color_lookup
 from distributed.metrics import time
-from distributed.utils import format_time, log_errors, parse_timedelta
+from distributed.utils import Logs, format_time, log_errors, parse_timedelta
 
 if dask.config.get("distributed.dashboard.export-tool"):
     from distributed.dashboard.export_tool import ExportTool
@@ -2166,37 +2165,9 @@ class WorkerTable(DashboardComponent):
 
 class SchedulerLogs:
     def __init__(self, scheduler):
-        template = Template(
-            """
-            {% for level, message in logs %}
-            <p class="dask-{{ level.lower() }}">
-                {{ message }}
-            </p>
-            {% endfor %}
-            <style>
-                p {
-                    font-family: monospace;
-                    margin:0;
-                }
-                p.dask-warning {
-                    font-weight: bold;
-                    color: orange
-                }
-                p.dask-critical {
-                    font-weight: bold;
-                    color: orangered;
-                }
-                p.dask-error {
-                    font-weight: bold;
-                    color: crimson;
-                }
-            </style>
-        """
-        )
+        logs = Logs(scheduler.get_logs())._repr_html_()
 
-        logs = scheduler.get_logs()
-
-        self.root = Div(text=template.render(logs=logs))
+        self.root = Div(text=logs)
 
 
 def systemmonitor_doc(scheduler, extra, doc):

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -14,8 +14,7 @@ from dask.utils import format_bytes
 
 from ..core import Status
 from ..utils import (
-    Log,
-    Logs,
+    MultiLogs,
     format_dashboard_link,
     log_errors,
     parse_timedelta,
@@ -208,21 +207,19 @@ class Cluster:
             print(log)
 
     async def _get_logs(self, cluster=True, scheduler=True, workers=True):
-        logs = Logs()
+        logs = MultiLogs()
 
         if cluster:
-            logs["Cluster"] = Log(
-                "\n".join(line[1] for line in self._cluster_manager_logs)
-            )
+            logs["Cluster"] = self._cluster_manager_logs
 
         if scheduler:
             L = await self.scheduler_comm.get_logs()
-            logs["Scheduler"] = Log("\n".join(line for level, line in L))
+            logs["Scheduler"] = L
 
         if workers:
             d = await self.scheduler_comm.worker_logs(workers=workers)
             for k, v in d.items():
-                logs[k] = Log("\n".join(line for level, line in v))
+                logs[k] = v
 
         return logs
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6906,10 +6906,9 @@ class Scheduler(SchedulerState, ServerNode):
         sysmon.update()
 
         # Scheduler logs
-        from distributed.dashboard.components.scheduler import SchedulerLogTable
+        from distributed.dashboard.components.scheduler import SchedulerLogs
 
-        log_table = SchedulerLogTable(self, sizing_mode="stretch_both")
-        log_table.update()
+        logs = SchedulerLogs(self)
 
         from bokeh.models import Div, Panel, Tabs
 
@@ -6969,7 +6968,7 @@ class Scheduler(SchedulerState, ServerNode):
         )
         bandwidth_types = Panel(child=bandwidth_types.root, title="Bandwidth (Types)")
         system = Panel(child=sysmon.root, title="System")
-        logs = Panel(child=log_table.root, title="Scheduler Logs")
+        logs = Panel(child=logs.root, title="Scheduler Logs")
 
         tabs = Tabs(
             tabs=[

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6905,6 +6905,12 @@ class Scheduler(SchedulerState, ServerNode):
         sysmon = SystemMonitor(self, last_count=last_count, sizing_mode="stretch_both")
         sysmon.update()
 
+        # Scheduler logs
+        from distributed.dashboard.components.scheduler import SchedulerLogTable
+
+        log_table = SchedulerLogTable(self, sizing_mode="stretch_both")
+        log_table.update()
+
         from bokeh.models import Div, Panel, Tabs
 
         import distributed
@@ -6963,12 +6969,14 @@ class Scheduler(SchedulerState, ServerNode):
         )
         bandwidth_types = Panel(child=bandwidth_types.root, title="Bandwidth (Types)")
         system = Panel(child=sysmon.root, title="System")
+        logs = Panel(child=log_table.root, title="Scheduler Logs")
 
         tabs = Tabs(
             tabs=[
                 html,
                 task_stream,
                 system,
+                logs,
                 compute,
                 workers,
                 scheduler,

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6308,6 +6308,7 @@ async def test_performance_report(c, s, a, b):
     assert "Dask Performance Report" in data
     assert "x = da.random" in data
     assert "Threads: 4" in data
+    assert "distributed.scheduler - INFO - Clear task state" in data
     assert dask.__version__ in data
 
     # Stacklevel two captures code two frames back -- which in this case

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -19,9 +19,8 @@ from distributed.metrics import time
 from distributed.utils import (
     LRU,
     All,
-    Log,
-    Logs,
     LoopRunner,
+    MultiLogs,
     TimeoutError,
     _maybe_complex,
     deprecated,
@@ -559,7 +558,7 @@ def test_format_bytes_compat():
 
 
 def test_logs():
-    d = Logs({"123": Log("Hello"), "456": Log("World!")})
+    d = MultiLogs({"123": [("INFO", "Hello")], "456": [("INFO", "World!")]})
     text = d._repr_html_()
     assert is_valid_xml("<div>" + text + "</div>")
     assert "Hello" in text


### PR DESCRIPTION
Adds a tab to the performance report with the logs of the scheduler. Note that these are all the logs currently contained in the scheduler's log deque. and not just the logs generated in the `performance_report` context:

![image](https://user-images.githubusercontent.com/20627856/121756993-1cd7e100-caea-11eb-92a0-73f891156eec.png)

- [ ] Closes #4781
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
