### PR TITLE
[Draft] `Service`s for out-of-band operations

### DIFF
--- a/distributed/service.py
+++ b/distributed/service.py
@@ -160,7 +160,7 @@ def service_result(service: Service) -> NoReturn:
     )
 
 
-ServiceTask = NewType("ServiceTask", str)
+ServiceKey = NewType("ServiceKey", str)
 """
 The name of a single key in the graph that's computed using a `Service`.
 
@@ -179,7 +179,7 @@ class Service:
     async def start(
         self: T,
         *,
-        key: ServiceTask,
+        key: ServiceKey,
         peers: Mapping[Address, ServiceHandle[T]],
         # ^ QUESTION: should peers be identified by address? Or should they get some opaque UUID?
         # Addresses aren't guaranteed to be unique. It might be helpful to guarantee that
@@ -341,7 +341,7 @@ R = TypeVar("R")
 
 class Concierge:
     "Interface for `Service` instances to update the progress of a ServiceTask"
-    key: ServiceTask
+    key: ServiceKey
 
     async def produce_key(self, key: str, data: Any) -> None:
         """

--- a/distributed/service.py
+++ b/distributed/service.py
@@ -129,6 +129,7 @@ empty if `TaskState.service` is True. In other words, you can't compute a `Servi
 directly, only its output keys.
 """
 
+from abc import ABC, abstractmethod
 from typing import (
     Any,
     Awaitable,
@@ -175,10 +176,8 @@ T = TypeVar("T", bound="Service")
 # TODO: use pep-673 Self type https://peps.python.org/pep-0673/
 
 
-class Service:
-    def __init__(self) -> None:
-        ...
-
+class Service(ABC):
+    @abstractmethod
     async def start(
         self: T,
         *,
@@ -247,6 +246,7 @@ class Service:
     # `peer_joined` and `peer_left` are more powerful, because they allow for Service resizing,
     # but still allow services to restart when workers leave (and wait for all to arrive) if
     # they wish.
+    @abstractmethod
     async def all_started(self) -> None:
         """
         Called once all instances in the original ``peers`` list have started.
@@ -256,6 +256,7 @@ class Service:
         """
         ...
 
+    @abstractmethod
     async def add_key(self, key: str, data: Any) -> None:
         """
         Called by the `Worker` to "hand off" data to the `Service`.
@@ -298,6 +299,7 @@ class Service:
     # async def peer_left(self, id: ServiceId) -> None:
     #     ...
 
+    @abstractmethod
     async def stop(self) -> None:
         """
         Called by the `Worker` when this service task should stop.
@@ -318,6 +320,7 @@ class Service:
         """
         ...
 
+    @abstractmethod
     def __sizeof__(self) -> int:
         """
         Amount of memory this `Service` is using for internal state.
@@ -326,6 +329,7 @@ class Service:
         """
         ...
 
