### PR TITLE
Send worker validation errors to scheduler and err on test completion

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -640,3 +640,24 @@ def test_invalid_transitions(capsys):
 
     assert "foo" in out + err
     assert "task-name" in out + err
+
+
+def test_invalid_worker_states(capsys):
+    @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
+    async def test_log_invalid_worker_task_states(c, s, a):
+        x = c.submit(inc, 1, key="task-name")
+        await x
+        a.tasks[x.key].state = "released"
+        with pytest.raises(Exception):
+            a.validate_task(a.tasks[x.key])
+
+        while not s.events["invalid-worker-task-states"]:
+            await asyncio.sleep(0.01)
+
+    with pytest.raises(Exception) as info:
+        test_log_invalid_worker_task_states()
+
+    out, err = capsys.readouterr()
+
+    assert "released" in out + err
+    assert "task-name" in out + err

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3993,6 +3993,16 @@ class Worker(ServerNode):
 
                 pdb.set_trace()
 
+            self.log_event(
+                "invalid-worker-task-states",
+                {
+                    "key": ts.key,
+                    "state": ts.state,
+                    "story": self.story(ts),
+                    "worker": self.address,
+                },
+            )
+
             raise AssertionError(
                 f"Invalid TaskState encountered for {ts!r}.\nStory:\n{self.story(ts)}\n"
             ) from e


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
