### PR TITLE
Ensure shuffle split default durations uses proper prefix

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -28,7 +28,7 @@ distributed:
     unknown-task-duration: 500ms  # Default duration for all tasks with unknown durations ("15m", "2h")
     default-task-durations:  # How long we expect function names to run ("1h", "1s") (helps for long tasks)
       rechunk-split: 1us
-      shuffle-split: 1us
+      split-shuffle: 1us
     validate: False         # Check scheduler state at every step for debugging
     dashboard:
       status:


### PR DESCRIPTION
The test is bit heavy considering that I simply want to verify that the prefix name of shuffle doesn't go unnoticed. but it works and still runs fast so I'm fine with it 😬 

- [x] Closes https://github.com/dask/dask/issues/7844
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
