### PR TITLE
 Only run gh-pages workflow on dask/distributed (pt. 2)

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -9,7 +9,7 @@ jobs:
   test-report:
     name: Test Report
     # Do not run the report job on forks
-    if: github.repository == 'dask/distributed' || github.event_name != 'workflow_dispatch'
+    if: github.repository == 'dask/distributed' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Following up on the feedback here ( https://github.com/dask/distributed/pull/5942#discussion_r829381010 ) to invert this condition. Should disable `gh-pages` deployment on forks.

cc @ian-r-rose

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
