### PR TITLE
Fix flaky test_exit_callback test

### DIFF
--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -243,7 +243,7 @@ async def test_exit_callback():
     assert not evt.is_set()
 
     to_child.put(None)
-    await evt.wait(timedelta(seconds=3))
+    await evt.wait(timedelta(seconds=5))
     assert evt.is_set()
     assert not proc.is_alive()
 
@@ -259,7 +259,7 @@ async def test_exit_callback():
     assert not evt.is_set()
 
     await proc.terminate()
-    await evt.wait(timedelta(seconds=3))
+    await evt.wait(timedelta(seconds=5))
     assert evt.is_set()
 
 


### PR DESCRIPTION
This test seems to fail on CI only. Try bumping the timeouts a bit
higher, presuming the errors are just due to things running a bit slower
than they do locally. If this doesn't work I'll have to debug further.