### PR TITLE
Add key to compute failed message

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -162,6 +162,7 @@ async def test_worker_bad_args(c, s, a, b):
     tb = await y._traceback()
     assert any("1 / 0" in line for line in pluck(3, traceback.extract_tb(tb)) if line)
     assert "Compute Failed" in hdlr.messages["warning"][0]
+    assert y.key in hdlr.messages["warning"][0]
     logger.setLevel(old_level)
 
     # Now we check that both workers are still alive.

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3770,10 +3770,12 @@ class Worker(ServerNode):
             else:
                 logger.warning(
                     "Compute Failed\n"
+                    "Key:       %s\n"
                     "Function:  %s\n"
                     "args:      %s\n"
                     "kwargs:    %s\n"
                     "Exception: %r\n",
+                    ts.key,
                     str(funcname(function))[:1000],
                     convert_args_to_str(args2, max_len=1000),
                     convert_kwargs_to_str(kwargs2, max_len=1000),


### PR DESCRIPTION
The key can be quite helpful if one tries to correlate the failure to other things like transitions