### PR TITLE
Disable NVML monitoring on WSL

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -84,6 +84,9 @@ def has_cuda_context():
         return False
     for index in range(device_get_count()):
         handle = pynvml.nvmlDeviceGetHandleByIndex(index)
+        # TODO: WSL doesn't support this NVML query yet; when NVML monitoring is enabled
+        # there we may need to wrap this in a try/except block.
+        # See https://github.com/dask/distributed/pull/5568
         if hasattr(pynvml, "nvmlDeviceGetComputeRunningProcesses_v2"):
             running_processes = pynvml.nvmlDeviceGetComputeRunningProcesses_v2(handle)
         else:

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -1,5 +1,4 @@
 import os
-from platform import uname
 
 import dask
 
@@ -17,7 +16,7 @@ def _in_wsl():
     """Check if we are in Windows Subsystem for Linux; some PyNVML queries are not supported there.
     Taken from https://www.scivision.dev/python-detect-wsl/
     """
-    return "microsoft-standard" in uname().release
+    return "microsoft-standard" in os.uname().release
 
 
 def init_once():

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -1,4 +1,5 @@
 import os
+from platform import uname
 
 import dask
 
@@ -16,7 +17,7 @@ def _in_wsl():
     """Check if we are in Windows Subsystem for Linux; some PyNVML queries are not supported there.
     Taken from https://www.scivision.dev/python-detect-wsl/
     """
-    return "microsoft-standard" in os.uname().release
+    return "microsoft-standard" in uname().release
 
 
 def init_once():


### PR DESCRIPTION
Adds a check `_in_wsl()` to check if Distributed is being run from a WSL Linux subshell, and if so disables NVML monitoring. This is due to the fact that WSL's NVML does not currently support all queries, which can result in a variety of issues when starting up a cluster for both Distributed and Dask-CUDA; see https://docs.nvidia.com/cuda/wsl-user-guide/index.html#features-not-yet-supported.

Note that with this PR, we should be able to revert https://github.com/dask/distributed/pull/5343, as we no longer have to worry about real-time NVML metric tracking on WSL. However, I think it would probably be better to leave those checks in for the case where all NVML queries in WSL work _except_ for GPU utilization.

cc @pentschev 

- [x] Closes #5567
- [x] Closes https://github.com/rapidsai/dask-cuda/issues/816
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
