### PR TITLE
[DNM] Scatter shuffle proof-of-concept

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1785,6 +1785,14 @@ class Client:
 
     async def _gather(self, futures, errors="raise", direct=None, local_worker=None):
         unpacked, future_set = unpack_remotedata(futures, byte_keys=True)
+        mismatched_futures = [f for f in future_set if f.client is not self]
+        if mismatched_futures:
+            raise ValueError(
+                "Cannot gather Futures created by another client. "
+                f"These are the {len(mismatched_futures)} (out of {len(futures)}) mismatched Futures and their client IDs "
+                f"(this client is {self.id}): "
+                f"{ {f: f.client.id for f in mismatched_futures} }"
+            )
         keys = [stringify(future.key) for future in future_set]
         bad_data = dict()
         data = {}

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2191,15 +2191,17 @@ class Client:
             hash=hash,
         )
 
-    async def _cancel(self, futures, force=False):
+    async def _cancel(self, futures, force=False, _report=True):
         keys = list({stringify(f.key) for f in futures_of(futures)})
-        await self.scheduler.cancel(keys=keys, client=self.id, force=force)
+        await self.scheduler.cancel(
+            keys=keys, client=self.id, force=force, _report=_report
+        )
         for k in keys:
             st = self.futures.pop(k, None)
             if st is not None:
                 st.cancel()
 
-    def cancel(self, futures, asynchronous=None, force=False):
+    def cancel(self, futures, asynchronous=None, force=False, _report=True):
         """
         Cancel running futures
 
@@ -2213,7 +2215,13 @@ class Client:
         force : boolean (False)
             Cancel this future even if other clients desire it
         """
-        return self.sync(self._cancel, futures, asynchronous=asynchronous, force=force)
+        return self.sync(
+            self._cancel,
+            futures,
+            asynchronous=asynchronous,
+            force=force,
+            _report=_report,
+        )
 
     async def _retry(self, futures):
         keys = list({stringify(f.key) for f in futures_of(futures)})

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2044,6 +2044,7 @@ class Client:
                 who_has={key: [local_worker.address] for key in data},
                 nbytes=valmap(sizeof, data),
                 client=self.id,
+                report=False,
             )
 
         else:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -379,14 +379,15 @@ class Future(WrappedKey):
         except ValueError:
             c = get_client(address)
         self.__init__(key, c)
-        c._send_to_scheduler(
-            {
-                "op": "update-graph",
-                "tasks": {},
-                "keys": [stringify(self.key)],
-                "client": c.id,
-            }
-        )
+        # TODO why was this here? Is it safe to remove?
+        # c._send_to_scheduler(
+        #     {
+        #         "op": "update-graph",
+        #         "tasks": {},
+        #         "keys": [stringify(self.key)],
+        #         "client": c.id,
+        #     }
+        # )
 
     def __del__(self):
         try:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -378,7 +378,7 @@ class Future(WrappedKey):
             c = Client.current(allow_global=False)
         except ValueError:
             c = get_client(address)
-        self.__init__(key, c)
+        self.__init__(key, c, inform=False)  # HACK inform!!
         # TODO why was this here? Is it safe to remove?
         # c._send_to_scheduler(
         #     {

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -94,9 +94,9 @@ class Cluster:
         )
         self._cluster_info.update(info)
 
-        self.periodic_callbacks["sync-cluster-info"] = PeriodicCallback(
-            self._sync_cluster_info, self._sync_interval * 1000
-        )
+        # self.periodic_callbacks["sync-cluster-info"] = PeriodicCallback(
+        #     self._sync_cluster_info, self._sync_interval * 1000
+        # )
         for pc in self.periodic_callbacks.values():
             pc.start()
         self.status = Status.running

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4956,17 +4956,17 @@ class Scheduler(SchedulerState, ServerNode):
 
         return "OK"
 
-    def stimulus_cancel(self, comm, keys=None, client=None, force=False):
+    def stimulus_cancel(self, comm, keys=None, client=None, force=False, _report=True):
         """Stop execution on a list of keys"""
         logger.info("Client %s requests to cancel %d keys", client, len(keys))
