### PR TITLE
Reactivate pytest_resourceleaks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -124,8 +124,11 @@ jobs:
           fi
           source continuous_integration/scripts/set_ulimit.sh
 
-          pytest distributed -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
-            --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID --cov=distributed --cov-report=xml
+          pytest distributed \
+            -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
+            --leaks=fds,processes,threads \
+            --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
+            --cov=distributed --cov-report=xml
 
       # - name: Debug with tmate on failure
       #   if: ${{ failure() }}

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -7,6 +7,7 @@ import struct
 import sys
 import weakref
 from ssl import SSLCertVerificationError, SSLError
+from typing import ClassVar
 
 from tornado import gen
 
@@ -384,7 +385,29 @@ class RequireEncryptionMixin:
 
 
 class BaseTCPConnector(Connector, RequireEncryptionMixin):
-    _executor = ThreadPoolExecutor(2, thread_name_prefix="TCP-Executor")
+    _executor: ClassVar[ThreadPoolExecutor] = ThreadPoolExecutor(
+        2, thread_name_prefix="TCP-Executor"
+    )
+    _client: ClassVar[TCPClient]
+
+    @classmethod
+    def warmup(cls) -> None:
+        """Pre-start threads and sockets to avoid catching them in checks for thread and
+        fd leaks
+        """
+        ex = cls._executor
+        while len(ex._threads) < ex._max_workers:
+            ex._adjust_thread_count()
+        cls._get_client()
+
+    @classmethod
+    def _get_client(cls):
+        if not hasattr(cls, "_client"):
+            resolver = netutil.ExecutorResolver(
+                close_executor=False, executor=cls._executor
+            )
+            cls._client = TCPClient(resolver=resolver)
+        return cls._client
 
     @property
     def client(self):
@@ -392,13 +415,7 @@ class BaseTCPConnector(Connector, RequireEncryptionMixin):
         # excess `ThreadPoolExecutor`s. We delay creation until inside an async
         # function to avoid accessing an IOLoop from a context where a backing
         # event loop doesn't exist.
-        cls = type(self)
-        if not hasattr(type(self), "_client"):
-            resolver = netutil.ExecutorResolver(
-                close_executor=False, executor=cls._executor
-            )
-            cls._client = TCPClient(resolver=resolver)
-        return cls._client
+        return self._get_client()
 
     async def connect(self, address, deserialize=True, **connection_args):
         self._check_encryption(address, connection_args)

--- a/distributed/pytest_resourceleaks.py
+++ b/distributed/pytest_resourceleaks.py
@@ -1,313 +1,365 @@
+"""A pytest plugin to trace resource leaks.
+
+Enabled from the command line with -L / --leaks. See `pytest --help` for further
+configuration settings.
+
+You may mark individual tests as known to be leaking with the fixture
+
+    @pytest.mark.leaking(check1, check2, ...)
+
+Where the valid checks are 'fds', 'memory', 'threads', 'processes', 'tracemalloc'.
+
+e.g.
+
+    @pytest.mark.leaking("threads")
+
+If you do, the specified checks won't report errors.
 """
