### PR TITLE
Remove legacy state mappings

### DIFF
--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -29,22 +29,22 @@ def test_adaptive_local_cluster(loop):
     ) as cluster:
         alc = cluster.adapt(interval="100 ms")
         with Client(cluster, loop=loop) as c:
-            assert not c.nthreads()
+            assert not cluster.scheduler.workers
             future = c.submit(lambda x: x + 1, 1)
             assert future.result() == 2
-            assert c.nthreads()
+            assert cluster.scheduler.workers
 
             sleep(0.1)
-            assert c.nthreads()  # still there after some time
+            assert cluster.scheduler.workers
 
             del future
 
             start = time()
-            while cluster.scheduler.nthreads:
+            while cluster.scheduler.workers:
                 sleep(0.01)
                 assert time() < start + 30
 
-            assert not c.nthreads()
+            assert not cluster.scheduler.workers
 
 
 @gen_test()

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -442,7 +442,7 @@ async def test_scale_up_and_down():
             cluster.scale(2)
             await cluster
             assert len(cluster.workers) == 2
-            assert len(cluster.scheduler.nthreads) == 2
+            assert len(cluster.scheduler.workers) == 2
 
             cluster.scale(1)
             await cluster

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -121,7 +121,7 @@ async def test_AllProgress(c, s, a, b):
     keys = {x.key, y.key, z.key}
     del x, y, z
 
-    while any(k in s.who_has for k in keys):
+    while any(s.tasks[k].who_has for k in keys):
         await asyncio.sleep(0.01)
 
     assert p.state["released"]["inc"] == keys

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -363,7 +363,10 @@ async def test_many_computations(c, s, a, b):
     done = c.submit(lambda x: None, futures)
 
     while not done.done():
-        assert len(s.processing) <= a.nthreads + b.nthreads
+        assert (
+            len([ws for ws in s.workers.values() if ws.processing])
+            <= a.nthreads + b.nthreads
+        )
         await asyncio.sleep(0.01)
 
     await done

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -69,7 +69,6 @@ from distributed.comm import CommClosedError
 from distributed.compatibility import LINUX, WINDOWS
 from distributed.core import Server, Status
 from distributed.metrics import time
-from distributed.objects import HasWhat, WhoHas
 from distributed.profile import wait_profiler
 from distributed.scheduler import CollectTaskMetaDataPlugin, KilledWorker, Scheduler
 from distributed.sizeof import sizeof
@@ -794,7 +793,7 @@ async def test_garbage_collection_with_scatter(c, s, a, b):
     [future] = await c.scatter([1])
     assert future.key in c.futures
     assert future.status == "finished"
-    assert s.who_wants[future.key] == {c.id}
+    assert {cs.client_key for cs in s.tasks[future.key].who_wants} == {c.id}
 
     key = future.key
     assert c.refcount[key] == 1
@@ -924,10 +923,10 @@ async def test_restrictions_submit(c, s, a, b):
     y = c.submit(inc, x, workers={b.ip})
     await wait([x, y])
 
-    assert s.host_restrictions[x.key] == {a.ip}
+    assert s.tasks[x.key].host_restrictions == {a.ip}
     assert x.key in a.data
 
-    assert s.host_restrictions[y.key] == {b.ip}
+    assert s.tasks[y.key].host_restrictions == {b.ip}
     assert y.key in b.data
 
 
@@ -937,10 +936,10 @@ async def test_restrictions_ip_port(c, s, a, b):
     y = c.submit(inc, x, workers={b.address})
     await wait([x, y])
 
-    assert s.worker_restrictions[x.key] == {a.address}
+    assert s.tasks[x.key].worker_restrictions == {a.address}
     assert x.key in a.data
 
-    assert s.worker_restrictions[y.key] == {b.address}
+    assert s.tasks[y.key].worker_restrictions == {b.address}
     assert y.key in b.data
 
 
@@ -953,7 +952,7 @@ async def test_restrictions_map(c, s, a, b):
     assert set(a.data) == {x.key for x in L}
     assert not b.data
     for x in L:
-        assert s.host_restrictions[x.key] == {a.ip}
+        assert s.tasks[x.key].host_restrictions == {a.ip}
 
 
 @pytest.mark.skipif(not LINUX, reason="Need 127.0.0.2 to mean localhost")
@@ -1381,13 +1380,6 @@ async def test_directed_scatter(c, s, a, b):
 
     await c.scatter([4, 5], workers=[b.name])
     assert len(b.data) == 2
