### PR TITLE
Make `Pipinstall` plugin default name unique

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import uuid
 
+from dask.base import tokenize
 from dask.utils import funcname
 
 logger = logging.getLogger(__name__)
@@ -220,14 +221,16 @@ class PipInstall(WorkerPlugin):
     >>> client.register_worker_plugin(plugin)
     """
 
-    name = "pip"
-
     def __init__(self, packages, pip_options=None, restart=False):
         self.packages = packages
         self.restart = restart
         if pip_options is None:
             pip_options = []
         self.pip_options = pip_options
+
+    @property
+    def name(self):
+        return f"pipinstall-{tokenize(self.__dict__)}"
 
     async def setup(self, worker):
         from ..lock import Lock

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -225,5 +225,7 @@ async def test_PipInstall_name(c, s, w):
     x = PipInstall(packages=["foo"])
     y = PipInstall(packages=["foo", "bar"])
     z = PipInstall(packages=["foo", "bar"], restart=True)
-    assert all("pipinstall" in i.name for i in (x, y, z))
+    assert all("pipinstall" in p.name for p in (x, y, z))
+    for p in [x, y, z]:
+        assert p.name == p.name
     assert len(set([x.name, y.name, z.name])) == 3

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from distributed import Worker, WorkerPlugin
+from distributed import PipInstall, Worker, WorkerPlugin
 from distributed.utils_test import async_wait_for, gen_cluster, inc
 
 
@@ -218,3 +218,12 @@ async def test_default_name(c, s, w):
     await c.register_worker_plugin(MyCustomPlugin())
     assert len(w.plugins) == 1
     assert next(iter(w.plugins)).startswith("MyCustomPlugin-")
+
+
+@gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)
+async def test_PipInstall_name(c, s, w):
+    x = PipInstall(packages=["foo"])
+    y = PipInstall(packages=["foo", "bar"])
+    z = PipInstall(packages=["foo", "bar"], restart=True)
+    assert all("pipinstall" in i.name for i in (x, y, z))
+    assert len(set([x.name, y.name, z.name])) == 3


### PR DESCRIPTION
Currently the default name is `"pip"` which results in

```python
client.register_worker_plugin(PipInstall(packages=["foo"]))
client.register_worker_plugin(PipInstall(packages=["bar"]))
```

not registering the second plugin. This PR ensures a unique name is generated for `PipInstall` plugins which are installing different packages 