### PR TITLE
Revisit recursive_to_dict

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -378,8 +378,8 @@ class Server:
         return {"type": type(self).__name__, "id": self.id}
 
     def _to_dict(
-        self, comm: Comm = None, *, exclude: Container[str] = None
-    ) -> dict[str, str]:
+        self, comm: Comm | None = None, *, exclude: Container[str] = ()
+    ) -> dict:
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.
@@ -395,7 +395,6 @@ class Server:
         Server.identity
         Client.dump_cluster_state
         """
-
         info = self.identity()
         extra = {
             "address": self.address,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4001,14 +4001,10 @@ class Scheduler(SchedulerState, ServerNode):
             "log": self.log,
             "tasks": self.tasks,
             "events": self.events,
+            "extensions": self.extensions,
         }
-        info.update(extra)
-        extensions = {}
-        for name, ex in self.extensions.items():
-            if hasattr(ex, "_to_dict"):
-                extensions[name] = ex._to_dict()
-        info["extensions"] = extensions
-        return recursive_to_dict(info, exclude=exclude)
+        info.update(recursive_to_dict(extra, exclude=exclude))
+        return info
 
     def get_worker_service_addr(self, worker, service_name, protocol=False):
         """

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -26,7 +26,7 @@ from contextlib import suppress
 from datetime import timedelta
 from functools import partial
 from numbers import Number
-from typing import Any, ClassVar, Container
+from typing import ClassVar, Container
 from typing import cast as pep484_cast
 
 import psutil
@@ -1732,10 +1732,10 @@ class TaskState:
         return nbytes
 
     @ccall
-    def _to_dict(self, *, exclude: Container[str] = None):
+    def _to_dict(self, *, exclude: "Container[str]" = ()) -> dict:
         """
         A very verbose dictionary representation for debugging purposes.
-        Not type stable and not inteded for roundtrips.
+        Not type stable and not intended for roundtrips.
 
         Parameters
         ----------
@@ -1746,12 +1746,13 @@ class TaskState:
         --------
         Client.dump_cluster_state
         """
-
-        if not exclude:
-            exclude = set()
         members = inspect.getmembers(self)
         return recursive_to_dict(
-            {k: v for k, v in members if k not in exclude and not callable(v)},
+            {
+                k: v
+                for k, v in members
+                if not k.startswith("_") and k not in exclude and not callable(v)
+            },
             exclude=exclude,
         )
 
