### PR TITLE
 Fix flaky `test_no_reconnect[--no-nanny]`

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -15,7 +15,6 @@ import dask.config
 from distributed import Client, Nanny, Scheduler, Worker, config, default_client
 from distributed.core import Server, rpc
 from distributed.metrics import time
-from distributed.utils import get_ip
 from distributed.utils_test import (
     _LockedCommPool,
     _UnhashableCallable,
@@ -27,7 +26,6 @@ from distributed.utils_test import (
     inc,
     new_config,
     tls_only_security,
-    wait_for_port,
 )
 
 
@@ -230,26 +228,6 @@ def _listen(delay=0):
         yield serv
     finally:
         t.join(5.0)
-
-
-def test_wait_for_port():
-    t1 = time()
-    with pytest.raises(RuntimeError):
-        wait_for_port((get_ip(), 9999), 0.5)
-    t2 = time()
-    assert t2 - t1 >= 0.5
-
-    with _listen(0) as s1:
-        t1 = time()
-        wait_for_port(s1.getsockname())
-        t2 = time()
-        assert t2 - t1 <= 1.0
-
-    with _listen(1) as s1:
-        t1 = time()
-        wait_for_port(s1.getsockname())
-        t2 = time()
-        assert t2 - t1 <= 2.0
 
 
 def test_new_config():

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1198,23 +1198,6 @@ def popen(args, **kwargs):
                 print(out.decode())
 
 
-def wait_for_port(address, timeout=5):
-    assert isinstance(address, tuple)
-    deadline = time() + timeout
-
-    while True:
-        timeout = deadline - time()
-        if timeout < 0:
-            raise RuntimeError(f"Failed to connect to {address}")
-        try:
-            sock = socket.create_connection(address, timeout=timeout)
-        except OSError:
-            pass
-        else:
-            sock.close()
-            break
-
-
 def wait_for(predicate, timeout, fail_func=None, period=0.001):
     deadline = time() + timeout
     while not predicate():

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1147,7 +1147,7 @@ def raises(func, exc=Exception):
         return True
 
 
-def terminate_process(proc):
+def _terminate_process(proc):
     if proc.poll() is None:
         if sys.platform.startswith("win"):
             proc.send_signal(signal.CTRL_BREAK_EVENT)
@@ -1186,7 +1186,7 @@ def popen(args, **kwargs):
 
     finally:
         try:
-            terminate_process(proc)
+            _terminate_process(proc)
         finally:
             # XXX Also dump stdout if return code != 0 ?
             out, err = proc.communicate()


### PR DESCRIPTION
- [x] Closes #5680 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

when investigating this flakey test on tmux I found that `distributed.utils_test.wait_for_port` was consuming 100% cpu in a tight loop around `socket.create_connection`, delaying the startup of the worker process longer than 5 seconds. I worked around this by running the `Scheduler` in the test directly.

this PR also restores the original purpose of the test:

`test_no_reconnect` was originally added here:
https://github.com/dask/distributed/commit/2c2a33fb513f4603b2ad9d40330b2a31d35b2692#diff-f23384aa58b61650a9a8b7986f731bc77294f89c9e65187fbfea0dace6692008R44-R51

the purpose of the test appears to be to see if once the connection to the scheduler is interrupted the worker process should terminate on its own, however in https://github.com/dask/distributed/commit/d1edbacdebd1c2a87d0dd68b70177f539c3a7574#diff-f23384aa58b61650a9a8b7986f731bc77294f89c9e65187fbfea0dace6692008R51 when the worker and scheduler context managers were swapped, however the `while is_alive(worker)` check was moved outside the `popen(['dask-worker', ...` context manager which terminates the process anyway.