### PR TITLE
Minor dashboard style updates

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1629,8 +1629,8 @@ def task_stream_figure(clear_interval="20s", **kwargs):
         y_range=y_range,
         toolbar_location="above",
         x_axis_type="datetime",
+        y_axis_location=None,
         tools="",
-        min_border_left=50,
         min_border_bottom=50,
         **kwargs,
     )
@@ -2336,7 +2336,6 @@ class TaskProgress(DashboardComponent):
             y_range=y_range,
             toolbar_location=None,
             tools="",
-            min_border_left=50,
             min_border_bottom=50,
             **kwargs,
         )

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -86,7 +86,7 @@ env = Environment(
 
 BOKEH_THEME = Theme(os.path.join(os.path.dirname(__file__), "..", "theme.yaml"))
 TICKS_1024 = {"base": 1024, "mantissas": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]}
-XLABEL_ORIENTATION = -math.pi / 12  # slanted downwards 15 degrees
+XLABEL_ORIENTATION = -math.pi / 9  # slanted downwards 20 degrees
 
 
 logos_dict = {
@@ -117,12 +117,14 @@ class Occupancy(DashboardComponent):
             self.root = figure(
                 title="Occupancy",
                 tools="",
+                toolbar_location="above",
                 id="bk-occupancy-plot",
                 x_axis_type="datetime",
+                min_border_bottom=50,
                 **kwargs,
             )
             rect = self.root.rect(
-                source=self.source, x="x", width="ms", y="y", height=1, color="color"
+                source=self.source, x="x", width="ms", y="y", height=0.9, color="color"
             )
             rect.nonselection_glyph = None
 
@@ -258,6 +260,7 @@ class ClusterMemory(DashboardComponent):
                 id="bk-cluster-memory-plot",
                 width=int(width / 2),
                 name="cluster_memory",
+                min_border_bottom=50,
                 **kwargs,
             )
             rect = self.root.rect(
@@ -265,7 +268,7 @@ class ClusterMemory(DashboardComponent):
                 x="x",
                 y="y",
                 width="width",
-                height=1,
+                height=0.9,
                 color="color",
                 alpha="alpha",
             )
@@ -374,6 +377,7 @@ class WorkersMemory(DashboardComponent):
                 id="bk-workers-memory-plot",
                 width=int(width / 2),
                 name="workers_memory",
+                min_border_bottom=50,
                 **kwargs,
             )
             rect = self.root.rect(
@@ -381,7 +385,7 @@ class WorkersMemory(DashboardComponent):
                 x="x",
                 y="y",
                 width="width",
-                height=1,
+                height=0.9,
                 color="color",
                 fill_alpha="alpha",
                 line_width=0,
@@ -584,7 +588,7 @@ class BandwidthTypes(DashboardComponent):
                 x="bandwidth-half",
                 y="type",
                 width="bandwidth",
-                height=1,
+                height=0.9,
                 color="blue",
             )
             self.root.x_range.start = 0
@@ -856,8 +860,6 @@ class ComputePerKey(DashboardComponent):
             )
 
             fig.y_range.start = 0
-            fig.min_border_right = 20
-            fig.min_border_bottom = 60
             fig.yaxis.axis_label = "Time (s)"
             fig.yaxis[0].formatter = NumeralTickFormatter(format="0")
             fig.yaxis.ticker = AdaptiveTicker(**TICKS_1024)
@@ -1022,8 +1024,6 @@ class AggregateAction(DashboardComponent):
             )
 
             self.root.y_range.start = 0
-            self.root.min_border_right = 20
-            self.root.min_border_bottom = 60
             self.root.yaxis[0].formatter = NumeralTickFormatter(format="0")
             self.root.yaxis.axis_label = "Time (s)"
             self.root.yaxis.ticker = AdaptiveTicker(**TICKS_1024)
@@ -1181,6 +1181,7 @@ class CurrentLoad(DashboardComponent):
                 id="bk-nprocessing-plot",
                 name="processing",
                 width=int(width / 2),
+                min_border_bottom=50,
                 **kwargs,
             )
             rect = processing.rect(
@@ -1188,7 +1189,7 @@ class CurrentLoad(DashboardComponent):
                 x="nprocessing-half",
                 y="y",
                 width="nprocessing",
-                height=1,
+                height=0.9,
                 color="nprocessing-color",
             )
             processing.x_range.start = 0
@@ -1201,6 +1202,7 @@ class CurrentLoad(DashboardComponent):
                 width=int(width / 2),
                 name="cpu_hist",
                 x_range=(0, 100),
