### PR TITLE
Resolve partial deadlock gather dep

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -9,10 +9,11 @@ import pytest
 from tornado import gen
 
 from distributed import Client, Nanny, Scheduler, Worker, config, default_client
-from distributed.core import rpc
+from distributed.core import Server, rpc
 from distributed.metrics import time
 from distributed.utils import get_ip
 from distributed.utils_test import (
+    _LockedCommPool,
     _UnhashableCallable,
     cluster,
     gen_cluster,
@@ -277,3 +278,98 @@ def test__UnhashableCallable():
     assert func(1) == 2
     with pytest.raises(TypeError, match="unhashable"):
         hash(func)
+
+
+class MyServer(Server):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.handlers["ping"] = self.pong
+        self.counter = 0
+
+    def pong(self, comm):
+        self.counter += 1
+        return "pong"
+
+
+@pytest.mark.asyncio
+async def test_locked_comm_drop_in_replacement(loop):
+
+    a = await MyServer({})
+    await a.listen(0)
+
+    read_event = asyncio.Event()
+    read_event.set()
+    read_queue = asyncio.Queue()
+    original_pool = a.rpc
+    a.rpc = _LockedCommPool(original_pool, read_event=read_event, read_queue=read_queue)
+
+    b = await MyServer({})
+    await b.listen(0)
+    # Event is set, the pool works like an ordinary pool
+    res = await a.rpc(b.address).ping()
+    assert await read_queue.get() == (b.address, "pong")
+    assert res == "pong"
+    assert b.counter == 1
+
+    read_event.clear()
+    # Can also be used without a lock to intercept network traffic
+    a.rpc = _LockedCommPool(original_pool, read_queue=read_queue)
+    a.rpc.remove(b.address)
+    res = await a.rpc(b.address).ping()
+    assert await read_queue.get() == (b.address, "pong")
+
+
+@pytest.mark.asyncio
+async def test_locked_comm_intercept_read(loop):
+
+    a = await MyServer({})
+    await a.listen(0)
+    b = await MyServer({})
+    await b.listen(0)
+
+    read_event = asyncio.Event()
+    read_queue = asyncio.Queue()
+    a.rpc = _LockedCommPool(a.rpc, read_event=read_event, read_queue=read_queue)
+
+    async def ping_pong():
+        return await a.rpc(b.address).ping()
+
+    fut = asyncio.create_task(ping_pong())
+
+    # We didn't block the write but merely the read. The remove should have
+    # received the message and responded already
+    while not b.counter:
+        await asyncio.sleep(0.001)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(fut), 0.01)
+
+    assert await read_queue.get() == (b.address, "pong")
+    read_event.set()
+    assert await fut == "pong"
+
+
+@pytest.mark.asyncio
+async def test_locked_comm_intercept_write(loop):
+
+    a = await MyServer({})
+    await a.listen(0)
+    b = await MyServer({})
+    await b.listen(0)
+
+    write_event = asyncio.Event()
+    write_queue = asyncio.Queue()
+    a.rpc = _LockedCommPool(a.rpc, write_event=write_event, write_queue=write_queue)
+
+    async def ping_pong():
+        return await a.rpc(b.address).ping()
+
+    fut = asyncio.create_task(ping_pong())
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(fut), 0.01)
+    # Write was blocked. The remote hasn't received the message, yet
+    assert b.counter == 0
+    assert await write_queue.get() == (b.address, {"op": "ping", "reply": True})
+    write_event.set()
+    assert await fut == "pong"

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -39,12 +39,14 @@ from tornado.ioloop import IOLoop
 
 import dask
 
+from distributed.comm.tcp import TCP
+
 from . import system
 from .client import Client, _global_clients, default_client
 from .comm import Comm
 from .compatibility import WINDOWS
 from .config import initialize_logging
-from .core import CommClosedError, Status, connect, rpc
+from .core import CommClosedError, ConnectionPool, Status, connect, rpc
 from .deploy import SpecCluster
 from .diagnostics.plugin import WorkerPlugin
 from .metrics import time
@@ -1616,3 +1618,77 @@ class TaskStateMetadataPlugin(WorkerPlugin):
             ts.metadata["start_time"] = time()
         elif start == "executing" and finish == "memory":
             ts.metadata["stop_time"] = time()
