### PR TITLE
check_process_leak overhaul

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1637,7 +1637,7 @@ def term_or_kill_active_children(timeout: float) -> None:
 def check_process_leak(
     check: bool = True, check_timeout: float = 40, term_timeout: float = 3
 ):
-    """Terminate any subprocesses spawned inside the context
+    """Terminate any currently-running subprocesses at both the beginning and end of this context
 
     Parameters
     ----------


### PR DESCRIPTION
Two tests in xarray decorated with ``@gen_cluster(client=True)``, therefore not spawning any processes, are very flaky as they fail systematically on ``check_process_leak``. I think the problem is caused by unrelated subprocesses, spawned by previous tests, that don't respond do SIGTERM.

xref: https://github.com/pydata/xarray/pull/6211
log: https://github.com/pydata/xarray/runs/4990065672