### PR TITLE
Use asyncio for TCP/TLS comms

### DIFF
--- a/distributed/comm/__init__.py
+++ b/distributed/comm/__init__.py
@@ -15,9 +15,15 @@ from .utils import get_tcp_server_address, get_tcp_server_addresses
 
 
 def _register_transports():
+    import os
+
     from . import asyncio_tcp, inproc, tcp, ws
 
-    if True:  # TODO: some kind of config
+    if os.getenv("DISTRIBUTED_USE_ASYNCIO_FOR_TCP", "").lower() not in (
+        "",
+        "0",
+        "false",
+    ):
         backends["tcp"] = asyncio_tcp.TCPBackend()
         backends["tls"] = asyncio_tcp.TLSBackend()
     else:

--- a/distributed/comm/__init__.py
+++ b/distributed/comm/__init__.py
@@ -10,11 +10,19 @@ from .addressing import (
     unparse_host_port,
 )
 from .core import Comm, CommClosedError, connect, listen
+from .registry import backends
 from .utils import get_tcp_server_address, get_tcp_server_addresses
 
 
 def _register_transports():
-    from . import inproc, tcp, ws
+    from . import asyncio_tcp, inproc, tcp, ws
+
+    if True:  # TODO: some kind of config
+        backends["tcp"] = asyncio_tcp.TCPBackend()
+        backends["tls"] = asyncio_tcp.TLSBackend()
+    else:
+        backends["tcp"] = tcp.TCPBackend()
+        backends["tls"] = tcp.TLSBackend()
 
     try:
         from . import ucx

--- a/distributed/comm/asyncio_tcp.py
+++ b/distributed/comm/asyncio_tcp.py
@@ -370,8 +370,8 @@ class DaskCommProtocol(asyncio.BufferedProtocol):
             raise CommClosedError("Connection closed")
         elif self._paused:
             # Wait until there's room in the write buffer
-            self._drain_waiter = self._loop.create_future()
-            await self._drain_waiter  # type: ignore
+            drain_waiter = self._drain_waiter = self._loop.create_future()
+            await drain_waiter
 
         # Ensure all memoryviews are in single-byte format
         frames = [f.cast("B") if isinstance(f, memoryview) else f for f in frames]

--- a/distributed/comm/asyncio_tcp.py
+++ b/distributed/comm/asyncio_tcp.py
@@ -346,13 +346,13 @@ class TCP(Comm):
 
     async def close(self):
         """Flush and close the comm"""
-        self._finalizer.detach()
         await self._protocol._close()
+        self._finalizer.detach()
 
     def abort(self):
         """Hard close the comm"""
-        self._finalizer.detach()
         self._protocol._abort()
+        self._finalizer.detach()
 
     def closed(self):
         return self._protocol.is_closed
@@ -471,11 +471,10 @@ class TCPListener(Listener):
             **self._extra_kwargs,
         )
 
-    def stop(self):
+    async def stop(self):
         # Stop listening
         self._handle.close()
