### PR TITLE
Fix test_schema tests

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -794,25 +794,25 @@ properties:
               UCX provides access to other transport methods including NVLink and InfiniBand.
             properties:
               cuda_copy:
-                type: boolean
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable CUDA support over UCX. This may be used even if
                   InfiniBand and NVLink are not supported or disabled, then transferring data over TCP.
               tcp:
-                type: boolean
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable TCP over UCX, even if InfiniBand and NVLink
                   are not supported or disabled.
               nvlink:
-                type: boolean
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable UCX over NVLink, implies ``distributed.comm.ucx.tcp=True``.
               infiniband:
-                type: boolean
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable UCX over InfiniBand, implies ``distributed.comm.ucx.tcp=True``.
               rdmacm:
-                type: boolean
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable UCX RDMA connection manager support,
                   requires ``distributed.comm.ucx.infiniband=True``.


### PR DESCRIPTION
I've noticed that the `test_schema` tests were failing, it seems that  the PR #5526 changed the `distributed.yaml` configuration ucx default values from False to Null which caused the tests to fail. 

This PR updates the distributed-schema to allow either a boolean or a None value. Please let me know if  you are happy with this change or if you would rather that I change the `distributed.yaml` file.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
