### PR TITLE
Handle NVMLError_Unknown in NVML diagnostics

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -26,7 +26,11 @@ def init_once():
     nvmlOwnerPID = os.getpid()
     try:
         pynvml.nvmlInit()
-    except (pynvml.NVMLError_LibraryNotFound, pynvml.NVMLError_DriverNotLoaded):
+    except (
+        pynvml.NVMLError_LibraryNotFound,
+        pynvml.NVMLError_DriverNotLoaded,
+        pynvml.NVMLError_Unknown,
+    ):
         nvmlLibraryNotFound = True
 
 


### PR DESCRIPTION
Resolves another error reported in https://github.com/dask/distributed/issues/4965, where Distributed is running on `nvidia-docker` without GPUs installed.