### PR TITLE
More idiomatic mypy configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,11 +34,7 @@ repos:
     rev: v0.942
     hooks:
       - id: mypy
-        args:
-          - --ignore-missing-imports
-          # Silence errors about Python 3.9-style delayed type annotations on Python 3.8
-          - --python-version
-          - "3.9"
+        args: []
         additional_dependencies:
           # Type stubs
           - types-docutils
@@ -46,6 +42,7 @@ repos:
           - types-paramiko
           - types-PyYAML
           - types-psutil
+          - types-setuptools
           # Typed libraries
           - numpy
           - dask

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
     rev: v0.942
     hooks:
       - id: mypy
+        # Override default --ignore-missing-imports
         args: []
         additional_dependencies:
           # Type stubs

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,3 +59,8 @@ timeout_method = thread
 # This should not be reduced; Windows CI has been observed to be occasionally
 # exceptionally slow.
 timeout = 300
+
+[mypy]
+# Silence errors about Python 3.9-style delayed type annotations on Python 3.8
+python_version = 3.9
+ignore_missing_imports = true


### PR DESCRIPTION
Move awkward-looking command-line argument from pre-config to setup.cfg
Now it is possible to run mypy directly from the command line and obtain the same results as in pre-commit (as long as all type stubs are installed).