### PR TITLE
Decrease timeout-minutes for GHA jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     # Do not run the schedule job on forks
     if: github.repository == 'dask/distributed' || github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     # Do not run the schedule job on forks
     if: github.repository == 'dask/distributed' || github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 180
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
At least since we split to partitioned CI jobs our test runtimes per job are typically at 30-40 min. 180 is way too large. I've run into this at ~https://github.com/dask/distributed/pull/5820~ https://github.com/dask/distributed/pull/5824

Edit: I linked the wrong PR, here is the test failure I was linking where the test suite teardown blocked the job for 3h https://github.com/dask/distributed/runs/5248080147?check_suite_focus=true