### PR TITLE
[DNM] Don't cancel futures on client reconnect

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1023,9 +1023,9 @@ class Client(SyncMethodMixin):
             self.status = "connecting"
             self.scheduler_comm = None
 
-            for st in self.futures.values():
-                st.cancel()
-            self.futures.clear()
+            # for st in self.futures.values():
+            #     st.cancel()
+            # self.futures.clear()
 
             timeout = self._timeout
             deadline = self.loop.time() + timeout


### PR DESCRIPTION
A user reported very unfortunate behavior due to a client canceling all its futures prior to attempting to reconnect back to a scheduler (which could be lost due to, for example, a network hiccup). We have an explicit test for this behavior

https://github.com/dask/distributed/blob/d50cee9bfcf72a43187bddbfb6485faae280755d/distributed/tests/test_client.py#L3753

but I'll admit it's not clear to me it's needed. This PR just comments out the future cancelling to see what else fails (if anything in CI)