### PR TITLE
WIP Any and All never awaited unfinished tasks

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -211,8 +211,7 @@ async def All(args, quiet_exceptions=()):
             result = await tasks.next()
         except Exception:
 
-            @gen.coroutine
-            def quiet():
+            async def quiet():
                 """Watch unfinished tasks
 
                 Otherwise if they err they get logged in a way that is hard to
@@ -221,11 +220,11 @@ async def All(args, quiet_exceptions=()):
                 """
                 for task in list(tasks._unfinished):
                     try:
-                        yield task
+                        await task
                     except quiet_exceptions:
                         pass
 
-            quiet()
+            await quiet()
             raise
         results[tasks.current_index] = result
     return results
@@ -249,8 +248,7 @@ async def Any(args, quiet_exceptions=()):
             result = await tasks.next()
         except Exception:
 
-            @gen.coroutine
-            def quiet():
+            async def quiet():
                 """Watch unfinished tasks
 
                 Otherwise if they err they get logged in a way that is hard to
@@ -259,11 +257,11 @@ async def Any(args, quiet_exceptions=()):
                 """
                 for task in list(tasks._unfinished):
                     try:
-                        yield task
+                        await task
                     except quiet_exceptions:
                         pass
 
-            quiet()
+            await quiet()
             raise
 
         results[tasks.current_index] = result


### PR DESCRIPTION
That slipped through at some point, I guess? I'm not entirely sure what the initial behaviour was but I noticed a few "exception never retrieved" messages in combination with recent deadlocks. Likely unrelated but I'm not entirely sure.

Either way, these `Any` and `All` constructs are likely obsolete by now and could be replaced by `asyncio.gather` and/or `asyncio.as_completed`.

I don't have time to go down that rabbit hole but I think removing All/Any would relieve us of a lot of complex code around these things.