### PR TITLE
drop pkg_resources in favour of importlib.metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,6 @@ repos:
           - types-docutils
           - types-requests
           - types-paramiko
-          - types-pkg_resources
           - types-PyYAML
           - types-setuptools
           - types-psutil

--- a/distributed/comm/registry.py
+++ b/distributed/comm/registry.py
@@ -4,9 +4,18 @@ import importlib.metadata
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from typing import Protocol
+
+
+class _EntryPoints(Protocol):
+    def __call__(self, **kwargs: str) -> Iterable[importlib.metadata.EntryPoint]:
+        ...
+
 
 if sys.version_info >= (3, 10):
-    _entry_points = importlib.metadata.entry_points
+    # py3.10 importlib.metadata type annotations are not in mypy yet
+    # https://github.com/python/typeshed/pull/7331
+    _entry_points: _EntryPoints = importlib.metadata.entry_points  # type: ignore[assignment]
 else:
 
     def _entry_points(

--- a/distributed/comm/registry.py
+++ b/distributed/comm/registry.py
@@ -73,18 +73,11 @@ class Backend(ABC):
 backends: dict[str, Backend] = {}
 
 
-def get_backend(scheme: str, require: object = None) -> Backend:
+def get_backend(scheme: str) -> Backend:
     """
     Get the Backend instance for the given *scheme*.
     It looks for matching scheme in dask's internal cache, and falls-back to
     package metadata for the group name ``distributed.comm.backends``
-
-    Parameters
-    ----------
-
-    require : object
-        Deprecated, previously verified that the backends requirements are
-        properly installed.
     """
 
     backend = backends.get(scheme)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -74,8 +74,6 @@ def _initialize_mp_context():
     if method == "forkserver":
         # Makes the test suite much faster
         preload = ["distributed"]
-        if "pkg_resources" in sys.modules:
-            preload.append("pkg_resources")
 
         from distributed.versions import optional_packages, required_packages
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ toolz >= 0.8.2
 tornado >= 6.0.3
 zict >= 0.1.3
 pyyaml
-setuptools


### PR DESCRIPTION
re: https://setuptools.pypa.io/en/latest/pkg_resources.html

> Use of pkg_resources is discouraged in favor of [importlib.resources](https://docs.python.org/3/library/importlib.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html), and their backports ([resources](https://pypi.org/project/importlib_resources), [metadata](https://pypi.org/project/importlib_metadata)). Please consider using those libraries instead of pkg_resources.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
