### PR TITLE
Update all UCX tests to use asyncio marker

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -303,7 +303,6 @@ async def test_stress():
         protocol="ucx",
         dashboard_address=":0",
         asynchronous=True,
-        processes=False,
         host=HOST,
     ) as cluster:
         async with Client(cluster, asynchronous=True):


### PR DESCRIPTION
By marking all UCX tests as asyncio we ensure that they all use the fixture that properly releases UCX resources once the event loop is closed.

This should fix CI failures that have appeared in https://github.com/rapidsai/ucx-py/pull/804, where a subset of Distributed tests run.