### PR TITLE
Do not catch CancelledError in CommPool

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1093,7 +1093,7 @@ class ConnectionPool:
             name="pending-connect",
         )
         self._connecting.add(pending_task)
-        pending_task.add_done_callback(lambda _: self._connecting.discard(pending_task))
+        pending_task.add_done_callback(self._connecting.discard)
         await pending_task
         task = None
         try:
@@ -1111,7 +1111,7 @@ class ConnectionPool:
                 )
             )
             self._connecting.add(task)
-            task.add_done_callback(lambda _: self._connecting.discard(task))
+            task.add_done_callback(self._connecting.discard)
             comm = await task
             comm.name = "ConnectionPool"
             comm._pool = weakref.ref(self)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1120,14 +1120,14 @@ class ConnectionPool:
         if self.semaphore.locked():
             self.collect()
 
-        connect_attempt = asyncio.create_task(self._connect(addr, timeout))
-        # This construcation is there to ensure that cancellation requests from
+        # This construction is there to ensure that cancellation requests from
         # the outside can be distinguished from cancellations of our own.
         # Once the CommPool closes, we'll cancel the connect_attempt which will
         # raise an OSError
         # If the ``connect`` is cancelled from the outside, the Event.wait will
         # be cancelled instead which we'll reraise as a CancelledError and allow
         # it to propagate
+        connect_attempt = asyncio.create_task(self._connect(addr, timeout))
         done = asyncio.Event()
         self._connecting.add(connect_attempt)
         connect_attempt.add_done_callback(lambda _: done.set())

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3787,7 +3787,6 @@ async def test_reconnect_timeout(c, s):
     ) as logger:
         await s.close()
         while c.status != "closed":
-            await c._update_scheduler_info()
             await asyncio.sleep(0.05)
     text = logger.getvalue()
     assert "Failed to reconnect" in text
@@ -5698,7 +5697,6 @@ async def test_quiet_scheduler_loss(c, s):
     c._periodic_callbacks["scheduler-info"].interval = 10
     with captured_logger(logging.getLogger("distributed.client")) as logger:
         await s.close()
-        await c._update_scheduler_info()
     text = logger.getvalue()
     assert "BrokenPipeError" not in text
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -636,10 +636,8 @@ async def test_connection_pool_close_while_connecting(monkeypatch):
     while not pool._connecting:
         await asyncio.sleep(0.01)
 
-    close_fut = asyncio.create_task(pool.close())
-
+    await pool.close()
     done, _ = await asyncio.wait(tasks)
-    await close_fut
     assert all(t.cancelled() for t in done)
     assert not pool.open
     assert not pool._n_connecting


### PR DESCRIPTION
This is another problem that I encountered in https://github.com/dask/distributed/pull/5910

Depending on the timing of whether or not a connection attempt is tried while the server is shutting down, this can cause failures, e.g. by getting stuck because the CancelledError is not properly propagated

----

The behaviour this PR suggests is to *cancel* all connection attempts once the CommPool is closed. Ideally, all tasks would already be stopped once this happens but this is by no means guaranteed to happen.