### PR TITLE
Mark all websocket tests as flaky

### DIFF
--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -20,6 +20,8 @@ from distributed.utils_test import (
     xfail_ssl_issue5601,
 )
 
+pytestmark = pytest.mark.flaky(reruns=2)
+
 
 def test_registered():
     assert "ws" in backends


### PR DESCRIPTION
This isn't ideal, but websockets are by their nature flaky.
We should fix this properly, but currently websockets aren't of
great importance.  I'd rather punt on this problem for now.