-        if client:
+        if client and _report:
             self.log_event(
                 client, {"action": "cancel", "count": len(keys), "force": force}
             )
         for key in keys:
-            self.cancel_key(key, client, force=force)
+            self.cancel_key(key, client, force=force, _report=_report)
 
-    def cancel_key(self, key, client, retries=5, force=False):
+    def cancel_key(self, key, client, retries=5, force=False, _report=True):
         """Cancel a particular key and all dependents"""
         # TODO: this should be converted to use the transition mechanism
         parent: SchedulerState = cast(SchedulerState, self)
@@ -4986,7 +4986,8 @@ class Scheduler(SchedulerState, ServerNode):
             for dts in list(ts._dependents):
                 self.cancel_key(dts._key, client, force=force)
         logger.info("Scheduler cancels key %s.  Force=%s", key, force)
-        self.report({"op": "cancelled-key", "key": key})
+        if _report:
+            self.report({"op": "cancelled-key", "key": key})
         clients = list(ts._who_wants) if force else [cs]
         for cs in clients:
             self.client_releases_keys(keys=[key], client=cs._client_key)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4958,7 +4958,7 @@ class Scheduler(SchedulerState, ServerNode):
 
     def stimulus_cancel(self, comm, keys=None, client=None, force=False, _report=True):
         """Stop execution on a list of keys"""
-        logger.info("Client %s requests to cancel %d keys", client, len(keys))
+        # logger.info("Client %s requests to cancel %d keys", client, len(keys))
         if client and _report:
             self.log_event(
                 client, {"action": "cancel", "count": len(keys), "force": force}
@@ -4985,7 +4985,7 @@ class Scheduler(SchedulerState, ServerNode):
         if force or ts._who_wants == {cs}:  # no one else wants this key
             for dts in list(ts._dependents):
                 self.cancel_key(dts._key, client, force=force)
-        logger.info("Scheduler cancels key %s.  Force=%s", key, force)
+        # logger.info("Scheduler cancels key %s.  Force=%s", key, force)
         if _report:
             self.report({"op": "cancelled-key", "key": key})
         clients = list(ts._who_wants) if force else [cs]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6773,9 +6773,7 @@ class Scheduler(SchedulerState, ServerNode):
         """
         parent: SchedulerState = cast(SchedulerState, self)
         with log_errors():
-            who_has = {
-                k: [self.coerce_address(vv) for vv in v] for k, v in who_has.items()
-            }
+            # TODO add `coerce_address` back for some cases
             logger.debug("Update data %s", who_has)
 
             for key, workers in who_has.items():

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6791,9 +6791,10 @@ class Scheduler(SchedulerState, ServerNode):
                     ws: WorkerState = parent._workers_dv[w]
                     if ws not in ts._who_has:
                         parent.add_replica(ts, ws)
-                self.report(
-                    {"op": "key-in-memory", "key": key, "workers": list(workers)}
-                )
+                if report:
+                    self.report(
+                        {"op": "key-in-memory", "key": key, "workers": list(workers)}
+                    )
 
             if client:
                 self.client_desires_keys(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4991,7 +4991,7 @@ class Scheduler(SchedulerState, ServerNode):
         for cs in clients:
             self.client_releases_keys(keys=[key], client=cs._client_key)
 
-    def client_desires_keys(self, keys=None, client=None):
+    def client_desires_keys(self, keys=None, client=None, report=True):
         parent: SchedulerState = cast(SchedulerState, self)
         cs: ClientState = parent._clients.get(client)
         if cs is None:
@@ -5006,7 +5006,7 @@ class Scheduler(SchedulerState, ServerNode):
             ts._who_wants.add(cs)
             cs._wants_what.add(ts)
 
-            if ts._state in ("memory", "erred"):
+            if report and ts._state in ("memory", "erred"):
                 self.report_on_key(ts=ts, client=client)
 
     def client_releases_keys(self, keys=None, client=None):
@@ -6761,6 +6761,7 @@ class Scheduler(SchedulerState, ServerNode):
         who_has: dict,
         nbytes: dict,
         client=None,
+        report=True,
         serializers=None,
     ):
         """
@@ -6795,7 +6796,9 @@ class Scheduler(SchedulerState, ServerNode):
                 )
 
             if client:
