### PR TITLE
ENH arrange tasks based on effective thread id

### DIFF
--- a/distributed/threadpoolexecutor.py
+++ b/distributed/threadpoolexecutor.py
@@ -76,6 +76,7 @@ class ThreadPoolExecutor(thread.ThreadPoolExecutor):
         self._thread_name_prefix = kwargs.get(
             "thread_name_prefix", "DaskThreadPoolExecutor"
         )
+        self._available_effective_thread_ids = set(range(self._max_workers))
 
     def _adjust_thread_count(self):
         if len(self._threads) < self._max_workers:
@@ -85,9 +86,24 @@ class ThreadPoolExecutor(thread.ThreadPoolExecutor):
                 + "-%d-%d" % (os.getpid(), next(self._counter)),
                 args=(self, self._work_queue),
             )
+            t._effective_thread_id = self._get_next_effective_thread_id()
             t.daemon = True
             self._threads.add(t)
             t.start()
+
+
+    def _get_next_effective_thread_id(self):
+        # This should be used with a lock held
+        if len(self._threads) < self._max_workers:
+            next_effective_thread_id = min(self._available_effective_thread_ids)
+            self._available_effective_thread_ids.remove(next_effective_thread_id)
+            return next_effective_thread_id
+        else:
+            raise ValueError("Threadpool is full")
+
+    def _remove_thread(self, t):
+        self._threads.remove(t)
+        self._available_effective_thread_ids.add(t._effective_thread_id)
 
     def shutdown(self, wait=True, timeout=None):
         with threads_lock:
@@ -114,7 +130,7 @@ def secede(adjust=True):
     """
     thread_state.proceed = False
     with threads_lock:
-        thread_state.executor._threads.remove(threading.current_thread())
+        thread_state.executor._remove_thread(threading.current_thread())
         if adjust:
             thread_state.executor._adjust_thread_count()
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -4523,7 +4523,7 @@ def apply_function_simple(
     -------
     msg: dictionary with status, result/error, timings, etc..
     """
-    ident = threading.get_ident()
+    ident = threading.current_thread()._effective_thread_id
     start = time()
     try:
         result = function(*args, **kwargs)
@@ -4559,7 +4559,7 @@ async def apply_function_async(
     -------
     msg: dictionary with status, result/error, timings, etc..
     """
-    ident = threading.get_ident()
+    ident = threading.current_thread()._effective_thread_id
     start = time()
     try:
         result = await function(*args, **kwargs)


### PR DESCRIPTION
- [x] Closes #4346
- [x] Supersedes #4370
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`


This PR implements the suggestion I made in https://github.com/dask/distributed/pull/4370#issuecomment-808927994, in order to make the task stream less misleading when using `joblib` with the `dask` backend for nested `Parallel` calls, which happens very often in `scikit-learn` (think grid-search + cross-validation for instance).  The original problem is discussed at length in https://github.com/dask/distributed/issues/4346#issue-761516160.


cc @lesteve @ogrisel @mrocklin 