### PR TITLE
Fix an issue where a reconnecting worker could cause an invalid transition

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4252,9 +4252,13 @@ class Scheduler(SchedulerState, ServerNode):
             worker_msgs: dict = {}
             if nbytes:
                 assert isinstance(nbytes, dict)
+                already_released_keys = list()
+                if self.validate:
+                    for t in types:
+                        assert isinstance(t, type)
                 for key in nbytes:
                     ts: TaskState = parent._tasks.get(key)
-                    if ts is not None:
+                    if ts is not None and ts.state != "released":
                         if ts.state == "memory":
                             self.add_keys(worker=address, keys=[key])
                         else:
@@ -4270,7 +4274,18 @@ class Scheduler(SchedulerState, ServerNode):
                                 recommendations, client_msgs, worker_msgs
                             )
                             recommendations = {}
-
+                    else:
+                        already_released_keys.append(key)
+                if already_released_keys:
+                    if address not in worker_msgs:
+                        worker_msgs[address] = list()
+                    worker_msgs[address].append(
+                        {
+                            "op": "free-keys",
+                            "keys": already_released_keys,
+                            "reason": f"reconnect-already-released-{time()}",
+                        }
+                    )
             for ts in list(parent._unrunnable):
                 valid: set = self.valid_workers(ts)
                 if valid is None or ws in valid:
@@ -4679,37 +4694,33 @@ class Scheduler(SchedulerState, ServerNode):
         client_msgs: dict = {}
         worker_msgs: dict = {}
 
-        ts: TaskState = parent._tasks.get(key)
-        if ts is None:
-            return recommendations, client_msgs, worker_msgs
-
-        if ts.state == "memory":
-            self.add_keys(worker=worker, keys=[key])
-            return recommendations, client_msgs, worker_msgs
-
         ws: WorkerState = parent._workers_dv[worker]
-        ts._metadata.update(kwargs["metadata"])
-
-        if ts._state != "released":
+        ts: TaskState = parent._tasks.get(key)
+        if ts is None or ts._state == "released":
+            logger.debug(
+                "Received already computed task, worker: %s, state: %s"
+                ", key: %s, who_has: %s",
+                worker,
+                ts._state if ts else "forgotten",
+                key,
+                ts._who_has if ts else {},
+            )
+            worker_msgs[worker] = [
+                {
+                    "op": "free-keys",
+                    "keys": [key],
+                    "reason": f"already-released-or-forgotten-{time()}",
+                }
+            ]
+        elif ts.state == "memory":
+            self.add_keys(worker=worker, keys=[key])
+        else:
+            ts._metadata.update(kwargs["metadata"])
             r: tuple = parent._transition(key, "memory", worker=worker, **kwargs)
             recommendations, client_msgs, worker_msgs = r
 
             if ts._state == "memory":
                 assert ws in ts._who_has
-        else:
-            logger.debug(
-                "Received already computed task, worker: %s, state: %s"
-                ", key: %s, who_has: %s",
-                worker,
-                ts._state,
-                key,
-                ts._who_has,
-            )
-            if ws not in ts._who_has:
-                worker_msgs[worker] = [
-                    {"op": "free-keys", "keys": [key], "reason": "Stimulus Finished"}
-                ]
-
         return recommendations, client_msgs, worker_msgs
 
     def stimulus_task_erred(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4253,9 +4253,6 @@ class Scheduler(SchedulerState, ServerNode):
             if nbytes:
                 assert isinstance(nbytes, dict)
                 already_released_keys = list()
-                if self.validate:
-                    for t in types:
-                        assert isinstance(t, type)
                 for key in nbytes:
                     ts: TaskState = parent._tasks.get(key)
                     if ts is not None and ts.state != "released":

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -40,6 +40,7 @@ from distributed.utils import (
     sync,
     thread_state,
     truncate_exception,
+    typename,
     warn_on_duration,
 )
 from distributed.utils_test import (
@@ -598,3 +599,12 @@ def test_parse_timedelta_deprecated():
 def test_iscoroutinefunction_unhashable_input():
     # Ensure iscoroutinefunction can handle unhashable callables
     assert not iscoroutinefunction(_UnhashableCallable())
+
+
+class MyType:
+    pass
+
+
+def test_typename_on_instances():
+    instance = MyType()
+    assert typename(instance) == typename(MyType)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2468,7 +2468,7 @@ async def test_worker_reconnects_mid_compute_multiple_states_on_scheduler(c, s, 
         # Let's put one task in memory to ensure the reconnect has tasks in
         # different states
         f1 = c.submit(inc, 1, workers=[a.address], allow_other_workers=True)
-        f2 = c.submit(sum, f1, workers=[a.address], allow_other_workers=True)
+        f2 = c.submit(inc, f1, workers=[a.address], allow_other_workers=True)
         a_address = a.address
 
         a.periodic_callbacks["heartbeat"].stop()
@@ -2512,9 +2512,6 @@ async def test_worker_reconnects_mid_compute_multiple_states_on_scheduler(c, s, 
 
     while not len(s.tasks[f2.key].who_has) == 2:
         await asyncio.sleep(0.001)
-
-    for ts in s.tasks.values():
-        assert isinstance(ts.type, type)
 
     del f1, f2, f3
     while any(w.tasks for w in [a, b]):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1160,6 +1160,8 @@ def typename(typ):
     >>> typename(Scheduler)
     'distributed.scheduler.Scheduler'
     """
+    if not isinstance(typ, type):
+        return typename(type(typ))
     try:
         return typ.__module__ + "." + typ.__name__
     except AttributeError:


### PR DESCRIPTION
If a worker reconnects with a key in memory which was already released by the scheduler, this would raise an invalid transition keyerror and would break the scheduler causing yet another deadlock.


There was also a weird issue about the `typename` function called on an instance instead of a type here
https://github.com/dask/distributed/blob/17cd4db5a86d8d78b6a4ac15a6fa41ad4e609ff6/distributed/worker.py#L922

would cause the type being submitted to be a `str` of the data object, unless it's a native object like an integer in which case it works as expected. I figured it is safer to let typename handle this situation. Very difficult to test for this particular position in the code which is why I only left another validation assert