### PR TITLE
Cleanup some of the scheduler dashboard code to use list comprehensions

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -153,14 +153,14 @@ class Occupancy(DashboardComponent):
             idle_workers = self.scheduler.idle
             saturated_workers = self.scheduler.saturated
 
-            color = [
-                "red"
-                if ws in idle_workers
-                else "green"
-                if ws in saturated_workers
-                else "blue"
-                for ws in workers
-            ]
+            color = []
+            for ws in workers:
+                if ws in self.scheduler.idle:
+                    color.append("red")
+                elif ws in self.scheduler.saturated:
+                    color.append("green")
+                else:
+                    color.append("blue")
 
             if total:
                 self.root.title.text = (
@@ -1021,17 +1021,17 @@ class SystemTimeseries(DashboardComponent):
     def get_data(self):
         workers = self.scheduler.workers.values()
 
-        read_bytes = sum(ws.metrics["read_bytes"] for ws in workers)
-        write_bytes = sum(ws.metrics["write_bytes"] for ws in workers)
-        cpu = sum(ws.metrics["cpu"] for ws in workers)
-        memory = sum(ws.metrics["memory"] for ws in workers)
-        read_bytes_disk = sum(ws.metrics["read_bytes_disk"] for ws in workers)
-        write_bytes_disk = sum(ws.metrics["write_bytes_disk"] for ws in workers)
-        time = sum(ws.metrics["time"] for ws in workers)
+        read_bytes = sum([ws.metrics["read_bytes"] for ws in workers])
+        write_bytes = sum([ws.metrics["write_bytes"] for ws in workers])
+        cpu = sum([ws.metrics["cpu"] for ws in workers])
+        memory = sum([ws.metrics["memory"] for ws in workers])
+        read_bytes_disk = sum([ws.metrics["read_bytes_disk"] for ws in workers])
+        write_bytes_disk = sum([ws.metrics["write_bytes_disk"] for ws in workers])
+        worker_time = sum([ws.metrics["time"] for ws in workers])
 
         result = {
             # use `or` to avoid ZeroDivision when no workers
-            "time": [time / (len(workers) or 1) * 1000],
+            "time": [worker_time / (len(workers) or 1) * 1000],
             "read_bytes": [read_bytes / (len(workers) or 1)],
             "write_bytes": [write_bytes / (len(workers) or 1)],
             "cpu": [cpu / (len(workers) or 1)],

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -149,14 +149,18 @@ class Occupancy(DashboardComponent):
             ms = [occ * 1000 for occ in occupancy]
             x = [occ / 500 for occ in occupancy]
             total = sum(occupancy)
-            color = []
-            for ws in workers:
-                if ws in self.scheduler.idle:
-                    color.append("red")
-                elif ws in self.scheduler.saturated:
-                    color.append("green")
-                else:
-                    color.append("blue")
+
+            idle_workers = self.scheduler.idle
+            saturated_workers = self.scheduler.saturated
+
+            color = [
+                "red"
+                if ws in idle_workers
+                else "green"
+                if ws in saturated_workers
+                else "blue"
+                for ws in workers
+            ]
 
             if total:
                 self.root.title.text = (
@@ -615,8 +619,8 @@ class BandwidthTypes(DashboardComponent):
                 "type": list(bw.keys()),
                 "bandwidth_text": [format_bytes(x) for x in bw.values()],
             }
-            self.root.title.text = "Bandwidth: " + format_bytes(
-                self.scheduler.bandwidth
+            self.root.title.text = (
+                f"Bandwidth: {format_bytes(self.scheduler.bandwidth)}"
             )
             update(self.source, result)
 
@@ -688,6 +692,15 @@ class BandwidthWorkers(DashboardComponent):
             hover.point_policy = "follow_mouse"
             self.root.add_tools(hover)
 
+    def worker_name(self, address):
+        try:
+            ws = self.scheduler.workers[address]
+        except KeyError:
+            return address
+        if ws.name is not None:
+            return str(ws.name)
+        return address
+
     @without_property_validation
     def update(self):
         with log_errors():
@@ -695,16 +708,12 @@ class BandwidthWorkers(DashboardComponent):
             if not bw:
                 return
 
-            def name(address):
-                try:
-                    ws = self.scheduler.workers[address]
-                except KeyError:
-                    return address
-                if ws.name is not None:
-                    return str(ws.name)
-                return address
-
-            x, y, value = zip(*((name(a), name(b), c) for (a, b), c in bw.items()))
+            x, y, value = zip(
+                *(
+                    (self.worker_name(a), self.worker_name(b), c)
+                    for (a, b), c in bw.items()
+                )
+            )
 
             self.color_map.high = max(value)
 
@@ -718,8 +727,8 @@ class BandwidthWorkers(DashboardComponent):
                 "bandwidth": value,
                 "bandwidth_text": list(map(format_bytes, value)),
             }
-            self.root.title.text = "Bandwidth: " + format_bytes(
-                self.scheduler.bandwidth
+            self.root.title.text = (
+                f"Bandwidth: {format_bytes(self.scheduler.bandwidth)}"
             )
             update(self.source, result)
 
@@ -835,16 +844,10 @@ class WorkerNetworkBandwidth(DashboardComponent):
             y_read = [i + 0.75 + i * h for i in range(len(workers))]
             y_write = [i + 0.25 + i * h for i in range(len(workers))]
 
-            x_read = []
-            x_write = []
-            x_read_disk = []
-            x_write_disk = []
-
-            for ws in workers:
-                x_read.append(ws.metrics["read_bytes"])
-                x_write.append(ws.metrics["write_bytes"])
-                x_read_disk.append(ws.metrics["read_bytes_disk"])
-                x_write_disk.append(ws.metrics["write_bytes_disk"])
+            x_read = [ws.metrics["read_bytes"] for ws in workers]
+            x_write = [ws.metrics["write_bytes"] for ws in workers]
+            x_read_disk = [ws.metrics["read_bytes_disk"] for ws in workers]
+            x_write_disk = [ws.metrics["write_bytes_disk"] for ws in workers]
 
             if self.scheduler.workers:
                 self.bandwidth.x_range.end = max(
@@ -1018,21 +1021,13 @@ class SystemTimeseries(DashboardComponent):
     def get_data(self):
         workers = self.scheduler.workers.values()
 
-        read_bytes = 0
-        write_bytes = 0
-        cpu = 0
-        memory = 0
-        read_bytes_disk = 0
-        write_bytes_disk = 0
-        time = 0
-        for ws in workers:
-            read_bytes += ws.metrics["read_bytes"]
-            write_bytes += ws.metrics["write_bytes"]
-            cpu += ws.metrics["cpu"]
-            memory += ws.metrics["memory"]
-            read_bytes_disk += ws.metrics["read_bytes_disk"]
-            write_bytes_disk += ws.metrics["write_bytes_disk"]
-            time += ws.metrics["time"]
+        read_bytes = sum(ws.metrics["read_bytes"] for ws in workers)
+        write_bytes = sum(ws.metrics["write_bytes"] for ws in workers)
+        cpu = sum(ws.metrics["cpu"] for ws in workers)
+        memory = sum(ws.metrics["memory"] for ws in workers)
+        read_bytes_disk = sum(ws.metrics["read_bytes_disk"] for ws in workers)
+        write_bytes_disk = sum(ws.metrics["write_bytes_disk"] for ws in workers)
+        time = sum(ws.metrics["time"] for ws in workers)
 
         result = {
             # use `or` to avoid ZeroDivision when no workers


### PR DESCRIPTION
List comprehensions are almost always faster than iterating over a list and calling `append`, and they generate a lot less memory pressure.

This PR adds list comprehensions to some obvious cases within the dashboard scheduler components. 