### PR TITLE
Support running the scheduler with multiple hosts

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -24,7 +24,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 
 @click.command(context_settings=dict(ignore_unknown_options=True))
-@click.option("--host", type=str, default="", help="URI, IP or hostname of this server")
+@click.option("--host", type=str, help="URI, IP or hostname of this server", multiple=True)
 @click.option("--port", type=int, default=None, help="Serving port")
 @click.option(
     "--interface",
@@ -150,7 +150,7 @@ def main(
         )
         dashboard = bokeh
 
-    if port is None and (not host or not re.search(r":\d", host)):
+    if port is None and (not host or not all(re.search(r":\d", h) for h in host)):
         port = 8786
 
     sec = {

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -24,7 +24,9 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 
 @click.command(context_settings=dict(ignore_unknown_options=True))
-@click.option("--host", type=str, help="URI, IP or hostname of this server", multiple=True)
+@click.option(
+    "--host", type=str, help="URI, IP or hostname of this server", multiple=True
+)
 @click.option("--port", type=int, default=None, help="Serving port")
 @click.option(
     "--interface",

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -41,6 +41,7 @@ from distributed.utils_test import (
     slowinc,
     tls_only_security,
     varying,
+    popen,
 )
 from distributed.worker import dumps_function, dumps_task, get_worker
 
@@ -3190,3 +3191,13 @@ async def test_set_restrictions(c, s, a, b):
     assert s.tasks[f.key].worker_restrictions == {a.address}
     s.reschedule(f)
     await f
+
+
+def test_cli_multiple_hosts(loop):
+    with popen(["dask-scheduler", "--no-dashboard", "--host=tcp://0.0.0.0:8700", "--host=tcp://0.0.0.0:8701"]):
+        c1 = Client("tcp://127.0.0.1:8700", loop=loop)
+        c2 = Client("tcp://127.0.0.1:8701", loop=loop)
+
+        assert c1.get_versions() == c2.get_versions()
+        c1.close()
+        c2.close()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3194,7 +3194,14 @@ async def test_set_restrictions(c, s, a, b):
 
 
 def test_cli_multiple_hosts(loop):
-    with popen(["dask-scheduler", "--no-dashboard", "--host=tcp://0.0.0.0:8700", "--host=tcp://0.0.0.0:8701"]):
+    with popen(
+        [
+            "dask-scheduler",
+            "--no-dashboard",
+            "--host=tcp://0.0.0.0:8700",
+            "--host=tcp://0.0.0.0:8701",
+        ]
+    ):
         c1 = Client("tcp://127.0.0.1:8700", loop=loop)
         c2 = Client("tcp://127.0.0.1:8701", loop=loop)
 


### PR DESCRIPTION
The scheduler supports listening on multiple interfaces, but the `dask-scheduler` CLI can not pass more than one.

This PR allows you to pass multiple `--host` values via the command line, enabling you to do:

```
dask-scheduler --host=tcp://0.0.0.0:8780 --host=tcp://0.0.0.0:8781 --host=tls://0.0.0.0:8782
```

This is handy if you want to have TLS from `outside -> scheduler`, but don't need it between `scheduler <-> workers` 