### PR TITLE
Bump Bokeh min version to 2.1.1

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -56,7 +56,7 @@ from distributed.dashboard.components.shared import (
     ProfileTimePlot,
     SystemMonitor,
 )
-from distributed.dashboard.utils import BOKEH_VERSION, PROFILING, transpose, update
+from distributed.dashboard.utils import PROFILING, transpose, update
 from distributed.diagnostics.graph_layout import GraphLayout
 from distributed.diagnostics.progress_stream import color_of, progress_quads
 from distributed.diagnostics.task_stream import TaskStreamPlugin
@@ -1698,7 +1698,7 @@ class Events(DashboardComponent):
             color="color",
             size=50,
             alpha=0.5,
-            **{"legend_field" if BOKEH_VERSION >= "1.4" else "legend": "action"},
+            legend_field="action",
         )
         self.root.yaxis.axis_label = "Action"
         self.root.legend.location = "top_left"
@@ -1978,7 +1978,7 @@ class TaskGraph(DashboardComponent):
             color=node_colors,
             source=self.node_source,
             view=node_view,
-            **{"legend_field" if BOKEH_VERSION >= "1.4" else "legend": "state"},
+            legend_field="state",
         )
         self.root.xgrid.grid_line_color = None
         self.root.ygrid.grid_line_color = None

--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -6,20 +6,16 @@ import bokeh
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.server.server import BokehTornado
-
-try:
-    from bokeh.server.util import create_hosts_allowlist
-except ImportError:
-    from bokeh.server.util import create_hosts_whitelist as create_hosts_allowlist
+from bokeh.server.util import create_hosts_allowlist
 
 import dask
 
-if LooseVersion(bokeh.__version__) < LooseVersion("1.0.0"):
+if LooseVersion(bokeh.__version__) < LooseVersion("2.1.1"):
     warnings.warn(
-        "\nDask needs bokeh >= 1.0 for the dashboard."
+        "\nDask needs bokeh >= 2.1.1 for the dashboard."
         "\nContinuing without the dashboard."
     )
-    raise ImportError("Dask needs bokeh >= 1.0")
+    raise ImportError("Dask needs bokeh >= 2.1.1")
 
 
 def BokehApplication(applications, server, prefix="/", template_variables={}):

--- a/distributed/dashboard/utils.py
+++ b/distributed/dashboard/utils.py
@@ -1,7 +1,5 @@
-from distutils.version import LooseVersion
 from numbers import Number
 
-import bokeh
 from bokeh.core.properties import without_property_validation
 from bokeh.io import curdoc
 from tlz.curried import first
@@ -10,9 +8,6 @@ try:
     import numpy as np
 except ImportError:
     np = None  # type: ignore
-
-
-BOKEH_VERSION = LooseVersion(bokeh.__version__)
 
 
 PROFILING = False

--- a/distributed/http/scheduler/missing_bokeh.py
+++ b/distributed/http/scheduler/missing_bokeh.py
@@ -8,9 +8,9 @@ class MissingBokeh(RequestHandler):
     def get(self):
         with log_errors():
             self.write(
-                "<p>Dask needs bokeh >= 1.0 for the dashboard.</p>"
+                "<p>Dask needs bokeh >= 2.1.1 for the dashboard.</p>"
                 "<p>Install with conda: conda install bokeh>=1.0</p>"
-                "<p>Install with pip: pip install bokeh>=1.0</p>"
+                "<p>Install with pip: pip install bokeh>=2.1.1</p>"
             )
 
 


### PR DESCRIPTION
- [x] Closes #3905
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

xref: https://github.com/dask/dask/pull/8431

cc @jrbourbeau 

This PR bumps the min Bokeh version to 2.1.1 per https://github.com/dask/distributed/issues/3905#issuecomment-969269158. As a side benefit, all old version-switching workaround code was removed. 

Ran tests locally with 2.1.1 and latest 2.4.2 successfully. 

Are changes warranted to the conda env files as well?