### PR TITLE
Ensure default client mechanism is threadsafe

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -108,7 +108,7 @@ class Actor(WrappedKey):
                 self._worker = None
             try:
                 self._client = get_client()
-                self._future = Future(key, inform=self._worker is None)
+                self._future = Future(key, self._client, inform=self._worker is None)
                 # ^ When running on a worker, only hold a weak reference to the key, otherwise the key could become unreleasable.
             except ValueError:
                 self._client = None

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1633,7 +1633,8 @@ class Client(SyncMethodMixin):
             return
 
         self.status = "closing"
-        _del_global_client(self)
+        if self._set_as_default:
+            _del_global_client(self)
 
         for preload in self.preloads:
             await preload.teardown()
@@ -5240,6 +5241,7 @@ def ensure_default_client(client: Client) -> None:
     client : Client
         The client
     """
+    client._set_as_default = True
     _set_global_client(client)
 
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -119,7 +119,6 @@ DEFAULT_EXTENSIONS = {
 }
 
 
-
 class _GlobalClientManager:
     def __init__(self):
         self._lock = threading.RLock()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -5566,16 +5566,3 @@ def temp_default_client(c: Client) -> Generator[None, None, None]:
         yield
     finally:
         _set_global_client(old_exec)
-
-
-def __getattr__(name):
-    if name == "ensure_default_get":
-        warnings.warn(
-            "`ensure_default_get` is deprecated and will be removed in a future release. "
-            "Please use `distributed.client.ensure_default_client` instead.",
-            category=FutureWarning,
-            stacklevel=2,
-        )
-        return ensure_default_client
-    else:
-        raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3462,7 +3462,9 @@ async def test_default_global_client_multi_clients(s):
 async def test_ensure_default_client(c, s, a, b):
     assert c is default_client()
 
-    async with Client(s.address, set_as_default=False, asynchronous=True) as c2:
+    async with Client(
+        s.address, set_as_default=False, asynchronous=True, name="c2"
+    ) as c2:
         assert c is default_client()
         assert c2 is not default_client()
         ensure_default_client(c2)


### PR DESCRIPTION
I encountered a problem that the default client and respective config settings were not properly reset when multiple clients were used and they were not closed in the correct order. 

For example [`test_cancel_multi_client`](https://github.com/dask/distributed/blob/b3f50ceff4012a64f8517da25060e24180c8a6d4/distributed/tests/test_client.py#L2365-L2390) closes the clients in the same order they were started but that would leave a global config set, e.g. scheduler="dask.distributed"

This led to leakage of state in test such that some tests would behave differently depending on what test was executed 

I noticed this happening in https://github.com/dask/distributed/pull/5791 but have no idea why we're not seeing this on main. I added a pytest autouse fixture to ensure no tests are leaking global clients.

Closes https://github.com/dask/distributed/issues/5772

Note: There are more issues about thread safe get_clients that are not addressed by this:  https://github.com/dask/distributed/issues/3827, https://github.com/dask/distributed/pull/5467

### Shortcoming / out of scope
If a user defines multiple default clients, modifies any of the keys `scheduler` or `shuffle` themselves, closing the last global/default client will overwrite the manual user setting to what it was before any Client was initialized. I'm fine with this since this _should_ not happen