### PR TITLE
Small `gen_test` fixes

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1751,7 +1751,11 @@ class TaskState:
             exclude = set()
         members = inspect.getmembers(self)
         return recursive_to_dict(
-            {k: v for k, v in members if k not in exclude and not callable(v)},
+            {
+                k: v
+                for k, v in members
+                if not k.startswith("__") and k not in exclude and not callable(v)
+            },
             exclude=exclude,
         )
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -856,9 +856,9 @@ async def start_cluster(
 async def end_cluster(s, workers):
     logger.debug("Closing out test cluster")
 
-    async def end_worker(w):
+    async def end_worker(w: Worker):
         with suppress(TimeoutError, CommClosedError, EnvironmentError):
-            await w.close(report=False)
+            await w.close(report=False, timeout=2)
 
     await asyncio.gather(*(end_worker(w) for w in workers))
     await s.close()  # wait until scheduler stops completely
@@ -1006,7 +1006,7 @@ def gen_cluster(
                                     )
 
                             task.cancel()
-                            while not task.cancelled():
+                            while not task.done():
                                 await asyncio.sleep(0.01)
                             raise TimeoutError(
                                 f"Test timeout after {timeout}s.\n{buffer.getvalue()}"


### PR DESCRIPTION
Things I found debugging https://github.com/dask/distributed/issues/5522

I added the timeout in `end_worker` because if the worker's threadpool is actually running anything (like, say, some deadlocked shuffle code 😬 ), then closing the worker will hang for forever (or at least a very very long time; I wasn't patient enough to find out).

cc @fjetter 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
