### PR TITLE
Deprecate rpc synchronous context manager

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -884,6 +884,11 @@ class rpc:
         return await asyncio.gather(*self.close_comms())
 
     def __enter__(self):
+        warnings.warn(
+            "the rpc synchronous context manager is deprecated",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -949,9 +954,20 @@ class PooledRPCCall:
 
     # For compatibility with rpc()
     def __enter__(self):
+        warnings.warn(
+            "the rpc synchronous context manager is deprecated",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
         pass
 
     def __repr__(self):

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -489,7 +489,7 @@ async def test_errors():
     async with Server({"div": stream_div}) as server:
         await server.listen(0)
 
-        with rpc(("127.0.0.1", server.port)) as r:
+        async with rpc(("127.0.0.1", server.port)) as r:
             with pytest.raises(ZeroDivisionError):
                 await r.div(x=1, y=0)
 
@@ -820,7 +820,7 @@ async def test_compression(compression, serialize):
         async with Server({"echo": serialize}) as server:
             await server.listen("tcp://")
 
-            with rpc(server.address) as r:
+            async with rpc(server.address) as r:
                 data = b"1" * 1000000
                 result = await r.echo(x=to_serialize(data))
                 assert result == {"result": data}

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -79,7 +79,7 @@ async def test_nanny_process_failure(c, s):
 @gen_cluster(nthreads=[])
 async def test_run(s):
     async with Nanny(s.address, nthreads=2) as n:
-        with rpc(n.address) as nn:
+        async with rpc(n.address) as nn:
             response = await nn.run(function=dumps(lambda: 1))
             assert response["status"] == "OK"
             assert response["result"] == 1
@@ -401,7 +401,7 @@ async def test_lifetime(s):
 @gen_cluster(client=True, nthreads=[])
 async def test_nanny_closes_cleanly_2(c, s):
     async with Nanny(s.address) as n:
-        with c.rpc(n.worker_address) as w:
+        async with c.rpc(n.worker_address) as w:
             IOLoop.current().add_callback(w.terminate)
             start = time()
             while n.status != Status.closed:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -297,7 +297,7 @@ async def test_retire_workers_empty(s):
 
 @gen_cluster()
 async def test_server_listens_to_other_ops(s, a, b):
-    with rpc(s.address) as r:
+    async with rpc(s.address) as r:
         ident = await r.identity()
         assert ident["type"] == "Scheduler"
         assert ident["id"].lower().startswith("scheduler")

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -39,12 +39,15 @@ def test_bare_cluster(loop):
         pass
 
 
-def test_cluster(loop):
+def test_cluster(cleanup):
+    async def identity():
+        async with rpc(s["address"]) as scheduler_rpc:
+            return await scheduler_rpc.identity()
+
     with cluster() as (s, [a, b]):
-        with rpc(s["address"]) as s:
-            ident = loop.run_sync(s.identity)
-            assert ident["type"] == "Scheduler"
-            assert len(ident["workers"]) == 2
+        ident = asyncio.run(identity())
+        assert ident["type"] == "Scheduler"
+        assert len(ident["workers"]) == 2
 
 
 @gen_cluster(client=True)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -765,7 +765,7 @@ async def disconnect(addr, timeout=3, rpc_kwargs=None):
     rpc_kwargs = rpc_kwargs or {}
 
     async def do_disconnect():
-        with rpc(addr, **rpc_kwargs) as w:
+        async with rpc(addr, **rpc_kwargs) as w:
             # If the worker was killed hard (e.g. sigterm) during test runtime,
             # we do not know at this point and may not be able to connect
             with suppress(EnvironmentError, CommClosedError):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -60,8 +60,9 @@ from distributed.core import (
     coerce_to_address,
     error_message,
     pingpong,
-    send_recv,
 )
+from distributed.core import rpc as RPCType
+from distributed.core import send_recv
 from distributed.diagnostics import nvml
 from distributed.diagnostics.plugin import _get_plugin_name
 from distributed.diskutils import WorkDir, WorkSpace
@@ -4822,7 +4823,7 @@ def benchmark_memory(
 
 async def benchmark_network(
     address: str,
-    rpc: ConnectionPool,
+    rpc: ConnectionPool | Callable[[str], RPCType],
     sizes: Iterable[str] = ("1 kiB", "10 kiB", "100 kiB", "1 MiB", "10 MiB", "50 MiB"),
     duration="1 s",
 ) -> dict[str, float]:
@@ -4837,7 +4838,7 @@ async def benchmark_network(
 
     duration = parse_timedelta(duration)
     out = {}
-    with rpc(address) as r:
+    async with rpc(address) as r:
         for size_str in sizes:
             size = parse_bytes(size_str)
             data = to_serialize(randbytes(size))

--- a/docs/source/foundations.rst
+++ b/docs/source/foundations.rst
@@ -154,7 +154,7 @@ with the stream data case above.
        # comm = await connect('tcp://127.0.0.1', 8888)
        # await comm.write({'op': 'add', 'x': 1, 'y': 2})
        # result = await comm.read()
-       with rpc('tcp://127.0.0.1:8888') as r:
+       async with rpc('tcp://127.0.0.1:8888') as r:
            result = await r.add(x=1, y=2)
 
        print(result)


### PR DESCRIPTION
the synchronous version often results in `unawaited coroutine
'rpc.close_rpc'` - or if `close_rpc()` raises an exception it's lost

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
