### PR TITLE
Add worker name as label to prometheus metrics

### DIFF
--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -24,54 +24,77 @@ class WorkerMetricCollector(PrometheusCollector):
         tasks = GaugeMetricFamily(
             self.build_name("tasks"),
             "Number of tasks at worker.",
-            labels=["state"],
+            labels=["state", "worker"],
         )
-        tasks.add_metric(["stored"], len(self.server.data))
-        tasks.add_metric(["executing"], self.server.executing_count)
-        tasks.add_metric(["ready"], len(self.server.ready))
-        tasks.add_metric(["waiting"], self.server.waiting_for_data_count)
+        tasks.add_metric(["stored", self.server.name], len(self.server.data))
+        tasks.add_metric(["executing", self.server.name], self.server.executing_count)
+        tasks.add_metric(["ready", self.server.name], len(self.server.ready))
+        tasks.add_metric(
+            ["waiting", self.server.name], self.server.waiting_for_data_count
+        )
         yield tasks
 
-        yield GaugeMetricFamily(
+        concurrent_fetch_requests = GaugeMetricFamily(
             self.build_name("concurrent_fetch_requests"),
             "Number of open fetch requests to other workers.",
-            value=len(self.server.in_flight_workers),
+            labels=["worker"],
         )
+        concurrent_fetch_requests.add_metric(
+            [self.server.name], len(self.server.in_flight_workers)
+        )
+        yield concurrent_fetch_requests
 
-        yield GaugeMetricFamily(
+        threads = GaugeMetricFamily(
             self.build_name("threads"),
             "Number of worker threads.",
-            value=self.server.nthreads,
+            labels=["worker"],
         )
+        threads.add_metric([self.server.name], self.server.nthreads)
+        yield threads
 
-        yield GaugeMetricFamily(
+        latency_seconds = GaugeMetricFamily(
             self.build_name("latency_seconds"),
             "Latency of worker connection.",
-            value=self.server.latency,
+            labels=["worker"],
         )
+        latency_seconds.add_metric([self.server.name], self.server.latency)
+        yield latency_seconds
 
         # all metrics using digests require crick to be installed
         # the following metrics will export NaN, if the corresponding digests are None
         if self.crick_available:
-            yield GaugeMetricFamily(
+            tick_duration_median_seconds = GaugeMetricFamily(
                 self.build_name("tick_duration_median_seconds"),
                 "Median tick duration at worker.",
-                value=self.server.digests["tick-duration"].components[1].quantile(50),
+                labels=["worker"],
             )
+            tick_duration_median_seconds.add_metric(
+                [self.server.name],
+                self.server.digests["tick-duration"].components[1].quantile(50),
+            )
+            yield tick_duration_median_seconds
 
-            yield GaugeMetricFamily(
+            task_duration_median_seconds = GaugeMetricFamily(
                 self.build_name("task_duration_median_seconds"),
                 "Median task runtime at worker.",
-                value=self.server.digests["task-duration"].components[1].quantile(50),
+                labels=["worker"],
             )
+            task_duration_median_seconds.add_metric(
+                [self.server.name],
+                self.server.digests["task-duration"].components[1].quantile(50),
+            )
+            yield task_duration_median_seconds
 
-            yield GaugeMetricFamily(
+            transfer_bandwidth_median_bytes = GaugeMetricFamily(
                 self.build_name("transfer_bandwidth_median_bytes"),
                 "Bandwidth for transfer at worker in Bytes.",
-                value=self.server.digests["transfer-bandwidth"]
-                .components[1]
-                .quantile(50),
+                labels=["worker"],
             )
+            transfer_bandwidth_median_bytes.add_metric(
+                [self.server.name],
+                self.server.digests["transfer-bandwidth"].components[1].quantile(50),
+            )
+            yield transfer_bandwidth_median_bytes
 
 
 class PrometheusHandler(RequestHandler):


### PR DESCRIPTION
Adds the worker name as a label on the prometheus metrics endpoint.

```
# HELP dask_worker_threads Number of worker threads.
# TYPE dask_worker_threads gauge
dask_worker_threads{worker="tcp://127.0.0.1:54841"} 12.0
```

Useful when wanting to filter worker by name and also for aggregating metrics.