### PR TITLE
Remove leaking reference to `workers` from `gen_cluster`

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1006,8 +1006,8 @@ def gen_cluster(
             with clean(timeout=active_rpc_timeout, **clean_kwargs) as loop:
 
                 async def coro():
-                    workers = []
                     with dask.config.set(config):
+                        workers = []
                         s = False
                         for _ in range(60):
                             try:


### PR DESCRIPTION
Extracted from #6336 to merge independently and enable using this for working on garbage collection of `Worker` instances.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