@@ -3977,8 +3978,8 @@ class Scheduler(SchedulerState, ServerNode):
         return d
 
     def _to_dict(
-        self, comm: Comm = None, *, exclude: Container[str] = None
-    ) -> "dict[str, Any]":
+        self, comm: "Comm | None" = None, *, exclude: "Container[str]" = ()
+    ) -> dict:
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.
@@ -3994,7 +3995,6 @@ class Scheduler(SchedulerState, ServerNode):
         Server.identity
         Client.dump_cluster_state
         """
-
         info = super()._to_dict(exclude=exclude)
         extra = {
             "transition_log": self.transition_log,
@@ -4007,6 +4007,7 @@ class Scheduler(SchedulerState, ServerNode):
         for name, ex in self.extensions.items():
             if hasattr(ex, "_to_dict"):
                 extensions[name] = ex._to_dict()
+        info["extensions"] = extensions
         return recursive_to_dict(info, exclude=exclude)
 
     def get_worker_service_addr(self, worker, service_name, protocol=False):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1732,7 +1732,7 @@ class TaskState:
         return nbytes
 
     @ccall
-    def _to_dict(self, *, exclude: "Container[str]" = ()) -> dict:
+    def _to_dict(self, *, exclude: "Container[str]" = ()):  # -> dict
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not intended for roundtrips.

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -4,7 +4,7 @@ import logging
 from collections import defaultdict, deque
 from math import log2
 from time import time
-from typing import Any, Container
+from typing import Container
 
 from tlz import topk
 from tornado.ioloop import PeriodicCallback
@@ -82,7 +82,7 @@ class WorkStealing(SchedulerPlugin):
 
         self.scheduler.stream_handlers["steal-response"] = self.move_task_confirm
 
-    def _to_dict(self, *, exclude: Container[str] = None) -> dict[str, Any]:
+    def _to_dict(self, *, exclude: Container[str] = ()) -> dict:
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -23,6 +23,7 @@ from time import sleep
 
 import psutil
 import pytest
+import yaml
 from tlz import concat, first, identity, isdistinct, merge, pluck, valmap
 
 import dask
@@ -7165,7 +7166,6 @@ async def test_dump_cluster_state_async(c, s, a, b, tmp_path, _format):
 
 @gen_cluster(client=True)
 async def test_dump_cluster_state_exclude(c, s, a, b, tmp_path):
-
     futs = c.map(inc, range(10))
     while len(s.tasks) != len(futs):
         await asyncio.sleep(0.01)
@@ -7175,15 +7175,10 @@ async def test_dump_cluster_state_exclude(c, s, a, b, tmp_path):
         "runspec",
     ]
     filename = tmp_path / "foo"
-    await c.dump_cluster_state(
-        filename=filename,
-        format="yaml",
-    )
+    await c.dump_cluster_state(filename=filename, format="yaml")
 
-    with open(str(filename) + ".yaml") as fd:
-        import yaml
-
-        state = yaml.load(fd, Loader=yaml.Loader)
+    with open(f"{filename}.yaml") as fd:
+        state = yaml.safe_load(fd)
 
     assert "workers" in state
     assert len(state["workers"]) == len(s.workers)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3255,11 +3255,12 @@ async def test__to_dict(c, s, a, b):
     futs = c.map(inc, range(100))
 
     await c.gather(futs)
-    dct = Scheduler._to_dict(s)
-    assert list(dct.keys()) == [
+    d = Scheduler._to_dict(s)
+    assert d.keys() == {
         "type",
         "id",
         "address",
+        "extensions",
         "services",
         "started",
         "workers",
@@ -3269,5 +3270,5 @@ async def test__to_dict(c, s, a, b):
         "log",
         "tasks",
         "events",
-    ]
-    assert dct["tasks"][futs[0].key]
+    }
+    assert d["tasks"][futs[0].key]

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -22,18 +22,15 @@ from asyncio import TimeoutError
 from collections import OrderedDict, UserDict, deque
 from concurrent.futures import CancelledError, ThreadPoolExecutor  # noqa: F401
 from contextlib import contextmanager, suppress
+from contextvars import ContextVar
 from hashlib import md5
 from importlib.util import cache_from_source
 from time import sleep
-from typing import TYPE_CHECKING
 from typing import Any as AnyType
-from typing import ClassVar, Container, Sequence, overload
+from typing import ClassVar, Container
 
 import click
 import tblib.pickling_support
-
-if TYPE_CHECKING:
-    from typing_extensions import Protocol
 
 try:
     import resource
@@ -1439,95 +1436,57 @@ def __getattr__(name):
         raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
-if TYPE_CHECKING:
-
-    class SupportsToDict(Protocol):
-        def _to_dict(
-            self, *, exclude: Container[str] | None = None, **kwargs
-        ) -> dict[str, AnyType]:
-            ...
+# Used internally by recursive_to_dict to let the YAML exporter catch infinite
+# recursion. If an object has already been encountered, a string representan will be
+# returned instead. This is necessary since we have multiple cyclic referencing data
+# structures.
+_recursive_to_dict_seen: ContextVar[set[int]] = ContextVar("_recursive_to_dict_seen")
 
 
-@overload
-def recursive_to_dict(
-    obj: SupportsToDict, exclude: Container[str] = None, seen: set[AnyType] = None
-) -> dict[str, AnyType]:
-    ...
-
-
-@overload
-def recursive_to_dict(
-    obj: Sequence, exclude: Container[str] = None, seen: set[AnyType] = None
-) -> Sequence:
-    ...
-
-
-@overload
-def recursive_to_dict(
-    obj: dict, exclude: Container[str] = None, seen: set[AnyType] = None
-) -> dict:
-    ...
-
-
-@overload
-def recursive_to_dict(
-    obj: None, exclude: Container[str] = None, seen: set[AnyType] = None
-) -> None:
-    ...
-
-
-def recursive_to_dict(obj, exclude=None, seen=None):
-    """
-    This is for debugging purposes only and calls ``_to_dict`` methods on ``obj`` or
-    it's elements recursively, if available. The output of this function is
-    intended to be json serializable.
+def recursive_to_dict(obj: AnyType, *, exclude: Container[str] = ()) -> AnyType:
+    """Recursively convert arbitrary Python objects to a JSON-serializable
+    representation. This is intended for debugging purposes only and calls ``_to_dict``
+    methods on encountered objects, if available.
 
     Parameters
     ----------
     exclude:
         A list of attribute names to be excluded from the dump.
         This will be forwarded to the objects ``_to_dict`` methods and these methods
-        are required to ensure this.
-    seen:
-        Used internally to avoid infinite recursion. If an object has already
-        been encountered, it's representation will be generated instead of its
-        ``_to_dict``. This is necessary since we have multiple cyclic referencing
-        data structures.
+        are required to accept this parameter.
     """
