### PR TITLE
Add custom exception types to the nvml diagnostics file

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -12,6 +12,14 @@ nvmlLibraryNotFound = False
 nvmlOwnerPID = None
 
 
+class NVMLNotFound(Exception):
+    pass
+
+
+class NoGPUSAvailable(Exception):
+    pass
+
+
 def init_once():
     global nvmlInitialized, nvmlLibraryNotFound, nvmlOwnerPID
 
@@ -46,9 +54,9 @@ def _pynvml_handles():
     count = device_get_count()
     if count == 0:
         if nvmlLibraryNotFound:
-            raise RuntimeError("PyNVML is installed, but NVML is not")
+            raise NVMLNotFound("PyNVML is installed, but NVML is not")
         else:
-            raise RuntimeError("No GPUs available")
+            raise NoGPUSAvailable("No GPUs available")
 
     try:
         cuda_visible_devices = [

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -23,6 +23,14 @@ def test_one_time():
     assert len(output["name"]) > 0
 
 
+def test_no_gpus_available():
+    if nvml.device_get_count() != 0:
+        pytest.skip("GPUs available")
+
+    with pytest.raises((nvml.NoGPUSAvailable, nvml.NVMLNotFound)):
+        nvml.one_time()
+
+
 def test_enable_disable_nvml():
     try:
         pynvml.nvmlShutdown()


### PR DESCRIPTION
Currently it's hard to distinguish errors when initalizing the `nvml` diagnostics library. For example, you might have some code that prints the GPU name using the `nvml.one_time()` method but you want to do something different if there are no GPUs found. To do this you need to do `if "No GPUs available" in exception"`, which is never nice.

This throws two different exception types, inheriting from `Exception` for compatibility, allowing you to handle things nicely.
