### PR TITLE
Increase client timeout from test_ucx_config_w_env_var

### DIFF
--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -119,7 +119,7 @@ def test_ucx_config_w_env_var(cleanup, loop):
             ],
             env=env,
         ):
-            with Client(sched_addr, loop=loop, timeout=10) as c:
+            with Client(sched_addr, loop=loop, timeout=60) as c:
                 while not c.scheduler_info()["workers"]:
                     sleep(0.1)
 


### PR DESCRIPTION
I've seen this test frequently hitting the timeout. I suggest to increase it for robustness

e.g. https://gpuci.gpuopenanalytics.com/job/dask/job/distributed/job/prb/job/distributed-prb/1476/

cc @dask/gpu 