### PR TITLE
Drop OSX builds for python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,9 +28,7 @@ jobs:
         partition: [ci1, not ci1]
         exclude:
           - os: macos-latest
-            python-version: 3.8
-          - os: macos-latest
-            python-version: 3.10
+            python-version: 3.9
         include:
           - partition: "ci1"
             partition-label: "ci1"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,11 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
         # Cherry-pick test modules to split the overall runtime roughly in half
         partition: [ci1, not ci1]
+        exclude:
+          - os: macos-latest
+            python-version: 3.8
+          - os: macos-latest
+            python-version: 3.10
         include:
           - partition: "ci1"
             partition-label: "ci1"

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -17,7 +17,6 @@ dependencies:
   - ipykernel
   - ipywidgets
   - jinja2
-  - joblib  # overridden by git tip below
   - msgpack-python
   - netcdf4
   - paramiko
@@ -45,6 +44,5 @@ dependencies:
       - git+https://github.com/dask/s3fs
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
-      - git+https://github.com/joblib/joblib
       - keras
       - pytest-asyncio<0.14.0 # `pytest-asyncio<0.14.0` isn't available on conda-forge for Python 3.10

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -1,4 +1,3 @@
-# This includes git tips for the most relevant dependencies
 name: dask-distributed
 channels:
   - conda-forge
@@ -7,17 +6,23 @@ dependencies:
   - python=3.10
   - packaging
   - pip
+  - asyncssh
   - bokeh
   - click
   - cloudpickle
   - coverage<6.3  # https://github.com/nedbat/coveragepy/issues/1310
   - dask  # overridden by git tip below
   - filesystem-spec  # overridden by git tip below
+  - h5py
   - ipykernel
   - ipywidgets
   - jinja2
+  - joblib  # overridden by git tip below
   - msgpack-python
+  - netcdf4
+  - paramiko
   - pre-commit
+  - prometheus_client
   - psutil
   - pytest
   - pytest-cov
@@ -27,14 +32,19 @@ dependencies:
   - pytest-timeout
   - requests
   - s3fs  # overridden by git tip below
+  - scikit-learn
+  - scipy
   - sortedcollections
   - tblib
   - toolz
   - tornado
   - zict  # overridden by git tip below
+  - zstandard
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/s3fs
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
+      - git+https://github.com/joblib/joblib
+      - keras
       - pytest-asyncio<0.14.0 # `pytest-asyncio<0.14.0` isn't available on conda-forge for Python 3.10

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -1,3 +1,4 @@
+# This includes git tips for the most relevant dependencies
 name: dask-distributed
 channels:
   - conda-forge
@@ -6,23 +7,17 @@ dependencies:
   - python=3.10
   - packaging
   - pip
-  - asyncssh
   - bokeh
   - click
   - cloudpickle
   - coverage<6.3  # https://github.com/nedbat/coveragepy/issues/1310
   - dask  # overridden by git tip below
   - filesystem-spec  # overridden by git tip below
-  - h5py
   - ipykernel
   - ipywidgets
   - jinja2
-  - joblib  # overridden by git tip below
   - msgpack-python
-  - netcdf4
-  - paramiko
   - pre-commit
-  - prometheus_client
   - psutil
   - pytest
   - pytest-cov
@@ -32,19 +27,14 @@ dependencies:
   - pytest-timeout
   - requests
   - s3fs  # overridden by git tip below
-  - scikit-learn
-  - scipy
   - sortedcollections
   - tblib
   - toolz
   - tornado
   - zict  # overridden by git tip below
-  - zstandard
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/s3fs
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
-      - git+https://github.com/joblib/joblib
-      - keras
       - pytest-asyncio<0.14.0 # `pytest-asyncio<0.14.0` isn't available on conda-forge for Python 3.10

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -1,3 +1,4 @@
+# This is a minimal set of requirements
 name: dask-distributed
 channels:
   - conda-forge
@@ -6,7 +7,6 @@ dependencies:
   - python=3.8
   - packaging
   - pip
-  - asyncssh
   - bokeh
   - click
   - cloudpickle
@@ -14,14 +14,10 @@ dependencies:
   - cython  # Only tested here; also a dependency of crick
   - dask  # overridden by git tip below
   - filesystem-spec
-  - h5py
   - ipykernel
   - ipywidgets
   - jinja2
-  - joblib
   - msgpack-python
-  - netcdf4
-  - paramiko
   - pre-commit
   - prometheus_client
   - psutil
@@ -34,15 +30,11 @@ dependencies:
   - pytest-timeout
   - requests
   - s3fs
-  - scikit-learn
-  - scipy
   - sortedcollections
   - tblib
   - toolz
   - tornado
   - zict
-  - zstandard
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/jcrist/crick  # Only tested here
-      - keras

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -1,4 +1,3 @@
-# This is a minimal set of requirements
 name: dask-distributed
 channels:
   - conda-forge
@@ -7,6 +6,7 @@ dependencies:
   - python=3.8
   - packaging
   - pip
+  - asyncssh
   - bokeh
   - click
   - cloudpickle
