### PR TITLE
Ensure garbage collection of `distributed.scheduler.TaskState` instances

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1062,7 +1062,9 @@ class TaskState:
     #: Cached hash of :attr:`~TaskState.client_key`
     _hash: int
 
-    __slots__ = tuple(__annotations__)  # type: ignore
+    __slots__ = tuple(__annotations__) + ("__weakref__",)  # type: ignore
+
+    _instances: weakref.WeakSet[TaskState] = weakref.WeakSet()
 
     def __init__(self, key: str, run_spec: object):
         self.key = key
@@ -1098,6 +1100,7 @@ class TaskState:
         self.metadata = {}
         self.annotations = {}
         self.erred_on = set()
+        TaskState._instances.add(self)
 
     def __hash__(self) -> int:
         return self._hash

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -56,7 +56,9 @@ from distributed.metrics import time
 from distributed.nanny import Nanny
 from distributed.node import ServerNode
 from distributed.proctitle import enable_proctitle_on_children
+from distributed.profile import wait_profiler
 from distributed.protocol import deserialize
+from distributed.scheduler import TaskState
 from distributed.security import Security
 from distributed.utils import (
     DequeHandler,
@@ -1792,6 +1794,11 @@ def check_instances():
         assert time() < start + 10
 
     _global_clients.clear()
+
+    wait_profiler()
+    gc.collect()
+
+    assert not TaskState._instances
 
     for w in Worker._instances:
         with suppress(RuntimeError):  # closed IOLoop


### PR DESCRIPTION
Partially addresses #6250

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
