### PR TITLE
Drop unused `_round_robin` global variable

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8526,9 +8526,6 @@ def validate_state(tasks, workers, clients):
             )
 
 
-_round_robin = [0]
-
-
 def heartbeat_interval(n):
     """
     Interval in seconds that we desire heartbeats based on number of workers


### PR DESCRIPTION
AFAICT this variable is unused. Not seeing any reference in `scheduler.py` or anywhere else in Distributed. The line dates back to 2015 according to `git blame`. So best guess this is something leftover that is no longer needed. Given this would propose we drop it. Though please feel free to correct me if I've missed something.

<hr>

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
