### PR TITLE
Add test setup fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -64,5 +64,7 @@ def initialize_test():
         logging.getLogger(name).setLevel(level)
 
     # Ensure a clean config
-    with dask.config.set(copy.deepcopy(_original_config)):
-        yield
+    dask.config.config.clear()
+    dask.config.config.update(copy.deepcopy(_original_config))
+
+    yield

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 # https://pytest.org/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
 import copy
+import logging
 
 import pytest
 
@@ -48,8 +49,20 @@ for node in ["scheduler", "worker", "nanny"]:
     _original_config["distributed"][node]["preload"] = []
     _original_config["distributed"][node]["preload-argv"] = []
 
+_logging_levels = {
+    name: logger.level
+    for name, logger in logging.root.manager.loggerDict.items()
+    if isinstance(logger, logging.Logger)
+}
+
 
 @pytest.fixture(autouse=True)
 def clean_config():
+
+    # Restore default logging levels
+    for name, level in _logging_levels.items():
+        logging.getLogger(name).setLevel(level)
+
+    # Ensure a clean config
     with dask.config.set(copy.deepcopy(_original_config)):
         yield

--- a/conftest.py
+++ b/conftest.py
@@ -57,7 +57,7 @@ _logging_levels = {
 
 
 @pytest.fixture(autouse=True)
-def clean_config():
+def initialize_test():
 
     # Restore default logging levels
     for name, level in _logging_levels.items():

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -77,12 +77,6 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-logging_levels = {
-    name: logger.level
-    for name, logger in logging.root.manager.loggerDict.items()
-    if isinstance(logger, logging.Logger)
-}
-
 _TEST_TIMEOUT = 30
 _offload_executor.submit(lambda: None).result()  # create thread during import
 
@@ -1580,11 +1574,6 @@ def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
                         with dask.config.set(
                             {"distributed.comm.timeouts.connect": "5s"}
                         ):
-                            # Restore default logging levels
-                            # XXX use pytest hooks/fixtures instead?
-                            for name, level in logging_levels.items():
-                                logging.getLogger(name).setLevel(level)
-
                             yield loop
 
                             with suppress(AttributeError):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -215,14 +215,6 @@ def mock_ipython():
     remote_magic._clients.clear()
 
 
-original_config = copy.deepcopy(dask.config.config)
-
-
-def reset_config():
-    dask.config.config.clear()
-    dask.config.config.update(copy.deepcopy(original_config))
-
-
 def nodebug(func):
     """
     A decorator to disable debug facilities during timing-sensitive tests.
@@ -1585,18 +1577,18 @@ def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
             with check_process_leak(check=processes):
                 with check_instances() if instances else nullcontext():
                     with check_active_rpc(loop, timeout):
-                        reset_config()
+                        with dask.config.set(
+                            {"distributed.comm.timeouts.connect": "5s"}
+                        ):
+                            # Restore default logging levels
+                            # XXX use pytest hooks/fixtures instead?
+                            for name, level in logging_levels.items():
+                                logging.getLogger(name).setLevel(level)
 
-                        dask.config.set({"distributed.comm.timeouts.connect": "5s"})
-                        # Restore default logging levels
-                        # XXX use pytest hooks/fixtures instead?
-                        for name, level in logging_levels.items():
-                            logging.getLogger(name).setLevel(level)
+                            yield loop
 
-                        yield loop
-
-                        with suppress(AttributeError):
-                            del thread_state.on_event_loop_thread
+                            with suppress(AttributeError):
+                                del thread_state.on_event_loop_thread
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds a new `initialize_test` fixture which is automatically applied to each test in our test suite. This fixture does a few things:

1. Disable custom preloads in tests, which can interact with tests in unexpected ways
2. Ensures Dask's configuration system is reset for each test
3. Restores default logging levels for each test

I should note that points 2 and 3 above were previously being done in our `clean` content manager (so all tests using `gen_cluster`, `gen_test`, or `cleanup`). This PR just broadens their reach to all tests. 

Closes https://github.com/dask/distributed/issues/5240

cc @mrocklin 