### PR TITLE
[WIP] Remove default comm timeout for tests

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1590,8 +1590,6 @@ def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
                 with check_instances() if instances else nullcontext():
                     with check_active_rpc(loop, timeout):
                         reset_config()
-
-                        dask.config.set({"distributed.comm.timeouts.connect": "5s"})
                         # Restore default logging levels
                         # XXX use pytest hooks/fixtures instead?
                         for name, level in logging_levels.items():


### PR DESCRIPTION
I'm curious what impact this will have on CI.

On `main` I can reproduce the `distributed/tests/test_stress.py::test_stress_creation_and_deletion` failure we've been seeing in CI lately using `pytest-xdist` / `pytest-repeat`

```
pytest distributed/tests/test_stress.py::test_stress_creation_and_deletion --runslow -n10 --count=20 -x
```

xref https://github.com/dask/distributed/issues/5388. With these changes, at least locally on my laptop, `test_stress_creation_and_deletion` passes. 