### PR TITLE
Use `w` for `writeable` branch in `pickle_loads`

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -91,7 +91,7 @@ def pickle_loads(header, frames):
     memoryviews = map(memoryview, buffers)
     for w, mv in zip(writeable, memoryviews):
         if w == mv.readonly:
-            if mv.readonly:
+            if w:
                 mv = memoryview(bytearray(mv))
             else:
                 mv = memoryview(bytes(mv))


### PR DESCRIPTION
Saves the attribute access as it is not needed. Also a bit clearer from a code readability perspective (make writeable when `w is True` otherwise make readonly when `w is False`).

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
