### PR TITLE
Remove extra quotation in worker failure docs

### DIFF
--- a/docs/source/killed.rst
+++ b/docs/source/killed.rst
@@ -17,7 +17,7 @@ to various exceptions appearing when you interact with your local client, such a
 
 Note the special case of ``KilledWorker``: this means that a particular task was
 tried on a worker, and it died, and then the same task was sent to another worker,
-which also died. After a configurable number of deaths (config key "
+which also died. After a configurable number of deaths (config key
 ``distributed.scheduler.allowed-failures``), Dask decides to blame the
 task itself, and returns this exception. Note, that it is possible for a task to be
 unfairly blamed - the worker happened to die while the task was active, perhaps


### PR DESCRIPTION
Noticed a small typo (an extra `"`) when reading through this page of the docs  