### PR TITLE
Improve `ensure_memoryview` test coverage & make minor fixes

### DIFF
--- a/distributed/comm/asyncio_tcp.py
+++ b/distributed/comm/asyncio_tcp.py
@@ -26,7 +26,7 @@ from distributed.comm.utils import (
     host_array,
     to_frames,
 )
-from distributed.utils import ensure_ip, get_ip, get_ipv6
+from distributed.utils import ensure_ip, ensure_memoryview, get_ip, get_ipv6
 
 logger = logging.getLogger(__name__)
 
@@ -379,7 +379,9 @@ class DaskCommProtocol(asyncio.BufferedProtocol):
             await drain_waiter
 
         # Ensure all memoryviews are in single-byte format
-        frames = [f.cast("B") if isinstance(f, memoryview) else f for f in frames]
+        frames = [
+            ensure_memoryview(f) if isinstance(f, memoryview) else f for f in frames
+        ]
 
         nframes = len(frames)
         frames_nbytes = [len(f) for f in frames]
@@ -847,12 +849,9 @@ class _ZeroCopyWriter:
 
     def _buffer_append(self, data: bytes) -> None:
         """Append new data to the send buffer"""
-        if not isinstance(data, memoryview):
-            data = memoryview(data)
-        if data.format != "B":
-            data = data.cast("B")
-        self._size += len(data)
-        self._buffers.append(data)
+        mv = ensure_memoryview(data)
+        self._size += len(mv)
+        self._buffers.append(mv)
 
     def _buffer_peek(self) -> list[memoryview]:
         """Get one or more buffers to write to the socket"""

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -46,7 +46,7 @@ from distributed.comm.utils import (
 )
 from distributed.protocol.utils import pack_frames_prelude, unpack_frames
 from distributed.system import MEMORY_LIMIT
-from distributed.utils import ensure_ip, get_ip, get_ipv6, nbytes
+from distributed.utils import ensure_ip, ensure_memoryview, get_ip, get_ipv6, nbytes
 
 logger = logging.getLogger(__name__)
 
@@ -305,7 +305,7 @@ class TCP(Comm):
                     if isinstance(each_frame, memoryview):
                         # Make sure that `len(data) == data.nbytes`
                         # See <https://github.com/tornadoweb/tornado/pull/2996>
-                        each_frame = memoryview(each_frame).cast("B")
+                        each_frame = ensure_memoryview(each_frame)
 
                     stream._write_buffer.append(each_frame)
                     stream._total_write_index += each_frame_nbytes

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -88,7 +88,7 @@ def pickle_loads(header, frames):
         writeable = len(buffers) * (None,)
 
     new = []
-    memoryviews = map(memoryview, buffers)
+    memoryviews = map(ensure_memoryview, buffers)
     for w, mv in zip(writeable, memoryviews):
         if w == mv.readonly:
             if w:
@@ -785,7 +785,7 @@ def _serialize_memoryview(obj):
 @dask_deserialize.register(memoryview)
 def _deserialize_memoryview(header, frames):
     if len(frames) == 1:
-        out = memoryview(frames[0]).cast("B")
+        out = ensure_memoryview(frames[0])
     else:
         out = memoryview(b"".join(frames))
     out = out.cast(header["format"], header["shape"])

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -248,20 +248,41 @@ def test_seek_delimiter_endline():
     assert f.tell() == 7
 
 
-def test_ensure_memoryview_empty():
-    result = ensure_memoryview(b"")
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"",
+        bytearray(),
+        b"1",
+        bytearray(b"1"),
+        memoryview(b"1"),
+        memoryview(bytearray(b"1")),
+        array("B", b"1"),
+        array("I", range(5)),
+        memoryview(b"123456")[::2],
+        memoryview(b"123456").cast("B", (2, 3)),
+        memoryview(b"0123456789").cast("B", (5, 2))[::2],
+    ],
+)
+def test_ensure_memoryview(data):
+    data_mv = memoryview(data)
+    result = ensure_memoryview(data)
     assert isinstance(result, memoryview)
