### PR TITLE
Fix flaky test_remove_replicas_while_computing

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3263,11 +3263,11 @@ async def test_remove_replicas_while_computing(c, s, a, b):
     while not ws_has_futs(all):
         await asyncio.sleep(0.01)
 
-    # Wait for some dependent tasks to be done. Note that at most we'll get half
-    # of the dependents finished as the others are blocked on dependents_event.
-    while not any(fut.status == "finished" for fut in dependents):
-        await asyncio.sleep(0.01)
-    assert not all(fut.status == "finished" for fut in dependents)
+    # Wait for some dependent tasks to be done. Note that the Worker has 2 threads, so
+    # it will block when it reaches the dependents[2]. This relies on the tasks
+    # scheduled by Client.map to be computed strictly from left to right.
+    await wait(dependents[1])
+    assert not any(fut.status == "finished" for fut in dependents[2:])
 
     # Try removing the initial keys
     s.request_remove_replicas(

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3280,7 +3280,7 @@ async def test_remove_replicas_while_computing(c, s, a, b):
     while not ws_has_futs(any):
         await asyncio.sleep(0.01)
 
-    # Let the other half of the dependent tasks complete
+    # Let the remaining dependent tasks complete
     await dependents_event.set()
     await wait(dependents)
     assert ws_has_futs(any) and not ws_has_futs(all)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3231,82 +3231,101 @@ async def test_remove_replicas_simple(c, s, a, b):
     assert all(s.tasks[f.key].who_has == {s.workers[a.address]} for f in futs)
 
 
+@pytest.mark.slow
 @gen_cluster(
     client=True,
+    nthreads=[("", 1), ("", 1)],
     config={"distributed.comm.recent-messages-log-length": 1_000},
 )
-async def test_remove_replicas_while_computing(c, s, *workers):
-    futs = c.map(inc, range(10), workers=[workers[0].address])
+async def test_remove_replicas_while_computing(c, s, a, b):
+    futs = c.map(inc, range(10), workers=[a.address])
 
-    # All interesting things will happen on that worker
-    w = workers[1]
-    intermediate = c.map(slowinc, futs, delay=0.05, workers=[w.address])
+    # All interesting things will happen on b
+    intermediate = c.map(slowinc, futs, delay=0.05, workers=[b.address])
 
     def reduce(*args, **kwargs):
-        import time
+        sleep(0.5)
 
-        time.sleep(0.5)
-        return
+    final = c.submit(reduce, intermediate, workers=[b.address], key="final")
 
-    final = c.submit(reduce, intermediate, workers=[w.address], key="final")
-
-    while not any(f.key in w.tasks for f in intermediate):
-        await asyncio.sleep(0.001)
+    while not any(f.key in b.tasks for f in intermediate):
+        await asyncio.sleep(0.01)
 
     # The scheduler removes keys from who_has/has_what immediately
     # Make sure the worker responds to the rejection and the scheduler corrects
     # the state
-    ws = s.workers[w.address]
-    while not all(s.tasks[fut.key] in ws.has_what for fut in futs):
-        await asyncio.sleep(0.001)
+    ws = s.workers[b.address]
 
+    def ws_has_futs(aggr_func):
+        nonlocal futs
+        return aggr_func(s.tasks[fut.key] in ws.has_what for fut in futs)
+
+    # Wait for all futs to transfer over
+    while not ws_has_futs(all):
+        await asyncio.sleep(0.01)
+
+    # Wait for some, but not all, intermediate tasks to be done.
+    while not any(fut.status == "finished" for fut in intermediate):
+        await asyncio.sleep(0.01)
+    # This assertion relies on the data transfer between workers to
+    # complete before 10x the slowinc delay
+    assert not all(fut.status == "finished" for fut in intermediate)
+
+    # Try removing the initial keys
     s.request_remove_replicas(
-        w.address, [fut.key for fut in futs], stimulus_id=f"test-{time()}"
+        b.address, [fut.key for fut in futs], stimulus_id=f"test-{time()}"
     )
-    # Scheduler removed keys immediately...
-    assert not any(s.tasks[fut.key] in ws.has_what for fut in futs)
-    # ... but the state is properly restored
-    while not any(s.tasks[fut.key] in ws.has_what for fut in futs):
+    # Scheduler removed all keys immediately...
+    assert not ws_has_futs(any)
+    # ... but the state is properly restored for all tasks for which the intermediate
+    # isn't done yet
+    while not ws_has_futs(any):
         await asyncio.sleep(0.01)
 
     await wait(intermediate)
+    assert ws_has_futs(any) and not ws_has_futs(all)
 
     # If a request is rejected, the worker responds with an add-keys message to
     # reenlist the key in the schedulers state system to avoid race conditions,
     # see also https://github.com/dask/distributed/issues/5265
     rejections = set()
-    for msg in w.log:
+    for msg in b.log:
         if msg[0] == "remove-replica-rejected":
             rejections.update(msg[1])
+    assert rejections
+
+    def answer_sent(key):
+        for batch in b.batched_stream.recent_message_log:
+            for msg in batch:
+                if "op" in msg and msg["op"] == "add-keys" and key in msg["keys"]:
+                    return True
+        return False
+
     for rejected_key in rejections:
-
-        def answer_sent(key):
-            for batch in w.batched_stream.recent_message_log:
-                for msg in batch:
-                    if "op" in msg and msg["op"] == "add-keys" and key in msg["keys"]:
-                        return True
-            return False
-
         assert answer_sent(rejected_key)
 
     # Since intermediate is done, futs replicas may be removed.
     # They might be already gone due to the above remove replica calls
     s.request_remove_replicas(
-        w.address, [fut.key for fut in futs], stimulus_id=f"test-{time()}"
+        b.address,
+        [fut.key for fut in futs if ws in s.tasks[fut.key].who_has],
+        stimulus_id=f"test-{time()}",
     )
 
-    while any(w.tasks[f.key].state != "released" for f in futs if f.key in w.tasks):
-        await asyncio.sleep(0.001)
+    while any(b.tasks[f.key].state != "released" for f in futs if f.key in b.tasks):
+        await asyncio.sleep(0.01)
 
     # The scheduler actually gets notified about the removed replica
-    while not all(len(s.tasks[f.key].who_has) == 1 for f in futs):
-        await asyncio.sleep(0.001)
+    while ws_has_futs(any):
+        await asyncio.sleep(0.01)
+    # A replica is still on workers[0]
+    assert all(len(s.tasks[f.key].who_has) == 1 for f in futs)
 
     await final
     del final, intermediate, futs
 
-    while any(w.tasks for w in workers):
-        await asyncio.sleep(0.001)
+    while any(w.tasks for w in (a, b)):
+        await asyncio.sleep(0.01)
 
 
 @gen_cluster(client=True, nthreads=[("", 1)] * 3)


### PR DESCRIPTION
On a 120 runs stress test, this test failed 3 times, all on MacOS:
https://github.com/crusaderky/distributed/runs/5308278349?check_suite_focus=true

```python
    async def test_remove_replicas_while_computing(c, s, *workers):
        [...]

        # Since intermediate is done, futs replicas may be removed.
        # They might be already gone due to the above remove replica calls
>       s.request_remove_replicas(
            w.address, [fut.key for fut in futs], stimulus_id=f"test-{time()}"
        )

    def request_remove_replicas(self, addr: str, keys: list, *, stimulus_id: str):
        [...]
        for key in keys:
            ts: TaskState = parent._tasks[key]
            if validate:
                # Do not destroy the last copy
>               assert len(ts._who_has) > 1
E               AssertionError
```

The issue is that it may take longer than 100ms for all 10 futs to be transferred from workers[0] to workers[1]. As a consequence, one of the intermediates is already done by the time the first remove_replicas() is invoked.

This PR ensures that the race condition happens every time, instead of only on a very slow environment, and then fixes it.