### PR TITLE
Improve test_hardware test

### DIFF
--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -1007,6 +1007,9 @@ async def test_prefix_bokeh(s, a, b):
     assert bokeh_app.prefix == f"/{prefix}"
 
 
-@gen_cluster(client=True, scheduler_kwargs={"dashboard": True})
-async def test_hardware(c, s, a, b):
-    Hardware(s)  # don't call update, takes too long for a test
+@gen_cluster(client=True, nthreads=[], scheduler_kwargs={"dashboard": True})
+async def test_hardware(c, s):
+    plot = Hardware(s)
+    while not plot.disk_data:
+        await asyncio.sleep(0.1)
+        plot.update()


### PR DESCRIPTION
There was an intermittent failure around this test.
It used to launch a coroutine that started some non-trivially
expensive computation.  We reduce the expense of that computation and
verify that that coroutine finishes, which should clean things up.