### PR TITLE
Short-circuit root-ish check for many deps

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2485,6 +2485,7 @@ class SchedulerState:
         if (
             valid_workers is None
             and len(group) > self._total_nthreads * 2
+            and len(group._dependencies) < 5
             and sum(map(len, group._dependencies)) < 5
         ):
             ws: WorkerState = group._last_worker


### PR DESCRIPTION
While looking into https://github.com/dask/distributed/issues/5083 I happened to notice that the dashboard felt very sluggish. I profiled with py-spy and discovered that the scheduler was spending 20% of runtime calculaing `sum(map(len, group._dependencies)) < 5`! A quick print statement showed some task groups depended on 25,728 other groups (each of size 1). We can easily skip those.

I originally had this conditional in the PR but we removed it for simplicity: https://github.com/dask/distributed/pull/4967#discussion_r661479904; turns out it was relevant after all!

<img width="1361" alt="Screen Shot 2021-07-23 at 3 27 20 PM" src="https://user-images.githubusercontent.com/3309802/126850491-14c02a6b-7acc-4495-ad78-fc8623f9f968.png">

FYI @d-v-b this solves your performance regression from https://github.com/dask/distributed/issues/5083.

cc @mrocklin @jrbourbeau 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
