### PR TITLE
Worker Network Timeseries

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -817,7 +817,7 @@ class WorkerNetworkBandwidth(DashboardComponent):
 class WorkerNetworkBandwidthTimeseries(DashboardComponent):
     """Timeseries for worker network bandwidth
 
-    Plots average read_bytes and write_bytes for the workers
+    Plots the sum of read_bytes and write_bytes for the workers
     as a function of time.
     """
 
@@ -877,7 +877,8 @@ class WorkerNetworkBandwidthTimeseries(DashboardComponent):
             time += ws.metrics["time"]
 
         result = {
-            "time": [time / (len(workers) or 1)],  # avoid ZeroDivision when no workers
+            # use or avoid ZeroDivision when no workers
+            "time": [time / (len(workers) or 1) * 1000],
             "read_bytes": [read_bytes],
             "write_bytes": [write_bytes],
         }

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -919,16 +919,17 @@ class SystemTimeseries(DashboardComponent):
                 x="time",
                 y="read_bytes",
                 color="red",
-                legend_label="read (sum)",
+                legend_label="read (mean)",
             )
             self.bandwidth.line(
                 source=self.source,
                 x="time",
                 y="write_bytes",
                 color="blue",
-                legend_label="write (sum)",
+                legend_label="write (mean)",
             )
 
+            self.bandwidth.legend.location = "top_left"
             self.bandwidth.yaxis.axis_label = "bytes / second"
             self.bandwidth.yaxis[0].formatter = NumeralTickFormatter(format="0.0b")
             self.bandwidth.y_range.start = 0
@@ -991,16 +992,17 @@ class SystemTimeseries(DashboardComponent):
                 x="time",
                 y="read_bytes_disk",
                 color="red",
-                legend_label="read (sum)",
+                legend_label="read (mean)",
             )
             self.disk.line(
                 source=self.source,
                 x="time",
                 y="write_bytes_disk",
                 color="blue",
-                legend_label="write (sum)",
+                legend_label="write (mean)",
             )
 
+            self.disk.legend.location = "top_left"
             self.disk.yaxis.axis_label = "bytes / second"
             self.disk.yaxis[0].formatter = NumeralTickFormatter(format="0.0b")
             self.disk.y_range.start = 0

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -837,7 +837,7 @@ class WorkerNetworkBandwidthTimeseries(DashboardComponent):
             x_range = DataRange1d(follow="end", follow_interval=20000, range_padding=0)
 
             self.root = figure(
-                title="Worker Network Bandwidth Timeseries",
+                title="Workers Network Bandwidth Timeseries",
                 x_axis_type="datetime",
                 tools="",
                 x_range=x_range,
@@ -851,17 +851,17 @@ class WorkerNetworkBandwidthTimeseries(DashboardComponent):
                 x="time",
                 y="read_bytes",
                 color="red",
-                legend_label="read",
+                legend_label="read (avg)",
             )
             self.root.line(
                 source=self.source,
                 x="time",
                 y="write_bytes",
                 color="blue",
-                legend_label="write",
+                legend_label="write (avg)",
             )
 
-        self.root.yaxis.axis_label = "Bytes / second"
+        self.root.yaxis.axis_label = "bytes / second"
 
         self.root.yaxis[0].formatter = NumeralTickFormatter(format="0.0b")
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -985,6 +985,20 @@ class SystemTimeseries(DashboardComponent):
         with log_errors():
             self.source.stream(self.get_data(), 1000)
 
+            if self.scheduler.workers:
+                y_end_cpu = sum(
+                    ws.nthreads or 1 for ws in self.scheduler.workers.values()
+                )
+                y_end_mem = sum(
+                    ws.memory_limit for ws in self.scheduler.workers.values()
+                )
+            else:
+                y_end_cpu = 1
+                y_end_mem = 100_000_000
+
+            self.cpu.y_range.end = y_end_cpu * 100
+            self.memory.y_range.end = y_end_mem
+
 
 class ComputePerKey(DashboardComponent):
     """Bar chart showing time spend in action by key prefix"""

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -779,7 +779,6 @@ class WorkerNetworkBandwidth(DashboardComponent):
             self.root.yaxis.visible = False
             self.root.ygrid.visible = False
             self.root.toolbar_location = None
-            self.root.yaxis.visible = False
 
     @without_property_validation
     def update(self):
