### PR TITLE
Fix longitudinal report

### DIFF
--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import io
 import os
 import re
@@ -137,7 +138,7 @@ def dataframe_from_jxml(run):
             else:
                 s = "x"
             status.append(s)
-            message.append(m)
+            message.append(html.escape(m))
     df = pandas.DataFrame(
         {"file": fname, "test": tname, "status": status, "message": message}
     )

--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
         for w in workflows
         if (
             pandas.to_datetime(w["created_at"])
-            > pandas.Timestamp.now(tz="UTC") - pandas.Timedelta(days=90)
+            > pandas.Timestamp.now(tz="UTC") - pandas.Timedelta(days=60)
             and w["conclusion"] != "cancelled"
             and w["name"].lower() == "tests"
         )


### PR DESCRIPTION
There was some weird variation in behavior here depending on precise versions of libraries that I didn't really track down, but the heart of the issue was that, a few days ago, a test failure message included a full HTML string that was not escaped, and messed up the resulting HTML document.

Fix is live on my [fork](https://ian-r-rose.github.io/distributed/test_report.html)

- [x] Closes #5761
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

