### PR TITLE
Allow log propagation by default

### DIFF
--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -108,10 +108,7 @@ async def test_ucx_config(ucx_loop, cleanup):
         assert ucx_environment == {"UCX_MEMTRACK_DEST": "stdout"}
 
 
-@pytest.mark.flaky(
-    reruns=10,
-    reruns_delay=5,
-)
+@pytest.mark.flaky(reruns=10, reruns_delay=5)
 def test_ucx_config_w_env_var(ucx_loop, cleanup, loop):
     env = os.environ.copy()
     env["DASK_RMM__POOL_SIZE"] = "1000.00 MB"

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -100,9 +100,22 @@ def _initialize_logging_old_style(config):
             level = logging_names[level.upper()]
         logger = logging.getLogger(name)
         logger.setLevel(level)
-        logger.handlers[:] = []
-        logger.addHandler(handler)
-        logger.propagate = False
+
+        # Ensure that we're not registering the logger twice in this hierarchy.
+        anc = None
+        already_registered = False
+        for ancestor in name.split("."):
+            if anc is None:
+                anc = logging.getLogger(ancestor)
+            else:
+                anc.getChild(ancestor)
+
+            if handler in anc.handlers:
+                already_registered = True
+                break
+
+        if not already_registered:
+            logger.addHandler(handler)
 
 
 def _initialize_logging_new_style(config):

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -100,7 +100,22 @@ def _initialize_logging_old_style(config):
             level = logging_names[level.upper()]
         logger = logging.getLogger(name)
         logger.setLevel(level)
-        logger.addHandler(handler)
+
+        # Ensure that we're not registering the logger twice in this hierarchy.
+        anc = None
+        already_registered = False
+        for ancestor in name.split("."):
+            if anc is None:
+                anc = logging.getLogger(ancestor)
+            else:
+                anc.getChild(ancestor)
+
+            if handler in anc.handlers:
+                already_registered = True
+                break
+
+        if not already_registered:
+            logger.addHandler(handler)
 
 
 def _initialize_logging_new_style(config):

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -100,22 +100,7 @@ def _initialize_logging_old_style(config):
             level = logging_names[level.upper()]
         logger = logging.getLogger(name)
         logger.setLevel(level)
-
-        # Ensure that we're not registering the logger twice in this hierarchy.
-        anc = None
-        already_registered = False
-        for ancestor in name.split("."):
-            if anc is None:
-                anc = logging.getLogger(ancestor)
-            else:
-                anc.getChild(ancestor)
-
-            if handler in anc.handlers:
-                already_registered = True
-                break
-
-        if not already_registered:
-            logger.addHandler(handler)
+        logger.addHandler(handler)
 
 
 def _initialize_logging_new_style(config):

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -210,7 +210,9 @@ class LocalCluster(SpecCluster):
             # Overcommit threads per worker, rather than undercommit
             threads_per_worker = max(1, int(math.ceil(CPU_COUNT / n_workers)))
         if n_workers and "memory_limit" not in worker_kwargs:
-            worker_kwargs["memory_limit"] = parse_memory_limit("auto", 1, n_workers)
+            worker_kwargs["memory_limit"] = parse_memory_limit(
+                "auto", 1, n_workers, logger=logger
+            )
 
         worker_kwargs.update(
             {

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -3,7 +3,7 @@ distributed:
   # logging:
   #   distributed: info
   #   distributed.client: warning
-  #   bokeh: critical
+  #   bokeh: error
   #   # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
   #   tornado: critical
   #   tornado.application: error

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -84,16 +84,15 @@ class ServerNode(Server):
     def service_ports(self):
         return {k: v.port for k, v in self.services.items()}
 
-    def _setup_logging(self, *loggers):
+    def _setup_logging(self, logger: logging.Logger) -> None:
         self._deque_handler = DequeHandler(
             n=dask.config.get("distributed.admin.log-length")
         )
         self._deque_handler.setFormatter(
             logging.Formatter(dask.config.get("distributed.admin.log-format"))
         )
-        for logger in loggers:
-            logger.addHandler(self._deque_handler)
-            weakref.finalize(self, logger.removeHandler, self._deque_handler)
+        logger.addHandler(self._deque_handler)
+        weakref.finalize(self, logger.removeHandler, self._deque_handler)
 
     def get_logs(self, start=0, n=None, timestamps=False):
         """

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7750,7 +7750,12 @@ if __name__ == "__main__":
 
 
 @pytest.mark.slow
-@pytest.mark.flaky(reruns=5, rerun_delay=10, only_rerun="Found blocklist match")
+# These lines sometimes appear:
+#     Creating scratch directories is taking a surprisingly long time
+#     Future exception was never retrieved
+#     tornado.util.TimeoutError
+#     Batched Comm Closed
+@pytest.mark.flaky(reruns=5, reruns_delay=5)
 @pytest.mark.parametrize("processes", [True, False])
 def test_quiet_close_process(processes, tmp_path):
     with open(tmp_path / "script.py", mode="w") as f:
@@ -7761,18 +7766,7 @@ def test_quiet_close_process(processes, tmp_path):
 
     lines = out.decode("utf-8").split("\n")
     lines = [stripped for line in lines if (stripped := line.strip())]
-
-    # List of frequent spurious messages that are beyond the scope of this test
-    blocklist = [
-        "Creating scratch directories is taking a surprisingly long time",
-        "Future exception was never retrieved",
-        "tornado.util.TimeoutError",
-    ]
-    lines2 = [line for line in lines if not any(ign in line for ign in blocklist)]
-    # Instant failure for messages not in blocklist
-    assert not lines2
-    # Retry up to 5 times if the only messages are in the blocklist
-    assert not lines, "Found blocklist match, retrying: " + str(lines)
+    assert not lines
 
 
 @gen_cluster(client=False, nthreads=[])

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1570,7 +1570,7 @@ async def test_close_async_task_handles_cancellation(c, s, a):
     )
     start = time()
     with captured_logger(
-        "distributed.worker_state_machine", level=logging.ERROR
+        "distributed.worker.state_machine", level=logging.ERROR
     ) as logger:
         await a.close(timeout=1)
     assert "Failed to cancel asyncio task" in logger.getvalue()
@@ -3733,8 +3733,7 @@ async def test_deprecation_of_renamed_worker_attributes(s, a, b):
 
 @gen_cluster(nthreads=[])
 async def test_worker_log_memory_limit_too_high(s):
-    with captured_logger("distributed.worker_memory") as caplog:
-        # caplog.set_level(logging.WARN, logger="distributed.worker")
+    with captured_logger("distributed.worker.memory") as caplog:
         async with Worker(s.address, memory_limit="1PB"):
             pass
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -132,7 +132,6 @@ from distributed.worker_state_machine import (
     UpdateDataEvent,
     WorkerState,
 )
-from distributed.worker_state_machine import logger as wsm_logger
 
 if TYPE_CHECKING:
     # FIXME import from typing (needs Python >=3.10)
@@ -572,7 +571,7 @@ class Worker(BaseWorker, ServerNode):
         profile_cycle_interval = parse_timedelta(profile_cycle_interval, default="ms")
         assert profile_cycle_interval
 
-        self._setup_logging(logger, wsm_logger)
+        self._setup_logging(logger)
 
         if not local_directory:
             local_directory = (
@@ -1489,7 +1488,7 @@ class Worker(BaseWorker, ServerNode):
         # nanny+worker, the nanny must be notified first. ==> Remove kwarg
         # nanny, see also Scheduler.retire_workers
         if self.status in (Status.closed, Status.closing, Status.failed):
-            logging.debug(
+            logger.debug(
                 "Attempted to close worker that is already %s. Reason: %s",
                 self.status,
                 reason,

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -40,7 +40,7 @@ from distributed.protocol.serialize import Serialize
 from distributed.sizeof import safe_sizeof as sizeof
 from distributed.utils import recursive_to_dict
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("distributed.worker.state_machine")
 
 if TYPE_CHECKING:
     # TODO import from typing (requires Python >=3.10)


### PR DESCRIPTION
Our default logging initialisation disables propagation. imo, this effectively disabled the logging hierarchy system and I do not understand why.

Investigating the issue back, this was introduced to avoid configuring the root logger and that is still necessary. with the simple for loop as before, not disabling propagation would log messages twice (the msg would propagate up the hierarchy and encounter the same handler again). this avoids that and enabled propagation

Why do I care about propagation? The pytest caplog fixture which is very handy is very useful and works be hooking into this logging hierarchy.

That will effectively let us get rid of `captured_logger` and simplify a few tests