@@ -848,7 +847,7 @@ class SystemTimeseries(DashboardComponent):
             x_range = DataRange1d(follow="end", follow_interval=20000, range_padding=0)
 
             self.bandwidth = figure(
-                title="Workers Network Bandwidth Timeseries",
+                title="Workers Network Bandwidth",
                 x_axis_type="datetime",
                 tools="",
                 x_range=x_range,
@@ -875,14 +874,16 @@ class SystemTimeseries(DashboardComponent):
             self.bandwidth.yaxis.axis_label = "bytes / second"
             self.bandwidth.yaxis[0].formatter = NumeralTickFormatter(format="0.0b")
             self.bandwidth.y_range.start = 0
+            self.bandwidth.yaxis.minor_tick_line_alpha = 0
+            self.bandwidth.xgrid.visible = False
 
             self.cpu = figure(
-                title="Workers CPU Timeseries",
+                title="Workers CPU",
                 x_axis_type="datetime",
                 tools="",
                 x_range=x_range,
-                id="bk-worker-network-cpu-ts",
-                name="worker_network_cpu-timeseries",
+                id="bk-worker-cpu-ts",
+                name="worker_cpu-timeseries",
                 **kwargs,
             )
 
@@ -893,14 +894,16 @@ class SystemTimeseries(DashboardComponent):
             )
             self.cpu.yaxis.axis_label = "Utilization"
             self.cpu.y_range.start = 0
+            self.cpu.yaxis.minor_tick_line_alpha = 0
+            self.cpu.xgrid.visible = False
 
             self.memory = figure(
-                title="Workers Memory Timeseries",
+                title="Workers Memory",
                 x_axis_type="datetime",
                 tools="",
                 x_range=x_range,
-                id="bk-worker-network-mem-ts",
-                name="worker_network_mem-timeseries",
+                id="bk-worker-memory-ts",
+                name="worker_memory-timeseries",
                 **kwargs,
             )
 
@@ -912,14 +915,16 @@ class SystemTimeseries(DashboardComponent):
             self.memory.yaxis.axis_label = "Bytes"
             self.memory.yaxis[0].formatter = NumeralTickFormatter(format="0.0b")
             self.memory.y_range.start = 0
+            self.memory.yaxis.minor_tick_line_alpha = 0
+            self.memory.xgrid.visible = False
 
             self.disk = figure(
-                title="Workers Network Disk Timeseries",
+                title="Workers Disk",
                 x_axis_type="datetime",
                 tools="",
                 x_range=x_range,
-                id="bk-worker-network-disk-ts",
-                name="worker_network_disk-timeseries",
+                id="bk-worker-disk-ts",
+                name="worker_disk-timeseries",
                 **kwargs,
             )
 
@@ -941,6 +946,8 @@ class SystemTimeseries(DashboardComponent):
             self.disk.yaxis.axis_label = "bytes / second"
             self.disk.yaxis[0].formatter = NumeralTickFormatter(format="0.0b")
             self.disk.y_range.start = 0
+            self.disk.yaxis.minor_tick_line_alpha = 0
+            self.disk.xgrid.visible = False
 
     def get_data(self):
         workers = self.scheduler.workers.values()

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -844,19 +844,23 @@ class WorkerNetworkBandwidth(DashboardComponent):
                 x_read_disk.append(ws.metrics["read_bytes_disk"])
                 x_write_disk.append(ws.metrics["write_bytes_disk"])
 
-            self.bandwidth.x_range.end = max(
-                max(x_read),
-                max(x_write),
-                100_000_000,
-                0.95 * self.bandwidth.x_range.end,
-            )
+            if self.scheduler.workers:
+                self.bandwidth.x_range.end = max(
+                    max(x_read),
+                    max(x_write),
+                    100_000_000,
+                    0.95 * self.bandwidth.x_range.end,
+                )
 
