### PR TITLE
Shutdown asynchronous cluster instances correctly at exit

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -210,7 +210,8 @@ class Cluster:
         )
 
     def sync(self, func, *args, asynchronous=None, callback_timeout=None, **kwargs):
-        asynchronous = asynchronous or self.asynchronous
+        if asynchronous is None:
+            asynchronous = self.asynchronous
         if asynchronous:
             future = func(*args, **kwargs)
             if callback_timeout is not None:

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -61,6 +61,7 @@ class Cluster(SyncMethodMixin):
         name=None,
         scheduler_sync_interval=1,
     ):
+        self._asynchronous = asynchronous
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
         self.loop = self._loop_runner.loop
 

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -660,4 +660,4 @@ def close_clusters():
         if cluster.shutdown_on_close:
             with suppress(gen.TimeoutError, TimeoutError):
                 if cluster.status != Status.closed:
-                    cluster.close(timeout=10)
+                    cluster.sync(cluster.close, asynchronous=False, callback_timeout=10)

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -658,6 +658,6 @@ async def run_spec(spec: dict, *args):
 def close_clusters():
     for cluster in list(SpecCluster._instances):
         if cluster.shutdown_on_close:
-            with suppress(gen.TimeoutError, TimeoutError):
+            with suppress(gen.TimeoutError, TimeoutError, RuntimeError):
                 if cluster.status != Status.closed:
                     cluster.sync(cluster.close, asynchronous=False, callback_timeout=10)

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -48,10 +48,12 @@ async def test_cluster_info():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("asynchronous", [True, False])
-async def test_sync_defaults_to_cluster_setting(asynchronous, loop_in_thread):
+@pytest.mark.parametrize("asynchronous_cluster", [True, False])
+async def test_sync_defaults_to_cluster_setting(
+    asynchronous_cluster, loop_in_thread, cleanup
+):
 
-    cluster = Cluster(asynchronous=asynchronous)
+    cluster = Cluster(asynchronous=asynchronous_cluster)
     cluster.loop = loop_in_thread
 
     async def foo():
@@ -59,7 +61,7 @@ async def test_sync_defaults_to_cluster_setting(asynchronous, loop_in_thread):
 
     result = cluster.sync(foo)
 
-    if asynchronous:
+    if asynchronous_cluster:
         assert isinstance(result, CoroutineType)
         assert await result == 1
     else:
@@ -69,7 +71,7 @@ async def test_sync_defaults_to_cluster_setting(asynchronous, loop_in_thread):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("asynchronous_cluster", [True, False])
 async def test_sync_allows_override_of_asychronous(
-    asynchronous_cluster, loop_in_thread
+    asynchronous_cluster, loop_in_thread, cleanup
 ):
 
     cluster = Cluster(asynchronous=asynchronous_cluster)

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -1,10 +1,8 @@
-import pytest
-
 from types import CoroutineType
 
+import pytest
+
 from distributed.deploy.cluster import Cluster
-from tornado.ioloop import IOLoop
-from distributed.utils_test import loop_in_thread
 
 
 @pytest.mark.asyncio

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -53,8 +53,7 @@ async def test_sync_defaults_to_cluster_setting(
     asynchronous_cluster, loop_in_thread, cleanup
 ):
 
-    cluster = Cluster(asynchronous=asynchronous_cluster)
-    cluster.loop = loop_in_thread
+    cluster = Cluster(asynchronous=asynchronous_cluster, loop=loop_in_thread)
 
     async def foo():
         return 1
@@ -73,9 +72,7 @@ async def test_sync_defaults_to_cluster_setting(
 async def test_sync_allows_override_of_asychronous(
     asynchronous_cluster, loop_in_thread, cleanup
 ):
-
-    cluster = Cluster(asynchronous=asynchronous_cluster)
-    cluster.loop = loop_in_thread
+    cluster = Cluster(asynchronous=asynchronous_cluster, loop=loop_in_thread)
 
     async def foo():
         return 1

--- a/distributed/tests/test_spec.py
+++ b/distributed/tests/test_spec.py
@@ -1,4 +1,3 @@
-import uuid
 from unittest.mock import MagicMock
 
 from distributed.deploy.spec import (

--- a/distributed/tests/test_spec.py
+++ b/distributed/tests/test_spec.py
@@ -1,4 +1,12 @@
-from distributed.deploy.spec import ProcessInterface
+import uuid
+from unittest.mock import MagicMock
+
+from distributed.deploy.spec import (
+    ProcessInterface,
+    SpecCluster,
+    Status,
+    close_clusters,
+)
 
 
 def test_address_default_none():
@@ -16,3 +24,25 @@ def test_child_address_persists():
     assert c.address is None
     c = Child("localhost")
     assert c.address == "localhost"
+
+
+def test_close_clusters(monkeypatch):
+    def mock_cluster(status: Status, shutdown_on_close: bool = True):
+        mock = MagicMock(spec=SpecCluster)
+        mock.status = status
+        mock.shutdown_on_close = shutdown_on_close
+        return mock
+
+    closed_cluster = mock_cluster(Status.closed)
+    skipped_cluster = mock_cluster(Status.running, shutdown_on_close=False)
+    running_cluster = mock_cluster(Status.running)
+
+    monkeypatch.setattr(SpecCluster, "_instances", {running_cluster, closed_cluster})
+
+    close_clusters()
+
+    closed_cluster.sync.assert_not_called()
+    skipped_cluster.sync.assert_not_called()
+    running_cluster.sync.assert_called_once_with(
+        running_cluster.close, asynchronous=False, callback_timeout=10
+    )


### PR DESCRIPTION
When working with clusters that have `asynchronous=True`, the `atexit` shutdown hook is not awaiting `cluster.close`. This results in lingering clusters and the following warning

```
/Users/mz/src/distributed/distributed/deploy/spec.py:663: RuntimeWarning: coroutine 'wait_for' was never awaited
  cluster.close(timeout=10)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
/Users/mz/src/distributed/distributed/deploy/spec.py:663: RuntimeWarning: coroutine 'SpecCluster._close' was never awaited
  cluster.close(timeout=10)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

The solution here is to force a synchronous call to `cluster.close` despite the value of `cluster.asynchronous`. (Here, I presume that the atexit handler cannot be an asynchronous function). ~I discovered that `cluster.sync(..., asynchronous=False)` was not respected so there is a small tweak there as well.~

~I've marked this as a draft so I can determine what tests need to change before requesting review.~

- ~[ ] Closes #xxxx~
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
