### PR TITLE
Update client.scheduler_info in wait_for_workers

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1287,6 +1287,7 @@ class Client(SyncMethodMixin):
 
     async def _wait_for_workers(self, n_workers=0, timeout=None):
         info = await self.scheduler.identity()
+        self._scheduler_identity = SchedulerInfo(info)
         if timeout:
             deadline = time() + parse_timedelta(timeout)
         else:
@@ -1299,6 +1300,7 @@ class Client(SyncMethodMixin):
                 )
             await asyncio.sleep(0.1)
             info = await self.scheduler.identity()
+            self._scheduler_identity = SchedulerInfo(info)
 
     def wait_for_workers(self, n_workers=0, timeout=None):
         """Blocking call to wait for n workers before continuing

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7436,3 +7436,10 @@ class TestClientSecurityLoader:
             with pytest.raises(ImportError, match="totally_fake_module_name_2.loader"):
                 async with Client("tls://bad-address:8888", asynchronous=True):
                     pass
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_wait_for_workers_updates_info(c, s):
+    async with Worker(s.address):
+        await c.wait_for_workers(1)
+        assert c.scheduler_info()["workers"]


### PR DESCRIPTION
Previously wait_for_workers would wait for the right number of workers,
but then the scheduler_info values were stale.  We had to wait a bit
until they updated.

But wait_for_workers gets updated info as part of it's operation.
Now we just copy this into scheduler_info as we get it.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
