### PR TITLE
[NO MRG] Minimal copy implementation of `array` deserialize

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -23,7 +23,7 @@ from distributed.protocol.utils import (
     pack_frames_prelude,
     unpack_frames,
 )
-from distributed.utils import has_keyword
+from distributed.utils import ensure_memoryview, has_keyword
 
 dask_serialize = dask.utils.Dispatch("dask_serialize")
 dask_deserialize = dask.utils.Dispatch("dask_deserialize")
@@ -765,12 +765,8 @@ def _serialize_array(obj):
 @dask_deserialize.register(array)
 def _deserialize_array(header, frames):
     a = array(header["typecode"])
-    for f in map(memoryview, frames):
-        try:
-            f = f.cast("B")
-        except TypeError:
-            f = f.tobytes()
-        a.frombytes(f)
+    for f in frames:
+        a.frombytes(ensure_memoryview(f))
     return a
 
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -94,8 +94,19 @@ def test_serialize_bytestrings():
 def test_serialize_arrays(typecode):
     a = array(typecode)
     a.extend(range(5))
+
+    # handle normal round trip through serialization
     header, frames = serialize(a)
     assert frames[0] == memoryview(a)
+    a2 = deserialize(header, frames)
+    assert type(a2) == type(a)
+    assert a2.typecode == a.typecode
+    assert a2 == a
+
+    # split up frames to test joining them back together
+    header, frames = serialize(a)
+    (f,) = frames
+    frames = [f[:2], f[2:]]
     a2 = deserialize(header, frames)
     assert type(a2) == type(a)
     assert a2.typecode == a.typecode

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -92,8 +92,7 @@ def test_serialize_bytestrings():
     "typecode", ["b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d"]
 )
 def test_serialize_arrays(typecode):
-    a = array(typecode)
-    a.extend(range(5))
+    a = array(typecode, range(5))
 
     # handle normal round trip through serialization
     header, frames = serialize(a)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -32,7 +32,7 @@ from distributed.protocol import (
     to_serialize,
 )
 from distributed.protocol.serialize import check_dask_serializable
-from distributed.utils import nbytes
+from distributed.utils import ensure_memoryview, nbytes
 from distributed.utils_test import gen_test, inc
 
 
@@ -105,7 +105,8 @@ def test_serialize_arrays(typecode):
     # split up frames to test joining them back together
     header, frames = serialize(a)
     (f,) = frames
-    frames = [f[:2], f[2:]]
+    f = ensure_memoryview(f) 
+    frames = [f[:1], f[1:2], f[2:-1], f[-1:]]
     a3 = deserialize(header, frames)
     assert type(a3) == type(a)
     assert a3.typecode == a.typecode

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -106,10 +106,10 @@ def test_serialize_arrays(typecode):
     header, frames = serialize(a)
     (f,) = frames
     frames = [f[:2], f[2:]]
-    a2 = deserialize(header, frames)
-    assert type(a2) == type(a)
-    assert a2.typecode == a.typecode
-    assert a2 == a
+    a3 = deserialize(header, frames)
+    assert type(a3) == type(a)
+    assert a3.typecode == a.typecode
+    assert a3 == a
 
 
 def test_Serialize():


### PR DESCRIPTION
Superseded by PR ( https://github.com/dask/distributed/pull/6300 )

This was an attempt to minimize copying when deserializing `array`. However it was only slightly faster than copying to `bytes` first and filling the `array` with the result. Also this could result in additional copies of the underlying `array` buffer if sufficient memory wasn't reserved. Given the added complexity and mild improvement, abandoned this approach. However thought it worthwhile to keep the history if there was ever a need to revisit.

<hr>

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
