### PR TITLE
Debug worker client

### DIFF
--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -347,7 +347,7 @@ def test_sync_func_on_main_thread(client):
     # https://github.com/dask/distributed/issues/5513
 
     async def inc(n):
-        return n+1
+        return n + 1
 
     async def f():
         with worker_client(separate_thread=True) as c:
@@ -365,7 +365,7 @@ async def test_async_func_on_main_thread(c, s, a, b):
     # https://github.com/dask/distributed/issues/5513
 
     async def inc(n):
-        return n+1
+        return n + 1
 
     async def f():
         with worker_client(separate_thread=True) as client:

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -180,9 +180,10 @@ async def test_separate_thread_false(c, s, a):
 
 
 @gen_cluster(client=True)
-async def test_client_executor(c, s, a, b):
+@pytest.mark.parametrize('separate_thread', [True, False])
+async def test_client_executor(c, s, a, b, separate_thread):
     def mysum():
-        with worker_client() as c:
+        with worker_client(separate_thread=separate_thread) as c:
             with c.get_executor() as e:
                 return sum(e.map(double, range(30)))
 
@@ -341,7 +342,8 @@ async def test_secede_does_not_claim_worker(c, s, a, b):
     assert res[b.address] > 25
 
 
-def test_sync_func_on_main_thread(client):
+@pytest.mark.parametrize('separate_thread', [True, False])
+def test_sync_func_on_main_thread(client, separate_thread):
     """A synchronous client running a worker that calls an async task which submits its own task to
     the scheduler should not fail"""
     # https://github.com/dask/distributed/issues/5513
@@ -350,7 +352,7 @@ def test_sync_func_on_main_thread(client):
         return n + 1
 
     async def f():
-        with worker_client(separate_thread=True) as c:
+        with worker_client(separate_thread=separate_thread) as c:
             m = c.submit(inc, 1)
             return m
 
@@ -359,7 +361,8 @@ def test_sync_func_on_main_thread(client):
 
 
 @gen_cluster(client=True)
-async def test_async_func_on_main_thread(c, s, a, b):
+@pytest.mark.parametrize('separate_thread', [True, False])
+async def test_async_func_on_main_thread(c, s, a, b, separate_thread):
     """An asynchronous client running a worker that calls an async task which submits its own task to
     the scheduler should not fail"""
     # https://github.com/dask/distributed/issues/5513
@@ -368,7 +371,7 @@ async def test_async_func_on_main_thread(c, s, a, b):
         return n + 1
 
     async def f():
-        with worker_client(separate_thread=True) as client:
+        with worker_client(separate_thread=separate_thread) as client:
             m = await client.submit(inc, 1)
             return m
 

--- a/distributed/worker_client.py
+++ b/distributed/worker_client.py
@@ -1,6 +1,6 @@
+import threading
 import warnings
 from contextlib import contextmanager
-import threading
 
 import dask
 


### PR DESCRIPTION
When a worker_client is created within an async function with `separate_thread=True`, the `secede()`call fails, since the running thread is also the main thread.  This PR validates that the `worker_client`is not running in the main thread before calling `secede().

- [ ] Closes #5513 
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
