### PR TITLE
Add support for `OrderedDict` to `unpack_remotedata`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1561,7 +1561,7 @@ class Client:
         )
 
         logger.debug("Submit %s(...), %s", funcname(func), key)
-        print("\n\n")
+
         return futures[skey]
 
     def map(
@@ -2546,7 +2546,6 @@ class Client:
             # Make sure `dsk` is a high level graph
             if not isinstance(dsk, HighLevelGraph):
                 dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
-            print(dsk.keys())
 
             annotations = {}
             if user_priority:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1561,7 +1561,7 @@ class Client:
         )
 
         logger.debug("Submit %s(...), %s", funcname(func), key)
-
+        print("\n\n")
         return futures[skey]
 
     def map(
@@ -2546,6 +2546,7 @@ class Client:
             # Make sure `dsk` is a high level graph
             if not isinstance(dsk, HighLevelGraph):
                 dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
+            print(dsk.keys())
 
             annotations = {}
             if user_priority:

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -1,17 +1,17 @@
-from unittest import mock
 from collections import OrderedDict
+from unittest import mock
 
 import pytest
 
 from distributed.comm import Comm
 from distributed.core import ConnectionPool
 from distributed.utils_comm import (
+    WrappedKey,
     gather_from_workers,
     pack_data,
     retry,
     subs_multiple,
     unpack_remotedata,
-    WrappedKey,
 )
 from distributed.utils_test import gen_cluster
 

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import random
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from functools import partial
 from itertools import cycle
 
@@ -230,7 +230,7 @@ def unpack_remotedata(o, byte_keys=False, myset=None):
             return o
         outs = [unpack_remotedata(item, byte_keys, myset) for item in o]
         return typ(outs)
-    elif typ is dict:
+    elif typ in (dict, OrderedDict):
         if o:
             return {k: unpack_remotedata(v, byte_keys, myset) for k, v in o.items()}
         else:

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -231,10 +231,9 @@ def unpack_remotedata(o, byte_keys=False, myset=None):
         outs = [unpack_remotedata(item, byte_keys, myset) for item in o]
         return typ(outs)
     elif typ in (dict, OrderedDict):
-        if o:
-            return {k: unpack_remotedata(v, byte_keys, myset) for k, v in o.items()}
-        else:
+        if not o:
             return o
+        return typ([[k, unpack_remotedata(v, byte_keys, myset)] for k, v in o.items()])
     elif issubclass(typ, WrappedKey):  # TODO use type is Future
         k = o.key
         if byte_keys:

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import random
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 from functools import partial
 from itertools import cycle
 

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -233,7 +233,7 @@ def unpack_remotedata(o, byte_keys=False, myset=None):
     elif typ in (dict, OrderedDict):
         if not o:
             return o
-        return typ([[k, unpack_remotedata(v, byte_keys, myset)] for k, v in o.items()])
+        return typ((k, unpack_remotedata(v, byte_keys, myset)) for k, v in o.items())
     elif issubclass(typ, WrappedKey):  # TODO use type is Future
         k = o.key
         if byte_keys:


### PR DESCRIPTION
- [x] Closes #5281
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

I don't see any tests for `unpack_remotedata` nor tests covering future unpacking in `test_highlevelgraph` -- Anywhere you'd like me to add a test case for this?