### PR TITLE
Updates to gpuCI and `test_ucx_config_w_env_var`

### DIFF
--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -41,7 +41,7 @@ gpuci_logger "Install dask"
 python -m pip install git+https://github.com/dask/dask
 
 gpuci_logger "Install distributed"
-python setup.py install
+python -m pip install -e .
 
 gpuci_logger "Check Python versions"
 python --version
@@ -52,4 +52,4 @@ conda config --show-sources
 conda list --show-channel-urls
 
 gpuci_logger "Python py.test for distributed"
-py.test -s $WORKSPACE/distributed/comm/tests/test_ucx_config.py::test_ucx_config_w_env_var -v -m gpu --runslow --junitxml="$WORKSPACE/junit-distributed.xml"
+py.test -s distributed/comm/tests/test_ucx_config.py::test_ucx_config_w_env_var -v -m gpu --runslow --junitxml="$WORKSPACE/junit-distributed.xml"

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -52,4 +52,4 @@ conda config --show-sources
 conda list --show-channel-urls
 
 gpuci_logger "Python py.test for distributed"
-py.test -s distributed/comm/tests/test_ucx_config.py::test_ucx_config_w_env_var -v -m gpu --runslow --junitxml="$WORKSPACE/junit-distributed.xml"
+py.test distributed -v -m gpu --runslow --junitxml="$WORKSPACE/junit-distributed.xml"

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -52,4 +52,4 @@ conda config --show-sources
 conda list --show-channel-urls
 
 gpuci_logger "Python py.test for distributed"
-py.test $WORKSPACE/distributed -v -m gpu --runslow --junitxml="$WORKSPACE/junit-distributed.xml"
+py.test -s $WORKSPACE/distributed/comm/tests/test_ucx_config.py::test_ucx_config_w_env_var -v -m gpu --runslow --junitxml="$WORKSPACE/junit-distributed.xml"

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -124,17 +124,35 @@ def test_ucx_config_w_env_var(cleanup, loop):
                 while not c.scheduler_info()["workers"]:
                     sleep(0.1)
 
-                print(f"\n\n{c.scheduler_info() = }\n\n")
-                print(f"\n\n{c.get_versions() = }\n\n")
+                from pprint import pprint
+
+                print("\n\nc.scheduler_info()")
+                pprint(c.scheduler_info())
+                print("\n\nc.get_versions()")
+                pprint(c.get_versions())
 
                 def _foo():
                     import sys
 
-                    return sys.executable
+                    import dask
 
-                print(f"\n\n{_foo() = }\n\n")
-                print(f"\n\n{c.run_on_scheduler(_foo) = }\n\n")
-                print(f"\n\n{c.run(_foo) = }\n\n")
+                    import distributed
+
+                    result = {
+                        "executable": sys.executable,
+                        "dask_version": dask.__version__,
+                        "dask_file": dask.__file__,
+                        "distributed_version": distributed.__version__,
+                        "distributed_file": distributed.__file__,
+                    }
+                    return result
+
+                print("\n\n_foo()")
+                pprint(_foo())
+                print("\n\nc.run_on_scheduler(_foo)")
+                pprint(c.run_on_scheduler(_foo))
+                print("\n\nc.run(_foo)")
+                pprint(c.run(_foo))
 
                 # Check for RMM pool resource type
                 rmm_resource = c.run_on_scheduler(

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -103,7 +103,6 @@ def test_ucx_config_w_env_var(cleanup, loop):
 
     port = "13339"
     sched_addr = f"ucx://{HOST}:{port}"
-    print(f"\n\n{sched_addr = }\n\n")
 
     with popen(
         ["dask-scheduler", "--no-dashboard", "--protocol", "ucx", "--port", port],
@@ -123,36 +122,6 @@ def test_ucx_config_w_env_var(cleanup, loop):
             with Client(sched_addr, loop=loop, timeout=10) as c:
                 while not c.scheduler_info()["workers"]:
                     sleep(0.1)
-
-                from pprint import pprint
-
-                print("\n\nc.scheduler_info()")
-                pprint(c.scheduler_info())
-                print("\n\nc.get_versions()")
-                pprint(c.get_versions())
-
-                def _foo():
-                    import sys
-
-                    import dask
-
-                    import distributed
-
-                    result = {
-                        "executable": sys.executable,
-                        "dask_version": dask.__version__,
-                        "dask_file": dask.__file__,
-                        "distributed_version": distributed.__version__,
-                        "distributed_file": distributed.__file__,
-                    }
-                    return result
-
-                print("\n\n_foo()")
-                pprint(_foo())
-                print("\n\nc.run_on_scheduler(_foo)")
-                pprint(c.run_on_scheduler(_foo))
-                print("\n\nc.run(_foo)")
-                pprint(c.run(_foo))
 
                 # Check for RMM pool resource type
                 rmm_resource = c.run_on_scheduler(

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -125,6 +125,16 @@ def test_ucx_config_w_env_var(cleanup, loop):
                     sleep(0.1)
 
                 print(f"\n\n{c.scheduler_info() = }\n\n")
+                print(f"\n\n{c.get_versions() = }\n\n")
+
+                def _foo():
+                    import sys
+
+                    return sys.executable
+
+                print(f"\n\n{_foo() = }\n\n")
+                print(f"\n\n{c.run_on_scheduler(_foo) = }\n\n")
+                print(f"\n\n{c.run(_foo) = }\n\n")
 
                 # Check for RMM pool resource type
                 rmm_resource = c.run_on_scheduler(

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -103,6 +103,7 @@ def test_ucx_config_w_env_var(cleanup, loop):
 
     port = "13339"
     sched_addr = f"ucx://{HOST}:{port}"
+    print(f"\n\n{sched_addr = }\n\n")
 
     with popen(
         ["dask-scheduler", "--no-dashboard", "--protocol", "ucx", "--port", port],
@@ -122,6 +123,8 @@ def test_ucx_config_w_env_var(cleanup, loop):
             with Client(sched_addr, loop=loop, timeout=10) as c:
                 while not c.scheduler_info()["workers"]:
                     sleep(0.1)
+
+                print(f"\n\n{c.scheduler_info() = }\n\n")
 
                 # Check for RMM pool resource type
                 rmm_resource = c.run_on_scheduler(


### PR DESCRIPTION
This PR contains a small tweak to avoid using `monkeypatch`ing in `test_ucx_config_w_env_var` in favor of explicitly passing environment variables to subprocesses started with `popen`. This _may_ fix the issue being discussed here https://github.com/dask/distributed/pull/5590#issuecomment-992966715, but I'm not able to run locally and confirm. Either way, I think this is a reasonable change to make (assuming it doesn't break something else)

xref https://github.com/dask/distributed/pull/5590