### PR TITLE
Fix test_stress_scatter_death

### DIFF
--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -196,32 +196,6 @@ async def test_default_name(c, s, w):
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
-async def test_release_key_deprecated(c, s, a):
-    class ReleaseKeyDeprecated(WorkerPlugin):
-        def __init__(self):
-            self._called = False
-
-        def release_key(self, key, state, cause, reason, report):
-            # Ensure that the handler still works
-            self._called = True
-            assert state == "memory"
-            assert key == "task"
-
-        def teardown(self, worker):
-            assert self._called
-            return super().teardown(worker)
-
-    await c.register_worker_plugin(ReleaseKeyDeprecated())
-
-    with pytest.warns(
-        FutureWarning, match="The `WorkerPlugin.release_key` hook is deprecated"
-    ):
-        assert await c.submit(inc, 1, key="x") == 2
-        while "x" in a.tasks:
-            await asyncio.sleep(0.01)
-
-
-@gen_cluster(client=True, nthreads=[("", 1)])
 async def test_assert_no_warning_no_overload(c, s, a):
     """Assert we do not receive a deprecation warning if we do not overload any
     methods

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3047,12 +3047,10 @@ async def test_task_flight_compute_oserror(c, s, a, b):
         ),
         # inc is lost and needs to be recomputed. Therefore, sum is released
         ("free-keys", ("f1",)),
-        ("f1", "purge-state"),
         # The recommendations here are hard to predict. Whatever key is
         # currently scheduled to be fetched, if any, will be recommended to be
         # released.
         ("f1", "waiting", "released", "released", lambda msg: msg["f1"] == "forgotten"),
-        ("f1", "purge-state"),
         ("f1", "released", "forgotten", "forgotten", {}),
         # Now, we actually compute the task *once*. This must not cycle back
         ("f1", "compute-task", "released"),

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3047,11 +3047,12 @@ async def test_task_flight_compute_oserror(c, s, a, b):
         ),
         # inc is lost and needs to be recomputed. Therefore, sum is released
         ("free-keys", ("f1",)),
-        ("f1", "release-key"),
+        ("f1", "purge-state"),
         # The recommendations here are hard to predict. Whatever key is
         # currently scheduled to be fetched, if any, will be recommended to be
         # released.
         ("f1", "waiting", "released", "released", lambda msg: msg["f1"] == "forgotten"),
+        ("f1", "purge-state"),
         ("f1", "released", "forgotten", "forgotten", {}),
         # Now, we actually compute the task *once*. This must not cycle back
         ("f1", "compute-task", "released"),

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -495,3 +495,23 @@ async def test_forget_data_needed(c, s, a, b):
     x = c.submit(inc, 2, key="x", workers=[a.address])
     y = c.submit(inc, x, key="y", workers=[b.address])
     assert await y == 4
+
+
+@gen_cluster(client=True, nthreads=[("", 1)] * 3)
+async def test_missing_handle_compute_dependency(c, s, w1, w2, w3):
+    """Test that it is OK for a dependency to be in state missing if a dependent is asked to be computed"""
+
+    w3.periodic_callbacks["find-missing"].stop()
+
+    f1 = c.submit(inc, 1, key="f1", workers=[w1.address])
+    f2 = c.submit(inc, 2, key="f2", workers=[w1.address])
+
+    w3.handle_acquire_replicas(
+        keys=[f1.key], who_has={f1.key: [w2.address]}, stimulus_id="acquire"
+    )
+
+    await wait_for_state(f1.key, "missing", w3)
+
+    f3 = c.submit(sum, [f1, f2], key="f3", workers=[w3.address])
+
+    await f3

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -4264,6 +4264,8 @@ class Worker(ServerNode):
         # normally in released state. However, the compute-task call for their
         # previous dependent provided them with who_has, such that this assert
         # is no longer true.
+        # assert not any(ts.key in has_what for has_what in self.has_what.values())
+
         assert not ts.waiting_for_data
         assert not ts.done
         assert not ts.exception

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -300,6 +300,22 @@ class TaskErredMsg(SendMessageToScheduler):
         d["status"] = "error"
         return d
 
+    @staticmethod
+    def from_task(
+        ts: TaskState, stimulus_id: str, thread: int | None = None
+    ) -> TaskErredMsg:
+        assert ts.exception
+        return TaskErredMsg(
+            key=ts.key,
+            exception=ts.exception,
+            traceback=ts.traceback,
+            exception_text=ts.exception_text,
+            traceback_text=ts.traceback_text,
+            thread=thread,
+            startstops=ts.startstops,
+            stimulus_id=stimulus_id,
+        )
+
 
 @dataclass
 class ReleaseWorkerDataMsg(SendMessageToScheduler):


### PR DESCRIPTION
Running test_scatter_death locally, I ran into three issues

1. an assert on a released task. This assert statement is currently wrong. It's a subtle race condition with cancelled states which can leave a released task around with informatino about who_has/has_what without transitioning it to fetch
2. if a dependency of a task is in state missing we should not try to transition it to fetch when performing the `transition_released_waiting` transition. This can cause a `assert ts.who_has` failure. 
3. I'm still facing a very rare [KeyError in validate_state](https://github.com/dask/distributed/blob/cc383a67a1141eac4e2dec832d375655554bce85/distributed/worker.py#L4298) This seems to be connected to 1.) If a task is merely in released state with who_has/has_what information and it is afterwards forgotten, we do not call the release_key method which purges task related state (name is confusing atm), i.e. real world implication is that the worker may have "zombie who_has information" which should not be harmful

Closes https://github.com/dask/distributed/issues/6305
Closes https://github.com/dask/distributed/issues/6191

I'm pretty sure 1. and 2. have been around a while. No idea why this is more likely to fail lately. @crusaderky mentioned a potential connection to https://github.com/dask/distributed/pull/6210 indicating that this always asserted/raised but we simply never noticed

I also am fairly certain that the system can recover from 2. if we were not to raise an assert statement and would not deadlock.

cc @crusaderky @jrbourbeau 