### PR TITLE
Handle `UCXNotConnected` error

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -383,10 +383,10 @@ class UCXConnector(Connector):
         init_once()
         try:
             ep = await ucx_create_endpoint(ip, port)
-        except (
-            ucp.exceptions.UCXCloseError,
-            ucp.exceptions.UCXCanceled,
-        ) + (getattr(ucp.exceptions, "UCXConnectionReset", ()),):
+        except (ucp.exceptions.UCXCloseError, ucp.exceptions.UCXCanceled,) + (
+            getattr(ucp.exceptions, "UCXConnectionReset", ()),
+            getattr(ucp.exceptions, "UCXNotConnected", ()),
+        ):
             raise CommClosedError("Connection closed before handshake completed")
         return self.comm_class(
             ep,


### PR DESCRIPTION
This is an issue that occurs non-deterministically, generally during
`client._reconnect` at shutdown when peers have already begun closing.
Therefore it needs to be catched and raise `CommClosedError`to prevent
unhandled errors.

Given the non-deterministic nature of the issue, testing it is very challenging and unfortunately there's no known test that can be added currently.

Error handling depends on https://github.com/rapidsai/ucx-py/pull/799 , but the change is backwards-compatible.