-
-
-def test_directed_scatter_sync(c, s, a, b, loop):
-    futures = c.scatter([1, 2, 3], workers=[b["address"]])
-    has_what = sync(loop, c.scheduler.has_what)
-    assert len(has_what[b["address"]]) == len(futures)
-    assert len(has_what[a["address"]]) == 0
 
 
 @gen_cluster(client=True)
@@ -1835,8 +1827,6 @@ def test_start_is_idempotent(c):
 
 @gen_cluster(client=True)
 async def test_client_with_scheduler(c, s, a, b):
-    assert s.nthreads == {a.address: a.nthreads, b.address: b.nthreads}
-
     x = c.submit(inc, 1)
     y = c.submit(inc, 2)
     z = c.submit(add, x, y)
@@ -1862,28 +1852,30 @@ async def test_allow_restrictions(c, s, a, b):
     x = c.submit(inc, 1, workers=a.ip)
     await x
     assert s.tasks[x.key].who_has == {aws}
-    assert not s.loose_restrictions
+    assert not any(ts.loose_restrictions for ts in s.tasks.values())
 
     x = c.submit(inc, 2, workers=a.ip, allow_other_workers=True)
     await x
     assert s.tasks[x.key].who_has == {aws}
-    assert x.key in s.loose_restrictions
+    assert s.tasks[x.key].loose_restrictions
 
     L = c.map(inc, range(3, 13), workers=a.ip, allow_other_workers=True)
     await wait(L)
     assert all(s.tasks[f.key].who_has == {aws} for f in L)
-    assert {f.key for f in L}.issubset(s.loose_restrictions)
+    for f in L:
+        assert s.tasks[f.key].loose_restrictions
 
     x = c.submit(inc, 15, workers="127.0.0.3", allow_other_workers=True)
 
     await x
     assert s.tasks[x.key].who_has
-    assert x.key in s.loose_restrictions
+    assert s.tasks[x.key].loose_restrictions
 
     L = c.map(inc, range(15, 25), workers="127.0.0.3", allow_other_workers=True)
     await wait(L)
     assert all(s.tasks[f.key].who_has for f in L)
-    assert {f.key for f in L}.issubset(s.loose_restrictions)
+    for f in L:
+        assert s.tasks[f.key].loose_restrictions
 
     with pytest.raises(ValueError):
         c.submit(inc, 1, allow_other_workers=True)
@@ -2050,8 +2042,8 @@ async def test_forget_simple(c, s, a, b):
     z = c.submit(add, x, y, workers=[a.ip], allow_other_workers=True)
 
     await wait([x, y, z])
-    assert not s.waiting_data.get(x.key)
-    assert not s.waiting_data.get(y.key)
+    assert not s.tasks[x.key].waiting_on
+    assert not s.tasks[y.key].waiting_on
 
     assert set(s.tasks) == {x.key, y.key, z.key}
 
@@ -2126,31 +2118,30 @@ async def test_forget_errors(c, s, a, b):
     z = c.submit(inc, y)
     await wait([y])
 
-    assert x.key in s.exceptions
-    assert x.key in s.exceptions_blame
-    assert y.key in s.exceptions_blame
-    assert z.key in s.exceptions_blame
+    assert s.tasks[x.key].exception
+    assert s.tasks[x.key].exception_blame
+    assert s.tasks[y.key].exception_blame
+    assert s.tasks[z.key].exception_blame
 
     s.client_releases_keys(keys=[z.key], client=c.id)
 
-    assert x.key in s.exceptions
-    assert x.key in s.exceptions_blame
-    assert y.key in s.exceptions_blame
-    assert z.key not in s.exceptions_blame
+    assert s.tasks[x.key].exception
+    assert s.tasks[x.key].exception_blame
+    assert s.tasks[y.key].exception_blame
+    assert z.key not in s.tasks
 
     s.client_releases_keys(keys=[x.key], client=c.id)
 
-    assert x.key in s.exceptions
-    assert x.key in s.exceptions_blame
-    assert y.key in s.exceptions_blame
-    assert z.key not in s.exceptions_blame
+    assert s.tasks[x.key].exception
+    assert s.tasks[x.key].exception_blame
+    assert s.tasks[y.key].exception_blame
+    assert z.key not in s.tasks
 
     s.client_releases_keys(keys=[y.key], client=c.id)
 
