### PR TITLE
Tabs on bottom left corner on dashboard

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2807,38 +2807,51 @@ def status_doc(scheduler, extra, doc):
 
         if len(scheduler.workers) < 50:
             nbytes_workers = NBytes(scheduler, sizing_mode="stretch_both")
-            processing = CurrentLoad(scheduler, sizing_mode="stretch_both")
+            current_load = CurrentLoad(scheduler, sizing_mode="stretch_both")
             occupancy = Occupancy(scheduler, sizing_mode="stretch_both")
-            processing_root = processing.processing_figure
-            cpu_root = processing.cpu_figure
+
+            processing_root = current_load.processing_figure
+            cpu_root = current_load.cpu_figure
             occupancy_root = occupancy.root
+
             processing_root.y_range = nbytes_workers.root.y_range
             cpu_root.y_range = nbytes_workers.root.y_range
             occupancy_root.y_range = nbytes_workers.root.y_range
         else:
             nbytes_workers = NBytesHistogram(scheduler, sizing_mode="stretch_both")
-            processing = ProcessingHistogram(scheduler, sizing_mode="stretch_both")
-            processing_root = processing.root
-            row(nbytes_workers.root, processing.root, sizing_mode="stretch_both")
+            processing_hist = ProcessingHistogram(scheduler, sizing_mode="stretch_both")
+            current_load = CurrentLoad(scheduler, sizing_mode="stretch_both")
+            occupancy = Occupancy(scheduler, sizing_mode="stretch_both")
+
+            cpu_root = current_load.cpu_figure
+            processing_hist_root = processing_hist.root
+            occupancy_root = occupancy.root
+
+            row(nbytes_workers.root, processing_hist.root, sizing_mode="stretch_both")
 
         nbytes_workers.update()
-        processing.update()
+        current_load.update()
         occupancy.update()
+
         add_periodic_callback(doc, nbytes_workers, 100)
-        add_periodic_callback(doc, processing, 100)
+        add_periodic_callback(doc, current_load, 100)
         add_periodic_callback(doc, occupancy, 100)
 
         doc.add_root(nbytes_workers.root)
 
         if len(scheduler.workers) < 50:
             tab1 = Panel(child=processing_root, title="Processing")
-            tab2 = Panel(child=cpu_root, title="CPU")
-            tab3 = Panel(child=occupancy_root, title="Occupancy")
-            proc_tabs = Tabs(tabs=[tab1, tab2, tab3], name="processing_tabs")
-
-            doc.add_root(proc_tabs)
         else:
-            print("im here")
+            processing_hist.update()
+            add_periodic_callback(doc, processing_hist, 100)
+
+            tab1 = Panel(child=processing_hist_root, title="Processing")
+
+        tab2 = Panel(child=cpu_root, title="CPU")
+        tab3 = Panel(child=occupancy_root, title="Occupancy")
+
+        proc_tabs = Tabs(tabs=[tab1, tab2, tab3], name="processing_tabs")
+        doc.add_root(proc_tabs)
 
         task_stream = TaskStream(
             scheduler,

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2807,46 +2807,35 @@ def status_doc(scheduler, extra, doc):
 
         if len(scheduler.workers) < 50:
             nbytes_workers = NBytes(scheduler, sizing_mode="stretch_both")
-            current_load = CurrentLoad(scheduler, sizing_mode="stretch_both")
-            occupancy = Occupancy(scheduler, sizing_mode="stretch_both")
+            processing = CurrentLoad(scheduler, sizing_mode="stretch_both")
 
-            processing_root = current_load.processing_figure
-            cpu_root = current_load.cpu_figure
-            occupancy_root = occupancy.root
+            processing_root = processing.processing_figure
 
-            processing_root.y_range = nbytes_workers.root.y_range
-            cpu_root.y_range = nbytes_workers.root.y_range
-            occupancy_root.y_range = nbytes_workers.root.y_range
         else:
             nbytes_workers = NBytesHistogram(scheduler, sizing_mode="stretch_both")
-            processing_hist = ProcessingHistogram(scheduler, sizing_mode="stretch_both")
-            current_load = CurrentLoad(scheduler, sizing_mode="stretch_both")
-            occupancy = Occupancy(scheduler, sizing_mode="stretch_both")
+            processing = ProcessingHistogram(scheduler, sizing_mode="stretch_both")
 
-            cpu_root = current_load.cpu_figure
-            processing_hist_root = processing_hist.root
-            occupancy_root = occupancy.root
+            processing_root = processing.root
 
-            row(nbytes_workers.root, processing_hist.root, sizing_mode="stretch_both")
+        current_load = CurrentLoad(scheduler, sizing_mode="stretch_both")
+        occupancy = Occupancy(scheduler, sizing_mode="stretch_both")
+
+        cpu_root = current_load.cpu_figure
+        occupancy_root = occupancy.root
 
         nbytes_workers.update()
+        processing.update()
         current_load.update()
         occupancy.update()
 
         add_periodic_callback(doc, nbytes_workers, 100)
+        add_periodic_callback(doc, processing, 100)
         add_periodic_callback(doc, current_load, 100)
         add_periodic_callback(doc, occupancy, 100)
 
         doc.add_root(nbytes_workers.root)
 
-        if len(scheduler.workers) < 50:
-            tab1 = Panel(child=processing_root, title="Processing")
-        else:
-            processing_hist.update()
-            add_periodic_callback(doc, processing_hist, 100)
-
-            tab1 = Panel(child=processing_hist_root, title="Processing")
-
+        tab1 = Panel(child=processing_root, title="Processing")
         tab2 = Panel(child=cpu_root, title="CPU")
         tab3 = Panel(child=occupancy_root, title="Occupancy")
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2808,8 +2808,13 @@ def status_doc(scheduler, extra, doc):
         if len(scheduler.workers) < 50:
             nbytes_workers = NBytes(scheduler, sizing_mode="stretch_both")
             processing = CurrentLoad(scheduler, sizing_mode="stretch_both")
+            occupancy = Occupancy(scheduler, sizing_mode="stretch_both")
             processing_root = processing.processing_figure
+            cpu_root = processing.cpu_figure
+            occupancy_root = occupancy.root
             processing_root.y_range = nbytes_workers.root.y_range
+            cpu_root.y_range = nbytes_workers.root.y_range
+            occupancy_root.y_range = nbytes_workers.root.y_range
         else:
             nbytes_workers = NBytesHistogram(scheduler, sizing_mode="stretch_both")
             processing = ProcessingHistogram(scheduler, sizing_mode="stretch_both")
@@ -2818,10 +2823,22 @@ def status_doc(scheduler, extra, doc):
 
         nbytes_workers.update()
         processing.update()
+        occupancy.update()
         add_periodic_callback(doc, nbytes_workers, 100)
         add_periodic_callback(doc, processing, 100)
+        add_periodic_callback(doc, occupancy, 100)
+
         doc.add_root(nbytes_workers.root)
-        doc.add_root(processing_root)
+
+        if len(scheduler.workers) < 50:
+            tab1 = Panel(child=processing_root, title="Processing")
+            tab2 = Panel(child=cpu_root, title="CPU")
+            tab3 = Panel(child=occupancy_root, title="Occupancy")
+            proc_tabs = Tabs(tabs=[tab1, tab2, tab3], name="processing_tabs")
+
+            doc.add_root(proc_tabs)
+        else:
+            print("im here")
 
         task_stream = TaskStream(
             scheduler,

--- a/distributed/http/templates/status.html
+++ b/distributed/http/templates/status.html
@@ -17,7 +17,7 @@
   </div>
 
   <div id="status-processing">
-    {{ embed(roots.processing) }}
+    {{ embed(roots.processing_tabs) }}
   </div>
 
   <div id="status-tasks">


### PR DESCRIPTION
- [x] Closes #4981
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Added tabs for CPU utilization and Occupancy on the Task processing plot on the dashboard. It works when having <50 workers and >50 workers.  If any of this tabs is not useful  and we want to remove then, let me know. Similarly if we believe we want a different tab in there.