### PR TITLE
Link test report from test results comment

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -42,7 +42,7 @@ jobs:
           check_name: Unit Test Results
           comment_title: |
             Unit Test Results
-            _See [test report](https://dask.org/distributed/test_report.html) for an extended result history._
+            _See [test report](https://dask.org/distributed/test_report.html) for an extended history of previous test failures. This is useful for diagnosing flaky tests._
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}

--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -39,6 +39,10 @@ jobs:
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
+          check_name: Unit Test Results
+          comment_title: |
+            Unit Test Results
+            _See [test report](https://dask.org/distributed/test_report.html) for an extended result history._
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}


### PR DESCRIPTION
Partially addresses #6500 by directly linking the test report from the test results comment in a PR. 

(Slightly outdated) Preview:
![image](https://user-images.githubusercontent.com/2699097/172465232-57a9f66a-81ee-4b78-a629-19b7f7508a9f.png)

_Notes:_
* Changes only become effective once this PR is merged. The comment in this PR will therefore look untouched. A created comment can be found at https://github.com/hendrikmakait/distributed/pull/3#issuecomment-1149043326
* This relies on the internal behavior of the [https://github.com/EnricoMi/publish-unit-test-result-action](https://github.com/EnricoMi/publish-unit-test-result-action) action and could break in future releases.
* The link is currently broken, see #6511.