-    assert x.key not in s.exceptions
-    assert x.key not in s.exceptions_blame
-    assert y.key not in s.exceptions_blame
-    assert z.key not in s.exceptions_blame
+    assert x.key not in s.tasks
+    assert y.key not in s.tasks
+    assert z.key not in s.tasks
 
 
 def test_repr_sync(c):
@@ -2160,18 +2151,6 @@ def test_repr_sync(c):
     assert c.scheduler.address in r
     assert str(2) in s  # nworkers
     assert "cores" in s or "threads" in s
-
-
-@gen_cluster(client=True)
-async def test_waiting_data(c, s, a, b):
-    x = c.submit(inc, 1)
-    y = c.submit(inc, 2)
-    z = c.submit(add, x, y, workers=[a.ip], allow_other_workers=True)
-
-    await wait([x, y, z])
-
-    assert not s.waiting_data.get(x.key)
-    assert not s.waiting_data.get(y.key)
 
 
 @gen_cluster()
@@ -2189,21 +2168,17 @@ async def test_multi_client(s, a, b):
 
     await wait([x, y])
 
-    assert s.wants_what == {
-        c.id: {x.key, y.key},
-        f.id: {y.key},
-        "fire-and-forget": set(),
-    }
-    assert s.who_wants == {x.key: {c.id}, y.key: {c.id, f.id}}
+    assert {ts.key for ts in s.clients[c.id].wants_what} == {x.key, y.key}
+    assert {ts.key for ts in s.clients[f.id].wants_what} == {y.key}
 
     await c.close()
 
-    while c.id in s.wants_what:
+    while c.id in s.clients:
         await asyncio.sleep(0.01)
 
-    assert c.id not in s.wants_what
-    assert c.id not in s.who_wants[y.key]
-    assert x.key not in s.who_wants
+    assert c.id not in s.clients
+    assert c.id not in s.tasks[y.key].who_wants
+    assert x.key not in s.tasks
 
     await f.close()
 
@@ -2252,24 +2227,23 @@ async def test_multi_garbage_collection(s, a, b):
     while x.key in a.data or x.key in b.data:
         await asyncio.sleep(0.01)
 
-    assert s.wants_what == {c.id: {y.key}, f.id: {y.key}, "fire-and-forget": set()}
-    assert s.who_wants == {y.key: {c.id, f.id}}
+    assert {ts.key for ts in s.clients[c.id].wants_what} == {y.key}
+    assert {ts.key for ts in s.clients[f.id].wants_what} == {y.key}
 
     y.__del__()
-    while x.key in s.wants_what[f.id]:
+    while x.key in {ts.key for ts in s.clients[f.id].wants_what}:
         await asyncio.sleep(0.01)
 
     await asyncio.sleep(0.1)
     assert y.key in a.data or y.key in b.data
-    assert s.wants_what == {c.id: {y.key}, f.id: set(), "fire-and-forget": set()}
-    assert s.who_wants == {y.key: {c.id}}
+    assert {ts.key for ts in s.clients[c.id].wants_what} == {y.key}
+    assert not s.clients[f.id].wants_what
 
     y2.__del__()
     while y.key in a.data or y.key in b.data:
         await asyncio.sleep(0.01)
 
-    assert not any(v for v in s.wants_what.values())
-    assert not s.who_wants
+    assert not s.tasks
 
     await c.close()
     await f.close()
@@ -2292,25 +2266,6 @@ async def test__broadcast_integer(c, s, *workers):
 async def test__broadcast_dict(c, s, a, b):
     d = await c.scatter({"x": 1}, broadcast=True)
     assert a.data == b.data == {"x": 1}
-
-
-def test_broadcast(c, s, a, b):
-    x, y = c.scatter([1, 2], broadcast=True)
-
-    has_what = sync(c.loop, c.scheduler.has_what)
-
-    assert {k: set(v) for k, v in has_what.items()} == {
-        a["address"]: {x.key, y.key},
-        b["address"]: {x.key, y.key},
-    }
-
-    [z] = c.scatter([3], broadcast=True, workers=[a["address"]])
-
-    has_what = sync(c.loop, c.scheduler.has_what)
-    assert {k: set(v) for k, v in has_what.items()} == {
-        a["address"]: {x.key, y.key, z.key},
-        b["address"]: {x.key, y.key},
-    }
 
 
 @gen_cluster(client=True)
