### PR TITLE
Remove experimental feature warning from actors docs

### DIFF
--- a/docs/source/actors.rst
+++ b/docs/source/actors.rst
@@ -227,5 +227,3 @@ Actors offer advanced capabilities, but with some cost:
     computations no diagnostics are available about these computations.
 3.  **No Load balancing:** Actors are allocated onto workers evenly, without
     serious consideration given to avoiding communication.
-4.  **Experimental:** Actors are a new feature and subject to change without
-    warning


### PR DESCRIPTION
**What does this PR implement?**
Remove "experimental" warning at the bottom of the actor's page.

**Reference issues/PRs**
This PR mirrors #5108 and https://github.com/dask/dask/pull/7925.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
