### PR TITLE
Refactor ensure_communicating

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -623,7 +623,7 @@ class Server:
                         "Failed while closing connection to %r: %s", address, e
                     )
 
-    async def handle_stream(self, comm, extra=None, every_cycle=()):
+    async def handle_stream(self, comm, extra=None):
         extra = extra or {}
         logger.info("Starting established connection")
 
@@ -652,12 +652,6 @@ class Server:
                         else:
                             logger.error("odd message %s", msg)
                     await asyncio.sleep(0)
-
-                for func in every_cycle:
-                    if is_coroutine_function(func):
-                        self.loop.add_callback(func)
-                    else:
-                        func()
 
         except OSError:
             pass

--- a/distributed/tests/test_stories.py
+++ b/distributed/tests/test_stories.py
@@ -134,14 +134,11 @@ async def test_worker_story_with_deps(c, s, a, b):
 
     story = a.story("res")
     assert story == []
-    story = b.story("res")
 
     # Story now includes randomized stimulus_ids and timestamps.
-    stimulus_ids = {ev[-2] for ev in story}
-    # Compute dep
-    # Success dep
-    # Compute res
-    assert len(stimulus_ids) == 3
+    story = b.story("res")
+    stimulus_ids = {ev[-2].rsplit("-", 1)[0] for ev in story}
+    assert stimulus_ids == {"compute-task", "task-finished"}
 
     # This is a simple transition log
     expected = [
@@ -155,8 +152,8 @@ async def test_worker_story_with_deps(c, s, a, b):
     assert_story(story, expected, strict=True)
 
     story = b.story("dep")
-    stimulus_ids = {ev[-2] for ev in story}
-    assert len(stimulus_ids) == 2, stimulus_ids
+    stimulus_ids = {ev[-2].rsplit("-", 1)[0] for ev in story}
+    assert stimulus_ids == {"compute-task"}
     expected = [
         ("dep", "ensure-task-exists", "released"),
         ("dep", "released", "fetch", "fetch", {}),

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -631,11 +631,13 @@ async def test_clean(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_message_breakup(c, s, a, b):
-    n = 100000
+    n = 100_000
     a.target_message_size = 10 * n
     b.target_message_size = 10 * n
-    xs = [c.submit(mul, b"%d" % i, n, workers=a.address) for i in range(30)]
-    y = c.submit(lambda *args: None, xs, workers=b.address)
+    xs = [
+        c.submit(mul, b"%d" % i, n, key=f"x{i}", workers=[a.address]) for i in range(30)
+    ]
+    y = c.submit(lambda _: None, xs, key="y", workers=[b.address])
     await y
 
     assert 2 <= len(b.incoming_transfer_log) <= 20

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3051,7 +3051,7 @@ async def test_missing_released_zombie_tasks_2(c, s, b):
             await asyncio.sleep(0)
 
         ts = b.tasks[f1.key]
-        assert ts.state == "fetch"
+        assert ts.state == "flight"
 
         while ts.state != "missing":
             # If we sleep for a longer time, the worker will spin into an

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1424,21 +1424,13 @@ def assert_amm_transfer_story(key: str, w_from: Worker, w_to: Worker) -> None:
     assert_story(
         w_to.story(key),
         [
-            (key, "ensure-task-exists", "released"),
-            (key, "released", "fetch", "fetch", {}),
-            ("gather-dependencies", w_from.address, lambda set_: key in set_),
             (key, "fetch", "flight", "flight", {}),
             ("request-dep", w_from.address, lambda set_: key in set_),
             ("receive-dep", w_from.address, lambda set_: key in set_),
             (key, "put-in-memory"),
             (key, "flight", "memory", "memory", {}),
         ],
-        # There may be additional ('missing', 'fetch', 'fetch') events if transfers
-        # are slow enough that the Active Memory Manager ends up requesting them a
-        # second time. Here we're asserting that no matter how slow CI is, all
-        # transfers will be completed within 2 seconds (hardcoded interval in
-        # Scheduler.retire_worker when AMM is not enabled).
-        strict=True,
+        strict=False,
     )
     assert key in w_to.data
     # The key may or may not still be in w_from.data, depending if the AMM had the

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2964,7 +2964,7 @@ class Worker(ServerNode):
                     assert d_ts not in recommendations
                 recommendations[d_ts] = ("flight", worker)
 
-            # A single iteration of _ensure_communicating may generate up to 1 GatherDep
+            # A single invocation of _ensure_communicating may generate up to 1 GatherDep
             # instruction per worker. Multiple tasks from the same worker may be
             # clustered in the same instruction by _select_keys_for_gather. But once
             # a worker has been selected for a GatherDep and added to in_flight_workers,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2809,7 +2809,7 @@ class Worker(ServerNode):
     @fail_hard
     def _handle_instructions(self, instructions: Instructions) -> None:
         while instructions:
-            ensure_communicating = None
+            ensure_communicating: EnsureCommunicatingAfterTransitions | None = None
             for inst in instructions:
                 task: asyncio.Task | None = None
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2964,9 +2964,9 @@ class Worker(ServerNode):
                     assert d_ts not in recommendations
                 recommendations[d_ts] = ("flight", worker)
 
-            # A single invocation of _ensure_communicating may generate up to 1 GatherDep
-            # instruction per worker. Multiple tasks from the same worker may be
-            # clustered in the same instruction by _select_keys_for_gather. But once
+            # A single invocation of _ensure_communicating may generate up to one
+            # GatherDep instruction per worker. Multiple tasks from the same worker may
+            # be clustered in the same instruction by _select_keys_for_gather. But once
             # a worker has been selected for a GatherDep and added to in_flight_workers,
             # it won't be selected again until the gather completes.
             instructions.append(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2811,7 +2811,7 @@ class Worker(ServerNode):
         while instructions:
             ensure_communicating = None
             for inst in instructions:
-                task = None
+                task: asyncio.Task | None = None
 
                 if isinstance(inst, SendMessageToScheduler):
                     self.batched_stream.send(inst.to_dict())

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1992,6 +1992,10 @@ class Worker(ServerNode):
             ts.dependencies.add(dep_ts)
             dep_ts.dependents.add(ts)
 
+        if nbytes is not None:
+            for key, value in nbytes.items():
+                self.tasks[key].nbytes = value
+
         if ts.state in READY | {"executing", "waiting", "resumed"}:
             pass
         elif ts.state == "memory":
@@ -2014,10 +2018,6 @@ class Worker(ServerNode):
         self._handle_instructions(instructions)
         self.update_who_has(who_has)
         self.transitions(recommendations, stimulus_id=stimulus_id)
-
-        if nbytes is not None:
-            for key, value in nbytes.items():
-                self.tasks[key].nbytes = value
 
     def _add_to_data_needed(self, ts: TaskState, stimulus_id: str) -> RecsInstrs:
         self.data_needed.push(ts)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2966,7 +2966,9 @@ class Worker(ServerNode):
 
             # A single iteration of _ensure_communicating may generate up to 1 GatherDep
             # instruction per worker. Multiple tasks from the same worker may be
-            # clustered in the same instruction by _select_keys_for_gather.
+            # clustered in the same instruction by _select_keys_for_gather. But once
+            # a worker has been selected for a GatherDep and added to in_flight_workers,
+            # it won't be selected again until the gather completes.
             instructions.append(
                 GatherDep(
                     worker=worker,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2863,6 +2863,8 @@ class Worker(ServerNode):
                     stimulus_id=ensure_communicating.stimulus_id
                 )
                 self.transitions(recs, stimulus_id=ensure_communicating.stimulus_id)
+            else:
+                instructions = []
 
     def maybe_transition_long_running(
         self, ts: TaskState, *, compute_duration: float, stimulus_id: str

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -259,18 +259,13 @@ class Instruction:
     __slots__ = ()
 
 
-# TODO https://github.com/dask/distributed/issues/5736
-
-# @dataclass
-# class GatherDep(Instruction):
-#    __slots__ = ("worker", "to_gather")
-#    worker: str
-#    to_gather: set[str]
-
-
-# @dataclass
-# class FindMissing(Instruction):
-#    __slots__ = ()
+@dataclass
+class GatherDep(Instruction):
+    worker: str
+    to_gather: set[str]
+    total_nbytes: int
+    stimulus_id: str
+    __slots__ = tuple(__annotations__)  # type: ignore
 
 
 @dataclass
@@ -431,6 +426,13 @@ class StateMachineEvent:
 
 @dataclass
 class UnpauseEvent(StateMachineEvent):
+    __slots__ = ()
+
+
+@dataclass
+class GatherDepDoneEvent(StateMachineEvent):
+    """Temporary hack - to be removed"""
+
     __slots__ = ()
 
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -288,7 +288,7 @@ class SendMessageToScheduler(Instruction):
 
 
 @dataclass
-class EnsureCommunicatingLater(Instruction):
+class EnsureCommunicatingAfterTransitions(Instruction):
     __slots__ = ("stimulus_id",)
     stimulus_id: str
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -288,6 +288,12 @@ class SendMessageToScheduler(Instruction):
 
 
 @dataclass
+class EnsureCommunicatingLater(Instruction):
+    __slots__ = ("stimulus_id",)
+    stimulus_id: str
+
+
+@dataclass
 class TaskFinishedMsg(SendMessageToScheduler):
     op = "task-finished"
 


### PR DESCRIPTION
Partially closes #5896 

## In scope for this PR
- Refactor ``ensure_communicating() -> None`` to ``_ensure_communicating() -> RecsInstr``
- Remove ``self.loop.add_callback(self.gather_dep, ...)``
- ``ensure_communicating`` is no longer called periodically "just in case" - neither from ``every_cycle`` nor from ``find_missing``
## Out of scope for this PR, but in scope for #5896 
- Refactor ``gather_dep``
- Get rid of ``GatherDepDoneEvent`` (introduced in this PR)
- Refactor ``_readd_busy_worker`` as an async instruction
## Out of scope for #5896 
- Refactor ``find_missing``
- Get rid of ``EnsureCommunicatingLater`` (introduced in this PR) and ``_select_keys_for_gather``