### PR TITLE
Avoid intermittent failure in test_cancel_fire_and_forget

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1457,6 +1457,8 @@ async def test_cancel_fire_and_forget(c, s, a, b):
     await asyncio.sleep(0.05)
     await future.cancel(force=True)
     assert future.status == "cancelled"
+    while s.tasks:  # in rare conditions this can take a little while
+        await asyncio.sleep(0.01)
     assert not s.tasks
 
 


### PR DESCRIPTION
It's possible that the cancel call actually comes before the tasks
arrive.  This is ok.  Dask actually handles it decently well, but our
checking of internal state in this test doesn't.  This change avoids
that case and avoids an intermittent failure.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
