### PR TITLE
First iteration for exception forwarding

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1226,6 +1226,13 @@ class Worker(ServerNode):
         warnings.warn("Worker._close has moved to Worker.close", stacklevel=2)
         return self.close(*args, **kwargs)
 
+    def forward_exception(self, msg=None, typ=Exception):
+        msg = error_message(typ(msg))
+        msg.pop("status")
+        msg["op"] = "server-exception"
+        msg["time"] = time()
+        self.batched_stream.send(msg)
+
     async def close(
         self, report=True, timeout=30, nanny=True, executor_wait=True, safe=False
     ):


### PR DESCRIPTION
Sometimes users are struggling with getting all the relevant informations in case exceptions occur in server code. If exceptions occur which are not directly linked to a task, there is currently no mechanism in place to forward these to the user. the only way is to rely on logging which can, depending on deployment, be a difficult thing to work with.

In an attempt to make this more accessible, this PR forwards all server related exceptions to a client. There is still an open discussion regarding how to deal with exceptions in general since they are currently handled and logged by tornado (https://github.com/dask/distributed/issues/5184) and I consider this out of scope for this PR. 

This PR offers an unpolished but working implementation to discuss the topic of how to expose this to the user

This draft offers
* programmatic access to the exceptions by storing them in a dictionary on client side (source, exception, traceback, timestamp)
* scheduler logs exceptions as events such that they could be visualized on our dashboard (out of scope)
* To manage spam, the client is able to filter exceptions based on type

Open questions
* Do we need filtering? If so, does it need to be more sophisticated, e.g. filter on msgs similar to python warnings
* Do we want to filter on the servers directly instead of the client
* configuration via distributed.yaml or kwargs? both?
* ?