### PR TITLE
Remove imports of dask.compatibility.

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -27,11 +27,10 @@ from tlz import first, groupby, keymap, merge, partition_all, valmap
 
 import dask
 from dask.base import collections_to_dsk, normalize_token, tokenize
-from dask.compatibility import apply
 from dask.core import flatten
 from dask.highlevelgraph import HighLevelGraph
 from dask.optimization import SubgraphCallable
-from dask.utils import ensure_dict, format_bytes, funcname, stringify
+from dask.utils import apply, ensure_dict, format_bytes, funcname, stringify
 
 try:
     from dask.delayed import single_key

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -17,7 +17,7 @@ from tlz import concat, first, frequencies, merge, valmap
 
 import dask
 from dask import delayed
-from dask.compatibility import apply
+from dask.utils import apply
 
 from distributed import Client, Nanny, Worker, fire_and_forget, wait
 from distributed.comm import Comm

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -23,10 +23,9 @@ from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
-from dask.compatibility import apply
 from dask.core import istask
 from dask.system import CPU_COUNT
-from dask.utils import format_bytes, funcname
+from dask.utils import apply, format_bytes, funcname
 
 from . import comm, preloading, profile, system, utils
 from .batched import BatchedSend


### PR DESCRIPTION
As a corollary to https://github.com/dask/dask/pull/7801.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
