### PR TITLE
Make `gen_test`s show up in VSCode test discovery

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -816,6 +816,7 @@ def gen_test(
         timeout = 3600
 
     def _(func):
+        @functools.wraps(func)
         def test_func(*args, **kwargs):
             with clean(**clean_kwargs) as loop:
                 injected_func = functools.partial(func, *args, **kwargs)


### PR DESCRIPTION
Not entirely sure why, but `@functools.wraps` on the test function makes them show up. This is convenient when VSCode users want to debug a `@gen_test` test.

- [x] Passes `pre-commit run --all-files`
