### PR TITLE
`@fail_hard` can kill the whole test suite; hide errors

### DIFF
--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -41,30 +41,30 @@ def test_submit_after_failed_worker_sync(loop):
 
 
 @pytest.mark.slow()
-@gen_cluster(client=True, timeout=60, active_rpc_timeout=10)
-async def test_submit_after_failed_worker_async(c, s, a, b):
+@pytest.mark.parametrize("compute_on_failed", [False, True])
+@gen_cluster(client=True, config={"distributed.comm.timeouts.connect": "500ms"})
+async def test_submit_after_failed_worker_async(c, s, a, b, compute_on_failed):
     async with Nanny(s.address, nthreads=2) as n:
-        while len(s.workers) < 3:
-            await asyncio.sleep(0.1)
+        await c.wait_for_workers(3)
 
         L = c.map(inc, range(10))
         await wait(L)
 
-        s.loop.add_callback(n.kill)
-        total = c.submit(sum, L)
-        result = await total
-        assert result == sum(map(inc, range(10)))
+        kill_task = asyncio.create_task(n.kill())
+        compute_addr = n.worker_address if compute_on_failed else a.address
+        total = c.submit(sum, L, workers=[compute_addr], allow_other_workers=True)
+        assert await total == sum(range(1, 11))
+        await kill_task
 
 
 @gen_cluster(client=True, timeout=60)
 async def test_submit_after_failed_worker(c, s, a, b):
     L = c.map(inc, range(10))
     await wait(L)
-    await a.close()
 
+    await a.close()
     total = c.submit(sum, L)
-    result = await total
-    assert result == sum(map(inc, range(10)))
+    assert await total == sum(range(1, 11))
 
 
 @pytest.mark.slow

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -227,9 +227,16 @@ async def _force_close(self):
     """
     try:
         await asyncio.wait_for(self.close(nanny=False, executor_wait=False), 30)
-    except (Exception, BaseException):  # <-- include BaseException here or not??
-        # Worker is in a very broken state if closing fails. We need to shut down immediately,
-        # to ensure things don't get even worse and this worker potentially deadlocks the cluster.
+    except (KeyboardInterrupt, SystemExit):  # pragma: nocover
+        raise
+    except (Exception, BaseException):  # pragma: nocover
+        # Worker is in a very broken state if closing fails. We need to shut down
+        # immediately, to ensure things don't get even worse and this worker potentially
+        # deadlocks the cluster.
+        if self.validate and not self.nanny:
+            # We're likely in a unit test. Don't kill the whole test suite!
+            raise
+
         logger.critical(
             "Error trying close worker in response to broken internal state. "
             "Forcibly exiting worker NOW",
@@ -948,6 +955,13 @@ class Worker(ServerNode):
         return self._deque_handler.deque
 
     def log_event(self, topic, msg):
+        if (
+            not self.batched_stream
+            or not self.batched_stream.comm
+            or self.batched_stream.comm.closed()
+        ):
+            return  # pragma: nocover
+
         full_msg = {
             "op": "log-event",
             "topic": topic,
@@ -4318,8 +4332,6 @@ class Worker(ServerNode):
             ) from e
 
     def validate_state(self):
-        if self.status not in WORKER_ANY_RUNNING:
-            return
         try:
             assert self.executing_count >= 0
             waiting_for_data_count = 0


### PR DESCRIPTION
- Fix issue where, if a Worker not wrapped by Nanny trips `@fail_hard` in the test suite, the whole test suite is killed with an opaque 'exit 1'
- Fix issue where, after a worker started by `@gen_cluster` has been closed for whatever reason - namely, by `@fail_hard` - it is spared from state validation, potentially resulting in a green test.