### PR TITLE
ignore the return value of signal.signal in test_disk_cleanup_on_terminate because it may not be pickleable

### DIFF
--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -755,8 +755,13 @@ async def test_disk_cleanup_on_terminate(c, s, a, ignore_sigterm):
     At the next iteration of the memory manager, if the process is still alive, the
     nanny sends SIGKILL.
     """
+
+    def do_ignore_sigterm():
+        # ignore the return value of signal.signal:  it may not be serializable
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
     if ignore_sigterm:
-        await c.run(signal.signal, signal.SIGTERM, signal.SIG_IGN)
+        await c.run(do_ignore_sigterm)
 
     fut = c.submit(inc, 1, key="myspill")
     await wait(fut)


### PR DESCRIPTION
this fixes a failure in test_disk_cleanup_on_terminate when running a subset of tests:

```
========================================================= FAILURES ==========================================================
___________________________________________ test_disk_cleanup_on_terminate[True] ____________________________________________

c = <Client: No scheduler connected>, s = <Scheduler 'tcp://127.0.0.1:38393', workers: 0, cores: 0, tasks: 0>
a = <Nanny: None, threads: 1>, ignore_sigterm = True

    @pytest.mark.slow
    @pytest.mark.parametrize(
        "ignore_sigterm",
        [
            False,
            pytest.param(True, marks=pytest.mark.skipif(WINDOWS, reason="Needs SIGKILL")),
        ],
    )
    @gen_cluster(
        nthreads=[("", 1)],
        client=True,
        Worker=Nanny,
        worker_kwargs={"memory_limit": "400 MiB"},
        config={"distributed.worker.memory.monitor-interval": "10ms"},
    )
    async def test_disk_cleanup_on_terminate(c, s, a, ignore_sigterm):
        """Test that the spilled data on disk is cleaned up when the nanny kills the worker.
    
        Unlike in a regular worker shutdown, where the worker deletes its own spill
        directory, the cleanup in case of termination from the monitor is performed by the
        nanny.
    
        The worker may be slow to accept SIGTERM, for whatever reason.
        At the next iteration of the memory manager, if the process is still alive, the
        nanny sends SIGKILL.
        """
        if ignore_sigterm:
>           await c.run(signal.signal, signal.SIGTERM, signal.SIG_IGN)

distributed/tests/test_worker_memory.py:759: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
distributed/client.py:2682: in _run
    responses = await self.scheduler.broadcast(
distributed/core.py:978: in send_recv_from_rpc
    return await send_recv(comm=comm, op=key, **kwargs)
distributed/core.py:742: in send_recv
    response = await comm.read(deserializers=deserializers)
distributed/comm/tcp.py:254: in read
    msg = await from_frames(
distributed/comm/utils.py:98: in from_frames
    res = _from_frames()
distributed/comm/utils.py:81: in _from_frames
    return protocol.loads(
distributed/protocol/core.py:159: in loads
    return msgpack.loads(
msgpack/_unpacker.pyx:194: in msgpack._cmsgpack.unpackb
    ???
distributed/protocol/core.py:139: in _decode_default
    return merge_and_deserialize(
distributed/protocol/serialize.py:487: in merge_and_deserialize
    return deserialize(header, merged_frames, deserializers=deserializers)
distributed/protocol/serialize.py:416: in deserialize
    return loads(header, frames)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

header = {'compression': (None, None), 'num-sub-frames': 2, 'serializer': 'error', 'split-num-sub-frames': (1, 1), ...}
frames = [<memory at 0x7f008c3681c0>, <memory at 0x7f008c368040>]

    def serialization_error_loads(header, frames):
        msg = "\n".join([codecs.decode(frame, "utf8") for frame in frames])
>       raise TypeError(msg)
E       TypeError: Could not serialize object of type method.
E       Traceback (most recent call last):
E         File "/home/graingert/projects/distributed/distributed/protocol/pickle.py", line 40, in dumps
E           result = pickle.dumps(x, **dump_kwargs)
E       TypeError: cannot pickle '_io.TextIOWrapper' object
E       
E       During handling of the above exception, another exception occurred:
E       
E       Traceback (most recent call last):
E         File "/home/graingert/projects/distributed/distributed/protocol/serialize.py", line 339, in serialize
E           header, frames = dumps(x, context=context) if wants_context else dumps(x)
E         File "/home/graingert/projects/distributed/distributed/protocol/serialize.py", line 70, in pickle_dumps
E           frames[0] = pickle.dumps(
E         File "/home/graingert/projects/distributed/distributed/protocol/pickle.py", line 51, in dumps
E           result = cloudpickle.dumps(x, **dump_kwargs)
E         File "/home/graingert/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/cloudpickle/cloudpickle_fast.py", line 73, in dumps
E           cp.dump(obj)
E         File "/home/graingert/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/cloudpickle/cloudpickle_fast.py", line 633, in dump
E           return Pickler.dump(self, obj)
E       TypeError: cannot pickle '_thread.RLock' object

distributed/protocol/serialize.py:179: TypeError
--------------------------------------------------- Captured stdout call ----------------------------------------------------
Dumped cluster state to test_cluster_dump/test_disk_cleanup_on_terminate.yaml
--------------------------------------------------- Captured stderr call ----------------------------------------------------
2022-06-07 11:33:34,574 - distributed.worker - INFO -       Start worker at:      tcp://127.0.0.1:46793
2022-06-07 11:33:34,574 - distributed.worker - INFO -          Listening to:      tcp://127.0.0.1:46793
2022-06-07 11:33:34,574 - distributed.worker - INFO -          dashboard at:            127.0.0.1:45855
2022-06-07 11:33:34,575 - distributed.worker - INFO - Waiting to connect to:      tcp://127.0.0.1:38393
2022-06-07 11:33:34,575 - distributed.worker - INFO - -------------------------------------------------
2022-06-07 11:33:34,575 - distributed.worker - INFO -               Threads:                          1
2022-06-07 11:33:34,575 - distributed.worker - INFO -                Memory:                 400.00 MiB
2022-06-07 11:33:34,575 - distributed.worker - INFO -       Local Directory: /tmp/tmptrjttqd2/dask-worker-space/worker-ul9kk8gd
2022-06-07 11:33:34,575 - distributed.worker - INFO - -------------------------------------------------
2022-06-07 11:33:34,923 - distributed.worker - INFO -         Registered to:      tcp://127.0.0.1:38393
2022-06-07 11:33:34,923 - distributed.worker - INFO - -------------------------------------------------
2022-06-07 11:33:34,923 - distributed.core - INFO - Starting established connection
2022-06-07 11:33:34,952 - distributed.worker - INFO - Run out-of-band function 'signal'
2022-06-07 11:33:34,953 - distributed.protocol.pickle - INFO - Failed to serialize <bound method Coverage._on_sigterm of <coverage.control.Coverage object at 0x7fbd24bccca0>>. Exception: cannot pickle '_thread.RLock' object
2022-06-07 11:33:34,954 - distributed.protocol.core - CRITICAL - Failed to deserialize
Traceback (most recent call last):
  File "/home/graingert/projects/distributed/distributed/protocol/core.py", line 159, in loads
    return msgpack.loads(
  File "msgpack/_unpacker.pyx", line 194, in msgpack._cmsgpack.unpackb
  File "/home/graingert/projects/distributed/distributed/protocol/core.py", line 139, in _decode_default
    return merge_and_deserialize(
  File "/home/graingert/projects/distributed/distributed/protocol/serialize.py", line 487, in merge_and_deserialize
    return deserialize(header, merged_frames, deserializers=deserializers)
  File "/home/graingert/projects/distributed/distributed/protocol/serialize.py", line 416, in deserialize
    return loads(header, frames)
  File "/home/graingert/projects/distributed/distributed/protocol/serialize.py", line 179, in serialization_error_loads
    raise TypeError(msg)
TypeError: Could not serialize object of type method.
Traceback (most recent call last):
  File "/home/graingert/projects/distributed/distributed/protocol/pickle.py", line 40, in dumps
    result = pickle.dumps(x, **dump_kwargs)
TypeError: cannot pickle '_io.TextIOWrapper' object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/graingert/projects/distributed/distributed/protocol/serialize.py", line 339, in serialize
    header, frames = dumps(x, context=context) if wants_context else dumps(x)
  File "/home/graingert/projects/distributed/distributed/protocol/serialize.py", line 70, in pickle_dumps
    frames[0] = pickle.dumps(
  File "/home/graingert/projects/distributed/distributed/protocol/pickle.py", line 51, in dumps
    result = cloudpickle.dumps(x, **dump_kwargs)
  File "/home/graingert/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/cloudpickle/cloudpickle_fast.py", line 73, in dumps
    cp.dump(obj)
  File "/home/graingert/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/cloudpickle/cloudpickle_fast.py", line 633, in dump
    return Pickler.dump(self, obj)
TypeError: cannot pickle '_thread.RLock' object

2022-06-07 11:33:35,031 - distributed.worker - INFO - Stopping worker at tcp://127.0.0.1:46793
2022-06-07 11:33:35,032 - distributed.worker - INFO - Connection to scheduler broken. Closing without reporting. ID: Worker-bd54fbd6-c370-4c0d-adf1-36a995638eaf Address tcp://127.0.0.1:46793 Status: Status.closing

```