### PR TITLE
Deprecate utilities which have moved to dask

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -5,9 +5,9 @@ from tornado import gen, locks
 from tornado.ioloop import IOLoop
 
 import dask
+from dask.utils import parse_timedelta
 
 from .core import CommClosedError
-from .utils import parse_timedelta
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/cfexecutor.py
+++ b/distributed/cfexecutor.py
@@ -4,8 +4,10 @@ import weakref
 from tlz import merge
 from tornado import gen
 
+from dask.utils import parse_timedelta
+
 from .metrics import time
-from .utils import TimeoutError, parse_timedelta, sync
+from .utils import TimeoutError, sync
 
 
 @gen.coroutine

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -36,6 +36,7 @@ from dask.utils import (
     ensure_dict,
     format_bytes,
     funcname,
+    parse_timedelta,
     stringify,
 )
 
@@ -78,7 +79,6 @@ from .utils import (
     key_split,
     log_errors,
     no_default,
-    parse_timedelta,
     sync,
     thread_state,
 )

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -8,11 +8,12 @@ from abc import ABC, abstractmethod, abstractproperty
 from contextlib import suppress
 
 import dask
+from dask.utils import parse_timedelta
 
 from ..metrics import time
 from ..protocol import pickle
 from ..protocol.compression import get_default_compression
-from ..utils import TimeoutError, parse_timedelta
+from ..utils import TimeoutError
 from . import registry
 from .addressing import parse_address
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -20,11 +20,12 @@ from tornado.tcpclient import TCPClient
 from tornado.tcpserver import TCPServer
 
 import dask
+from dask.utils import parse_timedelta
 
 from ..protocol.utils import pack_frames_prelude, unpack_frames
 from ..system import MEMORY_LIMIT
 from ..threadpoolexecutor import ThreadPoolExecutor
-from ..utils import ensure_ip, get_ip, get_ipv6, nbytes, parse_timedelta
+from ..utils import ensure_ip, get_ip, get_ipv6, nbytes
 from .addressing import parse_host_port, unparse_host_port
 from .core import Comm, CommClosedError, Connector, FatalCommClosedError, Listener
 from .registry import Backend, backends

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -10,8 +10,9 @@ import struct
 import weakref
 
 import dask
+from dask.utils import parse_bytes
 
