### PR TITLE
Mock process memory readings in test_worker.py

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,9 @@ name: Tests
 
 on:
   push:
+  pull_request:
+  schedule:
+    - cron: "0 6,18 * * *"
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
@@ -21,6 +24,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9"]
+        # Cherry-pick test modules to split the overall runtime roughly in half
+        partition: [ci1, not ci1]
+        include:
+          - partition: "ci1"
+            partition-label: "ci1"
+          - partition: "not ci1"
+            partition-label: "notci1"
 
         # Uncomment to stress-test the test suite for random failures.
         # Must also change env.TEST_ID below.
@@ -28,10 +38,11 @@ jobs:
         # To avoid hamstringing other people, change 'on: [push, pull_request]' above
         # to just 'on: [push]'; this way the stress test will run exclusively in your
         # branch (https://github.com/<your name>/distributed/actions).
-        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        # run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
 
     env:
-      TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.run }}
+      TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}
+      # TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}-${{ matrix.run }}
 
     steps:
       - name: Checkout source
@@ -118,8 +129,8 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          pytest distributed/tests/test_worker.py \
-            -m "not avoid_ci" --runslow \
+          pytest distributed \
+            -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
             --leaks=fds,processes,threads \
             --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
             --cov=distributed --cov-report=xml \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,9 +2,6 @@ name: Tests
 
 on:
   push:
-  pull_request:
-  schedule:
-    - cron: "0 6,18 * * *"
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -129,8 +129,8 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          pytest distributed \
-            -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
+          pytest distributed/tests/test_worker.py \
+            -m "not avoid_ci" --runslow \
             --leaks=fds,processes,threads \
             --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
             --cov=distributed --cov-report=xml \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,13 +24,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9"]
-        # Cherry-pick test modules to split the overall runtime roughly in half
-        partition: [ci1, not ci1]
-        include:
-          - partition: "ci1"
-            partition-label: "ci1"
-          - partition: "not ci1"
-            partition-label: "notci1"
 
         # Uncomment to stress-test the test suite for random failures.
         # Must also change env.TEST_ID below.
@@ -38,11 +31,10 @@ jobs:
         # To avoid hamstringing other people, change 'on: [push, pull_request]' above
         # to just 'on: [push]'; this way the stress test will run exclusively in your
         # branch (https://github.com/<your name>/distributed/actions).
-        # run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
 
     env:
-      TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}
-      # TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}-${{ matrix.run }}
+      TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.run }}
 
     steps:
       - name: Checkout source

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1389,7 +1389,12 @@ async def test_spill_hysteresis(
 
         # Add 100 MiB process memory. Spilling must not happen, even when managed=10GB
         futures = [
-            c.submit(BadSizeof, process=100 * 2**20, managed=managed, pure=False)
+            c.submit(
+                BadSizeof,
+                process=100 * 2**20,
+                managed=managed,
+                pure=False,
+            )
         ]
         await wait(futures)
         await asyncio.sleep(0.2)
@@ -1413,7 +1418,12 @@ async def test_spill_hysteresis(
             if time() > start + 0.5:  # pragma: nocover
                 print("Did not spill; adding a future")
                 futures.append(
-                    c.submit(BadSizeof, process=100e6, managed=managed, pure=False)
+                    c.submit(
+                        BadSizeof,
+                        process=100 * 2**20,
+                        managed=managed,
+                        pure=False,
+                    )
                 )
                 start = time()
             await asyncio.sleep(0.1)
@@ -1423,9 +1433,11 @@ async def test_spill_hysteresis(
         while prev_n == -1 or time() < start + 0.5:
             n = await nspilled()
             if n == len(futures):
-                raise pytest.xfail(
-                    "The whole contents of the SpillBuffer was spilled to disk; see "
-                    "https://github.com/dask/distributed/issues/5840"
+                # raise pytest.xfail(
+                raise AssertionError(
+                    "The whole content of the SpillBuffer was spilled to disk; see "
+                    "https://github.com/dask/distributed/issues/5840. "
+                    "Consider converting this to xfail"
                 )
             if n != prev_n:
                 prev_n = n

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -36,7 +36,7 @@ from distributed import (
     wait,
 )
 from distributed.comm.registry import backends
-from distributed.compatibility import LINUX, WINDOWS
+from distributed.compatibility import LINUX, MACOS, WINDOWS
 from distributed.core import CommClosedError, Status, rpc
 from distributed.diagnostics import nvml
 from distributed.diagnostics.plugin import PipInstall
@@ -1433,11 +1433,10 @@ async def test_spill_hysteresis(
         while prev_n == -1 or time() < start + 0.5:
             n = await nspilled()
             if n == len(futures):
-                # raise pytest.xfail(
-                raise AssertionError(
+                exc_cls = pytest.xfail if MACOS else AssertionError
+                raise exc_cls(
                     "The whole content of the SpillBuffer was spilled to disk; see "
-                    "https://github.com/dask/distributed/issues/5840. "
-                    "Consider converting this to xfail"
+                    "https://github.com/dask/distributed/issues/5840."
                 )
             if n != prev_n:
                 prev_n = n

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1449,47 +1449,44 @@ async def test_spill_hysteresis(
 @pytest.mark.slow
 @gen_cluster(
     nthreads=[("", 1)],
-    # Run the test in a freshly spawned interpreter to ensure a clear memory situation,
-    # as opposed to the potentially heavily fragmented and unpredictable condition of
-    # the process used to run all the tests so far
-    Worker=Nanny,
     client=True,
     worker_kwargs=dict(
-        # pause after ~300 MiB, assuming ~100 MiB unmanaged memory
-        memory_limit="500 MiB",
         memory_monitor_interval="10ms",
         memory_target_fraction=False,
         memory_spill_fraction=False,
         memory_pause_fraction=0.8,
-        memory_terminate_fraction=False,
     ),
 )
-async def test_pause_executor(c, s, nanny):
-    ws = s.workers[nanny.worker_address]
+async def test_pause_executor(c, s, a):
+    # See notes in test_spill_spill_threshold
+    memory = psutil.Process().memory_info().rss
+    a.memory_limit = (memory + 160e6) / 0.8  # Pause after 200 MB
 
+    # Note: it's crucial to have a very large single chunk of memory that gets descoped
+    # all at once in order to instigate release of process memory.
+    # Read: https://github.com/dask/distributed/issues/5840
     def f():
-        # Add 1 GiB unmanaged memory
-        # Note: it's crucial to have a very large single chunk of memory that gets
-        # descoped all at once in order to instigate release of process memory. Read:
-        # https://github.com/dask/distributed/issues/5840
-        x = "x" * 2**30
+        # Add 400 MB unmanaged memory
+        x = "x" * int(400e6)
         w = get_worker()
         while w.status != Status.paused:
             sleep(0.01)
 
-    assert ws.status == Status.running
-    x = c.submit(f, key="x")
-    while "x" not in s.tasks:
-        await asyncio.sleep(0.01)
-    futures = c.map(slowinc, range(8), delay=0.1)
+    with captured_logger(logging.getLogger("distributed.worker")) as logger:
+        future = c.submit(f, key="x")
+        futures = c.map(slowinc, range(30), delay=0.1)
 
-    while ws.status != Status.paused:
-        await asyncio.sleep(0.01)
+        while a.status != Status.paused:
+            await asyncio.sleep(0.01)
 
-    assert sum(f.status == "finished" for f in futures) < 4
-    # Wait for unpause
-    await wait(futures)
-    assert ws.status == Status.running
+        assert "Pausing worker" in logger.getvalue()
+        assert sum(f.status == "finished" for f in futures) < 4
+
+        while a.status != Status.running:
+            await asyncio.sleep(0.01)
+
+        assert "Resuming worker" in logger.getvalue()
+        await wait(futures)
 
 
 @gen_cluster(client=True, worker_kwargs={"profile_cycle_interval": "50 ms"})

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -20,13 +20,14 @@ import tempfile
 import threading
 import uuid
 import weakref
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from collections.abc import Callable
 from contextlib import contextmanager, nullcontext, suppress
 from glob import glob
 from itertools import count
 from time import sleep
 from typing import Any, Literal
+from unittest.mock import MagicMock
 
 from distributed.compatibility import MACOS
 from distributed.scheduler import Scheduler
@@ -1965,3 +1966,20 @@ def has_pytestmark(test_func: Callable, name: str) -> bool:
     """
     marks = getattr(test_func, "pytestmark", [])
     return any(mark.name == name for mark in marks)
+
+
+# Variant of psutil._pslinux.pmem, psutil._psosx.pmem, psutil._pswindows.pmem
+pmem = namedtuple("pmem", "rss")
+
+
+def mock_rss(dask_worker: Worker, nbytes: float) -> None:
+    """Mock all the process memory readings on a worker. Does not impact other workers.
+
+    Usage:
+
+    When using Workers:
+    >>> mock_rss(a, 100e6)
+    When using Nannies:
+    >>> await client.run(mock_rss, nbytes=100e6, workers=[a.worker_address])
+    """
+    dask_worker.monitor.proc.memory_info = MagicMock(return_value=pmem(int(nbytes)))


### PR DESCRIPTION
## In scope
- Change all tests in test_worker.py that rely on process memory readings to use a deterministic, robust and fast mock design instead
- Replace fragile timing-based test design with events.
- Supersedes #5850
- Mitigates #5840
- Closes #5848
- Partially reverts #3424

## Out of scope
- same treatment to ``test_scheduler.py::test_memory``
- remediation to ``test_active_memory_manager.py``, which should be carried out by adding a switch to use managed memory
- remediation to all tests around ``rebalance()``: postponed indefinitely due to the whole function to be reimplemented on top of the Active Memory Manager
