### PR TITLE
Remove duplicated dashboard panes

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -64,11 +64,6 @@ applications = {
     "/individual-groups": individual_doc(TaskGroupGraph, 200),
     "/individual-workers-memory": individual_doc(WorkersMemory, 100),
     "/individual-cluster-memory": individual_doc(ClusterMemory, 100),
-    # Temporary backwards compatibility with dask-labextension
-    # See https://github.com/dask/dask-labextension/issues/198
-    "/individual-nbytes": individual_doc(WorkersMemory, 100),
-    "/individual-nbytes-cluster": individual_doc(ClusterMemory, 100),
-    # End backwards compatibility
     "/individual-cpu": individual_doc(CurrentLoad, 100, fig_attr="cpu_figure"),
     "/individual-nprocessing": individual_doc(
         CurrentLoad, 100, fig_attr="processing_figure"


### PR DESCRIPTION
These result in duplicated dashboard panes with different names.

- [x] Closes https://github.com/dask/distributed/pull/4878#issuecomment-872396018
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Without this, the memory dashboards show up twice under different names:

![image](https://user-images.githubusercontent.com/5728311/124160809-8136f200-da51-11eb-9013-f3db829ad4fa.png)
