### PR TITLE
Computation class

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -7,8 +7,10 @@ import inspect
 import json
 import logging
 import os
+import re
 import sys
 import threading
+import traceback
 import uuid
 import warnings
 import weakref
@@ -2566,6 +2568,41 @@ class Client:
         """
         return self.run(function, *args, **kwargs)
 
+    @staticmethod
+    def _get_computation_code() -> str:
+        """Walk up the stack to the user code and extract the code surrounding
+        the compute/submit/persist call. All modules encountered which are
+        blacklisted by the option
+        `distributed.diagnostics.computations.ignore-modules` will be ignored.
+        This can be used to blacklist commonly used libraries which wrap
+        dask/distributed compute calls.
+        """
+
+        ignore_modules = dask.config.get(
+            "distributed.diagnostics.computations.ignore-modules"
+        )
+        if not isinstance(ignore_modules, list):
+            raise TypeError(
+                f"Ignored modules must be a list. Instead got ({type(ignore_modules)}, {ignore_modules})"
+            )
+
+        if ignore_modules:
+            pattern = "|".join([f"(?:{mod})" for mod in ignore_modules])
+            pattern = re.compile(pattern)
+        else:
+            pattern = None
+
+        for fr, _ in traceback.walk_stack(None):
+            if pattern is None or (
+                not pattern.match(fr.f_globals["__name__"])
+                and fr.f_code.co_name not in ("<listcomp>", "<dictcomp>")
+            ):
+                try:
+                    return inspect.getsource(fr)
+                except OSError:
+                    break
+        return "<Code not available>"
+
     def _graph_to_futures(
         self,
         dsk,
@@ -2612,6 +2649,7 @@ class Client:
 
             # Create futures before sending graph (helps avoid contention)
             futures = {key: Future(key, self, inform=False) for key in keyset}
+
             self._send_to_scheduler(
                 {
                     "op": "update-graph-hlg",
@@ -2621,6 +2659,7 @@ class Client:
                     "submitting_task": getattr(thread_state, "key", None),
                     "fifo_timeout": fifo_timeout,
                     "actors": actors,
+                    "code": self._get_computation_code(),
                 }
             )
             return futures

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -783,6 +783,20 @@ properties:
               not a problem and will be automatically disabled if no GPUs are found in the
               system, but in certain cases it may be desirable to completely disable NVML
               diagnostics.
+          computations:
+            type: object
+            properties:
+              max-history:
+                type: integer
+                minimum: 0
+                description: |
+                  The maximum number of Computations to remember.
+              ignore-modules:
+                type: array
+                description: |
+                  A list of modules which are ignored when trying to collect the
+                  code context when submitting a computation. Accepts regular
+                  expressions.
 
       dashboard:
         type: object

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -201,6 +201,16 @@ distributed:
 
   diagnostics:
     nvml: True
+    computations:
+      max-history: 100
+      ignore-modules:
+        - distributed
+        - dask
+        - xarray
+        - cudf
+        - cuml
+        - prefect
+        - xgboost
 
   ###################
   # Bokeh dashboard #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -10,6 +10,7 @@ import operator
 import os
 import random
 import sys
+import uuid
 import warnings
 import weakref
 from collections import defaultdict, deque
@@ -767,6 +768,115 @@ class WorkerState:
 
 @final
 @cclass
+class Computation:
+    """
+    Collection tracking a single compute or persist call
+
+    See also
+    --------
+    TaskPrefix
+    TaskGroup
+    TaskState
+    """
+
+    _start: double
+    _groups: set
+    _code: sortedcontainers.SortedSet
+    _recent: "Computation" = None
+
+    def __init__(self):
+        self._start = time()
+        self._groups = set()
+        self._code = sortedcontainers.SortedSet()
+        self._id = uuid.uuid4()
+        Computation.recent = self
+
+    @property
+    def code(self):
+        return self._code
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def stop(self):
+        if self.groups:
+            return max(tg.stop for tg in self.groups)
+        else:
+            return -1
+
+    @property
+    def states(self):
+        tg: TaskGroup
+        return merge_with(sum, [tg._states for tg in self._groups])
+
+    @property
+    def groups(self):
+        return self._groups
+
+    def __repr__(self):
+        return (
+            f"<Computation {self._id}: "
+            + "Tasks: "
+            + ", ".join(
+                "%s: %d" % (k, v) for (k, v) in sorted(self.states.items()) if v
+            )
+            + ">"
+        )
+
+    def _repr_html_(self):
+        text = f"""<b>Computation</b> {self._id}
+
+        <table>
+            <tr>
+                <td style="text-align: left;"><strong>Duration: </strong>{self.stop - self.start:.3f}</td>
+                <td style="text-align: left;"></td>
+            </tr>
+            <tr>
+                <td style="text-align: left;"><strong>Start: </strong>{self.start}</td>
+                <td style="text-align: left;"></td>
+            </tr>
+            <tr>
+                <td style="text-align: left;"><strong>Groups: </strong>{len(self.groups)}</td>
+                <td style="text-align: left;"></td>
+            </tr>
+            <tr>
+                <td style="text-align: left;"><strong>Tasks: </strong>
+                {", ".join(
+                    "%s: %d" % (k, v) for (k, v) in sorted(self.states.items()) if v
+                )}</td>
+                <td style="text-align: left;"></td>
+            </tr>
+        </table>
+
+        <details>
+        <summary style="margin-bottom": 20px><h4 style="display:inline">Code</h4></summary>
+        """
+
+        for ix, code in enumerate(self.code):
+            text += f"<h5>Code segment {ix + 1} / {len(self.code)}</h5>"
+            text += f"<code>{code}</code>"
+
+        text += """
+        </details>
+        <details>
+        <summary style="margin-bottom": 20px><h4 style="display:inline">Task Groups</h4></summary>
+        <ul>
+        """
+        for gr in self.groups:
+            text += f"""
+            <li> {gr._repr_html_()} </li>
+            """
+        text += """
+        </ul>
+        </details>
+        """
+        return text
+
+
+@final
+@cclass
 class TaskPrefix:
     """Collection tracking all tasks within a group
 
