### PR TITLE
assert_worker_story: Windows timestamps can be slightly in the future

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1802,8 +1802,10 @@ def assert_worker_story(
             assert isinstance(ev, tuple)
             assert isinstance(ev[-2], str) and ev[-2]  # stimulus_id
             assert isinstance(ev[-1], float)  # timestamp
-            assert prev_ts <= ev[-1]  # timestamps are monotonic ascending
-            assert now - 3600 < ev[-1] <= now  # timestamps are within the last hour
+            assert prev_ts <= ev[-1]  # Timestamps are monotonic ascending
+            # Timestamps are within the last hour. It's been observed that a timestamp
+            # generated in a Nanny process can be a few milliseconds in the future.
+            assert now - 3600 < ev[-1] <= now + 1
             prev_ts = ev[-1]
         except AssertionError:
             raise AssertionError(


### PR DESCRIPTION
I just had a test fail because a story timestamp, generated on a Nanny process, was 3ms in the future compared to a timestamp acquired on the main process after it. I'm unsure how this happened - something about the ``metrics._WindowsTime`` class - but also I don't think it's worth spending time investigating.

Failed test: https://github.com/dask/distributed/runs/4559620175?check_suite_focus=true
```
>               assert now - 3600 < ev[-1] <= now  # timestamps are within the last hour
E               AssertionError: assert 1639743133.019022 <= 1639743133.0167713
```