### PR TITLE
Refactoring gahter_dep / Remove missing data message

### DIFF
--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -102,19 +102,6 @@ async def test_abort_execution_to_fetch(c, s, a, b):
 
 
 @gen_cluster(client=True)
-async def test_worker_find_missing(c, s, a, b):
-    fut = c.submit(inc, 1, workers=[a.address])
-    await fut
-    # We do not want to use proper API since it would ensure that the cluster is
-    # informed properly
-    del a.data[fut.key]
-    del a.tasks[fut.key]
-
-    # Actually no worker has the data; the scheduler is supposed to reschedule
-    assert await c.submit(inc, fut, workers=[b.address]) == 3
-
-
-@gen_cluster(client=True)
 async def test_worker_stream_died_during_comm(c, s, a, b):
     write_queue = asyncio.Queue()
     write_event = asyncio.Event()

--- a/distributed/tests/test_stories.py
+++ b/distributed/tests/test_stories.py
@@ -138,8 +138,7 @@ async def test_worker_story_with_deps(c, s, a, b):
     # Story now includes randomized stimulus_ids and timestamps.
     story = b.story("res")
     stimulus_ids = {ev[-2].rsplit("-", 1)[0] for ev in story}
-    assert stimulus_ids == {"compute-task", "task-finished"}
-
+    assert stimulus_ids == {"compute-task", "gather-dep-success", "task-finished"}
     # This is a simple transition log
     expected = [
         ("res", "compute-task", "released"),
@@ -153,7 +152,7 @@ async def test_worker_story_with_deps(c, s, a, b):
 
     story = b.story("dep")
     stimulus_ids = {ev[-2].rsplit("-", 1)[0] for ev in story}
-    assert stimulus_ids == {"compute-task"}
+    assert stimulus_ids == {"compute-task", "gather-dep-success"}
     expected = [
         ("dep", "ensure-task-exists", "released"),
         ("dep", "released", "fetch", "fetch", {}),

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2946,7 +2946,6 @@ async def test_who_has_consistent_remove_replicas(c, s, *workers):
     coming_from.handle_stimulus(RemoveReplicasEvent(keys=[f1.key], stimulus_id="test"))
     await f2
 
-    assert_story(a.story(f1.key), [(f1.key, "missing-dep")])
     assert a.tasks[f1.key].suspicious_count == 0
     assert s.tasks[f1.key].suspicious == 0
 

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -23,6 +23,7 @@ from distributed.worker_state_machine import (
     ExecuteSuccessEvent,
     Instruction,
     RecommendationsConflict,
+    RefreshWhoHasEvent,
     ReleaseWorkerDataMsg,
     RescheduleEvent,
     RescheduleMsg,
@@ -603,3 +604,84 @@ async def test_missing_to_waiting(c, s, w1, w2, w3):
     await w1.close()
 
     await f1
+
+
+@gen_cluster(client=True, nthreads=[("", 1)] * 3)
+async def test_fetch_to_missing_on_refresh_who_has(c, s, w1, w2, w3):
+    """
+    1. Two tasks, x and y, are only available on a busy worker.
+       The worker sends request-refresh-who-has to the scheduler.
+    2. The scheduler responds that x has become missing, while y has gained an
+       additional replica
+    3. The handler for RefreshWhoHasEvent empties x.who_has and recommends a transition
+       to missing.
+    5. Before the recommendation can be implemented, the same event invokes
+       _ensure_communicating to let y to transition to flight. This in turn pops x from
+       data_needed - but x has an empty who_has, which is an exceptional situation.
+    6. The transition fetch->missing is executed, but x is  no longer in
+       data_needed - another exceptional situation.
+    """
+    x = c.submit(inc, 1, key="x", workers=[w1.address])
+    y = c.submit(inc, 2, key="y", workers=[w1.address])
+    await wait([x, y])
+    w1.total_in_connections = 0
+    s.request_acquire_replicas(w3.address, ["x", "y"], stimulus_id="test1")
+
+    # The tasks will now flip-flop between fetch and flight every 150ms
+    # (see Worker.retry_busy_worker_later)
+    await wait_for_state("x", "fetch", w3)
+    await wait_for_state("y", "fetch", w3)
+    assert w1.address in w3.busy_workers
+    # w3 sent {op: request-refresh-who-has, keys: [x, y]}
+    # There also may have been enough time for a refresh-who-has message to come back,
+    # which reiterated what the w3 already knew:
+    # {op: refresh-who-has, who_has={x: [w1.address], y: [w1.address]}}
+
+    # Let's instead simulate that, while request-refresh-who-has was in transit,
+    # w2 gained a replica of y and then subsequently w1 closed down.
+    # When request-refresh-who-has lands, the scheduler will respond:
+    # {op: refresh-who-has, who_has={x: [], y: [w2.address]}}
+    w3.handle_stimulus(
+        RefreshWhoHasEvent(who_has={"x": {}, "y": {w2.address}}, stimulus_id="test3")
+    )
+    assert w3.tasks["x"].state == "missing"
+    assert w3.tasks["y"].state == "flight"
+    assert w3.tasks["y"].who_has == {w2.address}
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_fetch_to_missing_on_network_failure(c, s, a):
+    """
+    1. Multiple tasks can be fetched from the same worker
+    2. Only some transition to flight, while the others remain in fetch state, e.g.
+       because of excessive size
+    3. gather_dep returns GatherDepNetworkFailureEvent
+    4. The event empties has_what. This impacts both the tasks in fetch as well as those
+       in flight. The event recommends a transition to missing for all tasks with empty
+       who_has.
+    5. Before the recommendation can be implemented, the same event invokes
+       _ensure_communicating, which pops the tasks in fetch state from data_needed - but
+       they have an empty who_has, which is an exceptional situation.
+    7. The transition fetch->missing is executed, but the tasks are no longer in
+       data_needed - another exceptional situation.
+    """
+    block_get_data = asyncio.Event()
+
+    class BlockedBreakingWorker(Worker):
+        async def get_data(self, comm, *args, **kwargs):
+            await block_get_data.wait()
+            raise OSError("fake error")
+
+    async with BlockedBreakingWorker(s.address) as b:
+        x = c.submit(inc, 1, key="x", workers=[b.address])
+        y = c.submit(inc, 2, key="y", workers=[b.address])
+        await wait([x, y])
+        s.request_acquire_replicas(a.address, ["x"], stimulus_id="test_x")
+        await wait_for_state("x", "flight", a)
+        s.request_acquire_replicas(a.address, ["y"], stimulus_id="test_y")
+        await wait_for_state("y", "fetch", a)
+
+        block_get_data.set()
+
+        await wait_for_state("x", "missing", a)
+        await wait_for_state("y", "missing", a)

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -682,4 +682,4 @@ async def test_fetch_to_missing_on_network_failure(c, s, a):
         block_get_data.set()
 
         await wait_for_state("x", "missing", a)
-        await wait_for_state("y", "missing", a)
+        # await wait_for_state("y", "missing", a)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3458,6 +3458,14 @@ class Worker(ServerNode):
     ) -> RecsInstrs:
         """gather_dep terminated: network failure while trying to
         communicate with remote worker
+        
+        Though the network failure could be transient, we assume it is not, and
+        preemptively act as though the other worker has died (including removing all
+        keys from it, even ones we did not fetch).
+
+        This optimization leads to faster completion of the fetch, since we immediately
+        either retry a different worker, or ask the scheduler to inform us of a new
+        worker if no other worker is available.
         """
         refetch = set(self._gather_dep_done_common(ev))
         refetch |= {self.tasks[key] for key in self.has_what[ev.worker]}

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -532,9 +532,86 @@ class RetryBusyWorkerEvent(StateMachineEvent):
 
 @dataclass
 class GatherDepDoneEvent(StateMachineEvent):
-    """Temporary hack - to be removed"""
+    """:class:`GatherDep` instruction terminated (abstract base class)"""
+
+    __slots__ = ("worker", "total_nbytes")
+    worker: str
+    total_nbytes: int  # Must be the same as in GatherDep instruction
+
+
+@dataclass
+class GatherDepSuccessEvent(GatherDepDoneEvent):
+    """:class:`GatherDep` instruction terminated:
+    remote worker fetched successfully
+    """
+
+    __slots__ = ("data",)
+
+    data: dict[str, object]  # There may be less keys than in GatherDep
+
+    def to_loggable(self, *, handled: float) -> StateMachineEvent:
+        out = copy(self)
+        out.handled = handled
+        out.data = {k: None for k in self.data}
+        return out
+
+    def _after_from_dict(self) -> None:
+        self.data = {k: None for k in self.data}
+
+
+@dataclass
+class GatherDepBusyEvent(GatherDepDoneEvent):
+    """:class:`GatherDep` instruction terminated:
+    remote worker is busy
+    """
 
     __slots__ = ()
+
+
+@dataclass
+class GatherDepNetworkFailureEvent(GatherDepDoneEvent):
+    """:class:`GatherDep` instruction terminated:
+    network failure while trying to communicate with remote worker
+    """
+
+    __slots__ = ()
+
+
+@dataclass
+class GatherDepFailureEvent(GatherDepDoneEvent):
+    """class:`GatherDep` instruction terminated:
+    generic error raised (not a network failure); e.g. data failed to deserialize.
+    """
+
+    exception: Serialize
+    traceback: Serialize | None
+    exception_text: str
+    traceback_text: str
+    __slots__ = tuple(__annotations__)  # type: ignore
+
+    def _after_from_dict(self) -> None:
+        self.exception = Serialize(Exception())
+        self.traceback = None
+
+    @classmethod
+    def from_exception(
+        cls,
+        err: BaseException,
+        *,
+        worker: str,
+        total_nbytes: int,
+        stimulus_id: str,
+    ) -> GatherDepFailureEvent:
+        msg = error_message(err)
+        return cls(
+            worker=worker,
+            total_nbytes=total_nbytes,
+            exception=msg["exception"],
+            traceback=msg["traceback"],
+            exception_text=msg["exception_text"],
+            traceback_text=msg["traceback_text"],
+            stimulus_id=stimulus_id,
+        )
 
 
 @dataclass

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -389,15 +389,6 @@ class ReleaseWorkerDataMsg(SendMessageToScheduler):
     key: str
 
 
-@dataclass
-class MissingDataMsg(SendMessageToScheduler):
-    op = "missing-data"
-
-    __slots__ = ("key", "errant_worker")
-    key: str
-    errant_worker: str
-
-
 # Not to be confused with RescheduleEvent below or the distributed.Reschedule Exception
 @dataclass
 class RescheduleMsg(SendMessageToScheduler):


### PR DESCRIPTION
This is building on top of https://github.com/dask/distributed/pull/6388 with a few significant changes

All changes are in the latest commit on top of the PR for review

- It is *not* reusing any "helper" code between GatherDep result event handlers other than `_gather_dep_done_common` which is basically solely to reset some state and set the ts.done attribute. All other shared usage of code for the result parsing of gather_dep has been a major source of inconsistencies and we should avoid it
- It already incorporates / closes https://github.com/dask/distributed/issues/6445 since the missing-data message is not required. I realize this is significant scope creep to the actual refactor. We could likely incorporate this again into the event handler upon success-but-missing but I would not add it to the network-failure result since this can cause otherwise severe race conditions, see also https://github.com/dask/distributed/pull/6112#discussion_r849287406
- It no longer transitions tasks directly to missing after a network failure. This breaks a few validation checks about fetching data but overall greatly simplifies the code. this relies on us picking up empty ts.who has sets in various places in the code which then transitions tasks to missing