### PR TITLE
Scroll bokeh div if they get too large to prevent other plots from inheriting their size

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2765,7 +2765,19 @@ class SchedulerLogs:
             "\n".join(line for level, line in scheduler.get_logs())
         )._repr_html_()
 
-        self.root = Div(text=logs)
+        self.root = Div(
+            text=logs,
+            style={
+                "width": "100%",
+                "height": "100%",
+                "max-width": "1920px",
+                "max-height": "1080px",
+                "padding": "12px",
+                "border": "1px solid lightgray",
+                "box-shadow": "inset 1px 0 8px 0 lightgray",
+                "overflow": "auto",
+            },
+        )
 
 
 def systemmonitor_doc(scheduler, extra, doc):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7346,7 +7346,19 @@ class Scheduler(SchedulerState, ServerNode):
             dask_version=dask.__version__,
             distributed_version=distributed.__version__,
         )
-        html = Div(text=html)
+        html = Div(
+            text=html,
+            style={
+                "width": "100%",
+                "height": "100%",
+                "max-width": "1920px",
+                "max-height": "1080px",
+                "padding": "12px",
+                "border": "1px solid lightgray",
+                "box-shadow": "inset 1px 0 8px 0 lightgray",
+                "overflow": "auto",
+            },
+        )
 
         html = Panel(child=html, title="Summary")
         compute = Panel(child=compute, title="Worker Profile (compute)")


### PR DESCRIPTION
Fixes #5132.

When investigating this I found that (a) long code snippets in the summary page could also trigger the behavior, and (b) wide logs/snippets did similar things.

This attaches some CSS to the divs in question to prevent them from getting too large.

- [x] Closes #5132
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

![image](https://user-images.githubusercontent.com/5728311/129556809-b6518633-90d1-428b-af42-28fa46da6cd2.png)
