### PR TITLE
Drop RMM compatibility code from RAPIDS < 0.11

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -80,17 +80,7 @@ def init_once():
     try:
         import rmm
 
-        if hasattr(rmm, "DeviceBuffer"):
-            device_array = lambda n: rmm.DeviceBuffer(size=n)
-        else:  # pre-0.11.0
-            import numba.cuda
-
-            def rmm_device_array(n):
-                a = rmm.device_array(n, dtype="u1")
-                weakref.finalize(a, numba.cuda.current_context)
-                return a
-
-            device_array = rmm_device_array
+        device_array = lambda n: rmm.DeviceBuffer(size=n)
     except ImportError:
         try:
             import numba.cuda


### PR DESCRIPTION
Cleaning up old compatibility code from RAPIDS < 0.11, which hasn't been supported for over a year.