### PR TITLE
Do not log in signal handler

### DIFF
--- a/distributed/_signals.py
+++ b/distributed/_signals.py
@@ -16,10 +16,11 @@ async def wait_for_signals(signals: list[signal.Signals]) -> None:
     old_handlers: dict[int, Any] = {}
 
     def handle_signal(signum, frame):
+        # *** Do not log or print anything in here
+        # https://stackoverflow.com/questions/45680378/how-to-explain-the-reentrant-runtimeerror-caused-by-printing-in-signal-handlers
         # Restore old signal handler to allow for quicker exit
         # if the user sends the signal again.
         signal.signal(signum, old_handlers[signum])
-        logger.info("Received signal %s (%d)", signal.Signals(signum).name, signum)
         loop.call_soon_threadsafe(event.set)
 
     for sig in signals:

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -487,6 +487,5 @@ def test_signal_handling(loop, sig):
         logs = stdout.decode().lower()
         assert stderr is None
         assert scheduler.returncode == 0
-        assert sig.name.lower() in logs
         assert "scheduler closing" in logs
         assert "end scheduler" in logs

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -683,7 +683,6 @@ async def test_signal_handling(c, s, nanny, sig):
         logs = stdout.decode().lower()
         assert stderr is None
         assert worker.returncode == 0
-        assert sig.name.lower() in logs
         if nanny == "--nanny":
             assert "closing nanny" in logs
             assert "stopping worker" in logs


### PR DESCRIPTION
I was working on our CLI tests to make them reliably use different ports and allow them to be run in parallel (https://github.com/dask/distributed/pull/6591)

After succeeding, I ran `test_dashboard_port_zero` a hundred times in parallel and encountered this exception

```
--- Logging error ---
Traceback (most recent call last):
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 1103, in emit
    stream.write(msg + self.terminator)
RuntimeError: reentrant call inside <_io.BufferedWriter name='<stderr>'>
```

<details>
<summary>Full traceback</summary>

```
--- Logging error ---
Traceback (most recent call last):
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 1103, in emit
    stream.write(msg + self.terminator)
RuntimeError: reentrant call inside <_io.BufferedWriter name='<stderr>'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 1103, in emit
    stream.write(msg + self.terminator)
  File "/Users/fjetter/workspace/distributed/distributed/_signals.py", line 23, in handle_signal
    logger.info("Received signal %s (%d)", signal.Signals(signum).name, signum)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 1477, in info
    self._log(INFO, msg, args, **kwargs)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 1624, in _log
    self.handle(record)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 1634, in handle
    self.callHandlers(record)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 1696, in callHandlers
    hdlr.handle(record)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 968, in handle
    self.emit(record)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 1108, in emit
    self.handleError(record)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/logging/__init__.py", line 1021, in handleError
    sys.stderr.write('--- Logging error ---\n')
RuntimeError: reentrant call inside <_io.BufferedWriter name='<stderr>'>
Call stack:
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/bin/dask-scheduler", line 33, in <module>
    sys.exit(load_entry_point('distributed', 'console_scripts', 'dask-scheduler')())
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/fjetter/workspace/distributed/distributed/cli/dask_scheduler.py", line 227, in main
    asyncio.run(run())
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/asyncio/base_events.py", line 633, in run_until_complete
    self.run_forever()
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/asyncio/base_events.py", line 600, in run_forever
    self._run_once()
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/asyncio/base_events.py", line 1896, in _run_once
    handle._run()
  File "/Users/fjetter/mambaforge/envs/dask-distributed-310/lib/python3.10/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 4600, in add_client
    self.remove_client(client=client, stimulus_id=f"remove-client-{time()}")
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 4618, in remove_client
    logger.info("Remove client %s", client)
Message: 'Remove client %s'
Arguments: ('Client-783447e2-ed98-11ec-af9f-4e7b98dead46',)
2022-06-16 19:19:27,073 - distributed.scheduler - INFO - Close client connection: Client-783447e2-ed98-11ec-af9f-4e7b98dead46
```

</details>


Indeed, after removing this log message, I was able to run the test concurrently many times without issues.

There is some explanation about this in https://stackoverflow.com/questions/45680378/how-to-explain-the-reentrant-runtimeerror-caused-by-printing-in-signal-handlers

Closes https://github.com/dask/distributed/issues/6395 🤞 