### PR TITLE
Use `ensure_memoryview` in `array` deserialization

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -23,7 +23,7 @@ from distributed.protocol.utils import (
     pack_frames_prelude,
     unpack_frames,
 )
-from distributed.utils import has_keyword
+from distributed.utils import ensure_memoryview, has_keyword
 
 dask_serialize = dask.utils.Dispatch("dask_serialize")
 dask_deserialize = dask.utils.Dispatch("dask_deserialize")
@@ -765,12 +765,8 @@ def _serialize_array(obj):
 @dask_deserialize.register(array)
 def _deserialize_array(header, frames):
     a = array(header["typecode"])
-    for f in map(memoryview, frames):
-        try:
-            f = f.cast("B")
-        except TypeError:
-            f = f.tobytes()
-        a.frombytes(f)
+    for f in frames:
+        a.frombytes(ensure_memoryview(f))
     return a
 
 


### PR DESCRIPTION
Simplify `array` deserialization by leveraging the `ensure_memoryview` utility function added in PR ( https://github.com/dask/distributed/pull/6273 ). This will still handle coercion of the `frames` in the way `array` expects without needing to include all the details in `array` deserialization itself.

<hr>

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
