### PR TITLE
Expand user path for scheduler file

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -633,7 +633,7 @@ class Client:
         self.status = "newly-created"
         self._pending_msg_buffer = []
         self.extensions = {}
-        self.scheduler_file = scheduler_file
+        self.scheduler_file = os.path.expanduser(scheduler_file)
         self._startup_kwargs = kwargs
         self.cluster = None
         self.scheduler = None

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3788,11 +3788,12 @@ class Scheduler(SchedulerState, ServerNode):
         self.loop.add_callback(self.reevaluate_occupancy)
 
         if self.scheduler_file:
-            with open(self.scheduler_file, "w") as f:
+            fn = os.path.expanduser(self.scheduler_file)
+
+            with open(fn, "w") as f:
                 json.dump(self.identity(), f, indent=2)
 
-            fn = self.scheduler_file  # remove file when we close the process
-
+            # remove file when we close the process
             def del_scheduler_file():
                 if os.path.exists(fn):
                     os.remove(fn)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -972,6 +972,7 @@ def nbytes(frame, _bytes_like=(bytes, bytearray)):
 
 def json_load_robust(fn, load=json.load):
     """Reads a JSON file from disk that may be being written as we read"""
+    fn = os.path.expanduser(fn)
     while not os.path.exists(fn):
         sleep(0.01)
     for i in range(10):


### PR DESCRIPTION
- [x] Closes #5072
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Expand user if something like `~/scheduler.json` is passed to `scheduler_file`.

I haven't added tests for this because I didn't want to create files in the user home directory as a side effect of testing. Open to suggestions on how to test this.