### PR TITLE
Remove all invocations of `IOLoop.run_sync` from CLI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,6 +121,7 @@ jobs:
 
           pytest distributed \
             -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
+            -k "test_sigint" \
             --leaks=fds,processes,threads \
             --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
             --cov=distributed --cov-report=xml \
@@ -138,9 +139,9 @@ jobs:
             python continuous_integration/scripts/parse_stdout.py < reports/stdout > reports/pytest.xml
           fi
 
-      # - name: Debug with tmate on failure
-      #   if: ${{ failure() }}
-      #   uses: mxschmitt/action-tmate@v3
+      - name: Debug with tmate on failure
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
 
       - name: Coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,7 +121,6 @@ jobs:
 
           pytest distributed \
             -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
-            -k "test_sigint" \
             --leaks=fds,processes,threads \
             --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
             --cov=distributed --cov-report=xml \
@@ -139,9 +138,9 @@ jobs:
             python continuous_integration/scripts/parse_stdout.py < reports/stdout > reports/pytest.xml
           fi
 
-      - name: Debug with tmate on failure
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+      # - name: Debug with tmate on failure
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3
 
       - name: Coverage
         uses: codecov/codecov-action@v1

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -223,7 +223,6 @@ def main(
         await wait_until_shutdown()
         logger.info("Stopped scheduler at %r", scheduler.address)
 
-
     try:
         asyncio.run(run())
     finally:

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -218,10 +218,12 @@ def main(
             wait_for_scheduler_to_finish()
         )
 
-        await asyncio.wait(
+        done, _ = await asyncio.wait(
             [wait_for_signals_and_close_task, wait_for_scheduler_to_finish_task],
             return_when=asyncio.FIRST_COMPLETED,
         )
+        # Re-raise exceptions from done tasks
+        [task.result() for task in done]
         logger.info("Stopped scheduler at %r", scheduler.address)
 
     try:

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -185,10 +185,7 @@ def main(
         limit = max(soft, hard // 2)
         resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
 
-    address = None
-
     async def run():
-        nonlocal address
         loop = IOLoop.current()
         logger.info("-" * 47)
 
@@ -223,13 +220,14 @@ def main(
                 await scheduler.close()
 
         await scheduler
-        address = scheduler.address
         await wait_until_shutdown()
+        logger.info("Stopped scheduler at %r", scheduler.address)
+
 
     try:
         asyncio.run(run())
     finally:
-        logger.info("End scheduler at %r", address)
+        logger.info("End scheduler")
 
 
 if __name__ == "__main__":

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -4,6 +4,7 @@ import gc
 import logging
 import os
 import re
+import signal
 import sys
 import warnings
 
@@ -11,7 +12,7 @@ import click
 from tornado.ioloop import IOLoop
 
 from distributed import Scheduler
-from distributed.cli.utils import wait_for_signal
+from distributed.cli.utils import wait_for_signals
 from distributed.preloading import validate_preload_argv
 from distributed.proctitle import (
     enable_proctitle_on_children,
@@ -204,7 +205,9 @@ def main(
         logger.info("-" * 47)
 
         async def wait_and_finish():
-            wait_for_signal_task = asyncio.create_task(wait_for_signal())
+            wait_for_signal_task = asyncio.create_task(
+                wait_for_signals([signal.SIGINT, signal.SIGTERM])
+            )
             wait_for_scheduler_task = asyncio.create_task(scheduler.finished())
             _, pending = await asyncio.wait(
                 [wait_for_signal_task, wait_for_scheduler_task],

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -475,7 +475,7 @@ def main(
 
     try:
         loop.run_sync(run)
-    except TimeoutError:
+    except (TimeoutError, asyncio.TimeoutError):
         # We already log the exception in nanny / worker. Don't do it again.
         if not signal_fired:
             logger.info("Timed out starting worker")

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -455,8 +455,7 @@ def main(
 
     async def close_all():
         # Unregister all workers from scheduler
-        if nanny:
-            await asyncio.gather(*(n.close(timeout=2) for n in nannies))
+        await asyncio.gather(*(n.close(timeout=2) for n in nannies))
 
     signal_fired = False
 

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -477,8 +477,9 @@ def main(
 
             if wait_for_signal_task in done:
                 signal_fired = True
-                # Unregister all workers from scheduler
-                await asyncio.gather(*(n.close(timeout=2) for n in nannies))
+                if nanny:
+                    # Unregister all workers from scheduler
+                    await asyncio.gather(*(n.close(timeout=2) for n in nannies))
 
         await asyncio.gather(*nannies)
         await wait_until_shutdown()

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -478,10 +478,12 @@ def main(
             wait_for_nannies_to_finish()
         )
 
-        await asyncio.wait(
+        done, _ = await asyncio.wait(
             [wait_for_signals_and_close_task, wait_for_nannies_to_finish_task],
             return_when=asyncio.FIRST_COMPLETED,
         )
+        # Re-raise exceptions from done tasks
+        [task.result() for task in done]
 
     try:
         asyncio.run(run())

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -5,6 +5,7 @@ import atexit
 import gc
 import logging
 import os
+import signal
 import sys
 import warnings
 from collections.abc import Iterator
@@ -19,7 +20,7 @@ import dask
 from dask.system import CPU_COUNT
 
 from distributed import Nanny
-from distributed.cli.utils import wait_for_signal
+from distributed.cli.utils import wait_for_signals
 from distributed.comm import get_address_host_port
 from distributed.deploy.utils import nprocesses_nthreads
 from distributed.preloading import validate_preload_argv
@@ -460,7 +461,9 @@ def main(
 
         async def wait_and_finish():
             nonlocal signal_fired
-            wait_for_signal_task = asyncio.create_task(wait_for_signal())
+            wait_for_signal_task = asyncio.create_task(
+                wait_for_signals([signal.SIGINT, signal.SIGTERM])
+            )
             wait_for_nannies_task = asyncio.create_task(wait_until_nannies_finish())
             done, _ = await asyncio.wait(
                 [wait_for_signal_task, wait_for_nannies_task],

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -457,12 +457,12 @@ def main(
         ]
 
         async def wait_for_nannies_to_finish():
-            """Wait for nannies to initialize and finish"""
+            """Wait for all nannies to initialize and finish"""
             await asyncio.gather(*nannies)
             await asyncio.gather(*(n.finished() for n in nannies))
 
         async def wait_for_signals_and_close():
-            """Wait for SIGINT or SIGTERM and close nannies upon receiving one of those signals"""
+            """Wait for SIGINT or SIGTERM and close all nannies upon receiving one of those signals"""
             nonlocal signal_fired
             await wait_for_signals([signal.SIGINT, signal.SIGTERM])
 

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -479,7 +479,7 @@ def main(
                 signal_fired = True
                 if nanny:
                     # Unregister all workers from scheduler
-                    await asyncio.gather(*(n.close(timeout=2) for n in nannies))
+                    await asyncio.gather(*(n.close(timeout=10) for n in nannies))
 
         await asyncio.gather(*nannies)
         await wait_until_shutdown()

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -477,6 +477,6 @@ def test_signal_handling(loop, sig):
         logs = stdout.decode().lower()
         assert stderr is None
         assert scheduler.returncode == 0
-        assert f"signal {sig}" in logs
+        assert sig.name.lower() in logs
         assert "scheduler closing" in logs
         assert "end scheduler" in logs

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -464,14 +464,13 @@ def test_multiple_workers(loop):
 @pytest.mark.skipif(WINDOWS, reason="POSIX only")
 @pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM])
 def test_signal_handling(loop, sig):
-    try:
-        scheduler = subprocess.Popen(
-            ["dask-scheduler"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
+    with subprocess.Popen(
+        ["dask-scheduler"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    ) as scheduler:
         # Wait for scheduler to start
-        with Client(f"127.0.0.1:{Scheduler.default_port}", loop=loop):
+        with Client(f"127.0.0.1:{Scheduler.default_port}", loop=loop) as c:
             pass
         scheduler.send_signal(sig)
         stdout, stderr = scheduler.communicate()
@@ -481,5 +480,3 @@ def test_signal_handling(loop, sig):
         assert f"signal {sig}" in logs
         assert "scheduler closing" in logs
         assert "end scheduler" in logs
-    finally:
-        scheduler.kill()

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -477,9 +477,9 @@ def test_signal_handling(loop, sig):
         stdout, stderr = scheduler.communicate()
         logs = stdout.decode().lower()
         assert stderr is None
+        assert scheduler.returncode == 0
         assert f"signal {sig}" in logs
         assert "scheduler closing" in logs
         assert "end scheduler" in logs
-        assert scheduler.returncode == 0
     finally:
         scheduler.kill()

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -465,7 +465,7 @@ def test_multiple_workers(loop):
 @pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM])
 def test_signal_handling(loop, sig):
     with subprocess.Popen(
-        ["dask-scheduler"],
+        ["python", "-m", "distributed.cli.dask_scheduler"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     ) as scheduler:

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -463,14 +463,16 @@ def test_multiple_workers(loop):
 @pytest.mark.slow
 @pytest.mark.skipif(WINDOWS, reason="POSIX only")
 @pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM])
-def test_signal_handling(sig):
+def test_signal_handling(loop, sig):
     try:
         scheduler = subprocess.Popen(
             ["dask-scheduler"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
-        sleep(1)
+        # Wait for scheduler to start
+        with Client(f"127.0.0.1:{Scheduler.default_port}", loop=loop):
+            pass
         scheduler.send_signal(sig)
         stdout, stderr = scheduler.communicate()
         logs = stdout.decode().lower()

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -5,6 +5,8 @@ pytest.importorskip("requests")
 
 import os
 import shutil
+import signal
+import subprocess
 import sys
 import tempfile
 from time import sleep
@@ -17,7 +19,7 @@ from dask.utils import tmpfile
 import distributed
 import distributed.cli.dask_scheduler
 from distributed import Client, Scheduler
-from distributed.compatibility import LINUX
+from distributed.compatibility import LINUX, WINDOWS
 from distributed.metrics import time
 from distributed.utils import get_ip, get_ip_interface
 from distributed.utils_test import (
@@ -414,9 +416,12 @@ def test_version_option():
 def test_idle_timeout(loop):
     start = time()
     runner = CliRunner()
-    runner.invoke(distributed.cli.dask_scheduler.main, ["--idle-timeout", "1s"])
+    result = runner.invoke(
+        distributed.cli.dask_scheduler.main, ["--idle-timeout", "1s"]
+    )
     stop = time()
     assert 1 < stop - start < 10
+    assert result.exit_code == 0
 
 
 def test_multiple_workers_2(loop):
@@ -453,3 +458,26 @@ def test_multiple_workers(loop):
                     while len(c.nthreads()) < 2:
                         sleep(0.1)
                         assert time() < start + 10
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(WINDOWS, reason="POSIX only")
+@pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM])
+def test_signal_handling(sig):
+    try:
+        scheduler = subprocess.Popen(
+            ["dask-scheduler"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        sleep(1)
+        scheduler.send_signal(sig)
+        stdout, stderr = scheduler.communicate()
+        logs = stdout.decode().lower()
+        assert stderr is None
+        assert f"signal {sig}" in logs
+        assert "scheduler closing" in logs
+        assert "end scheduler" in logs
+        assert scheduler.returncode == 0
+    finally:
+        scheduler.kill()

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -704,7 +704,7 @@ def test_timeout(nanny):
 @gen_cluster(client=True, nthreads=[])
 async def test_sigint(c, s, nanny):
     with popen(["dask-worker", s.address, nanny], flush_output=False) as worker:
-        await c.wait_for_workers(2)
+        await c.wait_for_workers(1)
         worker.send_signal(signal.SIGINT)
         logs = [worker.stdout.readline().decode().lower() for _ in range(25)]
         assert not any("timed out" in log for log in logs)

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -690,7 +690,14 @@ def dask_setup(worker):
 @pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
 def test_timeout(nanny):
     worker = subprocess.run(
-        ["dask-worker", "192.168.1.100:7777", nanny, "--death-timeout=1"],
+        [
+            "python",
+            "-m",
+            "distributed.cli.dask_worker",
+            "192.168.1.100:7777",
+            nanny,
+            "--death-timeout=1",
+        ],
         text=True,
         encoding="utf8",
         capture_output=True,

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -725,7 +725,7 @@ async def test_signal_handling(c, s, nanny, sig):
         logs = stdout.decode().lower()
         assert stderr is None
         assert worker.returncode == 0
-        assert f"signal {sig}" in logs
+        assert sig.name.lower() in logs
         if nanny == "--nanny":
             assert "closing nanny" in logs
             assert "stopping worker" in logs

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -769,40 +769,6 @@ async def test_sigterm(c, s, nanny):
 @pytest.mark.skipif(not WINDOWS, reason="Windows only")
 @pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
 @gen_cluster(client=True, nthreads=[])
-async def test_ctrl_c_event(c, s, nanny):
-    try:
-        worker = subprocess.Popen(
-            ["dask-worker", s.address, nanny],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            # Allow using CTRL_C_EVENT / CTRL_BREAK_EVENT
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
-        )
-        await c.wait_for_workers(1)
-
-        worker.send_signal(signal.CTRL_C_EVENT)
-        stdout, stderr = worker.communicate()
-        logs = stdout.decode().lower()
-        assert stderr is None
-        if nanny == "--nanny":
-            assert "closing nanny" in logs
-        else:
-            assert "nanny" not in logs
-        assert "stopping worker" in logs
-        assert "end worker" in logs
-        assert "signal" not in logs
-        assert "timed out" not in logs
-        assert "error" not in logs
-        assert "exception" not in logs
-        assert worker.returncode == 0
-    finally:
-        worker.kill()
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(not WINDOWS, reason="Windows only")
-@pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
-@gen_cluster(client=True, nthreads=[])
 async def test_ctrl_break_event(c, s, nanny):
     try:
         worker = subprocess.Popen(

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -719,6 +719,7 @@ async def test_signal_handling(c, s, nanny, sig):
         stdout, stderr = worker.communicate()
         logs = stdout.decode().lower()
         assert stderr is None
+        assert worker.returncode == 0
         assert f"signal {sig}" in logs
         if nanny == "--nanny":
             assert "closing nanny" in logs
@@ -729,6 +730,5 @@ async def test_signal_handling(c, s, nanny, sig):
         assert "timed out" not in logs
         assert "error" not in logs
         assert "exception" not in logs
-        assert worker.returncode == 0
     finally:
         worker.kill()

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -797,3 +797,37 @@ async def test_ctrl_c_event(c, s, nanny):
         assert worker.returncode == 0
     finally:
         worker.kill()
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not WINDOWS, reason="Windows only")
+@pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
+@gen_cluster(client=True, nthreads=[])
+async def test_ctrl_break_event(c, s, nanny):
+    try:
+        worker = subprocess.Popen(
+            ["dask-worker", s.address, nanny],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            # Allow using CTRL_C_EVENT / CTRL_BREAK_EVENT
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
+        await c.wait_for_workers(1)
+
+        worker.send_signal(signal.CTRL_BREAK_EVENT)
+        stdout, stderr = worker.communicate()
+        logs = stdout.decode().lower()
+        assert stderr is None
+        if nanny == "--nanny":
+            assert "closing nanny" in logs
+        else:
+            assert "nanny" not in logs
+        assert "stopping worker" in logs
+        assert "end worker" in logs
+        assert "signal" not in logs
+        assert "timed out" not in logs
+        assert "error" not in logs
+        assert "exception" not in logs
+        assert worker.returncode == 0
+    finally:
+        worker.kill()

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -707,7 +707,7 @@ def test_timeout(nanny):
 @gen_cluster(client=True, nthreads=[])
 async def test_signal_handling(c, s, nanny, sig):
     with subprocess.Popen(
-        ["dask-worker", s.address, nanny],
+        ["python", "-m", "distributed.cli.dask_worker", s.address, nanny],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     ) as worker:

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -722,9 +722,9 @@ async def test_signal_handling(c, s, nanny, sig):
         assert f"signal {sig}" in logs
         if nanny == "--nanny":
             assert "closing nanny" in logs
+            assert "stopping worker" in logs
         else:
             assert "nanny" not in logs
-        assert "stopping worker" in logs
         assert "end worker" in logs
         assert "timed out" not in logs
         assert "error" not in logs

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -732,37 +732,3 @@ async def test_signal_handling(c, s, nanny, sig):
         assert worker.returncode == 0
     finally:
         worker.kill()
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(not WINDOWS, reason="Windows only")
-@pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
-@gen_cluster(client=True, nthreads=[])
-async def test_ctrl_break_event(c, s, nanny):
-    try:
-        worker = subprocess.Popen(
-            ["dask-worker", s.address, nanny],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            # Allow using CTRL_C_EVENT / CTRL_BREAK_EVENT
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
-        )
-        await c.wait_for_workers(1)
-
-        worker.send_signal(signal.CTRL_BREAK_EVENT)
-        stdout, stderr = worker.communicate()
-        logs = stdout.decode().lower()
-        assert stderr is None
-        if nanny == "--nanny":
-            assert "closing nanny" in logs
-        else:
-            assert "nanny" not in logs
-        assert "stopping worker" in logs
-        assert "end worker" in logs
-        assert "signal" not in logs
-        assert "timed out" not in logs
-        assert "error" not in logs
-        assert "exception" not in logs
-        assert worker.returncode == 0
-    finally:
-        worker.kill()

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -701,18 +701,16 @@ def test_timeout(nanny):
     assert worker.returncode == 1
 
 
-@pytest.mark.slow
 @pytest.mark.skipif(WINDOWS, reason="POSIX only")
 @pytest.mark.parametrize("nanny", ["--nanny", "--no-nanny"])
 @pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM])
 @gen_cluster(client=True, nthreads=[])
 async def test_signal_handling(c, s, nanny, sig):
-    try:
-        worker = subprocess.Popen(
-            ["dask-worker", s.address, nanny],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
+    with subprocess.Popen(
+        ["dask-worker", s.address, nanny],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    ) as worker:
         await c.wait_for_workers(1)
 
         worker.send_signal(sig)
@@ -730,5 +728,3 @@ async def test_signal_handling(c, s, nanny, sig):
         assert "timed out" not in logs
         assert "error" not in logs
         assert "exception" not in logs
-    finally:
-        worker.kill()

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import signal

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -1,25 +1,26 @@
 import asyncio
 import logging
 import signal
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
-async def wait_for_signal():
-    """Wait for SIGINT or SIGTERM by setting global signal handlers"""
+async def wait_for_signals(signals: list[signal.Signals]):
+    """Wait for the passed signals by setting global signal handlers"""
     loop = asyncio.get_running_loop()
     event = asyncio.Event()
 
-    old_handlers = {}
+    old_handlers: dict[int, Any] = {}
 
-    def handle_signal(sig, frame):
+    def handle_signal(signum, frame):
         # Restore old signal handler to allow for quicker exit
         # if the user sends the signal again.
-        signal.signal(sig, old_handlers[sig])
-        logger.info("Received signal %d", sig)
+        signal.signal(signum, old_handlers[signum])
+        logger.info("Received signal %d", signum)
         loop.call_soon_threadsafe(event.set)
 
-    for sig in [signal.SIGINT, signal.SIGTERM]:
+    for sig in signals:
         old_handlers[sig] = signal.signal(sig, handle_signal)
 
     await event.wait()

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -19,7 +19,7 @@ async def wait_for_signals(signals: list[signal.Signals]) -> None:
         # Restore old signal handler to allow for quicker exit
         # if the user sends the signal again.
         signal.signal(signum, old_handlers[signum])
-        logger.info("Received signal %d", signum)
+        logger.info("Received signal %s (%d)", signal.Signals(signum).name, signum)
         loop.call_soon_threadsafe(event.set)
 
     for sig in signals:

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -20,7 +20,8 @@ def install_signal_handlers(loop=None, cleanup=None):
                     await cleanup(sig)
             finally:
                 loop.stop()
-            loop.add_callback_from_signal(cleanup_and_stop)
+
+        loop.add_callback_from_signal(cleanup_and_stop)
 
         # Restore old signal handler to allow for a quicker exit
         # if the user sends the signal again.

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -20,7 +20,7 @@ def install_signal_handlers(loop=None, cleanup=None):
                     await cleanup(sig)
             finally:
                 loop.stop()
-            loop.add_callback_from_signal(lambda: cleanup(sig))
+            loop.add_callback_from_signal(cleanup_and_stop)
 
         # Restore old signal handler to allow for a quicker exit
         # if the user sends the signal again.

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -2,64 +2,11 @@ import asyncio
 import logging
 import signal
 
-from tornado.ioloop import IOLoop
-
 logger = logging.getLogger(__name__)
 
 
-def install_signal_handlers(loop=None, cleanup=None):
-    """
-    Install global signal handlers to halt the Tornado IOLoop in case of
-    a SIGINT or SIGTERM.  *cleanup* is an optional callback called,
-    before the loop stops, with a single signal number argument.
-    """
-    import signal
-
-    loop = loop or IOLoop.current()
-
-    old_handlers = {}
-
-    def handle_signal(sig, frame):
-        async def cleanup_and_stop():
-            try:
-                if cleanup is not None:
-                    await cleanup(sig)
-            finally:
-                loop.stop()
-
-        loop.add_callback_from_signal(cleanup_and_stop)
-        # Restore old signal handler to allow for a quicker exit
-        # if the user sends the signal again.
-        signal.signal(sig, old_handlers[sig])
-
-    for sig in [signal.SIGINT, signal.SIGTERM]:
-        old_handlers[sig] = signal.signal(sig, handle_signal)
-
-
-def install_signal_handlers2(loop=None, cleanup=None):
-    """
-    Install global signal handlers to halt the Tornado IOLoop in case of
-    a SIGINT or SIGTERM.  *cleanup* is an optional callback called,
-    before the loop stops, with a single signal number argument.
-    """
-    import signal
-
-    loop = loop or IOLoop.current()
-
-    old_handlers = {}
-
-    def handle_signal(sig, frame):
-        if cleanup is not None:
-            loop.add_callback_from_signal(lambda: cleanup(sig))
-        # Restore old signal handler to allow for a quicker exit
-        # if the user sends the signal again.
-        signal.signal(sig, old_handlers[sig])
-
-    for sig in [signal.SIGINT, signal.SIGTERM]:
-        old_handlers[sig] = signal.signal(sig, handle_signal)
-
-
 async def wait_for_signal():
+    """Wait for SIGINT or SIGTERM by setting global signal handlers"""
     loop = asyncio.get_running_loop()
     event = asyncio.Event()
 

--- a/distributed/cli/utils.py
+++ b/distributed/cli/utils.py
@@ -8,7 +8,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-async def wait_for_signals(signals: list[signal.Signals]):
+async def wait_for_signals(signals: list[signal.Signals]) -> None:
     """Wait for the passed signals by setting global signal handlers"""
     loop = asyncio.get_running_loop()
     event = asyncio.Event()


### PR DESCRIPTION
- [x] Closes #6162, #5955
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
- [x] Manually tested that graceful shutdown upon keyboard interrupts works on Windows (thanks @sjperkins!)

This PR removes the usage of `IOLoop.run_sync` from `dask_scheduler.py` and `dask_worker.py` and adds tests for graceful shutdown. It also adds a graceful shutdown to the scheduler which previously ran into a hard `scheduler.stop()` instead. I have made slight changes to the logging, i.e. we _always_ log the received signal.


**Out of scope:**
* Graceful shutdown in `dask_spec.py`
* Graceful shutdown of workers used without nannies in `dask_worker.py`
* Preserving behavior of preload modules if they are using loops about whether or not they are initialized before the loop is created.