### PR TITLE
Log original exception upon compute failure

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3088,7 +3088,7 @@ class Worker(ServerNode):
                     str(funcname(function))[:1000],
                     convert_args_to_str(args2, max_len=1000),
                     convert_kwargs_to_str(kwargs2, max_len=1000),
-                    ts.exception_text,
+                    result["exception_text"],
                 )
                 recommendations[ts] = (
                     "error",


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/dask/distributed/pull/5046 which no longer showed the actual exception since this TaskState attribute is not set, yet, at this point.

This regression was introduced since we ignored a test for some reason. Seemed to have happened during the CI migration from travis to GH actions. I removed the file stuff around the test such that it should no longer cause problems