### PR TITLE
Use `packaging` rather than `distutils` to get version

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -4,6 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.7
+  - packaging
   - pip
   - asyncssh
   - bokeh

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -4,6 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.8
+  - packaging
   - pip
   - asyncssh
   - bokeh

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -5,6 +5,7 @@ channels:
   - pytorch
 dependencies:
   - python=3.9
+  - packaging
   - pip
   - asyncssh
   - bokeh

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -1,9 +1,8 @@
-from distutils.version import LooseVersion
-
 import click
+from packaging.version import parse as parse_version
 from tornado.ioloop import IOLoop
 
-CLICK_VERSION = LooseVersion(click.__version__)
+CLICK_VERSION = parse_version(click.__version__)
 
 py3_err_msg = """
 Warning: Your terminal does not set locales.
@@ -30,7 +29,7 @@ def check_python_3():
     import click.core
 
     # TODO: Remove use of internal click functions
-    if CLICK_VERSION < "8.0.0":
+    if CLICK_VERSION < parse_version("8.0.0"):
         click.core._verify_python3_env = lambda: None
     else:
         click.core._verify_python_env = lambda: None
@@ -38,7 +37,7 @@ def check_python_3():
     try:
         from click import _unicodefun
 
-        if CLICK_VERSION < "8.0.0":
+        if CLICK_VERSION < parse_version("8.0.0"):
             _unicodefun._verify_python3_env()
         else:
             _unicodefun._verify_python_env()

--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -1,16 +1,16 @@
 import functools
 import warnings
-from distutils.version import LooseVersion
 
 import bokeh
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.server.server import BokehTornado
 from bokeh.server.util import create_hosts_allowlist
+from packaging.version import parse as parse_version
 
 import dask
 
-if LooseVersion(bokeh.__version__) < LooseVersion("2.1.1"):
+if parse_version(bokeh.__version__) < parse_version("2.1.1"):
     warnings.warn(
         "\nDask needs bokeh >= 2.1.1 for the dashboard."
         "\nContinuing without the dashboard."

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 import unittest
 import weakref
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 from threading import Lock
 from time import sleep
 from urllib.parse import urlparse
@@ -456,7 +456,7 @@ async def test_scale_up_and_down():
 
 
 @pytest.mark.xfail(
-    sys.version_info >= (3, 8) and LooseVersion(tornado.version) < "6.0.3",
+    sys.version_info >= (3, 8) and parse_version(tornado.version) < parse_version("6.0.3"),
     reason="Known issue with Python 3.8 and Tornado < 6.0.3. "
     "See https://github.com/tornadoweb/tornado/pull/2683.",
     strict=True,

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -4,13 +4,13 @@ import subprocess
 import sys
 import unittest
 import weakref
-from packaging.version import parse as parse_version
 from threading import Lock
 from time import sleep
 from urllib.parse import urlparse
 
 import pytest
 import tornado
+from packaging.version import parse as parse_version
 from tornado.httpclient import AsyncHTTPClient
 from tornado.ioloop import IOLoop
 
@@ -456,7 +456,8 @@ async def test_scale_up_and_down():
 
 
 @pytest.mark.xfail(
-    sys.version_info >= (3, 8) and parse_version(tornado.version) < parse_version("6.0.3"),
+    sys.version_info >= (3, 8)
+    and parse_version(tornado.version) < parse_version("6.0.3"),
     reason="Known issue with Python 3.8 and Tornado < 6.0.3. "
     "See https://github.com/tornadoweb/tornado/pull/2683.",
     strict=True,

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -1,5 +1,4 @@
 from contextlib import suppress
-from distutils.version import LooseVersion
 from functools import partial
 
 from .compression import compressions, default_compression

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 import pytest
 
@@ -12,8 +12,8 @@ import dask.dataframe as dd
 from distributed.client import wait
 from distributed.utils_test import gen_cluster
 
-PANDAS_VERSION = LooseVersion(pd.__version__)
-PANDAS_GT_100 = PANDAS_VERSION >= LooseVersion("1.0.0")
+PANDAS_VERSION = parse_version(pd.__version__)
+PANDAS_GT_100 = PANDAS_VERSION >= parse_version("1.0.0")
 
 if PANDAS_GT_100:
     import pandas.testing as tm  # noqa: F401

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -1,6 +1,5 @@
-from packaging.version import parse as parse_version
-
 import pytest
+from packaging.version import parse as parse_version
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cloudpickle >= 1.5.0
 dask == 2021.12.0
 jinja2
 msgpack >= 0.6.0
+packaging >= 20.0
 psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1
 tblib >= 1.6.0


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

The much delayed, distributed side of https://github.com/dask/dask/pull/7820, this is important now since setuptools is now raising a warning when you use distutils like this. 