### PR TITLE
Sort worker list in info pages

### DIFF
--- a/distributed/http/templates/workers.html
+++ b/distributed/http/templates/workers.html
@@ -5,7 +5,7 @@
 
   <a class="button is-primary" href="logs.html">Logs</a>
   <a class="button is-primary" href="../../status">Bokeh</a>
-  {% set worker_list = list(workers.values()) %}
+  {% set worker_list = sorted(workers.values(), key=lambda ws: ws.name) %}
   {% include "worker-table.html" %}
 
 {% end %}


### PR DESCRIPTION
Previously this occured in random order, which made it hard to see things change as you update the info pages (these pages are statically generated)