### PR TITLE
Add NannyPlugins

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -23,6 +23,7 @@ from .core import Status, connect, rpc
 from .deploy import Adaptive, LocalCluster, SpecCluster, SSHCluster
 from .diagnostics.plugin import (
     Environ,
+    NannyPlugin,
     PipInstall,
     SchedulerPlugin,
     UploadDirectory,

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -21,7 +21,14 @@ from .client import (
 )
 from .core import Status, connect, rpc
 from .deploy import Adaptive, LocalCluster, SpecCluster, SSHCluster
-from .diagnostics.plugin import Environ, PipInstall, SchedulerPlugin, WorkerPlugin
+from .diagnostics.plugin import (
+    Environ,
+    PipInstall,
+    SchedulerPlugin,
+    UploadDirectory,
+    UploadFile,
+    WorkerPlugin,
+)
 from .diagnostics.progressbar import progress
 from .event import Event
 from .lock import Lock

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -21,7 +21,7 @@ from .client import (
 )
 from .core import Status, connect, rpc
 from .deploy import Adaptive, LocalCluster, SpecCluster, SSHCluster
-from .diagnostics.plugin import PipInstall, SchedulerPlugin, WorkerPlugin
+from .diagnostics.plugin import Environ, PipInstall, SchedulerPlugin, WorkerPlugin
 from .diagnostics.progressbar import progress
 from .event import Event
 from .lock import Lock

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4132,12 +4132,14 @@ class Client:
 
         Parameters
         ----------
-        plugin : WorkerPlugin
-            The plugin object to pass to the workers
+        plugin : WorkerPlugin or NannyPlugin
+            The plugin object to register.
         name : str, optional
             A name for the plugin.
             Registering a plugin with the same name will have no effect.
             If plugin has no name attribute a random name is used.
+        nanny : bool, optional
+            Whether to register the plugin with workers or nannies.
         **kwargs : optional
             If you pass a class as the plugin, instead of a class instance, then the
             class will be instantiated with any extra keyword arguments.

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4199,7 +4199,7 @@ class Client:
                 raise exc.with_traceback(tb)
         return responses
 
-    def unregister_worker_plugin(self, name):
+    def unregister_worker_plugin(self, name, nanny=None):
         """Unregisters a lifecycle worker plugin
 
         This unregisters an existing worker plugin. As part of the unregistration process
@@ -4233,7 +4233,7 @@ class Client:
         --------
         register_worker_plugin
         """
-        return self.sync(self._unregister_worker_plugin, name=name)
+        return self.sync(self._unregister_worker_plugin, name=name, nanny=nanny)
 
 
 class _WorkerSetupPlugin(WorkerPlugin):

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -198,7 +198,6 @@ class NannyPlugin:
     """
 
     restart = False
-    
 
     def setup(self, nanny):
         """
@@ -352,8 +351,6 @@ class UploadDirectory(NannyPlugin):
     >>> client.register_worker_plugin(UploadFile("/path/to/file.py"))  # doctest: +SKIP
     """
 
-    name = "upload_directory"
-
     def __init__(
         self,
         path,
@@ -369,6 +366,8 @@ class UploadDirectory(NannyPlugin):
         self.path = os.path.split(path)[-1]
         self.restart = restart
         self.update_path = update_path
+
+        self.name = "upload-directory-" + os.path.split(path)[-1]
 
         with tmpfile(extension="zip") as fn:
             with zipfile.ZipFile(fn, "w", zipfile.ZIP_DEFLATED) as z:

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -389,7 +389,7 @@ class UploadDirectory(NannyPlugin):
                 self.data = f.read()
 
     async def setup(self, nanny):
-        fn = os.path.join(nanny.local_directory, "tmp.zip")  # TODO: add random suffix
+        fn = os.path.join(nanny.local_directory, f"tmp-{str(uuid.uuid4())}.zip")
         with open(fn, "wb") as f:
             f.write(self.data)
 

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -355,7 +355,7 @@ class UploadDirectory(NannyPlugin):
         path,
         restart=False,
         update_path=False,
-        skip_words=(".git", ".github", ".pytest_cache", "tests"),
+        skip_words=(".git", ".github", ".pytest_cache", "tests", "docs"),
         skip=(lambda fn: os.path.splitext(fn)[1] == ".pyc",),
     ):
         """
@@ -379,7 +379,6 @@ class UploadDirectory(NannyPlugin):
                     archive_name = os.path.relpath(
                         os.path.join(root, file), os.path.join(path, "..")
                     )
-                    print(filename, archive_name)
                     z.write(filename, archive_name)
 
         with open("tmp.zip", "rb") as f:

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -186,10 +186,11 @@ class NannyPlugin:
 
     To implement a plugin implement some of the methods of this class and register
     the plugin to your client in order to have it attached to every existing and
-    future workers with ``Client.register_nanny_plugin``.
+    future nanny by passing ``nanny=True`` to
+    :meth:`Client.register_worker_plugin<distributed.Client.register_worker_plugin>`.
 
-    The attribute `restart` is used to control whether or not a running Worker needs
-    to be restarted when registering the plugin.
+    The ``restart`` attribute is used to control whether or not a running ``Worker``
+    needs to be restarted when registering the plugin.
 
     See Also
     --------
@@ -201,13 +202,13 @@ class NannyPlugin:
 
     def setup(self, nanny):
         """
-        Run when the plugin is attached to a worker. This happens when the plugin is registered
-        and attached to existing workers, or when a worker is created after the plugin has been
+        Run when the plugin is attached to a nanny. This happens when the plugin is registered
+        and attached to existing nannies, or when a nanny is created after the plugin has been
         registered.
         """
 
     def teardown(self, nanny):
-        """Run when the worker to which the plugin is attached to is closed"""
+        """Run when the nanny to which the plugin is attached to is closed"""
 
 
 def _get_worker_plugin_name(plugin) -> str:
@@ -337,18 +338,17 @@ class Environ(NannyPlugin):
 
 
 class UploadDirectory(NannyPlugin):
-    """A WorkerPlugin to upload a local file to workers.
+    """A NannyPlugin to upload a local file to workers.
 
     Parameters
     ----------
-    filepath: str
-        A path to the file (.py, egg, or zip) to upload
+    path: str
+        A path to the directory to upload
 
     Examples
     --------
-    >>> from distributed.diagnostics.plugin import UploadFile
-
-    >>> client.register_worker_plugin(UploadFile("/path/to/file.py"))  # doctest: +SKIP
+    >>> from distributed.diagnostics.plugin import UploadDirectory
+    >>> client.register_worker_plugin(UploadDirectory("/path/to/directory"), nanny=True)  # doctest: +SKIP
     """
 
     def __init__(

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -97,7 +97,6 @@ class Nanny(ServerNode):
         port=None,
         protocol=None,
         config=None,
-        plugins=(),
         **worker_kwargs,
     ):
         self._setup_logging(logger)
@@ -209,7 +208,6 @@ class Nanny(ServerNode):
         }
 
         self.plugins = {}
-        self._pending_plugins = plugins
 
         super().__init__(
             handlers=handlers, io_loop=self.loop, connection_args=self.connection_args
@@ -303,11 +301,6 @@ class Nanny(ServerNode):
 
         for preload in self.preloads:
             await preload.start()
-
-        await asyncio.gather(
-            *[self.plugin_add(plugin=plugin) for plugin in self._pending_plugins]
-        )
-        self._pending_plugins = ()
 
         if not os.path.exists(self.local_directory):
             os.makedirs(self.local_directory, exist_ok=True)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -114,14 +114,14 @@ class Nanny(ServerNode):
 
         if local_directory is None:
             local_directory = dask.config.get("temporary-directory") or os.getcwd()
-            if not os.path.exists(local_directory):
-                os.makedirs(local_directory)
             self._original_local_dir = local_directory
             local_directory = os.path.join(local_directory, "dask-worker-space")
         else:
             self._original_local_dir = local_directory
 
         self.local_directory = local_directory
+        if not os.path.exists(self.local_directory):
+            os.makedirs(self.local_directory, exist_ok=True)
 
         self.preload = preload
         if self.preload is None:
@@ -301,9 +301,6 @@ class Nanny(ServerNode):
 
         for preload in self.preloads:
             await preload.start()
-
-        if not os.path.exists(self.local_directory):
-            os.makedirs(self.local_directory, exist_ok=True)
 
         msg = await self.scheduler.register_nanny()
         for name, plugin in msg["nanny-plugins"].items():

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -409,24 +409,21 @@ class Nanny(ServerNode):
 
             assert name
 
-            if name in self.plugins:
-                return {"status": "repeat"}
-            else:
-                self.plugins[name] = plugin
+            self.plugins[name] = plugin
 
-                logger.info("Starting Nanny plugin %s" % name)
-                if hasattr(plugin, "setup"):
-                    try:
-                        result = plugin.setup(nanny=self)
-                        if isawaitable(result):
-                            result = await result
-                    except Exception as e:
-                        msg = error_message(e)
-                        return msg
-                if getattr(plugin, "restart", False):
-                    await self.restart()
+            logger.info("Starting Nanny plugin %s" % name)
+            if hasattr(plugin, "setup"):
+                try:
+                    result = plugin.setup(nanny=self)
+                    if isawaitable(result):
+                        result = await result
+                except Exception as e:
+                    msg = error_message(e)
+                    return msg
+            if getattr(plugin, "restart", False):
+                await self.restart()
 
-                return {"status": "OK"}
+            return {"status": "OK"}
 
     async def plugin_remove(self, comm=None, name=None):
         with log_errors(pdb=False):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -309,6 +309,9 @@ class Nanny(ServerNode):
         )
         self._pending_plugins = ()
 
+        if not os.path.exists(self.local_directory):
+            os.makedirs(self.local_directory, exist_ok=True)
+
         msg = await self.scheduler.register_nanny()
         for name, plugin in msg["nanny-plugins"].items():
             await self.plugin_add(plugin=plugin, name=name)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6921,6 +6921,9 @@ async def test_upload_directory(c, s, a, b, tmp_path):
     plugin = UploadDirectory(tmp_path, restart=True, update_path=True)
     await c.register_worker_plugin(plugin)
 
+    [name] = a.plugins
+    assert os.path.split(tmp_path)[-1] in name
+
     def f():
         import bar
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6927,3 +6927,7 @@ async def test_upload_directory(c, s, a, b, tmp_path):
     results = await c.run(f)
     assert results[a.worker_address] == 123
     assert results[b.worker_address] == 123
+
+    async with Nanny(s.address, local_directory=tmp_path / "foo", name="foo") as n:
+        results = await c.run(f)
+        assert results[n.worker_address] == 123

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6911,6 +6911,8 @@ async def test_computation_object_code_client_compute(c, s, a, b):
 async def test_upload_directory(c, s, a, b, tmp_path):
     from dask.distributed import UploadDirectory
 
+    files = set(os.listdir())
+
     with open(tmp_path / "foo.py", "w") as f:
         f.write("x = 123")
     with open(tmp_path / "bar.py", "w") as f:
@@ -6931,3 +6933,5 @@ async def test_upload_directory(c, s, a, b, tmp_path):
     async with Nanny(s.address, local_directory=tmp_path / "foo", name="foo") as n:
         results = await c.run(f)
         assert results[n.worker_address] == 123
+
+    assert files == set(os.listdir())  # no change

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6905,3 +6905,25 @@ async def test_computation_object_code_client_compute(c, s, a, b):
     assert len(comp.code) == 1
 
     assert comp.code[0] == test_function_code
+
+
+@gen_cluster(client=True, Worker=Nanny)
+async def test_upload_directory(c, s, a, b, tmp_path):
+    from dask.distributed import UploadDirectory
+
+    with open(tmp_path / "foo.py", "w") as f:
+        f.write("x = 123")
+    with open(tmp_path / "bar.py", "w") as f:
+        f.write("from foo import x")
+
+    plugin = UploadDirectory(tmp_path, restart=True, update_path=True)
+    await c.register_worker_plugin(plugin)
+
+    def f():
+        import bar
+
+        return bar.x
+
+    results = await c.run(f)
+    assert results[a.worker_address] == 123
+    assert results[b.worker_address] == 123

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -548,12 +548,12 @@ class BrokenWorker(worker.Worker):
         raise StartException("broken")
 
 
-@pytest.mark.asyncio
-async def test_worker_start_exception(cleanup):
+@gen_cluster(nthreads=[])
+async def test_worker_start_exception(s):
     # make sure this raises the right Exception:
     with pytest.raises(StartException):
-        async with Nanny("tcp://localhost:1", worker_class=BrokenWorker) as n:
-            await n.start()
+        async with Nanny(s.address, worker_class=BrokenWorker) as n:
+            pass
 
 
 @pytest.mark.asyncio

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -75,7 +75,7 @@ the scheduler as so:
        scheduler.add_plugin(plugin)
 
 Worker Plugins
-=================
+==============
 
 :class:`distributed.diagnostics.plugin.WorkerPlugin` provides a base class
 for creating your own worker plugins. In addition, Dask provides some
@@ -91,3 +91,17 @@ Built-In Worker Plugins
 
 .. autoclass:: distributed.diagnostics.plugin.PipInstall
 .. autoclass:: distributed.diagnostics.plugin.UploadFile
+
+
+Nanny Plugins
+=============
+
+.. autoclass:: distributed.diagnostics.plugin.NannyPlugin
+   :members:
+
+
+Built-In Nanny Plugins
+----------------------
+
+.. autoclass:: distributed.diagnostics.plugin.Environ
+.. autoclass:: distributed.diagnostics.plugin.UploadDirectory


### PR DESCRIPTION
This is like WorkerPlugin, but allows for code to run before the Worker
starts up.

Unfortunately this requires the Nanny to check in with the scheduler
before starting the Worker.  In principle this should be fast, but it
does delay the common case for the uncommon case.

This PR includes an Environ nanny-plugin.
If we go with this I think that we should move over PipInstall.
We might also move over UploadFile and make a new UploadDirectory

Fixes #5116 