### PR TITLE
Allow unknown tasks to be stolen

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2813,7 +2813,7 @@ class SchedulerState:
                 if tts._processing_on:
                     self.set_duration_estimate(tts, tts._processing_on)
                     if steal:
-                        steal.put_key_in_stealable(tts)
+                        steal.recalculate_cost(tts)
 
             ############################
             # Update State Information #

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -143,7 +143,10 @@ class WorkStealing(SchedulerPlugin):
         del self.stealable[worker]
 
     def teardown(self):
-        self.scheduler.periodic_callbacks["stealing"].stop()
+        pcs = self.scheduler.periodic_callbacks
+        if "stealing" in pcs:
+            pcs["stealing"].stop()
+            del pcs["stealing"]
 
     def transition(
         self, key, start, finish, compute_start=None, compute_stop=None, *args, **kwargs

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections import defaultdict, deque
 from math import log2
@@ -63,14 +64,11 @@ class WorkStealing(SchedulerPlugin):
         for worker in scheduler.workers:
             self.add_worker(worker=worker)
 
-        callback_time = parse_timedelta(
+        self._callback_time = parse_timedelta(
             dask.config.get("distributed.scheduler.work-stealing-interval"),
             default="ms",
         )
         # `callback_time` is in milliseconds
-        pc = PeriodicCallback(callback=self.balance, callback_time=callback_time * 1000)
-        self._pc = pc
-        self.scheduler.periodic_callbacks["stealing"] = pc
         self.scheduler.add_plugin(self)
         self.scheduler.extensions["stealing"] = self
         self.scheduler.events["stealing"] = deque(maxlen=100000)
@@ -79,8 +77,35 @@ class WorkStealing(SchedulerPlugin):
         self.in_flight = dict()
         # { worker state: occupancy }
         self.in_flight_occupancy = defaultdict(lambda: 0)
+        self._in_flight_event = asyncio.Event()
 
         self.scheduler.stream_handlers["steal-response"] = self.move_task_confirm
+
+    async def start(self, scheduler=None):
+        """Start the background coroutine to balance the tasks on the cluster.
+        Idempotent.
+        The scheduler argument is ignored. It is merely required to satisify the
+        plugin interface. Since this class is simultaneouly an extension, the
+        scheudler instance is already registered during initialization
+        """
+        if "stealing" in self.scheduler.periodic_callbacks:
+            return
+        pc = PeriodicCallback(
+            callback=self.balance, callback_time=self._callback_time * 1000
+        )
+        pc.start()
+        self.scheduler.periodic_callbacks["stealing"] = pc
+        self._in_flight_event.set()
+
+    async def stop(self):
+        """Stop the background task balancing tasks on the cluster.
+        This will block until all currently running stealing requests are
+        finished. Idempotent
+        """
+        pc = self.scheduler.periodic_callbacks.pop("stealing", None)
+        if pc:
+            pc.stop()
+        await self._in_flight_event.wait()
 
     def _to_dict(self, *, exclude: Container[str] = ()) -> dict:
         """
@@ -137,6 +162,7 @@ class WorkStealing(SchedulerPlugin):
                 self.in_flight_occupancy[victim] += d["victim_duration"]
                 if not self.in_flight:
                     self.in_flight_occupancy.clear()
+                    self._in_flight_event.set()
 
     def recalculate_cost(self, ts):
         if ts not in self.in_flight:
@@ -177,7 +203,7 @@ class WorkStealing(SchedulerPlugin):
         level: The location within a stealable list to place this value
         """
         split = ts.prefix.name
-        if split in fast_tasks or split in self.scheduler.unknown_durations:
+        if split in fast_tasks:
             return None, None
 
         if not ts.dependencies:  # no dependencies fast path
@@ -233,6 +259,7 @@ class WorkStealing(SchedulerPlugin):
                 "thief_duration": thief_duration,
                 "stimulus_id": stimulus_id,
             }
+            self._in_flight_event.clear()
 
             self.in_flight_occupancy[victim] -= victim_duration
             self.in_flight_occupancy[thief] += thief_duration
@@ -274,6 +301,7 @@ class WorkStealing(SchedulerPlugin):
 
         if not self.in_flight:
             self.in_flight_occupancy.clear()
+            self._in_flight_event.set()
 
         if self.scheduler.validate:
             assert ts.processing_on == victim

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -143,7 +143,7 @@ class WorkStealing(SchedulerPlugin):
         del self.stealable[worker]
 
     def teardown(self):
-        self._pc.stop()
+        self.scheduler.periodic_callbacks["stealing"].stop()
 
     def transition(
         self, key, start, finish, compute_start=None, compute_stop=None, *args, **kwargs

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4306,7 +4306,7 @@ async def test_retire_many_workers(c, s, *workers):
     config={"distributed.scheduler.default-task-durations": {"f": "10ms"}},
 )
 async def test_weight_occupancy_against_data_movement(c, s, a, b):
-    s.extensions["stealing"]._pc.callback_time = 1000000
+    await s.extensions["stealing"].stop()
 
     def f(x, y=0, z=0):
         sleep(0.01)
@@ -4329,7 +4329,7 @@ async def test_weight_occupancy_against_data_movement(c, s, a, b):
     config={"distributed.scheduler.default-task-durations": {"f": "10ms"}},
 )
 async def test_distribute_tasks_by_nthreads(c, s, a, b):
