### PR TITLE
Fixup test_worker_doesnt_await_task_completion

### DIFF
--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -202,7 +202,7 @@ def test_worker_doesnt_await_task_completion(loop):
             start = time()
             c.restart()
             stop = time()
-            assert stop - start < 5
+            assert stop - start < 20
 
 
 @pytest.mark.skipif(COMPILED, reason="Fails with cythonized scheduler")


### PR DESCRIPTION
This test was designed to verify that we don't wait for a 100s sleep
call to finish before terminating the workers.  However the time
provided, 5s, is about what it takes to restart anyway.  We now extend
this time to 20s, which is safely below 100s, and also safely above the
worker start time.

In the future we should figure out why it's taking us 5s to start up.
This is drifting upwards

This is a flaky test that I've noticed in a few recent PRs.