### PR TITLE
Revert AMM ReduceReplicas and parallel AMMs updates

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1859,7 +1859,6 @@ class SchedulerState:
     _task_groups: dict
     _task_prefixes: dict
     _task_metadata: dict
-    _replicated_tasks: set
     _total_nthreads: Py_ssize_t
     _total_occupancy: double
     _transitions_table: dict
@@ -1919,9 +1918,6 @@ class SchedulerState:
             self._tasks = tasks
         else:
             self._tasks = dict()
-        self._replicated_tasks = {
-            ts for ts in self._tasks.values() if len(ts._who_has) > 1
-        }
         self._computations = deque(
             maxlen=dask.config.get("distributed.diagnostics.computations.max-history")
         )
@@ -2038,10 +2034,6 @@ class SchedulerState:
     @property
     def task_metadata(self):
         return self._task_metadata
-
-    @property
-    def replicated_tasks(self):
-        return self._replicated_tasks
 
     @property
     def total_nthreads(self):
@@ -2828,14 +2820,18 @@ class SchedulerState:
                     dts._waiting_on.add(ts)
 
             # XXX factor this out?
+            ts_nbytes: Py_ssize_t = ts.get_nbytes()
             worker_msg = {
                 "op": "free-keys",
                 "keys": [key],
                 "reason": f"Memory->Released {key}",
             }
             for ws in ts._who_has:
+                del ws._has_what[ts]
+                ws._nbytes -= ts_nbytes
                 worker_msgs[ws._address] = [worker_msg]
-            self.remove_all_replicas(ts)
+
+            ts._who_has.clear()
 
             ts.state = "released"
 
@@ -3428,40 +3424,6 @@ class SchedulerState:
             return (len(ws._actors), start_time, ws._nbytes)
         else:
             return (start_time, ws._nbytes)
-
-    @ccall
-    def add_replica(self, ts: TaskState, ws: WorkerState):
-        """Note that a worker holds a replica of a task with state='memory'"""
-        if self._validate:
-            assert ws not in ts._who_has
-            assert ts not in ws._has_what
-
-        ws._nbytes += ts.get_nbytes()
-        ws._has_what[ts] = None
-        ts._who_has.add(ws)
-        if len(ts._who_has) == 2:
-            self._replicated_tasks.add(ts)
-
-    @ccall
-    def remove_replica(self, ts: TaskState, ws: WorkerState):
-        """Note that a worker no longer holds a replica of a task"""
-        ws._nbytes -= ts.get_nbytes()
-        del ws._has_what[ts]
-        ts._who_has.remove(ws)
-        if len(ts._who_has) == 1:
-            self._replicated_tasks.remove(ts)
-
-    @ccall
-    def remove_all_replicas(self, ts: TaskState):
-        """Remove all replicas of a task from all workers"""
-        ws: WorkerState
-        nbytes: Py_ssize_t = ts.get_nbytes()
-        for ws in ts._who_has:
-            ws._nbytes -= nbytes
-            del ws._has_what[ts]
-        if len(ts._who_has) > 1:
-            self._replicated_tasks.remove(ts)
-        ts._who_has.clear()
 
 
 class Scheduler(SchedulerState, ServerNode):
@@ -4774,23 +4736,70 @@ class Scheduler(SchedulerState, ServerNode):
         parent: SchedulerState = cast(SchedulerState, self)
         logger.debug("Stimulus task erred %s, %s", key, worker)
 
-        ts: TaskState = parent._tasks.get(key)
-        if ts is None or ts._state != "processing":
-            return {}, {}, {}
+        recommendations: dict = {}
+        client_msgs: dict = {}
+        worker_msgs: dict = {}
 