-            self.disk.x_range.end = max(
-                max(x_read_disk),
-                max(x_write_disk),
-                100_000_000,
-                0.95 * self.disk.x_range.end,
-            )
+                self.disk.x_range.end = max(
+                    max(x_read_disk),
+                    max(x_write_disk),
+                    100_000_000,
+                    0.95 * self.disk.x_range.end,
+                )
+            else:
+                self.bandwidth.x_range.end = 100_000_000
+                self.disk.x_range.end = 100_000_000
 
             result = {
                 "y_read": y_read,

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -816,15 +816,15 @@ class WorkerNetworkBandwidth(DashboardComponent):
 class SystemTimeseries(DashboardComponent):
     """Timeseries for worker network bandwidth, cpu, memory and disk.
 
-    bandwidth: plots the sum of read_bytes and write_bytes for the workers
+    bandwidth: plots the average of read_bytes and write_bytes for the workers
     as a function of time.
-    cpu: plots the sum of cpu for the workers as a function of time.
-    memory: plots the sum of memory for the workers as a function of time.
-    disk: plots the sum of read_bytes_disk and write_bytes_disk for the workers
+    cpu: plots the average of cpu for the workers as a function of time.
+    memory: plots the average of memory for the workers as a function of time.
+    disk: plots the average of read_bytes_disk and write_bytes_disk for the workers
     as a function of time.
 
-    The metrics plotted comme from the aggregation of
-    from ws.metrics["val"] for ws in scheduler.workers.values()
+    The metrics plotted come from the aggregation of
+    from ws.metrics["val"] for ws in scheduler.workers.values() divided by nuber of workers.
     """
 
     def __init__(self, scheduler, **kwargs):
@@ -972,12 +972,12 @@ class SystemTimeseries(DashboardComponent):
         result = {
             # use `or` to avoid ZeroDivision when no workers
             "time": [time / (len(workers) or 1) * 1000],
-            "read_bytes": [read_bytes],
-            "write_bytes": [write_bytes],
-            "cpu": [cpu],
-            "memory": [memory],
-            "read_bytes_disk": [read_bytes_disk],
-            "write_bytes_disk": [write_bytes_disk],
+            "read_bytes": [read_bytes / (len(workers) or 1)],
+            "write_bytes": [write_bytes / (len(workers) or 1)],
+            "cpu": [cpu / (len(workers) or 1)],
+            "memory": [memory / (len(workers) or 1)],
+            "read_bytes_disk": [read_bytes_disk / (len(workers) or 1)],
+            "write_bytes_disk": [write_bytes_disk / (len(workers) or 1)],
         }
         return result
 
@@ -989,10 +989,10 @@ class SystemTimeseries(DashboardComponent):
             if self.scheduler.workers:
                 y_end_cpu = sum(
                     ws.nthreads or 1 for ws in self.scheduler.workers.values()
-                )
+                ) / len(self.scheduler.workers.values())
                 y_end_mem = sum(
                     ws.memory_limit for ws in self.scheduler.workers.values()
-                )
+                ) / len(self.scheduler.workers.values())
             else:
                 y_end_cpu = 1
                 y_end_mem = 100_000_000

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -737,9 +737,12 @@ class WorkerNetworkBandwidth(DashboardComponent):
                     "y_write": [],
                     "x_read": [],
                     "x_write": [],
+                    "x_read_disk": [],
+                    "x_write_disk": [],
                 }
             )
