### PR TITLE
lazily get dask version information

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,10 +1,12 @@
 from . import config  # isort:skip; load distributed configuration first
 from . import widgets  # isort:skip; load distributed widgets second
+
+
 import dask
 from dask.config import config  # type: ignore
 
 from ._version import get_versions
-from .actor import Actor, BaseActorFuture
+from .actor import Actor, ActorFuture, BaseActorFuture
 from .client import (
     Client,
     CompatibleExecutor,
@@ -46,7 +48,20 @@ from .variable import Variable
 from .worker import Reschedule, Worker, get_client, get_worker, print, secede, warn
 from .worker_client import local_client, worker_client
 
-versions = get_versions()
-__version__ = versions["version"]
-__git_revision__ = versions["full-revisionid"]
-del get_versions, versions
+
+def __getattr__(name):
+    global __version__, __git_revision__
+
+    if name == "__version__":
+        from importlib.metadata import version
+
+        __version__ = version("distributed")
+        return __version__
+
+    if name == "__git_revision__":
+        from ._version import get_versions
+
+        __git_revision__ = get_versions()["full-revisionid"]
+        return __git_revision__
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/distributed/tests/test_init.py
+++ b/distributed/tests/test_init.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import importlib.metadata
+
+import distributed
+
+
+def test_version() -> None:
+    assert distributed.__version__ == importlib.metadata.version("distributed")
+
+
+def test_git_revision() -> None:
+    assert isinstance(distributed.__git_revision__, str)


### PR DESCRIPTION
this uses "importlib.metadata:version" - for __version__ which is much faster than git

- [x] Closes #5700 
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
