### PR TITLE
Use new Dask docs theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ toolz
 cloudpickle
 git+https://github.com/dask/dask
 sphinx
-dask-sphinx-theme>=1.3.5
+dask-sphinx-theme>=2
 sphinx-click

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,10 +118,7 @@ todo_include_todos = True
 
 # -- Options for HTML output ----------------------------------------------
 
-import dask_sphinx_theme
-
 html_theme = "dask_sphinx_theme"
-html_theme_path = [dask_sphinx_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Bumping the minimum docs theme to use the new version. This isn't strictly necessary but I wanted to raise a PR to trigger the rtd preview and check everything looks ok.

xref dask/dask-sphinx-theme#54