### PR TITLE
Close comm on CancelledError

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -37,7 +37,6 @@ from .comm import (
 from .metrics import time
 from .system_monitor import SystemMonitor
 from .utils import (
-    CancelledError,
     TimeoutError,
     get_traceback,
     has_keyword,

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1094,6 +1094,8 @@ class ConnectionPool:
         else:
             self.occupied[addr].remove(comm)
             if comm.closed():
+                # Either the user passed the close=True parameter to send_recv, or
+                # the RPC call raised OSError or CancelledError
                 self.semaphore.release()
             else:
                 self.available[addr].add(comm)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -519,7 +519,7 @@ class Server:
                             result = asyncio.ensure_future(result)
                             self._ongoing_coroutines.add(result)
                             result = await result
-                    except (CommClosedError, CancelledError, asyncio.CancelledError):
+                    except (CommClosedError, asyncio.CancelledError):
                         if self.status in (Status.running, Status.paused):
                             logger.info("Lost connection to %r", address, exc_info=True)
                         break
@@ -663,14 +663,12 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
             response = await comm.read(deserializers=deserializers)
         else:
             response = None
-    # Note: this is asyncio.TimeoutError, not the builtin TimeoutError which is a
-    # subclass of OSError
-    except (TimeoutError, OSError):
+    except (asyncio.TimeoutError, OSError):
         # On communication errors, we should simply close the communication
         # Note that OSError includes CommClosedError and socket timeouts
         force_close = True
         raise
-    except (CancelledError, asyncio.CancelledError):
+    except asyncio.CancelledError:
         # Do not reuse the comm to prevent the next call of send_recv from receiving
         # data from this call and/or accidentally putting multiple waiters on read().
         # Note that this relies on all Comm implementations to allow a write() in the

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -667,7 +667,7 @@ async def send_recv(comm, reply=True, serializers=None, deserializers=None, **kw
     # subclass of OSError
     except (TimeoutError, OSError):
         # On communication errors, we should simply close the communication
-        # This includes CommClosedError and socket timeouts
+        # Note that OSError includes CommClosedError and socket timeouts
         force_close = True
         raise
     except (CancelledError, asyncio.CancelledError):

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -535,6 +535,7 @@ async def test_send_recv_args():
 @gen_test(timeout=5)
 async def test_send_recv_cancelled():
     """Test that the comm channel is closed on CancelledError"""
+
     async def get_stuck(comm):
         await asyncio.Future()
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -35,6 +35,7 @@ from distributed.utils_test import (
     async_wait_for,
     captured_logger,
     gen_cluster,
+    gen_test,
     has_ipv6,
     inc,
     throws,
@@ -529,6 +530,27 @@ async def test_send_recv_args():
     assert comm.closed()
 
     server.stop()
+
+
+@gen_test(timeout=5)
+async def test_send_recv_cancelled():
+    """Test that the comm channel is closed on CancelledError"""
+    async def get_stuck(comm):
+        await asyncio.Future()
+
+    server = Server({"get_stuck": get_stuck})
+    await server.listen(0)
+
+    client_comm = await connect(server.address, deserialize=False)
+    while not server._comms:
+        await asyncio.sleep(0.01)
+    server_comm = next(iter(server._comms))
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(send_recv(client_comm, op="get_stuck"), timeout=0.1)
+    assert client_comm.closed()
+    while not server_comm.closed():
+        await asyncio.sleep(0.01)
 
 
 def test_coerce_to_address():


### PR DESCRIPTION
Fix crash in tornado that would happen when a task waiting on read() got cancelled (typically by a timeout). The comm would go back into the pool of available connections, without notifying the server and later causing two concurrent reads on client side.

```
tornado.application - ERROR - Exception in callback functools.partial(<bound method IOLoop._discard_future_result of <tornado.platform.asyncio.AsyncIOLoop object at 0x16ac14400>>, <Task finished name='Task-25633' coro=<Client._update_scheduler_info() done, defined at /Users/fjetter/workspace/distributed/distributed/client.py:1111> exception=AssertionError('Already reading')>)
Traceback (most recent call last):
  File "/Users/fjetter/mambaforge/envs/dask-distributed/lib/python3.8/site-packages/tornado/ioloop.py", line 741, in _run_callback
    ret = callback()
  File "/Users/fjetter/mambaforge/envs/dask-distributed/lib/python3.8/site-packages/tornado/ioloop.py", line 765, in _discard_future_result
    future.result()
  File "/Users/fjetter/workspace/distributed/distributed/client.py", line 1115, in _update_scheduler_info
    self._scheduler_identity = SchedulerInfo(await self.scheduler.identity())
  File "/Users/fjetter/workspace/distributed/distributed/core.py", line 886, in send_recv_from_rpc
    result = await send_recv(comm=comm, op=key, **kwargs)
  File "/Users/fjetter/workspace/distributed/distributed/core.py", line 663, in send_recv
    response = await comm.read(deserializers=deserializers)
  File "/Users/fjetter/workspace/distributed/distributed/comm/tcp.py", line 205, in read
    frames_nbytes = await stream.read_bytes(fmt_size)
  File "/Users/fjetter/mambaforge/envs/dask-distributed/lib/python3.8/site-packages/tornado/iostream.py", line 421, in read_bytes
    future = self._start_read()
  File "/Users/fjetter/mambaforge/envs/dask-distributed/lib/python3.8/site-packages/tornado/iostream.py", line 809, in _start_read
    assert self._read_future is None, "Already reading"
AssertionError: Already reading
```