@@ -2466,8 +2421,8 @@ async def test_async_persist(c, s, a, b):
     while y.key not in s.tasks and w.key not in s.tasks:
         await asyncio.sleep(0.01)
 
-    assert s.who_wants[y.key] == {c.id}
-    assert s.who_wants[w.key] == {c.id}
+    assert {cs.client_key for cs in s.tasks[y.key].who_wants} == {c.id}
+    assert {cs.client_key for cs in s.tasks[w.key].who_wants} == {c.id}
 
     yyf, wwf = c.compute([yy, ww])
     yyy, www = await c.gather([yyf, wwf])
@@ -3395,39 +3350,9 @@ async def test_set_as_default(s, a, b):
 
 
 @gen_cluster(client=True)
-async def test_get_processing(c, s, a, b):
-    processing = await c.processing()
-    assert processing == valmap(tuple, s.processing)
-
-    futures = c.map(
-        slowinc, range(10), delay=0.1, workers=[a.address], allow_other_workers=True
-    )
-
-    await asyncio.sleep(0.2)
-
-    x = await c.processing()
-    assert set(x) == {a.address, b.address}
-
-    x = await c.processing(workers=[a.address])
-    assert isinstance(x[a.address], (list, tuple))
-
-
-@gen_cluster(client=True)
 async def test_get_foo(c, s, a, b):
     futures = c.map(inc, range(10))
     await wait(futures)
-
-    x = await c.scheduler.ncores()
-    assert x == s.nthreads
-
-    x = await c.scheduler.ncores(workers=[a.address])
-    assert x == {a.address: s.nthreads[a.address]}
-
-    x = await c.scheduler.has_what()
-    assert valmap(sorted, x) == valmap(sorted, s.has_what)
-
-    x = await c.scheduler.has_what(workers=[a.address])
-    assert valmap(sorted, x) == {a.address: sorted(s.has_what[a.address])}
 
     x = await c.scheduler.nbytes(summary=False)
     assert x == s.get_nbytes(summary=False)
@@ -3436,10 +3361,14 @@ async def test_get_foo(c, s, a, b):
     assert x == {futures[0].key: s.tasks[futures[0].key].nbytes}
 
     x = await c.scheduler.who_has()
-    assert valmap(sorted, x) == valmap(sorted, s.who_has)
+    assert valmap(set, x) == {
+        key: {ws.address for ws in ts.who_has} for key, ts in s.tasks.items()
+    }
 
     x = await c.scheduler.who_has(keys=[futures[0].key])
-    assert valmap(sorted, x) == {futures[0].key: sorted(s.who_has[futures[0].key])}
+    assert valmap(set, x) == {
+        futures[0].key: {ws.address for ws in s.tasks[futures[0].key].who_has}
+    }
 
 
 def assert_dict_key_equal(expected, actual):
@@ -3632,28 +3561,6 @@ async def test_status(s):
 
     await c.close()
     assert c.status == "closed"
-
-
-@gen_cluster(client=True)
-async def test_async_whowhat(c, s, a, b):
-    [x] = await c.scatter([1], workers=a.address)
-
-    who_has = await c.who_has()
-    has_what = await c.has_what()
-    assert type(who_has) is WhoHas
-    assert type(has_what) is HasWhat
-
-    assert who_has == {x.key: (a.address,)}
-    assert has_what == {a.address: (x.key,), b.address: ()}
-
-
-def test_client_repr_html(c):
-    x = c.submit(inc, 1)
-
-    who_has = c.who_has()
-    has_what = c.has_what()
-    assert type(who_has) is WhoHas
-    assert type(has_what) is HasWhat
 
 
 @gen_cluster(client=True)
@@ -4239,7 +4146,9 @@ async def test_persist_workers_annotate(e, s, a, b, c):
     assert all(v.key in a.data for v in L1)
     assert total.key in b.data
 
-    assert s.loose_restrictions == {total2.key} | {v.key for v in L2}
+    assert s.tasks[total2.key].loose_restrictions
+    for v in L2:
+        assert s.tasks[v.key].loose_restrictions
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)] * 3, client=True)
@@ -4259,7 +4168,7 @@ async def test_persist_workers_annotate2(e, s, a, b, c):
         assert all(layer.annotations is None for layer in x.dask.layers.values())
 
     for v in L1:
-        assert s.worker_restrictions[v.key] == {a.address}
+        assert s.tasks[v.key].worker_restrictions == {a.address}
 
 
 @nodebug  # test timing is fragile
