### PR TITLE
Ensure multiple clients can cancel their key without interference

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4881,6 +4881,8 @@ class as_completed:
             if self.raise_errors and future.status == "error":
                 typ, exc, tb = result
                 raise exc.with_traceback(tb)
+            elif future.status == "cancelled":
+                res = (res[0], CancelledError(future.key))
         return res
 
     def __next__(self):

--- a/distributed/tests/test_as_completed.py
+++ b/distributed/tests/test_as_completed.py
@@ -240,12 +240,12 @@ async def test_str(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_as_completed_with_results_no_raise_async(c, s, a, b):
-    x = c.submit(throws, 1)
-    y = c.submit(inc, 5)
-    z = c.submit(inc, 1)
+    x = c.submit(throws, 1, key="x")
+    y = c.submit(inc, 5, key="y")
+    z = c.submit(inc, 1, key="z")
 
     ac = as_completed([x, y, z], with_results=True, raise_errors=False)
-    c.loop.add_callback(y.cancel)
+    await y.cancel()
     res = [el async for el in ac]
 
     dd = {r[0]: r[1:] for r in res}

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -687,9 +687,9 @@ async def test_restrictions(c, s, a, b):
     await x
     ts = a.tasks[x.key]
     assert ts.resource_restrictions == {"A": 1}
-    await c._cancel(x)
+    await c.cancel([x])
 
-    while ts.state != "memory":
+    while ts.state == "executing":
         # Resource should be unavailable while task isn't finished
         assert a.available_resources == {"A": 0}
         await asyncio.sleep(0.01)


### PR DESCRIPTION
Encountered this during https://github.com/dask/distributed/pull/6005

I assume the indentation of the `Scheduler.report` was done wrong in one of the bigger refactorings going on. The test passed because of two problems with the test

- the entire body after the `c.cancel` could run synchronously. Therefore, client `c` marked the future already as cancelled but Client `f` didn't receive the message of the scheduler, yet. Therefore the asserts on the FutureState were successful. Since the scheduler didn't actually cancel the key, `y` could be properly awaited.
- Since the test didn't wait for neither `f` nor `c` to be actually registered, the `cancel_key` uses it's retry feature that returns immediately and schedules another callback. On busy CI / stress, this callback could be scheduled before the second client is registered to the scheduler, therefore, the second client would never receive the erroneous cancellation report