### PR TITLE
Update imports to cudf.testing._utils

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -189,7 +189,7 @@ async def test_ping_pong_cudf(g):
     # *** ImportError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.11'
     # not found (required by python3.7/site-packages/pyarrow/../../../libarrow.so.12)
     cudf = pytest.importorskip("cudf")
-    from cudf.tests.utils import assert_eq
+    from cudf.testing._utils import assert_eq
 
     cudf_obj = g(cudf)
 


### PR DESCRIPTION
The module names have recently changed in https://github.com/rapidsai/cudf/pull/7495, this PR ensures compliance with that.