### PR TITLE
Rename plots to fit in the labextension

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -69,13 +69,13 @@ applications = {
     "/individual-workers": individual_doc(WorkerTable, 500),
     "/individual-bandwidth-types": individual_doc(BandwidthTypes, 500),
     "/individual-bandwidth-workers": individual_doc(BandwidthWorkers, 500),
-    "/individual-workers-network-bandwidth": individual_doc(
+    "/individual-workers-network": individual_doc(
         WorkerNetworkBandwidth, 500, fig_attr="bandwidth"
     ),
     "/individual-workers-disk": individual_doc(
         WorkerNetworkBandwidth, 500, fig_attr="disk"
     ),
-    "/individual-workers-network-bandwidth-timeseries": individual_doc(
+    "/individual-workers-network-timeseries": individual_doc(
         SystemTimeseries, 500, fig_attr="bandwidth"
     ),
     "/individual-workers-cpu-timeseries": individual_doc(

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -65,9 +65,9 @@ Individual bokeh plots
 - ``/individual-workers``
 - ``/individual-bandwidth-types``
 - ``/individual-bandwidth-workers``
-- ``/individual-workers-network-bandwidth``
+- ``/individual-workers-network``
 - ``/individual-workers-disk``
-- ``/individual-workers-network-bandwidth-timeseries``
+- ``/individual-workers-network-timeseries``
 - ``/individual-workers-cpu-timeseries``
 - ``/individual-workers-memory-timeseries``
 - ``/individual-workers-disk-timeseries``


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask-labextension/issues/211#issuecomment-902854174
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`

After plots were renamed they fit in the extension, looking like 
![Screen Shot 2021-08-20 at 2 06 23 PM](https://user-images.githubusercontent.com/7526622/130275840-be24bdcd-d23e-4b58-9329-f8d494c6246c.png)
