### PR TITLE
Standardize UCX config separator to `-`

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -331,7 +331,7 @@ async def test_simple():
 
 @pytest.mark.asyncio
 async def test_cuda_context():
-    with dask.config.set({"distributed.comm.ucx.create_cuda_context": True}):
+    with dask.config.set({"distributed.comm.ucx.create-cuda-context": True}):
         async with LocalCluster(
             protocol="ucx", n_workers=1, asynchronous=True
         ) as cluster:

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -30,7 +30,7 @@ async def test_ucx_config(cleanup):
         "rdmacm": False,
         "net-devices": "",
         "tcp": True,
-        "cuda_copy": True,
+        "cuda-copy": True,
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
@@ -49,7 +49,7 @@ async def test_ucx_config(cleanup):
         "rdmacm": False,
         "net-devices": "mlx5_0:1",
         "tcp": True,
-        "cuda_copy": False,
+        "cuda-copy": False,
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
@@ -68,7 +68,7 @@ async def test_ucx_config(cleanup):
         "rdmacm": True,
         "net-devices": "all",
         "tcp": True,
-        "cuda_copy": True,
+        "cuda-copy": True,
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
@@ -85,7 +85,7 @@ async def test_ucx_config(cleanup):
         "rdmacm": None,
         "net-devices": None,
         "tcp": None,
-        "cuda_copy": None,
+        "cuda-copy": None,
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -70,7 +70,7 @@ def init_once():
     # We ensure the CUDA context is created before initializing UCX. This can't
     # be safely handled externally because communications in Dask start before
     # preload scripts run.
-    if dask.config.get("distributed.comm.ucx.create_cuda_context") is True or (
+    if dask.config.get("distributed.comm.ucx.create-cuda-context") is True or (
         "TLS" in ucx_config and "cuda_copy" in ucx_config["TLS"]
     ):
         try:
@@ -577,7 +577,7 @@ def _scrub_ucx_config():
         if any(
             [
                 dask.config.get("distributed.comm.ucx.nvlink"),
-                dask.config.get("distributed.comm.ucx.cuda_copy"),
+                dask.config.get("distributed.comm.ucx.cuda-copy"),
             ]
         ):
             tls = tls + ",cuda_copy"

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -793,7 +793,7 @@ properties:
             description: |
               UCX provides access to other transport methods including NVLink and InfiniBand.
             properties:
-              cuda_copy:
+              cuda-copy:
                 type: boolean
                 description: |
                   Set environment variables to enable CUDA support over UCX. This may be used even if

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -187,7 +187,7 @@ distributed:
     socket-backlog: 2048
     recent-messages-log-length: 0  # number of messages to keep for debugging
     ucx:
-      cuda_copy: null  # enable cuda-copy
+      cuda-copy: null  # enable cuda-copy
       tcp: null  # enable tcp
       nvlink: null  # enable cuda_ipc
       infiniband: null  # enable Infiniband


### PR DESCRIPTION
Some of the UCX configurations use `_` whereas others use `-`. This is confusing so we now standardize everything to `-`. This also fixes an inconsistency from https://github.com/dask/distributed/pull/5526, where configuration files used `create-cuda-context`, but the configuration read was `create_cuda_context`.