### PR TITLE
Skip `test_ucx_unreachable` if `UCXUnreachable` is unavailable

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -363,6 +363,10 @@ async def test_ucx_protocol(cleanup, port):
         assert s.address.startswith("ucx://")
 
 
+@pytest.mark.skipif(
+    not hasattr(ucp._libs.exceptions, "UCXUnreachable"),
+    reason="Requires UCX-Py support for UCXUnreachable exception",
+)
 def test_ucx_unreachable():
     with pytest.raises(OSError, match="Timed out trying to connect to"):
         Client("ucx://255.255.255.255:12345", timeout=1)

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -364,7 +364,7 @@ async def test_ucx_protocol(cleanup, port):
 
 
 @pytest.mark.skipif(
-    not hasattr(ucp._libs.exceptions, "UCXUnreachable"),
+    not hasattr(ucp.exceptions, "UCXUnreachable"),
     reason="Requires UCX-Py support for UCXUnreachable exception",
 )
 def test_ucx_unreachable():


### PR DESCRIPTION
The test will fail on older UCX-Py versions otherwise, this was found out because recent UCX-Py builds are still unavailable.