### PR TITLE
Add HTML Repr for `Security` Class

### DIFF
--- a/distributed/security.py
+++ b/distributed/security.py
@@ -195,7 +195,7 @@ class Security:
 
         html = f"""
         <div style="margin-left: auto;">
-            <h3 style="margin-bottom: 0px;">Distributed Security</h3>
+            <h3 style="margin-bottom: 0px;"><b>Security</b></h3>
             <p>
                 <table style="width: 100%;">
                 <tr>

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -166,6 +166,42 @@ class Security:
                     items.append((k, repr(val)))
         return "Security(" + ", ".join(f"{k}={v}" for k, v in items) + ")"
 
+    def _repr_html_(self):
+        import html
+
+        keys = sorted(self.__slots__)
+        keys.remove("extra_conn_args")
+
+        attr = {}
+
+        for k in keys:
+            val = getattr(self, k)
+            if val is not None:
+                attr[k] = "<br />".join(repr(val).split("\\n"))
+
+        rows = ""
+
+        for key, val in attr.items():
+            rows += f"""
+            <tr>
+                <th style="text-align: left; width: 150px;">{key}</th>
+                <td style="text-align: left;">{val}</td>
+            </tr>
+            """
+
+        html = f"""
+        <div style="margin-left: auto;">
+            <h3 style="margin-bottom: 0px;">Distributed Security</h3>
+            <p>
+                <table style="width: 100%;">
+                {rows}
+                </table>
+            </p>
+        </div>
+        """
+
+        return html
+
     def get_tls_config_for_role(self, role):
         """
         Return the TLS configuration for the given role, as a flat dict.

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -153,44 +153,38 @@ class Security:
             out = dask.config.get(config_name)
         setattr(self, field, out)
 
-    def __repr__(self):
+    def attr_to_dict(self):
         keys = sorted(self.__slots__)
         keys.remove("extra_conn_args")
 
-        items = {}
+        attr = {}
 
         for k in keys:
             val = getattr(self, k)
             if val is not None:
                 if isinstance(val, str) and "\n" in val:
-                    items[k] = "Temporary (In-memory)"
+                    attr[k] = "Temporary (In-memory)"
                 elif isinstance(val, str):
-                    items[k] = f"Local ({os.path.abspath(val)})"
+                    attr[k] = f"Local ({os.path.abspath(val)})"
                 else:
-                    items[k] = val
+                    attr[k] = val
 
-        return items
+        return attr
+
+    def __repr__(self):
+        attr = self.attr_to_dict()
+        return (
+            "Security("
+            + ", ".join(f"{key}={value}" for key, value in attr.items())
+            + ")"
+        )
 
     def _repr_html_(self):
-        keys = sorted(self.__slots__)
-        keys.remove("extra_conn_args")
-        keys.remove("require_encryption")
-
-        encryption = "Required" if self.require_encryption else "Optional"
-
-        items = {}
-
-        for k in keys:
-            val = getattr(self, k)
-            if val is not None:
-                if isinstance(val, str) and "\n" in val:
-                    items[k] = "Temporary (In-memory)"
-                else:
-                    items[k] = f"Local ({os.path.abspath(val)})"
+        attr = self.attr_to_dict()
 
         rows = ""
 
