### PR TITLE
AMM: transfer priority

### DIFF
--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -283,9 +283,13 @@ class ActiveMemoryManagerExtension:
 
         stimulus_id = f"active_memory_manager-{time()}"
         for ws, keys in repl_by_worker.items():
-            self.scheduler.acquire_replicas(ws.address, keys, stimulus_id=stimulus_id)
+            self.scheduler.request_acquire_replicas(
+                ws.address, keys, stimulus_id=stimulus_id
+            )
         for ws, keys in drop_by_worker.items():
-            self.scheduler.remove_replicas(ws.address, keys, stimulus_id=stimulus_id)
+            self.scheduler.request_remove_replicas(
+                ws.address, keys, stimulus_id=stimulus_id
+            )
 
 
 class ActiveMemoryManagerPolicy:

--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -261,49 +261,31 @@ class ActiveMemoryManagerExtension:
         """Iterate through self.pending, which was filled by self._run_policies(), and
         push the suggestions to the workers through bulk comms. Return immediately.
         """
-        drop_by_worker: (defaultdict[WorkerState, set[TaskState]]) = defaultdict(set)
-        repl_by_worker: (
-            defaultdict[WorkerState, dict[TaskState, set[str]]]
-        ) = defaultdict(dict)
+        validate = self.scheduler.validate
+        drop_by_worker: (defaultdict[WorkerState, list[str]]) = defaultdict(list)
+        repl_by_worker: (defaultdict[WorkerState, list[str]]) = defaultdict(list)
 
         for ts, (pending_repl, pending_drop) in self.pending.items():
             if not ts.who_has:
                 continue
-            who_has = {ws_snd.address for ws_snd in ts.who_has - pending_drop}
-            assert who_has  # Never drop the last replica
-            for ws_rec in pending_repl:
-                assert ws_rec not in ts.who_has
-                repl_by_worker[ws_rec][ts] = who_has
+            if validate:
+                # Never drop the last replica
+                assert ts.who_has - pending_drop
+
+            for ws in pending_repl:
+                if validate:
+                    assert ws not in ts.who_has
+                repl_by_worker[ws].append(ts.key)
             for ws in pending_drop:
-                assert ws in ts.who_has
-                drop_by_worker[ws].add(ts)
+                if validate:
+                    assert ws in ts.who_has
+                drop_by_worker[ws].append(ts.key)
 
-        # Fire-and-forget enact recommendations from policies
-        stimulus_id = str(time())
-        for ws_rec, ts_to_who_has in repl_by_worker.items():
-            self.scheduler.stream_comms[ws_rec.address].send(
-                {
-                    "op": "acquire-replicas",
-                    "keys": [ts.key for ts in ts_to_who_has],
-                    "stimulus_id": "acquire-replicas-" + stimulus_id,
-                    "priorities": {ts.key: ts.priority for ts in ts_to_who_has},
-                    "who_has": {ts.key: v for ts, v in ts_to_who_has.items()},
-                },
-            )
-
-        for ws, tss in drop_by_worker.items():
-            # The scheduler immediately forgets about the replica and suggests the
-            # worker to drop it. The worker may refuse, at which point it will send back
-            # an add-keys message to reinstate it.
-            for ts in tss:
-                self.scheduler.remove_replica(ts, ws)
-            self.scheduler.stream_comms[ws.address].send(
-                {
-                    "op": "remove-replicas",
-                    "keys": [ts.key for ts in tss],
-                    "stimulus_id": "remove-replicas-" + stimulus_id,
-                }
-            )
+        stimulus_id = f"active_memory_manager-{time()}"
+        for ws, keys in repl_by_worker.items():
+            self.scheduler.acquire_replicas(ws.address, keys, stimulus_id=stimulus_id)
+        for ws, keys in drop_by_worker.items():
+            self.scheduler.remove_replicas(ws.address, keys, stimulus_id=stimulus_id)
 
 
 class ActiveMemoryManagerPolicy:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7920,8 +7920,8 @@ class Scheduler(SchedulerState, ServerNode):
             to_close = self.workers_to_close()
             return len(parent._workers_dv) - len(to_close)
 
-    def acquire_replicas(self, addr: str, keys: list, *, stimulus_id: str):
-        """Asynchronously request a worker to acquire a replica of the listed keys from
+    def request_acquire_replicas(self, addr: str, keys: list, *, stimulus_id: str):
+        """Asynchronously ask a worker to acquire a replica of the listed keys from
         other workers. This is a fire-and-forget operation which offers no feedback for
         success or failure, and is intended for housekeeping and not for computation.
         """
@@ -7943,8 +7943,8 @@ class Scheduler(SchedulerState, ServerNode):
             },
         )
 
-    def remove_replicas(self, addr: str, keys: list, *, stimulus_id: str):
-        """Asynchronously request a worker to discard its replica of the listed keys.
+    def request_remove_replicas(self, addr: str, keys: list, *, stimulus_id: str):
+        """Asynchronously ask a worker to discard its replica of the listed keys.
         This must never be used to destroy the last replica of a key. This is a
         fire-and-forget operation, intended for housekeeping and not for computation.
 


### PR DESCRIPTION
Fix crash:
```
Traceback (most recent call last):
  File "D:\a\distributed\distributed\distributed\core.py", line 587, in handle_stream
    handler(**merge(extra, msg))
  File "D:\a\distributed\distributed\distributed\worker.py", line 1922, in handle_acquire_replicas
    self.transitions(recommendations, stimulus_id=stimulus_id)
  File "D:\a\distributed\distributed\distributed\worker.py", line 2596, in transitions
    a_recs, a_smsgs = self._transition(ts, finish, stimulus_id=stimulus_id)
  File "D:\a\distributed\distributed\distributed\worker.py", line 2517, in _transition
    recs, smsgs = func(ts, *args, stimulus_id=stimulus_id, **kwargs)
  File "D:\a\distributed\distributed\distributed\worker.py", line 2052, in transition_released_fetch
    heapq.heappush(self.data_needed, (ts.priority, ts.key))
TypeError: '<' not supported between instances of 'NoneType' and 'tuple'
```
This would happen when the AMM replicates a task that was originally created through ``scatter``, therefore with no priority on the scheduler, while in the meantime another task that does have priority (anything involved in a computation) is being gathered on the same worker, either by the AMM itself or by ``compute``/``submit``/etc.

# New design decision
The AMM will no longer use the priority for the original computation when fetching a task.
In case of network contention, data transferred by the AMM will always be moved after data required by computations with priority >=0 (this includes default priority 0), and before data required by explicitly low-priority computations (``compute(..., priority=-1)`` or lower).

# Rejected designs
### Design
Use original compute() priority for AMM transfers. Only assign a priority to scattered tasks.
#### Rationale for rejection
This made no sense. I cannot think of any reason why the housekeeping of a high priority computation should itself be high priority.

### Design
Hardcode infinitely low priority, e.g. the AMM will replicate a task only if and when computations leave any free bandwidth
#### Rationale for rejection
Explicitly low priority computations should have no expectations of punctuality.
The AMM is a background process but shouldn't be treated as negligible in urgency, as it prevents crashes caused by out-of-memory.

### Design
Hardcode infinitely high priority, e.g. AMM always comes first and computations come second
#### Rationale for rejection
The benefit of this design would have been, once we implement the Rebalance policy, to have a more reliably balanced cluster under heavy load.
However, this would have a measurable performance impact on end-to-end computation time as soon as network bandwidth gets saturated.

### Design
Set the AMM priority as a configurable parameter in distributed.yaml
#### Rationale for rejection
It is generally a bad idea to ask the system administrator to predict how the users will use the system.
