### PR TITLE
Rename plot dropdown

### DIFF
--- a/distributed/http/templates/base.html
+++ b/distributed/http/templates/base.html
@@ -34,7 +34,7 @@
             {% endfor %}
             <div class="dropdown">
                 <li>
-                    <a href="javascript:void(0);">Plots</a>
+                    <a href="javascript:void(0);">More...</a>
                 </li>
                 <div class="dropdown-content">
                     <ul>


### PR DESCRIPTION
It was great to see the new dashboard plot dropdown : )

Just a suggestion, but this seems slightly more clear to me. cc @jacobtomlinson for thoughts 

<img width="1552" alt="Screen Shot 2021-06-29 at 10 33 49 AM" src="https://user-images.githubusercontent.com/11656932/123826794-b3b3e400-d8c5-11eb-85cc-1dba942abaa4.png">
