### PR TITLE
AMM: Graceful Worker Retirement

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4103,10 +4103,12 @@ class Client(SyncMethodMixin):
         else:
             raise ValueError(f"No event handler known for topic {topic}.")
 
-    def retire_workers(self, workers=None, close_workers=True, **kwargs):
+    def retire_workers(
+        self, workers: list[str] | None = None, close_workers: bool = True, **kwargs
+    ):
         """Retire certain workers on the scheduler
 
-        See dask.distributed.Scheduler.retire_workers for the full docstring.
+        See :meth:`distributed.Scheduler.retire_workers` for the full docstring.
 
         Parameters
         ----------

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -56,7 +56,7 @@ from distributed.utils import recursive_to_dict
 
 from . import preloading, profile
 from . import versions as version_module
-from .active_memory_manager import ActiveMemoryManagerExtension
+from .active_memory_manager import ActiveMemoryManagerExtension, RetireWorker
 from .batched import BatchedSend
 from .comm import (
     Comm,
@@ -6805,11 +6805,11 @@ class Scheduler(SchedulerState, ServerNode):
     async def retire_workers(
         self,
         comm=None,
-        workers=None,
-        remove=True,
-        close_workers=False,
-        names=None,
-        lock=True,
+        *,
+        workers: "list[str] | None" = None,
+        names: "list[str] | None" = None,
+        close_workers: bool = False,
+        remove: bool = True,
         **kwargs,
     ) -> dict:
         """Gracefully retire workers from cluster
@@ -6818,16 +6818,18 @@ class Scheduler(SchedulerState, ServerNode):
         ----------
         workers: list (optional)
             List of worker addresses to retire.
-            If not provided we call ``workers_to_close`` which finds a good set
         names: list (optional)
             List of worker names to retire.
-        remove: bool (defaults to True)
-            Whether or not to remove the worker metadata immediately or else
-            wait for the worker to contact us
+            Mutually exclusive with ``workers``.
+            If neither ``workers`` nor ``names`` are provided, we call
+            ``workers_to_close`` which finds a good set.
         close_workers: bool (defaults to False)
             Whether or not to actually close the worker explicitly from here.
             Otherwise we expect some external job scheduler to finish off the
             worker.
+        remove: bool (defaults to True)
+            Whether or not to remove the worker metadata immediately or else
+            wait for the worker to contact us
         **kwargs: dict
             Extra options to pass to workers_to_close to determine which
             workers we should drop
@@ -6845,78 +6847,123 @@ class Scheduler(SchedulerState, ServerNode):
         ws: WorkerState
         ts: TaskState
         with log_errors():
-            async with self._lock if lock else empty_context:
+            # This lock makes retire_workers, rebalance, and replicate mutually
+            # exclusive and will no longer be necessary once rebalance and replicate are
+            # migrated to the Active Memory Manager.
+            # Note that, incidentally, it also prevents multiple calls to retire_workers
+            # from running in parallel - this is unnecessary.
+            async with self._lock:
                 if names is not None:
                     if workers is not None:
                         raise TypeError("names and workers are mutually exclusive")
                     if names:
                         logger.info("Retire worker names %s", names)
