### PR TITLE
Do not drop BatchedSend payload if worker reconnects

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5510,7 +5510,7 @@ class Scheduler(SchedulerState, ServerNode):
             await self.handle_stream(comm=comm, extra={"worker": worker})
         finally:
             if worker in self.stream_comms:
-                worker_comm.abort()
+                await worker_comm.close()
                 await self.remove_worker(address=worker)
 
     def add_plugin(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1238,7 +1238,6 @@ class Worker(ServerNode):
                 comm, every_cycle=[self.ensure_communicating, self.ensure_computing]
             )
         except Exception as e:
-            self.batched_stream.please_stop = True
             logger.exception(e)
             raise
         finally:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1238,6 +1238,7 @@ class Worker(ServerNode):
                 comm, every_cycle=[self.ensure_communicating, self.ensure_computing]
             )
         except Exception as e:
+            self.batched_stream.please_stop = True
             logger.exception(e)
             raise
         finally:


### PR DESCRIPTION
If the scheduler<->worker stream closes during a background send or a background send is attempted although the connection was already closed, we'd lose any payload data tried to be submitted during that iteration.

I could trace the flakiness of `test_worker_reconnects_mid_compute_multiple_states_on_scheduler` back to this condition.

By simply prepending the payload to the buffer upon failure, there worker has a chance to resubmit this upon reconnect since the BatchedSend instance is the same

Closes https://github.com/dask/distributed/issues/5377

- [x] Dedicated unit test