### PR TITLE
Minimize copying in `maybe_compress` & `byte_sample`

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -167,7 +167,7 @@ def maybe_compress(
     # Store size as it is used in a few cases.
     payload_nbytes = nbytes(payload)
 
-    # Either too small to bother or too large, compression libraries often fail
+    # Either too small to bother or too large; compression libraries often fail
     if not (min_size < payload_nbytes < 2**31):
         return None, payload
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -186,7 +186,7 @@ def maybe_compress(
         compressed = compress(mv)
         if len(compressed) <= 0.9 * mv.nbytes:
             return compression, compressed
-    # Skip compression as `sample` or `payload` didn't compress well.
+    # Skip compression as `sample` or `payload` didn't compress well
     return None, payload
 
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -159,8 +159,7 @@ def maybe_compress(
     # Store size as it is used in a few cases.
     payload_nbytes = nbytes(payload)
 
-    # Either too small to bother or
-    # too large, compression libraries often fail
+    # Either too small to bother or too large, compression libraries often fail
     if not (min_size < payload_nbytes < 2**31):
         return None, payload
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -120,7 +120,8 @@ def byte_sample(b, size, n):
     ----------
     b : bytes or memoryview
     size : int
-        size of each sample to collect
+        target size of each sample to collect
+        (may be smaller if samples collide)
     n : int
         number of samples to collect
     """

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -176,8 +176,8 @@ def maybe_compress(
     if len(compress(sample)) > 0.9 * len(sample):  # sample not very compressible
         return None, payload
 
+    # Try compressing the real thing
     compressed = compress(mv)
-
     if len(compressed) > 0.9 * payload_nbytes:  # full data not very compressible
         return None, payload
     else:

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -163,8 +163,6 @@ def maybe_compress(
     """
     if not compression:
         return None, payload
-    if compression == "auto":
-        compression = default_compression
 
     # Store size as it is used in a few cases.
     payload_nbytes = nbytes(payload)
@@ -173,8 +171,10 @@ def maybe_compress(
     if not (min_size < payload_nbytes < 2**31):
         return None, payload
 
+    # Normalize function arguments
     sample_size = int(sample_size)
-
+    if compression == "auto":
+        compression = default_compression
     compress = compressions[compression]["compress"]
 
     # Take a view of payload for efficient usage

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -133,7 +133,12 @@ def byte_sample(b, size, n):
     ends.append(starts[-1] + size)
 
     parts = [b[start:end] for start, end in zip(starts, ends)]
-    return b"".join(parts)
+    if n == 0:
+        return b""
+    elif n == 1:
+        return parts[0]
+    else:
+        return b"".join(parts)
 
 
 def maybe_compress(

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -129,7 +129,7 @@ def byte_sample(b, size, n):
 
     b = ensure_memoryview(b)
 
-    starts = [random.randint(0, len(b) - size) for j in range(n)]
+    starts = [random.randint(0, b.nbytes - size) for j in range(n)]
     ends = []
     for i, start in enumerate(starts[:-1]):
         ends.append(min(start + size, starts[i + 1]))
@@ -180,7 +180,7 @@ def maybe_compress(
 
     # Try compressing a sample to see if it compresses well
     sample = byte_sample(mv, sample_size, nsamples)
-    if len(compress(sample)) <= 0.9 * len(sample):
+    if len(compress(sample)) <= 0.9 * sample.nbytes:
         # Try compressing the real thing and check how compressed it is
         compressed = compress(mv)
         if len(compressed) <= 0.9 * payload_nbytes:

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -161,10 +161,10 @@ def maybe_compress(
         return the original
     4.  We return the compressed result
     """
-    if compression == "auto":
-        compression = default_compression
     if not compression:
         return None, payload
+    if compression == "auto":
+        compression = default_compression
 
     # Store size as it is used in a few cases.
     payload_nbytes = nbytes(payload)

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -132,13 +132,13 @@ def byte_sample(b, size, n):
 
     parts = []
     max_start = b.nbytes - size
-    next_start = randint(0, max_start)
+    start = randint(0, max_start)
     for i in range(n - 1):
-        start = next_start
         next_start = randint(0, max_start)
         end = min(start + size, next_start)
         parts.append(b[start:end])
-    parts.append(b[next_start : next_start + size])
+        start = next_start
+    parts.append(b[start : start + size])
 
     if n == 1:
         return parts[0]

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -127,6 +127,7 @@ def byte_sample(b, size, n):
     if size == 0 or n == 0:
         return memoryview(b"")
 
+    assert size > 0 and n > 0
     b = ensure_memoryview(b)
 
     starts = [random.randint(0, b.nbytes - size) for j in range(n)]

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from contextlib import suppress
-from itertools import islice
 from random import randint
 from typing import Literal
 
@@ -131,14 +130,16 @@ def byte_sample(b, size, n):
 
     b = ensure_memoryview(b)
 
+    parts = []
     max_start = b.nbytes - size
-    starts = [randint(0, max_start) for j in range(n)]
-    ends = []
-    for i, start in enumerate(islice(starts, n - 1)):
-        ends.append(min(start + size, starts[i + 1]))
-    ends.append(starts[-1] + size)
+    next_start = randint(0, max_start)
+    for i in range(n - 1):
+        start = next_start
+        next_start = randint(0, max_start)
+        end = min(start + size, next_start)
+        parts.append(b[start:end])
+    parts.append(b[next_start : next_start + size])
 
-    parts = [b[start:end] for start, end in zip(starts, ends)]
     if n == 1:
         return parts[0]
     else:

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -131,15 +131,15 @@ def byte_sample(b, size, n):
 
     b = ensure_memoryview(b)
 
-    parts = []
+    parts = n * [None]
     max_start = b.nbytes - size
     start = randint(0, max_start)
     for i in range(n - 1):
         next_start = randint(0, max_start)
         end = min(start + size, next_start)
-        parts.append(b[start:end])
+        parts[i] = b[start:end]
         start = next_start
-    parts.append(b[start : start + size])
+    parts[-1] = b[start : start + size]
 
     if n == 1:
         return parts[0]

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -185,7 +185,7 @@ def maybe_compress(
         compressed = compress(mv)
         if len(compressed) <= 0.9 * mv.nbytes:
             return compression, compressed
-    # Sample or payload didn't compress well. Skip compressing.
+    # Skip compression as `sample` or `payload` didn't compress well.
     return None, payload
 
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -187,7 +187,7 @@ def maybe_compress(
         compressed = compress(mv)
         if len(compressed) <= 0.9 * mv.nbytes:
             return compression, compressed
-    # Skip compression as `sample` or `payload` didn't compress well
+    # Skip compression as the sample or the data didn't compress well
     return None, payload
 
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -124,6 +124,7 @@ def byte_sample(b, size, n):
     n : int
         number of samples to collect
     """
+    b = ensure_memoryview(b)
     starts = [random.randint(0, len(b) - size) for j in range(n)]
     ends = []
     for i, start in enumerate(starts[:-1]):

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -164,11 +164,8 @@ def maybe_compress(
     if not compression:
         return None, payload
 
-    # Store size as it is used in a few cases.
-    payload_nbytes = nbytes(payload)
-
     # Either too small to bother or too large; compression libraries often fail
-    if not (min_size < payload_nbytes < 2**31):
+    if not (min_size < nbytes(payload) < 2**31):
         return None, payload
 
     # Normalize function arguments

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -180,10 +180,10 @@ def maybe_compress(
 
     # Try compressing a sample to see if it compresses well
     sample = byte_sample(mv, sample_size, nsamples)
-    if len(compress(sample)) <= 0.9 * len(sample):  # sample is compressible
+    if len(compress(sample)) <= 0.9 * len(sample):
         # Try compressing the real thing and check how compressed it is
         compressed = compress(mv)
-        if len(compressed) <= 0.9 * payload_nbytes:  # full data is compressible
+        if len(compressed) <= 0.9 * payload_nbytes:
             return compression, compressed
     # Sample or payload didn't compress well. Skip compressing.
     return None, payload

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -125,6 +125,7 @@ def byte_sample(b, size, n):
         number of samples to collect
     """
     b = ensure_memoryview(b)
+
     starts = [random.randint(0, len(b) - size) for j in range(n)]
     ends = []
     for i, start in enumerate(starts[:-1]):

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -161,7 +161,6 @@ def maybe_compress(
     if len(payload) > 2**31:  # Too large, compression libraries often fail
         return None, payload
 
-    min_size = int(min_size)
     sample_size = int(sample_size)
 
     compress = compressions[compression]["compress"]

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -6,10 +6,10 @@ Includes utilities for determining whether or not to compress
 from __future__ import annotations
 
 import logging
-import random
 from collections.abc import Callable
 from contextlib import suppress
 from itertools import islice
+from random import randint
 from typing import Literal
 
 from packaging.version import parse as parse_version
@@ -131,7 +131,7 @@ def byte_sample(b, size, n):
     assert size > 0 and n > 0
     b = ensure_memoryview(b)
 
-    starts = [random.randint(0, b.nbytes - size) for j in range(n)]
+    starts = [randint(0, b.nbytes - size) for j in range(n)]
     ends = []
     for i, start in enumerate(islice(starts, n - 1)):
         ends.append(min(start + size, starts[i + 1]))

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -149,8 +149,8 @@ def byte_sample(b, size, n):
 
 def maybe_compress(
     payload,
-    min_size=1e4,
-    sample_size=1e4,
+    min_size=10_000,
+    sample_size=10_000,
     nsamples=5,
     compression=dask.config.get("distributed.comm.compression"),
 ):
@@ -172,7 +172,6 @@ def maybe_compress(
         return None, payload
 
     # Normalize function arguments
-    sample_size = int(sample_size)
     if compression == "auto":
         compression = default_compression
     compress = compressions[compression]["compress"]

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -125,10 +125,10 @@ def byte_sample(b, size, n):
     n : int
         number of samples to collect
     """
+    assert size >= 0 and n >= 0
     if size == 0 or n == 0:
         return memoryview(b"")
 
-    assert size > 0 and n > 0
     b = ensure_memoryview(b)
 
     starts = [randint(0, b.nbytes - size) for j in range(n)]

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -178,17 +178,15 @@ def maybe_compress(
     # Take a view of payload for efficient usage
     mv = ensure_memoryview(payload)
 
-    # Compress a sample, return original if not very compressed
+    # Try compressing a sample to see if it compresses well
     sample = byte_sample(mv, sample_size, nsamples)
-    if len(compress(sample)) > 0.9 * len(sample):  # sample not very compressible
-        return None, payload
-
-    # Try compressing the real thing
-    compressed = compress(mv)
-    if len(compressed) > 0.9 * payload_nbytes:  # full data not very compressible
-        return None, payload
-    else:
-        return compression, compressed
+    if len(compress(sample)) <= 0.9 * len(sample):  # sample is compressible
+        # Try compressing the real thing and check how compressed it is
+        compressed = compress(mv)
+        if len(compressed) <= 0.9 * payload_nbytes:  # full data is compressible
+            return compression, compressed
+    # Sample or payload didn't compress well. Skip compressing.
+    return None, payload
 
 
 def decompress(header, frames):

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -164,9 +164,9 @@ def maybe_compress(
     """
     if not compression:
         return None, payload
-
-    # Either too small to bother or too large; compression libraries often fail
     if not (min_size < nbytes(payload) < 2**31):
+        # Either too small to bother
+        # or too large (compression libraries often fail)
         return None, payload
 
     # Normalize function arguments

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -125,7 +125,7 @@ def byte_sample(b, size, n):
         number of samples to collect
     """
     if n == 0:
-        return b""
+        return memoryview(b"")
 
     b = ensure_memoryview(b)
 
@@ -139,7 +139,7 @@ def byte_sample(b, size, n):
     if n == 1:
         return parts[0]
     else:
-        return b"".join(parts)
+        return memoryview(b"".join(parts))
 
 
 def maybe_compress(

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -153,7 +153,6 @@ def maybe_compress(
     """
     if compression == "auto":
         compression = default_compression
-
     if not compression:
         return None, payload
     if len(payload) < min_size:

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -185,7 +185,7 @@ def maybe_compress(
     if len(compress(sample)) <= 0.9 * sample.nbytes:
         # Try compressing the real thing and check how compressed it is
         compressed = compress(mv)
-        if len(compressed) <= 0.9 * payload_nbytes:
+        if len(compressed) <= 0.9 * mv.nbytes:
             return compression, compressed
     # Sample or payload didn't compress well. Skip compressing.
     return None, payload

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -124,7 +124,7 @@ def byte_sample(b, size, n):
     n : int
         number of samples to collect
     """
-    if n == 0:
+    if size == 0 or n == 0:
         return memoryview(b"")
 
     b = ensure_memoryview(b)

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -131,7 +131,8 @@ def byte_sample(b, size, n):
 
     b = ensure_memoryview(b)
 
-    starts = [randint(0, b.nbytes - size) for j in range(n)]
+    max_start = b.nbytes - size
+    starts = [randint(0, max_start) for j in range(n)]
     ends = []
     for i, start in enumerate(islice(starts, n - 1)):
         ends.append(min(start + size, starts[i + 1]))

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -166,7 +166,7 @@ def maybe_compress(
     """
     if not compression:
         return None, payload
-    if not (min_size < nbytes(payload) < 2**31):
+    if not (min_size <= nbytes(payload) <= 2**31):
         # Either too small to bother
         # or too large (compression libraries often fail)
         return None, payload

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -9,6 +9,7 @@ import logging
 import random
 from collections.abc import Callable
 from contextlib import suppress
+from itertools import islice
 from typing import Literal
 
 from packaging.version import parse as parse_version
@@ -132,7 +133,7 @@ def byte_sample(b, size, n):
 
     starts = [random.randint(0, b.nbytes - size) for j in range(n)]
     ends = []
-    for i, start in enumerate(starts[:-1]):
+    for i, start in enumerate(islice(starts, n - 1)):
         ends.append(min(start + size, starts[i + 1]))
     ends.append(starts[-1] + size)
 

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -124,6 +124,9 @@ def byte_sample(b, size, n):
     n : int
         number of samples to collect
     """
+    if n == 0:
+        return b""
+
     b = ensure_memoryview(b)
 
     starts = [random.randint(0, len(b) - size) for j in range(n)]
@@ -133,9 +136,7 @@ def byte_sample(b, size, n):
     ends.append(starts[-1] + size)
 
     parts = [b[start:end] for start, end in zip(starts, ends)]
-    if n == 0:
-        return b""
-    elif n == 1:
+    if n == 1:
         return parts[0]
     else:
         return b"".join(parts)

--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -159,9 +159,9 @@ def maybe_compress(
     # Store size as it is used in a few cases.
     payload_nbytes = nbytes(payload)
 
-    if payload_nbytes < min_size:
-        return None, payload
-    if payload_nbytes > 2**31:  # Too large, compression libraries often fail
+    # Either too small to bother or
+    # too large, compression libraries often fail
+    if not (min_size < payload_nbytes < 2**31):
         return None, payload
 
     sample_size = int(sample_size)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -17,17 +17,9 @@ from distributed.protocol.serialize import (
     serialize_and_split,
 )
 from distributed.protocol.utils import msgpack_opts
+from distributed.utils import ensure_memoryview
 
 logger = logging.getLogger(__name__)
-
-
-def ensure_memoryview(obj):
-    """Ensure `obj` is a memoryview of datatype bytes"""
-    ret = memoryview(obj)
-    if ret.nbytes:
-        return ret.cast("B")
-    else:
-        return ret
 
 
 def dumps(

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -58,9 +58,19 @@ def test_compression_2():
     pytest.importorskip("lz4")
     np = pytest.importorskip("numpy")
     x = np.random.random(10000)
-    msg = dumps(to_serialize(x.tobytes()))
+    msg = dumps(to_serialize(x.data))
     compression = msgpack.loads(msg[1]).get("compression")
     assert all(c is None for c in compression)
+
+
+def test_compression_3():
+    pytest.importorskip("lz4")
+    np = pytest.importorskip("numpy")
+    x = np.ones(1000000)
+    frames = dumps({"x": Serialize(x.data)})
+    assert sum(map(nbytes, frames)) < x.nbytes
+    y = loads(frames)
+    assert {"x": x.data} == y
 
 
 def test_compression_without_deserialization():

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -48,10 +48,11 @@ def test_compression_1():
     pytest.importorskip("lz4")
     np = pytest.importorskip("numpy")
     x = np.ones(1000000)
-    frames = dumps({"x": Serialize(x.tobytes())})
-    assert sum(map(nbytes, frames)) < x.nbytes
+    b = x.tobytes()
+    frames = dumps({"x": Serialize(b)})
+    assert sum(map(nbytes, frames)) < nbytes(b)
     y = loads(frames)
-    assert {"x": x.tobytes()} == y
+    assert {"x": b} == y
 
 
 def test_compression_2():

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -28,6 +28,7 @@ from distributed.utils import (
     _maybe_complex,
     ensure_bytes,
     ensure_ip,
+    ensure_memoryview,
     format_dashboard_link,
     get_ip_interface,
     get_traceback,
@@ -267,6 +268,30 @@ def test_ensure_bytes_pyarrow_buffer():
     buf = pa.py_buffer(b"123")
     result = ensure_bytes(buf)
     assert isinstance(result, bytes)
+
+
+def test_ensure_memoryview():
+    data = [b"1", memoryview(b"1"), bytearray(b"1"), array.array("b", [49])]
+    for d in data:
+        result = ensure_memoryview(d)
+        assert isinstance(result, memoryview)
+        assert result == memoryview(b"1")
+
+
+def test_ensure_memoryview_ndarray():
+    np = pytest.importorskip("numpy")
+    result = ensure_memoryview(np.arange(12).reshape(3, 4)[:, ::2].T)
+    assert isinstance(result, memoryview)
+    assert result.ndim == 1
+    assert result.format == "B"
+    assert result.contiguous
+
+
+def test_ensure_memoryview_pyarrow_buffer():
+    pa = pytest.importorskip("pyarrow")
+    buf = pa.py_buffer(b"123")
+    result = ensure_memoryview(buf)
+    assert isinstance(result, memoryview)
 
 
 def test_nbytes():

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -270,6 +270,12 @@ def test_ensure_bytes_pyarrow_buffer():
     assert isinstance(result, bytes)
 
 
+def test_ensure_memoryview_empty():
+    result = ensure_memoryview(b"")
+    assert isinstance(result, memoryview)
+    assert result == memoryview(b"")
+
+
 def test_ensure_memoryview():
     data = [b"1", memoryview(b"1"), bytearray(b"1"), array.array("b", [49])]
     for d in data:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1021,7 +1021,7 @@ def ensure_memoryview(obj):
     else:
         mv = memoryview(obj)
 
-    if mv.nbytes:
+    if mv.nbytes and mv.contiguous:
         return mv.cast("B")
     else:
         return mv

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1021,7 +1021,9 @@ def ensure_memoryview(obj):
     else:
         mv = memoryview(obj)
 
-    if mv.nbytes and mv.contiguous:
+    if not mv.nbytes:
+        return memoryview(b"")
+    elif mv.contiguous:
         return mv.cast("B")
     else:
         return memoryview(mv.tobytes())

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1022,7 +1022,7 @@ def ensure_memoryview(obj):
         mv = memoryview(obj)
 
     if not mv.nbytes:
-        # Drop `obj` reference to allow freeing underlying data
+        # Drop `obj` reference to permit freeing underlying data
         return memoryview(b"")
     elif mv.contiguous:
         # Perform zero-copy reshape & cast

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1015,7 +1015,12 @@ def ensure_bytes(s):
 
 def ensure_memoryview(obj):
     """Ensure `obj` is a memoryview of datatype bytes"""
-    mv = memoryview(obj)
+    mv: memoryview
+    if type(obj) is memoryview:
+        mv = obj
+    else:
+        mv = memoryview(obj)
+
     if mv.nbytes:
         return mv.cast("B")
     else:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1028,7 +1028,7 @@ def ensure_memoryview(obj):
         # Perform zero-copy reshape & cast
         return mv.cast("B")
     else:
-        # Copy to contiguous form of expected type
+        # Copy to contiguous form of expected shape & type
         return memoryview(mv.tobytes())
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1022,10 +1022,10 @@ def ensure_memoryview(obj):
         mv = memoryview(obj)
 
     if not mv.nbytes:
-        # empty
+        # Drop `obj` reference so underlying data can be freed.
         return memoryview(b"")
     elif mv.contiguous:
-        # can reshape & cast zero-copy
+        # Perform zero-copy reshape & cast.
         return mv.cast("B")
     else:
         # `memoryview` is non-trivial & not contiguous.

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1022,14 +1022,13 @@ def ensure_memoryview(obj):
         mv = memoryview(obj)
 
     if not mv.nbytes:
-        # Drop `obj` reference so underlying data can be freed.
+        # Drop `obj` reference to allow freeing underlying data
         return memoryview(b"")
     elif mv.contiguous:
-        # Perform zero-copy reshape & cast.
+        # Perform zero-copy reshape & cast
         return mv.cast("B")
     else:
-        # `memoryview` is non-trivial & not contiguous.
-        # Copy it to contiguous form of the expected type.
+        # Copy to contiguous form of expected type
         return memoryview(mv.tobytes())
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1014,7 +1014,7 @@ def ensure_bytes(s):
 
 
 def ensure_memoryview(obj):
-    """Ensure `obj` is a `memoryview` that is 1-D contiguous of `uint8` type"""
+    """Ensure `obj` is a 1-D contiguous `uint8` `memoryview`"""
     mv: memoryview
     if type(obj) is memoryview:
         mv = obj

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1013,6 +1013,15 @@ def ensure_bytes(s):
             ) from e
 
 
+def ensure_memoryview(obj):
+    """Ensure `obj` is a memoryview of datatype bytes"""
+    ret = memoryview(obj)
+    if ret.nbytes:
+        return ret.cast("B")
+    else:
+        return ret
+
+
 def open_port(host=""):
     """Return a probably-open port
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1024,7 +1024,7 @@ def ensure_memoryview(obj):
     if mv.nbytes and mv.contiguous:
         return mv.cast("B")
     else:
-        return mv
+        return memoryview(mv.tobytes())
 
 
 def open_port(host=""):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1014,7 +1014,7 @@ def ensure_bytes(s):
 
 
 def ensure_memoryview(obj):
-    """Ensure `obj` is a memoryview of datatype bytes"""
+    """Ensure `obj` is a `memoryview` that is 1-D contiguous of `uint8` type"""
     mv: memoryview
     if type(obj) is memoryview:
         mv = obj
@@ -1022,10 +1022,14 @@ def ensure_memoryview(obj):
         mv = memoryview(obj)
 
     if not mv.nbytes:
+        # empty
         return memoryview(b"")
     elif mv.contiguous:
+        # can reshape & cast zero-copy
         return mv.cast("B")
     else:
+        # `memoryview` is non-trivial & not contiguous.
+        # Copy it to contiguous form of the expected type.
         return memoryview(mv.tobytes())
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1015,11 +1015,11 @@ def ensure_bytes(s):
 
 def ensure_memoryview(obj):
     """Ensure `obj` is a memoryview of datatype bytes"""
-    ret = memoryview(obj)
-    if ret.nbytes:
-        return ret.cast("B")
+    mv = memoryview(obj)
+    if mv.nbytes:
+        return mv.cast("B")
     else:
-        return ret
+        return mv
 
 
 def open_port(host=""):


### PR DESCRIPTION
Currently there are a bunch of copies that occur in `maybe_compress` and `byte_sample`. Some of these are explicit (like calling `ensure_bytes`) and some are implicit (like slicing). In either case it would be good to avoid additional memory allocation and copying in these functions when it is not needed. After all these code paths can be triggered when sending data over the wire or spilling to disk (either could be occurring due to memory pressure that we don't want to add to).

<hr>

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
