### PR TITLE
Serialization family to preserve headers of the underlying dumps functions.

### DIFF
--- a/distributed/protocol/cuda.py
+++ b/distributed/protocol/cuda.py
@@ -15,7 +15,9 @@ def cuda_dumps(x):
     except TypeError:
         raise NotImplementedError(type_name)
 
-    header, frames = dumps(x)
+    sub_header, frames = dumps(x)
+    header = {}
+    header["sub-header"] = sub_header
     header["type-serialized"] = pickle.dumps(type(x))
     header["serializer"] = "cuda"
     header["compression"] = (False,) * len(frames)  # no compression for gpu data
@@ -25,7 +27,7 @@ def cuda_dumps(x):
 def cuda_loads(header, frames):
     typ = pickle.loads(header["type-serialized"])
     loads = cuda_deserialize.dispatch(typ)
-    return loads(header, frames)
+    return loads(header["sub-header"], frames)
 
 
 register_serialization_family("cuda", cuda_dumps, cuda_loads)

--- a/distributed/protocol/cuda.py
+++ b/distributed/protocol/cuda.py
@@ -16,11 +16,12 @@ def cuda_dumps(x):
         raise NotImplementedError(type_name)
 
     sub_header, frames = dumps(x)
-    header = {}
-    header["sub-header"] = sub_header
-    header["type-serialized"] = pickle.dumps(type(x))
-    header["serializer"] = "cuda"
-    header["compression"] = (False,) * len(frames)  # no compression for gpu data
+    header = {
+        "sub-header": sub_header,
+        "type-serialized": pickle.dumps(type(x)),
+        "serializer": "cuda",
+        "compression": (False,) * len(frames),  # no compression for gpu data
+    }
     return header, frames
 
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -778,6 +778,7 @@ class ObjectDictSerializer:
             else:
                 if isinstance(v, dict):
                     h, f = self.serialize(v)