-    if obj is None:
-        return None
-    if isinstance(obj, str):
+    if isinstance(obj, (int, float, bool, str)) or obj is None:
         return obj
-    if seen is None:
-        seen = set()
+    if isinstance(obj, (type, bytes)):
+        return repr(obj)
+
+    # Prevent infinite recursion
+    try:
+        seen = _recursive_to_dict_seen.get()
+    except LookupError:
+        tok = _recursive_to_dict_seen.set(set())
+        try:
+            return recursive_to_dict(obj, exclude=exclude)
+        finally:
+            _recursive_to_dict_seen.reset(tok)
+
     if id(obj) in seen:
         return repr(obj)
     seen.add(id(obj))
-    if isinstance(obj, type):
-        return repr(obj)
+
     if hasattr(obj, "_to_dict"):
         return obj._to_dict(exclude=exclude)
-    if isinstance(obj, (deque, set)):
-        obj = tuple(obj)
-    if isinstance(obj, (list, tuple)):
-        return tuple(
-            recursive_to_dict(
-                el,
-                exclude=exclude,
-                seen=seen,
-            )
-            for el in obj
-        )
-    elif isinstance(obj, dict):
+    if isinstance(obj, (list, tuple, set, frozenset, deque)):
+        return [recursive_to_dict(el, exclude=exclude) for el in obj]
+    if isinstance(obj, dict):
         res = {}
         for k, v in obj.items():
-            k = recursive_to_dict(k, exclude=exclude, seen=seen)
+            k = recursive_to_dict(k, exclude=exclude)
+            v = recursive_to_dict(v, exclude=exclude)
             try:
-                hash(k)
+                res[k] = v
             except TypeError:
-                k = str(k)
-            v = recursive_to_dict(v, exclude=exclude, seen=seen)
-            res[k] = v
+                res[str(k)] = v
         return res
-    else:
-        return repr(obj)
+
+    return repr(obj)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1147,9 +1147,9 @@ class Worker(ServerNode):
             "memory_spill_fraction": self.memory_spill_fraction,
             "memory_pause_fraction": self.memory_pause_fraction,
             "logs": self.get_logs(),
-            "config": dict(dask.config.config),
-            "incoming_transfer_log": list(self.incoming_transfer_log),
-            "outgoing_transfer_log": list(self.outgoing_transfer_log),
+            "config": dask.config.config,
+            "incoming_transfer_log": self.incoming_transfer_log,
+            "outgoing_transfer_log": self.outgoing_transfer_log,
         }
         info.update(extra)
         return recursive_to_dict(info, exclude=exclude)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -225,7 +225,7 @@ class TaskState:
         nbytes = self.nbytes
         return nbytes if nbytes is not None else DEFAULT_DATA_SIZE
 
-    def _to_dict(self, *, exclude: Container[str] = None) -> dict[str, Any]:
+    def _to_dict(self, *, exclude: Container[str] = ()) -> dict:
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.
@@ -240,16 +240,8 @@ class TaskState:
         --------
         Client.dump_cluster_state
         """
-
-        if exclude is None:
-            exclude = set()
-
         return recursive_to_dict(
-            {
-                attr: getattr(self, attr)
-                for attr in self.__dict__.keys()
-                if attr not in exclude
-            },
+            {k: v for k, v in self.__dict__.items() if k not in exclude},
             exclude=exclude,
         )
 
@@ -1122,8 +1114,8 @@ class Worker(ServerNode):
         }
 
     def _to_dict(
-        self, comm: Comm = None, *, exclude: Container[str] = None
-    ) -> dict[str, Any]:
+        self, comm: Comm | None = None, *, exclude: Container[str] = ()
+    ) -> dict:
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.


### PR DESCRIPTION
- Fix RecursionError where the seen set was forgotten when passing through an object with the ``_to_dict`` method
- Replace tuples in output with lists to make it more YAML-friendly
- ``TaskState._to_dict`` output is now a lot terser
- ``Scheduler._to_dict`` output now includes extensions
- General implementation cleanup

FYI @fjetter 
