### PR TITLE
Remove cache in iscoroutinefunction to avoid holding on to refs

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1124,21 +1124,8 @@ def color_of(x, palette=palette):
     return palette[n % len(palette)]
 
 
-def _iscoroutinefunction(f):
-    return inspect.iscoroutinefunction(f) or gen.is_coroutine_function(f)
-
-
-@functools.lru_cache(None)
-def _iscoroutinefunction_cached(f):
-    return _iscoroutinefunction(f)
-
-
 def iscoroutinefunction(f):
-    # Attempt to use lru_cache version and fall back to non-cached version if needed
-    try:
-        return _iscoroutinefunction_cached(f)
-    except TypeError:  # unhashable type
-        return _iscoroutinefunction(f)
+    return inspect.iscoroutinefunction(f) or gen.is_coroutine_function(f)
 
 
 @contextmanager


### PR DESCRIPTION
This is currently suspected to be one of the reasons why our CI is behaving very awkwardly, e.g. why sometimes GC takes so long to run. We couldn't prove this but we know for a fact that this causes problems by accumulating DequeHandlers, see #5973 

I believe we should find a method which does not hold on to references if we indeed want to cache this. However, introducing any mechanic in here that would ensure us not holding on to references is likely much slower than simply using the inspect call.

The cache was introduced in https://github.com/dask/distributed/pull/4481 and basically reverts https://github.com/dask/distributed/issues/4469

We don't have any benchmarks about this I could run to verify the impact. Generally, I'm very surprised to see this taking so long. Based on a microbenchmark this is very fast

```python
Python 3.8.12 | packaged by conda-forge | (default, Jan 30 2022, 23:13:24)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.0.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from tornado import gen

In [2]: from distributed.utils import iscoroutinefunction

In [3]: class A:
   ...:     async def method(self):
   ...:         await asyncio.sleep(0)
   ...:         return
   ...:
   ...:     @gen.coroutine
   ...:     def gen_coro(self):
   ...:         yield gen.moment()

In [4]: %timeit iscoroutinefunction(A.method)
434 ns ± 1.74 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [5]: %timeit iscoroutinefunction(A.gen_coro)
513 ns ± 2.64 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [6]: import inspect

In [7]: %timeit inspect.iscoroutinefunction(A.method)
395 ns ± 1.76 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```


- [x] Closes #5973