### PR TITLE
Do not raise an exception if the github token cannot be found

### DIFF
--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -12,8 +12,6 @@ import pandas
 import requests
 
 TOKEN = os.environ.get("GITHUB_TOKEN")
-if not TOKEN:
-    raise RuntimeError("Failed to find a GitHub Token")
 
 # Mapping between a symbol (pass, fail, skip) and a color
 COLORS = {
@@ -162,6 +160,8 @@ def dataframe_from_jxml(run):
 
 
 if __name__ == "__main__":
+    if not TOKEN:
+        raise RuntimeError("Failed to find a GitHub Token")
     print("Getting all recent workflows...")
     workflows = get_workflow_listing()
 


### PR DESCRIPTION
Raising an exception during module import is a bit rude. More importantly, this can lead to `pytest` test discovery failures.

markers docs, see https://docs.pytest.org/en/6.2.x/example/markers.html#marking-whole-classes-or-modules