### PR TITLE
Clean up SSHCluster if failure to start

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -284,18 +284,19 @@ class SpecCluster(Cluster):
                 options = {"dashboard": True}
             self.scheduler_spec = {"cls": Scheduler, "options": options}
 
-        # Check if scheduler has already been created by a subclass
-        if self.scheduler is None:
-            cls = self.scheduler_spec["cls"]
-            if isinstance(cls, str):
-                cls = import_term(cls)
-            self.scheduler = cls(**self.scheduler_spec.get("options", {}))
-            self.scheduler = await self.scheduler
-        self.scheduler_comm = rpc(
-            getattr(self.scheduler, "external_address", None) or self.scheduler.address,
-            connection_args=self.security.get_connection_args("client"),
-        )
         try:
+            # Check if scheduler has already been created by a subclass
+            if self.scheduler is None:
+                cls = self.scheduler_spec["cls"]
+                if isinstance(cls, str):
+                    cls = import_term(cls)
+                self.scheduler = cls(**self.scheduler_spec.get("options", {}))
+                self.scheduler = await self.scheduler
+            self.scheduler_comm = rpc(
+                getattr(self.scheduler, "external_address", None)
+                or self.scheduler.address,
+                connection_args=self.security.get_connection_args("client"),
+            )
             await super()._start()
         except Exception as e:  # pragma: no cover
             self.status = Status.failed

--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -37,8 +37,10 @@ class Process(ProcessInterface):
         await super().start()
 
     async def close(self):
-        self.proc.kill()  # https://github.com/ronf/asyncssh/issues/112
-        self.connection.close()
+        if self.proc:
+            self.proc.kill()  # https://github.com/ronf/asyncssh/issues/112
+        if self.connection:
+            self.connection.close()
         await super().close()
 
 

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -30,7 +30,9 @@ def test_ssh_hosts_empty_list():
 @gen_test()
 async def test_ssh_cluster_raises_if_asyncssh_not_installed(monkeypatch):
     monkeypatch.setitem(sys.modules, "asyncssh", None)
-    with pytest.raises(ImportError, match="SSHCluster requires the `asyncssh` package"):
+    with pytest.raises(
+        (RuntimeError, ImportError), match="SSHCluster requires the `asyncssh` package"
+    ):
         async with SSHCluster(
             ["127.0.0.1"] * 3,
             connect_options=[dict(known_hosts=None)] * 3,


### PR DESCRIPTION
This was an intermittent test failure on windows.  See https://github.com/dask/distributed/runs/6032727847?check_suite_focus=true

If SSHCluster fails to launch it stays in a starting rather than closed state