### PR TITLE
Add type annotations to various functions within distributed.worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dask-worker-space/
 .ycm_extra_conf.py
 tags
 .ipynb_checkpoints
+.venv/

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import bisect
 import concurrent.futures
@@ -16,7 +18,10 @@ from contextlib import suppress
 from datetime import timedelta
 from inspect import isawaitable
 from pickle import PicklingError
-from typing import Dict, Hashable, Iterable, Optional
+from typing import TYPE_CHECKING, Dict, Hashable, Iterable, Optional
+
+if TYPE_CHECKING:
+    from .client import Client
 
 from tlz import first, keymap, merge, pluck  # noqa: F401
 from tornado.ioloop import IOLoop, PeriodicCallback
@@ -32,8 +37,6 @@ from dask.utils import (
     parse_timedelta,
     typename,
 )
-
-import distributed
 
 from . import comm, preloading, profile, system, utils
 from .batched import BatchedSend
@@ -3565,9 +3568,7 @@ def get_worker() -> Worker:
             raise ValueError("No workers found")
 
 
-def get_client(
-    address=None, timeout=None, resolve_address=True
-) -> Client:
+def get_client(address=None, timeout=None, resolve_address=True) -> Client:
     """Get a client while within a task.
 
     This client connects to the same scheduler to which the worker is connected

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2857,7 +2857,7 @@ class Worker(ServerNode):
         except Exception as ex:
             return {"status": "error", "exception": to_serialize(ex)}
 
-    def meets_resource_constraints(self, key) -> bool:
+    def meets_resource_constraints(self, key: str) -> bool:
         ts = self.tasks[key]
         if not ts.resource_restrictions:
             return True

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3449,14 +3449,14 @@ class Worker(ServerNode):
     #######################################
 
     @property
-    def client(self) -> "distributed.Client":
+    def client(self) -> Client:
         with self._lock:
             if self._client:
                 return self._client
             else:
                 return self._get_client()
 
-    def _get_client(self, timeout=None) -> "distributed.Client":
+    def _get_client(self, timeout=None) -> Client:
         """Get local client attached to this worker
 
         If no such client exists, create one
@@ -3567,7 +3567,7 @@ def get_worker() -> Worker:
 
 def get_client(
     address=None, timeout=None, resolve_address=True
-) -> "distributed.Client":
+) -> Client:
     """Get a client while within a task.
 
     This client connects to the same scheduler to which the worker is connected

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -20,7 +20,7 @@ from typing import Dict, Hashable, Iterable, Optional
 
 from tlz import first, keymap, merge, pluck  # noqa: F401
 from tornado.ioloop import IOLoop, PeriodicCallback
-import distributed
+
 import dask
 from dask.core import istask
 from dask.system import CPU_COUNT
@@ -32,6 +32,8 @@ from dask.utils import (
     parse_timedelta,
     typename,
 )
+
+import distributed
 
 from . import comm, preloading, profile, system, utils
 from .batched import BatchedSend
@@ -2813,7 +2815,12 @@ class Worker(ServerNode):
             return {"status": "OK"}
 
     async def actor_execute(
-        self, comm=None, actor=None, function=None, args=(), kwargs: Optional[dict] = None
+        self,
+        comm=None,
+        actor=None,
+        function=None,
+        args=(),
+        kwargs: Optional[dict] = None,
     ):
         kwargs = kwargs or {}
         separate_thread = kwargs.pop("separate_thread", True)
@@ -3442,14 +3449,14 @@ class Worker(ServerNode):
     #######################################
 
     @property
-    def client(self) -> 'distributed.Client':
+    def client(self) -> "distributed.Client":
         with self._lock:
             if self._client:
                 return self._client
             else:
                 return self._get_client()
 
-    def _get_client(self, timeout=None) -> 'distributed.Client':
+    def _get_client(self, timeout=None) -> "distributed.Client":
         """Get local client attached to this worker
 
         If no such client exists, create one
@@ -3558,7 +3565,9 @@ def get_worker() -> Worker:
             raise ValueError("No workers found")
 
 
