### PR TITLE
avoid some easy deprecated calls to asyncio.get_event_loop()

### DIFF
--- a/distributed/cli/dask_spec.py
+++ b/distributed/cli/dask_spec.py
@@ -36,7 +36,7 @@ def main(args, spec: str, spec_file: str):
         except KeyboardInterrupt:
             await asyncio.gather(*(w.close() for w in servers.values()))
 
-    asyncio.get_event_loop().run_until_complete(run())
+    asyncio.run(run())
 
 
 if __name__ == "__main__":

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -373,7 +373,7 @@ class SpecCluster(Cluster):
                 dask.config.get("distributed.deploy.lost-worker-timeout")
             )
 
-            asyncio.get_event_loop().call_later(delay, f)
+            asyncio.get_running_loop().call_later(delay, f)
         super()._update_worker_status(op, msg)
 
     def __await__(self):

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -380,15 +380,19 @@ async def test_adapt_cores_memory():
         assert adapt.maximum == 5
 
 
-def test_adaptive_config():
+@gen_test()
+async def test_adaptive_config():
     with dask.config.set(
         {"distributed.adaptive.minimum": 10, "distributed.adaptive.wait-count": 8}
     ):
-        adapt = Adaptive(interval="5s")
-        assert adapt.minimum == 10
-        assert adapt.maximum == math.inf
-        assert adapt.interval == 5
-        assert adapt.wait_count == 8
+        try:
+            adapt = Adaptive(interval="5s")
+            assert adapt.minimum == 10
+            assert adapt.maximum == math.inf
+            assert adapt.interval == 5
+            assert adapt.wait_count == 8
+        finally:
+            adapt.stop()
 
 
 @gen_test()

--- a/distributed/tests/test_spec.py
+++ b/distributed/tests/test_spec.py
@@ -1,18 +1,22 @@
 from distributed.deploy.spec import ProcessInterface
+from distributed.utils_test import gen_test
 
 
-def test_address_default_none():
-    p = ProcessInterface()
-    assert p.address is None
+@gen_test()
+async def test_address_default_none():
+    async with ProcessInterface() as p:
+        assert p.address is None
 
 
-def test_child_address_persists():
+@gen_test()
+async def test_child_address_persists():
     class Child(ProcessInterface):
         def __init__(self, address=None):
             self.address = address
             super().__init__()
 
-    c = Child()
-    assert c.address is None
-    c = Child("localhost")
-    assert c.address == "localhost"
+    async with Child() as c:
+        assert c.address is None
+
+    async with Child("localhost") as c:
+        assert c.address == "localhost"

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -122,10 +122,11 @@ def test_sync_timeout(loop_in_thread):
 
 
 def test_sync_closed_loop():
-    loop = IOLoop.current()
+    async def get_loop():
+        return IOLoop.current()
+
+    loop = asyncio.run(get_loop())
     loop.close()
-    IOLoop.clear_current()
-    IOLoop.clear_instance()
 
     with pytest.raises(RuntimeError) as exc_info:
         sync(loop, inc, 1)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1312,7 +1312,7 @@ def import_term(name: str):
 
 
 async def offload(fn, *args, **kwargs):
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     # Retain context vars while deserializing; see https://bugs.python.org/issue34014
     context = contextvars.copy_context()
     return await loop.run_in_executor(


### PR DESCRIPTION
when using `asyncio.run` in `gen_test` test that later call `asyncio.get_event_loop()` fail - even before python3.10:


```python
import asyncio

async def amain():
    pass

asyncio.run(amain())
asyncio.get_event_loop()
```

```pytb
Traceback (most recent call last):
  File "foo.py", line 7, in <module>
    asyncio.get_event_loop()
  File "/usr/lib/python3.8/asyncio/events.py", line 639, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'MainThread'.
```

* use `gen_test` for tests that acquire `IOLoop.current()`
* use `get_running_loop()` instead of `get_event_loop()`
* use `asyncio.run()` instead of `asyncio.get_event_loop().run_until_complete()`

- [ ] re https://github.com/dask/distributed/issues/6164
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
