### PR TITLE
Handle `UCXUnreachable` exception

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -361,3 +361,8 @@ async def test_transpose():
 async def test_ucx_protocol(cleanup, port):
     async with Scheduler(protocol="ucx", port=port, dashboard_address=":0") as s:
         assert s.address.startswith("ucx://")
+
+
+def test_ucx_unreachable():
+    with pytest.raises(OSError, match="Timed out trying to connect to"):
+        Client("ucx://255.255.255.255:12345", timeout=1)

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -420,6 +420,7 @@ class UCXConnector(Connector):
         except (ucp.exceptions.UCXCloseError, ucp.exceptions.UCXCanceled,) + (
             getattr(ucp.exceptions, "UCXConnectionReset", ()),
             getattr(ucp.exceptions, "UCXNotConnected", ()),
+            getattr(ucp.exceptions, "UCXUnreachable", ()),
         ):
             raise CommClosedError("Connection closed before handshake completed")
         return self.comm_class(


### PR DESCRIPTION
After https://github.com/openucx/ucx/pull/7282, stream endpoint failures are now raised and may include previously unhandled `UCS_ERR_UNREACHABLE` that was recently added to UCX-Py in https://github.com/rapidsai/ucx-py/pull/820.