### PR TITLE
Don't use time.time() or IOLoop.time()

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -8,6 +8,7 @@ import dask
 from dask.utils import parse_timedelta
 
 from .core import CommClosedError
+from .metrics import time
 
 logger = logging.getLogger(__name__)
 
@@ -83,12 +84,12 @@ class BatchedSend:
                 # Nothing to send
                 self.next_deadline = None
                 continue
-            if self.next_deadline is not None and self.loop.time() < self.next_deadline:
+            if self.next_deadline is not None and time() < self.next_deadline:
                 # Send interval not expired yet
                 continue
             payload, self.buffer = self.buffer, []
             self.batch_count += 1
-            self.next_deadline = self.loop.time() + self.interval
+            self.next_deadline = time() + self.interval
             try:
                 nbytes = yield self.comm.write(
                     payload, serializers=self.serializers, on_error="raise"

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1028,7 +1028,7 @@ class Client(SyncMethodMixin):
             self.futures.clear()
 
             timeout = self._timeout
-            deadline = self.loop.time() + timeout
+            deadline = time() + timeout
             while timeout > 0 and self.status == "connecting":
                 try:
                     await self._ensure_connected(timeout=timeout)
@@ -1036,7 +1036,7 @@ class Client(SyncMethodMixin):
                 except OSError:
                     # Wait a bit before retrying
                     await asyncio.sleep(0.1)
-                    timeout = deadline - self.loop.time()
+                    timeout = deadline - time()
                 except ImportError:
                     await self._close()
                     break

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -2,13 +2,15 @@ import logging
 import os
 import socket
 import sys
-import time
 import traceback
 from queue import Queue
 from threading import Thread
+from time import sleep
 
 from tlz import merge
 from tornado import gen
+
+from ..metrics import time
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +101,7 @@ def async_ssh(cmd_dict):
                 + bcolors.ENDC
             )
 
-            time.sleep(1)
+            sleep(1)
 
     # Execute the command, and grab file handles for stdout and stderr. Note
     # that we run the command using the user's default shell, but force it to
@@ -182,19 +184,19 @@ def async_ssh(cmd_dict):
     # thread to shut itself down.
     while cmd_dict["input_queue"].empty():
         # Kill some time so that this thread does not hog the CPU.
-        time.sleep(1.0)
+        sleep(1.0)
         # Send noise down the pipe to keep connection active
         transport.send_ignore()
         if communicate():
             break
 
     # Ctrl-C the executing command and wait a bit for command to end cleanly
-    start = time.time()
-    while time.time() < start + 5.0:
+    start = time()
+    while time() < start + 5.0:
         channel.send(b"\x03")  # Ctrl-C
         if communicate():
             break
-        time.sleep(1.0)
+        sleep(1.0)
 
     # Shutdown the channel, and close the SSH connection
     channel.close()
@@ -427,7 +429,7 @@ class SSHCluster:
 
                 # Kill some time and free up CPU before starting the next sweep
                 # through the processes.
-                time.sleep(0.1)
+                sleep(0.1)
 
             # end while true
 

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from collections import defaultdict
 from timeit import default_timer
 
@@ -11,6 +10,7 @@ from tlz import groupby, valmap
 from dask.base import tokenize
 from dask.utils import stringify
 
+from ..metrics import time
 from ..utils import key_split
 from .plugin import SchedulerPlugin
 
@@ -312,7 +312,7 @@ class GroupTiming(SchedulerPlugin):
 
     def _init(self):
         """Shared initializatoin code between __init__ and restart"""
-        now = time.time()
+        now = time()
 
         # Timestamps for tracking compute durations by task group.
         # Start with length 2 so that we always can compute a valid dt later.
@@ -329,13 +329,14 @@ class GroupTiming(SchedulerPlugin):
         if start == "processing" and finish == "memory":
             startstops = kwargs.get("startstops")
             if not startstops:
-                logger.warn(
-                    f"Task {key} finished processing, but timing information seems to be missing"
+                logger.warning(
+                    f"Task {key} finished processing, but timing information seems to "
+                    "be missing"
                 )
                 return
 
             # Possibly extend the timeseries if another dt has passed
-            now = time.time()
+            now = time()
             self.time[-1] = now
             while self.time[-1] - self.time[-2] > self.dt:
                 self.time[-1] = self.time[-2] + self.dt

--- a/distributed/locket.py
+++ b/distributed/locket.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import threading
-import time
 import weakref
+from time import sleep
+
+from .metrics import time
 
 __all__ = ["lock_file"]
 
@@ -97,15 +99,15 @@ def _acquire_non_blocking(acquire, timeout, retry_period, path):
     if retry_period is None:
         retry_period = 0.05
 
-    start_time = time.time()
+    start_time = time()
     while True:
         success = acquire()
         if success:
             return
-        elif timeout is not None and time.time() - start_time > timeout:
+        elif timeout is not None and time() - start_time > timeout:
             raise LockError(f"Couldn't lock {path}")
         else:
-            time.sleep(retry_period)
+            sleep(retry_period)
 
 
 class _LockSet:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -757,7 +757,7 @@ class WorkerProcess:
             if self.on_exit is not None:
                 self.on_exit(r)
 
-    async def kill(self, timeout=2, executor_wait=True):
+    async def kill(self, timeout: float = 2, executor_wait: bool = True):
         """
         Ensure the worker process is stopped, waiting at most
         *timeout* seconds before terminating it abruptly.
@@ -788,7 +788,7 @@ class WorkerProcess:
 
         if process.is_alive():
             logger.warning(
-                "Worker process still alive after %d seconds, killing", timeout
+                f"Worker process still alive after {timeout} seconds, killing"
             )
             try:
                 await process.terminate()

--- a/distributed/pytest_resourceleaks.py
+++ b/distributed/pytest_resourceleaks.py
@@ -6,9 +6,11 @@ import gc
 import os
 import sys
 import threading
-import time
+from time import sleep
 
 import pytest
+
+from .metrics import time
 
 
 def pytest_addoption(parser):
@@ -313,7 +315,7 @@ class LeakChecker:
                     leaks.append((checker, before, after))
             return leaks
 
-        t1 = time.time()
+        t1 = time()
         deadline = t1 + self.grace_delay
         leaks = run_measurements()
         if leaks:
@@ -322,8 +324,8 @@ class LeakChecker:
                 c.on_retry()
             leaks = run_measurements()
 
-        while leaks and time.time() < deadline:
-            time.sleep(0.1)
+        while leaks and time() < deadline:
+            sleep(0.1)
             self.cleanup()
             for c, _, _ in leaks:
                 c.on_retry()

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -1,5 +1,4 @@
 import random
-import time
 from concurrent.futures import (
     FIRST_COMPLETED,
     FIRST_EXCEPTION,
@@ -8,10 +7,12 @@ from concurrent.futures import (
     as_completed,
     wait,
 )
+from time import sleep
 
 import pytest
 from tlz import take
 
+from distributed.metrics import time
 from distributed.utils import CancelledError
 from distributed.utils_test import inc, slowadd, slowdec, slowinc, throws, varying
 
@@ -86,19 +87,19 @@ def test_wait(client):
 
 def test_cancellation(client):
     with client.get_executor(pure=False) as e:
-        fut = e.submit(time.sleep, 2.0)
-        start = time.time()
+        fut = e.submit(sleep, 2.0)
+        start = time()
         while number_of_processing_tasks(client) == 0:
-            assert time.time() < start + 30
-            time.sleep(0.01)
+            assert time() < start + 30
+            sleep(0.01)
         assert not fut.done()
 
         fut.cancel()
         assert fut.cancelled()
-        start = time.time()
+        start = time()
         while number_of_processing_tasks(client) != 0:
-            assert time.time() < start + 30
-            time.sleep(0.01)
+            assert time() < start + 30
+            sleep(0.01)
 
         with pytest.raises(CancelledError):
             fut.result()
@@ -155,7 +156,7 @@ def test_map(client):
         assert number_of_processing_tasks(client) > 0
         # Garbage collect the iterator => remaining tasks are cancelled
         del it
-        time.sleep(0.5)
+        sleep(0.5)
         assert number_of_processing_tasks(client) == 0
 
 
@@ -219,27 +220,27 @@ def test_retries(client):
 def test_shutdown_wait(client):
     # shutdown(wait=True) waits for pending tasks to finish
     e = client.get_executor()
-    start = time.time()
-    fut = e.submit(time.sleep, 1.0)
+    start = time()
+    fut = e.submit(sleep, 1.0)
     e.shutdown()
-    assert time.time() >= start + 1.0
-    time.sleep(0.1)  # wait for future outcome to propagate
+    assert time() >= start + 1.0
+    sleep(0.1)  # wait for future outcome to propagate
     assert fut.done()
     fut.result()  # doesn't raise
 
     with pytest.raises(RuntimeError):
-        e.submit(time.sleep, 1.0)
+        e.submit(sleep, 1.0)
 
 
 def test_shutdown_nowait(client):
     # shutdown(wait=False) cancels pending tasks
     e = client.get_executor()
-    start = time.time()
-    fut = e.submit(time.sleep, 5.0)
+    start = time()
+    fut = e.submit(sleep, 5.0)
     e.shutdown(wait=False)
-    assert time.time() < start + 2.0
-    time.sleep(0.1)  # wait for future outcome to propagate
+    assert time() < start + 2.0
+    sleep(0.1)  # wait for future outcome to propagate
     assert fut.cancelled()
 
     with pytest.raises(RuntimeError):
-        e.submit(time.sleep, 1.0)
+        e.submit(sleep, 1.0)

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -3,9 +3,9 @@ import os
 import shutil
 import sys
 import tempfile
-import time
 import urllib.error
 import urllib.request
+from time import sleep
 
 import pytest
 import tornado
@@ -15,6 +15,7 @@ import dask
 
 from distributed import Client, Nanny, Scheduler, Worker
 from distributed.compatibility import MACOS
+from distributed.metrics import time
 from distributed.utils_test import captured_logger, cluster, gen_cluster, gen_test
 
 PY_VERSION = sys.version_info[:2]
@@ -179,13 +180,13 @@ def create_preload_application():
 def scheduler_preload():
     p = multiprocessing.Process(target=create_preload_application)
     p.start()
-    start = time.time()
+    start = time()
     while not p.is_alive():
-        if time.time() > start + 5:
+        if time() > start + 5:
             raise AssertionError("Process didn't come up")
-        time.sleep(0.5)
+        sleep(0.5)
     # Make sure we can query the server
-    start = time.time()
+    start = time()
     request = urllib.request.Request("http://127.0.0.1:12345/preload", method="GET")
     while True:
         try:
@@ -193,9 +194,9 @@ def scheduler_preload():
             if response.status == 200:
                 break
         except urllib.error.URLError as e:
-            if time.time() > start + 10:
+            if time() > start + 10:
                 raise AssertionError("Webserver didn't come up", e)
-            time.sleep(0.5)
+            sleep(0.5)
 
     yield
     p.kill()
@@ -256,23 +257,23 @@ def create_worker_preload_application():
 def worker_preload():
     p = multiprocessing.Process(target=create_worker_preload_application)
     p.start()
-    start = time.time()
+    start = time()
     while not p.is_alive():
-        if time.time() > start + 5:
+        if time() > start + 5:
             raise AssertionError("Process didn't come up")
-        time.sleep(0.5)
+        sleep(0.5)
     # Make sure we can query the server
     request = urllib.request.Request("http://127.0.0.1:12346/preload", method="GET")
-    start = time.time()
+    start = time()
     while True:
         try:
             response = urllib.request.urlopen(request)
             if response.status == 200:
                 break
         except urllib.error.URLError as e:
-            if time.time() > start + 10:
+            if time() > start + 10:
                 raise AssertionError("Webserver didn't come up", e)
-            time.sleep(0.5)
+            sleep(0.5)
 
     yield
     p.kill()

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -1,12 +1,12 @@
 import sys
 import threading
-import time
+from time import sleep
 
 import pytest
 from tlz import first
 
-from distributed import metrics
 from distributed.compatibility import WINDOWS
+from distributed.metrics import time
 from distributed.profile import (
     call_stack,
     create,
@@ -22,10 +22,10 @@ from distributed.profile import (
 
 def test_basic():
     def test_g():
-        time.sleep(0.01)
+        sleep(0.01)
 
     def test_h():
-        time.sleep(0.02)
+        sleep(0.02)
 
     def test_f():
         for i in range(100):
@@ -39,7 +39,7 @@ def test_basic():
     state = create()
 
     for i in range(100):
-        time.sleep(0.02)
+        sleep(0.02)
         frame = sys._current_frames()[thread.ident]
         process(frame, None, state)
 
@@ -70,7 +70,7 @@ def test_basic_low_level():
     state = create()
 
     for i in range(100):
-        time.sleep(0.02)
+        sleep(0.02)
         frame = sys._current_frames()[threading.get_ident()]
         llframes = {threading.get_ident(): ll_get_stack(threading.get_ident())}
         for f in llframes.values():
@@ -179,24 +179,24 @@ def test_identifier():
 
 
 def test_watch():
-    start = metrics.time()
+    start = time()
 
     def stop():
-        return metrics.time() > start + 0.500
+        return time() > start + 0.500
 
     start_threads = threading.active_count()
 
     log = watch(interval="10ms", cycle="50ms", stop=stop)
 
-    start = metrics.time()  # wait until thread starts up
+    start = time()  # wait until thread starts up
     while threading.active_count() <= start_threads:
-        assert metrics.time() < start + 2
-        time.sleep(0.01)
+        assert time() < start + 2
+        sleep(0.01)
 
-    time.sleep(0.5)
+    sleep(0.5)
     assert 1 < len(log) < 10
 
-    start = metrics.time()
+    start = time()
     while threading.active_count() > start_threads:
-        assert metrics.time() < start + 2
-        time.sleep(0.01)
+        assert time() < start + 2
+        sleep(0.01)

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -134,7 +134,10 @@ def test_timeout_sync(client):
         v.get(timeout=0.2)
     stop = time()
 
-    assert 0.2 <= stop - start < 2.0
+    if WINDOWS:
+        assert 0.1 < stop - start < 2.0
+    else:
+        assert 0.2 < stop - start < 2.0
 
     with pytest.raises(TimeoutError):
         v.get(timeout=0.01)

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from time import monotonic, sleep
 
 import pytest
-from tornado.ioloop import IOLoop
 
 from distributed import Client, Nanny, TimeoutError, Variable, wait, worker_client
 from distributed.compatibility import WINDOWS
@@ -130,15 +129,12 @@ async def test_timeout(c, s, a, b):
 
 def test_timeout_sync(client):
     v = Variable("v")
-    start = IOLoop.current().time()
+    start = time()
     with pytest.raises(TimeoutError):
         v.get(timeout=0.2)
-    stop = IOLoop.current().time()
+    stop = time()
 
-    if WINDOWS:
-        assert 0.1 < stop - start < 2.0
-    else:
-        assert 0.2 < stop - start < 2.0
+    assert 0.2 <= stop - start < 2.0
 
     with pytest.raises(TimeoutError):
         v.get(timeout=0.01)

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -9,6 +9,7 @@ from tlz import merge
 from dask.utils import parse_timedelta, stringify
 
 from .client import Client, Future
+from .metrics import time
 from .utils import TimeoutError, log_errors
 from .worker import get_client, get_worker
 
@@ -74,10 +75,10 @@ class VariableExtension:
                 self.waiting_conditions[name].notify_all()
 
     async def get(self, comm=None, name=None, client=None, timeout=None):
-        start = self.scheduler.loop.time()
+        start = time()
         while name not in self.variables:
             if timeout is not None:
-                left = timeout - (self.scheduler.loop.time() - start)
+                left = timeout - (time() - start)
             else:
                 left = None
             if left and left < 0:


### PR DESCRIPTION
Replace all uses of time.time(), which on windows has an accuracy of 1 second, and IOLoop.time(), which is just a legacy alias to time.time(), with metrics.time everywhere.