### PR TITLE
Make sure GitHub artifacts are tagged with CI partition

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,11 @@ jobs:
         python-version: ["3.7", "3.8", "3.9"]
         # Cherry-pick test modules to split the overall runtime roughly in half
         partition: [ci1, not ci1]
+        include:
+          - partition: "ci1"
+            partition-label: "ci1"
+          - partition: "not ci1"
+            partition-label: "notci1"
 
         # Uncomment to stress-test the test suite for random failures.
         # Must also change env.TEST_ID below.
@@ -30,8 +35,8 @@ jobs:
         # run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
 
     env:
-      TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}
-      # TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.run }}
+      TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}
+      # TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}-${{ matrix.run }}
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
We currently upload pytest reports as GitHub artifacts, which in theory (if not practice yet) can be used to do post-hoc analyses of CI. However, these report names don't include the (relatively newly added) CI matrix partitioning. So each CI partition races, and the last one to upload an artifact wins.

This includes the CI partition in name in the artifact so they don't overwrite each other.

A step towards #5280 

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
