### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,9 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     description="Distributed scheduler for Dask",
     url="https://distributed.dask.org",
+    project_urls={
+        "Source": "https://github.com/dask/distributed",
+    },
     maintainer="Matthew Rocklin",
     maintainer_email="mrocklin@gmail.com",
     python_requires=">=3.8",


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.