### PR TITLE
Relax `distributed` / `dask-core` dependencies for pre-releases

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          mamba install "boa<9" conda-verify
+          mamba install boa conda-verify
 
           which python
           pip list

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          mamba install boa conda-verify
+          mamba install "boa<9" conda-verify
 
           which python
           pip list

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python >=3.7
   run:
     - python >=3.7
-    - dask-core >={{ dask_version }}={{ dask_build }}
+    - dask-core >={{ dask_version }}
     - distributed {{ version }}=*_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
     - cytoolz >=0.8.2
     - numpy >=1.18

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   noarch: python
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.7
     - dask-core {{ dask_version }}={{ dask_build }}
-    - distributed {{ version }}=py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+    - distributed {{ version }}=*_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
     - cytoolz >=0.8.2
     - numpy >=1.18
     - pandas >=1.0

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python >=3.7
   run:
     - python >=3.7
-    - dask-core {{ dask_version }}={{ dask_build }}
+    - dask-core >={{ dask_version }}={{ dask_build }}
     - distributed {{ version }}=*_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
     - cytoolz >=0.8.2
     - numpy >=1.18

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - dask-core {{ dask_version }}={{ dask_build }}
     - jinja2
     - msgpack-python >=0.6.0
+    - packaging >=20.0
     - psutil >=5.0
     - pyyaml
     - sortedcontainers !=2.0.0,!=2.0.1
@@ -43,7 +44,7 @@ requirements:
     - tornado >=5  # [py<38]
     - tornado >=6.0.3  # [py>=38]
     - zict >=0.1.3
-    - setuptools
+    - setuptools <60.0.0
 
   run_constrained:
     - openssl !=1.1.1e

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core >={{ dask_version }}={{ dask_build }}
+    - dask-core >={{ dask_version }}
     - jinja2
     - msgpack-python >=0.6.0
     - packaging >=20.0

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core {{ dask_version }}={{ dask_build }}
+    - dask-core >={{ dask_version }}={{ dask_build }}
     - jinja2
     - msgpack-python >=0.6.0
     - packaging >=20.0


### PR DESCRIPTION
This PR does the following:

- Removes the python version constraint of `dask` pre-release packages' `distributed` dependency; this allows the following to work as it should:

```
conda create -n test dask/label/dev::dask python=3.9
```

- Makes the `dask-core` dependency for `distributed` and `dask` pre-releases a min version constraint instead of a pinning; this isn't ideal, but make it so running `conda install dask/label/dev::dask` should always collect the latest `dask-core` / `distributed` pre-release packages

- Bumps the `distributed` recipe to match up with the changes made in https://github.com/conda-forge/distributed-feedstock/pull/194.

cc @jakirkham @galipremsagar 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
