### PR TITLE
Replace not not with bool()

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -528,7 +528,7 @@ class SpecCluster(Cluster):
 
     @property
     def _supports_scaling(self):
-        return not not self.new_spec
+        return bool(self.new_spec)
 
     async def scale_down(self, workers):
         # We may have groups, if so, map worker addresses to job names

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5059,7 +5059,7 @@ class Scheduler(SchedulerState, ServerNode):
         assert ts not in parent._unrunnable
         for dts in ts._dependencies:
             # We are waiting on a dependency iff it's not stored
-            assert (not not dts._who_has) != (dts in ts._waiting_on)
+            assert bool(dts._who_has) != (dts in ts._waiting_on)
             assert ts in dts._waiters  # XXX even if dts._who_has?
 
     def validate_processing(self, key):

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -70,7 +70,7 @@ class Security:
         if require_encryption is None:
             require_encryption = dask.config.get("distributed.comm.require-encryption")
         if require_encryption is None:
-            require_encryption = not not kwargs
+            require_encryption = bool(kwargs)
         self.require_encryption = require_encryption
         self._set_field(kwargs, "tls_ciphers", "distributed.comm.tls.ciphers")
         self._set_field(kwargs, "tls_ca_file", "distributed.comm.tls.ca-file")


### PR DESCRIPTION
I came across the `not not` pattern for the first time today. It sent me off down a google rabbit hole to try and figure out what was going on. It seems to make a truthy/falsey value explicitly `True` or `False`, which is effectively just casting it to a boolean. 

Unless there is a compelling reason to keep this I would prefer to use `bool()` as that is less surprising and more readable.