### PR TITLE
Disable pytest-timeout SIGALARM on MacOS

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Reconfigure pytest-timeout
         shell: bash -l {0}
-        # No SIGALRM available on Windows
-        if: ${{ matrix.os != 'windows-latest' }}
+        # No SIGALRM available on Windows. On MacOS, it kills the whole test suite.
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sed -i.bak 's/timeout_method = thread/timeout_method = signal/' setup.cfg
 
       - name: Test

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -22,7 +22,7 @@ from dask.utils import apply, parse_timedelta, stringify
 
 from distributed import Client, Nanny, Worker, fire_and_forget, wait
 from distributed.comm import Comm
-from distributed.compatibility import LINUX, WINDOWS
+from distributed.compatibility import LINUX, MACOS, WINDOWS
 from distributed.core import ConnectionPool, Status, connect, rpc
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps
@@ -3102,6 +3102,7 @@ async def test_transition_counter(c, s, a, b):
     assert s.transition_counter > 1
 
 
+@pytest.mark.skipif(MACOS and sys.version_info < (3, 9), reason="GH#5056")
 @pytest.mark.slow
 @gen_cluster(
     client=True,
@@ -3110,8 +3111,8 @@ async def test_transition_counter(c, s, a, b):
     timeout=60,
 )
 async def test_worker_heartbeat_after_cancel(c, s, *workers):
-    """This test is intended to ensure that after cancelation of a graph, the
-    worker heartbeat is always successful. The hearbeat may not be successful if
+    """This test is intended to ensure that after cancellation of a graph, the
+    worker heartbeat is always successful. The heartbeat may not be successful if
     the worker and scheduler state drift and the scheduler doesn't handle
     unknown information gracefully. One example would be a released/cancelled
     computation where the worker returns metrics about duration, type, etc. and

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,8 +53,9 @@ markers =
 
 # pytest-timeout settings
 # 'thread' kills off the whole test suite. 'signal' only kills the offending test.
-# However, 'signal' does not work on Windows. The CI script modifies this config file on
-# the fly on Linux and MacOS.
+# However, 'signal' doesn't work on Windows (due to lack of SIGALRM) and doesn't work on
+# the MacOS GitHub CI (although it's been reported to work on MacBooks).
+# The CI script modifies this config file on the fly on Linux.
 timeout_method = thread
 # This should not be reduced; Windows CI has been observed to be occasionally
 # exceptionally slow.


### PR DESCRIPTION
See #5056
Disable hanging test test_worker_heartbeat_after_cancel
Disable ineffective signal-based pytest-timeout on MacOS