-        # TODO: stop should really be asynchronous
-        asyncio.ensure_future(self._handle.wait_closed())
+        await self._handle.wait_closed()
 
     def get_host_port(self):
         """

--- a/distributed/comm/asyncio_tcp.py
+++ b/distributed/comm/asyncio_tcp.py
@@ -1,0 +1,550 @@
+import asyncio
+import logging
+import socket
+import struct
+import weakref
+
+try:
+    import ssl
+except ImportError:
+    ssl = None  # type: ignore
+
+import dask
+
+from ..utils import ensure_ip, get_ip, get_ipv6, nbytes
+from .addressing import parse_host_port, unparse_host_port
+from .core import Comm, CommClosedError, Connector, Listener
+from .registry import Backend
+from .utils import ensure_concrete_host, from_frames, to_frames
+
+logger = logging.getLogger(__name__)
+
+
+_COMM_CLOSED = object()
+
+
+class DaskCommProtocol(asyncio.BufferedProtocol):
+    def __init__(self, on_connection=None, min_read_size=128 * 1024):
+        super().__init__()
+        self.on_connection = on_connection
+        self._exception = None
+        self._queue = asyncio.Queue()
+        self._transport = None
+        self._paused = False
+        self._drain_waiter = None
+        self._loop = asyncio.get_running_loop()
+        self._is_closed = self._loop.create_future()
+
+        # Per-message state
+        self._using_default_buffer = True
+
+        self._default_buffer = memoryview(bytearray(min_read_size))
+        self._default_len = min_read_size
+        self._default_start = 0
+        self._default_end = 0
+
+        self._nframes = None
+        self._frame_lengths = None
+        self._frames = None
+        self._frame_index = None
+        self._frame_nbytes_needed = None
+
+    @property
+    def local_addr(self):
+        if self._transport is None:
+            return "<closed>"
+        try:
+            host, port = self._transport.get_extra_info("socket").getsockname()[:2]
+            return unparse_host_port(host, port)
+        except Exception:
+            breakpoint()  # TODO
+            return "<closed>"
+
+    @property
+    def peer_addr(self):
+        if self._transport is None:
+            return "<closed>"
+        try:
+            host, port = self._transport.get_extra_info("peername")
+            return unparse_host_port(host, port)
+        except Exception:
+            breakpoint()  # TODO
+            return "<closed>"
+
+    @property
+    def is_closed(self):
+        return self._transport is None
+
+    def _abort(self):
+        if self._transport is not None:
+            self._transport, transport = None, self._transport
+            transport.abort()
+
+    def _close_from_finalizer(self, comm_repr):
+        if self._transport is not None:
+            logger.warning(f"Closing dangling comm `{comm_repr}`")
+            self._abort()
+
+    async def _close(self):
+        if self._transport is not None:
+            self._transport, transport = None, self._transport
+            transport.close()
+        await self._is_closed
+
+    def connection_made(self, transport):
+        self._transport = transport
+        if self.on_connection is not None:
+            self.on_connection(self)
+
+    def get_buffer(self, sizehint):
+        if self._frames is None or self._frame_nbytes_needed < self._default_len:
+            self._using_default_buffer = True
+            return self._default_buffer[self._default_end :]
+        else:
+            self._using_default_buffer = False
+            frame = self._frames[self._frame_index]
+            return frame[-self._frame_nbytes_needed :]
+
+    def buffer_updated(self, nbytes):
+        if nbytes == 0:
+            return
+
+        if self._using_default_buffer:
+            self._default_end += nbytes
+            while self._parse_next():
+                pass
+            self._reset_default_buffer()
+        else:
+            self._frame_nbytes_needed -= nbytes
+            if not self._frame_nbytes_needed:
+                self._frame_index += 1
+                if self._frame_index == self._nframes:
+                    self._message_completed()
+                else:
+                    self._frame_nbytes_needed = self._frame_lengths[self._frame_index]
+
+    def _parse_next(self):
+        if self._nframes is None:
+            if not self._parse_nframes():
+                return False
+        if len(self._frame_lengths) < self._nframes:
+            if not self._parse_frame_lengths():
+                return False
+        return self._parse_frames()
+
+    def _parse_nframes(self):
+        if self._default_end - self._default_start > 8:
+            self._nframes = struct.unpack_from(
+                "<Q", self._default_buffer, offset=self._default_start
+            )[0]
+            self._default_start += 8
+            self._frame_lengths = []
+            return True
+        return False
+
+    def _parse_frame_lengths(self):
+        needed = self._nframes - len(self._frame_lengths)
+        available = (self._default_end - self._default_start) // 8
+        n_read = min(available, needed)
+        self._frame_lengths.extend(
+            struct.unpack_from(
+                f"<{n_read}Q", self._default_buffer, offset=self._default_start
+            )
+        )
+        self._default_start += 8 * n_read
+
+        if n_read == needed:
+            self._frames = [memoryview(bytearray(n)) for n in self._frame_lengths]
+            self._frame_index = 0
+            self._frame_nbytes_needed = (
+                self._frame_lengths[0] if self._frame_lengths else 0
+            )
+            return True
+        return False
+
+    def _parse_frames(self):
+        while True:
+            # Are we out of frames?
+            if self._frame_index == self._nframes:
+                self._message_completed()
+                return True
+            # Are we out of data?
+            available = self._default_end - self._default_start
+            if not available:
+                return False
+
+            frame = self._frames[self._frame_index]
+            n_read = min(self._frame_nbytes_needed, available)
+            frame[-self._frame_nbytes_needed : n_read] = self._default_buffer[
+                self._default_start : self._default_start + n_read
+            ]
+            self._default_start += n_read
+            self._frame_nbytes_needed -= n_read
+            if not self._frame_nbytes_needed:
+                self._frame_index += 1
+                if self._frame_index < self._nframes:
+                    self._frame_nbytes_needed = self._frame_lengths[self._frame_index]
+
+    def _reset_default_buffer(self):
+        start = self._default_start
+        end = self._default_end
+
+        if start < end and start != 0:
+            self._default_buffer[: end - start] = self._default_buffer[start:end]
+            self._default_start = 0
+            self._default_end = end - start
+        elif start == end:
+            self._default_start = 0
+            self._default_end = 0
+
+    def _message_completed(self):
+        self._queue.put_nowait(self._frames)
+        self._nframes = None
+        self._frames = None
+        self._frame_lengths = None
+
+    def connection_lost(self, exc=None):
+        if exc is None:
+            exc = CommClosedError("Connection closed")
+        self._exception = exc
+        self._transport = None
+        self._is_closed.set_result(None)
+
+        # Unblock read, if any
+        self._queue.put_nowait(_COMM_CLOSED)
+
+        # Unblock write, if any
+        if self._paused:
+            waiter = self._drain_waiter
+            if waiter is not None:
+                self._drain_waiter = None
+                if not waiter.done():
+                    waiter.set_exception(exc)
+
+    def pause_writing(self):
+        self._paused = True
+
+    def resume_writing(self):
+        self._paused = False
+
+        waiter = self._drain_waiter
+        if waiter is not None:
+            self._drain_waiter = None
+            if not waiter.done():
+                waiter.set_result(None)
+
+    async def read(self):
+        # Even if comm is closed, we still yield all received data before
+        # erroring
+        if self._queue is not None:
+            out = await self._queue.get()
+            if out is not _COMM_CLOSED:
+                return out
+            self._queue = None
+        raise self._exception
+
+    async def write(self, frames):
+        if self._exception:
+            raise self._exception
+
+        nframes = len(frames)
+        frames_nbytes = [nbytes(f) for f in frames]
+        header = struct.pack(f"{nframes + 1}Q", nframes, *frames_nbytes)
+        frames_nbytes_total = sum(frames_nbytes) + nbytes(header)
+        frames = [header, *frames]
+
+        if frames_nbytes_total < 2 ** 17:  # 128kiB
+            # small enough, send in one go
+            frames = [b"".join(frames)]
+
+        if len(frames) > 1:
+            self._transport.writelines(frames)
+        else:
+            self._transport.write(frames[0])
+        if self._transport.is_closing():
+            await asyncio.sleep(0)
+        elif self._paused:
+            self._drain_waiter = self._loop.create_future()
+            await self._drain_waiter
+
+        return frames_nbytes_total
+
+
+class TCP(Comm):
+    max_shard_size = dask.utils.parse_bytes(dask.config.get("distributed.comm.shard"))
+
+    def __init__(
+        self,
+        protocol,
+        local_addr: str,
+        peer_addr: str,
+        deserialize: bool = True,
+    ):
+        self._protocol = protocol
+        self._local_addr = local_addr
+        self._peer_addr = peer_addr
+        self._deserialize = deserialize
+        self._closed = False
+        super().__init__()
+
+        # setup a finalizer to close the protocol if the comm was never explicitly closed
+        self._finalizer = weakref.finalize(
+            self, self._protocol._close_from_finalizer, repr(self)
+        )
+        self._finalizer.atexit = False
+
+        # Fill in any extra info about this comm
+        self._extra_info = self._get_extra_info()
+
+    def _get_extra_info(self):
+        return {}
+
+    @property
+    def local_address(self) -> str:
+        return self._local_addr
+
+    @property
+    def peer_address(self) -> str:
+        return self._peer_addr
+
+    async def read(self, deserializers=None):
+        frames = await self._protocol.read()
+        try:
+            return await from_frames(
+                frames,
+                deserialize=self._deserialize,
+                deserializers=deserializers,
+                allow_offload=self.allow_offload,
+            )
+        except EOFError:
+            # Frames possibly garbled or truncated by communication error
+            self.abort()
+            raise CommClosedError("aborted stream on truncated data")
+
+    async def write(self, msg, serializers=None, on_error="message"):
+        frames = await to_frames(
+            msg,
+            allow_offload=self.allow_offload,
+            serializers=serializers,
+            on_error=on_error,
+            context={
+                "sender": self.local_info,
+                "recipient": self.remote_info,
+                **self.handshake_options,
+            },
+            frame_split_size=self.max_shard_size,
+        )
+        nbytes = await self._protocol.write(frames)
+        return nbytes
+
+    async def close(self):
+        """Flush and close the comm"""
+        self._finalizer.detach()
+        await self._protocol._close()
+
+    def abort(self):
+        """Hard close the comm"""
+        self._finalizer.detach()
+        self._protocol._abort()
+
+    def closed(self):
+        return self._protocol.is_closed
+
+    @property
+    def extra_info(self):
+        return self._extra_info
+
+
+class TLS(TCP):
+    def _get_extra_info(self):
+        get = self._protocol._transport.get_extra_info
+        return {"peercert": get("peercert"), "cipher": get("cipher")}
+
+
+def _expect_tls_context(connection_args):
+    ctx = connection_args.get("ssl_context")
+    if not isinstance(ctx, ssl.SSLContext):
+        raise TypeError(
+            "TLS expects a `ssl_context` argument of type "
+            "ssl.SSLContext (perhaps check your TLS configuration?)"
+            "  Instead got %s" % str(ctx)
+        )
+    return ctx
+
+
+def _error_if_require_encryption(address, **kwargs):
+    if kwargs.get("require_encryption"):
+        raise RuntimeError(
+            "encryption required by Dask configuration, "
+            "refusing communication from/to %r" % ("tcp://" + address,)
+        )
+
+
+class TCPConnector(Connector):
+    prefix = "tcp://"
+    comm_class = TCP
+
+    async def connect(self, address, deserialize=True, **kwargs):
+        loop = asyncio.get_event_loop()
+        ip, port = parse_host_port(address)
+
+        kwargs = self._get_extra_kwargs(address, **kwargs)
+        transport, protocol = await loop.create_connection(
+            DaskCommProtocol, ip, port, **kwargs
+        )
+        local_addr = self.prefix + protocol.local_addr
+        peer_addr = self.prefix + address
+        return self.comm_class(protocol, local_addr, peer_addr, deserialize=deserialize)
+
+    def _get_extra_kwargs(self, address, **kwargs):
+        _error_if_require_encryption(address, **kwargs)
+        return {}
+
+
+class TLSConnector(TCPConnector):
+    prefix = "tls://"
+    comm_class = TLS
+
+    def _get_extra_kwargs(self, address, **kwargs):
+        ctx = _expect_tls_context(kwargs)
+        return {"ssl": ctx}
+
+
+class TCPListener(Listener):
+    prefix = "tcp://"
+    comm_class = TCP
+
+    def __init__(
+        self,
+        address,
+        comm_handler,
+        deserialize=True,
+        allow_offload=True,
+        default_port=0,
+        **kwargs,
+    ):
+        self.ip, self.port = parse_host_port(address, default_port)
+        self.comm_handler = comm_handler
+        self.deserialize = deserialize
+        self.allow_offload = allow_offload
+        self._extra_kwargs = self._get_extra_kwargs(address, **kwargs)
+        self._active_handlers = weakref.WeakSet()
+        self.bound_address = None
+
+    def _get_extra_kwargs(self, address, **kwargs):
+        _error_if_require_encryption(address, **kwargs)
+        return {}
+
+    def _on_connection(self, protocol):
+        logger.debug("Incoming connection")
+        comm = self.comm_class(
+            protocol,
+            local_addr=self.prefix + protocol.local_addr,
+            peer_addr=self.prefix + protocol.peer_addr,
+            deserialize=self.deserialize,
+        )
+        comm.allow_offload = self.allow_offload
+        self._active_handlers.add(asyncio.ensure_future(self._comm_handler(comm)))
+
+    async def _comm_handler(self, comm):
+        try:
+            await self.on_connection(comm)
+        except CommClosedError:
+            logger.debug("Connection closed before handshake completed")
+            return
+        await self.comm_handler(comm)
+
+    async def start(self):
+        loop = asyncio.get_event_loop()
+        self._handle = await loop.create_server(
+            lambda: DaskCommProtocol(self._on_connection),
+            host=self.ip,
+            port=self.port,
+            **self._extra_kwargs,
+        )
+
+    def stop(self):
+        # Stop listening
+        self._handle.close()
+        # Cancel all active handlers
+        for handler in self._active_handlers:
+            handler.cancel()
+        # TODO: stop should really be asynchronous
+        asyncio.ensure_future(self._handle.wait_closed())
+
+    def get_host_port(self):
+        """
+        The listening address as a (host, port) tuple.
+        """
+        if self.bound_address is None:
+
+            def get_socket():
+                for family in [socket.AF_INET, socket.AF_INET6]:
+                    for sock in self._handle.sockets:
+                        if sock.family == socket.AF_INET:
+                            return sock
+                raise RuntimeError("No active INET socket found?")
+
+            sock = get_socket()
+            self.bound_address = sock.getsockname()[:2]
+        return self.bound_address
+
+    @property
+    def listen_address(self):
+        """
+        The listening address as a string.
+        """
+        return self.prefix + unparse_host_port(*self.get_host_port())
+
+    @property
+    def contact_address(self):
+        """
+        The contact address as a string.
+        """
+        host, port = self.get_host_port()
+        host = ensure_concrete_host(host)
+        return self.prefix + unparse_host_port(host, port)
+
+
+class TLSListener(TCPListener):
+    prefix = "tls://"
+    comm_class = TLS
+
+    def _get_extra_kwargs(self, address, **kwargs):
+        ctx = _expect_tls_context(kwargs)
+        return {"ssl": ctx}
+
+
+class TCPBackend(Backend):
+    _connector_class = TCPConnector
+    _listener_class = TCPListener
+
+    def get_connector(self):
+        return self._connector_class()
+
+    def get_listener(self, loc, handle_comm, deserialize, **connection_args):
+        return self._listener_class(loc, handle_comm, deserialize, **connection_args)
+
+    def get_address_host(self, loc):
+        return parse_host_port(loc)[0]
+
+    def get_address_host_port(self, loc):
+        return parse_host_port(loc)
+
+    def resolve_address(self, loc):
+        host, port = parse_host_port(loc)
+        return unparse_host_port(ensure_ip(host), port)
+
+    def get_local_address_for(self, loc):
+        host, port = parse_host_port(loc)
+        host = ensure_ip(host)
+        if ":" in host:
+            local_host = get_ipv6(host)
+        else:
+            local_host = get_ip(host)
+        return unparse_host_port(local_host, None)
+
+
+class TLSBackend(TCPBackend):
+    _connector_class = TLSConnector
+    _listener_class = TLSListener

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -30,7 +30,7 @@ from ..threadpoolexecutor import ThreadPoolExecutor
 from ..utils import ensure_ip, get_ip, get_ipv6, nbytes
 from .addressing import parse_host_port, unparse_host_port
 from .core import Comm, CommClosedError, Connector, FatalCommClosedError, Listener
-from .registry import Backend, backends
+from .registry import Backend
 from .utils import ensure_concrete_host, from_frames, get_tcp_server_address, to_frames
 
 logger = logging.getLogger(__name__)
@@ -622,7 +622,3 @@ class TCPBackend(BaseTCPBackend):
 class TLSBackend(BaseTCPBackend):
     _connector_class = TLSConnector
     _listener_class = TLSListener
-
-
-backends["tcp"] = TCPBackend()
-backends["tls"] = TLSBackend()

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -14,9 +14,9 @@ from tornado.concurrent import Future
 import dask
 
 import distributed
-from distributed.comm import CommClosedError
-from distributed.comm import asyncio_tcp as tcp
 from distributed.comm import (
+    CommClosedError,
+    asyncio_tcp,
     connect,
     get_address_host,
     get_local_address_for,
@@ -27,7 +27,6 @@ from distributed.comm import (
     resolve_address,
     unparse_host_port,
 )
-from distributed.comm.asyncio_tcp import TCP, TCPBackend, TCPConnector
 from distributed.comm.registry import backends, get_backend
 from distributed.metrics import time
 from distributed.protocol import Serialized, deserialize, serialize, to_serialize
@@ -45,6 +44,18 @@ if has_ipv6():
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         EXTERNAL_IP6 = get_ipv6()
+
+
+@pytest.fixture(params=["tornado", "asyncio"])
+def tcp(monkeypatch, request):
+    """Set the TCP backend to either tornado or asyncio"""
+    if request.param == "tornado":
+        import distributed.comm.tcp as tcp
+    else:
+        import distributed.comm.asyncio_tcp as tcp
+    monkeypatch.setitem(backends, "tcp", tcp.TCPBackend())
+    monkeypatch.setitem(backends, "tls", tcp.TLSBackend())
+    return tcp
 
 
 ca_file = get_cert("tls-ca-cert.pem")
@@ -117,7 +128,7 @@ async def debug_loop():
 #
 
 
-def test_parse_host_port():
+def test_parse_host_port(tcp):
     f = parse_host_port
 
     assert f("localhost:123") == ("localhost", 123)
@@ -140,7 +151,7 @@ def test_parse_host_port():
         f("::1")
 
 
-def test_unparse_host_port():
+def test_unparse_host_port(tcp):
     f = unparse_host_port
 
     assert f("localhost", 123) == "localhost:123"
@@ -157,14 +168,14 @@ def test_unparse_host_port():
     assert f("::1", "*") == "[::1]:*"
 
 
-def test_get_address_host():
+def test_get_address_host(tcp):
     f = get_address_host
 
     assert f("tcp://127.0.0.1:123") == "127.0.0.1"
     assert f("inproc://%s/%d/123" % (get_ip(), os.getpid())) == get_ip()
 
 
-def test_resolve_address():
+def test_resolve_address(tcp):
     f = resolve_address
 
     assert f("tcp://127.0.0.1:123") == "tcp://127.0.0.1:123"
@@ -184,7 +195,7 @@ def test_resolve_address():
     assert f("tls://localhost:456") == "tls://127.0.0.1:456"
 
 
-def test_get_local_address_for():
+def test_get_local_address_for(tcp):
     f = get_local_address_for
 
     assert f("tcp://127.0.0.1:80") == "tcp://127.0.0.1"
@@ -204,7 +215,7 @@ def test_get_local_address_for():
 
 
 @pytest.mark.asyncio
-async def test_tcp_listener_does_not_call_handler_on_handshake_error():
+async def test_tcp_listener_does_not_call_handler_on_handshake_error(tcp):
     handle_comm_called = False
 
     async def handle_comm(comm):
@@ -226,7 +237,7 @@ async def test_tcp_listener_does_not_call_handler_on_handshake_error():
 
 
 @pytest.mark.asyncio
-async def test_tcp_specific():
+async def test_tcp_specific(tcp):
     """
     Test concrete TCP API.
     """
@@ -269,7 +280,7 @@ async def test_tcp_specific():
 
 
 @pytest.mark.asyncio
-async def test_tls_specific():
+async def test_tls_specific(tcp):
     """
     Test concrete TLS API.
     """
@@ -315,8 +326,7 @@ async def test_tls_specific():
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="not applicable for asyncio")
-async def test_comm_failure_threading():
+async def test_comm_failure_threading(tcp):
     """
     When we fail to connect, make sure we don't make a lot
     of threads.