-from ..utils import ensure_ip, get_ip, get_ipv6, log_errors, nbytes, parse_bytes
+from ..utils import ensure_ip, get_ip, get_ipv6, log_errors, nbytes
 from .addressing import parse_host_port, unparse_host_port
 from .core import Comm, CommClosedError, Connector, Listener
 from .registry import Backend, backends

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -18,6 +18,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
+from dask.utils import parse_timedelta
 
 from . import profile, protocol
 from .comm import (
@@ -36,7 +37,6 @@ from .utils import (
     get_traceback,
     has_keyword,
     is_coroutine_function,
-    parse_timedelta,
     truncate_exception,
 )
 

--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -2,9 +2,10 @@ import logging
 from inspect import isawaitable
 
 import dask.config
+from dask.utils import parse_timedelta
 
 from ..protocol import pickle
-from ..utils import log_errors, parse_timedelta
+from ..utils import log_errors
 from .adaptive_core import AdaptiveCore
 
 logger = logging.getLogger(__name__)

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -6,8 +6,9 @@ from typing import Iterable
 import tlz as toolz
 from tornado.ioloop import IOLoop, PeriodicCallback
 
+from dask.utils import parse_timedelta
+
 from ..metrics import time
-from ..utils import parse_timedelta
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -9,19 +9,11 @@ from inspect import isawaitable
 from tornado.ioloop import PeriodicCallback
 
 import dask.config
-from dask.utils import _deprecated, format_bytes
+from dask.utils import _deprecated, format_bytes, parse_timedelta
 
 from ..core import Status
 from ..objects import SchedulerInfo
-from ..utils import (
-    Log,
-    Logs,
-    format_dashboard_link,
-    log_errors,
-    parse_timedelta,
-    sync,
-    thread_state,
-)
+from ..utils import Log, Logs, format_dashboard_link, log_errors, sync, thread_state
 from .adaptive import Adaptive
 
 logger = logging.getLogger(__name__)

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -11,18 +11,12 @@ from inspect import isawaitable
 from tornado import gen
 
 import dask
+from dask.utils import parse_bytes, parse_timedelta
 
 from ..core import CommClosedError, Status, rpc
 from ..scheduler import Scheduler
 from ..security import Security
-from ..utils import (
-    LoopRunner,
-    TimeoutError,
-    import_term,
-    parse_bytes,
-    parse_timedelta,
-    silence_logging,
-)
+from ..utils import LoopRunner, TimeoutError, import_term, silence_logging
 from .adaptive import Adaptive
 from .cluster import Cluster
 

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -8,10 +8,12 @@ from timeit import default_timer
 from tlz import valmap
 from tornado.ioloop import IOLoop
 
+import dask
+
 from ..client import default_client, futures_of
 from ..core import CommClosedError, coerce_to_address, connect
 from ..protocol.pickle import dumps
-from ..utils import LoopRunner, is_kernel, key_split, parse_timedelta
+from ..utils import LoopRunner, is_kernel, key_split
 from .progress import MultiProgress, Progress, format_time
 
 logger = logging.getLogger(__name__)
@@ -34,7 +36,7 @@ class ProgressBar:
                 break
 
         self.keys = {k.key if hasattr(k, "key") else k for k in keys}
-        self.interval = parse_timedelta(interval, default="s")
+        self.interval = dask.utils.parse_timedelta(interval, default="s")
         self.complete = complete
         self._start_time = default_timer()
 

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -4,8 +4,10 @@ import uuid
 from collections import defaultdict
 from contextlib import suppress
 
+from dask.utils import parse_timedelta
+
 from .client import Client
-from .utils import TimeoutError, log_errors, parse_timedelta
+from .utils import TimeoutError, log_errors
 from .worker import get_worker
 
 logger = logging.getLogger(__name__)

--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -3,8 +3,10 @@ import logging
 import uuid
 from collections import defaultdict, deque
 
+from dask.utils import parse_timedelta
+
 from .client import Client
-from .utils import TimeoutError, log_errors, parse_timedelta
+from .utils import TimeoutError, log_errors
 from .worker import get_worker
 
 logger = logging.getLogger(__name__)

--- a/distributed/multi_lock.py
+++ b/distributed/multi_lock.py
@@ -4,8 +4,10 @@ import uuid
 from collections import defaultdict
 from typing import Hashable, List
 
+from dask.utils import parse_timedelta
+
 from .client import Client
-from .utils import TimeoutError, log_errors, parse_timedelta
+from .utils import TimeoutError, log_errors
 from .worker import get_worker
 
 logger = logging.getLogger(__name__)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -17,6 +17,7 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
 from dask.system import CPU_COUNT
+from dask.utils import parse_timedelta
 
 from . import preloading
 from .comm import get_address_host, unparse_host_port
@@ -32,7 +33,6 @@ from .utils import (
     json_load_robust,
     mp_context,
     parse_ports,
-    parse_timedelta,
     silence_logging,
 )
 from .worker import Worker, parse_memory_limit, run

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -33,8 +33,10 @@ from time import sleep
 
 import tlz as toolz
 
+from dask.utils import format_time, parse_timedelta
+
 from .metrics import time
-from .utils import color_of, format_time, parse_timedelta
+from .utils import color_of
 
 
 def identifier(frame):

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -4,10 +4,12 @@ import threading
 import weakref
 from collections import defaultdict, deque
 
+from dask.utils import parse_timedelta
+
 from .core import CommClosedError
 from .metrics import time
 from .protocol.serialize import to_serialize
-from .utils import TimeoutError, parse_timedelta, sync
+from .utils import TimeoutError, sync
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -3,10 +3,10 @@ import logging
 import uuid
 from collections import defaultdict
 
-from dask.utils import stringify
+from dask.utils import parse_timedelta, stringify
 
 from .client import Client, Future
-from .utils import parse_timedelta, sync, thread_state
+from .utils import sync, thread_state
 from .worker import get_client, get_worker
 
 logger = logging.getLogger(__name__)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -38,6 +38,7 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
 from dask.highlevelgraph import HighLevelGraph
+from dask.utils import format_bytes, format_time, parse_bytes, parse_timedelta
 
 from . import preloading, profile
 from . import versions as version_module
@@ -70,15 +71,11 @@ from .utils import (
     All,
     TimeoutError,
     empty_context,
-    format_bytes,
-    format_time,
     get_fileno_limit,
     key_split,
     key_split_group,
     log_errors,
     no_default,
-    parse_bytes,
-    parse_timedelta,
     tmpfile,
     validate_key,
 )

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -8,11 +8,12 @@ from collections import defaultdict, deque
 from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
+from dask.utils import parse_timedelta
 
 from distributed.utils_comm import retry_operation
 
 from .metrics import time
-from .utils import log_errors, parse_timedelta, sync, thread_state
+from .utils import log_errors, sync, thread_state
 from .worker import get_client, get_worker
 
 logger = logging.getLogger(__name__)

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -7,11 +7,12 @@ from tlz import topk
 from tornado.ioloop import PeriodicCallback
 
 import dask
+from dask.utils import parse_timedelta
 
 from .comm.addressing import get_address_host
 from .core import CommClosedError
 from .diagnostics.plugin import SchedulerPlugin
-from .utils import log_errors, parse_timedelta
+from .utils import log_errors
 
 LATENCY = 10e-3
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,13 +1,11 @@
 import array
 import asyncio
-import datetime
 import io
 import os
 import queue
 import socket
 import sys
 import traceback
-from functools import partial
 from time import sleep
 
 import pytest
@@ -27,7 +25,6 @@ from distributed.utils import (
     ensure_bytes,
     ensure_ip,
     format_dashboard_link,
-    funcname,
     get_ip_interface,
     get_traceback,
     is_kernel,
@@ -35,9 +32,7 @@ from distributed.utils import (
     nbytes,
     offload,
     open_port,
-    parse_bytes,
     parse_ports,
-    parse_timedelta,
     read_block,
     seek_delimiter,
     set_thread_state,
@@ -248,15 +243,6 @@ def test_seek_delimiter_endline():
     f.seek(5)
     seek_delimiter(f, b"\n", 5)
     assert f.tell() == 7
-
-
-def test_funcname():
-    def f():
-        pass
-
-    assert funcname(f) == "f"
-    assert funcname(partial(f)) == "f"
-    assert funcname(partial(partial(f))) == "f"
 
 
 def test_ensure_bytes():
@@ -471,45 +457,6 @@ async def test_loop_runner_gen():
     await asyncio.sleep(0.01)
 
 
-def test_parse_bytes():
-    assert parse_bytes("100") == 100
-    assert parse_bytes("100 MB") == 100000000
-    assert parse_bytes("100M") == 100000000
-    assert parse_bytes("5kB") == 5000
-    assert parse_bytes("5.4 kB") == 5400
-    assert parse_bytes("1kiB") == 1024
-    assert parse_bytes("1Mi") == 2 ** 20
-    assert parse_bytes("1e6") == 1000000
-    assert parse_bytes("1e6 kB") == 1000000000
-    assert parse_bytes("MB") == 1000000
-
-
-def test_parse_timedelta():
-    for text, value in [
-        ("1s", 1),
-        ("100ms", 0.1),
-        ("5S", 5),
-        ("5.5s", 5.5),
-        ("5.5 s", 5.5),
-        ("1 second", 1),
-        ("3.3 seconds", 3.3),
-        ("3.3 milliseconds", 0.0033),
-        ("3500 us", 0.0035),
-        ("1 ns", 1e-9),
-        ("2m", 120),
-        ("2 minutes", 120),
-        (datetime.timedelta(seconds=2), 2),
-        (datetime.timedelta(milliseconds=100), 0.1),
-    ]:
-        result = parse_timedelta(text)
-        assert abs(result - value) < 1e-14
-
-    assert parse_timedelta("1ms", default="seconds") == 0.001
-    assert parse_timedelta("1", default="seconds") == 1
-    assert parse_timedelta("1", default="ms") == 0.001
-    assert parse_timedelta(1, default="ms") == 0.001
-
-
 @gen_test()
 async def test_all_exceptions_logging():
     async def throws():
@@ -541,11 +488,6 @@ def test_warn_on_duration():
 
     assert record
     assert any("foo" in str(rec.message) for rec in record)
-
-
-def test_format_bytes_compat():
-    # moved to dask, but exported here for compatibility
-    from distributed.utils import format_bytes  # noqa
 
 
 def test_logs():
@@ -611,3 +553,45 @@ def test_lru():
 async def test_offload():
     assert (await offload(inc, 1)) == 2
     assert (await offload(lambda x, y: x + y, 1, y=2)) == 3
+
+
+def test_serialize_for_cli_deprecated():
+    with pytest.warns(FutureWarning, match="serialize_for_cli is deprecated"):
+        from distributed.utils import serialize_for_cli
+    assert serialize_for_cli is dask.config.serialize
+
+
+def test_deserialize_for_cli_deprecated():
+    with pytest.warns(FutureWarning, match="deserialize_for_cli is deprecated"):
+        from distributed.utils import deserialize_for_cli
+    assert deserialize_for_cli is dask.config.deserialize
+
+
+def test_parse_bytes_deprecated():
+    with pytest.warns(FutureWarning, match="parse_bytes is deprecated"):
+        from distributed.utils import parse_bytes
+    assert parse_bytes is dask.utils.parse_bytes
+
+
+def test_format_bytes_deprecated():
+    with pytest.warns(FutureWarning, match="format_bytes is deprecated"):
+        from distributed.utils import format_bytes
+    assert format_bytes is dask.utils.format_bytes
+
+
+def test_format_time_deprecated():
+    with pytest.warns(FutureWarning, match="format_time is deprecated"):
+        from distributed.utils import format_time
+    assert format_time is dask.utils.format_time
+
+
+def test_funcname_deprecated():
+    with pytest.warns(FutureWarning, match="funcname is deprecated"):
+        from distributed.utils import funcname
+    assert funcname is dask.utils.funcname
+
+
+def test_parse_timedelta_deprecated():
+    with pytest.warns(FutureWarning, match="parse_timedelta is deprecated"):
+        from distributed.utils import parse_timedelta
+    assert parse_timedelta is dask.utils.parse_timedelta

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -6,10 +6,10 @@ from contextlib import suppress
 
 from tlz import merge
 
-from dask.utils import stringify
+from dask.utils import parse_timedelta, stringify
 
 from .client import Client, Future
-from .utils import TimeoutError, log_errors, parse_timedelta
+from .utils import TimeoutError, log_errors
 from .worker import get_client, get_worker
 
 logger = logging.getLogger(__name__)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -25,7 +25,7 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 import dask
 from dask.core import istask
 from dask.system import CPU_COUNT
-from dask.utils import apply, format_bytes, funcname
+from dask.utils import apply, format_bytes, funcname, parse_bytes, parse_timedelta
 
 from . import comm, preloading, profile, system, utils
 from .batched import BatchedSend
@@ -65,9 +65,7 @@ from .utils import (
     key_split,
     log_errors,
     offload,
-    parse_bytes,
     parse_ports,
-    parse_timedelta,
     silence_logging,
     thread_state,
     typename,

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 import dask
 
 from .threadpoolexecutor import rejoin, secede
-from .utils import parse_timedelta
 from .worker import get_client, get_worker, thread_state
 
 
@@ -46,7 +45,7 @@ def worker_client(timeout=None, separate_thread=True):
     if timeout is None:
         timeout = dask.config.get("distributed.comm.timeouts.connect")
 
-    timeout = parse_timedelta(timeout, "s")
+    timeout = dask.utils.parse_timedelta(timeout, "s")
 
     worker = get_worker()
     client = get_client(timeout=timeout)


### PR DESCRIPTION
Several utilities, e.g. `distributed.utils.parse_timedelta`, have been moved over to `dask.utils` but we've kept `import`s around in `distributed/utils.py` for backwards compatibility. This PR officially deprecates utilities which have migrated from `distributed` to `dask`. 