### PR TITLE
Support configuring TLS min/max version

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -723,7 +723,17 @@ properties:
                 type:
                 - string
                 - "null"
-                descsription: Allowed ciphers, specified as an OpenSSL cipher string.
+                description: Allowed ciphers, specified as an OpenSSL cipher string.
+
+              min-version:
+                enum: [null, 1.2, 1.3]
+                description: The minimum TLS version to support. Defaults to TLS 1.2.
+
+              max-version:
+                enum: [null, 1.2, 1.3]
+                description: |
+                  The maximum TLS version to support. Defaults to the maximum
+                  version supported by the platform.
 
               ca-file:
                 type:

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -207,13 +207,15 @@ distributed:
     require-encryption: null # Whether to require encryption on non-local comms
 
     tls:
-      ciphers: null   # Allowed ciphers, specified as an OpenSSL cipher string.
-      ca-file: null   # Path to a CA file, in pem format, optional
+      ciphers: null     # Allowed ciphers, specified as an OpenSSL cipher string.
+      min-version: 1.2  # The minimum TLS version supported.
+      max-version: null # The maximum TLS version supported.
+      ca-file: null     # Path to a CA file, in pem format, optional
       scheduler:
-        cert: null    # Path to certificate file for scheduler.
-        key: null     # Path to key file for scheduler. Alternatively, the key
-                      # can be appended to the cert file above, and this field
-                      # left blank.
+        cert: null      # Path to certificate file for scheduler.
+        key: null       # Path to key file for scheduler. Alternatively, the key
+                        # can be appended to the cert file above, and this field
+                        # left blank.
       worker:
         key: null
         cert: null

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -178,22 +178,22 @@ class Security:
             valid = {None, ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_3}
             if val not in valid:
                 raise ValueError(
-                    f"{field}={val!r} is not supported, expected one of {valid}"
+                    f"{field}={val!r} is not supported, expected one of {list(valid)}"
                 )
             if val is None:
                 val = default
         else:
-            val = dask.config.get(config_name)
             valid = {
+                None: default,
                 1.2: ssl.TLSVersion.TLSv1_2,
                 1.3: ssl.TLSVersion.TLSv1_3,
-                None: default,
             }
+            val = dask.config.get(config_name)
             if val in valid:
                 val = valid[val]
             else:
                 raise ValueError(
-                    f"{config_name}={val!r} is not supported, expected one of [null, 1.2, 1.3]"
+                    f"{config_name}={val!r} is not supported, expected one of {list(valid)}"
                 )
 
         setattr(self, field, val)

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -42,6 +42,8 @@ def test_defaults():
     assert sec.tls_scheduler_cert is None
     assert sec.tls_worker_key is None
     assert sec.tls_worker_cert is None
+    assert sec.tls_min_version is ssl.TLSVersion.TLSv1_2
+    assert sec.tls_max_version is None
     assert sec.extra_conn_args == {}
 
 
@@ -85,6 +87,29 @@ def test_from_config():
     assert sec.tls_worker_cert == "wcert.pem"
 
 
+@pytest.mark.parametrize("min_ver", [None, 1.2, 1.3])
+@pytest.mark.parametrize("max_ver", [None, 1.2, 1.3])
+def test_min_max_version_from_config(min_ver, max_ver):
+    versions = {1.2: ssl.TLSVersion.TLSv1_2, 1.3: ssl.TLSVersion.TLSv1_3}
+    min_ver_val = versions.get(min_ver, ssl.TLSVersion.TLSv1_2)
+    max_ver_val = versions.get(max_ver)
+    c = {
+        "distributed.comm.tls.min-version": min_ver,
+        "distributed.comm.tls.max-version": max_ver,
+    }
+    with dask.config.set(c):
+        sec = Security()
+    assert sec.tls_min_version == min_ver_val
+    assert sec.tls_max_version == max_ver_val
+
+
+@pytest.mark.parametrize("field", ["min-version", "max-version"])
+def test_min_max_version_config_errors(field):
+    with dask.config.set({f"distributed.comm.tls.{field}": "bad"}):
+        with pytest.raises(ValueError, match="'bad' is not supported, expected one of"):
+            sec = Security()
+
+
 def test_kwargs():
     c = {
         "distributed.comm.tls.ca-file": "ca.pem",
@@ -96,11 +121,15 @@ def test_kwargs():
             tls_scheduler_cert="newcert.pem",
             require_encryption=True,
             tls_ca_file=None,
+            tls_min_version=None,
+            tls_max_version=ssl.TLSVersion.TLSv1_3,
             extra_conn_args={"headers": {"Auth": "Token abc"}},
         )
     assert sec.require_encryption is True
     assert sec.tls_ca_file is None
     assert sec.tls_ciphers is None
