### PR TITLE
Reduce size of frames sent to websockets to 10MB

### DIFF
--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -19,7 +19,9 @@ if isinstance(OFFLOAD_THRESHOLD, str):
 
 
 async def to_frames(
-    msg, serializers=None, on_error="message", context=None, allow_offload=True
+    msg,
+    allow_offload=True,
+    **kwargs,
 ):
     """
     Serialize a message into a list of Distributed protocol frames.
@@ -27,11 +29,7 @@ async def to_frames(
 
     def _to_frames():
         try:
-            return list(
-                protocol.dumps(
-                    msg, serializers=serializers, on_error=on_error, context=context
-                )
-            )
+            return list(protocol.dumps(msg, **kwargs))
         except Exception as e:
             logger.info("Unserializable Message: %s", msg)
             logger.exception(e)

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -12,6 +12,8 @@ from tornado.httpserver import HTTPServer
 from tornado.iostream import StreamClosedError
 from tornado.websocket import WebSocketClosedError, WebSocketHandler, websocket_connect
 
+import dask
+
 from ..utils import ensure_bytes, nbytes
 from .addressing import parse_host_port, unparse_host_port
 from .core import Comm, CommClosedError, Connector, FatalCommClosedError, Listener
@@ -20,6 +22,12 @@ from .tcp import BaseTCPBackend, _expect_tls_context, convert_stream_closed_erro
 from .utils import ensure_concrete_host, from_frames, get_tcp_server_address, to_frames
 
 logger = logging.getLogger(__name__)
+
+
+BIG_BYTES_SHARD_SIZE = min(
+    dask.utils.parse_bytes(dask.config.get("distributed.comm.shard")),
+    10_000_000,
+)
 
 
 class WSHandler(WebSocketHandler):
@@ -106,6 +114,7 @@ class WSHandlerComm(Comm):
                 "recipient": self.remote_info,
                 **self.handshake_options,
             },
+            frame_split_size=BIG_BYTES_SHARD_SIZE,
         )
         n = struct.pack("Q", len(frames))
         try:

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -16,7 +16,9 @@ from .utils import msgpack_opts
 logger = logging.getLogger(__name__)
 
 
-def dumps(msg, serializers=None, on_error="message", context=None) -> list:
+def dumps(
+    msg, serializers=None, on_error="message", context=None, frame_split_size=None
+) -> list:
     """Transform Python message to bytestream suitable for communication
 
     Developer Notes
@@ -53,7 +55,11 @@ def dumps(msg, serializers=None, on_error="message", context=None) -> list:
                     sub_header, sub_frames = obj.header, obj.frames
                 else:
                     sub_header, sub_frames = serialize_and_split(
-                        obj, serializers=serializers, on_error=on_error, context=context
+                        obj,
+                        serializers=serializers,
+                        on_error=on_error,
+                        context=context,
+                        size=frame_split_size,
                     )
                     _inplace_compress_frames(sub_header, sub_frames)
                 sub_header["num-sub-frames"] = len(sub_frames)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -406,7 +406,9 @@ def deserialize(header, frames, deserializers=None):
     return loads(header, frames)
 
 
-def serialize_and_split(x, serializers=None, on_error="message", context=None):
+def serialize_and_split(
+    x, serializers=None, on_error="message", context=None, size=None
+):
     """Serialize and split compressable frames
 
     This function is a drop-in replacement of `serialize()` that calls `serialize()`
@@ -428,7 +430,7 @@ def serialize_and_split(x, serializers=None, on_error="message", context=None):
         frames, header.get("compression") or [None] * len(frames)
     ):
         if compression is None:  # default behavior
-            sub_frames = frame_split_size(frame)
+            sub_frames = frame_split_size(frame, n=size)
             num_sub_frames.append(len(sub_frames))
             offsets.append(len(out_frames))
             out_frames.extend(sub_frames)

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -25,6 +25,7 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     >>> frame_split_size([b'12345', b'678'], n=3)  # doctest: +SKIP
     [b'123', b'45', b'678']
     """
+    n = n or BIG_BYTES_SHARD_SIZE
     frame = memoryview(frame)
 
     if frame.nbytes <= n:


### PR DESCRIPTION
This also forces us to thread a keyword down through from to_frames to frame_split_size.

Websockets are often used in situations where large frames are not allowed.  This restricts the size of any frame sent through the websocket protocol to 10MB.

This isn't a great solution for a few reasons:

1. It's a fixed number, rather than something configurable.  
2. It's somewhat redundant with the distributed.comm.shard config value (I didn't want all users of websockets to have to set this value)

But the work of threading through the keyword is probably valuable, and maybe it helps to inspire a better solution.