### PR TITLE
Support receiving stimulus_id's in Scheduler.reschedule

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6697,7 +6697,7 @@ class Scheduler(SchedulerState, ServerNode):
 
     transition_story = story
 
-    def reschedule(self, key: str, worker: str, stimulus_id: str):
+    def reschedule(self, key: str, worker=None, *, stimulus_id: str):
         """Reschedule a task
 
         Things may have shifted and this task may now be better suited to run

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6697,7 +6697,7 @@ class Scheduler(SchedulerState, ServerNode):
 
     transition_story = story
 
-    def reschedule(self, key=None, worker=None, stimulus_id=None):
+    def reschedule(self, key: str, worker: str, stimulus_id: str):
         """Reschedule a task
 
         Things may have shifted and this task may now be better suited to run
@@ -6715,7 +6715,7 @@ class Scheduler(SchedulerState, ServerNode):
             return
         if worker and ts.processing_on.address != worker:
             return
-        self.transitions({key: "released"}, stimulus_id or f"reschedule-{time()}")
+        self.transitions({key: "released"}, stimulus_id)
 
     #####################
     # Utility functions #

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6697,7 +6697,7 @@ class Scheduler(SchedulerState, ServerNode):
 
     transition_story = story
 
-    def reschedule(self, key=None, worker=None):
+    def reschedule(self, key=None, worker=None, stimulus_id=None):
         """Reschedule a task
 
         Things may have shifted and this task may now be better suited to run
@@ -6715,7 +6715,7 @@ class Scheduler(SchedulerState, ServerNode):
             return
         if worker and ts.processing_on.address != worker:
             return
-        self.transitions({key: "released"}, f"reschedule-{time()}")
+        self.transitions({key: "released"}, stimulus_id or f"reschedule-{time()}")
 
     #####################
     # Utility functions #

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1481,7 +1481,7 @@ async def test_reschedule(c, s, a, b):
         await asyncio.sleep(0.001)
 
     for future in x:
-        s.reschedule(future.key, None, "test")
+        s.reschedule(future.key, stimulus_id="test")
 
     # Worker b gets more of the original tasks
     await wait(x)
@@ -1492,7 +1492,7 @@ async def test_reschedule(c, s, a, b):
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 async def test_reschedule_warns(c, s, a, b):
     with captured_logger(logging.getLogger("distributed.scheduler")) as sched:
-        s.reschedule("__this-key-does-not-exist__", None, "test")
+        s.reschedule("__this-key-does-not-exist__", stimulus_id="test")
 
     assert "not found on the scheduler" in sched.getvalue()
     assert "Aborting reschedule" in sched.getvalue()
@@ -3301,7 +3301,7 @@ async def test_set_restrictions(c, s, a, b):
     await f
     s.set_restrictions(worker={f.key: a.address})
     assert s.tasks[f.key].worker_restrictions == {a.address}
-    s.reschedule(f, None, "test")
+    s.reschedule(f, stimulus_id="test")
     await f
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1481,7 +1481,7 @@ async def test_reschedule(c, s, a, b):
         await asyncio.sleep(0.001)
 
     for future in x:
-        s.reschedule(key=future.key)
+        s.reschedule(future.key, None, "test")
 
     # Worker b gets more of the original tasks
     await wait(x)
@@ -1492,7 +1492,7 @@ async def test_reschedule(c, s, a, b):
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)
 async def test_reschedule_warns(c, s, a, b):
     with captured_logger(logging.getLogger("distributed.scheduler")) as sched:
-        s.reschedule(key="__this-key-does-not-exist__")
+        s.reschedule("__this-key-does-not-exist__", None, "test")
 
     assert "not found on the scheduler" in sched.getvalue()
     assert "Aborting reschedule" in sched.getvalue()
@@ -3301,7 +3301,7 @@ async def test_set_restrictions(c, s, a, b):
     await f
     s.set_restrictions(worker={f.key: a.address})
     assert s.tasks[f.key].worker_restrictions == {a.address}
-    s.reschedule(f)
+    s.reschedule(f, None, "test")
     await f
 
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1109,7 +1109,7 @@ async def test_steal_reschedule_reset_in_flight_occupancy(c, s, *workers):
 
     steal.move_task_request(victim_ts, wsA, wsB)
 
-    s.reschedule(victim_key)
+    s.reschedule(victim_key, None, "test")
     await c.gather(futs1)
 
     del futs1
@@ -1175,7 +1175,7 @@ async def test_reschedule_concurrent_requests_deadlock(c, s, *workers):
     steal.move_task_request(victim_ts, wsA, wsB)
 
     s.set_restrictions(worker={victim_key: [wsB.address]})
-    s.reschedule(victim_key)
+    s.reschedule(victim_key, None, "test")
     assert wsB == victim_ts.processing_on
     # move_task_request is not responsible for respecting worker restrictions
     steal.move_task_request(victim_ts, wsB, wsC)

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1109,7 +1109,7 @@ async def test_steal_reschedule_reset_in_flight_occupancy(c, s, *workers):
 
     steal.move_task_request(victim_ts, wsA, wsB)
 
-    s.reschedule(victim_key, None, "test")
+    s.reschedule(victim_key, stimulus_id="test")
     await c.gather(futs1)
 
     del futs1
@@ -1175,7 +1175,7 @@ async def test_reschedule_concurrent_requests_deadlock(c, s, *workers):
     steal.move_task_request(victim_ts, wsA, wsB)
 
     s.set_restrictions(worker={victim_key: [wsB.address]})
-    s.reschedule(victim_key, None, "test")
+    s.reschedule(victim_key, stimulus_id="test")
     assert wsB == victim_ts.processing_on
     # move_task_request is not responsible for respecting worker restrictions
     steal.move_task_request(victim_ts, wsB, wsC)


### PR DESCRIPTION
In the log output e.g. https://github.com/dask/distributed/runs/6348164203?check_suite_focus=true for https://github.com/dask/distributed/pull/6281/commits/d7549b0a3a98130a825936edaf98893ec9a6c0c9

the following errors are occuring but are silently ignored:

```
2022-05-09T08:38:04.1870734Z 2022-05-09 08:36:42,873 - distributed.core - ERROR - reschedule() got an unexpected keyword argument 'stimulus_id'
2022-05-09T08:38:04.1870845Z Traceback (most recent call last):
2022-05-09T08:38:04.1871030Z   File "/home/runner/work/distributed/distributed/distributed/core.py", line 651, in handle_stream
2022-05-09T08:38:04.1871136Z     handler(**merge(extra, msg))
2022-05-09T08:38:04.1871388Z TypeError: reschedule() got an unexpected keyword argument 'stimulus_id'
2022-05-09T08:38:04.1871819Z 2022-05-09 08:36:42,873 - distributed.scheduler - INFO - Remove worker <WorkerState 'tcp://127.0.0.1:33919', name: 0, status: running, memory: 0, processing: 12>
2022-05-09T08:38:04.1872097Z 2022-05-09 08:36:42,873 - distributed.core - INFO - Removing comms to tcp://127.0.0.1:33919
2022-05-09T08:38:04.1872525Z 2022-05-09 08:36:42,878 - distributed.core - ERROR - Exception while handling op register-worker
2022-05-09T08:38:04.1872639Z Traceback (most recent call last):
2022-05-09T08:38:04.1872833Z   File "/home/runner/work/distributed/distributed/distributed/core.py", line 585, in handle_comm
2022-05-09T08:38:04.1872910Z     result = await result
2022-05-09T08:38:04.1873097Z   File "/home/runner/work/distributed/distributed/distributed/utils.py", line 759, in wrapper
2022-05-09T08:38:04.1873201Z     return await func(*args, **kwargs)
2022-05-09T08:38:04.1873400Z   File "/home/runner/work/distributed/distributed/distributed/scheduler.py", line 3829, in add_worker
2022-05-09T08:38:04.1873572Z     await self.handle_worker(comm=comm, worker=address, stimulus_id=stimulus_id)
2022-05-09T08:38:04.1873775Z   File "/home/runner/work/distributed/distributed/distributed/scheduler.py", line 4924, in handle_worker
2022-05-09T08:38:04.1873926Z     await self.handle_stream(comm=comm, extra={"worker": worker})
2022-05-09T08:38:04.1874122Z   File "/home/runner/work/distributed/distributed/distributed/core.py", line 651, in handle_stream
2022-05-09T08:38:04.1874210Z     handler(**merge(extra, msg))
2022-05-09T08:38:04.1874465Z TypeError: reschedule() got an unexpected keyword argument 'stimulus_id'
```

`worker_state_machine.RescheduleMsg` always sends stimulus_ids so this should be handled.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
