### PR TITLE
Ensure shuffle split operations are blacklisted from work stealing

### DIFF
--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -452,4 +452,4 @@ def _can_steal(thief, ts, victim):
     return True
 
 
-fast_tasks = {"shuffle-split"}
+fast_tasks = {"split-shuffle"}


### PR DESCRIPTION
If shuffle split tasks are not blacklisted from work stealing, this can have
catastrophic effects on performance.
See also https://github.com/dask/distributed/issues/4962

