### PR TITLE
Add transition counter to Scheduler

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1770,6 +1770,7 @@ class SchedulerState:
     _validate: bint
     _workers: object
     _workers_dv: dict
+    _transition_counter: Py_ssize_t
 
     # Variables from dask.config, cached by __init__ for performance
     UNKNOWN_TASK_DURATION: double
@@ -1873,6 +1874,7 @@ class SchedulerState:
             dask.config.get("distributed.worker.memory.rebalance.sender-recipient-gap")
             / 2.0
         )
+        self._transition_counter = 0
 
         super().__init__(**kwargs)
 
@@ -2065,6 +2067,7 @@ class SchedulerState:
             func = self._transitions_table.get(start_finish)
             if func is not None:
                 a: tuple = func(key, *args, **kwargs)
+                self._transition_counter += 1
                 recommendations, client_msgs, worker_msgs = a
             elif "released" not in start_finish:
                 assert not args and not kwargs

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1943,6 +1943,10 @@ class SchedulerState:
         self._total_occupancy = v
 
     @property
+    def transition_counter(self):
+        return self._transition_counter
+
+    @property
     def unknown_durations(self):
         return self._unknown_durations
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2795,3 +2795,10 @@ async def test_rebalance_least_recently_inserted_sender_min(c, s, *_):
         a: (large_future.key,),
         b: tuple(f.key for f in small_futures),
     }
+
+
+@gen_cluster(client=True)
+async def test_transition_counter(c, s, a, b):
+    assert s._transition_counter == 0
+    await c.submit(inc, 1)
+    assert s._transition_counter > 1

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2799,6 +2799,6 @@ async def test_rebalance_least_recently_inserted_sender_min(c, s, *_):
 
 @gen_cluster(client=True)
 async def test_transition_counter(c, s, a, b):
-    assert s._transition_counter == 0
+    assert s.transition_counter == 0
     await c.submit(inc, 1)
-    assert s._transition_counter > 1
+    assert s.transition_counter > 1


### PR DESCRIPTION
This helps us identify if things have changed recently

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
