### PR TITLE
Increase test timeout if debugger is running

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -77,6 +77,7 @@ try:
 except ImportError:
     pass
 
+from pytest_timeout import is_debugging
 
 logger = logging.getLogger(__name__)
 
@@ -798,6 +799,8 @@ def gen_test(timeout: float = _TEST_TIMEOUT) -> Callable[[Callable], Callable]:
         "timeout should always be set and it should be smaller than the global one from"
         "pytest-timeout"
     )
+    if is_debugging():
+        timeout = 3600
 
     def _(func):
         def test_func(*args, **kwargs):
@@ -956,6 +959,8 @@ def gen_cluster(
         "timeout should always be set and it should be smaller than the global one from"
         "pytest-timeout"
     )
+    if is_debugging():
+        timeout = 3600
 
     scheduler_kwargs = merge(
         {"dashboard": False, "dashboard_address": ":0"}, scheduler_kwargs


### PR DESCRIPTION
This effectively disables the asyncio test timeout if a debugger is running. 