### PR TITLE
Revert "pin coverage to 6.2 (#5716)"

### DIFF
--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -10,7 +10,7 @@ dependencies:
   - bokeh
   - click
   - cloudpickle
-  - coverage<6.3  # https://github.com/nedbat/coveragepy/issues/1310
+  - coverage
   - cython  # Only tested here; also a dependency of crick
   - dask  # overridden by git tip below
   - filesystem-spec

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -10,7 +10,7 @@ dependencies:
   - bokeh
   - click
   - cloudpickle
-  - coverage<6.3  # https://github.com/nedbat/coveragepy/issues/1310
+  - coverage
   - dask  # overridden by git tip below
   - filesystem-spec
   - h5py

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -11,7 +11,7 @@ dependencies:
   - bokeh
   - click
   - cloudpickle
-  - coverage<6.3  # https://github.com/nedbat/coveragepy/issues/1310
+  - coverage
   - dask  # overridden by git tip below
   - filesystem-spec  # overridden by git tip below
   - h5py


### PR DESCRIPTION
This reverts commit 93742da6ff47aeb8f70e8fe314d3547f93429c4d.
Fixes #5717


- [x] Closes #5717
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`


coverage 6.3.1 should avoid the deadlock: https://github.com/nedbat/coveragepy/issues/1310#issuecomment-1027521713 
some people are reporting that the patch didn't help: https://github.com/nedbat/coveragepy/issues/1310#issuecomment-1027585964