### PR TITLE
Close executor in event loop if interpreter is closing

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7376,3 +7376,27 @@ async def test_wait_for_workers_updates_info(c, s):
     async with Worker(s.address):
         await c.wait_for_workers(1)
         assert c.scheduler_info()["workers"]
+
+
+client_script = """
+from dask.distributed import Client
+if __name__ == "__main__":
+    client = Client(processes=%s, n_workers=1)
+"""
+
+
+@pytest.mark.parametrize("processes", [True, False])
+def test_quiet_close_process(processes, tmp_path):
+    with open(tmp_path / "script.py", mode="w") as f:
+        f.write(client_script % processes)
+
+    proc = subprocess.Popen(
+        [sys.executable, tmp_path / "script.py"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    out, err = proc.communicate(timeout=10)
+
+    assert not out
+    assert not err

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1601,7 +1601,10 @@ class Worker(ServerNode):
             # weird deadlocks particularly if the task that is executing in
             # the thread is waiting for a server reply, e.g. when using
             # worker clients, semaphores, etc.
-            await to_thread(_close)
+            try:
+                await to_thread(_close)
+            except RuntimeError:  # Are we shutting down the process?
+                _close()  # Just run it directly
 
         self.stop()
         await self.rpc.close()


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/6255

Previously this would cause a RuntimeError during shutdown.

test incoming