### PR TITLE
Fix some timeouts

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -863,7 +863,7 @@ class WorkerProcess:
                 """
                 while True:
                     try:
-                        msg = child_stop_q.get(timeout=1000)
+                        msg = child_stop_q.get(timeout=1)
                     except Empty:
                         pass
                     else:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -861,16 +861,10 @@ class WorkerProcess:
                 Wait for an incoming stop message and then stop the
                 worker cleanly.
                 """
-                while True:
-                    try:
-                        msg = child_stop_q.get(timeout=1)
-                    except Empty:
-                        pass
-                    else:
-                        child_stop_q.close()
-                        assert msg.pop("op") == "stop"
-                        loop.add_callback(do_stop, **msg)
-                        break
+                msg = child_stop_q.get()
+                child_stop_q.close()
+                assert msg.pop("op") == "stop"
+                loop.add_callback(do_stop, **msg)
 
             t = threading.Thread(target=watch_stop_q, name="Nanny stop queue watch")
             t.daemon = True

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3995,11 +3995,11 @@ class Scheduler(SchedulerState, ServerNode):
         )
 
         if self.worker_ttl:
-            pc = PeriodicCallback(self.check_worker_ttl, self.worker_ttl)
+            pc = PeriodicCallback(self.check_worker_ttl, self.worker_ttl * 1000)
             self.periodic_callbacks["worker-ttl"] = pc
 
         if self.idle_timeout:
-            pc = PeriodicCallback(self.check_idle, self.idle_timeout / 4)
+            pc = PeriodicCallback(self.check_idle, self.idle_timeout * 1000 / 4)
             self.periodic_callbacks["idle-timeout"] = pc
 
         if extensions is None:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1726,6 +1726,7 @@ async def test_collect_versions(c, s, a, b):
     assert cs.versions == w1.versions == w2.versions
 
 
+@pytest.mark.xfail(reason="flaky and re-fails on rerun")
 @gen_cluster(client=True, config={"distributed.scheduler.idle-timeout": "500ms"})
 async def test_idle_timeout(c, s, a, b):
     beginning = time()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1726,7 +1726,6 @@ async def test_collect_versions(c, s, a, b):
     assert cs.versions == w1.versions == w2.versions
 
 
-@pytest.mark.xfail(reason="flaky and re-fails on rerun")
 @gen_cluster(client=True, config={"distributed.scheduler.idle-timeout": "500ms"})
 async def test_idle_timeout(c, s, a, b):
     beginning = time()


### PR DESCRIPTION
I briefly peaked into https://github.com/dask/distributed/issues/5585 but couldn't fix it, yet. there are actually many reasons for this being slow. However, I discovered a few timeouts where there has been a mixup between milliseconds and seconds setting wrong timeouts.

@crusaderky this might interest you