### PR TITLE
Add back Worker.transition_fetch_missing

### DIFF
--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -168,7 +168,6 @@ async def test_flight_to_executing_via_cancelled_resumed(c, s, a, b):
 
     b_story = b.story(fut1.key)
     assert any("receive-dep-failed" in msg for msg in b_story)
-    assert any("missing-dep" in msg for msg in b_story)
     assert any("cancelled" in msg for msg in b_story)
     assert any("resumed" in msg for msg in b_story)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3012,6 +3012,8 @@ class Worker(ServerNode):
                 for d in has_what:
                     ts = self.tasks[d]
                     ts.who_has.remove(worker)
+                    if not ts.who_has:
+                        recommendations[ts] = "missing"
 
             except Exception as e:
                 logger.exception(e)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3014,7 +3014,11 @@ class Worker(ServerNode):
                     ts.who_has.remove(worker)
                     if not ts.who_has:
                         recommendations[ts] = "missing"
-
+                        logger.info(
+                            "Lost worker connection to %s caused task %s to go missing",
+                            worker,
+                            ts.key,
+                        )
             except Exception as e:
                 logger.exception(e)
                 if self.batched_stream and LOG_PDB:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2680,9 +2680,8 @@ class Worker(ServerNode):
             if ts.state != "fetch":
                 continue
 
-            if not ts.who_has:
-                self.transition(ts, "missing", stimulus_id=stimulus_id)
-                continue
+            if self.validate:
+                assert ts.who_has
 
             workers = [w for w in ts.who_has if w not in self.in_flight_workers]
             if not workers:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -546,6 +546,7 @@ class Worker(ServerNode):
             ("executing", "released"): self.transition_executing_released,
             ("executing", "rescheduled"): self.transition_executing_rescheduled,
             ("fetch", "flight"): self.transition_fetch_flight,
+            ("fetch", "missing"): self.transition_fetch_missing,
             ("fetch", "released"): self.transition_generic_released,
             ("flight", "error"): self.transition_flight_error,
             ("flight", "fetch"): self.transition_flight_fetch,
@@ -1929,6 +1930,14 @@ class Worker(ServerNode):
         ts.done = False
         return {}, []
 
+    def transition_fetch_missing(
+        self, ts: TaskState, *, stimulus_id: str
+    ) -> RecsInstrs:
+        ts.state = "missing"
+        self._missing_dep_flight.add(ts)
+        ts.done = False
+        return {}, []
+
     def transition_released_fetch(
         self, ts: TaskState, *, stimulus_id: str
     ) -> RecsInstrs:
@@ -2671,8 +2680,9 @@ class Worker(ServerNode):
             if ts.state != "fetch":
                 continue
 
-            if self.validate:
-                assert ts.who_has
+            if not ts.who_has:
+                self.transition(ts, "missing", stimulus_id=stimulus_id)
+                continue
 
             workers = [w for w in ts.who_has if w not in self.in_flight_workers]
             if not workers:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3013,10 +3013,8 @@ class Worker(ServerNode):
                     ts.who_has.remove(worker)
                     if not ts.who_has:
                         recommendations[ts] = "missing"
-                        logger.info(
-                            "Lost worker connection to %s caused task %s to go missing",
-                            worker,
-                            ts.key,
+                        self.log.append(
+                            ("missing-who-has", worker, ts.key, stimulus_id, time())
                         )
             except Exception as e:
                 logger.exception(e)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -546,6 +546,7 @@ class Worker(ServerNode):
             ("executing", "released"): self.transition_executing_released,
             ("executing", "rescheduled"): self.transition_executing_rescheduled,
             ("fetch", "flight"): self.transition_fetch_flight,
+            ("fetch", "missing"): self.transition_fetch_missing,
             ("fetch", "released"): self.transition_generic_released,
             ("flight", "error"): self.transition_flight_error,
             ("flight", "fetch"): self.transition_flight_fetch,
@@ -1929,6 +1930,14 @@ class Worker(ServerNode):
         ts.done = False
         return {}, []
 
+    def transition_fetch_missing(
+        self, ts: TaskState, *, stimulus_id: str
+    ) -> RecsInstrs:
+        ts.state = "missing"
+        self._missing_dep_flight.add(ts)
+        ts.done = False
+        return {}, []
+
     def transition_released_fetch(
         self, ts: TaskState, *, stimulus_id: str
     ) -> RecsInstrs:
@@ -2669,6 +2678,10 @@ class Worker(ServerNode):
             ts = self.data_needed.pop()
 
             if ts.state != "fetch":
+                continue
+
+            if not ts.who_has:
+                self.transition(ts, "missing", stimulus_id=stimulus_id)
                 continue
 
             workers = [w for w in ts.who_has if w not in self.in_flight_workers]


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/5951

In https://github.com/dask/distributed/pull/5653
we removed the fetch -> missing transition
This caused deadlocks.  
Now we add it back in.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
