### PR TITLE
Fix black in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
-  -   repo: https://github.com/MarcoGorelli/absolufy-imports
-      rev: v0.3.1
-      hooks:
+  - repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
       - id: absolufy-imports
         name: absolufy-imports
-  -   repo: https://github.com/pycqa/isort
-      rev: 5.10.1
-      hooks:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
       - id: isort
         language_version: python3
   - repo: https://github.com/asottile/pyupgrade
@@ -17,17 +17,17 @@ repos:
       - id: pyupgrade
         args:
           - --py38-plus
-  -   repo: https://github.com/psf/black
-      rev: 22.1.0
-      hooks:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
       - id: black
         language_version: python3
         exclude: versioneer.py
         args:
           - --target-version=py38
-  -   repo: https://gitlab.com/pycqa/flake8
-      rev: 3.9.2
-      hooks:
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
       - id: flake8
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,14 @@ repos:
       - id: flake8
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.942
     hooks:
       - id: mypy
+        args:
+          - --ignore-missing-imports
+          # Silence errors about Python 3.9-style delayed type annotations on Python 3.8
+          - --python-version
+          - "3.9"
         additional_dependencies:
           # Type stubs
           - types-docutils


### PR DESCRIPTION
Fix CI failure that started this morning:
```
black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repofdmtj5xe/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/.cache/pre-commit/repofdmtj5xe/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1423, in patched_main
    patch_click()
  File "/home/runner/.cache/pre-commit/repofdmtj5xe/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1409, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repofdmtj5xe/py_env-python3/lib/python3.10/site-packages/click/__init__.py)
```