### PR TITLE
Sync worker status to the scheduler; new 'paused' status

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -248,18 +248,9 @@ class Server:
 
     @status.setter
     def status(self, new_status):
-        if isinstance(new_status, Status):
-            self._status = new_status
-        elif isinstance(new_status, str):
-            warnings.warn(
-                "Since distributed 2.23 `.status` is now an Enum, please assign "
-                f"`Status.{new_status}`",
-                PendingDeprecationWarning,
-                stacklevel=1,
-            )
-            self._status = Status.lookup[new_status]
-        else:
-            raise TypeError(f"Expected Status or str, got {new_status}")
+        if not isinstance(new_status, Status):
+            raise TypeError(f"Expected Status; got {new_status!r}")
+        self._status = new_status
 
     async def finished(self):
         """Wait until the server has finished"""

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -5,7 +5,6 @@ import sys
 import threading
 import traceback
 import uuid
-import warnings
 import weakref
 from collections import defaultdict
 from contextlib import suppress

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -54,6 +54,7 @@ class Status(Enum):
     init = "init"
     starting = "starting"
     running = "running"
+    paused = "paused"
     stopping = "stopping"
     stopped = "stopped"
     closing = "closing"
@@ -268,7 +269,7 @@ class Server:
         async def _():
             timeout = getattr(self, "death_timeout", 0)
             async with self._startup_lock:
-                if self.status == Status.running:
+                if self.status in (Status.running, Status.paused):
                     return self
                 if timeout:
                     try:
@@ -503,7 +504,7 @@ class Server:
                             self._ongoing_coroutines.add(result)
                             result = await result
                     except (CommClosedError, CancelledError):
-                        if self.status == Status.running:
+                        if self.status in (Status.running, Status.paused):
                             logger.info("Lost connection to %r", address, exc_info=True)
                         break
                     except Exception as e:

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -3,7 +3,6 @@ import atexit
 import copy
 import logging
 import math
-import warnings
 import weakref
 from contextlib import suppress
 from inspect import isawaitable
@@ -39,18 +38,9 @@ class ProcessInterface:
 
     @status.setter
     def status(self, new_status):
-        if isinstance(new_status, Status):
-            self._status = new_status
-        elif isinstance(new_status, str):
-            warnings.warn(
-                "Since distributed 2.19 `.status` is now an Enum, please assign "
-                f"`Status.{new_status}`",
-                PendingDeprecationWarning,
-                stacklevel=1,
-            )
-            self._status = Status.lookup[new_status]
-        else:
-            raise TypeError(f"expected Status or str, got {new_status}")
+        if not isinstance(new_status, Status):
+            raise TypeError(f"Expected Status; got {new_status!r}")
+        self._status = new_status
 
     def __init__(self, scheduler=None, name=None):
         self.address = getattr(self, "address", None)

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -41,15 +41,14 @@ class ProcessInterface:
     def status(self, new_status):
         if isinstance(new_status, Status):
             self._status = new_status
-        elif isinstance(new_status, str) or new_status is None:
+        elif isinstance(new_status, str):
             warnings.warn(
-                f"Since distributed 2.19 `.status` is now an Enum, please assign `Status.{new_status}`",
+                "Since distributed 2.19 `.status` is now an Enum, please assign "
+                f"`Status.{new_status}`",
                 PendingDeprecationWarning,
                 stacklevel=1,
             )
-            corresponding_enum_variants = [s for s in Status if s.value == new_status]
-            assert len(corresponding_enum_variants) == 1
-            self._status = corresponding_enum_variants[0]
+            self._status = Status.lookup[new_status]
         else:
             raise TypeError(f"expected Status or str, got {new_status}")
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -685,12 +685,9 @@ class WorkerState:
 
     @status.setter
     def status(self, new_status):
-        if isinstance(new_status, Status):
-            self._status = new_status
-        elif isinstance(new_status, str):
-            self._status = Status.lookup[new_status]
-        else:
-            raise TypeError(f"expected Status or str, got {new_status}")
+        if not isinstance(new_status, Status):
+            raise TypeError(f"Expected Status; got {new_status!r}")
+        self._status = new_status
 
     @property
     def time_delay(self):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4847,7 +4847,6 @@ class Scheduler(SchedulerState, ServerNode):
                 ["all", address],
                 {
                     "action": "remove-worker",
-                    "worker": address,
                     "processing-tasks": dict(ws._processing),
                 },
             )

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -70,39 +70,13 @@ def echo_no_serialize(comm, x):
 
 
 def test_server_status_is_always_enum():
-    """
-    Assignments with strings get converted to corresponding Enum variant
-    """
+    """Assignments with strings is forbidden"""
     server = Server({})
     assert isinstance(server.status, Status)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("ignore")
-        assert server.status != Status.stopped
-        server.status = "stopped"
-    assert isinstance(server.status, Status)
+    assert server.status != Status.stopped
+    server.status = Status.stopped
     assert server.status == Status.stopped