-        if ts._retries > 0:
-            ts._retries -= 1
-            return parent._transition(key, "waiting")
-        else:
-            return parent._transition(
-                key,
-                "erred",
-                cause=key,
-                exception=exception,
-                traceback=traceback,
-                worker=worker,
-                **kwargs,
-            )
+        ts: TaskState = parent._tasks.get(key)
+        if ts is None:
+            return recommendations, client_msgs, worker_msgs
+
+        if ts._state == "processing":
+            retries: Py_ssize_t = ts._retries
+            r: tuple
+            if retries > 0:
+                ts._retries = retries - 1
+                r = parent._transition(key, "waiting")
+            else:
+                r = parent._transition(
+                    key,
+                    "erred",
+                    cause=key,
+                    exception=exception,
+                    traceback=traceback,
+                    worker=worker,
+                    **kwargs,
+                )
+            recommendations, client_msgs, worker_msgs = r
+
+        return recommendations, client_msgs, worker_msgs
+
+    def stimulus_missing_data(
+        self, cause=None, key=None, worker=None, ensure=True, **kwargs
+    ):
+        """Mark that certain keys have gone missing.  Recover."""
+        parent: SchedulerState = cast(SchedulerState, self)
+        with log_errors():
+            logger.debug("Stimulus missing data %s, %s", key, worker)
+
+            recommendations: dict = {}
+            client_msgs: dict = {}
+            worker_msgs: dict = {}
+
+            ts: TaskState = parent._tasks.get(key)
+            if ts is None or ts._state == "memory":
+                return recommendations, client_msgs, worker_msgs
+            cts: TaskState = parent._tasks.get(cause)
+
+            if cts is not None and cts._state == "memory":  # couldn't find this
+                ws: WorkerState
+                cts_nbytes: Py_ssize_t = cts.get_nbytes()
+                for ws in cts._who_has:  # TODO: this behavior is extreme
+                    del ws._has_what[ts]
+                    ws._nbytes -= cts_nbytes
+                cts._who_has.clear()
+                recommendations[cause] = "released"
+
+            if key:
+                recommendations[key] = "released"
+
+            parent._transitions(recommendations, client_msgs, worker_msgs)
+            recommendations = {}
+
+            if parent._validate:
+                assert cause not in self.who_has
+
+            return recommendations, client_msgs, worker_msgs
 
     def stimulus_retry(self, comm=None, keys=None, client=None):
         parent: SchedulerState = cast(SchedulerState, self)
@@ -4905,13 +4914,14 @@ class Scheduler(SchedulerState, ServerNode):
                             self.allowed_failures,
                         )
 
-            for ts in list(ws._has_what):
-                parent.remove_replica(ts, ws)
+            for ts in ws._has_what:
+                ts._who_has.remove(ws)
                 if not ts._who_has:
                     if ts._run_spec:
                         recommendations[ts._key] = "released"
                     else:  # pure data
                         recommendations[ts._key] = "forgotten"
+            ws._has_what.clear()
 
             self.transitions(recommendations)
 
@@ -5061,7 +5071,6 @@ class Scheduler(SchedulerState, ServerNode):
         ts: TaskState = parent._tasks[key]
         dts: TaskState
         assert ts._who_has
-        assert bool(ts in parent._replicated_tasks) == (len(ts._who_has) > 1)
         assert not ts._processing_on
         assert not ts._waiting_on
         assert ts not in parent._unrunnable
@@ -5132,12 +5141,7 @@ class Scheduler(SchedulerState, ServerNode):
         for k, ts in parent._tasks.items():
             assert isinstance(ts, TaskState), (type(ts), ts)
             assert ts._key == k
-            assert bool(ts in parent._replicated_tasks) == (len(ts._who_has) > 1)
             self.validate_key(k, ts)
-
-        for ts in parent._replicated_tasks:
-            assert ts._state == "memory"
-            assert ts._key in parent._tasks
 
         c: str
         cs: ClientState
@@ -5339,14 +5343,24 @@ class Scheduler(SchedulerState, ServerNode):
 
         self.send_all(client_msgs, worker_msgs)
 
-    def handle_release_data(self, key=None, worker=None, **kwargs):
+    def handle_release_data(self, key=None, worker=None, client=None, **msg):
         parent: SchedulerState = cast(SchedulerState, self)
         ts: TaskState = parent._tasks.get(key)
-        if ts is None or ts._state == "memory":
+        if ts is None:
             return
         ws: WorkerState = parent._workers_dv.get(worker)
-        if ws is not None and ts._processing_on == ws:
-            parent._transitions({key: "released"}, {}, {})
+        if ws is None or ts._processing_on != ws:
+            return
+
+        recommendations: dict
+        client_msgs: dict
+        worker_msgs: dict
+
+        r: tuple = self.stimulus_missing_data(key=key, ensure=False, **msg)
+        recommendations, client_msgs, worker_msgs = r
+        parent._transitions(recommendations, client_msgs, worker_msgs)
+
+        self.send_all(client_msgs, worker_msgs)
 
     def handle_missing_data(self, key=None, errant_worker=None, **kwargs):
         parent: SchedulerState = cast(SchedulerState, self)
@@ -5358,7 +5372,9 @@ class Scheduler(SchedulerState, ServerNode):
             return
         ws: WorkerState = parent._workers_dv.get(errant_worker)
         if ws is not None and ws in ts._who_has:
