### PR TITLE
Rewrite test_client_timeout

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -57,7 +57,7 @@ from distributed.client import (
     wait,
 )
 from distributed.comm import CommClosedError
-from distributed.compatibility import LINUX, MACOS, WINDOWS
+from distributed.compatibility import LINUX, WINDOWS
 from distributed.core import Status
 from distributed.metrics import time
 from distributed.objects import HasWhat, WhoHas


### PR DESCRIPTION
In the latest stress test, this failed 25 out of 60 times on MacOS and 0 out of 178 times on Linux/Windows.