### PR TITLE
Bump RAPIDS_VER to 21.10

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -1,8 +1,8 @@
 PYTHON_VER:
-- 3.8
+- "3.8"
 
 CUDA_VER:
-- 11.2
+- "11.2"
 
 LINUX_VER:
 - ubuntu18.04

--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -8,6 +8,6 @@ LINUX_VER:
 - ubuntu18.04
 
 RAPIDS_VER:
-- 21.08
+- 21.10
 
 excludes:

--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -8,6 +8,6 @@ LINUX_VER:
 - ubuntu18.04
 
 RAPIDS_VER:
-- 21.10
+- "21.10"
 
 excludes:


### PR DESCRIPTION
This will ensure we get the latest nightly builds of cuDF / Dask-cuDF when running gpuCI.

cc @quasiben @jrbourbeau 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
