### PR TITLE
Mark some additional ucx-py tests for GPU

### DIFF
--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -537,6 +537,7 @@ async def check_client_server(
     listener.stop()
 
 
+@pytest.mark.gpu
 @pytest.mark.asyncio
 async def test_ucx_client_server():
     pytest.importorskip("distributed.comm.ucx")

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -307,9 +307,6 @@ class UCX(Comm):
 
     async def read(self, deserializers=("cuda", "dask", "pickle", "error")):
         with log_errors():
-            # if self.closed():
-            #     raise CommClosedError("Endpoint is closed -- unable to read message")
-
             if deserializers is None:
                 deserializers = ("cuda", "dask", "pickle", "error")
 

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -307,8 +307,8 @@ class UCX(Comm):
 
     async def read(self, deserializers=("cuda", "dask", "pickle", "error")):
         with log_errors():
-            if self.closed():
-                raise CommClosedError("Endpoint is closed -- unable to read message")
+            # if self.closed():
+            #     raise CommClosedError("Endpoint is closed -- unable to read message")
 
             if deserializers is None:
                 deserializers = ("cuda", "dask", "pickle", "error")

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1522,6 +1522,7 @@ async def test_interface_async(cleanup, loop, Worker):
                 assert all("127.0.0.1" == d["host"] for d in info["workers"].values())
 
 
+@pytest.mark.gpu
 @pytest.mark.asyncio
 @pytest.mark.parametrize("Worker", [Worker, Nanny])
 async def test_protocol_from_scheduler_address(cleanup, Worker):


### PR DESCRIPTION
Noticed that there are some tests that require ucx-py that are currently not being run on gpuCI - added the pytest marker to them

cc @quasiben @jrbourbeau 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
