### PR TITLE
Respect KeyboardInterrupt in sync

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -352,11 +352,15 @@ def sync(loop, func, *args, callback_timeout=None, **kwargs):
         finally:
             e.set()
 
+    def cancel():
+        if future is not None:
+            future.cancel()
+
     def wait(timeout):
         try:
             return e.wait(timeout)
         except KeyboardInterrupt:
-            loop.add_callback(future.cancel)
+            loop.add_callback(cancel)
             raise
 
     loop.add_callback(f)


### PR DESCRIPTION
continuation of https://github.com/dask/distributed/pull/5722 handling the uninitialized future and supporting KeyboardInterrupt when callback_timeout is passed

> Previously when we encountered a KeyboardInterrupt any underlying coroutines on which we were relying were allowed to continue.
> 
> Now we explicitly cancel the underlying future, and then raise that KeyboardInterrupt back up.
> 
> Keyboard Interrupts are hard to test properly. I ran the following in ipython.
> 
> ```python
> import asyncio
> import time
> from distributed.utils import sync
> from dask.distributed import Client
> 
> async def f():
>     while True:
>         await asyncio.sleep(0.5)
>         print("Hello")
> 
> client = Client(processes=False)
> client.sync(f)
> ```
> 
> I then let this run for a bit and then hit Ctrl-C. Previously I would get a bunch of "Hello"s after I hit Ctrl-C. Now I don't.
> 
>     * [ ]  Closes #xxxx
> 
>     * [ ]  Tests added / passed
> 
>     * [ ]  Passes `pre-commit run --all-files`
