### PR TITLE
Only allow fetch, flight, and resumed to transition to missing

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3046,7 +3046,7 @@ class Worker(ServerNode):
                 for d in has_what:
                     ts = self.tasks[d]
                     ts.who_has.remove(worker)
-                    if not ts.who_has and ts.state not in ("released", "memory"):
+                    if not ts.who_has and ts.state in ("fetch", "flight", "resumed"):
                         recommendations[ts] = "missing"
                         self.log.append(
                             ("missing-who-has", worker, ts.key, stimulus_id, time())
@@ -3093,7 +3093,7 @@ class Worker(ServerNode):
                         )
                         if ts.who_has:
                             recommendations[ts] = "fetch"
-                        elif ts.state not in ("released", "memory"):
+                        elif ts.state in ("fetch", "flight", "resumed"):
                             recommendations[ts] = "missing"
                 del data, response
                 self.transitions(recommendations, stimulus_id=stimulus_id)


### PR DESCRIPTION
Unfortunately this currently fails with

```
  File "/home/mrocklin/workspace/distributed/distributed/worker.py", line 3915, in validate_task_fetch
    assert ts.who_has
```

Follows on https://github.com/dask/distributed/pull/6123

cc @gjoseph92 