### PR TITLE
Migrate Security HTML repr to Jinja2

### DIFF
--- a/distributed/security.py
+++ b/distributed/security.py
@@ -8,6 +8,7 @@ except ImportError:
     ssl = None
 
 import dask
+from dask.widgets import get_template
 
 __all__ = ("Security",)
 
@@ -180,30 +181,7 @@ class Security:
         )
 
     def _repr_html_(self):
-        attr = self._attr_to_dict()
-
-        rows = ""
-
-        for key, val in attr.items():
-            rows += f"""
-            <tr>
-                <th style="text-align: left; width: 150px;">{key}</th>
-                <td style="text-align: left;">{val}</td>
-            </tr>
-            """
-
-        html = f"""
-        <div style="margin-left: auto;">
-            <h3 style="margin-bottom: 0px;"><b>Security</b></h3>
-            <p>
-                <table style="width: 100%;">
-                {rows}
-                </table>
-            </p>
-        </div>
-        """
-
-        return html
+        return get_template("security.html.j2").render(security=self._attr_to_dict())
 
     def get_tls_config_for_role(self, role):
         """

--- a/distributed/widgets/templates/security.html.j2
+++ b/distributed/widgets/templates/security.html.j2
@@ -1,0 +1,13 @@
+<div style="margin-left: auto;">
+    <h3 style="margin-bottom: 0px;"><b>Security</b></h3>
+    <p>
+        <table style="width: 100%;">
+        {% for key, val in security.items() %}
+            <tr>
+                <th style="text-align: left; width: 150px;">{{ key }}</th>
+                <td style="text-align: left;">{{ val }}</td>
+            </tr>
+        {% endfor %}
+        </table>
+    </p>
+</div>


### PR DESCRIPTION
Takes the new HTML repr for `Security` from #5178 and migrates it to use `dask.widgets` and Jinja2 instead of multi-line strings of HTML.