### PR TITLE
Ensure uniqueness of steal stimulus ID

### DIFF
--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1193,3 +1193,40 @@ async def test_correct_bad_time_estimate(c, s, *workers):
     assert any(s.tasks[f.key] in steal.key_stealable for f in futures)
     await wait(futures)
     assert all(w.data for w in workers), [sorted(w.data) for w in workers]
+
+
+@gen_cluster(client=True)
+async def test_steal_stimulus_id_unique(c, s, *workers):
+    steal = s.extensions["stealing"]
+    num_futs = 1_000
+    from distributed import Lock
+
+    lock = Lock()
+    async with lock:
+
+        def blocked(x, lock):
+            lock.acquire()
+
+        # Setup all tasks on worker 0 such that victim/thief relation is the
+        # same for all tasks.
+        futures = c.map(
+            blocked, range(num_futs), lock=lock, workers=[workers[0].address]
+        )
+        # Ensure all tasks are assigned to the worker since otherwise the
+        # move_task_request fails.
+        while len(workers[0].tasks) != num_futs:
+            await asyncio.sleep(0.1)
+        tasks = [s.tasks[f.key] for f in futures]
+        w0 = s.workers[workers[0].address]
+        w1 = s.workers[workers[1].address]
+        # Generating the move task requests as fast as possible increases the
+        # chance of duplicates if the uniqueness is not guaranteed.
+        for ts in tasks:
+            steal.move_task_request(ts, w0, w1)
+        stimulus_ids = set()
+        # Values stored in in_flight are used for response verification.
+        # Therefore all stimulus IDs are stored here and must be unique
+        for dct in steal.in_flight.values():
+            stimulus_ids.add(dct["stimulus_id"])
+        assert len(stimulus_ids) == num_futs
+        await c.cancel(futures)


### PR DESCRIPTION
The stimulus ID is used to verify worker responses to distinguish
concurrently running steal requests. The windows clock in particular is
not strictly monotonic which caused duplicates in this test setup.

For real life scenarios this race is so incredibly unlikely that I don't expect to see it in the wild. 

The UUID is about three times slower but I don't think this should be a performance problem.

Might address https://github.com/dask/distributed/issues/5494

xref https://github.com/dask/distributed/pull/5379