### PR TITLE
Disable HTTP API by default

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -53,7 +53,6 @@ distributed:
         - distributed.http.scheduler.prometheus
         - distributed.http.scheduler.info
         - distributed.http.scheduler.json
-        - distributed.http.scheduler.api
         - distributed.http.health
         - distributed.http.proxy
         - distributed.http.statics

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -16,6 +16,8 @@ from dask.sizeof import sizeof
 from distributed.utils import is_valid_xml
 from distributed.utils_test import gen_cluster, inc, slowinc
 
+DEFAULT_ROUTES = dask.config.get("distributed.scheduler.http.routes")
+
 
 @gen_cluster(client=True)
 async def test_connect(c, s, a, b):
@@ -258,7 +260,10 @@ def test_api_disabled_by_default():
 @gen_cluster(
     client=True,
     clean_kwargs={"threads": False},
-    config={"distributed.scheduler.http.routes": ["distributed.http.scheduler.api"]},
+    config={
+        "distributed.scheduler.http.routes": DEFAULT_ROUTES
+        + ["distributed.http.scheduler.api"]
+    },
 )
 async def test_api(c, s, a, b):
     async with aiohttp.ClientSession() as session:
@@ -273,7 +278,10 @@ async def test_api(c, s, a, b):
 @gen_cluster(
     client=True,
     clean_kwargs={"threads": False},
-    config={"distributed.scheduler.http.routes": ["distributed.http.scheduler.api"]},
+    config={
+        "distributed.scheduler.http.routes": DEFAULT_ROUTES
+        + ["distributed.http.scheduler.api"]
+    },
 )
 async def test_retire_workers(c, s, a, b):
     async with aiohttp.ClientSession() as session:
@@ -291,7 +299,10 @@ async def test_retire_workers(c, s, a, b):
 @gen_cluster(
     client=True,
     clean_kwargs={"threads": False},
-    config={"distributed.scheduler.http.routes": ["distributed.http.scheduler.api"]},
+    config={
+        "distributed.scheduler.http.routes": DEFAULT_ROUTES
+        + ["distributed.http.scheduler.api"]
+    },
 )
 async def test_get_workers(c, s, a, b):
     async with aiohttp.ClientSession() as session:
@@ -308,7 +319,10 @@ async def test_get_workers(c, s, a, b):
 @gen_cluster(
     client=True,
     clean_kwargs={"threads": False},
-    config={"distributed.scheduler.http.routes": ["distributed.http.scheduler.api"]},
+    config={
+        "distributed.scheduler.http.routes": DEFAULT_ROUTES
+        + ["distributed.http.scheduler.api"]
+    },
 )
 async def test_adaptive_target(c, s, a, b):
     async with aiohttp.ClientSession() as session:

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -10,6 +10,7 @@ pytest.importorskip("bokeh")
 from tornado.escape import url_escape
 from tornado.httpclient import AsyncHTTPClient, HTTPClientError
 
+import dask.config
 from dask.sizeof import sizeof
 
 from distributed.utils import is_valid_xml
@@ -248,8 +249,18 @@ async def test_eventstream(c, s, a, b):
     ws_client.close()
 
 
+def test_api_disabled_by_default():
+    assert "distributed.http.scheduler.api" not in dask.config.get(
+        "distributed.scheduler.http.routes"
+    )
+
+
 @gen_cluster(client=True, clean_kwargs={"threads": False})
 async def test_api(c, s, a, b):
