### PR TITLE
Do not allow closing workers to be awaited again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,8 @@ repos:
           - types-psutil
           - types-setuptools
           # Typed libraries
-          - numpy
           - dask
+          - numpy
+          - pytest
           - tornado
           - zict

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -205,8 +205,9 @@ class Actor(WrappedKey):
                         if self._future and not self._future.done():
                             await self._future
                             return await run_actor_function_on_worker()
-                        else:  # pragma: no cover
-                            raise OSError("Unable to contact Actor's worker")
+                        else:
+                            exc = OSError("Unable to contact Actor's worker")
+                            return _Error(exc)
                     if result["status"] == "OK":
                         return _OK(result["result"])
                     return _Error(result["exception"])

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1318,7 +1318,11 @@ class Client(SyncMethodMixin):
 
         def running_workers(info):
             return len(
-                [ws["status"] == Status.running for ws in info["workers"].values()]
+                [
+                    ws
+                    for ws in info["workers"].values()
+                    if ws["status"] == Status.running.name
+                ]
             )
 
         while n_workers and running_workers(info) < n_workers:

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -325,10 +325,7 @@ class SpecCluster(Cluster):
                     for w in to_close
                     if w in self.workers
                 ]
-                await asyncio.wait(tasks)
-                for task in tasks:  # for tornado gen.coroutine support
-                    with suppress(RuntimeError):
-                        await task
+                await asyncio.gather(*tasks)
             for name in to_close:
                 if name in self.workers:
                     del self.workers[name]
@@ -417,7 +414,7 @@ class SpecCluster(Cluster):
 
             await self.scheduler.close()
             for w in self._created:
-                assert w.status == Status.closed, w.status
+                assert w.status in {Status.closed, Status.failed}, w.status
 
         if hasattr(self, "_old_logging_level"):
             silence_logging(self._old_logging_level)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -582,6 +582,7 @@ class WorkerState:
             "last_seen": self.last_seen,
             "services": self.services,
             "metrics": self.metrics,
+            "status": self.status.name,
             "nanny": self.nanny,
             **self.extra,
         }
@@ -3233,7 +3234,6 @@ class Scheduler(SchedulerState, ServerNode):
         setproctitle("dask-scheduler [not started]")
         Scheduler._instances.add(self)
         self.rpc.allow_offload = False
-        self.status = Status.undefined
 
     ##################
     # Administration #
