### PR TITLE
Mark `ucx-py` tests for GPU

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -2,6 +2,8 @@ import asyncio
 
 import pytest
 
+pytestmark = pytest.mark.gpu
+
 ucp = pytest.importorskip("ucp")
 
 from distributed import Client, Scheduler, wait

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -2,6 +2,8 @@ from time import sleep
 
 import pytest
 
+pytestmark = pytest.mark.gpu
+
 import dask
 from dask.utils import format_bytes
 


### PR DESCRIPTION
These tests aren't currently being run as part of Dask-CUDA's CI, but struck me as something we would want running on GPU.

@quasiben @pentschev 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
