### PR TITLE
Support fixtures and `pytest.mark.parametrize` with `gen_cluster`

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -45,6 +45,18 @@ async def test_gen_cluster(c, s, a, b):
     assert await c.submit(lambda: 123) == 123
 
 
+@pytest.mark.parametrize("foo", [True, False])
+@gen_cluster(client=True)
+async def test_gen_cluster_parametrized(c, s, a, b, foo):
+    assert isinstance(foo, bool)
+    assert isinstance(c, Client)
+    assert isinstance(s, Scheduler)
+    for w in [a, b]:
+        assert isinstance(w, Worker)
+    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
+    assert await c.submit(lambda: 123) == 123
+
+
 @gen_cluster(
     client=True,
     Worker=Nanny,

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1,4 +1,5 @@
 import asyncio
+import pathlib
 import socket
 import threading
 from contextlib import contextmanager
@@ -43,6 +44,15 @@ async def test_gen_cluster(c, s, a, b):
         assert isinstance(w, Worker)
     assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
     assert await c.submit(lambda: 123) == 123
+
+
+@gen_cluster(client=True)
+async def test_gen_cluster_pytest_fixture(c, s, a, b, tmp_path):
+    assert isinstance(tmp_path, pathlib.Path)
+    assert isinstance(c, Client)
+    assert isinstance(s, Scheduler)
+    for w in [a, b]:
+        assert isinstance(w, Worker)
 
 
 @pytest.mark.parametrize("foo", [True])

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -53,8 +53,16 @@ async def test_gen_cluster_parametrized(c, s, a, b, foo):
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
-    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
-    assert await c.submit(lambda: 123) == 123
+
+
+@pytest.mark.parametrize("foo", [True, False])
+@gen_cluster(client=True)
+async def test_gen_cluster_parametrized_variadic_workers(c, s, *workers, foo):
+    assert isinstance(foo, bool)
+    assert isinstance(c, Client)
+    assert isinstance(s, Scheduler)
+    for w in workers:
+        assert isinstance(w, Worker)
 
 
 @gen_cluster(

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -45,20 +45,32 @@ async def test_gen_cluster(c, s, a, b):
     assert await c.submit(lambda: 123) == 123
 
 
-@pytest.mark.parametrize("foo", [True, False])
+@pytest.mark.parametrize("foo", [True])
 @gen_cluster(client=True)
 async def test_gen_cluster_parametrized(c, s, a, b, foo):
-    assert isinstance(foo, bool)
+    assert foo is True
     assert isinstance(c, Client)
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
 
 
-@pytest.mark.parametrize("foo", [True, False])
+@pytest.mark.parametrize("foo", [True])
+@pytest.mark.parametrize("bar", ["a", "b"])
+@gen_cluster(client=True)
+async def test_gen_cluster_multi_parametrized(c, s, a, b, foo, bar):
+    assert foo is True
+    assert bar in ("a", "b")
+    assert isinstance(c, Client)
+    assert isinstance(s, Scheduler)
+    for w in [a, b]:
+        assert isinstance(w, Worker)
+
+
+@pytest.mark.parametrize("foo", [True])
 @gen_cluster(client=True)
 async def test_gen_cluster_parametrized_variadic_workers(c, s, *workers, foo):
-    assert isinstance(foo, bool)
+    assert foo is True
     assert isinstance(c, Client)
     assert isinstance(s, Scheduler)
     for w in workers:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -987,12 +987,17 @@ def gen_cluster(
 
         # Patch the signature so pytest can inject fixtures
         orig_sig = inspect.signature(func)
-        n_drop_args = 1 + len(nthreads)  # scheduler, *workers
+        args = [None] * (1 + len(nthreads))  # scheduler, *workers
         if client:
-            n_drop_args += 1
+            args.insert(0, None)
 
+        bound = orig_sig.bind_partial(*args)
         test_func.__signature__ = orig_sig.replace(
-            parameters=list(orig_sig.parameters.values())[n_drop_args:]
+            parameters=[
+                p
+                for name, p in orig_sig.parameters.items()
+                if name not in bound.arguments
+            ]
         )
 
         return test_func

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -867,6 +867,10 @@ def gen_cluster(
     async def test_foo(scheduler, worker1, worker2, param):
         await ...  # use tornado coroutines
 
+    @gen_cluster()
+    async def test_foo(scheduler, worker1, worker2, pytest_fixture_a, pytest_fixture_b):
+        await ...  # use tornado coroutines
+
     See also:
         start
         end


### PR DESCRIPTION
I've often wanted to `@pytest.mark.parametrize` tests that use `@gen_cluster`. The current pattern is to define the main testing logic in a closure within the outer parametrized function ([example](https://github.com/dask/distributed/issues/3540#issuecomment-593992700)). This works okay, but it's a little unintuitive. By altering the signature of the wrapped function, we can make it play nicely with pytest.

Related to #3540 (if that weren't already closed, I'd say this closes it).

- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
