### PR TITLE
Raise error if registering a nanny plugin with workers not using nannies

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5856,9 +5856,25 @@ class Scheduler(SchedulerState, ServerNode):
                 if dh is not None:
                     workers.extend(dh["addresses"])
         # TODO replace with worker_list
-
         if nanny:
             addresses = [parent._workers_dv[w].nanny for w in workers]
+            without_nanny = sum(addr is None for addr in addresses)
+            if without_nanny == len(addresses):
+                raise RuntimeError(
+                    f"Attempting to broadcast message {msg['op']!r} to Nanny "
+                    f"workers but none of the {without_nanny} workers use "
+                    "nannies, so they will ignore it. To fix, recreate the "
+                    "cluster and ensure the `worker_class` is set to "
+                    "'dask.distributed.Nanny'."
+                )
+            else:
+                logger.warning(
+                    f"Unable to broadcast message {msg['op']!r} to Nanny workers "
+                    f"but {without_nanny} workers are not using nannies, so they "
+                    "will ignore it. To fix, recreate the cluster and ensure that "
+                    "`worker_class` is set to 'dask.distributed.Nanny' for all "
+                    "workers."
+                )
         else:
             addresses = workers
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5869,7 +5869,7 @@ class Scheduler(SchedulerState, ServerNode):
                 )
             else:
                 logger.warning(
-                    f"Unable to broadcast message {msg['op']!r} to Nanny workers "
+                    f"Broadcasting message {msg['op']!r} to Nanny workers "
                     f"but {without_nanny} workers are not using nannies, so they "
                     "will ignore it. To fix, recreate the cluster and ensure that "
                     "`worker_class` is set to 'dask.distributed.Nanny' for all "

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -673,9 +673,10 @@ async def test_broadcast_nanny(s, a, b):
 
 @gen_cluster(Worker=Worker)
 async def test_broadcast_nanny_raises_exception(s, a, b):
-    with pytest.raises(RuntimeError) as error:
+    with pytest.raises(
+        RuntimeError, match="`worker_class` is set to 'dask.distributed.Nanny'"
+    ):
         await s.broadcast(msg={"op": "plugin_add"}, nanny=True)
-    assert "`worker_class` is set to 'dask.distributed.Nanny'" in str(error.value)
 
 
 @gen_cluster(nthreads=[])

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3236,7 +3236,7 @@ async def test_set_restrictions(c, s, a, b):
 @gen_cluster(
     nthreads=[],
 )
-def test_check_nanny_workers_raises(s):
+async def test_check_nanny_workers_raises(s):
     with pytest.raises(
         RuntimeError, match="`worker_class` is set to 'dask.distributed.Nanny'"
     ):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3199,3 +3199,13 @@ async def test_worker_reconnect_task_memory_with_resources(c, s, a):
         assert ("no-worker", "memory") in {
             (start, finish) for (_, start, finish, _, _) in s.transition_log
         }
+
+
+@gen_cluster(
+    nthreads=[],
+)
+def test_check_nanny_workers_raises(s):
+    with pytest.raises(
+        RuntimeError, match="`worker_class` is set to 'dask.distributed.Nanny'"
+    ):
+        s._check_nanny_workers([None])

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -671,6 +671,13 @@ async def test_broadcast_nanny(s, a, b):
     assert result1 == result3
 
 
+@gen_cluster(Worker=Worker)
+async def test_broadcast_nanny_raises_exception(s, a, b):
+    with pytest.raises(RuntimeError) as error:
+        await s.broadcast(msg={"op": "plugin_add"}, nanny=True)
+    assert "`worker_class` is set to 'dask.distributed.Nanny'" in str(error.value)
+
+
 @gen_cluster(nthreads=[])
 async def test_worker_name(s):
     w = await Worker(s.address, name="alice")


### PR DESCRIPTION
Hello everyone,

This is a tiny PR following the instructions from @jrbourbeau and @gjoseph92 on the open issue. All I've done really was adding a  small test for this exception raising. :smile:  

- [x] Closes #5231
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
