### PR TITLE
Warn if CUDA context is created on incorrect device in UCX

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -63,6 +63,24 @@ def _pynvml_handles():
     return pynvml.nvmlDeviceGetHandleByIndex(gpu_idx)
 
 
+def has_cuda_context():
+    """Check whether the current process already has a CUDA context created.
+
+    Returns
+    -------
+    ``False`` if current process has no CUDA context created, otherwise returns the
+    index of the device for which there's a CUDA context.
+    """
+    init_once()
+    for index in range(device_get_count()):
+        handle = pynvml.nvmlDeviceGetHandleByIndex(index)
+        running_processes = pynvml.nvmlDeviceGetComputeRunningProcesses_v2(handle)
+        for proc in running_processes:
+            if os.getpid() == proc.pid:
+                return index
+    return False
+
+
 def real_time():
     h = _pynvml_handles()
     return {


### PR DESCRIPTION
Warns if for some reason the creation of CUDA context has already happened or occurs on the incorrect device in `LocalCluster`/`LocalCUDACluster`. This can be a problem if something initializes the CUDA runtime library too early.

The warnings were originally added directly to https://github.com/rapidsai/dask-cuda/pull/719. However, because communications in `Nanny` are initialized before Dask preload plugins, UCX creates the context directly within its own initializer. Because of that, Dask-CUDA will always think the CUDA context has already been incorrectly initialized when using UCX, which isn't true, with the globals added here Dask-CUDA can verify the CUDA contexts are indeed valid. Dask-CUDA is then able to check when the UCX module created the CUDA context, https://github.com/rapidsai/dask-cuda/pull/722 addresses that.

Because these things are related to the global Python context, it's difficult to test it with pytest. But below is a reproducer for both warnings:

<details><summary> gpu_assignment.py </summary>

```python
import create_context  # `create_context.py` file on running directory -- Triggers CUDA context has already been created

from dask.distributed import Client
from dask_cuda import LocalCUDACluster
from numba import cuda

cuda_ver = cuda.runtime.get_version()  # Doesn't create a context, but causes all workers to create context on device 0 when `numba.cuda.current_context()` is called


if __name__ == '__main__':
    cluster = LocalCUDACluster()
    client = Client(cluster)
```

</details>

<details><summary> create_context.py </summary>

```python
from numba import cuda
cuda.current_context()
```

</details>