### PR TITLE
Skip all cluster tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-  pull_request:
-  schedule:
-    - cron: "0 6,18 * * *"
+  # pull_request:
+  # schedule:
+  #   - cron: "0 6,18 * * *"
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,11 +38,11 @@ jobs:
         # To avoid hamstringing other people, change 'on: [push, pull_request]' above
         # to just 'on: [push]'; this way the stress test will run exclusively in your
         # branch (https://github.com/<your name>/distributed/actions).
-        # run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
 
     env:
-      TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}
-      # TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}-${{ matrix.run }}
+      # TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}
+      TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}-${{ matrix.run }}
 
     steps:
       - name: Checkout source

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -625,6 +625,7 @@ def cluster(
     scheduler_kwargs={},
     config={},
 ):
+    pytest.skip("Let's see if this mess is causing problems")
     ws = weakref.WeakSet()
     enable_proctitle_on_children()
 


### PR DESCRIPTION
I've been poking in the cluster fixture in utils_test a bit today and there are many issues about queues, processes, comms, etc. potentially not being properly closed. I ran this now once and had all builds green. I'm wondering if this is a driver in terms of instability

Note: "stress test" runs only on my fork, see https://github.com/fjetter/distributed/actions/runs/1865641537. 

This PR is for visibility