### PR TITLE
Use broader range in test_nanny_worker_port_range

### DIFF
--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -49,17 +49,17 @@ async def test_nanny_worker_port_range(c, s):
             "--host",
             "127.0.0.1",
             "--worker-port",
-            "9684:9686",
+            "10000:11000",
             "--nanny-port",
-            "9688:9690",
+            "11000:12000",
             "--no-dashboard",
         ]
     ):
         await c.wait_for_workers(3)
         worker_ports = await c.run(lambda dask_worker: dask_worker.port)
-        assert set(worker_ports.values()) == {9684, 9685, 9686}
+        assert all(10000 <= p <= 11000 for p in worker_ports.values())
         nanny_ports = await c.run(lambda dask_worker: dask_worker.port, nanny=True)
-        assert set(nanny_ports.values()) == {9688, 9689, 9690}
+        assert all(11000 <= p <= 12000 for p in nanny_ports.values())
 
 
 @gen_cluster(nthreads=[])


### PR DESCRIPTION
This test is designed to verify that we can restrict workers and nannies
to a range of ports.  It creates three workers and gives three ports.

However, if one of those ports are already taken then this test will
time out.  Unfortunately our cleanup is not perfect, and sometimes ports
are taken, leading to flaking tests.

This commit changes the behavior of the test by giving a much broader
range of port values, but still narrow enough that it is unlikely to
pass by chance.

This fixes (hopefully) a flaky test