### PR TITLE
Revert "Pin `pillow<9` to work around `torch` incompatability"

### DIFF
--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -23,7 +23,6 @@ dependencies:
   - lz4  # Only tested here
   - msgpack-python
   - netcdf4
-  - pillow<9.0  # https://github.com/pytorch/pytorch/issues/72293
   - paramiko
   - pre-commit
   - prometheus_client


### PR DESCRIPTION
Reverts dask/distributed#5755
fixes #5754

should be fixed by https://github.com/conda-forge/pillow-feedstock/pull/107/