@@ -324,6 +334,8 @@ async def test_comm_failure_threading():
     We only assert for PY3, because the thread limit only is
     set for python 3.  See github PR #2403 discussion for info.
     """
+    if tcp is asyncio_tcp:
+        pytest.skip("not applicable for asyncio")
 
     async def sleep_for_60ms():
         max_thread_count = 0
@@ -562,7 +574,7 @@ def inproc_check():
 
 
 @pytest.mark.asyncio
-async def test_default_client_server_ipv4():
+async def test_default_client_server_ipv4(tcp):
     # Default scheme is (currently) TCP
     await check_client_server("127.0.0.1", tcp_eq("127.0.0.1"))
     await check_client_server("127.0.0.1:3201", tcp_eq("127.0.0.1", 3201))
@@ -579,7 +591,7 @@ async def test_default_client_server_ipv4():
 
 @requires_ipv6
 @pytest.mark.asyncio
-async def test_default_client_server_ipv6():
+async def test_default_client_server_ipv6(tcp):
     await check_client_server("[::1]", tcp_eq("::1"))
     await check_client_server("[::1]:3211", tcp_eq("::1", 3211))
     await check_client_server("[::]", tcp_eq("::"), tcp_eq(EXTERNAL_IP6))
@@ -589,7 +601,7 @@ async def test_default_client_server_ipv6():
 
 
 @pytest.mark.asyncio
-async def test_tcp_client_server_ipv4():
+async def test_tcp_client_server_ipv4(tcp):
     await check_client_server("tcp://127.0.0.1", tcp_eq("127.0.0.1"))
     await check_client_server("tcp://127.0.0.1:3221", tcp_eq("127.0.0.1", 3221))
     await check_client_server("tcp://0.0.0.0", tcp_eq("0.0.0.0"), tcp_eq(EXTERNAL_IP4))
@@ -604,7 +616,7 @@ async def test_tcp_client_server_ipv4():
 
 @requires_ipv6
 @pytest.mark.asyncio
-async def test_tcp_client_server_ipv6():
+async def test_tcp_client_server_ipv6(tcp):
     await check_client_server("tcp://[::1]", tcp_eq("::1"))
     await check_client_server("tcp://[::1]:3231", tcp_eq("::1", 3231))
     await check_client_server("tcp://[::]", tcp_eq("::"), tcp_eq(EXTERNAL_IP6))
@@ -614,7 +626,7 @@ async def test_tcp_client_server_ipv6():
 
 
 @pytest.mark.asyncio
-async def test_tls_client_server_ipv4():
+async def test_tls_client_server_ipv4(tcp):
     await check_client_server("tls://127.0.0.1", tls_eq("127.0.0.1"), **tls_kwargs)
     await check_client_server(
         "tls://127.0.0.1:3221", tls_eq("127.0.0.1", 3221), **tls_kwargs
@@ -626,7 +638,7 @@ async def test_tls_client_server_ipv4():
 
 @requires_ipv6
 @pytest.mark.asyncio
-async def test_tls_client_server_ipv6():
+async def test_tls_client_server_ipv6(tcp):
     await check_client_server("tls://[::1]", tls_eq("::1"), **tls_kwargs)
 
 
@@ -642,7 +654,7 @@ async def test_inproc_client_server():
 
 
 @pytest.mark.asyncio
-async def test_tls_reject_certificate():
+async def test_tls_reject_certificate(tcp):
     cli_ctx = get_client_ssl_context()
     serv_ctx = get_server_ssl_context()
 
@@ -714,12 +726,12 @@ async def check_comm_closed_implicit(addr, delay=None, listen_args={}, connect_a
 
 
 @pytest.mark.asyncio
-async def test_tcp_comm_closed_implicit():
+async def test_tcp_comm_closed_implicit(tcp):
     await check_comm_closed_implicit("tcp://127.0.0.1")
 
 
 @pytest.mark.asyncio
-async def test_tls_comm_closed_implicit():
+async def test_tls_comm_closed_implicit(tcp):
     await check_comm_closed_implicit("tls://127.0.0.1", **tls_kwargs)
 
 
@@ -752,12 +764,12 @@ async def check_comm_closed_explicit(addr, listen_args={}, connect_args={}):
 
 
 @pytest.mark.asyncio
-async def test_tcp_comm_closed_explicit():
+async def test_tcp_comm_closed_explicit(tcp):
     await check_comm_closed_explicit("tcp://127.0.0.1")
 
 
 @pytest.mark.asyncio
-async def test_tls_comm_closed_explicit():
+async def test_tls_comm_closed_explicit(tcp):
     await check_comm_closed_explicit("tls://127.0.0.1", **tls_kwargs)
 
 
@@ -817,11 +829,13 @@ async def test_inproc_comm_closed_explicit_2():
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Not applicable for asyncio")
-async def test_comm_closed_on_buffer_error():
+async def test_comm_closed_on_buffer_error(tcp):
     # Internal errors from comm.stream.write, such as
     # BufferError should lead to the stream being closed
     # and not re-used. See GitHub #4133
+    if tcp is asyncio_tcp:
+        pytest.skip("Not applicable for asyncio")
+
     reader, writer = await get_tcp_comm_pair()
 
     def _write(data):
@@ -847,12 +861,12 @@ async def echo(comm):
 
 
 @pytest.mark.asyncio
-async def test_retry_connect(monkeypatch):
+async def test_retry_connect(tcp, monkeypatch):
     async def echo(comm):
         message = await comm.read()
         await comm.write(message)
 
-    class UnreliableConnector(TCPConnector):
+    class UnreliableConnector(tcp.TCPConnector):
         def __init__(self):
 
             self.num_failures = 2
@@ -866,7 +880,7 @@ async def test_retry_connect(monkeypatch):
                 self.failures += 1
                 raise OSError()
 
-    class UnreliableBackend(TCPBackend):
+    class UnreliableBackend(tcp.TCPBackend):
         _connector_class = UnreliableConnector
 
     monkeypatch.setitem(backends, "tcp", UnreliableBackend())
@@ -882,8 +896,8 @@ async def test_retry_connect(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handshake_slow_comm(monkeypatch):
-    class SlowComm(TCP):
+async def test_handshake_slow_comm(tcp, monkeypatch):
+    class SlowComm(tcp.TCP):
         def __init__(self, *args, delay_in_comm=0.5, **kwargs):
             super().__init__(*args, **kwargs)
             self.delay_in_comm = delay_in_comm
@@ -897,10 +911,10 @@ async def test_handshake_slow_comm(monkeypatch):
             res = await super(type(self), self).write(*args, **kwargs)
             return res
 
-    class SlowConnector(TCPConnector):
+    class SlowConnector(tcp.TCPConnector):
         comm_class = SlowComm
 
-    class SlowBackend(TCPBackend):
+    class SlowBackend(tcp.TCPBackend):
         def get_connector(self):
             return SlowConnector()
 
@@ -933,7 +947,7 @@ async def check_connect_timeout(addr):
 
 
 @pytest.mark.asyncio
-async def test_tcp_connect_timeout():
+async def test_tcp_connect_timeout(tcp):
     await check_connect_timeout("tcp://127.0.0.1:44444")
 
 
@@ -961,7 +975,7 @@ async def check_many_listeners(addr):
 
 
 @pytest.mark.asyncio
-async def test_tcp_many_listeners():
+async def test_tcp_many_listeners(tcp):
     await check_many_listeners("tcp://127.0.0.1")
     await check_many_listeners("tcp://0.0.0.0")
     await check_many_listeners("tcp://")
@@ -1117,7 +1131,7 @@ async def check_deserialize(addr):
 
 
 @pytest.mark.asyncio
-async def test_tcp_deserialize():
+async def test_tcp_deserialize(tcp):
     await check_deserialize("tcp://")
 
 
@@ -1165,7 +1179,7 @@ async def test_inproc_deserialize_roundtrip():
 
 
 @pytest.mark.asyncio
-async def test_tcp_deserialize_roundtrip():
+async def test_tcp_deserialize_roundtrip(tcp):
     await check_deserialize_roundtrip("tcp://")
 
 
@@ -1195,7 +1209,7 @@ async def check_deserialize_eoferror(addr):
 
 
 @pytest.mark.asyncio
-async def test_tcp_deserialize_eoferror():
+async def test_tcp_deserialize_eoferror(tcp):
     await check_deserialize_eoferror("tcp://")
 
 
@@ -1218,7 +1232,7 @@ async def check_repr(a, b):
 
 
 @pytest.mark.asyncio
-async def test_tcp_repr():
+async def test_tcp_repr(tcp):
     a, b = await get_tcp_comm_pair()
     assert a.local_address in repr(b)
     assert b.local_address in repr(a)
@@ -1226,7 +1240,7 @@ async def test_tcp_repr():
 
 
 @pytest.mark.asyncio
-async def test_tls_repr():
+async def test_tls_repr(tcp):
     a, b = await get_tls_comm_pair()
     assert a.local_address in repr(b)
     assert b.local_address in repr(a)
@@ -1249,13 +1263,13 @@ async def check_addresses(a, b):
 
 
 @pytest.mark.asyncio
-async def test_tcp_adresses():
+async def test_tcp_adresses(tcp):
     a, b = await get_tcp_comm_pair()
     await check_addresses(a, b)
 
 
 @pytest.mark.asyncio
-async def test_tls_adresses():
+async def test_tls_adresses(tcp):
     a, b = await get_tls_comm_pair()
     await check_addresses(a, b)
 

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -339,7 +339,7 @@ class WSListener(Listener):
                 self.server = HTTPServer(web.Application(routes), **self.server_args)
                 self.server.listen(self.port)
 
-    async def stop(self):
+    def stop(self):
         self.server.stop()
 
     def get_host_port(self):

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -844,6 +844,14 @@ properties:
                   ``True``, a CUDA context will be created on the first device listed in
                   ``CUDA_VISIBLE_DEVICES``.
 
+          tcp:
+            type: object
+            properties:
+              backend:
+                type: string
+                description: |
+                  The TCP backend implementation to use. Must be either `tornado` or `asyncio`.
+
           websockets:
             type: object
             properties:

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -221,6 +221,9 @@ distributed:
         key: null
         cert: null
 
+    tcp:
+      backend: tornado  # The backend to use for TCP, one of {tornado, asyncio}
+
     websockets:
       shard: 8MiB
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -591,8 +591,8 @@ async def test_connection_pool_close_while_connecting(monkeypatch):
     Ensure a closed connection pool guarantees to have no connections left open
     even if it is closed mid-connecting
     """
