### PR TITLE
avoid recursion error in profile.merge

### DIFF
--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -139,7 +139,10 @@ def merge(*args):
         for child in arg["children"]:
             children[child].append(arg["children"][child])
 
-    children = {k: merge(*v) for k, v in children.items()}
+    try:
+        children = {k: merge(*v) for k, v in children.items()}
+    except RecursionError:
+        children = {}
     count = sum(arg["count"] for arg in args)
     return {
         "description": args[0]["description"],


### PR DESCRIPTION
This isn't tested at all.  It's just something that seems like it might help with a few intermittent failures