### PR TITLE
Ensure steal requests from same-IP but distinct workers are rejected

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -189,6 +189,7 @@ class Server:
         self._address = None
         self._listen_address = None
         self._port = None
+        self._host = None
         self._comms = {}
         self.deserialize = deserialize
         self.monitor = SystemMonitor()
@@ -439,6 +440,18 @@ class Server:
         return self._listen_address
 
     @property
+    def host(self):
+        """
+        The host this Server is running on.
+
+        This will raise ValueError if the Server is listening on a
+        non-IP based protocol.
+        """
+        if not self._host:
+            self._host, self._port = get_address_host_port(self.address)
+        return self._host
+
+    @property
     def port(self):
         """
         The port number this Server is listening on.
@@ -447,7 +460,7 @@ class Server:
         non-IP based protocol.
         """
         if not self._port:
-            _, self._port = get_address_host_port(self.address)
+            self._host, self._port = get_address_host_port(self.address)
         return self._port
 
     def identity(self) -> dict[str, str]:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -453,6 +453,9 @@ class WorkerState:
     #: Arbitrary additional metadata to be added to :meth:`~WorkerState.identity`
     extra: dict[str, Any]
 
+    # The unique server ID this WorkerState is referencing
+    server_id: str
+
     __slots__ = tuple(__annotations__)
 
     def __init__(
@@ -466,10 +469,12 @@ class WorkerState:
         memory_limit: int,
         local_directory: str,
         nanny: str,
+        server_id: str,
         services: dict[str, int] | None = None,
         versions: dict[str, Any] | None = None,
         extra: dict[str, Any] | None = None,
     ):
+        self.server_id = server_id
         self.address = address
         self.pid = pid
         self.name = name
@@ -480,7 +485,7 @@ class WorkerState:
         self.versions = versions or {}
         self.nanny = nanny
         self.status = status
-        self._hash = hash((address, pid, name))
+        self._hash = hash(self.server_id)
         self.nbytes = 0
         self.occupancy = 0
         self._memory_unmanaged_old = 0
@@ -548,6 +553,7 @@ class WorkerState:
             services=self.services,
             nanny=self.nanny,
             extra=self.extra,
+            server_id=self.server_id,
         )
         ws.processing = {
             ts.key: cost for ts, cost in self.processing.items()  # type: ignore
@@ -3576,6 +3582,7 @@ class Scheduler(SchedulerState, ServerNode):
         *,
         address: str,
         status: str,
+        server_id: str,
         keys=(),
         nthreads=None,
         name=None,
@@ -3639,6 +3646,7 @@ class Scheduler(SchedulerState, ServerNode):
             versions=versions,
             nanny=nanny,
             extra=extra,
+            server_id=server_id,
         )
         if ws.status == Status.running:
             self.running.add(ws)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -507,9 +507,7 @@ class WorkerState:
         return self._hash
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, WorkerState):
-            return False
-        return hash(self) == hash(other)
+        return isinstance(other, WorkerState) and other.server_id == self.server_id
 
     @property
     def has_what(self) -> Set[TaskState]:

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -21,6 +21,7 @@ from distributed.scheduler import key_split
 from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import (
     captured_logger,
+    freeze_batched_send,
     gen_cluster,
     inc,
     nodebug_setup_module,
@@ -1127,6 +1128,76 @@ async def test_get_story(c, s, a, b):
     assert msgs
     assert msgs == msgs_ts
     assert all(isinstance(m, tuple) for m in msgs)
+
+
+@gen_cluster(
+    client=True,
+    config={
+        "distributed.scheduler.work-stealing-interval": 1_000_000,
+    },
+)
+async def test_steal_worker_dies_same_ip(c, s, w0, w1):
+    # https://github.com/dask/distributed/issues/5370
+    steal = s.extensions["stealing"]
+    ev = Event()
+    futs1 = c.map(
+        lambda _, ev: ev.wait(),
+        range(10),
+        ev=ev,
+        key=[f"f1-{ix}" for ix in range(10)],
+        workers=[w0.address],
+        allow_other_workers=True,
+    )
+    while not w0.active_keys:
+        await asyncio.sleep(0.01)
+
+    victim_key = list(w0.state.ready)[-1][1]
+
+    victim_ts = s.tasks[victim_key]
+
+    wsA = victim_ts.processing_on
+    assert wsA.address == w0.address
+    wsB = s.workers[w1.address]
+
+    steal.move_task_request(victim_ts, wsA, wsB)
+    len_before = len(s.events["stealing"])
+    with freeze_batched_send(w0.batched_stream):
+        while not any(
+            isinstance(event, StealRequestEvent) for event in w0.state.stimulus_log
+        ):
+            await asyncio.sleep(0.1)
+        async with contextlib.AsyncExitStack() as stack:
+            # Block batched stream of w0 to ensure the steal-confirmation doesn't
+            # arrive at the scheduler before we want it to
+            await w1.close()
+            # Kill worker wsB
+            # Restart new worker with same IP, name, etc.
+            while w1.address in s.workers:
+                await asyncio.sleep(0.1)
+
+            w_new = await stack.enter_async_context(
+                Worker(
+                    s.address,
+                    host=w1.host,
+                    port=w1.port,
+                    name=w1.name,
+                )
+            )
+            wsB2 = s.workers[w_new.address]
+            assert wsB2.address == wsB.address
+            assert wsB2 is not wsB
+            assert wsB2 != wsB
+            assert hash(wsB2) != hash(wsB)
+
+    # Wait for the steal response to arrive
+    while len_before == len(s.events["stealing"]):
+        await asyncio.sleep(0.1)
+
+    assert victim_ts.processing_on != wsB
+
+    await w_new.close(executor_wait=False)
+    await ev.set()
+    await c.gather(futs1)
 
 
 @gen_cluster(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1094,6 +1094,7 @@ class Worker(BaseWorker, ServerNode):
                         metrics=await self.get_metrics(),
                         extra=await self.get_startup_information(),
                         stimulus_id=f"worker-connect-{time()}",
+                        server_id=self.id,
                     ),
                     serializers=["msgpack"],
                 )


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/6356
Closes https://github.com/dask/distributed/issues/6198
Closes https://github.com/dask/distributed/issues/6263


https://github.com/dask/distributed/issues/6356 describes a situation where a worker may die and a new worker with the same IP would connect to the scheduler. This could mess up our stealing logic since the WorkerState objects we're referencing there would reference the wrong worker, i.e. state between the scheduler and stealing extension would drift.

With the test in this draft PR I could prove that this is indeed the case. However, so far nothing bad happens. Upon task completion, the scheduler would issue a `Unexpected worker completed task` message and send a `cancel-compute` event to the worker. The worker would ignore this event since the task is in state memory.

Before I fix the state drift I want to poke at this further since this is supposedly responsible for a couple of deadlocks. I would like to confirm that this is the only trigger for these deadlocks and there is nothing else going on.

This could definitely explain how a dead worker is shown on the dashboard https://github.com/dask/distributed/issues/6198 even if the deadlock was unrelated

FWIW I was always suspicious why this `Unexpected worker completed task` was necessary and struggled to reproduce it. This finally sheds some light onto it and I actually hope that we can get rid of this message and therefore the `cancel-compute` event entirely.