### PR TITLE
Fixup `cluster_info` sync handling

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import datetime
 import logging
 import threading
@@ -60,6 +59,7 @@ class Cluster:
         self._sync_interval = parse_timedelta(
             scheduler_sync_interval, default="seconds"
         )
+        self._sync_cluster_info_task = None
 
         if name is None:
             name = str(uuid.uuid4())[:8]
@@ -94,22 +94,55 @@ class Cluster:
         )
         self._cluster_info.update(info)
 
-        self.periodic_callbacks["sync-cluster-info"] = PeriodicCallback(
-            self._sync_cluster_info, self._sync_interval * 1000
-        )
+        # Start a background task for syncing cluster info with the scheduler
+        self._sync_cluster_info_task = asyncio.ensure_future(self._sync_cluster_info())
+
         for pc in self.periodic_callbacks.values():
             pc.start()
         self.status = Status.running
 
     async def _sync_cluster_info(self):
-        await self.scheduler_comm.set_metadata(
-            keys=["cluster-manager-info"],
-            value=copy.copy(self._cluster_info),
-        )
+        err_count = 0
+        warn_at = 5
+        max_interval = 10 * self._sync_interval
+        # Loop until the cluster is shutting down. We shouldn't really need
+        # this check (the `CancelledError` should be enough), but something
+        # deep in the comms code is silencing `CancelledError`s _some_ of the
+        # time, resulting in a cancellation not always bubbling back up to
+        # here. Relying on the status is fine though, not worth changing.
+        while self.status == Status.running:
+            try:
+                await self.scheduler_comm.set_metadata(
+                    keys=["cluster-manager-info"],
+                    value=self._cluster_info.copy(),
+                )
+                err_count = 0
+            except asyncio.CancelledError:
+                # Task is being closed. When we drop Python < 3.8 we can drop
+                # this check (since CancelledError is not a subclass of
+                # Exception then).
+                break
+            except Exception:
+                err_count += 1
+                # Only warn if multiple subsequent attempts fail, and only once
+                # per set of subsequent failed attempts. This way we're not
+                # excessively noisy during a connection blip, but we also don't
+                # silently fail.
+                if err_count == warn_at:
+                    logger.warning(
+                        "Failed to sync cluster info multiple times - perhaps "
+                        "there's a connection issue? Error:",
+                        exc_info=True,
+                    )
+            # Sleep, with error backoff
+            interval = min(max_interval, self._sync_interval * 1.5 ** err_count)
+            await asyncio.sleep(interval)
 
     async def _close(self):
         if self.status == Status.closed:
             return
+
+        self.status = Status.closing
 
         with suppress(AttributeError):
             self._adaptive.stop()
@@ -118,6 +151,11 @@ class Cluster:
             await self._watch_worker_status_comm.close()
         if self._watch_worker_status_task:
             await self._watch_worker_status_task
+
+        if self._sync_cluster_info_task:
+            self._sync_cluster_info_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._sync_cluster_info_task
 
         if self.scheduler_comm:
             await self.scheduler_comm.close_rpc()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7060,17 +7060,12 @@ class Scheduler(SchedulerState, ServerNode):
 
     def set_metadata(self, comm=None, keys=None, value=None):
         parent: SchedulerState = cast(SchedulerState, self)
-        try:
-            metadata = parent._task_metadata
-            for key in keys[:-1]:
-                if key not in metadata or not isinstance(metadata[key], (dict, list)):
-                    metadata[key] = {}
-                metadata = metadata[key]
-            metadata[keys[-1]] = value
-        except Exception:
-            import pdb
-
-            pdb.set_trace()
+        metadata = parent._task_metadata
+        for key in keys[:-1]:
+            if key not in metadata or not isinstance(metadata[key], (dict, list)):
+                metadata[key] = {}
+            metadata = metadata[key]
+        metadata[keys[-1]] = value
 
     def get_metadata(self, comm=None, keys=None, default=no_default):
         parent: SchedulerState = cast(SchedulerState, self)


### PR DESCRIPTION
Previously a network blip would cause this periodic callback to log an
error condition to the user every second. This fixes that in the
following way:

- We now catch error conditions and only log a warning after a few
consecutive errors (so a single network blip will go unnoticed).
- In the case of an error, we backoff a bit before retrying.

Fixes #5472.