### PR TITLE
Add possibility of spill to constrained disk [WIP]

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -501,10 +501,17 @@ properties:
                 description: >-
                   When the process memory reaches this level the nanny process will kill
                   the worker (if a nanny is present)
+              
+              spill-limit:
+                oneOf:
+                  - {type: string}
+                  - {enum: [false]}
+                description: |
+                A limit on the spilling to disk, after this limit is hit we stop writing to disk. 
 
           http:
             type: object
-            decription: Settings for Dask's embedded HTTP Server
+            description: Settings for Dask's embedded HTTP Server
             properties:
               routes:
                 type: array

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -145,6 +145,9 @@ distributed:
       pause: 0.80  # fraction at which we pause worker threads
       terminate: 0.95  # fraction at which we terminate the worker
 
+      #spill-limit to disk
+      spill-limit: False
+
     http:
       routes:
         - distributed.http.worker.prometheus

--- a/distributed/spill.py
+++ b/distributed/spill.py
@@ -6,8 +6,9 @@ from functools import (  # noqa: F401 do we use this total ordering
     partial,
     total_ordering,
 )
-from typing import Any, Literal
+from typing import Any
 
+from typing_extensions import Literal
 from zict import Buffer, File, Func
 
 from .protocol import deserialize_bytes, serialize_bytelist

--- a/distributed/spill.py
+++ b/distributed/spill.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Hashable, Mapping
-from functools import partial
-from typing import Any
+from ctypes import sizeof  # noqa: F401   do we use this?
+from functools import (  # noqa: F401 do we use this total ordering
+    partial,
+    total_ordering,
+)
+from typing import Any, Literal
 
 from zict import Buffer, File, Func
 
@@ -18,17 +22,25 @@ class SpillBuffer(Buffer):
     spilled_by_key: dict[Hashable, int]
     spilled_total: int
 
-    def __init__(self, spill_directory: str, target: int):
+    def __init__(
+        self,
+        spill_directory: str,
+        target: int,
+        disk_limit: int | Literal[False] | None = None,
+    ):
         self.spilled_by_key = {}
         self.spilled_total = 0
-        storage = Func(
+
+        self.disk_limit = disk_limit
+        self.spilled_total_disk = 0  # MAYBE CHOOSE A DIFFERENT NAME
+        self.storage = Func(
             partial(serialize_bytelist, on_error="raise"),
             deserialize_bytes,
             File(spill_directory),
         )
         super().__init__(
             {},
-            storage,
+            self.storage,
             target,
             weight=self._weight,
             fast_to_slow_callbacks=[self._on_evict],
@@ -49,9 +61,19 @@ class SpillBuffer(Buffer):
         """
         return self.slow
 
-    @staticmethod
-    def _weight(key: Hashable, value: Any) -> int:
-        return safe_sizeof(value)
+    # @staticmethod
+    def _weight(self, key: Hashable, value: Any) -> int:
+        # Disk limit will be false by default so we need to check we have a limit
+        # otherwise the second condition is always true
+        # this triggers the right path but will record -1 on the tracking of what's
+        # on fast so not really working
+        if self.disk_limit and (
+            safe_sizeof(value) + self.spilled_total_disk > self.disk_limit
+        ):
+            print("spill-limit reached keeping task in memory")
+            return -1  # this should keep the key in fast
+        else:
+            return safe_sizeof(value)
 
     def _on_evict(self, key: Hashable, value: Any) -> None:
         b = safe_sizeof(value)
@@ -70,6 +92,10 @@ class SpillBuffer(Buffer):
             b = safe_sizeof(value)
             self.spilled_by_key[key] = b
             self.spilled_total += b
+
+            if self.disk_limit:
+                # track total spilled to disk (on disk) if limit is provided
+                self.spilled_total_disk += len(self.storage.d.get(key))
 
     def __delitem__(self, key: Hashable) -> None:
         self.spilled_total -= self.spilled_by_key.pop(key, 0)


### PR DESCRIPTION
- [ ] Closes #5364
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This is the start of a PR that will add the possibility to spill to a constrained disk. Things are not quite working yet but wanted to have a draft up. 

Tried using a custom `__setitem__` do doesn't use the `super()` see: 
https://github.com/ncclementi/distributed/blob/81b12da2dcc1a6b958b4e4db4682bade536d7d41/distributed/spill.py#L91-L94

BUt the problem I'm having is that is not keeping the key on fast, but spilling it to disk. I think this is because of the way LRU works. 