### PR TITLE
Fix flaky test_gather_dep_one_worker_always_busy

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1972,8 +1972,8 @@ async def test_gather_dep_one_worker_always_busy(c, s, a, b):
     story = b.story("busy-gather")
     # 1 busy response straight away, followed by 1 retry every 150ms for 800ms.
     # The requests for b and g are clustered together in single messages.
-    # We need to be very lax in measuring as PeriodicCallback has been observed on CI to
-    # occasionally lag behind by >350ms.
+    # We need to be very lax in measuring as PeriodicCallback+network comms have been
+    # observed on CI to occasionally lag behind by several hundreds of ms.
     assert 2 <= len(story) <= 8
 
     async with Worker(s.address, name="x") as x:


### PR DESCRIPTION
Closes #6533 
The test was failing because the CI host would occasionally not fit at least 3 runs of PeriodicCallback(150ms) + network comms in a 500ms window.
Now relaxed to at least 2 runs in a 800ms window.