### PR TITLE
Remove wrong assert in handle compute

### DIFF
--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -426,7 +426,7 @@ async def test_cancelled_resumed_after_flight_with_dependencies(c, s, w2, w3):
 
         f1 = c.submit(inc, 1, key="f1", workers=[w1.address])
         f2 = c.submit(inc, 2, key="f2", workers=[w1.address])
-        f3 = c.submit(sum, [f1, f2], workers=[w1.address])
+        f3 = c.submit(sum, [f1, f2], key="f3", workers=[w1.address])
 
         await wait(f3)
         f4 = c.submit(inc, f3, key="f4", workers=[w2.address])
@@ -441,8 +441,7 @@ async def test_cancelled_resumed_after_flight_with_dependencies(c, s, w2, w3):
         )
         await s.remove_worker(w1.address, "stim-id")
 
-        while w2.tasks[f3.key].state != "resumed":
-            await asyncio.sleep(0.1)
+        await wait_for_state(f3.key, "resumed", w2)
         assert_story(
             w2.log,
             [

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -2,6 +2,7 @@ import asyncio
 
 import distributed
 from distributed import Event, Lock, Worker
+from distributed.client import wait
 from distributed.utils_test import (
     _LockedCommPool,
     assert_story,
@@ -396,3 +397,60 @@ async def test_cancelled_error_with_ressources(c, s, a):
     await lock_executing.release()
 
     assert await fut2 == 2
+
+
+@gen_cluster(client=True, nthreads=[("", 1)] * 2)
+async def test_cancelled_resumed_after_flight_with_dependencies(c, s, w2, w3):
+    # See https://github.com/dask/distributed/pull/6327#discussion_r872231090
+    block_get_data_1 = asyncio.Lock()
+    enter_get_data_1 = asyncio.Event()
+    await block_get_data_1.acquire()
+
+    class BlockGetDataWorker(Worker):
+        def __init__(self, *args, get_data_event, get_data_lock, **kwargs):
+            self._get_data_event = get_data_event
+            self._get_data_lock = get_data_lock
+            super().__init__(*args, **kwargs)
+
+        async def get_data(self, comm, *args, **kwargs):
+            self._get_data_event.set()
+            async with self._get_data_lock:
+                return await super().get_data(comm, *args, **kwargs)
+
+    async with await BlockGetDataWorker(
+        s.address,
+        get_data_event=enter_get_data_1,
+        get_data_lock=block_get_data_1,
+        name="w1",
+    ) as w1:
+
+        f1 = c.submit(inc, 1, key="f1", workers=[w1.address])
+        f2 = c.submit(inc, 2, key="f2", workers=[w1.address])
+        f3 = c.submit(sum, [f1, f2], workers=[w1.address])
+
+        await wait(f3)
+        f4 = c.submit(inc, f3, key="f4", workers=[w2.address])
+
+        await enter_get_data_1.wait()
+        s.set_restrictions(
+            {
+                f1.key: {w3.address},
+                f2.key: {w3.address},
+                f3.key: {w2.address},
+            }
+        )
+        await s.remove_worker(w1.address, "stim-id")
+
+        while w2.tasks[f3.key].state != "resumed":
+            await asyncio.sleep(0.1)
+        assert_story(
+            w2.log,
+            [
+                (f3.key, "flight", "released", "cancelled", {}),
+                # ...
+                (f3.key, "cancelled", "waiting", "resumed", {}),
+            ],
+        )
+    # w1 closed
+
+    assert await f4 == 6

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1984,13 +1984,6 @@ class Worker(ServerNode):
         self.transitions(recommendations, stimulus_id=stimulus_id)
         self._handle_instructions(instructions)
 
-        if self.validate:
-            # All previously unknown tasks that were created above by
-            # ensure_tasks_exists() have been transitioned to fetch or flight
-            assert all(
-                ts2.state != "released" for ts2 in (ts, *ts.dependencies)
-            ), self.story(ts, *ts.dependencies)
-
     ########################
     # Worker State Machine #
     ########################


### PR DESCRIPTION
This removes an erroneous assert statement introduced in #6327

See https://github.com/dask/distributed/pull/6327#discussion_r875926924 for details

The added test condition triggers this exact assert statement. However, the test passes properly if the assert is removed. All transitions happen as expected.

While debugging this, I noticed that the find-missing PC is actually running concurrently. I was surprised about this because the docs of `PeriodicCallback` specifically mention that an iteration is skipped if it takes too long, see https://github.com/tornadoweb/tornado/blob/43ae5839a56e445dd2d10539718f1e0c8053d995/tornado/ioloop.py#L863-L864 I'll break this out into a dedicated PR