### PR TITLE
Show warning level for package mismatches

### DIFF
--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -78,6 +78,7 @@ def test_version_mismatch(node, effect, kwargs_not_matching, pattern):
     i = column_matching.get(node, 3)
     assert "Mismatched versions found" in msg["warning"]
     assert "distributed" in msg["warning"]
+    assert "Critical" in msg["warning"]
     assert (
         pattern
         in re.search(
@@ -109,6 +110,7 @@ def test_python_mismatch(kwargs_matching):
     msg = error_message(**kwargs_matching)
     assert "Mismatched versions found" in msg["warning"]
     assert "python" in msg["warning"]
+    assert "Critical" in msg["warning"]
     assert (
         "0.0.0"
         in re.search(r"python\s+(?:(?:\|[^|\r\n]*)+\|(?:\r?\n|\r)?)+", msg["warning"])

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -148,20 +148,24 @@ def error_message(scheduler, workers, client, client_name="client"):
         elif len(worker_versions) == 0:
             worker_versions = None
 
-        errs.append((pkg, client_version, scheduler_version, worker_versions))
+        level = "Critical" if pkg in ["python", "dask", "distributed"] else "Warning"
+
+        errs.append((pkg, client_version, scheduler_version, worker_versions, level))
         if pkg in notes_mismatch_package.keys():
             notes.append(f"-  {pkg}: {notes_mismatch_package[pkg]}")
 
     out = {"warning": "", "error": ""}
 
     if errs:
-        err_table = asciitable(["Package", client_name, "scheduler", "workers"], errs)
-        err_msg = f"Mismatched versions found\n\n{err_table}"
+        err_table = asciitable(
+            ["Package", client_name, "scheduler", "workers", "level"], errs
+        )
+        err_msg = f"Mismatched versions found, may case instability. Please address critical mismatches before continuing.\n\n{err_table}"
         if notes:
             err_msg += "\nNotes: \n{}".format("\n".join(notes))
         out["warning"] += err_msg
 
-        for name, c, s, ws in errs:
+        for name, c, s, ws, l in errs:
             if not isinstance(ws, set):
                 ws = {ws}
 


### PR DESCRIPTION
I've noticed a few issues lately around mismatched versions of packages when deploying Dask. Some mismatches are not too big of an issue, minor versions of minor dependencies. But more regularly we see Python minor versions or dask/distributed version mismatches which result in hard to debug tracebacks and clusters which just will not work at all.

I propose that we either move to hard failing to connect a client when such a mismatch happens, or at least mark these mismatches as severe. This PR adds a `Level` column to the mismatch table and marks `python`, `dask` and `distributed` mismatches as `Critical` and everything else as `Warning`. 

```
Mismatched versions found, may case instability. Please address critical mismatches before continuing.

+---------+----------------+---------------+---------------+----------+
| Package | client         | scheduler     | workers       | level    |
+---------+----------------+---------------+---------------+----------+
| python  | 3.7.4.final.0  | 3.8.8.final.0 | 3.8.8.final.0 | Critical |
+---------+----------------+---------------+---------------+----------+
```

But I would also be happy to move to a harsher failure where the client refuses to connect.