### PR TITLE
Avoid multiple blocking calls by gathering UCX frames

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -5,6 +5,7 @@ See :ref:`communications` for more.
 
 .. _UCX: https://github.com/openucx/ucx
 """
+import asyncio
 import functools
 import logging
 import os
@@ -278,16 +279,6 @@ class UCX(Comm):
 
                 # Send meta data
 
-                # Send close flag and number of frames (_Bool, int64)
-                await self.ep.send(struct.pack("?Q", False, nframes))
-                # Send which frames are CUDA (bool) and
-                # how large each frame is (uint64)
-                await self.ep.send(
-                    struct.pack(nframes * "?" + nframes * "Q", *cuda_frames, *sizes)
-                )
-
-                # Send frames
-
                 # It is necessary to first synchronize the default stream before start
                 # sending We synchronize the default stream because UCX is not
                 # stream-ordered and syncing the default stream will wait for other
@@ -296,8 +287,22 @@ class UCX(Comm):
                 if any(cuda_send_frames):
                     synchronize_stream(0)
 
+                tasks = []
+
+                # Send close flag and number of frames (_Bool, int64)
+                tasks.append(self.ep.send(struct.pack("?Q", False, nframes)))
+                # Send which frames are CUDA (bool) and
+                # how large each frame is (uint64)
+                tasks.append(
+                    self.ep.send(
+                        struct.pack(nframes * "?" + nframes * "Q", *cuda_frames, *sizes)
+                    )
+                )
+
+                # Send frames
                 for each_frame in send_frames:
-                    await self.ep.send(each_frame)
+                    tasks.append(self.ep.send(each_frame))
+                await asyncio.gather(*tasks)
                 return sum(sizes)
             except (ucp.exceptions.UCXBaseException):
                 self.abort()
@@ -354,8 +359,10 @@ class UCX(Comm):
                 if any(cuda_recv_frames):
                     synchronize_stream(0)
 
+                tasks = []
                 for each_frame in recv_frames:
-                    await self.ep.recv(each_frame)
+                    tasks.append(self.ep.recv(each_frame))
+                await asyncio.gather(*tasks)
                 msg = await from_frames(
                     frames,
                     deserialize=self.deserialize,


### PR DESCRIPTION
This change provides a slight performance boost, up to ~10%.

<details><summary>Before</summary>

```
$ python dask_cuda/benchmarks/local_cudf_merge.py -d 0,3 --runs 5 -c 20_000_000 -p ucx --runs 51
Merge benchmark
-------------------------------
backend        | dask
merge type     | gpu
rows-per-chunk | 20000000
base-chunks    | 2
other-chunks   | 2
broadcast      | default
protocol       | ucx
device(s)      | 0,3
rmm-pool       | True
frac-match     | 0.3
tcp            | True
ib             | True
nvlink         | True
message api    | TAG
data-processed | 1.19 GiB
===============================
Wall-clock     | Throughput
-------------------------------
238.46 ms      | 5.00 GiB/s
178.76 ms      | 6.67 GiB/s
180.46 ms      | 6.61 GiB/s
...
===============================
avg-throughput | 7.36 GiB/s
mdn-throughput | 7.88 GiB/s
(w1,w2)        | 25% 50% 75% (total nbytes)
-------------------------------
(00,03)        | 15.88 GiB/s 22.90 GiB/s 24.32 GiB/s (44.59 GiB)
(03,00)        | 18.03 GiB/s 23.06 GiB/s 25.06 GiB/s (43.70 GiB)
```

</details>

<details><summary>After</summary>

```
$ python dask_cuda/benchmarks/local_cudf_merge.py -d 0,3 --runs 5 -c 20_000_000 -p ucx --runs 51
Merge benchmark
-------------------------------
backend        | dask
merge type     | gpu
rows-per-chunk | 20000000
base-chunks    | 2
other-chunks   | 2
broadcast      | default
protocol       | ucx
device(s)      | 0,3
rmm-pool       | True
frac-match     | 0.3
tcp            | True
ib             | True
nvlink         | True
message api    | TAG
data-processed | 1.19 GiB
===============================
Wall-clock     | Throughput
-------------------------------
247.85 ms      | 4.81 GiB/s
193.90 ms      | 6.15 GiB/s
165.19 ms      | 7.22 GiB/s
...
===============================
avg-throughput | 7.98 GiB/s
mdn-throughput | 8.42 GiB/s
(w1,w2)        | 25% 50% 75% (total nbytes)
-------------------------------
(00,03)        | 19.44 GiB/s 24.10 GiB/s 26.87 GiB/s (39.00 GiB)
(03,00)        | 19.69 GiB/s 23.14 GiB/s 26.34 GiB/s (38.56 GiB)
```

</details>