### PR TITLE
Add HTTP API to scheduler

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -52,6 +52,7 @@ distributed:
         - distributed.http.scheduler.prometheus
         - distributed.http.scheduler.info
         - distributed.http.scheduler.json
+        - distributed.http.scheduler.api
         - distributed.http.health
         - distributed.http.proxy
         - distributed.http.statics

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -24,6 +24,20 @@ class RetireWorkersHandler(RequestHandler):
             self.write(json.dumps({"Error": "Bad request"}))
 
 
+class WorkersToCloseHandler(RequestHandler):
+    async def post(self):
+        self.set_header("Content-Type", "text/json")
+        scheduler = self.server
+        try:
+            params = json.loads(self.request.body)
+            workers_to_close = {"workers": scheduler.workers_to_close(**params)}
+            self.write(json.dumps(workers_to_close))
+        except Exception as e:
+            self.set_status(400, str(e))
+            print(str(e))
+            self.write(json.dumps({"Error": "Bad request"}))
+
+
 class GetWorkersHandler(RequestHandler):
     def get(self):
         self.set_header("Content-Type", "text/json")
@@ -52,6 +66,7 @@ class AdaptiveTargetHandler(RequestHandler):
 routes: list[tuple] = [
     ("/api/v1", APIHandler, {}),
     ("/api/v1/retire_workers", RetireWorkersHandler, {}),
+    ("/api/v1/workers_to_close", WorkersToCloseHandler, {}),
     ("/api/v1/get_workers", GetWorkersHandler, {}),
     ("/api/v1/adaptive_target", AdaptiveTargetHandler, {}),
 ]

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -42,7 +42,7 @@ class AdaptiveTargetHandler(RequestHandler):
         scheduler = self.server
         desired_workers = scheduler.adaptive_target()
         response = {
-            "desired_workers": desired_workers,
+            "workers": desired_workers,
         }
         self.write(response)
 

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -26,6 +26,7 @@ class RetireWorkersHandler(RequestHandler):
 
 class GetWorkersHandler(RequestHandler):
     def get(self):
+        self.set_header("Content-Type", "text/json")
         scheduler = self.server
         response = {
             "num_workers": len(scheduler.workers),
@@ -34,17 +35,18 @@ class GetWorkersHandler(RequestHandler):
                 for ws in scheduler.workers.values()
             ],
         }
-        self.write(response)
+        self.write(json.dumps(response))
 
 
 class AdaptiveTargetHandler(RequestHandler):
     def get(self):
+        self.set_header("Content-Type", "text/json")
         scheduler = self.server
         desired_workers = scheduler.adaptive_target()
         response = {
             "workers": desired_workers,
         }
-        self.write(response)
+        self.write(json.dumps(response))
 
 
 routes: list[tuple] = [

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -24,14 +24,19 @@ class RetireWorkersHandler(RequestHandler):
             self.set_status(400, str(e))
             self.write(json.dumps({"Error": "Bad request"}))
 
+
 class GetWorkersHandler(RequestHandler):
     def get(self):
         scheduler = self.server
         response = {
             "num_workers": len(scheduler.workers),
-            "workers": [{"name": ws.name, "address": ws.address} for ws in scheduler.workers.values()]
+            "workers": [
+                {"name": ws.name, "address": ws.address}
+                for ws in scheduler.workers.values()
+            ],
         }
         self.write(response)
+
 
 class AdaptiveTargetHandler(RequestHandler):
     def get(self):
@@ -41,6 +46,7 @@ class AdaptiveTargetHandler(RequestHandler):
             "desired_workers": desired_workers,
         }
         self.write(response)