+    assert sec.tls_min_version is ssl.TLSVersion.TLSv1_2
+    assert sec.tls_max_version is ssl.TLSVersion.TLSv1_3
     assert sec.tls_client_key is None
     assert sec.tls_client_cert is None
     assert sec.tls_scheduler_key == "skey.pem"
@@ -108,6 +137,12 @@ def test_kwargs():
     assert sec.tls_worker_key is None
     assert sec.tls_worker_cert is None
     assert sec.extra_conn_args == {"headers": {"Auth": "Token abc"}}
+
+
+@pytest.mark.parametrize("key", ["tls_min_version", "tls_max_version"])
+def test_min_max_version_kwarg_errors(key):
+    with pytest.raises(ValueError, match="'bad' is not supported, expected one of"):
+        sec = Security(**{key: "bad"})
 
 
 def test_repr_temp_keys():
@@ -166,12 +201,16 @@ def test_connection_args():
     def basic_checks(ctx):
         assert ctx.verify_mode == ssl.CERT_REQUIRED
         assert ctx.check_hostname is False
+        assert ctx.minimum_version is ssl.TLSVersion.TLSv1_2
+        assert ctx.maximum_version is ssl.TLSVersion.TLSv1_3
 
     c = {
         "distributed.comm.tls.ca-file": ca_file,
         "distributed.comm.tls.scheduler.key": key1,
         "distributed.comm.tls.scheduler.cert": cert1,
         "distributed.comm.tls.worker.cert": keycert1,
+        "distributed.comm.tls.min-version": None,
+        "distributed.comm.tls.max-version": 1.3,
     }
     with dask.config.set(c):
         sec = Security()
@@ -238,12 +277,16 @@ def test_listen_args():
     def basic_checks(ctx):
         assert ctx.verify_mode == ssl.CERT_REQUIRED
         assert ctx.check_hostname is False
+        assert ctx.minimum_version is ssl.TLSVersion.TLSv1_2
+        assert ctx.maximum_version is ssl.TLSVersion.TLSv1_3
 
     c = {
         "distributed.comm.tls.ca-file": ca_file,
         "distributed.comm.tls.scheduler.key": key1,
         "distributed.comm.tls.scheduler.cert": cert1,
         "distributed.comm.tls.worker.cert": keycert1,
+        "distributed.comm.tls.min-version": None,
+        "distributed.comm.tls.max-version": 1.3,
     }
     with dask.config.set(c):
         sec = Security()

--- a/docs/source/tls.rst
+++ b/docs/source/tls.rst
@@ -45,6 +45,8 @@ One can also pass additional parameters:
 * a set of allowed *ciphers*, if you have strong requirements as to which
   algorithms are considered secure;  this setting's value should be an
   `OpenSSL cipher string <https://www.openssl.org/docs/man1.1.0/apps/ciphers.html>`_;
+* a *minimum* and/or *maximum* TLS version to support. For security reasons,
+  distributed only supports TLS versions >= 1.2.
 * whether to *require encryption*, to avoid using plain TCP communications
   by mistake.
 


### PR DESCRIPTION
This adds support for configuring minimum/maximum versions of TLS to
support for a connection.

Note that we also drop support for TLS versions < 1.2. These versions
are insecure, are deprecated in openSSL (and python 3.10), and shouldn't
be used. With this PR `distributed` requires TLS 1.2+. I don't
anticipate user issues from this change - TLS 1.2 was released in 2008
and should be supported everywhere at this point.

Fixes #5553.