### PR TITLE
Check for new name of timeouts artifact and be more fault tolerant.

### DIFF
--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -182,14 +182,18 @@ if __name__ == "__main__":
     for w in workflows:
         artifacts = get_artifacts_for_workflow(w["id"])
         # We also upload timeout reports as artifacts, but we don't want them here.
-        w["artifacts"] = [a for a in artifacts if "timeouts" not in a["name"]]
+        w["artifacts"] = [
+            a
+            for a in artifacts
+            if "timeouts" not in a["name"] and "cluster_dumps" not in a["name"]
+        ]
 
     print("Downloading and parsing artifacts...")
     for w in workflows:
         w["dfs"] = []
         for a in w["artifacts"]:
             xml = download_and_parse_artifact(a["archive_download_url"])
-            df = dataframe_from_jxml(xml)
+            df = dataframe_from_jxml(xml) if xml else None
             # Note: we assign a column with the workflow timestamp rather than the
             # artifact timestamp so that artifacts triggered under the same workflow
             # can be aligned according to the same trigger time.


### PR DESCRIPTION
The longitudinal test report has been for a few days since #5674 changed the name of some artifacts. This (1) handles the name change, and (2) tries to be a bit more resilient to such things in the future.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
