### PR TITLE
Dont start http server in Scheduler.__init__

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -184,7 +184,6 @@ def main(
         resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
 
     loop = IOLoop.current()
-    logger.info("-" * 47)
 
     scheduler = Scheduler(
         loop=loop,
@@ -196,12 +195,13 @@ def main(
         http_prefix=dashboard_prefix,
         **kwargs,
     )
-    logger.info("-" * 47)
 
     install_signal_handlers(loop)
 
     async def run():
+        logger.info("-" * 47)
         await scheduler
+        logger.info("-" * 47)
         await scheduler.finished()
 
     try:

--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -128,6 +128,9 @@ async def test_large_transfer(cleanup):
 
 
 @pytest.mark.asyncio
+@pytest.mark.filterwarnings(
+    "ignore:Dashboard and Scheduler are using the same server on port"
+)
 @pytest.mark.parametrize(
     "dashboard,protocol,security,port",
     [

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -426,7 +426,7 @@ class Server:
 
         logger.debug("Connection from %r to %s", address, type(self).__name__)
         self._comms[comm] = op
-        await self
+
         try:
             while True:
                 try:

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -248,8 +248,8 @@ def test_Client_unused_kwargs_with_address(loop):
 
 
 def test_Client_twice(loop):
-    with Client(loop=loop, silence_logs=False, dashboard_address=None) as c:
-        with Client(loop=loop, silence_logs=False, dashboard_address=None) as f:
+    with Client(loop=loop, silence_logs=False, dashboard_address=":0") as c:
+        with Client(loop=loop, silence_logs=False, dashboard_address=":0") as f:
             assert c.cluster.scheduler.port != f.cluster.scheduler.port
 
 
@@ -1048,7 +1048,9 @@ async def test_no_workers(cleanup):
 
 @pytest.mark.asyncio
 async def test_cluster_names():
-    async with LocalCluster(processes=False, asynchronous=True) as unnamed_cluster:
+    async with LocalCluster(
+        processes=False, asynchronous=True, dashboard_address=":0"
+    ) as unnamed_cluster:
         async with LocalCluster(
             processes=False, asynchronous=True, name="mycluster"
         ) as named_cluster:
@@ -1070,12 +1072,15 @@ async def test_local_cluster_redundant_kwarg(nanny):
         # Extra arguments are forwarded to the worker class. Depending on
         # whether we use the nanny or not, the error treatment is quite
         # different and we should assert that an exception is raised
-        async with await LocalCluster(
-            typo_kwarg="foo", processes=nanny, n_workers=1
+        async with LocalCluster(
+            typo_kwarg="foo",
+            processes=nanny,
+            n_workers=1,
+            asynchronous=True,
         ) as cluster:
 
             # This will never work but is a reliable way to block without hard
             # coding any sleep values
-            async with Client(cluster) as c:
+            async with Client(cluster, asynchronous=True) as c:
                 f = c.submit(sleep, 0)
                 await f

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -9,7 +9,6 @@ import tlz as toolz
 import dask
 from dask.distributed import Client, Nanny, Scheduler, SpecCluster, Worker
 
-from distributed.compatibility import WINDOWS
 from distributed.core import Status
 from distributed.deploy.spec import ProcessInterface, close_clusters, run_spec
 from distributed.metrics import time
@@ -218,7 +217,6 @@ async def test_restart(cleanup):
                     assert time() < start + 60
 
 
-@pytest.mark.skipif(WINDOWS, reason="HTTP Server doesn't close out")
 @pytest.mark.asyncio
 async def test_broken_worker():
     with pytest.raises(Exception) as info:
@@ -232,7 +230,6 @@ async def test_broken_worker():
     assert "Broken" in str(info.value)
 
 
-@pytest.mark.skipif(WINDOWS, reason="HTTP Server doesn't close out")
 @pytest.mark.slow
 def test_spec_close_clusters(loop):
     workers = {0: {"cls": Worker}}

--- a/distributed/deploy/utils_test.py
+++ b/distributed/deploy/utils_test.py
@@ -25,10 +25,14 @@ class ClusterTest:
         assert future.result() == 2
 
     def test_context_manager(self):
-        with self.Cluster(**self.kwargs) as c:
+        kwargs = self.kwargs.copy()
+        kwargs.pop("dashboard_address")
+        with self.Cluster(dashboard_address=":54321", **kwargs) as c:
             with Client(c) as e:
                 assert e.nthreads()
 
     def test_no_workers(self):
-        with self.Cluster(0, scheduler_port=0, **self.kwargs):
+        kwargs = self.kwargs.copy()
+        kwargs.pop("dashboard_address")
+        with self.Cluster(0, dashboard_address=":54321", scheduler_port=0, **kwargs):
             pass

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -84,6 +84,13 @@ from .utils_perf import disable_gc_diagnosis, enable_gc_diagnosis
 from .variable import VariableExtension
 
 try:
+    import bokeh  # noqa: F401
+
+    HAS_BOKEH = True
+except ImportError:
+    HAS_BOKEH = False
+
+try:
     from cython import compiled
 except ImportError:
     compiled = False
@@ -3438,24 +3445,11 @@ class Scheduler(SchedulerState, ServerNode):
             default_port=self.default_port,
         )
 
-        http_server_modules = dask.config.get("distributed.scheduler.http.routes")
-        show_dashboard = dashboard or (dashboard is None and dashboard_address)
-        missing_bokeh = False
-        # install vanilla route if show_dashboard but bokeh is not installed
-        if show_dashboard:
-            try:
-                import distributed.dashboard.scheduler
-            except ImportError:
-                missing_bokeh = True
-                http_server_modules.append("distributed.http.scheduler.missing_bokeh")
-        routes = get_handlers(
-            server=self, modules=http_server_modules, prefix=http_prefix
+        self._show_dashboard: bool = dashboard or (
+            dashboard is None and dashboard_address
         )
-        self.start_http_server(routes, dashboard_address, default_port=8787)
-        if show_dashboard and not missing_bokeh:
-            distributed.dashboard.scheduler.connect(
-                self.http_application, self.http_server, self, prefix=http_prefix
-            )
+        self._dashboard_address = dashboard_address
+        self._http_prefix = http_prefix
 
         # Communication state
         self.loop = loop or IOLoop.current()
@@ -3758,6 +3752,23 @@ class Scheduler(SchedulerState, ServerNode):
         enable_gc_diagnosis()
 
         self.clear_task_state()
+
+        http_server_modules = dask.config.get("distributed.scheduler.http.routes")
+        assert isinstance(http_server_modules, list)
+
+        # install vanilla route if show_dashboard but bokeh is not installed
+        if self._show_dashboard and not HAS_BOKEH:
+            http_server_modules.append("distributed.http.scheduler.missing_bokeh")
+        routes = get_handlers(
+            server=self, modules=http_server_modules, prefix=self._http_prefix
+        )
+        self.start_http_server(routes, self._dashboard_address, default_port=8787)
+        if self._show_dashboard and HAS_BOKEH:
+            import distributed.dashboard.scheduler
+
+            distributed.dashboard.scheduler.connect(
+                self.http_application, self.http_server, self, prefix=self._http_prefix
+            )
 
         with suppress(AttributeError):
             for c in self._worker_coroutines:
@@ -5463,7 +5474,7 @@ class Scheduler(SchedulerState, ServerNode):
     def clear_task_state(self):
         # XXX what about nested state such as ClientState.wants_what
         # (see also fire-and-forget...)
-        logger.info("Clear task state")
+        logger.debug("Clear task state")
         for collection in self._task_state_collections:
             collection.clear()
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6378,7 +6378,6 @@ async def test_performance_report(c, s, a, b):
     assert "Dask Performance Report" in data
     assert "x = da.random" in data
     assert "Threads: 4" in data
-    assert "distributed.scheduler - INFO - Clear task state" in data
     assert dask.__version__ in data
 
     # Stacklevel two captures code two frames back -- which in this case
@@ -6745,7 +6744,7 @@ async def test_get_client_functions_spawn_clusters(c, s, a):
         with LocalCluster(
             n_workers=1,
             processes=False,
-            dashboard_address=False,
+            dashboard_address=":0",
             worker_dashboard_address=False,
         ) as cluster2:
             with Client(cluster2) as c1:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2936,3 +2936,10 @@ async def test_transition_counter(c, s, a, b):
     assert s.transition_counter == 0
     await c.submit(inc, 1)
     assert s.transition_counter > 1
+
+
+def test_init_twice_no_warning():
+    with pytest.warns(None) as records:
+        for _ in range(2):
+            Scheduler()
+    assert not records

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,9 @@ parentdir_prefix = distributed-
 addopts = -v -rsxfE --durations=20
 filterwarnings =
     error:Since distributed.*:PendingDeprecationWarning
+
+    # See https://github.com/dask/distributed/issues/4806
+    error:Port:UserWarning:distributed.node
 minversion = 4
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
This should deal with the CI port already in use warning situation reported in #4806 

Highlights
* We have a few places where we start up a cluster (e.g. spec cluster or gen_cluster) where we do not close the scheduler if workers fail to start. This would leave ports still allocated
* Previously HTTP server sockets were opened during `Scheduler.__init__` which made some tests really awkward. This PR moves the start of the HTTP server to the `Scheduler.start` method.
* A few tests intentionally start two clusters/schedulers where I circumvented this warning by simply allowing random ports. This revealed a shortcoming of our API since there is currently no way to *not* start an HTTP server
* I added a filterwarnings statement in our setup.cfg to err whenever this warning is raised in our test setup. This is very strict but I would prefer keeping it and removing it again if it causes any issues. Preferably we'd have a test fixture which checks if the test left any open socks but I'm not aware of any code which can do this without root

Supersedes https://github.com/dask/distributed/pull/4896 and https://github.com/dask/distributed/pull/4921

- [x] Closes https://github.com/dask/distributed/issues/4806
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
