### PR TITLE
Add `urllib3` to nightly conda builds

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - setup.py
+      - requirements.txt
       - continuous_integration/recipes/**
       - .github/workflows/conda.yml
 

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -73,6 +73,7 @@ outputs:
         - tblib >=1.6.0
         - toolz >=0.8.2
         - tornado >=6.0.3
+        - urllib3
         - zict >=0.1.3
       run_constrained:
         - distributed-impl >={{ version }} *{{ build_ext }}


### PR DESCRIPTION
In https://github.com/dask/distributed/pull/5982 we added `urllib3` as a dependency. This was added over in our conda-forge recipe, but not not to our nightly conda build recipe (which is [currently failing](https://github.com/dask/distributed/runs/5891003024?check_suite_focus=true) due to `ModuleNotFoundError: No module named 'urllib3'`). This PR adds the new `urllib3` dependency to our nightly builds 

cc @charlesbluca @jakirkham 