### PR TITLE
Allow worker to prioritize tasks based on memory production/consumption

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4591,7 +4591,7 @@ class Scheduler(SchedulerState, ServerNode):
         runnables = [ts for ts in touched_tasks if ts._run_spec]
         for ts in runnables:
             if ts._priority is None and ts._run_spec:
-                ts._priority = (self.generation, 0)
+                ts._priority = (0, generation, 0)
 
         if restrictions:
             # *restrictions* is a dict keying task ids to lists of

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -19,6 +19,7 @@ from tlz import first, pluck, sliding_window
 
 import dask
 from dask import delayed
+from dask.sizeof import sizeof
 from dask.system import CPU_COUNT
 
 import distributed
@@ -2688,3 +2689,36 @@ async def test_gather_dep_exception_one_task_2(c, s, a, b):
     s.handle_missing_data(key="f1", errant_worker=a.address)
 
     await fut2
+
+
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
+async def test_TaskPrefix(c, s, w):
+    x = c.submit(inc, 0)
+    y = c.submit(dec, x)
+    z = c.submit(dec, y)
+
+    await z
+
+    assert w.prefixes["inc"].bytes_consumed == 0
+    assert w.prefixes["inc"].bytes_produced == sizeof(1)
+
+    assert w.prefixes["dec"].bytes_consumed == sizeof(1) + sizeof(0)
+    assert w.prefixes["dec"].bytes_produced == sizeof(0) + sizeof(-1)
+
+
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
+async def test_memory_prioritization(c, s, w):
+    np = pytest.importorskip("numpy")
+    # learn memory use
+    x = c.submit(np.arange, 1000000)
+    y = c.submit(np.sum, x)
+    await y
+    del x, y
+
+    arrays = c.map(np.arange, range(1_000_000, 1_000_010))
+    sums = c.map(np.sum, arrays)
+    await wait(sums)
+
+    assert min(w.tasks[future.key].priority for future in arrays) > max(
+        w.tasks[future.key].priority for future in sums
+    )


### PR DESCRIPTION
This adds a worker.py::TaskPrefix class that tracks consumption and
production of all computed tasks, grouped by task prefix.

Then we use these values when determining priorities,
(de)prioritizing tasks that (produce)/consume five times more data than
they (consume)/produce.

See https://github.com/dask/distributed/issues/5250 for background