### PR TITLE
Simplify `ensure_memoryview` test w/`array`

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -255,7 +255,7 @@ def test_ensure_memoryview_empty():
 
 
 def test_ensure_memoryview():
-    data = [b"1", memoryview(b"1"), bytearray(b"1"), array.array("B", [49])]
+    data = [b"1", memoryview(b"1"), bytearray(b"1"), array.array("B", b"1")]
     for d in data:
         result = ensure_memoryview(d)
         assert isinstance(result, memoryview)

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1,4 +1,3 @@
-import array
 import asyncio
 import contextvars
 import functools
@@ -8,6 +7,7 @@ import queue
 import socket
 import traceback
 import warnings
+from array import array
 from collections import deque
 from time import sleep
 
@@ -255,7 +255,7 @@ def test_ensure_memoryview_empty():
 
 
 def test_ensure_memoryview():
-    data = [b"1", memoryview(b"1"), bytearray(b"1"), array.array("B", b"1")]
+    data = [b"1", memoryview(b"1"), bytearray(b"1"), array("B", b"1")]
     for d in data:
         result = ensure_memoryview(d)
         assert isinstance(result, memoryview)

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -255,7 +255,7 @@ def test_ensure_memoryview_empty():
 
 
 def test_ensure_memoryview():
-    data = [b"1", memoryview(b"1"), bytearray(b"1"), array.array("b", [49])]
+    data = [b"1", memoryview(b"1"), bytearray(b"1"), array.array("B", [49])]
     for d in data:
         result = ensure_memoryview(d)
         assert isinstance(result, memoryview)


### PR DESCRIPTION
Simplifies the `array` test for `ensure_memoryview` based on this feedback ( https://github.com/dask/dask/pull/9059#discussion_r869687161 ).

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
