### PR TITLE
WIP Gc scheduler taskstate

### DIFF
--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -396,7 +396,8 @@ def watch(
     - dict[str, Any] (output of ``create()``)
     """
     log: deque[tuple[float, dict[str, Any]]] = deque(maxlen=maxlen)
-
+    # Disable the profiler. It is just creating noise for the refcounting
+    return log
     thread = threading.Thread(
         target=_watch,
         name="Profile",

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4296,7 +4296,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         event_msg = {
             "action": "remove-worker",
-            "processing-tasks": dict(ws.processing),
+            "processing-tasks": {ts.key: cost for ts, cost in ws.processing.items()},
         }
         self.log_event(address, event_msg.copy())
         event_msg["worker"] = address

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -49,7 +49,6 @@ class SemaphoreExtension:
     """
 
     def __init__(self, scheduler):
-        self.scheduler = scheduler
 
         # {semaphore_name: asyncio.Event}
         self.events = defaultdict(asyncio.Event)
@@ -58,7 +57,7 @@ class SemaphoreExtension:
         # {semaphore_name: {lease_id: lease_last_seen_timestamp}}
         self.leases = defaultdict(dict)
 
-        self.scheduler.handlers.update(
+        scheduler.handlers.update(
             {
                 "semaphore_register": self.create,
                 "semaphore_acquire": self.acquire,


### PR DESCRIPTION
I tried introducing a weakref instance check for the TaskState objects as proposed in https://github.com/dask/distributed/pull/6226#issuecomment-1111486576
but I failed because they are actually never GCed.

It is not surprising that our classes are highly interconnected things and I am not at all surprised that we explicitly need to collect but the cycle detection doesn't suffice to release these objects. Turns out, we're leaking a bunch of explicit references all over the place.
Some of these are not obvious and I figured this bit of effort I invested here is worth preserving. I'll comment in-code for a few (to me) surprising things