### PR TITLE
Do not require pytest_timeout for utils_test

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -77,7 +77,15 @@ try:
 except ImportError:
     pass
 
-from pytest_timeout import is_debugging
+try:
+    from pytest_timeout import is_debugging
+except ImportError:
+
+    def is_debugging() -> bool:
+        # The pytest_timeout logic is more sophisticated. Not only debuggers
+        # attach a trace callback but vendoring the entire logic is not worth it
+        return sys.gettrace() is not None
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Follow up to https://github.com/dask/distributed/pull/6218

downstream users are frequently using utils_test and we should not promote pytest-timeout to a runtime dependency just for that. This replacement captures the gist of the logic although pytest-timeout is dealing with many edge cases. I _think_ we're fine without these edge cases in most situations