### PR TITLE
More fault tolerant test report

### DIFF
--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -97,13 +97,13 @@ def download_and_parse_artifact(url):
     """
     Download the artifact at the url parse it.
     """
-    r = get_from_github(url)
-    f = zipfile.ZipFile(io.BytesIO(r.content))
     try:
+        r = get_from_github(url)
+        f = zipfile.ZipFile(io.BytesIO(r.content))
         run = junitparser.JUnitXml.fromstring(f.read(f.filelist[0].filename))
         return run
     except Exception:
-        print(f"Failed to parse {url}")
+        print(f"Failed to download/parse {url}")
         return None
 
 


### PR DESCRIPTION
I'm not sure why the CI job is choking on this one artifact (which we weren't previously encountering due to a more restricted time window), but we can be a bit more fault tolerant.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
