### PR TITLE
Revert refactor to `utils.Log[s]` and `Cluster.get_logs`

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -70,7 +70,7 @@ from distributed.diagnostics.task_stream import TaskStreamPlugin
 from distributed.diagnostics.task_stream import color_of as ts_color_of
 from distributed.diagnostics.task_stream import colors as ts_color_lookup
 from distributed.metrics import time
-from distributed.utils import Logs, format_time, log_errors, parse_timedelta
+from distributed.utils import Log, format_time, log_errors, parse_timedelta
 
 if dask.config.get("distributed.dashboard.export-tool"):
     from distributed.dashboard.export_tool import ExportTool
@@ -2165,7 +2165,9 @@ class WorkerTable(DashboardComponent):
 
 class SchedulerLogs:
     def __init__(self, scheduler):
-        logs = Logs(scheduler.get_logs())._repr_html_()
+        logs = Log(
+            "\n".join(line for level, line in scheduler.get_logs())
+        )._repr_html_()
 
         self.root = Div(text=logs)
 

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -15,7 +15,8 @@ from dask.utils import format_bytes
 from ..core import Status
 from ..objects import SchedulerInfo
 from ..utils import (
-    MultiLogs,
+    Log,
+    Logs,
     format_dashboard_link,
     log_errors,
     parse_timedelta,
@@ -209,19 +210,21 @@ class Cluster:
             print(log)
 
     async def _get_logs(self, cluster=True, scheduler=True, workers=True):
-        logs = MultiLogs()
+        logs = Logs()
 
         if cluster:
-            logs["Cluster"] = self._cluster_manager_logs
+            logs["Cluster"] = Log(
+                "\n".join(line[1] for line in self._cluster_manager_logs)
+            )
 
         if scheduler:
             L = await self.scheduler_comm.get_logs()
-            logs["Scheduler"] = L
+            logs["Scheduler"] = Log("\n".join(line for level, line in L))
 
         if workers:
             d = await self.scheduler_comm.worker_logs(workers=workers)
             for k, v in d.items():
-                logs[k] = v
+                logs[k] = Log("\n".join(line for level, line in v))
 
         return logs
 

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -287,6 +287,8 @@ async def test_logs(cleanup):
         await cluster
 
         logs = await cluster.get_logs()
+        assert isinstance(logs, dict)
+        assert all(isinstance(log, str) for log in logs)
         assert is_valid_xml("<div>" + logs._repr_html_() + "</div>")
         assert "Scheduler" in logs
         for worker in cluster.scheduler.workers:

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -19,8 +19,9 @@ from distributed.metrics import time
 from distributed.utils import (
     LRU,
     All,
+    Log,
+    Logs,
     LoopRunner,
-    MultiLogs,
     TimeoutError,
     _maybe_complex,
     deprecated,
@@ -549,7 +550,7 @@ def test_format_bytes_compat():
 
 
 def test_logs():
-    d = MultiLogs({"123": [("INFO", "Hello")], "456": [("INFO", "World!")]})
+    d = Logs({"123": Log("Hello"), "456": Log("World!")})
     text = d._repr_html_()
     assert is_valid_xml("<div>" + text + "</div>")
     assert "Hello" in text

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -550,7 +550,10 @@ def test_format_bytes_compat():
 
 
 def test_logs():
-    d = Logs({"123": Log("Hello"), "456": Log("World!")})
+    log = Log("Hello")
+    assert isinstance(log, str)
+    d = Logs({"123": log, "456": Log("World!")})
+    assert isinstance(d, dict)
     text = d._repr_html_()
     assert is_valid_xml("<div>" + text + "</div>")
     assert "Hello" in text

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1269,8 +1269,8 @@ def parse_ports(port):
 is_coroutine_function = iscoroutinefunction
 
 
-class Log(tuple):
-    """A container for a single log entry"""
+class Log(str):
+    """A container for newline-delimited string of log entries"""
 
     level_styles = {
         "WARNING": "font-weight: bold; color: orange;",
@@ -1279,34 +1279,34 @@ class Log(tuple):
     }
 
     def _repr_html_(self):
-        level, message = self
+        logs_html = []
+        for message in self.split("\n"):
+            style = "font-family: monospace; margin: 0;"
+            for level in self.level_styles:
+                if level in message:
+                    style += self.level_styles[level]
+                    break
 
-        style = "font-family: monospace; margin: 0;"
-        style += self.level_styles.get(level, "")
+            logs_html.append(
+                '<p style="{style}">{message}</p>'.format(
+                    style=html.escape(style),
+                    message=html.escape(message),
+                )
+            )
 
-        return '<p style="{style}">{message}</p>'.format(
-            style=html.escape(style),
-            message=html.escape(message),
-        )
-
-
-class Logs(list):
-    """A container for a list of log entries"""
-
-    def _repr_html_(self):
-        return "\n".join(Log(entry)._repr_html_() for entry in self)
+        return "\n".join(logs_html)
 
 
-class MultiLogs(dict):
-    """A container for a dict mapping strings to lists of log entries"""
+class Logs(dict):
+    """A container for a dict mapping names to strings of log entries"""
 
     def _repr_html_(self):
         summaries = [
             "<details>\n"
             "<summary style='display:list-item'>{title}</summary>\n"
-            "{logs}\n"
-            "</details>".format(title=title, logs=Logs(entries)._repr_html_())
-            for title, entries in sorted(self.items())
+            "{log}\n"
+            "</details>".format(title=title, log=log._repr_html_())
+            for title, log in sorted(self.items())
         ]
         return "\n".join(summaries)
 


### PR DESCRIPTION
The refactor of `utils.Log[s]` and `Cluster.get_logs` in #4909 can lead to errors in downstream projects that use these functions. This PR restores the original behavior of these functions, while making some minor adjustments to achieve what was done in #4909 (styling conditional on log level, tighter spacing between log entries).

- [ ] Closes #4940
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
