### PR TITLE
Robust test_get_returns_early

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3530,7 +3530,6 @@ def test_close_idempotent(c):
     c.close()
 
 
-@pytest.mark.repeat(1000)
 def test_get_returns_early(c):
     event = Event()
 


### PR DESCRIPTION
- [x] Closes https://github.com/dask/distributed/issues/6088
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
