### PR TITLE
AMM: Don't drop from the only running worker

### DIFF
--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -288,7 +288,7 @@ class ActiveMemoryManagerExtension:
             return None
 
         # The `candidates &` bit could seem redundant with `candidates -=` immediately
-        # below on first look, but beware of the second use of processing_on later on!
+        # below on first look, but beware of the second use of this variable later on!
         candidates_with_dependents_processing = candidates & {
             waiter_ts.processing_on for waiter_ts in ts.waiters
         }

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4999,18 +4999,12 @@ class Scheduler(SchedulerState, ServerNode):
 
             self.remove_resources(address)
 
-            dh: dict = parent._host_info.get(host)
-            if dh is None:
-                parent._host_info[host] = dh = {}
-
+            dh: dict = parent._host_info[host]
             dh_addresses: set = dh["addresses"]
             dh_addresses.remove(address)
             dh["nthreads"] -= ws._nthreads
             parent._total_nthreads -= ws._nthreads
-
             if not dh_addresses:
-                dh = None
-                dh_addresses = None
                 del parent._host_info[host]
 
             self.rpc.remove(address)

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import random
+from contextlib import contextmanager
 
 import pytest
 
@@ -15,8 +18,25 @@ from distributed.utils_test import captured_logger, gen_cluster, inc, slowinc
 NO_AMM_START = {"distributed.scheduler.active-memory-manager.start": False}
 
 
-def captured_amm_logger():
-    return captured_logger("distributed.active_memory_manager", level=logging.DEBUG)
+@contextmanager
+def assert_amm_log(expect: list[str]):
+    with captured_logger(
+        "distributed.active_memory_manager", level=logging.DEBUG
+    ) as logger:
+        yield
+    actual = logger.getvalue().splitlines()
+    if len(actual) != len(expect) or any(
+        not a.startswith(e) for a, e in zip(actual, expect)
+    ):
+        raise AssertionError(
+            "Log lines mismatch:\n"
+            + "\n".join(actual)
+            + "\n"
+            + "=" * 80
+            + "\n"
+            + "Does not match:\n"
+            + "\n".join(expect)
+        )
 
 
 class DemoPolicy(ActiveMemoryManagerPolicy):
@@ -72,21 +92,35 @@ async def test_no_policies(c, s, a, b):
 
 @gen_cluster(nthreads=[("", 1)] * 4, client=True, config=demo_config("drop", n=5))
 async def test_drop(c, s, *workers):
-    with captured_amm_logger() as logs:
-        s.extensions["amm"].run_once()
     # Logging is quiet if there are no suggestions
-    assert logs.getvalue() == ""
+    with assert_amm_log(
+        [
+            "Running policy: DemoPolicy()",
+            "Active Memory Manager run in ",
+        ],
+    ):
+        s.extensions["amm"].run_once()
 
     futures = await c.scatter({"x": 123}, broadcast=True)
     assert len(s.tasks["x"].who_has) == 4
     # Also test the extension handler
-    with captured_amm_logger() as logs:
+    with assert_amm_log(
+        [
+            "Running policy: DemoPolicy()",
+            "(drop, <TaskState 'x' memory>, None): dropping from ",
+            "(drop, <TaskState 'x' memory>, None): dropping from ",
+            "(drop, <TaskState 'x' memory>, None): dropping from ",
+            "(drop, <TaskState 'x' memory>, None) rejected: less than 2 replicas exist",
+            "(drop, <TaskState 'x' memory>, None) rejected: less than 2 replicas exist",
+            "Enacting suggestions for 1 tasks:",
+            "- <WorkerState ",
+            "- <WorkerState ",
+            "- <WorkerState ",
+            "Active Memory Manager run in ",
+        ],
+    ):
         s.extensions["amm"].run_once()
-    assert logs.getvalue() == (
-        "(drop, <TaskState 'x' memory>, None) rejected: less than 2 replicas exist\n"
-        "(drop, <TaskState 'x' memory>, None) rejected: less than 2 replicas exist\n"
-        "Enacting suggestions for 1 tasks\n"
-    )
+
     while len(s.tasks["x"].who_has) > 1:
         await asyncio.sleep(0.01)
     # The last copy is never dropped even if the policy asks so
