### PR TITLE
Actually support uvloop in distributed

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -2,7 +2,6 @@ from . import config  # isort:skip; load distributed configuration first
 from . import widgets  # isort:skip; load distributed widgets second
 import dask
 from dask.config import config  # type: ignore
-from dask.utils import import_required
 
 from ._version import get_versions
 from .actor import Actor, ActorFuture
@@ -51,24 +50,3 @@ versions = get_versions()
 __version__ = versions["version"]
 __git_revision__ = versions["full-revisionid"]
 del get_versions, versions
-
-if dask.config.get("distributed.admin.event-loop") in ("asyncio", "tornado"):
-    pass
-elif dask.config.get("distributed.admin.event-loop") == "uvloop":
-    import_required(
-        "uvloop",
-        "The distributed.admin.event-loop configuration value "
-        "is set to 'uvloop' but the uvloop module is not installed"
-        "\n\n"
-        "Please either change the config value or install one of the following\n"
-        "    conda install uvloop\n"
-        "    pip install uvloop",
-    )
-    import uvloop
-
-    uvloop.install()
-else:
-    raise ValueError(
-        "Expected distributed.admin.event-loop to be in ('asyncio', 'tornado', 'uvloop'), got %s"
-        % dask.config.get("distributed.admin.event-loop")
-    )

--- a/distributed/_ipython_utils.py
+++ b/distributed/_ipython_utils.py
@@ -211,6 +211,8 @@ def start_ipython(ip=None, ns=None, log=None):
     evt = Event()
 
     def _start():
+        # Create a new event loop for the new thread
+        loop = IOLoop()
         app.initialize([])
         app.kernel.pre_handler_hook = noop
         app.kernel.post_handler_hook = noop
@@ -220,8 +222,8 @@ def start_ipython(ip=None, ns=None, log=None):
         if ns:
             app.kernel.shell.user_ns.update(ns)
         evt.set()
-        # start the app's IOLoop in its thread
-        IOLoop.current().start()
+        # Start the event loop
+        loop.start()
 
     zmq_loop_thread = Thread(target=_start)
     zmq_loop_thread.daemon = True

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import logging.config
 import os
@@ -8,7 +9,7 @@ import yaml
 import dask
 from dask.utils import import_required
 
-from .compatibility import logging_names
+from .compatibility import WINDOWS, logging_names
 
 config = dask.config.config
 
@@ -165,7 +166,13 @@ def initialize_event_loop(config):
             "    pip install uvloop",
         )
         uvloop.install()
