### PR TITLE
Do not list closes keyword in list of bullet points

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
-- [ ] Closes #xxxx
+Closes #xxxx
+
 - [ ] Tests added / passed
 - [ ] Passes `pre-commit run --all-files`


### PR DESCRIPTION
Github fails to detect the keyword if it is put on a checkbox list like this and we do not get the nice "closes PR" feature
