### PR TITLE
Relax variable test_race

### DIFF
--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -213,7 +213,6 @@ async def test_race(c, s, *workers):
 
     futures = c.map(f, range(15))
     results = await c.gather(futures)
-    assert all(r > NITERS * 0.8 for r in results)
 
     while len(s.wants_what["variable-x"]) != 1:
         await asyncio.sleep(0.01)


### PR DESCRIPTION
The intent of this test is mostly to make sure that lots of workers can
access the same variable in parallel without breaking things.

Part of this test also ensures that none of them got too far behind the
others. This is very hard to actually guarantee though.  There was
some slippage built into the test, but a particularly long wait in one
of the workers can set the entire thing back arbitrarily far.  We
remove the extra part of this test.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
