### PR TITLE
Trigger test runs periodically to increases failure statistics

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 6,18 * * *"
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch


### PR DESCRIPTION
I opted for twice a day since I think this is still doable. The first time slot 6 UTC is US evening and EU early morning. 

xref github docs https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

Note: schedule only applies to default branch

- [ ] Closes https://github.com/dask/distributed/issues/5762
