### PR TITLE
Environ plugin: also update dask config

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 import zipfile
 
+import dask.config
 from dask.utils import funcname, tmpfile
 
 logger = logging.getLogger(__name__)
@@ -342,6 +343,8 @@ class Environ(NannyPlugin):
 
     async def setup(self, nanny):
         nanny.env.update(self.environ)
+        config = dask.config.collect_env(self.environ)
+        dask.config.update(nanny.config, config)
 
 
 class UploadDirectory(NannyPlugin):


### PR DESCRIPTION
Because Nannies pass their config into worker through a separate `config=` argument, setting dask config environment variables with the Enviorn nanny plugin confusingly had no effect. Now, any dask-config environment variables work automatically (besides memory limit, which is still handled specially by Nanny).

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`
