### PR TITLE
[REVIEW] ToPickle - Unpickle on the Scheduler

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -59,7 +59,7 @@ def dumps(
 
             header["compression"] = tuple(compression)
 
-        def create_sub_frames(obj) -> list:
+        def create_serialized_sub_frames(obj) -> list:
             typ = type(obj)
             if typ is Serialized:
                 sub_header, sub_frames = obj.header, obj.frames
@@ -78,7 +78,7 @@ def dumps(
             )
             return [sub_header] + sub_frames
 
-        def create_pickle_sub_frames(obj) -> list:
+        def create_pickled_sub_frames(obj) -> list:
             typ = type(obj)
             if typ is Pickled:
                 sub_header, sub_frames = obj.header, obj.frames
@@ -106,11 +106,11 @@ def dumps(
             typ = type(obj)
             if typ is Serialize or typ is Serialized:
                 offset = len(frames)
-                frames.extend(create_sub_frames(obj))
+                frames.extend(create_serialized_sub_frames(obj))
                 return {"__Serialized__": offset}
             elif typ is ToPickle or typ is Pickled:
                 offset = len(frames)
-                frames.extend(create_pickle_sub_frames(obj))
+                frames.extend(create_pickled_sub_frames(obj))
                 return {"__Pickled__": offset}
             else:
                 return msgpack_encode_default(obj)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -4,7 +4,7 @@ import msgpack
 
 import dask.config
 
-from distributed import pickle
+from distributed.protocol import pickle
 from distributed.protocol.compression import decompress, maybe_compress
 from distributed.protocol.serialize import (
     Pickled,

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -548,7 +548,11 @@ class ToPickle:
     """Mark an object that should be pickled
 
     Both the scheduler and workers with automatically unpickle this
-    object on arrival
+    object on arrival.
+
+    Notice, this requires that the scheduler is allowed to use pickle.
+    If the configuration option "distributed.scheduler.pickle" is set
+    to False, the scheduler will raise an exception instead.
     """
 
     def __init__(self, data):

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -522,8 +522,7 @@ to_serialize = Serialize
 
 
 class Serialized:
-    """
-    An object that is already serialized into header and frames
+    """An object that is already serialized into header and frames
 
     Normal serialization operations pass these objects through.  This is
     typically used within the scheduler which accepts messages that contain
@@ -537,6 +536,50 @@ class Serialized:
     def __eq__(self, other):
         return (
             isinstance(other, Serialized)
+            and other.header == self.header
+            and other.frames == self.frames
+        )
+
+    def __ne__(self, other):
+        return not (self == other)
+
+
+class ToPickle:
+    """Mark an object that should be pickled
+
+    Both the scheduler and workers with automatically unpickle this
+    object on arrival
+    """
+
+    def __init__(self, data):
+        self.data = data
+
+    def __repr__(self):
+        return "<ToPickle: %s>" % str(self.data)
+
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and other.data == self.data
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __hash__(self):
+        return hash(self.data)
+
+
+class Pickled:
+    """An object that is already pickled into header and frames
+
+    Normal pickled objects are unpickled by the scheduler.
+    """
+
+    def __init__(self, header, frames):
+        self.header = header
+        self.frames = frames
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, type(self))
             and other.header == self.header
             and other.frames == self.frames
         )

--- a/distributed/protocol/tests/test_to_pickle.py
+++ b/distributed/protocol/tests/test_to_pickle.py
@@ -14,7 +14,7 @@ class NonMsgPackSerializableLayer(MaterializedLayer):
     def __dask_distributed_pack__(self, *args, **kwargs):
         ret = super().__dask_distributed_pack__(*args, **kwargs)
         # Some info that contains a `list`, which msgpack will convert to
-        #  a tuple if getting the chance.
+        # a tuple if getting the chance.
         ret["myinfo"] = ["myinfo"]
         return ToPickle(ret)
 

--- a/distributed/protocol/tests/test_to_pickle.py
+++ b/distributed/protocol/tests/test_to_pickle.py
@@ -1,0 +1,33 @@
+import dask.config
+from dask.highlevelgraph import HighLevelGraph, MaterializedLayer
+
+from distributed.client import Client
+from distributed.protocol.serialize import ToPickle
+from distributed.utils_test import gen_cluster
+
+
+class NonMsgPackSerializableLayer(MaterializedLayer):
+    """Layer that use non-msgpack-serializable data"""
+
+    def __dask_distributed_pack__(self, *args, **kwargs):
+        ret = super().__dask_distributed_pack__(*args, **kwargs)
+        # Some info that contains a `list`, which msgpack will convert to
+        #  a tuple if getting the chance.
+        ret["myinfo"] = ["myinfo"]
+        return ToPickle(ret)
+
+    @classmethod
+    def __dask_distributed_unpack__(cls, state, *args, **kwargs):
+        assert state["myinfo"] == ["myinfo"]
+        return super().__dask_distributed_unpack__(state, *args, **kwargs)
+
+
+@gen_cluster(client=True)
+async def test_non_msgpack_serializable_layer(c: Client, s, w1, w2):
+    with dask.config.set({"distributed.scheduler.allowed-imports": "test_to_pickle"}):
+        a = NonMsgPackSerializableLayer({"x": 42})
+        layers = {"a": a}
+        dependencies = {"a": set()}
+        hg = HighLevelGraph(layers, dependencies)
+        res = await c.get(hg, "x", sync=False)
+        assert res == 42

--- a/distributed/protocol/tests/test_to_pickle.py
+++ b/distributed/protocol/tests/test_to_pickle.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import dask.config
 from dask.highlevelgraph import HighLevelGraph, MaterializedLayer
 
@@ -27,7 +29,7 @@ async def test_non_msgpack_serializable_layer(c: Client, s, w1, w2):
     with dask.config.set({"distributed.scheduler.allowed-imports": "test_to_pickle"}):
         a = NonMsgPackSerializableLayer({"x": 42})
         layers = {"a": a}
-        dependencies = {"a": set()}
+        dependencies: Dict[str, set] = {"a": set()}
         hg = HighLevelGraph(layers, dependencies)
         res = await c.get(hg, "x", sync=False)
         assert res == 42

--- a/distributed/protocol/tests/test_to_pickle.py
+++ b/distributed/protocol/tests/test_to_pickle.py
@@ -9,7 +9,7 @@ from distributed.utils_test import gen_cluster
 
 
 class NonMsgPackSerializableLayer(MaterializedLayer):
-    """Layer that use non-msgpack-serializable data"""
+    """Layer that uses non-msgpack-serializable data"""
 
     def __dask_distributed_pack__(self, *args, **kwargs):
         ret = super().__dask_distributed_pack__(*args, **kwargs)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -9,6 +9,7 @@ import json
 import logging
 import multiprocessing
 import os
+import pickle
 import pkgutil
 import re
 import socket
@@ -1008,7 +1009,7 @@ def nbytes(frame, _bytes_like=(bytes, bytearray)):
         return len(frame)
     else:
         try:
-            return frame.nbytes
+            return memoryview(frame).nbytes
         except AttributeError:
             return len(frame)
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -9,7 +9,6 @@ import json
 import logging
 import multiprocessing
 import os
-import pickle
 import pkgutil
 import re
 import socket

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1008,7 +1008,7 @@ def nbytes(frame, _bytes_like=(bytes, bytearray)):
         return len(frame)
     else:
         try:
-            return memoryview(frame).nbytes
+            return frame.nbytes
         except AttributeError:
             return len(frame)
 


### PR DESCRIPTION
Explore the usefulness of allowing unpickle on the scheduler.

Layers can now mark objects that should be unpickled on the scheduler (and worker) using `ToPickle`.

Notice, the PR is **not** ready for code review.

cc. @rjzamora 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