-            self.root = figure(
+
+            self.bandwidth = figure(
                 title="Worker Network Bandwidth",
                 tools="",
                 id="bk-worker-net-bandwidth",
@@ -748,7 +751,7 @@ class WorkerNetworkBandwidth(DashboardComponent):
             )
 
             # read_bytes
-            self.root.hbar(
+            self.bandwidth.hbar(
                 y="y_read",
                 right="x_read",
                 line_color=None,
@@ -760,7 +763,7 @@ class WorkerNetworkBandwidth(DashboardComponent):
             )
 
             # write_bytes
-            self.root.hbar(
+            self.bandwidth.hbar(
                 y="y_write",
                 right="x_write",
                 line_color=None,
@@ -771,14 +774,55 @@ class WorkerNetworkBandwidth(DashboardComponent):
                 source=self.source,
             )
 
-            self.root.axis[0].ticker = BasicTicker(**TICKS_1024)
-            self.root.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
-            self.root.xaxis.major_label_orientation = XLABEL_ORIENTATION
-            self.root.xaxis.minor_tick_line_alpha = 0
-            self.root.x_range = Range1d(start=0)
-            self.root.yaxis.visible = False
-            self.root.ygrid.visible = False
-            self.root.toolbar_location = None
+            self.bandwidth.axis[0].ticker = BasicTicker(**TICKS_1024)
+            self.bandwidth.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
+            self.bandwidth.xaxis.major_label_orientation = XLABEL_ORIENTATION
+            self.bandwidth.xaxis.minor_tick_line_alpha = 0
+            self.bandwidth.x_range = Range1d(start=0)
+            self.bandwidth.yaxis.visible = False
+            self.bandwidth.ygrid.visible = False
+            self.bandwidth.toolbar_location = None
+
+            self.disk = figure(
+                title="Workers Disk",
+                tools="",
+                id="bk-workers-disk",
+                name="worker_disk",
+                **kwargs,
+            )
+
+            # read_bytes_disk
+            self.disk.hbar(
+                y="y_read",
+                right="x_read_disk",
+                line_color=None,
+                left=0,
+                height=0.5,
+                fill_color="red",
+                legend_label="read",
+                source=self.source,
+            )
+
+            # write_bytes_disk
+            self.disk.hbar(
+                y="y_write",
+                right="x_write_disk",
+                line_color=None,
+                left=0,
+                height=0.5,
+                fill_color="blue",
+                legend_label="write",
+                source=self.source,
+            )
+
+            self.disk.axis[0].ticker = BasicTicker(**TICKS_1024)
+            self.disk.xaxis[0].formatter = NumeralTickFormatter(format="0.0 b")
+            self.disk.xaxis.major_label_orientation = XLABEL_ORIENTATION
+            self.disk.xaxis.minor_tick_line_alpha = 0
+            self.disk.x_range = Range1d(start=0)
+            self.disk.yaxis.visible = False
+            self.disk.ygrid.visible = False
+            self.disk.toolbar_location = None
 
     @without_property_validation
     def update(self):
@@ -791,16 +835,27 @@ class WorkerNetworkBandwidth(DashboardComponent):
 
             x_read = []
             x_write = []
+            x_read_disk = []
+            x_write_disk = []
 
             for ws in workers:
                 x_read.append(ws.metrics["read_bytes"])
                 x_write.append(ws.metrics["write_bytes"])
+                x_read_disk.append(ws.metrics["read_bytes_disk"])
+                x_write_disk.append(ws.metrics["write_bytes_disk"])
 
-            self.root.x_range.end = max(
+            self.bandwidth.x_range.end = max(
                 max(x_read),
                 max(x_write),
                 100_000_000,
-                0.95 * self.root.x_range.end,
+                0.95 * self.bandwidth.x_range.end,
+            )
+
+            self.disk.x_range.end = max(
+                max(x_read_disk),
+                max(x_write_disk),
+                100_000_000,
+                0.95 * self.disk.x_range.end,
             )
 
             result = {
@@ -808,6 +863,8 @@ class WorkerNetworkBandwidth(DashboardComponent):
                 "y_write": y_write,
                 "x_read": x_read,
                 "x_write": x_write,
+                "x_read_disk": x_read_disk,
+                "x_write_disk": x_write_disk,
             }
 
             update(self.source, result)

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -845,11 +845,12 @@ class SystemTimeseries(DashboardComponent):
             update(self.source, self.get_data())
 
             x_range = DataRange1d(follow="end", follow_interval=20000, range_padding=0)
+            tools = "reset, xpan, xwheel_zoom"
 
             self.bandwidth = figure(
                 title="Workers Network Bandwidth",
                 x_axis_type="datetime",
-                tools="",
+                tools=tools,
                 x_range=x_range,
                 id="bk-worker-network-bandwidth-ts",
                 name="worker_network_bandwidth-timeseries",
@@ -880,7 +881,7 @@ class SystemTimeseries(DashboardComponent):
             self.cpu = figure(
                 title="Workers CPU",
                 x_axis_type="datetime",
-                tools="",
+                tools=tools,
                 x_range=x_range,
                 id="bk-worker-cpu-ts",
                 name="worker_cpu-timeseries",
@@ -900,7 +901,7 @@ class SystemTimeseries(DashboardComponent):
             self.memory = figure(
                 title="Workers Memory",
                 x_axis_type="datetime",
-                tools="",
+                tools=tools,
                 x_range=x_range,
                 id="bk-worker-memory-ts",
                 name="worker_memory-timeseries",
@@ -921,7 +922,7 @@ class SystemTimeseries(DashboardComponent):
             self.disk = figure(
                 title="Workers Disk",
                 x_axis_type="datetime",
-                tools="",
+                tools=tools,
                 x_range=x_range,
                 id="bk-worker-disk-ts",
                 name="worker_disk-timeseries",

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -851,14 +851,14 @@ class WorkerNetworkBandwidthTimeseries(DashboardComponent):
                 x="time",
                 y="read_bytes",
                 color="red",
-                legend_label="read (avg)",
+                legend_label="read (sum)",
             )
             self.root.line(
                 source=self.source,
                 x="time",
                 y="write_bytes",
                 color="blue",
-                legend_label="write (avg)",
+                legend_label="write (sum)",
             )
 
         self.root.yaxis.axis_label = "bytes / second"
@@ -877,9 +877,9 @@ class WorkerNetworkBandwidthTimeseries(DashboardComponent):
             time += ws.metrics["time"]
 
         result = {
-            "time": [time / len(workers)],
-            "read_bytes": [read_bytes / len(workers)],
-            "write_bytes": [write_bytes / len(workers)],
+            "time": [time / (len(workers) or 1)],  # avoid ZeroDivision when no workers
+            "read_bytes": [read_bytes],
+            "write_bytes": [write_bytes],
         }
         return result
 

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -20,6 +20,7 @@ from .components.scheduler import (
     TaskProgress,
     TaskStream,
     WorkerNetworkBandwidth,
+    WorkerNetworkBandwidthTimeseries,
     WorkersMemory,
     WorkerTable,
     events_doc,
@@ -70,6 +71,9 @@ applications = {
     "/individual-bandwidth-workers": individual_doc(BandwidthWorkers, 500),
     "/individual-workers-network-bandwidth": individual_doc(
         WorkerNetworkBandwidth, 500
+    ),
+    "/individual-workers-network-bandwidth-timeseries": individual_doc(
+        WorkerNetworkBandwidthTimeseries, 500
     ),
     "/individual-memory-by-key": individual_doc(MemoryByKey, 500),
     "/individual-compute-time-per-key": individual_doc(ComputePerKey, 500),

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -15,12 +15,12 @@ from .components.scheduler import (
     MemoryByKey,
     Occupancy,
     SystemMonitor,
+    SystemTimeseries,
     TaskGraph,
     TaskGroupGraph,
     TaskProgress,
     TaskStream,
     WorkerNetworkBandwidth,
-    WorkerNetworkBandwidthTimeseries,
     WorkersMemory,
     WorkerTable,
     events_doc,
@@ -73,7 +73,13 @@ applications = {
         WorkerNetworkBandwidth, 500
     ),
     "/individual-workers-network-bandwidth-timeseries": individual_doc(
-        WorkerNetworkBandwidthTimeseries, 500
+        SystemTimeseries, 500, fig_attr="bandwidth"
+    ),
+    "/individual-workers-network-cpu-timeseries": individual_doc(
+        SystemTimeseries, 500, fig_attr="cpu"
+    ),
+    "/individual-workers-network-memory-timeseries": individual_doc(
+        SystemTimeseries, 500, fig_attr="memory"
     ),
     "/individual-memory-by-key": individual_doc(MemoryByKey, 500),
     "/individual-compute-time-per-key": individual_doc(ComputePerKey, 500),

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -70,7 +70,10 @@ applications = {
     "/individual-bandwidth-types": individual_doc(BandwidthTypes, 500),
     "/individual-bandwidth-workers": individual_doc(BandwidthWorkers, 500),
     "/individual-workers-network-bandwidth": individual_doc(
-        WorkerNetworkBandwidth, 500
+        WorkerNetworkBandwidth, 500, fig_attr="bandwidth"
+    ),
+    "/individual-workers-disk": individual_doc(
+        WorkerNetworkBandwidth, 500, fig_attr="disk"
     ),
     "/individual-workers-network-bandwidth-timeseries": individual_doc(
         SystemTimeseries, 500, fig_attr="bandwidth"

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -75,13 +75,13 @@ applications = {
     "/individual-workers-network-bandwidth-timeseries": individual_doc(
         SystemTimeseries, 500, fig_attr="bandwidth"
     ),
-    "/individual-workers-network-cpu-timeseries": individual_doc(
+    "/individual-workers-cpu-timeseries": individual_doc(
         SystemTimeseries, 500, fig_attr="cpu"
     ),
-    "/individual-workers-network-memory-timeseries": individual_doc(
+    "/individual-workers-memory-timeseries": individual_doc(
         SystemTimeseries, 500, fig_attr="memory"
     ),
-    "/individual-workers-network-disk-timeseries": individual_doc(
+    "/individual-workers-disk-timeseries": individual_doc(
         SystemTimeseries, 500, fig_attr="disk"
     ),
     "/individual-memory-by-key": individual_doc(MemoryByKey, 500),

--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -81,6 +81,9 @@ applications = {
     "/individual-workers-network-memory-timeseries": individual_doc(
         SystemTimeseries, 500, fig_attr="memory"
     ),
+    "/individual-workers-network-disk-timeseries": individual_doc(
+        SystemTimeseries, 500, fig_attr="disk"
+    ),
     "/individual-memory-by-key": individual_doc(MemoryByKey, 500),
     "/individual-compute-time-per-key": individual_doc(ComputePerKey, 500),
     "/individual-aggregate-time-per-action": individual_doc(AggregateAction, 500),

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -535,6 +535,12 @@ async def test_SystemTimeseries(c, s, a, b):
     assert systs.source.data["memory"][0] == sum(
         [ws.metrics["memory"] for ws in workers]
     )
+    assert systs.source.data["read_bytes_disk"][0] == sum(
+        [ws.metrics["read_bytes_disk"] for ws in workers]
+    )
+    assert systs.source.data["write_bytes_disk"][0] == sum(
+        [ws.metrics["write_bytes_disk"] for ws in workers]
+    )
     assert (
         systs.source.data["time"][0]
         == sum([ws.metrics["time"] for ws in workers]) / len(workers) * 1000
@@ -556,6 +562,12 @@ async def test_SystemTimeseries(c, s, a, b):
     assert systs.source.data["cpu"][1] == sum([ws.metrics["cpu"] for ws in workers])
     assert systs.source.data["memory"][1] == sum(
         [ws.metrics["memory"] for ws in workers]
+    )
+    assert systs.source.data["read_bytes_disk"][1] == sum(
+        [ws.metrics["read_bytes_disk"] for ws in workers]
+    )
+    assert systs.source.data["write_bytes_disk"][1] == sum(
+        [ws.metrics["write_bytes_disk"] for ws in workers]
     )
     assert (
         systs.source.data["time"][1]

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -507,6 +507,8 @@ async def test_WorkerNetworkBandwidth_metrics(c, s, a, b):
     for idx, ws in enumerate(s.workers.values()):
         assert ws.metrics["read_bytes"] == nb.source.data["x_read"][idx]
         assert ws.metrics["write_bytes"] == nb.source.data["x_write"][idx]
+        assert ws.metrics["read_bytes_disk"] == nb.source.data["x_read_disk"][idx]
+        assert ws.metrics["write_bytes_disk"] == nb.source.data["x_write_disk"][idx]
 
 
 @gen_cluster(client=True)

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -527,10 +527,10 @@ async def test_WorkerNetworkBandwidthTimeseries(c, s, a, b):
     assert all(len(v) == 1 for v in nbts.source.data.values())
     assert nbts.source.data["read_bytes"][0] == sum(
         [ws.metrics["read_bytes"] for ws in workers]
-    ) / len(workers)
+    )
     assert nbts.source.data["write_bytes"][0] == sum(
         [ws.metrics["write_bytes"] for ws in workers]
-    ) / len(workers)
+    )
     assert nbts.source.data["time"][0] == sum(
         [ws.metrics["time"] for ws in workers]
     ) / len(workers)
@@ -544,10 +544,10 @@ async def test_WorkerNetworkBandwidthTimeseries(c, s, a, b):
     assert all(len(v) == 2 for v in nbts.source.data.values())
     assert nbts.source.data["read_bytes"][1] == sum(
         [ws.metrics["read_bytes"] for ws in workers]
-    ) / len(workers)
+    )
     assert nbts.source.data["write_bytes"][1] == sum(
         [ws.metrics["write_bytes"] for ws in workers]
-    ) / len(workers)
+    )
     assert nbts.source.data["time"][1] == sum(
         [ws.metrics["time"] for ws in workers]
     ) / len(workers)

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -527,20 +527,22 @@ async def test_SystemTimeseries(c, s, a, b):
     assert all(len(v) == 1 for v in systs.source.data.values())
     assert systs.source.data["read_bytes"][0] == sum(
         [ws.metrics["read_bytes"] for ws in workers]
-    )
+    ) / len(workers)
     assert systs.source.data["write_bytes"][0] == sum(
         [ws.metrics["write_bytes"] for ws in workers]
-    )
-    assert systs.source.data["cpu"][0] == sum([ws.metrics["cpu"] for ws in workers])
+    ) / len(workers)
+    assert systs.source.data["cpu"][0] == sum(
+        [ws.metrics["cpu"] for ws in workers]
+    ) / len(workers)
     assert systs.source.data["memory"][0] == sum(
         [ws.metrics["memory"] for ws in workers]
-    )
+    ) / len(workers)
     assert systs.source.data["read_bytes_disk"][0] == sum(
         [ws.metrics["read_bytes_disk"] for ws in workers]
-    )
+    ) / len(workers)
     assert systs.source.data["write_bytes_disk"][0] == sum(
         [ws.metrics["write_bytes_disk"] for ws in workers]
-    )
+    ) / len(workers)
     assert (
         systs.source.data["time"][0]
         == sum([ws.metrics["time"] for ws in workers]) / len(workers) * 1000
@@ -555,20 +557,22 @@ async def test_SystemTimeseries(c, s, a, b):
     assert all(len(v) == 2 for v in systs.source.data.values())
     assert systs.source.data["read_bytes"][1] == sum(
         [ws.metrics["read_bytes"] for ws in workers]
-    )
+    ) / len(workers)
     assert systs.source.data["write_bytes"][1] == sum(
         [ws.metrics["write_bytes"] for ws in workers]
-    )
-    assert systs.source.data["cpu"][1] == sum([ws.metrics["cpu"] for ws in workers])
+    ) / len(workers)
+    assert systs.source.data["cpu"][1] == sum(
+        [ws.metrics["cpu"] for ws in workers]
+    ) / len(workers)
     assert systs.source.data["memory"][1] == sum(
         [ws.metrics["memory"] for ws in workers]
-    )
+    ) / len(workers)
     assert systs.source.data["read_bytes_disk"][1] == sum(
         [ws.metrics["read_bytes_disk"] for ws in workers]
-    )
+    ) / len(workers)
     assert systs.source.data["write_bytes_disk"][1] == sum(
         [ws.metrics["write_bytes_disk"] for ws in workers]
-    )
+    ) / len(workers)
     assert (
         systs.source.data["time"][1]
         == sum([ws.metrics["time"] for ws in workers]) / len(workers) * 1000

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -531,9 +531,10 @@ async def test_WorkerNetworkBandwidthTimeseries(c, s, a, b):
     assert nbts.source.data["write_bytes"][0] == sum(
         [ws.metrics["write_bytes"] for ws in workers]
     )
-    assert nbts.source.data["time"][0] == sum(
-        [ws.metrics["time"] for ws in workers]
-    ) / len(workers)
+    assert (
+        nbts.source.data["time"][0]
+        == sum([ws.metrics["time"] for ws in workers]) / len(workers) * 1000
+    )
 
     # Update worker system monitors and send updated metrics to the scheduler
     a.monitor.update()
@@ -548,9 +549,10 @@ async def test_WorkerNetworkBandwidthTimeseries(c, s, a, b):
     assert nbts.source.data["write_bytes"][1] == sum(
         [ws.metrics["write_bytes"] for ws in workers]
     )
-    assert nbts.source.data["time"][1] == sum(
-        [ws.metrics["time"] for ws in workers]
-    ) / len(workers)
+    assert (
+        nbts.source.data["time"][1]
+        == sum([ws.metrics["time"] for ws in workers]) / len(workers) * 1000
+    )
 
 
 @gen_cluster(client=True)

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -36,6 +36,7 @@ from distributed.dashboard.components.scheduler import (
     TaskProgress,
     TaskStream,
     WorkerNetworkBandwidth,
+    WorkerNetworkBandwidthTimeseries,
     WorkersMemory,
     WorkersMemoryHistogram,
     WorkerTable,
@@ -506,6 +507,50 @@ async def test_WorkerNetworkBandwidth_metrics(c, s, a, b):
     for idx, ws in enumerate(s.workers.values()):
         assert ws.metrics["read_bytes"] == nb.source.data["x_read"][idx]
         assert ws.metrics["write_bytes"] == nb.source.data["x_write"][idx]
+
+
+@gen_cluster(client=True)
+async def test_WorkerNetworkBandwidthTimeseries(c, s, a, b):
+    # Disable system monitor periodic callback to allow us to manually control
+    # when it is called below
+    a.periodic_callbacks["monitor"].stop()
+    b.periodic_callbacks["monitor"].stop()
+
+    # Update worker system monitors and send updated metrics to the scheduler
+    a.monitor.update()
+    b.monitor.update()
+    await asyncio.gather(a.heartbeat(), b.heartbeat())
+
+    nbts = WorkerNetworkBandwidthTimeseries(s)
+    workers = s.workers.values()
+
+    assert all(len(v) == 1 for v in nbts.source.data.values())
+    assert nbts.source.data["read_bytes"][0] == sum(
+        [ws.metrics["read_bytes"] for ws in workers]
+    ) / len(workers)
+    assert nbts.source.data["write_bytes"][0] == sum(
+        [ws.metrics["write_bytes"] for ws in workers]
+    ) / len(workers)
+    assert nbts.source.data["time"][0] == sum(
+        [ws.metrics["time"] for ws in workers]
+    ) / len(workers)
+
+    # Update worker system monitors and send updated metrics to the scheduler
+    a.monitor.update()
+    b.monitor.update()
+    await asyncio.gather(a.heartbeat(), b.heartbeat())
+    nbts.update()
+
+    assert all(len(v) == 2 for v in nbts.source.data.values())
+    assert nbts.source.data["read_bytes"][1] == sum(
+        [ws.metrics["read_bytes"] for ws in workers]
+    ) / len(workers)
+    assert nbts.source.data["write_bytes"][1] == sum(
+        [ws.metrics["write_bytes"] for ws in workers]
+    ) / len(workers)
+    assert nbts.source.data["time"][1] == sum(
+        [ws.metrics["time"] for ws in workers]
+    ) / len(workers)
 
 
 @gen_cluster(client=True)

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -35,6 +35,19 @@ class SystemMonitor:
             self._last_io_counters = ioc
             self._collect_net_io_counters = True
 
+        try:
+            disk_ioc = psutil.disk_io_counters()
+        except Exception:
+            self._collect_disk_io_counters = False
+        else:
+            self.last_time_disk = time()
+            self.read_bytes_disk = deque(maxlen=n)
+            self.write_bytes_disk = deque(maxlen=n)
+            self.quantities["read_bytes_disk"] = self.read_bytes_disk
+            self.quantities["write_bytes_disk"] = self.write_bytes_disk
+            self._last_disk_io_counters = disk_ioc
+            self._collect_disk_io_counters = True
+
         if not WINDOWS:
             self.num_fds = deque(maxlen=n)
             self.quantities["num_fds"] = self.num_fds
@@ -85,6 +98,27 @@ class SystemMonitor:
                 self.write_bytes.append(write_bytes)
                 result["read_bytes"] = read_bytes
                 result["write_bytes"] = write_bytes
+
+        if self._collect_disk_io_counters:
+            try:
+                disk_ioc = psutil.disk_io_counters()
+            except Exception:
+                pass
+            else:
+                last_disk = self._last_disk_io_counters
+                duration_disk = now - self.last_time_disk
+                read_bytes_disk = (disk_ioc.read_bytes - last_disk.read_bytes) / (
+                    duration_disk or 0.5
+                )
+                write_bytes_disk = (disk_ioc.write_bytes - last_disk.write_bytes) / (
+                    duration_disk or 0.5
+                )
+                self.last_time_disk = now
+                self._last_disk_io_counters = disk_ioc
+                self.read_bytes_disk.append(read_bytes_disk)
+                self.write_bytes_disk.append(write_bytes_disk)
+                result["read_bytes_disk"] = read_bytes_disk
+                result["write_bytes_disk"] = write_bytes_disk
 
         if not WINDOWS:
             num_fds = self.proc.num_fds()

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -66,6 +66,7 @@ Individual bokeh plots
 - ``/individual-bandwidth-types``
 - ``/individual-bandwidth-workers``
 - ``/individual-workers-network-bandwidth``
+- ``/individual-workers-disk``
 - ``/individual-workers-network-bandwidth-timeseries``
 - ``/individual-workers-cpu-timeseries``
 - ``/individual-workers-memory-timeseries``

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -67,6 +67,8 @@ Individual bokeh plots
 - ``/individual-bandwidth-workers``
 - ``/individual-workers-network-bandwidth``
 - ``/individual-workers-network-bandwidth-timeseries``
+- ``/individual-workers-network-cpu-timeseries``
+- ``/individual-workers-network-memory-timeseries``
 - ``/individual-memory-by-key``
 - ``/individual-compute-time-per-key``
 - ``/individual-aggregate-time-per-action``

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -66,6 +66,7 @@ Individual bokeh plots
 - ``/individual-bandwidth-types``
 - ``/individual-bandwidth-workers``
 - ``/individual-workers-network-bandwidth``
+- ``/individual-workers-network-bandwidth-timeseries``
 - ``/individual-memory-by-key``
 - ``/individual-compute-time-per-key``
 - ``/individual-aggregate-time-per-action``

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -67,8 +67,9 @@ Individual bokeh plots
 - ``/individual-bandwidth-workers``
 - ``/individual-workers-network-bandwidth``
 - ``/individual-workers-network-bandwidth-timeseries``
-- ``/individual-workers-network-cpu-timeseries``
-- ``/individual-workers-network-memory-timeseries``
+- ``/individual-workers-cpu-timeseries``
+- ``/individual-workers-memory-timeseries``
+- ``/individual-workers-disk-timeseries``
 - ``/individual-memory-by-key``
 - ``/individual-compute-time-per-key``
 - ``/individual-aggregate-time-per-action``


### PR DESCRIPTION
- [x] Closes #5090
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Currently computing the average for `read_bytes` and `write_bytes` across workers. If we decided we want the sum we can change that, let me know in the comments.