+    @abstractmethod
     def spilled_bytes(self) -> int:
         """
         Number of bytes on disk this `Service` is using for internal state.

--- a/distributed/service.py
+++ b/distributed/service.py
@@ -15,9 +15,9 @@ from typing import (
     TypeVar,
 )
 
-ServiceGroup = NewType("ServiceGroup", str)
+ServiceTask = NewType("ServiceTask", str)
 # ^ TODO need a better term. This refers to a single key in the graph, which creates Service instances
-# across many workers to accomplish its task. `ServiceInvocation`? `ServiceTask`? `ServiceGroup`?
+# across many workers to accomplish its task. `ServiceInvocation`? `ServiceTask`? `ServiceTask`?
 # There can be multiple types of Services (`ShuffleService`, `RechunkService`, `XGBoostService`),
 # and each one can be invoked multiple times (`'shuffle-1234'`, `'shuffle-5678'` `'rechunk-9876'`).
 # Each invocation is what we're calling the `ServiceID`. We need a term for both the invocation in general,
@@ -32,7 +32,7 @@ class Service:
     async def start(
         self: T,
         *,
-        group: ServiceGroup,
+        key: ServiceTask,
         peers: Mapping[Address, ServiceHandle[T]],
         # ^ QUESTION: should peers be identified by address? Or should they get some opaque UUID?
         # Addresses aren't guaranteed to be unique. It might be helpful to guarantee that
@@ -54,32 +54,32 @@ class Service:
 
         Parameters
         ----------
-        group:
-            The key name in the graph that created the Service. All instances created
-            from that key (across all workers) have the same ServiceGroup.
+        key:
+            The key in the graph that created the `Service`. All instances created from
+            that key (across all workers) receive the same ServiceTask ``key``.
 
-            Multiple instances of the same type of Service can exist on a worker at
-            once, but all are guaranteed to have different ``groups``.
+            Multiple instances of the same type of `Service` can exist on a worker at
+            once, but all are guaranteed to have a different ``key``.
         peers:
-            All the worker addresses (including this one) on which this ServiceGroup is
+            All the worker addresses (including this one) on which this ServiceTask is
             simultaneously being started, and `ServiceHandles` to communicate with them.
 
             Note that peer services are not guaranteed to be running yet.
         input_keys:
-            The input keys this ServiceGroup will receive, *across all workers*, in
+            The input keys this ServiceTask will receive, *across all workers*, in
             priority order.
         output_keys:
-            The output keys this ServiceGroup is expected to produce, *across all
+            The output keys this ServiceTask is expected to produce, *across all
             workers*, in priority order.
         concierge:
-            A `Concierge` instance the `Service` can use to communicate with the `Worker`.
-            Used to hand off output keys back to Dask, restart or fail the ServiceGroup,
-            etc.
+            A `Concierge` instance the `Service` can use to communicate with the
+            `Worker`. Used to hand off output keys back to Dask, restart or fail the
+            ServiceTask, etc.
         leader:
-            Whether this instance was chosen to be the "leader" of the ServiceGroup. The
+            Whether this instance was chosen to be the "leader" of the ServiceTask. The
             scheduler will pick exactly one instance in ``peers`` to be the leader. The
-            order in which `Service` instances start up on workers is of course undefined;
-            the leader may not be the first instance to actually start.
+            order in which `Service` instances start up on workers is of course
+            undefined; the leader may not be the first instance to actually start.
 
             The leader has no special treatment, and which instance is selected as the
             leader is irrelevant to Dask. This flag is passed purely as a convenience
@@ -143,7 +143,7 @@ class Service:
 
     async def stop(self) -> None:
         """
-        Called by the `Worker` when this ServiceGroup should stop.
+        Called by the `Worker` when this ServiceTask should stop.
 
         Cases in which `stop` is called:
         * Success: all ``output_keys`` have been produced.
@@ -156,7 +156,7 @@ class Service:
         The `Service` must clean up all state (files, connections, data, etc.)
         before `stop` returns.
 
-        After `stop` returns, a new `Service` instance with the same ServiceGroup
+        After `stop` returns, a new `Service` instance with the same ServiceTask
         may be created on the `Worker`.
         """
         ...
@@ -167,15 +167,15 @@ T = TypeVar("T", bound=Service)
 
 
 class Concierge:
-    "Interface for `Service` instances to update the progress of a ServiceGroup"
-    id: ServiceGroup
+    "Interface for `Service` instances to update the progress of a ServiceTask"
+    id: ServiceTask
 
     async def produce_key(self, key: str, data: Any) -> None:
         """
         Hand off output data from a `Service` back to Dask.
 
         Once ``await produce_key(key, data)`` has returned, the data is owned by the
-        worker and tracked by the scheduler. The service should release all references
+        worker and tracked by the scheduler. The `Service` should release all references
         to the data.
 
         If ``produce_key`` raises an error, the state of the data is undefined. In most
