### PR TITLE
Ignore bokeh warning in pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ filterwarnings =
     ignore:(?s)Exception ignored in. <function Client\.__del__.*RuntimeError. IOLoop is closed:pytest.PytestUnraisableExceptionWarning
     ignore:notifyAll\(\) is deprecated, use notify_all\(\) instead:DeprecationWarning:paramiko
     ignore:setDaemon\(\) is deprecated, set the daemon attribute instead:DeprecationWarning:paramiko
+    ignore:coroutine '_needs_document_lock.<locals>._needs_document_lock_wrapper' was never awaited
 minversion = 6
 markers =
     ci1: marks tests as belonging to 1 out of 2 partitions to run on CI ('-m "not ci1"' for second partition)


### PR DESCRIPTION
This fixes intermittent failures like https://github.com/dask/distributed/runs/6030629296?check_suite_focus=true

This isn't our fault, and has been fixed upstream