+                    h = {"nested-dict": h}
                 else:
                     h, f = serialize(v, serializers=(self.serializer, "pickle"))
                 header["complex"][k] = {
@@ -799,7 +800,11 @@ class ObjectDictSerializer:
         for k, d in header["complex"].items():
             h = d["header"]
             f = frames[d["start"] : d["stop"]]
-            v = deserialize(h, f)
+            nested_dict = h.get("nested-dict")
+            if nested_dict:
+                v = self.deserialize(nested_dict, f)
+            else:
+                v = deserialize(h, f)
             dd[k] = v
 
         return obj

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -32,12 +32,15 @@ def dask_dumps(x, context=None):
     except TypeError:
         raise NotImplementedError(type_name)
     if has_keyword(dumps, "context"):
-        header, frames = dumps(x, context=context)
+        sub_header, frames = dumps(x, context=context)
     else:
-        header, frames = dumps(x)
+        sub_header, frames = dumps(x)
 
+    sub_header, frames = dumps(x)
+    header = {}
+    header["sub-header"] = sub_header
     header["type"] = type_name
-    header["type-serialized"] = pickle.dumps(type(x), protocol=4)
+    header["type-serialized"] = pickle.dumps(type(x))
     header["serializer"] = "dask"
     return header, frames
 
@@ -45,7 +48,7 @@ def dask_dumps(x, context=None):
 def dask_loads(header, frames):
     typ = pickle.loads(header["type-serialized"])
     loads = dask_deserialize.dispatch(typ)
-    return loads(header, frames)
+    return loads(header["sub-header"], frames)
 
 
 def pickle_dumps(x, context=None):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -36,11 +36,12 @@ def dask_dumps(x, context=None):
     else:
         sub_header, frames = dumps(x)
 
-    header = {}
-    header["sub-header"] = sub_header
-    header["type"] = type_name
-    header["type-serialized"] = pickle.dumps(type(x))
-    header["serializer"] = "dask"
+    header = {
+        "sub-header": sub_header,
+        "type": type_name,
+        "type-serialized": pickle.dumps(type(x)),
+        "serializer": "dask",
+    }
     return header, frames
 
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -39,7 +39,7 @@ def dask_dumps(x, context=None):
     header = {
         "sub-header": sub_header,
         "type": type_name,
-        "type-serialized": pickle.dumps(type(x)),
+        "type-serialized": pickle.dumps(type(x), protocol=4),
         "serializer": "dask",
     }
     return header, frames

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -36,7 +36,6 @@ def dask_dumps(x, context=None):
     else:
         sub_header, frames = dumps(x)
 
-    sub_header, frames = dumps(x)
     header = {}
     header["sub-header"] = sub_header
     header["type"] = type_name

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -10,7 +10,6 @@ from distributed.protocol.serialize import (
     dask_serialize,
     deserialize,
     serialize,
-    serialize_and_split,
 )
 from distributed.system import MEMORY_LIMIT
 from distributed.utils import nbytes

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -2,7 +2,16 @@ import pytest
 
 from distributed.protocol import dumps, loads, maybe_compress, msgpack, to_serialize
 from distributed.protocol.compression import compressions
-from distributed.protocol.serialize import Serialize, Serialized, deserialize, serialize
+from distributed.protocol.cuda import cuda_deserialize, cuda_serialize
+from distributed.protocol.serialize import (
+    Serialize,
+    Serialized,
+    dask_deserialize,
+    dask_serialize,
+    deserialize,
+    serialize,
+    serialize_and_split,
+)
 from distributed.system import MEMORY_LIMIT
 from distributed.utils import nbytes
 
@@ -218,3 +227,30 @@ def test_maybe_compress_memoryviews():
     else:
         assert compression == "blosc"
         assert len(payload) < x.nbytes / 10
+
+
+@pytest.mark.parametrize("serializers", [("dask",), ("cuda",)])
+def test_preserve_header(serializers):
+    """
+    Test that a serialization family doesn't overwrite the headers
+    of the underlying registered dumps/loads functions.
+    """
+
+    class MyObj:
+        pass
+
+    @cuda_serialize.register(MyObj)
+    @dask_serialize.register(MyObj)
+    def _(x):
+        return {}, []
+
+    @cuda_deserialize.register(MyObj)
+    @dask_deserialize.register(MyObj)
+    def _(header, frames):
+        assert header == {}
+        assert frames == []
+        return MyObj()
+
+    header, frames = serialize(MyObj(), serializers=serializers)
+    o = deserialize(header, frames)
+    assert isinstance(o, MyObj)

--- a/distributed/protocol/tests/test_rmm.py
+++ b/distributed/protocol/tests/test_rmm.py
@@ -24,10 +24,10 @@ def test_serialize_rmm_device_buffer(size, serializers):
     y_np = y.copy_to_host()
 
     if serializers[0] == "cuda":
-        assert header["strides"] == (1,)
+        assert header["sub-header"]["strides"] == (1,)
         assert all(hasattr(f, "__cuda_array_interface__") for f in frames)
     elif serializers[0] == "dask":
-        assert header["strides"] == (1,)
+        assert header["sub-header"]["strides"] == (1,)
         assert all(isinstance(f, memoryview) for f in frames)
 
     assert (x_np == y_np).all()

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -430,18 +430,45 @@ async def test_profile_nested_sizeof():
     frames = await to_frames(msg)
 
 
-def test_compression_numpy_list():
-    class MyObj:
+def test_different_compression_families():
+    """Test serialization of a collection of items that use different compression
+
+    This scenario happens for instance when serializing collections of
+    cupy and numpy arrays.
+    """
+
+    class MyObjWithCompression:
         pass
 
-    @dask_serialize.register(MyObj)
-    def _(x):
-        header = {"compression": [False]}
-        frames = [b""]
-        return header, frames
+    class MyObjWithNoCompression:
+        pass
 
-    header, frames = serialize([MyObj(), MyObj()])
-    assert header["compression"] == [False, False]
+    def my_dumps_compression(obj, context=None):
+        if not isinstance(obj, MyObjWithCompression):
+            raise NotImplementedError()
+        header = {"compression": [True]}
+        return header, [bytes(2 ** 20)]
+
+    def my_dumps_no_compression(obj, context=None):
+        if not isinstance(obj, MyObjWithNoCompression):
+            raise NotImplementedError()
+
+        header = {"compression": [False]}
+        return header, [bytes(2 ** 20)]
+
+    def my_loads(header, frames):
+        return pickle.loads(frames[0])
+
+    register_serialization_family("with-compression", my_dumps_compression, my_loads)
+    register_serialization_family("no-compression", my_dumps_no_compression, my_loads)
+
+    header, _ = serialize(
+        [MyObjWithCompression(), MyObjWithNoCompression()],
+        serializers=("with-compression", "no-compression"),
+        on_error="raise",
+        iterate_collection=True,
+    )
+    assert header["compression"] == [True, False]
 
 
 @gen_test()

--- a/distributed/protocol/torch.py
+++ b/distributed/protocol/torch.py
@@ -9,10 +9,11 @@ def serialize_torch_Tensor(t):
     requires_grad_ = t.requires_grad
 
     if requires_grad_:
-        header, frames = serialize(t.detach().numpy())
+        sub_header, frames = serialize(t.detach().numpy())
     else:
-        header, frames = serialize(t.numpy())
+        sub_header, frames = serialize(t.numpy())
 
+    header = {"sub-header": sub_header}
     if t.grad is not None:
         grad_header, grad_frames = serialize(t.grad.numpy())
         header["grad"] = {"header": grad_header, "start": len(frames)}
@@ -49,7 +50,8 @@ def deserialize_torch_Tensor(header, frames):
 
 @dask_serialize.register(torch.nn.Parameter)
 def serialize_torch_Parameters(p):
-    header, frames = serialize(p.detach())
+    sub_header, frames = serialize(p.detach())
+    header = {"sub-header": sub_header}
     header["requires_grad"] = p.requires_grad
     return header, frames
 


### PR DESCRIPTION
Currently, the dask and cuda serialization families overwrite the header of the underlying dumps functions. For instance, the [`cuda_dumps`](https://github.com/dask/distributed/blob/d8c7c6b10f683c1aa2d566e1db1643aa38e601fd/distributed/protocol/cuda.py#L11) overwrite the `"type-serialized"`, which is a problem when Dask uses `pickle5` and the underlying loads function use `pickle protocol=4`.
Beside, overwriting an underlying protocol's header is bad style.

This PR fixes this issue


- [x] Closes https://github.com/rapidsai/dask-cuda/issues/746
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
