### PR TITLE
(for discussion) add hooks in wait_for_workers

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1315,7 +1315,11 @@ class Client(SyncMethodMixin):
         else:
             deadline = None
         while n_workers and len(info["workers"]) < n_workers:
+            if self.cluster:
+                self.cluster.handle_still_waiting_for_workers()
             if deadline and time() > deadline:
+                if self.cluster:
+                    self.cluster.handle_wait_for_workers_timeout()
                 raise TimeoutError(
                     "Only %d/%d workers arrived after %s"
                     % (len(info["workers"]), n_workers, timeout)

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -516,3 +516,17 @@ class Cluster(SyncMethodMixin):
 
     def __hash__(self):
         return id(self)
+
+    def handle_wait_for_workers_timeout(self):
+        """
+        Subclasses may (but need not) override this to implement special behavior (such as logging)
+        to be called when wait_for_workers times out.
+        """
+        pass
+
+    def handle_still_waiting_for_workers(self):
+        """
+        Subclasses may (but need not) override this to implement special behavior (such as logging)
+        to be called while waiting for workers.
+        """
+        pass


### PR DESCRIPTION
I work on Coiled's `Cluster`, which is a subclass of `distributed.deploy.Cluster`.

When our users call `client.wait_for_workers`, I'd like to give them information (e.g. via logging) about what's going on (e.g. progress launching EC2 instances), and when something goes wrong (the workers never arrive before timeout) I'd like to give them some information about what went wrong (e.g. details of errors in workers we tried to launch).

This PR is one idea for how we could do that: if `wait_for_workers` calls these new methods on the `Cluster` class, then subclasses can implement manager-specific logic for what to do (which I imagine will mostly be about giving users info, but could involve taking actions).

Thoughts?