### PR TITLE
Handle empty memoryviews of bytearrays when (de)serializing

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -772,7 +772,7 @@ def _deserialize_array(header, frames):
 def _serialize_memoryview(obj):
     if obj.format == "O":
         raise ValueError("Cannot serialize `memoryview` containing Python objects")
-    if obj.nbytes == 0 and obj.ndim > 1:
+    if not obj and obj.ndim > 1:
         raise ValueError("Cannot serialize empty non-1-D `memoryview`")
     header = {"format": obj.format, "shape": obj.shape}
     frames = [obj]
@@ -787,7 +787,7 @@ def _deserialize_memoryview(header, frames):
         out = memoryview(b"".join(frames))
 
     # handle empty bytearrays
-    if out.nbytes > 0:
+    if out:
         out = out.cast(header["format"], header["shape"])
     else:
         out = out.cast(header["format"])

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -783,7 +783,13 @@ def _deserialize_memoryview(header, frames):
         out = ensure_memoryview(frames[0])
     else:
         out = memoryview(b"".join(frames))
-    out = out.cast(header["format"], header["shape"])
+
+    # handle empty bytearrays
+    if out.nbytes > 0:
+        out = out.cast(header["format"], header["shape"])
+    else:
+        out = out.cast(header["format"])
+
     return out
 
 

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -786,7 +786,7 @@ def _deserialize_memoryview(header, frames):
     else:
         out = memoryview(b"".join(frames))
 
-    # handle empty bytearrays
+    # handle empty `memoryview`s
     if out:
         out = out.cast(header["format"], header["shape"])
     else:

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -772,6 +772,8 @@ def _deserialize_array(header, frames):
 def _serialize_memoryview(obj):
     if obj.format == "O":
         raise ValueError("Cannot serialize `memoryview` containing Python objects")
+    if obj.nbytes == 0 and obj.ndim > 1:
+        raise ValueError("Cannot serialize empty non-1-D `memoryview`")
     header = {"format": obj.format, "shape": obj.shape}
     frames = [obj]
     return header, frames

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -791,6 +791,7 @@ def _deserialize_memoryview(header, frames):
         out = out.cast(header["format"], header["shape"])
     else:
         out = out.cast(header["format"])
+        assert out.shape == header["shape"]
 
     return out
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -590,7 +590,7 @@ def test_ser_memoryview_object():
         serialize(data_in, on_error="raise")
 
 
-def test_ser_empty_memoryview():
+def test_ser_empty_1d_memoryview():
     mv = memoryview(b"")
 
     # serialize empty `memoryview`
@@ -601,6 +601,14 @@ def test_ser_empty_memoryview():
     assert type(mv2) == type(mv)
     assert mv2.format == mv.format
     assert mv2 == mv
+
+
+def test_ser_empty_nd_memoryview():
+    mv = memoryview(b"12").cast("B", (1, 2))[:0]
+
+    # serialize empty `memoryview`
+    with pytest.raises(TypeError):
+        serialize(mv, on_error="raise")
 
 
 @gen_cluster(client=True, Worker=Nanny)

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -88,8 +88,8 @@ def test_serialize_bytestrings():
         assert bb == b
 
 
-def test_serialize_empty_array():
-    a = array("I")
+@pytest.mark.parametrize("a", [array("I"), memoryview(bytearray())])
+def test_serialize_empty_objs(a):
 
     # serialize array
     header, frames = serialize(a)
@@ -99,7 +99,10 @@ def test_serialize_empty_array():
     # deserialize with no frames
     a2 = deserialize(header, frames)
     assert type(a2) == type(a)
-    assert a2.typecode == a.typecode
+
+    # memoryviews have no typecode
+    if getattr(a2, "typecode", False):
+        assert a2.typecode == a.typecode
     assert a2 == a
 
 

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -88,8 +88,8 @@ def test_serialize_bytestrings():
         assert bb == b
 
 
-@pytest.mark.parametrize("a", [array("I"), memoryview(bytearray())])
-def test_serialize_empty_objs(a):
+def test_serialize_empty_array():
+    a = array("I")
 
     # serialize array
     header, frames = serialize(a)
@@ -99,10 +99,7 @@ def test_serialize_empty_objs(a):
     # deserialize with no frames
     a2 = deserialize(header, frames)
     assert type(a2) == type(a)
-
-    # memoryviews have no typecode
-    if getattr(a2, "typecode", False):
-        assert a2.typecode == a.typecode
+    assert a2.typecode == a.typecode
     assert a2 == a
 
 
@@ -591,6 +588,19 @@ def test_ser_memoryview_object():
     data_in = memoryview(np.array(["hello"], dtype=object))
     with pytest.raises(TypeError):
         serialize(data_in, on_error="raise")
+
+
+def test_ser_empty_memoryview():
+    mv = memoryview(b"")
+
+    # serialize empty `memoryview`
+    header, frames = serialize(mv)
+    assert frames[0] == mv
+    # deserialize empty `memoryview`
+    mv2 = deserialize(header, frames)
+    assert type(mv2) == type(mv)
+    assert mv2.format == mv.format
+    assert mv2 == mv
 
 
 @gen_cluster(client=True, Worker=Nanny)


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/6542

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

@jakirkham can you review and take over if anything else is needed ?

cc @adamklein
