### PR TITLE
Fix RMM and UCX tests

### DIFF
--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -49,4 +49,4 @@ conda config --show-sources
 conda list --show-channel-urls
 
 gpuci_logger "Python py.test for dask"
-py.test $WORKSPACE -n 4 -v -m gpu --junitxml="$WORKSPACE/junit-distributed.xml" --cov-config="$WORKSPACE/.coveragerc" --cov=distributed --cov-report=xml:"$WORKSPACE/distributed-coverage.xml" --cov-report term
+py.test $WORKSPACE -v -m gpu --junitxml="$WORKSPACE/junit-distributed.xml"

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -49,4 +49,4 @@ conda config --show-sources
 conda list --show-channel-urls
 
 gpuci_logger "Python py.test for dask"
-py.test $WORKSPACE -v -m gpu --junitxml="$WORKSPACE/junit-distributed.xml"
+py.test $WORKSPACE -v -m gpu --runslow --junitxml="$WORKSPACE/junit-distributed.xml"

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -33,7 +33,6 @@ async def test_ucx_config(cleanup):
         "cuda_copy": True,
     }
 
-    # with dask.config.set(ucx=ucx):
     with dask.config.set({"distributed.comm.ucx": ucx}):
         ucx_config = _scrub_ucx_config()
         if ucx_110:


### PR DESCRIPTION
The `rmm.get_info()` function was removed a while back, and it's not possible anymore to query for a pool size. We can still verify the memory resource type to verify that an RMM pool is indeed used.

Changes in UCX configuration also caused tests to break, those failures are also fixed.