### PR TITLE
Handle Bokeh 3.0 CDSView change

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -56,7 +56,7 @@ from distributed.dashboard.components.shared import (
     ProfileTimePlot,
     SystemMonitor,
 )
-from distributed.dashboard.utils import PROFILING, transpose, update
+from distributed.dashboard.utils import BOKEH_VERSION, PROFILING, transpose, update
 from distributed.diagnostics.graph_layout import GraphLayout
 from distributed.diagnostics.progress_stream import color_of, progress_quads
 from distributed.diagnostics.task_stream import TaskStreamPlugin
@@ -1944,13 +1944,16 @@ class TaskGraph(DashboardComponent):
         self.edge_source = ColumnDataSource({"x": [], "y": [], "visible": []})
 
         node_view = CDSView(
-            source=self.node_source,
             filters=[GroupFilter(column_name="visible", group="True")],
         )
         edge_view = CDSView(
-            source=self.edge_source,
             filters=[GroupFilter(column_name="visible", group="True")],
         )
+
+        # Bokeh >= 3.0 automatically infers the source to use
+        if BOKEH_VERSION < "3.0":
+            node_view.source = self.node_source
+            edge_view.source = self.edge_source
 
         node_colors = factor_cmap(
             "state",

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1951,7 +1951,7 @@ class TaskGraph(DashboardComponent):
         )
 
         # Bokeh >= 3.0 automatically infers the source to use
-        if BOKEH_VERSION < "3.0":
+        if BOKEH_VERSION.major < 3:
             node_view.source = self.node_source
             edge_view.source = self.edge_source
 

--- a/distributed/dashboard/utils.py
+++ b/distributed/dashboard/utils.py
@@ -1,9 +1,9 @@
-from distutils.version import LooseVersion
 from numbers import Number
 
 import bokeh
 from bokeh.core.properties import without_property_validation
 from bokeh.io import curdoc
+from packaging.version import parse as parse_version
 from tlz.curried import first
 
 try:
@@ -11,7 +11,7 @@ try:
 except ImportError:
     np = None  # type: ignore
 
-BOKEH_VERSION = LooseVersion(bokeh.__version__)
+BOKEH_VERSION = parse_version(bokeh.__version__)
 
 PROFILING = False
 

--- a/distributed/dashboard/utils.py
+++ b/distributed/dashboard/utils.py
@@ -1,5 +1,7 @@
+from distutils.version import LooseVersion
 from numbers import Number
 
+import bokeh
 from bokeh.core.properties import without_property_validation
 from bokeh.io import curdoc
 from tlz.curried import first
@@ -9,6 +11,7 @@ try:
 except ImportError:
     np = None  # type: ignore
 
+BOKEH_VERSION = LooseVersion(bokeh.__version__)
 
 PROFILING = False
 


### PR DESCRIPTION
Starting with Bokeh 3.0, `CDSView` will automatically infer the correct `ColumnDatSource` to apply to, and therefore no longer has a `source` property. See 

* https://github.com/bokeh/bokeh/pull/11773

This PR adds an version check to explicitly switch appropriate behavior. 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`


NOTE: just checking CI at this point, I still need to actually manually test with `3.0.0dev` 
