### PR TITLE
Fix flaky test_workspace_concurrency

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -286,11 +286,10 @@ properties:
               For a list of handlers see the `dask.distributed.Scheduler.handlers` attribute.
 
           multiprocessing-method:
-            type:
-              enum:
-                - spawn
-                - fork
-                - forkserver
+            enum:
+              - spawn
+              - fork
+              - forkserver
             description: |
               How we create new workers, one of "spawn", "forkserver", or "fork"
 

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -286,7 +286,11 @@ properties:
               For a list of handlers see the `dask.distributed.Scheduler.handlers` attribute.
 
           multiprocessing-method:
-            type: string
+            type:
+              enum:
+                - spawn
+                - fork
+                - forkserver
             description: |
               How we create new workers, one of "spawn", "forkserver", or "fork"
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -46,7 +46,7 @@ from dask import istask
 from dask.utils import parse_timedelta as _parse_timedelta
 from dask.widgets import get_template
 
-from .compatibility import PYPY, WINDOWS
+from .compatibility import WINDOWS
 from .metrics import time
 
 try:
@@ -67,11 +67,9 @@ no_default = "__no_default__"
 
 
 def _initialize_mp_context():
-    if WINDOWS or PYPY:
-        return multiprocessing
-    else:
-        method = dask.config.get("distributed.worker.multiprocessing-method")
-        ctx = multiprocessing.get_context(method)
+    method = dask.config.get("distributed.worker.multiprocessing-method")
+    ctx = multiprocessing.get_context(method)
+    if method == "forkserver":
         # Makes the test suite much faster
         preload = ["distributed"]
         if "pkg_resources" in sys.modules:
@@ -87,7 +85,8 @@ def _initialize_mp_context():
             else:
                 preload.append(pkg)
         ctx.set_forkserver_preload(preload)
-        return ctx
+
+    return ctx
 
 
 mp_context = _initialize_mp_context()


### PR DESCRIPTION
Removed special mp_context treatment for Windows and Pypy. I ran a quick hello world in pypy and forkserver seems to work fine. In either case, the default is spawn, so only those users that explicitly set otherwise in the config should be affected. As a general rule, silently ignoring users' decisions is bad policy.

- Closes #2155
- Closes #4410
- Closes #4766
- xref #1509
- xref #3461
- Previous work:
  - #3484
  - #4504
  - #5022
  - #5168
