### PR TITLE
Disable worker dashboard by default in tests

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -870,7 +870,8 @@ def gen_cluster(
         nthreads = ncores
 
     worker_kwargs = merge(
-        {"memory_limit": system.MEMORY_LIMIT, "death_timeout": 10}, worker_kwargs
+        {"memory_limit": system.MEMORY_LIMIT, "death_timeout": 10, "dashboard": False},
+        worker_kwargs,
     )
 
     def _(func):


### PR DESCRIPTION
Messages like
```
  /home/runner/work/distributed/distributed/distributed/node.py:160: UserWarning: Port 8787 is already in use.
  Perhaps you already have a cluster running?
  Hosting the HTTP server on port 36717 instead
```
take a a _lot_ of lines in CI. Running the worker dashboard during tests seems unnecessary?

- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
