### PR TITLE
Deprecate worker plugin overwrite policy

### DIFF
--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -198,7 +198,8 @@ async def test_registering_with_name_arg(c, s, w):
     assert list(responses.values()) == [{"status": "OK"}]
 
     async with Worker(s.address, loop=s.loop):
-        responses = await c.register_worker_plugin(FooWorkerPlugin(), name="foo")
+        with pytest.warns(FutureWarning, match="worker plugin will be overwritten"):
+            responses = await c.register_worker_plugin(FooWorkerPlugin(), name="foo")
         assert list(responses.values()) == [{"status": "repeat"}] * 2
 
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2722,6 +2722,13 @@ class Worker(ServerNode):
             assert name
 
             if name in self.plugins:
+                warnings.warn(
+                    "Attempting to add a worker plugin with the same name as an already registered "
+                    f"plugin ({name}). Currently this results in no change and the previously registered "
+                    "plugin is not overwritten. This behavior is deprecated and in a future release "
+                    f"the previously registered {name} worker plugin will be overwritten.",
+                    category=FutureWarning,
+                )
                 return {"status": "repeat"}
             else:
                 self.plugins[name] = plugin


### PR DESCRIPTION
Current when a worker plugin is registered with the same name as an already registered plugin, we do not overwrite the previously registered plugin.

https://github.com/dask/distributed/blob/1999c158521db8a1ec356f4389c8e9c1666b6a94/distributed/worker.py#L2724-L2725

However, with nanny plugins this behavior is different and we do overwrite previously registered plugins with the same name. To avoid user confusion, this PR proposes we deprecate our current worker plugin overwrite behavior to match the existing nanny plugin semantic. This will be, I think, more intuitive and will maintainable (xref https://github.com/dask/distributed/pull/5127#issuecomment-888466290). 