### PR TITLE
Expose more worker options in the config system

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -2,14 +2,12 @@ properties:
   distributed:
     type: object
     properties:
-
       version:
         type: integer
 
       scheduler:
         type: object
         properties:
-
           allowed-failures:
             type: integer
             minimum: 0
@@ -22,8 +20,8 @@ properties:
 
           bandwidth:
             type:
-            - integer
-            - string
+              - integer
+              - string
             description: |
               The expected bandwidth between any pair of workers
 
@@ -45,8 +43,8 @@ properties:
 
           contact-address:
             type:
-            - string
-            - "null"
+              - string
+              - "null"
             description: |
               The address that the scheduler advertises to workers for communication with it.
 
@@ -56,8 +54,8 @@ properties:
 
           default-data-size:
             type:
-            - string
-            - integer
+              - string
+              - integer
             description: |
               The default size of a piece of data if we don't know anything about it.
 
@@ -71,8 +69,8 @@ properties:
 
           idle-timeout:
             type:
-            - string
-            - "null"
+              - string
+              - "null"
             description: |
               Shut down the scheduler after this duration if no activity has occured
 
@@ -119,8 +117,8 @@ properties:
 
           worker-ttl:
             type:
-            - string
-            - "null"
+              - string
+              - "null"
             description: |
               Time to live for workers.
 
@@ -205,16 +203,16 @@ properties:
                 properties:
                   ca-file:
                     type:
-                    - string
-                    - "null"
+                      - string
+                      - "null"
                   key:
                     type:
-                    - string
-                    - "null"
+                      - string
+                      - "null"
                   cert:
                     type:
-                    - string
-                    - "null"
+                      - string
+                      - "null"
               bokeh-application:
                 type: object
                 description: |
@@ -263,8 +261,7 @@ properties:
                 description: set to true to auto-start the AMM on Scheduler init
               interval:
                 type: string
-                description:
-                  Time expression, e.g. "2s". Run the AMM cycle every <interval>.
+                description: Time expression, e.g. "2s". Run the AMM cycle every <interval>.
               policies:
                 type: array
                 items:
@@ -273,7 +270,8 @@ properties:
                   properties:
                     class:
                       type: string
-                      description: fully qualified name of an ActiveMemoryManagerPolicy
+                      description:
+                        fully qualified name of an ActiveMemoryManagerPolicy
                         subclass
                   additionalProperties:
                     description: keyword arguments to the policy constructor, if any
@@ -363,6 +361,35 @@ properties:
               See https://distributed.dask.org/en/latest/resources.html for more information.
             properties: {}
 
+          name:
+            type: string
+            description: |
+              Name for the worker to use when registering with the scheduler. Must be unique.
+
+          contact-address:
+            type: string
+            description: |
+              Address that scheduler and other workers should dial back ones.
+
+              This is useful when the workers are NAT'd or otherwise obscured behind some other
+              IP address. This is common when running in containers with ports exposed on the host.
+              Or when running behind TCP proxies in a service mesh.
+
+          interface:
+            type: string
+            description: |
+              Network interface to listen on
+
+          host:
+            type: string
+            description: |
+              Host to bind to
+
+          port:
+            type: string
+            description: |
+              Port number to listen on
+
           lifetime:
             type: object
             description: |
@@ -376,8 +403,8 @@ properties:
             properties:
               duration:
                 type:
-                - string
-                - "null"
+                  - string
+                  - "null"
                 description: |
                   The time after creation to close the worker, like "1 hour"
               stagger:
@@ -396,7 +423,6 @@ properties:
                 type: boolean
                 description: |
                   Do we try to resurrect the worker after the lifetime deadline?
-
 
           profile:
             type: object
@@ -484,8 +510,8 @@ properties:
 
               target:
                 oneOf:
-                  - {type: number, minimum: 0, maximum: 1}
-                  - {enum: [false]}
+                  - { type: number, minimum: 0, maximum: 1 }
+                  - { enum: [false] }
                 description: >-
                   When the process memory (as observed by the operating system) gets
                   above this amount we start spilling the dask keys holding the largest
