### PR TITLE
Add support for partial functions to `iscoroutinefunction` util

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import gc
 import inspect
 import logging
@@ -6911,6 +6912,16 @@ async def test_async_task(c, s, a, b):
     future = c.submit(f, 10)
     result = await future
     assert result == 11
+
+
+@gen_cluster(client=True)
+async def test_async_task_with_partial(c, s, a, b):
+    async def f(x, y):
+        return x + y + 1
+
+    future = c.submit(functools.partial(f, 1), 10)
+    result = await future
+    assert result == 12
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,5 +1,6 @@
 import array
 import asyncio
+import functools
 import io
 import os
 import queue
@@ -604,3 +605,12 @@ def test_typename_deprecated():
 def test_iscoroutinefunction_unhashable_input():
     # Ensure iscoroutinefunction can handle unhashable callables
     assert not iscoroutinefunction(_UnhashableCallable())
+
+
+def test_iscoroutinefunction_nested_partial():
+    async def my_async_callable(x, y, z):
+        pass
+
+    assert iscoroutinefunction(
+        functools.partial(functools.partial(my_async_callable, 1), 2)
+    )

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1139,6 +1139,10 @@ def color_of(x, palette=palette):
 
 
 def _iscoroutinefunction(f):
+    # Python < 3.8 does not support determining if `partial` objects wrap async funcs
+    if sys.version_info < (3, 8):
+        while isinstance(f, functools.partial):
+            f = f.func
     return inspect.iscoroutinefunction(f) or gen.is_coroutine_function(f)
 
 


### PR DESCRIPTION
On Python 3.7, partial functions are not correctly evaluated by `inspect.iscoroutinefunction`. See https://bugs.python.org/issue33261

This PR adds a looping evaluation of `partial` objects into their underlying func for older Python versions. This allows `partial` async functions (support added in #5151) to be submitted and executed correctly.

- ~[ ] Closes #xxxx~
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
