### PR TITLE
Allow cluster-dumping only certain workers

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3826,6 +3826,7 @@ class Client(SyncMethodMixin):
         write_from_scheduler: bool | None = None,
         exclude: Collection[str] = ("run_spec",),
         format: Literal["msgpack", "yaml"] = "msgpack",
+        workers: list[str] | None = None,
         **storage_options,
     ):
         """Extract a dump of the entire cluster state and persist to disk or a URL.
@@ -3903,6 +3904,8 @@ class Client(SyncMethodMixin):
                     from yaml import Loader
                 with open("filename") as fd:
                     state = yaml.load(fd, Loader=Loader)
+        workers:
+            List of worker addresses. If None, all workers will be used.
         **storage_options:
             Any additional arguments to :func:`fsspec.open` when writing to a URL.
         """
@@ -3912,6 +3915,7 @@ class Client(SyncMethodMixin):
             write_from_scheduler=write_from_scheduler,
             exclude=exclude,
             format=format,
+            workers=workers,
             **storage_options,
         )
 
@@ -3921,6 +3925,7 @@ class Client(SyncMethodMixin):
         write_from_scheduler: bool | None = None,
         exclude: Collection[str] = cluster_dump.DEFAULT_CLUSTER_DUMP_EXCLUDE,
         format: Literal["msgpack", "yaml"] = cluster_dump.DEFAULT_CLUSTER_DUMP_FORMAT,
+        workers: list[str] | None = None,
         **storage_options,
     ):
         filename = str(filename)
@@ -3932,11 +3937,14 @@ class Client(SyncMethodMixin):
                 url=filename,
                 exclude=exclude,
                 format=format,
+                workers=workers,
                 **storage_options,
             )
         else:
             await cluster_dump.write_state(
-                partial(self.scheduler.get_cluster_state, exclude=exclude),
+                partial(
+                    self.scheduler.get_cluster_state, exclude=exclude, workers=workers
+                ),
                 filename,
                 format,
                 **storage_options,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3267,16 +3267,19 @@ class Scheduler(SchedulerState, ServerNode):
     async def get_cluster_state(
         self,
         exclude: "Collection[str]",
+        workers: "list[str] | None" = None,
     ) -> dict:
         "Produce the state dict used in a cluster state dump"
         # Kick off state-dumping on workers before we block the event loop in `self._to_dict`.
         workers_future = asyncio.gather(
             self.broadcast(
                 msg={"op": "dump_state", "exclude": exclude},
+                workers=workers,
                 on_error="return",
             ),
             self.broadcast(
                 msg={"op": "versions"},
+                workers=workers,
                 on_error="ignore",
             ),
         )
@@ -3306,11 +3309,15 @@ class Scheduler(SchedulerState, ServerNode):
         url: str,
         exclude: "Collection[str]",
         format: Literal["msgpack", "yaml"],
+        workers: "list[str] | None" = None,
         **storage_options: dict[str, Any],
     ) -> None:
         "Write a cluster state dump to an fsspec-compatible URL."
         await cluster_dump.write_state(
-            partial(self.get_cluster_state, exclude), url, format, **storage_options
+            partial(self.get_cluster_state, exclude, workers=workers),
+            url,
+            format,
+            **storage_options,
         )
 
     def get_worker_service_addr(

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7172,16 +7172,25 @@ def test_dump_cluster_state_write_from_scheduler(
     assert (scheduler_dir / "scheduler-explicit.msgpack.gz").is_file()
 
 
+@pytest.mark.parametrize("all_workers", [True, False])
 @pytest.mark.parametrize("local", [True, False])
 @pytest.mark.parametrize("_format", ["msgpack", "yaml"])
-def test_dump_cluster_state_sync(c, s, a, b, tmp_path, _format, local):
+def test_dump_cluster_state_sync(c, s, a, b, tmp_path, _format, local, all_workers):
     filename = tmp_path / "foo"
     if not local:
         pytest.importorskip("fsspec")
         # Make it look like an fsspec path
         filename = f"file://{filename}"
-    c.dump_cluster_state(filename, format=_format)
-    _verify_cluster_dump(filename, _format, {a["address"], b["address"]})
+
+    if all_workers:
+        workers = None
+        addrs = {a["address"], b["address"]}
+    else:
+        workers = [a["address"]]
+        addrs = set(workers)
+
+    c.dump_cluster_state(filename, format=_format, workers=workers)
+    _verify_cluster_dump(filename, _format, addrs)
 
 
 @pytest.mark.parametrize("local", [True, False])


### PR DESCRIPTION
This makes it easier to cluster-dump large clusters, when you know only a handful of workers are actually problematic (as is usually the case in a deadlock).

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
