### PR TITLE
Ensure cancelled error transition can properly release a key

### DIFF
--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -169,10 +169,10 @@ async def test_executing_cancelled_error(c, s, w):
     # refactoring. Below verifies some implementation specific test assumptions
 
     story = w.story(fut.key)
-    start_finish = [(msg[1], msg[2]) for msg in story if len(msg) == 6]
-    assert ("executing", "cancelled") in start_finish
-    assert ("cancelled", "error") in start_finish
-    assert ("error", "released") in start_finish
+    start_finish = [(msg[1], msg[2], msg[3]) for msg in story if len(msg) == 7]
+    assert ("executing", "released", "cancelled") in start_finish
+    assert ("cancelled", "error", "error") in start_finish
+    assert ("error", "released", "released") in start_finish
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
`ts._next = None` was used as a sentinel but it is much cleaner to be explicit here since the logic detecting this sentinel was flawed.

Closes https://github.com/dask/distributed/issues/5527