### PR TITLE
Resolve various issues with pre-release packages

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -80,10 +80,10 @@ jobs:
           # install anaconda for upload
           mamba install anaconda-client
 
-          anaconda upload --label dev noarch/*.tar.bz2
-          anaconda upload --label dev linux-64/*.tar.bz2
-          anaconda upload --label dev linux-aarch64/*.tar.bz2
-          anaconda upload --label dev linux-ppc64le/*.tar.bz2
-          anaconda upload --label dev osx-64/*.tar.bz2
-          anaconda upload --label dev osx-arm64/*.tar.bz2
-          anaconda upload --label dev win-64/*.tar.bz2
+          anaconda upload --force --label dev noarch/*.tar.bz2
+          anaconda upload --force --label dev linux-64/*.tar.bz2
+          anaconda upload --force --label dev linux-aarch64/*.tar.bz2
+          anaconda upload --force --label dev linux-ppc64le/*.tar.bz2
+          anaconda upload --force --label dev osx-64/*.tar.bz2
+          anaconda upload --force --label dev osx-arm64/*.tar.bz2
+          anaconda upload --force --label dev win-64/*.tar.bz2

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  repository_dispatch:
+    types:
+      - trigger-build
   pull_request:
 
 # When this workflow is queued, automatically cancel any previous running

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -65,8 +65,7 @@ jobs:
                            --output-folder build
       - name: Upload conda packages
         if: |
-          github.event_name == 'push'
-          && github.ref == 'refs/heads/main'
+          contains(['push', 'repository_dispatch'], github.event_name)
           && github.repository == 'dask/distributed'
         env:
           ANACONDA_API_TOKEN: ${{ secrets.DASK_CONDA_TOKEN }}

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.7
     - dask-core {{ dask_version }}={{ dask_build }}
-    - distributed {{ version }}=py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+    - distributed {{ version }}=*_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
     - cytoolz >=0.8.2
     - numpy >=1.18
     - pandas >=1.0

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - dask-core {{ dask_version }}={{ dask_build }}
     - jinja2
     - msgpack-python >=0.6.0
+    - packaging >=20.0
     - psutil >=5.0
     - pyyaml
     - sortedcontainers !=2.0.0,!=2.0.1
@@ -43,7 +44,7 @@ requirements:
     - tornado >=5  # [py<38]
     - tornado >=6.0.3  # [py>=38]
     - zict >=0.1.3
-    - setuptools
+    - setuptools <60.0.0
 
   run_constrained:
     - openssl !=1.1.1e


### PR DESCRIPTION
This PR is meant as a companion to https://github.com/dask/dask/pull/8664, and should resolve most of the issues we currently have with pre-release packages:

- removes the accidental hard-coded python version on `dask`'s `distributed` dependency
- allows `dask` / `distributed` builds to be triggered by repository dispatch events (which would be sent by dask/dask on commits after merging https://github.com/dask/dask/pull/8664)
- updates `distributed`'s recipe to reflect changes made in https://github.com/conda-forge/distributed-feedstock/pull/194/

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
