### PR TITLE
Fix typo in `.nthreads()` docstring example

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3500,7 +3500,7 @@ class Client(SyncMethodMixin):
 
         Examples
         --------
-        >>> c.threads()  # doctest: +SKIP
+        >>> c.nthreads()  # doctest: +SKIP
         {'192.168.1.141:46784': 8,
          '192.167.1.142:47548': 8,
          '192.167.1.143:47329': 8,


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
