### PR TITLE
Skip shuffle tests if `pandas` / `dask.dataframe` not installed

### DIFF
--- a/distributed/shuffle/tests/test_graph.py
+++ b/distributed/shuffle/tests/test_graph.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+import pytest
+
+pd = pytest.importorskip("pandas")
+pytest.importorskip("dask.dataframe")
+
 import dask
 import dask.dataframe as dd
 from dask.blockwise import Blockwise

--- a/distributed/shuffle/tests/test_shuffle_extension.py
+++ b/distributed/shuffle/tests/test_shuffle_extension.py
@@ -5,10 +5,10 @@ import string
 from collections import Counter
 from typing import TYPE_CHECKING
 
-import pandas as pd
 import pytest
 
-import dask.dataframe as dd
+pd = pytest.importorskip("pandas")
+dd = pytest.importorskip("dask.dataframe")
 
 from distributed.utils_test import gen_cluster
 


### PR DESCRIPTION
This isn't an issue in CI because `pandas` (an optional dependency) is always installed, but will show up if someone without `pandas` tries to run the test suite. Note https://github.com/dask/distributed/pull/4794 will catch this type of thing in the future. 

cc @gjoseph92 @crusaderky 