### PR TITLE
Remove support for PyPy

### DIFF
--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import logging
-import platform
 import sys
 
 logging_names: dict[str | int, int | str] = {}
 logging_names.update(logging._levelToName)  # type: ignore
 logging_names.update(logging._nameToLevel)  # type: ignore
 
-PYPY = platform.python_implementation().lower() == "pypy"
 LINUX = sys.platform == "linux"
 MACOS = sys.platform == "darwin"
 WINDOWS = sys.platform.startswith("win")

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import gc
 import logging
 import os
 import uuid
@@ -338,7 +337,6 @@ def test_weakref_cache(tmpdir, cls, expect_cached, size):
     # the same id as a deleted one
     id_x = x.id
     del x
-    gc.collect()  # Only needed on pypy
 
     if size < 100:
         buf["y"]

--- a/distributed/utils_perf.py
+++ b/distributed/utils_perf.py
@@ -5,7 +5,6 @@ from collections import deque
 
 from dask.utils import format_bytes
 
-from distributed.compatibility import PYPY
 from distributed.metrics import thread_time
 
 logger = _logger = logging.getLogger(__name__)
@@ -144,8 +143,6 @@ class GCDiagnosis:
         self._enabled = False
 
     def enable(self):
-        if PYPY:
-            return
         assert not self._enabled
         self._fractional_timer = FractionalTimer(n_samples=self.N_SAMPLES)
         try:
@@ -162,8 +159,6 @@ class GCDiagnosis:
         self._enabled = True
 
     def disable(self):
-        if PYPY:
-            return
         assert self._enabled
         gc.callbacks.remove(self._gc_callback)
         self._enabled = False
@@ -229,8 +224,6 @@ def enable_gc_diagnosis():
     """
     Ask to enable global GC diagnosis.
     """
-    if PYPY:
-        return
     global _gc_diagnosis_users
     with _gc_diagnosis_lock:
         if _gc_diagnosis_users == 0:
@@ -244,8 +237,6 @@ def disable_gc_diagnosis(force=False):
     """
     Ask to disable global GC diagnosis.
     """
-    if PYPY:
-        return
     global _gc_diagnosis_users
     with _gc_diagnosis_lock:
         if _gc_diagnosis_users > 0:

--- a/docs/source/protocol.rst
+++ b/docs/source/protocol.rst
@@ -135,13 +135,11 @@ the scheduler may differ.**
 This has a few advantages:
 
 1.  The Scheduler is protected from unpickling unsafe code
-2.  The Scheduler can be run under ``pypy`` for improved performance.  This is
-    only useful for larger clusters.
-3.  We could conceivably implement workers and clients for other languages
+2.  We could conceivably implement workers and clients for other languages
     (like R or Julia) and reuse the Python scheduler.  The worker and client
     code is fairly simple and much easier to reimplement than the scheduler,
     which is complex.
-4.  The scheduler might some day be rewritten in more heavily optimized C or Go
+3.  The scheduler might some day be rewritten in more heavily optimized C or Go
 
 Compression
 -----------


### PR DESCRIPTION
In the monthly community meeting on 2022-02-03, we decided to intentionally remove support for PyPy (pasted the corresponding section from the meeting notes below). This PR removes all PyPy support code. 

<details>
<summary>Relevant monthly meeting notes:</summary>

- Drop PyPy? https://github.com/dask/distributed/issues/5681 
    - We don’t see any users here
    - There is some mild cost
    - We don’t really support this today
    - We’re now going to intentionally not support it.

</details>

- [x] Closes https://github.com/dask/distributed/issues/5681
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

cc @jakirkham @mrocklin for visibility 