### PR TITLE
Add echo handler to Server class

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -139,6 +139,7 @@ class Server:
     ):
         self.handlers = {
             "identity": self.identity,
+            "echo": self.echo,
             "connection_stream": self.handle_stream,
         }
         self.handlers.update(handlers)
@@ -383,6 +384,9 @@ class Server:
 
     def identity(self, comm=None):
         return {"type": type(self).__name__, "id": self.id}
+
+    def echo(self, comm=None, data=None):
+        return data
 
     async def listen(self, port_or_addr=None, allow_offload=True, **kwargs):
         if port_or_addr is None:

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -42,10 +42,6 @@ from distributed.utils_test import (
 )
 
 
-def echo(comm, x):
-    return x
-
-
 class CountedObject:
     """
     A class which counts the number of live instances.
@@ -443,16 +439,16 @@ async def test_rpc_with_many_connections_inproc():
 
 async def check_large_packets(listen_arg):
     """tornado has a 100MB cap by default"""
-    server = Server({"echo": echo})
+    server = Server({})
     await server.listen(listen_arg)
 
     data = b"0" * int(200e6)  # slightly more than 100MB
     async with rpc(server.address) as conn:
-        result = await conn.echo(x=data)
+        result = await conn.echo(data=data)
         assert result == data
 
         d = {"x": data}
-        result = await conn.echo(x=d)
+        result = await conn.echo(data=d)
         assert result == d
 
     server.stop()
@@ -544,17 +540,17 @@ async def test_connect_raises():
 
 @pytest.mark.asyncio
 async def test_send_recv_args():
-    server = Server({"echo": echo})
+    server = Server({})
     await server.listen(0)
 
     comm = await connect(server.address)
-    result = await send_recv(comm, op="echo", x=b"1")
+    result = await send_recv(comm, op="echo", data=b"1")
     assert result == b"1"
     assert not comm.closed()
-    result = await send_recv(comm, op="echo", x=b"2", reply=False)
+    result = await send_recv(comm, op="echo", data=b"2", reply=False)
     assert result is None
     assert not comm.closed()
-    result = await send_recv(comm, op="echo", x=b"3", close=True)
+    result = await send_recv(comm, op="echo", data=b"3", close=True)
     assert result == b"3"
     assert comm.closed()
 


### PR DESCRIPTION
This adds an echo route to all Dask servers, including schedulers and
workers.

This makes it a bit easier to test connection and bandwidth issues

```python
result = await client.scheduler.echo(b"...")
```

This returns the same data back without modification

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
