### PR TITLE
Fix flaky test_as_completed_async_for_cancel

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6294,11 +6294,11 @@ async def test_as_completed_async_for_results(c, s, a, b):
     assert not s.counters["op"].components[0]["gather"]
 
 
-@pytest.mark.slow
 @gen_cluster(client=True)
 async def test_as_completed_async_for_cancel(c, s, a, b):
     x = c.submit(inc, 1)
-    y = c.submit(lambda: Event().wait())  # This task will never finish
+    ev = Event()
+    y = c.submit(lambda ev: ev.wait(), ev)
     ac = as_completed([x, y])
 
     await x
@@ -6306,6 +6306,7 @@ async def test_as_completed_async_for_cancel(c, s, a, b):
 
     futs = [future async for future in ac]
     assert futs == [x, y]
+    await ev.set()  # Allow for clean teardown
 
 
 @gen_test()


### PR DESCRIPTION
Fix race condition where x could terminate after y on a very slow CI host

https://github.com/dask/distributed/runs/5832769339?check_suite_focus=true
```
>       assert L == [x, y]
E       assert [<Future: can...55e867cbf56a>] == [<Future: fin...f50ab3d7198b>]
E         At index 0 diff: <Future: cancelled, key: sleep-0827998fccf8e5ae8a0df50ab3d7198b> != <Future: finished, type: int, key: inc-03d935909bba38f9a49655e867cbf56a>
E         Full diff:
E           [
E         +  <Future: cancelled, key: sleep-0827998fccf8e5ae8a0df50ab3d7198b>,
E            <Future: finished, type: int, key: inc-03d935909bba38f9a49655e867cbf56a>,
E         -  <Future: cancelled, key: sleep-0827998fccf8e5ae8a0df50ab3d7198b>,
E           ]
```