### PR TITLE
Client method to dump cluster state

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -134,3 +134,12 @@ jobs:
         with:
           name: ${{ env.TEST_ID }}
           path: reports
+      - name: Upload deadlock reports
+        # ensure this runs even if pytest fails
+        if: >
+          always() &&
+          (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure')
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.TEST_ID }}-deadlocks
+          path: test_timeout_reports

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -142,4 +142,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ env.TEST_ID }}-deadlocks
-          path: test_timeout_reports
+          path: test_timeout_dump

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -134,7 +134,7 @@ jobs:
         with:
           name: ${{ env.TEST_ID }}
           path: reports
-      - name: Upload deadlock reports
+      - name: Upload timeout reports
         # ensure this runs even if pytest fails
         if: >
           always() &&

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -141,5 +141,5 @@ jobs:
           (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure')
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.TEST_ID }}-deadlocks
+          name: ${{ env.TEST_ID }}-timeouts
           path: test_timeout_dump

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ dask-worker-space/
 tags
 .ipynb_checkpoints
 .venv/
+
+# Test timeouts will dump the cluster state in here
+test_timeout_dump/

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3499,11 +3499,15 @@ class Client:
                 exclude=exclude,
             ),
         )
+        versions = self._get_versions()
+        scheduler_info, worker_info, versions_info = await asyncio.gather(
+            scheduler_info, worker_info, versions
+        )
 
-        scheduler_info, worker_info = await asyncio.gather(scheduler_info, worker_info)
         state = {
             "scheduler": scheduler_info,
             "workers": worker_info,
+            "versions": versions_info,
         }
         filename = str(filename)
         if format == "msgpack":

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -24,9 +24,10 @@ from contextvars import ContextVar
 from functools import partial
 from numbers import Number
 from queue import Queue as pyQueue
-from typing import Awaitable, ClassVar, Literal, Sequence
+from typing import Awaitable, ClassVar, Sequence
 
 from tlz import first, groupby, keymap, merge, partition_all, valmap
+from typing_extensions import Literal
 
 import dask
 from dask.base import collections_to_dsk, normalize_token, tokenize
@@ -3561,8 +3562,12 @@ class Client:
             or::
 
                 import yaml
+                try:
+                    from yaml import CLoader as Loader
+                except ImportError:
+                    from yaml import Loader
                 with open("filename") as fd:
-                    state = yaml.load(fd)
+                    state = yaml.load(fd, Loader=Loader)
 
         """
         return self.sync(

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -150,7 +150,7 @@ class Server:
             "identity": self.identity,
             "echo": self.echo,
             "connection_stream": self.handle_stream,
-            "dump_state": self.to_dict,
+            "dump_state": self._to_dict,
         }
         self.handlers.update(handlers)
         if blocked_handlers is None:
@@ -385,7 +385,7 @@ class Server:
     def identity(self, comm=None) -> dict[str, str]:
         return {"type": type(self).__name__, "id": self.id}
 
-    def to_dict(
+    def _to_dict(
         self, comm: Comm = None, *, exclude: Container[str] = None
     ) -> dict[str, str]:
         """

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from contextlib import suppress
 from enum import Enum
 from functools import partial
-from typing import ClassVar
+from typing import ClassVar, Container
 
 import tblib
 from tlz import merge
@@ -24,6 +24,7 @@ from dask.utils import parse_timedelta
 
 from . import profile, protocol
 from .comm import (
+    Comm,
     CommClosedError,
     connect,
     get_address_host_port,
@@ -147,6 +148,7 @@ class Server:
             "identity": self.identity,
             "echo": self.echo,
             "connection_stream": self.handle_stream,
+            "dump_state": self.to_dict,
         }
         self.handlers.update(handlers)
         if blocked_handlers is None:
@@ -378,8 +380,37 @@ class Server:
             _, self._port = get_address_host_port(self.address)
         return self._port
 
-    def identity(self, comm=None):
+    def identity(self, comm=None) -> dict[str, str]:
         return {"type": type(self).__name__, "id": self.id}
+
+    def to_dict(
+        self, comm: Comm = None, *, exclude: Container[str] = None
+    ) -> dict[str, str]:
+        """
+        A very verbose dictionary representation for debugging purposes.
+        Not type stable and not inteded for roundtrips.
+
+        Parameters
+        ----------
+        comm:
+        exclude:
+            A list of attributes which must not be present in the output.
+
+        See also
+        --------
+        Server.identity
+        Client.dump_cluster_state
+        """
+        from distributed.utils import recursive_to_dict
+
+        info = self.identity()
+        extra = {
+            "address": self.address,
+            "status": self.status.name,
+            "thread_id": self.thread_id,
+        }
+        info.update(extra)
+        return recursive_to_dict(info, exclude=exclude)
 
     def echo(self, comm=None, data=None):
         return data

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -22,6 +22,8 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 import dask
 from dask.utils import parse_timedelta
 
