### PR TITLE
Fix `track_features` for distributed pre-releases

### DIFF
--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -44,7 +44,7 @@ outputs:
       script: >
         python -m pip install . -vv --no-deps
         --install-option="--with-cython=profile"  # [cython_enabled]
-      track_features: {{ "cythonized-scheduler" if cython_enabled else "" }}
+      track_features: {{ "[cythonized-scheduler]" if build_ext == "cython" else "" }}
       entry_points:
         - dask-scheduler = distributed.cli.dask_scheduler:go
         - dask-ssh = distributed.cli.dask_ssh:go

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -44,7 +44,8 @@ outputs:
       script: >
         python -m pip install . -vv --no-deps
         --install-option="--with-cython=profile"  # [cython_enabled]
-      track_features: "[cythonized-scheduler]"    # [cython_enabled]
+      track_features:             # [cython_enabled]
+        - cythonized-scheduler    # [cython_enabled]
       entry_points:
         - dask-scheduler = distributed.cli.dask_scheduler:go
         - dask-ssh = distributed.cli.dask_ssh:go

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -44,7 +44,8 @@ outputs:
       script: >
         python -m pip install . -vv --no-deps
         --install-option="--with-cython=profile"  # [cython_enabled]
-      track_features: {{ "[cythonized-scheduler]" if build_ext == "cython" else "" }}
+      track_features: "[cythonized-scheduler]"    # [cython_enabled]
+      track_features: ""                          # [not cython_enabled]
       entry_points:
         - dask-scheduler = distributed.cli.dask_scheduler:go
         - dask-ssh = distributed.cli.dask_ssh:go

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -45,7 +45,6 @@ outputs:
         python -m pip install . -vv --no-deps
         --install-option="--with-cython=profile"  # [cython_enabled]
       track_features: "[cythonized-scheduler]"    # [cython_enabled]
-      track_features: ""                          # [not cython_enabled]
       entry_points:
         - dask-scheduler = distributed.cli.dask_scheduler:go
         - dask-ssh = distributed.cli.dask_ssh:go


### PR DESCRIPTION
The Jinja template for `track_features` in the Distributed pre-release recipe is incorrect, making it so builds with Cython enabled / disabled both have the `cythonized-scheduler` feature.

This PR should resolve the issue (which I think is that `cython_enabled` is interpreted as a string `True/False` in Jinja?) and make it so this feature only applies to Cython builds.

cc @jakirkham @jrbourbeau 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
