### PR TITLE
Consolidate broken comm testing utilities

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -20,7 +20,6 @@ from dask import delayed
 from dask.utils import apply, parse_timedelta, stringify, tmpfile, typename
 
 from distributed import Client, Nanny, Worker, fire_and_forget, wait
-from distributed.comm import Comm
 from distributed.compatibility import LINUX, WINDOWS
 from distributed.core import ConnectionPool, Status, clean_exception, connect, rpc
 from distributed.metrics import time
@@ -28,6 +27,7 @@ from distributed.protocol.pickle import dumps, loads
 from distributed.scheduler import MemoryState, Scheduler
 from distributed.utils import TimeoutError
 from distributed.utils_test import (
+    BrokenComm,
     captured_logger,
     cluster,
     dec,
@@ -2112,26 +2112,6 @@ async def test_task_group_on_fire_and_forget(c, s, a, b):
         await asyncio.sleep(1)
 
     assert "Error transitioning" not in logs.getvalue()
-
-
-class BrokenComm(Comm):
-    peer_address = ""
-    local_address = ""
-
-    def close(self):
-        pass
-
-    def closed(self):
-        pass
-
-    def abort(self):
-        pass
-
-    def read(self, deserializers=None):
-        raise OSError()
-
-    def write(self, msg, serializers=None, on_error=None):
-        raise OSError()
 
 
 class FlakyConnectionPool(ConnectionPool):

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -10,10 +10,15 @@ import dask
 from dask.distributed import Client
 
 from distributed import Semaphore, fire_and_forget
-from distributed.comm import Comm
 from distributed.core import ConnectionPool
 from distributed.metrics import time
-from distributed.utils_test import captured_logger, cluster, gen_cluster, slowidentity
+from distributed.utils_test import (
+    BrokenComm,
+    captured_logger,
+    cluster,
+    gen_cluster,
+    slowidentity,
+)
 
 
 @gen_cluster(client=True)
@@ -261,26 +266,6 @@ async def test_release_once_too_many_resilience(c, s, a, b):
     assert not s.extensions["semaphores"].leases["x"]
     await sem.acquire()
     assert len(s.extensions["semaphores"].leases["x"]) == 1
-
-
-class BrokenComm(Comm):
-    peer_address = ""
-    local_address = ""
-
-    def close(self):
-        pass
-
-    def closed(self):
-        return True
-
-    def abort(self):
-        pass
-
-    def read(self, deserializers=None):
-        raise OSError()
-
-    def write(self, msg, serializers=None, on_error=None):
-        raise OSError()
 
 
 class FlakyConnectionPool(ConnectionPool):

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -2,10 +2,9 @@ from unittest import mock
 
 import pytest
 
-from distributed.comm import Comm
 from distributed.core import ConnectionPool
 from distributed.utils_comm import gather_from_workers, pack_data, retry, subs_multiple
-from distributed.utils_test import gen_cluster
+from distributed.utils_test import BrokenComm, gen_cluster
 
 
 def test_pack_data():
@@ -40,26 +39,6 @@ async def test_gather_from_workers_permissive(c, s, a, b):
 
     assert data == {"x": 1}
     assert list(missing) == ["y"]
-
-
-class BrokenComm(Comm):
-    peer_address = ""
-    local_address = ""
-
-    def close(self):
-        pass
-
-    def closed(self):
-        pass
-
-    def abort(self):
-        pass
-
-    def read(self, deserializers=None):
-        raise OSError()
-
-    def write(self, msg, serializers=None, on_error=None):
-        raise OSError()
 
 
 class BrokenConnectionPool(ConnectionPool):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1872,3 +1872,23 @@ def _format_story(story: list[tuple]) -> str:
     if not story:
         return "(empty story)"
     return "- " + "\n- ".join(str(ev) for ev in story)
+
+
+class BrokenComm(Comm):
+    peer_address = ""
+    local_address = ""
+
+    def close(self):
+        pass
+
+    def closed(self):
+        return True
+
+    def abort(self):
+        pass
+
+    def read(self, deserializers=None):
+        raise OSError()
+
+    def write(self, msg, serializers=None, on_error=None):
+        raise OSError()


### PR DESCRIPTION
I noticed we have three identical `BrokenComm` helper classes used throughout the test suite. This is a cleanup PR which consolidates those into a single occurrence in our `utils_test.py` module 

cc @crusaderky 