### PR TITLE
Refactor release key

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2994,7 +2994,7 @@ class Worker(ServerNode):
             # If task is marked as "constrained" we haven't yet assigned it an
             # `available_resources` to run on, that happens in
             # `transition_constrained_executing`
-            self.transition(ts, "forgotten", stimulus_id=stimulus_id)
+            self.transition(ts, "released", stimulus_id=stimulus_id)
 
     def release_key(
         self,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1843,7 +1843,7 @@ class Worker(ServerNode):
                 continue
             if not ts.is_protected():
                 self.log.append((ts.key, "remove-replica-confirmed", stimulus_id))
-                recommendations[ts] = "released" if ts.dependents else "forgotten"
+                recommendations[ts] = "released"
             else:
                 rejected.append(key)
 


### PR DESCRIPTION
This might fix https://github.com/dask/distributed/issues/5482

This is mostly a refactoring around the release key implementation (which is historically easily top3 contributor for deadlocks). It is now more streamlined and all release and propagate forgotten logic is now pulled together into `transition_generic_released` and `transition_released_forgotten` where it should be. `Worker.release_key` now basically merely performs a state reset, as it is intended. Transition logic and recommendation should be as compact as possible to make reasoning more easy.

I also removed a few places were we set a recommendation to "forgotten" without actual reason. The new logic is now more stable and should fix #5482 and goes as

*If a Task is released and does not have any dependents it is allowed to be forgotten*

It's hard to tell since it's been spread across the state machine but the previous condition was much more loosely defined.

I'll try reproducing #5482 and write a test for it...