### PR TITLE
Extract SchedulerState from Scheduler

### DIFF
--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -222,10 +222,10 @@ class ActiveMemoryManagerExtension:
             return None
 
         if candidates is None:
-            candidates = self.scheduler.running.copy()
+            candidates = self.scheduler.state.running.copy()
         else:
             # Don't modify orig_candidates
-            candidates = candidates & self.scheduler.running
+            candidates = candidates & self.scheduler.state.running
         if not candidates:
             log_reject("no running candidates")
             return None

--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -591,7 +591,7 @@ class RetireWorker(ActiveMemoryManagerPolicy):
                 drop_ws = (yield "drop", ts, {ws})
                 if drop_ws:
                     continue  # Use case 1 or 2
-                if ts.who_has & self.manager.scheduler.running:
+                if ts.who_has & self.manager.scheduler.state.running:
                     continue  # Use case 3 or 4
                 # Use case 5
 

--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -467,7 +467,7 @@ class ReduceReplicas(ActiveMemoryManagerPolicy):
         nkeys = 0
         ndrop = 0
 
-        for ts in self.manager.scheduler.replicated_tasks:
+        for ts in self.manager.scheduler.state.replicated_tasks:
             desired_replicas = 1  # TODO have a marker on TaskState
 
             # If a dependent task has not been assigned to a worker yet, err on the side

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4589,7 +4589,9 @@ class Scheduler(ServerNode):
         ws._last_seen = local_now
         if executing is not None:
             ws._executing = {
-                self.state.tasks[key]: duration for key, duration in executing.items()
+                self.state.tasks[key]: duration
+                for key, duration in executing.items()
+                if key in self.state.tasks
             }
 
         ws._metrics = metrics

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8533,7 +8533,7 @@ def validate_task_state(ts: TaskState):
         assert dts._state != "forgotten"
 
     assert (ts._processing_on is not None) == (ts._state == "processing")
