### PR TITLE
Add scroll to dashboard dropdown

### DIFF
--- a/distributed/http/static/css/base.css
+++ b/distributed/http/static/css/base.css
@@ -124,6 +124,8 @@ body {
   min-width: 160px;
   box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
   z-index: 2;
+  max-height: 90%;
+  overflow-y: scroll;
 }
 
 .dropdown-content ul li {


### PR DESCRIPTION
Closes #5410 

Sets the dropdown to 90% of window height and adds a scroll bar if necessary.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/1610850/137119795-eb07acd3-d965-4a80-9188-cc72ee0fc4e3.gif)


