### PR TITLE
Resolve work stealing deadlock caused by race in move_task_confirm

### DIFF
--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -216,6 +216,10 @@ class WorkStealing(SchedulerPlugin):
             return
         try:
             d = self.in_flight.pop(ts)
+            if d["stimulus_id"] != stimulus_id:
+                self.log(("stale-response", worker, stimulus_id))
+                self.in_flight[ts] = d
+                return
         except KeyError:
             self.log(("already-aborted", key, state, stimulus_id))
             return

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -693,7 +693,7 @@ async def test_dont_steal_already_released(c, s, a, b):
     while key in a.tasks and a.tasks[key].state != "released":
         await asyncio.sleep(0.05)
 
-    a.handle_steal_request(key)
+    a.handle_steal_request(key=key, stimulus_id="test")
     assert len(a.batched_stream.buffer) == 1
     msg = a.batched_stream.buffer[0]
     assert msg["op"] == "steal-response"
@@ -860,3 +860,80 @@ async def test_blacklist_shuffle_split(c, s, a, b):
                     assert "split" not in ts.prefix.name
         await asyncio.sleep(0.001)
     await res
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)] * 3,
+    config={
+        "distributed.scheduler.work-stealing-interval": 1_000_000,
+    },
+)
+async def test_steal_concurrent_simple(c, s, *workers):
+    steal = s.extensions["stealing"]
+    w0 = workers[0]
+    w1 = workers[1]
+    w2 = workers[2]
+    futs1 = c.map(
+        slowinc,
+        range(10),
+        key=[f"f1-{ix}" for ix in range(10)],
+        workers=[w0.address],
+    )
+
+    while not w0.tasks:
+        await asyncio.sleep(0.1)
+
+    # ready is a heap but we don't need last, just not the next
+    _, victim_key = w0.ready[-1]
+
+    ws0 = s.workers[w0.address]
+    ws1 = s.workers[w1.address]
+    ws2 = s.workers[w2.address]
+    victim_ts = s.tasks[victim_key]
+    steal.move_task_request(victim_ts, ws0, ws1)
+    steal.move_task_request(victim_ts, ws0, ws2)
+
+    await c.gather(futs1)
+
+    # Last wins
+    assert not ws1.has_what
+    assert ws2.has_what
+
+
+@gen_cluster(
+    client=True,
+    config={
+        "distributed.scheduler.work-stealing-interval": 1_000_000,
+    },
+    timeout=12345,
+)
+async def test_steal_reschedule_reset_in_flight_occupancy(c, s, *workers):
+    # https://github.com/dask/distributed/issues/5370
+    steal = s.extensions["stealing"]
+    w0 = workers[0]
+    futs1 = c.map(
+        slowinc,
+        range(10),
+        key=[f"f1-{ix}" for ix in range(10)],
+    )
+    while not w0.tasks:
+        await asyncio.sleep(0.01)
+
+    # ready is a heap but we don't need last, just not the next
+    _, victim_key = w0.ready[-1]
+
+    victim_ts = s.tasks[victim_key]
+
+    wsA = victim_ts.processing_on
+    other_workers = [ws for ws in s.workers.values() if ws != wsA]
+    wsB = other_workers[0]
+
+    steal.move_task_request(victim_ts, wsA, wsB)
+
+    s.reschedule(victim_key)
+    await c.gather(futs1)
+
+    del futs1
+
+    assert all(v == 0 for v in steal.in_flight_occupancy.values())

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -937,3 +937,42 @@ async def test_steal_reschedule_reset_in_flight_occupancy(c, s, *workers):
     del futs1
 
     assert all(v == 0 for v in steal.in_flight_occupancy.values())
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)] * 3,
+    config={
+        "distributed.scheduler.work-stealing-interval": 1_000_000,
+    },
+)
+async def test_reschedule_concurrent_requests_deadlock(c, s, *workers):
+    # https://github.com/dask/distributed/issues/5370
+    steal = s.extensions["stealing"]
+    w0 = workers[0]
+    futs1 = c.map(
+        slowinc,
+        range(10),
+        delay=1,
+        key=[f"f1-{ix}" for ix in range(10)],
+    )
+    while not w0.active_keys:
+        await asyncio.sleep(0.01)
+
+    # ready is a heap but we don't need last, just not the next
+    victim_key = list(w0.active_keys)[0]
+
+    victim_ts = s.tasks[victim_key]
+
+    wsA = victim_ts.processing_on
+    other_workers = [ws for ws in s.workers.values() if ws != wsA]
+    wsB = other_workers[0]
+    wsC = other_workers[1]
+
+    steal.move_task_request(victim_ts, wsA, wsB)
+
+    s.set_restrictions(worker={victim_key: [wsB.address]})
+    s.reschedule(victim_key)
+    assert wsB == victim_ts.processing_on
+    steal.move_task_request(victim_ts, wsB, wsC)
+    await c.gather(futs1)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2721,21 +2721,26 @@ class Worker(ServerNode):
                 pdb.set_trace()
             raise
 
-    def handle_steal_request(self, key):
+    def handle_steal_request(self, key, stimulus_id):
         # There may be a race condition between stealing and releasing a task.
         # In this case the self.tasks is already cleared. The `None` will be
         # registered as `already-computing` on the other end
         ts = self.tasks.get(key)
         state = ts.state if ts is not None else None
 
-        response = {"op": "steal-response", "key": key, "state": state}
+        response = {
+            "op": "steal-response",
+            "key": key,
+            "state": state,
+            "stimulus_id": stimulus_id,
+        }
         self.batched_stream.send(response)
 
         if state in {"ready", "waiting", "constrained"}:
             # If task is marked as "constrained" we haven't yet assigned it an
             # `available_resources` to run on, that happens in
             # `transition_constrained_executing`
-            self.transition(ts, "forgotten", stimulus_id=f"steal-request-{time()}")
+            self.transition(ts, "forgotten", stimulus_id=stimulus_id)
 
     def release_key(
         self,


### PR DESCRIPTION
This refactors the move_task_confirm and resolves a few minor bugs

- `self.scheduler.remove_worker` after an unccesseful event called the function improperly (argument mismatch) and would raise either way. Removing the worker is not necessary since the batchedcomm takes care of this and trigger all relevant key reschedulings
- similarly the rescheduling trigger only needed to act if the steal was confirmed and is now a bit more precise

The most important bug is a deadlock caused by a concurrent race condition of stealing requests. I do not prohibit concurrent steals for the same key but rather make the system robust to concurrency if it should happen. The concurrency control I'm applying is an ETag like transaction confirmation using a stealing stimulus ID which is further passed through the transitions on worker side such that it can be traced. Every received response will now be logged other than before were certain code branches were ignored making debugging harder.

- [x] Closes https://github.com/dask/distributed/issues/5370
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
