### PR TITLE
Fix a deadlock connected to task stealing and task deserialization

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2041,7 +2041,7 @@ async def test_process_executor(c, s, a, b):
         assert (await future) != os.getpid()
 
 
-def kill_yourself():
+def kill_process():
     import os
     import signal
 
@@ -2054,7 +2054,7 @@ async def test_process_executor_kills_process(c, s, a, b):
         a.executors["processes"] = e
         b.executors["processes"] = e
         with dask.annotate(executor="processes", retries=1):
-            future = c.submit(kill_yourself)
+            future = c.submit(kill_process)
 
         with pytest.raises(
             BrokenProcessPool,


### PR DESCRIPTION
If a task is stolen while the task runspec is being deserialized this allows
for an edge case where the executing_count is never decreased again
such that the ready queue is never worked off


The second commit refactors the Worker.execute exception handling a bit and covers everything in a single try/except. I removed the BaseException catch for the process pool since I do not think this is necessary. If users actually want to sys.exit who are we to judge? In real world examples if a process gets killed this is typically done by the OS using a signal like SIGINT or SIGTERM and for these situations the behaviour of such a processpool is actually quite different. the processpool ends up completely broken but I don't see anything we can do about this right now. See also https://github.com/dask/distributed/issues/5075


Closes https://github.com/dask/distributed/issues/5119

This issue is not a direct cause but this PR removes the only code path where the mentioned transition could even occur.