### PR TITLE
Modfy log_errors contextmanager to avoid traceback leaks

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -775,10 +775,13 @@ class _LogErrors:
         if not exc_type or issubclass(exc_type, (CommClosedError, gen.Return)):
             return
 
-        stack = inspect.stack()
-        frame = stack[self.unroll_stack]
-        mod = inspect.getmodule(frame[0])
-        modname = mod.__name__
+        i = self.unroll_stack
+
+        while traceback.tb_next and i > 0:
+            traceback = traceback.tb_next
+            i -= 1
+
+        modname = traceback.tb_frame.f_globals["__name__"]
 
         try:
             logger = logging.getLogger(modname)


### PR DESCRIPTION
In the existing implementation, tracebacks from exceptions aren't properly garbage collected.
The strategy in this PR avoids this.
Tested in https://github.com/dask/distributed/pull/6281 when enabling previously disabled `check_instance` tests.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
