### PR TITLE
Allow idempotent scheduler plugins to be registered via the RPC

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5678,7 +5678,9 @@ class Scheduler(SchedulerState, ServerNode):
                 f"Could not find plugin {name!r} among the current scheduler plugins"
             )
 
-    async def register_scheduler_plugin(self, comm=None, plugin=None, name=None):
+    async def register_scheduler_plugin(
+        self, comm=None, plugin=None, name=None, idempotent=False
+    ):
         """Register a plugin on the scheduler."""
         if not dask.config.get("distributed.scheduler.pickle"):
             raise ValueError(
@@ -5694,7 +5696,7 @@ class Scheduler(SchedulerState, ServerNode):
             if inspect.isawaitable(result):
                 await result
 
-        self.add_plugin(plugin, name=name)
+        self.add_plugin(plugin, name=name, idempotent=idempotent)
 
     def worker_send(self, worker, msg):
         """Send message to worker

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5679,7 +5679,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
 
     async def register_scheduler_plugin(
-        self, comm=None, plugin=None, name=None, idempotent=False
+        self, comm=None, plugin=None, name=None, idempotent=None
     ):
         """Register a plugin on the scheduler."""
         if not dask.config.get("distributed.scheduler.pickle"):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5691,6 +5691,12 @@ class Scheduler(SchedulerState, ServerNode):
             )
         plugin = loads(plugin)
 
+        if name is None:
+            name = _get_plugin_name(plugin)
+
+        if name in self.plugins and idempotent:
+            return
+
         if hasattr(plugin, "start"):
             result = plugin.start(self)
             if inspect.isawaitable(result):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3307,7 +3307,7 @@ async def test_non_idempotent_plugins(s):
 
     class NonIdempotentPlugin(SchedulerPlugin):
         def __init__(self, instance=None):
-            self.name = "idempotentplugin"
+            self.name = "nonidempotentplugin"
             self.instance = instance
             self.status = None
 
@@ -3316,9 +3316,9 @@ async def test_non_idempotent_plugins(s):
 
     first = NonIdempotentPlugin(instance="first")
     await s.register_scheduler_plugin(plugin=dumps(first), idempotent=False)
-    assert "idempotentplugin" in s.plugins
+    assert "nonidempotentplugin" in s.plugins
 
     second = NonIdempotentPlugin(instance="second")
     await s.register_scheduler_plugin(plugin=dumps(second), idempotent=False)
-    assert "idempotentplugin" in s.plugins
-    assert s.plugins["idempotentplugin"].instance == "second"
+    assert "nonidempotentplugin" in s.plugins
+    assert s.plugins["nonidempotentplugin"].instance == "second"

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3282,7 +3282,6 @@ async def test_idempotent_plugins(s):
         def __init__(self, instance=None):
             self.name = "idempotentplugin"
             self.instance = instance
-            self.status = None
 
         def start(self, scheduler):
             if self.instance != "first":
@@ -3309,10 +3308,6 @@ async def test_non_idempotent_plugins(s):
         def __init__(self, instance=None):
             self.name = "nonidempotentplugin"
             self.instance = instance
-            self.status = None
-
-        def start(self, scheduler):
-            pass
 
     first = NonIdempotentPlugin(instance="first")
     await s.register_scheduler_plugin(plugin=dumps(first), idempotent=False)


### PR DESCRIPTION
The `Scheduler.add_plugin` has an `idempotent` flag which can be set to `True` to ensure a plugin is only registered once the first time. The default behaviour is to overwrite the plugin with new ones from subsequent attempts.

This flag is not exposed to the `register_scheduler_plugin` RPC method. This PR simply passes that flag through.