### PR TITLE
Fix import error when distributed.rmm.pool-size is setted

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -147,6 +147,13 @@ def init_once():
                 return a
 
             device_array = numba_device_array
+
+            pool_size_str = dask.config.get("distributed.rmm.pool-size")
+            if pool_size_str is not None:
+                warnings.warn(
+                    "Initial RMM pool size defined, but RMM is not available. "
+                    "Please consider installing RMM or removing the pool size option."
+                )
         except ImportError:
 
             def device_array(n):

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -150,9 +150,16 @@ def init_once():
     pool_size_str = dask.config.get("distributed.rmm.pool-size")
     if pool_size_str is not None:
         pool_size = parse_bytes(pool_size_str)
-        rmm.reinitialize(
-            pool_allocator=True, managed_memory=False, initial_pool_size=pool_size
-        )
+        try:
+            import rmm
+
+            rmm.reinitialize(
+                pool_allocator=True, managed_memory=False, initial_pool_size=pool_size
+            )
+        except ImportError:
+            raise RuntimeError(
+                "In order to set distributed.rmm.pool-size, RMM is required"
+            )
 
 
 def _close_comm(ref):


### PR DESCRIPTION
Hi,
I try to use [dask-cuda](https://dask-cuda.readthedocs.io) with [UCX integration](https://docs.rapids.ai/api/dask-cuda/nightly/ucx.html) for our research.

On executing the following commands, 
```
$ DASK_DISTRIBUTED__COMM__UCX__CREATE_CUDA_CONTEXT=True  DASK_DISTRIBUTED__RMM__POOL_SIZE=1GB dask-scheduler --interface ib0 --protocol="ucx"
```
An error has occurred on `rmm.reinitialize()`.

This happened when
- `numba` is installed and
- `rmm` is *not* installed.

Because the previous process (set `device_array`) just checked whether *`rmm` or `numba` is installed*.

This seems to be solved just by `import rmm`.



### stack trace

```
  File "/work/NBB/skoyama/miniconda3/envs/ucx/lib/python3.9/site-packages/distributed/cli/dask_scheduler.py", line 208, in main
    loop.run_sync(run)
  File "/work/NBB/skoyama/miniconda3/envs/ucx/lib/python3.9/site-packages/tornado/ioloop.py", line 530, in run_sync
    return future_cell[0].result()
  File "/work/NBB/skoyama/miniconda3/envs/ucx/lib/python3.9/site-packages/distributed/cli/dask_scheduler.py", line 204, in run
    await scheduler
  File "/work/NBB/skoyama/miniconda3/envs/ucx/lib/python3.9/site-packages/distributed/core.py", line 309, in _
    await self.start()
  File "/work/NBB/skoyama/miniconda3/envs/ucx/lib/python3.9/site-packages/distributed/scheduler.py", line 3391, in start
    await self.listen(
  File "/work/NBB/skoyama/miniconda3/envs/ucx/lib/python3.9/site-packages/distributed/core.py", line 455, in listen
    listener = await listen(
  File "/work/NBB/skoyama/miniconda3/envs/ucx/lib/python3.9/site-packages/distributed/comm/core.py", line 212, in _
    await self.start()
  File "/work/NBB/skoyama/miniconda3/envs/ucx/lib/python3.9/site-packages/distributed/comm/ucx.py", line 462, in start
    init_once()
  File "/work/NBB/skoyama/miniconda3/envs/ucx/lib/python3.9/site-packages/distributed/comm/ucx.py", line 153, in init_once
    rmm.reinitialize(
UnboundLocalError: local variable 'rmm' referenced before assignment
```

Regards,

