### PR TITLE
Remove `test_ucx_config_w_env_var` flaky condition

### DIFF
--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -95,23 +95,26 @@ async def test_ucx_config(cleanup):
 
 
 @pytest.mark.flaky(
-    reruns=10, reruns_delay=5, condition=ucp.get_ucx_version() < (1, 11, 0)
+    reruns=10,
+    reruns_delay=5,
 )
 def test_ucx_config_w_env_var(cleanup, loop):
     env = os.environ.copy()
     env["DASK_RMM__POOL_SIZE"] = "1000.00 MB"
 
     port = "13339"
-    sched_addr = f"ucx://{HOST}:{port}"
+    sched_addr = f"ucx://127.0.0.1:{port}"
 
     with popen(
         ["dask-scheduler", "--no-dashboard", "--protocol", "ucx", "--port", port],
         env=env,
-    ) as sched:
+    ):
         with popen(
             [
                 "dask-worker",
                 sched_addr,
+                "--host",
+                "127.0.0.1",
                 "--no-dashboard",
                 "--protocol",
                 "ucx",

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -103,6 +103,8 @@ def test_ucx_config_w_env_var(cleanup, loop):
     env["DASK_RMM__POOL_SIZE"] = "1000.00 MB"
 
     port = "13339"
+    # Using localhost appears to be less flaky than {HOST}. Additionally, this is
+    # closer to how other dask-worker tests are written.
     sched_addr = f"ucx://127.0.0.1:{port}"
 
     with popen(


### PR DESCRIPTION
Mark `test_ucx_config_w_env_var` flaky independent of UCX version. Using `127.0.0.1` greatly reduces the probability of the issue, but it still happens ~1% of the time when I run it locally, therefore marking it flaky for the time being.