### PR TITLE
Add pandas to the list of checked packages for `client.get_versions()`.

### DIFF
--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -18,6 +18,7 @@ required_packages = [
 
 optional_packages = [
     ("numpy", lambda p: p.__version__),
+    ("pandas", lambda p: p.__version__),
     ("lz4", lambda p: p.__version__),
     ("blosc", lambda p: p.__version__),
 ]


### PR DESCRIPTION
- [x] Closes #5028 
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
