### PR TITLE
Remove test_restart_sync_no_center

### DIFF
--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -145,15 +145,14 @@ async def test_restart_cleared(c, s, a, b):
 
 
 @pytest.mark.skipif(COMPILED, reason="Fails with cythonized scheduler")
-def test_restart_sync_no_center(loop):
-    with cluster(nanny=True) as (s, [a, b]):
-        with Client(s["address"], loop=loop) as c:
-            x = c.submit(inc, 1)
-            c.restart()
-            assert x.cancelled()
-            y = c.submit(inc, 2)
-            assert y.result() == 3
-            assert len(c.nthreads()) == 2
+@gen_cluster(Worker=Nanny, client=True, timeout=60)
+async def test_restart_sync_no_center(c, s, a, b):
+    x = c.submit(inc, 1)
+    await c.restart()
+    assert x.cancelled()
+    y = c.submit(inc, 2)
+    assert (await y) == 3
+    assert len(await c.nthreads()) == 2
 
 
 @pytest.mark.skipif(COMPILED, reason="Fails with cythonized scheduler")

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -145,17 +145,6 @@ async def test_restart_cleared(c, s, a, b):
 
 
 @pytest.mark.skipif(COMPILED, reason="Fails with cythonized scheduler")
-@gen_cluster(Worker=Nanny, client=True, timeout=60)
-async def test_restart_sync_no_center(c, s, a, b):
-    x = c.submit(inc, 1)
-    await c.restart()
-    assert x.cancelled()
-    y = c.submit(inc, 2)
-    assert (await y) == 3
-    assert len(await c.nthreads()) == 2
-
-
-@pytest.mark.skipif(COMPILED, reason="Fails with cythonized scheduler")
 def test_restart_sync(loop):
     with cluster(nanny=True) as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:


### PR DESCRIPTION
This test is ANCIENT.  "Center" was the original term for "Scheduler"
back when only I was writing on this thing.

Anyway, this test was behaving oddly.  I'm shifting it to a gen_cluster
test and I suspect that that will either help things to work, or at
least will give us a lot more visibility about why it isn't working.