### PR TITLE
Do not close worker on comm error in heartbeat

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1250,17 +1250,12 @@ class Worker(ServerNode):
             )
             self.bandwidth_workers.clear()
             self.bandwidth_types.clear()
-        except CommClosedError:
-            logger.warning("Heartbeat to scheduler failed", exc_info=True)
-            await self.close()
         except OSError as e:
-            # Scheduler is gone. Respect distributed.comm.timeouts.connect
-            if "Timed out trying to connect" in str(e):
-                logger.info("Timed out while trying to connect during heartbeat")
-                await self.close()
-            else:
-                logger.exception(e)
-                raise e
+            logger.exception(e)
+        except Exception as e:
+            logger.exception("Unexpected exception during heartbeat. Closing worker.")
+            await self.close()
+            raise e
         finally:
             self.heartbeat_active = False
 


### PR DESCRIPTION
We should not close a worker if the heartbeat fails. The heartbeat is establishing a dedicated connection which can fail for a multitude of reasons.

The `Worker.batched_stream` should be the single source of truth for inferring whether the scheduler is still alive. If this connection breaks up we will close the worker in [`Worker.handle_scheduler`](https://github.com/dask/distributed/blob/7e49d8806d2cd8aa201d836cd9a4231827fd4396/distributed/worker.py#L1268-L1274)

If an unexpected exception occurs, the behavior is similar to a fail_hard which is much stricter than before but the proper behavior imo