### PR TITLE
Fix deadlock in handle_missing_dep if additional replicas are available

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2532,7 +2532,7 @@ class Worker(ServerNode):
                     logger.debug("New workers found for %s", dep.key)
                     self.log.append((dep.key, "new workers found"))
                     for dependent in dep.dependents:
-                        if dependent.key in dep.waiting_for_data:
+                        if dep.key in dependent.waiting_for_data:
                             self.data_needed.append(dependent.key)
             if still_missing:
                 logger.debug(


### PR DESCRIPTION
Yet another deadlock (the for-loop was not tested, my coverage PR is also landing shortly)

What happens is that the missing dependency management does currently only work properly if there are *no* replicas of the failed fetch are available. otherwise it can happen that the fetch is never rescheduled (add dependent to self.data_needed)


- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