-    assert result == memoryview(b"")
-
-
-def test_ensure_memoryview():
-    data = [b"1", memoryview(b"1"), bytearray(b"1"), array("B", b"1")]
-    for d in data:
-        result = ensure_memoryview(d)
-        assert isinstance(result, memoryview)
-        assert result == memoryview(b"1")
-        if isinstance(d, memoryview):
-            assert id(d) == id(result)
+    assert result.contiguous
+    assert result.ndim == 1
+    assert result.format == "B"
+    assert result == bytes(data_mv)
+    if data_mv.nbytes and data_mv.contiguous:
+        assert id(result.obj) == id(data_mv.obj)
+        assert result.readonly == data_mv.readonly
+        if isinstance(data, memoryview):
+            if data.ndim == 1 and data.format == "B":
+                assert id(result) == id(data)
+            else:
+                assert id(data) != id(result)
+    else:
+        assert id(result.obj) != id(data_mv.obj)
+        assert not result.readonly
 
 
 def test_ensure_memoryview_ndarray():

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -285,9 +285,22 @@ def test_ensure_memoryview(data):
         assert not result.readonly
 
 
-def test_ensure_memoryview_ndarray():
+@pytest.mark.parametrize(
+    "dt, nitems, shape, strides",
+    [
+        ("i8", 12, (12,), (8,)),
+        ("i8", 12, (3, 4), (32, 8)),
+        ("i8", 12, (4, 3), (8, 32)),
+        ("i8", 12, (3, 2), (32, 16)),
+        ("i8", 12, (2, 3), (16, 32)),
+    ],
+)
+def test_ensure_memoryview_ndarray(dt, nitems, shape, strides):
     np = pytest.importorskip("numpy")
-    result = ensure_memoryview(np.arange(12).reshape(3, 4)[:, ::2].T)
+    data = np.ndarray(
+        shape, dtype=dt, buffer=np.arange(nitems, dtype=dt), strides=strides
+    )
+    result = ensure_memoryview(data)
     assert isinstance(result, memoryview)
     assert result.ndim == 1
     assert result.format == "B"

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -260,6 +260,8 @@ def test_ensure_memoryview():
         result = ensure_memoryview(d)
         assert isinstance(result, memoryview)
         assert result == memoryview(b"1")
+        if isinstance(d, memoryview):
+            assert id(d) == id(result)
 
 
 def test_ensure_memoryview_ndarray():

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1021,13 +1021,13 @@ def ensure_memoryview(obj):
 
     if not mv.nbytes:
         # Drop `obj` reference to permit freeing underlying data
-        return memoryview(b"")
+        return memoryview(bytearray())
     elif mv.contiguous:
         # Perform zero-copy reshape & cast
         return mv.cast("B")
     else:
         # Copy to contiguous form of expected shape & type
-        return memoryview(mv.tobytes())
+        return memoryview(bytearray(mv))
 
 
 def open_port(host=""):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1022,12 +1022,12 @@ def ensure_memoryview(obj):
     if not mv.nbytes:
         # Drop `obj` reference to permit freeing underlying data
         return memoryview(bytearray())
-    elif mv.contiguous:
-        # Perform zero-copy reshape & cast
-        return mv.cast("B")
-    else:
+    elif not mv.contiguous:
         # Copy to contiguous form of expected shape & type
         return memoryview(bytearray(mv))
+    else:
+        # Perform zero-copy reshape & cast
+        return mv.cast("B")
 
 
 def open_port(host=""):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1025,9 +1025,12 @@ def ensure_memoryview(obj):
     elif not mv.contiguous:
         # Copy to contiguous form of expected shape & type
         return memoryview(bytearray(mv))
-    else:
+    elif mv.ndim != 1 or mv.format != "B":
         # Perform zero-copy reshape & cast
         return mv.cast("B")
+    else:
+        # Return `memoryview` as it already meets requirements
+        return mv
 
 
 def open_port(host=""):


### PR DESCRIPTION
Expands `ensure_memoryview`s test coverage to handle different types, shapes, strides, etc. Testing covers more cases in the builtin Python test coverage as well as the NumPy tests. Also more consistently use `bytearray`s to back memory when copies are required. Includes a fix for F-ordered data. Also returns the input argument as-is if it already meets all requirements, which is tested for. Finally adds `ensure_memoryview` in a few more places.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
