### PR TITLE
Raise errors on warnings from `dask` and `distributed`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,8 @@ parentdir_prefix = distributed-
 addopts = -v -rsxfE --durations=20
 filterwarnings =
     error:Since distributed.*:PendingDeprecationWarning
+    error:::dask[.*]
+    error:::distributed[.*]
 minversion = 4
 markers =
     ci1: marks tests as belonging to 1 out of 2 partitions to run on CI ('-m "not ci1"' for second partition)


### PR DESCRIPTION
This is similar to what we already do over in `dask`. This will help us reduce the warnings which users see. 