@@ -185,31 +185,30 @@ class Concierge:
 
     async def restart(self) -> None:
         """
-        Request that the ServiceGroup be restarted.
+        Request that the ServiceTask be restarted.
 
         `Service.stop` is guaranteed not to be called until after `restart` has
         returned.
 
         Once `restart` has returned, `Service.stop` will be called on all instances for
-        the ServiceGroup, and workers will release their references those instances.
-        Once `stop` has returned on all instances, the ServiceGroup's task will
-        transition to ``waiting`` on the scheduler. Then, it will transition back to
-        ``processing``, and new `Service` instances (with the same ServiceGroup) will be
-        started on all workers.
+        the ServiceTask, and workers will release their references those instances. Once
+        `stop` has returned on all instances, the task will transition to ``waiting`` on
+        the scheduler. Then, it will transition back to ``processing``, and new
+        `Service` instances (with the same ServiceTask key) will be started on all
+        workers.
         """
         ...
 
     async def error(self, exc: Exception) -> None:
         """
-        Fail the ServiceGroup with an error message.
+        Fail the ServiceTask with an error message.
 
         `Service.stop` is guaranteed not to be called until after `error` has returned.
 
         Once `restart` has returned, `Service.stop` will be called on all instances for
-        the ServiceGroup, and workers will release their references those instances.
-        Once `stop` has returned on all instances, the ServiceGroup's task will
-        transition to ``erred`` on the scheduler. The result of the task will be
-        ``exc``.
+        the ServiceTask, and workers will release their references those instances. Once
+        `stop` has returned on all instances, the task will transition to ``erred`` on
+        the scheduler. The result of the task will be ``exc``.
 
         If multiple instances call `error`, only the first ``exc`` to reach the
         scheduler will become the result; all others will be dropped (though all calls

--- a/distributed/service.py
+++ b/distributed/service.py
@@ -1,8 +1,134 @@
 from __future__ import annotations
 
+r"""
+Tasks that are actually stateful services running on all workers, for doing out-of-band
+operations in a controlled way.
+
+*Services* provide a structured way to combine task graphs of pure functions (Dask's main
+use case) with stateful, distributed subsystems. Some algorithms (DataFrame shuffling,
+array rechunking, etc.) are inefficient when represented as task graphs, but can be
+implemented simply and performantly as bespoke systems that handle their own low-level
+data transfer and computation manually.
+
+The `Service` interface offers a structured way to "hand off" data from the task-graph
+paradigm to these out-of-band operations, and to "hand back" the results so downstream
+tasks can use them, while maintaining resilience of the overall graph.
+
+In a graph like::
+
+    {
+        ("input", 1): 1,
+        ("input", 2): 2,
+        "foo-service": (FooService, [("input", 1), ("input", 2)]),  # annotated as a service
+        ("output", 1): (service_result, "foo-service"),             # never actually runs
+        ("output", 2): (service_result, "foo-service"),             # never actually runs
+        ("output", 3): (service_result, "foo-service"),             # never actually runs
+        ("downstream", 1): (use, ("output", 1)),
+        ("downstream", 2): (use, ("output", 2)),
+        ("downstream", 3): (use, ("output", 3)),
+    }
+
+Or visually::
+
+    d1   d2   d3
+    |    |    |
+    o1   o2   o3
+      \  |   /
+    foo-service
+        / \
+      i1  i2
+
+If the single ``foo-service`` task is annotated as a service, it'll actually be computed
+by launching ``FooService`` instances on every worker, passing the inputs into them,
+letting them do whatever out-of-band operations they wish (including communicating with
+each other or external systems), and waiting for them to produce the output keys. Once
+each output key is produced (the `service_result` functions never actually run), any
+tasks downstream of it can run.
+
+---------------------------------------------------------------------------------------
+
+Dask handles startup/shutdown, resilience, peer discovery, leader election, RPC
+interfaces, and composition for Services:
+
+Startup/shutdown
+----------------
+
+* Once the *first* input key to a service task is ready (state ``memory``), service
+  instances are started on all workers in the cluster.
+* Once the last output key is produced by a service, all instances are told to stop.
+* Any instance can error the service task; all other instances will be told to stop.
+* Any instance can restart the service task; all other instances will be told to stop,
+  then re-launched from scratch.
+* If the service task is cancelled (because keys downstream from it are released, etc.),
+  all instances are told to stop.
+
+Resilience
+----------
+
+* If a worker that's running a service leaves, the entire service task is restarted on
+  all workers. TODO change once `peer_joined`/`peer_left` are added.
+* If keys downstream of a service need to be recomputed, the service will be rerun, just
+  like regular tasks are.
+* The service is informed at runtime which inputs to expect and which outputs to
+  produce, so partial recomputation (some outputs already in memory, some not) can be
+  handled correctly.
+
+Peer discovery and RPC
+----------------------
+
+* At startup, services are given a list of their peers as RPC handles.
+* The RPC handle allows a `Service` to call arbitrary methods on its peers on other
+  workers.
+* Loopback calls (using the RPC to call yourself) take a fastpath, bypassing
+  serialization and the network stack.
+
+Leader election
+---------------
+* At startup, one instance is designated as the "leader", making it easier to coordinate
+  initialization tasks that need to run exactly once.
+
+Composition
+-----------
+
+One Service's outputs can be another Service's inputs.
+
+A `Service` can depend on multiple input Services, or both normal tasks and Services, or
+have no dependencies at all. Note, though, that input keys are always treated as a flat
+structure (`Service.add_key` is called, one key at a time, from whatever worker already
+holds the key). Therefore, if particular inputs need to be co-located, the `Service` is
+responsible for transferring them around internally. (Doing just that in clever ways is
+often the whole point of a `Service`.)
+
+                 o   o   o
+                  \  |  /
+              combiner-service
+          /   /        \   \   \
+         o   o          o   o   o
+          \ /            \  |  /
+     bar-service        baz-service
+     /   |   \          /  /  \  \
+    o    o    o        i  i    i  i
+      \  |   /          \  \  /  /
+     foo-service       normal-tasks
+
+Restrictions
+~~~~~~~~~~~~
+
+If a task depends on a `Service`, that must be its only dependency. For example, this
+will raise an error when the graph is submitted to the scheduler:
+
+     o     o   <-- tasks that depend on a Service cannot have >1 dependency
+     | \ / |
+     | / \ |
+    s-1   s-2
+     /\    /\
+    i  i  i  i
+
+A `Future` cannot refer to a `Service` task; that is, `TaskState.who_wants` must be
+empty if `TaskState.service` is True. In other words, you can't compute a `Service`
+directly, only its output keys.
 """
-Stateful services that run on all workers, for doing out-of-band operations in a controlled way.
-"""
+
 from typing import (
     Any,
     Awaitable,
@@ -10,19 +136,40 @@ from typing import (
     Generic,
     Mapping,
     NewType,
+    NoReturn,
     Protocol,
     Sequence,
     TypeVar,
 )
 
+from typing_extensions import ParamSpec
+
+
+def service_result(service: Service) -> NoReturn:
+    """
+    Placeholder function used in output tasks for a `Service`.
+
+    The scheduler will not actually run tasks that depend on a `Service`;
+    they are just added to the graph to create dependency structure.
+    Instead, Services use `Concierge.produce_key` to mark their output keys
+    as complete. Then, normal tasks that depend on those output keys can run.
+    """
+    raise RuntimeError(
+        f"`service_result` should not actually be called on {service!r}."
+        "Are you sure you're running on a distributed cluster?"
+    )
+
+
 ServiceTask = NewType("ServiceTask", str)
-# ^ TODO need a better term. This refers to a single key in the graph, which creates Service instances
-# across many workers to accomplish its task. `ServiceInvocation`? `ServiceTask`? `ServiceTask`?
-# There can be multiple types of Services (`ShuffleService`, `RechunkService`, `XGBoostService`),
-# and each one can be invoked multiple times (`'shuffle-1234'`, `'shuffle-5678'` `'rechunk-9876'`).
-# Each invocation is what we're calling the `ServiceID`. We need a term for both the invocation in general,
-# and for the group of instances (across many workers) handling that invocation.
+"""
+The name of a single key in the graph that's computed using a `Service`.
+
+The term "ServiceTask" is used to refer to overall computation of this key,
+performed by many `Service` instances running on different workers.
+"""
 Address = NewType("Address", str)
+T = TypeVar("T", bound="Service")
+# TODO: use pep-673 Self type https://peps.python.org/pep-0673/
 
 
 class Service:
@@ -56,7 +203,7 @@ class Service:
         ----------
         key:
             The key in the graph that created the `Service`. All instances created from
-            that key (across all workers) receive the same ServiceTask ``key``.
+            that key (across all workers) receive the same ``key``.
 
             Multiple instances of the same type of `Service` can exist on a worker at
             once, but all are guaranteed to have a different ``key``.
@@ -65,12 +212,15 @@ class Service:
             simultaneously being started, and `ServiceHandles` to communicate with them.
 
             Note that peer services are not guaranteed to be running yet.
+
+            The order of ``peers`` is undefined, but it will be the same for every
+            `Service` in ``peers``.
         input_keys:
             The input keys this ServiceTask will receive, *across all workers*, in
             priority order.
         output_keys:
-            The output keys this ServiceTask is expected to produce, *across all
-            workers*, in priority order.
+            The output keys this ServiceTask must produce, *across all workers*, in
+            priority order.
         concierge:
             A `Concierge` instance the `Service` can use to communicate with the
             `Worker`. Used to hand off output keys back to Dask, restart or fail the
@@ -86,23 +236,25 @@ class Service:
             for Services, to make it easier to coordinate initialization tasks that must
             run exactly once.
         **kwargs:
-            Forward-compatibility only—any additional arguments can be ignored.
+            Forward-compatibility only; any additional arguments can be ignored.
         """
         ...
 
-    # Not going to implement `all_started`; it's way too brittle.
-    # What if some peers die before they start?
-    # Then those addresses will _never_ start. Probably better to let Services
-    # that need this sort of coordination handle it themselves via a Semaphore.
+    # TODO: remove this in favor of `peer_joined` and `peer_left`.
+    # Once those methods are supported, and workers joining/leaving doesn't automatically
+    # restart the ServiceTask, we can't support `all_started` anymore: what if one of the
+    # original peers dies before it's started?
+    # `peer_joined` and `peer_left` are more powerful, because they allow for Service resizing,
+    # but still allow services to restart when workers leave (and wait for all to arrive) if
+    # they wish.
+    async def all_started(self) -> None:
+        """
+        Called once all instances in the original ``peers`` list have started.
 
-    # async def all_started(self) -> None:
-    #     """
-    #     Called once all instances in the original ``peers`` list have started.
-
-    #     Do not make the ``start`` method block until ``all_started`` has been called;
-    #     this will cause a deadlock.
-    #     """
-    #     ...
+        Do not make the ``start`` method block until ``all_started`` has been called;
+        this will cause a deadlock.
+        """
+        ...
 
     async def add_key(self, key: str, data: Any) -> None:
         """
@@ -114,6 +266,11 @@ class Service:
 
         ``add_key`` can be called as soon as ``start`` has returned. It will only be
         called with keys in ``input_keys``.
+
+        For a given input key, ``add_key`` will be called exactly once *across all workers*.
+        ``add_key`` is always called from a worker that already holds ``key`` (data is
+        not transferred just for ``add_key``). If multiple workers hold replicas of the key,
+        the worker on which ``add_key`` is called is undefined.
         """
         ...
 
@@ -148,7 +305,7 @@ class Service:
         Cases in which `stop` is called:
         * Success: all ``output_keys`` have been produced.
         * Failure: `Concierge.error` was called, or `Service.add_key` raised an error.
-        * Restart: `Concierge.restart` was called
+        * Restart: `Concierge.restart` was called.
         * Restart: a peer worker left (TODO remove this case!).
 
         The `Service` is not informed what the cause for stopping is.
@@ -157,18 +314,34 @@ class Service:
         before `stop` returns.
 
         After `stop` returns, a new `Service` instance with the same ServiceTask
-        may be created on the `Worker`.
+        key may be created on the `Worker`.
+        """
+        ...
+
+    def __sizeof__(self) -> int:
+        """
+        Amount of memory this `Service` is using for internal state.
+
+        This will be counted as managed memory by dask.
+        """
+        ...
+
+    def spilled_bytes(self) -> int:
+        """
+        Number of bytes on disk this `Service` is using for internal state.
+
+        This will be counted as spilled memory by dask.
         """
         ...
 
 
-T = TypeVar("T", bound=Service)
-# TODO: use pep-673 Self type https://peps.python.org/pep-0673/
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class Concierge:
     "Interface for `Service` instances to update the progress of a ServiceTask"
-    id: ServiceTask
+    key: ServiceTask
 
     async def produce_key(self, key: str, data: Any) -> None:
         """
@@ -205,14 +378,32 @@ class Concierge:
 
         `Service.stop` is guaranteed not to be called until after `error` has returned.
 
-        Once `restart` has returned, `Service.stop` will be called on all instances for
+        Once `error` has returned, `Service.stop` will be called on all instances for
         the ServiceTask, and workers will release their references those instances. Once
         `stop` has returned on all instances, the task will transition to ``erred`` on
         the scheduler. The result of the task will be ``exc``.
 
-        If multiple instances call `error`, only the first ``exc`` to reach the
+        If `error` is called multiple times, only the first ``exc`` to reach the
         scheduler will become the result; all others will be dropped (though all calls
         to `error` are logged on the `Worker`).
+        """
+        ...
+
+    async def run_in_executor(
+        self, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs
+    ) -> Awaitable[R]:
+        """
+        Schedule a function to run in the Worker's default executor.
+
+        This will take up a slot in `Worker.executing_count`, reducing the number of
+        other tasks (or `run_in_executor` calls) that can run concurrently. This allows
+        multiple Services (or Services and normal tasks) to cooperatively run
+        resource-intensive synchronous functions concurrently without oversubscribing
+        the `Worker`. This way, `Worker.nthreads` is respected even for out-of-band
+        functions.
+
+        For event-loop-blocking functions that aren't resource-intensive (network calls,
+        etc.), `distributed.compatibility.to_thread` is preferred.
         """
         ...
 
@@ -221,11 +412,11 @@ class Concierge:
 class ServiceHandle(Generic[T]):
     "RPC to a Service instance running on another worker"
 
-    def __getattr__(self, attr: str) -> RPC:
+    def __getattr__(self, attr: str) -> _RPC:
         ...
 
 
 # https://stackoverflow.com/a/65564936/17100540
-class RPC(Protocol):
+class _RPC(Protocol):
     def __call__(self, *args, **kwargs) -> Awaitable:
         ...

--- a/distributed/service.py
+++ b/distributed/service.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+"""
+Stateful services that run on all all workers, for doing out-of-band operations in a controlled way.
+"""
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Generic,
+    Mapping,
+    NewType,
+    Protocol,
+    Sequence,
+    TypeVar,
+)
+
+ServiceId = NewType("ServiceId", str)
+# ^ TODO need a better term. This refers to a single key in the graph, which creates Service instances
+# across many workers to accomplish its task. `ServiceInvocation`? `ServiceTask`? `ServiceGroup`?
+# There can be multiple types of Services (`ShuffleService`, `RechunkService`, `XGBoostService`),
+# and each one can be invoked multiple times (`'shuffle-1234'`, `'shuffle-5678'` `'rechunk-9876'`).
+# Each invocation is what we're calling the `ServiceID`. We need a term for both the invocation in general,
+# and for the group of instances (across many workers) handling that invocation.
+Address = NewType("Address", str)
+
+
+class Service:
+    def __init__(self, *args, **kwargs) -> None:
+        ...
+
+    async def start(
+        self: T,
+        *,
+        id: ServiceId,
+        peers: Mapping[Address, ServiceHandle[T]],
+        # ^ QUESTION: should peers be identified by address? Or should they get some opaque UUID?
+        # Addresses aren't guaranteed to be unique. It might be helpful to guarantee that
+        # the identifier for a peer always corresponds to a unique Service _instance_
+        # (if a worker restarts, the same address could correspond to multiple different instances
+        # of the Service).
+        input_keys: Sequence[str],
+        output_keys: Sequence[str],
+        concierge: Concierge,
+        produce_key_callback: Callable[[str, Any], Awaitable[None]],
+        leader: bool,
+        **kwargs,
+    ) -> None:
+        """
+        Called to start the `Service` on a `Worker`.
+
+        Once ``start`` returns, the `Service` instance is considered ready, and the
+        `Worker` can call ``add_key``.
+
+        Parameters
+        ----------
+        id:
+            The ID of this Service. Corresponds to the key name in the graph that
+            created the Service. All instances created from that key (across all
+            workers) have the same ID.
+
+            Multiple instances of the same type of Service can exist on a worker at
+            once, but all are guaranteed to have different IDs.
+        peers:
+            All the worker addresses (including this one) on which this service ID is
+            simultaneously being started, and `ServiceHandles` to communicate with them.
+
+            Note that peer services are not guaranteed to be running yet.
+        input_keys:
+            The input keys this Service ID will receive, *across all workers*, in
+            priority order.
+        output_keys:
+            The output keys this Service ID is expected to produce, *across all
+            workers*, in priority order.
+        concierge:
+            A `Concierge` instance the Service can use to communicate with the `Worker`.
+            Used to hand off output keys back to Dask, restart or fail the Service ID,
+            etc.
+        leader:
+            Whether this instance was chosen to be the "leader" of this Service ID. The
+            scheduler will pick exactly one instance in ``peers`` to be the leader. The
+            order in which Service instances start up on workers is of course undefined;
+            the leader may not be the first instance to actually start.
+
+            The leader has no special treatment, and which instance is selected as the
+            leader is irrelevant to Dask. This flag is passed purely as a convenience
+            for Services, to make it easier to coordinate initialization tasks that must
+            run exactly once.
+        **kwargs:
+            Forward-compatibility only—any additional arguments can be ignored.
+        """
+        ...
+
+    # Not going to implement `all_started`; it's way too brittle.
+    # What if some peers die before they start?
+    # Then those addresses will _never_ start. Probably better to let Services
+    # that need this sort of coordination handle it themselves via a Semaphore.
+
+    # async def all_started(self) -> None:
+    #     """
+    #     Called once all instances in the original ``peers`` list have started.
+
+    #     Do not make the ``start`` method block until ``all_started`` has been called;
+    #     this will cause a deadlock.
+    #     """
+    #     ...
+
+    async def add_key(self, key: str, data: Any) -> None:
+        """
+        Called by the `Worker` to "hand off" data to the `Service`.
+
+        Once ``add_key`` returns, this `Service` instance owns ``data``, and the
+        `Worker` will release all references to the data once no other tasks or clients
+        are also waiting on ``key``.
+
+        ``add_key`` can be called as soon as ``start`` has returned. It will only be
+        called with keys in ``input_keys``.
+        """
+        ...
+
+    # Peers joining and leaving won't be supported in the first iteration.
+    # For now, new workers will be ignored, and any worker leaving will trigger
+    # a restart of the whole service group? (Don't want to have this be released behavior
+    # though, since it'll make adding `peer_joined`/`peer_left` backwards-incompatible.)
+    # * Dealing with peers joining is somewhat complex. Do current instances get to
+    #   veto whether a new peer can join, or does any worker satisfying the restrictions
+    #   of the Service task get to join automatically? I assume `peer_joined` doesn't get
+    #   called until after `start` has returned on the new instance. What `peers` list gets
+    #   passed to the new peer (all current ones, I assume)? What happens when other workers
+    #   come up while the new peer's `start` is running—how do we buffer those `peer_joined`
+    #   messages to deliver to the peer that hasn't started up yet?
+    # * `peer_left` seems more straightforward.
+    # In general though, these may not scale well. In a 10k worker cluster, notifying every other
+    # worker when one comes and goes is a lot of noise.
+    # And mostly, if services would decide that a peer leaving (or joining) means they should
+    # restart, then the scheduler will be bombarded by restart messages from (N-1) workers
+    # when one worker leaves.
+
+    # async def peer_joined(self: T, addr: Address, handle: ServiceHandle[T]) -> None:
+    #     ...
+
+    # async def peer_left(self, addr: Address) -> None:
+    #     ...
+
+    async def stop(self) -> None:
+        """
+        Called by the `Worker` when this Service ID should stop.
+
+        Cases in which `stop` is called:
+        * Success: all ``output_keys`` have been produced.
+        * Failure: `Concierge.error` was called, or `Service.add_key` raised an error.
+        * Restart: `Concierge.restart` was called
+        * Restart: a peer worker left (TODO remove this case!).
+
+        The `Service` is not informed what the cause for stopping is.
+
+        The `Service` must clean up all state (files, connections, data, etc.)
+        before `stop` returns.
+
+        After `stop` returns, a new `Service` instance with the same Service ID
+        may be created.
+        """
+        ...
+
+
+T = TypeVar("T", bound=Service)
+# TODO: use pep-673 Self type https://peps.python.org/pep-0673/
+
+
+class Concierge:
+    "Interface for `Service` instances to update the progress of a Service ID"
+    id: ServiceId
+
+    async def produce_key(self, key: str, data: Any) -> None:
+        """
+        Hand off output data from a `Service` back to Dask.
+
+        Once ``await produce_key(key, data)`` has returned, the data is owned by the
+        worker and tracked by the scheduler. The service should release all references
+        to the data.
+
+        If ``produce_key`` raises an error, the state of the data is undefined. In most
+        cases, the service should call `restart` if this happens.
+        """
+        ...
+
+    async def restart(self) -> None:
+        """
+        Request that the Service ID be restarted.
+
+        `Service.stop` is guaranteed not to be called until after `restart` has
+        returned.
+
+        Once `restart` has returned, `Service.stop` will be called on all instances for
+        this ID across all workers, and workers will release their references to their
+        `Service` instance for this ID. Once `stop` has returned on all instances, the
+        Service ID's task will transition to ``waiting`` on the scheduler. Then, it will
+        transition back to ``processing``, and new `Service` instances (with the same
+        Service ID) will be started on all workers.
+        """
+        ...
+
+    async def error(self, exc: Exception) -> None:
+        """
+        Fail the Service ID with an error message.
+
+        `Service.stop` is guaranteed not to be called until after `error` has returned.
+
+        Once `error` has returned, `Service.stop` will be called on all instances for
+        this ID across all workers, and workers will release their references to their
+        `Service` instance for this ID. Once `stop` has returned on all instances, the
+        Service ID's task will transition to ``erred`` on the scheduler. The result of
+        the task will be ``exc``.
+
+        If multiple instances call `error`, only the first ``exc`` to reach the
+        scheduler will become the result; all others will be dropped (though all calls
+        to `error` are logged on the `Worker`).
+        """
+        ...
+
+
+# TODO: how to type annotate RPCs? https://github.com/python/mypy/issues/5523
+class ServiceHandle(Generic[T]):
+    "RPC to a Service instance running on another worker"
+
+    def __getattr__(self, attr: str) -> RPC:
+        ...
+
+
+# https://stackoverflow.com/a/65564936/17100540
+class RPC(Protocol):
+    def __call__(self, *args, **kwargs) -> Awaitable:
+        ...


