### PR TITLE
Use async with Server in test_core.py

### DIFF
--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -271,26 +271,24 @@ async def test_server_listen():
 
 
 async def check_rpc(listen_addr, rpc_addr=None, listen_args={}, connection_args={}):
-    server = Server({"ping": pingpong})
-    await server.listen(listen_addr, **listen_args)
-    if rpc_addr is None:
-        rpc_addr = server.address
+    async with Server({"ping": pingpong}) as server:
+        await server.listen(listen_addr, **listen_args)
+        if rpc_addr is None:
+            rpc_addr = server.address
 
-    async with rpc(rpc_addr, connection_args=connection_args) as remote:
-        response = await remote.ping()
-        assert response == b"pong"
-        assert remote.comms
+        async with rpc(rpc_addr, connection_args=connection_args) as remote:
+            response = await remote.ping()
+            assert response == b"pong"
+            assert remote.comms
 
-        response = await remote.ping(close=True)
-        assert response == b"pong"
-        response = await remote.ping()
-        assert response == b"pong"
+            response = await remote.ping(close=True)
+            assert response == b"pong"
+            response = await remote.ping()
+            assert response == b"pong"
 
-    assert not remote.comms
-    assert remote.status == Status.closed
-
-    server.stop()
-    await asyncio.sleep(0)
+        assert not remote.comms
+        assert remote.status == Status.closed
+        await asyncio.sleep(0)
 
 
 @gen_test()
@@ -334,35 +332,33 @@ async def test_rpc_inputs():
 async def check_rpc_message_lifetime(*listen_args):
     # Issue #956: rpc arguments and result shouldn't be kept alive longer
     # than necessary
-    server = Server({"echo": echo_serialize})
-    await server.listen(*listen_args)
+    async with Server({"echo": echo_serialize}) as server:
+        await server.listen(*listen_args)
 
-    # Sanity check
-    obj = CountedObject()
-    assert CountedObject.n_instances == 1
-    del obj
-    start = time()
-    while CountedObject.n_instances != 0:
-        await asyncio.sleep(0.01)
-        assert time() < start + 1
-
-    async with rpc(server.address) as remote:
+        # Sanity check
         obj = CountedObject()
-        res = await remote.echo(x=to_serialize(obj))
-        assert isinstance(res["result"], CountedObject)
-        # Make sure resource cleanup code in coroutines runs
-        await asyncio.sleep(0.05)
+        assert CountedObject.n_instances == 1
+        del obj
+        start = time()
+        while CountedObject.n_instances != 0:
+            await asyncio.sleep(0.01)
+            assert time() < start + 1
 
-        w1 = weakref.ref(obj)
-        w2 = weakref.ref(res["result"])
-        del obj, res
+        async with rpc(server.address) as remote:
+            obj = CountedObject()
+            res = await remote.echo(x=to_serialize(obj))
+            assert isinstance(res["result"], CountedObject)
+            # Make sure resource cleanup code in coroutines runs
+            await asyncio.sleep(0.05)
 
-        assert w1() is None
-        assert w2() is None
-        # If additional instances were created, they were deleted as well
-        assert CountedObject.n_instances == 0
+            w1 = weakref.ref(obj)
+            w2 = weakref.ref(res["result"])
+            del obj, res
 
-    server.stop()
+            assert w1() is None
+            assert w2() is None
+            # If additional instances were created, they were deleted as well
+            assert CountedObject.n_instances == 0
 
 
 @gen_test()
@@ -410,19 +406,17 @@ async def test_rpc_with_many_connections_inproc():
 
 async def check_large_packets(listen_arg):
     """tornado has a 100MB cap by default"""
-    server = Server({})
-    await server.listen(listen_arg)
+    async with Server({}) as server:
+        await server.listen(listen_arg)
 
-    data = b"0" * int(200e6)  # slightly more than 100MB
-    async with rpc(server.address) as conn:
-        result = await conn.echo(data=data)
-        assert result == data
+        data = b"0" * int(200e6)  # slightly more than 100MB
+        async with rpc(server.address) as conn:
+            result = await conn.echo(data=data)
+            assert result == data
 
-        d = {"x": data}
-        result = await conn.echo(data=d)
-        assert result == d
-
-    server.stop()
+            d = {"x": data}
+            result = await conn.echo(data=d)
+            assert result == d
 
 
 @pytest.mark.slow
@@ -437,16 +431,14 @@ async def test_large_packets_inproc():
 
 
 async def check_identity(listen_arg):
-    server = Server({})
-    await server.listen(listen_arg)
+    async with Server({}) as server:
+        await server.listen(listen_arg)
 
