### PR TITLE
Remove `zict`-related skips

### DIFF
--- a/distributed/spill.py
+++ b/distributed/spill.py
@@ -4,13 +4,10 @@ from collections.abc import Hashable, Mapping
 from functools import partial
 from typing import Any
 
+from zict import Buffer, File, Func
+
 from .protocol import deserialize_bytes, serialize_bytelist
 from .sizeof import safe_sizeof
-
-try:
-    from zict import Buffer, File, Func
-except ImportError:
-    raise ImportError("Please `python -m pip install zict` for spill-to-disk workers")
 
 
 class SpillBuffer(Buffer):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2473,8 +2473,6 @@ async def assert_memory(scheduler_or_workerstate, attr: str, min_, max_, timeout
     client=True, Worker=Nanny, worker_kwargs={"memory_limit": "500 MiB"}, timeout=120
 )
 async def test_memory(c, s, *_):
-    pytest.importorskip("zict")
-
     # WorkerState objects, as opposed to the Nanny objects passed by gen_cluster
     a, b = s.workers.values()
 

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -1,7 +1,5 @@
 import pytest
 
-pytest.importorskip("zict")
-
 from dask.sizeof import sizeof
 
 from distributed.spill import SpillBuffer


### PR DESCRIPTION
Given that `zict` is a required dependency 

https://github.com/dask/distributed/blob/afce4be8e05fb180e50a9d9e38465f1a82295e1b/requirements.txt#L12

we should be able to safely drop some existing `ImportError` / `pytest.importorskip` handling 

cc @crusaderky 