### PR TITLE
Place an upper limit on the `click` version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click >= 6.6
+click >= 6.6, <= 8.0.2
 cloudpickle >= 1.5.0
 dask == 2022.03.0
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click >= 6.6, <= 8.0.2
+click >= 6.6, <= 8.0.4
 cloudpickle >= 1.5.0
 dask == 2022.03.0
 jinja2


### PR DESCRIPTION
This places an upper limit on the required `click` version, the latest version does not include the required `_unicodefun` module.

- [ ] Closes #6013 
