### PR TITLE
Actor futures for as_completed

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -250,13 +250,13 @@ class ActorFuture:
         if not hasattr(self, "_cached_result"):
             out = await self.q.get()
             if out["status"] == "OK":
+                self.status = "finished"
                 self._cached_result = out["result"]
             else:
+                self.status = "error"
                 self._cached_result = out["exception"]
-        if isinstance(self._cached_result, Exception):
-            self.status = "error"
+        if self.status == "error":
             raise self._cached_result
-        self.status = "finished"
         return self._cached_result
 
     def result(self, timeout=None):

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -246,6 +246,9 @@ class ActorFuture:
     def __await__(self):
         return self.result()
 
+    def done(self):
+        return self.status != "pending"
+
     async def _result(self, raiseit=True):
         if not hasattr(self, "_cached_result"):
             out = await self.q.get()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4405,9 +4405,11 @@ class as_completed:
         """Add multiple futures to the collection.
 
         The added futures will emit from the iterator once they finish"""
+        from .actor import ActorFuture
+
         with self.lock:
             for f in futures:
-                if not isinstance(f, Future):
+                if not isinstance(f, (Future, ActorFuture)):
                     raise TypeError("Input must be a future, got %s" % f)
                 self.futures[f] += 1
                 self.loop.add_callback(self._track_future, f)

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -636,23 +636,16 @@ async def test_exception_async(client, s, a, b):
 
 
 def test_as_completed(client):
-    class Simple:
-        state = 0
-
-        def inc(self):
-            self.state += 1
-            return self.state
-
-    ac = client.submit(Simple, actor=True).result()
-    futs = [ac.inc() for _ in range(10)]
+    ac = client.submit(Counter, actor=True).result()
+    futures = [ac.increment() for _ in range(10)]
     max = 0
 
-    for fut in as_completed(futs):
-        value = fut.result()
+    for future in as_completed(futures):
+        value = future.result()
         if value > max:
             max = value
 
-    assert all(fut.done() for fut in futs)
+    assert all(future.done() for future in futures)
     assert max == 10
 
 

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -649,6 +649,18 @@ def test_as_completed(client):
     assert max == 10
 
 
+@gen_cluster(client=True, timeout=3)
+async def test_actor_future_awaitable(client, s, a, b):
+    ac = await client.submit(Counter, actor=True)
+    futures = [ac.increment() for _ in range(10)]
+
+    assert all([isinstance(future, ActorFuture) for future in futures])
+
+    out = await asyncio.gather(*futures)
+    assert all([future.done() for future in futures])
+    assert max(out) == 10
+
+
 @gen_cluster(client=True)
 async def test_serialize_with_pickle(c, s, a, b):
     class Foo:


### PR DESCRIPTION
- [x] Closes #5077
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Fixes the OP example, coded as below. This leaves the following edges:
- ActorFutures don't work with `client.gather()`, but this would be a very nice
- if the future results are not called, some cleanup at exit causes `OSError("Unable to contact Actor's worker")`

```python
import os
import platform
import random
import time
from distributed import Client, get_worker, as_completed


class Actor:
    def __init__(self, actor_id):
        self.actor_id = actor_id
        self.pid = os.getpid()
        self.hostname = platform.node()
        self.worker = get_worker().address

    def ping(self, msg=None):
        print(f"{self.actor_id} {self.pid} {self.hostname} {self.worker} {time.time()} - ping {msg or ''}")
        time.sleep(random.randint(1, 3))
        return self.actor_id


def main(client):
    anames = ["actor1", "actor2", "actor3", "actor4", "actor5"]
    afuts = [client.submit(Actor, a, actor=True) for a in anames]
    actors = {name: a for name, a in zip(anames, client.gather(afuts))}
    futs = [a.ping() for a in actors.values()]
    checks = []
    for res in as_completed(futs):
        pong = res.result()
        print(f"pong - {pong}")
        check = actors[pong].ping("Second")
        checks.append(check)
    for res in as_completed(checks):
        res.result()


if __name__ == "__main__":
    with Client() as client:
        main(client)
```

