### PR TITLE
Simplify logic in `get_default_compression`

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -114,17 +114,15 @@ with suppress(ImportError):
 
 def get_default_compression():
     default = dask.config.get("distributed.comm.compression")
-    if default != "auto":
-        if default in compressions:
-            return default
-        else:
-            raise ValueError(
-                "Default compression '%s' not found.\n"
-                "Choices include auto, %s"
-                % (default, ", ".join(sorted(map(str, compressions))))
-            )
-    else:
+    if default == "auto":
         return default_compression
+    if default in compressions:
+        return default
+    raise ValueError(
+        "Default compression '%s' not found.\n"
+        "Choices include auto, %s"
+        % (default, ", ".join(sorted(map(str, compressions))))
+    )
 
 
 get_default_compression()


### PR DESCRIPTION
Rewrite `get_default_compression` in terms of a couple of `if`s. This should make the logic a bit clearer.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
