### PR TITLE
Use deprecation utility from Dask

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -30,7 +30,14 @@ from dask.base import collections_to_dsk, normalize_token, tokenize
 from dask.core import flatten
 from dask.highlevelgraph import HighLevelGraph
 from dask.optimization import SubgraphCallable
-from dask.utils import apply, ensure_dict, format_bytes, funcname, stringify
+from dask.utils import (
+    _deprecated,
+    apply,
+    ensure_dict,
+    format_bytes,
+    funcname,
+    stringify,
+)
 
 try:
     from dask.delayed import single_key
@@ -2538,6 +2545,7 @@ class Client:
         """
         return self.sync(self._run, function, *args, **kwargs)
 
+    @_deprecated(use_instead="Client.run which detects async functions automatically")
     def run_coroutine(self, function, *args, **kwargs):
         """
         Spawn a coroutine on all workers.
@@ -2559,12 +2567,6 @@ class Client:
             Workers on which to run the function. Defaults to all known workers.
 
         """
-        warnings.warn(
-            "This method has been deprecated. "
-            "Instead use Client.run which detects async functions "
-            "automatically",
-            stacklevel=2,
-        )
         return self.run(function, *args, **kwargs)
 
     def _graph_to_futures(

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -3,14 +3,13 @@ import datetime
 import logging
 import threading
 import uuid
-import warnings
 from contextlib import suppress
 from inspect import isawaitable
 
 from tornado.ioloop import PeriodicCallback
 
 import dask.config
-from dask.utils import format_bytes
+from dask.utils import _deprecated, format_bytes
 
 from ..core import Status
 from ..objects import SchedulerInfo
@@ -248,8 +247,8 @@ class Cluster:
             self._get_logs, cluster=cluster, scheduler=scheduler, workers=workers
         )
 
+    @_deprecated(use_instead="get_logs")
     def logs(self, *args, **kwargs):
-        warnings.warn("logs is deprecated, use get_logs instead", DeprecationWarning)
         return self.get_logs(*args, **kwargs)
 
     @property

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -25,3 +25,10 @@ async def test_repr(cleanup):
     res = repr(cluster)
     expected = "Cluster(A, '<Not Connected>', workers=0, threads=0, memory=0 B)"
     assert res == expected
+
+
+@pytest.mark.asyncio
+async def test_logs_deprecated(cleanup):
+    cluster = Cluster(asynchronous=True)
+    with pytest.warns(FutureWarning, match="get_logs"):
+        cluster.logs()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2715,6 +2715,16 @@ def test_run_coroutine_sync(c, s, a, b):
     assert t2 - t1 <= 1.0
 
 
+@gen_cluster(client=True)
+async def test_run_coroutine_deprecated(c, s, a, b):
+    async def foo():
+        return "bar"
+
+    with pytest.warns(FutureWarning, match="Client.run "):
+        results = await c.run_coroutine(foo)
+    assert results == {a.address: "bar", b.address: "bar"}
+
+
 def test_run_exception(c):
     def raise_exception(exc_type, exc_msg):
         raise exc_type(exc_msg)

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -23,7 +23,6 @@ from distributed.utils import (
     MultiLogs,
     TimeoutError,
     _maybe_complex,
-    deprecated,
     ensure_bytes,
     ensure_ip,
     format_dashboard_link,
@@ -608,20 +607,3 @@ def test_lru():
 async def test_offload():
     assert (await offload(inc, 1)) == 2
     assert (await offload(lambda x, y: x + y, 1, y=2)) == 3
-
-
-def test_deprecated():
-    @deprecated()
-    def foo():
-        return "bar"
-
-    with pytest.warns(DeprecationWarning, match="foo is deprecated"):
-        assert foo() == "bar"
-
-    # Explicit version specified
-    @deprecated(version_removed="1.2.3")
-    def foo():
-        return "bar"
-
-    with pytest.warns(DeprecationWarning, match="removed in version 1.2.3"):
-        assert foo() == "bar"

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -49,7 +49,7 @@ from distributed.utils_test import (
     nodebug,
     slowinc,
 )
-from distributed.worker import Worker, error_message, logger, parse_memory_limit, weight
+from distributed.worker import Worker, error_message, logger, parse_memory_limit
 
 
 @pytest.mark.asyncio
@@ -1839,11 +1839,6 @@ async def test_story_with_deps(c, s, a, b):
         (key, "put-in-memory"),
     ]
     assert story == expected_story
-
-
-def test_weight_deprecated():
-    with pytest.warns(DeprecationWarning):
-        weight("foo", "bar")
 
 
 @gen_cluster(client=True)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -982,34 +982,6 @@ def nbytes(frame, _bytes_like=(bytes, bytearray)):
             return len(frame)
 
 
-def deprecated(*, version_removed: str = None):
-    """Decorator to mark a function as deprecated
-
-    Parameters
-    ----------
-    version_removed : str, optional
-        If specified, include the version in which the deprecated function
-        will be removed. Defaults to "a future release".
-    """
-
-    def decorator(func):
-        nonlocal version_removed
-        msg = f"{funcname(func)} is deprecated and will be removed in"
-        if version_removed is not None:
-            msg += f" version {version_removed}"
-        else:
-            msg += " a future release"
-
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
 def json_load_robust(fn, load=json.load):
     """Reads a JSON file from disk that may be being written as we read"""
     while not os.path.exists(fn):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -57,7 +57,6 @@ from .utils import (
     LRU,
     TimeoutError,
     _maybe_complex,
-    deprecated,
     get_ip,
     has_arg,
     import_file,
@@ -4015,11 +4014,6 @@ def convert_kwargs_to_str(kwargs, max_len=None):
             return "{{{}".format(", ".join(strs[: i + 1]))[:max_len]
     else:
         return "{{{}}}".format(", ".join(strs))
-
-
-@deprecated(version_removed="2021.06.0")
-def weight(k, v):
-    return sizeof(v)
 
 
 async def run(server, comm, function, args=(), kwargs=None, is_coro=None, wait=True):

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ numpydoc
 tornado
 toolz
 cloudpickle
-dask>=2020.12.0
+git+https://github.com/dask/dask
 sphinx
 dask-sphinx-theme>=1.3.5
 sphinx-click


### PR DESCRIPTION
To avoid duplicate deprecation utilities, this PR removes the `deprecated` in `distributed` in favor of the new `_deprecated` decorator recently added to `dask` (xref https://github.com/dask/dask/pull/7810) 