### PR TITLE
[WIP] Update threadpool

### DIFF
--- a/distributed/_concurrent_futures_thread.py
+++ b/distributed/_concurrent_futures_thread.py
@@ -227,6 +227,7 @@ class ThreadPoolExecutor(_base.Executor):
                     self._initargs,
                 ),
             )
+            t.daemon = True
             t.start()
             self._threads.add(t)
             _threads_queues[t] = self._work_queue

--- a/distributed/_concurrent_futures_thread.py
+++ b/distributed/_concurrent_futures_thread.py
@@ -1,45 +1,31 @@
-# This was copied from CPython 3.6
+# This was copied from CPython 3.10.2
 
 # Copyright 2009 Brian Quinlan. All Rights Reserved.
 # Licensed to PSF under a Contributor Agreement.
 
 """Implements ThreadPoolExecutor."""
 
-from __future__ import annotations
-
 __author__ = "Brian Quinlan (brian@sweetapp.com)"
 
-import atexit
 import itertools
 import os
 import queue
+import sys
 import threading
 import weakref
 from concurrent.futures import _base
 
-# Workers are created as daemon threads. This is done to allow the interpreter
-# to exit when there are still idle threads in a ThreadPoolExecutor's thread
-# pool (i.e. shutdown() was not called). However, allowing workers to die with
-# the interpreter has two undesirable properties:
-#   - The workers would still be running during interpreter shutdown,
-#     meaning that they would fail in unpredictable ways.
-#   - The workers could be killed while evaluating a work item, which could
-#     be bad if the callable being evaluated has external side-effects e.g.
-#     writing to a file.
-#
-# To work around this problem, an exit handler is installed which tells the
-# workers to exit when their work queues are empty and then waits until the
-# threads finish.
-
-_threads_queues: weakref.WeakKeyDictionary[
-    threading.Thread, queue.Queue
-] = weakref.WeakKeyDictionary()
+_threads_queues = weakref.WeakKeyDictionary()  # type: ignore
 _shutdown = False
+# Lock that ensures that new workers are not created while the interpreter is
+# shutting down. Must be held while mutating _threads_queues and _shutdown.
+_global_shutdown_lock = threading.Lock()
 
 
 def _python_exit():
     global _shutdown
-    _shutdown = True
+    with _global_shutdown_lock:
+        _shutdown = True
     items = list(_threads_queues.items())
     for t, q in items:
         q.put(None)
@@ -47,7 +33,37 @@ def _python_exit():
         t.join()
 
 
-atexit.register(_python_exit)
+# Register for `_python_exit()` to be called just before joining all
+# non-daemon threads. This is used instead of `atexit.register()` for
+# compatibility with subinterpreters, which no longer support daemon threads.
+# See bpo-39812 for context.
+if sys.version_info >= (3, 9):
+    threading._register_atexit(_python_exit)
+    _after_in_child = _global_shutdown_lock._at_fork_reinit
+    from types import GenericAlias
+else:
+    import atexit
+
+    atexit.register(_python_exit)
+    from functools import partial
+
+    def _at_fork_reinit(self):
+        self._block._at_fork_reinit()
+        self._owner = None
+        self._count = 0
+
+    _after_in_child = partial(_at_fork_reinit, _global_shutdown_lock)
+    del atexit, partial, _at_fork_reinit
+    GenericAlias = object
+
+# At fork, reinitialize the `_global_shutdown_lock` lock in the child process
+if hasattr(os, "register_at_fork"):
+
+    os.register_at_fork(
+        before=_global_shutdown_lock.acquire,
+        after_in_child=_after_in_child,
+        after_in_parent=_global_shutdown_lock.release,
+    )
 
 
 class _WorkItem:
@@ -58,18 +74,31 @@ class _WorkItem:
         self.kwargs = kwargs
 
     def run(self):
-        if not self.future.set_running_or_notify_cancel():  # pragma: no cover
+        if not self.future.set_running_or_notify_cancel():
             return
 
         try:
             result = self.fn(*self.args, **self.kwargs)
-        except BaseException as e:
-            self.future.set_exception(e)
+        except BaseException as exc:
+            self.future.set_exception(exc)
+            # Break a reference cycle with the exception 'exc'
+            self = None
         else:
             self.future.set_result(result)
 
+    __class_getitem__ = classmethod(GenericAlias)
 
-def _worker(executor_reference, work_queue):
+
+def _worker(executor_reference, work_queue, initializer, initargs):
+    if initializer is not None:
+        try:
+            initializer(*initargs)
+        except BaseException:
+            _base.LOGGER.critical("Exception in initializer:", exc_info=True)
+            executor = executor_reference()
+            if executor is not None:
+                executor._initializer_failed()
+            return
     try:
         while True:
             work_item = work_queue.get(block=True)
