### PR TITLE
Fix API JSON MIME type

### DIFF
--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -13,7 +13,7 @@ class APIHandler(RequestHandler):
 
 class RetireWorkersHandler(RequestHandler):
     async def post(self):
-        self.set_header("Content-Type", "text/json")
+        self.set_header("Content-Type", "application/json")
         scheduler = self.server
         try:
             params = json.loads(self.request.body)
@@ -32,7 +32,7 @@ class RetireWorkersHandler(RequestHandler):
 
 class GetWorkersHandler(RequestHandler):
     def get(self):
-        self.set_header("Content-Type", "text/json")
+        self.set_header("Content-Type", "application/json")
         scheduler = self.server
         try:
             response = {
@@ -50,7 +50,7 @@ class GetWorkersHandler(RequestHandler):
 
 class AdaptiveTargetHandler(RequestHandler):
     def get(self):
-        self.set_header("Content-Type", "text/json")
+        self.set_header("Content-Type", "application/json")
         scheduler = self.server
         try:
             desired_workers = scheduler.adaptive_target()

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -268,7 +268,7 @@ async def test_retire_workers(c, s, a, b):
             json=params,
         ) as resp:
             assert resp.status == 200
-            assert resp.headers["Content-Type"] == "text/json"
+            assert resp.headers["Content-Type"] == "application/json"
             retired_workers_info = json.loads(await resp.text())
             assert len(retired_workers_info) == 2
 
@@ -280,7 +280,7 @@ async def test_get_workers(c, s, a, b):
             "http://localhost:%d/api/v1/get_workers" % s.http_server.port
         ) as resp:
             assert resp.status == 200
-            assert resp.headers["Content-Type"] == "text/json"
+            assert resp.headers["Content-Type"] == "application/json"
             workers_info = json.loads(await resp.text())["workers"]
             workers_address = [worker.get("address") for worker in workers_info]
             assert set(workers_address) == {a.address, b.address}
@@ -293,6 +293,6 @@ async def test_adaptive_target(c, s, a, b):
             "http://localhost:%d/api/v1/adaptive_target" % s.http_server.port
         ) as resp:
             assert resp.status == 200
-            assert resp.headers["Content-Type"] == "text/json"
+            assert resp.headers["Content-Type"] == "application/json"
             num_workers = json.loads(await resp.text())["workers"]
             assert num_workers == 0


### PR DESCRIPTION
Looks like the correct MIME type for JSON is `application/json` and some HTTP libraries complain about it being `text/json`.

https://stackoverflow.com/questions/477816/what-is-the-correct-json-content-type