### PR TITLE
WIP Subscribe events - PubSub Extension

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -607,6 +607,15 @@ class Nanny(ServerNode):
             await comm.write("OK")
         await super().close()
 
+    async def _log_event(self, topic, msg):
+        await self.scheduler.log_event(
+            topic=topic,
+            msg=msg,
+        )
+
+    def log_event(self, topic, msg):
+        self.loop.add_callback(self._log_event, topic, msg)
+
 
 class WorkerProcess:
     # The interval how often to check the msg queue for init

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3708,6 +3708,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
         )
         self.event_counts = defaultdict(int)
+        self.event_subscriber = defaultdict(set)
         self.worker_plugins = dict()
         self.nanny_plugins = dict()
 
@@ -3734,6 +3735,8 @@ class Scheduler(SchedulerState, ServerNode):
             "heartbeat-client": self.client_heartbeat,
             "close-client": self.remove_client,
             "restart": self.restart,
+            "subscribe-topic": self.subscribe_topic,
+            "unsubscribe-topic": self.unsubscribe_topic,
         }
 
         self.handlers = {
@@ -7404,11 +7407,30 @@ class Scheduler(SchedulerState, ServerNode):
             for n in name:
                 self.events[n].append(event)
                 self.event_counts[n] += 1
+                self._report_event(n, event)
         else:
             self.events[name].append(event)
             self.event_counts[name] += 1
+            self._report_event(name, event)
 
-    def get_events(self, comm=None, topic=None):
+    def _report_event(self, name, event):
+        for client in self.event_subscriber[name]:
+            self.report(
+                {
+                    "op": "event",
+                    "topic": name,
+                    "event": event,
+                },
+                client=client,
+            )
+
+    def subscribe_topic(self, topic, client):
+        self.event_subscriber[topic].add(client)
+
+    def unsubscribe_topic(self, topic, client):
+        self.event_subscriber[topic].discard(client)
+
+    def get_events(self, comm, topic):
         if topic is not None:
             return tuple(self.events[topic])
         else:


### PR DESCRIPTION
This is an alternative implementation to https://github.com/dask/distributed/pull/5217 using the pubsub extensions

see also https://github.com/dask/distributed/issues/5184

The scheduler is treated as a special case for subscribing via the toggle `log_queue` when registering a publisher. This toggle signals that the events shall be logged in the internal `Scheduler.events` log as well. 

I am reusing the same mechanism as for client subscribers. As soon as a client subscribes to an event, the publisher is forced to loop in the scheduler and the scheduler communicates with the client.

Internal log_events take a shortcut which is currently a bit ugly. Didn't want to overcommit to this before we're sure this is a valid approach