@@ -3241,7 +3241,7 @@ class Scheduler(SchedulerState, ServerNode):
 
     def __repr__(self):
         return (
-            f"<Scheduler {self.address!r}, "
+            f"<Scheduler {self.address_safe!r}, "
             f"workers: {len(self.workers)}, "
             f"cores: {self.total_nthreads}, "
             f"tasks: {len(self.tasks)}>"
@@ -3374,10 +3374,9 @@ class Scheduler(SchedulerState, ServerNode):
         else:
             return ws.host, port
 
-    async def start(self):
+    async def start_unsafe(self):
         """Clear out old state and restart all running coroutines"""
-        await super().start()
-        assert self.status != Status.running
+        await super().start_unsafe()
 
         enable_gc_diagnosis()
 

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -290,7 +290,6 @@ async def test_failed_worker(c, s, a, b):
 
     assert "actor" in str(info.value).lower()
     assert "worker" in str(info.value).lower()
-    assert "lost" in str(info.value).lower()
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4254,6 +4254,7 @@ async def test_retire_workers_2(c, s, a, b):
 
     await s.retire_workers(workers=[a.address])
     assert b.data == {x.key: 1}
+
     assert {ws.address for ws in s.tasks[x.key].who_has} == {b.address}
     assert {ts.key for ts in s.workers[b.address].has_what} == {x.key}
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -150,6 +150,7 @@ class MyServer(Server):
     default_port = 8756
 
 
+@pytest.mark.slow
 @gen_test()
 async def test_server_listen():
     """
@@ -384,7 +385,7 @@ async def check_rpc_with_many_connections(listen_arg):
         for i in range(10):
             await remote.ping()
 
-    server = Server({"ping": pingpong})
+    server = await Server({"ping": pingpong})
     await server.listen(listen_arg)
 
     async with rpc(server.address) as remote:
@@ -552,6 +553,7 @@ async def test_connection_pool():
 
     servers = [Server({"ping": ping}) for i in range(10)]
     for server in servers:
+        await server
         await server.listen(0)
 
     rpc = await ConnectionPool(limit=5)
@@ -717,6 +719,7 @@ async def test_connection_pool_tls():
 
     servers = [Server({"ping": ping}) for i in range(10)]
     for server in servers:
+        await server
         await server.listen("tls://", **listen_args)
 
     rpc = await ConnectionPool(limit=5, connection_args=connection_args)
@@ -738,6 +741,7 @@ async def test_connection_pool_remove():
 
     servers = [Server({"ping": ping}) for i in range(5)]
     for server in servers:
+        await server
         await server.listen(0)
 
     rpc = await ConnectionPool(limit=10)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -27,7 +27,12 @@ from distributed.metrics import time
 from distributed.profile import wait_profiler
 from distributed.protocol.pickle import dumps
 from distributed.utils import TimeoutError, parse_ports
-from distributed.utils_test import captured_logger, gen_cluster, gen_test
+from distributed.utils_test import (
+    captured_logger,
+    gen_cluster,
+    gen_test,
+    raises_with_cause,
+)
 
 pytestmark = pytest.mark.ci1
 
@@ -139,7 +144,7 @@ async def test_nanny_death_timeout(s):
     with pytest.raises(TimeoutError):
         await w
 
-    assert w.status == Status.closed
+    assert w.status == Status.failed
 
 
 @gen_cluster(client=True, Worker=Nanny)
@@ -426,8 +431,11 @@ async def test_nanny_port_range(c, s):
         assert n1.port == 9867  # Selects first port in range
         async with Nanny(s.address, port=nanny_port, worker_port=worker_port) as n2:
             assert n2.port == 9868  # Selects next port in range
-            with pytest.raises(
-                ValueError, match="Could not start Nanny"
+            with raises_with_cause(
+                RuntimeError,
+                "Nanny failed to start.",
+                ValueError,
+                "with port 9867:9868",
             ):  # No more ports left
                 async with Nanny(s.address, port=nanny_port, worker_port=worker_port):
                     pass
@@ -477,7 +485,7 @@ class BrokenWorker(worker.Worker):
 @gen_cluster(nthreads=[])
 async def test_worker_start_exception(s):
     # make sure this raises the right Exception:
-    with pytest.raises(StartException):
+    with raises_with_cause(RuntimeError, None, StartException, None):
         async with Nanny(s.address, worker_class=BrokenWorker) as n:
             pass
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -29,6 +29,7 @@ from distributed.utils_test import (
     gen_test,
     inc,
     new_config,
+    raises_with_cause,
     tls_only_security,
 )
 from distributed.worker import InvalidTransition
@@ -619,7 +620,11 @@ def test_check_process_leak_post_cleanup(ignore_sigterm):
 
 @pytest.mark.parametrize("nanny", [True, False])
 def test_start_failure_worker(nanny):
-    with pytest.raises(TypeError):
+    if nanny:
+        ctx = raises_with_cause(RuntimeError, None, TypeError, None)
+    else:
+        ctx = pytest.raises(TypeError)
+    with ctx:
         with cluster(nanny=nanny, worker_kwargs={"foo": "bar"}):
             return
 
@@ -679,6 +684,43 @@ def test_invalid_worker_states(capsys):
 
     assert "released" in out + err
     assert "task-name" in out + err
+
+
+def test_raises_with_cause():
+    with raises_with_cause(RuntimeError, "exception", ValueError, "cause"):
+        raise RuntimeError("exception") from ValueError("cause")
+
+    with raises_with_cause(RuntimeError, "exception", ValueError, "tial mat"):
+        raise RuntimeError("exception") from ValueError("partial match")
+
+    with raises_with_cause(RuntimeError, None, ValueError, "cause"):
+        raise RuntimeError("exception") from ValueError("cause")
+
+    with raises_with_cause(RuntimeError, "exception", ValueError, None):
+        raise RuntimeError("exception") from ValueError("bar")
+
+    with raises_with_cause(RuntimeError, None, ValueError, None):
+        raise RuntimeError("foo") from ValueError("bar")
+
+    # we're trying to stick to pytest semantics
+    # If the exception types don't match, raise the original exception
+    # If the text doesn't match, raise an assert
+
+    with pytest.raises(RuntimeError):
+        with raises_with_cause(RuntimeError, "exception", ValueError, "cause"):
+            raise RuntimeError("exception") from OSError("cause")
+
+    with pytest.raises(ValueError):
+        with raises_with_cause(RuntimeError, "exception", ValueError, "cause"):
+            raise ValueError("exception") from ValueError("cause")
+
+    with pytest.raises(AssertionError):
+        with raises_with_cause(RuntimeError, "exception", ValueError, "foo"):
+            raise RuntimeError("exception") from ValueError("cause")
+
+    with pytest.raises(AssertionError):
+        with raises_with_cause(RuntimeError, "foo", ValueError, "cause"):
+            raise RuntimeError("exception") from ValueError("cause")
 
 
 def test_worker_fail_hard(capsys):

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -148,7 +148,7 @@ async def test_fail_to_pickle_target_2(c, s, a):
     config={
         "distributed.worker.memory.target": False,
         "distributed.worker.memory.spill": 0.7,
-        "distributed.worker.memory.monitor-interval": "10ms",
+        "distributed.worker.memory.monitor-interval": "100ms",
     },
 )
 async def test_fail_to_pickle_spill(c, s, a):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -25,7 +25,7 @@ from collections.abc import Callable
 from contextlib import contextmanager, nullcontext, suppress
 from itertools import count
 from time import sleep
-from typing import Any, Literal
+from typing import Any, Generator, Literal
 
 from distributed.compatibility import MACOS
 from distributed.scheduler import Scheduler
@@ -68,7 +68,6 @@ from distributed.protocol import deserialize
 from distributed.security import Security
 from distributed.utils import (
     DequeHandler,
-    TimeoutError,
     _offload_executor,
     get_ip,
     get_ipv6,
@@ -78,7 +77,7 @@ from distributed.utils import (
     reset_logger_locks,
     sync,
 )
-from distributed.worker import InvalidTransition, Worker
+from distributed.worker import WORKER_ANY_RUNNING, InvalidTransition, Worker
 
 try:
     import dask.array  # register config
@@ -166,7 +165,7 @@ def loop():
             except RuntimeError as e:
                 if not re.match("IOLoop is clos(ed|ing)", str(e)):
                     raise
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 pass
             else:
                 is_stopped.wait()
@@ -736,7 +735,7 @@ def cluster(
                 async def wait_for_workers():
                     async with rpc(saddr, **rpc_kwargs) as s:
                         while True:
-                            nthreads = await s.ncores()
+                            nthreads = await s.ncores_running()
                             if len(nthreads) == nworkers:
                                 break
                             if time() - start > 5:
@@ -936,7 +935,7 @@ async def end_cluster(s, workers):
     logger.debug("Closing out test cluster")
 
     async def end_worker(w):
-        with suppress(TimeoutError, CommClosedError, EnvironmentError):
+        with suppress(asyncio.TimeoutError, CommClosedError, EnvironmentError):
             await w.close(report=False)
 
     await asyncio.gather(*(end_worker(w) for w in workers))
@@ -1077,7 +1076,7 @@ def gen_cluster(
                             # Remove as much of the traceback as possible; it's
                             # uninteresting boilerplate from utils_test and asyncio and
                             # not from the code being tested.
-                            raise TimeoutError(
+                            raise asyncio.TimeoutError(
                                 f"Test timeout after {timeout}s.\n"
                                 "========== Test stack trace starts here ==========\n"
                                 f"{buffer.getvalue()}"
@@ -1772,7 +1771,7 @@ def check_instances():
     for w in Worker._instances:
         with suppress(RuntimeError):  # closed IOLoop
             w.loop.add_callback(w.close, report=False, executor_wait=False)
-            if w.status in Status.ANY_RUNNING:
+            if w.status in WORKER_ANY_RUNNING:
                 w.loop.add_callback(w.close)
     Worker._instances.clear()
 
@@ -1793,7 +1792,8 @@ def check_instances():
         raise ValueError("Unclosed Comms", L)
 
     assert all(
-        n.status == Status.closed or n.status == Status.init for n in Nanny._instances
+        n.status in {Status.closed, Status.init, Status.failed}
+        for n in Nanny._instances
     ), {n: n.status for n in Nanny._instances}
 
     # assert not list(SpecCluster._instances)  # TODO
@@ -2098,3 +2098,29 @@ def has_pytestmark(test_func: Callable, name: str) -> bool:
     """
     marks = getattr(test_func, "pytestmark", [])
     return any(mark.name == name for mark in marks)
+
+
+@contextmanager
+def raises_with_cause(
+    expected_exception: type[BaseException] | tuple[type[BaseException], ...],
+    match: str | None,
+    expected_cause: type[BaseException] | tuple[type[BaseException], ...],
+    match_cause: str | None,
+) -> Generator[None, None, None]:
+    """Contextmanager to assert that a certain exception with cause was raised
+
+    Parameters
+    ----------
+    exc_type:
+    """
+    with pytest.raises(expected_exception, match=match) as exc_info:
+        yield
+
+    exc = exc_info.value
+    assert exc.__cause__
+    if not isinstance(exc.__cause__, expected_cause):
+        raise exc
+    if match_cause:
+        assert re.search(
+            match_cause, str(exc.__cause__)
+        ), f"Pattern ``{match_cause}`` not found in ``{exc.__cause__}``"

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -558,6 +558,7 @@ class Worker(ServerNode):
         # Parameters to Server
         **kwargs,
     ):
