### PR TITLE
 Bump pre-release version to be greater than stable releases

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -39,11 +39,6 @@ jobs:
           mamba list
       - name: Build conda packages
         run: |
-          # compute pre-release package versions (current dask version with patch version bumped)
-          IFS='.' read -ra arr <<< `git describe --tags | awk '{split($0,a,"-"); print a[1]}'`
-          declare -i patch=${arr[-1]}+1
-          export VERSION=${arr[0]}.${arr[1]}.$patch
-
           # suffix for pre-release package versions
           export VERSION_SUFFIX=a`date +%y%m%d`
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -41,8 +41,8 @@ jobs:
         run: |
           # compute pre-release package versions (current dask version with patch version bumped)
           IFS='.' read -ra arr <<< `git describe --tags | awk '{split($0,a,"-"); print a[1]}'`
-          declare -i v=${arr[-1]}+1
-          export VERSION=${arr[0]}.${arr[1]}.$v
+          declare -i patch=${arr[-1]}+1
+          export VERSION=${arr[0]}.${arr[1]}.$patch
 
           # suffix for pre-release package versions
           export VERSION_SUFFIX=a`date +%y%m%d`

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -39,6 +39,11 @@ jobs:
           mamba list
       - name: Build conda packages
         run: |
+          # compute pre-release package versions (current dask version with patch version bumped)
+          IFS='.' read -ra arr <<< `git describe --tags | awk '{split($0,a,"-"); print a[1]}'`
+          declare -i v=${arr[-1]}+1
+          export VERSION=${arr[0]}.${arr[1]}.$v
+
           # suffix for pre-release package versions
           export VERSION_SUFFIX=a`date +%y%m%d`
 
@@ -46,8 +51,7 @@ jobs:
           arr=($(conda search --override-channels -c dask/label/dev dask-core | tail -n 1))
 
           # extract dask-core pre-release version / build
-          export DASK_VERSION=${arr[1]}
-          export DASK_BUILD=${arr[2]}
+          export DASK_CORE_VERSION=${arr[1]}
 
           # distributed pre-release build
           conda mambabuild continuous_integration/recipes/distributed \

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -1,4 +1,6 @@
-{% set version = environ.get('VERSION', '0.0.0.dev') + environ.get('VERSION_SUFFIX', '') %}
+{% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
+{% set new_patch = major_minor_patch[2] | int + 1 %}
+{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
 
 

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -1,7 +1,5 @@
-{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev') + environ.get('VERSION_SUFFIX', '') %}
-{% set dask_version = environ.get('DASK_VERSION', '0.0.0.dev') %}
-{% set dask_build = environ.get('DASK_BUILD', '') %}
-{% set py_version=environ.get('CONDA_PY', 36) %}
+{% set version = environ.get('VERSION', '0.0.0.dev') + environ.get('VERSION_SUFFIX', '') %}
+{% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
 
 
 package:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -1,4 +1,6 @@
-{% set version = environ.get('VERSION', '0.0.0.dev') + environ.get('VERSION_SUFFIX', '') %}
+{% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
+{% set new_patch = major_minor_patch[2] | int + 1 %}
+{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
 
 

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -1,6 +1,5 @@
-{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev') + environ.get('VERSION_SUFFIX', '') %}
-{% set dask_version = environ.get('DASK_VERSION', '0.0.0.dev') %}
-{% set dask_build = environ.get('DASK_BUILD', '') %}
+{% set version = environ.get('VERSION', '0.0.0.dev') + environ.get('VERSION_SUFFIX', '') %}
+{% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
 
 
 package:


### PR DESCRIPTION
This PR changes the version of the pre-release packages to be one patch version ahead of the latest stable release, so that conda interprets them as newer than the stable release they follow.

cc @jakirkham

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
