### PR TITLE
XFAIL tls explicit comm close test on py3.7

### DIFF
--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -769,6 +769,10 @@ async def test_tcp_comm_closed_explicit(tcp):
     await check_comm_closed_explicit("tcp://127.0.0.1")
 
 
+@pytest.mark.xfail(
+    sys.version_info[:2] == (3, 7),
+    reason="This test fails on python 3.7 with certain versions of openssl",
+)
 @pytest.mark.asyncio
 async def test_tls_comm_closed_explicit(tcp):
     await check_comm_closed_explicit("tls://127.0.0.1", **tls_kwargs)


### PR DESCRIPTION
This test fails with some versions of openssl. Since we're going to drop
python 3.7 soon anyway, I'm just xfailing this for now.

Fixes #5607.