### PR TITLE
🛑  DNM Deserialization: zero-copy merge subframes when possible

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -210,13 +210,14 @@ class TCP(Comm):
             raise
         else:
             try:
-                frames = unpack_frames(frames)
+                prelude_size, frames = unpack_frames(frames)
 
                 msg = await from_frames(
                     frames,
                     deserialize=self.deserialize,
                     deserializers=deserializers,
                     allow_offload=self.allow_offload,
+                    memoryview_offset=prelude_size,
                 )
             except EOFError:
                 # Frames possibly garbled or truncated by communication error

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -50,16 +50,29 @@ async def to_frames(
         return _to_frames()
 
 
-async def from_frames(frames, deserialize=True, deserializers=None, allow_offload=True):
+async def from_frames(
+    frames,
+    deserialize=True,
+    deserializers=None,
+    allow_offload=True,
+    memoryview_offset: int = 0,
+):
     """
     Unserialize a list of Distributed protocol frames.
+
+    When ``frames`` contains memoryviews that share an underlying buffer,
+    ``memoryview_offset`` must be the index into that underlying buffer
+    where the ``frames`` start (in bytes, not frame counts).
     """
     size = False
 
     def _from_frames():
         try:
             return protocol.loads(
-                frames, deserialize=deserialize, deserializers=deserializers
+                frames,
+                deserialize=deserialize,
+                deserializers=deserializers,
+                memoryview_offset=memoryview_offset,
             )
         except EOFError:
             if size > 1000:

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -108,7 +108,7 @@ def loads(frames, deserialize=True, deserializers=None):
                     if sub_frames and isinstance(sub_frames[0], memoryview):
                         obj = sub_frames[0].obj
                         for f in reversed(frames[:offset]):
-                            if not (isinstance(f, memoryview) and f.obj is obj):
+                            if not isinstance(f, memoryview) or f.obj is not obj:
                                 break
                             memoryview_offset += len(f)
 

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -101,9 +101,9 @@ def loads(frames, deserialize=True, deserializers=None):
                     if "compression" in sub_header:
                         sub_frames = decompress(sub_header, sub_frames)
 
-                    # HACK: check for memoryviews in preceding frames that share an underlying
-                    # buffer with these sub-frames, to figure out what offset in the underlying
-                    # buffer the sub-frames start at.
+                    # Check for memoryviews in preceding frames that share an underlying
+                    # buffer with these sub-frames, to figure out what offset in that buffer
+                    # `sub_frames` starts at.
                     memoryview_offset = 0
                     if sub_frames and isinstance(sub_frames[0], memoryview):
                         obj = sub_frames[0].obj

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -11,7 +11,7 @@ from .serialize import (
     msgpack_encode_default,
     serialize_and_split,
 )
-from .utils import msgpack_opts
+from .utils import copy_frames, msgpack_opts
 
 logger = logging.getLogger(__name__)
 
@@ -119,16 +119,8 @@ def loads(frames, deserialize=True, deserializers=None, memoryview_offset: int =
                                     # If given an initial offset for `frames[0]`, but we're working with a different
                                     # buffer, something is wrong. We don't know if there's an initial offset for this buffer too,
                                     # so to be safe, copy all sub-frames to new memory to prevent faulty zero-copy deserialization.
-                                    subframe_buffer = memoryview(b"".join(sub_frames))
-                                    i = 0
-                                    new_subframes = []
-                                    for frame in sub_frames:
-                                        new_subframes.append(
-                                            subframe_buffer[i : i + len(frame)]
-                                        )
-                                        i += len(frame)
+                                    sub_frames = copy_frames(sub_frames)
                                     subframe_memoryview_offset = 0
-
                                 break
                             subframe_memoryview_offset += len(f)
 

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -11,7 +11,7 @@ from .serialize import (
     msgpack_encode_default,
     serialize_and_split,
 )
-from .utils import copy_frames, msgpack_opts
+from .utils import msgpack_opts
 
 logger = logging.getLogger(__name__)
 
@@ -115,12 +115,10 @@ def loads(frames, deserialize=True, deserializers=None, memoryview_offset: int =
                             if not isinstance(f, memoryview) or f.obj is not obj:
                                 # Walking backwards from the start of `sub_frames`, reached a frame that doesn't
                                 # belong to the same memoryview
-                                if memoryview_offset != 0:
-                                    # If given an initial offset for `frames[0]`, but we're working with a different
-                                    # buffer, something is wrong. We don't know if there's an initial offset for this buffer too,
-                                    # so to be safe, copy all sub-frames to new memory to prevent faulty zero-copy deserialization.
-                                    sub_frames = copy_frames(sub_frames)
-                                    subframe_memoryview_offset = 0
+                                assert memoryview_offset == 0, (
+                                    f"Given an initial offset of {memoryview_offset} into the frames' underlying buffer "
+                                    "but the frames are backed by multiple buffers. This should not happen."
+                                )
                                 break
                             subframe_memoryview_offset += len(f)
 

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -115,20 +115,10 @@ def loads(frames, deserialize=True, deserializers=None, memoryview_offset: int =
                             if not isinstance(f, memoryview) or f.obj is not obj:
                                 # Walking backwards from the start of `sub_frames`, reached a frame that doesn't
                                 # belong to the same memoryview
-                                if memoryview_offset != 0:
-                                    # If given an initial offset for `frames[0]`, but we're working with a different
-                                    # buffer, something is wrong. We don't know if there's an initial offset for this buffer too,
-                                    # so to be safe, copy all sub-frames to new memory to prevent faulty zero-copy deserialization.
-                                    subframe_buffer = memoryview(b"".join(sub_frames))
-                                    i = 0
-                                    new_subframes = []
-                                    for frame in sub_frames:
-                                        new_subframes.append(
-                                            subframe_buffer[i : i + len(frame)]
-                                        )
-                                        i += len(frame)
-                                    subframe_memoryview_offset = 0
-
+                                assert memoryview_offset == 0, (
+                                    f"Given an initial offset of {memoryview_offset} into the frames' underlying buffer "
+                                    "but the frames are backed by multiple buffers. This should not happen."
+                                )
                                 break
                             subframe_memoryview_offset += len(f)
 

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -101,7 +101,11 @@ def loads(frames, deserialize=True, deserializers=None):
                     if "compression" in sub_header:
                         sub_frames = decompress(sub_header, sub_frames)
                     return merge_and_deserialize(
-                        sub_header, sub_frames, deserializers=deserializers
+                        sub_header,
+                        sub_frames,
+                        deserializers=deserializers,
+                        memoryview_offset=sum(len(f) for f in frames[:offset]),
+                        # ^ TODO: what if not all frames are memoryviews?
                     )
                 else:
                     return Serialized(sub_header, sub_frames)

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -459,7 +459,7 @@ def merge_and_deserialize(header, frames, deserializers=None, memoryview_offset=
 
     When ``frames`` contains memoryviews that share an underlying buffer,
     ``memoryview_offset`` must be the index into that underlying buffer
-    where the ``frames`` starts (in bytes, not frame counts).
+    where the ``frames`` start (in bytes, not frame counts).
 
     See Also
     --------

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -485,7 +485,6 @@ def merge_and_deserialize(header, frames, deserializers=None, memoryview_offset=
                     + (frame_byte_offsets[offset - 1] if offset else 0),
                 )
             merged_frames.append(merged)
-            memoryview_offset += len(merged)
 
     return deserialize(header, merged_frames, deserializers=deserializers)
 
@@ -637,7 +636,7 @@ def serialize_bytes(x, **kwargs):
 
 
 def deserialize_bytes(b):
-    frames = unpack_frames(b)
+    prelude_size, frames = unpack_frames(b)
     header, frames = frames[0], frames[1:]
     header_bytes = len(header)
     if header:
@@ -645,7 +644,9 @@ def deserialize_bytes(b):
     else:
         header = {}
     frames = decompress(header, frames)
-    return merge_and_deserialize(header, frames, memoryview_offset=header_bytes)
+    return merge_and_deserialize(
+        header, frames, memoryview_offset=prelude_size + header_bytes
+    )
 
 
 ################################

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -639,12 +639,13 @@ def serialize_bytes(x, **kwargs):
 def deserialize_bytes(b):
     frames = unpack_frames(b)
     header, frames = frames[0], frames[1:]
+    header_bytes = len(header)
     if header:
         header = msgpack.loads(header, raw=False, use_list=False)
     else:
         header = {}
     frames = decompress(header, frames)
-    return merge_and_deserialize(header, frames)
+    return merge_and_deserialize(header, frames, memoryview_offset=header_bytes)
 
 
 ################################

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import itertools
 import traceback
@@ -489,8 +491,8 @@ def merge_and_deserialize(header, frames, deserializers=None, memoryview_offset=
 
 
 def merge_subframes(
-    subframes: "list[memoryview | bytearray | bytes]", memoryview_offset: int = 0
-) -> "memoryview | bytearray":
+    subframes: list[memoryview | bytearray | bytes], memoryview_offset: int = 0
+) -> memoryview | bytearray:
     """Merge a list of frames into one buffer.
 
     If all frames are memoryviews backed by the same underlying buffer,

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -454,8 +454,12 @@ def serialize_and_split(
 def merge_and_deserialize(header, frames, deserializers=None, memoryview_offset=0):
     """Merge and deserialize frames
 
-    This function is a drop-in replacement of `deserialize()` that merges
-    frames that were split by `serialize_and_split()`
+    This function is a replacement for `deserialize()` that merges
+    frames that were split by `serialize_and_split()`.
+
+    When ``frames`` contains memoryviews that share an underlying buffer,
+    ``memoryview_offset`` must be the index into that underlying buffer
+    where the ``frames`` starts (in bytes, not frame counts).
 
     See Also
     --------
@@ -467,7 +471,6 @@ def merge_and_deserialize(header, frames, deserializers=None, memoryview_offset=
     if "split-num-sub-frames" not in header:
         merged_frames = frames
     else:
-        # TODO delay until there's a multi-frame section?
         frame_byte_offsets = list(itertools.accumulate(map(len, frames)))
         for n, offset in zip(header["split-num-sub-frames"], header["split-offsets"]):
             if n == 1:

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -185,11 +185,13 @@ def test_dumps_serialize_numpy_large():
     frames = dumps([to_serialize(x)])
     dtype, shape = x.dtype, x.shape
     checksum = crc32(x)
-    del x
     [y] = loads(frames)
 
     assert (y.dtype, y.shape) == (dtype, shape)
     assert crc32(y) == checksum, "Arrays are unequal"
+
+    x[:] = 2  # shared buffer; serialization is zero-copy
+    assert (x == y).all(), "Data was copied"
 
 
 @pytest.mark.parametrize(

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -1,6 +1,4 @@
-import pytest
-
-from distributed.protocol.utils import copy_frames, pack_frames, unpack_frames
+from distributed.protocol.utils import pack_frames, unpack_frames
 
 
 def test_pack_frames():
@@ -11,26 +9,3 @@ def test_pack_frames():
 
     assert frames == frames2
     assert prelude_size == len(b) - sum(len(x) for x in frames)
-
-
-@pytest.mark.parametrize(
-    "frames",
-    [
-        [],
-        [b"123"],
-        [b"123", b"asdf"],
-        [memoryview(b"abcd")[1:], b"x", memoryview(b"12345678")],
-    ],
-)
-def test_copy_frames(frames):
-    new = copy_frames(frames)
-    assert [bytes(f) for f in new] == [bytes(x) for x in frames]
-    assert all(isinstance(f, memoryview) for f in new)
-    if frames:
-        new_buffers = set(f.obj for f in new)
-        assert len(new_buffers) == 1
-        if len(frames) != 1 and not isinstance(frames[0], bytes):
-            # `b"".join([b"123"])` is zero-copy. We are okay allowing this optimization.
-            assert not new_buffers.intersection(
-                f.obj if isinstance(f, memoryview) else f for f in frames
-            )

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -1,4 +1,6 @@
-from distributed.protocol.utils import pack_frames, unpack_frames
+import pytest
+
+from distributed.protocol.utils import copy_frames, pack_frames, unpack_frames
 
 
 def test_pack_frames():
@@ -9,3 +11,26 @@ def test_pack_frames():
 
     assert frames == frames2
     assert prelude_size == len(b) - sum(len(x) for x in frames)
+
+
+@pytest.mark.parametrize(
+    "frames",
+    [
+        [],
+        [b"123"],
+        [b"123", b"asdf"],
+        [memoryview(b"abcd")[1:], b"x", memoryview(b"12345678")],
+    ],
+)
+def test_copy_frames(frames):
+    new = copy_frames(frames)
+    assert [bytes(f) for f in new] == [bytes(x) for x in frames]
+    assert all(isinstance(f, memoryview) for f in new)
+    if frames:
+        new_buffers = set(f.obj for f in new)
+        assert len(new_buffers) == 1
+        if len(frames) != 1 and not isinstance(frames[0], bytes):
+            # `b"".join([b"123"])` is zero-copy. We are okay allowing this optimization.
+            assert not new_buffers.intersection(
+                f.obj if isinstance(f, memoryview) else f for f in frames
+            )

--- a/distributed/protocol/tests/test_protocol_utils.py
+++ b/distributed/protocol/tests/test_protocol_utils.py
@@ -5,6 +5,7 @@ def test_pack_frames():
     frames = [b"123", b"asdf"]
     b = pack_frames(frames)
     assert isinstance(b, bytes)
-    frames2 = unpack_frames(b)
+    prelude_size, frames2 = unpack_frames(b)
 
     assert frames == frames2
+    assert prelude_size == len(b) - sum(len(x) for x in frames)

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -59,7 +59,9 @@ def unpack_frames(b):
     """Unpack bytes into a sequence of frames
 
     This assumes that length information is at the front of the bytestring,
-    as performed by pack_frames
+    as performed by pack_frames.
+    Returns the number of bytes in that length information header, and a list
+    of frames as zero-copy memoryview objects into ``b``.
 
     See Also
     --------
@@ -74,10 +76,10 @@ def unpack_frames(b):
     lengths = struct.unpack_from(f"{n_frames}{fmt}", b, fmt_size)
 
     frames = []
-    start = fmt_size * (1 + n_frames)
+    start = prelude_size = fmt_size * (1 + n_frames)
     for length in lengths:
         end = start + length
         frames.append(b[start:end])
         start = end
 
-    return frames
+    return prelude_size, frames

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -83,3 +83,17 @@ def unpack_frames(b):
         start = end
 
     return prelude_size, frames
+
+
+def copy_frames(frames):
+    """Copy frames into new contiguous memory.
+
+    Returns a duplicate frames list of memoryviews referencing the new memory.
+    """
+    buffer = memoryview(b"".join(frames))
+    i = 0
+    new_frames = []
+    for frame in frames:
+        new_frames.append(buffer[i : i + len(frame)])
+        i += len(frame)
+    return new_frames

--- a/distributed/protocol/utils.py
+++ b/distributed/protocol/utils.py
@@ -83,17 +83,3 @@ def unpack_frames(b):
         start = end
 
     return prelude_size, frames
-
-
-def copy_frames(frames):
-    """Copy frames into new contiguous memory.
-
-    Returns a duplicate frames list of memoryviews referencing the new memory.
-    """
-    buffer = memoryview(b"".join(frames))
-    i = 0
-    new_frames = []
-    for frame in frames:
-        new_frames.append(buffer[i : i + len(frame)])
-        i += len(frame)
-    return new_frames


### PR DESCRIPTION
When merging sub-frames before deserializing, if all the sub-frames are memoryviews backed by the same underlying buffer, "merge" them without copying by making a new memoryview pointing to the same buffer, instead of always copying.

Running @crusaderky's reproducer from https://github.com/dask/distributed/issues/5107 on `main`:
![before](https://user-images.githubusercontent.com/3309802/126837980-978cc99b-7ca6-44d5-9f91-0878e89bff8f.gif)
With this PR:
![after](https://user-images.githubusercontent.com/3309802/126837983-a4e08a6b-c73e-47a1-9ddd-c206be884ba9.gif)

Thinking more about my comment https://github.com/dask/distributed/issues/5107#issuecomment-885227654 (tldr: is copying unavoidable because we have to convert non-contiguous memory into contiguous memory?), I realized that in many cases, all the frames already _are_ in contiguous memory thanks to https://github.com/dask/distributed/pull/4506, and they're also zero-copy memoryviews thanks to https://github.com/dask/distributed/pull/3980 (go @jakirkham!). So merging frames in that case could become a bookkeeping operation, where we just make a view of the buffer spanning all the sub-frames we want to merge.

This appears to work but also feels hacky/brittle to me. It requires calculating and passing down offsets into the underlying buffer, and kinda makes some assumptions about how the chain of calling functions works. I might prefer:
* Reorganizing the functions such that [`unpack_frames`](https://github.com/gjoseph92/distributed/blob/1869b1899f690b7556db0a463bc639322ede548e/distributed/protocol/utils.py#L58-L83) also handles merging frames, since we already have the original buffer and all of the offsets we need there. However, that would require deserializing headers within `unpack_frames`, which is probably just as much of a mess.
* A wrapper class for `memoryview` that tracks its index when sliced, and logic to merge those. I think we'd have to write this in C/Cython though, otherwise it wouldn't expose the buffer protocol.
* Some way to get the index/slice a `memoryview` object is pointing to within its buffer. But I believe there's no Python API for this.

cc @madsbk

- [x] Closes #5107
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
