### PR TITLE
Rolling back some of #5103 to fix failing stress test

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4679,12 +4679,9 @@ class Scheduler(SchedulerState, ServerNode):
         ws: WorkerState = parent._workers_dv[worker]
         ts._metadata.update(kwargs["metadata"])
 
-        if ts._state != "released":
+        if ts._state == "processing":
             r: tuple = parent._transition(key, "memory", worker=worker, **kwargs)
             recommendations, client_msgs, worker_msgs = r
-
-            if ts._state == "memory":
-                assert ws in ts._who_has
         else:
             logger.debug(
                 "Received already computed task, worker: %s, state: %s"

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4672,7 +4672,7 @@ class Scheduler(SchedulerState, ServerNode):
         if ts is None:
             return recommendations, client_msgs, worker_msgs
 
-        if ts.state == "memory":
+        if ts._state == "memory":
             self.add_keys(worker=worker, keys=[key])
             return recommendations, client_msgs, worker_msgs
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5315,7 +5315,7 @@ class Scheduler(SchedulerState, ServerNode):
         ts: TaskState = parent._tasks.get(key)
         if ts is None:
             return
-        ws: WorkerState = parent._workers_dv[worker]
+        ws: WorkerState = parent._workers_dv.get(worker)
         if ts._processing_on != ws:
             return
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2495,7 +2495,7 @@ class Worker(ServerNode):
             if not deps:
                 return
 
-            for dep in deps:
+            for dep in list(deps):
                 if dep.suspicious_count > 5:
                     deps.remove(dep)
                     self.bad_dep(dep)


### PR DESCRIPTION
After #5103, `test_stress_creation_and_deletion` fails occasionally (approx. 1 out of 5 runs on my machine). 
```
pytest distributed/tests/test_stress.py::test_stress_creation_and_deletion --runslow
```

I have tracked the issue to the scheduler's `stimulus_task_finished()` method, which will fail when `ts._state` is `"waiting"`. 
Rolling back that change from #5103 seems to fix the issue. 

cc. @fjetter

- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
