### PR TITLE
Better support ProcessPoolExecutors

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -510,7 +510,6 @@ async def test_Executor(c, s):
     with ThreadPoolExecutor(2) as e:
         async with Worker(s.address, executor=e) as w:
             assert w.executor is e
-            w = await w
 
             future = c.submit(inc, 1)
             result = await future

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -5,7 +5,7 @@ import os
 import sys
 import threading
 import traceback
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from numbers import Number
 from operator import add
 from time import sleep
@@ -508,17 +508,15 @@ async def test_run_coroutine_dask_worker(c, s, a, b):
 @gen_cluster(client=True, nthreads=[])
 async def test_Executor(c, s):
     with ThreadPoolExecutor(2) as e:
-        w = Worker(s.address, executor=e)
-        assert w.executor is e
-        w = await w
+        async with Worker(s.address, executor=e) as w:
+            assert w.executor is e
+            w = await w
 
-        future = c.submit(inc, 1)
-        result = await future
-        assert result == 2
+            future = c.submit(inc, 1)
+            result = await future
+            assert result == 2
 
-        assert e._threads  # had to do some work
-
-        await w.close()
+            assert e._threads  # had to do some work
 
 
 @pytest.mark.skip(
@@ -2026,6 +2024,21 @@ async def test_multiple_executors(cleanup):
                 default_result, gpu_result = await c.gather(futures)
                 assert "Dask-Default-Threads" in default_result
                 assert "Dask-GPU-Threads" in gpu_result
+
+
+@gen_cluster(client=True)
+async def test_process_executor(c, s, a, b):
+    with ProcessPoolExecutor() as e:
+        a.executors["processes"] = e
+        b.executors["processes"] = e
+
+        future = c.submit(os.getpid, pure=False)
+        assert (await future) == os.getpid()
+
+        with dask.annotate(executor="processes"):
+            future = c.submit(os.getpid, pure=False)
+
+        assert (await future) != os.getpid()
 
 
 def assert_task_states_on_worker(expected, worker):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -19,7 +19,6 @@ from pickle import PicklingError
 from typing import Dict, Iterable, Optional
 
 from tlz import first, keymap, merge, pluck  # noqa: F401
-from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
@@ -4021,9 +4020,8 @@ except (Exception, RuntimeError):
     pass
 else:
 
-    @gen.coroutine
-    def gpu_metric(worker):
-        result = yield offload(nvml.real_time)
+    async def gpu_metric(worker):
+        result = await offload(nvml.real_time)
         return result
 
     DEFAULT_METRICS["gpu"] = gpu_metric


### PR DESCRIPTION
Previously we sent non-serializable state, like locks and the worker itself into the function that was sent to the executor

Now we only do this if we think that the executor is a ThreadPoolExecutor

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
