### PR TITLE
Add scheduler-sni option for dask workers

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -254,6 +254,12 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     help="Module that should be loaded by each nanny "
     'like "foo.bar" or "/path/to/foo.py"',
 )
+@click.option(
+    "--scheduler-sni",
+    type=str,
+    default=None,
+    help="Scheduler SNI (if different from scheduler hostname)",
+)
 @click.version_option()
 def main(
     scheduler,

--- a/distributed/cli/tests/test_tls_cli.py
+++ b/distributed/cli/tests/test_tls_cli.py
@@ -38,6 +38,24 @@ def test_basic(loop):
                 wait_for_cores(c)
 
 
+def test_sni(loop):
+    with popen(["dask-scheduler", "--no-dashboard"] + tls_args) as s:
+        with popen(
+            [
+                "dask-worker",
+                "--no-dashboard",
+                "--scheduler-sni",
+                "localhost",
+                "tls://127.0.0.1:8786",
+            ]
+            + tls_args
+        ) as w:
+            with Client(
+                "tls://127.0.0.1:8786", loop=loop, security=tls_security()
+            ) as c:
+                wait_for_cores(c)
+
+
 def test_nanny(loop):
     with popen(["dask-scheduler", "--no-dashboard"] + tls_args) as s:
         with popen(

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -436,9 +436,17 @@ class BaseTCPConnector(Connector, RequireEncryptionMixin):
         kwargs = self._get_connect_args(**connection_args)
 
         try:
-            stream = await self.client.connect(
-                ip, port, max_buffer_size=MAX_BUFFER_SIZE, **kwargs
-            )
+            # server_hostname option (for SNI) only works with tornado.iostream.IOStream
+            if "server_hostname" in kwargs:
+                plain_stream = await self.client.connect(
+                    ip, port, max_buffer_size=MAX_BUFFER_SIZE
+                )
+                stream = await plain_stream.start_tls(False, **kwargs)
+            else:
+                stream = await self.client.connect(
+                    ip, port, max_buffer_size=MAX_BUFFER_SIZE, **kwargs
+                )
+
             # Under certain circumstances tornado will have a closed connnection with an
             # error and not raise a StreamClosedError.
             #
@@ -480,8 +488,10 @@ class TLSConnector(BaseTCPConnector):
     encrypted = True
 
     def _get_connect_args(self, **connection_args):
-        ctx = _expect_tls_context(connection_args)
-        return {"ssl_options": ctx}
+        tls_args = {"ssl_options": _expect_tls_context(connection_args)}
+        if connection_args.get("server_hostname"):
+            tls_args["server_hostname"] = connection_args["server_hostname"]
+        return tls_args
 
 
 class BaseTCPListener(Listener, RequireEncryptionMixin):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -550,6 +550,7 @@ class Worker(ServerNode):
         memory_pause_fraction: float | Literal[False] | None = None,
         ###################################
         # Parameters to Server
+        scheduler_sni: str | None = None,
         **kwargs,
     ):
         self.tasks = {}
@@ -749,10 +750,11 @@ class Worker(ServerNode):
         self.security = security or Security()
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args("worker")
-
         self.actors = {}
         self.loop = loop or IOLoop.current()
         self.reconnect = reconnect
+        if scheduler_sni:
+            self.connection_args["server_hostname"] = scheduler_sni
 
         # Common executors always available
         self.executors = {


### PR DESCRIPTION
This adds support for dask workers to specify the SNI host
separately from the TLS endpoint.  In some environments (such
as a Kubernetes cluster running dask-gateway), the schedulers
may be behind a TLS proxy, while the workers are external to the
cluster.  This allows workers to connect to the schedulers
without the need for wildcard DNS.

Signed-off-by: Burt Holzman <burt@fnal.gov>

Closes #6289

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