-    assert (not not ts._who_has) == (ts._state == "memory"), (ts, ts._who_has)
+    assert bool(ts._who_has) == (ts._state == "memory"), (ts, ts._who_has)
 
     if ts._state == "processing":
         assert all([dts._who_has for dts in ts._dependencies]), (

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -301,8 +301,8 @@ class WorkStealing(SchedulerPlugin):
             _log_msg = [key, state, victim.address, thief.address, stimulus_id]
 
             if ts.state != "processing":
-                self.scheduler._reevaluate_occupancy_worker(thief)
-                self.scheduler._reevaluate_occupancy_worker(victim)
+                self.scheduler.state.reevaluate_occupancy_worker(thief)
+                self.scheduler.state.reevaluate_occupancy_worker(victim)
             elif (
                 state in _WORKER_STATE_UNDEFINED
                 or state in _WORKER_STATE_CONFIRM

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5233,10 +5233,10 @@ async def test_long_running_not_in_occupancy(c, s, a):
 
     ts = s.tasks[f.key]
     ws = s.workers[a.address]
-    s.set_duration_estimate(ts, ws)
+    s.state.set_duration_estimate(ts, ws)
     assert s.workers[a.address].occupancy == 0
 
-    s.reevaluate_occupancy(0)
+    s.state.reevaluate_occupancy(0)
     assert s.workers[a.address].occupancy == 0
     await l.release()
 
@@ -6893,7 +6893,7 @@ def test_computation_object_code_not_available(client):
     result = np.where(ddf.a > 4)
 
     def fetch_comp_code(dask_scheduler):
-        computations = list(dask_scheduler.computations)
+        computations = list(dask_scheduler.state.computations)
         assert len(computations) == 1
         comp = computations[0]
         assert len(comp.code) == 1

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3872,7 +3872,7 @@ async def test_idempotence(s, a, b):
     # Submit
     x = c.submit(inc, 1)
     await x
-    log = list(s.transition_log)
+    log = list(s.state.transition_log)
 
     len_single_submit = len(log)  # see last assert
 
@@ -3880,29 +3880,29 @@ async def test_idempotence(s, a, b):
     assert x.key == y.key
     await y
     await asyncio.sleep(0.1)
-    log2 = list(s.transition_log)
+    log2 = list(s.state.transition_log)
     assert log == log2
 
     # Error
     a = c.submit(div, 1, 0)
     await wait(a)
     assert a.status == "error"
-    log = list(s.transition_log)
+    log = list(s.state.transition_log)
 
     b = f.submit(div, 1, 0)
     assert a.key == b.key
     await wait(b)
     await asyncio.sleep(0.1)
-    log2 = list(s.transition_log)
+    log2 = list(s.state.transition_log)
     assert log == log2
 
-    s.transition_log.clear()
+    s.state.transition_log.clear()
     # Simultaneous Submit
     d = c.submit(inc, 2)
     e = c.submit(inc, 2)
     await wait([d, e])
 
-    assert len(s.transition_log) == len_single_submit
+    assert len(s.state.transition_log) == len_single_submit
 
     await c.close()
     await f.close()
@@ -4566,7 +4566,7 @@ def test_auto_normalize_collection_sync(c):
 
 
 def assert_no_data_loss(scheduler):
-    for key, start, finish, recommendations, _ in scheduler.transition_log:
+    for key, start, finish, recommendations, _ in scheduler.state.transition_log:
         if start == "memory" and finish == "released":
             for k, v in recommendations.items():
                 assert not (k == key and v == "waiting")
@@ -5557,7 +5557,7 @@ async def test_nested_compute(c, s, a, b):
     future = c.submit(fib, 8)
     result = await future
     assert result == 21
-    assert len(s.transition_log) > 50
+    assert len(s.state.transition_log) > 50
 
 
 @gen_cluster(client=True)
@@ -6873,7 +6873,7 @@ def test_computation_object_code_dask_compute(client):
     test_function_code = inspect.getsource(test_computation_object_code_dask_compute)
 
     def fetch_comp_code(dask_scheduler):
-        computations = list(dask_scheduler.computations)
+        computations = list(dask_scheduler.state.computations)
         assert len(computations) == 1
         comp = computations[0]
         assert len(comp.code) == 1
@@ -6913,7 +6913,7 @@ async def test_computation_object_code_dask_persist(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_dask_persist.__wrapped__
     )
-    computations = list(s.computations)
+    computations = list(s.state.computations)
     assert len(computations) == 1
     comp = computations[0]
     assert len(comp.code) == 1
@@ -6933,7 +6933,7 @@ async def test_computation_object_code_client_submit_simple(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_submit_simple.__wrapped__
     )
-    computations = list(s.computations)
+    computations = list(s.state.computations)
     assert len(computations) == 1
     comp = computations[0]
 
@@ -6954,7 +6954,7 @@ async def test_computation_object_code_client_submit_list_comp(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_submit_list_comp.__wrapped__
     )
-    computations = list(s.computations)
+    computations = list(s.state.computations)
     assert len(computations) == 1
     comp = computations[0]
 
@@ -6976,7 +6976,7 @@ async def test_computation_object_code_client_submit_dict_comp(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_submit_dict_comp.__wrapped__
     )
-    computations = list(s.computations)
+    computations = list(s.state.computations)
     assert len(computations) == 1
     comp = computations[0]
 
@@ -6996,7 +6996,7 @@ async def test_computation_object_code_client_map(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_map.__wrapped__
     )
-    computations = list(s.computations)
+    computations = list(s.state.computations)
     assert len(computations) == 1
     comp = computations[0]
     assert len(comp.code) == 1
@@ -7014,7 +7014,7 @@ async def test_computation_object_code_client_compute(c, s, a, b):
     test_function_code = inspect.getsource(
         test_computation_object_code_client_compute.__wrapped__
     )
-    computations = list(s.computations)
+    computations = list(s.state.computations)
     assert len(computations) == 1
     comp = computations[0]
     assert len(comp.code) == 1

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5236,7 +5236,7 @@ async def test_long_running_not_in_occupancy(c, s, a):
     s.state.set_duration_estimate(ts, ws)
     assert s.workers[a.address].occupancy == 0
 
-    s.state.reevaluate_occupancy(0)
+    s.reevaluate_occupancy(0)
     assert s.workers[a.address].occupancy == 0
     await l.release()
 

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -37,7 +37,7 @@ async def test_submit_from_worker(c, s, a, b):
     assert xx == 10 + 1 + (10 + 1) * 2
     assert yy == 20 + 1 + (20 + 1) * 2
 
-    assert len(s.transition_log) > 10
+    assert len(s.state.transition_log) > 10
     assert len([id for id in s.wants_what if id.lower().startswith("client")]) == 1
 
 


### PR DESCRIPTION
Refresh & follow-up to @martindurant's PR ( https://github.com/dask/distributed/pull/5176 )

Continues the worker to pull out `SchedulerState` as a separate object used by (though no longer a class inherited by) `Scheduler`.

Note: This does not separate `SchedulerState` into a new module, but this sets things up to make that step easier.

<hr>

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
