### PR TITLE
Simplify test_secede_balances

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5206,6 +5206,9 @@ class Scheduler(SchedulerState, ServerNode):
         duration accounting as if the task has stopped.
         """
         parent: SchedulerState = cast(SchedulerState, self)
+        if key not in parent._tasks:
+            logger.debug("Skipping long_running since key %s was already released", key)
+            return
         ts: TaskState = parent._tasks[key]
         steal = parent._extensions.get("stealing")
         if steal is not None:


### PR DESCRIPTION
The assertions in this test are a bit fragile and timing dependent.

The assert about the active number of threads is depending on the speed in which we can scheduler the tasks in the function `f`. While the newly scheduled tasks `inc` have a higher priority than `f`, if the scheduling of `inc` is slow for whatever reason the workers may execute *many* `f`s and therefore spawn more and more threads. Sleeping between secede and map fails the test 100% of times at this position.

Moving on to the log balancing asserts, this depends on many things. In an ideal world, both workers would execute an equal amount of tasks. that's rarely the case and I've seen this becoming untrue rather quickly. I changed this assert to something very conservative which still asserts that both calculate a few of `inc`.

Finally, the sleep and delay is not necessary from what I understand.

@mrocklin feel free to jump in if I misunderstood the intention of this test.


This test was added in https://github.com/dask/distributed/pull/1462