### PR TITLE
Fix typo in client side example foundations.rst

### DIFF
--- a/docs/source/foundations.rst
+++ b/docs/source/foundations.rst
@@ -120,7 +120,7 @@ Client Side
        await comm.close()
        print(result)
 
-   >>> asyncio.get_event_loop().run_until_complete(g())
+   >>> asyncio.get_event_loop().run_until_complete(f())
    3
 
    async def g():


### PR DESCRIPTION
This looks like a typo in the client side example code. 

I'm pretty sure it should refer to function f defined above (not function g, which does something different in the next bit of the example).