@@ -1027,6 +1137,9 @@ class TaskGroup:
             )
             + ">"
         )
+
+    def _repr_html_(self):
+        return repr(self)[1:-1]
 
     def __len__(self):
         return sum(self._states.values())
@@ -1768,6 +1881,7 @@ class SchedulerState:
     _aliases: dict
     _bandwidth: double
     _clients: dict
+    _computations: deque
     _extensions: dict
     _host_info: dict
     _idle: object
@@ -1838,6 +1952,9 @@ class SchedulerState:
             self._tasks = tasks
         else:
             self._tasks = dict()
+        self._computations = deque(
+            maxlen=dask.config.get("distributed.diagnostics.computations.max-history")
+        )
         self._task_groups = dict()
         self._task_prefixes = dict()
         self._task_metadata = dict()
@@ -1906,6 +2023,10 @@ class SchedulerState:
     @property
     def clients(self):
         return self._clients
+
+    @property
+    def computations(self):
+        return self._computations
 
     @property
     def extensions(self):
@@ -2011,7 +2132,9 @@ class SchedulerState:
 
     @ccall
     @exceptval(check=False)
-    def new_task(self, key: str, spec: object, state: str) -> TaskState:
+    def new_task(
+        self, key: str, spec: object, state: str, computation: Computation = None
+    ) -> TaskState:
         """Create a new task, and associated states"""
         ts: TaskState = TaskState(key, spec)
         ts._state = state
@@ -2028,6 +2151,8 @@ class SchedulerState:
         tg = self._task_groups.get(group_key)
         if tg is None:
             self._task_groups[group_key] = tg = TaskGroup(group_key)
+            if computation:
+                computation.groups.add(tg)
             tg._prefix = tp
             tp._groups.append(tg)
         tg.add(ts)
@@ -4175,6 +4300,7 @@ class Scheduler(SchedulerState, ServerNode):
         user_priority=0,
         actors=None,
         fifo_timeout=0,
+        code=None,
     ):
         unpacked_graph = HighLevelGraph.__dask_distributed_unpack__(hlg)
         dsk = unpacked_graph["dsk"]
@@ -4213,6 +4339,7 @@ class Scheduler(SchedulerState, ServerNode):
             actors,
             fifo_timeout,
             annotations,
