### PR TITLE
Improved cluster state dump in @gen_cluster

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from time import sleep
 
 import pytest
+import yaml
 from tornado import gen
 
 from distributed import Client, Nanny, Scheduler, Worker, config, default_client
@@ -17,6 +18,7 @@ from distributed.utils_test import (
     _LockedCommPool,
     _UnhashableCallable,
     cluster,
+    dump_cluster_state,
     gen_cluster,
     gen_test,
     inc,
@@ -422,3 +424,69 @@ def test_dump_cluster_state_timeout(tmp_path):
 
     assert "scheduler" in state
     assert "workers" in state
+
+
+@gen_cluster()
+async def test_dump_cluster_state(s, a, b, tmpdir):
+    await dump_cluster_state(s, [a, b], str(tmpdir), "dump")
+    with open(f"{tmpdir}/dump.yaml") as fh:
+        out = yaml.safe_load(fh)
+
+    assert out.keys() == {"scheduler", "workers", "versions"}
+    assert out["workers"].keys() == {a.address, b.address}
+
+
+@gen_cluster(nthreads=[])
+async def test_dump_cluster_state_no_workers(s, tmpdir):
+    await dump_cluster_state(s, [], str(tmpdir), "dump")
+    with open(f"{tmpdir}/dump.yaml") as fh:
+        out = yaml.safe_load(fh)
+
+    assert out.keys() == {"scheduler", "workers", "versions"}
+    assert out["workers"] == {}
+
+
+@gen_cluster(Worker=Nanny)
+async def test_dump_cluster_state_nannies(s, a, b, tmpdir):
+    await dump_cluster_state(s, [a, b], str(tmpdir), "dump")
+    with open(f"{tmpdir}/dump.yaml") as fh:
+        out = yaml.safe_load(fh)
+
+    assert out.keys() == {"scheduler", "workers", "versions"}
+    assert out["workers"].keys() == s.workers.keys()
+
+
+@gen_cluster()
+async def test_dump_cluster_state_unresponsive_local_worker(s, a, b, tmpdir):
+    a.stop()
+    await dump_cluster_state(s, [a, b], str(tmpdir), "dump")
+    with open(f"{tmpdir}/dump.yaml") as fh:
+        out = yaml.safe_load(fh)
+
+    assert out.keys() == {"scheduler", "workers", "versions"}
+    assert isinstance(out["workers"][a.address], dict)
+    assert isinstance(out["workers"][b.address], dict)
+
+
+@pytest.mark.slow
+@gen_cluster(
+    client=True,
+    Worker=Nanny,
+    config={"distributed.comm.timeouts.connect": "200ms"},
+)
+async def test_dump_cluster_unresponsive_remote_worker(c, s, a, b, tmpdir):
+    addr1, addr2 = s.workers
+    clog_fut = asyncio.create_task(
+        c.run(lambda dask_scheduler: dask_scheduler.stop(), workers=[addr1])
+    )
+    await asyncio.sleep(0.2)
+
+    await dump_cluster_state(s, [a, b], str(tmpdir), "dump")
+    with open(f"{tmpdir}/dump.yaml") as fh:
+        out = yaml.safe_load(fh)
+
+    assert out.keys() == {"scheduler", "workers", "versions"}
+    assert isinstance(out["workers"][addr2], dict)
+    assert out["workers"][addr1].startswith("OSError('Timed out trying to connect to")
+
+    clog_fut.cancel()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -40,6 +40,7 @@ except ImportError:
     ssl = None  # type: ignore
 
 import pytest
+import yaml
 from tlz import assoc, memoize, merge
 from tornado import gen
 from tornado.ioloop import IOLoop
@@ -49,6 +50,7 @@ import dask
 from distributed.comm.tcp import TCP
 
 from . import system
+from . import versions as version_module
 from .client import Client, _global_clients, default_client
 from .comm import Comm
 from .compatibility import WINDOWS
@@ -990,31 +992,13 @@ def gen_cluster(
                             # This stack indicates where the coro/test is suspended
                             task.print_stack(file=buffer)
 
-                            if client:
-                                assert c
-                                try:
-                                    if cluster_dump_directory:
-                                        os.makedirs(
-                                            cluster_dump_directory, exist_ok=True
-                                        )
-                                        filename = os.path.join(
-                                            cluster_dump_directory, func.__name__
-                                        )
-                                        fut = c.dump_cluster_state(
-                                            filename,
-                                            # Test dumps should be small enough that
-                                            # there is no need for a compressed
-                                            # binary representation and readability
-                                            # is more important
-                                            format="yaml",
-                                        )
-                                        assert fut is not None
-                                        await fut
-                                except Exception:
-                                    print(
-                                        f"Exception {sys.exc_info()} while trying to "
-                                        "dump cluster state."
-                                    )
+                            if cluster_dump_directory:
+                                await dump_cluster_state(
+                                    s,
+                                    ws,
+                                    output_dir=cluster_dump_directory,
+                                    func_name=func.__name__,
+                                )
 
                             task.cancel()
                             while not task.cancelled():
@@ -1094,6 +1078,41 @@ def gen_cluster(
         return test_func
 
     return _
+
+
+async def dump_cluster_state(
+    s: Scheduler, ws: list[ServerNode], output_dir: str, func_name: str
+) -> None:
+    """A variant of Client.dump_cluster_state, which does not expect on any of the below
+    to work:
+
+    - Having a client at all
+    - Client->Scheduler comms
+    - Scheduler->Worker comms (unless using Nannies)
+    """
+    scheduler_info = s._to_dict()
+    workers_info: dict[str, Any]
+    versions_info = version_module.get_versions()
+
+    if not ws or isinstance(ws[0], Worker):
+        workers_info = {w.address: w._to_dict() for w in ws}
+    else:
+        workers_info = await s.broadcast(msg={"op": "dump_state"}, on_error="return")
+        workers_info = {
+            k: repr(v) if isinstance(v, Exception) else v
+            for k, v in workers_info.items()
+        }
+
+    state = {
+        "scheduler": scheduler_info,
+        "workers": workers_info,
+        "versions": versions_info,
+    }
+    os.makedirs(output_dir, exist_ok=True)
+    fname = os.path.join(output_dir, func_name) + ".yaml"
+    with open(fname, "w") as fh:
+        yaml.safe_dump(state, fh)  # Automatically convert tuples to lists
+    print(f"Dumped cluster state to {fname}")
 
 
 def raises(func, exc=Exception):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1083,7 +1083,7 @@ def gen_cluster(
 async def dump_cluster_state(
     s: Scheduler, ws: list[ServerNode], output_dir: str, func_name: str
 ) -> None:
-    """A variant of Client.dump_cluster_state, which does not expect on any of the below
+    """A variant of Client.dump_cluster_state, which does not rely on any of the below
     to work:
 
     - Having a client at all


### PR DESCRIPTION
The automatic dump of the cluster state to YAML when gen_cluster times out will no longer
- rely on having a client at all
- rely on client->scheduler comms to still work
- rely on scheduler->worker comms to still work, unless using Nannies