### PR TITLE
Send buffers in chunks <2GB

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -281,12 +281,11 @@ class TCP(Comm):
                         chunk = each_frame[i:j]
                         chunk_nbytes = chunk.nbytes
 
-                        if chunk_nbytes:
-                            if stream._write_buffer is None:
-                                raise StreamClosedError()
+                        if stream._write_buffer is None:
+                            raise StreamClosedError()
 
-                            stream._write_buffer.append(chunk)
-                            stream._total_write_index += chunk_nbytes
+                        stream._write_buffer.append(chunk)
+                        stream._total_write_index += chunk_nbytes
 
             # start writing frames
             stream.write(b"")

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -274,7 +274,7 @@ class TCP(Comm):
                     if isinstance(each_frame, memoryview):
                         # Make sure that `len(data) == data.nbytes`
                         # See <https://github.com/tornadoweb/tornado/pull/2996>
-                        each_frame = memoryview(each_frame).cast("B")
+                        each_frame = each_frame.cast("B")
 
                     stream._write_buffer.append(each_frame)
                     stream._total_write_index += each_frame_nbytes

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -283,8 +283,10 @@ class TCP(Comm):
                     ):
                         chunk = each_frame[i:j]
                         chunk_nbytes = chunk.nbytes
-                        stream._write_buffer.append(chunk)
-                        stream._total_write_index += chunk_nbytes
+
+                        if chunk_nbytes:
+                            stream._write_buffer.append(chunk)
+                            stream._total_write_index += chunk_nbytes
 
             # start writing frames
             stream.write(b"")

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -202,7 +202,7 @@ class TCP(Comm):
                 2, range(0, frames_nbytes + C_INT_MAX, C_INT_MAX)
             ):
                 chunk = frames[i:j]
-                chunk_nbytes = len(chunk)
+                chunk_nbytes = chunk.nbytes
                 n = await stream.read_into(chunk)
                 assert n == chunk_nbytes, (n, chunk_nbytes)
         except StreamClosedError as e:

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -271,10 +271,11 @@ class TCP(Comm):
                     if stream._write_buffer is None:
                         raise StreamClosedError()
 
-                    if isinstance(each_frame, memoryview):
-                        # Make sure that `len(data) == data.nbytes`
-                        # See <https://github.com/tornadoweb/tornado/pull/2996>
-                        each_frame = each_frame.cast("B")
+                    each_frame = memoryview(each_frame)
+
+                    # Make sure that `len(data) == data.nbytes`
+                    # See <https://github.com/tornadoweb/tornado/pull/2996>
+                    each_frame = each_frame.cast("B")
 
                     stream._write_buffer.append(each_frame)
                     stream._total_write_index += each_frame_nbytes

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -268,9 +268,6 @@ class TCP(Comm):
             # trick to enque all frames for writing beforehand
             for each_frame_nbytes, each_frame in zip(frames_nbytes, frames):
                 if each_frame_nbytes:
-                    if stream._write_buffer is None:
-                        raise StreamClosedError()
-
                     each_frame = memoryview(each_frame)
 
                     # Make sure that `len(data) == data.nbytes`
@@ -285,6 +282,9 @@ class TCP(Comm):
                         chunk_nbytes = chunk.nbytes
 
                         if chunk_nbytes:
+                            if stream._write_buffer is None:
+                                raise StreamClosedError()
+
                             stream._write_buffer.append(chunk)
                             stream._total_write_index += chunk_nbytes
 


### PR DESCRIPTION
Works around the OpenSSL 1.0.2 bug demonstrated in issue ( https://github.com/dask/distributed/issues/4538 ), except unlike PR ( https://github.com/dask/distributed/pull/5115 ) which did this for reading, this does the same thing for writing. The error may be less likely to show up in the write path (as frames may simply be smaller than this limit). Still it seems like a good idea to protect against `OverflowError`s from OpenSSL.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
