### PR TITLE
Use `.data` with NumPy array allocation

### DIFF
--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -27,7 +27,7 @@ try:
     import numpy
 
     def numpy_host_array(n: int) -> memoryview:
-        return numpy.empty((n,), dtype="u1").data  # type: ignore
+        return numpy.empty((n,), dtype="u1").data
 
     host_array = numpy_host_array
 except ImportError:

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -27,7 +27,7 @@ try:
     import numpy
 
     def numpy_host_array(n: int) -> memoryview:
-        return memoryview(numpy.empty((n,), dtype="u1"))  # type: ignore
+        return numpy.empty((n,), dtype="u1").data  # type: ignore
 
     host_array = numpy_host_array
 except ImportError:


### PR DESCRIPTION
It is slightly faster (~50ns) to use `.data` with NumPy arrays instead of `memoryview`. This still returns a `memoryview` and aligns with how we handle NumPy arrays elsewhere (like in serialization).

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
