### PR TITLE
[WIP] Pass `executor_wait` during nanny restart

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -387,7 +387,7 @@ class Nanny(ServerNode):
     async def restart(self, comm=None, timeout=2, executor_wait=True):
         async def _():
             if self.process is not None:
-                await self.kill()
+                await self.kill(executor_wait=executor_wait)
                 await self.instantiate()
 
         try:


### PR DESCRIPTION
I noticed we weren't passing `executor_wait` through here. I'll want to test this out more before merging 