### PR TITLE
Collapse nav to hamburger sooner

### DIFF
--- a/distributed/http/static/css/base.css
+++ b/distributed/http/static/css/base.css
@@ -73,7 +73,7 @@ body {
   height: 22px;
 }
 
-@media screen and (max-width: 650px) {
+@media screen and (max-width: 800px) {
   .navbar li:not(#dask-logo):not(#navbar-toggle-icon) a {
     display: none;
   }
@@ -82,7 +82,7 @@ body {
   }
 }
 
-@media screen and (max-width: 650px) {
+@media screen and (max-width: 800px) {
   .navbar.responsive li:not(#navbar-toggle-icon) {
     float: none;
   }


### PR DESCRIPTION
I noticed this while looking at https://github.com/dask/distributed/issues/5089. Since there are more items in the nav, seems like a we should collapse them before they spill to the next line:

This PR: 
![Screenshot from 2021-07-19 17-19-37](https://user-images.githubusercontent.com/4806877/126230755-9c2685ad-e0d3-4e04-8438-97c668b09f81.png)
![Screenshot from 2021-07-19 17-19-52](https://user-images.githubusercontent.com/4806877/126230761-315a9bd6-cec4-42be-b3b3-5c37c7e2f4ac.png)
