### PR TITLE
Drop `setuptools` from `distributed` recipe

### DIFF
--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -73,7 +73,6 @@ outputs:
         - toolz >=0.8.2
         - tornado >=6.0.3
         - zict >=0.1.3
-        - setuptools <60.0.0
       run_constrained:
         - distributed-impl >={{ version }} *{{ build_ext }}
         - openssl !=1.1.1e


### PR DESCRIPTION
Propagates the dropping of `setuptools` as a runtime dependency as was done in PR ( https://github.com/dask/distributed/pull/5923 ). Same as the change in the conda-forge recipe ( https://github.com/conda-forge/distributed-feedstock/pull/200 ).

- [x] Closes https://github.com/dask/distributed/issues/5949
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