-def get_client(address=None, timeout=None, resolve_address=True) -> 'distributed.Client':
+def get_client(
+    address=None, timeout=None, resolve_address=True
+) -> "distributed.Client":
     """Get a client while within a task.
 
     This client connects to the same scheduler to which the worker is connected

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -4051,7 +4051,7 @@ def convert_args_to_str(args, max_len: Optional[int] = None) -> str:
         return "({})".format(", ".join(strs))
 
 
-def convert_kwargs_to_str(kwargs, max_len: Optional[int] = None):
+def convert_kwargs_to_str(kwargs: dict, max_len: Optional[int] = None) -> str:
     """Convert kwargs to a string, allowing for some arguments to raise
     exceptions during conversion and ignoring them.
     """

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -20,7 +20,7 @@ from typing import Dict, Hashable, Iterable, Optional
 
 from tlz import first, keymap, merge, pluck  # noqa: F401
 from tornado.ioloop import IOLoop, PeriodicCallback
-
+import distributed
 import dask
 from dask.core import istask
 from dask.system import CPU_COUNT
@@ -2813,8 +2813,9 @@ class Worker(ServerNode):
             return {"status": "OK"}
 
     async def actor_execute(
-        self, comm=None, actor=None, function=None, args=(), kwargs={}
+        self, comm=None, actor=None, function=None, args=(), kwargs: Optional[dict] = None
     ):
+        kwargs = kwargs or {}
         separate_thread = kwargs.pop("separate_thread", True)
         key = actor
         actor = self.actors[key]
@@ -2849,7 +2850,7 @@ class Worker(ServerNode):
         except Exception as ex:
             return {"status": "error", "exception": to_serialize(ex)}
 
-    def meets_resource_constraints(self, key):
+    def meets_resource_constraints(self, key) -> bool:
         ts = self.tasks[key]
         if not ts.resource_restrictions:
             return True
@@ -3259,8 +3260,7 @@ class Worker(ServerNode):
         return prof
 
     async def get_profile_metadata(self, comm=None, start=0, stop=None):
-        if stop is None:
-            add_recent = True
+        add_recent = stop is None
         now = time() + self.scheduler_delay
         stop = stop or now
         start = start or 0
@@ -3442,14 +3442,14 @@ class Worker(ServerNode):
     #######################################
 
     @property
-    def client(self):
+    def client(self) -> 'distributed.Client':
         with self._lock:
             if self._client:
                 return self._client
             else:
                 return self._get_client()
 
-    def _get_client(self, timeout=None):
+    def _get_client(self, timeout=None) -> 'distributed.Client':
         """Get local client attached to this worker
 
         If no such client exists, create one
@@ -3531,7 +3531,7 @@ class Worker(ServerNode):
         return self.active_threads[threading.get_ident()]
 
 
-def get_worker():
+def get_worker() -> Worker:
     """Get the worker currently running this task
 
     Examples
@@ -3558,7 +3558,7 @@ def get_worker():
             raise ValueError("No workers found")
 
 
-def get_client(address=None, timeout=None, resolve_address=True):
+def get_client(address=None, timeout=None, resolve_address=True) -> 'distributed.Client':
     """Get a client while within a task.
 
     This client connects to the same scheduler to which the worker is connected
@@ -3673,7 +3673,7 @@ class Reschedule(Exception):
     """
 
 
-def parse_memory_limit(memory_limit, nthreads, total_cores=CPU_COUNT):
+def parse_memory_limit(memory_limit, nthreads, total_cores=CPU_COUNT) -> Optional[int]:
     if memory_limit is None:
         return None
 
@@ -3802,7 +3802,7 @@ cache_dumps = LRU(maxsize=100)
 _cache_lock = threading.Lock()
 
 
-def dumps_function(func):
+def dumps_function(func) -> bytes:
     """Dump a function to bytes, cache functions"""
     try:
         with _cache_lock:
@@ -4023,7 +4023,7 @@ def get_msg_safe_str(msg):
     return msg
 
 
-def convert_args_to_str(args, max_len=None):
+def convert_args_to_str(args, max_len: Optional[int] = None) -> str:
     """Convert args to a string, allowing for some arguments to raise
     exceptions during conversion and ignoring them.
     """
@@ -4042,7 +4042,7 @@ def convert_args_to_str(args, max_len=None):
         return "({})".format(", ".join(strs))
 
 
-def convert_kwargs_to_str(kwargs, max_len=None):
+def convert_kwargs_to_str(kwargs, max_len: Optional[int] = None):
     """Convert kwargs to a string, allowing for some arguments to raise
     exceptions during conversion and ignoring them.
     """


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

This is my first contribution to this project, so I hope that it is OK! I've added type hints to `get_client()`, the lack of which I found quite annoying when starting with Dask.

I also added type hints to some other simple functions, and fixed a potential undefined local variable issue in `get_profile_metadata`. I also removed some mutable default arguments, and added `.venv/` to the `.gitignore`.

Please let me know if these are acceptable, or if you'd like any removed/changed!