+from distributed.utils import recursive_to_dict
+
 from . import profile, protocol
 from .comm import (
     Comm,
@@ -401,7 +403,6 @@ class Server:
         Server.identity
         Client.dump_cluster_state
         """
-        from distributed.utils import recursive_to_dict
 
         info = self.identity()
         extra = {

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1730,7 +1730,7 @@ class TaskState:
         return nbytes
 
     @ccall
-    def to_dict(self, *, exclude: Container[str] = None):
+    def _to_dict(self, *, exclude: Container[str] = None):
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.
@@ -3974,7 +3974,7 @@ class Scheduler(SchedulerState, ServerNode):
         }
         return d
 
-    def to_dict(
+    def _to_dict(
         self, comm: Comm = None, *, exclude: Container[str] = None
     ) -> "dict[str, Any]":
         """
@@ -3993,7 +3993,7 @@ class Scheduler(SchedulerState, ServerNode):
         Client.dump_cluster_state
         """
 
-        info = super().to_dict(exclude=exclude)
+        info = super()._to_dict(exclude=exclude)
         extra = {
             "transition_log": self.transition_log,
             "log": self.log,
@@ -4003,8 +4003,8 @@ class Scheduler(SchedulerState, ServerNode):
         info.update(extra)
         extensions = {}
         for name, ex in self.extensions.items():
-            if hasattr(ex, "to_dict"):
-                extensions[name] = ex.to_dict()
+            if hasattr(ex, "_to_dict"):
+                extensions[name] = ex._to_dict()
         return recursive_to_dict(info, exclude=exclude)
 
     def get_worker_service_addr(self, worker, service_name, protocol=False):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1727,7 +1727,8 @@ class TaskState:
             nbytes += ts.get_nbytes()
         return nbytes
 
-    def to_dict(self, *, exclude: Container[str] = None) -> "dict[str, Any]":
+    @ccall
+    def to_dict(self, *, exclude: Container[str] = None):
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.
@@ -1749,7 +1750,7 @@ class TaskState:
             {
                 attr: getattr(self, attr)
                 for attr in self.__slots__
-                if attr not in exclude
+                if attr not in exclude and hasattr(self, attr)
             },
             exclude=exclude,
         )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1747,9 +1747,9 @@ class TaskState:
 
         if not exclude:
             exclude = set()
-        members = inspect.getmembers(self, lambda v: not callable(v))
+        members = inspect.getmembers(self)
         return recursive_to_dict(
-            {k: v for k, v in members if k not in exclude},
+            {k: v for k, v in members if k not in exclude and not callable(v)},
             exclude=exclude,
         )
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1747,12 +1747,9 @@ class TaskState:
 
         if not exclude:
             exclude = set()
+        members = inspect.getmembers(self, lambda v: not callable(v))
         return recursive_to_dict(
-            {
-                attr: getattr(self, attr)
-                for attr in self.__slots__
-                if attr not in exclude and hasattr(self, attr)
-            },
+            {k: v for k, v in members if k not in exclude},
             exclude=exclude,
         )
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -49,6 +49,8 @@ from dask.highlevelgraph import HighLevelGraph
 from dask.utils import format_bytes, format_time, parse_bytes, parse_timedelta, tmpfile
 from dask.widgets import get_template
 
+from distributed.utils import recursive_to_dict
+
 from . import preloading, profile
 from . import versions as version_module
 from .active_memory_manager import ActiveMemoryManagerExtension
@@ -1742,7 +1744,6 @@ class TaskState:
         --------
         Client.dump_cluster_state
         """
-        from distributed.utils import recursive_to_dict
 
         if not exclude:
             exclude = set()
@@ -3994,7 +3995,6 @@ class Scheduler(SchedulerState, ServerNode):
         Server.identity
         Client.dump_cluster_state
         """
-        from distributed.utils import recursive_to_dict
 
         info = super().to_dict(exclude=exclude)
         extra = {

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -82,7 +82,7 @@ class WorkStealing(SchedulerPlugin):
 
         self.scheduler.stream_handlers["steal-response"] = self.move_task_confirm
 
-    def to_dict(self, *, exclude: Container[str] = None) -> dict[str, Any]:
+    def _to_dict(self, *, exclude: Container[str] = None) -> dict[str, Any]:
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import logging
 from collections import defaultdict, deque
 from math import log2
 from time import time
+from typing import Any, Container
 
 from tlz import topk
 from tornado.ioloop import PeriodicCallback
@@ -12,7 +15,7 @@ from dask.utils import parse_timedelta
 from .comm.addressing import get_address_host
 from .core import CommClosedError
 from .diagnostics.plugin import SchedulerPlugin
-from .utils import log_errors
+from .utils import log_errors, recursive_to_dict
 
 # Stealing requires multiple network bounces and if successful also task
 # submission which may include code serialization. Therefore, be very
@@ -78,6 +81,32 @@ class WorkStealing(SchedulerPlugin):
         self.in_flight_occupancy = defaultdict(lambda: 0)
 
         self.scheduler.stream_handlers["steal-response"] = self.move_task_confirm
+
+    def to_dict(self, *, exclude: Container[str] = None) -> dict[str, Any]:
+        """
+        A very verbose dictionary representation for debugging purposes.
+        Not type stable and not inteded for roundtrips.
+
+        Parameters
+        ----------
+        comm:
+        exclude:
+            A list of attributes which must not be present in the output.
+
+        See also
+        --------
+        Client.dump_cluster_state
+        """
+        return recursive_to_dict(
+            {
+                "stealable_all": self.stealable_all,
+                "stealable": self.stealable,
+                "key_stealable": self.key_stealable,
+                "in_flight": self.in_flight,
+                "in_flight_occupancy": self.in_flight_occupancy,
+            },
+            exclude=exclude,
+        )
 
     def log(self, msg):
         return self.scheduler.log_event("stealing", msg)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import functools
 import gc
 import inspect
@@ -7087,3 +7088,94 @@ def test_print_simple(capsys):
 
     out, err = capsys.readouterr()
     assert "Hello!:123" in out
+
+
+def _verify_cluster_dump(path, _format):
+    mode = "r"
+    _open = open
+    if _format == "msgpack":
+        import gzip
+
+        import msgpack
+
+        with gzip.open(path) as fd:
+            state = msgpack.unpack(fd)
+    else:
+        import yaml
+
+        with open(path) as fd:
+            state = yaml.load(fd)
+
+    assert isinstance(state, dict)
+    assert "scheduler_info" in state
+    assert "worker_info" in state
+
+
+@pytest.mark.parametrize("_format", ["msgpack", "json", "yaml"])
+def test_dump_cluster_state(c, s, a, b, tmp_path, _format):
+
+    if _format == "json":
+        ctx = pytest.raises(ValueError, match="Unsupported format")
+    else:
+        ctx = contextlib.nullcontext()
+
+    filename = tmp_path / "foo"
+    with ctx:
+        c.dump_cluster_state(
+            filename=filename,
+            format=_format,
+        )
+
+        _verify_cluster_dump(filename, _format)
+
+
+@pytest.mark.parametrize("_format", ["msgpack", "json", "yaml"])
+@gen_cluster(client=True)
+async def test_dump_cluster_state_async(c, s, a, b, tmp_path, _format):
+
+    if _format == "json":
+        ctx = pytest.raises(ValueError, match="Unsupported format")
+    else:
+        ctx = contextlib.nullcontext()
+
+    filename = tmp_path / "foo"
+    with ctx:
+        await c.dump_cluster_state(
+            filename=filename,
+            format=_format,
+        )
+
+        _verify_cluster_dump(filename, _format)
+
+
+@gen_cluster(client=True)
+async def test_dump_cluster_state_exclude(c, s, a, b, tmp_path):
+
+    futs = c.map(inc, range(10))
+    while len(s.tasks) != len(futs):
+        await asyncio.sleep(0.01)
+    exclude = [
+        # these are TaskState attributes
+        "_runspec",
+        "runspec",
+    ]
+    filename = tmp_path / "foo"
+    await c.dump_cluster_state(
+        filename=filename,
+        format="yaml",
+    )
+
+    with open(filename) as fd:
+        import yaml
+
+        state = yaml.load(fd)
+
+    assert "worker_info" in state
+    assert len(state["worker_info"]) == len(s.workers)
+    assert "scheduler_info" in state
+    assert "tasks" in state["scheduler_info"]
+    tasks = state["scheduler_info"]["tasks"]
+    assert len(tasks) == len(futs)
+    for k, task_dump in tasks.items():
+        assert not any(blocked in task_dump for blocked in exclude)
+        assert k in s.tasks

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7111,6 +7111,7 @@ def _verify_cluster_dump(path, _format):
     assert isinstance(state, dict)
     assert "scheduler" in state
     assert "workers" in state
+    assert "versions" in state
 
 
 @pytest.mark.parametrize("_format", ["msgpack", "json", "yaml"])

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7091,24 +7091,26 @@ def test_print_simple(capsys):
 
 
 def _verify_cluster_dump(path, _format):
-    mode = "r"
-    _open = open
+    path = str(path)
     if _format == "msgpack":
         import gzip
 
         import msgpack
+
+        path += ".msgpack.gz"
 
         with gzip.open(path) as fd:
             state = msgpack.unpack(fd)
     else:
         import yaml
 
+        path += ".yaml"
         with open(path) as fd:
             state = yaml.load(fd, Loader=yaml.Loader)
 
     assert isinstance(state, dict)
-    assert "scheduler_info" in state
-    assert "worker_info" in state
+    assert "scheduler" in state
+    assert "workers" in state
 
 
 @pytest.mark.parametrize("_format", ["msgpack", "json", "yaml"])
@@ -7165,16 +7167,16 @@ async def test_dump_cluster_state_exclude(c, s, a, b, tmp_path):
         format="yaml",
     )
 
-    with open(filename) as fd:
+    with open(str(filename) + ".yaml") as fd:
         import yaml
 
         state = yaml.load(fd, Loader=yaml.Loader)
 
-    assert "worker_info" in state
-    assert len(state["worker_info"]) == len(s.workers)
-    assert "scheduler_info" in state
-    assert "tasks" in state["scheduler_info"]
-    tasks = state["scheduler_info"]["tasks"]
+    assert "workers" in state
+    assert len(state["workers"]) == len(s.workers)
+    assert "scheduler" in state
+    assert "tasks" in state["scheduler"]
+    tasks = state["scheduler"]["tasks"]
     assert len(tasks) == len(futs)
     for k, task_dump in tasks.items():
         assert not any(blocked in task_dump for blocked in exclude)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7104,7 +7104,7 @@ def _verify_cluster_dump(path, _format):
         import yaml
 
         with open(path) as fd:
-            state = yaml.load(fd)
+            state = yaml.load(fd, Loader=yaml.Loader)
 
     assert isinstance(state, dict)
     assert "scheduler_info" in state
@@ -7168,7 +7168,7 @@ async def test_dump_cluster_state_exclude(c, s, a, b, tmp_path):
     with open(filename) as fd:
         import yaml
 
-        state = yaml.load(fd)
+        state = yaml.load(fd, Loader=yaml.Loader)
 
     assert "worker_info" in state
     assert len(state["worker_info"]) == len(s.workers)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3248,3 +3248,26 @@ async def test_unpause_schedules_unrannable_tasks(c, s, a):
 
     a.memory_pause_fraction = 0.8
     assert await fut == 2
+
+
+@gen_cluster(client=True)
+async def test_to_dict(c, s, a, b):
+    futs = c.map(inc, range(100))
+
+    await c.gather(futs)
+    dct = Scheduler.to_dict(s)
+    assert list(dct.keys()) == [
+        "type",
+        "id",
+        "address",
+        "services",
+        "started",
+        "workers",
+        "status",
+        "thread_id",
+        "transition_log",
+        "log",
+        "tasks",
+        "events",
+    ]
+    assert dct["tasks"][futs[0].key]

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3251,11 +3251,11 @@ async def test_unpause_schedules_unrannable_tasks(c, s, a):
 
 
 @gen_cluster(client=True)
-async def test_to_dict(c, s, a, b):
+async def test__to_dict(c, s, a, b):
     futs = c.map(inc, range(100))
 
     await c.gather(futs)
-    dct = Scheduler.to_dict(s)
+    dct = Scheduler._to_dict(s)
     assert list(dct.keys()) == [
         "type",
         "id",

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -506,7 +506,7 @@ def test_is_valid_xml():
         assert is_valid_xml("<a>foo")
 
 
-def testformat_dashboard_link():
+def test_format_dashboard_link():
     with dask.config.set({"distributed.dashboard.link": "foo"}):
         assert format_dashboard_link("host", 1234) == "foo"
 

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -506,7 +506,7 @@ def test_is_valid_xml():
         assert is_valid_xml("<a>foo")
 
 
-def test_format_dashboard_link():
+def testformat_dashboard_link():
     with dask.config.set({"distributed.dashboard.link": "foo"}):
         assert format_dashboard_link("host", 1234) == "foo"
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -364,7 +364,7 @@ def test_provide_stack_on_timeout():
 
     # If this timeout is too small, the cluster setup/teardown might take too
     # long and the timeout error we'll receive will be different
-    test = gen_cluster(client=True, timeout=2)(inner_test)
+    test = gen_cluster(client=True, timeout=2, cluster_dump_directory=False)(inner_test)
 
     start = time()
     with pytest.raises(asyncio.TimeoutError) as exc:

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -397,7 +397,7 @@ def test_dump_cluster_state_timeout(tmp_path):
     import yaml
 
     with open(tmp_path / files[0], "rb") as fd:
-        state = yaml.load(fd)
+        state = yaml.load(fd, Loader=yaml.Loader)
 
     assert "scheduler_info" in state
     assert "worker_info" in state

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -393,11 +393,11 @@ def test_dump_cluster_state_timeout(tmp_path):
 
     _, dirs, files = next(os.walk(tmp_path))
     assert not dirs
-    assert files == [inner_test.__name__]
+    assert files == [inner_test.__name__ + ".yaml"]
     import yaml
 
     with open(tmp_path / files[0], "rb") as fd:
         state = yaml.load(fd, Loader=yaml.Loader)
 
-    assert "scheduler_info" in state
-    assert "worker_info" in state
+    assert "scheduler" in state
+    assert "workers" in state

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1449,7 +1449,7 @@ def __getattr__(name):
 if TYPE_CHECKING:
 
     class SupportsToDict(Protocol):
-        def to_dict(
+        def _to_dict(
             self, *, exclude: Container[str] | None = None, **kwargs
         ) -> dict[str, AnyType]:
             ...
@@ -1485,18 +1485,20 @@ def recursive_to_dict(
 
 def recursive_to_dict(obj, exclude=None, seen=None):
     """
-    This is for debugging purposes only and calls `to_dict` methods on `obj` or
+    This is for debugging purposes only and calls ``_to_dict`` methods on ``obj`` or
     it's elements recursively, if available. The output of this function is
     intended to be json serializable.
 
     Parameters
     ----------
     exclude:
-        A list of attribute names to be excluded from the dump. This will be forwarded to the objects to_dict methods and these methods are required to ensure this.
+        A list of attribute names to be excluded from the dump.
+        This will be forwarded to the objects ``_to_dict`` methods and these methods
+        are required to ensure this.
     seen:
         Used internally to avoid infinite recursion. If an object has already
         been encountered, it's representation will be generated instead of its
-        to_dict. This is necessary since we have multiple cyclic referencing
+        ``_to_dict``. This is necessary since we have multiple cyclic referencing
         data structures.
     """
     if obj is None:
@@ -1510,8 +1512,8 @@ def recursive_to_dict(obj, exclude=None, seen=None):
     seen.add(id(obj))
     if isinstance(obj, type):
         return repr(obj)
-    if hasattr(obj, "to_dict"):
-        return obj.to_dict(exclude=exclude)
+    if hasattr(obj, "_to_dict"):
+        return obj._to_dict(exclude=exclude)
     if isinstance(obj, (deque, set)):
         obj = tuple(obj)
     if isinstance(obj, (list, tuple)):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1508,6 +1508,8 @@ def recursive_to_dict(obj, exclude=None, seen=None):
     if id(obj) in seen:
         return repr(obj)
     seen.add(id(obj))
+    if isinstance(obj, type):
+        return repr(obj)
     if hasattr(obj, "to_dict"):
         return obj.to_dict(exclude=exclude)
     if isinstance(obj, (deque, set)):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -25,10 +25,11 @@ from hashlib import md5
 from importlib.util import cache_from_source
 from time import sleep
 from typing import Any as AnyType
-from typing import ClassVar
+from typing import ClassVar, Container, Sequence, overload
 
 import click
 import tblib.pickling_support
+from typing_extensions import Protocol
 
 try:
     import resource
@@ -1440,3 +1441,91 @@ def __getattr__(name):
         return import_term(use_instead)
     else:
         raise AttributeError(f"module {__name__} has no attribute {name}")
+
+
+class SupportsToDict(Protocol):
+    def to_dict(
+        self, *, exclude: Container[str] | None = None, **kwargs
+    ) -> dict[str, AnyType]:
+        ...
+
+
+@overload
+def recursive_to_dict(
+    obj: SupportsToDict, exclude: Container[str] = None, seen: set[AnyType] = None
+) -> dict[str, AnyType]:
+    ...
+
+
+@overload
+def recursive_to_dict(
+    obj: Sequence, exclude: Container[str] = None, seen: set[AnyType] = None
+) -> Sequence:
+    ...
+
+
+@overload
+def recursive_to_dict(
+    obj: dict, exclude: Container[str] = None, seen: set[AnyType] = None
+) -> dict:
+    ...
+
+
+@overload
+def recursive_to_dict(
+    obj: None, exclude: Container[str] = None, seen: set[AnyType] = None
+) -> None:
+    ...
+
+
+def recursive_to_dict(obj, exclude=None, seen=None):
+    """
+    This is for debugging purposes only and calls `to_dict` methods on `obj` or
+    it's elements recursively, if available. The output of this function is
+    intended to be json serializable.
+
+    Parameters
+    ----------
+    exclude:
+        A list of attribute names to be excluded from the dump. This will be forwarded to the objects to_dict methods and these methods are required to ensure this.
+    seen:
+        Used internally to avoid infinite recursion. If an object has already
+        been encountered, it's representation will be generated instead of its
+        to_dict. This is necessary since we have multiple cyclic referencing
+        data structures.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, str):
+        return obj
+    if seen is None:
+        seen = set()
+    if id(obj) in seen:
+        return repr(obj)
+    seen.add(id(obj))
+    if hasattr(obj, "to_dict"):
+        return obj.to_dict(exclude=exclude)
+    if isinstance(obj, (deque, set)):
+        obj = tuple(obj)
+    if isinstance(obj, (list, tuple)):
+        return tuple(
+            recursive_to_dict(
+                el,
+                exclude=exclude,
+                seen=seen,
+            )
+            for el in obj
+        )
+    elif isinstance(obj, dict):
+        res = {}
+        for k, v in obj.items():
+            k = recursive_to_dict(k, exclude=exclude, seen=seen)
+            try:
+                hash(k)
+            except TypeError:
+                k = str(k)
+            v = recursive_to_dict(v, exclude=exclude, seen=seen)
+            res[k] = v
+        return res
+    else:
+        return repr(obj)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -24,12 +24,15 @@ from contextlib import contextmanager, suppress
 from hashlib import md5
 from importlib.util import cache_from_source
 from time import sleep
