### PR TITLE
Instructions for jemalloc with brew on macOS

### DIFF
--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -372,12 +372,14 @@ On Linux:
     conda install jemalloc
     LD_PRELOAD=$CONDA_PREFIX/lib/libjemalloc.so dask-worker <...>
 
-On MacOS:
+On macOS:
 
 .. code-block:: bash
 
     conda install jemalloc
     DYLD_INSERT_LIBRARIES=$CONDA_PREFIX/lib/libjemalloc.dylib dask-worker <...>
+
+Alternatively on macOS, install globally with `homebrew`_:
 
 .. code-block:: bash
 
@@ -429,3 +431,4 @@ API Documentation
 .. _malloc_trim: https://man7.org/linux/man-pages/man3/malloc_trim.3.html
 .. _brk: https://www.man7.org/linux/man-pages/man2/brk.2.html
 .. _jemalloc: http://jemalloc.net
+.. _homebrew: https://brew.sh/

--- a/docs/source/worker.rst
+++ b/docs/source/worker.rst
@@ -379,6 +379,11 @@ On MacOS:
     conda install jemalloc
     DYLD_INSERT_LIBRARIES=$CONDA_PREFIX/lib/libjemalloc.dylib dask-worker <...>
 
+.. code-block:: bash
+
+    brew install jemalloc
+    DYLD_INSERT_LIBRARIES=$(brew --prefix jemalloc)/lib/libjemalloc.dylib dask-worker <...>
+
 `jemalloc`_ offers a wealth of configuration settings; please refer to its
 documentation.
 


### PR DESCRIPTION
For those of us who prefer not to use conda, having a global install of jemalloc with homebrew is handy.

- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

cc @crusaderky 