### PR TITLE
Remove unittestmock for gather_dep and get_data_from_worker

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4451,7 +4451,9 @@ class Scheduler(SchedulerState, ServerNode):
         assert not ts.waiting_on
         assert ts not in self.unrunnable
         for dts in ts.dependents:
-            assert (dts in ts.waiters) == (dts.state in ("waiting", "processing"))
+            assert (dts in ts.waiters) == (
+                dts.state in ("waiting", "processing", "no-worker")
+            )
             assert ts not in dts.waiting_on
 
     def validate_no_worker(self, key):
@@ -7440,7 +7442,7 @@ def validate_task_state(ts: TaskState):
             str(dts),
             str(dts.dependents),
         )
-        if ts.state in ("waiting", "processing"):
+        if ts.state in ("waiting", "processing", "no-worker"):
             assert dts in ts.waiting_on or dts.who_has, (
                 "dep missing",
                 str(ts),
@@ -7449,7 +7451,7 @@ def validate_task_state(ts: TaskState):
         assert dts.state != "forgotten"
 
     for dts in ts.waiters:
-        assert dts.state in ("waiting", "processing"), (
+        assert dts.state in ("waiting", "processing", "no-worker"), (
             "waiter not in play",
             str(ts),
             str(dts),

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -1,9 +1,7 @@
 import asyncio
-from unittest import mock
 
 import distributed
-from distributed import Event
-from distributed.core import CommClosedError
+from distributed import Event, Worker
 from distributed.utils_test import (
     _LockedCommPool,
     assert_worker_story,
@@ -140,20 +138,18 @@ async def test_worker_stream_died_during_comm(c, s, a, b):
     assert any("receive-dep-failed" in msg for msg in b.log)
 
 
-@gen_cluster(client=True)
-async def test_flight_to_executing_via_cancelled_resumed(c, s, a, b):
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_flight_to_executing_via_cancelled_resumed(c, s, b):
+
     lock = asyncio.Lock()
     await lock.acquire()
 
-    async def wait_and_raise(*args, **kwargs):
-        async with lock:
-            raise CommClosedError()
+    class BrokenWorker(Worker):
+        async def get_data(self, comm, *args, **kwargs):
+            async with lock:
+                comm.abort()
 
-    with mock.patch.object(
-        distributed.worker,
-        "get_data_from_worker",
-        side_effect=wait_and_raise,
-    ):
+    async with BrokenWorker(s.address) as a:
         fut1 = c.submit(inc, 1, workers=[a.address], allow_other_workers=True)
         fut2 = c.submit(inc, fut1, workers=[b.address])
 
@@ -163,13 +159,13 @@ async def test_flight_to_executing_via_cancelled_resumed(c, s, a, b):
         await s.close_worker(worker=a.address)
         await wait_for_state(fut1.key, "resumed", b)
 
-    lock.release()
-    assert await fut2 == 3
+        lock.release()
+        assert await fut2 == 3
 
-    b_story = b.story(fut1.key)
-    assert any("receive-dep-failed" in msg for msg in b_story)
-    assert any("cancelled" in msg for msg in b_story)
-    assert any("resumed" in msg for msg in b_story)
+        b_story = b.story(fut1.key)
+        assert any("receive-dep-failed" in msg for msg in b_story)
+        assert any("cancelled" in msg for msg in b_story)
+        assert any("resumed" in msg for msg in b_story)
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
@@ -211,37 +207,36 @@ async def test_executing_cancelled_error(c, s, w):
     assert ("error", "released", "released") in start_finish
 
 
-@gen_cluster(client=True)
-async def test_flight_cancelled_error(c, s, a, b):
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_flight_cancelled_error(c, s, b):
     """One worker with one thread. We provoke an flight->cancelled transition
     and let the task err."""
     lock = asyncio.Lock()
     await lock.acquire()
 
-    async def wait_and_raise(*args, **kwargs):
-        async with lock:
-            raise RuntimeError()
+    class BrokenWorker(Worker):
+        block_get_data = True
 
-    with mock.patch.object(
-        distributed.worker,
-        "get_data_from_worker",
-        side_effect=wait_and_raise,
-    ):
+        async def get_data(self, comm, *args, **kwargs):
+            if self.block_get_data:
+                async with lock:
+                    comm.abort()
+            return await super().get_data(comm, *args, **kwargs)
+
+    async with BrokenWorker(s.address) as a:
         fut1 = c.submit(inc, 1, workers=[a.address], allow_other_workers=True)
         fut2 = c.submit(inc, fut1, workers=[b.address])
-
         await wait_for_state(fut1.key, "flight", b)
         fut2.release()
         fut1.release()
         await wait_for_state(fut1.key, "cancelled", b)
-
-    lock.release()
-    # At this point we do not fetch the result of the future since the future
-    # itself would raise a cancelled exception. At this point we're concerned
-    # about the worker. The task should transition over error to be eventually
-    # forgotten since we no longer hold a ref.
-    while fut1.key in b.tasks:
-        await asyncio.sleep(0.01)
-
-    # Everything should still be executing as usual after this
-    assert await c.submit(sum, c.map(inc, range(10))) == sum(map(inc, range(10)))
+        lock.release()
+        # At this point we do not fetch the result of the future since the
+        # future itself would raise a cancelled exception. At this point we're
+        # concerned about the worker. The task should transition over error to
+        # be eventually forgotten since we no longer hold a ref.
+        while fut1.key in b.tasks:
+            await asyncio.sleep(0.01)
+        a.block_get_data = False
+        # Everything should still be executing as usual after this
+        assert await c.submit(sum, c.map(inc, range(10))) == sum(map(inc, range(10)))

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3043,16 +3043,17 @@ async def test_missing_released_zombie_tasks(c, s, a, b):
         await asyncio.sleep(0.01)
 
 
-@gen_cluster(client=True)
-async def test_missing_released_zombie_tasks_2(c, s, a, b):
+class BrokenWorker(Worker):
+    async def get_data(self, comm, *args, **kwargs):
+        comm.abort()
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_missing_released_zombie_tasks_2(c, s, b):
     # If get_data_from_worker raises this will suggest a dead worker to B and it
     # will transition the task to missing. We want to make sure that a missing
     # task is properly released and not left as a zombie
-    with mock.patch.object(
-        distributed.worker,
-        "get_data_from_worker",
-        side_effect=CommClosedError,
-    ):
+    async with BrokenWorker(s.address) as a:
         f1 = c.submit(inc, 1, key="f1", workers=[a.address])
         f2 = c.submit(inc, f1, key="f2", workers=[b.address])
 
@@ -3188,8 +3189,8 @@ async def test_task_flight_compute_oserror(c, s, a, b):
     assert_worker_story(sum_story, expected_sum_story, strict=True)
 
 
-@gen_cluster(client=True)
-async def test_gather_dep_cancelled_rescheduled(c, s, a, b):
+@gen_cluster(client=True, nthreads=[])
+async def test_gather_dep_cancelled_rescheduled(c, s):
     """At time of writing, the gather_dep implementation filtered tasks again
     for in-flight state. The response parser, however, did not distinguish
     resulting in unwanted missing-data signals to the scheduler, causing
@@ -3207,74 +3208,87 @@ async def test_gather_dep_cancelled_rescheduled(c, s, a, b):
 
     See also test_gather_dep_do_not_handle_response_of_not_requested_tasks
     """
-    import distributed
+    in_gather_dep = asyncio.Event()
+    gather_dep_finished = asyncio.Event()
+    block_gather_dep = asyncio.Lock()
+    await block_gather_dep.acquire()
 
-    with mock.patch.object(distributed.worker.Worker, "gather_dep") as mocked_gather:
-        fut1 = c.submit(inc, 1, workers=[a.address], key="f1")
-        fut2 = c.submit(inc, fut1, workers=[a.address], key="f2")
-        await fut2
-        fut4 = c.submit(sum, fut1, fut2, workers=[b.address], key="f4")
-        fut3 = c.submit(inc, fut1, workers=[b.address], key="f3")
+    class InstrumentedWorker(Worker):
+        async def gather_dep(self, *args, **kwargs):
+            in_gather_dep.set()
+            async with block_gather_dep:
+                try:
+                    return await super().gather_dep(*args, **kwargs)
+                finally:
+                    gather_dep_finished.set()
 
-        fut2_key = fut2.key
+    block_get_data = asyncio.Lock()
+    in_get_data = asyncio.Event()
 
-        await _wait_for_state(fut2_key, b, "flight")
-        while not mocked_gather.call_args:
-            await asyncio.sleep(0)
+    class BlockedGetData(Worker):
+        async def get_data(self, comm, *args, **kwargs):
+            in_get_data.set()
+            async with block_get_data:
+                return await super().get_data(comm, *args, **kwargs)
 
-        fut4.release()
-        while fut4.key in b.tasks:
-            await asyncio.sleep(0)
+    async with BlockedGetData(s.address) as a:
+        async with InstrumentedWorker(s.address) as b:
+            fut1 = c.submit(inc, 1, workers=[a.address], key="f1")
+            fut2 = c.submit(inc, fut1, workers=[a.address], key="f2")
+            await fut2
+            await block_get_data.acquire()
+            fut4 = c.submit(sum, fut1, fut2, workers=[b.address], key="f4")
+            fut3 = c.submit(inc, fut1, workers=[b.address], key="f3")
 
-    assert b.tasks[fut2.key].state == "cancelled"
-    args, kwargs = mocked_gather.call_args
-    assert fut2.key in kwargs["to_gather"]
+            fut2_key = fut2.key
 
-    # The below synchronization and mock structure allows us to intercept the
-    # state after gather_dep has been scheduled and is waiting for the
-    # get_data_from_worker to finish. If state transitions happen during this
-    # time, the response parser needs to handle this properly
-    lock = asyncio.Lock()
-    event = asyncio.Event()
-    async with lock:
+            await _wait_for_state(fut2_key, b, "flight")
+            await in_gather_dep.wait()
 
-        async def wait_get_data(*args, **kwargs):
-            event.set()
-            async with lock:
-                return await distributed.worker.get_data_from_worker(*args, **kwargs)
+            fut4.release()
+            while fut4.key in b.tasks:
+                await asyncio.sleep(0)
 
-        with mock.patch.object(
-            distributed.worker,
-            "get_data_from_worker",
-            side_effect=wait_get_data,
-        ):
-            gather_dep_fut = asyncio.ensure_future(
-                Worker.gather_dep(b, *args, **kwargs)
-            )
+            assert b.tasks[fut2.key].state == "cancelled"
 
-            await event.wait()
+            block_gather_dep.release()
+
+            await in_get_data.wait()
 
             fut4 = c.submit(sum, [fut1, fut2], workers=[b.address], key="f4")
             while b.tasks[fut2.key].state != "flight":
                 await asyncio.sleep(0.1)
-    await gather_dep_fut
-    f2_story = b.story(fut2.key)
-    assert f2_story
-    await fut3
-    await fut4
+            block_get_data.release()
+            await gather_dep_finished.wait()
+            f2_story = b.story(fut2.key)
+            assert f2_story
+            await fut3
+            await fut4
 
 
-@gen_cluster(client=True)
-async def test_gather_dep_do_not_handle_response_of_not_requested_tasks(c, s, a, b):
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_gather_dep_do_not_handle_response_of_not_requested_tasks(c, s, a):
     """At time of writing, the gather_dep implementation filtered tasks again
     for in-flight state. The response parser, however, did not distinguish
     resulting in unwanted missing-data signals to the scheduler, causing
     potential rescheduling or data leaks.
     This test may become obsolete if the implementation changes significantly.
     """
-    import distributed
+    in_gather_dep = asyncio.Event()
+    gather_dep_finished = asyncio.Event()
+    block_gather_dep = asyncio.Lock()
+    await block_gather_dep.acquire()
 
-    with mock.patch.object(distributed.worker.Worker, "gather_dep") as mocked_gather:
+    class InstrumentedWorker(Worker):
+        async def gather_dep(self, *args, **kwargs):
+            in_gather_dep.set()
+            async with block_gather_dep:
+                try:
+                    return await super().gather_dep(*args, **kwargs)
+                finally:
+                    gather_dep_finished.set()
+
+    async with InstrumentedWorker(s.address) as b:
         fut1 = c.submit(inc, 1, workers=[a.address], key="f1")
         fut2 = c.submit(inc, fut1, workers=[a.address], key="f2")
         await fut2
@@ -3284,77 +3298,104 @@ async def test_gather_dep_do_not_handle_response_of_not_requested_tasks(c, s, a,
         fut2_key = fut2.key
 
         await _wait_for_state(fut2_key, b, "flight")
-        while not mocked_gather.call_args:
-            await asyncio.sleep(0)
+
+        await in_gather_dep.wait()
 
         fut4.release()
         while fut4.key in b.tasks:
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.05)
 
-    assert b.tasks[fut2.key].state == "cancelled"
-    args, kwargs = mocked_gather.call_args
-    assert fut2.key in kwargs["to_gather"]
+        assert b.tasks[fut2.key].state == "cancelled"
 
-    await Worker.gather_dep(b, *args, **kwargs)
-    assert fut2.key not in b.tasks
-    f2_story = b.story(fut2.key)
-    assert f2_story
-    assert not any("missing-dep" in msg for msg in f2_story)
-    await fut3
+        block_gather_dep.release()
+        await gather_dep_finished.wait()
+
+        assert fut2.key not in b.tasks
+        f2_story = b.story(fut2.key)
+        assert f2_story
+        assert not any("missing-dep" in msg for msg in f2_story)
+        await fut3
 
 
 @gen_cluster(
     client=True,
+    nthreads=[("", 1)],
     config={
         "distributed.comm.recent-messages-log-length": 1000,
     },
 )
-async def test_gather_dep_no_longer_in_flight_tasks(c, s, a, b):
-    import distributed
+async def test_gather_dep_no_longer_in_flight_tasks(c, s, a):
+    in_gather_dep = asyncio.Event()
+    gather_dep_finished = asyncio.Event()
+    block_gather_dep = asyncio.Lock()
+    await block_gather_dep.acquire()
 
-    with mock.patch.object(distributed.worker.Worker, "gather_dep") as mocked_gather:
+    class InstrumentedWorker(Worker):
+        async def gather_dep(self, *args, **kwargs):
+            in_gather_dep.set()
+            async with block_gather_dep:
+                try:
+                    return await super().gather_dep(*args, **kwargs)
+                finally:
+                    gather_dep_finished.set()
+
+    async with InstrumentedWorker(s.address) as b:
         fut1 = c.submit(inc, 1, workers=[a.address], key="f1")
         fut2 = c.submit(sum, fut1, fut1, workers=[b.address], key="f2")
 
         fut1_key = fut1.key
 
         await _wait_for_state(fut1_key, b, "flight")
-        while not mocked_gather.call_args:
-            await asyncio.sleep(0)
+        await in_gather_dep.wait()
 
         fut2.release()
         while fut2.key in b.tasks:
             await asyncio.sleep(0)
 
-    assert b.tasks[fut1.key].state == "cancelled"
+        assert b.tasks[fut1.key].state == "cancelled"
 
-    args, kwargs = mocked_gather.call_args
-    await Worker.gather_dep(b, *args, **kwargs)
+        block_gather_dep.release()
+        await gather_dep_finished.wait()
 
-    assert fut2.key not in b.tasks
-    f1_story = b.story(fut1.key)
-    f2_story = b.story(fut2.key)
-    assert f1_story
-    assert f2_story
-    assert not any("missing-dep" in msg for msg in f2_story)
+        assert fut2.key not in b.tasks
+        f1_story = b.story(fut1.key)
+        f2_story = b.story(fut2.key)
+        assert f1_story
+        assert f2_story
+        assert not any("missing-dep" in msg for msg in f2_story)
 
 
 @pytest.mark.parametrize("intermediate_state", ["resumed", "cancelled"])
 @pytest.mark.parametrize("close_worker", [False, True])
-@gen_cluster(client=True, nthreads=[("", 1)] * 3)
+@gen_cluster(client=True)
 async def test_deadlock_cancelled_after_inflight_before_gather_from_worker(
-    c, s, a, b, x, intermediate_state, close_worker
+    c, s, a, x, intermediate_state, close_worker
 ):
     """If a task was transitioned to in-flight, the gather-dep coroutine was
     scheduled but a cancel request came in before gather_data_from_worker was
     issued this might corrupt the state machine if the cancelled key is not
     properly handled"""
 
+    in_gather_dep = asyncio.Event()
+    gather_dep_finished = asyncio.Event()
+    block_gather_dep = asyncio.Lock()
+    await block_gather_dep.acquire()
+
+    class InstrumentedWorker(Worker):
+        async def gather_dep(self, *args, **kwargs):
+            in_gather_dep.set()
+            async with block_gather_dep:
+                try:
+                    return await super().gather_dep(*args, **kwargs)
+                finally:
+                    gather_dep_finished.set()
+
     fut1 = c.submit(slowinc, 1, workers=[a.address], key="f1")
     fut1B = c.submit(slowinc, 2, workers=[x.address], key="f1B")
     fut2 = c.submit(sum, [fut1, fut1B], workers=[x.address], key="f2")
     await fut2
-    with mock.patch.object(distributed.worker.Worker, "gather_dep") as mocked_gather:
+
+    async with InstrumentedWorker(s.address, name="b") as b:
         fut3 = c.submit(inc, fut2, workers=[b.address], key="f3")
 
         fut2_key = fut2.key
@@ -3362,16 +3403,16 @@ async def test_deadlock_cancelled_after_inflight_before_gather_from_worker(
         await _wait_for_state(fut2_key, b, "flight")
 
         s.set_restrictions(worker={fut1B.key: a.address, fut2.key: b.address})
-        while not mocked_gather.call_args:
-            await asyncio.sleep(0)
+
+        await in_gather_dep.wait()
 
         await s.remove_worker(address=x.address, safe=True, close=close_worker)
 
         await _wait_for_state(fut2_key, b, intermediate_state)
 
-    args, kwargs = mocked_gather.call_args
-    await Worker.gather_dep(b, *args, **kwargs)
-    await fut3
+        block_gather_dep.release()
+        await gather_dep_finished.wait()
+        await fut3
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])


### PR DESCRIPTION
Apparently some of these tests are not rock solid. 

E.g. in https://github.com/dask/distributed/pull/6166

https://github.com/dask/distributed/runs/6101034638?check_suite_focus=true

Based on the traceback, it looks like the mock.patch was not properly removed after leaving the context manager. To rule this out and see if there is something else ongoing, I removed the mocks in favour of some event/lock/subclass magic.

I realise that these tests are not great and are extremely difficult to maintain. We can have a conversation about removing some of them but I would like to not have this conversation right now. I consider this new approach easier to reason about and at least slightly easier to maintain. 

As part of https://github.com/dask/distributed/issues/5896 I very much hope that we can remove some, if not all of these tests and replace them with some much easier unit tests. I would like to have the conversation about removing code once we are in a position to replace them with something simpler. This is not in scope for this PR

<details>

<summary>Traceback</summary>


```python
    @gen_cluster(client=True)
    async def test_flight_cancelled_error(c, s, a, b):
        """One worker with one thread. We provoke an flight->cancelled transition
        and let the task err."""
        lock = asyncio.Lock()
        await lock.acquire()
    
        async def wait_and_raise(*args, **kwargs):
            async with lock:
                raise RuntimeError()
    
        with mock.patch.object(
            distributed.worker,
            "get_data_from_worker",
            side_effect=wait_and_raise,
        ):
            fut1 = c.submit(inc, 1, workers=[a.address], allow_other_workers=True)
            fut2 = c.submit(inc, fut1, workers=[b.address])
    
            await wait_for_state(fut1.key, "flight", b)
            fut2.release()
            fut1.release()
            await wait_for_state(fut1.key, "cancelled", b)
    
        lock.release()
        # At this point we do not fetch the result of the future since the future
        # itself would raise a cancelled exception. At this point we're concerned
        # about the worker. The task should transition over error to be eventually
        # forgotten since we no longer hold a ref.
        while fut1.key in b.tasks:
            await asyncio.sleep(0.01)
    
        # Everything should still be executing as usual after this
>       assert await c.submit(sum, c.map(inc, range(10))) == sum(map(inc, range(10)))

distributed\tests\test_cancelled_state.py:247: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
distributed\client.py:294: in _result
    raise exc.with_traceback(tb)
C:\Miniconda3\envs\dask-distributed\lib\unittest\mock.py:2164: in _execute_mock_call
    result = await effect(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   raise RuntimeError()
E   RuntimeError

distributed\tests\test_cancelled_state.py:223: RuntimeError
---------------------------- Captured stdout call -----------------------------
Dumped cluster state to test_cluster_dump\test_flight_cancelled_error.yaml
---------------------------- Captured stderr call -----------------------------
2022-04-20 19:43:01,398 - distributed.worker - ERROR - 
Traceback (most recent call last):
  File "d:\a\distributed\distributed\distributed\worker.py", line 3037, in gather_dep
    response = await get_data_from_worker(
  File "C:\Miniconda3\envs\dask-distributed\lib\unittest\mock.py", line 2164, in _execute_mock_call
    result = await effect(*args, **kwargs)
  File "D:\a\distributed\distributed\distributed\tests\test_cancelled_state.py", line 223, in wait_and_raise
    raise RuntimeError()
RuntimeError
2022-04-20 19:43:01,400 - distributed.utils - ERROR - 
Traceback (most recent call last):
  File "d:\a\distributed\distributed\distributed\utils.py", line 693, in log_errors
    yield
  File "d:\a\distributed\distributed\distributed\worker.py", line 3037, in gather_dep
    response = await get_data_from_worker(
  File "C:\Miniconda3\envs\dask-distributed\lib\unittest\mock.py", line 2164, in _execute_mock_call
    result = await effect(*args, **kwargs)
  File "D:\a\distributed\distributed\distributed\tests\test_cancelled_state.py", line 223, in wait_and_raise
    raise RuntimeError()
RuntimeError
2022-04-20 19:43:01,401 - tornado.application - ERROR - Exception in callback functools.partial(<bound method IOLoop._discard_future_result of <tornado.platform.asyncio.AsyncIOLoop object at 0x000002DC80D8D430>>, <Task finished name='Task-74891' coro=<Worker.gather_dep() done, defined at d:\a\distributed\distributed\distributed\worker.py:2981> exception=RuntimeError()>)
Traceback (most recent call last):
  File "C:\Miniconda3\envs\dask-distributed\lib\site-packages\tornado\ioloop.py", line 741, in _run_callback
    ret = callback()
  File "C:\Miniconda3\envs\dask-distributed\lib\site-packages\tornado\ioloop.py", line 765, in _discard_future_result
    future.result()
  File "d:\a\distributed\distributed\distributed\worker.py", line 3037, in gather_dep
    response = await get_data_from_worker(
  File "C:\Miniconda3\envs\dask-distributed\lib\unittest\mock.py", line 2164, in _execute_mock_call
    result = await effect(*args, **kwargs)
  File "D:\a\distributed\distributed\distributed\tests\test_cancelled_state.py", line 223, in wait_and_raise
    raise RuntimeError()
RuntimeError
```

</details>