### PR TITLE
WIP: Shared plasma

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -909,3 +909,8 @@ def register_generic(
     object_with_dict_serializer = ObjectDictSerializer(serializer_name)
     serialize_func.register(cls)(object_with_dict_serializer.serialize)
     deserialize_func.register(cls)(object_with_dict_serializer.deserialize)
+
+
+import distributed.protocol.shared as plasma_shared
+
+register_serialization_family("plasma", plasma_shared.ser, plasma_shared.deser)

--- a/distributed/protocol/shared.py
+++ b/distributed/protocol/shared.py
@@ -1,0 +1,73 @@
+import pickle
+
+import dask.config
+
+try:
+    from pyarrow.plasma import ObjectID, connect
+except ImportError:
+
+    def connect():
+        raise ImportError("pyarrow.plasma was not importable")
+
+
+PLASMA_SIZE_LIMIT = dask.config.get("distributed.protocol.shared.minsize", 1)
+PLASMA_PATH = dask.config.get("distributed.protocol.shared.plasma_path", "tmp/plasma")
+PLASMA_ON = dask.config.get("distributed.protocol.shared.plasma", "true") == "true"
+
+plasma = [None]
+
+
+def _get_plasma():
+    if plasma[0] is None:
+        plasma[0] = connect("/tmp/plasma")
+    return plasma[0]
+
+
+def _put_buffer(buf):
+    client = _get_plasma()
+    object_id = ObjectID.from_random()
+    buffer = memoryview(client.create(object_id, buf.nbytes))
+    buffer[:] = buf.cast("b")[:]
+    client.seal(object_id)
+    return b"plasma:" + object_id.binary()
+
+
+def ser(x, context=None):
+    frames = [None]
+
+    def add_buf(buf):
+        frames.append(memoryview(buf))
+
+    frames[0] = pickle.dumps(x, protocol=-1, buffer_callback=add_buf)
+    head = {"serializer": "plasma"}
+    if any(buf.nbytes > PLASMA_SIZE_LIMIT for buf in frames[1:]):
+        from distributed.worker import get_worker
+
+        try:
+            worker = get_worker()
+        except ValueError:
+            # on client; must be scattering
+            worker = None
+        frames[1:] = [
+            _put_buffer(buf, worker, id(x)) if buf.nbytes > PLASMA_SIZE_LIMIT else buf
+            for buf in frames[1:]
+        ]
+        if worker is not None:
+            k = any(k for k, d in worker.data if d is x)  # find object's dask key
+            new_obj = deser(
+                None, frames
+            )  # version of object pointing at shared buffers
+            worker.shared_data[id(new_obj)] = frames  # save shared buffers
+            worker.data[k] = new_obj  # replace original object
+    return head, frames
+
+
+def deser(header, frames):
+    client = _get_plasma()
+    for i, buf in enumerate(frames.copy()):
+        if isinstance(buf, (bytes, memoryview)) and buf[:7] == b"plasma:":
+            # probably faster to get all the buffers in a single call
+            ob = ObjectID(bytes(buf)[7:])
+            bufs = client.get_buffers([ob])
+            frames[i] = bufs[0]
+    return pickle.loads(frames[0], buffers=frames[1:])

--- a/distributed/protocol/shared.py
+++ b/distributed/protocol/shared.py
@@ -60,12 +60,15 @@ def ser(x, context=None):
         ]
         if worker is not None:
             # find object's dask key; it ought to exist
-            k = first((k for k, d in worker.data.items() if d is x))
-            new_obj = deser(
-                None, frames
-            )  # version of object pointing at shared buffers
-            worker.shared_data[id(new_obj)] = head, frames  # save shared buffers
-            worker.data[k] = new_obj  # replace original object
+            seq = [k for k, d in worker.data.items() if d is x]
+            # if key is not in data, this is probably a test in-process worker
+            if seq:
+                k = first(seq)
+                new_obj = deser(
+                    None, frames
+                )  # version of object pointing at shared buffers
+                worker.shared_data[id(new_obj)] = head, frames  # save shared buffers
+                worker.data[k] = new_obj  # replace original object
     return head, frames
 
 

--- a/distributed/protocol/tests/test_shared.py
+++ b/distributed/protocol/tests/test_shared.py
@@ -1,0 +1,41 @@
+import shlex
+import subprocess
+
+import pytest
+
+plasma = pytest.importorskip("pyarrow.plasma")
+np = pytest.importorskip("numpy")
+
+from distributed.utils_test import gen_cluster
+
+path = "/tmp/plasma"
+
+
+@pytest.fixture(scope="module")
+def plasma_process():
+    cmd = shlex.split(f"plasma_store -m 10000000 -s {path}")  # 10MB
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    yield
+    proc.terminate()
+    proc.wait()
+
+
+@pytest.fixture()
+def plasma_session(plasma_process):
+    client = plasma.connect(path)
+    client.evict(1000000)
+    yield client
+    client.evict(1000000)
+
+
+@gen_cluster(client=True)
+async def test_roundtrip(c, s, a, b, plasma_session):
+    # uses temporary and unlikely hard-coded buffer min size of 1 byte
+    x = np.arange(100)  # 800 bytes
+    f = await c.scatter(x)  # produces one shared buffer
+    f2 = c.submit(lambda y: y + 1, f)  # produces another shared buffer
+    f3 = c.submit(lambda y: y + 1, f)  # does not make another buffer, key exists
+    out = await f2
+    _ = await c.gather([f2, f3])  # does not make another buffer, ser already exists
+    assert (x + 1 == out).all()
+    assert all([_["data_size"] == x.nbytes for _ in plasma_session.list().values()])

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -590,7 +590,7 @@ class Worker(ServerNode):
 
         self.in_flight_workers = {}
         self.busy_workers = set()
-        self.shared_data = {}
+        self.shared_data: dict[int, Any] = {}
         self.total_out_connections = dask.config.get(
             "distributed.worker.connections.outgoing"
         )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -506,6 +506,7 @@ class Worker(ServerNode):
     plugins: dict[str, WorkerPlugin]
     _pending_plugins: tuple[WorkerPlugin, ...]
     _async_instructions: set[asyncio.Task]
+    shared_data: MutableMapping[str, list[bytes | memoryview]]
 
     def __init__(
         self,
@@ -589,6 +590,7 @@ class Worker(ServerNode):
 
         self.in_flight_workers = {}
         self.busy_workers = set()
+        self.shared_data = {}
         self.total_out_connections = dask.config.get(
             "distributed.worker.connections.outgoing"
         )


### PR DESCRIPTION
A pyarrow-plasma based shared memory model for multiple workers on a single node. Objects that produce buffers with pickle V5 will have those buffers moved to plasma if larger than a configurable size, and deserialised by viewing those buffers (no copy). This is particularly good when scattering a large object to many/all workers.

Any thoughts, before making this more complete?

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
