### PR TITLE
Disable pytest-asyncio if installed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,16 @@ tag_prefix =
 parentdir_prefix = distributed-
 
 [tool:pytest]
-addopts = -v -rsxfE --durations=20 --color=yes --ignore=continuous_integration --ignore=docs --ignore=.github --strict-markers --strict-config -p no:asyncio
+addopts =
+    -v -rsxfE
+    --durations=20
+    --color=yes
+    --ignore=continuous_integration
+    --ignore=docs
+    --ignore=.github
+    --strict-markers
+    --strict-config
+    -p no:asyncio
 filterwarnings =
     error
     ignore:Please use `dok_matrix` from the `scipy\.sparse` namespace, the `scipy\.sparse\.dok` namespace is deprecated.:DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ tag_prefix =
 parentdir_prefix = distributed-
 
 [tool:pytest]
-addopts = -v -rsxfE --durations=20 --color=yes --ignore=continuous_integration --ignore=docs --ignore=.github --strict-markers --strict-config
+addopts = -v -rsxfE --durations=20 --color=yes --ignore=continuous_integration --ignore=docs --ignore=.github --strict-markers --strict-config -p no:asyncio
 filterwarnings =
     error
     ignore:Please use `dok_matrix` from the `scipy\.sparse` namespace, the `scipy\.sparse\.dok` namespace is deprecated.:DeprecationWarning


### PR DESCRIPTION
Closes #6433

Tests do not run if `pytest-asyncio>0.14` is installed and that does get installed by other `dask-foo` projects which use it so explicitly disabling it here.