### PR TITLE
Race conditions from fetch to compute while AMM requests replica

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2199,12 +2199,6 @@ class SchedulerState:
                         worker_msgs,
                     )  # don't try to recreate
 
-            for dts in ts.waiters:
-                if dts.state in ("no-worker", "processing"):
-                    recommendations[dts.key] = "waiting"
-                elif dts.state == "waiting":
-                    dts.waiting_on.add(ts)
-
             # XXX factor this out?
             worker_msg = {
                 "op": "free-keys",
@@ -2228,6 +2222,12 @@ class SchedulerState:
                 recommendations[key] = "forgotten"
             elif ts.who_wants or ts.waiters:
                 recommendations[key] = "waiting"
+
+            for dts in ts.waiters:
+                if dts.state in ("no-worker", "processing"):
+                    recommendations[dts.key] = "waiting"
+                elif dts.state == "waiting":
+                    dts.waiting_on.add(ts)
 
             if self.validate:
                 assert not ts.waiting_on

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -138,7 +138,7 @@ async def test_worker_stream_died_during_comm(c, s, a, b):
     assert any("receive-dep-failed" in msg for msg in b.log)
 
 
-@gen_cluster(client=True, nthreads=[("", 1)], timeout=4)
+@gen_cluster(client=True, nthreads=[("", 1)])
 async def test_flight_to_executing_via_cancelled_resumed(c, s, b):
 
     block_get_data = asyncio.Lock()

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2325,7 +2325,7 @@ async def test_worker_state_error_long_chain(c, s, a, b):
         h.key: "memory",
         res.key: "error",
     }
-    await assert_task_states_on_worker(expected_states_B, b)
+    await assert_task_states_on_worker(expected_states_B, b), b.tasks
 
     g.release()
 
@@ -3157,7 +3157,10 @@ async def test_task_flight_compute_oserror(c, s, a, b):
         # inc is lost and needs to be recomputed. Therefore, sum is released
         ("free-keys", ("f1",)),
         ("f1", "release-key"),
-        ("f1", "waiting", "released", "released", {"f1": "forgotten"}),
+        # The recommendations here are hard to predict. Whatever key is
+        # currently scheduled to be fetched, if any, will be recommended to be
+        # released.
+        ("f1", "waiting", "released", "released", lambda msg: msg["f1"] == "forgotten"),
         ("f1", "released", "forgotten", "forgotten", {}),
         # Now, we actually compute the task *once*. This must not cycle back
         ("f1", "compute-task"),


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/6244

Two things in here

----

The order in which we fill the recommendations impacts the order in which we send messages. This specific case could mean

- Worker A holds key T1
- Worker B computes key T2 that depends on T1
- Worker B fetches T1 (not in flight, yet, just queued up)
- Worker A dies
- Scheduler transitions T1 back to released
- This transition recommends transitioning T2 back to released which will generate a worker message to B to release T2 again
- Scheduler transitions T2 to waiting and afterwards to processing

depending on the order, at the time the `handle-compute T1` signal arrives at B, the state will be either

- `T1: waiting`
- `T2: waiting` (which is strictly speaking false but shouldn't be harmful)
or just
- `T1:waiting`, i.e. T1 has no dependents from the POV of the worker


----

The problem of https://github.com/dask/distributed/issues/6244 is that a task is requested to be fetched and has no dependents on the worker. Therefore, if the worker is asked to release this task, there is no reason to hold on to it and it transitions it to forgotten. There is currently no way out of forgotten other than through another handle_compute or acquire_replica (i.e. another ensure_task_exists).

The particular transition fetch->compute will expand to a fetch->released->compute and we do not want to forget about the task. There are two options to avoid this

- If we encounter a forgotten task while doing these transitions, we could call ensure_task_exists to "revert" this
- We explicitly block forgotten transitions in such a chain (this is what I am proposing since I think it's the simplest approach)