### PR TITLE
Avoid deadlock when two tasks are concurrently waiting for an unresolved `ActorFuture`

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -4,7 +4,7 @@ import dask
 from dask.config import config  # type: ignore
 
 from ._version import get_versions
-from .actor import Actor, ActorFuture
+from .actor import Actor, BaseActorFuture
 from .client import (
     Client,
     CompatibleExecutor,

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -258,7 +258,7 @@ class ActorFuture(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def result(self):
+    def result(self, timeout=None):
         pass
 
     @abc.abstractmethod
@@ -279,7 +279,7 @@ class _EagerActorFuture(ActorFuture):
         return self._result
         yield
 
-    def result(self):
+    def result(self, timeout=None):
         return self._result
 
     def done(self):

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -314,7 +314,6 @@ class _Error:
         raise self._e
 
 
-@dataclass(frozen=False, eq=False)
 class ActorFuture(BaseActorFuture[_T]):
     def __init__(self, io_loop: IOLoop):
         self._io_loop = io_loop

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -213,10 +213,10 @@ class Actor(WrappedKey):
 
                 actor_future = ActorFuture(io_loop=self._io_loop)
 
-                async def wait_then_add_to_queue():
+                async def wait_then_set_result():
                     actor_future._set_result(await run_actor_function_on_worker())
 
-                self._io_loop.add_callback(wait_then_add_to_queue)
+                self._io_loop.add_callback(wait_then_set_result)
                 return actor_future
 
             return func

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4966,11 +4966,11 @@ class as_completed:
         """Add multiple futures to the collection.
 
         The added futures will emit from the iterator once they finish"""
-        from .actor import ActorFuture
+        from .actor import BaseActorFuture
 
         with self.lock:
             for f in futures:
-                if not isinstance(f, (Future, ActorFuture)):
+                if not isinstance(f, (Future, BaseActorFuture)):
                     raise TypeError("Input must be a future, got %s" % f)
                 self.futures[f] += 1
                 self.loop.add_callback(self._track_future, f)

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -8,7 +8,7 @@ import dask
 
 from distributed import (
     Actor,
-    ActorFuture,
+    BaseActorFuture,
     Client,
     Future,
     Nanny,
@@ -103,7 +103,7 @@ async def test_worker_actions(c, s, a, b, separate_thread):
         assert counter._address == a_address
 
         future = counter.increment(separate_thread=separate_thread)
-        assert isinstance(future, ActorFuture)
+        assert isinstance(future, BaseActorFuture)
         assert "Future" in type(future).__name__
         end = future.result(timeout=1)
         assert end > start
@@ -730,7 +730,7 @@ async def test_actor_future_awaitable(client, s, a, b):
     ac = await client.submit(Counter, actor=True)
     futures = [ac.increment() for _ in range(10)]
 
-    assert all([isinstance(future, ActorFuture) for future in futures])
+    assert all([isinstance(future, BaseActorFuture) for future in futures])
 
     out = await asyncio.gather(*futures)
     assert all([future.done() for future in futures])

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -647,7 +647,9 @@ def test_one_thread_deadlock_timeout():
         # An actor whose method argument is another actor
 
         def do_inc(self, ac):
-            return ac.increment().result(timeout=1)
+            # ac.increment() returns an EagerActorFuture and so the timeout
+            # cannot expire
+            return ac.increment().result(timeout=0.001)
 
     with cluster(nworkers=1) as (cl, _):
         client = Client(cl["address"])

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -39,16 +39,6 @@ class Counter:
         return self.n
 
 
-class UsesCounter:
-    # An actor whose method argument is another actor
-
-    def do_inc(self, ac):
-        return ac.increment().result()
-
-    async def ado_inc(self, ac):
-        return await ac.ainc()
-
-
 class List:
     L: list = []
 
@@ -618,6 +608,12 @@ def test_worker_actor_handle_is_weakref_from_compute_sync(client):
 
 
 def test_one_thread_deadlock():
+    class UsesCounter:
+        # An actor whose method argument is another actor
+
+        def do_inc(self, ac):
+            return ac.increment().result()
+
     with cluster(nworkers=2) as (cl, w):
         client = Client(cl["address"])
         ac = client.submit(Counter, actor=True).result()
@@ -628,6 +624,12 @@ def test_one_thread_deadlock():
 
 @gen_cluster(client=True)
 async def test_async_deadlock(client, s, a, b):
+    class UsesCounter:
+        # An actor whose method argument is another actor
+
+        async def ado_inc(self, ac):
+            return await ac.ainc()
+
     ac = await client.submit(Counter, actor=True)
     ac2 = await client.submit(UsesCounter, actor=True, workers=[ac._address])
 

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -706,6 +706,17 @@ async def test_actor_future_awaitable(client, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_actor_future_awaitable_deadlock(client, s, a, b):
+    ac = await client.submit(Counter, actor=True)
+    f = ac.increment()
+
+    async def coro():
+        return await f
+
+    assert await asyncio.gather(coro(), coro()) == [1, 1]
+
+
+@gen_cluster(client=True)
 async def test_serialize_with_pickle(c, s, a, b):
     class Foo:
         def __init__(self):

--- a/docs/source/actors.rst
+++ b/docs/source/actors.rst
@@ -115,15 +115,15 @@ However accessing an attribute or calling a method will trigger a communication
 to the remote worker, run the method on the remote worker in a separate thread
 pool, and then communicate the result back to the calling side.  For attribute
 access these operations block and return when finished, for method calls they
-return an ``ActorFuture`` immediately.
+return an ``BaseActorFuture`` immediately.
 
 .. code-block:: python
 
-   >>> future = counter.increment()  # Immediately returns an ActorFuture
+   >>> future = counter.increment()  # Immediately returns a BaseActorFuture
    >>> future.result()               # Block until finished and result arrives
    1
 
-``ActorFuture`` are similar to normal Dask ``Future`` objects, but not as fully
+``BaseActorFuture`` are similar to normal Dask ``Future`` objects, but not as fully
 featured.  They curently *only* support the ``result`` method and nothing else.
 They don't currently work with any other Dask functions that expect futures,
 like ``as_completed``, ``wait``, or ``client.gather``.  They can't be placed
@@ -167,7 +167,7 @@ workers have only a single thread for actors, but this may change in the
 future.
 
 The result is sent back immediately to the calling side, and is not stored on
-the worker with the actor.  It is cached on the ``ActorFuture`` object.
+the worker with the actor.  It is cached on the ``BaseActorFuture`` object.
 
 
 Calling from coroutines and async/await


### PR DESCRIPTION
- [x] Closes #5708
- [x] Closes #5350
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
