### PR TITLE
Fix slicing bug in `ensure_memoryview`

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -259,8 +259,12 @@ def test_seek_delimiter_endline():
         memoryview(bytearray(b"1")),
         array("B", b"1"),
         array("I", range(5)),
+        memoryview(b"123456")[1:-1],
         memoryview(b"123456")[::2],
+        memoryview(array("I", range(5)))[1:-1],
+        memoryview(array("I", range(5)))[::2],
         memoryview(b"123456").cast("B", (2, 3)),
+        memoryview(b"0123456789").cast("B", (5, 2))[1:-1],
         memoryview(b"0123456789").cast("B", (5, 2))[::2],
     ],
 )
@@ -273,7 +277,6 @@ def test_ensure_memoryview(data):
     assert result.format == "B"
     assert result == bytes(data_mv)
     if data_mv.nbytes and data_mv.contiguous:
-        assert id(result.obj) == id(data_mv.obj)
         assert result.readonly == data_mv.readonly
         if isinstance(data, memoryview):
             if data.ndim == 1 and data.format == "B":

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1029,9 +1029,8 @@ def ensure_memoryview(obj):
     elif mv.ndim != 1 or mv.format != "B":
         # Perform zero-copy reshape & cast
         # Use `PickleBuffer.raw()` as `memoryview.cast()` fails with F-order
-        # Pass `mv.obj` so the created `memoryview` has that as its `obj`
         # xref: https://github.com/python/cpython/issues/91484
-        return PickleBuffer(mv.obj).raw()
+        return PickleBuffer(mv).raw()
     else:
         # Return `memoryview` as it already meets requirements
         return mv


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/6448

The underlying issues seems to be related to slicing. This example demonstrates the issue below and has been included in the test suite.

```python
from distributed.utils import ensure_memoryview

mv = memoryview(b"0123456789").cast("B", (5, 2))[1:-1]
mv2 = ensure_memoryview(mv)

assert mv == mv2
```

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
