### PR TITLE
Remove unused Client `_shutdown` alias

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1377,8 +1377,6 @@ class Client:
 
         self.status = "closed"
 
-    _shutdown = _close
-
     def close(self, timeout=no_default):
         """Close this client
 


### PR DESCRIPTION
Happened to notice this vestigial code left over from #1275. A different `_shutdown` function is defined lower down here: https://github.com/dask/distributed/blob/7e2fe5c6995e3628e4c2d6987c00a591160f7c7b/distributed/client.py#L1432-L1439
so this alias is a no-op.

- [x] Passes `pre-commit run --all-files`
