### PR TITLE
Add SchedulerPlugin.log_event handler

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -112,6 +112,9 @@ class SchedulerPlugin:
     def remove_client(self, scheduler: Scheduler, client: str) -> None:
         """Run when a client disconnects"""
 
+    def log_event(self, name, msg) -> None:
+        """Run when an event is logged"""
+
 
 class WorkerPlugin:
     """Interface to extend the Worker

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6954,6 +6954,12 @@ class Scheduler(SchedulerState, ServerNode):
             self.event_counts[name] += 1
             self._report_event(name, event)
 
+            for plugin in list(self.plugins.values()):
+                try:
+                    plugin.log_event(name, msg)
+                except Exception:
+                    logger.info("Plugin failed with exception", exc_info=True)
+
     def _report_event(self, name, event):
         for client in self.event_subscriber[name]:
             self.report(


### PR DESCRIPTION
This makes it possible for plugins to track events

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