+
 
 routes: list[tuple] = [
     ("/api/v1", APIHandler, {}),

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+
 from tornado import web
 
 

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -17,8 +17,13 @@ class RetireWorkersHandler(RequestHandler):
         scheduler = self.server
         try:
             params = json.loads(self.request.body)
-            workers = params["workers"]
-            workers_info = await scheduler.retire_workers(workers)
+            n_workers = params.get("n", 0)
+            if n_workers:
+                workers = scheduler.workers_to_close(n=n_workers)
+                workers_info = await scheduler.retire_workers(workers=workers)
+            else:
+                workers = params.get("workers", {})
+                workers_info = await scheduler.retire_workers(workers=workers)
             self.write(json.dumps(workers_info))
         except Exception as e:
             self.set_status(500, str(e))

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -2,31 +2,49 @@ from __future__ import annotations
 
 import json
 
-from tornado import web
+from distributed.http.utils import RequestHandler
 
 
-class APIHandler(web.RequestHandler):
+class APIHandler(RequestHandler):
     def get(self):
         self.write("API V1")
         self.set_header("Content-Type", "text/plain")
 
 
-class RetireWorkersHandler(web.RequestHandler):
-    def initialize(self, dask_server):
-        self.dask_server = dask_server
-
+class RetireWorkersHandler(RequestHandler):
     async def post(self):
         self.set_header("Content-Type", "text/json")
+        scheduler = self.server
         try:
             params = json.loads(self.request.body)
-            workers_info = await self.dask_server.retire_workers(**params)
+            self.write(params)
+            workers_info = await scheduler.retire_workers(**params)
             self.write(json.dumps(workers_info))
         except Exception as e:
             self.set_status(400, str(e))
             self.write(json.dumps({"Error": "Bad request"}))
 
+class GetWorkersHandler(RequestHandler):
+    def get(self):
+        scheduler = self.server
+        response = {
+            "num_workers": len(scheduler.workers),
+            "workers": [{"name": ws.name, "address": ws.address} for ws in scheduler.workers.values()]
+        }
+        self.write(response)
+
+class AdaptiveTargetHandler(RequestHandler):
+    def get(self):
+        scheduler = self.server
+        desired_workers = scheduler.adaptive_target()
+        response = {
+            "desired_workers": desired_workers,
+        }
+        self.write(response)
 
 routes: list[tuple] = [
     ("/api/v1", APIHandler, {}),
     ("/api/v1/retire_workers", RetireWorkersHandler, {}),
+    ("/api/v1/get_workers", GetWorkersHandler, {}),
+    ("/api/v1/adaptive_target", AdaptiveTargetHandler, {}),
 ]

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -33,8 +33,7 @@ class WorkersToCloseHandler(RequestHandler):
             workers_to_close = {"workers": scheduler.workers_to_close(**params)}
             self.write(json.dumps(workers_to_close))
         except Exception as e:
-            self.set_status(400, str(e))
-            print(str(e))
+            self.set_status(500, str(e))
             self.write(json.dumps({"Error": "Bad request"}))
 
 

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from tornado import web
+
+
+class APIHandler(web.RequestHandler):
+    def get(self):
+        self.write("API V1")
+        self.set_header("Content-Type", "text/plain")
+
+
+class RetireWorkersHandler(web.RequestHandler):
+    def initialize(self, dask_server):
+        self.dask_server = dask_server
+
+    async def post(self):
+        self.set_header("Content-Type", "text/json")
+        try:
+            params = json.loads(self.request.body)
+            workers_info = await self.dask_server.retire_workers(**params)
+            self.write(json.dumps(workers_info))
+        except Exception as e:
+            self.set_status(400, str(e))
+            self.write(json.dumps({"Error": "Bad request"}))
+
+
+routes: list[tuple] = [
+    ("/api/v1", APIHandler, {}),
+    ("/api/v1/retire_workers", RetireWorkersHandler, {}),
+]

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -17,7 +17,6 @@ class RetireWorkersHandler(RequestHandler):
         scheduler = self.server
         try:
             params = json.loads(self.request.body)
-            self.write(params)
             workers_info = await scheduler.retire_workers(**params)
             self.write(json.dumps(workers_info))
         except Exception as e:

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -17,55 +17,50 @@ class RetireWorkersHandler(RequestHandler):
         scheduler = self.server
         try:
             params = json.loads(self.request.body)
-            workers_info = await scheduler.retire_workers(**params)
+            workers = params["workers"]
+            workers_info = await scheduler.retire_workers(workers)
             self.write(json.dumps(workers_info))
         except Exception as e:
-            self.set_status(400, str(e))
-            self.write(json.dumps({"Error": "Bad request"}))
-
-
-class WorkersToCloseHandler(RequestHandler):
-    async def post(self):
-        self.set_header("Content-Type", "text/json")
-        scheduler = self.server
-        try:
-            params = json.loads(self.request.body)
-            workers_to_close = {"workers": scheduler.workers_to_close(**params)}
-            self.write(json.dumps(workers_to_close))
-        except Exception as e:
             self.set_status(500, str(e))
-            self.write(json.dumps({"Error": "Bad request"}))
+            self.write(json.dumps({"Error": "Internal Server Error"}))
 
 
 class GetWorkersHandler(RequestHandler):
     def get(self):
         self.set_header("Content-Type", "text/json")
         scheduler = self.server
-        response = {
-            "num_workers": len(scheduler.workers),
-            "workers": [
-                {"name": ws.name, "address": ws.address}
-                for ws in scheduler.workers.values()
-            ],
-        }
-        self.write(json.dumps(response))
+        try:
+            response = {
+                "num_workers": len(scheduler.workers),
+                "workers": [
+                    {"name": ws.name, "address": ws.address}
+                    for ws in scheduler.workers.values()
+                ],
+            }
+            self.write(json.dumps(response))
+        except Exception as e:
+            self.set_status(500, str(e))
+            self.write(json.dumps({"Error": "Internal Server Error"}))
 
 
 class AdaptiveTargetHandler(RequestHandler):
     def get(self):
         self.set_header("Content-Type", "text/json")
         scheduler = self.server
-        desired_workers = scheduler.adaptive_target()
-        response = {
-            "workers": desired_workers,
-        }
-        self.write(json.dumps(response))
+        try:
+            desired_workers = scheduler.adaptive_target()
+            response = {
+                "workers": desired_workers,
+            }
+            self.write(json.dumps(response))
+        except Exception as e:
+            self.set_status(500, str(e))
+            self.write(json.dumps({"Error": "Internal Server Error"}))
 
 
 routes: list[tuple] = [
     ("/api/v1", APIHandler, {}),
     ("/api/v1/retire_workers", RetireWorkersHandler, {}),
-    ("/api/v1/workers_to_close", WorkersToCloseHandler, {}),
     ("/api/v1/get_workers", GetWorkersHandler, {}),
     ("/api/v1/adaptive_target", AdaptiveTargetHandler, {}),
 ]

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -271,7 +271,8 @@ async def test_retire_workers(c, s, a, b):
             json=params,
         ) as resp:
             assert resp.status == 200
