### PR TITLE
Remove explicit loop from asyncio tests

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6461,12 +6461,18 @@ async def test_performance_report(c, s, a, b):
     assert "cdn.bokeh.org" in data
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10), reason="No internal loop in Python 3.10"
+)
 @gen_cluster(nthreads=[])
 async def test_client_gather_semaphore_loop(s):
     async with Client(s.address, asynchronous=True) as c:
         assert c._gather_semaphore._loop is c.loop.asyncio_loop
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10), reason="No internal loop in Python 3.10"
+)
 @gen_cluster(client=True)
 async def test_as_completed_condition_loop(c, s, a, b):
     seq = c.map(inc, range(5))
@@ -6474,6 +6480,9 @@ async def test_as_completed_condition_loop(c, s, a, b):
     assert ac.condition._loop == c.loop.asyncio_loop
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10), reason="No internal loop in Python 3.10"
+)
 def test_client_connectionpool_semaphore_loop(s, a, b):
     with Client(s["address"]) as c:
         assert c.rpc.semaphore._loop is c.loop.asyncio_loop


### PR DESCRIPTION
In Python 3.5.3 and 3.6, the `get_event_loop` returned the expected result always, so in Python 3.8, this parameter was deprecated and in 3.10 it was removed.

- [x] Closes #5350
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`