-
-
-def test_server_status_assign_non_variant_raises():
-    server = Server({})
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("ignore")
-        with pytest.raises(KeyError):
-            server.status = "I do not exists"
-
-
-def test_server_status_assign_with_variant_warns():
-    server = Server({})
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("default")
-        with pytest.warns(PendingDeprecationWarning):
-            server.status = "running"
-
-
-def test_server_status_assign_with_variant_raises_in_tests():
-    """That would be the default in user code"""
-    server = Server({})
-    with pytest.raises(PendingDeprecationWarning):
+    with pytest.raises(TypeError):
         server.status = "running"
 
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 import socket
 import threading
-import warnings
 import weakref
 
 import pytest

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -87,7 +87,7 @@ def test_server_status_assign_non_variant_raises():
     server = Server({})
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("ignore")
-        with pytest.raises(AssertionError):
+        with pytest.raises(KeyError):
             server.status = "I do not exists"
 
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -305,7 +305,7 @@ async def test_throttle_outgoing_connections(c, s, a, *workers):
         # This is is very fragile, since a refactor of memory_monitor to
         # remove _memory_monitoring will break this test.
         dask_worker._memory_monitoring = True
-        dask_worker.paused = True
+        dask_worker.status = Status.paused
         dask_worker.outgoing_current_count = 2
 
     await c.run(pause, workers=[a.address])

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -316,7 +316,7 @@ async def test_worker_waits_for_scheduler():
         pass
     else:
         assert False
-    assert w.status not in (Status.closed, Status.running)
+    assert w.status not in (Status.closed, Status.running, Status.paused)
     await w.close(timeout=0.1)
 
 
@@ -919,7 +919,7 @@ async def test_fail_write_to_disk(c, s, a, b):
 async def test_fail_write_many_to_disk(c, s, a):
     a.validate = False
     await asyncio.sleep(0.1)
-    assert not a.paused
+    assert a.status == Status.running
 
     class Bad:
         def __init__(self, x):
@@ -1176,7 +1176,7 @@ async def test_pause_executor(c, s, a):
         future = c.submit(f)
         futures = c.map(slowinc, range(30), delay=0.1)
 
-        while not a.paused:
+        while a.status != Status.paused:
             await asyncio.sleep(0.01)
 
         out = logger.getvalue()
@@ -1597,7 +1597,7 @@ async def test_lifetime(c, s):
     async with Worker(s.address) as a, Worker(s.address, lifetime="1 seconds") as b:
         futures = c.map(slowinc, range(200), delay=0.1, worker=[b.address])
         await asyncio.sleep(1.5)
-        assert b.status != Status.running
+        assert b.status not in (Status.running, Status.paused)
         await b.finished()
         assert set(b.data) == set(a.data)  # successfully moved data over
 
@@ -2714,3 +2714,61 @@ async def test_gather_dep_exception_one_task_2(c, s, a, b):
     s.handle_missing_data(key="f1", errant_worker=a.address)
 
     await fut2
+
+
+@pytest.mark.slow
+@gen_cluster(
+    client=True,
+    Worker=Nanny,
+    nthreads=[("", 1)],
+    config={"distributed.worker.memory.pause": 0.5},
+    worker_kwargs={"memory_limit": 2 ** 29},  # 500 MiB
+)
+async def test_worker_status_sync(c, s, a):
+    (ws,) = s.workers.values()
+
+    while ws.status != Status.running:
+        await asyncio.sleep(0.01)
+
+    def leak():
+        distributed._test_leak = "x" * 2 ** 28  # 250 MiB
+
+    def clear_leak():
+        del distributed._test_leak
+
+    await c.run(leak)
+
+    while ws.status != Status.paused:
+        await asyncio.sleep(0.01)
+
+    await c.run(clear_leak)
+
+    while ws.status != Status.running:
+        await asyncio.sleep(0.01)
+
+    await s.retire_workers()
+
+    while ws.status != Status.closed:
+        await asyncio.sleep(0.01)
+
+    events = [ev for _, ev in s.events[ws.address] if ev["action"] != "heartbeat"]
+    assert events == [
+        {"action": "add-worker"},
+        {
+            "action": "worker-status-change",
+            "prev-status": "undefined",
+            "status": "running",
+        },
+        {
+            "action": "worker-status-change",
+            "prev-status": "running",
+            "status": "paused",
+        },
+        {
+            "action": "worker-status-change",
+            "prev-status": "paused",
+            "status": "running",
+        },
+        {"action": "remove-worker", "processing-tasks": {}},
+        {"action": "retired"},
+    ]

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1543,7 +1543,7 @@ def check_instances():
     for w in Worker._instances:
         with suppress(RuntimeError):  # closed IOLoop
             w.loop.add_callback(w.close, report=False, executor_wait=False)
-            if w.status == Status.running:
+            if w.status in (Status.running, Status.paused):
                 w.loop.add_callback(w.close)
     Worker._instances.clear()
 


### PR DESCRIPTION
At every change of Worker.status, perform a one-directional sync it to WorkerState.status on the scheduler side using bulk comms.
Remove the Worker.paused boolean flag and replace it with a new Status.paused, which is also synchronised.

This PR is propaedeutic to adding a Status.retiring flag in a future PR, which in turn is key to safely retire workers in the middle of a computation.