### PR TITLE
Use dependency injection for proc memory mocks

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -455,6 +455,7 @@ class Worker(ServerNode):
         lifetime_restart: bool | None = None,
         ###################################
         # Parameters to WorkerMemoryManager
+        memory_manager_cls: type[WorkerMemoryManager] = WorkerMemoryManager,
         memory_limit: str | float = "auto",
         # Allow overriding the dict-like that stores the task outputs.
         # This is meant for power users only. See WorkerMemoryManager for details.
@@ -786,7 +787,7 @@ class Worker(ServerNode):
         for ext in extensions:
             ext(self)
 
-        self.memory_manager = WorkerMemoryManager(
+        self.memory_manager = memory_manager_cls(
             self,
             data=data,
             memory_limit=memory_limit,

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -61,6 +61,7 @@ class WorkerMemoryManager:
     memory_monitor_interval: float
     _memory_monitoring: bool
     _throttled_gc: ThrottledGC
+    _worker: weakref.ReferenceType[Worker]
 
     def __init__(
         self,
@@ -298,6 +299,7 @@ class NannyMemoryManager:
     memory_limit: int | None
     memory_terminate_fraction: float | Literal[False]
     memory_monitor_interval: float | None
+    _nanny: weakref.ReferenceType[Nanny]
 
     def __init__(
         self,

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -313,7 +313,7 @@ class NannyMemoryManager:
             dask.config.get("distributed.worker.memory.monitor-interval"),
             default=None,
         )
-        self.nanny = weakref.ref(nanny)
+        self._nanny = weakref.ref(nanny)
         assert isinstance(self.memory_monitor_interval, (int, float))
         if self.memory_limit and self.memory_terminate_fraction is not False:
             pc = PeriodicCallback(
@@ -326,7 +326,7 @@ class NannyMemoryManager:
         """Get a measure for process memory.
         This can be a mock target.
         """
-        nanny = self.nanny()
+        nanny = self._nanny()
         if nanny:
             try:
                 proc = nanny._psutil_process
@@ -337,7 +337,7 @@ class NannyMemoryManager:
 
     def memory_monitor(self) -> None:
         """Track worker's memory. Restart if it goes above terminate fraction."""
-        nanny = self.nanny()
+        nanny = self._nanny()
         if (
             not nanny
             or nanny.status != Status.running


### PR DESCRIPTION
The mocks introduced in https://github.com/dask/distributed/pull/5878 are unstable in tests like [`test_fail_to_pickle_spill`](https://github.com/dask/distributed/blob/d667a9055169253b55fc079fe72c14aabf7ef2fc/distributed/tests/test_worker_memory.py#L141-L152)
because the mocks only register once the test is entered. With the extremely small memory limit, and the extreme small monitor-interval, the event loop appears to be stressed out sufficiently that the workers actually never come up in time and the test times out. Increasing the interval is one option. I encountered this during https://github.com/dask/distributed/pull/5910

The mocks are not to blame here but rather that we're patching an initialized instance after it has been started. IMO, the proper way would be to use dependency injection using a fake object instead of a monkeypatch.

This introduces a dependency injection pattern for the WorkerMemoryManager and defines a specific mock target as motivated already in https://github.com/dask/distributed/pull/5870#issuecomment-1054165512