@@ -493,24 +519,24 @@ properties:
 
               spill:
                 oneOf:
-                  - {type: number, minimum: 0, maximum: 1}
-                  - {enum: [false]}
+                  - { type: number, minimum: 0, maximum: 1 }
+                  - { enum: [false] }
                 description: >-
                   When the process memory (as observed by the operating system) gets
                   above this amount we spill all data to disk.
 
               pause:
                 oneOf:
-                  - {type: number, minimum: 0, maximum: 1}
-                  - {enum: [false]}
+                  - { type: number, minimum: 0, maximum: 1 }
+                  - { enum: [false] }
                 description: >-
                   When the process memory (as observed by the operating system) gets
                   above this amount we no longer start new tasks on this worker.
 
               terminate:
                 oneOf:
-                  - {type: number, minimum: 0, maximum: 1}
-                  - {enum: [false]}
+                  - { type: number, minimum: 0, maximum: 1 }
+                  - { enum: [false] }
                 description: >-
                   When the process memory reaches this level the nanny process will kill
                   the worker (if a nanny is present)
@@ -518,7 +544,7 @@ properties:
               max-spill:
                 oneOf:
                   - type: string
-                  - {type: number, minimum: 0}
+                  - { type: number, minimum: 0 }
                   - enum: [false]
                 description: >-
                   Limit of number of bytes to be spilled on disk.
@@ -545,7 +571,6 @@ properties:
         description: |
           Configuration settings for Dask Nannies
         properties:
-
           preload:
             type: array
             description: |
@@ -574,8 +599,7 @@ properties:
         properties:
           heartbeat:
             type: string
-            description:
-              This value is the time between heartbeats
+            description: This value is the time between heartbeats
 
               The client sends a periodic heartbeat message to the scheduler.
               If it misses enough of these then the scheduler assumes that it has gone.
@@ -585,7 +609,7 @@ properties:
             description: Interval between scheduler-info updates
 
           security-loader:
-            type: [string, 'null']
+            type: [string, "null"]
             description: |
               A fully qualified name (e.g. ``module.submodule.function``) of
               a callback to use for loading security credentials for the
@@ -608,7 +632,6 @@ properties:
               Arguments to pass into the preload scripts described above
 
               See https://docs.dask.org/en/latest/how-to/customize-initialization.html for more information
-
 
       deploy:
         type: object
@@ -670,13 +693,11 @@ properties:
         type: object
         description: Configuration settings for Dask communications
         properties:
-
           retry:
             type: object
             description: |
               Some operations (such as gathering data) are subject to re-tries with the below parameters
             properties:
-
               count:
                 type: integer
                 minimum: 0
@@ -702,8 +723,8 @@ properties:
 
           offload:
             type:
-            - boolean
-            - string
+              - boolean
+              - string
             description: |
               The size of message after which we choose to offload serialization to another thread
 
@@ -755,8 +776,8 @@ properties:
 
           require-encryption:
             type:
-            - boolean
-            - "null"
+              - boolean
+              - "null"
             description: |
               Whether to require encryption on non-local comms
 
@@ -774,8 +795,8 @@ properties:
             properties:
               ciphers:
                 type:
-                - string
-                - "null"
+                  - string
+                  - "null"
                 description: Allowed ciphers, specified as an OpenSSL cipher string.
 
               min-version:
@@ -790,8 +811,8 @@ properties:
 
               ca-file:
                 type:
-                - string
-                - "null"
+                  - string
+                  - "null"
                 description: Path to a CA file, in pem format
 
               scheduler:
@@ -800,13 +821,13 @@ properties:
                 properties:
                   cert:
                     type:
-                    - string
-                    - "null"
+                      - string
+                      - "null"
                     description: Path to certificate file
                   key:
                     type:
-                    - string
-                    - "null"
+                      - string
+                      - "null"
                     description: |
                       Path to key file.
 
@@ -819,13 +840,13 @@ properties:
                 properties:
                   cert:
                     type:
-                    - string
-                    - "null"
+                      - string
+                      - "null"
                     description: Path to certificate file
                   key:
                     type:
-                    - string
-                    - "null"
+                      - string
+                      - "null"
                     description: |
                       Path to key file.
 
@@ -838,13 +859,13 @@ properties:
                 properties:
                   cert:
                     type:
-                    - string
-                    - "null"
+                      - string
+                      - "null"
                     description: Path to certificate file
                   key:
                     type:
-                    - string
-                    - "null"
+                      - string
+                      - "null"
                     description: |
                       Path to key file.
 
@@ -857,30 +878,30 @@ properties:
               UCX provides access to other transport methods including NVLink and InfiniBand.
             properties:
               cuda-copy:
-                type: [boolean, 'null']
+                type: [boolean, "null"]
                 description: |
                   Set environment variables to enable CUDA support over UCX. This may be used even if
                   InfiniBand and NVLink are not supported or disabled, then transferring data over TCP.
               tcp:
-                type: [boolean, 'null']
+                type: [boolean, "null"]
                 description: |
                   Set environment variables to enable TCP over UCX, even if InfiniBand and NVLink
                   are not supported or disabled.
               nvlink:
-                type: [boolean, 'null']
+                type: [boolean, "null"]
                 description: |
                   Set environment variables to enable UCX over NVLink, implies ``distributed.comm.ucx.tcp=True``.
               infiniband:
-                type: [boolean, 'null']
+                type: [boolean, "null"]
                 description: |
                   Set environment variables to enable UCX over InfiniBand, implies ``distributed.comm.ucx.tcp=True``.
               rdmacm:
-                type: [boolean, 'null']
+                type: [boolean, "null"]
                 description: |
                   Set environment variables to enable UCX RDMA connection manager support,
                   requires ``distributed.comm.ucx.infiniband=True``.
               create-cuda-context:
-                type: [boolean, 'null']
+                type: [boolean, "null"]
                 description: |
                   Creates a CUDA context before UCX is initialized. This is necessary to enable UCX to
                   properly identify connectivity of GPUs with specialized networking hardware, such as
@@ -902,7 +923,7 @@ properties:
             properties:
               shard:
                 type:
-                - string
+                  - string
                 description: |
                   The maximum size of a websocket frame to send through a comm.
 
@@ -984,10 +1005,10 @@ properties:
               interval:
                 type: string
                 description: The time between ticks, default 20ms
-              limit :
+              limit:
                 type: string
                 description: The time allowed before triggering a warning
-              cycle :
+              cycle:
                 type: string
                 description: The time in between verifying event loop speed
 
@@ -1042,6 +1063,6 @@ properties:
           Configuration options for the RAPIDS Memory Manager.
         properties:
           pool-size:
-            type: [integer, 'null']
+            type: [integer, "null"]
             description: |
               The size of the memory pool in bytes.

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -2,12 +2,14 @@ properties:
   distributed:
     type: object
     properties:
+
       version:
         type: integer
 
       scheduler:
         type: object
         properties:
+
           allowed-failures:
             type: integer
             minimum: 0
@@ -20,8 +22,8 @@ properties:
 
           bandwidth:
             type:
-              - integer
-              - string
+            - integer
+            - string
             description: |
               The expected bandwidth between any pair of workers
 
@@ -43,8 +45,8 @@ properties:
 
           contact-address:
             type:
-              - string
-              - "null"
+            - string
+            - "null"
             description: |
               The address that the scheduler advertises to workers for communication with it.
 
@@ -54,8 +56,8 @@ properties:
 
           default-data-size:
             type:
-              - string
-              - integer
+            - string
+            - integer
             description: |
               The default size of a piece of data if we don't know anything about it.
 
@@ -69,8 +71,8 @@ properties:
 
           idle-timeout:
             type:
-              - string
-              - "null"
+            - string
+            - "null"
             description: |
               Shut down the scheduler after this duration if no activity has occured
 
@@ -117,8 +119,8 @@ properties:
 
           worker-ttl:
             type:
-              - string
-              - "null"
+            - string
+            - "null"
             description: |
               Time to live for workers.
 
@@ -203,16 +205,16 @@ properties:
                 properties:
                   ca-file:
                     type:
-                      - string
-                      - "null"
+                    - string
+                    - "null"
                   key:
                     type:
-                      - string
-                      - "null"
+                    - string
+                    - "null"
                   cert:
                     type:
-                      - string
-                      - "null"
+                    - string
+                    - "null"
               bokeh-application:
                 type: object
                 description: |
@@ -261,7 +263,8 @@ properties:
                 description: set to true to auto-start the AMM on Scheduler init
               interval:
                 type: string
-                description: Time expression, e.g. "2s". Run the AMM cycle every <interval>.
+                description:
+                  Time expression, e.g. "2s". Run the AMM cycle every <interval>.
               policies:
                 type: array
                 items:
@@ -270,8 +273,7 @@ properties:
                   properties:
                     class:
                       type: string
-                      description:
-                        fully qualified name of an ActiveMemoryManagerPolicy
+                      description: fully qualified name of an ActiveMemoryManagerPolicy
                         subclass
                   additionalProperties:
                     description: keyword arguments to the policy constructor, if any
@@ -370,7 +372,6 @@ properties:
             type: string
             description: |
               Address that scheduler and other workers should dial back ones.
-
               This is useful when the workers are NAT'd or otherwise obscured behind some other
               IP address. This is common when running in containers with ports exposed on the host.
               Or when running behind TCP proxies in a service mesh.
@@ -403,8 +404,8 @@ properties:
             properties:
               duration:
                 type:
-                  - string
-                  - "null"
+                - string
+                - "null"
                 description: |
                   The time after creation to close the worker, like "1 hour"
               stagger:
@@ -423,6 +424,7 @@ properties:
                 type: boolean
                 description: |
                   Do we try to resurrect the worker after the lifetime deadline?
+
 
           profile:
             type: object
@@ -510,8 +512,8 @@ properties:
 
               target:
                 oneOf:
-                  - { type: number, minimum: 0, maximum: 1 }
-                  - { enum: [false] }
+                  - {type: number, minimum: 0, maximum: 1}
+                  - {enum: [false]}
                 description: >-
                   When the process memory (as observed by the operating system) gets
                   above this amount we start spilling the dask keys holding the largest
@@ -519,24 +521,24 @@ properties:
 
               spill:
                 oneOf:
-                  - { type: number, minimum: 0, maximum: 1 }
-                  - { enum: [false] }
+                  - {type: number, minimum: 0, maximum: 1}
+                  - {enum: [false]}
                 description: >-
                   When the process memory (as observed by the operating system) gets
                   above this amount we spill all data to disk.
 
               pause:
                 oneOf:
-                  - { type: number, minimum: 0, maximum: 1 }
-                  - { enum: [false] }
+                  - {type: number, minimum: 0, maximum: 1}
+                  - {enum: [false]}
                 description: >-
                   When the process memory (as observed by the operating system) gets
                   above this amount we no longer start new tasks on this worker.
 
               terminate:
                 oneOf:
-                  - { type: number, minimum: 0, maximum: 1 }
-                  - { enum: [false] }
+                  - {type: number, minimum: 0, maximum: 1}
+                  - {enum: [false]}
                 description: >-
                   When the process memory reaches this level the nanny process will kill
                   the worker (if a nanny is present)
@@ -544,7 +546,7 @@ properties:
               max-spill:
                 oneOf:
                   - type: string
-                  - { type: number, minimum: 0 }
+                  - {type: number, minimum: 0}
                   - enum: [false]
                 description: >-
                   Limit of number of bytes to be spilled on disk.
@@ -571,6 +573,7 @@ properties:
         description: |
           Configuration settings for Dask Nannies
         properties:
+
           preload:
             type: array
             description: |
@@ -599,7 +602,8 @@ properties:
         properties:
           heartbeat:
             type: string
