### PR TITLE
Python 3.8 f-strings

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -9,10 +9,11 @@ import traceback
 import uuid
 import weakref
 from collections import defaultdict
+from collections.abc import Container
 from contextlib import suppress
 from enum import Enum
 from functools import partial
-from typing import ClassVar, Container
+from typing import ClassVar
 
 import tblib
 from tlz import merge

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -17,6 +17,7 @@ from collections import defaultdict, deque
 from collections.abc import (
     Callable,
     Collection,
+    Container,
     Hashable,
     Iterable,
     Iterator,
@@ -27,7 +28,7 @@ from contextlib import suppress
 from datetime import timedelta
 from functools import partial
 from numbers import Number
-from typing import ClassVar, Container, Literal
+from typing import ClassVar, Literal
 from typing import cast as pep484_cast
 
 import psutil

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -208,8 +208,9 @@ class SemaphoreExtension:
                 self._release_value(name, lease_id)
             else:
                 logger.warning(
-                    f"Tried to release semaphore but it was already released: "
-                    f"name={name}, lease_id={lease_id}. This can happen if the semaphore timed out before."
+                    "Tried to release semaphore but it was already released: "
+                    f"{name=}, {lease_id=}. "
+                    "This can happen if the semaphore timed out before."
                 )
 
     def _release_value(self, name, lease_id):

--- a/distributed/spill.py
+++ b/distributed/spill.py
@@ -5,13 +5,10 @@ import time
 from collections.abc import Mapping
 from contextlib import contextmanager
 from functools import partial
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import zict
 from packaging.version import parse as parse_version
-
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
 from .protocol import deserialize_bytes, serialize_bytelist
 from .sizeof import safe_sizeof

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -4,9 +4,9 @@ import asyncio
 import logging
 import uuid
 from collections import defaultdict, deque
+from collections.abc import Container
 from math import log2
 from time import time
-from typing import Container
 
 from tlz import topk
 from tornado.ioloop import PeriodicCallback

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2575,7 +2575,7 @@ async def test_memory(c, s, *nannies):
     assert a_leak > 50 and b_leak > 50
     a_leak += 10
     b_leak += 10
-    print(f"Leaking additional memory: a_leak={a_leak}; b_leak={b_leak}")
+    print(f"Leaking additional memory: {a_leak=}; {b_leak=}")
     await wait(
         [
             c.submit(leaking, 0, a_leak, 0, pure=False, workers=[a.name]),
@@ -2734,7 +2734,7 @@ async def assert_ndata(client, by_addr, total=None):
         if total is not None:
             assert sum(out.values()) == total
     except AssertionError:
-        raise AssertionError(f"Expected {by_addr}, total={total}; got {out}")
+        raise AssertionError(f"Expected {by_addr}; {total=}; got {out}")
 
 
 @gen_cluster(

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -20,7 +20,7 @@ import weakref
 import xml.etree.ElementTree
 from asyncio import TimeoutError
 from collections import OrderedDict, UserDict, deque
-from collections.abc import KeysView, ValuesView
+from collections.abc import Container, KeysView, ValuesView
 from concurrent.futures import CancelledError, ThreadPoolExecutor  # noqa: F401
 from contextlib import contextmanager, suppress
 from contextvars import ContextVar
@@ -28,7 +28,7 @@ from hashlib import md5
 from importlib.util import cache_from_source
 from time import sleep
 from typing import Any as AnyType
-from typing import ClassVar, Container
+from typing import ClassVar
 
 import click
 import tblib.pickling_support

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1213,7 +1213,7 @@ def parse_ports(port):
             raise ValueError(
                 "When specifying a range of ports like port_start:port_stop, "
                 "port_stop must be greater than port_start, but got "
-                f"port_start={port_start} and port_stop={port_stop}"
+                f"{port_start=} and {port_stop=}"
             )
         ports = list(range(port_start, port_stop + 1))
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1900,7 +1900,7 @@ def assert_worker_story(
                     break
     except StopIteration:
         raise AssertionError(
-            f"assert_worker_story(strict={strict}) failed\n"
+            f"assert_worker_story({strict=}) failed\n"
             f"story:\n{_format_story(story)}\n"
             f"expect:\n{_format_story(expect)}"
         ) from None

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -16,6 +16,7 @@ from collections import defaultdict, deque, namedtuple
 from collections.abc import (
     Callable,
     Collection,
+    Container,
     Iterable,
     Iterator,
     Mapping,
@@ -26,7 +27,7 @@ from contextlib import suppress
 from datetime import timedelta
 from inspect import isawaitable
 from pickle import PicklingError
-from typing import TYPE_CHECKING, Any, ClassVar, Container, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 if TYPE_CHECKING:
     from .diagnostics.plugin import WorkerPlugin


### PR DESCRIPTION
- Introduce compact f-string notation which requires Python 3.8+
- Clean up ``from typing import ...`` statements