### PR TITLE
Skip dask-ssh tests without paramiko

### DIFF
--- a/distributed/cli/tests/test_dask_ssh.py
+++ b/distributed/cli/tests/test_dask_ssh.py
@@ -6,6 +6,7 @@ from distributed.cli.dask_ssh import main
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.utils_test import popen
 
+pytest.importorskip("paramiko")
 pytestmark = [
     pytest.mark.xfail(MACOS, reason="very high flakiness; see distributed/issues/4543"),
     pytest.mark.skipif(WINDOWS, reason="no CI support; see distributed/issues/4509"),


### PR DESCRIPTION
The test otherwise fails somewhere internally attempting to import it:
```
___________________ test_ssh_cli_nprocs_renamed_to_nworkers ____________________
ConnectionRefusedError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

addr = 'tcp://127.0.0.1:8786', timeout = 15, deserialize = True
handshake_overrides = None
connection_args = {'extra_conn_args': {}, 'require_encryption': False, 'ssl_context': None}
scheme = 'tcp', loc = '127.0.0.1:8786'
backend = <distributed.comm.tcp.TCPBackend object at 0x7fdd34314e20>
connector = <distributed.comm.tcp.TCPConnector object at 0x7fdd1b979ae0>
comm = None, time_left = <function connect.<locals>.time_left at 0x7fdd1bcf7c70>
backoff_base = 0.01

    async def connect(
        addr, timeout=None, deserialize=True, handshake_overrides=None, **connection_args
    ):
        """
        Connect to the given address (a URI such as ``tcp://127.0.0.1:1234``)
        and yield a ``Comm`` object.  If the connection attempt fails, it is
        retried until the *timeout* is expired.
        """
        if timeout is None:
            timeout = dask.config.get("distributed.comm.timeouts.connect")
        timeout = parse_timedelta(timeout, default="seconds")
    
        scheme, loc = parse_address(addr)
        backend = registry.get_backend(scheme)
        connector = backend.get_connector()
        comm = None
    
        start = time()
    
        def time_left():
            deadline = start + timeout
            return max(0, deadline - time())
    
        backoff_base = 0.01
        attempt = 0
    
        # Prefer multiple small attempts than one long attempt. This should protect
        # primarily from DNS race conditions
        # gh3104, gh4176, gh4167
        intermediate_cap = timeout / 5
        active_exception = None
        while time_left() > 0:
            try:
>               comm = await asyncio.wait_for(
                    connector.connect(loc, deserialize=deserialize, **connection_args),
                    timeout=min(intermediate_cap, time_left()),
                )

distributed/comm/core.py:289: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

fut = <Task finished name='Task-389' coro=<BaseTCPConnector.connect() done, defined at /builddir/build/BUILD/distributed-202...<distributed.comm.tcp.TCPConnector object at 0x7fdd1b979ae0>: ConnectionRefusedError: [Errno 111] Connection refused')>
timeout = 0.0028645992279052734

    async def wait_for(fut, timeout):
        """Wait for the single Future or coroutine to complete, with timeout.
    
        Coroutine will be wrapped in Task.
    
        Returns result of the Future or coroutine.  When a timeout occurs,
        it cancels the task and raises TimeoutError.  To avoid the task
        cancellation, wrap it in shield().
    
        If the wait is cancelled, the task is also cancelled.
    
        This function is a coroutine.
        """
        loop = events.get_running_loop()
    
        if timeout is None:
            return await fut
    
        if timeout <= 0:
            fut = ensure_future(fut, loop=loop)
    
            if fut.done():
                return fut.result()
    
            await _cancel_and_wait(fut, loop=loop)
            try:
                return fut.result()
            except exceptions.CancelledError as exc:
                raise exceptions.TimeoutError() from exc
    
        waiter = loop.create_future()
        timeout_handle = loop.call_later(timeout, _release_waiter, waiter)
        cb = functools.partial(_release_waiter, waiter)
    
        fut = ensure_future(fut, loop=loop)
        fut.add_done_callback(cb)
    
        try:
            # wait until the future completes or the timeout
            try:
                await waiter
            except exceptions.CancelledError:
                if fut.done():
                    return fut.result()
                else:
                    fut.remove_done_callback(cb)
                    # We must ensure that the task is not running
                    # after wait_for() returns.
                    # See https://bugs.python.org/issue32751
                    await _cancel_and_wait(fut, loop=loop)
                    raise
    
            if fut.done():
>               return fut.result()

/usr/lib64/python3.10/asyncio/tasks.py:445: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <distributed.comm.tcp.TCPConnector object at 0x7fdd1b979ae0>
address = '127.0.0.1:8786', deserialize = True
connection_args = {'extra_conn_args': {}, 'require_encryption': False, 'ssl_context': None}
ip = '127.0.0.1', port = 8786, kwargs = {}

    async def connect(self, address, deserialize=True, **connection_args):
        self._check_encryption(address, connection_args)
        ip, port = parse_host_port(address)
        kwargs = self._get_connect_args(**connection_args)
    
        try:
            stream = await self.client.connect(
                ip, port, max_buffer_size=MAX_BUFFER_SIZE, **kwargs
            )
            # Under certain circumstances tornado will have a closed connnection with an
            # error and not raise a StreamClosedError.
            #
            # This occurs with tornado 5.x and openssl 1.1+
            if stream.closed() and stream.error:
                raise StreamClosedError(stream.error)
    
        except StreamClosedError as e:
            # The socket connect() call failed
>           convert_stream_closed_error(self, e)

distributed/comm/tcp.py:444: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

obj = <distributed.comm.tcp.TCPConnector object at 0x7fdd1b979ae0>
exc = ConnectionRefusedError(111, 'Connection refused')

    def convert_stream_closed_error(obj, exc):
        """
        Re-raise StreamClosedError as CommClosedError.
        """
        if exc.real_error is not None:
            # The stream was closed because of an underlying OS error
            exc = exc.real_error
            if ssl and isinstance(exc, ssl.SSLError):
                if "UNKNOWN_CA" in exc.reason:
                    raise FatalCommClosedError(f"in {obj}: {exc.__class__.__name__}: {exc}")
>           raise CommClosedError(f"in {obj}: {exc.__class__.__name__}: {exc}") from exc
E           distributed.comm.core.CommClosedError: in <distributed.comm.tcp.TCPConnector object at 0x7fdd1b979ae0>: ConnectionRefusedError: [Errno 111] Connection refused

distributed/comm/tcp.py:133: CommClosedError

The above exception was the direct cause of the following exception:

loop = <tornado.platform.asyncio.AsyncIOLoop object at 0x7fdd1b97a470>

    def test_ssh_cli_nprocs_renamed_to_nworkers(loop):
        n_workers = 2
        with popen(
            ["dask-ssh", f"--nprocs={n_workers}", "--nohost", "localhost"]
        ) as cluster:
>           with Client("tcp://127.0.0.1:8786", timeout="15 seconds", loop=loop) as c:

distributed/cli/tests/test_dask_ssh.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
distributed/client.py:933: in __init__
    self.start(timeout=timeout)
distributed/client.py:1091: in start
    sync(self.loop, self._start, **kwargs)
distributed/utils.py:378: in sync
    raise exc.with_traceback(tb)
distributed/utils.py:351: in f
    result = yield future
/usr/lib64/python3.10/site-packages/tornado/gen.py:762: in run
    value = future.result()
distributed/client.py:1183: in _start
    await self._ensure_connected(timeout=timeout)
distributed/client.py:1245: in _ensure_connected
    comm = await connect(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

addr = 'tcp://127.0.0.1:8786', timeout = 15, deserialize = True
handshake_overrides = None
connection_args = {'extra_conn_args': {}, 'require_encryption': False, 'ssl_context': None}
scheme = 'tcp', loc = '127.0.0.1:8786'
backend = <distributed.comm.tcp.TCPBackend object at 0x7fdd34314e20>
connector = <distributed.comm.tcp.TCPConnector object at 0x7fdd1b979ae0>
comm = None, time_left = <function connect.<locals>.time_left at 0x7fdd1bcf7c70>
backoff_base = 0.01

    async def connect(
        addr, timeout=None, deserialize=True, handshake_overrides=None, **connection_args
    ):
        """
        Connect to the given address (a URI such as ``tcp://127.0.0.1:1234``)
        and yield a ``Comm`` object.  If the connection attempt fails, it is
        retried until the *timeout* is expired.
        """
        if timeout is None:
            timeout = dask.config.get("distributed.comm.timeouts.connect")
        timeout = parse_timedelta(timeout, default="seconds")
    
        scheme, loc = parse_address(addr)
        backend = registry.get_backend(scheme)
        connector = backend.get_connector()
        comm = None
    
        start = time()
    
        def time_left():
            deadline = start + timeout
            return max(0, deadline - time())
    
        backoff_base = 0.01
        attempt = 0
    
        # Prefer multiple small attempts than one long attempt. This should protect
        # primarily from DNS race conditions
        # gh3104, gh4176, gh4167
        intermediate_cap = timeout / 5
        active_exception = None
        while time_left() > 0:
            try:
                comm = await asyncio.wait_for(
                    connector.connect(loc, deserialize=deserialize, **connection_args),
                    timeout=min(intermediate_cap, time_left()),
                )
                break
            except FatalCommClosedError:
                raise
            # Note: CommClosed inherits from OSError
            except (asyncio.TimeoutError, OSError) as exc:
                active_exception = exc
    
                # As descibed above, the intermediate timeout is used to distributed
                # initial, bulk connect attempts homogeneously. In particular with
                # the jitter upon retries we should not be worred about overloading
                # any more DNS servers
                intermediate_cap = timeout
                # FullJitter see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
    
                upper_cap = min(time_left(), backoff_base * (2**attempt))
                backoff = random.uniform(0, upper_cap)
                attempt += 1
                logger.debug(
                    "Could not connect to %s, waiting for %s before retrying", loc, backoff
                )
                await asyncio.sleep(backoff)
        else:
>           raise OSError(
                f"Timed out trying to connect to {addr} after {timeout} s"
            ) from active_exception
E           OSError: Timed out trying to connect to tcp://127.0.0.1:8786 after 15 s

distributed/comm/core.py:315: OSError
----------------------------- Captured stdout call -----------------------------


Print from stderr
  /
=================

/builddir/build/BUILDROOT/python-distributed-2022.2.1-1.fc37.x86_64/usr/lib64/python3.10/site-packages/distributed/cli/dask_ssh.py:175: FutureWarning: The --nprocs flag will be removed in a future release. It has been renamed to --nworkers.
  warnings.warn(
Exception in thread Thread-1 (async_ssh):
Traceback (most recent call last):
  File "/usr/lib64/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
Exception in thread Thread-2 (async_ssh):
  File "/usr/lib64/python3.10/threading.py", line 946, in run
Traceback (most recent call last):
  File "/usr/lib64/python3.10/threading.py", line 1009, in _bootstrap_inner
    self._target(*self._args, **self._kwargs)
  File "/builddir/build/BUILDROOT/python-distributed-2022.2.1-1.fc37.x86_64/usr/lib64/python3.10/site-packages/distributed/deploy/old_ssh.py", line 33, in async_ssh
    import paramiko
    self.run()
ModuleNotFoundError: No module named 'paramiko'
  File "/usr/lib64/python3.10/threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "/builddir/build/BUILDROOT/python-distributed-2022.2.1-1.fc37.x86_64/usr/lib64/python3.10/site-packages/distributed/deploy/old_ssh.py", line 33, in async_ssh
    import paramiko
ModuleNotFoundError: No module named 'paramiko'



Print from stdout
=================


---------------------------------------------------------------
                 Dask.distributed v2022.2.1

Worker nodes: 1
  0: localhost

scheduler node: localhost:8786
---------------------------------------------------------------



[ dask-ssh ]: Shutting down remote processes (this may take a moment).
[ dask-ssh ]: Remote processes have been terminated. Exiting.
```

- [n/a] Closes #xxxx
- [x] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