@@ -4279,10 +4188,12 @@ async def test_persist_workers(e, s, a, b, c):
     await wait(out)
 
     for v in L1 + L2 + [total, total2]:
-        assert s.worker_restrictions[v.key] == {a.address, b.address}
-    assert not any(c.address in r for r in s.worker_restrictions)
+        assert s.tasks[v.key].worker_restrictions == {a.address, b.address}
+    assert not any(c.address in ts.worker_restrictions for ts in s.tasks.values())
 
-    assert s.loose_restrictions == {total.key, total2.key} | {v.key for v in L1 + L2}
+    assert s.tasks[total.key].loose_restrictions
+    for v in L1 + L2:
+        assert s.tasks[v.key].loose_restrictions
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)] * 3, client=True)
@@ -4300,12 +4211,14 @@ async def test_compute_workers_annotate(e, s, a, b, c):
 
     await wait(out)
     for v in L1:
-        assert s.worker_restrictions[v.key] == {a.address}
+        assert s.tasks[v.key].worker_restrictions == {a.address}
     for v in L2:
-        assert s.worker_restrictions[v.key] == {c.address}
-    assert s.worker_restrictions[total.key] == {b.address}
+        assert s.tasks[v.key].worker_restrictions == {c.address}
+    assert s.tasks[total.key].worker_restrictions == {b.address}
 
-    assert s.loose_restrictions == {total.key} | {v.key for v in L1}
+    assert s.tasks[total.key].loose_restrictions
+    for v in L1:
+        assert s.tasks[v.key].loose_restrictions
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)] * 3, client=True)
@@ -4322,10 +4235,12 @@ async def test_compute_workers(e, s, a, b, c):
 
     await wait(out)
     for v in L1 + L2 + [total]:
-        assert s.worker_restrictions[v.key] == {a.address, b.address}
-    assert not any(c.address in r for r in s.worker_restrictions)
+        assert s.tasks[v.key].worker_restrictions == {a.address, b.address}
+    assert not any(c.address in ts.worker_restrictions for ts in s.tasks.values())
 
-    assert s.loose_restrictions == {total.key} | {v.key for v in L1 + L2}
+    assert s.tasks[total.key].loose_restrictions
+    for v in L1 + L2:
+        assert s.tasks[v.key].loose_restrictions
 
 
 @gen_cluster(client=True)
@@ -4357,8 +4272,8 @@ async def test_retire_workers_2(c, s, a, b):
 
     await s.retire_workers(workers=[a.address])
     assert b.data == {x.key: 1}
-    assert s.who_has == {x.key: {b.address}}
-    assert s.has_what == {b.address: {x.key}}
+    assert {ws.address for ws in s.tasks[x.key].who_has} == {b.address}
+    assert {ts.key for ts in s.workers[b.address].has_what} == {x.key}
 
     assert a.address not in s.workers
 
@@ -4375,7 +4290,7 @@ async def test_retire_many_workers(c, s, *workers):
     while len(s.workers) != 3:
         await asyncio.sleep(0.01)
 
-    assert len(s.has_what) == len(s.nthreads) == 3
+    assert len(s.workers) == 3
 
     assert all(future.done() for future in futures)
     assert all(s.tasks[future.key].state == "memory" for future in futures)
@@ -4675,19 +4590,6 @@ async def test_map_list_kwargs(c, s, a, b):
     futures = c.map(f, range(10), L=futures)
     results = await c.gather(futures)
     assert results == [i + 6 for i in range(10)]
-
-
-@gen_cluster(client=True)
-async def test_dont_clear_waiting_data(c, s, a, b):
-    x = await c.scatter(1)
-    y = c.submit(slowinc, x, delay=0.5)
-    while y.key not in s.tasks:
-        await asyncio.sleep(0.01)
-    key = x.key
-    del x
-    for i in range(5):
-        assert s.waiting_data[key]
-        await asyncio.sleep(0)
 
 
 @gen_cluster(client=True)
@@ -4993,8 +4895,8 @@ async def test_fire_and_forget(c, s, a, b):
     while len(s.tasks) > 1:
         await asyncio.sleep(0.01)
 
-    assert set(s.who_wants) == {future.key}
     assert set(s.tasks) == {future.key}
+    assert s.tasks[future.key].who_wants
 
 
 @gen_cluster(client=True)
@@ -5050,10 +4952,10 @@ async def test_close(s, a, b):
     c = await Client(s.address, asynchronous=True)
     future = c.submit(inc, 1)
     await wait(future)
