### PR TITLE
Use non-histogram plots up to 100 workers

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -196,7 +196,7 @@ class ProcessingHistogram(DashboardComponent):
             )
 
             self.root = figure(
-                title="Tasks Processing (Histogram)",
+                title="Tasks Processing (count)",
                 id="bk-nprocessing-histogram-plot",
                 name="processing",
                 y_axis_label="frequency",
@@ -523,7 +523,7 @@ class WorkersMemoryHistogram(DashboardComponent):
             )
 
             self.root = figure(
-                title="Bytes stored per worker (Histogram)",
+                title="Bytes stored per worker",
                 name="workers_memory",
                 id="bk-workers-memory-histogram-plot",
                 y_axis_label="frequency",
@@ -3144,7 +3144,7 @@ def status_doc(scheduler, extra, doc):
         add_periodic_callback(doc, cluster_memory, 100)
         doc.add_root(cluster_memory.root)
 
-        if len(scheduler.workers) < 50:
+        if len(scheduler.workers) <= 100:
             workers_memory = WorkersMemory(scheduler, sizing_mode="stretch_both")
             processing = CurrentLoad(scheduler, sizing_mode="stretch_both")
 


### PR DESCRIPTION
The histograph plots are a little unloved.  They don't show things like workers running out of memory, unmanaged memory, and so on.  We probably do still need them at the 1000 worker level, but I'd like to increase the space where we use the traditional plot a bit higher up.  This shifts that limit from 50 workers to 100 workers.  

This also removes "Histogram" from the plot title, which seems a little redundant.