### PR TITLE
Clarify that SchedulerPlugin must be subclassed

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -25,8 +25,11 @@ class SchedulerPlugin:
     Plugins are often used for diagnostics and measurement, but have full
     access to the scheduler and could in principle affect core scheduling.
 
-    To implement a plugin implement some of the methods of this class and add
-    the plugin to the scheduler with ``Scheduler.add_plugin(myplugin)``.
+    To implement a plugin:
+
+    1. subclass this class
+    2. override some of its methods
+    3. add the plugin to the scheduler with ``Scheduler.add_plugin(myplugin)``.
 
     Examples
     --------
@@ -50,7 +53,6 @@ class SchedulerPlugin:
 
         This runs at the end of the Scheduler startup process
         """
-        pass
 
     async def close(self):
         """Run when the scheduler closes down
@@ -58,7 +60,6 @@ class SchedulerPlugin:
         This runs at the beginning of the Scheduler shutdown process, but after
         workers have been asked to shut down gracefully
         """
-        pass
 
     def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
         """Run when a new graph / tasks enter the scheduler"""

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import socket
@@ -5,8 +7,13 @@ import subprocess
 import sys
 import uuid
 import zipfile
+from collections.abc import Awaitable
+from typing import TYPE_CHECKING
 
 from dask.utils import funcname, tmpfile
+
+if TYPE_CHECKING:
+    from distributed.scheduler import Scheduler  # circular import
 
 logger = logging.getLogger(__name__)
 
@@ -48,26 +55,28 @@ class SchedulerPlugin:
     >>> scheduler.add_plugin(plugin)  # doctest: +SKIP
     """
 
-    async def start(self, scheduler):
+    async def start(self, scheduler: Scheduler) -> None:
         """Run when the scheduler starts up
 
         This runs at the end of the Scheduler startup process
         """
 
-    async def close(self):
+    async def close(self) -> None:
         """Run when the scheduler closes down
 
         This runs at the beginning of the Scheduler shutdown process, but after
         workers have been asked to shut down gracefully
         """
 
-    def update_graph(self, scheduler, dsk=None, keys=None, restrictions=None, **kwargs):
+    def update_graph(
+        self, scheduler: Scheduler, keys: set[str], restrictions: dict, **kwargs
+    ) -> None:
         """Run when a new graph / tasks enter the scheduler"""
 
-    def restart(self, scheduler, **kwargs):
+    def restart(self, scheduler: Scheduler) -> None:
         """Run when the scheduler restarts itself"""
 
-    def transition(self, key, start, finish, *args, **kwargs):
+    def transition(self, key: str, start: str, finish: str, *args, **kwargs) -> None:
         """Run whenever a task changes state
 
         Parameters
@@ -82,16 +91,18 @@ class SchedulerPlugin:
             This may include worker ID, compute time, etc.
         """
 
-    def add_worker(self, scheduler=None, worker=None, **kwargs):
+    def add_worker(self, scheduler: Scheduler, worker: str) -> None | Awaitable[None]:
         """Run when a new worker enters the cluster"""
 
-    def remove_worker(self, scheduler=None, worker=None, **kwargs):
+    def remove_worker(
+        self, scheduler: Scheduler, worker: str
+    ) -> None | Awaitable[None]:
         """Run when a worker leaves the cluster"""
 
-    def add_client(self, scheduler=None, client=None, **kwargs):
+    def add_client(self, scheduler: Scheduler, client: str) -> None:
         """Run when a new client connects"""
 
-    def remove_client(self, scheduler=None, client=None, **kwargs):
+    def remove_client(self, scheduler: Scheduler, client: str) -> None:
         """Run when a client disconnects"""
 
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -57,13 +57,15 @@ from distributed import versions as version_module
 from distributed.active_memory_manager import ActiveMemoryManagerExtension, RetireWorker
 from distributed.batched import BatchedSend
 from distributed.comm import (
+    Comm,
+    CommClosedError,
     get_address_host,
     normalize_address,
     resolve_address,
     unparse_host_port,
 )
 from distributed.comm.addressing import addresses_from_user_args
-from distributed.core import CommClosedError, Status, clean_exception, rpc, send_recv
+from distributed.core import Status, clean_exception, rpc, send_recv
 from distributed.diagnostics.memory_sampler import MemorySamplerExtension
 from distributed.diagnostics.plugin import SchedulerPlugin, _get_plugin_name
 from distributed.event import EventExtension
@@ -5449,7 +5451,7 @@ class Scheduler(SchedulerState, ServerNode):
                         "Closed comm %r while trying to write %s", c, msg, exc_info=True
                     )
 
-    async def add_client(self, comm, client=None, versions=None):
+    async def add_client(self, comm: Comm, client: str, versions: dict) -> None:
         """Add client to network
 
         We listen to all future messages from this Comm.
@@ -5498,7 +5500,7 @@ class Scheduler(SchedulerState, ServerNode):
             except TypeError:  # comm becomes None during GC
                 pass
 
-    def remove_client(self, client=None):
+    def remove_client(self, client: str) -> None:
         """Remove client from network"""
         parent: SchedulerState = cast(SchedulerState, self)
         if self.status == Status.running:


### PR DESCRIPTION
https://github.com/dask/distributed/pull/5983#discussion_r834694234 adds a new method to SchedulerPlugin and concerns were raised about breaking potential duck-type plugins. 

The existing documentation is ambiguous, as it may be interpreted that a partial duck-type is fine - it doesn't; if the plugin misses any methods it will fail.