### PR TITLE
Fix flaky test_cancel_fire_and_forget

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1467,6 +1467,10 @@ async def test_cancel_fire_and_forget(c, s, a, b):
 
     fire_and_forget(future)
     await ev1.wait()
+    # Cancel the future for z when
+    # - x is in memory
+    # - y is processing
+    # - z is pending
     await future.cancel(force=True)
     assert future.status == "cancelled"
     while s.tasks:


### PR DESCRIPTION
https://github.com/dask/distributed/runs/5889416220?check_suite_focus=true

```
    @gen_cluster(client=True)
    async def test_cancel_fire_and_forget(c, s, a, b):
        x = delayed(slowinc)(1, delay=0.05)
        y = delayed(slowinc)(x, delay=0.05)
        z = delayed(slowinc)(y, delay=0.05)
        w = delayed(slowinc)(z, delay=0.05)
        future = c.compute(w)
        fire_and_forget(future)
    
        await asyncio.sleep(0.05)
        await future.cancel(force=True)
        assert future.status == "cancelled"
>       assert not s.tasks
E       AssertionError: assert not {'slowinc-07f21bf6-77d4-46da-84c7-0d0f82e7e1d1': <TaskState 'slowinc-07f21bf6-77d4-46da-84c7-0d0f82e7e1d1' waiting>, 'slowinc-140d6197-d9c9-413b-a31a-5f9f9af99049': <TaskState 'slowinc-140d6197-d9c9-413b-a31a-5f9f9af99049' processing>, 'slowinc-15ba1366-ef7e-4e4c-8ac7-463a65381dca': <TaskState 'slowinc-15ba1366-ef7e-4e4c-8ac7-463a65381dca' waiting>, 'slowinc-571b547f-d6cb-4b88-8c1c-9f28972eee76': <TaskState 'slowinc-571b547f-d6cb-4b88-8c1c-9f28972eee76' waiting>}
E        +  where {'slowinc-07f21bf6-77d4-46da-84c7-0d0f82e7e1d1': <TaskState 'slowinc-07f21bf6-77d4-46da-84c7-0d0f82e7e1d1' waiting>, 'slowinc-140d6197-d9c9-413b-a31a-5f9f9af99049': <TaskState 'slowinc-140d6197-d9c9-413b-a31a-5f9f9af99049' processing>, 'slowinc-15ba1366-ef7e-4e4c-8ac7-463a65381dca': <TaskState 'slowinc-15ba1366-ef7e-4e4c-8ac7-463a65381dca' waiting>, 'slowinc-571b547f-d6cb-4b88-8c1c-9f28972eee76': <TaskState 'slowinc-571b547f-d6cb-4b88-8c1c-9f28972eee76' waiting>} = <Scheduler 'tcp://127.0.0.1:59566', workers: 2, cores: 3, tasks: 4>.tasks
```