### PR TITLE
Update WorkerPlugin docstring about usage of TaskState objects

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -120,8 +120,12 @@ class WorkerPlugin:
     ...
     ...     def transition(self, key, start, finish, *args, **kwargs):
     ...         if finish == 'error':
-    ...             exc = self.worker.exceptions[key]
-    ...             self.logger.error("Task '%s' has failed with exception: %s" % (key, str(exc)))
+    ...             ts = self.worker.tasks[key]
+    ...             exc_info = (type(ts.exception), ts.exception, ts.traceback)
+    ...             self.logger.error(
+    ...                 "Error during computation of '%s'.", key,
+    ...                 exc_info=exc_info
+    ...             )
 
     >>> plugin = ErrorLogger()
     >>> client.register_worker_plugin(plugin)  # doctest: +SKIP

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -124,7 +124,9 @@ class Progress(SchedulerPlugin):
             self.scheduler.plugins.remove(self)
         if exception:
             self.status = "error"
-            self.extra.update({"exception": self.scheduler.exceptions[key], "key": key})
+            self.extra.update(
+                {"exception": self.scheduler.tasks[key].exception, "key": key}
+            )
         else:
             self.status = "finished"
         logger.debug("Remove Progress plugin")


### PR DESCRIPTION
This updates a wrong doc string which became invalid with the 2020.X.Y releases when we moved to `TaskState` objects on worker side.


- [x] Closes #5225
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
