### PR TITLE
Log and except errors on preload start

### DIFF
--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -183,6 +183,8 @@ class Preload:
         self.argv = list(argv)
         self.file_dir = file_dir
 
+        logger.info("Creating preload: %s", self.name)
+
         if is_webaddress(name):
             self.module = _download_module(name)
         else:
@@ -193,6 +195,7 @@ class Preload:
         dask_setup = getattr(self.module, "dask_setup", None)
 
         if dask_setup:
+            logger.info("Run preload setup: %s", self.name)
             if isinstance(dask_setup, click.Command):
                 context = dask_setup.make_context(
                     "dask_setup", self.argv, allow_extra_args=False
@@ -202,17 +205,16 @@ class Preload:
                 )
                 if inspect.isawaitable(result):
                     await result
-                logger.info("Run preload setup click command: %s", self.name)
             else:
                 future = dask_setup(self.dask_object)
                 if inspect.isawaitable(future):
                     await future
-                logger.info("Run preload setup function: %s", self.name)
 
     async def teardown(self):
         """Run when the server starts its close method"""
         dask_teardown = getattr(self.module, "dask_teardown", None)
         if dask_teardown:
+            logger.info("Run preload teardown: %s", self.name)
             future = dask_teardown(self.dask_object)
             if inspect.isawaitable(future):
                 await future

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3341,7 +3341,10 @@ class Scheduler(SchedulerState, ServerNode):
             weakref.finalize(self, del_scheduler_file)
 
         for preload in self.preloads:
-            await preload.start()
+            try:
+                await preload.start()
+            except Exception:
+                logger.exception("Failed to start preload")
 
         await asyncio.gather(
             *[plugin.start(self) for plugin in list(self.plugins.values())]
@@ -3381,8 +3384,8 @@ class Scheduler(SchedulerState, ServerNode):
         for preload in self.preloads:
             try:
                 await preload.teardown()
-            except Exception as e:
-                logger.exception(e)
+            except Exception:
+                logger.exception("Failed to tear down preload")
 
         await asyncio.gather(
             *[log_errors(plugin.close) for plugin in list(self.plugins.values())]

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -283,10 +283,13 @@ async def test_client_preload_click(s):
 
 
 @gen_test()
-async def test_teardown_failure_doesnt_crash_scheduler():
+async def test_failure_doesnt_crash():
     text = """
-def dask_teardown(worker):
+def dask_setup(worker):
     raise Exception(123)
+
+def dask_teardown(worker):
+    raise Exception(456)
 """
 
     with captured_logger(logging.getLogger("distributed.scheduler")) as s_logger:
@@ -297,6 +300,8 @@ def dask_teardown(worker):
 
     assert "123" in s_logger.getvalue()
     assert "123" in w_logger.getvalue()
+    assert "456" in s_logger.getvalue()
+    assert "456" in w_logger.getvalue()
 
 
 @gen_cluster(nthreads=[])

--- a/distributed/tests/test_preload.py
+++ b/distributed/tests/test_preload.py
@@ -171,7 +171,7 @@ async def test_web_preload():
         assert (
             re.match(
                 r"(?s).*Downloading preload at http://example.com/preload\n"
-                r".*Run preload setup function: http://example.com/preload\n"
+                r".*Run preload setup: http://example.com/preload\n"
                 r".*",
                 log.getvalue(),
             )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1416,7 +1416,10 @@ class Worker(ServerNode):
             self.name = self.address
 
         for preload in self.preloads:
-            await preload.start()
+            try:
+                await preload.start()
+            except Exception:
+                logger.exception("Failed to start preload")
 
         # Services listen on all addresses
         # Note Nanny is not a "real" service, just some metadata
@@ -1543,8 +1546,8 @@ class Worker(ServerNode):
         for preload in self.preloads:
             try:
                 await preload.teardown()
-            except Exception as e:
-                logger.exception(e)
+            except Exception:
+                logger.exception("Failed to tear down preload")
 
         for extension in self.extensions.values():
             if hasattr(extension, "close"):


### PR DESCRIPTION
Previously preloads could silently crash things on start.
Now we log and accept the errors