+                min_border_bottom=50,
                 **kwargs,
             )
             rect = cpu.rect(
@@ -1208,7 +1210,7 @@ class CurrentLoad(DashboardComponent):
                 x="cpu-half",
                 y="y",
                 width="cpu",
-                height=1,
+                height=0.9,
                 color="blue",
             )
             rect.nonselection_glyph = None
@@ -1627,8 +1629,9 @@ def task_stream_figure(clear_interval="20s", **kwargs):
         y_range=y_range,
         toolbar_location="above",
         x_axis_type="datetime",
-        min_border_right=35,
         tools="",
+        min_border_left=50,
+        min_border_bottom=50,
         **kwargs,
     )
 
@@ -2333,6 +2336,8 @@ class TaskProgress(DashboardComponent):
             y_range=y_range,
             toolbar_location=None,
             tools="",
+            min_border_left=50,
+            min_border_bottom=50,
             **kwargs,
         )
         self.root.line(  # just to define early ranges
@@ -2629,6 +2634,7 @@ class WorkerTable(DashboardComponent):
             height=60,
             width=width,
             tools="",
+            min_border_right=0,
             **kwargs,
         )
         mem_plot.circle(
@@ -2658,6 +2664,7 @@ class WorkerTable(DashboardComponent):
             height=60,
             width=width,
             tools="",
+            min_border_right=0,
             **kwargs,
         )
         cpu_plot.circle(

--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -435,6 +435,7 @@ class SystemMonitor(DashboardComponent):
             x_axis_type="datetime",
             height=height,
             tools=tools,
+            toolbar_location="above",
             x_range=x_range,
             **kwargs,
         )
@@ -457,6 +458,7 @@ class SystemMonitor(DashboardComponent):
             x_axis_type="datetime",
             height=height,
             tools=tools,
+            toolbar_location="above",
             x_range=x_range,
             **kwargs,
         )
@@ -480,6 +482,7 @@ class SystemMonitor(DashboardComponent):
             height=height,
             x_range=x_range,
             tools=tools,
+            toolbar_location="above",
             **kwargs,
         )
         self.bandwidth.line(
@@ -511,6 +514,7 @@ class SystemMonitor(DashboardComponent):
                 height=height,
                 x_range=x_range,
                 tools=tools,
+                toolbar_location="above",
                 **kwargs,
             )
 

--- a/distributed/dashboard/theme.yaml
+++ b/distributed/dashboard/theme.yaml
@@ -3,5 +3,7 @@ attrs:
     Plot:
         background_fill_color: null
         border_fill_color: null
+        min_border_left: 0
+        min_border_right: 10
     Toolbar:
       logo: null

--- a/distributed/dashboard/theme.yaml
+++ b/distributed/dashboard/theme.yaml
@@ -3,7 +3,7 @@ attrs:
     Plot:
         background_fill_color: null
         border_fill_color: null
-        min_border_left: 0
+        min_border_left: 10
         min_border_right: 10
     Toolbar:
       logo: null

--- a/distributed/http/static/css/status.css
+++ b/distributed/http/static/css/status.css
@@ -6,7 +6,7 @@
 @media (min-width: 0px) {
   #status-fluid {
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: 70px 2fr 6fr 2fr;
+    grid-template-rows: 90px 2fr 6fr 2fr;
   }
   #status-cluster-memory {
     grid-column: 1 / span 2;
@@ -33,7 +33,7 @@
 @media (min-width: 992px) {
   #status-fluid {
     grid-template-columns: 1fr 3fr;
-    grid-template-rows: 80px 4fr 1fr 1fr 4fr;
+    grid-template-rows: 100px 4fr 1fr 1fr 4fr;
   }
   #status-cluster-memory {
     grid-column: 1;


### PR DESCRIPTION
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

For you consideration, this is a very small PR that attempts to make a few small styling tweaks:

* line up plot borders better, especially vertical axes in stacked columns
* place toolbars above plots where there is already space to accommodate titles
* give hbars a slight separation (I find this much easier to interpret)
* angle tick labels a little less aggressively 

As an aside, the auto-ranging on updating bar charts like this has always struck me as not-great. What would folks think about an "only grow" option on data-ranges? I.e. the range would not shrink from previous peaks, so that changes are actually better visible over time. 

Edit: I'm actually not sure why the task graph has/gets all that border space on the left. Earlier I had thought an axis would how up when there was data, but I just notice that's not the case. Any objection to shrinking that empty space?

Some video screen grabs are below with the changes in large and small format styles. 

#### large screen

![large](https://user-images.githubusercontent.com/1078448/127561882-f910a735-ed48-4585-b116-573d36e45f92.gif)

#### small screen

![small](https://user-images.githubusercontent.com/1078448/127561829-6fd522c9-86fa-4583-9436-fb29ebd35b90.gif)