+        self._background_tasks: set[asyncio.Task] = set()
         self.tasks = {}
         self.waiting_for_data_count = 0
         self.has_what = defaultdict(set)
@@ -1007,11 +1008,16 @@ class Worker(ServerNode):
         prev_status = self.status
         ServerNode.status.__set__(self, value)
         stimulus_id = f"worker-status-change-{time()}"
-        self._send_worker_status_change(stimulus_id)
+        self._background_tasks.add(
+            asyncio.create_task(
+                self._send_worker_status_change(stimulus_id),
+                name="send-worker-status-change",
+            )
+        )
         if prev_status == Status.paused and value == Status.running:
             self.handle_stimulus(UnpauseEvent(stimulus_id=stimulus_id))
 
-    def _send_worker_status_change(self, stimulus_id: str) -> None:
+    async def _send_worker_status_change(self, stimulus_id: str) -> None:
         if (
             self.batched_stream
             and self.batched_stream.comm
@@ -1025,7 +1031,8 @@ class Worker(ServerNode):
                 },
             )
         elif self._status != Status.closed:
-            self.loop.call_later(0.05, self._send_worker_status_change, stimulus_id)
+            await asyncio.sleep(0.05)
+            await self._send_worker_status_change(stimulus_id=stimulus_id)
 
     async def get_metrics(self) -> dict:
         try:
