### PR TITLE
Fix doc build warnings

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3549,8 +3549,8 @@ class Client(SyncMethodMixin):
                 }
             }
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         filename:
             The output filename. The appropriate file suffix (`.msgpack.gz` or
             `.yaml`) will be appended automatically.
@@ -3723,8 +3723,8 @@ class Client(SyncMethodMixin):
             single argument `event` which is a tuple `(timestamp, msg)` where
             timestamp refers to the clock on the scheduler.
 
-        Example
-        -------
+        Examples
+        --------
 
         >>> import logging
         >>> logger = logging.getLogger("myLogger")  # Log config not shown

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1470,7 +1470,8 @@ class Client(SyncMethodMixin):
         pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-            See :ref:`pure functions` for more details.
+            See `pure functions <https://distributed.dask.org/en/latest/client.html#pure-functions>`_
+            for more details.
         workers : string or iterable of strings
             A set of worker addresses or hostnames on which computations may be
             performed. Leave empty to default to all workers (common case)
@@ -1489,11 +1490,12 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the ``resources`` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See :doc:`worker resources <resources>` for details on defining
-            resources.
+            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            for details on defining resources.
         actor : bool (default False)
             Whether this task should exist on the worker as a stateful actor.
-            See :doc:`actors` for additional details.
+            See `actors <https://distributed.dask.org/en/latest/actors.html>`_
+            for additional details.
         actors : bool (default False)
             Alias for `actor`
 
@@ -1594,7 +1596,8 @@ class Client(SyncMethodMixin):
         pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-            See :ref:`pure functions` for more details.
+            See `pure functions <https://distributed.dask.org/en/latest/client.html#pure-functions>`_
+            for more details.
         workers : string or iterable of strings
             A set of worker hostnames on which computations may be performed.
             Leave empty to default to all workers (common case)
@@ -1611,11 +1614,12 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See :doc:`worker resources <resources>` for details on defining
-            resources.
+            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            for details on defining resources.
         actor : bool (default False)
             Whether these tasks should exist on the worker as stateful actors.
-            See :doc:`actors` for additional details.
+            See `actors <https://distributed.dask.org/en/latest/actors.html>`_
+            for additional details.
         actors : bool (default False)
             Alias for `actor`
         batch_size : int, optional
@@ -2648,8 +2652,8 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the ``resources`` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See :doc:`worker resources <resources>` for details on defining
-            resources.
+            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            for details on defining resources.
         sync : bool (optional)
             Returns Futures if False or concrete values if True (default).
         direct : bool
@@ -2798,12 +2802,13 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See :doc:`worker resources <resources>` for details on defining
-            resources.
+            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            for details on defining resources.
         actors : bool or dict (default None)
             Whether these tasks should exist on the worker as stateful actors.
             Specified on a global (True/False) or per-task (``{'x': True,
-            'y': False}``) basis. See :doc:`actors` for additional details.
+            'y': False}``) basis. See `actors <https://distributed.dask.org/en/latest/actors.html>`_
+            for additional details.
         **kwargs
             Options to pass to the graph optimize calls
 
@@ -2943,12 +2948,13 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See :doc:`worker resources <resources>` for details on defining
-            resources.
+            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            for details on defining resources.
         actors : bool or dict (default None)
             Whether these tasks should exist on the worker as stateful actors.
             Specified on a global (True/False) or per-task (``{'x': True,
-            'y': False}``) basis. See :doc:`actors` for additional details.
+            'y': False}``) basis. See `actors <https://distributed.dask.org/en/latest/actors.html>`_
+            for additional details.
         **kwargs
             Options to pass to the graph optimize calls
 
@@ -4353,7 +4359,7 @@ class Client(SyncMethodMixin):
 
     @property
     def amm(self):
-        """Convenience accessors for the :doc:`active_memory_manager`"""
+        """Convenience accessors for the `active_memory_manager <https://distributed.dask.org/en/latest/active_memory_manager.html>`_"""
         from .active_memory_manager import AMMClientProxy
 
         return AMMClientProxy(self)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1470,7 +1470,7 @@ class Client(SyncMethodMixin):
         pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-            See `pure functions <https://distributed.dask.org/en/latest/client.html#pure-functions>`_
+            See `pure functions <https://distributed.dask.org/en/stable/client.html#pure-functions>`_
             for more details.
         workers : string or iterable of strings
             A set of worker addresses or hostnames on which computations may be
@@ -1490,11 +1490,11 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the ``resources`` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            See `worker resources <https://distributed.dask.org/en/stable/resources.html>`_
             for details on defining resources.
         actor : bool (default False)
             Whether this task should exist on the worker as a stateful actor.
