### PR TITLE
Local Python env Cluster

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -20,7 +20,13 @@ from .client import (
     wait,
 )
 from .core import Status, connect, rpc
-from .deploy import Adaptive, LocalCluster, SpecCluster, SSHCluster
+from .deploy import (
+    Adaptive,
+    LocalCluster,
+    LocalEnvCluster,
+    SpecCluster,
+    SSHCluster,
+)
 from .diagnostics.plugin import (
     Environ,
     NannyPlugin,

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -20,13 +20,7 @@ from .client import (
     wait,
 )
 from .core import Status, connect, rpc
-from .deploy import (
-    Adaptive,
-    LocalCluster,
-    LocalEnvCluster,
-    SpecCluster,
-    SSHCluster,
-)
+from .deploy import Adaptive, LocalCluster, LocalEnvCluster, SpecCluster, SSHCluster
 from .diagnostics.plugin import (
     Environ,
     NannyPlugin,

--- a/distributed/deploy/__init__.py
+++ b/distributed/deploy/__init__.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 from .adaptive import Adaptive
 from .cluster import Cluster
 from .local import LocalCluster
+from .local_env import LocalEnvCluster
 from .spec import ProcessInterface, SpecCluster
 from .ssh import SSHCluster
 

--- a/distributed/deploy/local_env.py
+++ b/distributed/deploy/local_env.py
@@ -1,0 +1,292 @@
+import asyncio
+import logging
+import sys
+import weakref
+from typing import List, Union
+
+import dask
+import dask.config
+
+from ..core import Status
+from ..scheduler import Scheduler as _Scheduler
+from ..utils import cli_keywords
+from ..worker import Worker as _Worker
+from .spec import ProcessInterface, SpecCluster
+
+logger = logging.getLogger(__name__)
+
+
+class Process(ProcessInterface):
+    """A superclass for SSH Workers and Nannies
+
+    See Also
+    --------
+    Worker
+    Scheduler
+    """
+
+    def __init__(self, **kwargs):
+        self.proc = None
+        super().__init__(**kwargs)
+
+    async def start(self):
+        weakref.finalize(
+            self, self.proc.kill
+        )
+        await super().start()
+
+    async def close(self):
+        self.proc.kill()
+        await super().close()
+
+    def __repr__(self):
+        return "<SSH %s: status=%s>" % (type(self).__name__, self.status)
+
+
+class Worker(Process):
+    """A Remote Dask Worker run by a specified Python executable
+
+    Parameters
+    ----------
+    scheduler: str
+        The address of the scheduler
+    python_exe: str
+        Full path to Python executable to run this worker
+    connect_options: dict
+        kwargs to be passed to asyncio subprocess connections
+    kwargs: dict
+        These will be passed through the dask-worker CLI to the
+        dask.distributed.Worker class
+    worker_module: str
+        The python module to run to start the worker
+    name: str
+        Optionally specify a name for this worker
+    """
+
+    def __init__(
+        self,
+        scheduler: str,
+        python_exe: str,
+        connect_options: dict,
+        kwargs: dict,
+        worker_module="distributed.cli.dask_worker",
+        name=None,
+    ):
+        super().__init__()
+
+        self.scheduler = scheduler
+        self.python_exe = python_exe
+        self.connect_options = connect_options
+        self.kwargs = kwargs
+        self.worker_module = worker_module
+        self.name = name
+
+    async def start(self):
+        set_env = await _set_env_helper(self.connect_options)
+
+        cmd = " ".join(
+            [
+                set_env,
+                self.python_exe,
+                "-m",
+                self.worker_module,
+                self.scheduler,
+                "--name",
+                str(self.name),
+            ]
+            + cli_keywords(self.kwargs, cls=_Worker, cmd=self.worker_module)
+        )
+        self.proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stderr=asyncio.subprocess.PIPE,
+            **self.connect_options
+        )
+
+        # We watch stderr in order to get the address, then we return
+        while True:
+            _, line = await self.proc.communicate()
+            if not line.decode().strip():
+                raise Exception("Worker failed to start")
+            else:
+                line = line.decode()
+            logger.info(line.strip())
+            if "worker at" in line:
+                self.address = line.split("worker at:")[1].strip()
+                self.status = Status.running
+                break
+        logger.debug("%s", line)
+        await super().start()
+
+
+class Scheduler(Process):
+    """A Remote Dask Scheduler run by a specified Python executable
+
+    Parameters
+    ----------
+    python_exe: str
+        Full path to Python executable to run this scheduler
+    connect_options: dict
+        kwargs to be passed to asyncio subprocess connections
+    kwargs: dict
+        These will be passed through the dask-scheduler CLI to the
+        dask.distributed.Scheduler class
+    """
+
+    def __init__(self, python_exe: str, connect_options: dict, kwargs: dict):
+        super().__init__()
+
+        self.python_exe = python_exe
+        self.kwargs = kwargs
+        self.connect_options = connect_options
+
+    async def start(self):
+        logger.debug("Created Scheduler")
+
+        set_env = await _set_env_helper(self.connect_options)
+
+        cmd = " ".join(
+            [
+                set_env,
+                self.python_exe,
+                "-m",
+                "distributed.cli.dask_scheduler"
+            ]
+            + cli_keywords(self.kwargs, cls=_Scheduler)
+        )
+        self.proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stderr=asyncio.subprocess.PIPE,
+            **self.connect_options
+        )
+
+        # We watch stderr in order to get the address, then we return
+        while True:
+            _, line = await self.proc.communicate()
+            if not line.decode().strip():
+                raise Exception("Worker failed to start")
+            else:
+                line = line.decode()
+            logger.info(line.strip())
+            if "Scheduler at" in line:
+                self.address = line.split("Scheduler at:")[1].strip()
+                break
+        logger.debug("%s", line)
+        await super().start()
+
+
+async def _set_env_helper(connect_options: dict):
+    proc = await asyncio.create_subprocess_shell("uname", **connect_options)
+    await proc.communicate()
+    if proc.returncode == 0:
+        set_env = 'env DASK_INTERNAL_INHERIT_CONFIG="{}"'.format(
+            dask.config.serialize(dask.config.global_config)
+        )
+    else:
+        proc = await asyncio.create_subprocess_shell(
+            "cmd /c ver",
+            **connect_options
+        )
+        await proc.communicate()
+        if proc.returncode == 0:
+            set_env = "set DASK_INTERNAL_INHERIT_CONFIG={} &&".format(
+                dask.config.serialize(dask.config.global_config)
+            )
+        else:
+            raise Exception(
+                "Scheduler failed to set DASK_INTERNAL_INHERIT_CONFIG variable "
+            )
+    return set_env
+
+def LocalEnvCluster(
+    python_exe: str,
+    connect_options: Union[List[dict], dict] = {},
+    worker_options: dict = {},
+    scheduler_options: dict = {},
+    worker_module: str = "distributed.cli.dask_worker",
+    **kwargs,
+):
+    """Deploy a Dask cluster that utilises a different Python executable
+
+    The SSHCluster function deploys a Dask Scheduler and Workers for you on a
+    set of machine addresses that you provide.  The first address will be used
+    for the scheduler while the rest will be used for the workers (feel free to
+    repeat the first hostname if you want to have the scheduler and worker
+    co-habitate one machine.)
+
+    You may configure the scheduler and workers by passing
+    ``scheduler_options`` and ``worker_options`` dictionary keywords.  See the
+    ``dask.distributed.Scheduler`` and ``dask.distributed.Worker`` classes for
+    details on the available options, but the defaults should work in most
+    situations.
+
+    You may configure your use of SSH itself using the ``connect_options``
+    keyword, which passes values to the ``asyncssh.connect`` function.  For
+    more information on these see the documentation for the ``asyncssh``
+    library https://asyncssh.readthedocs.io .
+
+    Parameters
+    ----------
+    python_exe : str
+        Full path to another Python executable, for example from another
+        conda env or Python venv.
+    connect_options : dict or list of dict, optional
+        Keywords to pass through to :func:`asyncssh.connect`.
+        This could include things such as ``port``, ``username``, ``password``
+        or ``known_hosts``. See docs for :func:`asyncssh.connect` and
+        :class:`asyncssh.SSHClientConnectionOptions` for full information.
+        If a list it must have the same length as ``hosts``.
+    worker_options : dict, optional
+        Keywords to pass on to workers.
+    scheduler_options : dict, optional
+        Keywords to pass on to scheduler.
+    worker_module : str, optional
+        Python module to call to start the worker.
+
+    Examples
+    --------
+    >>> from dask.distributed import Client, SSHCluster
+    >>> cluster = SSHCluster(
+    ...     ["localhost", "localhost", "localhost", "localhost"],
+    ...     connect_options={"known_hosts": None},
+    ...     worker_options={"nthreads": 2},
+    ...     scheduler_options={"port": 0, "dashboard_address": ":8797"}
+    ... )
+    >>> client = Client(cluster)
+
+    An example using a different worker module, in particular the
+    ``dask-cuda-worker`` command from the ``dask-cuda`` project.
+
+    >>> from dask.distributed import Client, SSHCluster
+    >>> cluster = SSHCluster(
+    ...     ["localhost", "hostwithgpus", "anothergpuhost"],
+    ...     connect_options={"known_hosts": None},
+    ...     scheduler_options={"port": 0, "dashboard_address": ":8797"},
+    ...     worker_module='dask_cuda.dask_cuda_worker')
+    >>> client = Client(cluster)
+
+    See Also
+    --------
+    dask.distributed.Scheduler
+    dask.distributed.Worker
+    asyncssh.connect
+    """
+    scheduler = {
+        "cls": Scheduler,
+        "options": {
+            "python_exe": python_exe,
+            "connect_options": connect_options,
+            "kwargs": scheduler_options,
+        },
+    }
+    workers = {
+        0: {
+            "cls": Worker,
+            "options": {
+                "python_exe": python_exe,
+                "connect_options": connect_options,
+                "kwargs": worker_options,
+                "worker_module": worker_module,
+            },
+        }
+    }
+    return SpecCluster(workers, scheduler, name="LocalEnvCluster", **kwargs)

