### PR TITLE
Drop `cast`ing which is effectively a no-op

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -87,10 +87,6 @@ def pickle_loads(header, frames):
                 mv = memoryview(bytearray(mv))
             else:
                 mv = memoryview(bytes(mv))
-            if mv.nbytes > 0:
-                mv = mv.cast(mv.format, mv.shape)
-            else:
-                mv = mv.cast(mv.format)
         new.append(mv)
 
     return pickle.loads(x, buffers=new)


### PR DESCRIPTION
In both of these cases `mv` is simply being cast to a `format` (and `shape`) that it already is. Though this was an accidental overwrite by a previous bug fix PR. The code previously tried to maintain `mv`'s `format` and `shape` before performing a copy. While that behavior could be restored, the current behavior has been unchanged for over a year. This indicates the `cast`ing was likely unnecessary to begin with. So just drop it. If we find we need it after all, it is easy to add correctly, which require different code than what is here anyways.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
