### PR TITLE
Dump cluster state on all test failures

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -139,13 +139,13 @@ jobs:
         with:
           name: ${{ env.TEST_ID }}
           path: reports
-      - name: Upload timeout reports
+      - name: Upload gen_cluster dumps for failed tests
         # ensure this runs even if pytest fails
         if: >
           always() &&
           (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure')
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.TEST_ID }}-timeouts
-          path: test_timeout_dump
+          name: ${{ env.TEST_ID }}_cluster_dumps
+          path: test_cluster_dump
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dask-worker-space/
 tags
 .ipynb_checkpoints
 .venv/
+.mypy_cache/
 
-# Test timeouts will dump the cluster state in here
-test_timeout_dump/
+# Test failures will dump the cluster state in here
+test_cluster_dump/

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -140,14 +140,16 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
         nthreads=nthreads,
         config={"distributed.scheduler.work-stealing": False},
     )
-    async def test(c, s, *workers):
+    async def test_decide_worker_coschedule_order_neighbors_(c, s, *workers):
         r"""
-        Ensure that sibling root tasks are scheduled to the same node, reducing future data transfer.
+        Ensure that sibling root tasks are scheduled to the same node, reducing future
+        data transfer.
 
-        We generate a wide layer of "root" tasks (random NumPy arrays). All of those tasks share 0-5
-        trivial dependencies. The ``ndeps=0`` and ``ndeps=1`` cases are most common in real-world use
-        (``ndeps=1`` is basically ``da.from_array(..., inline_array=False)`` or ``da.from_zarr``).
-        The graph is structured like this (though the number of tasks and workers is different):
+        We generate a wide layer of "root" tasks (random NumPy arrays). All of those
+        tasks share 0-5 trivial dependencies. The ``ndeps=0`` and ``ndeps=1`` cases are
+        most common in real-world use (``ndeps=1`` is basically ``da.from_array(...,
+        inline_array=False)`` or ``da.from_zarr``). The graph is structured like this
+        (though the number of tasks and workers is different):
 
             |-W1-|  |-W2-| |-W3-|  |-W4-|   < ---- ideal task scheduling
 
@@ -159,9 +161,9 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
             \   \   \   |   |   /   /   /
                    TRIVIAL * 0..5
 
-        Neighboring `random-` tasks should be scheduled on the same worker. We test that generally,
-        only one worker holds each row of the array, that the `random-` tasks are never transferred,
-        and that there are few transfers overall.
+        Neighboring `random-` tasks should be scheduled on the same worker. We test that
+        generally, only one worker holds each row of the array, that the `random-` tasks
+        are never transferred, and that there are few transfers overall.
         """
         da = pytest.importorskip("dask.array")
         np = pytest.importorskip("numpy")
@@ -222,16 +224,18 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
                 keys = log["keys"]
                 # The root-ish tasks should never be transferred
                 assert not any(k.startswith("random") for k in keys), keys
-                # `object-` keys (the trivial deps of the root random tasks) should be transferred
+                # `object-` keys (the trivial deps of the root random tasks) should be
+                # transferred
                 if any(not k.startswith("object") for k in keys):
                     # But not many other things should be
                     unexpected_transfers.append(list(keys))
 
-        # A transfer at the very end to move aggregated results is fine (necessary with unbalanced workers in fact),
-        # but generally there should be very very few transfers.
+        # A transfer at the very end to move aggregated results is fine (necessary with
+        # unbalanced workers in fact), but generally there should be very very few
+        # transfers.
         assert len(unexpected_transfers) <= 3, unexpected_transfers
 
-    test()
+    test_decide_worker_coschedule_order_neighbors_()
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1016,7 +1016,9 @@ def gen_cluster(
                             ) from None
 
                         except Exception:
-                            if cluster_dump_directory and not hasattr(test_func, "xfail"):
+                            if cluster_dump_directory and not hasattr(
+                                test_func, "xfail"
+                            ):
                                 await dump_cluster_state(
                                     s,
                                     ws,

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -678,7 +678,7 @@ def cluster(
             for worker in workers:
                 worker["address"] = worker["queue"].get(timeout=5)
         except queue.Empty:
-            raise pytest.xfail.Exception("Worker failed to start in test")
+            pytest.xfail("Worker failed to start in test")
 
         saddr = scheduler_q.get()
 
@@ -1014,6 +1014,9 @@ def gen_cluster(
                                 "========== Test stack trace starts here ==========\n"
                                 f"{buffer.getvalue()}"
                             ) from None
+
+                        except pytest.xfail.Exception:
+                            raise
 
                         except Exception:
                             if cluster_dump_directory and not has_pytestmark(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1016,7 +1016,7 @@ def gen_cluster(
                             ) from None
 
                         except Exception:
-                            if cluster_dump_directory:
+                            if cluster_dump_directory and not hasattr(test_func, "xfail"):
                                 await dump_cluster_state(
                                     s,
                                     ws,

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1016,7 +1016,7 @@ def gen_cluster(
                             ) from None
 
                         except Exception:
-                            if cluster_dump_directory and not hasattr(
+                            if cluster_dump_directory and not has_pytestmark(
                                 test_func, "xfail"
                             ):
                                 await dump_cluster_state(
@@ -1912,3 +1912,14 @@ class BrokenComm(Comm):
 
     def write(self, msg, serializers=None, on_error=None):
         raise OSError()
+
+
+def has_pytestmark(test_func: Callable, name: str) -> bool:
+    """Return True if the test function is marked by the given @pytest.mark.<name>;
+    False otherwise.
+
+    FIXME doesn't work with individually marked parameters inside
+          @pytest.mark.parametrize
+    """
+    marks = getattr(test_func, "pytestmark", [])
+    return any(mark.name == name for mark in marks)


### PR DESCRIPTION
Change ``@gen_cluster`` to perform a state dump on all test failures (notably, including xfails - this should be negligible in terms of extra cost) instead of just timeouts.

Shorten the stack trace in case of ``@gen_cluster`` timeout.