### PR TITLE
Unblock event loop while waiting for ThreadpoolExecutor to shut down

### DIFF
--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -1,7 +1,4 @@
 import asyncio
-import contextvars
-import functools
-import sys
 
 import pytest
 from click.testing import CliRunner
@@ -18,32 +15,11 @@ from dask.utils import tmpfile
 
 import distributed.cli.dask_worker
 from distributed import Client
-from distributed.compatibility import LINUX
+from distributed.compatibility import LINUX, to_thread
 from distributed.deploy.utils import nprocesses_nthreads
 from distributed.metrics import time
 from distributed.utils import parse_ports, sync
 from distributed.utils_test import gen_cluster, popen, requires_ipv6
-
-if sys.version_info >= (3, 9):
-    from asyncio import to_thread
-else:
-
-    async def to_thread(*func_args, **kwargs):
-        """Asynchronously run function *func* in a separate thread.
-        Any *args and **kwargs supplied for this function are directly passed
-        to *func*. Also, the current :class:`contextvars.Context` is propagated,
-        allowing context variables from the main thread to be accessed in the
-        separate thread.
-        Return a coroutine that can be awaited to get the eventual result of *func*.
-
-        backport from
-        https://github.com/python/cpython/blob/3f1ea163ea54513e00e0e9d5442fee1b639825cc/Lib/asyncio/threads.py#L12-L25
-        """
-        func, *args = func_args
-        loop = asyncio.get_running_loop()
-        ctx = contextvars.copy_context()
-        func_call = functools.partial(ctx.run, func, *args, **kwargs)
-        return await loop.run_in_executor(None, func_call)
 
 
 def test_nanny_worker_ports(loop):

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import contextvars
+import functools
 import logging
 import platform
 import sys
@@ -12,3 +15,25 @@ PYPY = platform.python_implementation().lower() == "pypy"
 LINUX = sys.platform == "linux"
 MACOS = sys.platform == "darwin"
 WINDOWS = sys.platform.startswith("win")
+
+
+if sys.version_info >= (3, 9):
+    from asyncio import to_thread
+else:
+
+    async def to_thread(*func_args, **kwargs):
+        """Asynchronously run function *func* in a separate thread.
+        Any *args and **kwargs supplied for this function are directly passed
+        to *func*. Also, the current :class:`contextvars.Context` is propagated,
+        allowing context variables from the main thread to be accessed in the
+        separate thread.
+        Return a coroutine that can be awaited to get the eventual result of *func*.
+
+        backport from
+        https://github.com/python/cpython/blob/3f1ea163ea54513e00e0e9d5442fee1b639825cc/Lib/asyncio/threads.py#L12-L25
+        """
+        func, *args = func_args
+        loop = asyncio.get_running_loop()
+        ctx = contextvars.copy_context()
+        func_call = functools.partial(ctx.run, func, *args, **kwargs)
+        return await loop.run_in_executor(None, func_call)

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-import contextvars
-import functools
 import logging
 import platform
 import sys
@@ -20,20 +17,23 @@ WINDOWS = sys.platform.startswith("win")
 if sys.version_info >= (3, 9):
     from asyncio import to_thread
 else:
+    import contextvars
+    import functools
+    from asyncio import events
 
-    async def to_thread(*func_args, **kwargs):
+    async def to_thread(func, /, *args, **kwargs):
         """Asynchronously run function *func* in a separate thread.
         Any *args and **kwargs supplied for this function are directly passed
         to *func*. Also, the current :class:`contextvars.Context` is propagated,
         allowing context variables from the main thread to be accessed in the
         separate thread.
+
         Return a coroutine that can be awaited to get the eventual result of *func*.
 
         backport from
         https://github.com/python/cpython/blob/3f1ea163ea54513e00e0e9d5442fee1b639825cc/Lib/asyncio/threads.py#L12-L25
         """
-        func, *args = func_args
-        loop = asyncio.get_running_loop()
+        loop = events.get_running_loop()
         ctx = contextvars.copy_context()
         func_call = functools.partial(ctx.run, func, *args, **kwargs)
         return await loop.run_in_executor(None, func_call)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3807,8 +3807,8 @@ def test_unique_task_heap():
     assert repr(heap) == "<UniqueTaskHeap: 0 items>"
 
 
-@gen_cluster(client=True, nthreads=[])
-async def test_do_not_block_event_loop_during_shutdown(c, s):
+@gen_cluster(nthreads=[])
+async def test_do_not_block_event_loop_during_shutdown(s):
     loop = asyncio.get_running_loop()
     called_handler = threading.Event()
     block_handler = threading.Event()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -45,13 +45,12 @@ from dask.utils import (
     typename,
 )
 
-from distributed.compatibility import to_thread
-
 from . import comm, preloading, profile, system, utils
 from .batched import BatchedSend
 from .comm import Comm, connect, get_address_host
 from .comm.addressing import address_from_user_args, parse_address
 from .comm.utils import OFFLOAD_THRESHOLD
+from .compatibility import to_thread
 from .core import (
     CommClosedError,
     Status,


### PR DESCRIPTION
I don't exactly understand what's happening but this may be an explanation for why we're occasionally seeing a lot of "event loop was blocked ..." warnings in our test suites. Potentially this may also explain some other spurious timeout errors

What's happening is that, by default, we close the workers after a test with `gen_cluster` in [`end_cluster`](https://github.com/dask/distributed/blob/a86f4bb568b5aeb60f5a2a8e24f86592a407b09d/distributed/utils_test.py#L885-L894) using `Worker.close(report=False)`, i.e. the default values of `timeout=30` and `executor_wait=True` are respected.

I went through the test_semaphore cases because I noticed them all to be very slow. I figured I'd adjust a few parameters and speed up the entire thing. The test `test_close_async` was particularly interesting since it had a timeout of 120s defined which is required because a task is scheduled (fire_and_forget) that *never* finishes since it waits for a locked semaphore. Therefore, the ThreadPool could never gracefully shut down. Adding a timeout to this call actually didn't help but instead I saw this warning pop up.

It turns out that the executor.shutdown does block the event loop while waiting for a threading lock to be released
![image](https://user-images.githubusercontent.com/8629629/156186743-4e9a22e8-aa14-41f8-a5f5-08c271762391.png)

The code I wrote resolves all of this but it feels weird... 

cc @graingert @gjoseph92 @crusaderky 