### PR TITLE
Remove `reconnect` argument from Nanny

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -113,7 +113,6 @@ class Nanny(ServerNode):
         services=None,
         name=None,
         memory_limit="auto",
-        reconnect=True,
         validate=False,
         quiet=False,
         resources=None,
@@ -192,7 +191,6 @@ class Nanny(ServerNode):
 
         self._given_worker_port = worker_port
         self.nthreads = nthreads or CPU_COUNT
-        self.reconnect = reconnect
         self.validate = validate
         self.resources = resources
         self.death_timeout = parse_timedelta(death_timeout)
@@ -521,9 +519,9 @@ class Nanny(ServerNode):
                 await self._unregister()
             except OSError:
                 logger.exception("Failed to unregister")
-                if not self.reconnect:
-                    await self.close()
-                    return
+                # Always try to reconnect to scheduler
+                await self.close()
+                return
 
         try:
             if self.status not in (

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -105,9 +105,7 @@ async def test_no_hang_when_scheduler_closes(s, a, b):
 
 
 @pytest.mark.slow
-@gen_cluster(
-    Worker=Nanny, nthreads=[("127.0.0.1", 1)], worker_kwargs={"reconnect": False}
-)
+@gen_cluster(Worker=Nanny, nthreads=[("127.0.0.1", 1)])
 async def test_close_on_disconnect(s, w):
     await s.close()
 


### PR DESCRIPTION
`reconnect=True` (previous default) is now the only option. This is not a necessary change to make. It just simplifies things to not have it. See discussion in https://github.com/dask/distributed/pull/6361#discussion_r876407918.

Merge after https://github.com/dask/distributed/pull/6361.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
