### PR TITLE
Update `locket._LockFile` implementation to avoid leaving open files

### DIFF
--- a/distributed/locket.py
+++ b/distributed/locket.py
@@ -168,9 +168,9 @@ class _LockFile:
                     path=self._path,
                 )
 
-        def release(self):
-            with open(self._path, "wb") as fd:
-                _unlock_file(fd)
+    def release(self):
+        with open(self._path, "wb") as fd:
+            _unlock_file(fd)
 
 
 class _Locker:

--- a/distributed/locket.py
+++ b/distributed/locket.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import os
 import threading
+import warnings
 import weakref
 from time import sleep
 
@@ -169,8 +171,9 @@ class _LockFile:
                 )
 
     def release(self):
-        with open(self._path, "wb") as fd:
-            _unlock_file(fd)
+        if os.path.exists(self._path):
+            with open(self._path, "wb") as fd:
+                _unlock_file(fd)
 
 
 class _Locker:


### PR DESCRIPTION
The `LockFile` implementation opens a file descriptor to check locks. In the non-blocking case, if the lock cannot be acquired, a `LockError` is thrown and an open file descriptor is left dangling. In normal operation, this file is closed on lock release, but since the lock has already been acquired by another instance of the `LockFile`, release never occurs. On teardown, a `ResourceWarning` is thrown by the Python runtime e.g.

```python
E               Traceback (most recent call last):
E                 File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/distributed/diskutils.py", line 173, in _purge_leftovers
E                   if self._check_lock_or_purge(path):
E               ResourceWarning: unclosed file <_io.BufferedWriter name='/home/runner/work/orion/orion/dask-worker-space/worker-ie4t4hva.dirlock'>
```

I discovered this in teardown calls to `distributed.diskutils::WorkSpace._check_lock_or_purge` as you can see above.

This implementation drops caching of the `_file` descriptor on the `LockFile` object. An alternate implementation could retain the caching but close the file and set it to `None` on exception during `acquire`.

This diff is best viewed with whitespace changes ignored https://github.com/dask/distributed/pull/6122/files?w=1

- [x] Closes https://github.com/dask/distributed/issues/2486
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
