### PR TITLE
Relax test_asyncprocess.py::test_simple

### DIFF
--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -79,7 +79,7 @@ async def test_simple():
     t1 = time()
     await proc.join(timeout=0.02)
     dt = time() - t1
-    assert 0.2 >= dt >= 0.01
+    assert 0.2 >= dt >= 0.001
     assert proc.is_alive()
     assert proc.pid is not None
     assert proc.exitcode is None


### PR DESCRIPTION
The timeout here can be a little faster than expected

Observed in https://github.com/dask/distributed/runs/6055427183?check_suite_focus=true

This hopefully helps to resolve an intermittent test

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
