### PR TITLE
Wait on worker execution until plugins have started

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -253,7 +253,7 @@ class Server:
         self.io_loop.add_callback(set_thread_ident)
         self._startup_lock = asyncio.Lock()
         self.__startup_exc: Exception | None = None
-        self.__started = asyncio.Event()
+        self._started = asyncio.Event()
 
         self.rpc = ConnectionPool(
             limit=connection_limit,
@@ -325,7 +325,7 @@ class Server:
                 await _close_on_failure(exc)
                 raise RuntimeError(f"{type(self).__name__} failed to start.") from exc
             self.status = Status.running
-            self.__started.set()
+            self._started.set()
         return self
 
     async def __aenter__(self):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3733,6 +3733,7 @@ class Worker(ServerNode):
     async def execute(self, key: str, *, stimulus_id: str) -> StateMachineEvent | None:
         if self.status in {Status.closing, Status.closed, Status.closing_gracefully}:
             return None
+        await self._started.wait()
         ts = self.tasks.get(key)
         if not ts:
             return None


### PR DESCRIPTION
Previously a worker was technically able to accept tasks before it was
in a started state.  This uses the `_started` Event on the Server class
and avoids execution until that is set.

This could be improved.  Ideally we wouldn't consider really accepting
tasks at all until we were in a started state.  This is a good first
step though.

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