### PR DESCRIPTION
This is a draft of the interface for a `Service`—a new interface in distributed that could facilitate doing out-of-band operations in a controlled way.

From the docstring:

> *Services* provide a structured way to combine task graphs of pure functions (Dask's main
> use case) with stateful, distributed subsystems. Some algorithms (DataFrame shuffling,
> array rechunking, etc.) are inefficient when represented as task graphs, but can be
> implemented simply and performantly as bespoke systems that handle their own low-level
> data transfer and computation manually.
> 
> The `Service` interface offers a structured way to "hand off" data from the task-graph
> paradigm to these out-of-band operations, and to "hand back" the results so downstream
> tasks can use them, while maintaining resilience of the overall graph.

I've been kicking around this idea for a bit as a better framework for P2P shuffling (xref https://github.com/dask/distributed/pull/5435, https://github.com/dask/distributed/pull/5520, https://github.com/dask/distributed/pull/5524, https://github.com/dask/distributed/issues/5939) that solves both the [resilience needs](https://github.com/gjoseph92/distributed/blob/p2p-shuffle/proposal/distributed/shuffle/shuffle-design.md#retries-and-cancellation), and some tricky edge cases around graph structure (culling, partial recomputation). I'm hoping it could be generally applicable to similar problems in the future (array rechunking, map-overlap, ML training, etc.)

I suggest reading the docstring for those interested, and reading the `Service` ABC for those really interested :)

I think actually implementing this would be somewhat similar to what it took to add Actors (Services and Actors are kinda similar), in terms of special-casing things in many scheduler transition functions, and adding support on Workers for running these.

The whole idea is a little hacky, and a little odd, and adding even more complexity right now feels like the wrong direction. But if we're serious about wanting to do things like P2P shuffles, building a first-class framework for expressing out-of-band operations _within_ the task graph will be the best approach to resilience.

Is it over-optimized for P2P shuffles? Maybe. Could it all be implemented as a huge P2P shuffle scheduler plugin? Maybe. Personally though, I find it easier to think about (and test, and ensure correctness) in this generic sense than to merge with all the details of shuffling.

cc @mrocklin @fjetter 