### PR TITLE
 log `gen_cluster` process benchmarks after each test 

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -97,9 +97,7 @@ _TEST_TIMEOUT = 30
 _offload_executor.submit(lambda: None).result()  # create thread during import
 
 
-@pytest.fixture(autouse=True)
-def log_process_info():
-    yield
+def _log_process_info():
     benchmarks = [
         "cpu_percent",
         "memory_percent",
@@ -165,6 +163,8 @@ def log_process_info():
 
     def print_tree(benchmark, tree, max_depth=20, indent=""):
         if max_depth <= 0:
+            if tree:
+                print(f"{indent}...")
             return
 
         for i, proc in enumerate(
@@ -1074,6 +1074,7 @@ def gen_cluster(
                                 workers[:] = ws
                                 args = [s] + workers
                                 break
+                        _log_process_info()
                         if s is False:
                             raise Exception("Could not start cluster")
                         if client:
@@ -1137,6 +1138,7 @@ def gen_cluster(
                             raise
 
                         finally:
+                            _log_process_info()
                             if client and c.status not in ("closing", "closed"):
                                 await c._close(fast=s.status == Status.closed)
                             await end_cluster(s, workers)


### PR DESCRIPTION
- [x] Closes #5763
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`


failed tests show a benchmark report:

```
===== cpu_percent =====
102.60000000000001: 0 kernel_task  root
  102.60000000000001: 1 launchd <no cmdline> root
    101.4: 403 bash /bin/bash /usr/local/opt/runner/runprovisioner.sh runner
      101.4: 621 provisioner /usr/local/opt/runner/provisioner/provisioner runner
        101.4: 690 Runner.Listener /Users/runner/runners/2.287.1/bin/Runner.Listener run runner
          101.4: 694 Runner.Worker /Users/runner/runners/2.287.1/bin/Runner.Worker spawnclient 112 116 runner
            98.0: 3181 bash /bin/bash -l /Users/runner/work/_temp/11f5fe87-5e11-4e16-a4aa-7a4c5bd0bd9c.sh runner
              98.0: 3204 python3.8 /Users/runner/miniconda3/envs/dask-distributed/bin/python /Users/runner/miniconda3/envs/dask-distributed/bin/pytest distributed -s -m 'not avoid_ci and ci1' --runslow --leaks=fds,processes,threads --junitxml reports/pytest.xml -o junit_suite_name=macos-latest-3.8-ci1 --cov=distributed --cov-report=xml runner
    0.9: 2556 photoanalysisd /System/Library/PrivateFrameworks/PhotoAnalysis.framework/Versions/A/Support/photoanalysisd runner
    0.2: 343 Finder /System/Library/CoreServices/Finder.app/Contents/MacOS/Finder runner
    0.1: 422 vmware-tools-daemon '/Library/Application Support/VMware Tools/vmware-tools-daemon' --name vmusr --common-path '/Library/Application Support/VMware Tools/Plugins/Common' --plugin-path '/Library/Application Support/VMware Tools/Plugins/User' runner
    0: 54 syslogd <no cmdline> root
    ...
===== memory_percent =====
17.74768829345704: 0 kernel_task  root
  17.74768829345704: 1 launchd <no cmdline> root
    2.619252886090959: 403 bash /bin/bash /usr/local/opt/runner/runprovisioner.sh runner
      2.5965009416852673: 621 provisioner /usr/local/opt/runner/provisioner/provisioner runner
        2.192606244768415: 690 Runner.Listener /Users/runner/runners/2.287.1/bin/Runner.Listener run runner
          1.8006461007254462: 694 Runner.Worker /Users/runner/runners/2.287.1/bin/Runner.Worker spawnclient 112 116 runner
            1.3457706996372767: 3181 bash /bin/bash -l /Users/runner/work/_temp/11f5fe87-5e11-4e16-a4aa-7a4c5bd0bd9c.sh runner
              1.337160382952009: 3204 python3.8 /Users/runner/miniconda3/envs/dask-distributed/bin/python /Users/runner/miniconda3/envs/dask-distributed/bin/pytest distributed -s -m 'not avoid_ci and ci1' --runslow --leaks=fds,processes,threads --junitxml reports/pytest.xml -o junit_suite_name=macos-latest-3.8-ci1 --cov=distributed --cov-report=xml runner
    0.4530225481305804: 438 NewsToday2 /System/Applications/News.app/Contents/PlugIns/NewsToday2.appex/Contents/MacOS/NewsToday2 runner
    0.3829683576311384: 440 StocksWidget /System/Applications/Stocks.app/Contents/PlugIns/StocksWidget.appex/Contents/MacOS/StocksWidget runner
    0.3735406058175223: 447 UIKitSystem /System/Library/CoreServices/UIKitSystem.app/Contents/MacOS/UIKitSystem system_app_start runner
    0.35046168736049105: 437 WeatherWidget /System/Library/CoreServices/ClimateProxy.app/Contents/PlugIns/WeatherWidget.appex/Contents/MacOS/WeatherWidget runner
    ...
===== num_fds =====
1985: 0 kernel_task  root
  1985: 1 launchd <no cmdline> root
    454: 403 bash /bin/bash /usr/local/opt/runner/runprovisioner.sh runner
      450: 621 provisioner /usr/local/opt/runner/provisioner/provisioner runner
        302: 690 Runner.Listener /Users/runner/runners/2.287.1/bin/Runner.Listener run runner
          185: 694 Runner.Worker /Users/runner/runners/2.287.1/bin/Runner.Worker spawnclient 112 116 runner
            55: 3181 bash /bin/bash -l /Users/runner/work/_temp/11f5fe87-5e11-4e16-a4aa-7a4c5bd0bd9c.sh runner
              45: 3204 python3.8 /Users/runner/miniconda3/envs/dask-distributed/bin/python /Users/runner/miniconda3/envs/dask-distributed/bin/pytest distributed -s -m 'not avoid_ci and ci1' --runslow --leaks=fds,processes,threads --junitxml reports/pytest.xml -o junit_suite_name=macos-latest-3.8-ci1 --cov=distributed --cov-report=xml runner
    207: 334 UserEventAgent /usr/libexec/UserEventAgent '(Aqua)' runner
    135: 389 cloudd /System/Library/PrivateFrameworks/CloudKitDaemon.framework/Support/cloudd runner
    48: 354 fontd /System/Library/Frameworks/ApplicationServices.framework/Frameworks/ATS.framework/Support/fontd runner
    39: 999 suggestd /System/Library/PrivateFrameworks/CoreSuggestions.framework/Versions/A/Support/suggestd runner
    ...
```
