### PR TITLE
Generate tests summary

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -1,0 +1,41 @@
+# Copied from https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.23/README.md#support-fork-repositories-and-dependabot-branches
+# Warning: changes to this workflow will NOT be picked up until they land in the main branch!
+# See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
+
+name: Publish test results
+
+on:
+  workflow_run:
+    workflows: [Tests]
+    types: [completed]
+
+jobs:
+  publish-test-results:
+    name: Publish test results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and extract artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir artifacts && cd artifacts
+
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: artifacts/**/*.xml
+          comment_mode: off

--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'
 
+    # Needed to post comments on the PR
+    permissions:
+      checks: write
+      pull-requests: write
+
     steps:
       - name: Download and extract artifacts
         env:
@@ -38,4 +43,3 @@ jobs:
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
           files: artifacts/**/*.xml
-          comment_mode: off

--- a/.github/workflows/ssh_debug.yaml.donotrun
+++ b/.github/workflows/ssh_debug.yaml.donotrun
@@ -1,7 +1,6 @@
 name: Debug passwordless `ssh localhost`
 
-on: []
-# on: [pull_request]  # Uncomment to enable
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -130,7 +130,7 @@ jobs:
       - name: Coverage
         uses: codecov/codecov-action@v1
 
-      - name: Upload test artifacts
+      - name: Upload test results
         # ensure this runs even if pytest fails
         if: >
           always() &&
@@ -149,3 +149,14 @@ jobs:
           name: ${{ env.TEST_ID }}_cluster_dumps
           path: test_cluster_dump
           if-no-files-found: ignore
+
+  # Publish an artifact for the event; used by publish-test-results.yaml
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Event File
+          path: ${{ github.event_path }}


### PR DESCRIPTION
Aggregate pytest failures in a single, easy to consume screen.
Note that the benefit of this PR cannot be seen until it's merged into main.
See https://github.com/crusaderky/distributed/pull/1 for demo.