### PR TITLE
Ensure `dask-worker` and `dask-scheduler` pick up preload configuration values 

### DIFF
--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -315,6 +315,19 @@ def test_preload_remote_module(loop, tmp_path):
                 )
 
 
+def test_preload_config(loop):
+    # Ensure dask-scheduler pulls the preload from the Dask config if
+    # not specified via a command line option
+    with tmpfile() as fn:
+        env = {"DASK_DISTRIBUTED__SCHEDULER__PRELOAD": PRELOAD_TEXT}
+        with popen(["dask-scheduler", "--scheduler-file", fn], env=env):
+            with Client(scheduler_file=fn, loop=loop) as c:
+                assert (
+                    c.run_on_scheduler(lambda dask_scheduler: dask_scheduler.foo)
+                    == "bar"
+                )
+
+
 PRELOAD_COMMAND_TEXT = """
 import click
 _config = {}

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -319,7 +319,8 @@ def test_preload_config(loop):
     # Ensure dask-scheduler pulls the preload from the Dask config if
     # not specified via a command line option
     with tmpfile() as fn:
-        env = {"DASK_DISTRIBUTED__SCHEDULER__PRELOAD": PRELOAD_TEXT}
+        env = os.environ.copy()
+        env["DASK_DISTRIBUTED__SCHEDULER__PRELOAD"] = PRELOAD_TEXT
         with popen(["dask-scheduler", "--scheduler-file", fn], env=env):
             with Client(scheduler_file=fn, loop=loop) as c:
                 assert (

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -495,25 +495,23 @@ class MyWorker(Worker):
                 assert all(name == "MyWorker" for name in worker_types.values())
 
 
-@pytest.mark.asyncio
-async def test_preload_config(cleanup):
+@gen_cluster(nthreads=[], client=True)
+async def test_preload_config(c, s):
     # Ensure dask-worker pulls the preload from the Dask config if
     # not specified via a command line option
     preload_text = """
 def dask_setup(worker):
     worker.foo = 'setup'
 """
-    async with Scheduler(port=0) as s:
-        async with Client(s.address, asynchronous=True) as c:
-            env = os.environ.copy()
-            env["DASK_DISTRIBUTED__WORKER__PRELOAD"] = preload_text
-            with popen(
-                [
-                    "dask-worker",
-                    s.address,
-                ],
-                env=env,
-            ):
-                await c.wait_for_workers(1)
-                [foo] = (await c.run(lambda dask_worker: dask_worker.foo)).values()
-                assert foo == "setup"
+    env = os.environ.copy()
+    env["DASK_DISTRIBUTED__WORKER__PRELOAD"] = preload_text
+    with popen(
+        [
+            "dask-worker",
+            s.address,
+        ],
+        env=env,
+    ):
+        await c.wait_for_workers(1)
+        [foo] = (await c.run(lambda dask_worker: dask_worker.foo)).values()
+        assert foo == "setup"

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -505,7 +505,8 @@ def dask_setup(worker):
 """
     async with Scheduler(port=0) as s:
         async with Client(s.address, asynchronous=True) as c:
-            env = {"DASK_DISTRIBUTED__WORKER__PRELOAD": preload_text}
+            env = os.environ.copy()
+            env["DASK_DISTRIBUTED__WORKER__PRELOAD"] = preload_text
             with popen(
                 [
                     "dask-worker",

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -582,7 +582,7 @@ class Worker(ServerNode):
             self._workdir = self._workspace.new_work_dir(prefix="worker-")
             self.local_directory = self._workdir.dir_path
 
-        if preload is None:
+        if not preload:
             preload = dask.config.get("distributed.worker.preload")
         if preload_argv is None:
             preload_argv = dask.config.get("distributed.worker.preload-argv")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -584,7 +584,7 @@ class Worker(ServerNode):
 
         if not preload:
             preload = dask.config.get("distributed.worker.preload")
-        if preload_argv is None:
+        if not preload_argv:
             preload_argv = dask.config.get("distributed.worker.preload-argv")
         self.preloads = preloading.process_preloads(
             self, preload, preload_argv, file_dir=self.local_directory


### PR DESCRIPTION
This PR supersedes https://github.com/dask/distributed/pull/4511 and ensures `dask-scheduler` and `dask-worker` pick up preloads when set as configuration values. 

cc @crusaderky @daimon99
