### PR TITLE
Use `default_initializer` in `WorkerProcess`es

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -809,12 +809,10 @@ class WorkerProcess:
         try:
             os.environ.update(env)
             dask.config.set(config)
-            try:
-                from dask.multiprocessing import initialize_worker_process
-            except ImportError:  # old Dask version
-                pass
-            else:
-                initialize_worker_process()
+
+            from dask.multiprocessing import default_initializer
+
+            default_initializer()
 
             if silence_logs:
                 logger.setLevel(silence_logs)


### PR DESCRIPTION
Builds off of PR ( https://github.com/dask/dask/pull/9087 )

This function was refactored out in Dask and still has the same functionality. While `initialize_worker_process` does work, it does a bit more than is needed (taking a UDF to initialize too). So just use `default_initializer`.

Also there is no need to handle old Dask versions here since we now pin Dask & Distributed to the exact same version. So drop the fallback code.

<hr>

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
