### PR TITLE
Add target='_blank' for redirects of dashboard link

### DIFF
--- a/distributed/widgets/templates/client.html.j2
+++ b/distributed/widgets/templates/client.html.j2
@@ -21,7 +21,7 @@
         {% if dashboard_link %}
             <tr>
                 <td style="text-align: left;">
-                    <strong>Dashboard: </strong> <a href="{{ dashboard_link }}">{{ dashboard_link }}</a>
+                    <strong>Dashboard: </strong> <a href="{{ dashboard_link }}" target="_blank">{{ dashboard_link }}</a>
                 </td>
                 <td style="text-align: left;"></td>
             </tr>

--- a/distributed/widgets/templates/cluster.html.j2
+++ b/distributed/widgets/templates/cluster.html.j2
@@ -7,7 +7,7 @@
         <table style="width: 100%; text-align: left;">
             <tr>
                 <td style="text-align: left;">
-                    <strong>Dashboard:</strong> <a href="{{ dashboard_link }}">{{ dashboard_link }}</a>
+                    <strong>Dashboard:</strong> <a href="{{ dashboard_link }} target="_blank"">{{ dashboard_link }}</a>
                 </td>
                 <td style="text-align: left;">
                     <strong>Workers:</strong> {{ workers | length }}

--- a/distributed/widgets/templates/cluster.html.j2
+++ b/distributed/widgets/templates/cluster.html.j2
@@ -7,7 +7,7 @@
         <table style="width: 100%; text-align: left;">
             <tr>
                 <td style="text-align: left;">
-                    <strong>Dashboard:</strong> <a href="{{ dashboard_link }} target="_blank"">{{ dashboard_link }}</a>
+                    <strong>Dashboard:</strong> <a href="{{ dashboard_link }}" target="_blank">{{ dashboard_link }}</a>
                 </td>
                 <td style="text-align: left;">
                     <strong>Workers:</strong> {{ workers | length }}

--- a/distributed/widgets/templates/scheduler_info.html.j2
+++ b/distributed/widgets/templates/scheduler_info.html.j2
@@ -15,7 +15,7 @@
                 </tr>
                 <tr>
                     <td style="text-align: left;">
-                        <strong>Dashboard:</strong> <a href="{{ scheduler | format_dashboard_address }}">{{ scheduler | format_dashboard_address }}</a>
+                        <strong>Dashboard:</strong> <a href="{{ scheduler | format_dashboard_address }}" target="_blank">{{ scheduler | format_dashboard_address }}</a>
                     </td>
                     <td style="text-align: left;">
                         <strong>Total threads:</strong> {{ workers.values() | map(attribute='nthreads') | sum }}
@@ -57,7 +57,7 @@
                     </tr>
                     <tr>
                         <td style="text-align: left;">
-                            <strong>Dashboard: </strong> <a href="{{ worker | format_dashboard_address }}">{{ worker | format_dashboard_address }}</a>
+                            <strong>Dashboard: </strong> <a href="{{ worker | format_dashboard_address }}" target="_blank">{{ worker | format_dashboard_address }}</a>
                         </td>
                         <td style="text-align: left;">
                             <strong>Memory: </strong> {{ worker["memory_limit"] | format_bytes }}


### PR DESCRIPTION
- [x] Closes  #5192
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

This will cause a redirect to a new tab every time a dashboard link is clicked on the html repr displayed in the notebooks. I'm still missing one case which is the `LocalCluster`link, but I couldn't find where is the template with the `href` to the dashboard for the case of LocalCLuster. For reference, I'm talking about this link:

![Screen Shot 2021-08-19 at 4 22 48 PM](https://user-images.githubusercontent.com/7526622/130138752-416b5282-a4c7-47ba-82ea-2e45d59d8843.png)

cc: @jacobtomlinson 