### PR TITLE
Revert test setup fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,5 @@
 # https://pytest.org/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
-import copy
-import logging
-
 import pytest
-
-import dask
 
 # Uncomment to enable more logging and checks
 # (https://docs.python.org/3/library/asyncio-dev.html)
@@ -40,31 +35,3 @@ def pytest_collection_modifyitems(config, items):
 
 
 pytest_plugins = ["distributed.pytest_resourceleaks"]
-
-
-_original_config = copy.deepcopy(dask.config.config)
-# Custom preloads can interact with the test suite in unexpected ways
-# so we remove them when running tests
-for node in ["scheduler", "worker", "nanny"]:
-    _original_config["distributed"][node]["preload"] = []
-    _original_config["distributed"][node]["preload-argv"] = []
-
-_logging_levels = {
-    name: logger.level
-    for name, logger in logging.root.manager.loggerDict.items()
-    if isinstance(logger, logging.Logger)
-}
-
-
-@pytest.fixture(autouse=True)
-def initialize_test():
-
-    # Restore default logging levels
-    for name, level in _logging_levels.items():
-        logging.getLogger(name).setLevel(level)
-
-    # Ensure a clean config
-    dask.config.config.clear()
-    dask.config.config.update(copy.deepcopy(_original_config))
-
-    yield


### PR DESCRIPTION
The changes in https://github.com/dask/distributed/pull/5242 introduced test failures over in `dask` (see the CI failures in https://github.com/dask/dask/pull/8127) due to the previous config cleaning behavior used in `gen_cluster`. This PR simply reverts the changes in https://github.com/dask/distributed/pull/5242 and I'll follow-up with a solution that will extend config cleaning behavior to all tests in `distributed` while still letting `gen_cluster` be used in other's projects testing infrastructure. 

cc @fjetter 