### PR TITLE
Add git hash to `distributed-impl` version

### DIFF
--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -18,10 +18,10 @@ build:
 
 outputs:
   - name: distributed-impl
-    version: {{ version }}+{{ GIT_DESCRIBE_HASH }}
+    version: {{ version }}
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
-      string: {{ build_ext }}
+      string: {{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_ext }}
       noarch: generic
     test:
       commands:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -18,7 +18,7 @@ build:
 
 outputs:
   - name: distributed-impl
-    version: {{ version }}
+    version: {{ version }}+{{ GIT_DESCRIBE_HASH }}
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: {{ build_ext }}


### PR DESCRIPTION
Makes each `distributed-impl` package unique to resolve the upload errors observed in #5864

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