+            code=code,
         )
 
     def update_graph(
@@ -4231,6 +4358,7 @@ class Scheduler(SchedulerState, ServerNode):
         actors=None,
         fifo_timeout=0,
         annotations=None,
+        code=None,
     ):
         """
         Add new computations to the internal dask graph
@@ -4252,6 +4380,18 @@ class Scheduler(SchedulerState, ServerNode):
                 del tasks[k]
 
         dependencies = dependencies or {}
+
+        if (
+            parent._total_occupancy > 1e-9 and Computation._recent is not None
+        ):  # Still working on something
+            computation = Computation._recent
+        else:
+            computation = Computation()
+            Computation._recent = computation
+            self._computations.append(computation)
+
+        if code and code not in computation._code:  # add new code blocks
+            computation._code.add(code)
 
         n = 0
         while len(tasks) != n:  # walk through new tasks, cancel any bad deps
@@ -4314,7 +4454,9 @@ class Scheduler(SchedulerState, ServerNode):
             # XXX Have a method get_task_state(self, k) ?
             ts = parent._tasks.get(k)
             if ts is None:
-                ts = parent.new_task(k, tasks.get(k), "released")
+                ts = parent.new_task(
+                    k, tasks.get(k), "released", computation=computation
+                )
             elif not ts._run_spec:
                 ts._run_spec = tasks.get(k)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6782,7 +6782,7 @@ def test_computation_object_code_dask_compute(client):
     test_function_code = inspect.getsource(test_computation_object_code_dask_compute)
 
     def fetch_comp_code(dask_scheduler):
-        computations = list(dask_scheduler._computations)
+        computations = list(dask_scheduler.computations)
         assert len(computations) == 1
         comp = computations[0]
         assert len(comp.code) == 1
@@ -6803,7 +6803,7 @@ async def test_computation_object_code_dask_persist(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_dask_persist.__wrapped__
     )
-    computations = list(s._computations)
+    computations = list(s.computations)
     assert len(computations) == 1
     comp = computations[0]
     assert len(comp.code) == 1
@@ -6823,7 +6823,7 @@ async def test_computation_object_code_client_submit_simple(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_submit_simple.__wrapped__
     )
-    computations = list(s._computations)
+    computations = list(s.computations)
     assert len(computations) == 1
     comp = computations[0]
 
@@ -6844,7 +6844,7 @@ async def test_computation_object_code_client_submit_list_comp(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_submit_list_comp.__wrapped__
     )
-    computations = list(s._computations)
+    computations = list(s.computations)
     assert len(computations) == 1
     comp = computations[0]
 
@@ -6866,7 +6866,7 @@ async def test_computation_object_code_client_submit_dict_comp(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_submit_dict_comp.__wrapped__
     )
-    computations = list(s._computations)
+    computations = list(s.computations)
     assert len(computations) == 1
     comp = computations[0]
 
@@ -6886,7 +6886,7 @@ async def test_computation_object_code_client_map(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_map.__wrapped__
     )
-    computations = list(s._computations)
+    computations = list(s.computations)
     assert len(computations) == 1
     comp = computations[0]
     assert len(comp.code) == 1
@@ -6904,7 +6904,7 @@ async def test_computation_object_code_client_compute(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_compute.__wrapped__
     )
-    computations = list(s._computations)
+    computations = list(s.computations)
     assert len(computations) == 1
     comp = computations[0]
     assert len(comp.code) == 1

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -25,7 +25,7 @@ from contextlib import contextmanager, nullcontext, suppress
 from glob import glob
 from time import sleep
 
-from distributed.scheduler import Scheduler
+from distributed.scheduler import Computation, Scheduler
 
 try:
     import ssl
@@ -893,6 +893,7 @@ def gen_cluster(
         if not iscoroutinefunction(func):
             func = gen.coroutine(func)
 
+        @functools.wraps(func)
         def test_func(*outer_args, **kwargs):
             result = None
             workers = []
@@ -1511,6 +1512,7 @@ def check_instances():
     Scheduler._instances.clear()
     SpecCluster._instances.clear()
     Worker._initialized_clients.clear()
+    Computation._recent = None
     # assert all(n.status == "closed" for n in Nanny._instances), {
     #     n: n.status for n in Nanny._instances
     # }
@@ -1563,6 +1565,7 @@ def check_instances():
 
     Nanny._instances.clear()
     DequeHandler.clear_all_instances()
+    Computation._recent = None
 
 
 @contextmanager

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -25,7 +25,7 @@ from contextlib import contextmanager, nullcontext, suppress
 from glob import glob
 from time import sleep
 
-from distributed.scheduler import Computation, Scheduler
+from distributed.scheduler import Scheduler
 
 try:
     import ssl
@@ -1512,7 +1512,6 @@ def check_instances():
     Scheduler._instances.clear()
     SpecCluster._instances.clear()
     Worker._initialized_clients.clear()
-    Computation._recent = None
     # assert all(n.status == "closed" for n in Nanny._instances), {
     #     n: n.status for n in Nanny._instances
     # }
@@ -1565,7 +1564,6 @@ def check_instances():
 
     Nanny._instances.clear()
     DequeHandler.clear_all_instances()
-    Computation._recent = None
 
 
 @contextmanager


### PR DESCRIPTION
This supercedes https://github.com/dask/distributed/pull/4972 and closes https://github.com/dask/distributed/issues/4613

Notable changes to https://github.com/dask/distributed/pull/4972

* Source code attached to the computation object is now inferred by walking back the stack. All calls originating from dask and distributed modules are ignored. First frame of a non-ignored module is interpreted as user code and we'll extract that source. The ignore list is currently only dask and distributed but we can add other common libs like xarray, prefect as suggested in #XYZ. I tested this in jupyter notebooks and unit tests and it worked as I think it should. I ended up needing to write special treatment for list/dict comprehension and wouldn't be surprised to see more special cases popping up. we'll see
* The max history and ignore modules can now be configured
* The module ignore thing uses regular expressions. This may be overkill and I'm not entirely sure if this poses a security issue. Implementation actually felt even simpler compared to a "split / str compare". I figured that people might want to use glob patterns or something more sophisticated than hard coded paths. regex was the "simplest" choice. If that faces resistance, I'll go for a simple str compare (startswith, is in, etc.)
* I added a poor mans HTML repr (don't be too critical, I just copied stuff around) simply to get started. I hope that somebody with a better sense for style will iterate on this
* I chose to go for a dedicated UUID nevertheless (see https://github.com/dask/distributed/pull/4972#issuecomment-868505817) mostly because I believe we need a UUID, especially when connecting to an external service and I couldn't find the UUID @mrocklin was referring to. 

![image](https://user-images.githubusercontent.com/8629629/123984981-61f28300-d9c5-11eb-84be-a4672472b83d.png)
