### PR TITLE
use asyncio.run to run gen_cluster

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,12 +65,6 @@ jobs:
         shell: bash -l {0}
         run: conda config --show
 
-      - name: Install stacktrace
-        shell: bash -l {0}
-        # stacktrace for Python 3.8+ has not been released at the moment of writing
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' }}
-        run: mamba install -c conda-forge -c defaults -c numba libunwind stacktrace
-
       - name: Hack around https://github.com/ipython/ipython/issues/12197
         # This upstream issue causes an interpreter crash when running
         # distributed/protocol/tests/test_serialize.py::test_profile_nested_sizeof

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,8 +67,8 @@ jobs:
 
       - name: Install stacktrace
         shell: bash -l {0}
-        # stacktrace for Python 3.8 has not been released at the moment of writing
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version < '3.8' }}
+        # stacktrace for Python 3.8+ has not been released at the moment of writing
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' }}
         run: mamba install -c conda-forge -c defaults -c numba libunwind stacktrace
 
       - name: Hack around https://github.com/ipython/ipython/issues/12197

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         # Cherry-pick test modules to split the overall runtime roughly in half
         partition: [ci1, not ci1]
         include:

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -1,0 +1,56 @@
+name: dask-distributed
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.10
+  - packaging
+  - pip
+  - asyncssh
+  - bokeh
+  - click
+  - cloudpickle
+  - coverage<6.3  # https://github.com/nedbat/coveragepy/issues/1310
+  - dask  # overridden by git tip below
+  - filesystem-spec  # overridden by git tip below
+  - h5py
+  - ipykernel
+  - ipywidgets
+  - jinja2
+  - joblib  # overridden by git tip below
+  - jupyter_client
+  - lz4  # Only tested here
+  - msgpack-python
+  - netcdf4
+  - paramiko
+  - pre-commit
+  - prometheus_client
+  - psutil
+  - pynvml  # Only tested here
+  - pytest
+  - pytest-cov
+  - pytest-faulthandler
+  - pytest-repeat
+  - pytest-rerunfailures
+  - pytest-timeout
+  - python-blosc  # Only tested here
+  - python-snappy  # Only tested here
+  - requests
+  - s3fs  # overridden by git tip below
+  - scikit-learn
+  - scipy
+  - sortedcollections
+  - tblib
+  - toolz
+  - tornado=6
+  - zict  # overridden by git tip below
+  - zstandard
+  - pip:
+      - git+https://github.com/dask/dask
+      - git+https://github.com/dask/s3fs
+      - git+https://github.com/dask/zict
+      # FIXME https://github.com/dask/distributed/issues/5345
+      # - git+https://github.com/intake/filesystem_spec
+      - git+https://github.com/joblib/joblib
+      - keras
+      - pytest-asyncio<0.14.0 # `pytest-asyncio<0.14.0` isn't available on conda-forge for Python 3.10

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -131,12 +131,9 @@ class ServerNode(Server):
             import ssl
 
             ssl_options = ssl.create_default_context(
-                cafile=tls_ca_file, purpose=ssl.Purpose.SERVER_AUTH
+                cafile=tls_ca_file, purpose=ssl.Purpose.CLIENT_AUTH
             )
             ssl_options.load_cert_chain(tls_cert, keyfile=tls_key)
-            # We don't care about auth here, just encryption
-            ssl_options.check_hostname = False
-            ssl_options.verify_mode = ssl.CERT_NONE
 
         self.http_server = HTTPServer(self.http_application, ssl_options=ssl_options)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6471,13 +6471,12 @@ async def test_client_gather_semaphore_loop(s):
         assert c._gather_semaphore._loop is c.loop.asyncio_loop
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 10), reason="No internal loop in Python 3.10"
-)
 @gen_cluster(client=True)
 async def test_as_completed_condition_loop(c, s, a, b):
     seq = c.map(inc, range(5))
     ac = as_completed(seq)
+    async for _ in ac:
+        pass
     assert ac.condition._loop == c.loop.asyncio_loop
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6463,7 +6463,8 @@ async def test_performance_report(c, s, a, b):
 
 
 @pytest.mark.skipif(
-    sys.version_info >= (3, 10), reason="No internal loop in Python 3.10"
+    sys.version_info >= (3, 10),
+    reason="On Py3.10+ semaphore._loop is not bound until .acquire() blocks",
 )
 @gen_cluster(nthreads=[])
 async def test_client_gather_semaphore_loop(s):
@@ -6482,7 +6483,8 @@ async def test_as_completed_condition_loop(c, s, a, b):
 
 
 @pytest.mark.skipif(
-    sys.version_info >= (3, 10), reason="No internal loop in Python 3.10"
+    sys.version_info >= (3, 10),
+    reason="On Py3.10+ semaphore._loop is not bound until .acquire() blocks",
 )
 def test_client_connectionpool_semaphore_loop(s, a, b):
     with Client(s["address"]) as c:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6475,6 +6475,7 @@ async def test_client_gather_semaphore_loop(s):
 async def test_as_completed_condition_loop(c, s, a, b):
     seq = c.map(inc, range(5))
     ac = as_completed(seq)
+    # consume the ac so that the ac.condition is bound to the loop on py3.10+
     async for _ in ac:
         pass
     assert ac.condition._loop == c.loop.asyncio_loop

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6462,12 +6462,18 @@ async def test_performance_report(c, s, a, b):
     assert "cdn.bokeh.org" in data
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10), reason="No internal loop in Python 3.10"
+)
 @gen_cluster(nthreads=[])
 async def test_client_gather_semaphore_loop(s):
     async with Client(s.address, asynchronous=True) as c:
         assert c._gather_semaphore._loop is c.loop.asyncio_loop
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10), reason="No internal loop in Python 3.10"
+)
 @gen_cluster(client=True)
 async def test_as_completed_condition_loop(c, s, a, b):
     seq = c.map(inc, range(5))
@@ -6475,6 +6481,9 @@ async def test_as_completed_condition_loop(c, s, a, b):
     assert ac.condition._loop == c.loop.asyncio_loop
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10), reason="No internal loop in Python 3.10"
+)
 def test_client_connectionpool_semaphore_loop(s, a, b):
     with Client(s["address"]) as c:
         assert c.rpc.semaphore._loop is c.loop.asyncio_loop


### PR DESCRIPTION
should be the minimum needed to avoid deprecation warnings on dask/distributed

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
In 3.10, the _internal_ `_loop` attribute of several asyncio classes has
been removed.