### PR TITLE
Fix Nanny shutdown edge case

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -926,8 +926,8 @@ class WorkerProcess:
                 loop.run_sync(do_stop)
             finally:
                 with suppress(ValueError):
-                    child_stop_q.put({"op": "close"})  # probably redundant
+                    child_stop_q.put({"op": "stop"})  # usually redundant
                 with suppress(ValueError):
-                    child_stop_q.close()  # probably redundant
+                    child_stop_q.close()  # usually redundant
                 child_stop_q.join_thread()
                 thread.join(timeout=2)


### PR DESCRIPTION
Introduced in https://github.com/dask/distributed/pull/6146, which was putting a `close` message instead of `stop`:
https://github.com/dask/distributed/blob/b8b45c6e641f298f465d47139f1fb297c4a5799a/distributed/nanny.py#L855-L862

This error was triggered in #6320, but clearly doesn't happen in CI normally. I have not tried to add a test for it. It was already untested when added.

cc @mrocklin @fjetter 

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