-        for key, val in items.items():
+        for key, val in attr.items():
             rows += f"""
             <tr>
                 <th style="text-align: left; width: 150px;">{key}</th>
@@ -203,10 +197,6 @@ class Security:
             <h3 style="margin-bottom: 0px;"><b>Security</b></h3>
             <p>
                 <table style="width: 100%;">
-                <tr>
-                    <th style="text-align: left; width: 150px;">Encryption</th>
-                    <td style="text-align: left;">{encryption}</td>
-                </tr>
                 {rows}
                 </table>
             </p>

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -181,7 +181,7 @@ class Security:
                 if isinstance(val, str) and "\n" in val:
                     location[k] = "Temporary (In-memory)"
                 else:
-                    location[k] = f"Local ({val})"
+                    location[k] = f"Local ({os.path.abspath(val)})"
 
         rows = ""
 

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -169,10 +169,11 @@ class Security:
                 else:
                     location[k] = val
 
-        return "Security\n" + ", ".join(
-            f"{key}={value}" for key, value in location.items()
+        return (
+            "Security("
+            + ", ".join(f"{key}={value}" for key, value in location.items())
+            + ")"
         )
-        # return location
 
     def _repr_html_(self):
         keys = sorted(self.__slots__)

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -172,7 +172,7 @@ class Security:
         return attr
 
     def __repr__(self):
-        attr = self.attr_to_dict()
+        attr = self._attr_to_dict()
         return (
             "Security("
             + ", ".join(f"{key}={value}" for key, value in attr.items())
@@ -180,7 +180,7 @@ class Security:
         )
 
     def _repr_html_(self):
-        attr = self.attr_to_dict()
+        attr = self._attr_to_dict()
 
         rows = ""
 

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -167,8 +167,6 @@ class Security:
         return "Security(" + ", ".join(f"{k}={v}" for k, v in items) + ")"
 
     def _repr_html_(self):
-        import html
-
         keys = sorted(self.__slots__)
         keys.remove("extra_conn_args")
 

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -176,7 +176,7 @@ class Security:
         return (
             "Security("
             + ",\n    ".join(f"{key}={value}" for key, value in attr.items())
-            + ")"
+            + "\n)"
         )
 
     def _repr_html_(self):

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -157,23 +157,19 @@ class Security:
         keys = sorted(self.__slots__)
         keys.remove("extra_conn_args")
 
-        location = {}
+        items = {}
 
         for k in keys:
             val = getattr(self, k)
             if val is not None:
                 if isinstance(val, str) and "\n" in val:
-                    location[k] = "Temporary (In-memory)"
+                    items[k] = "Temporary (In-memory)"
                 elif isinstance(val, str):
-                    location[k] = f"Local ({os.path.abspath(val)})"
+                    items[k] = f"Local ({os.path.abspath(val)})"
                 else:
-                    location[k] = val
+                    items[k] = val
 
-        return (
-            "Security("
-            + ", ".join(f"{key}={value}" for key, value in location.items())
-            + ")"
-        )
+        return items
 
     def _repr_html_(self):
         keys = sorted(self.__slots__)
@@ -182,19 +178,19 @@ class Security:
 
         encryption = "Required" if self.require_encryption else "Optional"
 
-        location = {}
+        items = {}
 
         for k in keys:
             val = getattr(self, k)
             if val is not None:
                 if isinstance(val, str) and "\n" in val:
-                    location[k] = "Temporary (In-memory)"
+                    items[k] = "Temporary (In-memory)"
                 else:
-                    location[k] = f"Local ({os.path.abspath(val)})"
+                    items[k] = f"Local ({os.path.abspath(val)})"
 
         rows = ""
 
-        for key, val in location.items():
+        for key, val in items.items():
             rows += f"""
             <tr>
                 <th style="text-align: left; width: 150px;">{key}</th>

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -175,8 +175,8 @@ class Security:
         attr = self.attr_to_dict()
         return (
             "Security("
-            + ",\n    ".join(f"{key}={value}" for key, value in attr.items())
-            + "\n)"
+            + ", ".join(f"'{key}'='{value}'" for key, value in attr.items())
+            + ")"
         )
 
     def _repr_html_(self):

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -156,15 +156,23 @@ class Security:
     def __repr__(self):
         keys = sorted(self.__slots__)
         keys.remove("extra_conn_args")
-        items = []
+
+        location = {}
+
         for k in keys:
             val = getattr(self, k)
             if val is not None:
                 if isinstance(val, str) and "\n" in val:
