### PR TITLE
Increase latency for stealing

### DIFF
--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -14,7 +14,11 @@ from .core import CommClosedError
 from .diagnostics.plugin import SchedulerPlugin
 from .utils import log_errors
 
-LATENCY = 10e-3
+# Stealing requires multiple network bounces and if successful also task
+# submission which may include code serialization. Therefore, be very
+# conservative in the latency estimation to suppress too aggressive stealing
+# of small tasks
+LATENCY = 0.1
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
In my latest dive into stealing code I investigated some of the logs and saw a lot of _ridiculous_ steal requests. Task durations of ~10ms and occupancy differences between thief and victim of ~100ms. 

Not only do we not care for such a difference but the act of stealing is guaranteed to be more expensive than letting things be.

Stealing requires at least three network bounces (steal-request, steal-confirm, compute-task) which includes code serialization if successful. It almost impossible to do this in the currently hard coded 1ms. The 100ms I propose are likely too conservative but I don't think this is necessarily a bad thing for stealing. I don't have time for large scale tests but am very confident that this should by much higher than it is right now. Thoughts, concerns?

cc @gjoseph92 @crusaderky 