### PR TITLE
Start building pre-releases with cythonized scheduler

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -52,13 +52,13 @@ jobs:
           conda mambabuild continuous_integration/recipes/distributed \
                            --channel dask/label/dev \
                            --no-anaconda-upload \
-                           --output-folder build
+                           --output-folder .
 
           # dask pre-release build
           conda mambabuild continuous_integration/recipes/dask \
                            --channel dask/label/dev \
                            --no-anaconda-upload \
-                           --output-folder build
+                           --output-folder .
       - name: Upload conda packages
         if: |
           github.event_name == 'push'
@@ -67,20 +67,8 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.DASK_CONDA_TOKEN }}
         run: |
-          # convert distributed to other architectures
-          cd build && conda convert linux-64/*.tar.bz2 -p osx-64 \
-                                                       -p osx-arm64 \
-                                                       -p linux-ppc64le \
-                                                       -p linux-aarch64 \
-                                                       -p win-64
-
           # install anaconda for upload
           mamba install anaconda-client
 
           anaconda upload --label dev noarch/*.tar.bz2
           anaconda upload --label dev linux-64/*.tar.bz2
-          anaconda upload --label dev linux-aarch64/*.tar.bz2
-          anaconda upload --label dev linux-ppc64le/*.tar.bz2
-          anaconda upload --label dev osx-64/*.tar.bz2
-          anaconda upload --label dev osx-arm64/*.tar.bz2
-          anaconda upload --label dev win-64/*.tar.bz2

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - setup.py
+      - continuous_integration/recipes/**
+      - .github/workflows/conda.yml
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.8
     - dask-core >={{ dask_version }}
-    - distributed {{ version }}=*_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+    - distributed {{ version }}=*{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}*
     - cytoolz >=0.8.2
     - numpy >=1.18
     - pandas >=1.0

--- a/continuous_integration/recipes/distributed/conda_build_config.yaml
+++ b/continuous_integration/recipes/distributed/conda_build_config.yaml
@@ -2,5 +2,5 @@ python:
     - 3.8
     - 3.9
 cython_enabled:
-    - true   # [linux]
-    - false
+    - True   # [linux]
+    - False

--- a/continuous_integration/recipes/distributed/conda_build_config.yaml
+++ b/continuous_integration/recipes/distributed/conda_build_config.yaml
@@ -1,3 +1,6 @@
 python:
     - 3.8
     - 3.9
+build_ext:
+    - "cython"
+    - "nocython"

--- a/continuous_integration/recipes/distributed/conda_build_config.yaml
+++ b/continuous_integration/recipes/distributed/conda_build_config.yaml
@@ -3,4 +3,4 @@ python:
     - 3.9
 build_ext:
     - "cython"  # [linux]
-    - "nocython"
+    - "python"

--- a/continuous_integration/recipes/distributed/conda_build_config.yaml
+++ b/continuous_integration/recipes/distributed/conda_build_config.yaml
@@ -2,5 +2,5 @@ python:
     - 3.8
     - 3.9
 cython_enabled:
-    - True   # [linux]
-    - False
+    - true   # [linux]
+    - false

--- a/continuous_integration/recipes/distributed/conda_build_config.yaml
+++ b/continuous_integration/recipes/distributed/conda_build_config.yaml
@@ -1,3 +1,6 @@
+python:
+    - 3.8
+    - 3.9
 cython_enabled:
     - True   # [linux]
     - False

--- a/continuous_integration/recipes/distributed/conda_build_config.yaml
+++ b/continuous_integration/recipes/distributed/conda_build_config.yaml
@@ -1,6 +1,6 @@
 python:
     - 3.8
     - 3.9
-build_ext:
-    - "cython"  # [linux]
-    - "python"
+cython_enabled:
+    - True   # [linux]
+    - False

--- a/continuous_integration/recipes/distributed/conda_build_config.yaml
+++ b/continuous_integration/recipes/distributed/conda_build_config.yaml
@@ -1,6 +1,3 @@
-python:
-    - 3.8
-    - 3.9
 cython_enabled:
     - True   # [linux]
     - False

--- a/continuous_integration/recipes/distributed/conda_build_config.yaml
+++ b/continuous_integration/recipes/distributed/conda_build_config.yaml
@@ -2,5 +2,5 @@ python:
     - 3.8
     - 3.9
 build_ext:
-    - "cython"
+    - "cython"  # [linux]
     - "nocython"

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -2,7 +2,8 @@
 {% set new_patch = major_minor_patch[2] | int + 1 %}
 {% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
-{% set build_ext = "cython" if cython_enabled else "python" %}
+{% set build_ext = "cython" %}  # [cython_enabled]
+{% set build_ext = "python" %}  # [not cython_enabled]
 
 
 package:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -2,9 +2,6 @@
 {% set new_patch = major_minor_patch[2] | int + 1 %}
 {% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
-
-{% set proc_version = "1.0.0" %}
-{% set proc_build_number = "0" %}
 {% set cython_enabled = build_ext == "cython" %}
 
 
@@ -20,9 +17,9 @@ build:
 
 outputs:
   - name: distributed-proc
-    version: {{ proc_version }}
+    version: {{ version }}
     build:
-      number: {{ proc_build_number }}
+      number: {{ GIT_DESCRIBE_NUMBER }}
       string: {{ build_ext }}
     test:
       commands:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -16,7 +16,7 @@ build:
   number: {{ GIT_DESCRIBE_NUMBER }}
 
 outputs:
-  - name: distributed-proc
+  - name: distributed-impl
     version: {{ version }}
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
@@ -70,7 +70,7 @@ outputs:
         - zict >=0.1.3
         - setuptools <60.0.0
       run_constrained:
-        - distributed-proc * {{ build_ext }}
+        - distributed-impl * {{ build_ext }}
         - openssl !=1.1.1e
     test:
       imports:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -17,7 +17,6 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
 
 outputs:
   - name: distributed-proc
@@ -38,6 +37,8 @@ outputs:
   - name: distributed
     version: {{ version }}
     build:
+      number: {{ GIT_DESCRIBE_NUMBER }}
+      string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
       script: python -m pip install . -vv                                           # [not cython_enabled]
       script: python -m pip install . -vv --install-option="--with-cython=profile"  # [cython_enabled]
       track_features: {{ "[cythonized-scheduler]" if cython_enabled else "" }}

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -9,7 +9,7 @@
 
 
 package:
-  name: distributed-ext
+  name: distributed-split
   version: {{ version }}
 
 source:
@@ -40,8 +40,8 @@ outputs:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
       script: python -m pip install . -vv                                           # [not cython_enabled]
-      script: python -m pip install . -vv --install-option="--with-cython=profile"  # [cython_enabled]
-      track_features: {{ "[cythonized-scheduler]" if cython_enabled else "" }}
+      script: python -m pip install . -vv --no-deps --install-option="--with-cython=profile"  # [cython_enabled]
+      track_features: {{ "cythonized-scheduler" if cython_enabled else "" }}
       entry_points:
         - dask-scheduler = distributed.cli.dask_scheduler:go
         - dask-ssh = distributed.cli.dask_ssh:go
@@ -50,7 +50,7 @@ outputs:
       build:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - compilers                              # [cython_enabled]
+        - {{ compiler('c') }}                    # [cython_enabled]
         - cython >=0.29,<0.30                    # [cython_enabled]
       host:
         - python
@@ -69,11 +69,11 @@ outputs:
         - sortedcontainers !=2.0.0,!=2.0.1
         - tblib >=1.6.0
         - toolz >=0.8.2
-        - tornado >=5  # [py<38]
-        - tornado >=6.0.3  # [py>=38]
+        - tornado >=6.0.3
         - zict >=0.1.3
         - setuptools <60.0.0
       run_constrained:
+        - distributed-proc * {{ build_ext }}
         - openssl !=1.1.1e
     test:
       imports:
@@ -88,6 +88,7 @@ outputs:
         - dask-scheduler --help
         - dask-ssh --help
         - dask-worker --help
+        - python -c "from distributed.scheduler import COMPILED; assert COMPILED is {{ cython_enabled }}"
       requires:
         - pip
     about:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -37,8 +37,8 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
-      noarch: python # [nocython]
-      script: python -m pip install . -vv                                           # [not cython_enabled]
+      noarch: python                                                                          # [not cython_enabled]
+      script: python -m pip install . -vv                                                     # [not cython_enabled]
       script: python -m pip install . -vv --no-deps --install-option="--with-cython=profile"  # [cython_enabled]
       track_features: {{ "cythonized-scheduler" if cython_enabled else "" }}
       entry_points:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -38,7 +38,7 @@ outputs:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
       noarch: python                                                                          # [build_ext == "python"]
-      script: |
+      script: >
         python -m pip install . -vv
           --no-deps
           --install-option="--with-cython=profile"  # [build_ext == "cython"]

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -21,6 +21,7 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: {{ build_ext }}
+      noarch: generic
     test:
       commands:
         - exit 0
@@ -36,6 +37,7 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
+      noarch: python # [nocython]
       script: python -m pip install . -vv                                           # [not cython_enabled]
       script: python -m pip install . -vv --no-deps --install-option="--with-cython=profile"  # [cython_enabled]
       track_features: {{ "cythonized-scheduler" if cython_enabled else "" }}
@@ -45,13 +47,11 @@ outputs:
         - dask-worker = distributed.cli.dask_worker:go
     requirements:
       build:
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - {{ compiler('c') }}                    # [cython_enabled]
-        - cython >=0.29,<0.30                    # [cython_enabled]
       host:
         - python
         - pip
+        - cython                                 # [cython_enabled]
       run:
         - python
         - click >=6.6

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -3,9 +3,13 @@
 {% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
 
+{% set proc_version = "1.0.0" %}
+{% set proc_build_number = "0" %}
+{% set cython_enabled = build_ext == "cython" %}
+
 
 package:
-  name: distributed
+  name: distributed-ext
   version: {{ version }}
 
 source:
@@ -13,69 +17,88 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-  script: {{ PYTHON }} -m pip install . -vv
-  entry_points:
-    - dask-scheduler = distributed.cli.dask_scheduler:go
-    - dask-ssh = distributed.cli.dask_ssh:go
-    - dask-worker = distributed.cli.dask_worker:go
+  string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
 
-requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-  host:
-    - python
-    - pip
+outputs:
+  - name: distributed-proc
+    version: {{ proc_version }}
+    build:
+      number: {{ proc_build_number }}
+      string: {{ build_ext }}
+    test:
+      commands:
+        - exit 0
+    about:
+      home: https://distributed.dask.org
+      summary: A meta-package to select Distributed pre-release build variant
+      license: BSD-3-Clause
+      license_family: BSD
+      license_file: LICENSE.txt
 
-  run:
-    - python
-    - click >=6.6
-    - cloudpickle >=1.5.0
-    - cytoolz >=0.8.2
-    - dask-core >={{ dask_version }}
-    - jinja2
-    - msgpack-python >=0.6.0
-    - packaging >=20.0
-    - psutil >=5.0
-    - pyyaml
-    - sortedcontainers !=2.0.0,!=2.0.1
-    - tblib >=1.6.0
-    - toolz >=0.8.2
-    - tornado >=5  # [py<38]
-    - tornado >=6.0.3  # [py>=38]
-    - zict >=0.1.3
-    - setuptools <60.0.0
-
-  run_constrained:
-    - openssl !=1.1.1e
-
-test:
-  imports:
-    - distributed
-    - distributed.cli
-    - distributed.comm
-    - distributed.deploy
-    - distributed.diagnostics
-    - distributed.protocol
-  commands:
-    - pip check
-    - dask-scheduler --help
-    - dask-ssh --help
-    - dask-worker --help
-  requires:
-    - pip
-
-about:
-  home: https://distributed.dask.org
-  summary: Distributed scheduler for Dask
-  license: BSD-3-Clause
-  license_family: BSD
-  license_file: LICENSE.txt
-  description: |
-    Distributed is a lightweight library for distributed computing in Python.
-    It extends both the concurrent.futures and dask APIs to moderate sized
-    clusters.
-  doc_url: https://distributed.dask.org
-  doc_source_url: https://github.com/dask/distributed/blob/main/docs/source/index.rst
-  dev_url: https://github.com/dask/distributed
+  - name: distributed
+    version: {{ version }}
+    build:
+      script: {{ PYTHON }} -m pip install . -vv                                           # [not cython_enabled]
+      script: {{ PYTHON }} -m pip install . -vv --install-option="--with-cython=profile"  # [cython_enabled]
+      track_features: {{ "[cythonized-scheduler]" if cython_enabled else "" }}
+      entry_points:
+        - dask-scheduler = distributed.cli.dask_scheduler:go
+        - dask-ssh = distributed.cli.dask_ssh:go
+        - dask-worker = distributed.cli.dask_worker:go
+    requirements:
+      build:
+        - python                                 # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+        - compilers                              # [cython_enabled]
+        - cython >=0.29,<0.30                    # [cython_enabled]
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - click >=6.6
+        - cloudpickle >=1.5.0
+        - cytoolz >=0.8.2
+        - dask-core >={{ dask_version }}
+        - jinja2
+        - msgpack-python >=0.6.0
+        - packaging >=20.0
+        - psutil >=5.0
+        - pyyaml
+        - sortedcontainers !=2.0.0,!=2.0.1
+        - tblib >=1.6.0
+        - toolz >=0.8.2
+        - tornado >=5  # [py<38]
+        - tornado >=6.0.3  # [py>=38]
+        - zict >=0.1.3
+        - setuptools <60.0.0
+      run_constrained:
+        - openssl !=1.1.1e
+    test:
+      imports:
+        - distributed
+        - distributed.cli
+        - distributed.comm
+        - distributed.deploy
+        - distributed.diagnostics
+        - distributed.protocol
+      commands:
+        - pip check
+        - dask-scheduler --help
+        - dask-ssh --help
+        - dask-worker --help
+      requires:
+        - pip
+    about:
+      home: https://distributed.dask.org
+      summary: Distributed scheduler for Dask
+      license: BSD-3-Clause
+      license_family: BSD
+      license_file: LICENSE.txt
+      description: |
+        Distributed is a lightweight library for distributed computing in Python.
+        It extends both the concurrent.futures and dask APIs to moderate sized
+        clusters.
+      doc_url: https://distributed.dask.org
+      doc_source_url: https://github.com/dask/distributed/blob/main/docs/source/index.rst
+      dev_url: https://github.com/dask/distributed

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -37,10 +37,9 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
-      noarch: python                                                                          # [build_ext == "python"]
+      noarch: python                              # [build_ext == "python"]
       script: >
-        python -m pip install . -vv
-        --no-deps
+        python -m pip install . -vv --no-deps
         --install-option="--with-cython=profile"  # [build_ext == "cython"]
       track_features: {{ "cythonized-scheduler" if cython_enabled else "" }}
       entry_points:
@@ -49,11 +48,11 @@ outputs:
         - dask-worker = distributed.cli.dask_worker:go
     requirements:
       build:
-        - {{ compiler('c') }}                    # [build_ext == "cython"]
+        - {{ compiler('c') }}                     # [build_ext == "cython"]
       host:
         - python
         - pip
-        - cython                                 # [build_ext == "cython"]
+        - cython                                  # [build_ext == "cython"]
       run:
         - python
         - click >=6.6

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -38,8 +38,8 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: >
-        py
-        {{ python | replace(".", "") }}           # [cython_enabled]
+        py                                        # [not cython_enabled]
+        py{{ python | replace(".", "") }}         # [cython_enabled]
         _{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
       noarch: python                              # [not cython_enabled]
       skip: True                                  # [cython_enabled and py<38]

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -37,9 +37,11 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
-      noarch: python                                                                          # [not cython_enabled]
-      script: python -m pip install . -vv                                                     # [not cython_enabled]
-      script: python -m pip install . -vv --no-deps --install-option="--with-cython=profile"  # [cython_enabled]
+      noarch: python                                                                          # [build_ext == "python"]
+      script: |
+        python -m pip install . -vv
+          --no-deps
+          --install-option="--with-cython=profile"  # [build_ext == "cython"]
       track_features: {{ "cythonized-scheduler" if cython_enabled else "" }}
       entry_points:
         - dask-scheduler = distributed.cli.dask_scheduler:go
@@ -47,11 +49,11 @@ outputs:
         - dask-worker = distributed.cli.dask_worker:go
     requirements:
       build:
-        - {{ compiler('c') }}                    # [cython_enabled]
+        - {{ compiler('c') }}                    # [build_ext == "cython"]
       host:
         - python
         - pip
-        - cython                                 # [cython_enabled]
+        - cython                                 # [build_ext == "cython"]
       run:
         - python
         - click >=6.6

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -40,8 +40,8 @@ outputs:
       noarch: python                                                                          # [build_ext == "python"]
       script: >
         python -m pip install . -vv
-          --no-deps
-          --install-option="--with-cython=profile"  # [build_ext == "cython"]
+        --no-deps
+        --install-option="--with-cython=profile"  # [build_ext == "cython"]
       track_features: {{ "cythonized-scheduler" if cython_enabled else "" }}
       entry_points:
         - dask-scheduler = distributed.cli.dask_scheduler:go

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -37,10 +37,8 @@ outputs:
     version: {{ version }}
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
-      string: >
-        py                                        # [not cython_enabled]
-        py{{ python | replace(".", "") }}         # [cython_enabled]
-        _{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
+      string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}  # [not cython_enabled]
+      string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}  # [cython_enabled]
       noarch: python                              # [not cython_enabled]
       skip: True                                  # [cython_enabled and py<38]
       script: >

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -38,8 +38,8 @@ outputs:
   - name: distributed
     version: {{ version }}
     build:
-      script: {{ PYTHON }} -m pip install . -vv                                           # [not cython_enabled]
-      script: {{ PYTHON }} -m pip install . -vv --install-option="--with-cython=profile"  # [cython_enabled]
+      script: python -m pip install . -vv                                           # [not cython_enabled]
+      script: python -m pip install . -vv --install-option="--with-cython=profile"  # [cython_enabled]
       track_features: {{ "[cythonized-scheduler]" if cython_enabled else "" }}
       entry_points:
         - dask-scheduler = distributed.cli.dask_scheduler:go

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -37,8 +37,12 @@ outputs:
     version: {{ version }}
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
-      string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
+      string: >
+        py
+        {{ python | replace(".", "") }}           # [cython_enabled]
+        _{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
       noarch: python                              # [not cython_enabled]
+      skip: True                                  # [cython_enabled and py<38]
       script: >
         python -m pip install . -vv --no-deps
         --install-option="--with-cython=profile"  # [cython_enabled]

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -2,7 +2,7 @@
 {% set new_patch = major_minor_patch[2] | int + 1 %}
 {% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
-{% set cython_enabled = build_ext == "cython" %}
+{% set build_ext = "cython" if cython_enabled else "python" %}
 
 
 package:
@@ -37,10 +37,10 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
-      noarch: python                              # [build_ext == "python"]
+      noarch: python                              # [not cython_enabled]
       script: >
         python -m pip install . -vv --no-deps
-        --install-option="--with-cython=profile"  # [build_ext == "cython"]
+        --install-option="--with-cython=profile"  # [cython_enabled]
       track_features: {{ "cythonized-scheduler" if cython_enabled else "" }}
       entry_points:
         - dask-scheduler = distributed.cli.dask_scheduler:go
@@ -48,11 +48,11 @@ outputs:
         - dask-worker = distributed.cli.dask_worker:go
     requirements:
       build:
-        - {{ compiler('c') }}                     # [build_ext == "cython"]
+        - {{ compiler('c') }}                     # [cython_enabled]
       host:
         - python
         - pip
-        - cython                                  # [build_ext == "cython"]
+        - cython                                  # [cython_enabled]
       run:
         - python
         - click >=6.6


### PR DESCRIPTION
This PR modifies the Distributed pre-release recipe to build Cython variants of Distributed using the steps outlined by @jakirkham in https://github.com/dask/distributed/issues/4442#issuecomment-763074600.

Choosing which Distributed variant to install should be doable by specifying the `distributed-proc` build string during an install / env creation command, though with `track_features="cythonized-scheduler"` specified for Cython builds Conda should always prioritize non-Cython builds by default.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