-                    items.append((k, "..."))
+                    location[k] = "Temporary (In-memory)"
+                elif isinstance(val, str):
+                    location[k] = f"Local ({os.path.abspath(val)})"
                 else:
-                    items.append((k, repr(val)))
-        return "Security(" + ", ".join(f"{k}={v}" for k, v in items) + ")"
+                    location[k] = val
+
+        return "Security\n" + ", ".join(
+            f"{key}={value}" for key, value in location.items()
+        )
+        # return location
 
     def _repr_html_(self):
         keys = sorted(self.__slots__)

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -153,7 +153,7 @@ class Security:
             out = dask.config.get(config_name)
         setattr(self, field, out)
 
-    def attr_to_dict(self):
+    def _attr_to_dict(self):
         keys = sorted(self.__slots__)
         keys.remove("extra_conn_args")
 

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -175,7 +175,7 @@ class Security:
         attr = self.attr_to_dict()
         return (
             "Security("
-            + ", ".join(f"{key}={value}" for key, value in attr.items())
+            + ",\n    ".join(f"{key}={value}" for key, value in attr.items())
             + ")"
         )
 

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -169,17 +169,23 @@ class Security:
     def _repr_html_(self):
         keys = sorted(self.__slots__)
         keys.remove("extra_conn_args")
+        keys.remove("require_encryption")
 
-        attr = {}
+        encryption = "Required" if self.require_encryption else "Optional"
+
+        location = {}
 
         for k in keys:
             val = getattr(self, k)
             if val is not None:
-                attr[k] = "<br />".join(repr(val).split("\\n"))
+                if isinstance(val, str) and "\n" in val:
+                    location[k] = "Temporary (In-memory)"
+                else:
+                    location[k] = f"Local ({val})"
 
         rows = ""
 
-        for key, val in attr.items():
+        for key, val in location.items():
             rows += f"""
             <tr>
                 <th style="text-align: left; width: 150px;">{key}</th>
@@ -192,6 +198,10 @@ class Security:
             <h3 style="margin-bottom: 0px;">Distributed Security</h3>
             <p>
                 <table style="width: 100%;">
+                <tr>
+                    <th style="text-align: left; width: 150px;">Encryption</th>
+                    <td style="text-align: left;">{encryption}</td>
+                </tr>
                 {rows}
                 </table>
             </p>

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -175,7 +175,7 @@ class Security:
         attr = self.attr_to_dict()
         return (
             "Security("
-            + ", ".join(f"'{key}'='{value}'" for key, value in attr.items())
+            + ", ".join(f"{key}={value}" for key, value in attr.items())
             + ")"
         )
 

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -110,12 +110,17 @@ def test_kwargs():
     assert sec.extra_conn_args == {"headers": {"Auth": "Token abc"}}
 
 
-def test_repr():
+def test_repr_temp_keys():
+    sec = Security.temporary()
+    representation = repr(sec)
+    assert "Temporary (In-memory)" in representation
+
+
+def test_repr_local_keys():
     sec = Security(tls_ca_file="ca.pem", tls_scheduler_cert="scert.pem")
-    assert (
-        repr(sec)
-        == "Security(require_encryption=True, tls_ca_file='ca.pem', tls_scheduler_cert='scert.pem')"
-    )
+    representation = repr(sec)
+    assert "ca.pem" in representation
+    assert "scert.pem" in representation
 
 
 def test_tls_config_for_role():


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

I have added the HTML Representation of the `Security` class and also tweaked the `__repr__` to specify where the keys/certs are stored.

## `_repr_html_`

![image](https://user-images.githubusercontent.com/62539811/129478645-076d9348-c399-48b4-b4b1-9300143e1eab.png)

## `__repr__`

![image](https://user-images.githubusercontent.com/62539811/129478671-18c84467-e29f-43e9-b13d-b309df22b2f0.png)




/cc @martindurant @GenevieveBuckley