### PR TITLE
Fix `KeyError: 'startstops'` in performance report

### DIFF
--- a/distributed/diagnostics/task_stream.py
+++ b/distributed/diagnostics/task_stream.py
@@ -33,7 +33,8 @@ class TaskStreamPlugin(SchedulerPlugin):
         if start == "processing":
             if key not in self.scheduler.tasks:
                 return
-            if not kwargs.get("startstops", []):
+            if not kwargs.get("startstops"):
+                # Other methods require `kwargs` to have a non-empty list of `startstops`
                 return
             kwargs["key"] = key
             if finish == "memory" or finish == "erred":

--- a/distributed/diagnostics/task_stream.py
+++ b/distributed/diagnostics/task_stream.py
@@ -33,6 +33,8 @@ class TaskStreamPlugin(SchedulerPlugin):
         if start == "processing":
             if key not in self.scheduler.tasks:
                 return
+            if not kwargs.get("startstops", []):
+                return
             kwargs["key"] = key
             if finish == "memory" or finish == "erred":
                 self.buffer.append(kwargs)


### PR DESCRIPTION
I'm not sure what actually causes this; I assume it has to do with esoteric error cases on the worker and this code path: https://github.com/dask/distributed/blob/c4de83ff35966a1a86f4e23a705fc7dcdbd65683/distributed/worker.py#L2193-L2194 Therefore I don't really know how to test it properly. But I think this should fix it.

I also noticed that if `startstops` is just empty, as opposed to missing, the `max` would fail with a ValueError (have never seen this happen IRL though). So I'm just dropping all cases where `startstops` doesn't contain information.

- [x] Closes #5171
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