-A pytest plugin to trace resource leaks.
-"""
-import collections
+from __future__ import annotations
+
 import gc
 import os
 import sys
 import threading
+import tracemalloc
+from collections import defaultdict
 from time import sleep
+from typing import Any, ClassVar
 
+import psutil
 import pytest
 
+from .comm.tcp import BaseTCPConnector
+from .compatibility import WINDOWS
 from .metrics import time
 
 
 def pytest_addoption(parser):
     group = parser.getgroup("resource leaks")
+    known_checkers = ", ".join(sorted("'%s'" % s for s in all_checkers))
     group.addoption(
         "-L",
         "--leaks",
-        action="store",
-        dest="leaks",
-        help="""\
-List of resources to monitor for leaks before and after each test.
-Can be 'all' or a comma-separated list of resource names
-(possible values: {known_checkers}).
-""".format(
-            known_checkers=", ".join(sorted("'%s'" % s for s in all_checkers))
-        ),
+        help="List of resources to monitor for leaks before and after each test. "
+        "Can be 'all' or a comma-separated list of resource names "
+        f"(possible values: {known_checkers}).",
     )
     group.addoption(
         "--leaks-timeout",
-        action="store",
         type=float,
-        dest="leaks_timeout",
         default=0.5,
-        help="""\
-Wait at most this number of seconds to mark a test leaking
-(default: %(default)s).
-""",
+        help="Wait at most these many seconds before marking a test as leaking "
+        "(default: %(default)s)",
     )
     group.addoption(
         "--leaks-fail",
         action="store_true",
-        dest="leaks_mark_failed",
-        default=False,
-        help="""Mark leaked tests failed.""",
-    )
-    group.addoption(
-        "--leak-retries",
-        action="store",
-        type=int,
-        dest="leak_retries",
-        default=1,
-        help="""\
-Max number of times to retry a test when it leaks, to ignore
-warmup-related issues (default: 1).
-""",
+        help="Mark leaked tests as failed",
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config) -> None:
     leaks = config.getvalue("leaks")
-    if leaks:
-        if leaks == "all":
-            leaks = sorted(all_checkers)
-        else:
-            leaks = leaks.split(",")
-        unknown = sorted(set(leaks) - set(all_checkers))
-        if unknown:
-            raise ValueError(f"unknown resources: {unknown!r}")
+    if not leaks:
+        return
+    if leaks == "all":
+        leaks = sorted(c for c in all_checkers if c != "demo")
+    else:
+        leaks = leaks.split(",")
+    unknown = sorted(set(leaks) - set(all_checkers))
+    if unknown:
+        raise ValueError(f"unknown resources: {unknown!r}")
 
-        checkers = [all_checkers[leak]() for leak in leaks]
-        checker = LeakChecker(
-            checkers=checkers,
-            grace_delay=config.getvalue("leaks_timeout"),
-            mark_failed=config.getvalue("leaks_mark_failed"),
-            max_retries=config.getvalue("leak_retries"),
-        )
-        config.pluginmanager.register(checker, "leaks_checker")
-
-
-all_checkers = {}
+    checkers = [all_checkers[leak]() for leak in leaks]
+    checker = LeakChecker(
+        checkers=checkers,
+        grace_delay=config.getvalue("leaks_timeout"),
+        mark_failed=config.getvalue("leaks_fail"),
+    )
+    config.pluginmanager.register(checker, "leaks_checker")
 
 
-def register_checker(name):
-    def decorate(cls):
-        assert issubclass(cls, ResourceChecker), cls
-        assert name not in all_checkers
-        all_checkers[name] = cls
-        return cls
-
-    return decorate
+all_checkers: dict[str, type[ResourceChecker]] = {}
 
 
 class ResourceChecker:
-    def on_start_test(self):
+    name: ClassVar[str]
+
+    def __init_subclass__(cls, name: str):
+        assert name not in all_checkers
+        cls.name = name
+        all_checkers[name] = cls
+
+    def on_start_test(self) -> None:
         pass
 
-    def on_stop_test(self):
+    def on_stop_test(self) -> None:
         pass
 
-    def on_retry(self):
+    def on_retry(self) -> None:
         pass
 
-    def measure(self):
+    def measure(self) -> Any:
         raise NotImplementedError
 
-    def has_leak(self, before, after):
+    def has_leak(self, before: Any, after: Any) -> bool:
         raise NotImplementedError
 
-    def format(self, before, after):
+    def format(self, before: Any, after: Any) -> str:
         raise NotImplementedError
 
 
-@register_checker("fds")
-class FDChecker(ResourceChecker):
-    def measure(self):
-        if os.name == "posix":
-            import psutil
+class DemoChecker(ResourceChecker, name="demo"):
+    """Checker that always leaks. Used to test the core LeakChecker functionality."""
 
-            return psutil.Process().num_fds()
-        else:
-            return 0
+    i: int
 
-    def has_leak(self, before, after):
+    def __init__(self):
+        self.i = 0
+
+    def measure(self) -> int:
+        self.i += 1
+        return self.i
+
+    def has_leak(self, before: int, after: int) -> bool:
         return after > before
 
-    def format(self, before, after):
-        return "leaked %d file descriptor(s)" % (after - before)
+    def format(self, before: int, after: int) -> str:
+        return f"Counter increased from {before} to {after}"
 
 
-@register_checker("memory")
-class RSSMemoryChecker(ResourceChecker):
-    def measure(self):
-        import psutil
+class FDChecker(ResourceChecker, name="fds"):
+    def __init__(self):
+        BaseTCPConnector.warmup()
 
+    def measure(self) -> int:
+        if WINDOWS:
+            return 0
+        return psutil.Process().num_fds()
+
+    def has_leak(self, before: int, after: int) -> bool:
+        return after > before
+
+    def format(self, before: int, after: int) -> str:
+        return f"leaked {after - before} file descriptor(s)"
+
+
+class RSSMemoryChecker(ResourceChecker, name="memory"):
+    LEAK_THRESHOLD = 10 * 2 ** 20
+
+    def measure(self) -> int:
         return psutil.Process().memory_info().rss
 
-    def has_leak(self, before, after):
-        return after > before + 1e7
+    def has_leak(self, before: int, after: int) -> bool:
+        return after > before + self.LEAK_THRESHOLD
 
-    def format(self, before, after):
-        return "leaked %d MB of RSS memory" % ((after - before) / 1e6)
+    def format(self, before: int, after: int) -> str:
+        return f"leaked {(after - before) / 2**20:.1f} MiB of RSS memory"
 
 
-@register_checker("threads")
-class ActiveThreadsChecker(ResourceChecker):
-    def measure(self):
+class ActiveThreadsChecker(ResourceChecker, name="threads"):
+    def __init__(self):
+        BaseTCPConnector.warmup()
+
+    def measure(self) -> set[threading.Thread]:
         return set(threading.enumerate())
 
-    def has_leak(self, before, after):
+    def has_leak(
+        self, before: set[threading.Thread], after: set[threading.Thread]
+    ) -> bool:
         return not after <= before
 
-    def format(self, before, after):
+    def format(
+        self, before: set[threading.Thread], after: set[threading.Thread]
+    ) -> str:
         leaked = after - before
         assert leaked
-        return "leaked %d Python threads: %s" % (len(leaked), sorted(leaked, key=str))
+        return f"leaked {len(leaked)} Python threads: {sorted(leaked, key=str)}"
 
 
-class _ChildProcess(
-    collections.namedtuple("_ChildProcess", ("pid", "name", "cmdline"))
-):
-    @classmethod
-    def from_process(cls, p):
-        return cls(p.pid, p.name(), p.cmdline())
+class ChildProcess:
+    """Child process info
+
+    We use pid and creation time as keys to disambiguate between processes (and protect
+    against pid reuse); other properties such as cmdline may change for a given process
+    """
+
+    pid: int
+    name: str
+    cmdline: list[str]
+    create_time: float
+
+    def __init__(self, p: psutil.Process):
+        self.pid = p.pid
+        self.name = p.name()
+        self.cmdline = p.cmdline()
+        self.create_time = p.create_time()
+
+    def __hash__(self) -> int:
+        return self.pid
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, ChildProcess)
+            and self.pid == other.pid
+            and self.create_time == other.create_time
+        )
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, ChildProcess):
+            raise TypeError(other)
+        return self.pid < other.pid
 
 
-@register_checker("processes")
-class ChildProcessesChecker(ResourceChecker):
-    def measure(self):
-        import psutil
-
-        # We use pid and creation time as keys to disambiguate between
-        # processes (and protect against pid reuse)
-        # Other properties such as cmdline may change for a given process
-        children = {}
+class ChildProcessesChecker(ResourceChecker, name="processes"):
+    def measure(self) -> set[ChildProcess]:
+        children = set()
         p = psutil.Process()
         for c in p.children(recursive=True):
             try:
                 with c.oneshot():
-                    if c.ppid() == p.pid and os.path.samefile(c.exe(), sys.executable):
-                        cmdline = c.cmdline()
-                        if any(
+                    if (
+                        c.ppid() == p.pid
+                        and os.path.samefile(c.exe(), sys.executable)
+                        and any(
+                            # Skip multiprocessing resource tracker
                             a.startswith(
-                                "from multiprocessing.semaphore_tracker import main"
+                                "from multiprocessing.resource_tracker import main"
                             )
-                            for a in cmdline
-                        ):
-                            # Skip multiprocessing semaphore tracker
-                            continue
-                        if any(
-                            a.startswith("from multiprocessing.forkserver import main")
-                            for a in cmdline
-                        ):
-                            # Skip forkserver process, the forkserver's children
+                            # Skip forkserver process; the forkserver's children
                             # however will be recorded normally
-                            continue
-                    children[(c.pid, c.create_time())] = _ChildProcess.from_process(c)
+                            or a.startswith(
+                                "from multiprocessing.forkserver import main"
+                            )
+                            for a in c.cmdline()
+                        )
+                    ):
+                        continue
+
+                    children.add(ChildProcess(c))
             except psutil.NoSuchProcess:
                 pass
         return children
 
-    def has_leak(self, before, after):
-        return not set(after) <= set(before)
+    def has_leak(self, before: set[ChildProcess], after: set[ChildProcess]) -> bool:
+        return not after <= before
 
-    def format(self, before, after):
-        leaked = set(after) - set(before)
+    def format(self, before: set[ChildProcess], after: set[ChildProcess]) -> str:
+        leaked = sorted(after - before)
         assert leaked
-        formatted = []
-        for key in sorted(leaked):
-            p = after[key]
-            formatted.append(
-                "  - pid={p.pid}, name={p.name!r}, cmdline={p.cmdline!r}".format(p=p)
-            )
-        return "leaked %d processes:\n%s" % (len(leaked), "\n".join(formatted))
+        return f"leaked {len(leaked)} processes:\n" + "\n".join(
+            f"  - pid={p.pid}, name={p.name!r}, cmdline={p.cmdline!r}" for p in leaked
+        )
 
 
-@register_checker("tracemalloc")
-class TracemallocMemoryChecker(ResourceChecker):
-    def __init__(self):
-        global tracemalloc
-        import tracemalloc
+class TracemallocMemoryChecker(ResourceChecker, name="tracemalloc"):
+    # Report a leak if the traced memory increased by at least this many bytes
+    LEAK_THRESHOLD = 2 ** 20
+    # Report at most this many leaks
+    NDIFF = 5
+    # Report less than NDIFF leaks if they amount to less than this many bytes
+    MIN_SIZE_DIFF = 200 * 1024
 
-    def on_start_test(self):
+    def on_start_test(self) -> None:
         tracemalloc.start(1)
 
-    def on_stop_test(self):
+    def on_stop_test(self) -> None:
         tracemalloc.stop()
 
-    def measure(self):
-        import tracemalloc
-
-        current, peak = tracemalloc.get_traced_memory()
+    def measure(self) -> tuple[int, tracemalloc.Snapshot]:
+        current, _ = tracemalloc.get_traced_memory()
         snap = tracemalloc.take_snapshot()
         return current, snap
 
-    def has_leak(self, before, after):
-        return after[0] > before[0] + 1e6
+    def has_leak(
+        self,
+        before: tuple[int, tracemalloc.Snapshot],
+        after: tuple[int, tracemalloc.Snapshot],
+    ):
+        return after[0] > before[0] + self.LEAK_THRESHOLD
 
-    def format(self, before, after):
+    def format(
+        self,
+        before: tuple[int, tracemalloc.Snapshot],
+        after: tuple[int, tracemalloc.Snapshot],
+    ) -> str:
         bytes_before, snap_before = before
         bytes_after, snap_after = after
         diff = snap_after.compare_to(snap_before, "traceback")
-        ndiff = 5
-        min_size_diff = 2e5
 
-        lines = []
-        lines += [
-            "leaked %.1f MB of traced Python memory"
-            % ((bytes_after - bytes_before) / 1e6)
+        lines = [
+            "leaked {:.1f} MiB of traced Python memory".format(
+                (bytes_after - bytes_before) / 2 ** 20
+            )
         ]
-        for stat in diff[:ndiff]:
+        for stat in diff[: self.NDIFF]:
             size_diff = stat.size_diff or stat.size
-            if size_diff < min_size_diff:
+            if size_diff < self.MIN_SIZE_DIFF:
                 break
             count = stat.count_diff or stat.count
-            lines += ["  - leaked %.1f MB in %d calls at:" % (size_diff / 1e6, count)]
+            lines += [f"  - leaked {size_diff / 2**20:.1f} MiB in {count} calls at:"]
             lines += ["    " + line for line in stat.traceback.format()]
 
         return "\n".join(lines)
 
 
 class LeakChecker:
-    def __init__(self, checkers, grace_delay, mark_failed, max_retries):
+    checkers: list[ResourceChecker]
+    grace_delay: float
+    mark_failed: bool
+
+    # {nodeid: {checkers}}
+    skip_checkers: dict[str, set[ResourceChecker]]
+    # {nodeid: {checker: [(before, after)]}}
+    counters: dict[str, dict[ResourceChecker, list[tuple[Any, Any]]]]
+    # {nodeid: [(checker, before, after)]}
+    leaks: dict[str, list[tuple[ResourceChecker, Any, Any]]]
+    # {nodeid: {outcomes}}
+    outcomes: defaultdict[str, set[str]]
+
+    def __init__(
+        self,
+        checkers: list[ResourceChecker],
+        grace_delay: float,
+        mark_failed: bool,
+    ):
         self.checkers = checkers
         self.grace_delay = grace_delay
         self.mark_failed = mark_failed
-        self.max_retries = max_retries
 
-        # {nodeid: {checkers}}
         self.skip_checkers = {}
-        # {nodeid: {checker: [(before, after)]}}
         self.counters = {}
-        # {nodeid: [(checker, before, after)]}
         self.leaks = {}
-        # {nodeid: {outcomes}}
-        self.outcomes = collections.defaultdict(set)
+        self.outcomes = defaultdict(set)
 
-        # Reentrancy guard
-        self._retrying = False
-
-    def cleanup(self):
+    def cleanup(self) -> None:
         gc.collect()
 
-    def checks_for_item(self, nodeid):
+    def checks_for_item(self, nodeid: str) -> list[ResourceChecker]:
         return [c for c in self.checkers if c not in self.skip_checkers.get(nodeid, ())]
 
-    def measure(self, nodeid):
+    def measure(self, nodeid: str) -> list[tuple[ResourceChecker, Any]]:
         # Return items in order
         return [(c, c.measure()) for c in self.checks_for_item(nodeid)]
 
-    def measure_before_test(self, nodeid):
+    def measure_before_test(self, nodeid: str) -> None:
         for checker in self.checks_for_item(nodeid):
             checker.on_start_test()
         for checker, before in self.measure(nodeid):
             assert before is not None
             self.counters[nodeid][checker].append((before, None))
 
-    def measure_after_test(self, nodeid):
+    def measure_after_test(self, nodeid: str) -> None:
         outcomes = self.outcomes[nodeid]
-        assert outcomes
-        if outcomes != {"passed"}:
+        # pytest_rerunfailures (@pytest.mark.flaky) breaks this plugin and causes
+        # outcomes to be empty.
+        if "passed" not in outcomes:
             # Test failed or skipped
             return
 
-        def run_measurements():
+        def run_measurements() -> list[tuple[ResourceChecker, Any, Any]]:
             leaks = []
             for checker, after in self.measure(nodeid):
-                assert after is not None
                 c = self.counters[nodeid][checker]
                 before, _ = c[-1]
                 c[-1] = (before, after)
@@ -339,34 +391,6 @@ class LeakChecker:
         for checker in self.checks_for_item(nodeid):
             checker.on_stop_test()
 
-    def maybe_retry(self, item, nextitem=None):
-        def run_test_again():
-            # This invokes our setup/teardown hooks again
-            # Inspired by https://pypi.python.org/pypi/pytest-rerunfailures
-            from _pytest.runner import runtestprotocol
-
-            item._initrequest()  # Re-init fixtures
-            runtestprotocol(item, nextitem=nextitem, log=False)
-
-        nodeid = item.nodeid
-        leaks = self.leaks.get(nodeid)
-        if leaks:
-            self._retrying = True
-            try:
-                for i in range(self.max_retries):
-                    run_test_again()
-            except Exception:
-                print("--- Exception when re-running test ---")
-                import traceback
-
-                traceback.print_exc()
-            else:
-                leaks = self.leaks.get(nodeid)
-            finally:
-                self._retrying = False
-
-        return leaks
-
     # Note on hook execution order:
     #   pytest_runtest_protocol
     #       pytest_runtest_setup
@@ -380,22 +404,25 @@ class LeakChecker:
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_protocol(self, item, nextitem):
-        if not self._retrying:
-            nodeid = item.nodeid
-            assert nodeid not in self.counters
-            self.counters[nodeid] = {c: [] for c in self.checkers}
+        if not self.checkers:
+            return
 
-            leaking = item.get_marker("leaking")
-            if leaking is not None:
-                unknown = sorted(set(leaking.args) - set(all_checkers))
-                if unknown:
-                    raise ValueError(
-                        f"pytest.mark.leaking: unknown resources {unknown!r}"
-                    )
-                classes = tuple(all_checkers[a] for a in leaking.args)
-                self.skip_checkers[nodeid] = {
-                    c for c in self.checkers if isinstance(c, classes)
-                }
+        nodeid = item.nodeid
+        assert nodeid not in self.counters
+        self.counters[nodeid] = {c: [] for c in self.checkers}
+
+        leaking_mark = item.get_closest_marker("leaking")
+        if leaking_mark:
+            unknown = sorted(set(leaking_mark.args) - set(all_checkers))
+            if unknown:
+                raise ValueError(
+                    f"pytest.mark.leaking: unknown resources {unknown}; "
+                    f"must be one of {list(all_checkers)}"
+                )
+            classes = tuple(all_checkers[a] for a in leaking_mark.args)
+            self.skip_checkers[nodeid] = {
+                c for c in self.checkers if isinstance(c, classes)
+            }
 
         yield
 
@@ -408,34 +435,31 @@ class LeakChecker:
     def pytest_runtest_teardown(self, item):
         yield
         self.measure_after_test(item.nodeid)
-        if not self._retrying:
-            leaks = self.maybe_retry(item)
-            if leaks and self.mark_failed:
-                # Trigger fail here to allow stopping with `-x`
-                pytest.fail()
+        leaks = self.leaks.get(item.nodeid)
+        if leaks and self.mark_failed:
+            # Trigger fail here to allow stopping with `-x`
+            pytest.fail()
 
     @pytest.hookimpl(hookwrapper=True, trylast=True)
     def pytest_report_teststatus(self, report):
         nodeid = report.nodeid
-        outcomes = self.outcomes[nodeid]
-        outcomes.add(report.outcome)
+        self.outcomes[nodeid].add(report.outcome)
         outcome = yield
-        if not self._retrying:
-            if report.when == "teardown":
-                leaks = self.leaks.get(report.nodeid)
-                if leaks:
-                    if self.mark_failed:
-                        outcome.force_result(("failed", "L", "LEAKED"))
-                        report.outcome = "failed"
-                        report.longrepr = "\n".join(
-                            [
-                                f"{nodeid} {checker.format(before, after)}"
-                                for checker, before, after in leaks
-                            ]
-                        )
-                    else:
-                        outcome.force_result(("leaked", "L", "LEAKED"))
-                # XXX should we log retried tests
+        if report.when == "teardown":
+            leaks = self.leaks.get(report.nodeid)
+            if leaks:
+                if self.mark_failed:
+                    outcome.force_result(("failed", "L", "LEAKED"))
+                    report.outcome = "failed"
+                    report.longrepr = "\n".join(
+                        [
+                            f"{nodeid} leaking {checker.name}: "
+                            f"{checker.format(before, after)}"
+                            for checker, before, after in leaks
+                        ]
+                    )
+                else:
+                    outcome.force_result(("leaked", "L", "LEAKED"))
 
     @pytest.hookimpl
     def pytest_terminal_summary(self, terminalreporter, exitstatus):
@@ -448,4 +472,7 @@ class LeakChecker:
             for rep in leaked:
                 nodeid = rep.nodeid
                 for checker, before, after in self.leaks[nodeid]:
-                    tr.line(f"{rep.nodeid} {checker.format(before, after)}")
+                    tr.line(
+                        f"{rep.nodeid} leaking {checker.name}: "
+                        f"{checker.format(before, after)}"
+                    )

--- a/distributed/pytest_resourceleaks.py
+++ b/distributed/pytest_resourceleaks.py
@@ -161,17 +161,16 @@ class FDChecker(ResourceChecker, name="fds"):
         BaseTCPConnector.warmup()
 
     def measure(self) -> int:
-        proc = psutil.Process()
-        return proc.num_handles() if WINDOWS else proc.num_fds()  # type: ignore
+        if WINDOWS:
+            # Don't use num_handles(); you'll get tens of thousands of reported leaks
+            return 0
+        return psutil.Process().num_fds()
 
     def has_leak(self, before: int, after: int) -> bool:
         return after > before
 
     def format(self, before: int, after: int) -> str:
-        return (
-            f"leaked {after - before} {'handle' if WINDOWS else 'file descriptor'}(s) "
-            f"({before}->{after})"
-        )
+        return f"leaked {after - before} file descriptor(s) ({before}->{after})"
 
 
 class RSSMemoryChecker(ResourceChecker, name="memory"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ markers =
     avoid_ci: marks tests as flaky or broken on CI on all OSs
     ipython: marks tests as exercising IPython
     gpu: marks tests we want to run on GPUs
+    leaking: ignore leaked resources; see pytest_resourceleaks.py for usage
 
 # pytest-timeout settings
 # 'thread' kills off the whole test suite. 'signal' only kills the offending test.


### PR DESCRIPTION
Closes #5760 

The pytest_resourceleaks plugin has been dormant since @pitrou wrote it in 2017.
This PR refreshes the code, updating it to the latest pytest and python APIs, and enables some checks in CI.

# Known issues
- I couldn't figure out a straightforward way to write automated unit tests. I tested it by hand on a Linux box.
- Making the ``--leak-reruns=1`` option work requires pytest-fu skills beyond my own. There's an example in the [pytest_rerunfailures code](https://github.com/pytest-dev/pytest-rerunfailures/blob/master/pytest_rerunfailures.py#L467) but I could not adapt it. So I was forced to remove the feature completely. This means that a test like this:
```python
def test1():
    pytest.importorskip("jsonschema")
```
will be reported to leak 10 MiB of RAM according to the ``memory`` check (based on psutil) and 4 MiB according to the ``tracemalloc`` check, even with reruns enabled. This makes these two checks impossible to enable without generating a huge amount of noise.
- Speaking of pytest_rerunfailures, the ``@pytest.mark.flaky`` decorator completely disables this plugin.
- As we have already experienced during the experimentation with MALLOC_TRIM, you cannot expect the process memory to go down immediately and deterministically as soon as you garbage collect Python objects. This makes the ``memory`` check too noisy to enable.
- The ``@gen_cluster`` fixture leaks 2 fds on the first test decorated with it within a test suite; I suspect it to be caused by an incomplete warmup routine of ``distributed.comm.tcp.BaseTCPConnector``.
- Many, many tests are leaking file descriptors, processes, and threads left and right. Fixing them all looks like a daunting task and is beyond the scope of this PR.
- Because of the above, I could not enable the ``--leaks-errors`` option.
