### PR TITLE
Remove render_mode kwarg from boekh LabelSets

### DIFF
--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -449,7 +449,6 @@ class SystemMonitor(DashboardComponent):
                 y_units="screen",
                 text="cpu",
                 text_font_size="1em",
-                render_mode="css",
                 source=self.label_source,
             )
         )
@@ -472,7 +471,6 @@ class SystemMonitor(DashboardComponent):
                 y_units="screen",
                 text="memory",
                 text_font_size="1em",
-                render_mode="css",
                 source=self.label_source,
             )
         )


### PR DESCRIPTION
Removed the `render_mode` key word argument from instances of `bokeh.models.annotations.LabelSet` in order to resolve #5614.