### PR TITLE
Review Scheduler/Worker repr

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -751,12 +751,12 @@ class WorkerState:
         return ws
 
     def __repr__(self):
-        return "<WorkerState %r, name: %s, status: %s, memory: %d, processing: %d>" % (
-            self._address,
-            self._name,
-            self._status.name,
-            len(self._has_what),
-            len(self._processing),
+        name = f", name: {self.name}" if self.name != self.address else ""
+        return (
+            f"<WorkerState {self._address!r}{name}, "
+            f"status: {self._status.name}, "
+            f"memory: {len(self._has_what)}, "
+            f"processing: {len(self._processing)}>"
         )
 
     def _repr_html_(self):
@@ -3984,11 +3984,11 @@ class Scheduler(SchedulerState, ServerNode):
 
     def __repr__(self):
         parent: SchedulerState = cast(SchedulerState, self)
-        return '<Scheduler: "%s" workers: %d cores: %d, tasks: %d>' % (
-            self.address,
-            len(parent._workers_dv),
-            parent._total_nthreads,
-            len(parent._tasks),
+        return (
+            f"<Scheduler {self.address!r}, "
+            f"workers: {len(parent._workers_dv)}, "
+            f"cores: {parent._total_nthreads}, "
+            f"tasks: {len(parent._tasks)}>"
         )
 
     def _repr_html_(self):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3374,3 +3374,29 @@ async def test_non_idempotent_plugins(s):
     await s.register_scheduler_plugin(plugin=dumps(second), idempotent=False)
     assert "nonidempotentplugin" in s.plugins
     assert s.plugins["nonidempotentplugin"].instance == "second"
+
+
+@gen_cluster(nthreads=[("", 1)])
+async def test_repr(s, a):
+    async with Worker(s.address, nthreads=2) as b:  # name = address by default
+        ws_a = s.workers[a.address]
+        ws_b = s.workers[b.address]
+        while ws_b.status != Status.running:
+            await asyncio.sleep(0.01)
+        assert repr(s) == f"<Scheduler {s.address!r}, workers: 2, cores: 3, tasks: 0>"
+        assert (
+            repr(a)
+            == f"<Worker {a.address!r}, name: 0, status: running, stored: 0, running: 0/1, ready: 0, comm: 0, waiting: 0>"
+        )
+        assert (
+            repr(b)
+            == f"<Worker {b.address!r}, status: running, stored: 0, running: 0/2, ready: 0, comm: 0, waiting: 0>"
+        )
+        assert (
+            repr(ws_a)
+            == f"<WorkerState {a.address!r}, name: 0, status: running, memory: 0, processing: 0>"
+        )
+        assert (
+            repr(ws_b)
+            == f"<WorkerState {b.address!r}, status: running, memory: 0, processing: 0>"
+        )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1073,17 +1073,15 @@ class Worker(ServerNode):
     ##################
 
     def __repr__(self):
-        return "<%s: %r, %s, %s, stored: %d, running: %d/%d, ready: %d, comm: %d, waiting: %d>" % (
-            self.__class__.__name__,
-            self.address,
-            self.name,
-            self.status,
-            len(self.data),
-            self.executing_count,
-            self.nthreads,
-            len(self.ready),
-            self.in_flight_tasks,
-            self.waiting_for_data_count,
+        name = f", name: {self.name}" if self.name != self.address else ""
+        return (
+            f"<{self.__class__.__name__} {self.address!r}{name}, "
+            f"status: {self.status.name}, "
+            f"stored: {len(self.data)}, "
+            f"running: {self.executing_count}/{self.nthreads}, "
+            f"ready: {len(self.ready)}, "
+            f"comm: {self.in_flight_tasks}, "
+            f"waiting: {self.waiting_for_data_count}>"
         )
 
     @property


### PR DESCRIPTION
Harmonize the repr output of Scheduler, Worker, and WorkerState.
Hide Worker name when it defaults to the address.

The aim of this PR is to make AMM debug logs more readable.