### PR TITLE
Allow deserialized plugins in `register_scheduler_plugin`

### DIFF
--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -198,3 +198,14 @@ async def test_log_event_plugin(c, s, a, b):
     await c.submit(f)
 
     assert ("foo", 123) in s._recorded_events
+
+
+@gen_cluster(client=True)
+async def test_register_plugin_on_scheduler(c, s, a, b):
+    class MyPlugin(SchedulerPlugin):
+        async def start(self, scheduler: Scheduler) -> None:
+            scheduler._foo = "bar"  # type: ignore
+
+    await s.register_scheduler_plugin(MyPlugin())
+
+    assert s._foo == "bar"

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4865,7 +4865,8 @@ class Scheduler(SchedulerState, ServerNode):
                 "arbitrary bytestrings using pickle via the "
                 "'distributed.scheduler.pickle' configuration setting."
             )
-        plugin = loads(plugin)
+        if not isinstance(plugin, SchedulerPlugin):
+            plugin = loads(plugin)
 
         if name is None:
             name = _get_plugin_name(plugin)


### PR DESCRIPTION
Previously we would always deserialize the input.
However in situations where we register the plugin directly on the
scheduler (such as within a preload) this isn't necessary.