### PR TITLE
[WIP] Update `Worker._executing` handling

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2060,6 +2060,7 @@ class Worker(ServerNode):
     def transition_generic_error(
         self, ts, exception, traceback, exception_text, traceback_text, *, stimulus_id
     ):
+        self._executing.discard(ts)
         ts.exception = exception
         ts.traceback = traceback
         ts.exception_text = exception_text
@@ -2073,7 +2074,6 @@ class Worker(ServerNode):
     ):
         for resource, quantity in ts.resource_restrictions.items():
             self.available_resources[resource] += quantity
-        self._executing.discard(ts)
         return self.transition_generic_error(
             ts,
             exception,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2135,7 +2135,6 @@ class Worker(ServerNode):
         return recommendations, []
 
     def transition_executing_released(self, ts, *, stimulus_id):
-        self._executing.discard(ts)
         ts._previous = ts.state
         # See https://github.com/dask/distributed/pull/5046#discussion_r685093940
         ts.state = "cancelled"

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2135,6 +2135,7 @@ class Worker(ServerNode):
         return recommendations, []
 
     def transition_executing_released(self, ts, *, stimulus_id):
+        self._executing.discard(ts)
         ts._previous = ts.state
         # See https://github.com/dask/distributed/pull/5046#discussion_r685093940
         ts.state = "cancelled"


### PR DESCRIPTION
This is a possible fix for https://github.com/dask/distributed/issues/5497. With this change the example in https://github.com/dask/distributed/issues/5497 no longer deadlocks. I'm pushing changes up early to test against the full CI suite 

- [ ] Closes https://github.com/dask/distributed/issues/5497
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

cc @gjoseph92 @fjetter 