### PR TITLE
Reduce default websocket frame size and make configurable

### DIFF
--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -25,6 +25,7 @@ async def to_frames(
 ):
     """
     Serialize a message into a list of Distributed protocol frames.
+    Any kwargs are forwarded to protocol.dumps().
     """
 
     def _to_frames():

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -19,7 +19,9 @@ if isinstance(OFFLOAD_THRESHOLD, str):
 
 
 async def to_frames(
-    msg, serializers=None, on_error="message", context=None, allow_offload=True
+    msg,
+    allow_offload=True,
+    **kwargs,
 ):
     """
     Serialize a message into a list of Distributed protocol frames.
@@ -27,11 +29,7 @@ async def to_frames(
 
     def _to_frames():
         try:
-            return list(
-                protocol.dumps(
-                    msg, serializers=serializers, on_error=on_error, context=context
-                )
-            )
+            return list(protocol.dumps(msg, **kwargs))
         except Exception as e:
             logger.info("Unserializable Message: %s", msg)
             logger.exception(e)

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -24,9 +24,8 @@ from .utils import ensure_concrete_host, from_frames, get_tcp_server_address, to
 logger = logging.getLogger(__name__)
 
 
-BIG_BYTES_SHARD_SIZE = min(
-    dask.utils.parse_bytes(dask.config.get("distributed.comm.shard")),
-    10_000_000,
+BIG_BYTES_SHARD_SIZE = dask.utils.parse_bytes(
+    dask.config.get("distributed.comm.websockets.shard")
 )
 
 

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -12,6 +12,8 @@ from tornado.httpserver import HTTPServer
 from tornado.iostream import StreamClosedError
 from tornado.websocket import WebSocketClosedError, WebSocketHandler, websocket_connect
 
+import dask
+
 from ..utils import ensure_bytes, nbytes
 from .addressing import parse_host_port, unparse_host_port
 from .core import Comm, CommClosedError, Connector, FatalCommClosedError, Listener
@@ -20,6 +22,12 @@ from .tcp import BaseTCPBackend, _expect_tls_context, convert_stream_closed_erro
 from .utils import ensure_concrete_host, from_frames, get_tcp_server_address, to_frames
 
 logger = logging.getLogger(__name__)
+
+
+BIG_BYTES_SHARD_SIZE = min(
+    dask.utils.parse_bytes(dask.config.get("distributed.comm.shard")),
+    10_000_000,
+)
 
 
 class WSHandler(WebSocketHandler):
@@ -106,6 +114,7 @@ class WSHandlerComm(Comm):
                 "recipient": self.remote_info,
                 **self.handshake_options,
             },
+            frame_split_size=BIG_BYTES_SHARD_SIZE,
         )
         n = struct.pack("Q", len(frames))
         try:

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -759,6 +759,20 @@ properties:
                       Alternatively, the key can be appended to the cert file
                       above, and this field left blank
 
+          websockets:
+            type: object
+            properties:
+              shard:
+                type:
+                - string
+                description: |
+                  The maximum size of a websocket frame to send through a comm.
+
+                  This is somewhat duplicative of distributed.comm.shard, but websockets
+                  often have much smaller maximum message sizes than othe protocols, so
+                  this attribute is used to set a smaller default shard size and to
+                  allow separate control of websocket message sharding.
+
       diagnostics:
         type: object
         properties:

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -196,6 +196,9 @@ distributed:
         key: null
         cert: null
 
+    websockets:
+      shard: 8MiB
+
   diagnostics:
     nvml: True
 

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -16,7 +16,9 @@ from .utils import msgpack_opts
 logger = logging.getLogger(__name__)
 
 
-def dumps(msg, serializers=None, on_error="message", context=None) -> list:
+def dumps(
+    msg, serializers=None, on_error="message", context=None, frame_split_size=None
+) -> list:
     """Transform Python message to bytestream suitable for communication
 
     Developer Notes
@@ -53,7 +55,11 @@ def dumps(msg, serializers=None, on_error="message", context=None) -> list:
                     sub_header, sub_frames = obj.header, obj.frames
                 else:
                     sub_header, sub_frames = serialize_and_split(
-                        obj, serializers=serializers, on_error=on_error, context=context
+                        obj,
+                        serializers=serializers,
+                        on_error=on_error,
+                        context=context,
+                        size=frame_split_size,
                     )
                     _inplace_compress_frames(sub_header, sub_frames)
                 sub_header["num-sub-frames"] = len(sub_frames)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -406,7 +406,9 @@ def deserialize(header, frames, deserializers=None):
     return loads(header, frames)
 
 
-def serialize_and_split(x, serializers=None, on_error="message", context=None):
+def serialize_and_split(
+    x, serializers=None, on_error="message", context=None, size=None
+):
     """Serialize and split compressable frames
 
     This function is a drop-in replacement of `serialize()` that calls `serialize()`
@@ -428,7 +430,7 @@ def serialize_and_split(x, serializers=None, on_error="message", context=None):
         frames, header.get("compression") or [None] * len(frames)
     ):
         if compression is None:  # default behavior
-            sub_frames = frame_split_size(frame)
+            sub_frames = frame_split_size(frame, n=size)
             num_sub_frames.append(len(sub_frames))
             offsets.append(len(out_frames))
             out_frames.extend(sub_frames)

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -25,6 +25,7 @@ def frame_split_size(frame, n=BIG_BYTES_SHARD_SIZE) -> list:
     >>> frame_split_size([b'12345', b'678'], n=3)  # doctest: +SKIP
     [b'123', b'45', b'678']
     """
+    n = n or BIG_BYTES_SHARD_SIZE
     frame = memoryview(frame)
 
     if frame.nbytes <= n:


### PR DESCRIPTION
Supersedes #5052 . In addition to making the default websocket maximum-frame-size smaller, this makes the specific value configurable. It's somewhat redundant with `distributed.comm.shard`, but the constraints on websockets are sufficiently different that a separate config seems okay.

This does *not* implement the fix in #5061, as that would read a config value for every frame, which is costly. So the config value will in general not be changed after import time.
 
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
