### PR TITLE
Register UCX close callback

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -365,6 +365,7 @@ class UCX(Comm):
                 return msg
 
     async def close(self):
+        self._closed = True
         if self._ep is not None:
             try:
                 await self.ep.send(struct.pack("?Q", True, 0))
@@ -381,6 +382,7 @@ class UCX(Comm):
             self._ep = None
 
     def abort(self):
+        self._closed = True
         if self._ep is not None:
             self._ep.abort()
             self._ep = None

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1510,6 +1510,13 @@ class Worker(ServerNode):
 
             self.stop_services()
 
+            # Give some time for a UCX scheduler to complete closing endpoints
+            # before closing self.batched_stream, otherwise the local endpoint
+            # may be closed too early and errors be raised on the scheduler when
+            # trying to send closing message.
+            if self._protocol == "ucx":
+                await asyncio.sleep(0.2)
+
             if (
                 self.batched_stream
                 and self.batched_stream.comm


### PR DESCRIPTION
With UCX, an endpoint is considered invalid to write immediately after it's closed or an error is raised due to the remote endpoint having closed. However, some messages may have already arrived and enqueued at the UCX endpoint but not having been read by the application. We must ensure that an endpoint is not valid for writing anymore immediately after an error has happened, but reading can still be done while there are enqueued, unread messages. By registering a close callback we can achieve that to prevent unclean closing of Distributed comms.

This change depends on https://github.com/rapidsai/ucx-py/pull/795 for clean closing, but checks ensure using an older UCX-Py build without that feature still works.

Closes https://github.com/rapidsai/dask-cuda/issues/713 .