### PR TITLE
Ignore file not found warning for timeout artifact

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -148,3 +148,4 @@ jobs:
         with:
           name: ${{ env.TEST_ID }}-timeouts
           path: test_timeout_dump
+          if-no-files-found: ignore


### PR DESCRIPTION
That's issuing useless warnings if no files are there (which is typically a good thing!)