### PR TITLE
Worker dashboard: More tooltip information on peer comms

### DIFF
--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -111,7 +111,8 @@ class CommunicatingStream(DashboardComponent):
                 "duration",
                 "who",
                 "y",
-                "hover",
+                "transfer",
+                "keys",
                 "alpha",
                 "bandwidth",
                 "total",
@@ -135,6 +136,7 @@ class CommunicatingStream(DashboardComponent):
 
             fig.rect(
                 source=self.incoming,
+                name="Incoming",
                 x="middle",
                 y="y",
                 width="duration",
@@ -144,6 +146,7 @@ class CommunicatingStream(DashboardComponent):
             )
             fig.rect(
                 source=self.outgoing,
+                name="Outgoing",
                 x="middle",
                 y="y",
                 width="duration",
@@ -152,7 +155,14 @@ class CommunicatingStream(DashboardComponent):
                 alpha="alpha",
             )
 
-            hover = HoverTool(point_policy="follow_mouse", tooltips="""@hover""")
+            hover = HoverTool(
+                point_policy="follow_mouse",
+                tooltips=[
+                    ("Transfer", "@transfer"),
+                    ("Keys", "@keys{safe}"),
+                    ("Direction", "$name"),
+                ],
+            )
             fig.add_tools(
                 hover,
                 ResetTool(),
@@ -187,7 +197,6 @@ class CommunicatingStream(DashboardComponent):
                 for msg in msgs:
                     if "compressed" in msg:
                         del msg["compressed"]
-                    del msg["keys"]
 
                     bandwidth = msg["total"] / (msg["duration"] or 0.5)
                     bw = max(min(bandwidth / 500e6, 1), 0.3)
@@ -198,10 +207,13 @@ class CommunicatingStream(DashboardComponent):
                         self.who[msg["who"]] = len(self.who)
                         msg["y"] = self.who[msg["who"]]
 
-                    msg["hover"] = "{} / {} = {}/s".format(
+                    msg["transfer"] = "{} / {} = {}/s".format(
                         format_bytes(msg["total"]),
                         format_time(msg["duration"]),
                         format_bytes(msg["total"] / msg["duration"]),
+                    )
+                    msg["keys"] = "<br>".join(
+                        f"{k}: {format_bytes(v)}" for k, v in msg["keys"].items()
                     )
 
                     for k in ["middle", "duration", "start", "stop"]:


### PR DESCRIPTION
Show the name(s) of the keys being transferred, and their sizes, in the tooltop. Also show the transfer direction—knowing what blue vs read means is unintuitive at first.

After:
![Screen Shot 2021-08-18 at 2 39 03 PM](https://user-images.githubusercontent.com/3309802/129969882-58d45e26-58ab-496f-b879-43047eecebe9.png)
Before:
![Screen Shot 2021-08-18 at 2 45 21 PM](https://user-images.githubusercontent.com/3309802/129969890-4c1a3dde-6d13-471d-9962-4a515533868e.png)


- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
