### PR TITLE
restore signal handlers after wait for signals is done

### DIFF
--- a/distributed/_signals.py
+++ b/distributed/_signals.py
@@ -25,4 +25,8 @@ async def wait_for_signals(signals: list[signal.Signals]) -> None:
     for sig in signals:
         old_handlers[sig] = signal.signal(sig, handle_signal)
 
-    await event.wait()
+    try:
+        await event.wait()
+    finally:
+        for sig in signals:
+            signal.signal(sig, old_handlers[sig])


### PR DESCRIPTION
if `wait_for_signals` is cancelled - eg by the `idle-timeout=1s` expiring it left the `wait_for_signals.handle_signal` in place
this is usually not a problem because it's only called as the first operation of a brand new process. However when it's called via 
`CliRunner().invoke(` this causes the signal handler to be set for all subsequent tests which impacts using Ctrl+C during development.


- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
