### PR TITLE
[WIP] Download preload urls in the Preload constructor 

### DIFF
--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -9,7 +9,7 @@ from types import ModuleType
 from typing import List
 
 import click
-from tornado.httpclient import AsyncHTTPClient
+import urllib3
 
 from dask.utils import tmpfile
 
@@ -119,13 +119,14 @@ def _import_module(name, file_dir=None) -> ModuleType:
     return module
 
 
-async def _download_module(url: str) -> ModuleType:
+def _download_module(url: str) -> ModuleType:
     logger.info("Downloading preload at %s", url)
     assert is_webaddress(url)
 
-    client = AsyncHTTPClient()
-    response = await client.fetch(url)
-    source = response.body.decode()
+    client = urllib3.PoolManager()
+
+    response = client.request("GET", url)
+    source = response.data.decode()
 
     compiled = compile(source, url, "exec")
     module = ModuleType(url)
@@ -155,16 +156,13 @@ class Preload:
         self.argv = argv
         self.file_dir = file_dir
 
-        if not is_webaddress(name):
-            self.module = _import_module(name, file_dir)
+        if is_webaddress(name):
+            self.module = _download_module(name)
         else:
-            self.module = None
+            self.module = _import_module(name, file_dir)
 
     async def start(self):
         """Run when the server finishes its start method"""
-        if is_webaddress(self.name):
-            self.module = await _download_module(self.name)
-
         dask_setup = getattr(self.module, "dask_setup", None)
 
         if dask_setup:

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -13,7 +13,10 @@ from tornado import web
 import dask
 
 from distributed import Client, Nanny, Scheduler, Worker
+from distributed.compatibility import MACOS
 from distributed.utils_test import captured_logger, cluster, gen_cluster, gen_test
+
+PY_VERSION = sys.version_info[:2]
 
 PRELOAD_TEXT = """
 _worker_info = {}
@@ -198,6 +201,9 @@ def scheduler_preload():
     p.join(timeout=5)
 
 
+@pytest.mark.skipif(
+    MACOS and PY_VERSION == (3, 7), reason="HTTP Server doesn't come up"
+)
 @pytest.mark.asyncio
 async def test_web_preload(cleanup, scheduler_preload):
     with captured_logger("distributed.preloading") as log:
@@ -272,6 +278,9 @@ def worker_preload():
     p.join(timeout=5)
 
 
+@pytest.mark.skipif(
+    MACOS and PY_VERSION == (3, 7), reason="HTTP Server doesn't come up"
+)
 @pytest.mark.asyncio
 async def test_web_preload_worker(cleanup, worker_preload):
     async with Scheduler(port=8786, host="localhost") as s:

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -188,9 +188,9 @@ def scheduler_preload():
             response = client.request("GET", "http://127.0.0.1:12345/preload")
             if response.status == 200:
                 break
-        except urllib3.exceptions.HTTPError:
-            if time.time() > start + 5:
-                raise AssertionError("Webserver didn't come up")
+        except urllib3.exceptions.HTTPError as e:
+            if time.time() > start + 10:
+                raise AssertionError("Webserver didn't come up", e)
             time.sleep(0.5)
 
     yield
@@ -262,9 +262,9 @@ def worker_preload():
             response = client.request("GET", "http://127.0.0.1:12346/preload")
             if response.status == 200:
                 break
-        except urllib3.exceptions.HTTPError:
-            if time.time() > start + 5:
-                raise AssertionError("Webserver didn't come up")
+        except urllib3.exceptions.HTTPError as e:
+            if time.time() > start + 10:
+                raise AssertionError("Webserver didn't come up", e)
             time.sleep(0.5)
 
     yield


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`

Follow up from: https://github.com/dask/distributed/pull/5185

Go back to processes and waiting a bit until the process and the webserver are up.  

I'll leave #5185 open for a bit and try to figure out what's the difference between the environments.
