### PR TITLE
Better use of space in Groups 

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2241,6 +2241,9 @@ class TaskGroupGraph(DashboardComponent):
         self.nodes_source.data.update(nodes_data)
         self.arrows_source.data.update(arrows_data)
 
+        self.root.x_range = DataRange1d()
+        self.root.y_range = DataRange1d()
+
 
 class TaskProgress(DashboardComponent):
     """Progress bars per task type"""


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

This is a quick fix I found to use a bit better some of the space in the Groups plot. We still have a lot of unused space but this is a bit better than before. For comparison here are the before and after the proposed patch to compare. The improvement is not huge but it's a bit better

**Before (current status):**
![non_datarange1d](https://user-images.githubusercontent.com/7526622/123987802-7c146d00-d995-11eb-87ee-bca8f8577b12.png)

**After patch/fix:**
![datarange1d](https://user-images.githubusercontent.com/7526622/123987876-8afb1f80-d995-11eb-9ee3-ce42c4f1e958.png)
 