### PR TITLE
Simplify frame handling in `ws`

### DIFF
--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -36,7 +36,6 @@ from distributed.comm.utils import (
     get_tcp_server_address,
     to_frames,
 )
-from distributed.utils import nbytes
 
 logger = logging.getLogger(__name__)
 
@@ -137,16 +136,18 @@ class WSHandlerComm(Comm):
             frame_split_size=BIG_BYTES_SHARD_SIZE,
         )
         n = struct.pack("Q", len(frames))
+        nbytes_frames = 0
         try:
             await self.handler.write_message(n, binary=True)
             for frame in frames:
                 if type(frame) is not bytes:
                     frame = bytes(frame)
                 await self.handler.write_message(frame, binary=True)
+                nbytes_frames += len(frame)
         except WebSocketClosedError as e:
             raise CommClosedError(str(e))
 
-        return sum(map(nbytes, frames))
+        return nbytes_frames
 
     def abort(self):
         self.handler.close()
@@ -228,16 +229,18 @@ class WS(Comm):
             frame_split_size=BIG_BYTES_SHARD_SIZE,
         )
         n = struct.pack("Q", len(frames))
+        nbytes_frames = 0
         try:
             await self.sock.write_message(n, binary=True)
             for frame in frames:
                 if type(frame) is not bytes:
                     frame = bytes(frame)
                 await self.sock.write_message(frame, binary=True)
+                nbytes_frames += len(frame)
         except WebSocketClosedError as e:
             raise CommClosedError(e)
 
-        return sum(map(nbytes, frames))
+        return nbytes_frames
 
     async def close(self):
         if not self.sock.close_code:

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -36,7 +36,7 @@ from distributed.comm.utils import (
     get_tcp_server_address,
     to_frames,
 )
-from distributed.utils import ensure_bytes, nbytes
+from distributed.utils import nbytes
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +140,9 @@ class WSHandlerComm(Comm):
         try:
             await self.handler.write_message(n, binary=True)
             for frame in frames:
-                await self.handler.write_message(ensure_bytes(frame), binary=True)
+                if type(frame) is not bytes:
+                    frame = bytes(frame)
+                await self.handler.write_message(frame, binary=True)
         except WebSocketClosedError as e:
             raise CommClosedError(str(e))
 
@@ -229,7 +231,9 @@ class WS(Comm):
         try:
             await self.sock.write_message(n, binary=True)
             for frame in frames:
-                await self.sock.write_message(ensure_bytes(frame), binary=True)
+                if type(frame) is not bytes:
+                    frame = bytes(frame)
+                await self.sock.write_message(frame, binary=True)
         except WebSocketClosedError as e:
             raise CommClosedError(e)
 


### PR DESCRIPTION
Cuts down the overhead associated with frame handling in `ws` by simply handling `frame` coercion to `bytes` directly and tracking the number of bytes sent while sending. As the use case here is quite simple this also makes it a bit easier to see what is going on with each `frame`.

<hr>

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
