### PR TITLE
Include addresses in closed comm repr 

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -155,16 +155,13 @@ class Comm(ABC):
         return out
 
     def __repr__(self):
-        clsname = self.__class__.__name__
-        if self.closed():
-            return f"<closed {clsname}>"
-        else:
-            return "<{} {} local={} remote={}>".format(
-                clsname,
-                self.name or "",
-                self.local_address,
-                self.peer_address,
-            )
+        return "<{}{} {} local={} remote={}>".format(
+            self.__class__.__name__,
+            " (closed)" if self.closed() else "",
+            self.name or "",
+            self.local_address,
+            self.peer_address,
+        )
 
 
 class Listener(ABC):

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -1200,11 +1200,11 @@ async def check_repr(a, b):
     await a.close()
     assert "closed" in repr(a)
     assert a.local_address in repr(a)
-    assert b.local_address in repr(a)
+    assert b.peer_address in repr(a)
     await b.close()
     assert "closed" in repr(b)
     assert a.local_address in repr(b)
-    assert b.local_address in repr(b)
+    assert b.peer_address in repr(b)
 
 
 @pytest.mark.asyncio

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -1199,8 +1199,12 @@ async def check_repr(a, b):
     assert "closed" not in repr(b)
     await a.close()
     assert "closed" in repr(a)
+    assert a.local_address in repr(a)
+    assert b.local_address in repr(a)
     await b.close()
     assert "closed" in repr(b)
+    assert a.local_address in repr(b)
+    assert b.local_address in repr(b)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR updates our comm reprs to include local and remote address after the comm has been closed (this information is already included when the comm is running). This means the repr for closed comm will look like

```
<TLS (closed)  local=tls://... remote=tls://...>
```

instead of 

```
<closed TLS>
```

which will help aid debugging (xref https://github.com/dask/distributed/issues/5202)

cc @mrocklin @fjetter