### PR TITLE
AMM: redesign start/stop methods

### DIFF
--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import weakref
 from collections import defaultdict
-from collections.abc import Generator
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Generator
+from typing import TYPE_CHECKING, Any
 
 from tornado.ioloop import PeriodicCallback
 
@@ -338,14 +337,14 @@ class AMMClientProxy:
     client is synchronous.
     """
 
-    _client: weakref.ref[Client]
+    _client: Client
 
     def __init__(self, client: Client):
-        self._client = weakref.ref(client)
+        self._client = client
 
-    def _run(self, lambda_):
-        return self._client().run_on_scheduler(
-            lambda dask_scheduler: lambda_(dask_scheduler.extensions["amm"])
+    def _run(self, f: Callable[[ActiveMemoryManagerExtension], Any]):
+        return self._client.run_on_scheduler(
+            lambda dask_scheduler: f(dask_scheduler.extensions["amm"])
         )
 
     def start(self):

--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -295,8 +295,7 @@ class ActiveMemoryManagerPolicy:
         None,
     ]:
         """This method is invoked by the ActiveMemoryManager every few seconds, or
-        whenever the user invokes :func:`distributed.active_memory_manager.run_once`
-        from the client.
+        whenever the user invokes ``client.amm.run_once``.
         It is an iterator that must emit any of the following:
 
         - "replicate", <TaskState>, None

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4275,6 +4275,13 @@ class Client:
         """
         return self.sync(self._unregister_worker_plugin, name=name, nanny=nanny)
 
+    @property
+    def amm(self):
+        """Convenience accessors for the :doc:`active_memory_manager`"""
+        from .active_memory_manager import AMMClientProxy
+
+        return AMMClientProxy(self)
+
 
 class _WorkerSetupPlugin(WorkerPlugin):
     """This is used to support older setup functions as callbacks"""

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -249,8 +249,7 @@ properties:
             properties:
               start:
                 type: boolean
-                description: set to true to auto-start the AMM on Scheduler init;
-                  false to manually start it with client.scheduler.amm_start()
+                description: set to true to auto-start the AMM on Scheduler init
               interval:
                 type: string
                 description:

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -62,8 +62,9 @@ distributed:
 
     active-memory-manager:
       # Set to true to auto-start the Active Memory Manager on Scheduler start; if false
-      # you'll have to either manually start it with client.scheduler.amm_start() or run
-      # it once with client.scheduler.amm_run().
+      # you'll have to either manually start it with
+      # distributed.active_memory_manager.start or run it once with
+      # distributed.active_memory_manager.run_once.
       start: false
       # Once started, run the AMM cycle every <interval>
       interval: 2s

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -62,9 +62,8 @@ distributed:
 
     active-memory-manager:
       # Set to true to auto-start the Active Memory Manager on Scheduler start; if false
-      # you'll have to either manually start it with
-      # distributed.active_memory_manager.start or run it once with
-      # distributed.active_memory_manager.run_once.
+      # you'll have to either manually start it with client.amm.start() or run it once
+      # with client.amm.run_once().
       start: false
       # Once started, run the AMM cycle every <interval>
       interval: 2s

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -178,6 +178,25 @@ async def test_not_registered(c, s, a, b):
         await asyncio.sleep(0.01)
 
 
+def test_client_proxy_sync(client):
+    assert not client.amm.running()
+    client.amm.start()
+    assert client.amm.running()
+    client.amm.stop()
+    assert not client.amm.running()
+    client.amm.run_once()
+
+
+@gen_cluster(client=True, config=NO_AMM_START)
+async def test_client_proxy_async(c, s, a, b):
+    assert not await c.amm.running()
+    await c.amm.start()
+    assert await c.amm.running()
+    await c.amm.stop()
+    assert not await c.amm.running()
+    await c.amm.run_once()
+
+
 @gen_cluster(client=True, config=demo_config("drop"))
 async def test_drop_not_in_memory(c, s, a, b):
     """ts.who_has is empty"""

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -86,7 +86,9 @@ async def test_start_stop(c, s, a, b):
     s.extensions["amm"].start()
     while len(s.tasks["x"].who_has) > 1:
         await asyncio.sleep(0.01)
+    s.extensions["amm"].start()  # Double start is a no-op
     s.extensions["amm"].stop()
+    s.extensions["amm"].stop()  # Double stop is a no-op
     # AMM is not running anymore
     await c.replicate(x, 2)
     await asyncio.sleep(0.2)
@@ -132,6 +134,9 @@ async def test_add_policy(c, s, a, b):
     m3.run_once()
     while len(s.tasks["z"].who_has) == 2:
         await asyncio.sleep(0.01)
+
+    with pytest.raises(TypeError):
+        m3.add_policy("not a policy")
 
 
 @gen_cluster(client=True, config=demo_config("drop", key="x", start=False))

--- a/docs/source/active_memory_manager.rst
+++ b/docs/source/active_memory_manager.rst
@@ -7,8 +7,9 @@ usage of workers across the Dask cluster. It is disabled by default.
 Memory imbalance and duplication
 --------------------------------
 Whenever a Dask task returns data, it is stored on the worker that executed the task for
-as long as it's a dependency of other tasks, is referenced by a ``Client`` through a
-``Future``, or is part of a :doc:`published dataset <publish>`.
+as long as it's a dependency of other tasks, is referenced by a
+:class:`~distributed.Client` through a :class:`~distributed.Future`, or is part of a
+:doc:`published dataset <publish>`.
 
 Dask assigns tasks to workers following criteria of CPU occupancy, :doc:`resources`, and
 locality. In the trivial use case of tasks that are not connected to each other, take
@@ -38,7 +39,7 @@ The AMM can be enabled through the :doc:`Dask configuration file <configuration>
 
 The above is the recommended setup and will run all enabled *AMM policies* (see below)
 every two seconds. Alternatively, you can manually start/stop the AMM from the
-``Client`` or trigger a one-off iteration:
+:class:`~distributed.`Client` or trigger a one-off iteration:
 
 .. code-block:: python
 
@@ -57,6 +58,10 @@ long as they don't harm data integrity. These suggestions can be of two types:
   This should not be confused with replication caused by task dependencies.
 - Delete one or more replicas of an in-memory task. The AMM will never delete the last
   replica of a task, even if a policy asks to.
+
+There are no "move" operations. A move is performed in two passes: first a policy
+creates a copy; in the next AMM iteration, the same or another policy deletes the
+original (if the copy succeeded).
 
 Unless a policy puts constraints on which workers should be impacted, the AMM will
 automatically create replicas on workers with the lowest memory usage first and delete
@@ -90,7 +95,7 @@ Built-in policies
 ReduceReplicas
 ++++++++++++++
 class
-    ``distributed.active_memory_manager.ReduceReplicas``
+    :class:`distributed.active_memory_manager.ReduceReplicas`
 parameters
     None
 
@@ -128,7 +133,7 @@ define two methods:
         Create one replica of the target task on the worker with the lowest memory among
         the listed candidates.
     ``yield "drop", <TaskState>, None``
-        Delete one replica of the target task one the worker with the highest memory
+        Delete one replica of the target task on the worker with the highest memory
         usage across the whole cluster.
     ``yield "drop", <TaskState>, {<WorkerState>, <WorkerState>, ...}``
         Delete one replica of the target task on the worker with the highest memory
@@ -186,8 +191,8 @@ Example
 The following custom policy ensures that keys "foo" and "bar" are replicated on all
 workers at all times. New workers will receive a replica soon after connecting to the
 scheduler. The policy will do nothing if the target keys are not in memory somewhere or
-if all workers already hold a replica.
-Note that this example is incompatible with the ``ReduceReplicas`` built-in policy.
+if all workers already hold a replica. Note that this example is incompatible with the
+:class:`~distributed.active_memory_manager.ReduceReplicas built-in policy.
 
 In mymodule.py (it must be accessible by the scheduler):
 

--- a/docs/source/active_memory_manager.rst
+++ b/docs/source/active_memory_manager.rst
@@ -43,12 +43,11 @@ every two seconds. Alternatively, you can manually start/stop the AMM from the
 
 .. code-block:: python
 
-   >>> from distributed import active_memory_manager as amm
-   >>> amm.start(client)  # Start running every 2 seconds
-   >>> amm.stop(client)  # Stop running periodically
-   >>> amm.running(client)
+   >>> client.amm.start()  # Start running every 2 seconds
+   >>> client.amm.stop()  # Stop running periodically
+   >>> client.amm.running()
    False
-   >>> amm.run_once(client)
+   >>> client.amm.run_once()
 
 
 Policies
@@ -250,6 +249,9 @@ API reference
    :members:
 
 .. autoclass:: distributed.active_memory_manager.ActiveMemoryManagerPolicy
+   :members:
+
+.. autoclass:: distributed.active_memory_manager.AMMClientProxy
    :members:
 
 .. autoclass:: distributed.active_memory_manager.ReduceReplicas

--- a/docs/source/active_memory_manager.rst
+++ b/docs/source/active_memory_manager.rst
@@ -43,9 +43,12 @@ every two seconds. Alternatively, you can manually start/stop the AMM from the
 
 .. code-block:: python
 
-   >>> client.scheduler.amm_start()  # Start running every 2 seconds
-   >>> client.scheduler.amm_stop()  # Stop running periodically
-   >>> client.scheduler.amm_run_once()
+   >>> from distributed import active_memory_manager as amm
+   >>> amm.start(client)  # Start running every 2 seconds
+   >>> amm.stop(client)  # Stop running periodically
+   >>> amm.running(client)
+   False
+   >>> amm.run_once(client)
 
 
 Policies

--- a/docs/source/active_memory_manager.rst
+++ b/docs/source/active_memory_manager.rst
@@ -39,7 +39,7 @@ The AMM can be enabled through the :doc:`Dask configuration file <configuration>
 
 The above is the recommended setup and will run all enabled *AMM policies* (see below)
 every two seconds. Alternatively, you can manually start/stop the AMM from the
-:class:`~distributed.`Client` or trigger a one-off iteration:
+:class:`~distributed.Client` or trigger a one-off iteration:
 
 .. code-block:: python
 
@@ -108,8 +108,9 @@ computation, this policy drops all excess replicas.
 .. note::
    This policy is incompatible with :meth:`~distributed.Client.replicate` and with the
    ``broadcast=True`` parameter of :meth:`~distributed.Client.scatter`. If you invoke
-   ``replicate`` to create additional replicas and then later run this policy, it will
-   delete all replicas but one (but not necessarily the new ones).
+   :meth:`~distributed.Client.replicate` to create additional replicas and then later
+   run this policy, it will delete all replicas but one (but not necessarily the new
+   ones).
 
 
 Custom policies
@@ -167,8 +168,8 @@ The ``run`` method can access the following attributes:
     The :class:`~distributed.active_memory_manager.ActiveMemoryManagerExtension` that
     the policy is attached to
 ``self.manager.scheduler``
-    :class:`~distributed.Scheduler` to which the suggestions will be applied. From there
-    you can access various attributes such as ``tasks`` and ``workers``.
+    :class:`~distributed.scheduler.Scheduler` to which the suggestions will be applied.
+    From there you can access various attributes such as ``tasks`` and ``workers``.
 ``self.manager.workers_memory``
     Read-only mapping of ``{WorkerState: bytes}``. bytes is the expected RAM usage of
     the worker after all suggestions accepted so far in the current AMM iteration, from
@@ -194,7 +195,7 @@ The following custom policy ensures that keys "foo" and "bar" are replicated on 
 workers at all times. New workers will receive a replica soon after connecting to the
 scheduler. The policy will do nothing if the target keys are not in memory somewhere or
 if all workers already hold a replica. Note that this example is incompatible with the
-:class:`~distributed.active_memory_manager.ReduceReplicas built-in policy.
+:class:`~distributed.active_memory_manager.ReduceReplicas` built-in policy.
 
 In mymodule.py (it must be accessible by the scheduler):
 
@@ -253,5 +254,6 @@ API reference
 
 .. autoclass:: distributed.active_memory_manager.AMMClientProxy
    :members:
+   :undoc-members:
 
 .. autoclass:: distributed.active_memory_manager.ReduceReplicas


### PR DESCRIPTION
This is a redesign pass over ``client.scheduler.amm_start()`` &co.
The accessors had a few problems:

- They're asynchronous when you have a synchronous client
- typing ``await client.scheduler.amm_start()`` in a Jupyter Notebook while the client is synchronous will result in a deadlock due to event loop mismatch
- poor naming - it's much nicer to have a singular amm namespace
- they were polluting the scheduler attributes
- missing access to current running status

IMHO no deprecation cycle needed as the whole system is still considered experimental.