### PR TITLE
Further RecursionError fixes in recursive_to_repr

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3251,11 +3251,11 @@ async def test_unpause_schedules_unrannable_tasks(c, s, a):
 
 
 @gen_cluster(client=True)
-async def test__to_dict(c, s, a, b):
+async def test_Scheduler__to_dict(c, s, a, b):
     futs = c.map(inc, range(100))
 
     await c.gather(futs)
-    d = Scheduler._to_dict(s)
+    d = s._to_dict()
     assert d.keys() == {
         "type",
         "id",
@@ -3272,6 +3272,26 @@ async def test__to_dict(c, s, a, b):
         "events",
     }
     assert d["tasks"][futs[0].key]
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_TaskState__to_dict(c, s):
+    """tasks that are listed as dependencies of other tasks are dumped as a short repr
+    and always appear in full under Scheduler.tasks
+    """
+    x = c.submit(inc, 1, key="x")
+    y = c.submit(inc, x, key="y")
+    z = c.submit(inc, 2, key="z")
+    while len(s.tasks) < 3:
+        await asyncio.sleep(0.01)
+
+    tasks = s._to_dict()["tasks"]
+
+    assert isinstance(tasks["x"], dict)
+    assert isinstance(tasks["y"], dict)
+    assert isinstance(tasks["z"], dict)
+    assert tasks["x"]["dependents"] == ["<TaskState 'y' waiting>"]
+    assert tasks["y"]["dependencies"] == ["<TaskState 'x' no-worker>"]
 
 
 @gen_cluster(nthreads=[])

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -692,5 +692,11 @@ def test_recursive_to_dict():
     # Test recursion
     a = []
     c = C(a)
-    a.append(c)
-    assert recursive_to_dict(a, exclude=["foo"]) == [["C:", "[<C>]"]]
+    a += [c, c]
+    # The blacklist of already-seen objects is reentrant: a is converted to string when
+    # found inside itself; c must *not* be converted to string the second time it's
+    # found, because it's outside of itself.
+    assert recursive_to_dict(a, exclude=["foo"]) == [
+        ["C:", "[<C>, <C>]"],
+        ["C:", "[<C>, <C>]"],
+    ]

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -994,8 +994,9 @@ def gen_cluster(
                                 assert c
                                 try:
                                     if cluster_dump_directory:
-                                        if not os.path.exists(cluster_dump_directory):
-                                            os.makedirs(cluster_dump_directory)
+                                        os.makedirs(
+                                            cluster_dump_directory, exist_ok=True
+                                        )
                                         filename = os.path.join(
                                             cluster_dump_directory, func.__name__
                                         )
@@ -1011,7 +1012,8 @@ def gen_cluster(
                                         await fut
                                 except Exception:
                                     print(
-                                        f"Exception {sys.exc_info()} while trying to dump cluster state."
+                                        f"Exception {sys.exc_info()} while trying to "
+                                        "dump cluster state."
                                     )
 
                             task.cancel()


### PR DESCRIPTION
- The seen set is now reentrant - if an object appears twice but the second instance is not inside the first, it will be converted to dict as normal.
- When a TaskState references another TaskState (e.g. in dependents or dependencies), you'll get the repr of the child even if the child has not been seen yet. This prevents very deeply nested structures (I got a RecursionError with a chain of 188 tasks).