### PR TITLE
Ensure shard config option is actually configurable, 

### DIFF
--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -4,6 +4,8 @@ import pytest
 
 np = pytest.importorskip("numpy")
 
+import dask
+
 from distributed.protocol import (
     decompress,
     deserialize,
@@ -16,10 +18,11 @@ from distributed.protocol import (
 from distributed.protocol.compression import maybe_compress
 from distributed.protocol.numpy import itemsize
 from distributed.protocol.pickle import HIGHEST_PROTOCOL
-from distributed.protocol.utils import BIG_BYTES_SHARD_SIZE
 from distributed.system import MEMORY_LIMIT
 from distributed.utils import ensure_bytes, nbytes, tmpfile
 from distributed.utils_test import gen_cluster
+
+BIG_BYTES_SHARD_SIZE = dask.utils.parse_bytes(dask.config.get("distributed.comm.shard"))
 
 
 def test_serialize():

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -1,4 +1,6 @@
-from distributed.protocol.utils import pack_frames, unpack_frames
+import dask
+
+from distributed.protocol.utils import frame_split_size, pack_frames, unpack_frames
 
 
 def test_pack_frames():
@@ -8,3 +10,13 @@ def test_pack_frames():
     frames2 = unpack_frames(b)
 
     assert frames == frames2
+
+
+def test_frame_split_is_configurable():
+    frame = b"1234abcd" * (2 ** 20)  # 8 MiB
+    with dask.config.set({"distributed.comm.shard": "3MiB"}):
+        split_frames = frame_split_size(frame)
+        assert len(split_frames) == 3
+    with dask.config.set({"distributed.comm.shard": "5MiB"}):
+        split_frames = frame_split_size(frame)
+        assert len(split_frames) == 2

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -1,4 +1,6 @@
 import dask
+from dask.sizeof import sizeof
+from dask.utils import parse_bytes
 
 from distributed.protocol.utils import frame_split_size, pack_frames, unpack_frames
 
@@ -14,6 +16,7 @@ def test_pack_frames():
 
 def test_frame_split_is_configurable():
     frame = b"1234abcd" * (2 ** 20)  # 8 MiB
+    assert sizeof(frame) == parse_bytes("8MiB")
     with dask.config.set({"distributed.comm.shard": "3MiB"}):
         split_frames = frame_split_size(frame)
         assert len(split_frames) == 3

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -4,9 +4,6 @@ import dask
 
 from ..utils import nbytes
 
-BIG_BYTES_SHARD_SIZE = dask.utils.parse_bytes(dask.config.get("distributed.comm.shard"))
-
-
 msgpack_opts = {
     ("max_%s_len" % x): 2 ** 31 - 1 for x in ["str", "bin", "array", "map", "ext"]
 }
@@ -14,7 +11,7 @@ msgpack_opts["strict_map_key"] = False
 msgpack_opts["raw"] = False
 
 
-def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
+def frame_split_size(frame, n=None) -> list:
     """
     Split a frame into a list of frames of maximum size
 
@@ -25,6 +22,7 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     >>> frame_split_size([b'12345', b'678'], n=3)  # doctest: +SKIP
     [b'123', b'45', b'678']
     """
+    n = n or dask.utils.parse_bytes(dask.config.get("distributed.comm.shard"))
     frame = memoryview(frame)
 
     if frame.nbytes <= n:


### PR DESCRIPTION
Since function defaults are only evaluated once, this isn't actually configurable after `distributed` is imported.

- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