-            description: This value is the time between heartbeats
+            description:
+              This value is the time between heartbeats
 
               The client sends a periodic heartbeat message to the scheduler.
               If it misses enough of these then the scheduler assumes that it has gone.
@@ -609,7 +613,7 @@ properties:
             description: Interval between scheduler-info updates
 
           security-loader:
-            type: [string, "null"]
+            type: [string, 'null']
             description: |
               A fully qualified name (e.g. ``module.submodule.function``) of
               a callback to use for loading security credentials for the
@@ -632,6 +636,7 @@ properties:
               Arguments to pass into the preload scripts described above
 
               See https://docs.dask.org/en/latest/how-to/customize-initialization.html for more information
+
 
       deploy:
         type: object
@@ -693,11 +698,13 @@ properties:
         type: object
         description: Configuration settings for Dask communications
         properties:
+
           retry:
             type: object
             description: |
               Some operations (such as gathering data) are subject to re-tries with the below parameters
             properties:
+
               count:
                 type: integer
                 minimum: 0
@@ -723,8 +730,8 @@ properties:
 
           offload:
             type:
-              - boolean
-              - string
+            - boolean
+            - string
             description: |
               The size of message after which we choose to offload serialization to another thread
 
@@ -776,8 +783,8 @@ properties:
 
           require-encryption:
             type:
-              - boolean
-              - "null"
+            - boolean
+            - "null"
             description: |
               Whether to require encryption on non-local comms
 
@@ -795,8 +802,8 @@ properties:
             properties:
               ciphers:
                 type:
-                  - string
-                  - "null"
+                - string
+                - "null"
                 description: Allowed ciphers, specified as an OpenSSL cipher string.
 
               min-version:
@@ -811,8 +818,8 @@ properties:
 
               ca-file:
                 type:
-                  - string
-                  - "null"
+                - string
+                - "null"
                 description: Path to a CA file, in pem format
 
               scheduler:
@@ -821,13 +828,13 @@ properties:
                 properties:
                   cert:
                     type:
-                      - string
-                      - "null"
+                    - string
+                    - "null"
                     description: Path to certificate file
                   key:
                     type:
-                      - string
-                      - "null"
+                    - string
+                    - "null"
                     description: |
                       Path to key file.
 
@@ -840,13 +847,13 @@ properties:
                 properties:
                   cert:
                     type:
-                      - string
-                      - "null"
+                    - string
+                    - "null"
                     description: Path to certificate file
                   key:
                     type:
-                      - string
-                      - "null"
+                    - string
+                    - "null"
                     description: |
                       Path to key file.
 
@@ -859,13 +866,13 @@ properties:
                 properties:
                   cert:
                     type:
-                      - string
-                      - "null"
+                    - string
+                    - "null"
                     description: Path to certificate file
                   key:
                     type:
-                      - string
-                      - "null"
+                    - string
+                    - "null"
                     description: |
                       Path to key file.
 
@@ -878,30 +885,30 @@ properties:
               UCX provides access to other transport methods including NVLink and InfiniBand.
             properties:
               cuda-copy:
-                type: [boolean, "null"]
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable CUDA support over UCX. This may be used even if
                   InfiniBand and NVLink are not supported or disabled, then transferring data over TCP.
               tcp:
-                type: [boolean, "null"]
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable TCP over UCX, even if InfiniBand and NVLink
                   are not supported or disabled.
               nvlink:
-                type: [boolean, "null"]
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable UCX over NVLink, implies ``distributed.comm.ucx.tcp=True``.
               infiniband:
-                type: [boolean, "null"]
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable UCX over InfiniBand, implies ``distributed.comm.ucx.tcp=True``.
               rdmacm:
-                type: [boolean, "null"]
+                type: [boolean, 'null']
                 description: |
                   Set environment variables to enable UCX RDMA connection manager support,
                   requires ``distributed.comm.ucx.infiniband=True``.
               create-cuda-context:
-                type: [boolean, "null"]
+                type: [boolean, 'null']
                 description: |
                   Creates a CUDA context before UCX is initialized. This is necessary to enable UCX to
                   properly identify connectivity of GPUs with specialized networking hardware, such as
