### PR TITLE
Update _cluster_info dict in init

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -45,6 +45,7 @@ class Cluster:
     """
 
     _supports_scaling = True
+    _cluster_info = {}
 
     def __init__(self, asynchronous, quiet=False, name=None, scheduler_sync_interval=1):
         self.scheduler_info = {"workers": {}}
@@ -63,7 +64,11 @@ class Cluster:
         if name is None:
             name = str(uuid.uuid4())[:8]
 
-        self._cluster_info = {"name": name, "type": typename(type(self))}
+        self._cluster_info = {
+            "name": name,
+            "type": typename(type(self)),
+            **self._cluster_info,
+        }
         self.status = Status.created
 
     @property

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -32,3 +32,14 @@ async def test_logs_deprecated(cleanup):
     cluster = Cluster(asynchronous=True)
     with pytest.warns(FutureWarning, match="get_logs"):
         cluster.logs()
+
+
+@pytest.mark.asyncio
+async def test_cluster_info():
+    class FooCluster(Cluster):
+        def __init__(self):
+            self._cluster_info["foo"] = "bar"
+            super().__init__(asynchronous=False)
+
+    cluster = FooCluster()
+    assert "foo" in cluster._cluster_info


### PR DESCRIPTION
The `_cluster_info` dict is designed to be populated during `__init__`. But some `FooCluster` subclass implementations call `super().__init__()` first, and some last. 

For instance all `SpecCluster` implementations require the super init to be called last because in sync mode the super starts the event loop and enters the `_start` method during init.

This change avoids the `_cluster_info` from being overwritten in either scenario.