### PR TITLE
add occupancy as individual plot

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -19,6 +19,7 @@ from .components.scheduler import (
     MemoryByKey,
     NBytes,
     NBytesCluster,
+    Occupancy,
     SystemMonitor,
     TaskGraph,
     TaskProgress,
@@ -90,6 +91,7 @@ applications = {
     "/individual-nprocessing": individual_doc(
         CurrentLoad, 100, fig_attr="processing_figure"
     ),
+    "/individual-occupancy": individual_doc(Occupancy, 100),
     "/individual-workers": individual_doc(WorkerTable, 500),
     "/individual-bandwidth-types": individual_doc(BandwidthTypes, 500),
     "/individual-bandwidth-workers": individual_doc(BandwidthWorkers, 500),

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -59,6 +59,7 @@ Individual bokeh plots
 - ``/individual-nbytes-cluster``
 - ``/individual-cpu``
 - ``/individual-nprocessing``
+- ``/individual-occupancy``
 - ``/individual-workers``
 - ``/individual-bandwidth-types``
 - ``/individual-bandwidth-workers``


### PR DESCRIPTION
- [x] Closes #4870
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Adding occupancy chart as an individual plot. 
