### PR TITLE
Split large header in comms

### DIFF
--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -209,3 +209,14 @@ async def test_wss_roundtrip(c, s, a, b):
     future = await c.scatter(x)
     y = await future
     assert (x == y).all()
+
+
+@gen_cluster(client=True, scheduler_kwargs={"protocol": "ws://"})
+async def test_ws_roundtrip_large(c, s, a, b):
+    import numpy as np
+
+    x = np.random.random(25000000)
+
+    future = c.submit(lambda x: x, x)
+    y = await future
+    assert (x == y).all()

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -120,6 +120,10 @@ class WSHandlerComm(Comm):
             },
             frame_split_size=BIG_BYTES_SHARD_SIZE,
         )
+        assert all(len(frame) <= BIG_BYTES_SHARD_SIZE for frame in frames), list(
+            map(len, frames)
+        )
+
         n = struct.pack("Q", len(frames))
         try:
             await self.handler.write_message(n, binary=True)
@@ -218,6 +222,10 @@ class WS(Comm):
             },
             frame_split_size=BIG_BYTES_SHARD_SIZE,
         )
+        assert all(len(frame) <= BIG_BYTES_SHARD_SIZE for frame in frames), list(
+            map(len, frames)
+        )
+
         n = struct.pack("Q", len(frames))
         try:
             await self.sock.write_message(n, binary=True)


### PR DESCRIPTION
Today we try to split up large messages in comms.
This is useful in a few situations:

1.  Websockets, which often pass frames through middleware that requires
    small messages
2.  TLS, which fails on some OpenSSL versions with frames above the size
    of an int

We correctly cut up data frames into smaller pieces to address these
issues.  However we don't apply this same logic to the header frame,
which may still contain very large bytestrings.  This commit adds a
workaround in protocol dumps/loads which watches for this event and
splits the header frame up if necessary.

It works, but it's not very smooth.  I would prefer that in the future
we think about what a proper header should look like and ensure that it
contains no user data.  In the meantime this should help.

cc @ian-r-rose @jakirkham 