### PR TITLE
WIP Rework control flow for `missing` tasks

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2199,12 +2199,6 @@ class SchedulerState:
                         worker_msgs,
                     )  # don't try to recreate
 
-            for dts in ts.waiters:
-                if dts.state in ("no-worker", "processing"):
-                    recommendations[dts.key] = "waiting"
-                elif dts.state == "waiting":
-                    dts.waiting_on.add(ts)
-
             # XXX factor this out?
             worker_msg = {
                 "op": "free-keys",
@@ -2228,6 +2222,12 @@ class SchedulerState:
                 recommendations[key] = "forgotten"
             elif ts.who_wants or ts.waiters:
                 recommendations[key] = "waiting"
+
+            for dts in ts.waiters:
+                if dts.state in ("no-worker", "processing"):
+                    recommendations[dts.key] = "waiting"
+                elif dts.state == "waiting":
+                    dts.waiting_on.add(ts)
 
             if self.validate:
                 assert not ts.waiting_on

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2325,7 +2325,7 @@ async def test_worker_state_error_long_chain(c, s, a, b):
         h.key: "memory",
         res.key: "error",
     }
-    await assert_task_states_on_worker(expected_states_B, b)
+    await assert_task_states_on_worker(expected_states_B, b), b.tasks
 
     g.release()
 
@@ -3157,7 +3157,10 @@ async def test_task_flight_compute_oserror(c, s, a, b):
         # inc is lost and needs to be recomputed. Therefore, sum is released
         ("free-keys", ("f1",)),
         ("f1", "release-key"),
-        ("f1", "waiting", "released", "released", {"f1": "forgotten"}),
+        # The recommendations here are hard to predict. Whatever key is
+        # currently scheduled to be fetched, if any, will be recommended to be
+        # released.
+        ("f1", "waiting", "released", "released", lambda msg: msg["f1"] == "forgotten"),
         ("f1", "released", "forgotten", "forgotten", {}),
         # Now, we actually compute the task *once*. This must not cycle back
         ("f1", "compute-task"),


### PR DESCRIPTION
This reworks the control flow for missing tasks which should get rid of all `assert ts.who_has` issues. The essence is that all `_to_fetch` transitions will check on who_has and transition to missing instead. Combined with the check in the exception handler of gather_dep AND the guard in ensure_communicating, this should plug all holes where this could be introduced 🤞 

It also includes https://github.com/dask/distributed/pull/6248

Locally, the `test_chaos_rechunk` hasn't failed in 100 tries (running concurrently) (This already includes the fail_hard decorator)

I would like to get my other PRs merged that modify the state machine and revisit this afterwards