+from typing import TYPE_CHECKING
 from typing import Any as AnyType
 from typing import ClassVar, Container, Sequence, overload
 
 import click
 import tblib.pickling_support
-from typing_extensions import Protocol
+
+if TYPE_CHECKING:
+    from typing_extensions import Protocol
 
 try:
     import resource
@@ -1443,11 +1446,13 @@ def __getattr__(name):
         raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
-class SupportsToDict(Protocol):
-    def to_dict(
-        self, *, exclude: Container[str] | None = None, **kwargs
-    ) -> dict[str, AnyType]:
-        ...
+if TYPE_CHECKING:
+
+    class SupportsToDict(Protocol):
+        def to_dict(
+            self, *, exclude: Container[str] | None = None, **kwargs
+        ) -> dict[str, AnyType]:
+            ...
 
 
 @overload

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -27,9 +27,10 @@ from contextlib import contextmanager, nullcontext, suppress
 from glob import glob
 from itertools import count
 from time import sleep
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from typing_extensions import Literal
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 from distributed.scheduler import Scheduler
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -880,6 +880,7 @@ def gen_cluster(
     config: dict[str, Any] = {},
     clean_kwargs: dict[str, Any] = {},
     allow_unclosed: bool = False,
+    cluster_dump_directory="test_timeout_dump",
 ) -> Callable[[Callable], Callable]:
     from distributed import Client
 
