### PR TITLE
Cache url-escaped values in scheduler dashboard

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -5,6 +5,7 @@ import os
 from collections import defaultdict
 from functools import lru_cache
 from numbers import Number
+from typing import List
 
 import numpy as np
 from bokeh.core.properties import without_property_validation
@@ -443,11 +444,8 @@ class WorkersMemory(DashboardComponent):
 
     @without_property_validation
     def update(self):
-        def quadlist(i) -> list:
-            out = []
-            for ii in i:
-                out += [ii, ii, ii, ii]
-            return out
+        def quadlist(i) -> List[tuple]:
+            return [(ii, ii, ii, ii) for ii in i]
 
         with log_errors():
             workers = self.scheduler.workers.values()

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3,6 +3,7 @@ import math
 import operator
 import os
 from collections import defaultdict
+from functools import lru_cache
 from numbers import Number
 
 import numpy as np
@@ -94,6 +95,11 @@ logos_dict = {
 }
 
 
+@lru_cache(maxsize=2048)
+def url_escape_cached(value: str):
+    return escape.url_escape(value)
+
+
 class Occupancy(DashboardComponent):
     """Occupancy (in time) per worker"""
 
@@ -172,7 +178,7 @@ class Occupancy(DashboardComponent):
                     "worker": [ws.address for ws in workers],
                     "ms": ms,
                     "color": color,
-                    "escaped_worker": [escape.url_escape(ws.address) for ws in workers],
+                    "escaped_worker": [url_escape_cached(ws.address) for ws in workers],
                     "x": x,
                     "y": y,
                 }
@@ -487,7 +493,7 @@ class WorkersMemory(DashboardComponent):
                 "alpha": [1, 0.7, 0.4, 1] * len(workers),
                 "worker": quadlist(ws.address for ws in workers),
                 "escaped_worker": quadlist(
-                    escape.url_escape(ws.address) for ws in workers
+                    url_escape_cached(ws.address) for ws in workers
                 ),
                 "y": quadlist(range(len(workers))),
                 "proc_memory": quadlist(procmemory),
@@ -1511,7 +1517,7 @@ class CurrentLoad(DashboardComponent):
                 "nprocessing-half": [np / 2 for np in nprocessing],
                 "nprocessing-color": nprocessing_color,
                 "worker": [ws.address for ws in workers],
-                "escaped_worker": [escape.url_escape(ws.address) for ws in workers],
+                "escaped_worker": [url_escape_cached(ws.address) for ws in workers],
                 "y": list(range(len(workers))),
             }
 


### PR DESCRIPTION
I saw this on a long-ish running job. It seems trivial to cache the results of urlencoding the worker addresses. All the escaping showed up as taking a non-trivial amount of time - upwards of 2 minutes of CPU time in total for this graph.

`quadlist()` was also a big contributor, so I made that a bit more efficient. 

![Dask-perf](https://user-images.githubusercontent.com/1027207/141151136-599c25b8-552e-4446-aa36-98abe095ea7a.png)
