### PR TITLE
Allow Client to subscribe to events // Remote printing and warning

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -44,7 +44,7 @@ from .semaphore import Semaphore
 from .threadpoolexecutor import rejoin
 from .utils import CancelledError, TimeoutError, sync
 from .variable import Variable
-from .worker import Reschedule, Worker, get_client, get_worker, print, secede
+from .worker import Reschedule, Worker, get_client, get_worker, print, secede, warn
 from .worker_client import local_client, worker_client
 
 versions = get_versions()

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -44,7 +44,7 @@ from .semaphore import Semaphore
 from .threadpoolexecutor import rejoin
 from .utils import CancelledError, TimeoutError, sync
 from .variable import Variable
-from .worker import Reschedule, Worker, get_client, get_worker, secede
+from .worker import Reschedule, Worker, get_client, get_worker, print, secede
 from .worker_client import local_client, worker_client
 
 versions = get_versions()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -705,6 +705,7 @@ class Client:
             self._set_config = dask.config.set(
                 scheduler="dask.distributed", shuffle="tasks"
             )
+        self.event_handlers = {}
 
         self._stream_handlers = {
             "key-in-memory": self._handle_key_in_memory,
@@ -714,6 +715,7 @@ class Client:
             "task-erred": self._handle_task_erred,
             "restart": self._handle_restart,
             "error": self._handle_error,
+            "event": self._handle_event,
         }
 
         self._state_handlers = {
@@ -3569,6 +3571,61 @@ class Client:
             provided, then logs for all topics will be returned.
         """
         return self.sync(self.scheduler.events, topic=topic)
+
+    async def _handle_event(self, topic, event):
+        if topic not in self.event_handlers:
+            self.unsubscribe_topic(topic)
+            return
+        handler = self.event_handlers[topic]
+        ret = handler(event)
+        if inspect.isawaitable(ret):
+            await ret
+
+    def subscribe_topic(self, topic, handler):
+        """Subscribe to a topic and execute a handler for every received event
+
+        Parameters
+        ----------
+        topic: str
+            The topic name
+        handler: callable or coroutinefunction
+            A handler called for every received event. The handler must accept a
+            single argument `event` which is a tuple `(timestamp, msg)` where
+            timestamp refers to the clock on the scheduler.
+
+        Example
+        -------
+
+        >>> import logging
+        >>> logger = logging.getLogger("myLogger")  # Log config not shown
+        >>> client.subscribe_topic("topic-name", lambda: logger.info)
+
+        See Also
+        --------
+        dask.distributed.Client.unsubscribe_topic
+        dask.distributed.Client.get_events
+        dask.distributed.Client.log_event
+        """
+        if topic in self.event_handlers:
+            logger.info("Handler for %s already set. Overwriting.", topic)
+        self.event_handlers[topic] = handler
+        msg = {"op": "subscribe-topic", "topic": topic, "client": self.id}
+        self._send_to_scheduler(msg)
+
+    def unsubscribe_topic(self, topic):
+        """Unsubscribe from a topic and remove event handler
+
+        See Also
+        --------
+        dask.distributed.Client.subscribe_topic
+        dask.distributed.Client.get_events
+        dask.distributed.Client.log_event
+        """
+        if topic in self.event_handlers:
+            msg = {"op": "unsubscribe-topic", "topic": topic, "client": self.id}
+            self._send_to_scheduler(msg)
+        else:
+            raise ValueError(f"No event handler known for topic {topic}.")
 
     def retire_workers(self, workers=None, close_workers=True, **kwargs):
         """Retire certain workers on the scheduler

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -493,6 +493,19 @@ class AllExit(Exception):
     """Custom exception class to exit All(...) early."""
 
 
+def _handle_print(event):
+    _, msg = event
+    if isinstance(msg, dict) and "args" in msg and "kwargs" in msg:
+        print(*msg["args"], **msg["kwargs"])
+    else:
+        print(msg)
+
+
+def _handle_warn(event):
+    _, msg = event
+    warnings.warn(msg)
+
+
 class Client:
     """Connect to and submit computation to a Dask cluster
 
@@ -575,6 +588,8 @@ class Client:
     """
 
     _instances = weakref.WeakSet()
+
+    default_event_handlers = {"print": _handle_print, "warn": _handle_warn}
 
     def __init__(
         self,
@@ -1016,6 +1031,9 @@ class Client:
 
         for pc in self._periodic_callbacks.values():
             pc.start()
+
+        for topic, handler in Client.default_event_handlers.items():
+            self.subscribe_topic(topic, handler)
 
         self._handle_scheduler_coroutine = asyncio.ensure_future(self._handle_report())
         self.coroutines.append(self._handle_scheduler_coroutine)

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import re
 
@@ -102,6 +103,7 @@ async def test_prometheus(c, s, a, b):
         assert client.samples[0].value == 1.0
 
 
+@pytest.mark.repeat(100)
 @gen_cluster(client=True, clean_kwargs={"threads": False})
 async def test_prometheus_collect_task_states(c, s, a, b):
     pytest.importorskip("prometheus_client")
@@ -139,6 +141,8 @@ async def test_prometheus_collect_task_states(c, s, a, b):
 
     # submit a task which should show up in the prometheus scraping
     future = c.submit(slowinc, 1, delay=0.5)
+    while not any(future.key in w.tasks for w in [a, b]):
+        await asyncio.sleep(0.001)
 
     active_metrics, forgotten_tasks = await fetch_metrics()
     assert active_metrics.keys() == expected
@@ -148,7 +152,11 @@ async def test_prometheus_collect_task_states(c, s, a, b):
     res = await c.gather(future)
     assert res == 2
 
-    del future
+    future.release()
+
+    while any(future.key in w.tasks for w in [a, b]):
+        await asyncio.sleep(0.001)
+
     active_metrics, forgotten_tasks = await fetch_metrics()
     assert active_metrics.keys() == expected
     assert sum(active_metrics.values()) == 0.0

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -607,6 +607,15 @@ class Nanny(ServerNode):
             await comm.write("OK")
         await super().close()
 
+    async def _log_event(self, topic, msg):
+        await self.scheduler.log_event(
+            topic=topic,
+            msg=msg,
+        )
+
+    def log_event(self, topic, msg):
+        self.loop.add_callback(self._log_event, topic, msg)
+
 
 class WorkerProcess:
     # The interval how often to check the msg queue for init

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7504,7 +7504,7 @@ class Scheduler(SchedulerState, ServerNode):
 
     def log_event(self, name, msg):
         event = (time(), msg)
-        if isinstance(name, list):
+        if isinstance(name, (list, tuple)):
             for n in name:
                 self.events[n].append(event)
                 self.event_counts[n] += 1

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3710,6 +3710,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
         )
         self.event_counts = defaultdict(int)
+        self.event_subscriber = defaultdict(set)
         self.worker_plugins = dict()
         self.nanny_plugins = dict()
 
@@ -3736,6 +3737,8 @@ class Scheduler(SchedulerState, ServerNode):
             "heartbeat-client": self.client_heartbeat,
             "close-client": self.remove_client,
             "restart": self.restart,
+            "subscribe-topic": self.subscribe_topic,
+            "unsubscribe-topic": self.unsubscribe_topic,
         }
 
         self.handlers = {
@@ -7505,11 +7508,30 @@ class Scheduler(SchedulerState, ServerNode):
             for n in name:
                 self.events[n].append(event)
                 self.event_counts[n] += 1
+                self._report_event(n, event)
         else:
             self.events[name].append(event)
             self.event_counts[name] += 1
+            self._report_event(name, event)
 
-    def get_events(self, comm=None, topic=None):
+    def _report_event(self, name, event):
+        for client in self.event_subscriber[name]:
+            self.report(
+                {
+                    "op": "event",
+                    "topic": name,
+                    "event": event,
+                },
+                client=client,
+            )
+
+    def subscribe_topic(self, topic, client):
+        self.event_subscriber[topic].add(client)
+
+    def unsubscribe_topic(self, topic, client):
+        self.event_subscriber[topic].discard(client)
+
+    def get_events(self, comm, topic):
         if topic is not None:
             return tuple(self.events[topic])
         else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7531,7 +7531,7 @@ class Scheduler(SchedulerState, ServerNode):
     def unsubscribe_topic(self, topic, client):
         self.event_subscriber[topic].discard(client)
 
-    def get_events(self, comm, topic):
+    def get_events(self, comm=None, topic=None):
         if topic is not None:
             return tuple(self.events[topic])
         else:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7008,7 +7008,7 @@ async def test_events_subscribe_topic(c, s, a):
         log.append(event)
         await asyncio.sleep(0)
 
-    c.subscribe_topic("test-topic", user_event_handler)
+    c.subscribe_topic("test-topic", async_user_event_handler)
     await asyncio.sleep(0.01)
     a.log_event("test-topic", {"async": "event"})
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7061,6 +7061,17 @@ async def test_log_event_warn(c, s, a, b):
         await c.submit(foo)
 
 
+@gen_cluster(client=True)
+async def test_log_event_warn_dask_warns(c, s, a, b):
+    from dask.distributed import warn
+
+    def foo():
+        warn("Hello!")
+
+    with pytest.warns(Warning, match="Hello!"):
+        await c.submit(foo)
+
+
 @gen_cluster(client=True, Worker=Nanny)
 async def test_print(c, s, a, b, capsys):
     from dask.distributed import print

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7095,6 +7095,19 @@ async def test_print(c, s, a, b, capsys):
     assert "Hello!:123" in out
 
 
+@gen_cluster(client=True, Worker=Nanny)
+async def test_print_non_msgpack_serializable(c, s, a, b, capsys):
+    from dask.distributed import print
+
+    def foo():
+        print(object())
+
+    await c.submit(foo)
+
+    out, err = capsys.readouterr()
+    assert "<object object at" in out
+
+
 def test_print_simple(capsys):
     from dask.distributed import print
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6989,9 +6989,9 @@ async def test_events_subscribe_topic(c, s, a):
 
     a.log_event("test-topic", {"important": "event"})
 
-    await asyncio.sleep(0.01)
+    while len(log) != 1:
+        await asyncio.sleep(0.01)
 
-    assert len(log) == 1
     time_, msg = log[0]
     assert isinstance(time_, float)
     assert msg == {"important": "event"}
@@ -7011,8 +7011,10 @@ async def test_events_subscribe_topic(c, s, a):
     c.subscribe_topic("test-topic", user_event_handler)
     await asyncio.sleep(0.01)
     a.log_event("test-topic", {"async": "event"})
-    await asyncio.sleep(0.01)
-    assert len(log) == 2
+
+    while len(log) != 2:
+        await asyncio.sleep(0.01)
+
     time_, msg = log[1]
     assert isinstance(time_, float)
     assert msg == {"async": "event"}

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7004,6 +7004,9 @@ async def test_events_subscribe_topic(c, s, a):
 
     a.log_event("test-topic", {"forget": "me"})
 
+    while len(s.events["test-topic"]) == 1:
+        await asyncio.sleep(0.01)
+
     assert len(log) == 1
 
     async def async_user_event_handler(event):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6973,3 +6973,78 @@ async def test_async_task(c, s, a, b):
     future = c.submit(f, 10)
     result = await future
     assert result == 11
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_events_subscribe_topic(c, s, a):
+
+    log = []
+
+    def user_event_handler(event):
+        log.append(event)
+
+    c.subscribe_topic("test-topic", user_event_handler)
+
+    await asyncio.sleep(0.01)
+
+    a.log_event("test-topic", {"important": "event"})
+
+    await asyncio.sleep(0.01)
+
+    assert len(log) == 1
+    time_, msg = log[0]
+    assert isinstance(time_, float)
+    assert msg == {"important": "event"}
+
+    c.unsubscribe_topic("test-topic")
+
+    await asyncio.sleep(0.01)
+
+    a.log_event("test-topic", {"forget": "me"})
+    await asyncio.sleep(0.01)
+    assert len(log) == 1
+
+    async def async_user_event_handler(event):
+        log.append(event)
+        await asyncio.sleep(0)
+
+    c.subscribe_topic("test-topic", user_event_handler)
+    await asyncio.sleep(0.01)
+    a.log_event("test-topic", {"async": "event"})
+    await asyncio.sleep(0.01)
+    assert len(log) == 2
+    time_, msg = log[1]
+    assert isinstance(time_, float)
+    assert msg == {"async": "event"}
+
+    # Even though the middle event was not subscribed to, the scheduler still
+    # knows about all and we can retrieve them
+    all_events = await c.get_events(topic="test-topic")
+    assert len(all_events) == 3
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_events_all_servers_use_same_channel(c, s, a):
+    """Ensure that logs from all server types (scheduler, worker, nanny)
+    and the clients themselves arrive"""
+
+    log = []
+
+    def user_event_handler(event):
+        log.append(event)
+
+    c.subscribe_topic("test-topic", user_event_handler)
+    async with Nanny(s.address) as n:
+        a.log_event("test-topic", "worker")
+        n.log_event("test-topic", "nanny")
+        s.log_event("test-topic", "scheduler")
+        await c.log_event("test-topic", "client")
+
+    await asyncio.sleep(0.1)
+    assert len(log) == 4 == len(set(log))
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_events_unsubscribe_raises_if_unknown(c, s):
+    with pytest.raises(ValueError, match="No event handler known for topic unknown"):
+        c.unsubscribe_topic("unknown")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -32,6 +32,7 @@ from dask.utils import (
     parse_bytes,
     parse_timedelta,
     typename,
+    stringify,
 )
 
 from . import comm, preloading, profile, system, utils
@@ -4142,7 +4143,9 @@ def print(*args, **kwargs):
     except ValueError:
         pass
     else:
-        worker.log_event("print", {"args": args, "kwargs": kwargs})
+        msg = {"args": args, "kwargs": kwargs}
+        # https://github.com/dask/distributed/pull/5217#discussion_r690797717
+        worker.log_event("print", stringify(msg, exclusive=[]))
 
     builtins.print(*args, **kwargs)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -31,8 +31,8 @@ from dask.utils import (
     funcname,
     parse_bytes,
     parse_timedelta,
-    typename,
     stringify,
+    typename,
 )
 
 from . import comm, preloading, profile, system, utils

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1,5 +1,6 @@
 import asyncio
 import bisect
+import builtins
 import concurrent.futures
 import errno
 import heapq
@@ -4129,3 +4130,18 @@ else:
         return nvml.one_time()
 
     DEFAULT_STARTUP_INFORMATION["gpu"] = gpu_startup
+
+
+def print(*args, **kwargs):
+    """Dask print function
+    This prints both wherever this function is run, and also in the user's
+    client session
+    """
+    try:
+        worker = get_worker()
+    except ValueError:
+        pass
+    else:
+        worker.log_event("print", {"args": args, "kwargs": kwargs})
+
+    builtins.print(*args, **kwargs)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -4145,3 +4145,18 @@ def print(*args, **kwargs):
         worker.log_event("print", {"args": args, "kwargs": kwargs})
 
     builtins.print(*args, **kwargs)
+
+
+def warn(*args, **kwargs):
+    """Dask warn function
+    This raises a warning both wherever this function is run, and also
+    in the user's client session
+    """
+    try:
+        worker = get_worker()
+    except ValueError:
+        pass
+    else:
+        worker.log_event("warn", {"args": args, "kwargs": kwargs})
+
+    warnings.warn(*args, **kwargs)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -4143,9 +4143,11 @@ def print(*args, **kwargs):
     except ValueError:
         pass
     else:
-        msg = {"args": args, "kwargs": kwargs}
-        # https://github.com/dask/distributed/pull/5217#discussion_r690797717
-        worker.log_event("print", stringify(msg, exclusive=[]))
+        msg = {
+            "args": tuple(stringify(arg) for arg in args),
+            "kwargs": {k: stringify(v) for k, v in kwargs.items()},
+        }
+        worker.log_event("print", msg)
 
     builtins.print(*args, **kwargs)
 


### PR DESCRIPTION
There is the idea floating around to log exceptions into our internal event system. See also https://github.com/dask/distributed/issues/5184

This is an attempt to enable a simple publish+subscribe mechanism for these events. This works as a prototype but I'm not entirely sure whether this is a good idea since we also have the actual `pubsub` extension which is a bit more powerful.

There are a few notable differences

1. `pubsub` allows for direct Worker<->Worker communication. We don't necessarily need that but it doesn't hurt, does it?
2. `pubsub` serializes all messages using our protocol.to_serialize mechanism. iiuc, this ensures that the message is never actually deserialized on the scheduler?
3. `log_events` to store all logged events on the scheduler in a deque.

We already advertise the log_event functionality in our docs https://distributed.dask.org/en/latest/logging.html#structured-logs but the pubsub extension is more powerful and I don't like the idea of having two systems if there is no good reason for it. It's not hard to extend the pubsub extensions to also log events (on whitelisted topics) in a deque, i.e. we could reuse this mechanism for events but we'd need to break 2.)

