### PR TITLE
Clean up usage around plain rpc

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -877,11 +877,11 @@ class rpc:
 
         return send_recv_from_rpc
 
-    def close_rpc(self):
+    async def close_rpc(self):
         if self.status != Status.closed:
             rpc.active.discard(self)
         self.status = Status.closed
-        return asyncio.gather(*self.close_comms())
+        return await asyncio.gather(*self.close_comms())
 
     def __enter__(self):
         return self

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -16,7 +16,7 @@ import dask
 from dask.utils import parse_bytes, parse_timedelta
 from dask.widgets import get_template
 
-from distributed.core import CommClosedError, Status, rpc
+from distributed.core import Status, rpc
 from distributed.deploy.adaptive import Adaptive
 from distributed.deploy.cluster import Cluster
 from distributed.scheduler import Scheduler
@@ -404,16 +404,15 @@ class SpecCluster(Cluster):
             if isawaitable(f):
                 await f
             await self._correct_state()
-            for future in self._futures:
-                await future
-            async with self._lock:
-                with suppress(CommClosedError, OSError):
-                    if self.scheduler_comm:
-                        await self.scheduler_comm.close(close_workers=True)
-                    else:
-                        logger.warning("Cluster closed without starting up")
+            await asyncio.gather(*self._futures)
 
-            await self.scheduler.close()
+            if self.scheduler_comm:
+                await self.scheduler_comm.close_rpc()
+            else:
+                logger.warning("Cluster closed without starting up")
+
+            async with self._lock:
+                await self.scheduler.close(close_workers=True)
             for w in self._created:
                 assert w.status == Status.closed, w.status
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6108,7 +6108,7 @@ class Scheduler(SchedulerState, ServerNode):
                 except TimeoutError:
                     logger.error(
                         "Nannies didn't report back restarted within "
-                        "timeout.  Continuuing with restart process"
+                        "timeout.  Continuing with restart process"
                     )
                 else:
                     if not all(resp == "OK" for resp in resps):

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -57,38 +57,33 @@ async def gather_from_workers(who_has, rpc, close=True, serializers=None, who=No
                 bad_keys.add(key)
         if bad_keys:
             all_bad_keys |= bad_keys
-
-        rpcs = {addr: rpc(addr) for addr in d}
-        try:
-            coroutines = {
-                address: asyncio.ensure_future(
-                    get_data_from_worker(
-                        rpc,
-                        keys,
-                        address,
-                        who=who,
-                        serializers=serializers,
-                        max_connections=False,
-                    )
+        coroutines = {
+            address: asyncio.create_task(
+                get_data_from_worker(
+                    rpc,
+                    keys,
+                    address,
+                    who=who,
+                    serializers=serializers,
+                    max_connections=False,
+                ),
+                name=f"get-data-from-{address}",
+            )
+            for address, keys in d.items()
+        }
+        response = {}
+        for worker, c in coroutines.items():
+            try:
+                r = await c
+            except OSError:
+                missing_workers.add(worker)
+            except ValueError as e:
+                logger.info(
+                    "Got an unexpected error while collecting from workers: %s", e
                 )
-                for address, keys in d.items()
-            }
-            response = {}
-            for worker, c in coroutines.items():
-                try:
-                    r = await c
-                except OSError:
-                    missing_workers.add(worker)
-                except ValueError as e:
-                    logger.info(
-                        "Got an unexpected error while collecting from workers: %s", e
-                    )
-                    missing_workers.add(worker)
-                else:
-                    response.update(r["data"])
-        finally:
-            for r in rpcs.values():
-                await r.close_rpc()
+                missing_workers.add(worker)
+            else:
+                response.update(r["data"])
 
         bad_addresses |= {v for k, v in rev.items() if k not in response}
         results.update(response)


### PR DESCRIPTION
While looking into https://github.com/dask/distributed/issues/6080 I realized that plain [`rpc`](https://github.com/dask/distributed/blob/6e307662be633695f57bce79458b77e9be2e5702/distributed/core.py#L749-L766) instances are incredibly rare. They have been mostly replaced by `ConnectionPool` and the `PooledRPCCall`. 

The three places I found them being used can be seen below and they all did something wrong

- `gather_from_workers` instantiates a couple but is never using them
- `SpecCluster. _close` is using it to call a handler `close` that doesn't exist.
- `Scheduler.restart` is using a couple of `rpc` to connect to the nannies. This may leave dangling comms or rpcs if exceptions pop up, e.g. during teardown. the async exit stack should be preferred

I think SpecCluster and Scheduler.restart, the pool would work just fine. I didn't want to change too much in one go and think this should already help