### PR TITLE
Remove excessive timeout of test_steal_during_task_deserialization

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2456,7 +2456,7 @@ async def test_forget_dependents_after_release(c, s, a):
     assert fut2.key not in {d.key for d in a.tasks[fut.key].dependents}
 
 
-@gen_cluster(client=True, nthreads=[("", 1)] * 2)
+@gen_cluster(client=True)
 async def test_steal_during_task_deserialization(c, s, a, b, monkeypatch):
     stealing_ext = s.extensions["stealing"]
     stealing_ext._pc.stop()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2456,8 +2456,8 @@ async def test_forget_dependents_after_release(c, s, a):
     assert fut2.key not in {d.key for d in a.tasks[fut.key].dependents}
 
 
-@gen_cluster(client=True, nthreads=[("", 1)] * 2, timeout=5000000)
-async def test_steak_during_task_deserialization(c, s, a, b, monkeypatch):
+@gen_cluster(client=True, nthreads=[("", 1)] * 2)
+async def test_steal_during_task_deserialization(c, s, a, b, monkeypatch):
     stealing_ext = s.extensions["stealing"]
     stealing_ext._pc.stop()
     from distributed.utils import ThreadPoolExecutor


### PR DESCRIPTION
This slipped through our rigorous review process of https://github.com/dask/distributed/pull/5128