@@ -979,7 +980,26 @@ def gen_cluster(
 
                             if client:
                                 assert c
-                                await dump_cluster_state(c, func.__name__)
+                                try:
+                                    if not os.path.exists(cluster_dump_directory):
+                                        os.makedirs(cluster_dump_directory)
+                                    filename = os.path.join(
+                                        cluster_dump_directory, func.__name__
+                                    )
+                                    fut = c.dump_cluster_state(
+                                        filename,
+                                        # Test dumps should be small enough that
+                                        # there is no need for a compressed
+                                        # binary representation and readability
+                                        # is more important
+                                        format="yaml",
+                                    )
+                                    assert fut is not None
+                                    await fut
+                                except Exception:
+                                    print(
+                                        f"Exception {sys.exc_info()} while trying to dump cluster state."
+                                    )
 
                             task.cancel()
                             while not task.cancelled():
@@ -1726,156 +1746,3 @@ class _LockedCommPool(ConnectionPool):
         return LockedComm(
             comm, self.read_event, self.read_queue, self.write_event, self.write_queue
         )
-
-
-async def dump_cluster_state(client, directory):
-    from collections import deque
-
-    def _normalize(o, simple=False):
-        from distributed.scheduler import TaskState as TSScheduler
-        from distributed.scheduler import WorkerState
-        from distributed.worker import TaskState as TSWorker
-
-        # Blacklist runspec since this includes serialized functions
-        # and arguments which might include sensitive data
-        blacklist_attributes = [
-            "runspec",
-            "_run_spec",
-            "exception",
-            "traceback",
-            "_exception",
-            "_traceback",
-        ]
-
-        if isinstance(o, dict):
-            try:
-                res = {}
-                for k, v in o.items():
-                    k = _normalize(k, simple=simple)
-                    try:
-                        hash(k)
-                    except TypeError:
-                        k = str(k)
-                    v = _normalize(v, simple=simple)
-                    res[k] = v
-                return res
-
-            except TypeError:
-                print({k: type(k) for k in o})
-                raise
-        elif isinstance(o, (set, deque, tuple, list)):
-            return [_normalize(el, simple=simple) for el in o]
-        elif isinstance(o, WorkerState):
-            res = o.identity()
-            res["memory"] = {
-                "managed": o.memory.managed,
-                "managed_in_memory": o.memory.managed_in_memory,
-                "managed_spilled": o.memory.managed_spilled,
-                "unmanaged": o.memory.unmanaged,
-                "unmanaged_recent": o.memory.unmanaged_recent,
-            }
-            return res
-        elif isinstance(o, TSScheduler):
-            if simple:
-                # Due to cylcic references in the dependent/dependency graph
-                # mapping this causes an infinite recursion
-                return str(o)
-            base = {
-                "type": str(type(o)),
-                "repr": str(o),
-            }
-            base.update(
-                {
-                    s: _normalize(getattr(o, s), simple=True)
-                    for s in TSScheduler.__slots__
-                    if s not in blacklist_attributes
-                }
-            )
-            return base
-        elif isinstance(o, (TSWorker, TSScheduler)):
-            if simple:
-                # Due to cylcic references in the dependent/dependency graph
-                # mapping this causes an infinite recursion
-                return str(o)
-            return _normalize(
-                {k: v for k, v in o.__dict__.items() if k not in blacklist_attributes},
-                simple=True,
-            )
-        else:
-            return str(o)
-
-    def get_worker_info(dask_worker):
-        import dask
-
-        return _normalize(
-            {
-                "status": dask_worker.status,
-                "ready": dask_worker.ready,
-                "constrained": dask_worker.constrained,
-                "long_running": dask_worker.long_running,
-                "executing_count": dask_worker.executing_count,
-                "in_flight_tasks": dask_worker.in_flight_tasks,
-                "in_flight_workers": dask_worker.in_flight_workers,
-                "paused": dask_worker.paused
-                if hasattr(dask_worker, "paused")
-                else None,
-                "log": dask_worker.log,
-                "tasks": dask_worker.tasks,
-                "memory_limit": dask_worker.memory_limit,
-                "memory_target_fraction": dask_worker.memory_target_fraction,
-                "memory_spill_fraction": dask_worker.memory_spill_fraction,
-                "memory_pause_fraction": dask_worker.memory_pause_fraction,
-                "logs": dask_worker.get_logs(),
-                "config": dict(dask.config.config),
-                "incoming_transfer_log": list(dask_worker.incoming_transfer_log),
-                "outgoing_transfer_log": list(dask_worker.outgoing_transfer_log),
-            }
-        )
-
-    def get_scheduler_info(dask_scheduler):
-        import dask
-
-        state = {
-            "transition_log": dask_scheduler.transition_log,
-            "log": dask_scheduler.log,
-            "tasks": dask_scheduler.tasks,
-            "workers": dask_scheduler.workers,
-            "logs": dask_scheduler.get_logs(),
-            "config": dict(dask.config.config),
-            "events": dask_scheduler.events,
-        }
-        if "stealing" in dask_scheduler.extensions:
-            ext = dask_scheduler.extensions["stealing"]
-            attrs = [
-                "stealable_all",
-                "stealable",
-                "key_stealable",
-                "in_flight",
-            ]
-            stealing = {at: getattr(ext, at) for at in attrs}
-
-            in_flight_occ = ext.in_flight_occupancy
-            stealing["in_flight_occupancy"] = {
-                ws.name: v for ws, v in in_flight_occ.items()
-            }
-            state["stealing"] = stealing
-        return _normalize(state)
-
-    import gzip
-
-    import msgpack
-
-    scheduler_info = await client.run_on_scheduler(get_scheduler_info)
-    worker_info = await client.run(get_worker_info)
-
-    filename = directory
-    state = {
-        "scheduler_info": scheduler_info,
-        "worker_info": worker_info,
-    }
-    directory = "test_timeout_reports"
-    if not os.path.exists(directory):
-        os.mkdir(directory)
-
-    with gzip.open(os.path.join(directory, f"{filename}.msgpack.gz"), "wb") as fd:
-        return msgpack.pack(state, fd)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -29,6 +29,8 @@ from itertools import count
 from time import sleep
 from typing import Any
 
+from typing_extensions import Literal
+
 from distributed.scheduler import Scheduler
 
 try:
@@ -880,7 +882,7 @@ def gen_cluster(
     config: dict[str, Any] = {},
     clean_kwargs: dict[str, Any] = {},
     allow_unclosed: bool = False,
-    cluster_dump_directory="test_timeout_dump",
+    cluster_dump_directory: str | Literal[False] = "test_timeout_dump",
 ) -> Callable[[Callable], Callable]:
     from distributed import Client
 
@@ -981,21 +983,22 @@ def gen_cluster(
                             if client:
                                 assert c
                                 try:
-                                    if not os.path.exists(cluster_dump_directory):
-                                        os.makedirs(cluster_dump_directory)
-                                    filename = os.path.join(
-                                        cluster_dump_directory, func.__name__
-                                    )
-                                    fut = c.dump_cluster_state(
-                                        filename,
-                                        # Test dumps should be small enough that
-                                        # there is no need for a compressed
-                                        # binary representation and readability
-                                        # is more important
-                                        format="yaml",
-                                    )
-                                    assert fut is not None
-                                    await fut
+                                    if cluster_dump_directory:
+                                        if not os.path.exists(cluster_dump_directory):
+                                            os.makedirs(cluster_dump_directory)
+                                        filename = os.path.join(
+                                            cluster_dump_directory, func.__name__
+                                        )
+                                        fut = c.dump_cluster_state(
+                                            filename,
+                                            # Test dumps should be small enough that
+                                            # there is no need for a compressed
+                                            # binary representation and readability
+                                            # is more important
+                                            format="yaml",
+                                        )
+                                        assert fut is not None
+                                        await fut
                                 except Exception:
                                     print(
                                         f"Exception {sys.exc_info()} while trying to dump cluster state."

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -19,7 +19,7 @@ from contextlib import suppress
 from datetime import timedelta
 from inspect import isawaitable
 from pickle import PicklingError
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Container
 
 if TYPE_CHECKING:
     from typing_extensions import Literal
@@ -46,7 +46,7 @@ from dask.utils import (
 
 from . import comm, preloading, profile, system, utils
 from .batched import BatchedSend
-from .comm import connect, get_address_host
+from .comm import Comm, connect, get_address_host
 from .comm.addressing import address_from_user_args, parse_address
 from .comm.utils import OFFLOAD_THRESHOLD
 from .core import (
@@ -83,6 +83,7 @@ from .utils import (
     log_errors,
     offload,
     parse_ports,
+    recursive_to_dict,
     silence_logging,
     thread_state,
     warn_on_duration,
@@ -222,6 +223,35 @@ class TaskState:
     def get_nbytes(self) -> int:
         nbytes = self.nbytes
         return nbytes if nbytes is not None else DEFAULT_DATA_SIZE
+
+    def to_dict(self, *, exclude: Container[str] = None) -> dict[str, Any]:
+        """
+        A very verbose dictionary representation for debugging purposes.
+        Not type stable and not inteded for roundtrips.
+
+        Parameters
+        ----------
+        comm:
+        exclude:
+            A list of attributes which must not be present in the output.
+
+        See also
+        --------
+        Client.dump_cluster_state
+        """
+        from distributed.utils import recursive_to_dict
+
+        if exclude is None:
+            exclude = set()
+
+        return recursive_to_dict(
+            {
+                attr: getattr(self, attr)
+                for attr in self.__dict__.keys()
+                if attr not in exclude
+            },
+            exclude=exclude,
+        )
 
     def is_protected(self) -> bool:
         return self.state in PROCESSING or any(
@@ -1090,6 +1120,47 @@ class Worker(ServerNode):
             "ncores": self.nthreads,  # backwards compatibility
             "memory_limit": self.memory_limit,
         }
+
+    def to_dict(
+        self, comm: Comm = None, *, exclude: Container[str] = None
+    ) -> dict[str, Any]:
+        """
+        A very verbose dictionary representation for debugging purposes.
+        Not type stable and not inteded for roundtrips.
+
+        Parameters
+        ----------
+        comm:
+        exclude:
+            A list of attributes which must not be present in the output.
+
+        See also
+        --------
+        Worker.identity
+        Client.dump_cluster_state
+        """
+        info = super().to_dict(exclude=exclude)
+        extra = {
+            "status": self.status,
+            "ready": self.ready,
+            "constrained": self.constrained,
+            "long_running": self.long_running,
+            "executing_count": self.executing_count,
+            "in_flight_tasks": self.in_flight_tasks,
+            "in_flight_workers": self.in_flight_workers,
+            "log": self.log,
+            "tasks": self.tasks,
+            "memory_limit": self.memory_limit,
+            "memory_target_fraction": self.memory_target_fraction,
+            "memory_spill_fraction": self.memory_spill_fraction,
+            "memory_pause_fraction": self.memory_pause_fraction,
+            "logs": self.get_logs(),
+            "config": dict(dask.config.config),
+            "incoming_transfer_log": list(self.incoming_transfer_log),
+            "outgoing_transfer_log": list(self.outgoing_transfer_log),
+        }
+        info.update(extra)
+        return recursive_to_dict(info, exclude=exclude)
 
     #####################
     # External Services #

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -239,7 +239,6 @@ class TaskState:
         --------
         Client.dump_cluster_state
         """
-        from distributed.utils import recursive_to_dict
 
         if exclude is None:
             exclude = set()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -224,7 +224,7 @@ class TaskState:
         nbytes = self.nbytes
         return nbytes if nbytes is not None else DEFAULT_DATA_SIZE
 
-    def to_dict(self, *, exclude: Container[str] = None) -> dict[str, Any]:
+    def _to_dict(self, *, exclude: Container[str] = None) -> dict[str, Any]:
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.
@@ -1120,7 +1120,7 @@ class Worker(ServerNode):
             "memory_limit": self.memory_limit,
         }
 
-    def to_dict(
+    def _to_dict(
         self, comm: Comm = None, *, exclude: Container[str] = None
     ) -> dict[str, Any]:
         """
@@ -1138,7 +1138,7 @@ class Worker(ServerNode):
         Worker.identity
         Client.dump_cluster_state
         """
-        info = super().to_dict(exclude=exclude)
+        info = super()._to_dict(exclude=exclude)
         extra = {
             "status": self.status,
             "ready": self.ready,


### PR DESCRIPTION
This adds a client method to dump the entire cluster state in a file for debugging purposes. This has been incredibly handy for the deadlock scenarios I've been debugging recently.

This method is called automatically in case a test is running into a timeout and persists the content as part of a GH artefact. This should help us debug spurious, flaky test failures.

I implemented the test dump as a yaml for readability but for real world examples, yaml is not well suited. In my experience these dumps can grow several ~MB~ GB and a feasible approach, so far, was to use msgpack + gzip. That's all not set in stone.

The implementation is not very elegant but I added a `to_dict` method, similar but more verbose to `identity` to most relevant classes. If somebody has an idea about a more elegant approach, I'm all ears

<details>

<summary>Example output</summary>

```yaml
scheduler_info:
  address: tcp://127.0.0.1:38993
  events:
    Client-cb05ef34-372a-11ec-881b-e9dd5dbb64c5: !!python/tuple
    - '(1635341747.6048865, {''action'': ''add-client'', ''client'': ''Client-cb05ef34-372a-11ec-881b-e9dd5dbb64c5''})'
    all: !!python/tuple
    - !!python/tuple
      - '1635341747.5759628'
      - action: add-worker
        worker: tcp://127.0.0.1:41249
    - !!python/tuple
      - '1635341747.5792954'
      - action: add-worker
        worker: tcp://127.0.0.1:42413
    - !!python/tuple
      - '1635341747.6048865'
      - action: add-client
        client: Client-cb05ef34-372a-11ec-881b-e9dd5dbb64c5
    stealing: !!python/tuple []
    tcp://127.0.0.1:41249: !!python/tuple
    - !!python/tuple
      - '1635341747.5758505'
      - action: heartbeat
        bandwidth:
          total: '100000000'
          types: {}
          workers: {}
        cpu: '0.0'
        executing: '0'
        in_flight: '0'
        in_memory: '0'
        memory: '134877184'
        num_fds: '24'
        read_bytes: '0.0'
        read_bytes_disk: '0.0'
        ready: '0'
        spilled_nbytes: '0'
        time: '1635341747.557952'
        write_bytes: '0.0'
        write_bytes_disk: '0.0'
    - !!python/tuple
      - '1635341747.5759585'
      - action: add-worker
    - !!python/tuple
      - '1635341747.5858035'
      - action: worker-status-change
        prev-status: undefined
        status: running
    - !!python/tuple
      - '1635341748.5936973'
      - action: heartbeat
        bandwidth:
          total: '100000000'
          types: {}
          workers: {}
        cpu: '4.0'
        executing: '0'
        in_flight: '0'
        in_memory: '0'
        memory: '135020544'
        num_fds: '39'
        read_bytes: '0.0'
        read_bytes_disk: '0.0'
        ready: '0'
        spilled_nbytes: '0'
        time: '1635341748.5843215'
        write_bytes: '0.0'
        write_bytes_disk: '0.0'
    - !!python/tuple
      - '1635341749.5884714'
      - action: heartbeat
        bandwidth:
          total: '100000000'
          types: {}
          workers: {}
        cpu: '4.0'
        executing: '0'
        in_flight: '0'
        in_memory: '0'
        memory: '135135232'
        num_fds: '43'
        read_bytes: '0.0'
        read_bytes_disk: '0.0'
        ready: '0'
        spilled_nbytes: '0'
        time: '1635341749.5846045'
        write_bytes: '0.0'
        write_bytes_disk: '0.0'
    tcp://127.0.0.1:42413: !!python/tuple
    - !!python/tuple
      - '1635341747.579201'
      - action: heartbeat
        bandwidth:
          total: '100000000'
          types: {}
          workers: {}
        cpu: '0.0'
        executing: '0'
        in_flight: '0'
        in_memory: '0'
        memory: '134877184'
        num_fds: '25'
        read_bytes: '0.0'
        read_bytes_disk: '0.0'
        ready: '0'
        spilled_nbytes: '0'
        time: '1635341747.5610273'
        write_bytes: '0.0'
        write_bytes_disk: '0.0'
    - !!python/tuple
      - '1635341747.579291'
      - action: add-worker
    - !!python/tuple
      - '1635341747.5859537'
      - action: worker-status-change
        prev-status: undefined
        status: running
    - !!python/tuple
      - '1635341748.5940423'
      - action: heartbeat
        bandwidth:
          total: '100000000'
          types: {}
          workers: {}
        cpu: '11.4'
        executing: '0'
        in_flight: '0'
        in_memory: '0'
        memory: '135020544'
        num_fds: '39'
        read_bytes: '16806.444267185172'
        read_bytes_disk: '0.0'
        ready: '0'
        spilled_nbytes: '0'
        time: '1635341748.085588'
        write_bytes: '26748.096587213608'
        write_bytes_disk: '0.0'
    - !!python/tuple
      - '1635341749.5887933'
      - action: heartbeat
        bandwidth:
          total: '100000000'
          types: {}
          workers: {}
        cpu: '4.0'
        executing: '0'
        in_flight: '0'
        in_memory: '0'
        memory: '135135232'
        num_fds: '43'
        read_bytes: '0.0'
        read_bytes_disk: '0.0'
        ready: '0'
        spilled_nbytes: '0'
        time: '1635341749.5856717'
        write_bytes: '0.0'
        write_bytes_disk: '0.0'
  id: Scheduler-87138d38-3606-49a3-b896-5d2d5d31bff7
  log: !!python/tuple []
  services:
    dashboard: '33755'
  started: '1635341747.549502'
  status: running
  tasks: {}
  thread_id: '140209022129984'
  transition_log: !!python/tuple []
  type: Scheduler
  workers:
    tcp://127.0.0.1:41249:
      host: 127.0.0.1
      id: '0'
      last_seen: '1635341749.5884442'
      local_directory: /home/runner/work/distributed/distributed/dask-worker-space/worker-eru8w8qn
      memory_limit: '7291699200'
      metrics:
        bandwidth:
          total: '100000000'
          types: {}
          workers: {}
        cpu: '4.0'
        executing: '0'
        in_flight: '0'
        in_memory: '0'
        memory: '135135232'
        num_fds: '43'
        read_bytes: '0.0'
        read_bytes_disk: '0.0'
        ready: '0'
        spilled_nbytes: '0'
        time: '1635341749.5846045'
        write_bytes: '0.0'
        write_bytes_disk: '0.0'
      name: '0'
      nanny: null
      nthreads: '1'
      resources: {}
      services:
        dashboard: '34057'
      type: Worker
    tcp://127.0.0.1:42413:
      host: 127.0.0.1
      id: '1'
      last_seen: '1635341749.588775'
      local_directory: /home/runner/work/distributed/distributed/dask-worker-space/worker-uj4ir590
      memory_limit: '7291699200'
      metrics:
        bandwidth:
          total: '100000000'
          types: {}
          workers: {}
        cpu: '4.0'
        executing: '0'
        in_flight: '0'
        in_memory: '0'
        memory: '135135232'
        num_fds: '43'
        read_bytes: '0.0'
        read_bytes_disk: '0.0'
        ready: '0'
        spilled_nbytes: '0'
        time: '1635341749.5856717'
        write_bytes: '0.0'
        write_bytes_disk: '0.0'
      name: '1'
      nanny: null
      nthreads: '2'
      resources: {}
      services:
        dashboard: '41997'
      type: Worker
worker_info:
  tcp://127.0.0.1:41249:
    address: tcp://127.0.0.1:41249
    config:
      array:
        chunk-size: 128MiB
        rechunk-threshold: '4'
        slicing:
          split-large-chunks: null
        svg:
          size: '120'
      dataframe:
        parquet:
          metadata-task-size-local: '512'
          metadata-task-size-remote: '16'
        shuffle-compression: null
      distributed:
        adaptive:
          interval: 1s
          maximum: inf
          minimum: '0'
          target-duration: 5s
          wait-count: '3'
        admin:
          event-loop: tornado
          log-format: '%(name)s - %(levelname)s - %(message)s'
          log-length: '10000'
          max-error-length: '10000'
          pdb-on-err: 'False'
          system-monitor:
            interval: 500ms
          tick:
            interval: 20ms
            limit: 3s
        client:
          heartbeat: 5s
          scheduler-info-interval: 2s
        comm:
          compression: auto
          default-scheme: tcp
          offload: 10MiB
          recent-messages-log-length: '0'
          require-encryption: null
          retry:
            count: '0'
            delay:
              max: 20s
              min: 1s
          shard: 64MiB
          socket-backlog: '2048'
          timeouts:
            connect: 5s
            tcp: 30s
          tls:
            ca-file: null
            ciphers: null
            client:
              cert: null
              key: null
            scheduler:
              cert: null
              key: null
            worker:
              cert: null
              key: null
          ucx:
            cuda_copy: 'False'
            infiniband: 'False'
            net-devices: null
            nvlink: 'False'
            rdmacm: 'False'
            reuse-endpoints: null
            tcp: 'False'
          websockets:
            shard: 8MiB
          zstd:
            level: '3'
            threads: '0'
        dashboard:
          export-tool: 'False'
          graph-max-items: '5000'
          link: '{scheme}://{host}:{port}/status'
          prometheus:
            namespace: dask
        deploy:
          cluster-repr-interval: 500ms
          lost-worker-timeout: 15s
        diagnostics:
          computations:
            ignore-modules: !!python/tuple
            - distributed
            - dask
            - xarray
            - cudf
            - cuml
            - prefect
            - xgboost
            max-history: '100'
          nvml: 'True'
        nanny:
          environ:
            MALLOC_TRIM_THRESHOLD_: '65536'
            MKL_NUM_THREADS: '1'
            OMP_NUM_THREADS: '1'
          preload: !!python/tuple []
          preload-argv: !!python/tuple []
        rmm:
          pool-size: null
        scheduler:
          active-memory-manager:
            interval: 2s
            policies: !!python/tuple
            - class: distributed.active_memory_manager.ReduceReplicas
            start: 'False'
          allowed-failures: '3'
          allowed-imports: !!python/tuple
          - dask
          - distributed
          bandwidth: '100000000'
          blocked-handlers: !!python/tuple []
          dashboard:
            bokeh-application:
              allow_websocket_origin: !!python/tuple
              - '*'
              check_unused_sessions_milliseconds: '500'
              keep_alive_milliseconds: '500'
            status:
              task-stream-length: '1000'
            tasks:
              task-stream-length: '100000'
            tls:
              ca-file: null
              cert: null
              key: null
          default-data-size: 1kiB
          default-task-durations:
            rechunk-split: 1us
            split-shuffle: 1us
          events-cleanup-delay: 1h
          events-log-length: '100000'
          http:
            routes: !!python/tuple
            - distributed.http.scheduler.prometheus
            - distributed.http.scheduler.info
            - distributed.http.scheduler.json
            - distributed.http.health
            - distributed.http.proxy
            - distributed.http.statics
          idle-timeout: null
          locks:
            lease-timeout: 30s
            lease-validation-interval: 10s
          pickle: 'True'
          preload: !!python/tuple []
          preload-argv: !!python/tuple []
          transition-log-length: '100000'
          unknown-task-duration: 500ms
          validate: 'False'
          work-stealing: 'True'
          work-stealing-interval: 100ms
          worker-ttl: null
        version: '2'
        worker:
          blocked-handlers: !!python/tuple []
          connections:
            incoming: '10'
            outgoing: '50'
          daemon: 'True'
          http:
            routes: !!python/tuple
            - distributed.http.worker.prometheus
            - distributed.http.health
            - distributed.http.statics
          lifetime:
            duration: null
            restart: 'False'
            stagger: 0 seconds
          memory:
            pause: '0.8'
            rebalance:
              measure: optimistic
              recipient-max: '0.6'
              sender-min: '0.3'
              sender-recipient-gap: '0.1'
            recent-to-old-time: 30s
            spill: '0.7'
            target: '0.6'
            terminate: '0.95'
          multiprocessing-method: spawn
          preload: !!python/tuple []
          preload-argv: !!python/tuple []
          profile:
            cycle: 1000ms
            interval: 10ms
            low-level: 'False'
          resources: {}
          use-file-locking: 'True'
          validate: 'False'
      optimization:
        fuse:
          active: null
          ave-width: '1'
          max-depth-new-edges: null
          max-height: inf
          max-width: null
          rename-keys: 'True'
          subgraphs: null
      scheduler: dask.distributed
      shuffle: tasks
      temporary-directory: null
      tokenize:
        ensure-deterministic: 'False'
    constrained: !!python/tuple []
    executing_count: '0'
    id: Worker-5bd7c8a8-6ca3-4457-ac0f-0c49fa1e56f5
    in_flight_tasks: '0'
    in_flight_workers: {}
    incoming_transfer_log: !!python/tuple []
    log: !!python/tuple []
    logs: !!python/tuple
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:41249'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -          Listening to:      tcp://127.0.0.1:41249'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -          dashboard at:            127.0.0.1:34057'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO - Waiting to connect to:      tcp://127.0.0.1:38993'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -               Threads:                          1'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -                Memory:                   6.79
        GiB'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -       Local Directory: /home/runner/work/distributed/distributed/dask-worker-space/worker-eru8w8qn'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:42413'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -          Listening to:      tcp://127.0.0.1:42413'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -          dashboard at:            127.0.0.1:41997'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO - Waiting to connect to:      tcp://127.0.0.1:38993'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -               Threads:                          2'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -                Memory:                   6.79
        GiB'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -       Local Directory: /home/runner/work/distributed/distributed/dask-worker-space/worker-uj4ir590'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -         Registered to:      tcp://127.0.0.1:38993'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -         Registered to:      tcp://127.0.0.1:38993'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    long_running: !!python/tuple []
    memory_limit: '7291699200'
    memory_pause_fraction: '0.8'
    memory_spill_fraction: '0.7'
    memory_target_fraction: '0.6'
    ncores: '1'
    nthreads: '1'
    outgoing_transfer_log: !!python/tuple []
    ready: !!python/tuple []
    scheduler: tcp://127.0.0.1:38993
    status: '<Status.running: ''running''>'
    tasks: {}
    thread_id: '140209022129984'
    type: Worker
  tcp://127.0.0.1:42413:
    address: tcp://127.0.0.1:42413
    config:
      array:
        chunk-size: 128MiB
        rechunk-threshold: '4'
        slicing:
          split-large-chunks: null
        svg:
          size: '120'
      dataframe:
        parquet:
          metadata-task-size-local: '512'
          metadata-task-size-remote: '16'
        shuffle-compression: null
      distributed:
        adaptive:
          interval: 1s
          maximum: inf
          minimum: '0'
          target-duration: 5s
          wait-count: '3'
        admin:
          event-loop: tornado
          log-format: '%(name)s - %(levelname)s - %(message)s'
          log-length: '10000'
          max-error-length: '10000'
          pdb-on-err: 'False'
          system-monitor:
            interval: 500ms
          tick:
            interval: 20ms
            limit: 3s
        client:
          heartbeat: 5s
          scheduler-info-interval: 2s
        comm:
          compression: auto
          default-scheme: tcp
          offload: 10MiB
          recent-messages-log-length: '0'
          require-encryption: null
          retry:
            count: '0'
            delay:
              max: 20s
              min: 1s
          shard: 64MiB
          socket-backlog: '2048'
          timeouts:
            connect: 5s
            tcp: 30s
          tls:
            ca-file: null
            ciphers: null
            client:
              cert: null
              key: null
            scheduler:
              cert: null
              key: null
            worker:
              cert: null
              key: null
          ucx:
            cuda_copy: 'False'
            infiniband: 'False'
            net-devices: null
            nvlink: 'False'
            rdmacm: 'False'
            reuse-endpoints: null
            tcp: 'False'
          websockets:
            shard: 8MiB
          zstd:
            level: '3'
            threads: '0'
        dashboard:
          export-tool: 'False'
          graph-max-items: '5000'
          link: '{scheme}://{host}:{port}/status'
          prometheus:
            namespace: dask
        deploy:
          cluster-repr-interval: 500ms
          lost-worker-timeout: 15s
        diagnostics:
          computations:
            ignore-modules: !!python/tuple
            - distributed
            - dask
            - xarray
            - cudf
            - cuml
            - prefect
            - xgboost
            max-history: '100'
          nvml: 'True'
        nanny:
          environ:
            MALLOC_TRIM_THRESHOLD_: '65536'
            MKL_NUM_THREADS: '1'
            OMP_NUM_THREADS: '1'
          preload: !!python/tuple []
          preload-argv: !!python/tuple []
        rmm:
          pool-size: null
        scheduler:
          active-memory-manager:
            interval: 2s
            policies: !!python/tuple
            - class: distributed.active_memory_manager.ReduceReplicas
            start: 'False'
          allowed-failures: '3'
          allowed-imports: !!python/tuple
          - dask
          - distributed
          bandwidth: '100000000'
          blocked-handlers: !!python/tuple []
          dashboard:
            bokeh-application:
              allow_websocket_origin: !!python/tuple
              - '*'
              check_unused_sessions_milliseconds: '500'
              keep_alive_milliseconds: '500'
            status:
              task-stream-length: '1000'
            tasks:
              task-stream-length: '100000'
            tls:
              ca-file: null
              cert: null
              key: null
          default-data-size: 1kiB
          default-task-durations:
            rechunk-split: 1us
            split-shuffle: 1us
          events-cleanup-delay: 1h
          events-log-length: '100000'
          http:
            routes: !!python/tuple
            - distributed.http.scheduler.prometheus
            - distributed.http.scheduler.info
            - distributed.http.scheduler.json
            - distributed.http.health
            - distributed.http.proxy
            - distributed.http.statics
          idle-timeout: null
          locks:
            lease-timeout: 30s
            lease-validation-interval: 10s
          pickle: 'True'
          preload: !!python/tuple []
          preload-argv: !!python/tuple []
          transition-log-length: '100000'
          unknown-task-duration: 500ms
          validate: 'False'
          work-stealing: 'True'
          work-stealing-interval: 100ms
          worker-ttl: null
        version: '2'
        worker:
          blocked-handlers: !!python/tuple []
          connections:
            incoming: '10'
            outgoing: '50'
          daemon: 'True'
          http:
            routes: !!python/tuple
            - distributed.http.worker.prometheus
            - distributed.http.health
            - distributed.http.statics
          lifetime:
            duration: null
            restart: 'False'
            stagger: 0 seconds
          memory:
            pause: '0.8'
            rebalance:
              measure: optimistic
              recipient-max: '0.6'
              sender-min: '0.3'
              sender-recipient-gap: '0.1'
            recent-to-old-time: 30s
            spill: '0.7'
            target: '0.6'
            terminate: '0.95'
          multiprocessing-method: spawn
          preload: !!python/tuple []
          preload-argv: !!python/tuple []
          profile:
            cycle: 1000ms
            interval: 10ms
            low-level: 'False'
          resources: {}
          use-file-locking: 'True'
          validate: 'False'
      optimization:
        fuse:
          active: null
          ave-width: '1'
          max-depth-new-edges: null
          max-height: inf
          max-width: null
          rename-keys: 'True'
          subgraphs: null
      scheduler: dask.distributed
      shuffle: tasks
      temporary-directory: null
      tokenize:
        ensure-deterministic: 'False'
    constrained: !!python/tuple []
    executing_count: '0'
    id: Worker-bc9ba117-6ebd-4c25-8ff7-c181040cf688
    in_flight_tasks: '0'
    in_flight_workers: {}
    incoming_transfer_log: !!python/tuple []
    log: !!python/tuple []
    logs: !!python/tuple
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:41249'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -          Listening to:      tcp://127.0.0.1:41249'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -          dashboard at:            127.0.0.1:34057'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO - Waiting to connect to:      tcp://127.0.0.1:38993'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -               Threads:                          1'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -                Memory:                   6.79
        GiB'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -       Local Directory: /home/runner/work/distributed/distributed/dask-worker-space/worker-eru8w8qn'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:42413'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -          Listening to:      tcp://127.0.0.1:42413'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -          dashboard at:            127.0.0.1:41997'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO - Waiting to connect to:      tcp://127.0.0.1:38993'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -               Threads:                          2'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -                Memory:                   6.79
        GiB'
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -       Local Directory: /home/runner/work/distributed/distributed/dask-worker-space/worker-uj4ir590'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -         Registered to:      tcp://127.0.0.1:38993'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    - !!python/tuple
      - INFO
      - 'distributed.worker - INFO -         Registered to:      tcp://127.0.0.1:38993'
    - !!python/tuple
      - INFO
      - distributed.worker - INFO - -------------------------------------------------
    long_running: !!python/tuple []
    memory_limit: '7291699200'
    memory_pause_fraction: '0.8'
    memory_spill_fraction: '0.7'
    memory_target_fraction: '0.6'
    ncores: '2'
    nthreads: '2'
    outgoing_transfer_log: !!python/tuple []
    ready: !!python/tuple []
    scheduler: tcp://127.0.0.1:38993
    status: '<Status.running: ''running''>'
    tasks: {}
    thread_id: '140209022129984'
    type: Worker
```

</details>

- [ ] Closes https://github.com/dask/distributed/issues/5437
- [ ] Closes https://github.com/dask/distributed/issues/5068
