### PR TITLE
Restore signature compatibility for dask-gateway

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3354,13 +3354,18 @@ class Scheduler(SchedulerState, ServerNode):
         setproctitle(f"dask-scheduler [{self.address}]")
         return self
 
-    async def close(self):
+    async def close(self, fast=None, close_workers=None):
         """Send cleanup signal to all coroutines then wait until finished
 
         See Also
         --------
         Scheduler.cleanup
         """
+        if fast is not None or close_workers is not None:
+            warnings.warn(
+                "The 'fast' and 'close_workers' parameters in Scheduler.close have no effect and will be removed in a future version of distributed.",
+                FutureWarning,
+            )
         if self.status in (Status.closing, Status.closed):
             await self.finished()
             return

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3595,3 +3595,11 @@ async def test_worker_state_unique_regardless_of_address(s, w):
     assert ws1 is not ws2
     assert ws1 != ws2
     assert hash(ws1) != ws2
+
+
+@gen_cluster(nthreads=[("", 1)])
+async def test_scheduler_close_fast_deprecated(s, w):
+    ws1 = s.workers[w.address]
+    host, port = parse_host_port(ws1.address)
+    with pytest.warns(FutureWarning):
+        await s.close(fast=True)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3599,7 +3599,5 @@ async def test_worker_state_unique_regardless_of_address(s, w):
 
 @gen_cluster(nthreads=[("", 1)])
 async def test_scheduler_close_fast_deprecated(s, w):
-    ws1 = s.workers[w.address]
-    host, port = parse_host_port(ws1.address)
     with pytest.warns(FutureWarning):
         await s.close(fast=True)


### PR DESCRIPTION
A minimal fix to get dask-gateway working with distributed again.

Doesn't actually restore any behavior, doesn't add it to the other
subclasses.

Closes #6559 