### PR TITLE
[DNM] Don't queue tasks on workers

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3096,8 +3096,12 @@ class TaskProgress(DashboardComponent):
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@erred</span>
                 </div>
                 <div>
-                    <span style="font-size: 14px; font-weight: bold;">Ready:</span>&nbsp;
+                    <span style="font-size: 14px; font-weight: bold;">Processing:</span>&nbsp;
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@processing</span>
+                </div>
+                <div>
+                    <span style="font-size: 14px; font-weight: bold;">No worker:</span>&nbsp;
+                    <span style="font-size: 10px; font-family: Monaco, monospace;">@no_worker</span>
                 </div>
                 """,
         )
@@ -3112,6 +3116,7 @@ class TaskProgress(DashboardComponent):
             "released": {},
             "processing": {},
             "waiting": {},
+            "no_worker": {},
         }
 
         for tp in self.scheduler.task_prefixes.values():
@@ -3122,6 +3127,7 @@ class TaskProgress(DashboardComponent):
                 state["released"][tp.name] = active_states["released"]
                 state["processing"][tp.name] = active_states["processing"]
                 state["waiting"][tp.name] = active_states["waiting"]
+                state["no_worker"][tp.name] = active_states["no-worker"]
 
         state["all"] = {k: sum(v[k] for v in state.values()) for k in state["memory"]}
 
@@ -3134,7 +3140,7 @@ class TaskProgress(DashboardComponent):
 
         totals = {
             k: sum(state[k].values())
-            for k in ["all", "memory", "erred", "released", "waiting"]
+            for k in ["all", "memory", "erred", "released", "waiting", "no_worker"]
         }
         totals["processing"] = totals["all"] - sum(
             v for k, v in totals.items() if k != "all"
@@ -3144,6 +3150,7 @@ class TaskProgress(DashboardComponent):
             "Progress -- total: %(all)s, "
             "in-memory: %(memory)s, processing: %(processing)s, "
             "waiting: %(waiting)s, "
+            "no worker: %(no_worker)s, "
             "erred: %(erred)s" % totals
         )
 

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -20,7 +20,7 @@ distributed:
     idle-timeout: null      # Shut down after this duration, like "1h" or "30 minutes"
     transition-log-length: 100000
     events-log-length: 100000
-    work-stealing: True     # workers should steal tasks from each other
+    work-stealing: False     # workers should steal tasks from each other
     work-stealing-interval: 100ms  # Callback time for work stealing
     worker-ttl: "5 minutes" # like '60s'. Time to live for workers.  They must heartbeat faster than this
     pickle: True            # Is the scheduler allowed to deserialize arbitrary bytestrings


### PR DESCRIPTION
With this change, workers are not sent more tasks than they have threads. This eliminates root task overproduction and removes the need for work stealing.

I didn't originally intend to make this change (originally, I wanted to remove queuing of root tasks only, not all tasks). I just discovered that it was the natural outcome of https://github.com/dask/distributed/issues/6560 without co-assignment. I thought that was interesting, so I'm opening this for discussion.

This is the minimal diff to enact this change. There is _lots_ we would change/rip out if we went forward with this. The purpose of this PR is just to try the change on some common workloads and see how performance is affected.

Performance will likely be poor on some workloads without speculative task assignment and root task co-assignment.

I believe there's a relatively simple optimization we could make here that would bring performance about in line with current scheduling (minus co-assignment): do allow queuing extra tasks onto workers when those tasks meet specific criteria. The criteria would match the fan-out style tasks you see in a task-based shuffle, `rechunk`, or `map_overlap`. But that's an optimization to play with later.

## Why?

I was working on the "ignore root task co-assignment" side of withholding root tasks https://github.com/dask/distributed/issues/6560. Initially I was going to try withholding just root tasks.

1. The root task co-assignment logic becomes useless, so it should just be ripped out. All it would do is co-assign the first `ws.nthreads` tasks per worker. All other tasks would end up assigned via the normal logic. So I just removed the co-assign code for simplicity. Now root tasks aren't special anymore.
2. I added logic saying "pick a worker with `decide_worker`, but if that worker is full, put the task in `no-worker` instead". But that raises an obvious question: what if there was a different, not-full worker available we could have picked instead?
3. If we're going to toss out assignments to busy workers, then we shouldn't even consider busy workers in `decide_worker`.
4. If you restrict `decide_worker` to only the `idle` workers set, you get this PR.

See the test added for an example of an embarrassingly-parallel workload that's currently unrunnable on main (workers repeatedly run out of memory and die), which runs smoothly in a constant amount of memory with this PR.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
