### PR TITLE
Add option to specify a scheduler address for workers to use

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -342,7 +342,11 @@ class SpecCluster(Cluster):
                     opts["name"] = name
                 if isinstance(cls, str):
                     cls = import_term(cls)
-                worker = cls(self.scheduler.address, **opts)
+                worker = cls(
+                    getattr(self.scheduler, "contact_address", None)
+                    or self.scheduler.address,
+                    **opts,
+                )
                 self._created.add(worker)
                 workers.append(worker)
             if workers:

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -43,6 +43,17 @@ properties:
 
               For a list of handlers see the `dask.distributed.Scheduler.handlers` attribute.
 
+          contact-address:
+            type:
+            - string
+            - "null"
+            description: |
+              The address that the scheduler advertises to workers for communication with it.
+
+              To be specified when the address to which the scheduler binds cannot be the same
+              as the address that workers use to contact the scheduler (e.g. because the former
+              is private and the scheduler is in a different network than the workers).
+
           default-data-size:
             type:
             - string

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -12,6 +12,7 @@ distributed:
     allowed-failures: 3     # number of retries before a task is considered bad
     bandwidth: 100000000    # 100 MB/s estimated worker-worker bandwidth
     blocked-handlers: []
+    contact-address: null
     default-data-size: 1kiB
     # Number of seconds to wait until workers or clients are removed from the events log
     # after they have been removed from the scheduler

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3641,6 +3641,12 @@ class Scheduler(SchedulerState, ServerNode):
     Users typically do not interact with the scheduler directly but rather with
     the client object ``Client``.
 
+    The ``contact_address`` parameter allows to advertise a specific address to
+    the workers for communication with the scheduler, which is different than
+    the address the scheduler binds to. This is useful when the scheduler
+    listens on a private address, which therefore cannot be used by the workers
+    to contact it.
+
     **State**
 
     The scheduler contains the following state variables.  Each variable is
@@ -3705,11 +3711,14 @@ class Scheduler(SchedulerState, ServerNode):
         preload=None,
         preload_argv=(),
         plugins=(),
+        contact_address=None,
         **kwargs,
     ):
         self._setup_logging(logger)
 
         # Attributes
+        if contact_address:
+            self.contact_address = contact_address
         if allowed_failures is None:
             allowed_failures = dask.config.get("distributed.scheduler.allowed-failures")
         self.allowed_failures = allowed_failures

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3717,8 +3717,9 @@ class Scheduler(SchedulerState, ServerNode):
         self._setup_logging(logger)
 
         # Attributes
-        if contact_address:
-            self.contact_address = contact_address
+        if contact_address is None:
+            contact_address = dask.config.get("distributed.scheduler.contact-address")
+        self.contact_address = contact_address
         if allowed_failures is None:
             allowed_failures = dask.config.get("distributed.scheduler.allowed-failures")
         self.allowed_failures = allowed_failures


### PR DESCRIPTION
This is a a draft PR to follow up on the discussion here: https://github.com/dask/dask-jobqueue/issues/548 . The goal is to provide an option to specify the address that workers should use to contact the scheduler. This is useful when workers can't contact the scheduler on the address it listens on (e.g. because the scheduler is inside a container and that address is private).

The proposed changes are based on @oshadura's [patch](https://github.com/CoffeaTeam/coffea-casa/blob/master/docker/coffea-casa-cc7/distributed/0004-Add-possibility-to-setup-external_adress-for-schedul.patch), with a new option name to avoid a clash with the already existing `external_address`. The chosen name (`address_for_worker`) can of course be discussed (suggestions are welcome).

This solution also modifies the `Scheduler` class to add the new option. Thanks to this modification, the option can be provided when constructing a cluster like this:

```python
cluster = HTCondorCluster(
    scheduler_options={
        'address_for_worker': address
    },
)
```

@guillaumeeb had some ideas on how to implement this without modifying the scheduler. We can discuss here how that would look like - I am not sure how the user would specify the new option when creating the cluster if the scheduler is not modified.