### PR TITLE
Use `pip install .` instead of calling `setup.py`

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -28,7 +28,7 @@ To install distributed from source, clone the repository from `github
 
     git clone https://github.com/dask/distributed.git
     cd distributed
-    pip install .
+    python -m pip install .
 
 
 Notes


### PR DESCRIPTION
It is almost the same but is more consistent and future proof.