-    from distributed.comm.asyncio_tcp import TCPBackend, TCPConnector
     from distributed.comm.registry import backends
+    from distributed.comm.tcp import TCPBackend, TCPConnector
 
     class SlowConnector(TCPConnector):
         async def connect(self, address, deserialize, **connection_args):

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -591,8 +591,8 @@ async def test_connection_pool_close_while_connecting(monkeypatch):
     Ensure a closed connection pool guarantees to have no connections left open
     even if it is closed mid-connecting
     """
+    from distributed.comm.asyncio_tcp import TCPBackend, TCPConnector
     from distributed.comm.registry import backends
-    from distributed.comm.tcp import TCPBackend, TCPConnector
 
     class SlowConnector(TCPConnector):
         async def connect(self, address, deserialize, **connection_args):

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -31,7 +31,6 @@ from distributed import (
     get_worker,
     wait,
 )
-from distributed.comm.asyncio_tcp import TCPBackend
 from distributed.comm.registry import backends
 from distributed.compatibility import LINUX, WINDOWS
 from distributed.core import CommClosedError, Status, rpc
@@ -1538,6 +1537,7 @@ async def test_protocol_from_scheduler_address(cleanup, Worker):
 async def test_host_uses_scheduler_protocol(cleanup, monkeypatch):
     # Ensure worker uses scheduler's protocol to determine host address, not the default scheme
     # See https://github.com/dask/distributed/pull/4883
+    from distributed.comm.tcp import TCPBackend
 
     class BadBackend(TCPBackend):
         def get_address_host(self, loc):

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -31,8 +31,8 @@ from distributed import (
     get_worker,
     wait,
 )
+from distributed.comm.asyncio_tcp import TCPBackend
 from distributed.comm.registry import backends
-from distributed.comm.tcp import TCPBackend
 from distributed.compatibility import LINUX, WINDOWS
 from distributed.core import CommClosedError, Status, rpc
 from distributed.diagnostics import nvml
@@ -1952,7 +1952,6 @@ async def test_worker_client_uses_default_no_close(c, s, a):
 @gen_cluster(nthreads=[("127.0.0.1", 0)])
 async def test_worker_client_closes_if_created_on_worker_one_worker(s, a):
     async with Client(s.address, set_as_default=False, asynchronous=True) as c:
-
         with pytest.raises(ValueError):
             default_client()
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -43,7 +43,7 @@ from tornado.ioloop import IOLoop
 
 import dask
 
-from distributed.comm.tcp import TCP
+from distributed.comm.asyncio_tcp import TCP
 
 from . import system
 from .client import Client, _global_clients, default_client
@@ -1499,6 +1499,9 @@ def check_thread_leak():
             # TODO: Make sure profile thread is cleaned up
             # and remove the line below
             and "Profile" not in thread.name
+            # asyncio default executor thread pool is not shut down until loop
+            # is shut down
+            and "asyncio_" not in thread.name
         ]
         if not bad_threads:
             break

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -46,7 +46,7 @@ from tornado.ioloop import IOLoop
 
 import dask
 
-from distributed.comm.asyncio_tcp import TCP
+from distributed.comm.tcp import TCP
 
 from . import system
 from .client import Client, _global_clients, default_client


### PR DESCRIPTION
This is a WIP PR for using asyncio instead of tornado for TCP/TLS comms.
There are a few goals here:

- Reduce our dependency on tornado, in favor of the builtin asyncio
support
- Lower latency for small/medium sized messages. Right now the tornado
call stack in the IOStream interface increases our latency for small
messages. We can do better here by making use of asyncio protocols.
- Equal performance for large messages. We should be able to make zero
copy reads/writes just as before. In this case I wouldn't expect a
performance increase from asyncio for large (10 MiB+) messages, but we
also shouldn't see a slowdown.
- Improved TLS performance. The TLS implementation in asyncio (and
more-so in uvloop) is better optimized than the implementation in
tornado. We should see a measurable performance boost here.
- Reduced GIL contention when using TLS. Right now a single write or
read through tornado drops and reaquires the GIL several times. If there
are busy background threads, this can lead to the IO thread having to
wait for the GIL mutex multiple times, leading to lower IO
performance. The implementations in asyncio/uvloop don't drop the GIL
except for IO (instead of also dropping it for TLS operations), which
leads to fewer chances of another thread picking up the GIL and slowing
IO.

This PR is still a WIP, and still has some TODOs:
- Pause the read side of the protocol after a certain limit. Right now
the protocol will buffer in memory without a reader, providing no
backpressure.
- The tornado comms version includes some unnecessary length info in
it's framing that I didn't notice when implementing the asyncio version
originally. As is, the asyncio comm can't talk to the tornado comm.
We'll want to fix this for now, as it would break cross-version support
(but we can remove the excess framing later if/when we make other
breaking changes).
- Right now the asyncio implementation is slower than expected for large
frames. Need to profile and debug why.
- Do we want to keep both the tornado and asyncio implementations around
for a while behind a config knob, or do we want to fully replace the
implementation with asyncio? I tend towards the latter, but may add an
interim config in this PR (to be ripped out before merge) to make it
easier for users to test and benchmark this PR.


Fixes #4513.