@@ -923,7 +930,7 @@ properties:
             properties:
               shard:
                 type:
-                  - string
+                - string
                 description: |
                   The maximum size of a websocket frame to send through a comm.
 
@@ -1005,10 +1012,10 @@ properties:
               interval:
                 type: string
                 description: The time between ticks, default 20ms
-              limit:
+              limit :
                 type: string
                 description: The time allowed before triggering a warning
-              cycle:
+              cycle :
                 type: string
                 description: The time in between verifying event loop speed
 
@@ -1063,6 +1070,6 @@ properties:
           Configuration options for the RAPIDS Memory Manager.
         properties:
           pool-size:
-            type: [integer, "null"]
+            type: [integer, 'null']
             description: |
               The size of the memory pool in bytes.

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -85,7 +85,12 @@ distributed:
     preload-argv: []        # See https://docs.dask.org/en/latest/how-to/customize-initialization.html
     daemon: True
     validate: False         # Check worker state at every step for debugging
-    resources: {}           # Key: value pairs specifying worker resources.
+    resources: {}           # Key: value pairs specifying worker resources
+    name: null              # Name for the worker to use when registering with the scheduler (must be unique)
+    contact-address: null   # Address that scheduler and other workers should dial back on
+    interface: null         # Network interface to listen on
+    host: null              # Host to bind to
+    port: null              # Port to listen on
     lifetime:
       duration: null        # Time after which to gracefully shutdown the worker
       stagger: 0 seconds    # Random amount by which to stagger lifetimes

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -672,7 +672,9 @@ class Worker(ServerNode):
             scheduler_addr = coerce_to_address(scheduler_ip)
         else:
             scheduler_addr = coerce_to_address((scheduler_ip, scheduler_port))
-        self.contact_address = contact_address
+        self.contact_address = dask.config.get(
+            "distributed.worker.contact-address", override_with=contact_address
+        )
 
         if protocol is None:
             protocol_address = scheduler_addr.split("://")
@@ -680,17 +682,23 @@ class Worker(ServerNode):
                 protocol = protocol_address[0]
             assert protocol
 
-        self._start_port = port
-        self._start_host = host
-        if host:
+        self._start_port = dask.config.get(
+            "distributed.worker.port", override_with=port
+        )
+        self._start_host = dask.config.get(
+            "distributed.worker.host", override_with=host
+        )
+        if self._start_host:
             # Helpful error message if IPv6 specified incorrectly
-            _, host_address = parse_address(host)
+            _, host_address = parse_address(self._start_host)
             if host_address.count(":") > 1 and not host_address.startswith("["):
                 raise ValueError(
                     "Host address with IPv6 must be bracketed like '[::1]'; "
                     f"got {host_address}"
                 )
-        self._interface = interface
+        self._interface = dask.config.get(
+            "distributed.worker.interface", override_with=interface
+        )
         self._protocol = protocol
 
         self.nthreads = nthreads or CPU_COUNT
@@ -739,7 +747,9 @@ class Worker(ServerNode):
             )
 
         self.batched_stream = BatchedSend(interval="2ms", loop=self.loop)
-        self.name = name
+        self.name = dask.config.get(
+            "distributed.worker.name", override_with=name
+        ).format(**os.environ)
         self.scheduler_delay = 0
         self.stream_comms = {}
         self.heartbeat_active = False
@@ -829,7 +839,7 @@ class Worker(ServerNode):
         pc = PeriodicCallback(self.find_missing, 1000)  # type: ignore
         self.periodic_callbacks["find-missing"] = pc
 
-        self._address = contact_address
+        self._address = self.contact_address
 
         if extensions is None:
             extensions = DEFAULT_EXTENSIONS


### PR DESCRIPTION
Closes #6375

Given that @mrocklin seemed happy with this approach I thought I'd throw together a quick PR to see how this feels. Happy to add more of the `Worker` kwargs to this or rethink the approach as @fjetter suggested.

My goal here is for things that can be set via CLI flags on `dask-worker` can also be set via environment variables.