### PR TITLE
Add `Log` and `Logs` to API docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -65,6 +65,13 @@ API
    performance_report
 
 
+**Utilities**
+
+.. autosummary::
+   distributed.utils.Log
+   distributed.utils.Logs
+
+
 Asynchronous methods
 --------------------
 
@@ -173,6 +180,13 @@ Other
    :members:
 .. autoclass:: Variable
    :members:
+
+
+Utilities
+---------
+
+.. autoclass:: distributed.utils.Log
+.. autoclass:: distributed.utils.Logs
 
 
 Adaptive


### PR DESCRIPTION
This is a start towards publicly communicating what utility functions we expect to be in our public API (xref https://github.com/dask/distributed/pull/4941#pullrequestreview-688788160). Eventually we'll want to expand this list and start prepending underscores to the names of utilities not on this list, but this is a start. 

cc @ian-r-rose @charlesbluca