### PR TITLE
Improve `catch_unhandled_exceptions`

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3644,28 +3644,37 @@ async def test_reconnect():
     await c._close(fast=True)
 
 
-class UnhandledException(Exception):
+class UnhandledExceptions(Exception):
     pass
 
 
 @contextmanager
 def catch_unhandled_exceptions() -> Generator[None, None, None]:
     loop = asyncio.get_running_loop()
-    ctx: dict[str, Any] | None = None
+    ctxs: list[dict[str, Any]] = []
 
     old_handler = loop.get_exception_handler()
 
     @loop.set_exception_handler
     def _(loop: object, context: dict[str, Any]) -> None:
-        nonlocal ctx
-        ctx = context
+        ctxs.append(context)
 
     try:
         yield
     finally:
         loop.set_exception_handler(old_handler)
-    if ctx:
-        raise UnhandledException(ctx["message"]) from ctx.get("exception")
+    if ctxs:
+        msgs = []
+        for i, ctx in enumerate(ctxs, 1):
+            msgs.append(ctx["message"])
+            print(
+                f"------ Unhandled exception {i}/{len(ctxs)}: {ctx['message']!r} ------"
+            )
+            print(ctx)
+            if exc := ctx.get("exception"):
+                traceback.print_exception(type(exc), exc, exc.__traceback__)
+
+        raise UnhandledExceptions(", ".join(msgs))
 
 
 @gen_cluster(client=True, nthreads=[], client_kwargs={"timeout": 0.5})


### PR DESCRIPTION
* Catch multiple exceptions, not just the last one (not sure if this actually happens, but I imagined it could)
* Retain the full `context` message, which contains useful information such as the `asyncio.Task`, etc.
* Print full tracebacks when possible

Split out from #6329. Before, you'd just see an error like
```
test_client.UnhandledExceptions: Task was destroyed but it is pending!
```
which is very hard to track down. Now, you see
```
----------------------------- Captured stdout call -----------------------------
------ Unhandled exception 1/1: 'Task was destroyed but it is pending!' ------
{'message': 'Task was destroyed but it is pending!', 'task': <Task pending name='background-send-Client' coro=<BatchedSend._background_send() done, defined at /home/runner/work/distributed/distributed/distributed/batched.py:80> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f2e00d00280>()]>>}
```
which is a little bit more useful to track down.

cc @graingert 

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