-    assert c.id in s.wants_what
+    assert c.id in s.clients
     await c.close()
 
-    while c.id in s.wants_what or s.tasks:
+    while c.id in s.clients or s.tasks:
         await asyncio.sleep(0.01)
 
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -63,7 +63,7 @@ async def test_nanny_process_failure(c, s):
 
         # assert n.worker_address != original_address  # most likely
 
-        while n.worker_address not in s.nthreads or n.worker_dir is None:
+        while n.worker_address not in s.workers or n.worker_dir is None:
             await asyncio.sleep(0.01)
 
         second_dir = n.worker_dir

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -109,7 +109,7 @@ async def test_submit(c, s, a, pause):
         high = c.submit(inc, 2, key="high", priority=1)
 
     await wait(high)
-    assert all(s.processing.values())
+    assert all(ws.processing for ws in s.workers.values())
     assert s.tasks[low.key].state == "processing"
     await ev.set()
     await wait(low)
@@ -124,7 +124,7 @@ async def test_map(c, s, a, pause):
         high = c.map(inc, [4, 5, 6], key=["h1", "h2", "h3"], priority=1)
 
     await wait(high)
-    assert all(s.processing.values())
+    assert all(ws.processing for ws in s.workers.values())
     assert all(s.tasks[fut.key].state == "processing" for fut in low)
     await ev.set()
     await clog
@@ -140,7 +140,7 @@ async def test_compute(c, s, a, pause):
         high = c.compute(dinc(2, dask_key_name="high"), priority=1)
 
     await wait(high)
-    assert all(s.processing.values())
+    assert all(ws.processing for ws in s.workers.values())
     assert s.tasks[low.key].state == "processing"
     await ev.set()
     await clog
@@ -156,7 +156,7 @@ async def test_persist(c, s, a, pause):
         high = dinc(2, dask_key_name="high").persist(priority=1)
 
     await wait(high)
-    assert all(s.processing.values())
+    assert all(ws.processing for ws in s.workers.values())
     assert s.tasks[low.key].state == "processing"
     await ev.set()
     await wait(clog)

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -60,7 +60,9 @@ async def test_publish_roundtrip(s, a, b):
     data = await c.scatter([0, 1, 2])
     await c.publish_dataset(data=data)
 
-    assert "published-data" in s.who_wants[data[0].key]
+    assert any(
+        cs.client_key == "published-data" for cs in s.tasks[data[0].key].who_wants
+    )
     result = await f.get_dataset(name="data")
 
     assert len(result) == len(data)
@@ -90,7 +92,7 @@ async def test_unpublish(c, s, a, b):
     assert "data" not in s.extensions["publish"].datasets
 
     start = time()
-    while key in s.who_wants:
+    while key in s.tasks:
         await asyncio.sleep(0.01)
         assert time() < start + 5
 

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -145,18 +145,18 @@ async def test_same_futures(c, s, a, b):
     for i in range(5):
         await q.put(future)
 
-    assert s.wants_what["queue-x"] == {future.key}
+    assert {ts.key for ts in s.clients["queue-x"].wants_what} == {future.key}
 
     for i in range(4):
         future2 = await q.get()
-        assert s.wants_what["queue-x"] == {future.key}
+        assert {ts.key for ts in s.clients["queue-x"].wants_what} == {future.key}
         await asyncio.sleep(0.05)
-        assert s.wants_what["queue-x"] == {future.key}
+        assert {ts.key for ts in s.clients["queue-x"].wants_what} == {future.key}
 
     await q.get()
 
     start = time()
-    while s.wants_what["queue-x"]:
+    while "queue-x" in s.clients and s.clients["queue-x"].wants_what:
         await asyncio.sleep(0.01)
         assert time() - start < 2
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -64,8 +64,7 @@ bob = "bob:1234"
 async def test_administration(s, a, b):
     assert isinstance(s.address, str)
     assert s.address in str(s)
-    assert str(sum(s.nthreads.values())) in repr(s)
-    assert str(len(s.nthreads)) in repr(s)
+    assert str(len(s.workers)) in repr(s)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
@@ -296,24 +295,6 @@ async def test_retire_workers_empty(s):
 
 
 @gen_cluster()