@@ -385,6 +419,123 @@ async def test_drop_prefers_paused_workers(c, s, *workers):
     assert ws not in ts.who_has
 
 
+@pytest.mark.slow
+@gen_cluster(client=True, config=demo_config("drop"))
+async def test_drop_with_paused_workers_with_running_tasks_1(c, s, a, b):
+    """If there is exactly 1 worker that holds a replica of a task that isn't paused or
+    retiring, and there are 1+ paused/retiring workers with the same task, don't drop
+    anything.
+
+    Use case 1 (don't drop):
+    a is paused and with dependent tasks executing on it
+    b is running and has no dependent tasks
+    """
+    x = (await c.scatter({"x": 1}, broadcast=True))["x"]
+    y = c.submit(slowinc, x, delay=2, key="y", workers=[a.address])
+    while "y" not in a.tasks or a.tasks["y"].state != "executing":
+        await asyncio.sleep(0.01)
+    a.memory_pause_fraction = 1e-15
+    while s.workers[a.address].status != Status.paused:
+        await asyncio.sleep(0.01)
+    assert s.tasks["y"].state == "processing"
+    assert a.tasks["y"].state == "executing"
+
+    s.extensions["amm"].run_once()
+    await y
+    assert len(s.tasks["x"].who_has) == 2
+
+
+@gen_cluster(client=True, config=demo_config("drop"))
+async def test_drop_with_paused_workers_with_running_tasks_2(c, s, a, b):
+    """If there is exactly 1 worker that holds a replica of a task that isn't paused or
+    retiring, and there are 1+ paused/retiring workers with the same task, don't drop
+    anything.
+
+    Use case 2 (drop from a):
+    a is paused and has no dependent tasks
+    b is running and has no dependent tasks
+    """
+    x = (await c.scatter({"x": 1}, broadcast=True))["x"]
+    a.memory_pause_fraction = 1e-15
+    while s.workers[a.address].status != Status.paused:
+        await asyncio.sleep(0.01)
+
+    s.extensions["amm"].run_once()
+    await asyncio.sleep(0.2)
+    assert {ws.address for ws in s.tasks["x"].who_has} == {b.address}
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("pause", [True, False])
+@gen_cluster(client=True, config=demo_config("drop"))
+async def test_drop_with_paused_workers_with_running_tasks_3_4(c, s, a, b, pause):
+    """If there is exactly 1 worker that holds a replica of a task that isn't paused or
+    retiring, and there are 1+ paused/retiring workers with the same task, don't drop
+    anything.
+
+    Use case 3 (drop from b):
+    a is paused and with dependent tasks executing on it
+    b is paused and has no dependent tasks
+
+    Use case 4 (drop from b):
+    a is running and with dependent tasks executing on it
+    b is running and has no dependent tasks
+    """
+    x = (await c.scatter({"x": 1}, broadcast=True))["x"]
+    y = c.submit(slowinc, x, delay=2, key="y", workers=[a.address])
+    while "y" not in a.tasks or a.tasks["y"].state != "executing":
+        await asyncio.sleep(0.01)
+
+    if pause:
+        a.memory_pause_fraction = 1e-15
+        b.memory_pause_fraction = 1e-15
+        while any(ws.status != Status.paused for ws in s.workers.values()):
+            await asyncio.sleep(0.01)
+
+    assert s.tasks["y"].state == "processing"
+    assert a.tasks["y"].state == "executing"
+
+    s.extensions["amm"].run_once()
+    await y
+    assert {ws.address for ws in s.tasks["x"].who_has} == {a.address}
+
+
+@pytest.mark.slow
+@gen_cluster(client=True, nthreads=[("", 1)] * 3, config=demo_config("drop"))
+async def test_drop_with_paused_workers_with_running_tasks_5(c, s, w1, w2, w3):
+    """If there is exactly 1 worker that holds a replica of a task that isn't paused or
+    retiring, and there are 1+ paused/retiring workers with the same task, don't drop
+    anything.
+
+    Use case 5 (drop from w2):
+    w1 is paused and with dependent tasks executing on it
+    w2 is running and has no dependent tasks
+    w3 is running and with dependent tasks executing on it
+    """
+    x = (await c.scatter({"x": 1}, broadcast=True))["x"]
+    y1 = c.submit(slowinc, x, delay=2, key="y1", workers=[w1.address])
+    y2 = c.submit(slowinc, x, delay=2, key="y2", workers=[w3.address])
+    while (
+        "y1" not in w1.tasks
+        or w1.tasks["y1"].state != "executing"
+        or "y2" not in w3.tasks
+        or w3.tasks["y2"].state != "executing"
+    ):
+        await asyncio.sleep(0.01)
+    w1.memory_pause_fraction = 1e-15
+    while s.workers[w1.address].status != Status.paused:
+        await asyncio.sleep(0.01)
+    assert s.tasks["y1"].state == "processing"
+    assert s.tasks["y2"].state == "processing"
+    assert w1.tasks["y1"].state == "executing"
+    assert w3.tasks["y2"].state == "executing"
+
+    s.extensions["amm"].run_once()
+    await y1
+    await y2
+    assert {ws.address for ws in s.tasks["x"].who_has} == {w1.address, w3.address}
+
+
 @gen_cluster(nthreads=[("", 1)] * 4, client=True, config=demo_config("replicate", n=2))
 async def test_replicate(c, s, *workers):
     futures = await c.scatter({"x": 123})
