### PR TITLE
Prevent `RecursionError` in `Worker._to_dict`

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3355,8 +3355,7 @@ async def test_TaskState__to_dict(c, s, a):
     x = c.submit(inc, 1, key="x")
     y = c.submit(inc, x, key="y")
     z = c.submit(inc, 2, key="z")
-    while len(a.tasks) < 3:
-        await asyncio.sleep(0.01)
+    await wait([x, y, z])
 
     tasks = a._to_dict()["tasks"]
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3311,3 +3311,57 @@ async def test_deadlock_cancelled_after_inflight_before_gather_from_worker(
     args, kwargs = mocked_gather.call_args
     await Worker.gather_dep(b, *args, **kwargs)
     await fut3
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_Worker__to_dict(c, s, a):
+    x = c.submit(inc, 1, key="x")
+    await wait(x)
+    d = a._to_dict()
+    assert d.keys() == {
+        "type",
+        "id",
+        "scheduler",
+        "nthreads",
+        "ncores",
+        "memory_limit",
+        "address",
+        "status",
+        "thread_id",
+        "ready",
+        "constrained",
+        "long_running",
+        "executing_count",
+        "in_flight_tasks",
+        "in_flight_workers",
+        "log",
+        "tasks",
+        "memory_target_fraction",
+        "memory_spill_fraction",
+        "memory_pause_fraction",
+        "logs",
+        "config",
+        "incoming_transfer_log",
+        "outgoing_transfer_log",
+    }
+    assert d["tasks"]["x"]["key"] == "x"
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_TaskState__to_dict(c, s, a):
+    """tasks that are listed as dependencies of other tasks are dumped as a short repr
+    and always appear in full under Worker.tasks
+    """
+    x = c.submit(inc, 1, key="x")
+    y = c.submit(inc, x, key="y")
+    z = c.submit(inc, 2, key="z")
+    while len(a.tasks) < 3:
+        await asyncio.sleep(0.01)
+
+    tasks = a._to_dict()["tasks"]
+
+    assert isinstance(tasks["x"], dict)
+    assert isinstance(tasks["y"], dict)
+    assert isinstance(tasks["z"], dict)
+    assert tasks["x"]["dependents"] == ["<TaskState 'y' memory>"]
+    assert tasks["y"]["dependencies"] == ["<TaskState 'x' memory>"]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -127,6 +127,8 @@ DEFAULT_DATA_SIZE = parse_bytes(
 
 SerializedTask = namedtuple("SerializedTask", ["function", "args", "kwargs", "task"])
 
+_taskstate_to_dict_guard = False
+
 
 class InvalidTransition(Exception):
     pass
@@ -220,13 +222,13 @@ class TaskState:
         self._next = None
 
     def __repr__(self):
-        return f"<Task {self.key!r} {self.state}>"
+        return f"<TaskState {self.key!r} {self.state}>"
 
     def get_nbytes(self) -> int:
         nbytes = self.nbytes
         return nbytes if nbytes is not None else DEFAULT_DATA_SIZE
 
-    def _to_dict(self, *, exclude: Container[str] = ()) -> dict:
+    def _to_dict(self, *, exclude: Container[str] = ()) -> dict | str:
         """
         A very verbose dictionary representation for debugging purposes.
         Not type stable and not inteded for roundtrips.
@@ -241,10 +243,21 @@ class TaskState:
         --------
         Client.dump_cluster_state
         """
-        return recursive_to_dict(
-            {k: v for k, v in self.__dict__.items() if k not in exclude},
-            exclude=exclude,
-        )
+        # When a task references another task, just print the task repr. All tasks
+        # should neatly appear under Worker.tasks. This also prevents a RecursionError
+        # during particularly heavy loads, which have been observed to happen whenever
+        # there's an acyclic dependency chain of ~200+ tasks.
+        global _taskstate_to_dict_guard
+        if _taskstate_to_dict_guard:
+            return repr(self)
+        _taskstate_to_dict_guard = True
+        try:
+            return recursive_to_dict(
+                {k: v for k, v in self.__dict__.items() if k not in exclude},
+                exclude=exclude,
+            )
+        finally:
+            _taskstate_to_dict_guard = False
 
     def is_protected(self) -> bool:
         return self.state in PROCESSING or any(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -231,7 +231,7 @@ class TaskState:
     def _to_dict(self, *, exclude: Container[str] = ()) -> dict | str:
         """
         A very verbose dictionary representation for debugging purposes.
-        Not type stable and not inteded for roundtrips.
+        Not type stable and not intended for roundtrips.
 
         Parameters
         ----------


### PR DESCRIPTION
Mirror in ``worker.TaskState._to_dict`` the guard system from ``scheduler.TaskState._to_dict`` that prevents a long (>188) acyclic chain of tasks from raising RecursionError