### PR TITLE
Add lambda support to assert_worker_story

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -439,6 +439,7 @@ def test_assert_worker_story():
     assert_worker_story(story, [])
     assert_worker_story(story, [("foo",)])
     assert_worker_story(story, [("foo",), ("bar",)])
+    assert_worker_story(story, [("baz", lambda d: d[1] == 2)])
     with pytest.raises(AssertionError):
         assert_worker_story(story, [("foo", "nomatch")])
     with pytest.raises(AssertionError):
@@ -447,6 +448,10 @@ def test_assert_worker_story():
         assert_worker_story(story, [("baz", {1: 3})])
     with pytest.raises(AssertionError):
         assert_worker_story(story, [("foo",), ("bar",), ("baz", "extra"), ("+1",)])
+    with pytest.raises(AssertionError):
+        assert_worker_story(story, [("baz", lambda d: d[1] == 3)])
+    with pytest.raises(KeyError):  # Faulty lambda
+        assert_worker_story(story, [("baz", lambda d: d[2] == 1)])
     assert_worker_story([], [])
     assert_worker_story([("foo", "id1", now)], [("foo",)])
     with pytest.raises(AssertionError):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1808,6 +1808,13 @@ def assert_worker_story(
     expect: list[tuple]
         Expected events. Each expected event must contain exactly 2 less fields than the
         story (the last two fields are always the stimulus_id and the timestamp).
+
+        Elements of the events can be
+
+        - callables, which accept a single event as argument and return True for match
+          and False for no match;
+        - arbitrary objects, which are compared with a == b
+
     strict: bool, optional
         If True, the story must contain exactly as many events as expect.
         If False (the default), the story may contain more events than expect; extra
@@ -1839,7 +1846,11 @@ def assert_worker_story(
             while True:
                 event = next(story_it)
                 # Ignore (stimulus_id, timestamp)
-                if event[:-2] == ev_expect:
+                event = event[:-2]
+                if len(event) == len(ev_expect) and all(
+                    ex(ev) if callable(ex) else ev == ex
+                    for ev, ex in zip(event, ev_expect)
+                ):
                     break
     except StopIteration:
         raise AssertionError(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1809,11 +1809,19 @@ def assert_worker_story(
         Expected events. Each expected event must contain exactly 2 less fields than the
         story (the last two fields are always the stimulus_id and the timestamp).
 
-        Elements of the events can be
+        Elements of the expect tuples can be
 
-        - callables, which accept a single event as argument and return True for match
-          and False for no match;
+        - callables, which accept a single element of the event tuple as argument and
+          return True for match and False for no match;
         - arbitrary objects, which are compared with a == b
+
+        e.g.
+        .. code-block:: python
+
+            expect=[
+                ("x", "missing", "fetch", "fetch", {}),
+                ("gather-dependencies", worker_addr, lambda set_: "x" in set_),
+            ]
 
     strict: bool, optional
         If True, the story must contain exactly as many events as expect.


### PR DESCRIPTION
Real life use case:
```python
assert_worker_story(
    a.story("x"),
    [("gather-dependencies", b.address, lambda set_: "x" in set_)],
)
```