### PR TITLE
Except more errors in pynvml.nvmlInit()

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -26,7 +26,7 @@ def init_once():
     nvmlOwnerPID = os.getpid()
     try:
         pynvml.nvmlInit()
-    except pynvml.NVMLError_LibraryNotFound:
+    except (pynvml.NVMLError_LibraryNotFound, pynvml.NVMLError_DriverNotLoaded):
         nvmlLibraryNotFound = True
 
 


### PR DESCRIPTION


Longer term it is probably worth handling any errors emanating from `pynvml.nvmlInit()`.

- [x] Closes https://github.com/dask/distributed/issues/4965
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
