### PR TITLE
[WIP] Report code coverage after tests have finished

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,11 @@ coverage:
   round: down
   range: "85...100"
 
+  # Prevent red "X"s from showing up on PR checks
+  # before all CI builds have completed
+  notify:
+    wait_for_ci: yes
+
   status:
     project:
       default:


### PR DESCRIPTION
Checking to see if we can avoid getting coverage red "X"s before all coverage reports have been uploaded
