### PR TITLE
Dont require workers to report to scheduler if scheduler shuts down

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3833,7 +3833,10 @@ class Scheduler(SchedulerState, ServerNode):
         if close_workers:
             await self.broadcast(msg={"op": "close_gracefully"}, nanny=True)
             for worker in parent._workers_dv:
-                self.worker_send(worker, {"op": "close"})
+                # Report would require the worker to unregister with the
+                # currently closing scheduler. This is not necessary and might
+                # delay shutdown of the worker unnecessarily
+                self.worker_send(worker, {"op": "close", "report": False})
             for i in range(20):  # wait a second for send signals to clear
                 if parent._workers_dv:
                     await asyncio.sleep(0.05)


### PR DESCRIPTION
If the scheduler is shutting down it is not necessary for the workers to
report back since there is no failure handling happening anymore. The
report would otherwise delay worker shutdown and may even result in
connection failure logs.

This occasionally lets tests fail since workers are still in "closing" state since they are stuck in the unregister call

- Closes https://github.com/dask/distributed/issues/4976

cc @crusaderky 