-        assert len(c.scheduler_info()["workers"]) == 0
+            await resp.text()
+            assert len(c.scheduler_info()["workers"]) == 0
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
@@ -293,4 +294,5 @@ async def test_adaptive_target(c, s, a, b):
             "http://localhost:%d/api/v1/adaptive_target" % s.http_server.port
         ) as resp:
             assert resp.status == 200
-            assert int(await resp.text()) == 0
+            num_workers = json.loads(await resp.text())["workers"]
+            assert num_workers == 0

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -274,6 +274,20 @@ async def test_retire_workers(c, s, a, b):
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
+async def test_workers_to_close(c, s, a, b):
+    async with aiohttp.ClientSession() as session:
+        params = {"n": 2}
+        async with session.post(
+            "http://localhost:%d/api/v1/workers_to_close" % s.http_server.port,
+            json=params,
+        ) as resp:
+            assert resp.status == 200
+            assert resp.headers["Content-Type"] == "text/json"
+            workers_to_close = json.loads(await resp.text())["workers"]
+            assert len(workers_to_close) == 2
+
+
+@gen_cluster(client=True, clean_kwargs={"threads": False})
 async def test_get_workers(c, s, a, b):
     async with aiohttp.ClientSession() as session:
         async with session.get(

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -271,8 +271,6 @@ async def test_retire_workers(c, s, a, b):
             json=params,
         ) as resp:
             assert resp.status == 200
-            await resp.text()
-            assert len(c.scheduler_info()["workers"]) == 0
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -274,20 +274,6 @@ async def test_retire_workers(c, s, a, b):
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
-async def test_workers_to_close(c, s, a, b):
-    async with aiohttp.ClientSession() as session:
-        params = {"n": 2}
-        async with session.post(
-            "http://localhost:%d/api/v1/workers_to_close" % s.http_server.port,
-            json=params,
-        ) as resp:
-            assert resp.status == 200
-            assert resp.headers["Content-Type"] == "text/json"
-            workers_to_close = json.loads(await resp.text())["workers"]
-            assert len(workers_to_close) == 2
-
-
-@gen_cluster(client=True, clean_kwargs={"threads": False})
 async def test_get_workers(c, s, a, b):
     async with aiohttp.ClientSession() as session:
         async with session.get(

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -250,16 +250,13 @@ async def test_eventstream(c, s, a, b):
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
 async def test_api(c, s, a, b):
-    http_client = AsyncHTTPClient()
-
-    response = await http_client.fetch(
-        "http://localhost:%d/api/v1" % s.http_server.port
-    )
-    assert response.code == 200
-    assert response.headers["Content-Type"] == "text/plain"
-
-    txt = response.body.decode("utf8")
-    assert txt == "API V1"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            "http://localhost:%d/api/v1" % s.http_server.port
+        ) as resp:
+            assert resp.status == 200
+            assert resp.headers["Content-Type"] == "text/plain"
+            assert (await resp.text()) == "API V1"
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
@@ -271,6 +268,9 @@ async def test_retire_workers(c, s, a, b):
             json=params,
         ) as resp:
             assert resp.status == 200
+            assert resp.headers["Content-Type"] == "text/json"
+            retired_workers_info = json.loads(await resp.text())
+            assert len(retired_workers_info) == 2
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
@@ -280,6 +280,7 @@ async def test_get_workers(c, s, a, b):
             "http://localhost:%d/api/v1/get_workers" % s.http_server.port
         ) as resp:
             assert resp.status == 200