+
+
+class LockedComm(TCP):
+    def __init__(self, comm, read_event, read_queue, write_event, write_queue):
+        self.write_event = write_event
+        self.write_queue = write_queue
+        self.read_event = read_event
+        self.read_queue = read_queue
+        self.comm = comm
+        assert isinstance(comm, TCP)
+
+    def __getattr__(self, name):
+        return getattr(self.comm, name)
+
+    async def write(self, msg, serializers=None, on_error="message"):
+        if self.write_queue:
+            await self.write_queue.put((self.comm.peer_address, msg))
+        if self.write_event:
+            await self.write_event.wait()
+        return await self.comm.write(msg, serializers=serializers, on_error=on_error)
+
+    async def read(self, deserializers=None):
+        msg = await self.comm.read(deserializers=deserializers)
+        if self.read_queue:
+            await self.read_queue.put((self.comm.peer_address, msg))
+        if self.read_event:
+            await self.read_event.wait()
+        return msg
+
+
+class _LockedCommPool(ConnectionPool):
+    """A ConnectionPool wrapper to intercept network traffic between servers
+
+    This wrapper can be attached to a running server to intercept outgoing read or write requests in test environments.
+
+    Examples
+    --------
+    >>> w = await Worker(...)
+    >>> read_event = asyncio.Event()
+    >>> read_queue = asyncio.Queue()
+    >>> w.rpc = _LockedCommPool(
+            w.rpc,
+            read_event=read_event,
+            read_queue=read_queue,
+        )
+    # It might be necessary to remove all existing comms
+    # if the wrapped pool has been used before
+    >>> w.remove(remote_address)
+
+    >>> async def ping_pong():
+            return await w.rpc(remote_address).ping()
+    >>> with pytest.raises(asyncio.TimeoutError):
+    >>>     await asyncio.wait_for(ping_pong(), 0.01)
+    >>> read_event.set()
+    >>> await ping_pong()
+    """
+
+    def __init__(
+        self, pool, read_event=None, read_queue=None, write_event=None, write_queue=None
+    ):
+        self.write_event = write_event
+        self.write_queue = write_queue
+        self.read_event = read_event
+        self.read_queue = read_queue
+        self.pool = pool
+
+    def __getattr__(self, name):
+        return getattr(self.pool, name)
+
+    async def connect(self, *args, **kwargs):
+        comm = await self.pool.connect(*args, **kwargs)
+        return LockedComm(
+            comm, self.read_event, self.read_queue, self.write_event, self.write_queue
+        )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2443,38 +2443,56 @@ class Worker(ServerNode):
                 assert set(to_gather_keys).issubset(
                     set(self.in_flight_workers.get(worker))
                 )
+
                 for d in self.in_flight_workers.pop(worker):
-
                     ts = self.tasks.get(d)
-
-                    if not busy and d in data:
-                        self.transition(ts, "memory", value=data[d])
-                    elif ts is None or ts.state == "executing":
-                        self.log.append(("already-executing", d))
-                        self.release_key(d, reason="already executing at gather")
-                    elif ts.state == "flight" and not ts.dependents:
-                        self.log.append(("flight no-dependents", d))
-                        self.release_key(
-                            d, reason="In-flight task no longer has dependents."
+                    try:
+                        if not busy and d in data:
+                            self.transition(ts, "memory", value=data[d])
+                        elif ts is None or ts.state == "executing":
+                            self.log.append(("already-executing", d))
+                            self.release_key(d, reason="already executing at gather")
+                        elif ts.state == "flight" and not ts.dependents:
+                            self.log.append(("flight no-dependents", d))
+                            self.release_key(
+                                d, reason="In-flight task no longer has dependents."
+                            )
+                        elif (
+                            not busy
+                            and d not in data
+                            and ts.dependents
+                            and ts.state != "memory"
+                        ):
+                            ts.who_has.discard(worker)
+                            self.has_what[worker].discard(ts.key)
+                            self.log.append(("missing-dep", d))
+                            self.batched_stream.send(
+                                {
+                                    "op": "missing-data",
+                                    "errant_worker": worker,
+                                    "key": d,
+                                }
+                            )
+                            self.transition(ts, "fetch")
+                        elif ts.state not in ("ready", "memory"):
+                            self.transition(ts, "fetch")
+                        else:
+                            logger.debug(
+                                "Unexpected task state encountered for %r after gather_dep",
+                                ts,
+                            )
+                    except Exception as exc:
+                        emsg = error_message(exc)
+                        assert ts is not None, ts
+                        self.log.append(
+                            (ts.key, "except-gather-dep-result", emsg, time())
                         )
-                    elif (
-                        not busy
-                        and d not in data
-                        and ts.dependents
-                        and ts.state != "memory"
-                    ):
-                        ts.who_has.discard(worker)
-                        self.has_what[worker].discard(ts.key)
-                        self.log.append(("missing-dep", d))
-                        self.batched_stream.send(
-                            {"op": "missing-data", "errant_worker": worker, "key": d}
-                        )
-                        self.transition(ts, "fetch")
-                    elif ts.state not in ("ready", "memory"):
-                        self.transition(ts, "fetch")
-                    else:
+                        # FIXME: We currently cannot release this task and its
+                        # dependent safely
                         logger.debug(
-                            "Unexpected task state encountered for %s after gather_dep"
+                            "Exception occured while handling `gather_dep` response for %r",
+                            ts,
+                            exc_info=True,
                         )
 
                 if self.validate:


### PR DESCRIPTION
This partially resolves a deadlock associated with transition errors after gather_dep. The reason that transition errors can even occur at this point is that while a task is fetching, the state on the worker may have changed. In particular if the task is released and rescheduled for fetch while the `gather_dep` coroutine is still running, this may trigger a `fetch->memory` transition which is otherwise forbidden

Closes https://github.com/dask/distributed/issues/5152