### PR TITLE
Await worker arrival in SSH `test_nprocs`

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -143,7 +143,6 @@ class Worker(Process):
                 ),
             ]
         )
-        print(cmd)
 
         self.proc = await self.connection.create_process(cmd)
 

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 import sys
 import warnings
@@ -85,7 +86,7 @@ class Worker(Process):
         self.scheduler = scheduler
         self.worker_class = worker_class
         self.connect_options = connect_options
-        self.kwargs = kwargs
+        self.kwargs = copy.copy(kwargs)
         self.name = name
         self.remote_python = remote_python
         self.nprocs = self.kwargs.pop("nprocs", 1)
@@ -135,7 +136,6 @@ class Worker(Process):
                             "cls": self.worker_class,
                             "opts": {
                                 **self.kwargs,
-                                "name": self.name,
                             },
                         }
                         for i in range(self.nprocs)
@@ -143,6 +143,7 @@ class Worker(Process):
                 ),
             ]
         )
+        print(cmd)
 
         self.proc = await self.connection.create_process(cmd)
 

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -69,7 +69,7 @@ async def test_nprocs():
     ) as cluster:
         assert len(cluster.workers) == 2
         async with Client(cluster, asynchronous=True) as client:
-            client.wait_for_workers(4)
+            await client.wait_for_workers(4)
             result = await client.submit(lambda x: x + 1, 10)
             assert result == 11
         assert not cluster._supports_scaling


### PR DESCRIPTION
I noticed the following warning is currently emitted when the test suite is run:

```
distributed/deploy/tests/test_ssh.py::test_nprocs
  /home/runner/work/distributed/distributed/distributed/deploy/tests/test_ssh.py:72: RuntimeWarning: coroutine 'Client._wait_for_workers' was never awaited
    client.wait_for_workers(4)
```

This PR add an `await` accordingly. cc @jacobtomlinson 