### PR TITLE
Transition table as a ClassVar

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1440,7 +1440,7 @@ class SchedulerState:
                 dependents = set(ts.dependents)
                 dependencies = set(ts.dependencies)
 
-            func = self.TRANSITIONS_TABLE.get((start, finish))
+            func = self._TRANSITIONS_TABLE.get((start, finish))
             if func is not None:
                 recommendations, client_msgs, worker_msgs = func(
                     self, key, stimulus_id, *args, **kwargs
@@ -1455,7 +1455,7 @@ class SchedulerState:
                 a_recs, a_cmsgs, a_wmsgs = a
 
                 v = a_recs.get(key, finish)
-                func = self.TRANSITIONS_TABLE["released", v]
+                func = self._TRANSITIONS_TABLE["released", v]
                 b_recs: dict
                 b_cmsgs: dict
                 b_wmsgs: dict
@@ -2490,7 +2490,7 @@ class SchedulerState:
     #         self, key: str, stimulus_id: str, *args, **kwargs
     #     ) -> (recommendations, client_msgs, worker_msgs)
     # }
-    TRANSITIONS_TABLE: ClassVar[
+    _TRANSITIONS_TABLE: ClassVar[
         Mapping[tuple[str, str], Callable[..., tuple[dict, dict, dict]]]
     ] = {
         ("released", "waiting"): transition_released_waiting,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2604,7 +2604,7 @@ class Worker(ServerNode):
     #         self, ts: TaskState, *args, stimulus_id: str
     #     ) -> (recommendations, instructions)
     # }
-    TRANSITIONS_TABLE: ClassVar[
+    _TRANSITIONS_TABLE: ClassVar[
         Mapping[tuple[TaskStateState, TaskStateState], Callable[..., RecsInstrs]]
     ] = {
         ("cancelled", "fetch"): transition_cancelled_fetch,
@@ -2675,7 +2675,7 @@ class Worker(ServerNode):
             return {}, []
 
         start = ts.state
-        func = self.TRANSITIONS_TABLE.get((start, cast(TaskStateState, finish)))
+        func = self._TRANSITIONS_TABLE.get((start, cast(TaskStateState, finish)))
 
         # Notes:
         # - in case of transition through released, this counter is incremented by 2


### PR DESCRIPTION
1. Declutter the ``__init__`` method
2. Emphasize that the table is immutable
3. Remove a wealth of circular references to the Scheduler and Worker instances

CC @hendrikmakait