### PR TITLE
WorkerState are different for different addresses

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -477,7 +477,7 @@ class WorkerState:
         self.versions = versions or {}
         self.nanny = nanny
         self.status = status
-        self._hash = hash(address)
+        self._hash = hash(address) + hash(pid) + hash(name)
         self.nbytes = 0
         self.occupancy = 0
         self._memory_unmanaged_old = 0
@@ -501,7 +501,7 @@ class WorkerState:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, WorkerState):
             return False
-        return self.address == other.address
+        return hash(self) == hash(other)
 
     @property
     def has_what(self) -> Set[TaskState]:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -477,7 +477,7 @@ class WorkerState:
         self.versions = versions or {}
         self.nanny = nanny
         self.status = status
-        self._hash = hash(address) + hash(pid) + hash(name)
+        self._hash = hash((address, pid, name))
         self.nbytes = 0
         self.occupancy = 0
         self._memory_unmanaged_old = 0


### PR DESCRIPTION
Should be a step towards https://github.com/dask/distributed/issues/6392

I don't see any downsides of extending the hash to PID + name. This should give us a uniqueness for WorkerState objects.

We still are using addresses as reference across the code but I think this is still a valuable step