### PR TITLE
Set `float_to_top` `isort` flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/pycqa/isort
-      rev: 5.8.0
+      rev: 5.9.3
       hooks:
       - id: isort
         language_version: python3

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,9 @@
 # https://pytest.org/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
 import pytest
 
+# Make all fixtures available
+from distributed.utils_test import *  # noqa
+
 # Uncomment to enable more logging and checks
 # (https://docs.python.org/3/library/asyncio-dev.html)
 # Note this makes things slower and might consume much memory.
@@ -15,9 +18,6 @@ else:
         faulthandler.enable()
     except Exception:
         pass
-
-# Make all fixtures available
-from distributed.utils_test import *  # noqa
 
 
 def pytest_addoption(parser):

--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -6,13 +6,7 @@ after which we can import them instead of having our own definitions.
 
 import atexit
 import os
-
-try:
-    import queue
-except ImportError:
-    # Python 2
-    import Queue as queue
-
+import queue
 import sys
 from subprocess import Popen
 from threading import Event, Thread

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -1,14 +1,11 @@
-import psutil
-import pytest
-
-pytest.importorskip("requests")
-
 import os
 import shutil
 import sys
 import tempfile
 from time import sleep
 
+import psutil
+import pytest
 import requests
 from click.testing import CliRunner
 
@@ -23,6 +20,8 @@ from distributed.utils_test import (
     assert_can_connect_locally_4,
     popen,
 )
+
+pytest.importorskip("requests")
 
 
 def test_defaults(loop):

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -6,7 +6,6 @@ from time import sleep
 
 import psutil
 import pytest
-import requests
 from click.testing import CliRunner
 
 import distributed
@@ -21,7 +20,7 @@ from distributed.utils_test import (
     popen,
 )
 
-pytest.importorskip("requests")
+requests = pytest.importorskip("requests")
 
 
 def test_defaults(loop):

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -4,7 +4,6 @@ from multiprocessing import cpu_count
 from time import sleep
 
 import pytest
-import requests
 from click.testing import CliRunner
 
 import distributed.cli.dask_worker
@@ -15,7 +14,7 @@ from distributed.metrics import time
 from distributed.utils import parse_ports, sync, tmpfile
 from distributed.utils_test import gen_cluster, popen, terminate_process, wait_for_port
 
-pytest.importorskip("requests")
+requests = pytest.importorskip("requests")
 
 
 def test_nanny_worker_ports(loop):

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -1,15 +1,11 @@
 import asyncio
-
-import pytest
-from click.testing import CliRunner
-
-pytest.importorskip("requests")
-
 import os
 from multiprocessing import cpu_count
 from time import sleep
 
+import pytest
 import requests
+from click.testing import CliRunner
 
 import distributed.cli.dask_worker
 from distributed import Client, Scheduler
@@ -18,6 +14,8 @@ from distributed.deploy.utils import nprocesses_nthreads
 from distributed.metrics import time
 from distributed.utils import parse_ports, sync, tmpfile
 from distributed.utils_test import gen_cluster, popen, terminate_process, wait_for_port
+
+pytest.importorskip("requests")
 
 
 def test_nanny_worker_ports(loop):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -25,6 +25,8 @@ from numbers import Number
 from queue import Queue as pyQueue
 
 from tlz import first, groupby, keymap, merge, partition_all, valmap
+from tornado import gen
+from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
 from dask.base import collections_to_dsk, normalize_token, tokenize
@@ -40,13 +42,6 @@ from dask.utils import (
     parse_timedelta,
     stringify,
 )
-
-try:
-    from dask.delayed import single_key
-except ImportError:
-    single_key = first
-from tornado import gen
-from tornado.ioloop import IOLoop, PeriodicCallback
 
 from . import versions as version_module
 from .batched import BatchedSend
@@ -97,6 +92,12 @@ from .utils_comm import (
     unpack_remotedata,
 )
 from .worker import get_client, get_worker, secede
+
+try:
+    from dask.delayed import single_key
+except ImportError:
+    single_key = first
+
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -31,6 +31,7 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 import dask
 from dask.base import collections_to_dsk, normalize_token, tokenize
 from dask.core import flatten
