### PR TITLE
Scheduler worker reconnect drops messages

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3547,7 +3547,7 @@ class Scheduler(SchedulerState, ServerNode):
     @log_errors
     async def add_worker(
         self,
-        comm=None,
+        comm,
         *,
         address: str,
         status: str,
@@ -3585,8 +3585,7 @@ class Scheduler(SchedulerState, ServerNode):
                 "message": "name taken, %s" % name,
                 "time": time(),
             }
-            if comm:
-                await comm.write(msg)
+            await comm.write(msg)
             return
 
         self.log_event(address, {"action": "add-worker"})
@@ -3719,10 +3718,9 @@ class Scheduler(SchedulerState, ServerNode):
         )
         msg.update(version_warning)
 
-        if comm:
-            await comm.write(msg)
+        await comm.write(msg)
 
-        await self.handle_worker(comm=comm, worker=address, stimulus_id=stimulus_id)
+        await self.handle_worker(comm, address, stimulus_id=stimulus_id)
 
     async def add_nanny(self, comm):
         msg = {
@@ -4803,7 +4801,7 @@ class Scheduler(SchedulerState, ServerNode):
         else:
             self.running.discard(ws)
 
-    async def handle_worker(self, comm=None, worker=None, stimulus_id=None):
+    async def handle_worker(self, comm, worker: str, stimulus_id=None):
         """
         Listen to responses from a single worker
 


### PR DESCRIPTION
When a worker connects, it sends a list of data it already has. On the scheduler side, we were handling each item and transitioning it to `memory`. But on each iteration, we overwrite the list of messages to send to the client and worker. So if a worker reconnected with >1 key in memory, we'd drop critical instructions to send to clients and the worker.

Progress towards https://github.com/dask/distributed/issues/6228, https://github.com/dask/distributed/issues/5480.

Pulled out from #6272/#6329

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @crusaderky @fjetter @mrocklin 