@@ -1607,6 +1614,7 @@ class Worker(ServerNode):
 
         self.status = Status.closed
         await super().close()
+        await asyncio.gather(*self._background_tasks)
 
         setproctitle("dask-worker [closed]")
         return "OK"
@@ -3354,7 +3362,12 @@ class Worker(ServerNode):
                 "Invalid Worker.status transition: %s -> %s", self._status, new_status
             )
             # Reiterate the current status to the scheduler to restore sync
-            self._send_worker_status_change(stimulus_id)
+            self._background_tasks.add(
+                asyncio.create_task(
+                    self._send_worker_status_change(stimulus_id),
+                    name="send-worker-status-change",
+                )
+            )
         else:
             # Update status and send confirmation to the Scheduler (see status.setter)
             self.status = new_status


### PR DESCRIPTION
This fixes some of our deadlock situations causing tests to time out while closing a worker.

This is not a ready fix but rather a preliminary one to communicate the issue.

What's happening:

- A worker is closing
- Worker.status is set to `closing`. This will ensure `Worker.close` is idempotent and let every other caller to await finished, see https://github.com/dask/distributed/blob/39c5e8856cb05ad1833a0f6ee6c3fea0ddab1c1c/distributed/worker.py#L1647-L1648
- While it is closing, an incoming RPC triggers an [`await self`](https://github.com/dask/distributed/blob/39c5e8856cb05ad1833a0f6ee6c3fea0ddab1c1c/distributed/core.py#L465)
- The `await self` will attempt to start the worker again since `closing` is not part of `Status.ANY_RUNNING`
- The restart will set the status to `running` such that a second close attempt will actually try to run a close concurrently. the second call is actually what is deadlocking then while trying to shutdown the threadpool executor

Open questions:
- Is it justified that we have multiple close attempts?
- Why did this ever work?
- ...

cc @crusaderky @graingert 

closes https://github.com/dask/distributed/issues/5932