### PR TITLE
Ensure connectionpool does not leave comms if closed mid connect

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -946,6 +946,12 @@ class ConnectionPool:
         self.server = weakref.ref(server) if server else None
         self._created = weakref.WeakSet()
         self._instances.add(self)
+        # _n_connecting and _connecting have subtle different semantics. The set
+        # _connecting contains futures actively trying to establish a connection
+        # while the _n_connecting also accounts for connection attempts which
+        # are waiting due to the connection limit
+        self._connecting = set()
+        self.status = Status.init
 
     def _validate(self):
         """
@@ -987,6 +993,7 @@ class ConnectionPool:
     async def start(self):
         # Invariant: semaphore._value == limit - open - _n_connecting
         self.semaphore = asyncio.Semaphore(self.limit)
+        self.status = Status.running
 
     async def connect(self, addr, timeout=None):
         """
@@ -1007,27 +1014,38 @@ class ConnectionPool:
 
         self._n_connecting += 1
         await self.semaphore.acquire()
-
+        fut = None
         try:
-            comm = await connect(
-                addr,
-                timeout=timeout or self.timeout,
-                deserialize=self.deserialize,
-                **self.connection_args,
+            if self.status != Status.running:
+                raise CommClosedError("ConnectionPool closed already")
+
+            fut = asyncio.ensure_future(
+                connect(
+                    addr,
+                    timeout=timeout or self.timeout,
+                    deserialize=self.deserialize,
+                    **self.connection_args,
+                )
             )
+            self._connecting.add(fut)
+            comm = await fut
             comm.name = "ConnectionPool"
             comm._pool = weakref.ref(self)
             comm.allow_offload = self.allow_offload
             self._created.add(comm)
-        except Exception:
+
+            occupied.add(comm)
+
+            return comm
+        except asyncio.CancelledError as exc:
             self.semaphore.release()
-            raise
+            raise CommClosedError("ConnectionPool closed already") from exc
+        except Exception as exc:
+            self.semaphore.release()
+            raise exc
         finally:
+            self._connecting.discard(fut)
             self._n_connecting -= 1
-
-        occupied.add(comm)
-
-        return comm
 
     def reuse(self, addr, comm):
         """
@@ -1082,16 +1100,26 @@ class ConnectionPool:
         """
         Close all communications
         """
+        self.status = Status.closed
         for d in [self.available, self.occupied]:
-            comms = [comm for comms in d.values() for comm in comms]
+            comms = set()
+            while d:
+                comms.update(d.popitem()[1])
+
             await asyncio.gather(
                 *[comm.close() for comm in comms], return_exceptions=True
             )
+
             for _ in comms:
                 self.semaphore.release()
 
-        for comm in self._created:
-            IOLoop.current().add_callback(comm.abort)
+        for conn_fut in self._connecting:
+            conn_fut.cancel()
+
+        # We might still have tasks haning in the semaphore. This will let them
+        # run into an exception and raise a commclosed
+        while self._n_connecting:
+            await asyncio.sleep(0.005)
 
 
 def coerce_to_address(o):

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1017,7 +1017,9 @@ class ConnectionPool:
         fut = None
         try:
             if self.status != Status.running:
-                raise CommClosedError(f"ConnectionPool not running.  Status: {self.status}")
+                raise CommClosedError(
+                    f"ConnectionPool not running.  Status: {self.status}"
+                )
 
             fut = asyncio.ensure_future(
                 connect(
@@ -1039,7 +1041,9 @@ class ConnectionPool:
             return comm
         except asyncio.CancelledError as exc:
             self.semaphore.release()
-            raise CommClosedError("ConnectionPool closed already") from exc
+            raise CommClosedError(
+                f"ConnectionPool not running.  Status: {self.status}"
+            ) from exc
         except Exception as exc:
             self.semaphore.release()
             raise exc

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1017,7 +1017,7 @@ class ConnectionPool:
         fut = None
         try:
             if self.status != Status.running:
-                raise CommClosedError("ConnectionPool closed already")
+                raise CommClosedError(f"ConnectionPool not running.  Status: {self.status}")
 
             fut = asyncio.ensure_future(
                 connect(

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -651,7 +651,9 @@ async def test_connection_pool_close_while_connecting(monkeypatch):
     assert pool._connecting
     close_fut = asyncio.create_task(pool.close())
 
-    with pytest.raises(CommClosedError, match="ConnectionPool closed already"):
+    with pytest.raises(
+        CommClosedError, match="ConnectionPool not running.  Status: Status.closed"
+    ):
         await asyncio.gather(*tasks)
 
     await close_fut


### PR DESCRIPTION
There is a chance for the `ConnectionPool` to leave connections open even after it was closed. 

This came up during https://github.com/dask/distributed/pull/4734