### PR TITLE
add pragma - deploy

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -218,7 +218,7 @@ class Cluster(SyncMethodMixin):
             self.scheduler_info.update(msg)
         elif op == "remove":
             del self.scheduler_info["workers"][msg]
-        else:
+        else:  # pragma: no cover
             raise ValueError("Invalid op", op, msg)
 
     def adapt(self, Adaptive=Adaptive, **kwargs) -> Adaptive:
@@ -407,7 +407,7 @@ class Cluster(SyncMethodMixin):
                     update()
 
             scale.on_click(scale_cb)
-        else:
+        else:  # pragma: no cover
             accordion = HTML("")
 
         scale_status = HTML(self._scaling_status())

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -293,7 +293,7 @@ class SpecCluster(Cluster):
         )
         try:
             await super()._start()
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             self.status = Status.failed
             await self._close()
             raise RuntimeError(f"Cluster failed to start. {str(e)}") from e
@@ -432,7 +432,7 @@ class SpecCluster(Cluster):
 
     def _threads_per_worker(self) -> int:
         """Return the number of threads per worker for new workers"""
-        if not self.new_spec:
+        if not self.new_spec:  # pragma: no cover
             raise ValueError("To scale by cores= you must specify cores per worker")
 
         for name in ["nthreads", "ncores", "threads", "cores"]:
@@ -442,7 +442,7 @@ class SpecCluster(Cluster):
 
     def _memory_per_worker(self) -> int:
         """Return the memory limit per worker for new workers"""
-        if not self.new_spec:
+        if not self.new_spec:  # pragma: no cover
             raise ValueError(
                 "to scale by memory= your worker definition must include a "
                 "memory_limit definition"


### PR DESCRIPTION
- [ ] partially addresses #5445 for files in `distributed/deploy/`:

> Pragma no cover
> - We have cases with relatively long switch-like statements ending in a final exception, e.g. ValueError "unknown value"
> - Conditional imports may need be covered with pragma statements and/or a dedicated job