### PR TITLE
Fix WORKER_ANY_RUNNING regression

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -584,8 +584,7 @@ class Server:
                             self._ongoing_coroutines.add(result)
                             result = await result
                     except CommClosedError:
-                        if self.status in Status.ANY_RUNNING:
-                            logger.info("Lost connection to %r", address, exc_info=True)
+                        logger.info("Lost connection to %r", address, exc_info=True)
                         break
                     except Exception as e:
                         logger.exception("Exception while handling op %s", op)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -584,7 +584,8 @@ class Server:
                             self._ongoing_coroutines.add(result)
                             result = await result
                     except CommClosedError:
-                        logger.info("Lost connection to %r", address, exc_info=True)
+                        if self.status == Status.running:
+                            logger.info("Lost connection to %r", address, exc_info=True)
                         break
                     except Exception as e:
                         logger.exception("Exception while handling op %s", op)


### PR DESCRIPTION
I removed `Status.ANY_RUNNING` recently for a more explicit WORKER_ANY_RUNNING.
Using the WORKER_ANY_RUNNING in the server core doesn't make any sense so I think just logging this message is OK