### PR TITLE
Remove `coverage` pin from Python 3.10 environment

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -10,7 +10,7 @@ dependencies:
   - bokeh
   - click
   - cloudpickle
-  - coverage<6.3  # https://github.com/nedbat/coveragepy/issues/1310
+  - coverage
   - dask  # overridden by git tip below
   - filesystem-spec  # overridden by git tip below
   - h5py


### PR DESCRIPTION
accidentally left over from https://github.com/dask/distributed/pull/5952 and wasn't reverted via https://github.com/dask/distributed/issues/5717

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