@@ -533,20 +684,35 @@ async def test_replicate_avoids_paused_workers_2(c, s, a, b):
     },
 )
 async def test_ReduceReplicas(c, s, *workers):
-    with captured_amm_logger() as logs:
-        s.extensions["amm"].run_once()
     # Logging is quiet if there are no suggestions
-    assert logs.getvalue() == ""
+    with assert_amm_log(
+        [
+            "Running policy: ReduceReplicas()",
+            "Running policy: ReduceReplicas()",
+            "Active Memory Manager run in ",
+        ],
+    ):
+        s.extensions["amm"].run_once()
 
     futures = await c.scatter({"x": 123}, broadcast=True)
     assert len(s.tasks["x"].who_has) == 4
 
-    with captured_amm_logger() as logs:
+    with assert_amm_log(
+        [
+            "Running policy: ReduceReplicas()",
+            "(drop, <TaskState 'x' memory>, None): dropping from <WorkerState ",
+            "(drop, <TaskState 'x' memory>, None): dropping from <WorkerState ",
+            "(drop, <TaskState 'x' memory>, None): dropping from <WorkerState ",
+            "ReduceReplicas: Dropping 3 superfluous replicas of 1 tasks",
+            "Running policy: ReduceReplicas()",
+            "Enacting suggestions for 1 tasks:",
+            "- <WorkerState ",
+            "- <WorkerState ",
+            "- <WorkerState ",
+            "Active Memory Manager run in ",
+        ],
+    ):
         s.extensions["amm"].run_once()
-    assert logs.getvalue() == (
-        "ReduceReplicas: Dropping 3 superfluous replicas of 1 tasks\n"
-        "Enacting suggestions for 1 tasks\n"  # core AMM extension
-    )
 
     while len(s.tasks["x"].who_has) > 1:
         await asyncio.sleep(0.01)


### PR DESCRIPTION
Backport from #5381.

IF there is only one candidate worker that could drop a key
AND the candidate has status=running
AND there were additional candidates, all with status=paused or closing_gracefully (so they would be normally preferred for dropping to candidates with status=running), but they were discarded because they have dependent tasks running on them
THEN temporarily keep the extra replica on the candidate with status=running.

There are two reasons for this:
First, a worker with status=paused or closing_gracefully is more likely to be gone soon, or worse to die abruptly soon, than one with status=running.

Second, this prevents a ping-pong effect between ReduceReplicas and RetireWorker (#5381) under stress, where:
 
1. on the first AMM iteration, RetireWorker replicates in-memory tasks from worker A (very busy and being retired) to worker B (idle)
2. on the second AMM iteration 2 seconds later, ReduceReplicas drops the same tasks from B (because the replicas on A have dependants on the same worker)
3. on the third AMM iteration 2 seconds later, goto 1

As a result, A may never be retired for as long as there's any task running with dependants on it.
After this PR, it won't make any difference if ReduceReplicas is running or not - both ReduceReplicas and RetireWorker will take identical drop decision.

This PR also drastically improves AMM debug-level logging.