-    async with rpc(server.address) as remote:
-        a = await remote.identity()
-        b = await remote.identity()
-        assert a["type"] == "Server"
-        assert a["id"] == b["id"]
-
-    server.stop()
+        async with rpc(server.address) as remote:
+            a = await remote.identity()
+            b = await remote.identity()
+            assert a["type"] == "Server"
+            assert a["id"] == b["id"]
 
 
 @gen_test()
@@ -462,32 +454,27 @@ async def test_identity_inproc():
 @gen_test()
 async def test_ports():
     loop = IOLoop.current()
-    for port in range(9877, 9887):
-        server = Server({}, io_loop=loop)
-        try:
-            await server.listen(port)
-        except OSError:  # port already taken?
-            pass
+    async with Server({}) as server:
+        for port in range(9877, 9887):
+            try:
+                await server.listen(port)
+            except OSError:  # port already taken?
+                pass
+            else:
+                break
         else:
-            break
-    else:
-        raise Exception()
-    try:
+            raise Exception()
+
         assert server.port == port
 
         with pytest.raises((OSError, socket.error)):
-            server2 = Server({}, io_loop=loop)
-            await server2.listen(port)
-    finally:
-        server.stop()
+            async with Server({}) as server2:
+                await server2.listen(port)
 
-    try:
-        server3 = Server({}, io_loop=loop)
+    async with Server({}) as server3:
         await server3.listen(0)
         assert isinstance(server3.port, int)
         assert server3.port > 1024
-    finally:
-        server3.stop()
 
 
 def stream_div(comm=None, x=None, y=None):
@@ -496,12 +483,12 @@ def stream_div(comm=None, x=None, y=None):
 
 @gen_test()
 async def test_errors():
-    server = Server({"div": stream_div})
-    await server.listen(0)
+    async with Server({"div": stream_div}) as server:
+        await server.listen(0)
 
-    with rpc(("127.0.0.1", server.port)) as r:
-        with pytest.raises(ZeroDivisionError):
-            await r.div(x=1, y=0)
+        with rpc(("127.0.0.1", server.port)) as r:
+            with pytest.raises(ZeroDivisionError):
+                await r.div(x=1, y=0)
 
 
 @gen_test()
@@ -512,21 +499,19 @@ async def test_connect_raises():
 
 @gen_test()
 async def test_send_recv_args():
-    server = Server({})
-    await server.listen(0)
+    async with Server({}) as server:
+        await server.listen(0)
 
-    comm = await connect(server.address)
-    result = await send_recv(comm, op="echo", data=b"1")
-    assert result == b"1"
-    assert not comm.closed()
-    result = await send_recv(comm, op="echo", data=b"2", reply=False)
-    assert result is None
-    assert not comm.closed()
-    result = await send_recv(comm, op="echo", data=b"3", close=True)
-    assert result == b"3"
-    assert comm.closed()
-
-    server.stop()
+        comm = await connect(server.address)
+        result = await send_recv(comm, op="echo", data=b"1")
+        assert result == b"1"
+        assert not comm.closed()
+        result = await send_recv(comm, op="echo", data=b"2", reply=False)
+        assert result is None
+        assert not comm.closed()
+        result = await send_recv(comm, op="echo", data=b"3", close=True)
+        assert result == b"3"
+        assert comm.closed()
 
 
 @gen_test(timeout=5)
@@ -536,19 +521,19 @@ async def test_send_recv_cancelled():
     async def get_stuck(comm):
         await asyncio.Future()
 
-    server = Server({"get_stuck": get_stuck})
-    await server.listen(0)
+    async with Server({"get_stuck": get_stuck}) as server:
+        await server.listen(0)
 
-    client_comm = await connect(server.address, deserialize=False)
-    while not server._comms:
-        await asyncio.sleep(0.01)
-    server_comm = next(iter(server._comms))
+        client_comm = await connect(server.address, deserialize=False)
+        while not server._comms:
+            await asyncio.sleep(0.01)
+        server_comm = next(iter(server._comms))
 
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(send_recv(client_comm, op="get_stuck"), timeout=0.1)
-    assert client_comm.closed()
-    while not server_comm.closed():
-        await asyncio.sleep(0.01)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(send_recv(client_comm, op="get_stuck"), timeout=0.1)
+        assert client_comm.closed()
+        while not server_comm.closed():
+            await asyncio.sleep(0.01)
 
 
 def test_coerce_to_address():
@@ -603,6 +588,7 @@ async def test_connection_pool():
         assert time() < start + 2
 
     await rpc.close()
+    await asyncio.gather(*[server.close() for server in servers])
 
 
 @gen_test()
@@ -626,27 +612,27 @@ async def test_connection_pool_close_while_connecting(monkeypatch):
 
     monkeypatch.setitem(backends, "tcp", SlowBackend())
 
