### PR TITLE
Fix `Scheduler.restart` logic

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5097,18 +5097,13 @@ class Scheduler(SchedulerState, ServerNode):
 
         # Close non-Nanny workers. We have no way to restart them, so we just let them go,
         # and assume a deployment system is going to restart them for us.
-        close_results = await asyncio.gather(
+        await asyncio.gather(
             *(
                 self.remove_worker(address=addr, stimulus_id=stimulus_id)
                 for addr in self.workers
                 if addr not in nanny_workers
-            ),
-            return_exceptions=True,
+            )
         )
-        for r in close_results:
-            if isinstance(r, Exception):
-                # TODO this is probably not, in fact, normal.
-                logger.info("Exception while restarting.  This is normal.", exc_info=r)
 
         self.clear_task_state()
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5091,19 +5091,24 @@ class Scheduler(SchedulerState, ServerNode):
                 stimulus_id=stimulus_id,
             )
 
-        nannies = {addr: ws.nanny for addr, ws in self.workers.items()}
+        nanny_workers: dict[str, str] = {
+            addr: ws.nanny for addr, ws in self.workers.items() if ws.nanny
+        }
 
-        for addr in list(self.workers):
-            try:
-                # Ask the worker to close if it doesn't have a nanny,
-                # otherwise the nanny will kill it anyway
-                await self.remove_worker(
-                    address=addr, close=addr not in nannies, stimulus_id=stimulus_id
-                )
-            except Exception:
-                logger.info(
-                    "Exception while restarting.  This is normal", exc_info=True
-                )
+        # Close non-Nanny workers. We have no way to restart them, so we just let them go,
+        # and assume a deployment system is going to restart them for us.
+        close_results = await asyncio.gather(
+            *(
+                self.remove_worker(address=addr, stimulus_id=stimulus_id)
+                for addr in self.workers
+                if addr not in nanny_workers
+            ),
+            return_exceptions=True,
+        )
+        for r in close_results:
+            if isinstance(r, Exception):
+                # TODO this is probably not, in fact, normal.
+                logger.info("Exception while restarting.  This is normal.", exc_info=r)
 
         self.clear_task_state()
 
@@ -5113,21 +5118,27 @@ class Scheduler(SchedulerState, ServerNode):
             except Exception as e:
                 logger.exception(e)
 
-        logger.debug("Send kill signal to nannies: %s", nannies)
+        logger.debug("Send kill signal to nannies: %s", nanny_workers)
         async with contextlib.AsyncExitStack() as stack:
             nannies = [
                 await stack.enter_async_context(
                     rpc(nanny_address, connection_args=self.connection_args)
                 )
-                for nanny_address in nannies.values()
-                if nanny_address is not None
+                for nanny_address in nanny_workers.values()
             ]
 
-            resps = All(
-                [nanny.restart(close=True, timeout=timeout * 0.8) for nanny in nannies]
-            )
             try:
-                resps = await asyncio.wait_for(resps, timeout)
+                resps = await asyncio.wait_for(
+                    asyncio.gather(
+                        *(
+                            nanny.restart(close=True, timeout=timeout * 0.8)
+                            for nanny in nannies
+                        )
+                    ),
+                    timeout,
+                )
+                # NOTE: the `WorkerState` entries for these workers will be removed
+                # naturally when they disconnect from the scheduler.
             except TimeoutError:
                 logger.error(
                     "Nannies didn't report back restarted within "

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5091,7 +5091,7 @@ class Scheduler(SchedulerState, ServerNode):
                 stimulus_id=stimulus_id,
             )
 
-        nanny_workers: dict[str, str] = {
+        nanny_workers = {
             addr: ws.nanny for addr, ws in self.workers.items() if ws.nanny
         }
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -630,9 +630,10 @@ async def test_restart(c, s, a, b):
 
 @gen_cluster(client=True, Worker=Nanny, timeout=60)
 async def test_restart_some_nannies_some_not(
-    c: Client, s: Scheduler, a: Nanny, b: Nanny
+    c, s, a, b
 ):
-    original_pids = set((await c.run(os.getpid)).values())
+    original_pids = {a.process.process.pid, b.process.process.pid}
+    assert all(original_pids)
     original_workers = dict(s.workers)
     async with Worker(s.address, nthreads=1) as w:
         await c.wait_for_workers(3)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -632,7 +632,7 @@ async def test_restart(c, s, a, b):
 async def test_restart_some_nannies_some_not(
     c: Client, s: Scheduler, a: Nanny, b: Nanny
 ):
-    original_pids = await c.run(os.getpid)
+    original_pids = set((await c.run(os.getpid)).values())
     original_workers = dict(s.workers)
     async with Worker(s.address, nthreads=1) as w:
         await c.wait_for_workers(3)
@@ -667,7 +667,7 @@ async def test_restart_some_nannies_some_not(
 
         assert len(s.workers) == 2
         # Confirm they restarted
-        new_pids = await c.run(os.getpid)
+        new_pids = set((await c.run(os.getpid)).values())
         assert new_pids != original_pids
         # The workers should have new addresses
         assert s.workers.keys().isdisjoint(original_workers.keys())

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1215,9 +1215,6 @@ class Worker(ServerNode):
         if self.heartbeat_active:
             logger.debug("Heartbeat skipped: channel busy")
             return
-        if self.status in {Status.closing, Status.closed, Status.failed}:
-            logger.debug(f"Heartbeat skipped: {self.status=}")
-            return
         self.heartbeat_active = True
         logger.debug("Heartbeat: %s", self.address)
         try:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1215,6 +1215,9 @@ class Worker(ServerNode):
         if self.heartbeat_active:
             logger.debug("Heartbeat skipped: channel busy")
             return
+        if self.status in {Status.closing, Status.closed, Status.failed}:
+            logger.debug(f"Heartbeat skipped: {self.status=}")
+            return
         self.heartbeat_active = True
         logger.debug("Heartbeat: %s", self.address)
         try:


### PR DESCRIPTION
`Scheduler.restart` used to remove every worker without closing it. This was bad practice (#6390), as well as incorrect: it certainly seemed the intent was only to remove non-Nanny workers. See detailed explanation in https://github.com/dask/distributed/issues/6455#issuecomment-1146243158.

Closes #6455, closes #6452, closes #6494. I also will make a separate PR with https://github.com/dask/distributed/issues/6494#issuecomment-1146185148 (which won't be necessary to fix the restart issue, just a good cleanup task to do.)

cc @fjetter @hendrikmakait @jrbourbeau 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
