### PR TITLE
Allow requirements verification to be ignored when loading backends from entrypoints

### DIFF
--- a/distributed/comm/registry.py
+++ b/distributed/comm/registry.py
@@ -57,26 +57,35 @@ class Backend(ABC):
 backends = {}
 
 
-def get_backend(scheme):
+def get_backend(scheme: str, require: bool = True) -> Backend:
     """
     Get the Backend instance for the given *scheme*.
     It looks for matching scheme in dask's internal cache, and falls-back to
     package metadata for the group name ``distributed.comm.backends``
+
+    Parameters
+    ----------
+
+    require : bool
+        Verify that the backends requirements are properly installed. See
+        https://setuptools.readthedocs.io/en/latest/pkg_resources.html for more
+        information.
     """
 
     backend = backends.get(scheme)
     if backend is None:
         import pkg_resources
 
-        backend = next(
-            iter(
-                backend_class_ep.load()()
-                for backend_class_ep in pkg_resources.iter_entry_points(
-                    "distributed.comm.backends", scheme
-                )
-            ),
-            None,
-        )
+        backend = None
+        for backend_class_ep in pkg_resources.iter_entry_points(
+            "distributed.comm.backends", scheme
+        ):
+            # resolve and require are equivalent to load
+            backend_factory = backend_class_ep.resolve()
+            if require:
+                backend_class_ep.require()
+            backend = backend_factory()
+
         if backend is None:
             raise ValueError(
                 "unknown address scheme %r (known schemes: %s)"

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -1275,5 +1275,9 @@ def test_register_backend_entrypoint():
         "udp", mod.__name__, attrs=["UDPBackend"], dist=dist
     )
 
+    # The require is disabled here since particularly unit tests may install
+    # dirty or dev versions which are conflicting with backend entrypoints if
+    # they are demanding for exact, stable versions. This should not fail the
+    # test
     result = get_backend("udp", require=False)
     assert result == 1

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -1275,5 +1275,5 @@ def test_register_backend_entrypoint():
         "udp", mod.__name__, attrs=["UDPBackend"], dist=dist
     )
 
-    result = get_backend("udp")
+    result = get_backend("udp", require=False)
     assert result == 1


### PR DESCRIPTION
I am running locally into the problem that this test raises due to a dirty distributed version being installed although the UDP backend to be loaded in the test is requiring the pinned, stable, released version 2021.06..01. This require disables the requirement verification for this test but is otherwise identical in functionality. The require was previously a argument to `load` but is deprecated in favour of these two separate calls

