### PR TITLE
Resolve workflow syntax error in `ssh_debug.yaml`

### DIFF
--- a/.github/workflows/ssh_debug.yaml
+++ b/.github/workflows/ssh_debug.yaml
@@ -1,8 +1,8 @@
+name: Debug passwordless `ssh localhost`
+
+on: [pull_request]
+
 # uncomment to enable
-# name: Debug passwordless `ssh localhost`
-
-# on: [pull_request]
-
 # jobs:
 #   test:
 #     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ssh_debug.yaml
+++ b/.github/workflows/ssh_debug.yaml
@@ -1,6 +1,6 @@
 name: Debug passwordless `ssh localhost`
 
-on: [pull_request]  # Uncomment to enable
+on: [pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ssh_debug.yaml
+++ b/.github/workflows/ssh_debug.yaml
@@ -1,11 +1,11 @@
 name: Debug passwordless `ssh localhost`
 
-on: []
-# on: [pull_request]  # Uncomment to enable
+on: [pull_request]  # Uncomment to enable
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    if: false  # comment to enable
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ssh_debug.yaml
+++ b/.github/workflows/ssh_debug.yaml
@@ -2,46 +2,46 @@ name: Debug passwordless `ssh localhost`
 
 on: [pull_request]
 
-# uncomment to enable
-# jobs:
-#   test:
-#     runs-on: ${{ matrix.os }}
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         os:
-#           - ubuntu-latest
-#           - macos-latest
-#           # - windows-latest  # FIXME https://github.com/dask/distributed/issues/4509
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    if: false  # comment out to enable
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          # - windows-latest  # FIXME https://github.com/dask/distributed/issues/4509
 
-#     steps:
-#       - name: Setup SSH
-#         shell: bash -l {0}
-#         run: bash continuous_integration/scripts/setup_ssh.sh
+    steps:
+      - name: Setup SSH
+        shell: bash -l {0}
+        run: bash continuous_integration/scripts/setup_ssh.sh
 
-#       - name: Dump SSH config
-#         shell: bash -l {0}
-#         run: |
-#           ls -ld ~ ~/.ssh ~/.ssh/*
-#           for f in ~/.ssh/* /etc/ssh/sshd_config; do
-#             echo ==================================
-#             echo $f
-#             echo ==================================
-#             cat $f
-#           done
+      - name: Dump SSH config
+        shell: bash -l {0}
+        run: |
+          ls -ld ~ ~/.ssh ~/.ssh/*
+          for f in ~/.ssh/* /etc/ssh/sshd_config; do
+            echo ==================================
+            echo $f
+            echo ==================================
+            cat $f
+          done
 
-#       - name: Test SSH vs. localhost
-#         shell: bash -l {0}
-#         run: ssh -vvv localhost 'echo hello world'
+      - name: Test SSH vs. localhost
+        shell: bash -l {0}
+        run: ssh -vvv localhost 'echo hello world'
 
-#       - name: Test SSH vs. 127.0.0.1
-#         shell: bash -l {0}
-#         run: ssh -vvv 127.0.0.1 'echo hello world'
+      - name: Test SSH vs. 127.0.0.1
+        shell: bash -l {0}
+        run: ssh -vvv 127.0.0.1 'echo hello world'
 
-#       - name: Test SSH vs. hostname
-#         shell: bash -l {0}
-#         run: ssh -vvv $(hostname) 'echo hello world'
+      - name: Test SSH vs. hostname
+        shell: bash -l {0}
+        run: ssh -vvv $(hostname) 'echo hello world'
 
-#       - name: Debug with tmate on failure
-#         if: ${{ failure() }}
-#         uses: mxschmitt/action-tmate@v3
+      - name: Debug with tmate on failure
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ssh_debug.yaml
+++ b/.github/workflows/ssh_debug.yaml
@@ -1,47 +1,47 @@
-name: Debug passwordless `ssh localhost`
+# uncomment to enable
+# name: Debug passwordless `ssh localhost`
 
-on: [pull_request]
+# on: [pull_request]
 
-jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    if: false  # comment to enable
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          # - windows-latest  # FIXME https://github.com/dask/distributed/issues/4509
+# jobs:
+#   test:
+#     runs-on: ${{ matrix.os }}
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         os:
+#           - ubuntu-latest
+#           - macos-latest
+#           # - windows-latest  # FIXME https://github.com/dask/distributed/issues/4509
 
-    steps:
-      - name: Setup SSH
-        shell: bash -l {0}
-        run: bash continuous_integration/scripts/setup_ssh.sh
+#     steps:
+#       - name: Setup SSH
+#         shell: bash -l {0}
+#         run: bash continuous_integration/scripts/setup_ssh.sh
 
-      - name: Dump SSH config
-        shell: bash -l {0}
-        run: |
-          ls -ld ~ ~/.ssh ~/.ssh/*
-          for f in ~/.ssh/* /etc/ssh/sshd_config; do
-            echo ==================================
-            echo $f
-            echo ==================================
-            cat $f
-          done
+#       - name: Dump SSH config
+#         shell: bash -l {0}
+#         run: |
+#           ls -ld ~ ~/.ssh ~/.ssh/*
+#           for f in ~/.ssh/* /etc/ssh/sshd_config; do
+#             echo ==================================
+#             echo $f
+#             echo ==================================
+#             cat $f
+#           done
 
-      - name: Test SSH vs. localhost
-        shell: bash -l {0}
-        run: ssh -vvv localhost 'echo hello world'
+#       - name: Test SSH vs. localhost
+#         shell: bash -l {0}
+#         run: ssh -vvv localhost 'echo hello world'
 
-      - name: Test SSH vs. 127.0.0.1
-        shell: bash -l {0}
-        run: ssh -vvv 127.0.0.1 'echo hello world'
+#       - name: Test SSH vs. 127.0.0.1
+#         shell: bash -l {0}
+#         run: ssh -vvv 127.0.0.1 'echo hello world'
 
-      - name: Test SSH vs. hostname
-        shell: bash -l {0}
-        run: ssh -vvv $(hostname) 'echo hello world'
+#       - name: Test SSH vs. hostname
+#         shell: bash -l {0}
+#         run: ssh -vvv $(hostname) 'echo hello world'
 
-      - name: Debug with tmate on failure
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+#       - name: Debug with tmate on failure
+#         if: ${{ failure() }}
+#         uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
The SSH debugging workflow is disabled by default by having an empty `on` condition; however, instead of disabling the workflow, this results in a GitHub Actions syntax error, which raises a notification for the failure whenever pushes are made to a fork of Distributed.

This PR disables this workflow at the job level, with an `if: false` condition. This avoids the syntax error notification on forks, but means that the job will show up in checks on PRs (all of which are immediately skipped).

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