+from dask.delayed import single_key
 from dask.highlevelgraph import HighLevelGraph
 from dask.optimization import SubgraphCallable
 from dask.utils import (
@@ -92,12 +93,6 @@ from .utils_comm import (
     unpack_remotedata,
 )
 from .worker import get_client, get_worker, secede
-
-try:
-    from dask.delayed import single_key
-except ImportError:
-    single_key = first
-
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -8,15 +8,8 @@ import sys
 import weakref
 from ssl import SSLCertVerificationError, SSLError
 
-from tornado import gen
-
-try:
-    import ssl
-except ImportError:
-    ssl = None
-
 from tlz import sliding_window
-from tornado import netutil
+from tornado import gen, netutil
 from tornado.iostream import StreamClosedError
 from tornado.tcpclient import TCPClient
 from tornado.tcpserver import TCPServer
@@ -32,6 +25,12 @@ from .addressing import parse_host_port, unparse_host_port
 from .core import Comm, CommClosedError, Connector, FatalCommClosedError, Listener
 from .registry import Backend, backends
 from .utils import ensure_concrete_host, from_frames, get_tcp_server_address, to_frames
+
+try:
+    import ssl
+except ImportError:
+    ssl = None
+
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -2,16 +2,17 @@ import asyncio
 
 import pytest
 
-pytestmark = pytest.mark.gpu
-
-ucp = pytest.importorskip("ucp")
-
 from distributed import Client, Scheduler, wait
 from distributed.comm import connect, listen, parse_address, ucx
 from distributed.comm.registry import backends, get_backend
 from distributed.deploy.local import LocalCluster
 from distributed.protocol import to_serialize
 from distributed.utils_test import gen_cluster, gen_test, inc
+
+pytestmark = pytest.mark.gpu
+
+ucp = pytest.importorskip("ucp")
+
 
 try:
     HOST = ucp.get_address()

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -2,14 +2,15 @@ from time import sleep
 
 import pytest
 
-pytestmark = pytest.mark.gpu
-
 import dask
 
 from distributed import Client
 from distributed.comm.ucx import _scrub_ucx_config
 from distributed.utils import get_ip
 from distributed.utils_test import popen
+
+pytestmark = pytest.mark.gpu
+
 
 try:
     HOST = get_ip()

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -40,6 +40,7 @@ from bokeh.palettes import Viridis11
 from bokeh.plotting import figure
 from bokeh.themes import Theme
 from bokeh.transform import cumsum, factor_cmap, linear_cmap
+from jinja2 import Environment, FileSystemLoader
 from tlz import curry, pipe
 from tlz.curried import concat, groupby, map
 from tornado import escape
@@ -47,11 +48,6 @@ from tornado import escape
 import dask
 from dask import config
 from dask.utils import format_bytes, format_time, key_split, parse_timedelta
-
-try:
-    import numpy as np
-except ImportError:
-    np = False
 
 from distributed.dashboard.components import add_periodic_callback
 from distributed.dashboard.components.shared import (
@@ -69,6 +65,12 @@ from distributed.diagnostics.task_stream import colors as ts_color_lookup
 from distributed.metrics import time
 from distributed.utils import Log, log_errors
 
+try:
+    import numpy as np
+except ImportError:
+    np = False
+
+
 if dask.config.get("distributed.dashboard.export-tool"):
     from distributed.dashboard.export_tool import ExportTool
 else:
@@ -76,7 +78,6 @@ else:
 
 logger = logging.getLogger(__name__)
 
-from jinja2 import Environment, FileSystemLoader
 
 env = Environment(
     loader=FileSystemLoader(

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -19,6 +19,7 @@ from bokeh.models.widgets import DataTable, TableColumn
 from bokeh.palettes import RdBu
 from bokeh.plotting import figure
 from bokeh.themes import Theme
+from jinja2 import Environment, FileSystemLoader
 from tlz import merge, partition_all
 
 from dask.utils import format_bytes, format_time
@@ -37,7 +38,6 @@ from distributed.utils import key_split, log_errors
 
 logger = logging.getLogger(__name__)
 
-from jinja2 import Environment, FileSystemLoader
 
 env = Environment(
     loader=FileSystemLoader(

--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -7,12 +7,13 @@ from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.server.server import BokehTornado
 
+import dask
+
 try:
     from bokeh.server.util import create_hosts_allowlist
 except ImportError:
     from bokeh.server.util import create_hosts_whitelist as create_hosts_allowlist
 
-import dask
 
 if LooseVersion(bokeh.__version__) < LooseVersion("1.0.0"):
     warnings.warn(

--- a/distributed/dashboard/tests/test_components.py
+++ b/distributed/dashboard/tests/test_components.py
@@ -1,9 +1,6 @@
 import asyncio
 
 import pytest
-
-pytest.importorskip("bokeh")
-
 from bokeh.models import ColumnDataSource, Model
 
 from distributed.dashboard.components.shared import (
@@ -12,6 +9,8 @@ from distributed.dashboard.components.shared import (
     ProfileTimePlot,
 )
 from distributed.utils_test import gen_cluster, slowinc
+
+pytest.importorskip("bokeh")
 
 
 @pytest.mark.parametrize("Component", [Processing])

--- a/distributed/dashboard/tests/test_components.py
+++ b/distributed/dashboard/tests/test_components.py
@@ -1,6 +1,11 @@
 import asyncio
 
 import pytest
+
+# isort: off
+bokeh = pytest.importorskip("bokeh")
+# isort: on
+
 from bokeh.models import ColumnDataSource, Model
 
 from distributed.dashboard.components.shared import (
@@ -9,8 +14,6 @@ from distributed.dashboard.components.shared import (
     ProfileTimePlot,
 )
 from distributed.utils_test import gen_cluster, slowinc
-
-pytest.importorskip("bokeh")
 
 
 @pytest.mark.parametrize("Component", [Processing])

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -6,8 +6,6 @@ import sys
 from time import sleep
 
 import pytest
-
-pytest.importorskip("bokeh")
 from bokeh.server.server import BokehTornado
 from tlz import first
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
@@ -45,6 +43,9 @@ from distributed.dashboard.scheduler import applications
 from distributed.metrics import time
 from distributed.utils import format_dashboard_link
 from distributed.utils_test import dec, div, gen_cluster, get_cert, inc, slowinc
+
+pytest.importorskip("bokeh")
+
 
 scheduler.PROFILING = False
 

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -6,6 +6,11 @@ import sys
 from time import sleep
 
 import pytest
+
+# isort: off
+pytest.importorskip("bokeh")
+# isort: on
+
 from bokeh.server.server import BokehTornado
 from tlz import first
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
@@ -43,9 +48,6 @@ from distributed.dashboard.scheduler import applications
 from distributed.metrics import time
 from distributed.utils import format_dashboard_link
 from distributed.utils_test import dec, div, gen_cluster, get_cert, inc, slowinc
-
-pytest.importorskip("bokeh")
-
 
 scheduler.PROFILING = False
 

--- a/distributed/dashboard/tests/test_worker_bokeh.py
+++ b/distributed/dashboard/tests/test_worker_bokeh.py
@@ -4,8 +4,6 @@ from operator import add, sub
 from time import sleep
 
 import pytest
-
-pytest.importorskip("bokeh")
 from tlz import first
 from tornado.httpclient import AsyncHTTPClient
 
@@ -21,6 +19,8 @@ from distributed.dashboard.components.worker import (
 )
 from distributed.metrics import time
 from distributed.utils_test import dec, gen_cluster, inc
+
+pytest.importorskip("bokeh")
 
 
 @gen_cluster(

--- a/distributed/dashboard/tests/test_worker_bokeh.py
+++ b/distributed/dashboard/tests/test_worker_bokeh.py
@@ -4,6 +4,10 @@ from operator import add, sub
 from time import sleep
 
 import pytest
+
+# isort: off
+pytest.importorskip("bokeh")
+# isort: on
 from tlz import first
 from tornado.httpclient import AsyncHTTPClient
 
@@ -19,8 +23,6 @@ from distributed.dashboard.components.worker import (
 )
 from distributed.metrics import time
 from distributed.utils_test import dec, gen_cluster, inc
-
-pytest.importorskip("bokeh")
 
 
 @gen_cluster(

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -4,16 +4,16 @@ import socket
 import sys
 import time
 import traceback
+from threading import Thread
+
+from tlz import merge
+from tornado import gen
 
 try:
     from queue import Queue
 except ImportError:  # Python 2.7 fix
     from Queue import Queue
 
-from threading import Thread
-
-from tlz import merge
-from tornado import gen
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/deploy/tests/test_old_ssh.py
+++ b/distributed/deploy/tests/test_old_ssh.py
@@ -2,11 +2,11 @@ from time import sleep
 
 import pytest
 
-pytest.importorskip("paramiko")
-
 from distributed import Client
 from distributed.deploy.old_ssh import SSHCluster
 from distributed.metrics import time
+
+pytest.importorskip("paramiko")
 
 
 @pytest.mark.avoid_ci

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -1,14 +1,15 @@
-import pytest
-
-pytest.importorskip("asyncssh")
-
 import sys
+
+import pytest
 
 import dask
 
 from distributed import Client
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.deploy.ssh import SSHCluster
+
+pytest.importorskip("asyncssh")
+
 
 pytestmark = [
     pytest.mark.xfail(MACOS, reason="very high flakiness; see distributed/issues/4543"),

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -2,14 +2,14 @@ import os
 
 import pytest
 
-pytestmark = pytest.mark.gpu
-
-pynvml = pytest.importorskip("pynvml")
-
 import dask
 
 from distributed.diagnostics import nvml
 from distributed.utils_test import gen_cluster
+
+pytestmark = pytest.mark.gpu
+
+pynvml = pytest.importorskip("pynvml")
 
 
 def test_one_time():

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -1,12 +1,12 @@
 import pytest
 
-pytest.importorskip("bokeh")
-
 from dask import delayed
 
 from distributed.client import wait
 from distributed.diagnostics.progress_stream import progress_quads, progress_stream
 from distributed.utils_test import div, gen_cluster, inc
+
+pytest.importorskip("bokeh")
 
 
 def test_progress_quads():

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -2,6 +2,10 @@ import re
 from operator import add
 
 import pytest
+
+# isort: off
+pytest.importorskip("ipywidgets")
+# isort: on
 from ipykernel.comm import Comm
 from ipywidgets import Widget
 from tlz import valmap
@@ -14,9 +18,6 @@ from distributed.diagnostics.progressbar import (
 )
 from distributed.utils_test import dec, gen_cluster, gen_tls_cluster, inc, throws
 from distributed.worker import dumps_task
-
-pytest.importorskip("ipywidgets")
-
 
 #################
 # Utility stuff #

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -1,9 +1,22 @@
+import re
+from operator import add
+
 import pytest
+from ipykernel.comm import Comm
+from ipywidgets import Widget
+from tlz import valmap
+
+from distributed.client import wait
+from distributed.diagnostics.progressbar import (
+    MultiProgressWidget,
+    ProgressWidget,
+    progress,
+)
+from distributed.utils_test import dec, gen_cluster, gen_tls_cluster, inc, throws
+from distributed.worker import dumps_task
 
 pytest.importorskip("ipywidgets")
 
-from ipykernel.comm import Comm
-from ipywidgets import Widget
 
 #################
 # Utility stuff #
@@ -70,20 +83,6 @@ def record_display(*args):
 #####################
 # Distributed stuff #
 #####################
-
-import re
-from operator import add
-
-from tlz import valmap
-
-from distributed.client import wait
-from distributed.diagnostics.progressbar import (
-    MultiProgressWidget,
-    ProgressWidget,
-    progress,
-)
-from distributed.utils_test import dec, gen_cluster, gen_tls_cluster, inc, throws
-from distributed.worker import dumps_task
 
 
 @gen_cluster(client=True)

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -2,9 +2,6 @@ import json
 import re
 
 import pytest
-
-pytest.importorskip("bokeh")
-
 from tornado.escape import url_escape
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError
 
@@ -12,6 +9,8 @@ from dask.sizeof import sizeof
 
 from distributed.utils import is_valid_xml
 from distributed.utils_test import gen_cluster, inc, slowinc
+
+pytest.importorskip("bokeh")
 
 
 @gen_cluster(client=True)

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -12,6 +12,8 @@ from tlz import identity
 
 import dask
 
+from ..utils import ensure_bytes
+
 try:
     import blosc
 
@@ -21,7 +23,6 @@ try:
 except ImportError:
     blosc = False
 
-from ..utils import ensure_bytes
 
 compressions = {None: {"compress": identity, "decompress": identity}}
 

--- a/distributed/protocol/tests/test_arrow.py
+++ b/distributed/protocol/tests/test_arrow.py
@@ -1,11 +1,12 @@
 import pytest
 
-pa = pytest.importorskip("pyarrow")
-pd = pytest.importorskip("pandas")
-
 import distributed
 from distributed.protocol import deserialize, serialize, to_serialize
 from distributed.utils_test import gen_cluster
+
+pa = pytest.importorskip("pyarrow")
+pd = pytest.importorskip("pandas")
+
 
 df = pd.DataFrame({"A": list("abc"), "B": [1, 2, 3]})
 tbl = pa.Table.from_pandas(df, preserve_index=False)

--- a/distributed/protocol/tests/test_collection_cuda.py
+++ b/distributed/protocol/tests/test_collection_cuda.py
@@ -1,10 +1,10 @@
 import pytest
 
-pytestmark = pytest.mark.gpu
-
 from dask.dataframe.utils import assert_eq
 
 from distributed.protocol import deserialize, serialize
+
+pytestmark = pytest.mark.gpu
 
 
 @pytest.mark.parametrize("collection", [tuple, dict])

--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -2,9 +2,10 @@ import pickle
 
 import pytest
 
+from distributed.protocol import deserialize, serialize
+
 pytestmark = pytest.mark.gpu
 
-from distributed.protocol import deserialize, serialize
 
 cupy = pytest.importorskip("cupy")
 numpy = pytest.importorskip("numpy")

--- a/distributed/protocol/tests/test_h5py.py
+++ b/distributed/protocol/tests/test_h5py.py
@@ -3,10 +3,13 @@ import traceback
 
 import pytest
 
-h5py = pytest.importorskip("h5py")
+import dask.array as da
 
 from distributed.protocol import deserialize, serialize
 from distributed.utils import tmpfile
+from distributed.utils_test import gen_cluster
+
+h5py = pytest.importorskip("h5py")
 
 
 def silence_h5py_issue775(func):
@@ -79,11 +82,6 @@ def test_raise_error_on_serialize_write_permissions():
                 deserialize(*serialize(x))
             with pytest.raises(TypeError):
                 deserialize(*serialize(f))
-
-
-import dask.array as da
-
-from distributed.utils_test import gen_cluster
 
 
 @silence_h5py_issue775

--- a/distributed/protocol/tests/test_highlevelgraph.py
+++ b/distributed/protocol/tests/test_highlevelgraph.py
@@ -1,6 +1,7 @@
 import ast
 
 import pytest
+from numpy.testing import assert_array_equal
 
 import dask
 import dask.array as da
@@ -11,8 +12,6 @@ from distributed.utils_test import gen_cluster
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
-
-from numpy.testing import assert_array_equal
 
 
 @gen_cluster(client=True)

--- a/distributed/protocol/tests/test_highlevelgraph.py
+++ b/distributed/protocol/tests/test_highlevelgraph.py
@@ -1,7 +1,6 @@
 import ast
 
 import pytest
-from numpy.testing import assert_array_equal
 
 import dask
 import dask.array as da
@@ -146,7 +145,7 @@ async def test_array_annotations(c, s, a, b):
     with dask.config.set(optimization__fuse__active=False):
         result = await c.compute(B)
 
-    assert_array_equal(result, 2)
+    np.testing.assert_array_equal(result, 2)
 
     # There are annotation matches per array chunk (i.e. task)
     assert plugin.qux_matches == A.npartitions

--- a/distributed/protocol/tests/test_keras.py
+++ b/distributed/protocol/tests/test_keras.py
@@ -1,9 +1,9 @@
 import pytest
 
+from distributed.protocol import deserialize, dumps, loads, serialize, to_serialize
+
 keras = pytest.importorskip("keras")
 np = pytest.importorskip("numpy")
-
-from distributed.protocol import deserialize, dumps, loads, serialize, to_serialize
 
 
 def test_serialize_deserialize_model():

--- a/distributed/protocol/tests/test_netcdf4.py
+++ b/distributed/protocol/tests/test_netcdf4.py
@@ -1,10 +1,11 @@
 import pytest
 
-import dask.array as da
-
 from distributed.protocol import deserialize, serialize
 from distributed.utils import tmpfile
 from distributed.utils_test import gen_cluster
+
+da = pytest.importorskip("dask.array")
+
 
 netCDF4 = pytest.importorskip("netCDF4")
 np = pytest.importorskip("numpy")

--- a/distributed/protocol/tests/test_netcdf4.py
+++ b/distributed/protocol/tests/test_netcdf4.py
@@ -1,10 +1,13 @@
 import pytest
 
-netCDF4 = pytest.importorskip("netCDF4")
-np = pytest.importorskip("numpy")
+import dask.array as da
 
 from distributed.protocol import deserialize, serialize
 from distributed.utils import tmpfile
+from distributed.utils_test import gen_cluster
+
+netCDF4 = pytest.importorskip("netCDF4")
+np = pytest.importorskip("numpy")
 
 
 def create_test_dataset(fn):
@@ -72,11 +75,6 @@ def test_serialize_deserialize_group():
                 assert y.dimensions == ("x",)
                 assert x.dtype == y.dtype
                 assert (x[:] == y[:]).all()
-
-
-import dask.array as da
-
-from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True)

--- a/distributed/protocol/tests/test_numba.py
+++ b/distributed/protocol/tests/test_numba.py
@@ -2,9 +2,10 @@ import pickle
 
 import pytest
 
+from distributed.protocol import deserialize, serialize
+
 pytestmark = pytest.mark.gpu
 
-from distributed.protocol import deserialize, serialize
 
 cuda = pytest.importorskip("numba.cuda")
 np = pytest.importorskip("numpy")

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -19,7 +19,9 @@ from distributed.system import MEMORY_LIMIT
 from distributed.utils import ensure_bytes, nbytes, tmpfile
 from distributed.utils_test import gen_cluster
 
+# isort:off
 np = pytest.importorskip("numpy")
+# isort:on
 
 
 def test_serialize():

--- a/distributed/protocol/tests/test_numpy.py
+++ b/distributed/protocol/tests/test_numpy.py
@@ -2,8 +2,6 @@ from zlib import crc32
 
 import pytest
 
-np = pytest.importorskip("numpy")
-
 from distributed.protocol import (
     decompress,
     deserialize,
@@ -20,6 +18,8 @@ from distributed.protocol.utils import BIG_BYTES_SHARD_SIZE
 from distributed.system import MEMORY_LIMIT
 from distributed.utils import ensure_bytes, nbytes, tmpfile
 from distributed.utils_test import gen_cluster
+
+np = pytest.importorskip("numpy")
 
 
 def test_serialize():

--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -1,5 +1,10 @@
 import pytest
 
+# isort: off
+pd = pytest.importorskip("pandas")
+np = pytest.importorskip("numpy")
+# isort: on
+
 from dask.dataframe.utils import assert_eq
 
 from distributed.protocol import (
@@ -11,10 +16,6 @@ from distributed.protocol import (
     to_serialize,
 )
 from distributed.utils import ensure_bytes
-
-pd = pytest.importorskip("pandas")
-np = pytest.importorskip("numpy")
-
 
 dfs = [
     pd.DataFrame({}),

--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -1,8 +1,5 @@
 import pytest
 
-pd = pytest.importorskip("pandas")
-np = pytest.importorskip("numpy")
-
 from dask.dataframe.utils import assert_eq
 
 from distributed.protocol import (
@@ -14,6 +11,10 @@ from distributed.protocol import (
     to_serialize,
 )
 from distributed.utils import ensure_bytes
+
+pd = pytest.importorskip("pandas")
+np = pytest.importorskip("numpy")
+
 
 dfs = [
     pd.DataFrame({}),

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -1,8 +1,9 @@
 import pytest
 
+from distributed.protocol import deserialize, serialize
+
 pytestmark = pytest.mark.gpu
 
-from distributed.protocol import deserialize, serialize
 
 numpy = pytest.importorskip("numpy")
 cuda = pytest.importorskip("numba.cuda")

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -6,12 +6,8 @@ import msgpack
 import pytest
 from tlz import identity
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
-
 import dask
+from dask import delayed
 
 from distributed import Nanny, wait
 from distributed.comm.utils import from_frames, to_frames
@@ -33,7 +29,12 @@ from distributed.protocol import (
 )
 from distributed.protocol.serialize import check_dask_serializable
 from distributed.utils import nbytes
-from distributed.utils_test import gen_test, inc
+from distributed.utils_test import gen_cluster, gen_test, inc
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 
 class MyObj:
@@ -160,11 +161,6 @@ def test_serialize_iterate_collection():
     # Check serialize/deserialize directly
     assert deserialize(*serialize(task1, iterate_collection=True)) == expect
     assert deserialize(*serialize(task2, iterate_collection=True)) == expect
-
-
-from dask import delayed
-
-from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True)

--- a/distributed/protocol/tests/test_sparse.py
+++ b/distributed/protocol/tests/test_sparse.py
@@ -1,9 +1,9 @@
 import pytest
 
+from distributed.protocol import deserialize, serialize
+
 np = pytest.importorskip("numpy")
 sparse = pytest.importorskip("sparse")
-
-from distributed.protocol import deserialize, serialize
 
 
 def test_serialize_deserialize_sparse():

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -2,12 +2,13 @@ import datetime
 import os
 import tempfile
 
+import dask
+
 try:
     import ssl
 except ImportError:
     ssl = None
 
-import dask
 
 __all__ = ("Security",)
 

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -4,10 +4,12 @@ import pytest
 
 import dask
 import dask.bag as db
-import dask.dataframe as dd
 
 from distributed.client import wait
 from distributed.utils_test import gen_cluster
+
+dd = pytest.importorskip("dask.dataframe")
+
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -2,15 +2,16 @@ from distutils.version import LooseVersion
 
 import pytest
 
-np = pytest.importorskip("numpy")
-pd = pytest.importorskip("pandas")
-
 import dask
 import dask.bag as db
 import dask.dataframe as dd
 
 from distributed.client import wait
 from distributed.utils_test import gen_cluster
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+
 
 PANDAS_VERSION = LooseVersion(pd.__version__)
 PANDAS_GT_100 = PANDAS_VERSION >= LooseVersion("1.0.0")

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -23,10 +23,10 @@ from distributed.protocol.pickle import dumps
 from distributed.utils import TimeoutError, parse_ports, tmpfile
 from distributed.utils_test import captured_logger, gen_cluster, gen_test, inc
 
-pytestmark = pytest.mark.gpu
-
-
-pytestmark = pytest.mark.ci1
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.ci1,
+]
 
 
 @pytest.mark.slow

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -9,9 +9,6 @@ from time import sleep
 
 import psutil
 import pytest
-
-pytestmark = pytest.mark.gpu
-
 from tlz import first, valmap
 from tornado.ioloop import IOLoop
 
@@ -25,6 +22,9 @@ from distributed.metrics import time
 from distributed.protocol.pickle import dumps
 from distributed.utils import TimeoutError, parse_ports, tmpfile
 from distributed.utils_test import captured_logger, gen_cluster, gen_test, inc
+
+pytestmark = pytest.mark.gpu
+
 
 pytestmark = pytest.mark.ci1
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2495,7 +2495,6 @@ async def assert_memory(scheduler_or_workerstate, attr: str, min_, max_, timeout
     client=True, Worker=Nanny, worker_kwargs={"memory_limit": "500 MiB"}, timeout=120
 )
 async def test_memory(c, s, *_):
-    pytest.importorskip("zict")
 
     # WorkerState objects, as opposed to the Nanny objects passed by gen_cluster
     a, b = s.workers.values()

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -1,10 +1,5 @@
 from contextlib import contextmanager
 
-try:
-    import ssl
-except ImportError:
-    ssl = None
-
 import pytest
 
 import dask
@@ -12,6 +7,12 @@ import dask
 from distributed.comm import connect, listen
 from distributed.security import Security
 from distributed.utils_test import get_cert
+
+try:
+    import ssl
+except ImportError:
+    ssl = None
+
 
 ca_file = get_cert("tls-ca-cert.pem")
 

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -1,10 +1,10 @@
 import pytest
 
-pytest.importorskip("zict")
-
 from dask.sizeof import sizeof
 
 from distributed.spill import SpillBuffer
+
+pytest.importorskip("zict")
 
 
 def test_spillbuffer(tmpdir):

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -4,8 +4,6 @@ from dask.sizeof import sizeof
 
 from distributed.spill import SpillBuffer
 
-pytest.importorskip("zict")
-
 
 def test_spillbuffer(tmpdir):
     buf = SpillBuffer(str(tmpdir), target=300)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -29,12 +29,6 @@ from typing import Dict, List
 
 import click
 import tblib.pickling_support
-
-try:
-    import resource
-except ImportError:
-    resource = None
-
 import tlz as toolz
 from tornado import gen
 from tornado.ioloop import IOLoop
@@ -43,13 +37,20 @@ import dask
 from dask import istask
 from dask.utils import parse_timedelta as _parse_timedelta
 
+from .compatibility import PYPY, WINDOWS
+from .metrics import time
+
+try:
+    import resource
+except ImportError:
+    resource = None
+
+
 try:
     from tornado.ioloop import PollIOLoop
 except ImportError:
     PollIOLoop = None  # dropped in tornado 6.0
 
-from .compatibility import PYPY, WINDOWS
-from .metrics import time
 
 try:
     from dask.context import thread_state

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -25,19 +25,14 @@ from contextlib import contextmanager, nullcontext, suppress
 from glob import glob
 from time import sleep
 
-from distributed.scheduler import Scheduler
-
-try:
-    import ssl
-except ImportError:
-    ssl = None
-
 import pytest
 from tlz import assoc, memoize, merge
 from tornado import gen
 from tornado.ioloop import IOLoop
 
 import dask
+
+from distributed.scheduler import Scheduler
 
 from . import system
 from .client import Client, _global_clients, default_client
@@ -65,6 +60,12 @@ from .utils import (
     thread_state,
 )
 from .worker import Worker
+
+try:
+    import ssl
+except ImportError:
+    ssl = None
+
 
 try:
     import dask.array  # register config

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,13 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+import dask_sphinx_theme
+from docutils.parsers.rst import directives
+from sphinx.ext.autosummary import Autosummary, get_documenter
+from sphinx.util.inspect import safe_getattr
+
+import distributed
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.todo",
@@ -63,7 +70,6 @@ author = "Anaconda, Inc."
 # built documents.
 #
 # The short X.Y version.
-import distributed
 
 version = distributed.__version__
 # The full version, including alpha/beta/rc tags.
@@ -116,7 +122,6 @@ todo_include_todos = True
 
 # -- Options for HTML output ----------------------------------------------
 
-import dask_sphinx_theme
 
 html_theme = "dask_sphinx_theme"
 html_theme_path = [dask_sphinx_theme.get_html_theme_path()]
@@ -426,15 +431,9 @@ def copy_legacy_redirects(app, docname):
                 f.write(page)
 
 
-from docutils.parsers.rst import directives
-
 # -- Configuration to keep autosummary in sync with autoclass::members ----------------------------------------------
 # Fixes issues/3693
 # See https://stackoverflow.com/questions/20569011/python-sphinx-autosummary-automated-listing-of-member-functions
-from sphinx.ext.autosummary import Autosummary, get_documenter
-from sphinx.util.inspect import safe_getattr
-
-
 class AutoAutoSummary(Autosummary):
     """Create a summary for methods and attributes (autosummary).
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,11 @@ max-line-length = 120
 sections = FUTURE,STDLIB,THIRDPARTY,DISTRIBUTED,FIRSTPARTY,LOCALFOLDER
 profile = black
 skip_gitignore = true
-force_to_top = true
+float_to_top = true
 default_section = THIRDPARTY
 known_first_party = distributed
 known_distributed = dask
+skip=versioneer.py,_concurrent_futures_thread.py
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
That's certainly not a priority but I am sometimes annoyed by imports not being bubbled up to the top of the file which is what I would expect for our auto formatter to do. I noticed a `force_to_top` flag to be set in our setup.cfg but this has been used incorrectly. The `force_to_top` is supposed to be a set of import names which are forced to be in the top of their respective sections, e.g. `force_to_top=dask` would be a correct usage and would force dask to be pushed top accordingly.
I _think_ the intended behaviour this should set is `float_to_top` instead. 

see also https://pycqa.github.io/isort/docs/configuration/options.html