### PR TITLE
Cluster dump inspection improvements

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3899,21 +3899,17 @@ class Client(SyncMethodMixin):
             Either ``"msgpack"`` or ``"yaml"``. If msgpack is used (default),
             the output will be stored in a gzipped file as msgpack.
 
+            ``"msgpack"`` is generally preferred, since it's far faster to write
+            and far smaller on disk. If you want to examine the dump in human-readable
+            format, consider creating the dump in msgpack format, then (in an IPython session
+            or separate script), using `DumpArtefact.to_yamls` to create a directory
+            tree of separate YAML files, which are easier to work with.
+
             To read::
 
-                import gzip, msgpack
-                with gzip.open("filename") as fd:
-                    state = msgpack.unpack(fd)
+                from distributed.cluster_dump import DumpArtefact
+                dump = DumpArtefact.from_url("filename")
 
-            or::
-
-                import yaml
-                try:
-                    from yaml import CLoader as Loader
-                except ImportError:
-                    from yaml import Loader
-                with open("filename") as fd:
-                    state = yaml.load(fd, Loader=Loader)
         **storage_options:
             Any additional arguments to :func:`fsspec.open` when writing to a URL.
         """

--- a/distributed/cluster_dump.py
+++ b/distributed/cluster_dump.py
@@ -291,6 +291,7 @@ class DumpArtefact(Mapping):
             "tasks",
         ),
         scheduler_expand_keys: Collection[str] = (
+            "clients",
             "events",
             "extensions",
             "log",

--- a/distributed/cluster_dump.py
+++ b/distributed/cluster_dump.py
@@ -333,13 +333,7 @@ class DumpArtefact(Mapping):
 
         workers = self.dump["workers"]
         for i, (addr, info) in enumerate(workers.items()):
-            try:
-                worker_name = self.dump["scheduler"]["workers"][addr]["name"]
-            except KeyError:
-                if log:
-                    print(f"    Worker {addr} unknown to scheduler")
-                worker_name = addr.replace("://", "-").replace("/", "_")
-
+            worker_name = addr.replace("://", "-").replace("/", "_")
             log_dir = root_dir / worker_name
             log_dir.mkdir(parents=True, exist_ok=True)
 

--- a/distributed/cluster_dump.py
+++ b/distributed/cluster_dump.py
@@ -251,7 +251,13 @@ class DumpArtefact(Mapping):
     def to_yamls(
         self,
         root_dir: str | Path | None = None,
-        worker_expand_keys: Collection[str] = ("config", "log", "logs", "tasks"),
+        worker_expand_keys: Collection[str] = (
+            "config",
+            "incoming_transfer_log",
+            "log",
+            "logs",
+            "tasks",
+        ),
         scheduler_expand_keys: Collection[str] = (
             "events",
             "extensions",

--- a/distributed/cluster_dump.py
+++ b/distributed/cluster_dump.py
@@ -283,6 +283,8 @@ class DumpArtefact(Mapping):
         worker_expand_keys: Collection[str] = (
             "config",
             "incoming_transfer_log",
+            "outgoing_transfer_log",
+            "pending_data_per_worker",
             "log",
             "logs",
             "tasks",

--- a/distributed/cluster_dump.py
+++ b/distributed/cluster_dump.py
@@ -12,6 +12,7 @@ import fsspec
 import msgpack
 
 from distributed.compatibility import to_thread
+from distributed.stories import msg_with_datetime
 from distributed.stories import scheduler_story as _scheduler_story
 from distributed.stories import worker_story as _worker_story
 
@@ -375,7 +376,10 @@ class DumpArtefact(Mapping):
 
             for name, _logs in worker_state.items():
                 filename = str(log_dir / f"{name}.yaml")
+                if name == "log":
+                    _logs = list(map(msg_with_datetime, _logs))
                 with open(filename, "w") as fd:
+
                     with _block_literals(dumper) if name == "logs" else nullcontext():
                         yaml.dump(_logs, fd, Dumper=dumper)
 
@@ -392,6 +396,9 @@ class DumpArtefact(Mapping):
             filename = str(log_dir / f"{name}.yaml")
             if log:
                 print(f"    Dumping {i+1:>2}/{len(scheduler_state)} {filename}")
+
+            if name == "transition_log":
+                _logs = list(map(msg_with_datetime, _logs))
 
             with open(filename, "w") as fd:
                 with _block_literals(dumper) if name == "logs" else nullcontext():

--- a/distributed/cluster_dump.py
+++ b/distributed/cluster_dump.py
@@ -236,7 +236,7 @@ class DumpArtefact(Mapping):
                 / f"story-{key_or_stimulus_id[0] if len(key_or_stimulus_id) == 1 else key_or_stimulus_id}.yaml"
             )
 
-            print(f"Dumping story {i:>3}/{len(stories)} to {path}")
+            print(f"Dumping story {i+1:>3}/{len(stories)} to {path}")
             with open(path, "w") as f:
                 yaml.dump(story, f, Dumper=yaml.CSafeDumper)
 
@@ -363,7 +363,7 @@ class DumpArtefact(Mapping):
             log_dir.mkdir(parents=True, exist_ok=True)
 
             if log:
-                print(f"Dumping worker {i:>4}/{len(workers)} to {log_dir}")
+                print(f"Dumping worker {i+1:>4}/{len(workers)} to {log_dir}")
 
             worker_state = self._compact_state(info, worker_expand_keys)
 
@@ -384,7 +384,7 @@ class DumpArtefact(Mapping):
         for i, (name, _logs) in enumerate(scheduler_state.items()):
             filename = str(log_dir / f"{name}.yaml")
             if log:
-                print(f"    Dumping {i:>2}/{len(scheduler_state)} {filename}")
+                print(f"    Dumping {i+1:>2}/{len(scheduler_state)} {filename}")
 
             with open(filename, "w") as fd:
                 yaml.dump(_logs, fd, Dumper=dumper)

--- a/distributed/cluster_dump.py
+++ b/distributed/cluster_dump.py
@@ -298,7 +298,7 @@ class DumpArtefact(Mapping):
             Keys that are not in this iterable are compacted into a
             ``general.yaml`` file.
         background:
-            If True, run in a separate thread in the background.
+            If True, run in a separate daemon thread in the background.
             Returns the `threading.Thread` object immediately.
         log:
             Print progress updates if True. Defaults to None, which means
@@ -317,6 +317,7 @@ class DumpArtefact(Mapping):
                     background=False,
                     log=log if log is not None else False,
                 ),
+                daemon=True,
             )
             t.start()
             return t

--- a/distributed/stories.py
+++ b/distributed/stories.py
@@ -41,7 +41,7 @@ def worker_story(keys: set, log: Iterable, datetimes: bool = False) -> list:
     story : list
     """
     return [
-        _msg_with_datetime(msg) if datetimes else msg
+        msg_with_datetime(msg) if datetimes else msg
         for msg in log
         if any(key in msg for key in keys)
         or any(
@@ -53,7 +53,7 @@ def worker_story(keys: set, log: Iterable, datetimes: bool = False) -> list:
 T = TypeVar("T", list, tuple)
 
 
-def _msg_with_datetime(msg: T) -> T:
+def msg_with_datetime(msg: T) -> T:
     dt = msg[-1]
     try:
         dt = datetime.fromtimestamp(dt)


### PR DESCRIPTION
Various quality-of-life improvements to the cluster dump inspection process
* Add print statements to `to_yamls`, since it can be pretty slow and it's nice to see what's going on
* Add option to run `to_yamls` in a background thread, so you can start inspecting the `DumpArtefact` right away
* Name worker subdirectories in `to_yamls` by address (more easily cross-referenceable)
* Fix `worker_story` to just return each worker's story separately. Trying to combine them all by event type is ultimately less useful
* Add `worker_stories_to_yamls` to dump all the worker stories to separate YAML files (matching your `to_yamls` directories)
* Format event log timestamps as datetimes in `to_yamls` methods for easier reading and cross-referencing to logs
* Add more things by default to the `expand_keys` lists
* When dumping logs, use YAML block literals (`|`) so `\n` actually becomes a newline, instead of printing as an escaped character. This makes tracebacks much easier to read.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
