### PR TITLE
Ensure distributed.comm.core.connect can always be cancelled

### DIFF
--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -18,6 +18,7 @@ from distributed.comm.addressing import parse_address
 from distributed.metrics import time
 from distributed.protocol import pickle
 from distributed.protocol.compression import get_default_compression
+from distributed.utils import ensure_cancellation
 
 logger = logging.getLogger(__name__)
 
@@ -286,8 +287,11 @@ async def connect(
     active_exception = None
     while time_left() > 0:
         try:
+            task = ensure_cancellation(
+                connector.connect(loc, deserialize=deserialize, **connection_args)
+            )
             comm = await asyncio.wait_for(
-                connector.connect(loc, deserialize=deserialize, **connection_args),
+                task,
                 timeout=min(intermediate_cap, time_left()),
             )
             break

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1086,6 +1086,7 @@ class ConnectionPool:
                     deserialize=self.deserialize,
                     **self.connection_args,
                 )
+
                 comm.name = "ConnectionPool"
                 comm._pool = weakref.ref(self)
                 comm.allow_offload = self.allow_offload
@@ -1099,8 +1100,6 @@ class ConnectionPool:
                 raise
             finally:
                 self._connecting_count -= 1
-        except asyncio.CancelledError:
-            raise CommClosedError("ConnectionPool closing.")
         finally:
             self._pending_count -= 1
 
@@ -1121,30 +1120,15 @@ class ConnectionPool:
         if self.semaphore.locked():
             self.collect()
 
-        # This construction is there to ensure that cancellation requests from
-        # the outside can be distinguished from cancellations of our own.
-        # Once the CommPool closes, we'll cancel the connect_attempt which will
-        # raise an OSError
-        # If the ``connect`` is cancelled from the outside, the Event.wait will
-        # be cancelled instead which we'll reraise as a CancelledError and allow
-        # it to propagate
         connect_attempt = asyncio.create_task(self._connect(addr, timeout))
-        done = asyncio.Event()
         self._connecting.add(connect_attempt)
-        connect_attempt.add_done_callback(lambda _: done.set())
         connect_attempt.add_done_callback(self._connecting.discard)
-
         try:
-            await done.wait()
+            return await connect_attempt
         except asyncio.CancelledError:
-            # This is an outside cancel attempt
-            connect_attempt.cancel()
-            try:
-                await connect_attempt
-            except CommClosedError:
-                pass
+            if self.status == Status.closed:
+                raise CommClosedError("ConnectionPool closed.")
             raise
-        return await connect_attempt
 
     def reuse(self, addr, comm):
         """

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5743,12 +5743,13 @@ async def test_client_active_bad_port():
     application = tornado.web.Application([(r"/", tornado.web.RequestHandler)])
     http_server = tornado.httpserver.HTTPServer(application)
     http_server.listen(8080)
-    with dask.config.set({"distributed.comm.timeouts.connect": "10ms"}):
-        c = Client("127.0.0.1:8080", asynchronous=True)
-        with pytest.raises((TimeoutError, IOError)):
-            await c
-        await c._close(fast=True)
-    http_server.stop()
+    try:
+        with dask.config.set({"distributed.comm.timeouts.connect": "10ms"}):
+            with pytest.raises((TimeoutError, IOError)):
+                async with Client("127.0.0.1:8080", asynchronous=True) as c:
+                    pass
+    finally:
+        http_server.stop()
 
 
 @pytest.mark.parametrize("direct", [True, False])


### PR DESCRIPTION
I noticed that tests like `test_worker_waits_for_scheduler` are not properly running even though the test logic is extremely simple.

The test `test_worker_waits_for_scheduler` particularly hangs in the `asyncio.wait_for` statement waiting for the worker to come up.
After some debugging, it appears the worker is stuck in the connect retry implementation trying to connect to the scheduler. This connect should've been cancelled after the `wait_for` hits its timeout but it wasn't.

It appears there is a race condition when cancelling a task. If the Task is cancelled right after it is finished and the exception is set, it will not raise a CancelledError but the original Exception. I don't know if this is a bug in CPython but it is not the behaviour I anticipated. I wrote the `ensure_cancellation` wrapper to make sure this behaviour is deterministic

cc @graingert 

Closes https://github.com/dask/distributed/issues/5861