### PR TITLE
Log all invalid worker transitions to scheduler

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -61,6 +61,7 @@ from distributed.utils_test import (
     slowsum,
 )
 from distributed.worker import (
+    InvalidTransition,
     Worker,
     benchmark_disk,
     benchmark_memory,
@@ -3477,6 +3478,29 @@ async def test_tick_interval(c, s, a, b):
     while s.workers[a.address].metrics["event_loop_interval"] < 0.100:
         await asyncio.sleep(0.01)
         time.sleep(0.200)
+
+
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
+async def test_log_invalid_transitions(c, s, a):
+    x = c.submit(inc, 1)
+    y = c.submit(inc, x)
+    xkey = x.key
+    del x
+    await y
+    while a.tasks[xkey].state != "released":
+        await asyncio.sleep(0.01)
+    ts = a.tasks[xkey]
+    with pytest.raises(InvalidTransition):
+        a.transition(ts, "foo", stimulus_id="bar")
+
+    while not s.events["invalid-worker-transition"]:
+        await asyncio.sleep(0.01)
+
+    assert "foo" in str(s.events["invalid-worker-transition"])
+    assert a.address in str(s.events["invalid-worker-transition"])
+    assert ts.key in str(s.events["invalid-worker-transition"])
+
+    del s.events["invalid-worker-transition"]  # for test cleanup
 
 
 class BreakingWorker(Worker):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -864,6 +864,7 @@ async def start_cluster(
         await asyncio.sleep(0.01)
         if time() > start + 30:
             await asyncio.gather(*(w.close(timeout=1) for w in workers))
+            assert not s.events["invalid-worker-transition"]
             await s.close(fast=True)
             raise TimeoutError("Cluster creation timeout")
     return s, workers
@@ -877,6 +878,7 @@ async def end_cluster(s, workers):
             await w.close(report=False)
 
     await asyncio.gather(*(end_worker(w) for w in workers))
+    assert not s.events["invalid-worker-transition"]
     await s.close()  # wait until scheduler stops completely
     s.stop()
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -864,8 +864,8 @@ async def start_cluster(
         await asyncio.sleep(0.01)
         if time() > start + 30:
             await asyncio.gather(*(w.close(timeout=1) for w in workers))
-            assert not s.events["invalid-worker-transition"]
             await s.close(fast=True)
+            assert not s.events["invalid-worker-transition"]
             raise TimeoutError("Cluster creation timeout")
     return s, workers
 
@@ -878,9 +878,9 @@ async def end_cluster(s, workers):
             await w.close(report=False)
 
     await asyncio.gather(*(end_worker(w) for w in workers))
-    assert not s.events["invalid-worker-transition"]
     await s.close()  # wait until scheduler stops completely
     s.stop()
+    assert not s.events["invalid-worker-transition"]
 
 
 def gen_cluster(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2552,10 +2552,7 @@ class Worker(ServerNode):
                         "worker": self.address,
                     },
                 )
-                raise InvalidTransition(
-                    f"Impossible transition from {start} to {finish} for {ts.key}",
-                    self.story(ts),
-                )
+                raise InvalidTransition(ts.key, start, finish, self.story(ts))
 
         else:
             self.log_event(
@@ -2568,10 +2565,7 @@ class Worker(ServerNode):
                     "worker": self.address,
                 },
             )
-            raise InvalidTransition(
-                f"Impossible transition from {start} to {finish} for {ts.key}",
-                self.story(ts),
-            )
+            raise InvalidTransition(ts.key, start, finish, self.story(ts))
 
         self.log.append(
             (

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2540,11 +2540,31 @@ class Worker(ServerNode):
                 recs.update(b_recs)
                 instructions += b_instructions
             except InvalidTransition:
+                self.log_event(
+                    "invalid-worker-transition",
+                    {
+                        "key": ts.key,
+                        "start": start,
+                        "finish": finish,
+                        "story": self.story(ts),
+                        "worker": self.address,
+                    },
+                )
                 raise InvalidTransition(
                     f"Impossible transition from {start} to {finish} for {ts.key}"
                 ) from None
 
         else:
+            self.log_event(
+                "invalid-worker-transition",
+                {
+                    "key": ts.key,
+                    "start": start,
+                    "finish": finish,
+                    "story": self.story(ts),
+                    "worker": self.address,
+                },
+            )
             raise InvalidTransition(
                 f"Impossible transition from {start} to {finish} for {ts.key}"
             )

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -67,7 +67,21 @@ class StartStop(TypedDict, total=False):
 
 
 class InvalidTransition(Exception):
-    pass
+    def __init__(self, key, start, finish, story):
+        self.key = key
+        self.start = start
+        self.finish = finish
+        self.story = story
+
+    def __repr__(self):
+        return (
+            f"InvalidTransition: {self.key} :: {self.start}->{self.finish}"
+            + "\n"
+            + "  Story:\n    "
+            + "\n    ".join(map(str, self.story))
+        )
+
+    __str__ = __repr__
 
 
 @lru_cache


### PR DESCRIPTION
Also incorporate this into the testing framework so that we fail loudly
in this occurs in the test suite, even while hidden in a coroutine.