-            parent.remove_replica(ts, ws)
+            ts._who_has.remove(ws)
+            del ws._has_what[ts]
+            ws._nbytes -= ts.get_nbytes()
         if not ts._who_has:
             if ts._run_spec:
                 self.transitions({key: "released"})
@@ -5376,8 +5392,11 @@ class Scheduler(SchedulerState, ServerNode):
         ts: TaskState
         recommendations: dict = {}
         for ts in removed_tasks:
-            parent.remove_replica(ts, ws)
-            if not ts._who_has:
+            del ws._has_what[ts]
+            ws._nbytes -= ts.get_nbytes()
+            wh: set = ts._who_has
+            wh.remove(ws)
+            if not wh:
                 recommendations[ts._key] = "released"
         if recommendations:
             self.transitions(recommendations)
@@ -5697,11 +5716,14 @@ class Scheduler(SchedulerState, ServerNode):
                     )
                     if not workers or ts is None:
                         continue
+                    ts_nbytes: Py_ssize_t = ts.get_nbytes()
                     recommendations: dict = {key: "released"}
                     for worker in workers:
                         ws = parent._workers_dv.get(worker)
-                        if ws is not None and ws in ts._who_has:
-                            parent.remove_replica(ts, ws)
+                        if ws is not None and ts in ws._has_what:
+                            del ws._has_what[ts]
+                            ts._who_has.remove(ws)
+                            ws._nbytes -= ts_nbytes
                             parent._transitions(
                                 recommendations, client_msgs, worker_msgs
                             )
@@ -5900,8 +5922,10 @@ class Scheduler(SchedulerState, ServerNode):
             if ts is None or ts._state != "memory":
                 logger.warning(f"Key lost during replication: {key}")
                 continue
-            if ws not in ts._who_has:
-                parent.add_replica(ts, ws)
+            if ts not in ws._has_what:
+                ws._nbytes += ts.get_nbytes()
+                ws._has_what[ts] = None
+                ts._who_has.add(ws)
 
         return keys_failed
 
@@ -5938,9 +5962,11 @@ class Scheduler(SchedulerState, ServerNode):
 
         for key in keys:
             ts: TaskState = parent._tasks.get(key)
-            if ts is not None and ws in ts._who_has:
+            if ts is not None and ts in ws._has_what:
                 assert ts._state == "memory"
-                parent.remove_replica(ts, ws)
+                del ws._has_what[ts]
+                ts._who_has.remove(ws)
+                ws._nbytes -= ts.get_nbytes()
                 if not ts._who_has:
                     # Last copy deleted
                     self.transitions({key: "released"})
@@ -6688,8 +6714,10 @@ class Scheduler(SchedulerState, ServerNode):
         for key in keys:
             ts: TaskState = parent._tasks.get(key)
             if ts is not None and ts._state == "memory":
-                if ws not in ts._who_has:
-                    parent.add_replica(ts, ws)
+                if ts not in ws._has_what:
+                    ws._nbytes += ts.get_nbytes()
+                    ws._has_what[ts] = None
+                    ts._who_has.add(ws)
             else:
                 superfluous_data.append(key)
         if superfluous_data:
@@ -6731,14 +6759,17 @@ class Scheduler(SchedulerState, ServerNode):
                 if ts is None:
                     ts: TaskState = parent.new_task(key, None, "memory")
                 ts.state = "memory"
-                ts_nbytes = nbytes.get(key, -1)
+                ts_nbytes: Py_ssize_t = nbytes.get(key, -1)
                 if ts_nbytes >= 0:
                     ts.set_nbytes(ts_nbytes)
-
+                else:
+                    ts_nbytes = ts.get_nbytes()
                 for w in workers:
                     ws: WorkerState = parent._workers_dv[w]
-                    if ws not in ts._who_has:
-                        parent.add_replica(ts, ws)
+                    if ts not in ws._has_what:
+                        ws._nbytes += ts_nbytes
+                        ws._has_what[ts] = None
+                        ts._who_has.add(ws)
                 self.report(
                     {"op": "key-in-memory", "key": key, "workers": list(workers)}
                 )
