### PR TITLE
Prevent infinite transition loops; more aggressive validate_state()

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -1027,6 +1027,13 @@ properties:
             type: boolean
             description: Enter Python Debugger on scheduling error
 
+          transition-counter-max:
+            oneOf:
+              - enum: [false]
+              - type: integer
+            description: Cause the scheduler or workers to break if they reach this
+              number of transitions
+
           system-monitor:
             type: object
             description: |

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -277,6 +277,10 @@ distributed:
     log-length: 10000  # default length of logs to keep in memory
     log-format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     pdb-on-err: False       # enter debug mode on scheduling error
+    # Cause scheduler and workers to break if they reach this many transitions.
+    # Used to debug infinite transition loops.
+    # Note: setting this will cause healthy long-running services to eventually break.
+    transition-counter-max: False
     system-monitor:
       interval: 500ms
     event-loop: tornado

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1446,7 +1446,7 @@ class SchedulerState:
             # - this increase happens before the actual transitions, so that it can
             #   catch potential infinite recursions
             self.transition_counter += 1
-            if self.validate and self.transition_counter_max:
+            if self.transition_counter_max:
                 assert self.transition_counter < self.transition_counter_max
 
             recommendations = {}  # type: ignore

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1380,6 +1380,7 @@ class SchedulerState:
         "validate",
         "workers",
         "transition_counter",
+        "transition_counter_max",
         "plugins",
         "UNKNOWN_TASK_DURATION",
         "MEMORY_RECENT_TO_OLD_TIME",
@@ -1472,6 +1473,9 @@ class SchedulerState:
             / 2.0
         )
         self.transition_counter = 0
+        self.transition_counter_max = dask.config.get(
+            "distributed.admin.transition-counter-max"
+        )
 
     @property
     def memory(self) -> MemoryState:
@@ -1548,16 +1552,24 @@ class SchedulerState:
         Scheduler.transitions : transitive version of this function
         """
         try:
+            ts: TaskState = self.tasks.get(key)  # type: ignore
+            if ts is None:
+                return {}, {}, {}
+            start = ts._state
+            if start == finish:
+                return {}, {}, {}
+
+            # Notes:
+            # - in case of transition through released, this counter is incremented by 2
+            # - this increase happens before the actual transitions, so that it can
+            #   catch potential infinite recursions
+            self.transition_counter += 1
+            if self.validate and self.transition_counter_max:
+                assert self.transition_counter < self.transition_counter_max
+
             recommendations = {}  # type: ignore
             worker_msgs = {}  # type: ignore
             client_msgs = {}  # type: ignore
-
-            ts: TaskState = self.tasks.get(key)  # type: ignore
-            if ts is None:
-                return recommendations, client_msgs, worker_msgs
-            start = ts._state
-            if start == finish:
-                return recommendations, client_msgs, worker_msgs
 
             if self.plugins:
                 dependents = set(ts.dependents)
@@ -1569,7 +1581,7 @@ class SchedulerState:
                 recommendations, client_msgs, worker_msgs = func(
                     key, stimulus_id, *args, **kwargs
                 )  # type: ignore
-                self.transition_counter += 1
+
             elif "released" not in start_finish:
                 assert not args and not kwargs, (args, kwargs, start_finish)
                 a_recs: dict
@@ -3294,6 +3306,7 @@ class Scheduler(SchedulerState, ServerNode):
         info = super()._to_dict(exclude=exclude)
         extra = {
             "transition_log": self.transition_log,
+            "transition_counter": self.transition_counter,
             "log": self.log,
             "tasks": self.tasks,
             "task_groups": self.task_groups,
@@ -4617,6 +4630,8 @@ class Scheduler(SchedulerState, ServerNode):
             actual_total_occupancy,
             self.total_occupancy,
         )
+        if self.transition_counter_max:
+            assert self.transition_counter < self.transition_counter_max
 
     ###################
     # Manage Messages #

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -228,7 +228,12 @@ async def test_stress_steal(c, s, *workers):
 
 
 @pytest.mark.slow
-@gen_cluster(nthreads=[("127.0.0.1", 1)] * 10, client=True, timeout=180)
+@gen_cluster(
+    nthreads=[("", 1)] * 10,
+    client=True,
+    timeout=180,
+    config={"distributed.admin.transition-counter-max": 500_000},
+)
 async def test_close_connections(c, s, *workers):
     da = pytest.importorskip("dask.array")
     x = da.random.random(size=(1000, 1000), chunks=(1000, 1))
@@ -291,7 +296,12 @@ async def test_no_delay_during_large_transfer(c, s, w):
 
 
 @pytest.mark.slow
-@gen_cluster(client=True, Worker=Nanny, nthreads=[("127.0.0.1", 2)] * 6)
+@gen_cluster(
+    client=True,
+    Worker=Nanny,
+    nthreads=[("", 2)] * 6,
+    config={"distributed.admin.transition-counter-max": 500_000},
+)
 async def test_chaos_rechunk(c, s, *workers):
     s.allowed_failures = 10000
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3435,6 +3435,7 @@ async def test_Worker__to_dict(c, s, a):
         "busy_workers",
         "log",
         "stimulus_log",
+        "transition_counter",
         "tasks",
         "logs",
         "config",

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2666,8 +2666,7 @@ class Worker(ServerNode):
         #   catch potential infinite recursions
         self.transition_counter += 1
         if (
-            self.validate
-            and self.transition_counter_max
+            self.transition_counter_max
             and self.transition_counter >= self.transition_counter_max
         ):
             self.log_event(

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -75,13 +75,17 @@ class InvalidTransition(Exception):
 
     def __repr__(self):
         return (
-            f"InvalidTransition: {self.key} :: {self.start}->{self.finish}"
+            f"{self.__class__.__name__}: {self.key} :: {self.start}->{self.finish}"
             + "\n"
             + "  Story:\n    "
             + "\n    ".join(map(str, self.story))
         )
 
     __str__ = __repr__
+
+
+class TransitionCounterMaxExceeded(InvalidTransition):
+    pass
 
 
 @lru_cache


### PR DESCRIPTION
#6305 introduces an infinite loop in the worker transitions.
Such loop never releases the GIL,
which means that the ``@gen_cluster`` timeout doesn't work,
which means that after 5 minutes pytest_timeout kicks in,
which means that you get no logs and no cluster dump whatsoever.

This PR:
- Runs validate_state() at the end of every test for all workers, in addition to the scheduler. This excludes workers wrapped by nannies and workers not started by gen_cluster itself.
- Runs validate_state() on Scheduler and Workers in case of TimeoutError, hoping to get an error about invalid state instead of the much more opaque timeout message
- Implements a limit for the number of transitions a scheduler or a worker can go through before it breaks gracefully after at most 30s (gen_cluster timeout). When it happens, pytest records all logs and a full cluster dump is generated.