### PR TITLE
Fix `test_ucx_unreachable` on UCX < 1.12

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -368,5 +368,9 @@ async def test_ucx_protocol(cleanup, port):
     reason="Requires UCX-Py support for UCXUnreachable exception",
 )
 def test_ucx_unreachable():
-    with pytest.raises(OSError, match="Timed out trying to connect to"):
-        Client("ucx://255.255.255.255:12345", timeout=1)
+    if ucp.get_ucx_version() > (1, 12, 0):
+        with pytest.raises(OSError, match="Timed out trying to connect to"):
+            Client("ucx://255.255.255.255:12345", timeout=1)
+    else:
+        with pytest.raises(ucp.exceptions.UCXError, match="Destination is unreachable"):
+            Client("ucx://255.255.255.255:12345", timeout=1)


### PR DESCRIPTION
The `test_ucx_unreachable` issue for UCX >= 1.12 was fixed by https://github.com/dask/distributed/pull/5560, but in UCX 1.11 we need a different check which is addressed here.