-    s.extensions["stealing"]._pc.callback_time = 1000000
+    await s.extensions["stealing"].stop()
 
     def f(x, y=0):
         sleep(0.01)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1020,7 +1020,7 @@ async def test_balance_many_workers(c, s, *workers):
 @nodebug
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 30)
 async def test_balance_many_workers_2(c, s, *workers):
-    s.extensions["stealing"]._pc.callback_time = 100000000
+    await s.extensions["stealing"].stop()
     futures = c.map(slowinc, range(90), delay=0.2)
     await wait(futures)
     assert {len(w.has_what) for w in s.workers.values()} == {3}

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -199,10 +199,11 @@ async def test_allow_tasks_stolen_before_first_completes(c, s, a, b):
 
     async with lock:
         first = c.submit(blocked_task, 0, lock, workers=[a.address], key="f-0")
+        while first.key not in a.tasks:
+            await asyncio.sleep(0.001)
         # Ensure the task is indeed blocked
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(first, 0.01)
-        assert first.key in a.tasks
 
         more_tasks = c.map(
             blocked_task,

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1209,7 +1209,7 @@ async def test_get_current_task(c, s, a, b):
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 async def test_reschedule(c, s, a, b):
-    s.extensions["stealing"]._pc.stop()
+    await s.extensions["stealing"].stop()
     a_address = a.address
 
     def f(x):
@@ -2601,7 +2601,7 @@ async def test_forget_dependents_after_release(c, s, a):
 @gen_cluster(client=True)
 async def test_steal_during_task_deserialization(c, s, a, b, monkeypatch):
     stealing_ext = s.extensions["stealing"]
-    stealing_ext._pc.stop()
+    await stealing_ext.stop()
     from distributed.utils import ThreadPoolExecutor
 
     class CountingThreadPool(ThreadPoolExecutor):


### PR DESCRIPTION
This effectively reverts https://github.com/dask/distributed/pull/5392 which enforced that unknown tasks couldn't be stolen. This was flagged as a regression since a test asserting this behaviour was introduced in very early stages of the stealing development https://github.com/dask/distributed/pull/278. Back then we didn't have any intermediate runtime information about the task but this is no longer true and this behaviour can be revised.

- [x] Closes https://github.com/dask/distributed/issues/5564

For testability, I added `WorkStealing.start` and `WorkStealing.stop` since I believe for proper timing based tests we should have the possibility to disable the background PC. Otherwise it is very hard to assert specifically what's happening. If preferred, I can factor this out into a dedicated PR
