### PR TITLE
Remove test_failed_worker_without_warning

### DIFF
--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -101,43 +101,6 @@ async def test_gather_then_submit_after_failed_workers(c, s, w, x, y, z):
 
 @pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
 @gen_cluster(Worker=Nanny, client=True, timeout=60)
-async def test_failed_worker_without_warning(c, s, a, b):
-    L = c.map(inc, range(10))
-    await wait(L)
-
-    original_pid = a.pid
-    with suppress(CommClosedError):
-        await c._run(os._exit, 1, workers=[a.worker_address])
-    start = time()
-    while a.pid == original_pid:
-        await asyncio.sleep(0.01)
-        assert time() - start < 10
-
-    await asyncio.sleep(0.5)
-
-    start = time()
-    while len(s.nthreads) < 2:
-        await asyncio.sleep(0.01)
-        assert time() - start < 10
-
-    await wait(L)
-
-    L2 = c.map(inc, range(10, 20))
-    await wait(L2)
-    assert all(len(keys) > 0 for keys in s.has_what.values())
-    nthreads2 = dict(s.nthreads)
-
-    await c.restart()
-
-    L = c.map(inc, range(10))
-    await wait(L)
-    assert all(len(keys) > 0 for keys in s.has_what.values())
-
-    assert not (set(nthreads2) & set(s.nthreads))  # no overlap
-
-
-@pytest.mark.xfail(COMPILED, reason="Fails with cythonized scheduler")
-@gen_cluster(Worker=Nanny, client=True, timeout=60)
 async def test_restart(c, s, a, b):
     assert s.nthreads == {a.worker_address: 1, b.worker_address: 2}
 


### PR DESCRIPTION
I noticed this test failing without reason and looked into it a bit. 

* The title says it was tested that no warning is raised in case of a failed worker. Nothing of the sort is asserted
* Instead, it tests that nannys restart workers. This is thoroughly tested in test_nanny.py
* work is somehow evenly dispatched to all new workers

especially the last condition is not necessarily true and it may be possible to have all tasks assigned to the same worker. This is what failed in CI for me, e.g. https://github.com/dask/distributed/runs/5139439263?check_suite_focus=true

I suggest to remove this test entirely