--- a/distributed/deploy/local_env.py
+++ b/distributed/deploy/local_env.py
@@ -247,7 +247,6 @@ def LocalEnvCluster(
     >>> from dask.distributed import Client, LocalEnvCluster
     >>> cluster = LocalEnvCluster(
     ...     "/Users/user/miniconda3/envs/myenv/bin/python",
-    ...     connect_options={"known_hosts": None},
     ...     worker_options={"nthreads": 1},
     ... )
     >>> client = Client(cluster)

--- a/distributed/deploy/local_env.py
+++ b/distributed/deploy/local_env.py
@@ -45,24 +45,21 @@ class Process(ProcessInterface):
         -------
             Dask config to inherit, if any.
         """
-        keyname = "DASK_INTERNAL_INHERIT_CONFIG"
         proc = await asyncio.create_subprocess_shell("uname", **self.connect_options)
         await proc.communicate()
         if proc.returncode == 0:
-            # set_env = 'env DASK_INTERNAL_INHERIT_CONFIG="{}"'.format(
-            #     dask.config.serialize(dask.config.global_config)
-            # )
-            set_env = {keyname: f"{dask.config.serialize(dask.config.global_config)}"}
+            set_env = 'env DASK_INTERNAL_INHERIT_CONFIG="{}"'.format(
+                dask.config.serialize(dask.config.global_config)
+            )
         else:
             proc = await asyncio.create_subprocess_shell(
                 "cmd /c ver", **self.connect_options
             )
             await proc.communicate()
             if proc.returncode == 0:
-                # set_env = "set DASK_INTERNAL_INHERIT_CONFIG={} &&".format(
-                #     dask.config.serialize(dask.config.global_config)
-                # )
-                set_env = {keyname: f"{dask.config.serialize(dask.config.global_config)}"}
+                set_env = "set DASK_INTERNAL_INHERIT_CONFIG={} &&".format(
+                    dask.config.serialize(dask.config.global_config)
+                )
             else:
                 name = self.__class__.__name__
                 emsg = f"{name} failed to set DASK_INTERNAL_INHERIT_CONFIG variable"
@@ -128,48 +125,25 @@ class Worker(Process):
     async def start(self):
         set_env = await self._set_env_helper()
 
-        cmds = [
-            "-m",
-            self.worker_module,
-            self.scheduler,
-            "--name",
-            str(self.name),
-        ] + cli_keywords(self.kwargs, cls=_Worker, cmd=self.worker_module)
-
-        self.proc = await asyncio.create_subprocess_exec(
-            self.python_executable,
-            *cmds,
-            stderr=asyncio.subprocess.PIPE,
-            env=set_env,
-            **self.connect_options
+        cmd = " ".join(
+            [
+                set_env,
+                self.python_executable,
+                "-m",
+                self.worker_module,
+                self.scheduler,
+                "--name",
+                str(self.name),
+            ]
+            + cli_keywords(self.kwargs, cls=_Worker, cmd=self.worker_module)
+        )
+        self.proc = await asyncio.create_subprocess_shell(
+            cmd, stderr=asyncio.subprocess.PIPE, **self.connect_options
         )
 
         search_string = "worker at"
         await self._get_address(search_string)
         await super().start()
-
-    # async def _start(self):
-    #     set_env = await self._set_env_helper()
-    #
-    #     cmd = " ".join(
-    #         [
-    #             set_env,
-    #             self.python_executable,
-    #             "-m",
-    #             self.worker_module,
-    #             self.scheduler,
-    #             "--name",
-    #             str(self.name),
-    #         ]
-    #         + cli_keywords(self.kwargs, cls=_Worker, cmd=self.worker_module)
-    #     )
-    #     self.proc = await asyncio.create_subprocess_shell(
-    #         cmd, stderr=asyncio.subprocess.PIPE, **self.connect_options
-    #     )
-    #
-    #     search_string = "worker at"
-    #     await self._get_address(search_string)
-    #     await super().start()
 
 
 class Scheduler(Process):
@@ -198,36 +172,17 @@ class Scheduler(Process):
 
         set_env = await self._set_env_helper()
 
-        cmds = ["-m", "distributed.cli.dask_scheduler"] + cli_keywords(self.kwargs, cls=_Scheduler)
-
-        self.proc = await asyncio.create_subprocess_exec(
-            self.python_executable,
-            *cmds,
-            stderr=asyncio.subprocess.PIPE,
-            env=set_env,
-            **self.connect_options
+        cmd = " ".join(
+            [set_env, self.python_executable, "-m", "distributed.cli.dask_scheduler"]
+            + cli_keywords(self.kwargs, cls=_Scheduler)
+        )
+        self.proc = await asyncio.create_subprocess_shell(
+            cmd, stderr=asyncio.subprocess.PIPE, **self.connect_options
         )
 
         search_string = "Scheduler at"
         await self._get_address(search_string)
         await super().start()
-
-    # async def _start(self):
-    #     logger.debug("Created Scheduler")
-    #
-    #     set_env = await self._set_env_helper()
-    #
-    #     cmd = " ".join(
-    #         [set_env, self.python_executable, "-m", "distributed.cli.dask_scheduler"]
-    #         + cli_keywords(self.kwargs, cls=_Scheduler)
-    #     )
-    #     self.proc = await asyncio.create_subprocess_shell(
-    #         cmd, stderr=asyncio.subprocess.PIPE, **self.connect_options
-    #     )
-    #
-    #     search_string = "Scheduler at"
-    #     await self._get_address(search_string)
-    #     await super().start()
 
 
 def LocalEnvCluster(

--- a/distributed/deploy/local_env.py
+++ b/distributed/deploy/local_env.py
@@ -218,11 +218,12 @@ def LocalEnvCluster(
 ):
     """Deploy a Dask cluster that utilises a different Python executable
 
-    The SSHCluster function deploys a Dask Scheduler and Workers for you on a
-    set of machine addresses that you provide.  The first address will be used
-    for the scheduler while the rest will be used for the workers (feel free to
-    repeat the first hostname if you want to have the scheduler and worker
-    co-habitate one machine.)
+    The LocalEnvCluster function deploys a Dask Scheduler and Workers for you on
+    your local machine, running in the Python environment specified by
+    `python_exe`. This allows you to run a Dask cluster in a different Python
+    environment to the host Python environment; particularly useful when
+    combined with `dask-labextension` as you can run a Dask Scheduler and
+    Workers in a different Python env to the env hosting JupyterLab.
 
     You may configure the scheduler and workers by passing
     ``scheduler_options`` and ``worker_options`` dictionary keywords.  See the
@@ -230,10 +231,11 @@ def LocalEnvCluster(
     details on the available options, but the defaults should work in most
     situations.
 
-    You may configure your use of SSH itself using the ``connect_options``
-    keyword, which passes values to the ``asyncssh.connect`` function.  For
-    more information on these see the documentation for the ``asyncssh``
-    library https://asyncssh.readthedocs.io .
+    You may configure how to connect to the local Scheduler and Workers using
+    the ``connect_options`` keyword, which passes values to the
+    ``asyncio.create_subprocess_shell`` function.  For more information on this
+    see the documentation on the
+    [asyncio library](https://docs.python.org/3/library/asyncio-subprocess.html#asyncio-subprocess).
 
     Parameters
     ----------
@@ -253,33 +255,21 @@ def LocalEnvCluster(
     worker_module : str, optional
         Python module to call to start the worker.
 
-    Examples
-    --------
-    >>> from dask.distributed import Client, SSHCluster
-    >>> cluster = SSHCluster(
-    ...     ["localhost", "localhost", "localhost", "localhost"],
+    Example
+    -------
+    >>> from dask.distributed import Client, LocalEnvCluster
+    >>> cluster = LocalEnvCluster(
+    ...     "/Users/user/miniconda3/envs/myenv/bin/python",
     ...     connect_options={"known_hosts": None},
-    ...     worker_options={"nthreads": 2},
-    ...     scheduler_options={"port": 0, "dashboard_address": ":8797"}
+    ...     worker_options={"nthreads": 1},
     ... )
-    >>> client = Client(cluster)
-
-    An example using a different worker module, in particular the
-    ``dask-cuda-worker`` command from the ``dask-cuda`` project.
-
-    >>> from dask.distributed import Client, SSHCluster
-    >>> cluster = SSHCluster(
-    ...     ["localhost", "hostwithgpus", "anothergpuhost"],
-    ...     connect_options={"known_hosts": None},
-    ...     scheduler_options={"port": 0, "dashboard_address": ":8797"},
-    ...     worker_module='dask_cuda.dask_cuda_worker')
     >>> client = Client(cluster)
 
     See Also
     --------
     dask.distributed.Scheduler
     dask.distributed.Worker
-    asyncssh.connect
+    asyncio.create_subprocess_shell
     """
     scheduler = {
         "cls": Scheduler,

--- a/distributed/deploy/local_env.py
+++ b/distributed/deploy/local_env.py
@@ -47,7 +47,7 @@ class Worker(Process):
     ----------
     scheduler: str
         The address of the scheduler
-    python_exe: str
+    python_executable: str
         Full path to Python executable to run this worker
     connect_options: dict
         kwargs to be passed to asyncio subprocess connections
@@ -63,7 +63,7 @@ class Worker(Process):
     def __init__(
         self,
         scheduler: str,
-        python_exe: str,
+        python_executable: str,
         connect_options: dict,
         kwargs: dict,
         worker_module="distributed.cli.dask_worker",
@@ -72,7 +72,7 @@ class Worker(Process):
         super().__init__()
 
         self.scheduler = scheduler
-        self.python_exe = python_exe
+        self.python_executable = python_executable
         self.connect_options = connect_options
         self.kwargs = kwargs
         self.worker_module = worker_module
@@ -84,7 +84,7 @@ class Worker(Process):
         cmd = " ".join(
             [
                 set_env,
-                self.python_exe,
+                self.python_executable,
                 "-m",
                 self.worker_module,
                 self.scheduler,
@@ -118,7 +118,7 @@ class Scheduler(Process):
 
     Parameters
     ----------
-    python_exe: str
+    python_executable: str
         Full path to Python executable to run this scheduler
     connect_options: dict
         kwargs to be passed to asyncio subprocess connections
@@ -127,10 +127,10 @@ class Scheduler(Process):
         dask.distributed.Scheduler class
     """
 
-    def __init__(self, python_exe: str, connect_options: dict, kwargs: dict):
+    def __init__(self, python_executable: str, connect_options: dict, kwargs: dict):
         super().__init__()
 
-        self.python_exe = python_exe
+        self.python_executable = python_executable
         self.kwargs = kwargs
         self.connect_options = connect_options
 
@@ -140,7 +140,7 @@ class Scheduler(Process):
         set_env = await _set_env_helper(self.connect_options)
 
         cmd = " ".join(
-            [set_env, self.python_exe, "-m", "distributed.cli.dask_scheduler"]
+            [set_env, self.python_executable, "-m", "distributed.cli.dask_scheduler"]
             + cli_keywords(self.kwargs, cls=_Scheduler)
         )
         self.proc = await asyncio.create_subprocess_shell(
@@ -196,7 +196,7 @@ async def _set_env_helper(connect_options: dict):
 
 
 def LocalEnvCluster(
-    python_exe: str,
+    python_executable: str,
     connect_options: Union[List[dict], dict] = {},
     worker_options: dict = {},
     scheduler_options: dict = {},
@@ -207,8 +207,8 @@ def LocalEnvCluster(
 
     The LocalEnvCluster function deploys a Dask Scheduler and Workers for you on
     your local machine, running in the Python environment specified by
-    `python_exe`. This allows you to run a Dask cluster in a different Python
-    environment to the host Python environment; particularly useful when
+    `python_executable`. This allows you to run a Dask cluster in a different
+    Python environment to the host Python environment; particularly useful when
     combined with `dask-labextension` as you can run a Dask Scheduler and
     Workers in a different Python env to the env hosting JupyterLab.
 
@@ -226,8 +226,8 @@ def LocalEnvCluster(
 
     Parameters
     ----------
-    python_exe : str
-        Full path to another Python executable, for example from another
+    python_executable : str
+        Full path to a Python executable, for example from another
         conda env or Python venv.
     connect_options : dict or list of dict, optional
         Keywords to pass through to :func:`asyncssh.connect`.
@@ -260,7 +260,7 @@ def LocalEnvCluster(
     scheduler = {
         "cls": Scheduler,
         "options": {
-            "python_exe": python_exe,
+            "python_executable": python_executable,
             "connect_options": connect_options,
             "kwargs": scheduler_options,
         },
@@ -269,7 +269,7 @@ def LocalEnvCluster(
         0: {
             "cls": Worker,
             "options": {
-                "python_exe": python_exe,
+                "python_executable": python_executable,
                 "connect_options": connect_options,
                 "kwargs": worker_options,
                 "worker_module": worker_module,

--- a/distributed/deploy/local_env.py
+++ b/distributed/deploy/local_env.py
@@ -29,9 +29,7 @@ class Process(ProcessInterface):
         super().__init__(**kwargs)
 
     async def start(self):
-        weakref.finalize(
-            self, self.proc.kill
-        )
+        weakref.finalize(self, self.proc.kill)
         await super().start()
 
     async def close(self):
@@ -96,18 +94,16 @@ class Worker(Process):
             + cli_keywords(self.kwargs, cls=_Worker, cmd=self.worker_module)
         )
         self.proc = await asyncio.create_subprocess_shell(
-            cmd,
-            stderr=asyncio.subprocess.PIPE,
-            **self.connect_options
+            cmd, stderr=asyncio.subprocess.PIPE, **self.connect_options
         )
 
         # We watch stderr in order to get the address, then we return
         while True:
             line = await self.proc.stderr.readline()
-            if not line.decode('ascii').strip():
+            if not line.decode("ascii").strip():
                 raise Exception("Worker failed to start")
             else:
-                line = line.decode('ascii').strip()
+                line = line.decode("ascii").strip()
             logger.info(line)
             if "worker at" in line:
                 self.address = line.split("worker at:")[1].strip()
@@ -144,27 +140,20 @@ class Scheduler(Process):
         set_env = await _set_env_helper(self.connect_options)
 
         cmd = " ".join(
-            [
-                set_env,
-                self.python_exe,
-                "-m",
-                "distributed.cli.dask_scheduler"
-            ]
+            [set_env, self.python_exe, "-m", "distributed.cli.dask_scheduler"]
             + cli_keywords(self.kwargs, cls=_Scheduler)
         )
         self.proc = await asyncio.create_subprocess_shell(
-            cmd,
-            stderr=asyncio.subprocess.PIPE,
-            **self.connect_options
+            cmd, stderr=asyncio.subprocess.PIPE, **self.connect_options
         )
 
         # We watch stderr in order to get the address, then we return
         while True:
             line = await self.proc.stderr.readline()
-            if not line.decode('ascii').strip():
+            if not line.decode("ascii").strip():
                 raise Exception("Scheduler failed to start")
             else:
-                line = line.decode('ascii').strip()
+                line = line.decode("ascii").strip()
             logger.info(line)
             if "Scheduler at" in line:
                 self.address = line.split("Scheduler at:")[1].strip()
@@ -193,10 +182,7 @@ async def _set_env_helper(connect_options: dict):
             dask.config.serialize(dask.config.global_config)
         )
     else:
-        proc = await asyncio.create_subprocess_shell(
-            "cmd /c ver",
-            **connect_options
-        )
+        proc = await asyncio.create_subprocess_shell("cmd /c ver", **connect_options)
         await proc.communicate()
         if proc.returncode == 0:
             set_env = "set DASK_INTERNAL_INHERIT_CONFIG={} &&".format(
@@ -207,6 +193,7 @@ async def _set_env_helper(connect_options: dict):
                 "Scheduler failed to set DASK_INTERNAL_INHERIT_CONFIG variable "
             )
     return set_env
+
 
 def LocalEnvCluster(
     python_exe: str,

--- a/distributed/deploy/local_env.py
+++ b/distributed/deploy/local_env.py
@@ -222,12 +222,9 @@ def LocalEnvCluster(
         conda env or Python venv.
     n_workers : int
         Number of workers to start
-    connect_options : dict or list of dict, optional
-        Keywords to pass through to :func:`asyncssh.connect`.
-        This could include things such as ``port``, ``username``, ``password``
-        or ``known_hosts``. See docs for :func:`asyncssh.connect` and
-        :class:`asyncssh.SSHClientConnectionOptions` for full information.
-        If a list it must have the same length as ``hosts``.
+    connect_options : dict, optional
+        Keywords to pass through to :func:`asyncio.create_subprocess_shell`.
+        See docs for :func:`asyncio.create_subprocess_shell` for full information.
     worker_options : dict, optional
         Keywords to pass on to workers.
     scheduler_options : dict, optional

--- a/distributed/deploy/local_env.py
+++ b/distributed/deploy/local_env.py
@@ -187,6 +187,7 @@ class Scheduler(Process):
 
 def LocalEnvCluster(
     python_executable: str,
+    n_workers: int = 1,
     connect_options: Union[List[dict], dict] = {},
     worker_options: dict = {},
     scheduler_options: dict = {},
@@ -219,6 +220,8 @@ def LocalEnvCluster(
     python_executable : str
         Full path to a Python executable, for example from another
         conda env or Python venv.
+    n_workers : int
+        Number of workers to start
     connect_options : dict or list of dict, optional
         Keywords to pass through to :func:`asyncssh.connect`.
         This could include things such as ``port``, ``username``, ``password``
@@ -256,7 +259,7 @@ def LocalEnvCluster(
         },
     }
     workers = {
-        0: {
+        i: {
             "cls": Worker,
             "options": {
                 "python_executable": python_executable,
@@ -265,5 +268,6 @@ def LocalEnvCluster(
                 "worker_module": worker_module,
             },
         }
+        for i in range(n_workers)
     }
     return SpecCluster(workers, scheduler, name="LocalEnvCluster", **kwargs)

--- a/distributed/deploy/tests/test_local_env.py
+++ b/distributed/deploy/tests/test_local_env.py
@@ -1,6 +1,6 @@
-import pytest
-
 import sys
+
+import pytest
 
 import dask
 
@@ -32,7 +32,7 @@ async def test_job_submission():
         scheduler_options={"port": 20001, "idle_timeout": "5s"},
         worker_options={"death_timeout": "5s"},
     ) as cluster:
-        async with Client(cluster) as client:
+        async with Client(cluster, asynchronous=True) as client:
             result = await client.submit(lambda x: x + 1, 10)
             assert result == 11
 
@@ -41,11 +41,11 @@ async def test_job_submission():
 async def test_multiple_workers():
     n_workers = 2
     async with LocalEnvCluster(
-            sys.executable,
-            n_workers=n_workers,
-            asynchronous=True,
-            scheduler_options={"port": 20002, "idle_timeout": "5s"},
-            worker_options={"death_timeout": "5s"},
+        sys.executable,
+        n_workers=n_workers,
+        asynchronous=True,
+        scheduler_options={"port": 20002, "idle_timeout": "5s"},
+        worker_options={"death_timeout": "5s"},
     ) as cluster:
         assert len(cluster.workers) == n_workers
 
@@ -54,10 +54,10 @@ async def test_multiple_workers():
 async def test_bad_executable():
     with pytest.raises(Exception):
         async with LocalEnvCluster(
-                "/foo/bar/baz/python",
-                asynchronous=True,
-                scheduler_options={"port": 20003, "idle_timeout": "5s"},
-                worker_options={"death_timeout": "5s"},
+            "/foo/bar/baz/python",
+            asynchronous=True,
+            scheduler_options={"port": 20003, "idle_timeout": "5s"},
+            worker_options={"death_timeout": "5s"},
         ) as cluster:
             assert cluster
         cluster.close()
@@ -77,6 +77,6 @@ async def test_set_env():
             scheduler_options={"port": 20004, "idle_timeout": "5s"},
             worker_options={"death_timeout": "5s"},
         ) as cluster:
-            async with Client(cluster) as client:
+            async with Client(cluster, asynchronous=True) as client:
                 result = await client.submit(f)
                 assert result == value

--- a/distributed/deploy/tests/test_local_env.py
+++ b/distributed/deploy/tests/test_local_env.py
@@ -13,6 +13,7 @@ from distributed.deploy.local_env import LocalEnvCluster
 async def test_basic():
     async with LocalEnvCluster(
         sys.executable,
+        asynchronous=True,
         scheduler_options={"port": 0, "idle_timeout": "5s"},
         worker_options={"death_timeout": "5s"},
     ) as cluster:
@@ -27,6 +28,7 @@ async def test_basic():
 async def test_job_submission():
     async with LocalEnvCluster(
         sys.executable,
+        asynchronous=True,
         scheduler_options={"port": 0, "idle_timeout": "5s"},
         worker_options={"death_timeout": "5s"},
     ) as cluster:
@@ -41,6 +43,7 @@ async def test_multiple_workers():
     async with LocalEnvCluster(
             sys.executable,
             n_workers=n_workers,
+            asynchronous=True,
             scheduler_options={"port": 0, "idle_timeout": "5s"},
             worker_options={"death_timeout": "5s"},
     ) as cluster:
@@ -52,6 +55,7 @@ async def test_bad_executable():
     with pytest.raises(Exception):
         async with LocalEnvCluster(
                 "/foo/bar/baz/python",
+                asynchronous=True,
                 scheduler_options={"port": 0, "idle_timeout": "5s"},
                 worker_options={"death_timeout": "5s"},
         ) as cluster:
@@ -69,6 +73,7 @@ async def test_set_env():
     with dask.config.set(foo=value):
         async with LocalEnvCluster(
             sys.executable,
+            asynchronous=True,
             scheduler_options={"port": 0, "idle_timeout": "5s"},
             worker_options={"death_timeout": "5s"},
         ) as cluster:

--- a/distributed/deploy/tests/test_local_env.py
+++ b/distributed/deploy/tests/test_local_env.py
@@ -1,0 +1,77 @@
+import pytest
+
+import sys
+
+import dask
+
+from distributed import Client
+from distributed.core import Status
+from distributed.deploy.local_env import LocalEnvCluster
+
+
+@pytest.mark.asyncio
+async def test_basic():
+    async with LocalEnvCluster(
+        sys.executable,
+        scheduler_options={"port": 0, "idle_timeout": "5s"},
+        worker_options={"death_timeout": "5s"},
+    ) as cluster:
+        assert len(cluster.workers) == 1
+        assert cluster.scheduler.python_executable == sys.executable
+        assert cluster.workers[0].python_executable == sys.executable
+        assert "LocalEnv" in repr(cluster)
+    assert cluster.status == Status.closed
+
+
+@pytest.mark.asyncio
+async def test_job_submission():
+    async with LocalEnvCluster(
+        sys.executable,
+        scheduler_options={"port": 0, "idle_timeout": "5s"},
+        worker_options={"death_timeout": "5s"},
+    ) as cluster:
+        async with Client(cluster) as client:
+            result = await client.submit(lambda x: x + 1, 10)
+            assert result == 11
+
+
+@pytest.mark.asyncio
+async def test_multiple_workers():
+    n_workers = 2
+    async with LocalEnvCluster(
+            sys.executable,
+            n_workers=n_workers,
+            scheduler_options={"port": 0, "idle_timeout": "5s"},
+            worker_options={"death_timeout": "5s"},
+    ) as cluster:
+        assert len(cluster.workers) == n_workers
+
+
+@pytest.mark.asyncio
+async def test_bad_executable():
+    with pytest.raises(Exception):
+        async with LocalEnvCluster(
+                "/foo/bar/baz/python",
+                scheduler_options={"port": 0, "idle_timeout": "5s"},
+                worker_options={"death_timeout": "5s"},
+        ) as cluster:
+            assert cluster
+        cluster.close()
+
+
+@pytest.mark.asyncio
+async def test_set_env():
+    value = 100
+
+    def f():
+        return dask.config.get("foo")
+
+    with dask.config.set(foo=value):
+        async with LocalEnvCluster(
+            sys.executable,
+            scheduler_options={"port": 0, "idle_timeout": "5s"},
+            worker_options={"death_timeout": "5s"},
+        ) as cluster:
+            async with Client(cluster) as client:
+                result = await client.submit(f)
+                assert result == value

--- a/distributed/deploy/tests/test_local_env.py
+++ b/distributed/deploy/tests/test_local_env.py
@@ -14,7 +14,7 @@ async def test_basic():
     async with LocalEnvCluster(
         sys.executable,
         asynchronous=True,
-        scheduler_options={"port": 0, "idle_timeout": "5s"},
+        scheduler_options={"port": 20000, "idle_timeout": "5s"},
         worker_options={"death_timeout": "5s"},
     ) as cluster:
         assert len(cluster.workers) == 1
@@ -29,7 +29,7 @@ async def test_job_submission():
     async with LocalEnvCluster(
         sys.executable,
         asynchronous=True,
-        scheduler_options={"port": 0, "idle_timeout": "5s"},
+        scheduler_options={"port": 20001, "idle_timeout": "5s"},
         worker_options={"death_timeout": "5s"},
     ) as cluster:
         async with Client(cluster) as client:
@@ -44,7 +44,7 @@ async def test_multiple_workers():
             sys.executable,
             n_workers=n_workers,
             asynchronous=True,
-            scheduler_options={"port": 0, "idle_timeout": "5s"},
+            scheduler_options={"port": 20002, "idle_timeout": "5s"},
             worker_options={"death_timeout": "5s"},
     ) as cluster:
         assert len(cluster.workers) == n_workers
@@ -56,7 +56,7 @@ async def test_bad_executable():
         async with LocalEnvCluster(
                 "/foo/bar/baz/python",
                 asynchronous=True,
-                scheduler_options={"port": 0, "idle_timeout": "5s"},
+                scheduler_options={"port": 20003, "idle_timeout": "5s"},
                 worker_options={"death_timeout": "5s"},
         ) as cluster:
             assert cluster
@@ -74,7 +74,7 @@ async def test_set_env():
         async with LocalEnvCluster(
             sys.executable,
             asynchronous=True,
-            scheduler_options={"port": 0, "idle_timeout": "5s"},
+            scheduler_options={"port": 20004, "idle_timeout": "5s"},
             worker_options={"death_timeout": "5s"},
         ) as cluster:
             async with Client(cluster) as client:


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask-labextension/issues/82
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Add a new distributed cluster manager that provides a Scheduler and Workers, running on localhost, but which are run using a different, user-specified Python executable. 

**Rationale**
This is particularly desirable functionality when using the dask labextension and JupyterLab, as dask-labextension will launch a `LocalCluster` using the same Python executable as provides the JupyterLab instance. This may not always be desirable, notably when also using Cloud JupyterLab services (such as SageMaker Studio or AzureML), where you do not have control over the Python executable running the JupyterLab instance.

Note: no tests yet! I'd appreciate some input on how I might test this...

cc @jacobtomlinson @jrbourbeau 