### PR TITLE
Include maximum shard size in second to_frames method

### DIFF
--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -216,6 +216,7 @@ class WS(Comm):
                 "recipient": self.remote_info,
                 **self.handshake_options,
             },
+            frame_split_size=BIG_BYTES_SHARD_SIZE,
         )
         n = struct.pack("Q", len(frames))
         try:


### PR DESCRIPTION
Websockets are weird in that they have two different Comm objects.
Previously we added the maximum shard size setting to one,
but not the other