### PR TITLE
always bind the Scheduler to the IOLoop.current() - and deprecate the Scheduler(loop= kwarg

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -9,7 +9,6 @@ import sys
 import warnings
 
 import click
-from tornado.ioloop import IOLoop
 
 from distributed import Scheduler
 from distributed._signals import wait_for_signals
@@ -186,11 +185,9 @@ def main(
         resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
 
     async def run():
-        loop = IOLoop.current()
         logger.info("-" * 47)
 
         scheduler = Scheduler(
-            loop=loop,
             security=sec,
             host=host,
             port=port,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2882,6 +2882,14 @@ class Scheduler(SchedulerState, ServerNode):
         transition_counter_max=False,
         **kwargs,
     ):
+        if loop is not None:
+            warnings.warn(
+                "the loop kwarg to Scheduler is deprecated",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        self.loop = IOLoop.current()
         self._setup_logging(logger)
 
         # Attributes
@@ -2961,7 +2969,6 @@ class Scheduler(SchedulerState, ServerNode):
             )
 
         # Communication state
-        self.loop = loop or IOLoop.current()
         self.client_comms = {}
         self.stream_comms = {}
         self._worker_coroutines = []

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -15,6 +15,7 @@ import cloudpickle
 import psutil
 import pytest
 from tlz import concat, first, merge, valmap
+from tornado.ioloop import IOLoop
 
 import dask
 from dask import delayed
@@ -779,8 +780,14 @@ async def test_update_graph_culls(s, a, b):
 
 
 def test_io_loop(loop):
-    s = Scheduler(loop=loop, dashboard_address=":0", validate=True)
-    assert s.io_loop is loop
+    async def main():
+        with pytest.warns(
+            DeprecationWarning, match=r"the loop kwarg to Scheduler is deprecated"
+        ):
+            s = Scheduler(loop=loop, dashboard_address=":0", validate=True)
+        assert s.io_loop is IOLoop.current()
+
+    asyncio.run(main())
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
refs #6163 

Passing anything other than `IOLoop.current()` will fail when you try to use the Scheduler anyway:
self._lock will be bound to `IOLoop.current().asyncio_loop` aka `asyncio.get_running_loop()`:
https://github.com/dask/distributed/blob/fc42dbd89afa4ab6709b197db5c2a14c284e99bf/distributed/scheduler.py#L2923
and start_http_server runs on the IOLoop.current() also:
https://github.com/dask/distributed/blob/fc42dbd89afa4ab6709b197db5c2a14c284e99bf/distributed/scheduler.py#L2963

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/graingert/projects/distributed/distributed/scheduler.py", line 2957, in __init__
    self.start_http_server(routes, dashboard_address, default_port=8787)
  File "/home/graingert/projects/distributed/distributed/node.py", line 158, in start_http_server
    self.http_server.listen(**tlz.merge(http_address, {"port": 0}))
  File "/home/graingert/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/tornado/tcpserver.py", line 152, in listen
    self.add_sockets(sockets)
  File "/home/graingert/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/tornado/tcpserver.py", line 165, in add_sockets
    self._handlers[sock.fileno()] = add_accept_handler(
  File "/home/graingert/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/tornado/netutil.py", line 246, in add_accept_handler
    io_loop = IOLoop.current()
  File "/home/graingert/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/tornado/ioloop.py", line 263, in current
    loop = asyncio.get_event_loop()
DeprecationWarning: There is no current event loop
```


- [x] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