-                self.client_desires_keys(keys=list(who_has), client=client)
+                self.client_desires_keys(
+                    keys=list(who_has), client=client, report=report
+                )
 
     def report_on_key(self, key: str = None, ts: TaskState = None, client: str = None):
         parent: SchedulerState = cast(SchedulerState, self)

--- a/distributed/shuffle/scatter.py
+++ b/distributed/shuffle/scatter.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from dask.base import tokenize
+from dask.dataframe import DataFrame
+from dask.dataframe.core import _concat
+from dask.dataframe.shuffle import shuffle_group
+from dask.highlevelgraph import HighLevelGraph
+from dask.sizeof import sizeof
+
+from distributed import Future, get_client
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+T = TypeVar("T")
+
+
+class QuickSizeof(Generic[T]):
+    "Wrapper to bypass slow `sizeof` calls"
+
+    def __init__(self, obj: T, size: int) -> None:
+        self.obj = obj
+        self.size = size
+
+    def __sizeof__(self) -> int:
+        return self.size
+
+
+def split(
+    df: pd.DataFrame,
+    column: str,
+    npartitions_output: int,
+    ignore_index: bool,
+    name: str,
+    row_size_estimate: int,
+    partition_info: dict[str, int] = None,
+) -> dict[int, Future]:
+    assert isinstance(partition_info, dict), "partition_info is not a dict"
+    client = get_client()
+
+    shards: dict[int, pd.DataFrame] = shuffle_group(
+        df,
+        cols=column,
+        stage=0,
+        k=npartitions_output,
+        npartitions=npartitions_output,
+        ignore_index=ignore_index,
+        nfinal=npartitions_output,
+    )
+    input_partition_i = partition_info["number"]
+    # Change keys to be unique among all tasks---the dict keys here end up being
+    # the task keys on the scheduler.
+    # Also wrap in `QuickSizeof` to significantly speed up the worker storing each
+    # shard in its zict buffer.
+    shards_rekeyed = {
+        f"({name!r}, {input_partition_i}, {output_partition_i})": QuickSizeof(
+            shard, len(shard) * row_size_estimate
+        )
+        for output_partition_i, shard in shards.items()
+    }
+    # NOTE: `scatter` called within a task has very different (undocumented) behavior:
+    # it writes the keys directly to the current worker, then informs the scheduler
+    # that these keys exist on the current worker. No communications to other workers ever.
+    futures: dict[str, Future] = client.scatter(shards_rekeyed)
+    return dict(zip(shards, futures.values()))
+
+
+def gather_regroup(i: int, all_futures: list[dict[int, Future]]) -> pd.DataFrame:
+    client = get_client()
+    futures = [fs[i] for fs in all_futures if i in fs]
+    shards: list[QuickSizeof[pd.DataFrame]] = client.gather(futures, direct=True)
+    # Since every worker holds a reference to all futures until the very last task completes,
+    # forcibly cancel these futures now to allow memory to be released eagerly.
+    # This is safe because we're only cancelling futures for this output partition,
+    # and there's exactly one task for each output partition.
+    client.cancel(futures, force=True)
+
+    return _concat([s.obj for s in shards])
+
+
+def rearrange_by_column_scatter(
+    df: DataFrame, column: str, npartitions=None, ignore_index=False
+) -> DataFrame:
+    token = tokenize(df, column)
+
+    npartitions = npartitions or df.npartitions
+    row_size_estimate = sizeof(df._meta_nonempty) // len(df._meta_nonempty)
+    splits = df.map_partitions(
+        split,
+        column,
+        npartitions,
+        ignore_index,
+        f"shuffle-split-{token}",
+        row_size_estimate,
+        meta=df,
+    )
+
+    all_futures = splits.__dask_keys__()
+    name = f"shuffle-regroup-{token}"
+    dsk = {(name, i): (gather_regroup, i, all_futures) for i in range(npartitions)}
+    return DataFrame(
+        HighLevelGraph.from_collections(name, dsk, [splits]),
+        name,
+        df._meta,
+        [None] * (npartitions + 1),
+    )

