### PR TITLE
AMM: Test that acquire-replicas of a task already in flight is a no-op

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2864,8 +2864,9 @@ async def test_acquire_replicas_already_in_flight(c, s, *nannies):
     _acquire_replicas(s, b, x)
     await asyncio.sleep(0.5)
 
-    story = await c.run(lambda dask_worker: dask_worker.story(x.key), workers=[b])
+    story = await c.run(lambda dask_worker: dask_worker.story("x"), workers=[b])
     events = [ev for ev in story[b] if ev[-1] >= start]
+    assert len(events) == 2
     assert events[0][:3] == ("x", "ensure-task-exists", "flight")
     assert events[1][:4] == ("x", "flight", "fetch", "flight")
 


### PR DESCRIPTION
Add tests to #5563.

Full story, before #5563:
```
('x', 'ensure-task-exists', 'released', 'compute-task-1638881645.363173', 1638881645.3635883)
('x', 'released', 'fetch', 'fetch', {}, 'compute-task-1638881645.363173', 1638881645.3636189)
('x', 'fetch', 'flight', 'flight', {}, 'ensure-communicating-1638881645.3636773', 1638881645.363723)
('x', 'ensure-task-exists', 'flight', 'acquire-replicas-1638881645.8633003', 1638881645.8648033)
('x', 'flight', 'fetch', 'fetch', {}, 'acquire-replicas-1638881645.8633003', 1638881645.8648908)
('x', 'release-key', 'ensure-communicating-1638881645.3636773')
('x', 'fetch', 'released', 'released', {}, 'ensure-communicating-1638881645.3636773', 1638881647.3704028)
('x', 'put-in-memory', 'ensure-communicating-1638881645.3636773', 1638881647.3705134)
('x', 'released', 'memory', 'memory', {'y': 'ready'}, 'ensure-communicating-1638881645.3636773', 1638881647.37053)
('x', 'fetch', 'memory', 'memory', {'y': 'ready'}, 'ensure-communicating-1638881645.3636773', 1638881647.3705366)
```

After #5563:
```
('x', 'ensure-task-exists', 'released', 'compute-task-1638882484.004325', 1638882484.0047045)
('x', 'released', 'fetch', 'fetch', {}, 'compute-task-1638882484.004325', 1638882484.0047295)
('x', 'fetch', 'flight', 'flight', {}, 'ensure-communicating-1638882484.004781', 1638882484.0048206)
('x', 'ensure-task-exists', 'flight', 'acquire-replicas-1638882484.5047143', 1638882484.5052886)
('x', 'flight', 'fetch', 'flight', {}, 'acquire-replicas-1638882484.5047143', 1638882484.5053265)
('x', 'put-in-memory', 'ensure-communicating-1638882484.004781', 1638882486.0103726)
('x', 'flight', 'memory', 'memory', {'y': 'ready'}, 'ensure-communicating-1638882484.004781', 1638882486.0103946)
```