@@ -77,13 +106,24 @@ def _worker(executor_reference, work_queue):
                 work_item.run()
                 # Delete references to object. See issue16284
                 del work_item
+
+                # attempt to increment idle count
+                executor = executor_reference()
+                if executor is not None:
+                    executor._idle_semaphore.release()
+                del executor
                 continue
+
             executor = executor_reference()
             # Exit if:
             #   - The interpreter is shutting down OR
             #   - The executor that owns the worker has been collected OR
             #   - The executor that owns the worker has been shutdown.
             if _shutdown or executor is None or executor._shutdown:
+                # Flag the executor as shutting down as early as possible if it
+                # is not gc-ed yet.
+                if executor is not None:
+                    executor._shutdown = True
                 # Notice other workers
                 work_queue.put(None)
                 return
@@ -92,39 +132,68 @@ def _worker(executor_reference, work_queue):
         _base.LOGGER.critical("Exception in worker", exc_info=True)
 
 
+class BrokenThreadPool(_base.BrokenExecutor):
+    """
+    Raised when a worker thread in a ThreadPoolExecutor failed initializing.
+    """
+
+
 class ThreadPoolExecutor(_base.Executor):
 
     # Used to assign unique thread names when thread_name_prefix is not supplied.
-    _counter = itertools.count()
+    _counter = itertools.count().__next__
 
-    def __init__(self, max_workers=None, thread_name_prefix=""):
+    def __init__(
+        self, max_workers=None, thread_name_prefix="", initializer=None, initargs=()
+    ):
         """Initializes a new ThreadPoolExecutor instance.
 
         Args:
             max_workers: The maximum number of threads that can be used to
                 execute the given calls.
             thread_name_prefix: An optional name prefix to give our threads.
+            initializer: A callable used to initialize worker threads.
+            initargs: A tuple of arguments to pass to the initializer.
         """
         if max_workers is None:
-            # Use this number because ThreadPoolExecutor is often
-            # used to overlap I/O instead of CPU work.
-            max_workers = (os.cpu_count() or 1) * 5
+            # ThreadPoolExecutor is often used to:
+            # * CPU bound task which releases GIL
+            # * I/O bound task (which releases GIL, of course)
+            #
+            # We use cpu_count + 4 for both types of tasks.
+            # But we limit it to 32 to avoid consuming surprisingly large resource
+            # on many core machine.
+            max_workers = min(32, (os.cpu_count() or 1) + 4)
         if max_workers <= 0:
             raise ValueError("max_workers must be greater than 0")
 
+        if initializer is not None and not callable(initializer):
+            raise TypeError("initializer must be a callable")
+
         self._max_workers = max_workers
-        self._work_queue = queue.Queue()
+        self._work_queue = queue.SimpleQueue()
+        self._idle_semaphore = threading.Semaphore(0)
         self._threads = set()
+        self._broken = False
         self._shutdown = False
         self._shutdown_lock = threading.Lock()
         self._thread_name_prefix = thread_name_prefix or (
-            "ThreadPoolExecutor-%d" % next(self._counter)
+            "ThreadPoolExecutor-%d" % self._counter()
         )
+        self._initializer = initializer
+        self._initargs = initargs
 
-    def submit(self, fn, *args, **kwargs):
-        with self._shutdown_lock:
-            if self._shutdown:  # pragma: no cover
+    def submit(self, fn, /, *args, **kwargs):
+        with self._shutdown_lock, _global_shutdown_lock:
+            if self._broken:
+                raise BrokenThreadPool(self._broken)
+
+            if self._shutdown:
                 raise RuntimeError("cannot schedule new futures after shutdown")
+            if _shutdown:
+                raise RuntimeError(
+                    "cannot schedule new futures after " "interpreter shutdown"
+                )
 
             f = _base.Future()
             w = _WorkItem(f, fn, args, kwargs)
@@ -136,29 +205,62 @@ class ThreadPoolExecutor(_base.Executor):
     submit.__doc__ = _base.Executor.submit.__doc__
 
     def _adjust_thread_count(self):
+        # if idle threads are available, don't spin new threads
+        if self._idle_semaphore.acquire(timeout=0):
+            return
+
         # When the executor gets lost, the weakref callback will wake up
         # the worker threads.
         def weakref_cb(_, q=self._work_queue):
             q.put(None)
 
-        # TODO(bquinlan): Should avoid creating new threads if there are more
-        # idle threads than items in the work queue.
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
             t = threading.Thread(
                 name=thread_name,
                 target=_worker,
-                args=(weakref.ref(self, weakref_cb), self._work_queue),
+                args=(
+                    weakref.ref(self, weakref_cb),
+                    self._work_queue,
+                    self._initializer,
+                    self._initargs,
+                ),
             )
