### PR TITLE
Bump `RAPIDS_VER` for gpuCI

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -8,6 +8,6 @@ LINUX_VER:
 - ubuntu18.04
 
 RAPIDS_VER:
-- "21.10"
+- "21.12"
 
 excludes:


### PR DESCRIPTION
With cudf 21.12 nightlies out, we can now bump gpuCI here to use RAPIDS_VER=21.12. Note that this shouldn't be merged until rapidsai/dask-build-environment#8 is merged and the new images built.
