### PR TITLE
Update individual profile plot sizing

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2947,7 +2947,7 @@ def individual_doc(cls, interval, scheduler, extra, doc, fig_attr="root", **kwar
 
 def individual_profile_doc(scheduler, extra, doc):
     with log_errors():
-        prof = ProfileTimePlot(scheduler, sizing_mode="scale_width", doc=doc)
+        prof = ProfileTimePlot(scheduler, sizing_mode="stretch_both", doc=doc)
         doc.add_root(prof.root)
         prof.trigger_update()
         doc.theme = BOKEH_THEME
@@ -2955,7 +2955,7 @@ def individual_profile_doc(scheduler, extra, doc):
 
 def individual_profile_server_doc(scheduler, extra, doc):
     with log_errors():
-        prof = ProfileServer(scheduler, sizing_mode="scale_width", doc=doc)
+        prof = ProfileServer(scheduler, sizing_mode="stretch_both", doc=doc)
         doc.add_root(prof.root)
         prof.trigger_update()
         doc.theme = BOKEH_THEME


### PR DESCRIPTION
This updates our individual profile plots to look more like the profile plots available in the dashboard tab (which fit better in the browser window)

On the current `main` (note the plot is large and I need to scroll to see the full contents):

<img width="1552" alt="Screen Shot 2021-07-28 at 11 13 01 AM" src="https://user-images.githubusercontent.com/11656932/127358560-27b8000d-caa6-477d-8291-34df3e0da1e9.png">

With the changes in this PR (fits nicely to my browser size):

<img width="1552" alt="Screen Shot 2021-07-28 at 11 12 26 AM" src="https://user-images.githubusercontent.com/11656932/127358587-6622ef2b-90b6-4548-9010-f241591cadd1.png">


cc @ncclementi 