-            See `actors <https://distributed.dask.org/en/latest/actors.html>`_
+            See `actors <https://distributed.dask.org/en/stable/actors.html>`_
             for additional details.
         actors : bool (default False)
             Alias for `actor`
@@ -1596,7 +1596,7 @@ class Client(SyncMethodMixin):
         pure : bool (defaults to True)
             Whether or not the function is pure.  Set ``pure=False`` for
             impure functions like ``np.random.random``.
-            See `pure functions <https://distributed.dask.org/en/latest/client.html#pure-functions>`_
+            See `pure functions <https://distributed.dask.org/en/stable/client.html#pure-functions>`_
             for more details.
         workers : string or iterable of strings
             A set of worker hostnames on which computations may be performed.
@@ -1614,11 +1614,11 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            See `worker resources <https://distributed.dask.org/en/stable/resources.html>`_
             for details on defining resources.
         actor : bool (default False)
             Whether these tasks should exist on the worker as stateful actors.
-            See `actors <https://distributed.dask.org/en/latest/actors.html>`_
+            See `actors <https://distributed.dask.org/en/stable/actors.html>`_
             for additional details.
         actors : bool (default False)
             Alias for `actor`
@@ -2652,7 +2652,7 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the ``resources`` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            See `worker resources <https://distributed.dask.org/en/stable/resources.html>`_
             for details on defining resources.
         sync : bool (optional)
             Returns Futures if False or concrete values if True (default).
@@ -2802,12 +2802,12 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            See `worker resources <https://distributed.dask.org/en/stable/resources.html>`_
             for details on defining resources.
         actors : bool or dict (default None)
             Whether these tasks should exist on the worker as stateful actors.
             Specified on a global (True/False) or per-task (``{'x': True,
-            'y': False}``) basis. See `actors <https://distributed.dask.org/en/latest/actors.html>`_
+            'y': False}``) basis. See `actors <https://distributed.dask.org/en/stable/actors.html>`_
             for additional details.
         **kwargs
             Options to pass to the graph optimize calls
@@ -2948,12 +2948,12 @@ class Client(SyncMethodMixin):
         resources : dict (defaults to {})
             Defines the `resources` each instance of this mapped task requires
             on the worker; e.g. ``{'GPU': 2}``.
-            See `worker resources <https://distributed.dask.org/en/latest/resources.html>`_
+            See `worker resources <https://distributed.dask.org/en/stable/resources.html>`_
             for details on defining resources.
         actors : bool or dict (default None)
             Whether these tasks should exist on the worker as stateful actors.
             Specified on a global (True/False) or per-task (``{'x': True,
-            'y': False}``) basis. See `actors <https://distributed.dask.org/en/latest/actors.html>`_
+            'y': False}``) basis. See `actors <https://distributed.dask.org/en/stable/actors.html>`_
             for additional details.
         **kwargs
             Options to pass to the graph optimize calls
@@ -4169,7 +4169,7 @@ class Client(SyncMethodMixin):
     def register_scheduler_plugin(self, plugin, name=None, **kwargs):
         """Register a scheduler plugin.
 
-        See https://distributed.readthedocs.io/en/latest/plugins.html#scheduler-plugins
+        See https://distributed.readthedocs.io/en/stable/plugins.html#scheduler-plugins
 
         Parameters
         ----------
@@ -4359,7 +4359,7 @@ class Client(SyncMethodMixin):
 
     @property
     def amm(self):
-        """Convenience accessors for the `active_memory_manager <https://distributed.dask.org/en/latest/active_memory_manager.html>`_"""
+        """Convenience accessors for the `active_memory_manager <https://distributed.dask.org/en/stable/active_memory_manager.html>`_"""
         from .active_memory_manager import AMMClientProxy
 
         return AMMClientProxy(self)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j4
+SPHINXOPTS    = -j4 -W --keep-going
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build

--- a/docs/source/queues.rst
+++ b/docs/source/queues.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Data Streams with Queues
 ========================
 


### PR DESCRIPTION
- [X] Fixes https://github.com/dask/dask/issues/5610
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`

This is related to the Dask PR: https://github.com/dask/dask/pull/8432

Fixes Dask and distributed docs build warnings via the following changes:

- Fix section headers in docstrings
- Add `:orphan:` metadata to `queues` page to avoid toctree warnings
- Change page and section references in docstrings to absolute links, which avoids `unknown document` and `undefined label` warnings in Dask docs build for `distributed` API docs (since the docstrings are used but the source `.rst` files are not built in the Dask docs build)
- Treat docs warnings as errors (to avoid introducing new warnings in the future)