### PR TITLE
Adjust transfer costs in `worker_objective`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3416,13 +3416,15 @@ class SchedulerState:
         dts: TaskState
         nbytes: Py_ssize_t
         comm_bytes: Py_ssize_t = 0
+        xfers: Py_ssize_t = 0
         for dts in ts._dependencies:
             if ws not in dts._who_has:
                 nbytes = dts.get_nbytes()
                 comm_bytes += nbytes
+                xfers += 1
 
         stack_time: double = ws._occupancy / ws._nthreads
-        start_time: double = stack_time + comm_bytes / self._bandwidth
+        start_time: double = stack_time + comm_bytes / self._bandwidth + xfers * 0.01
 
         if ts._actor:
             return (len(ws._actors), start_time, ws._nbytes)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3415,12 +3415,13 @@ class SchedulerState:
         """
         dts: TaskState
         nbytes: Py_ssize_t
-        comm_bytes: Py_ssize_t = 0
+        comm_bytes: double = 0
         xfers: Py_ssize_t = 0
         for dts in ts._dependencies:
             if ws not in dts._who_has:
                 nbytes = dts.get_nbytes()
-                comm_bytes += nbytes
+                # amortize transfer cost over all waiters
+                comm_bytes += nbytes / len(dts._waiters)
                 xfers += 1
 
         stack_time: double = ws._occupancy / ws._nthreads


### PR DESCRIPTION
This should maybe be two PRs, since there are two different things happening:

1. Add a fixed (currently 10ms) penalty per transfer as discussed in https://github.com/dask/distributed/issues/5324#issuecomment-920912511. This should help discourage small transfers. I'd prefer if this cost weren't just a magic 0.01 number though.
2. Amortize the transfer cost by the number of waiters. This is related to https://github.com/dask/distributed/pull/5325. See the commit message b4ebbee for more description:

    > The idea is that if a key we need has many dependents, we should amortize the cost of transferring it to a new worker, since those other dependencies could then run on the new worker more cheaply. "We'll probably have to move this at some point anyway, might as well do it now."
    > This isn't actually intended to encourage transfers though. It's more meant to discourage transferring keys that could have just stayed in one place. The goal is that if A and B are on different workers, and we're the only task that will ever need A, but plenty of other tasks will need B, we should schedule alongside A even if B is a bit larger to move. This will Probably™️ lead to smoother scheduling overall.

    I haven't tested this at all yet; it's just a theory right now. Just looking for thoughts.

- [ ] Closes #5324
- [ ] Tests added / passed
- [x] Passes `black distributed` / `flake8 distributed` / `isort distributed`

cc @fjetter @crusaderky @mrocklin 