-    server = Server({})
-    await server.listen("tcp://")
+    async with Server({}) as server:
+        await server.listen("tcp://")
 
-    pool = await ConnectionPool(limit=2)
+        pool = await ConnectionPool(limit=2)
 
-    async def connect_to_server():
-        comm = await pool.connect(server.address)
-        pool.reuse(server.address, comm)
+        async def connect_to_server():
+            comm = await pool.connect(server.address)
+            pool.reuse(server.address, comm)
 
-    # #tasks > limit
-    tasks = [asyncio.create_task(connect_to_server()) for _ in range(5)]
+        # #tasks > limit
+        tasks = [asyncio.create_task(connect_to_server()) for _ in range(5)]
 
-    while not pool._connecting:
-        await asyncio.sleep(0.01)
+        while not pool._connecting:
+            await asyncio.sleep(0.01)
 
-    await pool.close()
-    for t in tasks:
-        with pytest.raises(CommClosedError):
-            await t
-    assert not pool.open
-    assert not pool._n_connecting
+        await pool.close()
+        for t in tasks:
+            with pytest.raises(CommClosedError):
+                await t
+        assert not pool.open
+        assert not pool._n_connecting
 
 
 @gen_test()
@@ -667,24 +653,24 @@ async def test_connection_pool_outside_cancellation(monkeypatch):
 
     monkeypatch.setitem(backends, "tcp", SlowBackend())
 
-    server = Server({})
-    await server.listen("tcp://")
-    pool = await ConnectionPool(limit=2)
+    async with Server({}) as server:
+        await server.listen("tcp://")
+        pool = await ConnectionPool(limit=2)
 
-    async def connect_to_server():
-        comm = await pool.connect(server.address)
-        pool.reuse(server.address, comm)
+        async def connect_to_server():
+            comm = await pool.connect(server.address)
+            pool.reuse(server.address, comm)
 
-    # #tasks > limit
-    tasks = [asyncio.create_task(connect_to_server()) for _ in range(5)]
-    while not pool._connecting:
-        await asyncio.sleep(0.01)
+        # #tasks > limit
+        tasks = [asyncio.create_task(connect_to_server()) for _ in range(5)]
+        while not pool._connecting:
+            await asyncio.sleep(0.01)
 
-    for t in tasks:
-        t.cancel()
+        for t in tasks:
+            t.cancel()
 
-    done, _ = await asyncio.wait(tasks)
-    assert all(t.cancelled() for t in tasks)
+        done, _ = await asyncio.wait(tasks)
+        assert all(t.cancelled() for t in tasks)
 
 
 @gen_test()
@@ -738,6 +724,7 @@ async def test_connection_pool_tls():
     assert rpc.active == 0
 
     await rpc.close()
+    await asyncio.gather(*[server.close() for server in servers])
 
 
 @gen_test()
@@ -777,21 +764,22 @@ async def test_connection_pool_remove():
     rpc.reuse(serv.address, comm)
 
     await rpc.close()
+    await asyncio.gather(*[server.close() for server in servers])
 
 
 @gen_test()
 async def test_counters():
-    server = Server({"div": stream_div})
-    await server.listen("tcp://")
+    async with Server({"div": stream_div}) as server:
+        await server.listen("tcp://")
 
-    async with rpc(server.address) as r:
-        for i in range(2):
-            await r.identity()
-        with pytest.raises(ZeroDivisionError):
-            await r.div(x=1, y=0)
+        async with rpc(server.address) as r:
+            for i in range(2):
+                await r.identity()
+            with pytest.raises(ZeroDivisionError):
+                await r.div(x=1, y=0)
 
-        c = server.counters
-        assert c["op"].components[0] == {"identity": 2, "div": 1}
+            c = server.counters
+            assert c["op"].components[0] == {"identity": 2, "div": 1}
 
 
 @gen_cluster(config={"distributed.admin.tick.interval": "20 ms"})
@@ -840,18 +828,16 @@ def test_compression(compression, serialize, loop):
 
 @gen_test()
 async def test_rpc_serialization():
-    server = Server({"echo": echo_serialize})
-    await server.listen("tcp://")
+    async with Server({"echo": echo_serialize}) as server:
+        await server.listen("tcp://")
 
-    async with rpc(server.address, serializers=["msgpack"]) as r:
-        with pytest.raises(TypeError):
-            await r.echo(x=to_serialize(inc))
+        async with rpc(server.address, serializers=["msgpack"]) as r:
+            with pytest.raises(TypeError):
+                await r.echo(x=to_serialize(inc))
 
-    async with rpc(server.address, serializers=["msgpack", "pickle"]) as r:
-        result = await r.echo(x=to_serialize(inc))
-        assert result == {"result": inc}
-
-    server.stop()
+        async with rpc(server.address, serializers=["msgpack", "pickle"]) as r:
+            result = await r.echo(x=to_serialize(inc))
+            assert result == {"result": inc}
 
 
 @gen_cluster()
