### PR TITLE
Stale label github action

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -16,6 +16,6 @@ jobs:
           stale-issue-label: 'needs attention'
           stale-pr-label: 'needs attention'
           exempt-issue-labels: 'good intro to dask,good first issue,Good First Issue,good second issue,feature request'
-          exempt-pr-labels: 'awaiting-approval,work-in-progress'
+          #exempt-pr-labels: 'awaiting-approval,work-in-progress'
           exempt-draft-pr: true
           start-date: '2020-04-18T00:00:00Z' # ignore before this date, ISO 8601 or RFC 2822


### PR DESCRIPTION
As [discussed here](https://github.com/dask/community/issues/60) we want a bot to automatically label stale issues in the repository, in the least obnoxious way possible.

This PR introduces a yml file for the github [actions/stale](https://github.com/actions/stale), to run automatically on a regular interval.

- [x] Reference https://github.com/dask/community/issues/60
- [ ] ~~Tests added / passed~~
- [ ] ~~Passes `pre-commit run --all-files`~~
