### PR TITLE
Revert "drop deprecated tornado.netutil.ExecutorResolver"

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -1,6 +1,3 @@
-from __future__ import annotations
-
-import asyncio
 import ctypes
 import errno
 import functools
@@ -10,7 +7,7 @@ import struct
 import sys
 import weakref
 from ssl import SSLCertVerificationError, SSLError
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from tornado import gen
 
@@ -46,6 +43,7 @@ from distributed.comm.utils import (
 )
 from distributed.protocol.utils import pack_frames_prelude, unpack_frames
 from distributed.system import MEMORY_LIMIT
+from distributed.threadpoolexecutor import ThreadPoolExecutor
 from distributed.utils import ensure_ip, get_ip, get_ipv6, nbytes
 
 logger = logging.getLogger(__name__)
@@ -404,31 +402,38 @@ class RequireEncryptionMixin:
             )
 
 
-class _DefaultLoopResolver(netutil.Resolver):
-    """
-    Resolver implementation using `asyncio.loop.getaddrinfo`.
-    backport from Tornado 6.2+
-    https://github.com/tornadoweb/tornado/blob/3de78b7a15ba7134917a18b0755ea24d7f8fde94/tornado/netutil.py#L416-L432
-    """
-
-    async def resolve(
-        self, host: str, port: int, family: socket.AddressFamily = socket.AF_UNSPEC
-    ) -> list[tuple[int, Any]]:
-        # On Solaris, getaddrinfo fails if the given port is not found
-        # in /etc/services and no socket type is given, so we must pass
-        # one here.  The socket type used here doesn't seem to actually
-        # matter (we discard the one we get back in the results),
-        # so the addresses we return should still be usable with SOCK_DGRAM.
-        return [
-            (fam, address)
-            for fam, _, _, _, address in await asyncio.get_running_loop().getaddrinfo(
-                host, port, family=family, type=socket.SOCK_STREAM
-            )
-        ]
-
-
 class BaseTCPConnector(Connector, RequireEncryptionMixin):
-    client: ClassVar[TCPClient] = TCPClient(resolver=_DefaultLoopResolver())
+    _executor: ClassVar[ThreadPoolExecutor] = ThreadPoolExecutor(
+        2, thread_name_prefix="TCP-Executor"
+    )
+    _client: ClassVar[TCPClient]
+
+    @classmethod
+    def warmup(cls) -> None:
+        """Pre-start threads and sockets to avoid catching them in checks for thread and
+        fd leaks
+        """
+        ex = cls._executor
+        while len(ex._threads) < ex._max_workers:
+            ex._adjust_thread_count()
+        cls._get_client()
+
+    @classmethod
+    def _get_client(cls):
+        if not hasattr(cls, "_client"):
+            resolver = netutil.ExecutorResolver(
+                close_executor=False, executor=cls._executor
+            )
+            cls._client = TCPClient(resolver=resolver)
+        return cls._client
+
+    @property
+    def client(self):
+        # The `TCPClient` is cached on the class itself to avoid creating
+        # excess `ThreadPoolExecutor`s. We delay creation until inside an async
+        # function to avoid accessing an IOLoop from a context where a backing
+        # event loop doesn't exist.
+        return self._get_client()
 
     async def connect(self, address, deserialize=True, **connection_args):
         self._check_encryption(address, connection_args)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -47,7 +47,7 @@ from distributed import system
 from distributed import versions as version_module
 from distributed.client import Client, _global_clients, default_client
 from distributed.comm import Comm
-from distributed.comm.tcp import TCP
+from distributed.comm.tcp import TCP, BaseTCPConnector
 from distributed.compatibility import WINDOWS
 from distributed.config import initialize_logging
 from distributed.core import CommClosedError, ConnectionPool, Status, connect, rpc
@@ -1589,6 +1589,9 @@ def save_sys_modules():
 @contextmanager
 def check_thread_leak():
     """Context manager to ensure we haven't leaked any threads"""
+    # "TCP-Executor" threads are never stopped once they are started
+    BaseTCPConnector.warmup()
+
     active_threads_start = threading.enumerate()
 
     yield


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/6087

Reverts dask/distributed#6031