### PR TITLE
fix for jitter in NBytes and NBytesCluster

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -342,13 +342,9 @@ class NBytesCluster(DashboardComponent):
                 "unmanaged_recent": [meminfo.unmanaged_recent] * 4,
                 "spilled": [meminfo.managed_spilled] * 4,
             }
-            # FIXME https://github.com/dask/distributed/issues/4675
-            #       This causes flickering after adding workers and when enough memory
-            #       is spilled out
+
             x_end = max(limit, meminfo.process + meminfo.managed_spilled)
-            self.root.x_range = DataRange1d(start=0, end=x_end, range_padding=0)  # max(
-            #    limit, meminfo.process + meminfo.managed_spilled
-            # )
+            self.root.x_range = DataRange1d(start=0, end=x_end, range_padding=0)
 
             title = f"Bytes stored: {format_bytes(meminfo.process)}"
             if meminfo.managed_spilled:
@@ -511,9 +507,7 @@ class NBytes(DashboardComponent):
             result = {
                 k: [vi for vi, w in zip(v, width) if w] for k, v in result.items()
             }
-            # FIXME https://github.com/dask/distributed/issues/4675
-            #       This causes flickering after adding workers and when enough memory
-            #       is spilled to disk
+
             self.root.x_range = DataRange1d(start=0, end=max_limit, range_padding=0)
             update(self.source, result)
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -283,7 +283,6 @@ class NBytesCluster(DashboardComponent):
             self.root.axis[0].ticker = BasicTicker(**TICKS_1024)
             self.root.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
             self.root.xaxis.major_label_orientation = XLABEL_ORIENTATION
-            self.root.x_range.start = 0
             self.root.xaxis.minor_tick_line_alpha = 0
             self.root.yaxis.visible = False
             self.root.ygrid.visible = False
@@ -346,9 +345,10 @@ class NBytesCluster(DashboardComponent):
             # FIXME https://github.com/dask/distributed/issues/4675
             #       This causes flickering after adding workers and when enough memory
             #       is spilled out
-            self.root.x_range.end = max(
-                limit, meminfo.process + meminfo.managed_spilled
-            )
+            x_end = max(limit, meminfo.process + meminfo.managed_spilled)
+            self.root.x_range = DataRange1d(start=0, end=x_end, range_padding=0)  # max(
+            #    limit, meminfo.process + meminfo.managed_spilled
+            # )
 
             title = f"Bytes stored: {format_bytes(meminfo.process)}"
             if meminfo.managed_spilled:
@@ -404,7 +404,6 @@ class NBytes(DashboardComponent):
             self.root.axis[0].ticker = BasicTicker(**TICKS_1024)
             self.root.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
             self.root.xaxis.major_label_orientation = XLABEL_ORIENTATION
-            self.root.x_range.start = 0
             self.root.xaxis.minor_tick_line_alpha = 0
             self.root.yaxis.visible = False
             self.root.ygrid.visible = False
@@ -515,7 +514,7 @@ class NBytes(DashboardComponent):
             # FIXME https://github.com/dask/distributed/issues/4675
             #       This causes flickering after adding workers and when enough memory
             #       is spilled to disk
-            self.root.x_range.end = max_limit
+            self.root.x_range = DataRange1d(start=0, end=max_limit, range_padding=0)
             update(self.source, result)
 
 


### PR DESCRIPTION
- [x] Closes #4872 , #4675
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

This PR fixes the jitter on the `NBytes` and `NBytesClyuster` plots on the dashboard. I tried the example posted by @crusaderky in issue #4675 and it doesn't jitter anymore, and for the case where we have spill memory being significant I run this example and it doesn't jitter. 

```python
from dask.distributed import Client, wait
client = Client()

import dask.array as da

n = da.random.random((20000, 20000))
m = da.random.random((20000, 20000))
p = n.dot(m.T).persist()
```

Let me know if there are other examples currently not working, and we'll give it a try. 