### PR TITLE
Ensure test_scheduler_bokeh does not modify PROFILING permanently

### DIFF
--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -46,7 +46,13 @@ from distributed.metrics import time
 from distributed.utils import format_dashboard_link
 from distributed.utils_test import dec, div, gen_cluster, get_cert, inc, slowinc
 
-scheduler.PROFILING = False
+
+@pytest.fixture(autouse=True)
+def ensure_scheduler_profiling_off():
+    before = scheduler.PROFILING
+    scheduler.PROFILING = False
+    yield
+    scheduler.PROFILING = before
 
 
 @gen_cluster(client=True, scheduler_kwargs={"dashboard": True})


### PR DESCRIPTION
I don't think this has any serious implications but this test modifies global state without resetting it. This is a typical source for the "This test only breaks if the other one is running before it" problem. 

Defining a fixture like this will toggle the variable for every test in this module, ensuring that we do not modify any state permanently. If we wanted to disable this for the entire `dashboard/tests` module, we could put it in a `dashboard/tests/conftest.py`, etc.