### PR TITLE
Fix Nbytes jitter - less expensive. 

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -282,7 +282,7 @@ class ClusterMemory(DashboardComponent):
             self.root.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
             self.root.xaxis.major_label_orientation = XLABEL_ORIENTATION
             self.root.xaxis.minor_tick_line_alpha = 0
-            self.root.x_range = Range1d(start=0, end=1)
+            self.root.x_range = Range1d(start=0)
             self.root.yaxis.visible = False
             self.root.ygrid.visible = False
 
@@ -402,7 +402,7 @@ class WorkersMemory(DashboardComponent):
             self.root.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
             self.root.xaxis.major_label_orientation = XLABEL_ORIENTATION
             self.root.xaxis.minor_tick_line_alpha = 0
-            self.root.x_range = Range1d(start=0, end=1)
+            self.root.x_range = Range1d(start=0)
             self.root.yaxis.visible = False
             self.root.ygrid.visible = False
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -282,6 +282,7 @@ class ClusterMemory(DashboardComponent):
             self.root.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
             self.root.xaxis.major_label_orientation = XLABEL_ORIENTATION
             self.root.xaxis.minor_tick_line_alpha = 0
+            self.root.x_range = Range1d(start=0, end=1)
             self.root.yaxis.visible = False
             self.root.ygrid.visible = False
 
@@ -342,7 +343,9 @@ class ClusterMemory(DashboardComponent):
             }
 
             x_end = max(limit, meminfo.process + meminfo.managed_spilled)
-            self.root.x_range = DataRange1d(start=0, end=x_end, range_padding=0)
+            self.root.x_range.end = (
+                x_end  # = DataRange1d(start=0, end=x_end, range_padding=0)
+            )
 
             title = f"Bytes stored: {format_bytes(meminfo.process)}"
             if meminfo.managed_spilled:
@@ -399,6 +402,7 @@ class WorkersMemory(DashboardComponent):
             self.root.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
             self.root.xaxis.major_label_orientation = XLABEL_ORIENTATION
             self.root.xaxis.minor_tick_line_alpha = 0
+            self.root.x_range = Range1d(start=0, end=1)
             self.root.yaxis.visible = False
             self.root.ygrid.visible = False
 
@@ -506,7 +510,9 @@ class WorkersMemory(DashboardComponent):
                 k: [vi for vi, w in zip(v, width) if w] for k, v in result.items()
             }
 
-            self.root.x_range = DataRange1d(start=0, end=max_limit, range_padding=0)
+            self.root.x_range.end = (
+                max_limit  # = DataRange1d(start=0, end=max_limit, range_padding=0)
+            )
             update(self.source, result)
 
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -343,9 +343,7 @@ class ClusterMemory(DashboardComponent):
             }
 
             x_end = max(limit, meminfo.process + meminfo.managed_spilled)
-            self.root.x_range.end = (
-                x_end  # = DataRange1d(start=0, end=x_end, range_padding=0)
-            )
+            self.root.x_range.end = x_end
 
             title = f"Bytes stored: {format_bytes(meminfo.process)}"
             if meminfo.managed_spilled:
@@ -510,9 +508,7 @@ class WorkersMemory(DashboardComponent):
                 k: [vi for vi, w in zip(v, width) if w] for k, v in result.items()
             }
 
-            self.root.x_range.end = (
-                max_limit  # = DataRange1d(start=0, end=max_limit, range_padding=0)
-            )
+            self.root.x_range.end = max_limit
             update(self.source, result)
 
 


### PR DESCRIPTION
- [x] Closes #5035
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

This PR intends to fix the slowdown caused by using DataRange1d in the update of the WorkersMemory and ClusterMemory plots on the dashboard. 

I tried the adding workers workflow from https://github.com/dask/distributed/issues/4675#issue-851238088 and things look much better now. I noticed that there is some flickering on the Clustermemory plot, but it's just an adjustment of the end of the x-axis,which stops very fast (before it was impossible to see the plot). 

I also tried to make things spilled to disk, and the flickering is gone. This was the code I tried:
```python
from dask.distributed import Client, wait
client = Client()

import dask.array as da

x = da.random.random((50000, 50000))
y = (x + x.T)
z = x - x.mean(axis=0)
z = z.persist()
```

cc  @gjoseph92 @jrbourbeau 