### PR TITLE
Add a lock to `distributed.profile` for better concurrency control

### DIFF
--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -339,18 +339,18 @@ def _watch(
     last = time()
 
     while not stop():
-        with lock:
-            if time() > last + cycle:
+        if time() > last + cycle:
+            recent = create()
+            with lock:
                 log.append((time(), recent))
-                recent = create()
                 last = time()
-            try:
-                frame = sys._current_frames()[thread_id]
-            except KeyError:
-                return
+                try:
+                    frame = sys._current_frames()[thread_id]
+                except KeyError:
+                    return
 
-            process(frame, None, recent, omit=omit)
-            del frame
+                process(frame, None, recent, omit=omit)
+                del frame
         sleep(interval)
 
 

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -317,15 +317,6 @@ def plot_data(state, profile_interval=0.010):
     }
 
 
-def wait_profiler() -> None:
-    """Wait until a moment when no instances of watch() are sampling the frames.
-    You must call this function whenever you would otherwise expect an object to be
-    immediately released after it's descoped.
-    """
-    with lock:
-        pass
-
-
 def _watch(
     thread_id: int,
     log: deque[tuple[float, dict[str, Any]]],  # [(timestamp, output of create()), ...]

--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -5,7 +5,7 @@ from operator import add
 
 import pytest
 
-from distributed.profile import wait_profiler
+from distributed import profile
 from distributed.protocol import deserialize, serialize
 from distributed.protocol.pickle import HIGHEST_PROTOCOL, dumps, loads
 
@@ -181,7 +181,7 @@ def test_pickle_functions(protocol):
         assert func3(1) == func(1)
 
         del func, func2, func3
-        wait_profiler()
-        assert wr() is None
-        assert wr2() is None
-        assert wr3() is None
+        with profile.lock:
+            assert wr() is None
+            assert wr2() is None
+            assert wr3() is None

--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -12,10 +12,10 @@ import pytest
 
 import dask
 
+from distributed import profile
 from distributed.compatibility import WINDOWS
 from distributed.diskutils import WorkSpace
 from distributed.metrics import time
-from distributed.profile import wait_profiler
 from distributed.utils import mp_context
 from distributed.utils_test import captured_logger
 
@@ -53,8 +53,8 @@ def test_workdir_simple(tmpdir):
     a.release()
     assert_contents(["bb", "bb.dirlock"])
     del b
-    wait_profiler()
-    gc.collect()
+    with profile.lock:
+        gc.collect()
     assert_contents([])
 
     # Generated temporary name with a prefix
@@ -89,12 +89,12 @@ def test_two_workspaces_in_same_directory(tmpdir):
 
     del ws
     del b
-    wait_profiler()
-    gc.collect()
+    with profile.lock:
+        gc.collect()
     assert_contents(["aa", "aa.dirlock"], trials=5)
     del a
-    wait_profiler()
-    gc.collect()
+    with profile.lock:
+        gc.collect()
     assert_contents([], trials=5)
 
 
@@ -188,8 +188,8 @@ def test_locking_disabled(tmpdir):
             a.release()
             assert_contents(["bb"])
             del b
-            wait_profiler()
-            gc.collect()
+            with profile.lock:
+                gc.collect()
             assert_contents([])
 
         lock_file.assert_not_called()

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -261,6 +261,8 @@ async def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
     await c.restart()
     y = c.submit(inc, 1)
     del x
+
+    # Ensure that the profiler has stopped and released all references to x so that it can be garbage-collected
     with profile.lock:
         pass
     await asyncio.sleep(0.1)

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -10,11 +10,10 @@ from tlz import first, partition_all
 
 from dask import delayed
 
-from distributed import Client, Nanny, wait
+from distributed import Client, Nanny, profile, wait
 from distributed.comm import CommClosedError
 from distributed.compatibility import MACOS
 from distributed.metrics import time
-from distributed.profile import wait_profiler
 from distributed.utils import CancelledError, sync
 from distributed.utils_test import (
     captured_logger,
@@ -262,7 +261,8 @@ async def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
     await c.restart()
     y = c.submit(inc, 1)
     del x
-    wait_profiler()
+    with profile.lock:
+        pass
     await asyncio.sleep(0.1)
     await y
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -19,12 +19,11 @@ from tornado.ioloop import IOLoop
 import dask
 from dask.utils import tmpfile
 
-from distributed import Nanny, Scheduler, Worker, rpc, wait, worker
+from distributed import Nanny, Scheduler, Worker, profile, rpc, wait, worker
 from distributed.compatibility import LINUX, WINDOWS
 from distributed.core import CommClosedError, Status
 from distributed.diagnostics import SchedulerPlugin
 from distributed.metrics import time
-from distributed.profile import wait_profiler
 from distributed.protocol.pickle import dumps
 from distributed.utils import TimeoutError, parse_ports
 from distributed.utils_test import (
@@ -170,8 +169,8 @@ async def test_num_fds(s):
     # Warm up
     async with Nanny(s.address):
         pass
-    wait_profiler()
-    gc.collect()
+    with profile.lock:
+        gc.collect()
 
     before = proc.num_fds()
 

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -224,6 +224,7 @@ def test_watch_requires_lock_to_run():
 
     start_threads = threading.active_count()
 
+    # Hog the lock over the entire duration of watch
     thread = threading.Thread(
         target=hold_lock, name="Hold Lock", kwargs={"stop": stop_lock}
     )

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -18,6 +18,7 @@ from distributed.profile import (
     info_frame,
     ll_get_stack,
     llprocess,
+    lock,
     merge,
     plot_data,
     process,
@@ -200,6 +201,44 @@ def test_watch():
 
     sleep(0.5)
     assert 1 < len(log) < 10
+
+    start = time()
+    while threading.active_count() > start_threads:
+        assert time() < start + 2
+        sleep(0.01)
+
+
+def test_watch_requires_lock_to_run():
+    start = time()
+
+    def stop_lock():
+        return time() > start + 0.600
+
+    def stop_profile():
+        return time() > start + 0.500
+
+    def hold_lock(stop):
+        with lock:
+            while not stop():
+                sleep(0.1)
+
+    start_threads = threading.active_count()
+
+    thread = threading.Thread(
+        target=hold_lock, name="Hold Lock", kwargs={"stop": stop_lock}
+    )
+    thread.daemon = True
+    thread.start()
+
+    log = watch(interval="10ms", cycle="50ms", stop=stop_profile)
+
+    start = time()  # wait until thread starts up
+    while threading.active_count() < start_threads + 2:
+        assert time() < start + 2
+        sleep(0.01)
+
+    sleep(0.5)
+    assert len(log) == 0
 
     start = time()
     while threading.active_count() > start_threads:

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -338,6 +338,8 @@ def test_weakref_cache(tmpdir, cls, expect_cached, size):
     # the same id as a deleted one
     id_x = x.id
     del x
+
+    # Ensure that the profiler has stopped and released all references to x so that it can be garbage-collected
     with profile.lock:
         pass
 

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -8,8 +8,8 @@ import pytest
 
 from dask.sizeof import sizeof
 
+from distributed import profile
 from distributed.compatibility import WINDOWS
-from distributed.profile import wait_profiler
 from distributed.protocol import serialize_bytelist
 from distributed.spill import SpillBuffer, has_zict_210, has_zict_220
 from distributed.utils_test import captured_logger
@@ -338,7 +338,8 @@ def test_weakref_cache(tmpdir, cls, expect_cached, size):
     # the same id as a deleted one
     id_x = x.id
     del x
-    wait_profiler()
+    with profile.lock:
+        pass
 
     if size < 100:
         buf["y"]

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -12,12 +12,11 @@ from tlz import concat, sliding_window
 
 import dask
 
-from distributed import Event, Lock, Nanny, Worker, wait, worker_client
+from distributed import Event, Lock, Nanny, Worker, profile, wait, worker_client
 from distributed.compatibility import LINUX
 from distributed.config import config
 from distributed.core import Status
 from distributed.metrics import time
-from distributed.profile import wait_profiler
 from distributed.scheduler import key_split
 from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import (
@@ -948,8 +947,8 @@ async def test_cleanup_repeated_tasks(c, s, a, b):
 
     assert not s.tasks
 
-    wait_profiler()
-    assert not list(ws)
+    with profile.lock:
+        assert not list(ws)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 2)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -34,6 +34,7 @@ from distributed import (
     default_client,
     get_client,
     get_worker,
+    profile,
     wait,
 )
 from distributed.comm.registry import backends
@@ -42,7 +43,6 @@ from distributed.core import CommClosedError, Status, rpc
 from distributed.diagnostics import nvml
 from distributed.diagnostics.plugin import PipInstall
 from distributed.metrics import time
-from distributed.profile import wait_profiler
 from distributed.protocol import pickle
 from distributed.scheduler import Scheduler
 from distributed.utils_test import (
@@ -1851,8 +1851,8 @@ async def test_stimulus_story(c, s, a):
     del f
     while "f" in a.data:
         await asyncio.sleep(0.01)
-    wait_profiler()
-    assert ref() is None
+    with profile.lock:
+        assert ref() is None
 
     story = a.stimulus_story("f", "f2")
     assert {ev.key for ev in story} == {"f", "f2"}


### PR DESCRIPTION
Adds a `Lock` to `distributed.profile` to enable better concurrency control. In particular, it allows running garbage collection without a profiling thread holding references to objects, which is necessary for #6250.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
