### PR TITLE
End TextProgressBar with newline (#3414)

### DIFF
--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -163,7 +163,7 @@ class TextProgressBar(ProgressBar):
             sys.stdout.flush()
 
     def _draw_stop(self, **kwargs):
-        sys.stdout.write("\r")
+        sys.stdout.write("\33[2K\r")
         sys.stdout.flush()
 
 


### PR DESCRIPTION
So that the progress bar diagnostic doesn't interfere with other print statements or logging by the user. I stumbled upon the same problem reported in the linked issue, this is my reproducer for it:

```python
import time
import random

from dask import delayed
from dask.distributed import Client, LocalCluster, progress


def inc(x):
    time.sleep(random.random())
    return x + 1

def dec(x):
    time.sleep(random.random())
    return x - 1

def add(x, y):
    time.sleep(random.random())
    return x + y

inc = delayed(inc)
dec = delayed(dec)
add = delayed(add)

if __name__ == "__main__":
    cluster = LocalCluster(n_workers=2, threads_per_worker=1, processes=True)
    client = Client(cluster)

    x = inc(1)
    y = dec(2)
    z = add(x, y)
    print("Starting computation")
    res = z.persist()
    progress(res)
    print(f"Computation ended, result is {res.compute()}")
```
The output
```
$: python test_dask_delayed.py 
Starting computation
Computation ended, result is 3###########] | 100% Completed |  1.5s
```

### After this PR
```
$: python test_dask_delayed.py 
Starting computation
Computation ended, result is 3
```




- [x] Closes #3414

