### PR TITLE
Update computation code retrieval logic

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2522,7 +2522,7 @@ class Client:
 
         for fr, _ in traceback.walk_stack(None):
             if pattern is None or (
-                not pattern.match(fr.f_globals["__name__"])
+                not pattern.match(fr.f_globals.get("__name__", ""))
                 and fr.f_code.co_name not in ("<listcomp>", "<dictcomp>")
             ):
                 try:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6774,6 +6774,25 @@ def test_computation_object_code_dask_compute(client):
     assert code == test_function_code
 
 
+def test_computation_object_code_not_available(client):
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+    df = pd.DataFrame({"a": range(10)})
+    ddf = dd.from_pandas(df, npartitions=3)
+    result = np.where(ddf.a > 4)
+
+    def fetch_comp_code(dask_scheduler):
+        computations = list(dask_scheduler.computations)
+        assert len(computations) == 1
+        comp = computations[0]
+        assert len(comp.code) == 1
+        return comp.code[0]
+
+    code = client.run_on_scheduler(fetch_comp_code)
+    assert code == "<Code not available>"
+
+
 @gen_cluster(client=True)
 async def test_computation_object_code_dask_persist(c, s, a, b):
     da = pytest.importorskip("dask.array")


### PR DESCRIPTION
This PR implements the fix proposed in https://github.com/dask/distributed/issues/5224#issuecomment-900697076 for when  `__name__` is not available. In this case, we will not attempt to retrieve the user code for a computation and will instead return `"<Code not available>"` 

- [x] Closes https://github.com/dask/distributed/issues/5224
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
