### PR TITLE
Addressing #5159 (IPv6 dask-worker support) by propagating empty host…

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -339,6 +339,9 @@ def main(
     try:
         if listen_address:
             (host, worker_port) = get_address_host_port(listen_address, strict=True)
+            if ":" in host:
+                # IPv6 -- bracket to pass as user args
+                host = f"[{host}]"
 
         if contact_address:
             # we only need this to verify it is getting parsed

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -97,7 +97,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "--listen-address",
     type=str,
     default=None,
-    help="The address to which the worker binds. Example: tcp://0.0.0.0:9000",
+    help="The address to which the worker binds. Example: tcp://0.0.0.0:9000 or tcp://:9000 for IPv4+IPv6",
 )
 @click.option(
     "--contact-address",

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -6,8 +6,8 @@ from click.testing import CliRunner
 pytest.importorskip("requests")
 
 import os
-from multiprocessing import cpu_count
 import socket
+from multiprocessing import cpu_count
 from time import sleep
 
 import requests

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -309,9 +309,7 @@ def test_contact_listen_address(loop, nanny, listen_address):
 
 @pytest.mark.skipif(not socket.has_ipv6, reason="Needs IPv6 support to test")
 @pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
-@pytest.mark.parametrize(
-    "listen_address", ["tcp://:39838", "tcp://[::1]:39838"]
-)
+@pytest.mark.parametrize("listen_address", ["tcp://:39838", "tcp://[::1]:39838"])
 def test_listen_address_ipv6(loop, nanny, listen_address):
     with popen(["dask-scheduler", "--no-dashboard"]):
         with popen(
@@ -335,9 +333,11 @@ def test_listen_address_ipv6(loop, nanny, listen_address):
                     sleep(0.1)
                 info = client.scheduler_info()
                 assert expected_name in info["workers"]
-                assert client.submit(lambda x: x+1, 10).result() == 11
+                assert client.submit(lambda x: x + 1, 10).result() == 11
+
                 def func(dask_worker):
                     return dask_worker.listener.listen_address
+
                 assert client.run(func) == {expected_name: expected_listen}
 
 

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -60,7 +60,9 @@ def parse_host_port(address, default_port=None):
         return address
 
     def _fail():
-        raise ValueError(f"invalid address {address!r}; maybe: ipv6 needs brackets like [::1]")
+        raise ValueError(
+            f"invalid address {address!r}; maybe: ipv6 needs brackets like [::1]"
+        )
 
     def _default():
         if default_port is None:

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -85,6 +85,7 @@ def parse_host_port(address, default_port=None):
         # Generic notation: 'addr:port' or 'addr'.
         host, sep, port = address.rpartition(":")
         if not sep:
+            host = port
             port = _default()
         elif ":" in host:
             _fail()

--- a/distributed/comm/addressing.py
+++ b/distributed/comm/addressing.py
@@ -60,7 +60,7 @@ def parse_host_port(address, default_port=None):
         return address
 
     def _fail():
-        raise ValueError(f"invalid address {address!r}")
+        raise ValueError(f"invalid address {address!r}; maybe: ipv6 needs brackets like [::1]")
 
     def _default():
         if default_port is None:
@@ -83,7 +83,7 @@ def parse_host_port(address, default_port=None):
             port = tail[1:]
     else:
         # Generic notation: 'addr:port' or 'addr'.
-        host, sep, port = address.partition(":")
+        host, sep, port = address.rpartition(":")
         if not sep:
             port = _default()
         elif ":" in host:
@@ -113,6 +113,8 @@ def get_address_host_port(addr, strict=False):
 
     >>> get_address_host_port('tcp://1.2.3.4:80')
     ('1.2.3.4', 80)
+    >>> get_address_host_port('tcp://[::1]:80')
+    ('::1', 80)
     """
     scheme, loc = parse_address(addr, strict=strict)
     backend = registry.get_backend(scheme)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -443,11 +443,13 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         comm_handler,
         deserialize=True,
         allow_offload=True,
+        default_host=None,
         default_port=0,
         **connection_args,
     ):
         self._check_encryption(address, connection_args)
         self.ip, self.port = parse_host_port(address, default_port)
+        self.default_host = default_host
         self.comm_handler = comm_handler
         self.deserialize = deserialize
         self.allow_offload = allow_offload
@@ -518,14 +520,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         if self.bound_address is None:
             self.bound_address = get_tcp_server_address(self.tcp_server)
         # IPv6 getsockname() can return more a 4-len tuple
-
-        host, port = self.bound_address[:2]
-        # Rewrite to connectable address
-        if host == "::":
-            host = "::1"
-        elif host == "0.0.0.0":
-            host = "127.0.0.1"
-        return host, port
+        return self.bound_address[:2]
 
     @property
     def listen_address(self):
@@ -540,7 +535,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         The contact address as a string.
         """
         host, port = self.get_host_port()
-        host = ensure_concrete_host(host)
+        host = ensure_concrete_host(host, default_host=self.default_host)
         return self.prefix + unparse_host_port(host, port)
 
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -518,7 +518,14 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         if self.bound_address is None:
             self.bound_address = get_tcp_server_address(self.tcp_server)
         # IPv6 getsockname() can return more a 4-len tuple
-        return self.bound_address[:2]
+
+        host, port = self.bound_address[:2]
+        # Rewrite to connectable address
+        if host == "::":
+            host = "::1"
+        if host == "0.0.0.0":
+            host = "127.0.0.1"
+        return host, port
 
     @property
     def listen_address(self):

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -523,7 +523,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         # Rewrite to connectable address
         if host == "::":
             host = "::1"
-        if host == "0.0.0.0":
+        elif host == "0.0.0.0":
             host = "127.0.0.1"
         return host, port
 

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -113,14 +113,14 @@ def get_tcp_server_address(tcp_server):
     return get_tcp_server_addresses(tcp_server)[0]
 
 
-def ensure_concrete_host(host):
+def ensure_concrete_host(host, default_host=None):
     """
     Ensure the given host string (or IP) denotes a concrete host, not a
     wildcard listening address.
     """
     if host in ("0.0.0.0", ""):
-        return get_ip()
+        return default_host or get_ip()
     elif host == "::":
-        return get_ipv6()
+        return default_host or get_ipv6()
     else:
         return host

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1060,11 +1060,11 @@ async def test_service_hosts_match_worker(s):
     # Check various malformed IPv6 addresses
     # Since these hostnames get passed to distributed.comm.address_from_user_args,
     # bracketing is mandatory for IPv6.
-    with pytest.raises(AssertionError) as exc:
+    with pytest.raises(ValueError) as exc:
         async with Worker(s.address, host="::") as w:
             pass
     assert "bracketed" in str(exc)
-    with pytest.raises(AssertionError) as exc:
+    with pytest.raises(ValueError) as exc:
         async with Worker(s.address, host="tcp://::1") as w:
             pass
     assert "bracketed" in str(exc)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1484,12 +1484,12 @@ async def test_local_directory_make_new_directory(s):
 @gen_cluster(nthreads=[], client=True)
 async def test_host_address(c, s):
     w = await Worker(s.address, host="127.0.0.2")
-    assert "127.0.0.1" in w.address
+    assert "127.0.0.2" in w.address
     await w.close()
 
     n = await Nanny(s.address, host="127.0.0.3")
-    assert "127.0.0.1" in n.address
-    assert "127.0.0.1" in n.worker_address
+    assert "127.0.0.3" in n.address
+    assert "127.0.0.3" in n.worker_address
     await n.close()
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -675,9 +675,14 @@ def ensure_ip(hostname):
     --------
     >>> ensure_ip('localhost')
     '127.0.0.1'
+    >>> ensure_ip('')  # Maps as localhost for binding e.g. 'tcp://:8811'
+    '127.0.0.1'
     >>> ensure_ip('123.123.123.123')  # pass through IP addresses
     '123.123.123.123'
     """
+    if not hostname:
+        hostname = 'localhost'
+
     # Prefer IPv4 over IPv6, for compatibility
     families = [socket.AF_INET, socket.AF_INET6]
     for fam in families:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -681,7 +681,7 @@ def ensure_ip(hostname):
     '123.123.123.123'
     """
     if not hostname:
-        hostname = 'localhost'
+        hostname = "localhost"
 
     # Prefer IPv4 over IPv6, for compatibility
     families = [socket.AF_INET, socket.AF_INET6]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -288,10 +288,6 @@ class Worker(ServerNode):
     * **in_flight_workers**: ``{worker: {task}}``
         The workers from which we are currently gathering data and the
         dependencies we expect from those connections
-    * **busy_workers**: ``{worker}``
-        The workers from which we have tried to gather data and received
-        a busy response. These will be removed from the list as they are
-        needed.
     * **comm_bytes**: ``int``
         The total number of bytes in flight
     * **threads**: ``{key: int}``
@@ -427,7 +423,6 @@ class Worker(ServerNode):
 
         self.in_flight_tasks = 0
         self.in_flight_workers = dict()
-        self.busy_workers = set()
         self.total_out_connections = dask.config.get(
             "distributed.worker.connections.outgoing"
         )
@@ -2174,15 +2169,9 @@ class Worker(ServerNode):
                         in_flight = True
                         continue
                     host = get_address_host(self.address)
-                    workers_not_busy = [
-                        w for w in workers if w not in self.busy_workers
-                    ]
-                    local = [w for w in workers_not_busy if get_address_host(w) == host]
+                    local = [w for w in workers if get_address_host(w) == host]
                     if local:
                         worker = random.choice(local)
-                    elif not workers_not_busy:
-                        self.busy_workers.difference_update(workers)
-                        worker = random.choice(list(workers))
                     else:
                         worker = random.choice(list(workers))
                     to_gather, total_nbytes = self.select_keys_for_gather(
@@ -2377,7 +2366,6 @@ class Worker(ServerNode):
 
                 if response["status"] == "busy":
                     self.log.append(("busy-gather", worker, to_gather_keys))
-                    self.busy_workers.add(worker)
                     for key in to_gather_keys:
                         ts = self.tasks.get(key)
                         if ts and ts.state == "flight":

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -557,9 +557,11 @@ class Worker(ServerNode):
         if host:
             # Helpful error message if IPv6 specified incorrectly
             _, host_address = parse_address(host)
-            assert host_address.count(":") <= 1 or host_address.startswith(
-                "["
-            ), "Host address with IPv6 must be bracketed like '[::1]'"
+            if host_address.count(":") > 1 and not host_address.startswith("["):
+                raise ValueError(
+                    "Host address with IPv6 must be bracketed like '[::1]'; "
+                    f"got {host_address}"
+                )
         self._interface = interface
         self._protocol = protocol
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -29,7 +29,7 @@ from dask.utils import apply, format_bytes, funcname, parse_bytes, parse_timedel
 from . import comm, preloading, profile, system, utils
 from .batched import BatchedSend
 from .comm import connect, get_address_host
-from .comm.addressing import address_from_user_args
+from .comm.addressing import address_from_user_args, parse_address
 from .comm.utils import OFFLOAD_THRESHOLD
 from .core import (
     CommClosedError,
@@ -553,6 +553,11 @@ class Worker(ServerNode):
 
         self._start_port = port
         self._start_host = host
+        if host:
+            # Helpful error message if IPv6 specified incorrectly
+            _, host_address = parse_address(host)
+            assert host_address.count(":") <= 1 or host_address.startswith("["), \
+                    "Host address with IPv6 must be bracketed like '[::1]'"
         self._interface = interface
         self._protocol = protocol
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -552,11 +552,6 @@ class Worker(ServerNode):
             if len(protocol_address) == 2:
                 protocol = protocol_address[0]
 
-        # Target interface on which we contact the scheduler by default
-        # TODO: it is unfortunate that we special-case inproc here
-        if not host and not interface and not scheduler_addr.startswith("inproc://"):
-            host = get_ip(get_address_host(scheduler_addr))
-
         self._start_port = port
         self._start_host = host
         self._interface = interface

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -56,7 +56,6 @@ from .utils import (
     LRU,
     TimeoutError,
     _maybe_complex,
-    get_ip,
     has_arg,
     import_file,
     iscoroutinefunction,


### PR DESCRIPTION
… correctly

- [x] Closes #5159. Seems to support dask-workers listening on both IPv4 and IPv6, as well as either/or. Solves dashboard log access problem mentioned in that bug, and appears to allow work to process.
- [x] Tests added / passed -- tests have been added. Related bug mentioned in comments split into #5206. This PR should be good to go if the CI passes.
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

@jacobtomlinson Let me know what you think. Thanks!
