### PR TITLE
Fix deadlock caused by an erred task (executing->cancelled->error)

### DIFF
--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -1,7 +1,10 @@
 import asyncio
 from unittest import mock
 
+import pytest
+
 import distributed
+from distributed import Worker
 from distributed.core import CommClosedError
 from distributed.utils_test import _LockedCommPool, gen_cluster, inc, slowinc
 
@@ -131,3 +134,132 @@ async def test_flight_to_executing_via_cancelled_resumed(c, s, a, b):
     assert any("missing-dep" in msg for msg in b_story)
     assert any("cancelled" in msg for msg in b_story)
     assert any("resumed" in msg for msg in b_story)
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_executing_cancelled_error(c, s, w):
+    """One worker with one thread. We provoke an executing->cancelled transition
+    and let the task err. This test ensures that there is no residual state
+    (e.g. a semaphore) left blocking the thread"""
+    lock = distributed.Lock()
+    await lock.acquire()
+
+    async def wait_and_raise(*args, **kwargs):
+        async with lock:
+            raise RuntimeError()
+
+    fut = c.submit(wait_and_raise)
+    await wait_for_state(fut.key, "executing", w)
+
+    fut.release()
+    await wait_for_state(fut.key, "cancelled", w)
+    await lock.release()
+
+    # At this point we do not fetch the result of the future since the future
+    # itself would raise a cancelled exception. At this point we're concerned
+    # about the worker. The task should transition over error to be eventually
+    # forgotten since we no longer hold a ref.
+    while fut.key in w.tasks:
+        await asyncio.sleep(0.01)
+
+    # Everything should still be executing as usual after this
+    await c.submit(sum, c.map(inc, range(10))) == sum(map(inc, range(10)))
+
+    # Everything above this line should be generically true, regardless of
+    # refactoring. Below verifies some implementation specific test assumptions
+
+    story = w.story(fut.key)
+    start_finish = [(msg[1], msg[2]) for msg in story if len(msg) == 6]
+    assert ("executing", "cancelled") in start_finish
+    assert ("cancelled", "error") in start_finish
+    assert ("error", "released") in start_finish
+
+
+@gen_cluster(client=True)
+async def test_flight_cancelled_error(c, s, a, b):
+    """One worker with one thread. We provoke an flight->cancelled transition
+    and let the task err."""
+    lock = asyncio.Lock()
+    await lock.acquire()
+
+    async def wait_and_raise(*args, **kwargs):
+        async with lock:
+            raise RuntimeError()
+
+    with mock.patch.object(
+        distributed.worker,
+        "get_data_from_worker",
+        side_effect=wait_and_raise,
+    ):
+        fut1 = c.submit(inc, 1, workers=[a.address], allow_other_workers=True)
+        fut2 = c.submit(inc, fut1, workers=[b.address])
+
+        await wait_for_state(fut1.key, "flight", b)
+        fut2.release()
+        fut1.release()
+        await wait_for_state(fut1.key, "cancelled", b)
+
+    lock.release()
+    # At this point we do not fetch the result of the future since the future
+    # itself would raise a cancelled exception. At this point we're concerned
+    # about the worker. The task should transition over error to be eventually
+    # forgotten since we no longer hold a ref.
+    while fut1.key in b.tasks:
+        await asyncio.sleep(0.01)
+
+    # Everything should still be executing as usual after this
+    await c.submit(sum, c.map(inc, range(10))) == sum(map(inc, range(10)))
+
+
+class LargeButForbiddenSerialization:
+    def __reduce__(self):
+        raise RuntimeError("I will never serialize!")
+
+    def __sizeof__(self) -> int:
+        """Ensure this is immediately tried to spill"""
+        return 1_000_000_000_000
+
+
+def test_ensure_spilled_immediately(tmpdir):
+    """See also test_value_raises_during_spilling"""
+    import sys
+
+    from distributed.spill import SpillBuffer
+
+    mem_target = 1000
+    buf = SpillBuffer(tmpdir, target=mem_target)
+    buf["key"] = 1
+
+    obj = LargeButForbiddenSerialization()
+    assert sys.getsizeof(obj) > mem_target
+    with pytest.raises(
+        TypeError,
+        match=f"Could not serialize object of type {LargeButForbiddenSerialization.__name__}",
+    ):
+        buf["error"] = obj
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_value_raises_during_spilling(c, s):
+    """See also test_ensure_spilled_immediately"""
+
+    # Use a worker with a default memory limit
+    async with Worker(
+        s.address,
+    ) as w:
+
+        def produce_evil_data():
+            return LargeButForbiddenSerialization()
+
+        fut = c.submit(produce_evil_data)
+
+        await wait_for_state(fut.key, "error", w)
+
+        with pytest.raises(
+            TypeError,
+            match=f"Could not serialize object of type {LargeButForbiddenSerialization.__name__}",
+        ):
+            await fut
+
+        # Everything should still be executing as usual after this
+        await c.submit(sum, c.map(inc, range(10))) == sum(map(inc, range(10)))

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -616,7 +616,7 @@ class Worker(ServerNode):
             ("cancelled", "waiting"): self.transition_cancelled_waiting,
             ("cancelled", "forgotten"): self.transition_cancelled_forgotten,
             ("cancelled", "memory"): self.transition_cancelled_memory,
