### PR TITLE
Ensure resumed tasks are not accidentally forgotten

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2208,7 +2208,7 @@ class Worker(ServerNode):
     ) -> RecsInstrs:
         assert ts._previous == "executing" or ts.key in self.long_running
         # We'll ignore instructions, i.e. we choose to not submit the failure
-        # message to the scheudler since from the schedulers POV it already
+        # message to the scheduler since from the schedulers POV it already
         # released this task
         recs, _ = self.transition_executing_error(
             ts,


### PR DESCRIPTION
closes https://github.com/dask/distributed/issues/6194
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Three changes in this PR

- Fix an erroneous transition resumed->released which previously actually released a key but instead it should transition to cancelled if the task is still being processed.
- Removed a redundant cancelled->resumed transition which makes the logs **much** less verbose and easier to read. This transition was only an indirection and I instead _inlined_ the code at the two places where this matters. The transition log now reads as expected in these situations
- Ensure that `ts._next` is not set for cancelled tasks. Cancelled tasks should *always* transition to released once they are done. 