### PR TITLE
Ensure distributed can be imported in thread

### DIFF
--- a/distributed/tests/test_imports.py
+++ b/distributed/tests/test_imports.py
@@ -1,0 +1,36 @@
+import subprocess
+import sys
+
+script = """
+import threading
+import traceback
+
+import_succeeded = False
+
+def import_dask_distributed():
+    try:
+        import dask.distributed  # noqa
+    except Exception:
+        # Print the exception for debugging
+        traceback.print_exc()
+    else:
+        global import_succeeded
+        import_succeeded = True
+
+thread = threading.Thread(target=import_dask_distributed, daemon=True)
+thread.start()
+thread.join()
+
+assert import_succeeded
+
+# Now try to use distributed from the main thread, and check that it works
+from dask.distributed import Client
+with Client(processes=False) as client:
+    res = client.submit(lambda x: x + 1, 1).result()
+    assert res == 2
+"""
+
+
+def test_can_import_distributed_in_background_thread():
+    """See https://github.com/dask/distributed/issues/5587"""
+    subprocess.check_call([sys.executable, "-c", script])


### PR DESCRIPTION
Fixes a bug introduced where `distributed` could not be first imported
in a background thread, since `tornado` would attempt to create an
`IOLoop` on import, and no event loop exists in a background thread by
default. We now delay creating a tornado `TCPClient` until use.

Fixes #5587.
Fixes https://github.com/dask/dask/issues/8466.
Fixes #4521
Supersedes #4672