+    if "distributed.http.scheduler.api" not in dask.config.get(
+        "distributed.scheduler.http.routes"
+    ):
+        pytest.skip()
     async with aiohttp.ClientSession() as session:
         async with session.get(
             "http://localhost:%d/api/v1" % s.http_server.port
@@ -261,6 +272,10 @@ async def test_api(c, s, a, b):
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
 async def test_retire_workers(c, s, a, b):
+    if "distributed.http.scheduler.api" not in dask.config.get(
+        "distributed.scheduler.http.routes"
+    ):
+        pytest.skip()
     async with aiohttp.ClientSession() as session:
         params = {"workers": [a.address, b.address]}
         async with session.post(
@@ -275,6 +290,10 @@ async def test_retire_workers(c, s, a, b):
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
 async def test_get_workers(c, s, a, b):
+    if "distributed.http.scheduler.api" not in dask.config.get(
+        "distributed.scheduler.http.routes"
+    ):
+        pytest.skip()
     async with aiohttp.ClientSession() as session:
         async with session.get(
             "http://localhost:%d/api/v1/get_workers" % s.http_server.port
@@ -288,6 +307,10 @@ async def test_get_workers(c, s, a, b):
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})
 async def test_adaptive_target(c, s, a, b):
+    if "distributed.http.scheduler.api" not in dask.config.get(
+        "distributed.scheduler.http.routes"
+    ):
+        pytest.skip()
     async with aiohttp.ClientSession() as session:
         async with session.get(
             "http://localhost:%d/api/v1/adaptive_target" % s.http_server.port

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -255,12 +255,12 @@ def test_api_disabled_by_default():
     )
 
 
-@gen_cluster(client=True, clean_kwargs={"threads": False})
+@gen_cluster(
+    client=True,
+    clean_kwargs={"threads": False},
+    config={"distributed.scheduler.http.routes": ["distributed.http.scheduler.api"]},
+)
 async def test_api(c, s, a, b):
-    if "distributed.http.scheduler.api" not in dask.config.get(
-        "distributed.scheduler.http.routes"
-    ):
-        pytest.skip()
     async with aiohttp.ClientSession() as session:
         async with session.get(
             "http://localhost:%d/api/v1" % s.http_server.port
@@ -270,12 +270,12 @@ async def test_api(c, s, a, b):
             assert (await resp.text()) == "API V1"
 
 
-@gen_cluster(client=True, clean_kwargs={"threads": False})
+@gen_cluster(
+    client=True,
+    clean_kwargs={"threads": False},
+    config={"distributed.scheduler.http.routes": ["distributed.http.scheduler.api"]},
+)
 async def test_retire_workers(c, s, a, b):
-    if "distributed.http.scheduler.api" not in dask.config.get(
-        "distributed.scheduler.http.routes"
-    ):
-        pytest.skip()
     async with aiohttp.ClientSession() as session:
         params = {"workers": [a.address, b.address]}
         async with session.post(
@@ -288,12 +288,12 @@ async def test_retire_workers(c, s, a, b):
             assert len(retired_workers_info) == 2
 
 
-@gen_cluster(client=True, clean_kwargs={"threads": False})
+@gen_cluster(
+    client=True,
+    clean_kwargs={"threads": False},
+    config={"distributed.scheduler.http.routes": ["distributed.http.scheduler.api"]},
+)
 async def test_get_workers(c, s, a, b):
-    if "distributed.http.scheduler.api" not in dask.config.get(
-        "distributed.scheduler.http.routes"
-    ):
-        pytest.skip()
     async with aiohttp.ClientSession() as session:
         async with session.get(
             "http://localhost:%d/api/v1/get_workers" % s.http_server.port
@@ -305,12 +305,12 @@ async def test_get_workers(c, s, a, b):
             assert set(workers_address) == {a.address, b.address}
 
 
-@gen_cluster(client=True, clean_kwargs={"threads": False})
+@gen_cluster(
+    client=True,
+    clean_kwargs={"threads": False},
+    config={"distributed.scheduler.http.routes": ["distributed.http.scheduler.api"]},
+)
 async def test_adaptive_target(c, s, a, b):
-    if "distributed.http.scheduler.api" not in dask.config.get(
-        "distributed.scheduler.http.routes"
-    ):
-        pytest.skip()
     async with aiohttp.ClientSession() as session:
         async with session.get(
             "http://localhost:%d/api/v1/adaptive_target" % s.http_server.port


### PR DESCRIPTION
Workaround for #6407.

Disables the HTTP API by default but allows it to be enabled in environments where auth is handled externally to distributed.

A longer-term fix is to implement some basic HTTP authentication on the API, once that is done #6407 can be closed and the API enabled by default again.

cc @gjoseph92 