@@ -861,50 +847,50 @@ async def test_thread_id(s, a, b):
 
 @gen_test()
 async def test_deserialize_error():
-    server = Server({"throws": throws})
-    await server.listen(0)
+    async with Server({"throws": throws}) as server:
+        await server.listen(0)
 
-    comm = await connect(server.address, deserialize=False)
-    with pytest.raises(Exception, match=r"RuntimeError\('hello!'\)") as info:
-        await send_recv(comm, op="throws", x="foo")
+        comm = await connect(server.address, deserialize=False)
+        with pytest.raises(Exception, match=r"RuntimeError\('hello!'\)") as info:
+            await send_recv(comm, op="throws", x="foo")
 
-    assert type(info.value) == Exception
-    for c in str(info.value):
-        assert c.isalpha() or c in "(',!)"  # no crazy bytestrings
+        assert type(info.value) == Exception
+        for c in str(info.value):
+            assert c.isalpha() or c in "(',!)"  # no crazy bytestrings
 
-    await comm.close()
+        await comm.close()
 
 
 @gen_test()
 async def test_connection_pool_detects_remote_close():
-    server = Server({"ping": pingpong})
-    await server.listen("tcp://")
+    async with Server({"ping": pingpong}) as server:
+        await server.listen("tcp://")
 
-    # open a connection, use it and give it back to the pool
-    p = await ConnectionPool(limit=10)
-    conn = await p.connect(server.address)
-    await send_recv(conn, op="ping")
-    p.reuse(server.address, conn)
+        # open a connection, use it and give it back to the pool
+        p = await ConnectionPool(limit=10)
+        conn = await p.connect(server.address)
+        await send_recv(conn, op="ping")
+        p.reuse(server.address, conn)
 
-    # now close this connection on the *server*
-    assert len(server._comms) == 1
-    server_conn = list(server._comms.keys())[0]
-    await server_conn.close()
+        # now close this connection on the *server*
+        assert len(server._comms) == 1
+        server_conn = list(server._comms.keys())[0]
+        await server_conn.close()
 
-    # give the ConnectionPool some time to realize that the connection is closed
-    await asyncio.sleep(0.1)
+        # give the ConnectionPool some time to realize that the connection is closed
+        await asyncio.sleep(0.1)
 
-    # the connection pool should not hand out `conn` again
-    conn2 = await p.connect(server.address)
-    assert conn2 is not conn
-    p.reuse(server.address, conn2)
-    # check that `conn` has ben removed from the internal data structures
-    assert p.open == 1 and p.active == 0
+        # the connection pool should not hand out `conn` again
+        conn2 = await p.connect(server.address)
+        assert conn2 is not conn
+        p.reuse(server.address, conn2)
+        # check that `conn` has ben removed from the internal data structures
+        assert p.open == 1 and p.active == 0
 
-    # check connection pool invariants hold even after it detects a closed connection
-    # while creating conn2:
-    p._validate()
-    await p.close()
+        # check connection pool invariants hold even after it detects a closed connection
+        # while creating conn2:
+        p._validate()
+        await p.close()
 
 
 @gen_test()
@@ -972,20 +958,20 @@ async def test_server_comms_mark_active_handlers():
         await asyncio.sleep(0.2)
         return "done"
 
-    server = await Server({"wait": long_handler})
-    await server.listen(0)
-    assert server._comms == {}
+    async with Server({"wait": long_handler}) as server:
+        await server.listen(0)
+        assert server._comms == {}
 
-    comm = await connect(server.address)
-    await comm.write({"op": "wait"})
-    while not server._comms:
-        await asyncio.sleep(0.05)
-    assert set(server._comms.values()) == {"wait"}
-    assert await comm.read() == "done"
-    assert set(server._comms.values()) == {None}
-    await comm.close()
-    while server._comms:
-        await asyncio.sleep(0.01)
+        comm = await connect(server.address)
+        await comm.write({"op": "wait"})
+        while not server._comms:
+            await asyncio.sleep(0.05)
+        assert set(server._comms.values()) == {"wait"}
+        assert await comm.read() == "done"
+        assert set(server._comms.values()) == {None}
+        await comm.close()
+        while server._comms:
+            await asyncio.sleep(0.01)
 
 
 @gen_test()


### PR DESCRIPTION
Previously we would create and rarely clean up servers in tests.
Now we use the async context manager whenever it is easy to do.

This was inspired by the following CI test failure.

https://github.com/dask/distributed/runs/5962479318?check_suite_focus=true

This doesn't necessarily solve the problem, but it was easy to do and I doubt that it hurts.