-            t.daemon = True
             t.start()
             self._threads.add(t)
             _threads_queues[t] = self._work_queue
 
-    def shutdown(self, wait=True):
+    def _initializer_failed(self):
+        with self._shutdown_lock:
+            self._broken = (
+                "A thread initializer failed, the thread pool " "is not usable anymore"
+            )
+            # Drain work queue and mark pending futures failed
+            while True:
+                try:
+                    work_item = self._work_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if work_item is not None:
+                    work_item.future.set_exception(BrokenThreadPool(self._broken))
+
+    def shutdown(self, wait=True, *, cancel_futures=False):
         with self._shutdown_lock:
             self._shutdown = True
+            if cancel_futures:
+                # Drain all work items from the queue, and then cancel their
+                # associated futures.
+                while True:
+                    try:
+                        work_item = self._work_queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if work_item is not None:
+                        work_item.future.cancel()
+
+            # Send a wake-up to prevent threads calling
+            # _work_queue.get(block=True) from permanently blocking.
             self._work_queue.put(None)
         if wait:
             for t in self._threads:

--- a/distributed/_concurrent_futures_thread.py
+++ b/distributed/_concurrent_futures_thread.py
@@ -37,7 +37,7 @@ def _python_exit():
 # non-daemon threads. This is used instead of `atexit.register()` for
 # compatibility with subinterpreters, which no longer support daemon threads.
 # See bpo-39812 for context.
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 10):
     threading._register_atexit(_python_exit)
     _after_in_child = _global_shutdown_lock._at_fork_reinit
     from types import GenericAlias

--- a/distributed/tests/test_threadpoolexecutor.py
+++ b/distributed/tests/test_threadpoolexecutor.py
@@ -27,32 +27,6 @@ def test_tpe():
             assert time() < start + 1
 
 
-def test_shutdown_timeout():
-    e = ThreadPoolExecutor(1)
-    futures = [e.submit(sleep, 0.1 * i) for i in range(1, 3, 1)]
-    sleep(0.01)
-
-    start = time()
-    e.shutdown()
-    end = time()
-    assert end - start > 0.1
-
-
-import pytest
-
-
-@pytest.mark.skip()
-def test_shutdown_timeout_raises():
-    e = ThreadPoolExecutor(1)
-    futures = [e.submit(sleep, 0.1 * i) for i in range(1, 3, 1)]
-    sleep(0.05)
-
-    start = time()
-    e.shutdown(timeout=0.1)
-    end = time()
-    assert end - start > 0.05
-
-
 def test_shutdown_wait():
     e = ThreadPoolExecutor(1)
     future = e.submit(sleep, 1)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1735,10 +1735,9 @@ class Worker(ServerNode):
             for executor in self.executors.values():
                 if executor is utils._offload_executor:
                     continue  # Never shutdown the offload executor
-                if isinstance(executor, ThreadPoolExecutor):
-                    executor._work_queue.queue.clear()
-                    executor.shutdown(wait=executor_wait, timeout=timeout)
-                else:
+                try:
+                    executor.shutdown(wait=executor_wait, cancel_futures=True)
+                except TypeError:
                     executor.shutdown(wait=executor_wait)
 
             self.stop()


### PR DESCRIPTION
This updates the threadpool to the most recent version as is currently in python 3.10.2. It required a few compatibility adjustments to make it work for py3.8 but nothing major imo.

Incorporatign secede/rejoin was a bit more tricky and I'm not entirely sure if I didn't put in a bug around the idle counter/semaphore when a thread rejoins. However, if I'm not wrong, a miscounting in this semaphore would only remove the optimization of not spawning additional threads if there are idle workers which I don't consider to be a big deal.

I decided to remove the shutdown timeout that was introduced in https://github.com/dask/distributed/pull/1330

* The tests never actually worked. They test a lower limit for the shutdown but even if the timeout was removed, all tests would pass. Rather, the tests should've checked an upper threshold
* I am not entirely convinced this is necessary, if not even harmful. Afaik, the python interpreter will not shut down unless all (non-daemon) threads finished, therefore timing out the shutdown would never close a worker faster in a real application than if we waited for the shutdown to finish properly.
* In tests, this can overshadow flaws in our tests and will most definitely leak threads that run concurrently to other tests. We should avoid this as good as possible. Worst case would be that the threads never finish and we'd hit the pytest-timeout. I suspect these problems should be straight forward to debug.
* The original issue mentions a memory leak but I cannot see how this relates to the shutdown.

If any of the above reasons are false or I missed anything, adding the shutdown timeout again should be easy enough


cc @graingert 