### PR TITLE
Log exitcode when restarting worker

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -465,7 +465,9 @@ class Nanny(ServerNode):
                 Status.closing_gracefully,
             ):
                 if self.auto_restart:
-                    logger.warning("Restarting worker")
+                    logger.warning(
+                        f"Restarting worker: worker exited with exitcode '{exitcode}'"
+                    )
                     await self.instantiate()
             elif self.status == Status.closing_gracefully:
                 await self.close()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -639,7 +639,7 @@ class WorkerProcess:
             assert r is not None
             if r != 0:
                 msg = self._death_message(self.process.pid, r)
-                logger.warn(msg)
+                logger.warning(msg)
             self.status = Status.stopped
             self.stopped.set()
             # Release resources

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -465,9 +465,7 @@ class Nanny(ServerNode):
                 Status.closing_gracefully,
             ):
                 if self.auto_restart:
-                    logger.warning(
-                        f"Restarting worker: worker exited with exitcode '{exitcode}'"
-                    )
+                    logger.warning("Restarting worker")
                     await self.instantiate()
             elif self.status == Status.closing_gracefully:
                 await self.close()
@@ -641,7 +639,7 @@ class WorkerProcess:
             assert r is not None
             if r != 0:
                 msg = self._death_message(self.process.pid, r)
-                logger.info(msg)
+                logger.warn(msg)
             self.status = Status.stopped
             self.stopped.set()
             # Release resources

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -566,7 +566,7 @@ async def test_failure_during_worker_initialization(cleanup):
 
 
 def _exitcode_tester(_):
-    if get_worker().name != 0:
+    if get_worker().name == 0:
         sys.exit(1)
     return 1
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -571,6 +571,9 @@ def _exitcode_tester(_):
     return 1
 
 
+@pytest.mark.skipif(
+    WINDOWS, reason="sys.exit(1) kills the entire pytest process on windows"
+)
 @gen_cluster(client=True, Worker=Nanny)
 async def test_warn_exitcode(client, scheduler, worker_a, worker_b):
     with captured_logger("distributed.nanny", logging.WARNING) as log:


### PR DESCRIPTION
- [x] towards #5082
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

I created a test but `caplog` doesn't receive any logged events. When I run `pytest -s` I see that the correct message is being logged.