-async def test_remove_client(s, a, b):
-    s.update_graph(
-        tasks={"x": dumps_task((inc, 1)), "y": dumps_task((inc, "x"))},
-        dependencies={"x": [], "y": ["x"]},
-        keys=["y"],
-        client="ident",
-    )
-
-    assert s.tasks
-    assert s.dependencies
-
-    s.remove_client(client="ident")
-
-    assert not s.tasks
-    assert not s.dependencies
-
-
-@gen_cluster()
 async def test_server_listens_to_other_ops(s, a, b):
     with rpc(s.address) as r:
         ident = await r.identity()
@@ -332,7 +313,7 @@ async def test_remove_worker_from_scheduler(s, a, b):
 
     assert a.address in s.stream_comms
     await s.remove_worker(address=a.address)
-    assert a.address not in s.nthreads
+    assert a.address not in s.workers
     assert len(s.workers[b.address].processing) == len(dsk)  # b owns everything
 
 
@@ -340,21 +321,21 @@ async def test_remove_worker_from_scheduler(s, a, b):
 async def test_remove_worker_by_name_from_scheduler(s, a, b):
     assert a.address in s.stream_comms
     assert await s.remove_worker(address=a.name) == "OK"
-    assert a.address not in s.nthreads
+    assert a.address not in s.workers
     assert await s.remove_worker(address=a.address) == "already-removed"
 
 
 @gen_cluster(config={"distributed.scheduler.events-cleanup-delay": "10 ms"})
 async def test_clear_events_worker_removal(s, a, b):
     assert a.address in s.events
-    assert a.address in s.nthreads
+    assert a.address in s.workers
     assert b.address in s.events
-    assert b.address in s.nthreads
+    assert b.address in s.workers
 
     await s.remove_worker(address=a.address)
     # Shortly after removal, the events should still be there
     assert a.address in s.events
-    assert a.address not in s.nthreads
+    assert a.address not in s.workers
     s.validate_state()
 
     start = time()
@@ -432,14 +413,14 @@ async def test_scheduler_init_pulls_blocked_handlers_from_config(s):
 @gen_cluster()
 async def test_feed(s, a, b):
     def func(scheduler):
-        return dumps(dict(scheduler.worker_info))
+        return dumps(dict(scheduler.workers))
 
     comm = await connect(s.address)
     await comm.write({"op": "feed", "function": dumps(func), "interval": 0.01})
 
     for i in range(5):
         response = await comm.read()
-        expected = dict(s.worker_info)
+        expected = dict(s.workers)
         assert cloudpickle.loads(response) == expected
 
     await comm.close()
@@ -634,7 +615,6 @@ async def test_restart(c, s, a, b):
         assert not ws.processing
 
     assert not s.tasks
-    assert not s.dependencies
 
 
 @gen_cluster()
@@ -790,7 +770,6 @@ async def test_update_graph_culls(s, a, b):
         client="client",
     )
     assert "z" not in s.tasks
-    assert "z" not in s.dependencies
 
 
 def test_io_loop(loop):
@@ -859,7 +838,7 @@ async def test_retire_workers(c, s, a, b):
     workers = await s.retire_workers()
     assert list(workers) == [a.address]
     assert workers[a.address]["nthreads"] == a.nthreads
-    assert list(s.nthreads) == [b.address]
+    assert list(s.workers) == [b.address]
 
     assert s.workers_to_close() == []
 
@@ -920,14 +899,14 @@ async def test_workers_to_close_grouped(c, s, *workers):
 
     # Assert that job in one worker blocks closure of group
     future = c.submit(slowinc, 1, delay=0.2, workers=workers[0].address)
-    while len(s.rprocessing) < 1:
+    while not any(ws.processing for ws in s.workers.values()):
         await asyncio.sleep(0.001)
 
     assert set(s.workers_to_close(key=key)) == {workers[2].address, workers[3].address}
 
     del future
 
-    while len(s.rprocessing) > 0:
+    while any(ws.processing for ws in s.workers.values()):
         await asyncio.sleep(0.001)
 
     # Assert that *total* byte count in group determines group priority
@@ -962,7 +941,7 @@ async def test_file_descriptors(c, s):
     N = 20
     nannies = await asyncio.gather(*(Nanny(s.address, loop=s.loop) for _ in range(N)))
 
-    while len(s.nthreads) < N:
+    while len(s.workers) < N:
         await asyncio.sleep(0.1)
 
     num_fds_2 = proc.num_fds()
@@ -1529,13 +1508,13 @@ async def test_retries(c, s, a, b):
     result = await future
     assert result == 42
     assert s.tasks[future.key].retries == 1
