### PR TITLE
Preserve contextvars during comm offload

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -557,18 +557,14 @@ async def test_offload():
 
 @pytest.mark.asyncio
 async def test_offload_preserves_contextvars():
-    var = contextvars.ContextVar("var", default="foo")
+    var = contextvars.ContextVar("var")
 
-    def change_var():
-        var.set("bar")
-        return var.get()
+    async def set_var(v: str):
+        var.set(v)
+        r = await offload(var.get)
+        assert r == v
 
-    o1 = offload(var.get)
-    o2 = offload(change_var)
-
-    r1, r2 = await asyncio.gather(o1, o2)
-    assert (r1, r2) == ("foo", "bar")
-    assert var.get() == "foo"
+    await asyncio.gather(set_var("foo"), set_var("bar"))
 
 
 def test_serialize_for_cli_deprecated():


### PR DESCRIPTION
Not currently used for anything, so debatable if we want to merge this now. However, this will eventually help with https://github.com/dask/distributed/issues/5485, I had already written the code in https://github.com/dask/distributed/pull/5473, and perhaps it'll save someone else future confusion.

Implementation referenced from https://github.com/python/cpython/pull/9688

Originally I used this for 30af07e, which I thought about opening a PR for. However, I think we should take a more general approach, namely #5485 and cleaning up all the inconsistencies around `get_client()`, `Client.current()`, `default_client()`, and `get_worker()`.

cc @crusaderky @fjetter 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
