### PR TITLE
Catch NotADirectoryError in SafeTemporaryDirectory

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -646,7 +646,7 @@ class _SafeTemporaryDirectory(tempfile.TemporaryDirectory):
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
             return super().__exit__(exc_type, exc_val, exc_tb)
-        except PermissionError:
+        except (PermissionError, NotADirectoryError):
             # It appears that we either have a process still interacting with
             # the tmpdirs of the workers or that win process are not releasing
             # their lock in time. We are receiving PermissionErrors during


### PR DESCRIPTION
The Permission error is apparently reraised as a NotADirectoryError