### PR TITLE
Raise error if asyncssh isn't installed when using SSHCluster

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -95,7 +95,7 @@ class Worker(Process):
             import asyncssh  # import now to avoid adding to module startup time
         except ImportError:
             raise ImportError(
-                "Dask's SSHCluster requires the `asyncssh`, package to be installed. "
+                "Dask's SSHCluster requires the `asyncssh` package to be installed. "
                 "Please install it using pip or conda."
             )
 
@@ -190,7 +190,7 @@ class Scheduler(Process):
             import asyncssh  # import now to avoid adding to module startup time
         except ImportError:
             raise ImportError(
-                "Dask's SSHCluster requires the `asyncssh`, package to be installed. "
+                "Dask's SSHCluster requires the `asyncssh` package to be installed. "
                 "Please install it using pip or conda."
             )
 

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -91,7 +91,12 @@ class Worker(Process):
         self.nprocs = self.kwargs.pop("nprocs", 1)
 
     async def start(self):
-        import asyncssh  # import now to avoid adding to module startup time
+        try:
+            import asyncssh  # import now to avoid adding to module startup time
+        except ImportError:
+            raise ImportError(
+                "Dask SSHCluster requires `asyncssh`, please install it using pip or conda."
+            )
 
         self.connection = await asyncssh.connect(self.address, **self.connect_options)
 
@@ -180,7 +185,12 @@ class Scheduler(Process):
         self.remote_python = remote_python
 
     async def start(self):
-        import asyncssh  # import now to avoid adding to module startup time
+        try:
+            import asyncssh  # import now to avoid adding to module startup time
+        except ImportError:
+            raise ImportError(
+                "Dask SSHCluster requires `asyncssh`, please install it using pip or conda."
+            )
 
         logger.debug("Created Scheduler Connection")
 

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -95,7 +95,8 @@ class Worker(Process):
             import asyncssh  # import now to avoid adding to module startup time
         except ImportError:
             raise ImportError(
-                "Dask SSHCluster requires `asyncssh`, please install it using pip or conda."
+                "Dask's SSHCluster requires the `asyncssh`, package to be installed. "
+                "Please install it using pip or conda."
             )
 
         self.connection = await asyncssh.connect(self.address, **self.connect_options)
@@ -189,7 +190,8 @@ class Scheduler(Process):
             import asyncssh  # import now to avoid adding to module startup time
         except ImportError:
             raise ImportError(
-                "Dask SSHCluster requires `asyncssh`, please install it using pip or conda."
+                "Dask's SSHCluster requires the `asyncssh`, package to be installed. "
+                "Please install it using pip or conda."
             )
 
         logger.debug("Created Scheduler Connection")

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -27,9 +27,9 @@ def test_ssh_hosts_empty_list():
 
 
 @pytest.mark.asyncio
-async def test_ssh_cluster_raises_if_asyncssh_not_installed(monkeypatch):
+async def test_ssh_cluster_raises_if_asyncssh_not_installed(monkeypatch, cleanup):
     monkeypatch.setitem(sys.modules, "asyncssh", None)
-    with pytest.raises(ImportError):
+    with pytest.raises(ImportError, match="SSHCluster requires the `asyncssh` package"):
         async with SSHCluster(
             ["127.0.0.1"] * 3,
             connect_options=[dict(known_hosts=None)] * 3,

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -27,6 +27,20 @@ def test_ssh_hosts_empty_list():
 
 
 @pytest.mark.asyncio
+async def test_ssh_cluster_raises_if_asyncssh_not_installed(monkeypatch):
+    monkeypatch.setitem(sys.modules, "asyncssh", None)
+    with pytest.raises(ImportError):
+        async with SSHCluster(
+            ["127.0.0.1"] * 3,
+            connect_options=[dict(known_hosts=None)] * 3,
+            asynchronous=True,
+            scheduler_options={"idle_timeout": "5s"},
+            worker_options={"death_timeout": "5s"},
+        ) as cluster:
+            assert not cluster
+
+
+@pytest.mark.asyncio
 async def test_basic():
     async with SSHCluster(
         ["127.0.0.1"] * 3,


### PR DESCRIPTION
I'm slowly getting my feet wet with the distributed code base and I am picking some small easy win issues to do such.

James mentioned on [this comment on the issue](https://github.com/dask/distributed/issues/5424#issuecomment-943800419) that perhaps we should raise a more informative error saying that the user needs to install `asyncssh` manually.

Silly question but should i add a test for this?

- [x] Closes #5424
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
