### PR TITLE
RFC Allow a loop cycle after every message in the batch

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -586,7 +586,7 @@ class Server:
                                 handler(**merge(extra, msg))
                         else:
                             logger.error("odd message %s", msg)
-                    await asyncio.sleep(0)
+                        await asyncio.sleep(0)
 
                 for func in every_cycle:
                     if is_coroutine_function(func):


### PR DESCRIPTION
I stumbled upon this thing and again realized how incredibly complex our system is. For those not familiar, asyncio treats a sleep 0 as a sentinel and skips exactly one loop iteration.
This sleep indentation is interesting because the state on master allows an event loop iteration after an entire batch of messages has been worked off. If I move the indentation and therefore allow a loop iteration after every message, a lot of our tests break. I don't think any of our tests should be as sensitive as to react to such a subtle change.

I'm wondering if looking into this would help us with overall CI stability


That's also interesting since we're treating this quite differently for couroutine functions and ordinary functions (see a few lines above)

FWIW I tried aligning the behaviour of these two cases a while ago in https://github.com/dask/distributed/pull/4734 but failed to stabilize the branch. Back then I ran into many of our flaky tests while cleaning this up. FWIW, in the branch over there, I removed the sleep entirely


cc @crusaderky @jcrist 
