### PR TITLE
Long running occupancy

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3560,8 +3560,7 @@ class SchedulerState:
             return
         if ws._occupancy > old * 1.3 or old > ws._occupancy * 1.3:
             for ts in ws._processing:
-                steal.remove_key_from_stealable(ts)
-                steal.put_key_in_stealable(ts)
+                steal.recalculate_cost(ts)
 
 
 class Scheduler(SchedulerState, ServerNode):
@@ -5549,7 +5548,9 @@ class Scheduler(SchedulerState, ServerNode):
         ws._occupancy -= occ
         parent._total_occupancy -= occ
         # Cannot remove from processing since we're using this for things like
-        # idleness detection
+        # idleness detection. Idle workers are typically targeted for
+        # downscaling but we should not downscale workers with long running
+        # tasks
         ws._processing[ts] = 0
         ws._long_running.add(ts)
         self.check_idle_saturated(ws)

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -313,16 +313,8 @@ class WorkStealing(SchedulerPlugin):
             _log_msg = [key, state, victim.address, thief.address, stimulus_id]
 
             if ts.state != "processing":
-                self.log(("not-processing", *_log_msg))
-                old_thief = thief.occupancy
-                new_thief = sum(thief.processing.values())
-                old_victim = victim.occupancy
-                new_victim = sum(victim.processing.values())
-                thief.occupancy = new_thief
-                victim.occupancy = new_victim
-                self.scheduler.total_occupancy += (
-                    new_thief - old_thief + new_victim - old_victim
-                )
+                self.scheduler._reevaluate_occupancy_worker(thief)
+                self.scheduler._reevaluate_occupancy_worker(victim)
             elif (
                 state in _WORKER_STATE_UNDEFINED
                 or state in _WORKER_STATE_CONFIRM

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5129,7 +5129,7 @@ async def test_long_running_not_in_occupancy(c, s, a):
 
     f = c.submit(long_running, l)
     while f.key not in s.tasks:
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
     assert s.workers[a.address].occupancy == parse_timedelta(
         dask.config.get("distributed.scheduler.unknown-task-duration")
     )

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -30,7 +30,7 @@ import dask
 import dask.bag as db
 from dask import delayed
 from dask.optimization import SubgraphCallable
-from dask.utils import stringify, tmpfile
+from dask.utils import parse_timedelta, stringify, tmpfile
 
 from distributed import (
     CancelledError,
@@ -5130,7 +5130,9 @@ async def test_long_running_not_in_occupancy(c, s, a):
     f = c.submit(long_running, l)
     while f.key not in s.tasks:
         await asyncio.sleep(0)
-    assert s.workers[a.address].occupancy == s.UNKNOWN_TASK_DURATION
+    assert s.workers[a.address].occupancy == parse_timedelta(
+        dask.config.get("distributed.scheduler.unknown-task-duration")
+    )
 
     while s.workers[a.address].occupancy:
         await asyncio.sleep(0.01)


### PR DESCRIPTION
We're removing long running tasks from a workers occupancy. However, occasionally we're recalculating the worker occupancy to account for new information since the occupancy gets inaccurate over time. However, this reevaluation does not take into account `long-running` tasks since the scheduler does not further break the state `processing` down. Similar for the substate `executing`, we're tracking this on a per-worker base and we should do the same for the `long-running` substate

This builds on top of https://github.com/dask/distributed/pull/5392 since I pulled together the occupancy calculation over there.

Fixes of this PR in last commit https://github.com/dask/distributed/commit/9c20b323bdb5314c563d4281b493ab44ff97e660

- [x] Closes https://github.com/dask/distributed/issues/5332
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
