### PR TITLE
Decouple serialization, frame splitting, and compression in protocol 

### DIFF
--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -209,3 +209,14 @@ async def test_wss_roundtrip(c, s, a, b):
     future = await c.scatter(x)
     y = await future
     assert (x == y).all()
+
+
+@gen_cluster(client=True, scheduler_kwargs={"protocol": "ws://"})
+async def test_ws_roundtrip_large(c, s, a, b):
+    import numpy as np
+
+    x = np.random.random(25000000)
+
+    future = c.submit(lambda x: x, x)
+    y = await future
+    assert (x == y).all()

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -120,6 +120,10 @@ class WSHandlerComm(Comm):
             },
             frame_split_size=BIG_BYTES_SHARD_SIZE,
         )
+        assert all(len(frame) <= BIG_BYTES_SHARD_SIZE for frame in frames), list(
+            map(len, frames)
+        )
+
         n = struct.pack("Q", len(frames))
         try:
             await self.handler.write_message(n, binary=True)
@@ -218,6 +222,10 @@ class WS(Comm):
             },
             frame_split_size=BIG_BYTES_SHARD_SIZE,
         )
+        assert all(len(frame) <= BIG_BYTES_SHARD_SIZE for frame in frames), list(
+            map(len, frames)
+        )
+
         n = struct.pack("Q", len(frames))
         try:
             await self.sock.write_message(n, binary=True)

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -189,6 +189,8 @@ def maybe_compress(
         return None, payload
     if len(payload) > 2 ** 31:  # Too large, compression libraries often fail
         return None, payload
+    if not isinstance(payload, (bytes, bytearray, memoryview)):  # Example: cuda objects
+        return None, payload
 
     min_size = int(min_size)
     sample_size = int(sample_size)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -1,16 +1,12 @@
+import functools
 import logging
 
 import msgpack
 
-from .compression import decompress, maybe_compress
-from .serialize import (
-    Serialize,
-    Serialized,
-    merge_and_deserialize,
-    msgpack_decode_default,
-    msgpack_encode_default,
-    serialize_and_split,
-)
+from .compression import compressions, maybe_compress
+from .serialize import Serialize, Serialized
+from .serialize import deserialize as _deserialize
+from .serialize import msgpack_decode_default, msgpack_encode_default, serialize
 from .utils import msgpack_opts
 
 logger = logging.getLogger(__name__)
@@ -54,14 +50,12 @@ def dumps(
                 if typ is Serialized:
                     sub_header, sub_frames = obj.header, obj.frames
                 else:
-                    sub_header, sub_frames = serialize_and_split(
+                    sub_header, sub_frames = serialize(
                         obj,
                         serializers=serializers,
                         on_error=on_error,
                         context=context,
-                        size=frame_split_size,
                     )
-                    _inplace_compress_frames(sub_header, sub_frames)
                 sub_header["num-sub-frames"] = len(sub_frames)
                 frames.append(
                     msgpack.dumps(
@@ -75,14 +69,44 @@ def dumps(
 
         frames[0] = msgpack.dumps(msg, default=_encode_default, use_bin_type=True)
 
-        if len(frames[0]) > frame_split_size:
-            from distributed.protocol.utils import frame_split_size as split
+        # Split large frames
+        frames2 = []
+        lengths = []
+        compressions = []
+        from distributed.protocol.utils import frame_split_size as split
 
-            msg_frames = split(frames[0], n=frame_split_size)
-            header = msgpack.dumps({"large-header": True, "count": len(msg_frames)})
-            frames = [header] + msg_frames + frames[1:]
+        for frame in frames:
+            if frame_split_size and len(frame) > frame_split_size:
+                sub_frames = split(frame, n=frame_split_size)
+                frames2.extend(sub_frames)
+                lengths.append(len(sub_frames))
+            else:
+                frames2.append(frame)
+                lengths.append(1)
 
-        return frames
+        frames = frames2
+
+        # Compress frames
+        if context and "compression" in context:
+            compress_opts = {"compression": context["compression"]}
+        else:
+            compress_opts = {}
+
+        for i, frame in enumerate(frames):
+            compression, compressed = maybe_compress(frame, **compress_opts)
+            frames[i] = compressed  # work in-place to avoid memory buildup
+            compressions.append(compression)
+
+        if any(length > 1 for length in lengths) or any(compressions):
+            header = {
+                "split-and-compressed": True,
+                "lengths": lengths,
+                "compressions": compressions,
+            }
+            return [msgpack.dumps(header)] + frames
+
+        else:
+            return frames
 
     except Exception:
         logger.critical("Failed to Serialize", exc_info=True)
@@ -94,7 +118,7 @@ def loads(frames, deserialize=True, deserializers=None):
 
     try:
 
-        def _decode_default(obj):
+        def _decode_default(obj, frames=[]):
             offset = obj.get("__Serialized__", 0)
             if offset > 0:
                 sub_header = msgpack.loads(
@@ -106,9 +130,7 @@ def loads(frames, deserialize=True, deserializers=None):
                 offset += 1
                 sub_frames = frames[offset : offset + sub_header["num-sub-frames"]]
                 if deserialize:
-                    if "compression" in sub_header:
-                        sub_frames = decompress(sub_header, sub_frames)
-                    return merge_and_deserialize(
+                    return _deserialize(
                         sub_header, sub_frames, deserializers=deserializers
                     )
                 else:
@@ -117,14 +139,48 @@ def loads(frames, deserialize=True, deserializers=None):
                 return msgpack_decode_default(obj)
 
         result = msgpack.loads(
-            frames[0], object_hook=_decode_default, use_list=False, **msgpack_opts
+            frames[0],
+            object_hook=functools.partial(_decode_default, frames=frames),
+            use_list=False,
+            **msgpack_opts,
         )
-        if isinstance(result, dict) and "large-header" in result:
-            frame = b"".join(frames[1 : result["count"] + 1])
-            frames = [frame] + frames[result["count"] + 1 :]
-            return loads(frames, deserialize=deserialize, deserializers=deserializers)
-        else:
-            return result
+
+        # Complex case, need to merge and decompress frames
+        if isinstance(result, dict) and "split-and-compressed" in result:
+            frames = frames[1:]
+
+            # Decompress all compressed frames
+            for i, (frame, compression) in enumerate(
+                zip(frames, result["compressions"])
+            ):
+                if compression:
+                    decompress = compressions[compression]["decompress"]
+                    decompressed = decompress(frame)
+                    frames[i] = decompressed
+
+            # Join all split frames
+            frames2 = []
+            i = 0
+            for length in result["lengths"]:
+                if length == 1:
+                    frames2.append(frames[i])
+                    frames[i] = None  # keep memory footprint low
+                else:
+                    frames2.append(bytearray().join(frames[i : i + length]))
+                    for j in range(i, i + length):
+                        frames[j] = None  # keep memory footprint low
+                i += length
+
+            frames = frames2
+
+            result = msgpack.loads(
+                frames[0],
+                object_hook=functools.partial(_decode_default, frames=frames),
+                use_list=False,
+                **msgpack_opts,
+            )
+
+        return result
 
     except Exception:
         logger.critical("Failed to deserialize", exc_info=True)

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -220,13 +220,13 @@ def test_compress_numpy():
     frames = dumps({"x": to_serialize(x)})
     assert sum(map(nbytes, frames)) < x.nbytes
 
-    header = msgpack.loads(frames[1], raw=False, use_list=False, strict_map_key=False)
+    header = msgpack.loads(frames[0], raw=False, use_list=False, strict_map_key=False)
     try:
         import blosc  # noqa: F401
     except ImportError:
         pass
     else:
-        assert all(c == "blosc" for c in header["compression"])
+        assert any(c == "blosc" for c in header["compressions"])
 
 
 def test_compress_memoryview():

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -22,13 +22,14 @@ def test_compression_1():
     assert {"x": x.tobytes()} == y
 
 
-def test_compression_2():
+def test_compression_small():
     pytest.importorskip("lz4")
     np = pytest.importorskip("numpy")
     x = np.random.random(10000)
     msg = dumps(to_serialize(x.tobytes()))
-    compression = msgpack.loads(msg[1]).get("compression")
-    assert all(c is None for c in compression)
+    assert not any(b"compression" in frame for frame in msg)
+    assert not any(b"blosc" in frame for frame in msg)
+    assert not any(b"lz4" in frame for frame in msg)
 
 
 def test_compression_without_deserialization():
@@ -36,7 +37,7 @@ def test_compression_without_deserialization():
     np = pytest.importorskip("numpy")
     x = np.ones(1000000)
 
-    frames = dumps({"x": Serialize(x)})
+    frames = dumps({"x": to_serialize(x)})
     assert all(len(frame) < 1000000 for frame in frames)
 
     msg = loads(frames, deserialize=False)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -451,12 +451,11 @@ async def test_frame_split():
 
     size = dask.utils.parse_bytes("3MiB")
     split_frames = await to_frames({"x": to_serialize(data)}, frame_split_size=size)
-    print(split_frames)
-    assert len(split_frames) == 3 + 2  # Three splits and two headers
+    assert len(split_frames) == 3 + 3  # Three splits and three headers
 
     size = dask.utils.parse_bytes("5MiB")
     split_frames = await to_frames({"x": to_serialize(data)}, frame_split_size=size)
-    assert len(split_frames) == 2 + 2  # Two splits and two headers
+    assert len(split_frames) == 2 + 3  # Two splits and three headers
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently compression and frame splitting are tightly interwoven with
traversing through messages.  This can be efficient, but results in a
complex system where it's hard to reason about when things get split or
compressed (indeed, this lead to a difficult to track down bug with
frame splitting).

This commit separates these processes into three separate stages:

1.  Serialize all objects into frames
2.  Split large frames
3.  Compress compressible frames

This results in a much more uniform application of splitting and
compressing.  However, this comes with a couple of undesired effects.

1.  We add a new header if either splitting or compressing has occurred
2.  We no longer avoid decompression when we don't want to deserialize

There is probably a clean way to achieve most/all of our goals here.
I wanted to push this up to start this conversation.


cc @quasiben @jakirkham @madsbk 