@@ -7705,7 +7736,9 @@ def _add_to_memory(
     if state._validate:
         assert ts not in ws._has_what
 
-    state.add_replica(ts, ws)
+    ts._who_has.add(ws)
+    ws._has_what[ts] = None
+    ws._nbytes += ts.get_nbytes()
 
     deps: list = list(ts._dependents)
     if len(deps) > 1:
@@ -7781,8 +7814,12 @@ def _propagate_forgotten(
     ts._dependencies.clear()
     ts._waiting_on.clear()
 
+    ts_nbytes: Py_ssize_t = ts.get_nbytes()
+
     ws: WorkerState
     for ws in ts._who_has:
+        del ws._has_what[ts]
+        ws._nbytes -= ts_nbytes
         w: str = ws._address
         if w in state._workers_dv:  # in case worker has died
             worker_msgs[w] = [
@@ -7792,7 +7829,7 @@ def _propagate_forgotten(
                     "reason": f"propagate-forgotten {ts.key}",
                 }
             ]
-    state.remove_all_replicas(ts)
+    ts._who_has.clear()
 
 
 @cfunc

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -101,65 +101,6 @@ async def test_auto_start(c, s, a, b):
     assert len(s.tasks["x"].who_has) == 1
 
 
-@gen_cluster(client=True, config=demo_config("drop", key="x"))
-async def test_add_policy(c, s, a, b):
-    p2 = DemoPolicy(action="drop", key="y", n=10, candidates=None)
-    p3 = DemoPolicy(action="drop", key="z", n=10, candidates=None)
-
-    # policies parameter can be:
-    # - None: get from config
-    # - explicit set, which can be empty
-    m1 = s.extensions["amm"]
-    m2 = ActiveMemoryManagerExtension(s, {p2}, register=False, start=False)
-    m3 = ActiveMemoryManagerExtension(s, set(), register=False, start=False)
-
-    assert len(m1.policies) == 1
-    assert len(m2.policies) == 1
-    assert len(m3.policies) == 0
-    m3.add_policy(p3)
-    assert len(m3.policies) == 1
-
-    futures = await c.scatter({"x": 1, "y": 2, "z": 3}, broadcast=True)
-    m1.run_once()
-    while len(s.tasks["x"].who_has) == 2:
-        await asyncio.sleep(0.01)
-
-    m2.run_once()
-    while len(s.tasks["y"].who_has) == 2:
-        await asyncio.sleep(0.01)
-
-    m3.run_once()
-    while len(s.tasks["z"].who_has) == 2:
-        await asyncio.sleep(0.01)
-
-
-@gen_cluster(client=True, config=demo_config("drop", key="x", start=False))
-async def test_multi_start(c, s, a, b):
-    """Multiple AMMs can be started in parallel"""
-    p2 = DemoPolicy(action="drop", key="y", n=10, candidates=None)
-    p3 = DemoPolicy(action="drop", key="z", n=10, candidates=None)
-
-    # policies parameter can be:
-    # - None: get from config
-    # - explicit set, which can be empty
-    m1 = s.extensions["amm"]
-    m2 = ActiveMemoryManagerExtension(s, {p2}, register=False, start=True, interval=0.1)
-    m3 = ActiveMemoryManagerExtension(s, {p3}, register=False, start=True, interval=0.1)
-
-    assert not m1.started
-    assert m2.started
-    assert m3.started
-
-    futures = await c.scatter({"x": 1, "y": 2, "z": 3}, broadcast=True)
-
-    # The AMMs should run within 0.1s of the broadcast.
-    # Add generous extra padding to prevent flakiness.
-    await asyncio.sleep(0.5)
-    assert len(s.tasks["x"].who_has) == 2
-    assert len(s.tasks["y"].who_has) == 1
-    assert len(s.tasks["z"].who_has) == 1
-
-
 @gen_cluster(client=True, config=NO_AMM_START)
 async def test_not_registered(c, s, a, b):
     futures = await c.scatter({"x": 1}, broadcast=True)


### PR DESCRIPTION
A group recently reported offline that they were running into deadlocked clusters with the [current `distributed` `main` branch](https://github.com/dask/distributed/commit/05677bb2be375231d563bc099624965d7e1bc4b1) (xref https://github.com/dask/community/issues/182#issuecomment-921961476). After running `git bisect` they were able to narrow down https://github.com/dask/distributed/pull/5297 as the place where things began to lock up.

As https://github.com/dask/distributed/pull/5315 and https://github.com/dask/distributed/pull/5297 both contain updates to our active memory management system, which is still under active development and disabled by default, this PR proposes we revert those two PRs prior to the 2021.09.1 release. This will help us avoid having users impacted by the deadlock issue and give @fjetter @crusaderky and me more time to determine what exactly in https://github.com/dask/distributed/pull/5315 and https://github.com/dask/distributed/pull/5297 is problematic. 

cc @crusaderky @fjetter @jakirkham 