### PR TITLE
Don't initialize `mp_context` on import

### DIFF
--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -26,7 +26,7 @@ from distributed.comm.registry import backends, get_backend
 from distributed.compatibility import to_thread
 from distributed.metrics import time
 from distributed.protocol import Serialized, deserialize, serialize, to_serialize
-from distributed.utils import get_ip, get_ipv6, mp_context
+from distributed.utils import get_ip, get_ipv6, get_mp_context
 from distributed.utils_test import (
     gen_test,
     get_cert,
@@ -1328,6 +1328,6 @@ def test_register_backend_entrypoint(tmp_path):
     (dist_info / "entry_points.txt").write_bytes(
         b"[distributed.comm.backends]\nudp = dask_udp:udp_backend\n"
     )
-    with mp_context.Pool(1) as pool:
+    with get_mp_context().Pool(1) as pool:
         assert pool.apply(_get_backend_on_path, args=(tmp_path,)) == 1
     pool.join()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -43,9 +43,9 @@ from distributed.security import Security
 from distributed.utils import (
     TimeoutError,
     get_ip,
+    get_mp_context,
     json_load_robust,
     log_errors,
-    mp_context,
     parse_ports,
     silence_logging,
 )
@@ -638,8 +638,8 @@ class WorkerProcess:
             await self.running.wait()
             return self.status
 
-        self.init_result_q = init_q = mp_context.Queue()
-        self.child_stop_q = mp_context.Queue()
+        self.init_result_q = init_q = get_mp_context().Queue()
+        self.child_stop_q = get_mp_context().Queue()
         uid = uuid.uuid4().hex
 
         self.process = AsyncProcess(

--- a/distributed/process.py
+++ b/distributed/process.py
@@ -17,7 +17,7 @@ from tornado.ioloop import IOLoop
 
 import dask
 
-from distributed.utils import TimeoutError, mp_context
+from distributed.utils import TimeoutError, get_mp_context
 
 logger = logging.getLogger(__name__)
 
@@ -76,9 +76,9 @@ class AsyncProcess:
         # monitor from the child and exit when the parent goes away unexpectedly
         # (for example due to SIGKILL). This variable is otherwise unused except
         # for the assignment here.
-        parent_alive_pipe, self._keep_child_alive = mp_context.Pipe(duplex=False)
+        parent_alive_pipe, self._keep_child_alive = get_mp_context().Pipe(duplex=False)
 
-        self._process = mp_context.Process(
+        self._process = get_mp_context().Process(
             target=self._run,
             name=name,
             args=(

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -72,7 +72,7 @@ from distributed.core import Server, Status
 from distributed.metrics import time
 from distributed.scheduler import CollectTaskMetaDataPlugin, KilledWorker, Scheduler
 from distributed.sizeof import sizeof
-from distributed.utils import is_valid_xml, mp_context, sync, tmp_text
+from distributed.utils import get_mp_context, is_valid_xml, sync, tmp_text
 from distributed.utils_test import (
     TaskStateMetadataPlugin,
     _UnhashableCallable,
@@ -2197,7 +2197,7 @@ def long_running_client_connection(address):
 
 @gen_cluster()
 async def test_cleanup_after_broken_client_connection(s, a, b):
-    proc = mp_context.Process(target=long_running_client_connection, args=(s.address,))
+    proc = get_mp_context().Process(target=long_running_client_connection, args=(s.address,))
     proc.daemon = True
     proc.start()
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2197,7 +2197,9 @@ def long_running_client_connection(address):
 
 @gen_cluster()
 async def test_cleanup_after_broken_client_connection(s, a, b):
-    proc = get_mp_context().Process(target=long_running_client_connection, args=(s.address,))
+    proc = get_mp_context().Process(
+        target=long_running_client_connection, args=(s.address,)
+    )
     proc.daemon = True
     proc.start()
 

--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -16,7 +16,7 @@ from distributed import profile
 from distributed.compatibility import WINDOWS
 from distributed.diskutils import WorkSpace
 from distributed.metrics import time
-from distributed.utils import mp_context
+from distributed.utils import get_mp_context
 from distributed.utils_test import captured_logger
 
 
@@ -226,9 +226,9 @@ def test_workspace_concurrency(tmpdir):
     """
     base_dir = str(tmpdir)
 
-    err_q = mp_context.Queue()
-    purged_q = mp_context.Queue()
-    stop_evt = mp_context.Event()
+    err_q = get_mp_context().Queue()
+    purged_q = get_mp_context().Queue()
+    stop_evt = get_mp_context().Event()
     ws = WorkSpace(base_dir)
     # Make sure purging only happens in the child processes
     ws._purge_leftovers = lambda: None
@@ -238,9 +238,9 @@ def test_workspace_concurrency(tmpdir):
     max_procs = 2 if WINDOWS else 16
 
     # Run a bunch of child processes that will try to purge concurrently
-    barrier = mp_context.Barrier(parties=max_procs + 1)
+    barrier = get_mp_context().Barrier(parties=max_procs + 1)
     processes = [
-        mp_context.Process(
+        get_mp_context().Process(
             target=_workspace_concurrency,
             args=(base_dir, purged_q, err_q, stop_evt, barrier),
         )

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -2,6 +2,7 @@ import asyncio
 import contextvars
 import functools
 import io
+import multiprocessing
 import os
 import queue
 import socket
@@ -29,6 +30,7 @@ from distributed.utils import (
     ensure_memoryview,
     format_dashboard_link,
     get_ip_interface,
+    get_mp_context,
     get_traceback,
     is_kernel,
     is_valid_xml,
@@ -159,6 +161,18 @@ def test_get_ip_interface():
     assert get_ip_interface(iface) == "127.0.0.1"
     with pytest.raises(ValueError, match=f"'__notexist'.+network interface.+'{iface}'"):
         get_ip_interface("__notexist")
+
+
+@pytest.mark.skipif(
+    WINDOWS, reason="Windows doesn't support different multiprocessing contexts"
+)
+def test_get_mp_context():
+    # this will need updated if the default multiprocessing context changes from spawn.
+    assert get_mp_context() is multiprocessing.get_context("spawn")
+    with dask.config.set({"distributed.worker.multiprocessing-method": "forkserver"}):
+        assert get_mp_context() is multiprocessing.get_context("forkserver")
+    with dask.config.set({"distributed.worker.multiprocessing-method": "fork"}):
+        assert get_mp_context() is multiprocessing.get_context("fork")
 
 
 def test_truncate_exception():

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -634,7 +634,9 @@ def test_check_process_leak_pre_cleanup(ignore_sigterm):
 def test_check_process_leak_post_cleanup(ignore_sigterm):
     barrier = get_mp_context().Barrier(parties=2)
     with check_process_leak(check=False, term_timeout=0.2):
-        p = get_mp_context().Process(target=garbage_process, args=(barrier, ignore_sigterm))
+        p = get_mp_context().Process(
+            target=garbage_process, args=(barrier, ignore_sigterm)
+        )
         p.start()
         barrier.wait()
     assert not p.is_alive()

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -23,7 +23,7 @@ from distributed.compatibility import WINDOWS
 from distributed.core import Server, Status, rpc
 from distributed.metrics import time
 from distributed.tests.test_batched import EchoServer
-from distributed.utils import mp_context
+from distributed.utils import get_mp_context
 from distributed.utils_test import (
     _LockedCommPool,
     _UnhashableCallable,
@@ -594,10 +594,10 @@ def garbage_process(barrier, ignore_sigterm: bool = False, t: float = 3600) -> N
 
 
 def test_check_process_leak():
-    barrier = mp_context.Barrier(parties=2)
+    barrier = get_mp_context().Barrier(parties=2)
     with pytest.raises(AssertionError):
         with check_process_leak(check=True, check_timeout=0.01):
-            p = mp_context.Process(target=garbage_process, args=(barrier,))
+            p = get_mp_context().Process(target=garbage_process, args=(barrier,))
             p.start()
             barrier.wait()
     assert not p.is_alive()
@@ -605,9 +605,9 @@ def test_check_process_leak():
 
 def test_check_process_leak_slow_cleanup():
     """check_process_leak waits a bit for processes to terminate themselves"""
-    barrier = mp_context.Barrier(parties=2)
+    barrier = get_mp_context().Barrier(parties=2)
     with check_process_leak(check=True):
-        p = mp_context.Process(target=garbage_process, args=(barrier, False, 0.2))
+        p = get_mp_context().Process(target=garbage_process, args=(barrier, False, 0.2))
         p.start()
         barrier.wait()
     assert not p.is_alive()
@@ -618,8 +618,8 @@ def test_check_process_leak_slow_cleanup():
     [False, pytest.param(True, marks=pytest.mark.skipif(WINDOWS, reason="no SIGKILL"))],
 )
 def test_check_process_leak_pre_cleanup(ignore_sigterm):
-    barrier = mp_context.Barrier(parties=2)
-    p = mp_context.Process(target=garbage_process, args=(barrier, ignore_sigterm))
+    barrier = get_mp_context().Barrier(parties=2)
+    p = get_mp_context().Process(target=garbage_process, args=(barrier, ignore_sigterm))
     p.start()
     barrier.wait()
 
@@ -632,9 +632,9 @@ def test_check_process_leak_pre_cleanup(ignore_sigterm):
     [False, pytest.param(True, marks=pytest.mark.skipif(WINDOWS, reason="no SIGKILL"))],
 )
 def test_check_process_leak_post_cleanup(ignore_sigterm):
-    barrier = mp_context.Barrier(parties=2)
+    barrier = get_mp_context().Barrier(parties=2)
     with check_process_leak(check=False, term_timeout=0.2):
-        p = mp_context.Process(target=garbage_process, args=(barrier, ignore_sigterm))
+        p = get_mp_context().Process(target=garbage_process, args=(barrier, ignore_sigterm))
         p.start()
         barrier.wait()
     assert not p.is_alive()


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

The `fork` and `spawn` methods offered by multiprocessing interact badly with many infiniband (or other high performance) interconnects which don't support fork after the relevant low-level networking library has been initialised (or else crash in strange ways). Multiprocessing's `forkserver` method offers a way round this. As long as the forkserver is started (via `multiprocessing.forkserver.ensure_running()`) before networking library initialisation then things work (the child process that does the forking doesn't need the network library).

While one can control the method that distributed uses by setting `DASK_DISTRIBUTED__WORKER__MULTIPROCESSING_METHOD=forkserver` in the environment, it would be nice to be able to control this programmatically as well (using the `"distributed.worker.multiprocessing-method"` key). This PR enables that by deferring the context creation to function call time (at which point the distributed config can be inspected, and might already have been modified) rather than module import time. Since multiprocessing contexts are singleton objects, this should not be a performance hit.

Query: dask _also_ provides a `get_context` method in `dask.multiprocessing` that respects a different config option (`"multiprocessing.context"`). The only difference is that the distributed version of the function adds a bunch of modules to the preload list for the forkserver case. Should I refactor to use the `dask.multiprocessing` version and handle preload there?