-    elif event_loop not in {"asyncio", "tornado"}:
+    elif event_loop in {"asyncio", "tornado"}:
+        if WINDOWS:
+            # WindowsProactorEventLoopPolicy is not compatible with tornado 6
+            # fallback to the pre-3.8 default of Selector
+            # https://github.com/tornadoweb/tornado/issues/2608
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventPolicy())
+    else:
         raise ValueError(
             "Expected distributed.admin.event-loop to be in ('asyncio', 'tornado', 'uvloop'), got %s"
             % dask.config.get("distributed.admin.event-loop")

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -6,6 +6,7 @@ import sys
 import yaml
 
 import dask
+from dask.utils import import_required
 
 from .compatibility import logging_names
 
@@ -151,4 +152,25 @@ def initialize_logging(config):
             _initialize_logging_old_style(config)
 
 
+def initialize_event_loop(config):
+    event_loop = dask.config.get("distributed.admin.event-loop")
+    if event_loop == "uvloop":
+        uvloop = import_required(
+            "uvloop",
+            "The distributed.admin.event-loop configuration value "
+            "is set to 'uvloop' but the uvloop module is not installed"
+            "\n\n"
+            "Please either change the config value or install one of the following\n"
+            "    conda install uvloop\n"
+            "    pip install uvloop",
+        )
+        uvloop.install()
+    elif event_loop not in {"asyncio", "tornado"}:
+        raise ValueError(
+            "Expected distributed.admin.event-loop to be in ('asyncio', 'tornado', 'uvloop'), got %s"
+            % dask.config.get("distributed.admin.event-loop")
+        )
+
+
 initialize_logging(dask.config.config)
+initialize_event_loop(dask.config.config)

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -171,7 +171,7 @@ def initialize_event_loop(config):
             # WindowsProactorEventLoopPolicy is not compatible with tornado 6
             # fallback to the pre-3.8 default of Selector
             # https://github.com/tornadoweb/tornado/issues/2608
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventPolicy())
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     else:
         raise ValueError(
             "Expected distributed.admin.event-loop to be in ('asyncio', 'tornado', 'uvloop'), got %s"

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -180,17 +180,9 @@ class Server:
         if not hasattr(self.io_loop, "profile"):
             ref = weakref.ref(self.io_loop)
 
-            if hasattr(self.io_loop, "asyncio_loop"):
-
-                def stop():
-                    loop = ref()
-                    return loop is None or loop.asyncio_loop.is_closed()
-
-            else:
-
-                def stop():
-                    loop = ref()
-                    return loop is None or loop._closing
+            def stop():
+                loop = ref()
+                return loop is None or loop.asyncio_loop.is_closed()
 
             self.io_loop.profile = profile.watch(
                 omit=("profile.py", "selectors.py"),

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -16,6 +16,7 @@ from ..objects import SchedulerInfo
 from ..utils import (
     Log,
     Logs,
+    LoopRunner,
     NoOpAwaitable,
     SyncMethodMixin,
     format_dashboard_link,
@@ -52,10 +53,19 @@ class Cluster(SyncMethodMixin):
     _supports_scaling = True
     _cluster_info: dict = {}
 
-    def __init__(self, asynchronous, quiet=False, name=None, scheduler_sync_interval=1):
+    def __init__(
+        self,
+        asynchronous=False,
+        loop=None,
+        quiet=False,
+        name=None,
+        scheduler_sync_interval=1,
+    ):
+        self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
+        self.loop = self._loop_runner.loop
+
         self.scheduler_info = {"workers": {}}
         self.periodic_callbacks = {}
-        self._asynchronous = asynchronous
         self._watch_worker_status_comm = None
         self._watch_worker_status_task = None
         self._cluster_manager_logs = []

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -1,7 +1,6 @@
 import asyncio
 import datetime
 import logging
-import threading
 import uuid
 from contextlib import suppress
 from inspect import isawaitable
@@ -14,13 +13,20 @@ from dask.widgets import get_template
 
 from ..core import Status
 from ..objects import SchedulerInfo
-from ..utils import Log, Logs, format_dashboard_link, log_errors, sync, thread_state
+from ..utils import (
+    Log,
+    Logs,
+    NoOpAwaitable,
+    SyncMethodMixin,
+    format_dashboard_link,
+    log_errors,
+)
 from .adaptive import Adaptive
 
 logger = logging.getLogger(__name__)
 
 
-class Cluster:
+class Cluster(SyncMethodMixin):
     """Superclass for cluster objects
 
     This class contains common functionality for Dask Cluster manager classes.
@@ -169,9 +175,7 @@ class Cluster:
         # If the cluster is already closed, we're already done
         if self.status == Status.closed:
             if self.asynchronous:
-                future = asyncio.Future()
-                future.set_result(None)
-                return future
+                return NoOpAwaitable()
             else:
                 return
 
@@ -237,25 +241,6 @@ class Cluster:
         >>> cluster.scale(10)  # scale cluster to ten workers
         """
         raise NotImplementedError()
-
-    @property
-    def asynchronous(self):
-        return (
-            self._asynchronous
-            or getattr(thread_state, "asynchronous", False)
-            or hasattr(self.loop, "_thread_identity")
-            and self.loop._thread_identity == threading.get_ident()
-        )
-
-    def sync(self, func, *args, asynchronous=None, callback_timeout=None, **kwargs):
-        asynchronous = asynchronous or self.asynchronous
-        if asynchronous:
-            future = func(*args, **kwargs)
-            if callback_timeout is not None:
-                future = asyncio.wait_for(future, callback_timeout)
-            return future
-        else:
-            return sync(self.loop, func, *args, **kwargs)
 
     def _log(self, log):
         """Log a message.

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -19,7 +19,13 @@ from dask.widgets import get_template
 from ..core import CommClosedError, Status, rpc
 from ..scheduler import Scheduler
 from ..security import Security
-from ..utils import LoopRunner, TimeoutError, import_term, silence_logging
+from ..utils import (
+    LoopRunner,
+    NoOpAwaitable,
+    TimeoutError,
+    import_term,
+    silence_logging,
+)
 from .adaptive import Adaptive
 from .cluster import Cluster
 
@@ -101,19 +107,6 @@ class ProcessInterface:
 
     async def __aexit__(self, *args, **kwargs):
         await self.close()
-
-
-class NoOpAwaitable:
-    """An awaitable object that always returns None.
-
-    Useful to return from a method that can be called in both asynchronous and
-    synchronous contexts"""
-
-    def __await__(self):
-        async def f():
-            return None
-
-        return f().__await__()
 
 
 class SpecCluster(Cluster):

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -19,13 +19,7 @@ from dask.widgets import get_template
 from ..core import CommClosedError, Status, rpc
 from ..scheduler import Scheduler
 from ..security import Security
-from ..utils import (
-    LoopRunner,
-    NoOpAwaitable,
-    TimeoutError,
-    import_term,
-    silence_logging,
-)
+from ..utils import NoOpAwaitable, TimeoutError, import_term, silence_logging
 from .adaptive import Adaptive
 from .cluster import Cluster
 
@@ -249,9 +243,6 @@ class SpecCluster(Cluster):
                 level=silence_logs, root="bokeh"
             )
 
-        self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
-        self.loop = self._loop_runner.loop
-
         self._instances.add(self)
         self._correct_state_waiting = None
         self._name = name or type(self).__name__
@@ -259,6 +250,7 @@ class SpecCluster(Cluster):
 
         super().__init__(
             asynchronous=asynchronous,
+            loop=loop,
             name=name,
             scheduler_sync_interval=scheduler_sync_interval,
         )

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from dask.utils import parse_timedelta, stringify
 
 from .client import Client, Future
-from .utils import sync, thread_state
 from .worker import get_client, get_worker
 
 logger = logging.getLogger(__name__)
@@ -175,33 +174,26 @@ class Queue:
             # Initialise new client
             self.client = get_worker().client
         self.name = name or "queue-" + uuid.uuid4().hex
-        self._event_started = asyncio.Event()
-        if self.client.asynchronous or getattr(
-            thread_state, "on_event_loop_thread", False
-        ):
+        self.maxsize = maxsize
 
-            async def _create_queue():
-                await self.client.scheduler.queue_create(
-                    name=self.name, maxsize=maxsize
-                )
-                self._event_started.set()
-
-            self.client.loop.add_callback(_create_queue)
+        if self.client.asynchronous:
+            self._started = asyncio.ensure_future(self._start())
         else:
-            sync(
-                self.client.loop,
-                self.client.scheduler.queue_create,
-                name=self.name,
-                maxsize=maxsize,
-            )
-            self._event_started.set()
+            self.client.sync(self._start)
+
+    async def _start(self):
+        await self.client.scheduler.queue_create(name=self.name, maxsize=self.maxsize)
+        return self
 
     def __await__(self):
-        async def _():
-            await self._event_started.wait()
-            return self
+        if hasattr(self, "_started"):
+            return self._started.__await__()
+        else:
 
-        return _().__await__()
+            async def _():
+                return self
+
+            return _().__await__()
 
     async def _put(self, value, timeout=None):
         if isinstance(value, Future):

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -5,7 +5,7 @@ import warnings
 from asyncio import TimeoutError
 from collections import defaultdict, deque
 
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import PeriodicCallback
 
 import dask
 from dask.utils import parse_timedelta
@@ -13,7 +13,7 @@ from dask.utils import parse_timedelta
 from distributed.utils_comm import retry_operation
 
 from .metrics import time
-from .utils import log_errors, sync, thread_state
+from .utils import SyncMethodMixin, log_errors
 from .worker import get_client, get_worker
 
 logger = logging.getLogger(__name__)
@@ -269,7 +269,7 @@ class SemaphoreExtension:
                     del metric_dict[name]
 
 
-class Semaphore:
+class Semaphore(SyncMethodMixin):
     """Semaphore
 
     This `semaphore <https://en.wikipedia.org/wiki/Semaphore_(programming)>`_
@@ -410,10 +410,6 @@ class Semaphore:
         # PC uses the correct event loop.
         self.loop.add_callback(pc.start)
 
-    @property
-    def asynchronous(self):
-        return self.loop is IOLoop.current()
-
     async def _register(self):
         await retry_operation(
             self.scheduler.semaphore_register,
@@ -432,22 +428,6 @@ class Semaphore:
             return self
 
         return create_semaphore().__await__()
-
-    def sync(self, func, *args, asynchronous=None, callback_timeout=None, **kwargs):
-        callback_timeout = parse_timedelta(callback_timeout)
-        if (
-            asynchronous
-            or self.asynchronous
-            or getattr(thread_state, "asynchronous", False)
-        ):
-            future = func(*args, **kwargs)
-            if callback_timeout is not None:
-                future = asyncio.wait_for(future, callback_timeout)
-            return future
-        else:
-            return sync(
-                self.loop, func, *args, callback_timeout=callback_timeout, **kwargs
-            )
 
     async def _refresh_leases(self):
         if self.refresh_leases and self._leases:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5034,12 +5034,13 @@ async def test_get_client(c, s, a, b):
     assert c.asynchronous
 
     def f(x):
-        client = get_client()
-        future = client.submit(inc, x)
         import distributed
 
+        client = get_client()
         assert not client.asynchronous
         assert client is distributed.tmp_client
+
+        future = client.submit(inc, x)
         return future.result()
 
     import distributed

--- a/distributed/tests/test_config.py
+++ b/distributed/tests/test_config.py
@@ -352,3 +352,16 @@ def test_schema_is_complete():
                 test_matches(c[k], s["properties"][k])
 
     test_matches(config, schema)
+
+
+def test_uvloop_event_loop():
+    """Check that configuring distributed to use uvloop actually sets the event loop policy"""
+    pytest.importorskip("uvloop")
+    script = (
+        "import distributed, asyncio, uvloop\n"
+        "assert isinstance(asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy)"
+    )
+    subprocess.check_call(
+        [sys.executable, "-c", script],
+        env={"DASK_DISTRIBUTED__ADMIN__EVENT_LOOP": "uvloop"},
+    )

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -49,11 +49,6 @@ from dask import istask
 from dask.utils import parse_timedelta as _parse_timedelta
 from dask.widgets import get_template
 
-try:
-    from tornado.ioloop import PollIOLoop  # type: ignore
-except ImportError:
-    PollIOLoop = None  # dropped in tornado 6.0
-
 from .compatibility import PYPY, WINDOWS
 from .metrics import time
 
@@ -276,22 +271,71 @@ async def Any(args, quiet_exceptions=()):
     return results
 
 
+class NoOpAwaitable:
+    """An awaitable object that always returns None.
+
+    Useful to return from a method that can be called in both asynchronous and
+    synchronous contexts"""
+
+    def __await__(self):
+        async def f():
+            return None
+
+        return f().__await__()
+
+
+class SyncMethodMixin:
+    """
+    A mixin for adding an `asynchronous` attribute and `sync` method to a class.
+
+    Subclasses must define a `loop` attribute for an associated
+    `tornado.IOLoop`, and may also add a `_asynchronous` attribute indicating
+    whether the class should default to asynchronous behavior.
+    """
+
+    @property
+    def asynchronous(self):
+        """Are we running in the event loop?"""
+        return in_async_call(self.loop, default=getattr(self, "_asynchronous", False))
+
+    def sync(self, func, *args, asynchronous=None, callback_timeout=None, **kwargs):
+        """Call `func` with `args` synchronously or asynchronously depending on
+        the calling context"""
+        callback_timeout = _parse_timedelta(callback_timeout)
+        if asynchronous is None:
+            asynchronous = self.asynchronous
+        if asynchronous:
+            future = func(*args, **kwargs)
+            if callback_timeout is not None:
+                future = asyncio.wait_for(future, callback_timeout)
+            return future
+        else:
+            return sync(
+                self.loop, func, *args, callback_timeout=callback_timeout, **kwargs
+            )
+
+
+def in_async_call(loop, default=False):
+    """Whether this call is currently within an async call"""
+    if getattr(thread_state, "asynchronous", 0):
+        return True
+    try:
+        return loop.asyncio_loop is asyncio.get_running_loop()
+    except RuntimeError:
+        # No *running* loop in thread. If the event loop isn't running, it
+        # _could_ be started later in this thread though. Return the default.
+        if not loop.asyncio_loop.is_running():
+            return default
+        return False
+
+
 def sync(loop, func, *args, callback_timeout=None, **kwargs):
     """
     Run coroutine in loop running in separate thread.
     """
     callback_timeout = _parse_timedelta(callback_timeout, "s")
-    # Tornado's PollIOLoop doesn't raise when using closed, do it ourselves
-    if PollIOLoop and (
-        (isinstance(loop, PollIOLoop) and getattr(loop, "_closing", False))
-        or (hasattr(loop, "asyncio_loop") and loop.asyncio_loop._closed)
-    ):
+    if loop.asyncio_loop.is_closed():
         raise RuntimeError("IOLoop is closed")
-    try:
-        if loop.asyncio_loop.is_closed():  # tornado 6
-            raise RuntimeError("IOLoop is closed")
-    except AttributeError:
-        pass
 
     e = threading.Event()
     main_tid = threading.get_ident()
@@ -358,10 +402,9 @@ class LoopRunner:
     _lock = threading.Lock()
 
     def __init__(self, loop=None, asynchronous=False):
-        current = IOLoop.current()
         if loop is None:
             if asynchronous:
-                self._loop = current
+                self._loop = IOLoop.current()
             else:
                 # We're expecting the loop to run in another thread,
                 # avoid re-using this thread's assigned loop
@@ -409,10 +452,7 @@ class LoopRunner:
             loop.add_callback(loop_cb)
             # run loop forever if it's not running already
             try:
-                if (
-                    getattr(loop, "asyncio_loop", None) is None
-                    or not loop.asyncio_loop.is_running()
-                ):
+                if not loop.asyncio_loop.is_running():
                     loop.start()
             except Exception as e:
                 start_exc[0] = e
@@ -1022,49 +1062,6 @@ def reset_logger_locks():
     for name in logging.Logger.manager.loggerDict.keys():
         for handler in logging.getLogger(name).handlers:
             handler.createLock()
-
-
-is_server_extension = False
-
-if "notebook" in sys.modules:
-    import traitlets
-    from notebook.notebookapp import NotebookApp
-
-    is_server_extension = traitlets.config.Application.initialized() and isinstance(
-        traitlets.config.Application.instance(), NotebookApp
-    )
-
-if not is_server_extension:
-    is_kernel_and_no_running_loop = False
-
-    if is_kernel():
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            is_kernel_and_no_running_loop = True
-
-    if not is_kernel_and_no_running_loop:
-
-        # TODO: Use tornado's AnyThreadEventLoopPolicy, instead of class below,
-        # once tornado > 6.0.3 is available.
-        if WINDOWS:
-            # WindowsProactorEventLoopPolicy is not compatible with tornado 6
-            # fallback to the pre-3.8 default of Selector
-            # https://github.com/tornadoweb/tornado/issues/2608
-            BaseEventLoopPolicy = asyncio.WindowsSelectorEventLoopPolicy  # type: ignore
-        else:
-            BaseEventLoopPolicy = asyncio.DefaultEventLoopPolicy
-
-        class AnyThreadEventLoopPolicy(BaseEventLoopPolicy):  # type: ignore
-            def get_event_loop(self):
-                try:
-                    return super().get_event_loop()
-                except (RuntimeError, AssertionError):
-                    loop = self.new_event_loop()
-                    self.set_event_loop(loop)
-                    return loop
-
-        asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
 
 
 @functools.lru_cache(1000)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -72,7 +72,6 @@ from .utils import (
     mp_context,
     reset_logger_locks,
     sync,
-    thread_state,
 )
 from .worker import RUNNING, Worker
 
@@ -1652,9 +1651,6 @@ def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
                             logging.getLogger(name).setLevel(level)
 
                         yield loop
-
-                        with suppress(AttributeError):
-                            del thread_state.on_event_loop_thread
 
 
 @pytest.fixture

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -77,6 +77,7 @@ from .utils import (
     get_ip,
     has_arg,
     import_file,
+    in_async_call,
     iscoroutinefunction,
     json_load_robust,
     key_split,
@@ -3954,7 +3955,7 @@ class Worker(ServerNode):
         if not self._client:
             from .client import Client
 
-            asynchronous = self.loop is IOLoop.current()
+            asynchronous = in_async_call(self.loop)
             self._client = Client(
                 self.scheduler,
                 loop=self.loop,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1412,7 +1412,6 @@ class Worker(ServerNode):
         await super().start()
 
         enable_gc_diagnosis()
-        thread_state.asynchronous = 1
 
         ports = parse_ports(self._start_port)
         for port in ports:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1412,7 +1412,7 @@ class Worker(ServerNode):
         await super().start()
 
         enable_gc_diagnosis()
-        thread_state.on_event_loop_thread = True
+        thread_state.asynchronous = 1
 
         ports = parse_ports(self._start_port)
         for port in ports:


### PR DESCRIPTION
Previously distributed relied on the AnyThreadEventLoopPolicy,
which configuring uvloop would override, preventing distributed from
actually working with uvloop. We remove the need for
`AnyThreadEventLoopPolicy` and fixup uvloop configuration to fix this.

This also standardizes the `.asynchronous` and `sync` methods on classes
that support them. This is currently `Client`, `Cluster`, and
`Semaphore` for some reason. `Event`/`Lock`/... don't have these
methods, not sure why semaphore does, but I left it as is for now.

Fixes #5309, supersedes #5312.
