### PR TITLE
remove remaining run_sync calls from tests

### DIFF
--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -6,7 +6,6 @@ from functools import partial
 
 import pytest
 from tornado import ioloop
-from tornado.concurrent import Future
 
 import dask
 
@@ -24,6 +23,7 @@ from distributed.comm import (
     unparse_host_port,
 )
 from distributed.comm.registry import backends, get_backend
+from distributed.compatibility import to_thread
 from distributed.metrics import time
 from distributed.protocol import Serialized, deserialize, serialize, to_serialize
 from distributed.utils import get_ip, get_ipv6, mp_context
@@ -423,28 +423,16 @@ async def check_inproc_specific(run_client):
         assert listener.contact_address not in client_addresses
 
 
-def run_coro(func, *args, **kwargs):
-    return func(*args, **kwargs)
+async def run_coro(func, *args, **kwargs):
+    return await func(*args, **kwargs)
 
 
-def run_coro_in_thread(func, *args, **kwargs):
-    fut = Future()
-    main_loop = ioloop.IOLoop.current()
+async def run_coro_in_thread(func, *args, **kwargs):
+    async def run_with_timeout():
+        t = asyncio.create_task(func(*args, **kwargs))
+        return await asyncio.wait_for(t, timeout=10)
 
-    def run():
-        thread_loop = ioloop.IOLoop()  # need fresh IO loop for run_sync()
-        try:
-            res = thread_loop.run_sync(partial(func, *args, **kwargs), timeout=10)
-        except Exception:
-            main_loop.add_callback(fut.set_exc_info, sys.exc_info())
-        else:
-            main_loop.add_callback(fut.set_result, res)
-        finally:
-            thread_loop.close()
-
-    t = threading.Thread(target=run)
-    t.start()
-    return fut
+    return await to_thread(asyncio.run, run_with_timeout())
 
 
 @gen_test()

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -59,7 +59,8 @@ from distributed.utils_test import (
 )
 
 
-def test_All(loop):
+@gen_test()
+async def test_All():
     async def throws():
         1 / 0
 
@@ -69,21 +70,18 @@ def test_All(loop):
     async def inc(x):
         return x + 1
 
-    async def f():
-        results = await All([inc(i) for i in range(10)])
-        assert results == list(range(1, 11))
+    results = await All([inc(i) for i in range(10)])
+    assert results == list(range(1, 11))
 
-        start = time()
-        for tasks in [[throws(), slow()], [slow(), throws()]]:
-            try:
-                await All(tasks)
-                assert False
-            except ZeroDivisionError:
-                pass
-            end = time()
-            assert end - start < 10
-
-    loop.run_sync(f)
+    start = time()
+    for tasks in [[throws(), slow()], [slow(), throws()]]:
+        try:
+            await All(tasks)
+            assert False
+        except ZeroDivisionError:
+            pass
+        end = time()
+        assert end - start < 10
 
 
 def test_sync_error(loop_in_thread):

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import mock
 
 import pytest
@@ -57,7 +58,7 @@ async def test_gather_from_workers_permissive_flaky(c, s, a, b):
     assert bad_workers == [a.address]
 
 
-def test_retry_no_exception(loop):
+def test_retry_no_exception(cleanup):
     n_calls = 0
     retval = object()
 
@@ -66,14 +67,14 @@ def test_retry_no_exception(loop):
         n_calls += 1
         return retval
 
-    assert (
-        loop.run_sync(lambda: retry(coro, count=0, delay_min=-1, delay_max=-1))
-        is retval
-    )
+    async def f():
+        return await retry(coro, count=0, delay_min=-1, delay_max=-1)
+
+    assert asyncio.run(f()) is retval
     assert n_calls == 1
 
 
-def test_retry0_raises_immediately(loop):
+def test_retry0_raises_immediately(cleanup):
     # test that using max_reties=0 raises after 1 call
 
     n_calls = 0
@@ -83,13 +84,16 @@ def test_retry0_raises_immediately(loop):
         n_calls += 1
         raise RuntimeError(f"RT_ERROR {n_calls}")
 
+    async def f():
+        return await retry(coro, count=0, delay_min=-1, delay_max=-1)
+
     with pytest.raises(RuntimeError, match="RT_ERROR 1"):
-        loop.run_sync(lambda: retry(coro, count=0, delay_min=-1, delay_max=-1))
+        asyncio.run(f())
 
     assert n_calls == 1
 
 
-def test_retry_does_retry_and_sleep(loop):
+def test_retry_does_retry_and_sleep(cleanup):
     # test the retry and sleep pattern of `retry`
     n_calls = 0
 
@@ -107,18 +111,19 @@ def test_retry_does_retry_and_sleep(loop):
         sleep_calls.append(amount)
         return
 
+    async def f():
+        return await retry(
+            coro,
+            retry_on_exceptions=(MyEx,),
+            count=5,
+            delay_min=1.0,
+            delay_max=6.0,
+            jitter_fraction=0.0,
+        )
+
     with mock.patch("asyncio.sleep", my_sleep):
         with pytest.raises(MyEx, match="RT_ERROR 6"):
-            loop.run_sync(
-                lambda: retry(
-                    coro,
-                    retry_on_exceptions=(MyEx,),
-                    count=5,
-                    delay_min=1.0,
-                    delay_max=6.0,
-                    jitter_fraction=0.0,
-                )
-            )
+            asyncio.run(f())
 
     assert n_calls == 6
     assert sleep_calls == [0.0, 1.0, 3.0, 6.0, 6.0]


### PR DESCRIPTION
followup to https://github.com/dask/distributed/pull/6170

This PR removes the tornado run_sync calls from the body of tests

- [ ] re https://github.com/dask/distributed/issues/6164
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
