### PR TITLE
Remove `AnyThreadEventLoopPolicy`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -47,7 +47,7 @@ try:
 except ImportError:
     single_key = first
 from tornado import gen
-from tornado.ioloop import PeriodicCallback
+from tornado.ioloop import IOLoop, PeriodicCallback
 
 from . import versions as version_module
 from .batched import BatchedSend
@@ -79,7 +79,6 @@ from .utils import (
     format_dashboard_link,
     has_keyword,
     log_errors,
-    loop_is_current,
     no_default,
     sync,
     thread_state,
@@ -786,7 +785,7 @@ class Client:
         find ourselves in contexts when it is better to operate synchronously.
         """
         try:
-            return self._asynchronous and loop_is_current(self.loop)
+            return self._asynchronous and self.loop is IOLoop.current(instance=False)
         except RuntimeError:
             return False
 
@@ -855,7 +854,7 @@ class Client:
         elif (
             self._loop_runner.is_started()
             and self.scheduler
-            and not (self.asynchronous and loop_is_current(self.loop))
+            and not (self.asynchronous and self.loop is IOLoop.current(instance=False))
         ):
             info = sync(self.loop, self.scheduler.identity)
             scheduler = self.scheduler

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -47,7 +47,7 @@ try:
 except ImportError:
     single_key = first
 from tornado import gen
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import PeriodicCallback
 
 from . import versions as version_module
 from .batched import BatchedSend
@@ -79,6 +79,7 @@ from .utils import (
     format_dashboard_link,
     has_keyword,
     log_errors,
+    loop_is_current,
     no_default,
     sync,
     thread_state,
@@ -785,7 +786,7 @@ class Client:
         find ourselves in contexts when it is better to operate synchronously.
         """
         try:
-            return self._asynchronous and self.loop is IOLoop.current()
+            return self._asynchronous and loop_is_current(self.loop)
         except RuntimeError:
             return False
 
@@ -854,7 +855,7 @@ class Client:
         elif (
             self._loop_runner.is_started()
             and self.scheduler
-            and not (self.asynchronous and self.loop is IOLoop.current())
+            and not (self.asynchronous and loop_is_current(self.loop))
         ):
             info = sync(self.loop, self.scheduler.identity)
             scheduler = self.scheduler

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -5,7 +5,7 @@ import warnings
 from asyncio import TimeoutError
 from collections import defaultdict, deque
 
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import PeriodicCallback
 
 import dask
 from dask.utils import parse_timedelta
@@ -13,7 +13,7 @@ from dask.utils import parse_timedelta
 from distributed.utils_comm import retry_operation
 
 from .metrics import time
-from .utils import log_errors, sync, thread_state
+from .utils import log_errors, loop_is_current, sync, thread_state
 from .worker import get_client, get_worker
 
 logger = logging.getLogger(__name__)
@@ -412,7 +412,7 @@ class Semaphore:
 
     @property
     def asynchronous(self):
-        return self.loop is IOLoop.current()
+        return loop_is_current(self.loop)
 
     async def _register(self):
         await retry_operation(

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -5,7 +5,7 @@ import warnings
 from asyncio import TimeoutError
 from collections import defaultdict, deque
 
-from tornado.ioloop import PeriodicCallback
+from tornado.ioloop import IOLoop, PeriodicCallback
 
 import dask
 from dask.utils import parse_timedelta
@@ -13,7 +13,7 @@ from dask.utils import parse_timedelta
 from distributed.utils_comm import retry_operation
 
 from .metrics import time
-from .utils import log_errors, loop_is_current, sync, thread_state
+from .utils import log_errors, sync, thread_state
 from .worker import get_client, get_worker
 
 logger = logging.getLogger(__name__)
@@ -412,7 +412,7 @@ class Semaphore:
 
     @property
     def asynchronous(self):
-        return loop_is_current(self.loop)
+        return self.loop is IOLoop.current(instance=False)
 
     async def _register(self):
         await retry_operation(

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -4,7 +4,6 @@ import io
 import os
 import queue
 import socket
-import threading
 import traceback
 from time import sleep
 
@@ -31,7 +30,6 @@ from distributed.utils import (
     is_kernel,
     is_valid_xml,
     iscoroutinefunction,
-    loop_is_current,
     nbytes,
     offload,
     open_port,
@@ -446,7 +444,7 @@ def test_two_loop_runners(loop_in_thread):
 @gen_test()
 async def test_loop_runner_gen():
     runner = LoopRunner(asynchronous=True)
-    assert loop_is_current(runner.loop)
+    assert runner.loop is IOLoop.current(instance=False)
     assert not runner.is_started()
     await asyncio.sleep(0.01)
     runner.start()
@@ -606,25 +604,3 @@ def test_typename_deprecated():
 def test_iscoroutinefunction_unhashable_input():
     # Ensure iscoroutinefunction can handle unhashable callables
     assert not iscoroutinefunction(_UnhashableCallable())
-
-
-def test_loop_is_current():
-    loop = IOLoop.current()
-    assert loop_is_current(loop)
-    assert not loop_is_current(IOLoop())
-
-    err = []
-
-    def from_thread():
-        try:
-            assert not loop_is_current(loop)
-            assert IOLoop.current(instance=False) is None
-        except Exception as e:
-            err.append(e)
-
-    t = threading.Thread(target=from_thread)
-    t.start()
-    t.join()
-
-    if err:
-        raise err[0]

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -495,6 +495,15 @@ class LoopRunner:
         return self._loop
 
 
+def loop_is_current(loop: IOLoop) -> bool:
+    "Whether an event loop object is the currently-running loop for this thread"
+    try:
+        return loop is IOLoop.current(instance=False)
+        # ^ `instance=False` prevents creating a new loop object if one doesn't exist
+    except RuntimeError:
+        return False
+
+
 @contextmanager
 def set_thread_state(**kwargs):
     old = {}

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -495,15 +495,6 @@ class LoopRunner:
         return self._loop
 
 
-def loop_is_current(loop: IOLoop) -> bool:
-    "Whether an event loop object is the currently-running loop for this thread"
-    try:
-        return loop is IOLoop.current(instance=False)
-        # ^ `instance=False` prevents creating a new loop object if one doesn't exist
-    except RuntimeError:
-        return False
-
-
 @contextmanager
 def set_thread_state(**kwargs):
     old = {}

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1034,49 +1034,6 @@ def reset_logger_locks():
             handler.createLock()
 
 
-is_server_extension = False
-
-if "notebook" in sys.modules:
-    import traitlets
-    from notebook.notebookapp import NotebookApp
-
-    is_server_extension = traitlets.config.Application.initialized() and isinstance(
-        traitlets.config.Application.instance(), NotebookApp
-    )
-
-if not is_server_extension:
-    is_kernel_and_no_running_loop = False
-
-    if is_kernel():
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            is_kernel_and_no_running_loop = True
-
-    if not is_kernel_and_no_running_loop:
-
-        # TODO: Use tornado's AnyThreadEventLoopPolicy, instead of class below,
-        # once tornado > 6.0.3 is available.
-        if WINDOWS and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
-            # WindowsProactorEventLoopPolicy is not compatible with tornado 6
-            # fallback to the pre-3.8 default of Selector
-            # https://github.com/tornadoweb/tornado/issues/2608
-            BaseEventLoopPolicy = asyncio.WindowsSelectorEventLoopPolicy
-        else:
-            BaseEventLoopPolicy = asyncio.DefaultEventLoopPolicy
-
-        class AnyThreadEventLoopPolicy(BaseEventLoopPolicy):
-            def get_event_loop(self):
-                try:
-                    return super().get_event_loop()
-                except (RuntimeError, AssertionError):
-                    loop = self.new_event_loop()
-                    self.set_event_loop(loop)
-                    return loop
-
-        asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
-
-
 @functools.lru_cache(1000)
 def has_keyword(func, keyword):
     return keyword in inspect.signature(func).parameters

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -70,7 +70,6 @@ from .utils import (
     json_load_robust,
     key_split,
     log_errors,
-    loop_is_current,
     offload,
     parse_ports,
     silence_logging,
@@ -3496,7 +3495,7 @@ class Worker(ServerNode):
         if not self._client:
             from .client import Client
 
-            asynchronous = loop_is_current(self.loop)
+            asynchronous = self.loop is IOLoop.current(instance=False)
             self._client = Client(
                 self.scheduler,
                 loop=self.loop,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -70,6 +70,7 @@ from .utils import (
     json_load_robust,
     key_split,
     log_errors,
+    loop_is_current,
     offload,
     parse_ports,
     silence_logging,
@@ -3495,7 +3496,7 @@ class Worker(ServerNode):
         if not self._client:
             from .client import Client
 
-            asynchronous = self.loop is IOLoop.current()
+            asynchronous = loop_is_current(self.loop)
             self._client = Client(
                 self.scheduler,
                 loop=self.loop,


### PR DESCRIPTION
Just curious to see what fails so far.

With #5310 and #5311, closes #5309 (and ensures `uvloop` will work with everything)

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `black distributed` / `flake8 distributed` / `isort distributed`
