### PR TITLE
Increase robustness to TimeoutError during connect

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -297,9 +297,11 @@ async def connect(
         except (asyncio.TimeoutError, OSError) as exc:
             active_exception = exc
 
-            # The intermediate capping is mostly relevant for the initial
-            # connect. Afterwards we should be more forgiving
-            intermediate_cap = intermediate_cap * 1.5
+            # As descibed above, the intermediate timeout is used to distributed
+            # initial, bulk connect attempts homogeneously. In particular with
+            # the jitter upon retries we should not be worred about overloading
+            # any more DNS servers
+            intermediate_cap = timeout
             # FullJitter see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 
             upper_cap = min(time_left(), backoff_base * (2 ** attempt))


### PR DESCRIPTION
This intermediate cap is very aggressive and I believe this causes instabilities. We should be more forgiving. The initial intermediate cap is intended to account for slow or flaky DNS servers and I believe removing this artificial intermediate cap is safe since we have a backoff and jitter.

There have been lengthy discussions around the intermediate cap on https://github.com/dask/distributed/pull/4176

see also 
- https://github.com/dask/distributed/pull/4167
- https://github.com/dask/distributed/pull/3104

cc @jacobtomlinson @jcrist @gjoseph92 

This might close https://github.com/dask/distributed/issues/5095