-            ("cancelled", "error"): self.transition_generic_error,
+            ("cancelled", "error"): self.transition_cancelled_error,
             ("resumed", "memory"): self.transition_generic_memory,
             ("resumed", "error"): self.transition_generic_error,
             ("resumed", "released"): self.transition_generic_released,
@@ -1704,13 +1704,14 @@ class Worker(ServerNode):
                 recommendations[ts] = ("memory", value)
             except KeyError:
                 self.tasks[key] = ts = TaskState(key)
-                recs, smsgs = self._put_key_in_memory(
-                    ts, value, stimulus_id=stimulus_id
-                )
-                recommendations.update(recs)
-                scheduler_messages += smsgs
-                ts.priority = None
-                ts.duration = None
+
+                try:
+                    recs = self._put_key_in_memory(ts, value, stimulus_id=stimulus_id)
+                except Exception as e:
+                    msg = error_message(e)
+                    recommendations = {ts: tuple(msg.values())}
+                else:
+                    recommendations.update(recs)
 
             self.log.append((key, "receive-from-scatter"))
 
@@ -1919,7 +1920,7 @@ class Worker(ServerNode):
             pass
         elif ts.state == "memory":
             recommendations[ts] = "memory"
-            scheduler_msgs.append(self.get_task_state_for_scheduler(ts))
+            scheduler_msgs.append(self._get_task_finished_msg(ts))
         elif ts.state in {
             "released",
             "fetch",
@@ -2057,6 +2058,32 @@ class Worker(ServerNode):
 
         return {}, []
 
+    def transition_cancelled_error(
+        self, ts, exception, traceback, exception_text, traceback_text, *, stimulus_id
+    ):
+        recs, msgs = {}, []
+        if ts._previous == "executing":
+            recs, msgs = self.transition_executing_error(
+                ts,
+                exception,
+                traceback,
+                exception_text,
+                traceback_text,
+                stimulus_id=stimulus_id,
+            )
+        elif ts._previous == "flight":
+            recs, msgs = self.transition_flight_error(
+                ts,
+                exception,
+                traceback,
+                exception_text,
+                traceback_text,
+                stimulus_id=stimulus_id,
+            )
+        if ts._next:
+            recs[ts] = ts._next
+        return recs, msgs
+
     def transition_generic_error(
         self, ts, exception, traceback, exception_text, traceback_text, *, stimulus_id
     ):
@@ -2064,8 +2091,19 @@ class Worker(ServerNode):
         ts.traceback = traceback
         ts.exception_text = exception_text
         ts.traceback_text = traceback_text
-        smsgs = [self.get_task_state_for_scheduler(ts)]
         ts.state = "error"
+        smsgs = [
+            {
+                "op": "task-erred",
+                "status": "error",
+                "key": ts.key,
+                "thread": self.threads.get(ts.key),
+                "exception": ts.exception,
+                "traceback": ts.traceback,
+                "exception_text": ts.exception_text,
+                "traceback_text": ts.traceback_text,
+            }
+        ]
         return {}, smsgs
 
     def transition_executing_error(
@@ -2158,9 +2196,14 @@ class Worker(ServerNode):
         self._executing.discard(ts)
         self._in_flight_tasks.discard(ts)
         ts.coming_from = None
-
-        recs, smsgs = self._put_key_in_memory(ts, value, stimulus_id=stimulus_id)
-        smsgs.append(self.get_task_state_for_scheduler(ts))
+        try:
+            recs = self._put_key_in_memory(ts, value, stimulus_id=stimulus_id)
+        except Exception as e:
+            msg = error_message(e)
+            recs = {ts: tuple(msg.values())}
+            return recs, []
+        assert ts.key in self.data or ts.key in self.actors
+        smsgs = [self._get_task_finished_msg(ts)]
         return recs, smsgs
 
     def transition_executing_memory(self, ts, value=no_value, *, stimulus_id):
@@ -2260,16 +2303,44 @@ class Worker(ServerNode):
         return {}, smsgs
 
     def transition_released_memory(self, ts, value, *, stimulus_id):
-        recs, smsgs = self._put_key_in_memory(ts, value, stimulus_id=stimulus_id)
-        smsgs.append({"op": "add-keys", "keys": [ts.key], "stimulus_id": stimulus_id})
-        return recs, smsgs
+        recommendations = {}
+        try:
+            recommendations = self._put_key_in_memory(
+                ts, value, stimulus_id=stimulus_id
+            )
+        except Exception as e:
+            msg = error_message(e)
+            recommendations[ts] = (
+                "error",
+                msg["exception"],
+                msg["traceback"],
+                msg["exception_text"],
+                msg["traceback_text"],
+            )
+            return recommendations, []
+        smsgs = [{"op": "add-keys", "keys": [ts.key], "stimulus_id": stimulus_id}]
+        return recommendations, smsgs
 
     def transition_flight_memory(self, ts, value, *, stimulus_id):
         self._in_flight_tasks.discard(ts)
         ts.coming_from = None
-        recs, smsgs = self._put_key_in_memory(ts, value, stimulus_id=stimulus_id)
-        smsgs.append({"op": "add-keys", "keys": [ts.key], "stimulus_id": stimulus_id})
-        return recs, smsgs
+        recommendations = {}
+        try:
+            recommendations = self._put_key_in_memory(
+                ts, value, stimulus_id=stimulus_id
+            )
+        except Exception as e:
+            msg = error_message(e)
+            recommendations[ts] = (
+                "error",
+                msg["exception"],
+                msg["traceback"],
+                msg["exception_text"],
+                msg["traceback_text"],
+            )
+            return recommendations, []
+        smsgs = [{"op": "add-keys", "keys": [ts.key], "stimulus_id": stimulus_id}]
+        return recommendations, smsgs
 
     def transition_released_forgotten(self, ts, *, stimulus_id):
         recommendations = {}
@@ -2488,70 +2559,69 @@ class Worker(ServerNode):
         for el in skipped_worker_in_flight:
             heapq.heappush(self.data_needed, el)
 
-    def get_task_state_for_scheduler(self, ts):
-        if ts.key in self.data or self.actors.get(ts.key):
-            typ = ts.type
-            if ts.nbytes is None or typ is None:
-                try:
-                    value = self.data[ts.key]
-                except KeyError:
-                    value = self.actors[ts.key]
-                ts.nbytes = sizeof(value)
-                typ = ts.type = type(value)
-                del value
+    def _get_task_finished_msg(self, ts):
+        if ts.key not in self.data and ts.key not in self.actors:
+            raise RuntimeError(f"Task {ts} not ready")
+        typ = ts.type
+        if ts.nbytes is None or typ is None:
             try:
-                typ_serialized = dumps_function(typ)
-            except PicklingError:
-                # Some types fail pickling (example: _thread.lock objects),
-                # send their name as a best effort.
-                typ_serialized = pickle.dumps(typ.__name__, protocol=4)
-            d = {
-                "op": "task-finished",
-                "status": "OK",
-                "key": ts.key,
-                "nbytes": ts.nbytes,
-                "thread": self.threads.get(ts.key),
-                "type": typ_serialized,
-                "typename": typename(typ),
-                "metadata": ts.metadata,
-            }
-        elif ts.exception is not None:
-            d = {
-                "op": "task-erred",
-                "status": "error",
-                "key": ts.key,
-                "thread": self.threads.get(ts.key),
-                "exception": ts.exception,
-                "traceback": ts.traceback,
-                "exception_text": ts.exception_text,
-                "traceback_text": ts.traceback_text,
-            }
-        else:
-            logger.error("Key not ready to send to worker, %s: %s", ts.key, ts.state)
-            return None
+                value = self.data[ts.key]
+            except KeyError:
+                value = self.actors[ts.key]
+            ts.nbytes = sizeof(value)
+            typ = ts.type = type(value)
+            del value
+        try:
+            typ_serialized = dumps_function(typ)
+        except PicklingError:
+            # Some types fail pickling (example: _thread.lock objects),
+            # send their name as a best effort.
+            typ_serialized = pickle.dumps(typ.__name__, protocol=4)
+        d = {
+            "op": "task-finished",
+            "status": "OK",
+            "key": ts.key,
+            "nbytes": ts.nbytes,
+            "thread": self.threads.get(ts.key),
+            "type": typ_serialized,
+            "typename": typename(typ),
+            "metadata": ts.metadata,
+        }
         if ts.startstops:
             d["startstops"] = ts.startstops
         return d
 
     def _put_key_in_memory(self, ts, value, *, stimulus_id):
+        """
+        Put a key into memory and set data related task state attributes.
+        On success, generate recommendations for dependents.
+
+        This method does not generate any scheduler messages since this method
+        cannot distinguish whether it has to be an `add-task` or a
+        `task-finished` signal. The caller is required to generate this message
+        on success.
+
+        Raises
+        ------
+        TypeError:
+            In case the data is put into the in memory buffer and an exception
+            occurs during spilling, this raises an exception. This has to be
+            handled by the caller since most callers generate scheduler messages
+            on success (see comment above) but we need to signal that this was
+            not successful.
+            Can only trigger if spill to disk is enabled and the task is not an
+            actor.
+        """
         if ts.key in self.data:
             ts.state = "memory"
-            return {}, []
+            return {}
 
         recommendations = {}
-        scheduler_messages = []
         if ts.key in self.actors:
             self.actors[ts.key] = value
         else:
             start = time()
-            try:
-                self.data[ts.key] = value
-            except Exception as e:
-                msg = error_message(e)
-                ts.exception = msg["exception"]
-                ts.traceback = msg["traceback"]
-                recommendations[ts] = ("error", msg["exception"], msg["traceback"])
-                return recommendations, []
+            self.data[ts.key] = value
             stop = time()
             if stop - start > 0.020:
                 ts.startstops.append(
@@ -2571,7 +2641,7 @@ class Worker(ServerNode):
                 recommendations[dep] = "ready"
 
         self.log.append((ts.key, "put-in-memory", stimulus_id, time()))
-        return recommendations, scheduler_messages
+        return recommendations
 
     def select_keys_for_gather(self, worker, dep):
         assert isinstance(dep, str)
@@ -2714,6 +2784,7 @@ class Worker(ServerNode):
         if self.status not in RUNNING:
             return
 
+        recommendations: dict[TaskState, str | tuple] = {}
         with log_errors():
             response = {}
             to_gather_keys: set[str] = set()
@@ -2780,6 +2851,10 @@ class Worker(ServerNode):
                     import pdb
 
                     pdb.set_trace()
+                msg = error_message(e)
+                for k in self.in_flight_workers[worker]:
+                    ts = self.tasks[k]
+                    recommendations[ts] = tuple(msg.values())
                 raise
             finally:
                 self.comm_nbytes -= total_nbytes
@@ -2791,8 +2866,6 @@ class Worker(ServerNode):
                         ("busy-gather", worker, to_gather_keys, stimulus_id, time())
                     )
 
-                recommendations: dict[TaskState, str | tuple] = {}
-
                 for d in self.in_flight_workers.pop(worker):
                     ts = self.tasks[d]
                     ts.done = True
@@ -2802,7 +2875,7 @@ class Worker(ServerNode):
                         recommendations[ts] = ("memory", data[d])
                     elif busy:
                         recommendations[ts] = "fetch"
-                    else:
+                    elif ts not in recommendations:
                         ts.who_has.discard(worker)
                         self.has_what[worker].discard(ts.key)
                         self.log.append((d, "missing-dep"))

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2092,19 +2092,21 @@ class Worker(ServerNode):
         ts.exception_text = exception_text
         ts.traceback_text = traceback_text
         ts.state = "error"
-        smsgs = [
-            {
-                "op": "task-erred",
-                "status": "error",
-                "key": ts.key,
-                "thread": self.threads.get(ts.key),
-                "exception": ts.exception,
-                "traceback": ts.traceback,
-                "exception_text": ts.exception_text,
-                "traceback_text": ts.traceback_text,
-            }
-        ]
-        return {}, smsgs
+        smsg = {
+            "op": "task-erred",
+            "status": "error",
+            "key": ts.key,
+            "thread": self.threads.get(ts.key),
+            "exception": ts.exception,
+            "traceback": ts.traceback,
+            "exception_text": ts.exception_text,
+            "traceback_text": ts.traceback_text,
+        }
+
+        if ts.startstops:
+            smsg["startstops"] = ts.startstops
+
+        return {}, [smsg]
 
     def transition_executing_error(
         self, ts, exception, traceback, exception_text, traceback_text, *, stimulus_id


### PR DESCRIPTION
This fixes a deadlock caused by an erred task not freeing slots on the threadpool

Supersedes https://github.com/dask/distributed/pull/5501 and https://github.com/dask/distributed/pull/5500


Closes https://github.com/dask/distributed/issues/5497


Most notable change to the other proposed solutions is that this includes tests. Writing the tests also revealed problems around how `_put_key_in_memory` is implemented leading me to factor the exception handling out. Mid-/Long term I believe this should be addressed by changing the zict buffer to not raise in case of spillage/serialization error. It could instead simply store the item in memory even if it is too large. However, that's way beyond the scope of this fix.