### PR TITLE
Log rather than raise exceptions in `preload.teardown()`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3368,7 +3368,10 @@ class Scheduler(SchedulerState, ServerNode):
         setproctitle("dask-scheduler [closing]")
 
         for preload in self.preloads:
-            await preload.teardown()
+            try:
+                await preload.teardown()
+            except Exception as e:
+                logger.exception(e)
 
         await asyncio.gather(
             *[plugin.close() for plugin in list(self.plugins.values())]

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -302,3 +302,14 @@ async def test_client_preload_config_click(s):
     ):
         async with Client(address=s.address, asynchronous=True) as c:
             assert c.foo == value
+
+
+@gen_test()
+async def test_teardown_failure_doesnt_crash_scheduler():
+    text = """
+def dask_teardown(worker):
+    raise Exception(123)
+"""
+    async with Scheduler(dashboard_address=":0", preload=text) as s:
+        async with Worker(s.address, preload=[text]) as w:
+            pass

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1489,7 +1489,10 @@ class Worker(ServerNode):
                 )
 
         for preload in self.preloads:
-            await preload.teardown()
+            try:
+                await preload.teardown()
+            except Exception as e:
+                logger.exception(e)
 
         for extension in self.extensions.values():
             if hasattr(extension, "close"):


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/6437