### PR TITLE
Ensure `safe_sizeof` warning is accurate

### DIFF
--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -1,5 +1,4 @@
 import logging
-from typing import SupportsInt
 
 from dask.sizeof import sizeof
 from dask.utils import format_bytes
@@ -7,7 +6,7 @@ from dask.utils import format_bytes
 logger = logging.getLogger(__name__)
 
 
-def safe_sizeof(obj, default_size: SupportsInt = 1e6) -> int:
+def safe_sizeof(obj, default_size: float = 1e6) -> int:
     """Safe variant of sizeof that captures and logs exceptions
 
     This returns a default size of 1e6 if the sizeof function fails
@@ -16,7 +15,7 @@ def safe_sizeof(obj, default_size: SupportsInt = 1e6) -> int:
         return sizeof(obj)
     except Exception:
         logger.warning(
-            f"Sizeof calculation failed. Defaulting to {format_bytes(default_size)}",
+            f"Sizeof calculation failed. Defaulting to {format_bytes(int(default_size))}",
             exc_info=True,
         )
         return int(default_size)

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -1,11 +1,13 @@
 import logging
+from typing import SupportsInt
 
 from dask.sizeof import sizeof
+from dask.utils import format_bytes
 
 logger = logging.getLogger(__name__)
 
 
-def safe_sizeof(obj, default_size=1e6):
+def safe_sizeof(obj, default_size: SupportsInt = 1e6) -> int:
     """Safe variant of sizeof that captures and logs exceptions
 
     This returns a default size of 1e6 if the sizeof function fails
@@ -13,5 +15,8 @@ def safe_sizeof(obj, default_size=1e6):
     try:
         return sizeof(obj)
     except Exception:
-        logger.warning("Sizeof calculation failed.  Defaulting to 1MB", exc_info=True)
+        logger.warning(
+            f"Sizeof calculation failed. Defaulting to {format_bytes(default_size)}",
+            exc_info=True,
+        )
         return int(default_size)

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -13,13 +13,22 @@ def test_safe_sizeof(obj):
     assert safe_sizeof(obj) == sizeof(obj)
 
 
-def test_safe_sizeof_raises():
+def test_safe_sizeof_logs_on_failure():
     class BadlySized:
         def __sizeof__(self):
             raise ValueError("bar")
 
     foo = BadlySized()
+
+    # Defaults to 0.95 MiB by default
     with captured_logger(logging.getLogger("distributed.sizeof")) as logs:
         assert safe_sizeof(foo) == 1e6
 
-    assert "Sizeof calculation failed.  Defaulting to 1MB" in logs.getvalue()
+    assert "Sizeof calculation failed. Defaulting to 0.95 MiB" in logs.getvalue()
+
+    # Can provide custom `default_size`
+    with captured_logger(logging.getLogger("distributed.sizeof")) as logs:
+        default_size = 2 * (1024 ** 2)  # 2 MiB
+        assert safe_sizeof(foo, default_size=default_size) == default_size
+
+    assert "Defaulting to 2.00 MiB" in logs.getvalue()


### PR DESCRIPTION
When chatting when @ncclementi yesterday, we noticed the message logged here doesn't take into account that `default_size` is configurable 