### PR TITLE
Separate `Coordination` section in API docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -48,6 +48,7 @@ API
    Event
    Lock
    MultiLock
+   Semaphore
    Queue
    Variable
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -40,7 +40,7 @@ API
 .. autoautosummary:: distributed.Future
    :methods:
 
-**Coordination**
+**Synchronization**
 
 .. currentmodule:: distributed
 
@@ -124,8 +124,8 @@ Future
    :members:
 
 
-Coordination
-------------
+Synchronization
+---------------
 
 .. autoclass:: Event
    :members:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -40,7 +40,7 @@ API
 .. autoautosummary:: distributed.Future
    :methods:
 
-**Client Coordination**
+**Coordination**
 
 .. currentmodule:: distributed
 
@@ -122,6 +122,24 @@ Future
 .. autoclass:: Future
    :members:
 
+
+Coordination
+------------
+
+.. autoclass:: Event
+   :members:
+.. autoclass:: Lock
+   :members:
+.. autoclass:: MultiLock
+   :members:
+.. autoclass:: Semaphore
+   :members:
+.. autoclass:: Queue
+   :members:
+.. autoclass:: Variable
+   :members:
+
+
 Cluster
 -------
 
@@ -167,19 +185,6 @@ Other
 .. autoclass:: get_task_stream
 .. autoclass:: get_task_metadata
 .. autoclass:: performance_report
-
-.. autoclass:: Event
-   :members:
-.. autoclass:: Lock
-   :members:
-.. autoclass:: MultiLock
-   :members:
-.. autoclass:: Semaphore
-   :members:
-.. autoclass:: Queue
-   :members:
-.. autoclass:: Variable
-   :members:
 
 
 Utilities


### PR DESCRIPTION
Just noticed these classes were hard to find in the docs, since there was no heading for them listed—you had to scroll through the whole API docs page.

I also renamed the section from "Client Coordination" to "Coordination", since I think that's more intuitive. (If I were a user I'd be looking for "Synchronization" or something, a la the Python threading/multiprocessing/asyncio docs.) "Client coordination" sounds like coordinating multiple users sharing a cluster to me.