--- a/distributed/shuffle/scatter.py
+++ b/distributed/shuffle/scatter.py
@@ -57,7 +57,8 @@ def split(
     # Also wrap in `QuickSizeof` to significantly speed up the worker storing each
     # shard in its zict buffer.
     shards_rekeyed = {
-        f"({name!r}, {input_partition_i}, {output_partition_i})": QuickSizeof(
+        # NOTE: this name is optimized to be easy for `key_split` to process
+        f"{name}-{input_partition_i}-{output_partition_i}": QuickSizeof(
             shard, len(shard) * row_size_estimate
         )
         for output_partition_i, shard in shards.items()

--- a/distributed/shuffle/scatter.py
+++ b/distributed/shuffle/scatter.py
@@ -80,7 +80,7 @@ def gather_regroup(i: int, all_futures: list[dict[int, Future]]) -> pd.DataFrame
     # forcibly cancel these futures now to allow memory to be released eagerly.
     # This is safe because we're only cancelling futures for this output partition,
     # and there's exactly one task for each output partition.
-    client.cancel(futures, force=True)
+    client.cancel(futures, force=True, _report=False)
 
     return _concat([s.obj for s in shards])
 

--- a/distributed/shuffle/scatter.py
+++ b/distributed/shuffle/scatter.py
@@ -97,7 +97,7 @@ def rearrange_by_column_scatter(
         column,
         npartitions,
         ignore_index,
-        f"shuffle-split-{token}",
+        f"shuffle-shards-{token}",
         row_size_estimate,
         meta=df,
         enforce_metadata=False,

--- a/distributed/shuffle/scatter.py
+++ b/distributed/shuffle/scatter.py
@@ -100,6 +100,8 @@ def rearrange_by_column_scatter(
         f"shuffle-split-{token}",
         row_size_estimate,
         meta=df,
+        enforce_metadata=False,
+        transform_divisions=False,
     )
 
     all_futures = splits.__dask_keys__()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -573,6 +573,17 @@ async def test_gather(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_gather_mismatched_client(c, s, a, b):
+    c2 = await Client(s.address, asynchronous=True)
+
+    x = c.submit(inc, 10)
+    y = c2.submit(inc, 5)
+
+    with pytest.raises(ValueError, match="Futures created by another client"):
+        await c.gather([x, y])
+
+
+@gen_cluster(client=True)
 async def test_gather_lost(c, s, a, b):
     [x] = await c.scatter([1], workers=a.address)
     y = c.submit(inc, 1, workers=b.address)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2533,11 +2533,12 @@ class Worker(ServerNode):
                     worker,
                 )
 
-                start = time()
-                response = await get_data_from_worker(
-                    self.rpc, to_gather_keys, worker, who=self.address
-                )
-                stop = time()
+                with self.client.as_current():
+                    start = time()
+                    response = await get_data_from_worker(
+                        self.rpc, to_gather_keys, worker, who=self.address
+                    )
+                    stop = time()
                 if response["status"] == "busy":
                     return
 


### PR DESCRIPTION
This is a semi-working proof-of-concept of a different approach to scalable(ish) shuffling. The idea is basically this: tracking millions of _tasks_ is too much overhead on the scheduler, but what about millions of _keys_? Keys (static pieces of data) should be a bit easier to deal with: they don't have dependencies, they don't need to be scheduled, etc. Perhaps we can get the scheduler to track tens of millions of keys with relatively little effort?

The idea is the same as what I proposed in https://github.com/dask/dask/issues/7613#issuecomment-952286052: tasks split up input data and `scatter` it, returning Futures. Other tasks take the Futures and `gather` them, fetching the data.

<details><summary>In detail</summary>

So within an input task, we:
* split an input partition into pieces, one per output partition
* `scatter` all of those shards (pieces), getting back Futures referencing them
  * there is [special undocumented behavior](https://github.com/dask/distributed/blob/a82935d269b0d1136ad270a4cd7e20b8fdd37693/distributed/client.py#L2040-L2047) for `scatter` within a task: just it takes the data, stores it in the worker's memory, and informs the scheduler that the data is there. No communication with other workers; basically lets you hand off multiple pieces of data to the system to be tracked without running a separate task to produce each piece.
* return those Futures from the task

Then each output task depends on _every_ one of these input tasks:
* receives Futures for every shard (even the ones it doesn't need)
* pull out just the Futures we need for output partition N
* `gather` those Futures, transferring the data from the source worker to the current worker
* concatenate all the shards; that's your output partition
* (optional) cancel the Futures you just gathered so workers holding them can release that data

</details>

With this approach, we keep the _graph_ size `O(N)` in the number of partitions. The number of _keys_ is still `O(N^2)`, but we're hoping we can handle keys much more efficiently (initial results indicate this is maybe true with some more careful thought).

There are a few reasons I find this approach appealing compared to https://github.com/dask/distributed/pull/5435:
1. It's bypassing the system much less. We're just combining two core distributed features: tasks and Futures.
2. Resilience, retries, and cleanup come for free:
    * Tasks are pure and not just run for side effects; we actually use the data they produce (Futures).
    * If data (Futures) are lost from a worker dying, rerunning _just_ the tasks that created them will correctly re-create them. And if a worker dies midway through a task, that task can just be rerun on a different worker.
    * If tasks are cancelled, the data (Futures) they depend on are released. Releasing those Futures causes the data they reference to be released (possibly on a different worker).
    * There is no out-of-band state; releasing the keys cleans up everything
3. Spilling to disk happens automatically though the worker's standard zict buffer, since the data is owned by the worker[^1].
4. Memory is managed; data spilled to disk shows up automatically in the dashboard.

[^1] though because disk IO blocks the event loop (https://github.com/dask/distributed/issues/4424), performance is awful with this PR unless you disable spilling. When the loop is blocked, data can't transfer, which stops up the whole operation—the spice must flow!

However, there are also some big downsides:
1. There's an `O(N^2)` component. A 100,000-partition DataFrame would require 10 billion keys for all the sub-partitions. I'm not sure we'll ever be able to handle that scale on the scheduler. In practice, I think this approach would have a lower upper bound in scalability than https://github.com/dask/distributed/pull/5435.
2. Communication and computation/disk IO can't overlap. It's a pull-based shuffle. In https://github.com/dask/dask/pull/8223, we have a push-based shuffle: immediately sending parts to the appropriate place, and storing them there (in memory or on disk). Here, we store the parts where they're produced, then pull different subsets of them to the right worker at the end. This actually has a huge resilience advantage (worker failure just requires rerunning the tasks from that one worker; others are unaffected), but it may not be able to achieve the same performance.
3. There's just a lot less room to optimize and control things than a dedicated implementation.
4. Futures don't work quite the way we'd need for this to be performant. They communicate with the scheduler (and cause the scheduler to communicate) too often.

So how does this perform? Well, the first try was abysmal. But there was a lot of very low-hanging fruit I've either fixed or hacked past in this PR.

Currently, it's slower than a task-based shuffle for small datasets locally on my machine:
`dask.datasets.timeseries(start="2000-01-01", end="2001-01-01")`: 44sec `shuffle="scatter`, 22sec `shuffle="tasks"`
But it can handle bigger datasets that tasks cannot:
`dask.datasets.timeseries(start="2000-01-01", end="2005-01-01")`: ~5min `shuffle="scatter"`, `shuffle="tasks"` failed

Yet weirdly, on a cluster, it performs much worse. I'm not sure why yet; it has something to do with when all the futures get replicated to every worker. Generally what's hurting performance is:
* Futures informing the scheduler that a client requests keys (every worker tells the scheduler that it requests every sub-partition; this is `O(N^2 * W)`! But is it even necessary?)
* Cancelling Futures and handling the transitions caused by that
* Pickling, unpickling, msgpack

The bottom line is that this doesn't even come close to working as well as https://github.com/dask/dask/pull/8223. And it's almost certainly not the most performant or scalable design for shuffling we could make.

But what I find appealing about this is that, because it's not circumventing dask, the improvements needed to make this work tend to be things we should do anyway, and that benefit the whole system, even for users who aren't shuffling. There's nothing new to add; it's just making current features as robust, performant, and correct as they should be.

Note that the point of this PR is just to record for posterity that somebody has tried this once. I do not plan to continue working on this PR or this approach currently.