### PR TITLE
Add workflow to automate gpuCI updates

### DIFF
--- a/.github/workflows/update-gpuci.yaml
+++ b/.github/workflows/update-gpuci.yaml
@@ -1,0 +1,51 @@
+name: Check for gpuCI updates
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Daily “At 00:00” UTC
+  workflow_dispatch:
+
+jobs:
+  update-gpuci:
+    runs-on: ubuntu-latest
+    if: github.repository == 'dask/distributed'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get latest cuDF nightly version
+        id: latest_version
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
+        with:
+          org: "rapidsai-nightly"
+          package: "cudf"
+          version_system: "CalVer"
+
+      - name: Strip git tags from versions
+        env:
+          FULL_RAPIDS_VER: ${{ steps.latest_version.outputs.version }}
+        run: echo "RAPIDS_VER=${FULL_RAPIDS_VER::-10}" >> $GITHUB_ENV
+
+      - name: Find and Replace Release
+        uses: jacobtomlinson/gha-find-replace@0.1.4
+        with:
+          include: 'continuous_integration\/gpuci\/axis\.yaml'
+          find: "RAPIDS_VER:\n- .*"
+          replace: |-
+            RAPIDS_VER:
+            - "${{ env.RAPIDS_VER }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
+          title: "Update gpuCI `RAPIDS_VER` to `${{ env.RAPIDS_VER }}`"
+          team-reviewers: "dask/gpu"
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          branch: "upgrade-gpuci-rapids"
+          body: |
+            A new cuDF nightly version has been detected.
+
+            Updated `axis.yaml` to use `${{ env.RAPIDS_VER }}`.


### PR DESCRIPTION
Adds a workflow similar to that in https://github.com/dask/dask/pull/8215, which searches for new cuDF nightly versions daily to see if gpuCI should be updated, opening a PR if this is the case.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
