### PR TITLE
Update `gen_test` tests to be more robust

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -152,13 +152,18 @@ async def test_gen_cluster_tls(e, s, a, b):
     assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
 
 
+@pytest.mark.xfail(
+    reason="Test should always fail to ensure the body of the test function was run",
+    strict=True,
+)
 @gen_test()
 async def test_gen_test():
     await asyncio.sleep(0.01)
+    assert False
 
 
 @pytest.mark.xfail(
-    reason="Test should fail to ensure the body of the test function was run",
+    reason="Test should always fail to ensure the body of the test function was run",
     strict=True,
 )
 @gen_test()
@@ -168,7 +173,7 @@ def test_gen_test_legacy_implicit():
 
 
 @pytest.mark.xfail(
-    reason="Test should fail to ensure the body of the test function was run",
+    reason="Test should always fail to ensure the body of the test function was run",
     strict=True,
 )
 @gen_test()

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -157,15 +157,25 @@ async def test_gen_test():
     await asyncio.sleep(0.01)
 
 
+@pytest.mark.xfail(
+    reason="Test should fail to ensure the body of the test function was run",
+    strict=True,
+)
 @gen_test()
 def test_gen_test_legacy_implicit():
     yield asyncio.sleep(0.01)
+    assert False
 
 
+@pytest.mark.xfail(
+    reason="Test should fail to ensure the body of the test function was run",
+    strict=True,
+)
 @gen_test()
 @gen.coroutine
 def test_gen_test_legacy_explicit():
     yield asyncio.sleep(0.01)
+    assert False
 
 
 @contextmanager


### PR DESCRIPTION
This slightly modifies our `gen_test` tests to ensure the contents of the test functions are actually executed. To accomplish this I decided to do a strict `xfail` check, but am certainly open to other approaches. 