### PR TITLE
Avoid deprecated random set sampling

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6390,7 +6390,7 @@ class Scheduler(SchedulerState, ServerNode):
             if delete:
                 del_worker_tasks = defaultdict(set)
                 for ts in tasks:
-                    del_candidates = ts._who_has & workers
+                    del_candidates = tuple(ts._who_has & workers)
                     if len(del_candidates) > n:
                         for ws in random.sample(
                             del_candidates, len(del_candidates) - n
@@ -6422,7 +6422,7 @@ class Scheduler(SchedulerState, ServerNode):
                     count = min(n_missing, branching_factor * len(ts._who_has))
                     assert count > 0
 
-                    for ws in random.sample(workers - ts._who_has, count):
+                    for ws in random.sample(tuple(workers - ts._who_has), count):
                         gathers[ws._address][ts._key] = [
                             wws._address for wws in ts._who_has
                         ]


### PR DESCRIPTION
This PR avoid using `random.sample` on a `set`, which is [deprecated in Python](https://docs.python.org/3.9/library/random.html#random.sample) now

cc @QuLogic 

- [x] Closes https://github.com/dask/distributed/issues/5354
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
