### PR TITLE
Fix flaky `test_shuffle_extension.py::test_get_partition`

### DIFF
--- a/distributed/shuffle/tests/test_shuffle_extension.py
+++ b/distributed/shuffle/tests/test_shuffle_extension.py
@@ -260,8 +260,10 @@ async def test_get_partition(c: Client, s: Scheduler, *workers: Worker):
     )
     await ext._barrier(metadata.id)
 
-    with pytest.raises(AssertionError, match="belongs on"):
-        ext.get_output_partition(metadata.id, 7)
+    for addr, ext in exts.items():
+        if metadata.worker_for(0) != addr:
+            with pytest.raises(AssertionError, match="belongs on"):
+                ext.get_output_partition(metadata.id, 0)
 
     full = pd.concat([p1, p2])
     expected_groups = full.groupby("partition")
@@ -278,6 +280,5 @@ async def test_get_partition(c: Client, s: Scheduler, *workers: Worker):
     # Once all partitions are retrieved, shuffles are cleaned up
     for ext in exts.values():
         assert not ext.shuffles
-
-    with pytest.raises(ValueError, match="not registered"):
-        ext.get_output_partition(metadata.id, 0)
+        with pytest.raises(ValueError, match="not registered"):
+            ext.get_output_partition(metadata.id, 0)


### PR DESCRIPTION
A test was assuming the order of the workers passed by `gen_cluster` matched the order of `scheduler.workers`, which is not guaranteed.

I reread all the rest of the tests and didn't see any other such potential issues. But I did make a couple small tweaks to improve readability.

- [x] Partially fixes #5688
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
