### PR TITLE
Mark `test_gpu_monitoring_recent` as flaky

### DIFF
--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -118,6 +118,7 @@ async def test_gpu_metrics(s, a, b):
     )
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 @gen_cluster()
 async def test_gpu_monitoring_recent(s, a, b):
     if nvml.device_get_count() < 1:


### PR DESCRIPTION
Mark `test_gpu_monitoring_recent` as flaky, as reported and discussed in https://github.com/dask/distributed/issues/5287 .