### PR TITLE
Re-enable NVML monitoring for WSL

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -14,7 +14,7 @@ nvmlInitialized = False
 nvmlLibraryNotFound = False
 nvmlWslInsufficientDriver = False
 nvmlOwnerPID = None
-minimumWslVersion = "512.15"
+minimumWslVersion = "513.15"
 
 
 def _in_wsl():

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -14,7 +14,7 @@ nvmlInitialized = False
 nvmlLibraryNotFound = False
 nvmlWslInsufficientDriver = False
 nvmlOwnerPID = None
-minimumWslVersion = "513.15"
+minimumWslVersion = "512.15"
 
 
 def _in_wsl():

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -14,6 +14,7 @@ nvmlInitialized = False
 nvmlLibraryNotFound = False
 nvmlWslInsufficientDriver = False
 nvmlOwnerPID = None
+minimumWslVersion = "512.15"
 
 
 def _in_wsl():
@@ -53,7 +54,7 @@ def init_once():
     if (
         not nvmlLibraryNotFound
         and parse_version(pynvml.nvmlSystemGetDriverVersion().decode())
-        < parse_version("512.15")
+        < parse_version(minimumWslVersion)
         and _in_wsl()
     ):
         nvmlWslInsufficientDriver = True
@@ -81,7 +82,8 @@ def _pynvml_handles():
             )
         if nvmlWslInsufficientDriver:
             raise RuntimeError(
-                "NVML is installed, but NVIDIA drivers are outdated for WSL"
+                "Outdated NVIDIA drivers for WSL, please upgrade to "
+                f"{minimumWslVersion} or newer"
             )
         else:
             raise RuntimeError("No GPUs available")

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -76,10 +76,12 @@ def device_get_count():
 def _pynvml_handles():
     count = device_get_count()
     if count == 0:
-        if pynvml is None or nvmlLibraryNotFound:
+        if pynvml is None:
             raise RuntimeError(
                 "NVML monitoring requires PyNVML and NVML to be installed"
             )
+        if nvmlLibraryNotFound:
+            raise RuntimeError("PyNVML is installed, but NVML is not")
         if nvmlWslInsufficientDriver:
             raise RuntimeError(
                 "Outdated NVIDIA drivers for WSL, please upgrade to "

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -75,8 +75,10 @@ def device_get_count():
 def _pynvml_handles():
     count = device_get_count()
     if count == 0:
-        if nvmlLibraryNotFound:
-            raise RuntimeError("PyNVML is installed, but NVML is not")
+        if pynvml is None or nvmlLibraryNotFound:
+            raise RuntimeError(
+                "NVML monitoring requires PyNVML and NVML to be installed"
+            )
         if nvmlWslInsufficientDriver:
             raise RuntimeError(
                 "NVML is installed, but NVIDIA drivers are outdated for WSL"

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -108,7 +108,7 @@ def has_cuda_context():
     index of the device for which there's a CUDA context.
     """
     init_once()
-    if nvmlLibraryNotFound or not nvmlInitialized:
+    if not nvmlInitialized:
         return False
     for index in range(device_get_count()):
         handle = pynvml.nvmlDeviceGetHandleByIndex(index)

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -39,9 +39,9 @@ def test_enable_disable_nvml():
     with dask.config.set({"distributed.diagnostics.nvml": True}):
         nvml.init_once()
         assert (
-            nvml.nvmlInitialized is True
-            or nvml.nvmlLibraryNotFound is True
-            or nvml.nvmlWslInsufficientDriver is True
+            nvml.nvmlInitialized
+            ^ nvml.nvmlLibraryNotFound
+            ^ nvml.nvmlWslInsufficientDriver
         )
 
 

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -150,3 +150,9 @@ async def test_gpu_monitoring_range_query(s, a, b):
         assert all(res[w.address]["range_query"][m] is not None for m in ms)
         assert res[w.address]["count"] is not None
         assert res[w.address]["last_time"] is not None
+
+
+@gen_cluster()
+async def test_wsl_monitoring_enabled(s, a, b):
+    assert nvml.nvmlInitialized is True
+    assert nvml.nvmlWslInsufficientDriver is False

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -45,6 +45,18 @@ def test_enable_disable_nvml():
         )
 
 
+def test_wsl_monitoring_enabled():
+    try:
+        pynvml.nvmlShutdown()
+    except pynvml.NVMLError_Uninitialized:
+        pass
+    else:
+        nvml.nvmlInitialized = False
+
+    nvml.init_once()
+    assert nvml.nvmlWslInsufficientDriver is False
+
+
 def run_has_cuda_context(queue):
     try:
         assert not nvml.has_cuda_context()

--- a/distributed/diagnostics/tests/test_nvml.py
+++ b/distributed/diagnostics/tests/test_nvml.py
@@ -38,7 +38,11 @@ def test_enable_disable_nvml():
 
     with dask.config.set({"distributed.diagnostics.nvml": True}):
         nvml.init_once()
-        assert nvml.nvmlInitialized is True
+        assert (
+            nvml.nvmlInitialized is True
+            or nvml.nvmlLibraryNotFound is True
+            or nvml.nvmlWslInsufficientDriver is True
+        )
 
 
 def run_has_cuda_context(queue):
@@ -150,9 +154,3 @@ async def test_gpu_monitoring_range_query(s, a, b):
         assert all(res[w.address]["range_query"][m] is not None for m in ms)
         assert res[w.address]["count"] is not None
         assert res[w.address]["last_time"] is not None
-
-
-@gen_cluster()
-async def test_wsl_monitoring_enabled(s, a, b):
-    assert nvml.nvmlInitialized is True
-    assert nvml.nvmlWslInsufficientDriver is False


### PR DESCRIPTION
After trying out NVML monitoring on WSL2 with the latest NVIDIA drivers, it looks like a lot of the issues encountered before are no longer occurring:

- we are now able to query active processes using `nvmlDeviceGetComputeRunningProcesses`
- we are now able to query GPU utilization using `nvmlDeviceGetUtilizationRates`

This PR re-enables NVML monitoring on WSL2 with the caveat that the NVIDIA driver version must be at or above the latest version as of now (512.15); if it isn't, monitoring will be disabled as was the case before. This should hopefully reduce the number of issues opened around WSL2 that boil down to outdated drivers.

cc @pentschev 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
