### PR TITLE
Make disk access in system monitor configurable

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -984,8 +984,8 @@ class WorkerNetworkBandwidth(DashboardComponent):
         for ws in workers:
             x_read.append(ws.metrics["read_bytes"])
             x_write.append(ws.metrics["write_bytes"])
-            x_read_disk.append(ws.metrics["read_bytes_disk"])
-            x_write_disk.append(ws.metrics["write_bytes_disk"])
+            x_read_disk.append(ws.metrics.get("read_bytes_disk", 0))
+            x_write_disk.append(ws.metrics.get("write_bytes_disk", 0))
 
         if self.scheduler.workers:
             self.bandwidth.x_range.end = max(
@@ -1173,8 +1173,8 @@ class SystemTimeseries(DashboardComponent):
             write_bytes += ws.metrics["write_bytes"]
             cpu += ws.metrics["cpu"]
             memory += ws.metrics["memory"]
-            read_bytes_disk += ws.metrics["read_bytes_disk"]
-            write_bytes_disk += ws.metrics["write_bytes_disk"]
+            read_bytes_disk += ws.metrics.get("read_bytes_disk", 0)
+            write_bytes_disk += ws.metrics.get("write_bytes_disk", 0)
             time += ws.metrics["time"]
 
         result = {

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -50,6 +50,7 @@ from distributed.diagnostics.task_stream import TaskStreamPlugin
 from distributed.metrics import time
 from distributed.utils import format_dashboard_link
 from distributed.utils_test import dec, div, gen_cluster, get_cert, inc, slowinc
+from distributed.worker import Worker
 
 # Imported from distributed.dashboard.utils
 scheduler.PROFILING = False  # type: ignore
@@ -504,22 +505,33 @@ async def test_WorkerNetworkBandwidth(c, s, a, b):
 async def test_WorkerNetworkBandwidth_metrics(c, s, a, b):
     # Disable system monitor periodic callback to allow us to manually control
     # when it is called below
-    a.periodic_callbacks["monitor"].stop()
-    b.periodic_callbacks["monitor"].stop()
+    with dask.config.set({"distributed.admin.system-monitor.disk": False}):
+        async with Worker(s.address) as w:
+            a.periodic_callbacks["monitor"].stop()
+            b.periodic_callbacks["monitor"].stop()
+            w.periodic_callbacks["monitor"].stop()
 
-    # Update worker system monitors and send updated metrics to the scheduler
-    a.monitor.update()
-    b.monitor.update()
-    await asyncio.gather(a.heartbeat(), b.heartbeat())
+            # Update worker system monitors and send updated metrics to the scheduler
+            a.monitor.update()
+            b.monitor.update()
+            w.monitor.update()
+            await asyncio.gather(a.heartbeat(), b.heartbeat())
+            await asyncio.gather(a.heartbeat(), b.heartbeat(), w.heartbeat())
 
-    nb = WorkerNetworkBandwidth(s)
-    nb.update()
+            nb = WorkerNetworkBandwidth(s)
+            nb.update()
 
-    for idx, ws in enumerate(s.workers.values()):
-        assert ws.metrics["read_bytes"] == nb.source.data["x_read"][idx]
-        assert ws.metrics["write_bytes"] == nb.source.data["x_write"][idx]
-        assert ws.metrics["read_bytes_disk"] == nb.source.data["x_read_disk"][idx]
-        assert ws.metrics["write_bytes_disk"] == nb.source.data["x_write_disk"][idx]
+            for idx, ws in enumerate(s.workers.values()):
+                assert ws.metrics["read_bytes"] == nb.source.data["x_read"][idx]
+                assert ws.metrics["write_bytes"] == nb.source.data["x_write"][idx]
+                assert (
+                    ws.metrics.get("read_bytes_disk", 0)
+                    == nb.source.data["x_read_disk"][idx]
+                )
+                assert (
+                    ws.metrics.get("write_bytes_disk", 0)
+                    == nb.source.data["x_write_disk"][idx]
+                )
 
 
 @gen_cluster(client=True)

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -1039,6 +1039,9 @@ properties:
               interval:
                 type: string
                 description: Polling time to query cpu/memory statistics default 500ms
+              disk:
+                type: boolean
+                description: Should we include disk metrics?  (they can cause issues in some systems)
 
       rmm:
         type: object

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -280,6 +280,7 @@ distributed:
     pdb-on-err: False       # enter debug mode on scheduling error
     system-monitor:
       interval: 500ms
+      disk: true
     event-loop: tornado
   rmm:
     pool-size: null

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -2,6 +2,8 @@ from collections import deque
 
 import psutil
 
+import dask
+
 from distributed.compatibility import WINDOWS
 from distributed.metrics import time
 
@@ -40,7 +42,9 @@ class SystemMonitor:
         except Exception:
             self._collect_disk_io_counters = False
         else:
-            if disk_ioc is None:  # diskless machine
+            if disk_ioc is None or not dask.config.get(  # diskless machine
+                "distributed.admin.system-monitor.disk"
+            ):
                 self._collect_disk_io_counters = False
             else:
                 self.last_time_disk = time()

--- a/distributed/tests/test_system_monitor.py
+++ b/distributed/tests/test_system_monitor.py
@@ -1,5 +1,7 @@
 from time import sleep
 
+import dask
+
 from distributed.system_monitor import SystemMonitor
 
 
@@ -51,3 +53,14 @@ def test_range_query():
 
     assert all(len(v) == 4 for v in sm.range_query(10).values())
     assert all(len(v) == 5 for v in sm.range_query(0).values())
+
+
+def test_disk_config():
+    sm = SystemMonitor()
+    a = sm.update()
+    assert "read_bytes_disk" in sm.quantities
+
+    with dask.config.set({"distributed.admin.system-monitor.disk": False}):
+        sm = SystemMonitor()
+        a = sm.update()
+        assert "read_bytes_disk" not in sm.quantities


### PR DESCRIPTION
Disk access is of marginal value, and somewhat of a pain to deal with.
This makes it configurable.

We might also ask ourselves if we should turn it off by default.