### PR TITLE
Add rpc call for getting task prefixes

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3922,7 +3922,7 @@ class Scheduler(SchedulerState, ServerNode):
             "heartbeat_worker": self.heartbeat_worker,
             "get_task_status": self.get_task_status,
             "get_task_stream": self.get_task_stream,
-            "task_prefix": self.get_task_prefixes,
+            "get_task_prefix_states": self.get_task_prefix_states,
             "register_scheduler_plugin": self.register_scheduler_plugin,
             "register_worker_plugin": self.register_worker_plugin,
             "unregister_worker_plugin": self.unregister_worker_plugin,
@@ -7244,7 +7244,7 @@ class Scheduler(SchedulerState, ServerNode):
                 restrictions = {restrictions}
             ts._worker_restrictions = set(restrictions)
 
-    def get_task_prefixes(self, comm=None):
+    def get_task_prefix_states(self, comm=None):
         with log_errors():
             state = {
                 "memory": {},

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7246,22 +7246,21 @@ class Scheduler(SchedulerState, ServerNode):
 
     def get_task_prefix_states(self, comm=None):
         with log_errors():
-            state = {
-                "memory": {},
-                "erred": {},
-                "released": {},
-                "processing": {},
-                "waiting": {},
-            }
+            state = {}
 
             for tp in self.task_prefixes.values():
                 active_states = tp.active_states
-                if any(active_states.get(s) for s in state.keys()):
-                    state["memory"][tp.name] = active_states["memory"]
-                    state["erred"][tp.name] = active_states["erred"]
-                    state["released"][tp.name] = active_states["released"]
-                    state["processing"][tp.name] = active_states["processing"]
-                    state["waiting"][tp.name] = active_states["waiting"]
+                if any(
+                    active_states.get(s)
+                    for s in {"memory", "erred", "released", "processing", "waiting"}
+                ):
+                    state[tp.name] = {
+                        "memory": active_states["memory"],
+                        "erred": active_states["erred"],
+                        "released": active_states["released"],
+                        "processing": active_states["processing"],
+                        "waiting": active_states["waiting"],
+                    }
 
         return state
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3922,6 +3922,7 @@ class Scheduler(SchedulerState, ServerNode):
             "heartbeat_worker": self.heartbeat_worker,
             "get_task_status": self.get_task_status,
             "get_task_stream": self.get_task_stream,
+            "task_prefix": self.get_task_prefixes,
             "register_scheduler_plugin": self.register_scheduler_plugin,
             "register_worker_plugin": self.register_worker_plugin,
             "unregister_worker_plugin": self.unregister_worker_plugin,
@@ -7242,6 +7243,27 @@ class Scheduler(SchedulerState, ServerNode):
             if isinstance(restrictions, str):
                 restrictions = {restrictions}
             ts._worker_restrictions = set(restrictions)
+
+    def get_task_prefixes(self, comm=None):
+        with log_errors():
+            state = {
+                "memory": {},
+                "erred": {},
+                "released": {},
+                "processing": {},
+                "waiting": {},
+            }
+
+            for tp in self.task_prefixes.values():
+                active_states = tp.active_states
+                if any(active_states.get(s) for s in state.keys()):
+                    state["memory"][tp.name] = active_states["memory"]
+                    state["erred"][tp.name] = active_states["erred"]
+                    state["released"][tp.name] = active_states["released"]
+                    state["processing"][tp.name] = active_states["processing"]
+                    state["waiting"][tp.name] = active_states["waiting"]
+
+        return state
 
     def get_task_status(self, comm=None, keys=None):
         parent: SchedulerState = cast(SchedulerState, self)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1274,9 +1274,9 @@ async def test_exception_on_exception(c, s, a, b):
 
 
 @gen_cluster(client=True)
-async def test_get_task_prefixes(c, s, a, b):
+async def test_get_task_prefix_states(c, s, a, b):
     x = await c.submit(inc, 1)
-    res = s.get_task_prefixes()
+    res = s.get_task_prefix_states()
 
     data = {
         "erred": {"inc": 0},
@@ -1289,10 +1289,10 @@ async def test_get_task_prefixes(c, s, a, b):
     assert res == data
     del x
 
-    while s.get_task_prefixes() == data:
+    while s.get_task_prefix_states() == data:
         await asyncio.sleep(0.01)
 
-    res = s.get_task_prefixes()
+    res = s.get_task_prefix_states()
     assert res == {
         "erred": {},
         "memory": {},

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1287,7 +1287,6 @@ async def test_get_task_prefix_states(c, s, a, b):
             "waiting": 0,
         }
     }
-    x = await c.submit(inc, 1)
     assert res == data
     del x
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1274,6 +1274,35 @@ async def test_exception_on_exception(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_get_task_prefixes(c, s, a, b):
+    x = await c.submit(inc, 1)
+    res = s.get_task_prefixes()
+
+    data = {
+        "erred": {"inc": 0},
+        "memory": {"inc": 1},
+        "processing": {"inc": 0},
+        "released": {"inc": 0},
+        "waiting": {"inc": 0},
+    }
+    x = await c.submit(inc, 1)
+    assert res == data
+    del x
+
+    while s.get_task_prefixes() == data:
+        await asyncio.sleep(0.01)
+
+    res = s.get_task_prefixes()
+    assert res == {
+        "erred": {},
+        "memory": {},
+        "processing": {},
+        "released": {},
+        "waiting": {},
+    }
+
+
+@gen_cluster(client=True)
 async def test_get_nbytes(c, s, a, b):
     [x] = await c.scatter([1])
     assert s.get_nbytes(summary=False) == {x.key: sizeof(1)}

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1279,11 +1279,13 @@ async def test_get_task_prefix_states(c, s, a, b):
     res = s.get_task_prefix_states()
 
     data = {
-        "erred": {"inc": 0},
-        "memory": {"inc": 1},
-        "processing": {"inc": 0},
-        "released": {"inc": 0},
-        "waiting": {"inc": 0},
+        "inc": {
+            "erred": 0,
+            "memory": 1,
+            "processing": 0,
+            "released": 0,
+            "waiting": 0,
+        }
     }
     x = await c.submit(inc, 1)
     assert res == data
@@ -1293,13 +1295,7 @@ async def test_get_task_prefix_states(c, s, a, b):
         await asyncio.sleep(0.01)
 
     res = s.get_task_prefix_states()
-    assert res == {
-        "erred": {},
-        "memory": {},
-        "processing": {},
-        "released": {},
-        "waiting": {},
-    }
+    assert res == {}
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

PR adds RPC call for getting task prefixes.  This is useful when the client needs to fetch what's currently running.   For example, in https://github.com/jacobtomlinson/dask-ctl/pull/1 , we are building a textual based dashboard and we'd like to display progress bars of the current tasks prefixes just as we do in the bokeh based dashboard
