### PR TITLE
Add `distributed.client.security-loader` config

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -648,13 +648,13 @@ def _handle_warn(event):
 
 
 def _maybe_call_security_loader(address):
-    security_loader = dask.config.get("distributed.client.security-loader")
-    if security_loader:
+    security_loader_term = dask.config.get("distributed.client.security-loader")
+    if security_loader_term:
         try:
-            security_loader = import_term(security_loader)
+            security_loader = import_term(security_loader_term)
         except Exception as exc:
             raise ImportError(
-                f"Failed to import `{security_loader}` configured at "
+                f"Failed to import `{security_loader_term}` configured at "
                 f"`distributed.client.security-loader` - is this module "
                 f"installed?"
             ) from exc

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -560,6 +560,17 @@ properties:
             type: string
             description: Interval between scheduler-info updates
 
+          security-loader:
+            type: [string, 'null']
+            description: |
+              A fully qualified name (e.g. ``module.submodule.function``) of
+              a callback to use for loading security credentials for the
+              client. If no security object is explicitly passed when creating
+              a ``Client``, this callback is called with a dict containing
+              client information (currently just ``address``), and should
+              return a ``Security`` object to use for this client, or ``None``
+              to fallback to the default security configuration.
+
       deploy:
         type: object
         description: Configuration settings for general Dask deployment

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -162,6 +162,7 @@ distributed:
   client:
     heartbeat: 5s  # Interval between client heartbeats
     scheduler-info-interval: 2s  # Interval between scheduler-info updates
+    security-loader: null  # A callable to load security credentials if none are provided explicitly
 
   deploy:
     lost-worker-timeout: 15s  # Interval after which to hard-close a lost worker job

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7431,7 +7431,6 @@ class TestClientSecurityLoader:
         with dask.config.set(
             {"distributed.client.security-loader": "totally_fake_module_name_2.loader"}
         ):
-            with pytest.raises(ImportError) as exc:
+            with pytest.raises(ImportError, match="totally_fake_module_name_2.loader"):
                 async with Client("tls://bad-address:8888", asynchronous=True):
                     pass
-            assert "totally_fake_module_name_2.loader" in str(exc.value)


### PR DESCRIPTION
This adds a new client-side config hook for loading `Security`
configuration based on the scheduler address. This hook is only called
if no explicit `Security` object is passed to the `Client` call _and_
the client is connecting via an address (and _not_ via a `Cluster`
object). In this case the `security_loader` hook gets passed a
dictionary of information (so we can add fields later) and returns a
`Security` object to use (or `None` to fallback to the default
`Security` configuration).

This can be useful in contexts where a different security configuration
should be used to connect to different schedulers, as it lets an admin
configure a hook for selecting which certs to use when connecting to a
scheduler address without requiring the user manually do so.