@@ -14,13 +14,18 @@ dependencies:
   - cython  # Only tested here; also a dependency of crick
   - dask  # overridden by git tip below
   - filesystem-spec
+  - h5py
   - ipykernel
   - ipywidgets
   - jinja2
+  - joblib
   - msgpack-python
+  - netcdf4
+  - paramiko
   - pre-commit
   - prometheus_client
   - psutil
+  - pynvml  # Only tested here
   - pytest
   - pytest-asyncio<0.14.0
   - pytest-cov
@@ -30,11 +35,15 @@ dependencies:
   - pytest-timeout
   - requests
   - s3fs
+  - scikit-learn
+  - scipy
   - sortedcollections
   - tblib
   - toolz
   - tornado
   - zict
+  - zstandard
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/jcrist/crick  # Only tested here
+      - keras

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -18,7 +18,6 @@ dependencies:
   - ipykernel
   - ipywidgets
   - jinja2
-  - joblib
   - msgpack-python
   - netcdf4
   - paramiko

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -18,7 +18,6 @@ dependencies:
   - ipykernel
   - ipywidgets
   - jinja2
-  - joblib
   - lz4  # Only tested here
   - msgpack-python
   - netcdf4

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -1,3 +1,4 @@
+# This includes a set of all optional dependencies
 name: dask-distributed
 channels:
   - conda-forge
@@ -7,22 +8,21 @@ dependencies:
   - python=3.9
   - packaging
   - pip
-  - asyncssh
+  - asyncssh  # Only tested here
   - bokeh
   - click
   - cloudpickle
   - coverage
   - dask  # overridden by git tip below
   - filesystem-spec
-  - h5py
+  - h5py  # Only tested here
   - ipykernel
   - ipywidgets
   - jinja2
-  - joblib
   - lz4  # Only tested here
   - msgpack-python
-  - netcdf4
-  - paramiko
+  - netcdf4  # Only tested here
+  - paramiko  # Only tested here
   - pre-commit
   - prometheus_client
   - psutil
@@ -39,15 +39,15 @@ dependencies:
   - pytorch  # Only tested here
   - requests
   - s3fs
-  - scikit-learn
-  - scipy
+  - scikit-learn  # Only tested here
+  - scipy  # Only tested here
   - sortedcollections
   - tblib
   - toolz
   - torchvision  # Only tested here
   - tornado
   - zict
-  - zstandard
+  - zstandard  # Only tested here
   - pip:
       - git+https://github.com/dask/dask
-      - keras
+      - keras  # Only tested here

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -1,4 +1,3 @@
-# This includes a set of all optional dependencies
 name: dask-distributed
 channels:
   - conda-forge
@@ -8,25 +7,25 @@ dependencies:
   - python=3.9
   - packaging
   - pip
-  - asyncssh  # Only tested here
+  - asyncssh
   - bokeh
   - click
   - cloudpickle
   - coverage
   - dask  # overridden by git tip below
   - filesystem-spec
-  - h5py  # Only tested here
+  - h5py
   - ipykernel
   - ipywidgets
   - jinja2
+  - joblib
   - lz4  # Only tested here
   - msgpack-python
-  - netcdf4  # Only tested here
-  - paramiko  # Only tested here
+  - netcdf4
+  - paramiko
   - pre-commit
   - prometheus_client
   - psutil
-  - pynvml  # Only tested here
   - pytest
   - pytest-asyncio<0.14.0
   - pytest-cov
@@ -39,15 +38,15 @@ dependencies:
   - pytorch  # Only tested here
   - requests
   - s3fs
-  - scikit-learn  # Only tested here
-  - scipy  # Only tested here
+  - scikit-learn
+  - scipy
   - sortedcollections
   - tblib
   - toolz
   - torchvision  # Only tested here
   - tornado
   - zict
-  - zstandard  # Only tested here
+  - zstandard
   - pip:
       - git+https://github.com/dask/dask
-      - keras  # Only tested here
+      - keras

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -392,7 +392,6 @@ intersphinx_mapping = {
 # https://tech.signavio.com/2017/managing-sphinx-redirects
 redirect_files = [
     # old html, new html
-    ("joblib.html", "https://ml.dask.org/joblib.html"),
     ("setup.html", "https://docs.dask.org/en/latest/setup.html"),
     ("ec2.html", "https://docs.dask.org/en/latest/setup/cloud.html"),
     ("configuration.html", "https://docs.dask.org/en/latest/configuration.html"),


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/6040

I went a bit further than what has been discussed in the above issue, mostly to have things cleaned up a bit.

- I cleaned up the 3.9 build since I believe we should have one build with as minimal dependencies as possible (e.g. to verify that we don't have obscure import errors)
- We need to test all of our optional dependencies, this is now done in 3.9
- Lastly, we want to test against upstream changes for some of our important dependencies where we're testing against git tips

Based on this cleanup, I figured the most important build to keep around for OSX would be the "all dependencies" one which is 3.9 atm.

If this cleanup is too aggressive, we can go with [Matt's proposal](https://github.com/dask/distributed/issues/6040#issuecomment-1085848863) and just drop py3.9