### PR TITLE
Fix `fail_hard` for sync functions

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -195,8 +195,7 @@ def fail_hard(method):
                         },
                     )
                     logger.exception(e)
-                else:
-                    self.loop.add_callback(_force_close, self)
+                self.loop.add_callback(_force_close, self)
 
     return wrapper
 


### PR DESCRIPTION
The `else` meant we would, in fact, not fail hard at all.

cc @fjetter @mrocklin xref https://github.com/dask/distributed/pull/6210

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
