### PR TITLE
docs: mention default value of Client's `timeout`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -677,7 +677,7 @@ class Client(SyncMethodMixin):
         ``'127.0.0.1:8786'`` or a cluster object like ``LocalCluster()``
     loop
         The event loop
-    timeout: int
+    timeout: int (defaults to configuration ``distributed.comm.timeouts.connect``)
         Timeout duration for initial connection to the scheduler
     set_as_default: bool (True)
         Use this Client as the global dask scheduler


### PR DESCRIPTION
I got confused by the `no_default` in [the docs](https://distributed.dask.org/en/stable/api.html#distributed.Client), and had to read the code to see that `no_default` actually gets replaced with the value of the `distributed.comm.timeouts.connect` configuration.

Let's mention it in the docs to save the next person from having to do the same :slightly_smiling_face: