### PR TITLE
Handle int worker names in info page

### DIFF
--- a/distributed/http/templates/workers.html
+++ b/distributed/http/templates/workers.html
@@ -5,7 +5,7 @@
 
   <a class="button is-primary" href="logs.html">Logs</a>
   <a class="button is-primary" href="../../status">Bokeh</a>
-  {% set worker_list = sorted(workers.values(), key=lambda ws: ws.name) %}
+  {% set worker_list = sorted(workers.values(), key=lambda ws: str(ws.name)) %}
   {% include "worker-table.html" %}
 
 {% end %}


### PR DESCRIPTION
#6135 introduced a regression(?) when running on `dask_kubernetes`: the default worker names in that context are integers `0`, `1`, ....; now the Info page fails to render with
```
2022-04-19 19:15:40,782 - distributed.utils - ERROR - '<' not supported between instances of 'str' and 'int'
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/distributed/utils.py", line 693, in log_errors
    yield
  File "/usr/local/lib/python3.9/site-packages/distributed/http/scheduler/info.py", line 34, in get
    self.render(
  File "/usr/local/lib/python3.9/site-packages/tornado/web.py", line 863, in render
    html = self.render_string(template_name, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/tornado/web.py", line 1012, in render_string
    return t.generate(**namespace)
  File "/usr/local/lib/python3.9/site-packages/tornado/template.py", line 362, in generate
    return execute()
  File "workers_html.generated.py", line 24, in _tt_execute
    worker_list = sorted(workers.values(), key=lambda ws: ws.name)  # workers.html:8 (via main.html:10)
```
I can certainly see an argument that these names ought to be `str` already...but since that wasn't enforced previously, it still seems a bit more generous to just allow that case for now. @mrocklin what do you think?