### PR TITLE
Require major.minor Python version match

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1278,7 +1278,6 @@ class Client(SyncMethodMixin):
             msg = await asyncio.wait_for(comm.read(), timeout)
         else:
             msg = await comm.read()
-        assert len(msg) == 1
         assert msg[0]["op"] == "stream-start"
 
         if msg[0].get("error"):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1084,6 +1084,8 @@ class Worker(ServerNode):
                 response = await future
                 if response.get("warning"):
                     logger.warning(response["warning"])
+                if response.get("error"):
+                    raise Exception(response["error"])
 
                 _end = time()
                 middle = (_start + _end) / 2


### PR DESCRIPTION
Pickle regularly fails without this.

Note, this fails mypy for some reason that I can't understand.

This includes informative error messages like the following:

```
    Python version mismatch.  Trying to connect ...

    Worker with Python 3.8.13.final.0
    and
    Scheduler with Python 3.9.6.final.0

    Dask requires major.minor version numbers, like "3.10" to match exactly.
```

My apologies that there is no test for this.
Testing across versions with pytest is hard.
