### PR TITLE
[DNM] P2P shuffle skeleton - scheduler plugin

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -188,7 +188,7 @@ DEFAULT_EXTENSIONS = [
     ActiveMemoryManagerExtension,
     MemorySamplerExtension,
 ]
-DEFAULT_PLUGINS: tuple[SchedulerPlugin, ...] = (
+DEFAULT_PLUGINS: "tuple[SchedulerPlugin, ...]" = (
     (shuffle.ShuffleSchedulerPlugin(),) if shuffle.SHUFFLE_AVAILABLE else ()
 )
 # ^ TODO this assumes one Scheduler per process; probably a bad idea.

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -191,6 +191,7 @@ DEFAULT_EXTENSIONS = [
 DEFAULT_PLUGINS: tuple[SchedulerPlugin, ...] = (
     (shuffle.ShuffleSchedulerPlugin(),) if shuffle.SHUFFLE_AVAILABLE else ()
 )
+# ^ TODO this assumes one Scheduler per process; probably a bad idea.
 
 ALL_TASK_STATES = declare(
     set, {"released", "waiting", "no-worker", "processing", "erred", "memory"}

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -51,7 +51,7 @@ from dask.widgets import get_template
 
 from distributed.utils import recursive_to_dict
 
-from . import preloading, profile
+from . import preloading, profile, shuffle
 from . import versions as version_module
 from .active_memory_manager import ActiveMemoryManagerExtension
 from .batched import BatchedSend
@@ -188,6 +188,9 @@ DEFAULT_EXTENSIONS = [
     ActiveMemoryManagerExtension,
     MemorySamplerExtension,
 ]
+DEFAULT_PLUGINS: tuple[SchedulerPlugin, ...] = (
+    (shuffle.ShuffleSchedulerPlugin(),) if shuffle.SHUFFLE_AVAILABLE else ()
+)
 
 ALL_TASK_STATES = declare(
     set, {"released", "waiting", "no-worker", "processing", "erred", "memory"}
@@ -3623,7 +3626,7 @@ class Scheduler(SchedulerState, ServerNode):
         http_prefix="/",
         preload=None,
         preload_argv=(),
-        plugins=(),
+        plugins=DEFAULT_PLUGINS,
         **kwargs,
     ):
         self._setup_logging(logger)

--- a/distributed/shuffle/__init__.py
+++ b/distributed/shuffle/__init__.py
@@ -1,0 +1,20 @@
+try:
+    import pandas
+except ImportError:
+    SHUFFLE_AVAILABLE = False
+else:
+    del pandas
+    SHUFFLE_AVAILABLE = True
+
+    from .common import ShuffleId
+    from .graph import rearrange_by_column_p2p
+    from .shuffle_scheduler import ShuffleSchedulerPlugin
+    from .shuffle_worker import ShuffleWorkerExtension
+
+__all__ = [
+    "SHUFFLE_AVAILABLE",
+    "ShuffleId",
+    "rearrange_by_column_p2p",
+    "ShuffleWorkerExtension",
+    "ShuffleSchedulerPlugin",
+]

--- a/distributed/shuffle/common.py
+++ b/distributed/shuffle/common.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import math
+from typing import NewType
+
+ShuffleId = NewType("ShuffleId", str)
+
+
+def worker_for(output_partition: int, npartitions: int, workers: list[str]) -> str:
+    "Get the address of the worker which should hold this output partition number"
+    if output_partition < 0:
+        raise IndexError(f"Negative output partition: {output_partition}")
+    if output_partition >= npartitions:
+        raise IndexError(
+            f"Output partition {output_partition} does not exist in a shuffle producing {npartitions} partitions"
+        )
+    i = len(workers) * output_partition // npartitions
+    return workers[i]
+
+
+def partition_range(
+    worker: str, npartitions: int, workers: list[str]
+) -> tuple[int, int]:
+    "Get the output partition numbers (inclusive) that a worker will hold"
+    i = workers.index(worker)
+    first = math.ceil(npartitions * i / len(workers))
+    last = math.ceil(npartitions * (i + 1) / len(workers)) - 1
+    return first, last
+
+
+def npartitions_for(worker: str, npartitions: int, workers: list[str]) -> int:
+    "Get the number of output partitions a worker will hold"
+    first, last = partition_range(worker, npartitions, workers)
+    return last - first + 1

--- a/distributed/shuffle/graph.py
+++ b/distributed/shuffle/graph.py
@@ -41,16 +41,15 @@ def shuffle_transfer(
     ext.sync(ext.add_partition(data, id, npartitions, column))
 
 
-def shuffle_unpack(
-    id: ShuffleId, i: int, empty: pd.DataFrame, barrier=None
-) -> pd.DataFrame:
-    ext = get_shuffle_extension()
-    return ext.sync(ext.get_output_partition(id, i, empty))
-
-
 def shuffle_barrier(id: ShuffleId, transfers: list[None]) -> None:
     ext = get_shuffle_extension()
     ext.sync(ext.barrier(id))
+
+
+def shuffle_unpack(
+    id: ShuffleId, i: int, empty: pd.DataFrame, barrier=None
+) -> pd.DataFrame:
+    return get_shuffle_extension().get_output_partition(id, i, empty)
 
 
 def rearrange_by_column_p2p(

--- a/distributed/shuffle/graph.py
+++ b/distributed/shuffle/graph.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dask.base import tokenize
+from dask.blockwise import BlockwiseDepDict, blockwise
+from dask.dataframe import DataFrame
+from dask.delayed import Delayed
+from dask.highlevelgraph import HighLevelGraph
+
+from .common import ShuffleId
+from .shuffle_worker import ShuffleWorkerExtension
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+def get_shuffle_extension() -> ShuffleWorkerExtension:
+    from distributed import get_worker
+
+    return get_worker().extensions["shuffle"]
+
+
+def shuffle_transfer(
+    data: pd.DataFrame, id: ShuffleId, npartitions: int, column: str
+) -> None:
+    ext = get_shuffle_extension()
+    ext.sync(ext.add_partition(data, id, npartitions, column))
+
+
+def shuffle_unpack(
+    id: ShuffleId, i: int, empty: pd.DataFrame, barrier=None
+) -> pd.DataFrame:
+    ext = get_shuffle_extension()
+    return ext.sync(ext.get_output_partition(id, i, empty))
+
+
+def shuffle_barrier(id: ShuffleId, transfers: list[None]) -> None:
+    ext = get_shuffle_extension()
+    ext.sync(ext.barrier(id))
+
+
+def rearrange_by_column_p2p(
+    df: DataFrame,
+    column: str,
+    npartitions: int | None = None,
+):
+    npartitions = npartitions or df.npartitions
+    token = tokenize(df, column, npartitions)
+
+    transferred = df.map_partitions(
+        shuffle_transfer,
+        token,
+        npartitions,
+        column,
+        meta=df,
+        enforce_metadata=False,
+        transform_divisions=False,
+    )
+
+    barrier_key = "shuffle-barrier-" + token
+    barrier_dsk = {barrier_key: (shuffle_barrier, token, transferred.__dask_keys__())}
+    barrier = Delayed(
+        barrier_key,
+        HighLevelGraph.from_collections(
+            barrier_key, barrier_dsk, dependencies=[transferred]
+        ),
+    )
+
+    name = "shuffle-unpack-" + token
+    dsk = blockwise(
+        shuffle_unpack,
+        name,
+        "i",
+        token,
+        None,
+        BlockwiseDepDict({(i,): i for i in range(npartitions)}),
+        "i",
+        df._meta,
+        None,
+        barrier_key,
+        None,
+        numblocks={},
+    )
+
+    return DataFrame(
+        HighLevelGraph.from_collections(name, dsk, [barrier]),
+        name,
+        df._meta,
+        [None] * (npartitions + 1),
+    )

--- a/distributed/shuffle/shuffle_scheduler.py
+++ b/distributed/shuffle/shuffle_scheduler.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+from distributed.diagnostics import SchedulerPlugin
+from distributed.utils import key_split_group
+
+from .common import ShuffleId, worker_for
+
+if TYPE_CHECKING:
+    from distributed import Scheduler
+    from distributed.scheduler import TaskState
+
+
+TASK_PREFIX = "('shuffle_"
+
+
+@dataclass
+class ShuffleState:
+    workers: list[str]
+    out_tasks_left: int
+    barrier_reached: bool = False
+
+
+class ShuffleSchedulerPlugin(SchedulerPlugin):
+    started_prefixes: dict[str, Callable[[ShuffleId, str], None]]
+    output_keys: dict[str, ShuffleId]
+    shuffles: dict[ShuffleId, ShuffleState]
+    scheduler: Scheduler
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.shuffles = {}
+        self.output_keys = {}
+        self.started_prefixes = {
+            f"{TASK_PREFIX}transfer-": self.transfer,
+            f"{TASK_PREFIX}barrier-": self.barrier,
+        }
+
+    async def start(self, scheduler: Scheduler) -> None:
+        self.scheduler = scheduler
+
+    def transfer(self, id: ShuffleId, key: str) -> None:
+        state = self.shuffles.get(id, None)
+        if state:
+            assert (
+                not state.barrier_reached
+            ), f"Duplicate shuffle: {key} running after barrier already reached"
+            # TODO allow plugins to return recommendations, so we can error this task in some way
+            return
+
+        addrs = list(self.scheduler.workers)
+        # TODO handle resource/worker restrictions
+
+        # Check how many output tasks there actually are, purely for validation right now.
+        # This lets us catch the "error" of culling shuffle output tasks.
+        # In the future, we may use it to actually handle culled shuffles properly.
+        ts: TaskState = self.scheduler.tasks[key]
+        assert (
+            len(ts.dependents) == 1
+        ), f"{key} should have exactly one dependency (the barrier), not {ts.dependents}"
+        barrier = next(iter(ts.dependents))
+        nout = len(barrier.dependents)
+
+        self.shuffles[id] = ShuffleState(addrs, nout)
+
+        # TODO allow plugins to return worker messages (though hopefully these will get batched anyway)
+        msg = [{"op": "shuffle_init", "id": id, "workers": addrs, "n_out_tasks": nout}]
+        self.scheduler.send_all(
+            {},
+            {addr: msg for addr in addrs},
+        )
+
+    def barrier(self, id: ShuffleId, key: str) -> None:
+        state = self.shuffles[id]
+        assert (
+            not state.barrier_reached
+        ), f"Duplicate barrier: {key} running but barrier already reached"
+        state.barrier_reached = True
+
+        # Identify output tasks
+        ts: TaskState = self.scheduler.tasks[key]
+
+        # Set worker restrictions on output tasks, and register their keys for us to watch in transitions
+        for dts in ts.dependents:
+            assert (
+                len(dts.dependencies) == 1
+            ), f"Output task {dts} (of shuffle {id}) should have 1 dependency, not {dts.dependencies}"
+
+            assert (
+                not dts.worker_restrictions
+            ), f"Output task {dts.key} (of shuffle {id}) already has worker restrictions {dts.worker_restrictions}"
+
+            try:
+                dts._worker_restrictions = {
+                    self.worker_for_key(dts.key, state.out_tasks_left, state.workers)
+                }
+            except (RuntimeError, IndexError, ValueError) as e:
+                raise type(e)(
+                    f"Could not pick worker to run dependent {dts.key} of {key}: {e}"
+                ) from None
+
+            self.output_keys[dts.key] = id
+
+    def unpack(self, id: ShuffleId, key: str) -> None:
+        # Check if all output keys are done
+
+        # NOTE: we don't actually need this `unpack` step or tracking output keys;
+        # we could just delete the state in `barrier`.
+        # But we do it so we can detect duplicate shuffles, where a `transfer` task
+        # tries to reuse a shuffle ID that we're unpacking.
+        # (It does also allow us to clean up worker restrictions on error)
+        state = self.shuffles[id]
+        assert (
+            state.barrier_reached
+        ), f"Output {key} complete but barrier for shuffle {id} not yet reached"
+        assert (
+            state.out_tasks_left > 0
+        ), f"Output {key} complete; nout_left = {state.out_tasks_left} for shuffle {id}"
+
+        state.out_tasks_left -= 1
+
+        if not state.out_tasks_left:
+            # Shuffle is done. Yay!
+            del self.shuffles[id]
+
+    def erred(self, id: ShuffleId, key: str) -> None:
+        try:
+            state = self.shuffles.pop(id)
+        except KeyError:
+            return
+
+        if state.barrier_reached:
+            # Remove worker restrictions for output tasks, in case the shuffle is re-submitted
+            for k, id_ in list(self.output_keys.items()):
+                if id_ == id:
+                    ts: TaskState = self.scheduler.tasks[k]
+                    ts._worker_restrictions.clear()
+                    del self.output_keys[k]
+
+    def transition(self, key: str, start: str, finish: str, *args, **kwargs):
+        if key.startswith(TASK_PREFIX):
+            # transfer/barrier starting to run
+            if start == "waiting" and finish in ("processing", "memory"):
+                for prefix, handler in self.started_prefixes.items():
+                    if key.startswith(prefix):
+                        # Is this too brittle, assuming IDs are 32 characters?
+                        # Inferring from the key name is brittle in general...
+                        id = key[len(prefix) : len(prefix) + 32]
+                        return handler(ShuffleId(id), key)
+
+            # transfer/barrier task erred
+            elif finish == "erred":
+                id = key_split_group(key).split("-")[-1]
+                return self.erred(ShuffleId(id), key)
+
+        # Task completed
+        if start in ("waiting", "processing") and finish in (
+            "memory",
+            "released",
+            "erred",
+        ):
+            try:
+                id = self.output_keys[key]
+            except KeyError:
+                return
+            # Known unpack task completed or erred
+            if finish == "erred":
+                return self.erred(id, key)
+            return self.unpack(id, key)
+
+    def worker_for_key(self, key: str, npartitions: int, workers: list[str]) -> str:
+        "Worker address this task should be assigned to"
+        # Infer which output partition number this task is fetching by parsing its key
+        # FIXME this is so brittle.
+        # For example, after `df.set_index(...).to_delayed()`, you could create
+        # keys that don't have indices in them, and get fused (because they should!).
+        m = re.match(r"\(.+, (\d+)\)$", key)
+        if not m:
+            raise RuntimeError(f"{key} does not look like a DataFrame key")
+
+        idx = int(m.group(0))
+        addr = worker_for(idx, npartitions, workers)
+        if addr not in self.scheduler.workers:
+            raise RuntimeError(
+                f"Worker {addr} for output partition {idx} no longer known"
+            )
+        return addr

--- a/distributed/shuffle/shuffle_scheduler.py
+++ b/distributed/shuffle/shuffle_scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from distributed.diagnostics import SchedulerPlugin
 from distributed.utils import key_split_group
@@ -25,12 +25,12 @@ class ShuffleState:
 
 
 class ShuffleSchedulerPlugin(SchedulerPlugin):
+    name: ClassVar[str] = "ShuffleSchedulerPlugin"
     output_keys: dict[str, ShuffleId]
     shuffles: dict[ShuffleId, ShuffleState]
     scheduler: Scheduler
 
     def __init__(self) -> None:
-        super().__init__()
         self.shuffles = {}
         self.output_keys = {}
 

--- a/distributed/shuffle/shuffle_worker.py
+++ b/distributed/shuffle/shuffle_worker.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from distributed.protocol import to_serialize
+
+from .common import ShuffleId, npartitions_for, worker_for
+
+if TYPE_CHECKING:
+    from distributed import Worker
+
+
+@dataclass
+class ShuffleState:
+    workers: list[str]
+    npartitions: int
+    out_parts_left: int
+    barrier_reached: bool = False
+
+
+class ShuffleWorkerExtension:
+    "Extend the Worker with routes and state for peer-to-peer shuffles"
+    worker: Worker
+    shuffles: dict[ShuffleId, ShuffleState]
+    waiting_for_metadata: dict[ShuffleId, asyncio.Event]
+    output_data: defaultdict[ShuffleId, defaultdict[int, list[pd.DataFrame]]]
+
+    def __init__(self, worker: Worker) -> None:
+        # Attach to worker
+        worker.extensions["shuffle"] = self
+        worker.stream_handlers["shuffle_init"] = self.shuffle_init
+        worker.handlers["shuffle_receive"] = self.shuffle_receive
+        worker.handlers["shuffle_inputs_done"] = self.shuffle_inputs_done
+
+        # Initialize
+        self.worker: Worker = worker
+        self.shuffles = {}
+        self.waiting_for_metadata = {}
+        self.output_data = defaultdict(lambda: defaultdict(list))
+
+    # Handlers
+    ##########
+
+    def shuffle_init(self, id: ShuffleId, workers: list[str], n_out_tasks: int) -> None:
+        if id in self.shuffles:
+            raise ValueError(
+                f"Shuffle {id!r} is already registered on worker {self.worker.address}"
+            )
+        self.shuffles[id] = ShuffleState(
+            workers,
+            n_out_tasks,
+            npartitions_for(self.worker.address, n_out_tasks, workers),
+        )
+        try:
+            # Invariant: if `waiting_for_metadata` event is set, key is already in `shuffles`
+            self.waiting_for_metadata[id].set()
+        except KeyError:
+            pass
+
+    def shuffle_receive(
+        self,
+        comm: object,
+        id: ShuffleId,
+        output_partition: int,
+        data: pd.DataFrame,
+    ) -> None:
+        try:
+            state = self.shuffles[id]
+        except KeyError:
+            # NOTE: `receive` could be called before `init`, if some other worker
+            # processed their `init` faster than us and then sent us data.
+            # That's why we keep `output_data` separate from `shuffles`.
+            pass
+        else:
+            assert not state.barrier_reached, f"`receive` called after barrier for {id}"
+            receiver = worker_for(output_partition, state.npartitions, state.workers)
+            assert receiver == self.worker.address, (
+                f"{self.worker.address} received output partition {output_partition} "
+                f"for shuffle {id}, which was expected to go to {receiver}."
+            )
+
+        self.output_data[id][output_partition].append(data)
+
+    async def shuffle_inputs_done(self, comm: object, id: ShuffleId) -> None:
+        state = await self.get_shuffle(id)
+        assert not state.barrier_reached, f"`inputs_done` called again for {id}"
+        state.barrier_reached = True
+
+        if not state.out_parts_left:
+            # No output partitions, remove shuffle it now:
+            # `get_output_partition` will never be called.
+            # This happens when there are fewer output partitions than workers.
+            self.remove(id)
+
+    # Tasks
+    #######
+
+    async def _add_partition(
+        self, id: ShuffleId, npartitions: int, column: str, data: pd.DataFrame
+    ) -> None:
+        # Block until scheduler has called init
+        state = await self.get_shuffle(id)
+        assert not state.barrier_reached, f"`add_partition` for {id} after barrier"
+
+        if npartitions != state.npartitions:
+            raise NotImplementedError(
+                f"Expected shuffle {id} to produce {npartitions} output tasks, "
+                f"but it only has {state.npartitions}. Did you sub-select from the "
+                "shuffled DataFrame, like `df.set_index(...).loc['foo':'bar']`?\n"
+                "This is not yet supported for peer-to-peer shuffles. Either remove "
+                "the sub-selection or use `shuffle='tasks'` for now."
+            )
+        # Group and send data
+        await self.send_partition(data, column, id, npartitions, state.workers)
+
+    async def _barrier(self, id: ShuffleId) -> None:
+        # NOTE: requires workers list. This is guaranteed because it depends on `add_partition`,
+        # which got the workers list from the scheduler. So this task must run on a worker where
+        # `add_partition` has already run.
+        state = await self.get_shuffle(id)
+        assert not state.barrier_reached, f"`barrier` for {id} called multiple times"
+
+        # Call `shuffle_inputs_done` on peers.
+        # Note that this will call `shuffle_inputs_done` on our own worker as well.
+        # Concurrently, the scheduler is setting worker restrictions on its own.
+        await asyncio.gather(
+            *(
+                self.worker.rpc(worker).shuffle_inputs_done(id=id)
+                for worker in state.workers
+            ),
+        )
+
+    async def get_output_partition(
+        self, id: ShuffleId, i: int, empty: pd.DataFrame
+    ) -> pd.DataFrame:
+        state = self.shuffles[id]
+        # ^ Don't need to `get_shuffle`; `shuffle_inputs_done` has run already and guarantees it's there
+        assert state.barrier_reached, f"`get_output_partition` for {id} before barrier"
+        assert (
+            state.out_parts_left > 0
+        ), f"No outputs remaining, but requested output partition {i} on {self.worker.address} for {id}."
+        # ^ Note: this is impossible with our cleanup-on-empty
+
+        worker = worker_for(i, state.npartitions, state.workers)
+        assert worker == self.worker.address, (
+            f"{self.worker.address} received output partition {i} "
+            f"for shuffle {id}, which was expected to go to {worker}."
+        )
+
+        try:
+            parts = self.output_data[id].pop(i)
+        except KeyError:
+            result = empty
+        else:
+            result = pd.concat(parts, copy=False)
+
+        state.out_parts_left -= 1
+        if not state.out_parts_left:
+            # Shuffle is done. Yay!
+            self.remove(id)
+
+        return result
+
+    # Helpers
+    #########
+
+    def remove(self, id: ShuffleId) -> None:
+        state = self.shuffles.pop(id)
+        assert state.barrier_reached, f"Removed {id} before barrier"
+        assert (
+            not state.out_parts_left
+        ), f"Removed {id} with {state.out_parts_left} outputs left"
+
+        event = self.waiting_for_metadata.pop(id, None)
+        if event:
+            assert event.is_set(), f"Removed {id} while still waiting for metadata"
+
+        data = self.output_data.pop(id, None)
+        assert (
+            not data
+        ), f"Removed {id}, which still has data for output partitions {list(data)}"
+
+    async def get_shuffle(self, id: ShuffleId):
+        try:
+            return self.shuffles[id]
+        except KeyError:
+            event = self.waiting_for_metadata.setdefault(id, asyncio.Event())
+            try:
+                await asyncio.wait_for(event.wait(), timeout=5)  # TODO config
+            except TimeoutError:
+                raise TimeoutError(
+                    f"Timed out waiting for scheduler to start shuffle {id}"
+                ) from None
+            # Invariant: once `waiting_for_metadata` event is set, key is already in `shuffles`.
+            # And once key is in `shuffles`, no `get_shuffle` will create a new event.
+            # So we can safely remove the event now.
+            self.waiting_for_metadata.pop(id, None)
+            return self.shuffles[id]
+
+    async def send_partition(
+        self,
+        data: pd.DataFrame,
+        column: str,
+        id: ShuffleId,
+        npartitions: int,
+        workers: list[str],
+    ) -> None:
+        tasks = []
+        # TODO grouping is blocking, should it be offloaded to a thread?
+        # It mostly doesn't release the GIL though, so may not make much difference.
+        for output_partition, data in data.groupby(column):
+            addr = worker_for(int(output_partition), npartitions, workers)
+            task = asyncio.create_task(
+                self.worker.rpc(addr).shuffle_receive(
+                    id=id,
+                    output_partition=output_partition,
+                    data=to_serialize(data),
+                )
+            )
+            tasks.append(task)
+
+        # TODO handle errors and cancellation here
+        await asyncio.gather(*tasks)

--- a/distributed/shuffle/tests/test_common.py
+++ b/distributed/shuffle/tests/test_common.py
@@ -1,0 +1,51 @@
+import string
+from collections import Counter
+
+import pytest
+
+from ..common import npartitions_for, partition_range, worker_for
+
+
+@pytest.mark.parametrize("npartitions", [1, 2, 3, 5])
+@pytest.mark.parametrize("n_workers", [1, 2, 3, 5])
+def test_worker_for_distribution(npartitions: int, n_workers: int):
+    "Test that `worker_for` distributes evenly"
+    workers = list(string.ascii_lowercase[:n_workers])
+
+    with pytest.raises(IndexError, match="Negative"):
+        worker_for(-1, npartitions, workers)
+
+    assignments = [worker_for(i, npartitions, workers) for i in range(npartitions)]
+
+    # Test `partition_range`
+    for w in workers:
+        first, last = partition_range(w, npartitions, workers)
+        assert all(
+            [
+                first <= p_i <= last if a == w else p_i < first or p_i > last
+                for p_i, a in enumerate(assignments)
+            ]
+        )
+
+    counter = Counter(assignments)
+    assert len(counter) == min(npartitions, n_workers)
+
+    # Test `npartitions_for`
+    calculated_counter = {w: npartitions_for(w, npartitions, workers) for w in workers}
+    assert counter == {
+        w: count for w, count in calculated_counter.items() if count != 0
+    }
+    assert calculated_counter.keys() == set(workers)
+    # ^ this also checks that workers receiving 0 output partitions were calculated properly
+
+    # Test the distribution of worker assignments.
+    # All workers should be assigned the same number of partitions, or if
+    # there's an odd number, some workers will be assigned only one extra partition.
+    counts = set(counter.values())
+    assert len(counts) <= 2
+    if len(counts) == 2:
+        lo, hi = sorted(counts)
+        assert lo == hi - 1
+
+    with pytest.raises(IndexError, match="does not exist"):
+        worker_for(npartitions, npartitions, workers)

--- a/distributed/shuffle/tests/test_graph.py
+++ b/distributed/shuffle/tests/test_graph.py
@@ -93,7 +93,6 @@ async def test_basic_state(c: Client, s: Scheduler, *workers: Worker):
     for ext in exts:
         assert not ext.shuffles
         assert not ext.output_data
-        assert not ext.waiting_for_metadata
 
     plugin = s.plugins[ShuffleSchedulerPlugin.name]
     assert isinstance(plugin, ShuffleSchedulerPlugin)

--- a/distributed/shuffle/tests/test_graph.py
+++ b/distributed/shuffle/tests/test_graph.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+import pandas as pd
+
 import dask
 import dask.dataframe as dd
 from dask.blockwise import Blockwise
@@ -128,4 +130,61 @@ def test_multiple_linear(client: Client):
 
     dd.utils.assert_eq(
         s2, df.assign(x=lambda df: df.x + 1).shuffle("x", shuffle="tasks")
+    )
+
+
+def test_multiple_concurrent(client: Client):
+    df1 = dd.demo.make_timeseries(freq="15D", partition_freq="30D")
+    df2 = dd.demo.make_timeseries(
+        start="2001-01-01", end="2001-12-31", freq="15D", partition_freq="30D"
+    )
+    s1 = shuffle(df1, "id")
+    s2 = shuffle(df2, "id")
+    assert s1._name != s2._name
+
+    merged = dd.map_partitions(
+        lambda p1, p2: pd.merge(p1, p2, on="id"), s1, s2, align_dataframes=False
+    )
+
+    # TODO this fails because blockwise merges the two `unpack` layers together like
+    #      X
+    #    /  \      -->   X
+    #   X    X
+
+    # So the HLG structure is
+    #
+    #      Actual:                  Expected:
+    #
+    #                                   merge
+    #                                 /       \
+    #    unpack+merge              unpack   unpack
+    #      /      \                  |         |
+    #  barrier   barrier          barrier   barrier
+    #    |          |                |         |
+    #  xfer        xfer             xfer      xfer
+
+    # And in the scheduler plugin's barrier, we check that the dependents
+    # of a `barrier` depend only on that one barrier.
+    # But here, they depend on _both_ barriers.
+    # This check is probably overly restrictive, because with blockwise fusion
+    # after the unpack, it's in fact quite likely that other dependencies would
+    # appear.
+    #
+    # This is probably solveable, but tricky.
+    # We'd have to confirm that:
+    # 1. The other dependencies aren't barriers
+    # 2. If the other dependencies are barriers:
+    #    - that shuffle has the same number of partitions _and_ the same set of workers
+    #
+    # Otherwise, these tasks just cannot be fused, because their data is going to
+    # different places. Yet another thing we might need to deal with at the optimization level.
+
+    # _Or_, could the scheduler plugin look for this situation in advance before starting the
+    # shuffle, and if it sees that multiple shuffles feed into the output tasks of the one
+    # it's starting, ensure that their worker assignments all line up? (This would mean ensuring
+    # they all have the same list of workers; in order to be fused they must already have the
+    # same number output partitions.)
+
+    dd.utils.assert_eq(
+        merged, dd.merge(df1, df2, on="id", shuffle="tasks"), check_index=False
     )

--- a/distributed/shuffle/tests/test_graph.py
+++ b/distributed/shuffle/tests/test_graph.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import dask
+import dask.dataframe as dd
+from dask.blockwise import Blockwise
+from dask.dataframe.shuffle import partitioning_index, rearrange_by_column_tasks
+from dask.utils_test import hlg_layer_topological
+
+from distributed.utils_test import gen_cluster
+
+from .. import ShuffleWorkerExtension, rearrange_by_column_p2p
+from ..shuffle_scheduler import TASK_PREFIX, ShuffleSchedulerPlugin, parse_key
+
+if TYPE_CHECKING:
+    from distributed import Client, Scheduler, Worker
+
+
+def shuffle(
+    df: dd.DataFrame, on: str, rearrange=rearrange_by_column_p2p
+) -> dd.DataFrame:
+    "Simple version of `DataFrame.shuffle`, so we don't need dask to know about 'p2p'"
+    return (
+        df.assign(
+            partition=lambda df: df[on].map_partitions(
+                partitioning_index, df.npartitions, transform_divisions=False
+            )
+        )
+        .pipe(rearrange, "partition")
+        .drop("partition", axis=1)
+    )
+
+
+def test_shuffle_helper(client: Client):
+    df = dd.demo.make_timeseries(freq="15D", partition_freq="30D")
+    shuffle_helper = shuffle(df, "id", rearrange=rearrange_by_column_tasks)
+    dask_shuffle = df.shuffle("id", shuffle="tasks")
+    dd.utils.assert_eq(shuffle_helper, dask_shuffle)
+
+
+def test_graph():
+    df = dd.demo.make_timeseries(freq="15D", partition_freq="30D")
+    shuffled = shuffle(df, "id")
+    shuffled.dask.validate()
+
+    # Check graph optimizes correctly
+    (opt,) = dask.optimize(shuffled)
+    opt.dask.validate()
+
+    assert len(opt.dask.layers) == 3
+    # create+transfer -> barrier -> unpack+drop_by_shallow_copy
+    transfer_layer = hlg_layer_topological(opt.dask, 0)
+    assert isinstance(transfer_layer, Blockwise)
+    shuffle_id = transfer_layer.indices[0][0]
+    # ^ don't ask why it's in position 0; some oddity of blockwise fusion.
+    # Don't be surprised if this breaks unexpectedly.
+    assert isinstance(hlg_layer_topological(opt.dask, -1), Blockwise)
+
+    # Check that task names contain the shuffle ID itself.
+    # This is how the scheduler plugin infers the shuffle ID.
+    for key in opt.dask.to_dict():
+        key = str(key)
+        if "transfer" in key or "barrier" in key:
+            try:
+                parts = parse_key(key)
+                assert parts
+                prefix, group, id = parts
+            except Exception:
+                print(key)
+                raise
+            assert prefix == TASK_PREFIX
+            assert id == shuffle_id
+
+
+def test_basic(client: Client):
+    df = dd.demo.make_timeseries(freq="15D", partition_freq="30D")
+    shuffled = shuffle(df, "id")
+
+    dd.utils.assert_eq(shuffled, df.shuffle("id", shuffle="tasks"))
+    # ^ NOTE: this works because `assert_eq` sorts the rows before comparing
+
+
+@gen_cluster([("", 2)] * 4, client=True)
+async def test_basic_state(c: Client, s: Scheduler, *workers: Worker):
+    df = dd.demo.make_timeseries(freq="15D", partition_freq="30D")
+    shuffled = shuffle(df, "id")
+
+    exts: list[ShuffleWorkerExtension] = [w.extensions["shuffle"] for w in workers]
+    for ext in exts:
+        assert not ext.shuffles
+        assert not ext.output_data
+        assert not ext.waiting_for_metadata
+
+    plugin = s.plugins[ShuffleSchedulerPlugin.name]
+    assert isinstance(plugin, ShuffleSchedulerPlugin)
+    assert not plugin.shuffles
+    assert not plugin.output_keys
+
+    f = c.compute(shuffled)
+    # TODO this is a bad/pointless test. the `f.done()` is necessary in case the shuffle is really fast.
+    # To test state more thoroughly, we'd need a way to 'stop the world' at various stages. Like have the
+    # scheduler pause everything when the barrier is reached. Not sure yet how to implement that.
+    while (
+        not all(len(ext.shuffles) == 1 for ext in exts)
+        and len(plugin.shuffles) == 1
+        and not f.done()
+    ):
+        await asyncio.sleep(0.1)
+
+    await f
+    assert all(not ext.shuffles for ext in exts)
+    assert not plugin.shuffles
+    assert not plugin.output_keys
+    assert not any(ts.worker_restrictions for ts in s.tasks.values())
+
+
+def test_multiple_linear(client: Client):
+    df = dd.demo.make_timeseries(freq="15D", partition_freq="30D")
+    s1 = shuffle(df, "id")
+    s1["x"] = s1["x"] + 1
+    s2 = shuffle(s1, "x")
+
+    (opt,) = dask.optimize(s2)
+    assert len(opt.dask.layers) == 5
+    # create+transfer -> barrier -> unpack+transfer -> barrier -> unpack
+
+    dd.utils.assert_eq(
+        s2, df.assign(x=lambda df: df.x + 1).shuffle("x", shuffle="tasks")
+    )

--- a/distributed/shuffle/tests/test_shuffle_worker.py
+++ b/distributed/shuffle/tests/test_shuffle_worker.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from distributed.utils_test import gen_cluster
+
+from ..common import ShuffleId, npartitions_for, worker_for
+from ..shuffle_worker import ShuffleState, ShuffleWorkerExtension
+
+if TYPE_CHECKING:
+    from distributed import Client, Scheduler, Worker
+
+
+@gen_cluster([("", 1)])
+async def test_installation(s: Scheduler, worker: Worker):
+    ext = worker.extensions["shuffle"]
+    assert isinstance(ext, ShuffleWorkerExtension)
+    assert worker.stream_handlers["shuffle_init"] == ext.shuffle_init
+    assert worker.handlers["shuffle_receive"] == ext.shuffle_receive
+    assert worker.handlers["shuffle_inputs_done"] == ext.shuffle_inputs_done
+
+    assert ext.worker is worker
+    assert not ext.shuffles
+    assert not ext.output_data
+
+
+@gen_cluster([("", 1)])
+async def test_init(s: Scheduler, worker: Worker):
+    ext: ShuffleWorkerExtension = worker.extensions["shuffle"]
+    assert not ext.shuffles
+
+    id = ShuffleId("foo")
+    workers = [worker.address, "tcp://foo"]
+    npartitions = 4
+
+    ext.shuffle_init(id, workers, npartitions)
+    assert ext.shuffles == {
+        id: ShuffleState(workers, npartitions, 2, barrier_reached=False)
+    }
+
+    with pytest.raises(ValueError, match="already registered"):
+        ext.shuffle_init(id, [], 0)
+
+    # Unchanged after trying to re-register
+    assert list(ext.shuffles) == [id]
+
+
+@gen_cluster([("", 1)] * 4)
+async def test_add_partition(s: Scheduler, *workers: Worker):
+    exts: dict[str, ShuffleWorkerExtension] = {
+        w.address: w.extensions["shuffle"] for w in workers
+    }
+
+    id = ShuffleId("foo")
+    npartitions = 8
+    addrs = list(exts)
+    column = "partition"
+
+    for ext in exts.values():
+        ext.shuffle_init(id, addrs, npartitions)
+
+    partition = pd.DataFrame(
+        {
+            "A": ["a", "b", "c", "d", "e", "f", "g", "h"],
+            column: [0, 1, 2, 3, 4, 5, 6, 7],
+        }
+    )
+
+    ext = exts[addrs[0]]
+    await ext.add_partition(partition, id, npartitions, column)
+
+    for i, data in partition.groupby(column):
+        i = int(i)
+        addr = worker_for(i, npartitions, addrs)
+        ext = exts[addr]
+        received = ext.output_data[id][i]
+        assert len(received) == 1
+        assert_frame_equal(data, received[0])
+
+    with pytest.raises(ValueError, match="not registered"):
+        await ext.add_partition(partition, ShuffleId("bar"), npartitions, column)
+
+    # TODO (resilience stage) test failed sends
+
+
+@gen_cluster([("", 1)] * 4, client=True)
+async def test_barrier(c: Client, s: Scheduler, *workers: Worker):
+    exts: dict[str, ShuffleWorkerExtension] = {
+        w.address: w.extensions["shuffle"] for w in workers
+    }
+
+    id = ShuffleId("foo")
+    npartitions = 3
+    addrs = list(exts)
+    column = "partition"
+
+    for ext in exts.values():
+        ext.shuffle_init(id, addrs, npartitions)
+
+    partition = pd.DataFrame(
+        {
+            "A": ["a", "b", "c"],
+            column: [0, 1, 2],
+        }
+    )
+    first_ext = exts[addrs[0]]
+    await first_ext.add_partition(partition, id, npartitions, column)
+
+    await first_ext.barrier(id)
+
+    # Check all workers have been informed of the barrier
+    for addr, ext in exts.items():
+        if npartitions_for(addr, npartitions, addrs):
+            assert ext.shuffles[id].barrier_reached
+        else:
+            # No output partitions on this worker; shuffle already cleaned up
+            assert not ext.shuffles
+            assert not ext.output_data
+
+    # Test check on self
+    with pytest.raises(AssertionError, match="called multiple times"):
+        await first_ext.barrier(id)
+
+    first_ext.shuffles[id].barrier_reached = False
+
+    # RPC to other workers fails
+    with pytest.raises(AssertionError, match="`inputs_done` called again"):
+        await first_ext.barrier(id)
+
+
+@gen_cluster([("", 1)] * 4, client=True)
+async def test_get_partition(c: Client, s: Scheduler, *workers: Worker):
+    exts: dict[str, ShuffleWorkerExtension] = {
+        w.address: w.extensions["shuffle"] for w in workers
+    }
+
+    id = ShuffleId("foo")
+    npartitions = 8
+    addrs = list(exts)
+    column = "partition"
+
+    for ext in exts.values():
+        ext.shuffle_init(id, addrs, npartitions)
+
+    p1 = pd.DataFrame(
+        {
+            "A": ["a", "b", "c", "d", "e", "f", "g", "h"],
+            "partition": [0, 1, 2, 3, 4, 5, 6, 6],
+        }
+    )
+    p2 = pd.DataFrame(
+        {
+            "A": ["a", "b", "c", "d", "e", "f", "g", "h"],
+            "partition": [0, 1, 2, 3, 0, 0, 2, 3],
+        }
+    )
+
+    first_ext = exts[addrs[0]]
+    await asyncio.gather(
+        first_ext.add_partition(p1, id, npartitions, column),
+        first_ext.add_partition(p2, id, npartitions, column),
+    )
+    await first_ext.barrier(id)
+
+    empty = pd.DataFrame({"A": [], column: []})
+
+    with pytest.raises(AssertionError, match="was expected to go"):
+        first_ext.get_output_partition(id, 7, empty)
+
+    full = pd.concat([p1, p2])
+    expected_groups = full.groupby("partition")
+    for output_i in range(npartitions):
+        addr = worker_for(output_i, npartitions, addrs)
+        ext = exts[addr]
+        shuffle = ext.shuffles[id]
+        parts_left_before = shuffle.out_parts_left
+
+        result = ext.get_output_partition(id, output_i, empty)
+
+        try:
+            expected = expected_groups.get_group(output_i)
+        except KeyError:
+            expected = empty
+        assert_frame_equal(expected, result)
+        assert shuffle.out_parts_left == parts_left_before - 1
+
+    # Once all partitions are retrieved, shuffles are cleaned up
+    for ext in exts.values():
+        assert not ext.shuffles
+
+    with pytest.raises(ValueError, match="not registered"):
+        first_ext.get_output_partition(id, 0, empty)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -44,7 +44,7 @@ from dask.utils import (
     typename,
 )
 
-from . import comm, preloading, profile, system, utils
+from . import comm, preloading, profile, shuffle, system, utils
 from .batched import BatchedSend
 from .comm import Comm, connect, get_address_host
 from .comm.addressing import address_from_user_args, parse_address
@@ -114,6 +114,8 @@ READY = {"ready", "constrained"}
 RUNNING = {Status.running, Status.paused, Status.closing_gracefully}
 
 DEFAULT_EXTENSIONS: list[type] = [PubSubWorkerExtension]
+if shuffle.SHUFFLE_AVAILABLE:
+    DEFAULT_EXTENSIONS.append(shuffle.ShuffleWorkerExtension)
 
 DEFAULT_METRICS: dict[str, Callable[[Worker], Any]] = {}
 


### PR DESCRIPTION
Alternative to https://github.com/dask/distributed/pull/5520: a peer-to-peer shuffle skeleton, based on a scheduler plugin to handle much of the synchronization.

There are some hacky things, but generally I think this shows more promise than #5520. Things this can do that the other PR cannot:
- Wait to initialize a shuffle until it actually starts
- Support blockwise fusion of the output tasks
- Detect when input task culling has happened and raise an immediate error. There's also a path forward from here for actually supporting this culling

This also doesn't match the design in #5435—in reality, a bit needed to change to work with the scheduler driving things—but overall, I like this design more than #5520. It also feels a little easier to build off of.

This needs unit tests, especially for the more exciting logic around concurrent shuffles, waiting for the scheduler, etc. But in the basic tests, it seems to shuffle correctly, including sequential and concurrent shuffles, and also passes `test_shuffle.py`.

Since this design differs a little from #5435, here's a rough diagram of the flow:
<img width="2043" alt="scheduler-plugin-flow" src="https://user-images.githubusercontent.com/3309802/142506227-52547bd4-5bf0-4b14-9922-e919707e3562.png">


cc @fjetter 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
