### PR TITLE
[DNM] Lower connect timeout only for local test execution

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1739,8 +1739,10 @@ def clean(threads=not WINDOWS, instances=True, timeout=1, processes=True):
                         reset_config()
 
                         if not ON_CI:
+                            # Tests should set this explicitly if they are
+                            # relying on timeouts
                             ctx = dask.config.set(
-                                {"distributed.comm.timeouts.connect": "5s"}
+                                {"distributed.comm.timeouts.connect": "300s"}
                             )
                         else:
                             ctx = nullcontext()


### PR DESCRIPTION
Not entirely sure if this is connected to our stability issues but I don't see a reason why we would want to lower the connect timeout other than decreasing test runtimes. On CI I'm not too worried about a few seconds more runtime considering this should increase test robustness.

Tests which are actively relying on this timeout to expire (e.g. dead workers are part of the test) should specifically lower this and make their intention clear.

I'm also open to removing this entirely but I could see the point of having smaller timeouts when running locally.