+            assert resp.headers["Content-Type"] == "text/json"
             workers_info = json.loads(await resp.text())["workers"]
             workers_address = [worker.get("address") for worker in workers_info]
             assert set(workers_address) == {a.address, b.address}
@@ -292,5 +293,6 @@ async def test_adaptive_target(c, s, a, b):
             "http://localhost:%d/api/v1/adaptive_target" % s.http_server.port
         ) as resp:
             assert resp.status == 200
+            assert resp.headers["Content-Type"] == "text/json"
             num_workers = json.loads(await resp.text())["workers"]
             assert num_workers == 0

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -245,3 +245,32 @@ async def test_eventstream(c, s, a, b):
     )
     assert "websocket" in str(s.plugins).lower()
     ws_client.close()
+
+
+@gen_cluster(client=True, clean_kwargs={"threads": False})
+async def test_api(c, s, a, b):
+    http_client = AsyncHTTPClient()
+
+    response = await http_client.fetch(
+        "http://localhost:%d/api/v1" % s.http_server.port
+    )
+    assert response.code == 200
+    assert response.headers["Content-Type"] == "text/plain"
+
+    txt = response.body.decode("utf8")
+    assert txt == "API V1"
+
+
+@gen_cluster(client=True, clean_kwargs={"threads": False})
+async def test_retire_workers(c, s, a, b):
+    assert True
+
+
+@gen_cluster(client=True, clean_kwargs={"threads": False})
+async def test_get_workers(c, s, a, b):
+    assert True
+
+
+@gen_cluster(client=True, clean_kwargs={"threads": False})
+async def test_adaptive_target(c, s, a, b):
+    assert True

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -48,6 +48,9 @@ Pages and JSON endpoints served by the scheduler
 - ``/sitemap.json``: list of available endpoints
 - ``/statics/()``: static file content (CSS, etc)
 - ``/stealing``: worker occupancy metrics, to evaluate task stealing
+- ``/api/v1/retire_workers`` : retire certain workers on the scheduler
+- ``/api/v1/get_workers`` : get all workers on the scheduler
+- ``/api/v1/adaptive_target`` : get the target number of workers based on the scheduler's load 
 
 Individual bokeh plots
 ----------------------

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -62,14 +62,6 @@ Scheduler methods exposed by the API with an example of the request body they ta
         "workers":["tcp://127.0.0.1:53741", "tcp://127.0.0.1:53669"]
     }
 
-- ``/api/v1/workers_to_close`` : get a list of n workers that the scheduler can safely close
-
-.. code-block:: json
-
-    {
-        "n":2
-    }
-
 - ``/api/v1/get_workers`` : get all workers on the scheduler
 - ``/api/v1/adaptive_target`` : get the target number of workers based on the scheduler's load 
 

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -48,7 +48,26 @@ Pages and JSON endpoints served by the scheduler
 - ``/sitemap.json``: list of available endpoints
 - ``/statics/()``: static file content (CSS, etc)
 - ``/stealing``: worker occupancy metrics, to evaluate task stealing
+
+Scheduler API
+-------------
+
+Scheduler methods exposed by the API with an example of the request body they take
+
 - ``/api/v1/retire_workers`` : retire certain workers on the scheduler
+
+.. code-block:: json
+    {
+        "workers":["tcp://127.0.0.1:53741", "tcp://127.0.0.1:53669"]
+    }
+
+- ``/api/v1/workers_to_close`` : get a list of n workers that the scheduler can safely close
+
+.. code-block:: json
+    {
+        "n":2
+    }
+
 - ``/api/v1/get_workers`` : get all workers on the scheduler
 - ``/api/v1/adaptive_target`` : get the target number of workers based on the scheduler's load 
 

--- a/docs/source/http_services.rst
+++ b/docs/source/http_services.rst
@@ -57,6 +57,7 @@ Scheduler methods exposed by the API with an example of the request body they ta
 - ``/api/v1/retire_workers`` : retire certain workers on the scheduler
 
 .. code-block:: json
+
     {
         "workers":["tcp://127.0.0.1:53741", "tcp://127.0.0.1:53669"]
     }
@@ -64,6 +65,7 @@ Scheduler methods exposed by the API with an example of the request body they ta
 - ``/api/v1/workers_to_close`` : get a list of n workers that the scheduler can safely close
 
 .. code-block:: json
+
     {
         "n":2
     }


### PR DESCRIPTION
Closes #5935 

This PR exposes some of the scheduler endpoints we need to replace the Dask RPC in the [Operator](https://github.com/dask/dask-kubernetes/issues/256).

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
