### PR TITLE
[WIP] Move _download_module into Preload constructor

### DIFF
--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -4,12 +4,12 @@ import logging
 import os
 import shutil
 import sys
+import urllib3
 from importlib import import_module
 from types import ModuleType
 from typing import List
 
 import click
-from tornado.httpclient import AsyncHTTPClient
 
 from dask.utils import tmpfile
 
@@ -119,13 +119,14 @@ def _import_module(name, file_dir=None) -> ModuleType:
     return module
 
 
-async def _download_module(url: str) -> ModuleType:
+def _download_module(url: str) -> ModuleType:
     logger.info("Downloading preload at %s", url)
     assert is_webaddress(url)
 
-    client = AsyncHTTPClient()
-    response = await client.fetch(url)
-    source = response.body.decode()
+    client = urllib3.PoolManager()
+
+    response = client.request("GET", url)
+    source = response.data.decode()
 
     compiled = compile(source, url, "exec")
     module = ModuleType(url)
@@ -155,16 +156,13 @@ class Preload:
         self.argv = argv
         self.file_dir = file_dir
 
-        if not is_webaddress(name):
-            self.module = _import_module(name, file_dir)
+        if is_webaddress(name):
+            self.module = _download_module(name)
         else:
-            self.module = None
+            self.module = _import_module(name, file_dir)
 
     async def start(self):
         """Run when the server finishes its start method"""
-        if is_webaddress(self.name):
-            self.module = await _download_module(self.name)
-
         dask_setup = getattr(self.module, "dask_setup", None)
 
         if dask_setup:

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -4,12 +4,12 @@ import logging
 import os
 import shutil
 import sys
-import urllib3
 from importlib import import_module
 from types import ModuleType
 from typing import List
 
 import click
+import urllib3
 
 from dask.utils import tmpfile
 

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -172,8 +172,8 @@ def dask_setup(dask_server):
     p = multiprocessing.Process(target=create_application)
     p.start()
     yield
-    p.terminate()
-    p.join()
+    p.kill()
+    p.join(timeout=5)
 
 
 @pytest.mark.asyncio
@@ -226,8 +226,8 @@ dask.config.set(scheduler_address="tcp://127.0.0.1:8786")
     p = multiprocessing.Process(target=create_application)
     p.start()
     yield
-    p.terminate()
-    p.join()
+    p.kill()
+    p.join(timeout=5)
 
 
 @pytest.mark.asyncio

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -164,14 +164,12 @@ def dask_setup(dask_server):
 """.strip()
             )
 
-    def create_application(ctx):
+    def create_application():
         app = web.Application([(r"/preload", MyHandler)])
         server = app.listen(12345, address="127.0.0.1")
         tornado.ioloop.IOLoop.instance().start()
 
-    ctx = multiprocessing.get_context("spawn")
-    queue = ctx.Queue()
-    p = multiprocessing.Process(target=create_application, args=(queue,))
+    p = multiprocessing.Process(target=create_application)
     p.start()
     yield
     p.kill()
@@ -220,14 +218,12 @@ dask.config.set(scheduler_address="tcp://127.0.0.1:8786")
 """.strip()
             )
 
-    def create_application(ctx):
+    def create_application():
         application = web.Application([(r"/preload", MyHandler)])
         server = application.listen(12346, address="127.0.0.1")
         tornado.ioloop.IOLoop.instance().start()
 
-    ctx = multiprocessing.get_context("spawn")
-    queue = ctx.Queue()
-    p = multiprocessing.Process(target=create_application, args=(queue,))
+    p = multiprocessing.Process(target=create_application)
     p.start()
     yield
     p.kill()

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -166,7 +166,7 @@ def dask_setup(dask_server):
 
     def create_application(ctx):
         app = web.Application([(r"/preload", MyHandler)])
-        server = app.listen(12345)
+        server = app.listen(12345, address="127.0.0.1")
         tornado.ioloop.IOLoop.instance().start()
 
     ctx = multiprocessing.get_context("spawn")
@@ -183,7 +183,7 @@ async def test_web_preload(cleanup, scheduler_preload):
     with captured_logger("distributed.preloading") as log:
         async with Scheduler(
             host="localhost",
-            preload=["http://localhost:12345/preload"],
+            preload=["http://127.0.0.1:12345/preload"],
         ) as s:
             assert s.foo == 1
     assert "12345/preload" in log.getvalue()
@@ -222,7 +222,7 @@ dask.config.set(scheduler_address="tcp://127.0.0.1:8786")
 
     def create_application(ctx):
         application = web.Application([(r"/preload", MyHandler)])
-        server = application.listen(12345)
+        server = application.listen(12346, address="127.0.0.1")
         tornado.ioloop.IOLoop.instance().start()
 
     ctx = multiprocessing.get_context("spawn")
@@ -237,5 +237,5 @@ dask.config.set(scheduler_address="tcp://127.0.0.1:8786")
 @pytest.mark.asyncio
 async def test_web_preload_worker(cleanup, worker_preload):
     async with Scheduler(port=8786, host="localhost") as s:
-        async with Nanny(preload_nanny=["http://localhost:12345/preload"]) as nanny:
+        async with Nanny(preload_nanny=["http://127.0.0.1:12346/preload"]) as nanny:
             assert nanny.scheduler_addr == s.address

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -1,4 +1,3 @@
-from logging import logMultiprocessing
 import multiprocessing
 import os
 import shutil

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -5,7 +5,6 @@ import tempfile
 import threading
 
 import pytest
-import tornado
 from tornado import web
 
 import dask
@@ -219,7 +218,6 @@ dask.config.set(scheduler_address="tcp://127.0.0.1:8786")
     async def run_webserver():
         application = web.Application([(r"/preload", WorkerPreloadHandler)])
         server = application.listen(12346, address="127.0.0.1")
-        tornado.ioloop.IOLoop.current().start()
         event.set()
 
     loop_in_thread.add_callback(run_webserver)

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -173,6 +173,7 @@ def dask_setup(dask_server):
     p.start()
     yield
     p.terminate()
+    p.join()
 
 
 @pytest.mark.asyncio
@@ -226,6 +227,7 @@ dask.config.set(scheduler_address="tcp://127.0.0.1:8786")
     p.start()
     yield
     p.terminate()
+    p.join()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Turn _download_module into a sync function

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
