### PR TITLE
Add check for unsupported NVML metrics

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -10,11 +10,10 @@ except ImportError:
 nvmlInitialized = False
 nvmlLibraryNotFound = False
 nvmlOwnerPID = None
-nvmlNotSupported = None
 
 
 def init_once():
-    global nvmlInitialized, nvmlLibraryNotFound, nvmlOwnerPID, nvmlNotSupported
+    global nvmlInitialized, nvmlLibraryNotFound, nvmlOwnerPID
 
     if dask.config.get("distributed.diagnostics.nvml") is False:
         nvmlInitialized = False
@@ -27,7 +26,6 @@ def init_once():
     nvmlOwnerPID = os.getpid()
     try:
         pynvml.nvmlInit()
-        nvmlNotSupported = _pynvml_not_supported()
     except (
         pynvml.NVMLError_LibraryNotFound,
         pynvml.NVMLError_DriverNotLoaded,
@@ -65,34 +63,6 @@ def _pynvml_handles():
     return pynvml.nvmlDeviceGetHandleByIndex(gpu_idx)
 
 
-def _pynvml_not_supported():
-    h = _pynvml_handles()
-
-    try:
-        util = pynvml.nvmlDeviceGetUtilizationRates(h).gpu
-    except pynvml.NVMLError_NotSupported:
-        util = None
-    try:
-        mem = pynvml.nvmlDeviceGetMemoryInfo(h).used
-    except pynvml.NVMLError_NotSupported:
-        mem = None
-    try:
-        total = pynvml.nvmlDeviceGetMemoryInfo(h).total
-    except pynvml.NVMLError_NotSupported:
-        total = None
-    try:
-        name = pynvml.nvmlDeviceGetName(h).decode()
-    except pynvml.NVMLError_NotSupported:
-        name = None
-
-    return {
-        "util": util is None,
-        "mem": mem is None,
-        "total": total is None,
-        "name": name is None,
-    }
-
-
 def has_cuda_context():
     """Check whether the current process already has a CUDA context created.
 
@@ -111,25 +81,45 @@ def has_cuda_context():
     return False
 
 
+def _get_utilization(h):
+    try:
+        return pynvml.nvmlDeviceGetUtilizationRates(h).gpu
+    except pynvml.NVMLError_NotSupported:
+        return None
+
+
+def _get_memory_used(h):
+    try:
+        return pynvml.nvmlDeviceGetMemoryInfo(h).used
+    except pynvml.NVMLError_NotSupported:
+        return None
+
+
+def _get_memory_total(h):
+    try:
+        return pynvml.nvmlDeviceGetMemoryInfo(h).total
+    except pynvml.NVMLError_NotSupported:
+        return None
+
+
+def _get_name(h):
+    try:
+        return pynvml.nvmlDeviceGetName(h).decode()
+    except pynvml.NVMLError_NotSupported:
+        return None
+
+
 def real_time():
     h = _pynvml_handles()
     return {
-        "utilization": None
-        if nvmlNotSupported["util"]
-        else pynvml.nvmlDeviceGetUtilizationRates(h).gpu,
-        "memory-used": None
-        if nvmlNotSupported["mem"]
-        else pynvml.nvmlDeviceGetMemoryInfo(h).used,
+        "utilization": _get_utilization(h),
+        "memory-used": _get_memory_used(h),
     }
 
 
 def one_time():
     h = _pynvml_handles()
     return {
-        "memory-total": None
-        if nvmlNotSupported["util"]
-        else pynvml.nvmlDeviceGetMemoryInfo(h).total,
-        "name": None
-        if nvmlNotSupported["util"]
-        else pynvml.nvmlDeviceGetName(h).decode(),
+        "memory-total": _get_memory_total(h),
+        "name": _get_name(h),
     }

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -83,15 +83,31 @@ def has_cuda_context():
 
 def real_time():
     h = _pynvml_handles()
+    try:
+        util = pynvml.nvmlDeviceGetUtilizationRates(h).gpu
+    except pynvml.NVMLError_NotSupported:
+        util = None
+    try:
+        mem = pynvml.nvmlDeviceGetMemoryInfo(h).used
+    except pynvml.NVMLError_NotSupported:
+        mem = None
     return {
-        "utilization": pynvml.nvmlDeviceGetUtilizationRates(h).gpu,
-        "memory-used": pynvml.nvmlDeviceGetMemoryInfo(h).used,
+        "utilization": util,
+        "memory-used": mem,
     }
 
 
 def one_time():
     h = _pynvml_handles()
+    try:
+        total = pynvml.nvmlDeviceGetMemoryInfo(h).total
+    except pynvml.NVMLError_NotSupported:
+        total = None
+    try:
+        name = pynvml.nvmlDeviceGetName(h).decode()
+    except pynvml.NVMLError_NotSupported:
+        name = None
     return {
-        "memory-total": pynvml.nvmlDeviceGetMemoryInfo(h).total,
-        "name": pynvml.nvmlDeviceGetName(h).decode(),
+        "memory-total": total,
+        "name": name,
     }


### PR DESCRIPTION
Adds some checks to `nvml.one_time` and `nvml.real_time` to handle the case where GPUs are available for monitoring, but some metrics are unsupported for whatever reason.

- [ ] Closes #5342
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
