### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ssh_debug.yaml.donotrun
+++ b/.github/workflows/ssh_debug.yaml.donotrun
@@ -2,8 +2,13 @@ name: Debug passwordless `ssh localhost`
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    permissions:
+      contents: none
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -168,6 +168,8 @@ jobs:
   # Publish an artifact for the event; used by publish-test-results.yaml
   event_file:
     # Do not run the schedule job on forks
+    permissions:
+      contents: none
     if: github.repository == 'dask/distributed' || github.event_name != 'schedule'
     name: "Event File"
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
