### PR TITLE
Use colorblind-friendly color palette

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1093,27 +1093,17 @@ def command_has_keyword(cmd, k):
     return False
 
 
-# from bokeh.palettes import viridis
-# palette = viridis(18)
+# from https://personal.sron.nl/~pault/#fig:scheme_light
 palette = [
-    "#440154",
-    "#471669",
-    "#472A79",
-    "#433C84",
-    "#3C4D8A",
-    "#355D8C",
-    "#2E6C8E",
-    "#287A8E",
-    "#23898D",
-    "#1E978A",
-    "#20A585",
-    "#2EB27C",
-    "#45BF6F",
-    "#64CB5D",
-    "#88D547",
-    "#AFDC2E",
-    "#D7E219",
-    "#FDE724",
+    "#77AADD",
+    "#EE8866",
+    "#EEDD88",
+    "#FFAABB",
+    "#99DDFF",
+    "#44BB99",
+    "#BBCC33",
+    "#AAAA00",
+    "#DDDDDD",
 ]
 
 


### PR DESCRIPTION
Changes Viridis-based continuous color palette to coloblind-friendly categorical palette.

Example of current 18-color palette:

<img width="1239" alt="Screen Shot 2022-03-23 at 12 12 12 PM" src="https://user-images.githubusercontent.com/527578/159746745-eab24981-5b21-469d-abec-a4f0c76c1fc2.png">

Problems:

1. This is a palette generated from Viridis, which is for continuous/ordinal data, not categorical data.
2. Because of (1), many colors are hard to distinguish from one another.
3. Text is nearly illegible for some of the very dark background colors being used.
4. Palette is not colorblind-friendly.

Frankly, it's impossible to choose any 18 colors such that every pair is visually distinct. It's even more difficult when you have to exclude ones with low luminosity and take into account color blindness. Thus, I've replaced this color scheme with a colorblind-friendly, 9-color palette from https://personal.sron.nl/~pault/#fig:scheme_light:

![scheme_light](https://user-images.githubusercontent.com/527578/159750176-81ba4f28-bc39-40e5-b86a-d7d6c2b049fc.png)

This addresses all of the problems noted above.