### PR TITLE
avoid redundant cleanup fixture in gen_test tests

### DIFF
--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -139,7 +139,7 @@ async def test_large_transfer_with_no_compression():
     ],
 )
 @gen_test()
-async def test_http_and_comm_server(cleanup, dashboard, protocol, security, port):
+async def test_http_and_comm_server(dashboard, protocol, security, port):
     if security:
         xfail_ssl_issue5601()
         pytest.importorskip("cryptography")
@@ -159,7 +159,7 @@ async def test_http_and_comm_server(cleanup, dashboard, protocol, security, port
 
 @pytest.mark.parametrize("protocol", ["ws://", "wss://"])
 @gen_test()
-async def test_connection_made_with_extra_conn_args(cleanup, protocol):
+async def test_connection_made_with_extra_conn_args(protocol):
     if protocol == "ws://":
         security = Security(
             extra_conn_args={"headers": {"Authorization": "Token abcd"}}

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -5,7 +5,7 @@ from distributed.utils_test import gen_test
 
 
 @gen_test()
-async def test_eq(cleanup):
+async def test_eq():
     clusterA = Cluster(asynchronous=True, name="A")
     clusterA2 = Cluster(asynchronous=True, name="A2")
     clusterB = Cluster(asynchronous=True, name="B")
@@ -20,7 +20,7 @@ async def test_eq(cleanup):
 
 
 @gen_test()
-async def test_repr(cleanup):
+async def test_repr():
     cluster = Cluster(asynchronous=True, name="A")
     assert cluster.scheduler_address == "<Not Connected>"
     res = repr(cluster)
@@ -29,7 +29,7 @@ async def test_repr(cleanup):
 
 
 @gen_test()
-async def test_logs_deprecated(cleanup):
+async def test_logs_deprecated():
     cluster = Cluster(asynchronous=True)
     with pytest.warns(FutureWarning, match="get_logs"):
         cluster.logs()

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -936,7 +936,7 @@ async def test_scale_memory_cores():
 
 @pytest.mark.parametrize("memory_limit", ["2 GiB", None])
 @gen_test()
-async def test_repr(memory_limit, cleanup):
+async def test_repr(memory_limit):
     async with LocalCluster(
         n_workers=2,
         processes=False,
@@ -973,7 +973,7 @@ async def test_threads_per_worker_set_to_0():
 
 @pytest.mark.parametrize("temporary", [True, False])
 @gen_test()
-async def test_capture_security(cleanup, temporary):
+async def test_capture_security(temporary):
     if temporary:
         xfail_ssl_issue5601()
         pytest.importorskip("cryptography")
@@ -1145,7 +1145,7 @@ async def test_cluster_host_used_throughout_cluster(host, use_nanny):
 
 
 @gen_test()
-async def test_connect_to_closed_cluster(cleanup):
+async def test_connect_to_closed_cluster():
     async with LocalCluster(processes=False, asynchronous=True) as cluster:
         async with Client(cluster, asynchronous=True) as c1:
             assert await c1.submit(inc, 1) == 2

--- a/distributed/deploy/tests/test_slow_adaptive.py
+++ b/distributed/deploy/tests/test_slow_adaptive.py
@@ -36,7 +36,7 @@ scheduler = {"cls": Scheduler, "options": {"dashboard_address": ":0"}}
 
 
 @gen_test()
-async def test_startup(cleanup):
+async def test_startup():
     start = time()
     async with SpecCluster(
         scheduler=scheduler,
@@ -78,7 +78,7 @@ async def test_scale_up_down():
 
 
 @gen_test()
-async def test_adaptive(cleanup):
+async def test_adaptive():
     start = time()
     async with SpecCluster(
         scheduler=scheduler,

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -28,7 +28,7 @@ def test_ssh_hosts_empty_list():
 
 
 @gen_test()
-async def test_ssh_cluster_raises_if_asyncssh_not_installed(monkeypatch, cleanup):
+async def test_ssh_cluster_raises_if_asyncssh_not_installed(monkeypatch):
     monkeypatch.setitem(sys.modules, "asyncssh", None)
     with pytest.raises(ImportError, match="SSHCluster requires the `asyncssh` package"):
         async with SSHCluster(

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6174,7 +6174,7 @@ async def test_shutdown():
 
 
 @gen_test()
-async def test_shutdown_localcluster(cleanup):
+async def test_shutdown_localcluster():
     async with LocalCluster(
         n_workers=1, asynchronous=True, processes=False, dashboard_address=":0"
     ) as lc:

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -500,7 +500,7 @@ class KeyboardInterruptWorker(worker.Worker):
 
 @pytest.mark.parametrize("protocol", ["tcp", "ucx"])
 @gen_test()
-async def test_nanny_closed_by_keyboard_interrupt(cleanup, protocol):
+async def test_nanny_closed_by_keyboard_interrupt(protocol):
     if protocol == "ucx":  # Skip if UCX isn't available
         pytest.importorskip("ucp")
 

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -135,7 +135,7 @@ async def dask_setup(worker):
 
 
 @gen_test()
-async def test_preload_import_time(cleanup):
+async def test_preload_import_time():
     text = """
 from distributed.comm.registry import backends
 from distributed.comm.tcp import TCPBackend

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -264,7 +264,7 @@ def test_tls_cluster(tls_client):
 
 
 @gen_test()
-async def test_tls_scheduler(security, cleanup):
+async def test_tls_scheduler(security):
     async with Scheduler(
         security=security, host="localhost", dashboard_address=":0"
     ) as s:

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -393,7 +393,7 @@ async def test_chained_error_message(c, s, a, b):
 
 
 @gen_test()
-async def test_plugin_exception(cleanup):
+async def test_plugin_exception():
     class MyPlugin:
         def setup(self, worker=None):
             raise ValueError("Setup failed")
@@ -410,7 +410,7 @@ async def test_plugin_exception(cleanup):
 
 
 @gen_test()
-async def test_plugin_multiple_exceptions(cleanup):
+async def test_plugin_multiple_exceptions():
     class MyPlugin1:
         def setup(self, worker=None):
             raise ValueError("MyPlugin1 Error")
@@ -438,7 +438,7 @@ async def test_plugin_multiple_exceptions(cleanup):
 
 
 @gen_test()
-async def test_plugin_internal_exception(cleanup):
+async def test_plugin_internal_exception():
     async with Scheduler(port=0) as s:
         with pytest.raises(UnicodeDecodeError, match="codec can't decode"):
             async with Worker(
@@ -1374,7 +1374,7 @@ async def test_protocol_from_scheduler_address(Worker):
 
 
 @gen_test()
-async def test_host_uses_scheduler_protocol(cleanup, monkeypatch):
+async def test_host_uses_scheduler_protocol(monkeypatch):
     # Ensure worker uses scheduler's protocol to determine host address, not the default scheme
     # See https://github.com/dask/distributed/pull/4883
     from distributed.comm.tcp import TCPBackend


### PR DESCRIPTION
related to https://github.com/dask/distributed/issues/6049

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

`gen_test` calls `with clean()` and so makes the `cleanup` fixture redundant