### PR TITLE
ignore coroutine 'ServerSession\.with_document_locked' was never awaited

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ filterwarnings =
     ignore:coroutine 'PooledRPCCall\.__getattr__\.<locals>\.send_recv_from_rpc' was never awaited:RuntimeWarning
     ignore:coroutine 'Scheduler\.restart' was never awaited:RuntimeWarning
     ignore:coroutine 'Semaphore._refresh_leases' was never awaited:RuntimeWarning
+    ignore:coroutine 'ServerSession\.with_document_locked' was never awaited
     ignore:overflow encountered in long_scalars:RuntimeWarning
     ignore:Creating scratch directories is taking a surprisingly long time.*:UserWarning
     ignore:Running on a single-machine scheduler when a distributed client is active might lead to unexpected results\.:UserWarning
@@ -75,7 +76,6 @@ filterwarnings =
     ignore:(?s)Exception ignored in. <function Client\.__del__.*RuntimeError. IOLoop is closed:pytest.PytestUnraisableExceptionWarning
     ignore:notifyAll\(\) is deprecated, use notify_all\(\) instead:DeprecationWarning:paramiko
     ignore:setDaemon\(\) is deprecated, set the daemon attribute instead:DeprecationWarning:paramiko
-    ignore:coroutine '_needs_document_lock.<locals>._needs_document_lock_wrapper' was never awaited
 minversion = 6
 markers =
     ci1: marks tests as belonging to 1 out of 2 partitions to run on CI ('-m "not ci1"' for second partition)


### PR DESCRIPTION
Closes #6394

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

failure from https://github.com/graingert/distributed/runs/6593930661?check_suite_focus=true#step:11:1759
```

>               warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
E               pytest.PytestUnraisableExceptionWarning: Exception ignored in: <coroutine object ServerSession.with_document_locked at 0x7f69604daf10>
E               
E               Traceback (most recent call last):
E                 File "/usr/share/miniconda3/envs/dask-distributed/lib/python3.10/warnings.py", line 506, in _warn_unawaited_coroutine
E                   warn(msg, category=RuntimeWarning, stacklevel=2, source=coro)
E               RuntimeWarning: coroutine 'ServerSession.with_document_locked' was never awaited

/usr/share/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning
------------------------------ Captured log call -------------------------------
ERROR    asyncio:base_events.py:1744 Task was destroyed but it is pending!
task: <Task pending name='Task-22382' coro=<ServerSession.with_document_locked() running at /usr/share/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/bokeh/server/session.py:78> cb=[multi_future.<locals>.callback() at /usr/share/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/tornado/gen.py:520]>
- generated xml file: /home/runner/work/distributed/distributed/reports/pytest.xml -
```

traceback source from the destroyed task:

https://github.com/bokeh/bokeh/blob/a1931d48512a1cb369746025d48344a6ad1834b2/bokeh/server/session.py#L78
https://github.com/tornadoweb/tornado/blob/2047e7ae3c825bf52dad10cc8402d09e11091bc1/tornado/gen.py#L520

see also https://github.com/bokeh/bokeh/pull/11976