-    assert future.key not in s.exceptions
+    assert not s.tasks[future.key].exception
 
     future = c.submit(varying(args), retries=2, pure=False)
     result = await future
     assert result == 42
     assert s.tasks[future.key].retries == 0
-    assert future.key not in s.exceptions
+    assert not s.tasks[future.key].exception
 
     future = c.submit(varying(args), retries=1, pure=False)
     with pytest.raises(ZeroDivisionError) as exc_info:

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -90,7 +90,7 @@ async def test_nanny(c, s, a, b):
         assert isinstance(n, Nanny)
         assert n.address.startswith("tls://")
         assert n.worker_address.startswith("tls://")
-    assert s.nthreads == {n.worker_address: n.nthreads for n in [a, b]}
+    assert set(s.workers) == {n.worker_address for n in [a, b]}
 
     x = c.submit(inc, 10)
     result = await x

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -52,7 +52,7 @@ async def test_gen_cluster(c, s, a, b):
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
-    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
+    assert set(s.workers) == {w.address for w in [a, b]}
     assert await c.submit(lambda: 123) == 123
 
 
@@ -132,7 +132,7 @@ async def test_gen_cluster_without_client(s, a, b):
     assert isinstance(s, Scheduler)
     for w in [a, b]:
         assert isinstance(w, Worker)
-    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
+    assert set(s.workers) == {w.address for w in [a, b]}
 
     async with Client(s.address, asynchronous=True) as c:
         future = c.submit(lambda x: x + 1, 1)
@@ -153,7 +153,7 @@ async def test_gen_cluster_tls(e, s, a, b):
     for w in [a, b]:
         assert isinstance(w, Worker)
         assert w.address.startswith("tls://")
-    assert s.nthreads == {w.address: w.nthreads for w in [a, b]}
+    assert set(s.workers) == {w.address for w in [a, b]}
 
 
 @pytest.mark.xfail(

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -214,7 +214,7 @@ async def test_race(c, s, *workers):
     futures = c.map(f, range(15))
     results = await c.gather(futures)
 
-    while len(s.wants_what["variable-x"]) != 1:
+    while "variable-x" in s.tasks:
         await asyncio.sleep(0.01)
 
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2720,7 +2720,7 @@ async def test_acquire_replicas(c, s, a, b):
 
     s.request_acquire_replicas(b.address, [fut.key], stimulus_id=f"test-{time()}")
 
-    while len(s.who_has[fut.key]) != 2:
+    while len(s.tasks[fut.key].who_has) != 2:
         await asyncio.sleep(0.005)
 
     for w in (a, b):
@@ -2746,7 +2746,7 @@ async def test_acquire_replicas_same_channel(c, s, a, b):
     while futA.key not in b.tasks or not b.tasks[futA.key].state == "memory":
         await asyncio.sleep(0.005)
 
-    while len(s.who_has[futA.key]) != 2:
+    while len(s.tasks[futA.key].who_has) != 2:
         await asyncio.sleep(0.005)
 
     # Ensure that both the replica and an ordinary dependency pass through the

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -31,13 +31,13 @@ async def test_submit_from_worker(c, s, a, b):
             return result
 
     x, y = c.map(func, [10, 20])
-    xx, yy = await c._gather([x, y])
+    xx, yy = await c.gather([x, y])
 
     assert xx == 10 + 1 + (10 + 1) * 2
     assert yy == 20 + 1 + (20 + 1) * 2
 
     assert len(s.transition_log) > 10
-    assert len([id for id in s.wants_what if id.lower().startswith("client")]) == 1
+    assert len([id for id in s.clients if id.lower().startswith("client")]) == 1
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
@@ -76,7 +76,7 @@ async def test_scatter_from_worker(c, s, a, b):
     assert result is True
 
     start = time()
-    while not all(v == 1 for v in s.nthreads.values()):
+    while not all(ws.nthreads == 1 for ws in s.workers.values()):
         await asyncio.sleep(0.1)
         assert time() < start + 5
 


### PR DESCRIPTION
These are a historical artifact of how we used to manage state in the
scheduler.  They were mostly around because lots of old tests depended
on this state.  I've gone through and manually updated all of the tests.

This PR is also a good example of what PRs to distributed used to look
like before we switched away from precise state-driven tests.
Thank goodness that 90% of our tests no longer dive into internal state.
