### PR TITLE
jupyter-client 7 compatiblity

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -17,7 +17,7 @@ dependencies:
   - ipywidgets
   - jinja2
   - joblib
-  - jupyter_client<7  # FIXME distributed#5272
+  - jupyter_client
   - msgpack-python
   - netcdf4
   - paramiko

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -16,7 +16,7 @@ dependencies:
   - ipywidgets
   - jinja2
   - joblib
-  - jupyter_client<7  # FIXME distributed#5272
+  - jupyter_client
   - msgpack-python
   - netcdf4
   - paramiko

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -17,7 +17,7 @@ dependencies:
   - ipywidgets
   - jinja2
   - joblib  # overridden by git tip below
-  - jupyter_client<7  # FIXME distributed#5272
+  - jupyter_client
   - lz4  # Only tested here
   - msgpack-python
   - netcdf4

--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -76,10 +76,8 @@ def register_worker_magic(connection_info, magic_name="worker"):
     which run the given cell in a remote kernel.
     """
     ip = get_ipython()
-    info = dict(connection_info)  # copy
-    key = info.pop("key")
-    kc = BlockingKernelClient(**connection_info)
-    kc.session.key = key
+    kc = BlockingKernelClient()
+    kc.load_connection_info(connection_info)
     kc.start_channels()
 
     def remote(line, cell=None):
@@ -122,13 +120,12 @@ def remote_magic(line, cell=None):
 
     # turn info dict to hashable str for use as lookup key in _clients cache
     key = ",".join(map(str, sorted(connection_info.items())))
-    session_key = connection_info.pop("key")
 
     if key in remote_magic._clients:
         kc = remote_magic._clients[key]
     else:
-        kc = BlockingKernelClient(**connection_info)
-        kc.session.key = session_key
+        kc = BlockingKernelClient()
+        kc.load_connection_info(connection_info)
         kc.start_channels()
         kc.wait_for_ready(timeout=10)
         remote_magic._clients[key] = kc

--- a/distributed/tests/test_ipython.py
+++ b/distributed/tests/test_ipython.py
@@ -25,9 +25,8 @@ def test_start_ipython_workers(loop, zmq_ctx):
         with Client(s["address"], loop=loop) as e:
             info_dict = e.start_ipython_workers()
             info = first(info_dict.values())
-            key = info.pop("key")
-            kc = BlockingKernelClient(**info)
-            kc.session.key = key
+            kc = BlockingKernelClient()
+            kc.load_connection_info(info)
             kc.start_channels()
             kc.wait_for_ready(timeout=10)
             msg_id = kc.execute("worker")
@@ -45,9 +44,8 @@ def test_start_ipython_scheduler(loop, zmq_ctx):
     with cluster(1) as (s, [a]):
         with Client(s["address"], loop=loop) as e:
             info = e.start_ipython_scheduler()
-            key = info.pop("key")
-            kc = BlockingKernelClient(**info)
-            kc.session.key = key
+            kc = BlockingKernelClient()
+            kc.load_connection_info(info)
             kc.start_channels()
             msg_id = kc.execute("scheduler")
             reply = kc.get_shell_msg(timeout=10)


### PR DESCRIPTION
- [x] unpin jupyter-client on CI
- [x] check directly if event loop is running, rather than relying on `loop.start()` raising a RuntimeError as the only signal of a running event loop, which isn't true if nest_asyncio has been applied
- [x] don't let importing jupyter_client clobber the event loop policy (should fix Windows errors)
- [x] Closes #5272
- [x] Tests added / passed (locally, waiting for CI)
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`



WIP because I haven't got the Windows fixes yet, but this should get it passing on other platforms.