### PR TITLE
Remove Nanny auto_restart state

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -40,7 +40,7 @@ from distributed.multi_lock import MultiLock
 from distributed.nanny import Nanny
 from distributed.pubsub import Pub, Sub
 from distributed.queues import Queue
-from distributed.scheduler import Scheduler
+from distributed.scheduler import KilledWorker, Scheduler
 from distributed.security import Security
 from distributed.semaphore import Semaphore
 from distributed.threadpoolexecutor import rejoin

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -228,7 +228,6 @@ class Nanny(ServerNode):
         self.services = services
         self.name = name
         self.quiet = quiet
-        self.auto_restart = True
 
         if silence_logs:
             silence_logging(level=silence_logs)
@@ -366,7 +365,6 @@ class Nanny(ServerNode):
         Blocks until both the process is down and the scheduler is properly
         informed
         """
-        self.auto_restart = False
         if self.process is None:
             return "OK"
 
@@ -528,9 +526,8 @@ class Nanny(ServerNode):
                 Status.closed,
                 Status.closing_gracefully,
             ):
-                if self.auto_restart:
-                    logger.warning("Restarting worker")
-                    await self.instantiate()
+                logger.warning("Restarting worker")
+                await self.instantiate()
             elif self.status == Status.closing_gracefully:
                 await self.close()
 

--- a/distributed/tests/test_chaos.py
+++ b/distributed/tests/test_chaos.py
@@ -21,12 +21,7 @@ async def test_KillWorker(c, s, w, mode):
 
     await c.register_worker_plugin(plugin)
 
-    # Otherwise we sometimes stop the test just when we're starting a new
-    # nanny, and leak a thread
-    def f(dask_worker):
-        dask_worker.auto_restart = False
-
-    await c.run(f, nanny=True)
-
     while s.workers:
         await asyncio.sleep(0.001)
+
+    await w.close()

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -32,14 +32,6 @@ from distributed.utils_test import captured_logger, gen_cluster, gen_test
 pytestmark = pytest.mark.ci1
 
 
-@gen_cluster(nthreads=[])
-async def test_many_kills(s):
-    async with Nanny(s.address, nthreads=2) as n:
-        assert n.is_alive()
-        await asyncio.gather(*(n.kill() for _ in range(5)))
-        await asyncio.gather(*(n.kill() for _ in range(5)))
-
-
 @gen_cluster(Worker=Nanny)
 async def test_str(s, a, b):
     assert a.worker_address in str(a)
@@ -468,10 +460,9 @@ async def test_nanny_closed_by_keyboard_interrupt(protocol):
         async with Nanny(
             s.address, nthreads=1, worker_class=KeyboardInterruptWorker
         ) as n:
-            n.auto_restart = False
             await n.process.stopped.wait()
             # Check that the scheduler has been notified about the closed worker
-            assert len(s.workers) == 0
+            assert "remove-worker" in str(s.events)
 
 
 class StartException(Exception):


### PR DESCRIPTION
Previously ...

If you called client.restart, then nannies would stop auto-restarting any failed workers

```python
client.restart()

client.submit(bad_function)

# where did all of my workers go?  Why didn't they come back?
```

Now nannies continue to restart workers if they die even after a restart.  This is the intended behavior.