### PR TITLE
Add support for diskless machines to system monitor

### DIFF
--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -40,13 +40,16 @@ class SystemMonitor:
         except Exception:
             self._collect_disk_io_counters = False
         else:
-            self.last_time_disk = time()
-            self.read_bytes_disk = deque(maxlen=n)
-            self.write_bytes_disk = deque(maxlen=n)
-            self.quantities["read_bytes_disk"] = self.read_bytes_disk
-            self.quantities["write_bytes_disk"] = self.write_bytes_disk
-            self._last_disk_io_counters = disk_ioc
-            self._collect_disk_io_counters = True
+            if disk_ioc is None:  # diskless machine
+                self._collect_net_io_counters = False
+            else:
+                self.last_time_disk = time()
+                self.read_bytes_disk = deque(maxlen=n)
+                self.write_bytes_disk = deque(maxlen=n)
+                self.quantities["read_bytes_disk"] = self.read_bytes_disk
+                self.quantities["write_bytes_disk"] = self.write_bytes_disk
+                self._last_disk_io_counters = disk_ioc
+                self._collect_disk_io_counters = True
 
         if not WINDOWS:
             self.num_fds = deque(maxlen=n)

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -41,7 +41,7 @@ class SystemMonitor:
             self._collect_disk_io_counters = False
         else:
             if disk_ioc is None:  # diskless machine
-                self._collect_net_io_counters = False
+                self._collect_disk_io_counters = False
             else:
                 self.last_time_disk = time()
                 self.read_bytes_disk = deque(maxlen=n)


### PR DESCRIPTION
`psutil.disk_io_counters()` returns `None` on diskless machines. This PR ensures we handle that case in our system monitor. 

- [x] Closes https://github.com/dask/distributed/issues/5254
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
