### PR TITLE
Adjust worker batched send interval to cluster size

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7138,23 +7138,6 @@ class Scheduler(SchedulerState, ServerNode):
         )
         return dict(zip(parent._workers_dv, results))
 
-    def batched_send_interval(self) -> float:
-        min_ms: float = 2.0
-        max_ms: float = 50.0
-        cpu_fraction: float = self.proc.cpu_percent() / 100
-        print(cpu_fraction)
-        if cpu_fraction < 0.5:
-            return min_ms / 1000
-        target_ms: float = (max_ms - min_ms) * cpu_fraction + min_ms
-        return min(target_ms, max_ms) / 1000
-        # return (
-        #     min_ms
-        #     if target_ms < min_ms
-        #     else max_ms
-        #     if target_ms > max_ms
-        #     else target_ms
-        # )
-
     ###########
     # Cleanup #
     ###########

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -857,33 +857,12 @@ async def test_adjust_batched_send_interval(c, s, a, b):
     await wait_for_heartbeat()
     assert a.batched_stream.interval == 0.005
 
+    # Scale up cluster so send interval increases
     workers = [Worker(s.address, nthreads=1) for i in range(27)]
     await asyncio.gather(*workers)
     await wait_for_heartbeat()
 
     assert a.batched_stream.interval > 0.005
-
-
-# def test_batched_send_interval(client, a):
-#     sleep(1)
-#     address = a["address"]
-#     initials = client.run(lambda dask_worker: dask_worker.batched_stream.interval)
-#     assert initials[address] == 2 / 1000
-#     heartbeat_interval = (
-#         client.run(
-#             lambda dask_worker: dask_worker.periodic_callbacks[
-#                 "heartbeat"
-#             ].callback_time
-#         )[address]
-#         / 1000
-#     )
-#     # sleep(a.periodic_callbacks["heartbeat"].callback_time / 1000 + 0.1)
-#     sleep(heartbeat_interval + 0.2)
-#     intervals = client.run(lambda dask_worker: dask_worker.batched_stream.interval)
-#     assert intervals == initials
-#     client.run_on_scheduler(run_for, heartbeat_interval + 0.2)
-#     intervals = client.run(lambda dask_worker: dask_worker.batched_stream.interval)
-#     assert intervals[address] >= 27.5 / 1000
 
 
 @pytest.mark.parametrize("worker", [Worker, Nanny])

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1000,7 +1000,6 @@ class Worker(ServerNode):
                 response["heartbeat-interval"] * 1000
             )
             self.batched_stream.interval = response["batched-send-interval"]
-            # print(response["batched-send-interval"])
             self.bandwidth_workers.clear()
             self.bandwidth_types.clear()
         except CommClosedError:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -651,7 +651,7 @@ class Worker(ServerNode):
                 self.nthreads, thread_name_prefix="Dask-Default-Threads"
             )
 
-        self.batched_stream = BatchedSend(interval="2ms", loop=self.loop)
+        self.batched_stream = BatchedSend(interval="25ms", loop=self.loop)
         self.name = name
         self.scheduler_delay = 0
         self.stream_comms = dict()
@@ -999,6 +999,8 @@ class Worker(ServerNode):
             self.periodic_callbacks["heartbeat"].callback_time = (
                 response["heartbeat-interval"] * 1000
             )
+            self.batched_stream.interval = response["batched-send-interval"]
+            # print(response["batched-send-interval"])
             self.bandwidth_workers.clear()
             self.bandwidth_types.clear()
         except CommClosedError:


### PR DESCRIPTION
Dynamically adjust how often workers send updates to the scheduler based on the size of the cluster.

See https://github.com/dask/distributed/issues/4881#issuecomment-859208156 for context.

Initially, I thought about using the scheduler's current CPU utilization as the scaling metric (rather than purely cluster size), since that's the resource this is actually trying to conserve. However, CPU is quite spiky, making it both hard to test and possibly a poor metric without some more complex code to dampen that spikiness.

I currently have the values of 5ms-100ms range, targeting 5k scheduler messages per second. This is roughly based on the fact that a 20ms interval seemed decent for a 100 worker cluster in https://github.com/dask/distributed/issues/4881 and on @mrocklin's comment here https://github.com/dask/distributed/issues/4881#issuecomment-859832671. These numbers are provisional, and I want to do more testing before merging this.

- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
