### PR TITLE
Rename total comm bytes and provide doc string

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -676,6 +676,9 @@ async def test_clean_nbytes(c, s, a, b):
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 20)
 async def test_gather_many_small(c, s, a, *workers):
+    """If the dependencies of a given task are very small, do not limit the
+    number of concurrent outgoing connections
+    """
     a.total_out_connections = 2
     futures = await c._scatter(list(range(100)))
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -235,7 +235,10 @@ class Worker(ServerNode):
         The maximum number of concurrent outgoing requests for data
     * **total_in_connections**: ``int``
         The maximum number of concurrent incoming requests for data
-    * **total_comm_nbytes**: ``int``
+    * **comm_threshold_bytes**: ``int``
+        As long as the total number of bytes in flight is below this threshold
+        we will not limit the number of outgoing connections for a single tasks
+        dependency fetch.
     * **batched_stream**: ``BatchedSend``
         A batched stream along which we communicate to the scheduler
     * **log**: ``[(message)]``
@@ -426,7 +429,7 @@ class Worker(ServerNode):
         self.total_in_connections = dask.config.get(
             "distributed.worker.connections.incoming"
         )
-        self.total_comm_nbytes = 10e6
+        self.comm_threshold_bytes = 10e6
         self.comm_nbytes = 0
         self._missing_dep_flight = set()
 
@@ -2144,7 +2147,7 @@ class Worker(ServerNode):
 
                 while dependencies_fetch and (
                     len(self.in_flight_workers) < self.total_out_connections
-                    or self.comm_nbytes < self.total_comm_nbytes
+                    or self.comm_nbytes < self.comm_threshold_bytes
                 ):
                     to_gather_ts = dependencies_fetch.pop()
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2291,6 +2291,15 @@ class Worker(ServerNode):
 
         return deps, total_bytes
 
+    @property
+    def total_comm_bytes(self):
+        warnings.warn(
+            "The attribute `Worker.total_comm_bytes` has been renamed to `comm_threshold_bytes`. "
+            "Future versions will only support the new name.",
+            DeprecationWarning,
+        )
+        return self.comm_threshold_bytes
+
     async def gather_dep(
         self,
         worker: str,


### PR DESCRIPTION
I actually thought this was dead code until I saw this is actually tested. I changed the attributes name since "total comm" rather feels like a counter instead of a limiter or threshold.