### PR TITLE
Stealing dashboard fixes

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1253,7 +1253,7 @@ class StealingEvents(DashboardComponent):
             "color": color,
             "duration": total_duration,
             "radius": radius,
-            "cost_factor": min(10, self.steal.cost_multipliers[level]),
+            "cost_factor": self.steal.cost_multipliers[level],
         }
 
         return d

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -103,15 +103,14 @@ async def test_stealing_events(c, s, a, b):
     se = StealingEvents(s)
 
     futures = c.map(
-        slowinc, range(100), delay=0.1, workers=a.address, allow_other_workers=True
+        slowinc, range(10), delay=0.1, workers=a.address, allow_other_workers=True
     )
 
-    while not b.tasks:  # will steal soon
-        await asyncio.sleep(0.01)
-
+    await wait(futures)
     se.update()
-
     assert len(first(se.source.data.values()))
+    assert b.tasks
+    assert sum(se.source.data["count"]) >= len(b.tasks)
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
This includes a few fixes for the secret `/stealing` dashboard.

The only content change is that the steal events plot now plots the level on the y axis instead of the cost_multiplier with a log scale. the only reason is because the level is well bound and includes 15 levels while the cost_multipler may theoretically be arbitrarily large (depending on the work stealing logic we're using. currently this is capped as well, still...)

Note: the following is a scaling scenario which is why the timseries for occupancy behaves weird

## Main
![main](https://user-images.githubusercontent.com/8629629/122926833-8cf72a00-d368-11eb-802e-6d5df42fb1ab.gif)


## This branch

![fixed_dashboard](https://user-images.githubusercontent.com/8629629/122926844-908ab100-d368-11eb-8527-56f5ed23eb8d.gif)
