### PR TITLE
Mark `distributed/tests/test_client.py::test_profile_server` as flaky

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6050,6 +6050,7 @@ async def test_futures_of_sorted(c, s, a, b):
         assert str(k) in str(f)
 
 
+@pytest.mark.flaky(reruns=10, reruns_delay=5)
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": "10ms"})
 async def test_profile_server(c, s, a, b):
     for i in range(5):


### PR DESCRIPTION
This test failure showed up in `cloudpickle`s downstream CI suite. Since it's a known flaky test (xref https://github.com/dask/distributed/issues/4251) I'll propose we temporarily mark it as such 