### PR TITLE
Increase worker.suspicious_counter threshold

### DIFF
--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -96,6 +96,9 @@ async def test_stress_creation_and_deletion(c, s):
     # Assertions are handled by the validate mechanism in the scheduler
     da = pytest.importorskip("dask.array")
 
+    def _disable_suspicious_counter(dask_worker):
+        dask_worker._suspicious_count_limit = None
+
     rng = da.random.RandomState(0)
     x = rng.random(size=(2000, 2000), chunks=(100, 100))
     y = ((x + 1).T + (x * 2) - x.mean(axis=1)).sum().round(2)
@@ -104,13 +107,15 @@ async def test_stress_creation_and_deletion(c, s):
     async def create_and_destroy_worker(delay):
         start = time()
         while time() < start + 5:
-            async with Nanny(s.address, nthreads=2):
+            async with Nanny(s.address, nthreads=2) as n:
+                await c.run(_disable_suspicious_counter, workers=[n.worker_address])
                 await asyncio.sleep(delay)
             print("Killed nanny")
 
     await asyncio.gather(*(create_and_destroy_worker(0.1 * i) for i in range(20)))
 
     async with Nanny(s.address, nthreads=2):
+        await c.run(_disable_suspicious_counter)
         assert await c.compute(z) == 8000884.93
 
 


### PR DESCRIPTION
This stress test spawns and kills workers continuously. The way the worker suspicious counter is implemented, the `ValueError: Could not find dependent` exception is almost guaranteed to be provoked eventually.

If anyhing, I interpret the failure of this test a success since the logic of this suspicious counter was broken in the past (tasks were too eagerly released to give the counter any chance to be ever increased)

I chose to set this threshold privately and opted against exposing it as a dask configuration for now. In https://github.com/dask/distributed/pull/5046 I ended up removing it because there was no sane way to actually trigger this condition. this stress test is the first time I'm seeing this but this stress test is also a good case for why this is a bad mechanism.
In the past I encountered this bad_dep handler in cases where the remote raised an exception trying to serialize the data, for instance. I would prefer dealing with this case by *handling* that exception instead of resorting to a spurious suspicious counter.

Anyhow, fixing this requires more effort than I currently can invest in this and this seems like a reasonably compromise

@madsbk thanks for spotting this!

- [x] Closes https://github.com/dask/distributed/pull/5215
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
