### PR TITLE
Add some clarifications to docs

### DIFF
--- a/docs/source/scheduling-state.rst
+++ b/docs/source/scheduling-state.rst
@@ -66,7 +66,9 @@ Tasks flow along the following states with the following allowed transitions:
 *  *No-worker*: Ready to be computed, but no appropriate worker exists
    (for example because of resource restrictions, or because no worker is
    connected at all).
-*  *Processing*: Actively being computed by one or more workers
+*  *Processing*: All dependencies are available and the task is assigned to a
+   worker for compute (the scheduler doesn't know whether it's in a worker
+   queue or actively being computed).
 *  *Memory*: In memory on one or more workers
 *  *Erred*: Task computation, or one of its dependencies, has encountered an error
 *  *Forgotten* (not actually a state): Task is no longer needed by any client

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -225,9 +225,10 @@ usage then the worker will start dumping unused data to disk, even if internal
 Halt worker threads
 ~~~~~~~~~~~~~~~~~~~
 
-At 80% load, the worker's thread pool will stop accepting new tasks.  This
-gives time for the write-to-disk functionality to take effect even in the face
-of rapidly accumulating data.
+At 80% load, the worker's thread pool will stop starting computation on
+additional tasks in the worker's queue. This gives time for the write-to-disk
+functionality to take effect even in the face of rapidly accumulating data.
+Currently executing tasks continue to run.
 
 
 Kill Worker


### PR DESCRIPTION
- [x] Closes #4975 & #4939
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Please feel free to add corrections / wordsmiths