### PR TITLE
close client in sync test_actor tests

### DIFF
--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -635,8 +635,7 @@ def test_one_thread_deadlock():
         def do_inc(self, ac):
             return ac.increment().result()
 
-    with cluster(nworkers=1) as (cl, _):
-        client = Client(cl["address"])
+    with cluster(nworkers=1) as (cl, _), Client(cl["address"]) as client:
         ac = client.submit(Counter, actor=True).result()
         ac2 = client.submit(UsesCounter, actor=True).result()
 
@@ -652,8 +651,7 @@ def test_one_thread_deadlock_timeout():
             # cannot expire
             return ac.increment().result(timeout=0.001)
 
-    with cluster(nworkers=1) as (cl, _):
-        client = Client(cl["address"])
+    with cluster(nworkers=1) as (cl, _), Client(cl["address"]) as client:
         ac = client.submit(Counter, actor=True).result()
         ac2 = client.submit(UsesCounter, actor=True).result()
 
@@ -667,8 +665,7 @@ def test_one_thread_deadlock_sync_client():
         def do_inc(self, ac):
             return get_client().sync(ac.increment)
 
-    with cluster(nworkers=1) as (cl, _):
-        client = Client(cl["address"])
+    with cluster(nworkers=1) as (cl, _), Client(cl["address"]) as client:
         ac = client.submit(Counter, actor=True).result()
         ac2 = client.submit(UsesCounter, actor=True).result()
 
@@ -701,8 +698,7 @@ def test_exception():
         def prop(self):
             raise MyException
 
-    with cluster(nworkers=2) as (cl, w):
-        client = Client(cl["address"])
+    with cluster(nworkers=2) as (cl, w), Client(cl["address"]) as client:
         ac = client.submit(Broken, actor=True).result()
         acfut = ac.method()
         with pytest.raises(MyException):


### PR DESCRIPTION
refs https://github.com/dask/distributed/issues/6453

Not sure if this is a fix, but closing the client explicitly usually helps with unclosed comms

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