-                    names = set(map(str, names))
-                    workers = {
-                        ws._address
+                    names_set = {str(name) for name in names}
+                    wss = {
+                        ws
                         for ws in parent._workers_dv.values()
-                        if str(ws._name) in names
+                        if str(ws._name) in names_set
                     }
-                elif workers is None:
-                    while True:
-                        try:
-                            workers = self.workers_to_close(**kwargs)
-                            if not workers:
-                                return {}
-                            return await self.retire_workers(
-                                workers=workers,
-                                remove=remove,
-                                close_workers=close_workers,
-                                lock=False,
-                            )
-                        except KeyError:  # keys left during replicate
-                            pass
-
-                workers = {
-                    parent._workers_dv[w] for w in workers if w in parent._workers_dv
-                }
-                if not workers:
+                elif workers is not None:
+                    wss = {
+                        parent._workers_dv[address]
+                        for address in workers
+                        if address in parent._workers_dv
+                    }
+                else:
+                    wss = {
+                        parent._workers_dv[address]
+                        for address in self.workers_to_close(**kwargs)
+                    }
+                if not wss:
                     return {}
-                logger.info("Retire workers %s", workers)
 
-                # Keys orphaned by retiring those workers
-                keys = {k for w in workers for k in w.has_what}
-                keys = {ts._key for ts in keys if ts._who_has.issubset(workers)}
-
-                if keys:
-                    other_workers = set(parent._workers_dv.values()) - workers
-                    if not other_workers:
-                        return {}
-                    logger.info("Moving %d keys to other workers", len(keys))
-                    await self.replicate(
-                        keys=keys,
-                        workers=[ws._address for ws in other_workers],
-                        n=1,
-                        delete=False,
-                        lock=False,
+                stop_amm = False
+                amm: ActiveMemoryManagerExtension = self.extensions["amm"]
+                if not amm.running:
+                    amm = ActiveMemoryManagerExtension(
+                        self, policies=set(), register=False, start=True, interval=2.0
                     )
+                    stop_amm = True
 
-                worker_keys = {ws._address: ws.identity() for ws in workers}
-                if close_workers:
-                    await asyncio.gather(
-                        *[self.close_worker(worker=w, safe=True) for w in worker_keys]
-                    )
-                if remove:
-                    await asyncio.gather(
-                        *[self.remove_worker(address=w, safe=True) for w in worker_keys]
-                    )
+                try:
+                    coros = []
+                    for ws in wss:
+                        logger.info("Retiring worker %s", ws._address)
 
-                self.log_event(
-                    "all",
-                    {
-                        "action": "retire-workers",
-                        "workers": worker_keys,
-                        "moved-keys": len(keys),
-                    },
+                        policy = RetireWorker(ws._address)
+                        amm.add_policy(policy)
+
+                        # Change Worker.status to closing_gracefully. Immediately set
+                        # the same on the scheduler to prevent race conditions.
+                        prev_status = ws.status
+                        ws.status = Status.closing_gracefully
+                        self.running.discard(ws)
+                        self.stream_comms[ws.address].send(
+                            {"op": "worker-status-change", "status": ws.status.name}
+                        )
+
+                        coros.append(
+                            self._retire_worker(
+                                ws,
+                                policy,
+                                prev_status=prev_status,
+                                close_workers=close_workers,
+                                remove=remove,
+                            )
+                        )
+
+                    # Give the AMM a kick, in addition to its periodic running. This is
+                    # to avoid unnecessarily waiting for a potentially arbitrarily long
+                    # time (depending on interval settings)
+                    amm.run_once()
+
+                    workers_info = dict(await asyncio.gather(*coros))
+                    workers_info.pop(None, None)
+                finally:
+                    if stop_amm:
+                        amm.stop()
+
+            self.log_event("all", {"action": "retire-workers", "workers": workers_info})
+            self.log_event(list(workers_info), {"action": "retired"})
+
+            return workers_info
+
+    async def _retire_worker(
+        self,
+        ws: WorkerState,
+        policy: RetireWorker,
+        prev_status: Status,
+        close_workers: bool,
+        remove: bool,
+    ) -> tuple:  # tuple[str | None, dict]
+        parent: SchedulerState = cast(SchedulerState, self)
+
+        while not policy.done():
+            if policy.no_recipients:
+                # Abort retirement. This time we don't need to worry about race
+                # conditions and we can wait for a round-trip.
+                self.stream_comms[ws.address].send(
+                    {"op": "worker-status-change", "status": prev_status.name}
                 )
-                self.log_event(list(worker_keys), {"action": "retired"})
+                return None, {}
 
-                return worker_keys
+            # Sleep 0.01s when there are 4 tasks or less
+            # Sleep 0.5s when there are 200 or more
+            poll_interval = max(0.01, min(0.5, len(ws.has_what) / 400))
+            await asyncio.sleep(poll_interval)
+
+        logger.debug(
+            "All unique keys on worker %s have been replicated elsewhere", ws._address
+        )
+
+        if close_workers and ws._address in parent._workers_dv:
+            await self.close_worker(worker=ws._address, safe=True)
+        if remove:
+            await self.remove_worker(address=ws._address, safe=True)
+
+        logger.info("Retired worker %s", ws._address)
+        return ws._address, ws.identity()
 
     def add_keys(self, comm=None, worker=None, keys=(), stimulus_id=None):
         """

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -852,7 +852,7 @@ async def test_RetireWorker_no_recipients(c, s, w1, w2, w3, w4):
     assert not s.extensions["amm"].policies
     assert set(s.workers) in ({w2.address, w3.address}, {w2.address, w4.address})
     # After a Scheduler -> Worker -> WorkerState roundtrip, workers that failed to
-    # retired went back from closing_gracefully to running and can run tasks
+    # retire went back from closing_gracefully to running and can run tasks
     while any(ws.status != Status.running for ws in s.workers.values()):
         await asyncio.sleep(0.01)
     assert await c.submit(inc, 1) == 2
@@ -881,7 +881,7 @@ async def test_RetireWorker_all_recipients_are_paused(c, s, a, b):
     assert set(s.workers) == {a.address, b.address}
 
     # After a Scheduler -> Worker -> WorkerState roundtrip, workers that failed to
-    # retired went back from closing_gracefully to running and can run tasks
+    # retire went back from closing_gracefully to running and can run tasks
     while ws_a.status != Status.running:
         await asyncio.sleep(0.01)
     assert await c.submit(inc, 1) == 2
@@ -1011,7 +1011,7 @@ async def test_ReduceReplicas_stress(c, s, *nannies):
     await tensordot_stress(c)
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @pytest.mark.avoid_ci(reason="distributed#5371")
 @pytest.mark.parametrize("use_ReduceReplicas", [False, True])
 @gen_cluster(

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -4,10 +4,11 @@ import asyncio
 import logging
 import random
 from contextlib import contextmanager
+from time import sleep
 
 import pytest
 
-from distributed import Nanny
+from distributed import Nanny, wait
 from distributed.active_memory_manager import (
     ActiveMemoryManagerExtension,
     ActiveMemoryManagerPolicy,
@@ -722,6 +723,218 @@ async def test_ReduceReplicas(c, s, *workers):
         await asyncio.sleep(0.01)
 
 
+@pytest.mark.parametrize("start_amm", [False, True])
+@gen_cluster(client=True)
+async def test_RetireWorker_amm_on_off(c, s, a, b, start_amm):
+    """retire_workers must work both with and without the AMM started"""
+    if start_amm:
+        await c.amm.start()
+    else:
+        await c.amm.stop()
+
+    futures = await c.scatter({"x": 1}, workers=[a.address])
+    await c.retire_workers([a.address])
+    assert a.address not in s.workers
+    assert "x" in b.data
+
+
+@gen_cluster(
+    client=True,
+    config={
+        "distributed.scheduler.active-memory-manager.start": True,
+        "distributed.scheduler.active-memory-manager.interval": 0.1,
+        "distributed.scheduler.active-memory-manager.policies": [],
+    },
+)
+async def test_RetireWorker_no_remove(c, s, a, b):
+    """Test RetireWorker behaviour on retire_workers(..., remove=False)"""
+
+    x = await c.scatter({"x": "x"}, workers=[a.address])
+    await c.retire_workers([a.address], close_workers=False, remove=False)
+    # Wait 2 AMM iterations
+    # retire_workers may return before all keys have been dropped from a
+    while s.tasks["x"].who_has != {s.workers[b.address]}:
+        await asyncio.sleep(0.01)
+    assert a.address in s.workers
+    # Policy has been removed without waiting for worker to disappear from
+    # Scheduler.workers
+    assert not s.extensions["amm"].policies
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("use_ReduceReplicas", [False, True])
+@gen_cluster(
+    client=True,
+    Worker=Nanny,
+    config={
+        "distributed.scheduler.active-memory-manager.start": True,
+        "distributed.scheduler.active-memory-manager.interval": 0.1,
+        "distributed.scheduler.active-memory-manager.policies": [
+            {"class": "distributed.active_memory_manager.ReduceReplicas"},
+        ],
+    },
+)
+async def test_RetireWorker_with_ReduceReplicas(c, s, *nannies, use_ReduceReplicas):
+    """RetireWorker and ReduceReplicas work well with each other.
+
+    If ReduceReplicas is enabled,
+    1. On the first AMM iteration, either ReduceReplicas or RetireWorker (arbitrarily
+       depending on which comes first in the iteration of
+       ActiveMemoryManagerExtension.policies) deletes non-unique keys, choosing from
+       workers to be retired first. At the same time, RetireWorker replicates unique
+       keys.
+    2. On the second AMM iteration, either ReduceReplicas or RetireWorker deletes the
+       keys replicated at the previous round from the worker to be retired.
+
+    If ReduceReplicas is not enabled, all drops are performed by RetireWorker.
+
+    This test fundamentally relies on workers in the process of being retired to be
+    always picked first by ActiveMemoryManagerExtension._find_dropper.
+    """
+    ws_a, ws_b = s.workers.values()
+    if not use_ReduceReplicas:
+        s.extensions["amm"].policies.clear()
+
+    x = c.submit(lambda: "x" * 2 ** 26, key="x", workers=[ws_a.address])  # 64 MiB
+    y = c.submit(lambda: "y" * 2 ** 26, key="y", workers=[ws_a.address])  # 64 MiB
+    z = c.submit(lambda x: None, x, key="z", workers=[ws_b.address])  # copy x to ws_b
+    # Make sure that the worker NOT being retired has the most RAM usage to test that
+    # it is not being picked first since there's a retiring worker.
+    w = c.submit(lambda: "w" * 2 ** 28, key="w", workers=[ws_b.address])  # 256 MiB
+    await wait([x, y, z, w])
+
+    await c.retire_workers([ws_a.address], remove=False)
+    # retire_workers may return before all keys have been dropped from a
+    while ws_a.has_what:
+        await asyncio.sleep(0.01)
+    assert {ts.key for ts in ws_b.has_what} == {"x", "y", "z", "w"}
+
+
+@gen_cluster(client=True, nthreads=[("", 1)] * 3, config=NO_AMM_START)
+async def test_RetireWorker_all_replicas_are_being_retired(c, s, w1, w2, w3):
+    """There are multiple replicas of a key, but they all reside on workers that are
+    being retired
+    """
+    ws1 = s.workers[w1.address]
+    ws2 = s.workers[w2.address]
+    ws3 = s.workers[w3.address]
+    fut = await c.scatter({"x": "x"}, workers=[w1.address, w2.address], broadcast=True)
+    assert s.tasks["x"].who_has == {ws1, ws2}
+    await c.retire_workers([w1.address, w2.address])
+    assert s.tasks["x"].who_has == {ws3}
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)] * 4,
+    config={
+        "distributed.scheduler.active-memory-manager.start": True,
+        # test that we're having a manual amm.run_once() "kick" from retire_workers
+        "distributed.scheduler.active-memory-manager.interval": 999,
+        "distributed.scheduler.active-memory-manager.policies": [],
+    },
+)
+async def test_RetireWorker_no_recipients(c, s, w1, w2, w3, w4):
+    """All workers are retired at once.
+
+    Test use cases:
+    1. (w1) worker contains no data -> it is retired
+    2. (w2) worker contains unique data -> it is not retired
+    3. (w3, w4) worker contains non-unique data, but all replicas are on workers that
+       are being retired -> all but one are retired
+    """
+    x = await c.scatter({"x": "x"}, workers=[w2.address])
+    y = await c.scatter({"y": "y"}, workers=[w3.address, w4.address], broadcast=True)
+
+    out = await c.retire_workers([w1.address, w2.address, w3.address, w4.address])
+
+    assert set(out) in ({w1.address, w3.address}, {w1.address, w4.address})
+    assert not s.extensions["amm"].policies
+    assert set(s.workers) in ({w2.address, w3.address}, {w2.address, w4.address})
+    # After a Scheduler -> Worker -> WorkerState roundtrip, workers that failed to
+    # retired went back from closing_gracefully to running and can run tasks
+    while any(ws.status != Status.running for ws in s.workers.values()):
+        await asyncio.sleep(0.01)
+    assert await c.submit(inc, 1) == 2
+
+
+@gen_cluster(
+    client=True,
+    config={
+        "distributed.scheduler.active-memory-manager.start": True,
+        "distributed.scheduler.active-memory-manager.interval": 999,
+        "distributed.scheduler.active-memory-manager.policies": [],
+    },
+)
+async def test_RetireWorker_all_recipients_are_paused(c, s, a, b):
+    ws_a = s.workers[a.address]
+    ws_b = s.workers[b.address]
+
+    b.memory_pause_fraction = 1e-15
+    while ws_b.status != Status.paused:
+        await asyncio.sleep(0.01)
+
+    x = await c.scatter("x", workers=[a.address])
+    out = await c.retire_workers([a.address])
+    assert out == {}
+    assert not s.extensions["amm"].policies
+    assert set(s.workers) == {a.address, b.address}
+
+    # After a Scheduler -> Worker -> WorkerState roundtrip, workers that failed to
+    # retired went back from closing_gracefully to running and can run tasks
+    while ws_a.status != Status.running:
+        await asyncio.sleep(0.01)
+    assert await c.submit(inc, 1) == 2
+
+
+# FIXME can't drop runtime of this test below 10s; see distributed#5585
+@pytest.mark.slow
+@gen_cluster(
+    client=True,
+    Worker=Nanny,
+    nthreads=[("", 1)] * 3,
+    config={
+        "distributed.scheduler.worker-ttl": "500ms",
+        "distributed.scheduler.active-memory-manager.start": True,
+        "distributed.scheduler.active-memory-manager.interval": 0.1,
+        "distributed.scheduler.active-memory-manager.policies": [],
+    },
+)
+async def test_RetireWorker_faulty_recipient(c, s, *nannies):
+    """RetireWorker requests to replicate a key onto a unresponsive worker.
+    The AMM will iterate multiple times, repeating the command, until eventually the
+    scheduler declares the worker dead and removes it from the pool; at that point the
+    AMM will choose another valid worker and complete the job.
+    """
+    # ws1 is being retired
+    # ws2 has the lowest RAM usage and is chosen as a recipient, but is unresponsive
+    ws1, ws2, ws3 = s.workers.values()
+    f = c.submit(lambda: "x", key="x", workers=[ws1.address])
+    await wait(f)
+    assert s.tasks["x"].who_has == {ws1}
+
+    # Fill ws3 with 200 MB of managed memory
+    # We're using plenty to make sure it's safely more than the unmanaged memory of ws2
+    clutter = c.map(lambda i: "x" * 4_000_000, range(50), workers=[ws3.address])
+    await wait([f] + clutter)
+    while ws3.memory.process < 200_000_000:
+        # Wait for heartbeat
+        await asyncio.sleep(0.01)
+    assert ws2.memory.process < ws3.memory.process
+
+    # Make ws2 unresponsive
+    clog_fut = asyncio.create_task(c.run(sleep, 3600, workers=[ws2.address]))
+    await asyncio.sleep(0.2)
+    assert ws2.address in s.workers
+
+    await c.retire_workers([ws1.address])
+    assert ws1.address not in s.workers
+    # The AMM tried over and over to send the data to ws2, until it was declared dead
+    assert ws2.address not in s.workers
+    assert s.tasks["x"].who_has == {ws3}
+    clog_fut.cancel()
+
+
 class DropEverything(ActiveMemoryManagerPolicy):
     """Inanely suggest to drop every single key in the cluster"""
 
@@ -796,3 +1009,48 @@ async def test_ReduceReplicas_stress(c, s, *nannies):
     policy must not disrupt the computation too much.
     """
     await tensordot_stress(c)
+
+
+# @pytest.mark.slow
+@pytest.mark.avoid_ci(reason="distributed#5371")
+@pytest.mark.parametrize("use_ReduceReplicas", [False, True])
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)] * 10,
+    Worker=Nanny,
+    config={
+        "distributed.scheduler.active-memory-manager.start": True,
+        # If interval is too low, then the AMM will rerun while tasks have not yet have
+        # the time to migrate. This is OK if it happens occasionally, but if this
+        # setting is too aggressive the cluster will get flooded with repeated comm
+        # requests.
+        "distributed.scheduler.active-memory-manager.interval": 2.0,
+        "distributed.scheduler.active-memory-manager.policies": [
+            {"class": "distributed.active_memory_manager.ReduceReplicas"},
+        ],
+    },
+)
+async def test_RetireWorker_stress(c, s, *nannies, use_ReduceReplicas):
+    """It is safe to retire the best part of a cluster in the middle of a computation"""
+    if not use_ReduceReplicas:
+        s.extensions["amm"].policies.clear()
+
+    addrs = list(s.workers)
+    random.shuffle(addrs)
+    print(f"Removing all workers except {addrs[-1]}")
+
+    # Note: Scheduler._lock effectively prevents multiple calls to retire_workers from
+    # running at the same time. However, the lock only exists for the benefit of legacy
+    # (non-AMM) rebalance() and replicate() methods. Once the lock is removed, these
+    # calls will become parallel and the test *should* continue working.
+
+    tasks = [asyncio.create_task(tensordot_stress(c))]
+    await asyncio.sleep(1)
+    tasks.append(asyncio.create_task(c.retire_workers(addrs[0:2])))
+    await asyncio.sleep(1)
+    tasks.append(asyncio.create_task(c.retire_workers(addrs[2:5])))
+    await asyncio.sleep(1)
+    tasks.append(asyncio.create_task(c.retire_workers(addrs[5:9])))
+
+    await asyncio.gather(*tasks)
+    assert set(s.workers) == {addrs[9]}

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1640,8 +1640,6 @@ def assert_amm_transfer_story(key: str, w_from: Worker, w_to: Worker) -> None:
         [
             (key, "ensure-task-exists", "released"),
             (key, "released", "fetch", "fetch", {}),
-            (key, "fetch", "missing", "missing", {}),
-            (key, "missing", "fetch", "fetch", {}),
             ("gather-dependencies", w_from.address, lambda set_: key in set_),
             (key, "fetch", "flight", "flight", {}),
             ("request-dep", w_from.address, lambda set_: key in set_),

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1631,6 +1631,37 @@ async def test_worker_listens_on_same_interface_by_default(cleanup, Worker):
             assert s.ip == w.ip
 
 
+def assert_amm_transfer_story(key: str, w_from: Worker, w_to: Worker) -> None:
+    """Test that an in-memory key was transferred from worker w_from to worker w_to by
+    the Active Memory Manager and it was not recalculated on w_to
+    """
+    assert_worker_story(
+        w_to.story(key),
+        [
+            (key, "ensure-task-exists", "released"),
+            (key, "released", "fetch", "fetch", {}),
+            (key, "fetch", "missing", "missing", {}),
+            (key, "missing", "fetch", "fetch", {}),
+            ("gather-dependencies", w_from.address, lambda set_: key in set_),
+            (key, "fetch", "flight", "flight", {}),
+            ("request-dep", w_from.address, lambda set_: key in set_),
+            ("receive-dep", w_from.address, lambda set_: key in set_),
+            (key, "put-in-memory"),
+            (key, "flight", "memory", "memory", {}),
+        ],
+        # There may be additional ('missing', 'fetch', 'fetch') events if transfers
+        # are slow enough that the Active Memory Manager ends up requesting them a
+        # second time. Here we're asserting that no matter how slow CI is, all
+        # transfers will be completed within 2 seconds (hardcoded interval in
+        # Scheduler.retire_worker when AMM is not enabled).
+        strict=True,
+    )
+    assert key in w_to.data
+    # The key may or may not still be in w_from.data, depending if the AMM had the
+    # chance to run a second time after the copy was successful.
+
+
+@pytest.mark.slow
 @gen_cluster(client=True)
 async def test_close_gracefully(c, s, a, b):
     futures = c.map(slowinc, range(200), delay=0.1, workers=[b.address])
@@ -1645,6 +1676,8 @@ async def test_close_gracefully(c, s, a, b):
             break
         await asyncio.sleep(0.01)
 
+    assert any(ts for ts in b.tasks.values() if ts.state == "executing")
+
     await b.close_gracefully()
 
     assert b.status == Status.closed
@@ -1653,15 +1686,7 @@ async def test_close_gracefully(c, s, a, b):
     # All tasks that were in memory in b have been copied over to a;
     # they have not been recomputed
     for key in mem:
-        assert_worker_story(
-            a.story(key),
-            [
-                (key, "put-in-memory"),
-                (key, "receive-from-scatter"),
-            ],
-            strict=True,
-        )
-        assert key in a.data
+        assert_amm_transfer_story(key, b, a)
 
 
 @pytest.mark.slow
@@ -1690,15 +1715,7 @@ async def test_lifetime(c, s, a):
     # All tasks that were in memory in b have been copied over to a;
     # they have not been recomputed
     for key in mem:
-        assert_worker_story(
-            a.story(key),
-            [
-                (key, "put-in-memory"),
-                (key, "receive-from-scatter"),
-            ],
-            strict=True,
-        )
-        assert key in a.data
+        assert_amm_transfer_story(key, b, a)
 
 
 @gen_cluster(worker_kwargs={"lifetime": "10s", "lifetime_stagger": "2s"})

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -76,7 +76,7 @@ from .utils import (
     reset_logger_locks,
     sync,
 )
-from .worker import RUNNING, Worker
+from .worker import Worker
 
 try:
     import dask.array  # register config
@@ -1641,7 +1641,7 @@ def check_instances():
     for w in Worker._instances:
         with suppress(RuntimeError):  # closed IOLoop
             w.loop.add_callback(w.close, report=False, executor_wait=False)
-            if w.status in RUNNING:
+            if w.status in Status.ANY_RUNNING:
                 w.loop.add_callback(w.close)
     Worker._instances.clear()
 

--- a/docs/source/active_memory_manager.rst
+++ b/docs/source/active_memory_manager.rst
@@ -257,3 +257,6 @@ API reference
    :undoc-members:
 
 .. autoclass:: distributed.active_memory_manager.ReduceReplicas
+
+.. autoclass:: distributed.active_memory_manager.RetireWorker
+   :members:


### PR DESCRIPTION
Scheduler.retire_workers(), either when called from the client or from the adaptive scaler, can now be invoked safely in the middle of a computation.

### Done
- Reimplement method using the Active Memory Manager
- retire_workers sets the worker status to closing_gracefully
- Prevent workers that are closing_gracefully from running queued tasks (they will be reassigned when the worker shuts down)
- paused workers never receive tasks from retiring workers
- unit tests

### Out of scope
- Steal away tasks from a worker in paused or closing_gracefully status (xref #3761)
- Adaptive scaler to effectively scale down in the middle of a computation
- Automatically transition "paused" status to "closing_gracefully" after a certain timeout
- Reimplement rebalance() and replicate() using the AMM

CC @mrocklin @jrbourbeau @fjetter 