### PR TITLE
[WIP] Queue root tasks on scheduler, not workers

### DIFF
--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -62,6 +62,9 @@ class HeapSet(MutableSet[T]):
     def __contains__(self, value: object) -> bool:
         return value in self._data
 
+    def __bool__(self) -> bool:
+        return bool(self._data)
+
     def __len__(self) -> int:
         return len(self._data)
 

--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -4,8 +4,14 @@ import heapq
 import weakref
 from collections import OrderedDict, UserDict
 from collections.abc import Callable, Hashable, Iterator
-from typing import MutableSet  # TODO move to collections.abc (requires Python >=3.9)
-from typing import Any, TypeVar, cast
+from typing import (  # TODO move to collections.abc (requires Python >=3.9)
+    AbstractSet,
+    Any,
+    Iterable,
+    MutableSet,
+    TypeVar,
+    cast,
+)
 
 T = TypeVar("T", bound=Hashable)
 
@@ -112,3 +118,109 @@ class HeapSet(MutableSet[T]):
     def clear(self) -> None:
         self._data.clear()
         self._heap.clear()
+
+
+class OrderedSet(MutableSet[T]):
+    """
+    A insertion-ordered set.
+
+    All operations are O(1) complexity.
+
+    Equality tests between OrderedSet objects are order-sensitive. Equality tests
+    between OrderedSet objects and other AbstractSet objects are order-insensitive like
+    regular sets.
+    """
+
+    __slots__ = ("_data",)
+    _data: dict[T, None]
+
+    def __init__(self, iterable: Iterable[T] | None = None) -> None:
+        if iterable:
+            self._data = dict.fromkeys(iterable)
+        else:
+            self._data = {}
+
+    def add(self, value: T) -> None:
+        self._data[value] = None
+        # NOTE: updating an already-existing item in a dict does not change iteration order
+
+    def discard(self, value: T) -> None:
+        self._data.pop(value, None)
+
+    def clear(self) -> None:
+        self._data.clear()
+
+    def copy(self) -> OrderedSet[T]:
+        new = type(self)()
+        new._data = self._data.copy()
+        return new
+
+    def pop(self) -> T:
+        "Remove and return the last-inserted item"
+        if not self._data:
+            raise KeyError("pop on an empty set")
+        return self._data.popitem()[0]
+
+    def popleft(self) -> T:
+        "Remove and return the first-inserted item"
+        if not self._data:
+            raise KeyError("popleft on an empty set")
+        first = next(iter(self._data))
+        self._data.pop(first)
+        return first
+
+    def peek(self) -> T:
+        if not self._data:
+            raise KeyError("peek into empty set")
+        return next(reversed(self._data))
+
+    def peekleft(self) -> T:
+        if not self._data:
+            raise KeyError("peekleft into empty set")
+        return next(iter(self._data))
+
+    def rotate(self, n=1) -> None:
+        """
+        Rotate the OrderedSet ``n`` steps to the right.
+
+        Note that each rotation is an O(1) operation, so the time-complexity
+        is equivalent to ``n``.
+        """
+        if n == 0:
+            return
+        if n < 0:
+            raise ValueError(f"{type(self).__name__} can only be rotated to the right")
+        n = n % len(self)
+        for _ in range(n):
+            self.add(self.popleft())
+
+    def update(self, iterable: Iterable[T]) -> None:
+        for x in iterable:
+            self._data[x] = None
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({', '.join(map(str, self))})>"
+
+    def __contains__(self, value: object) -> bool:
+        return value in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self) -> Iterator[T]:
+        """Iterate over all elements in insertion order."""
+        return iter(self._data)
+
+    def __reverse__(self) -> Iterator[T]:
+        """Iterate over all elements in reverse insertion order."""
+        return reversed(self._data)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, type(self)):
+            return len(other._data) == len(self._data) and all(
+                a == b for a, b in zip(self._data, other._data)
+            )
+        if isinstance(other, AbstractSet):
+            return self._data.keys() == other
+
+        return NotImplemented

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2980,7 +2980,7 @@ class TaskProgress(DashboardComponent):
         self.scheduler = scheduler
 
         data = progress_quads(
-            dict(all={}, memory={}, erred={}, released={}, processing={})
+            dict(all={}, memory={}, erred={}, released={}, processing={}, queued={})
         )
         self.source = ColumnDataSource(data=data)
 
@@ -3049,6 +3049,18 @@ class TaskProgress(DashboardComponent):
             left="erred-loc",
             right="processing-loc",
             fill_color="gray",
+            fill_alpha=0.35,
+            line_alpha=0,
+        )
+        self.root.quad(
+            source=self.source,
+            top="top",
+            bottom="bottom",
+            left="processing-loc",
+            right="queued-loc",
+            fill_color="gray",
+            hatch_pattern="/",
+            hatch_color="white",
             fill_alpha=0.35,
             line_alpha=0,
         )

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3100,20 +3100,20 @@ class TaskProgress(DashboardComponent):
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@all</span>
                 </div>
                 <div>
+                    <span style="font-size: 14px; font-weight: bold;">Queued:</span>&nbsp;
+                    <span style="font-size: 10px; font-family: Monaco, monospace;">@queued</span>
+                </div>
+                <div>
+                    <span style="font-size: 14px; font-weight: bold;">Processing:</span>&nbsp;
+                    <span style="font-size: 10px; font-family: Monaco, monospace;">@processing</span>
+                </div>
+                <div>
                     <span style="font-size: 14px; font-weight: bold;">Memory:</span>&nbsp;
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@memory</span>
                 </div>
                 <div>
                     <span style="font-size: 14px; font-weight: bold;">Erred:</span>&nbsp;
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@erred</span>
-                </div>
-                <div>
-                    <span style="font-size: 14px; font-weight: bold;">Ready:</span>&nbsp;
-                    <span style="font-size: 10px; font-family: Monaco, monospace;">@processing</span>
-                </div>
-                <div>
-                    <span style="font-size: 14px; font-weight: bold;">Queued:</span>&nbsp;
-                    <span style="font-size: 10px; font-family: Monaco, monospace;">@queued</span>
                 </div>
                 """,
         )
@@ -3160,9 +3160,10 @@ class TaskProgress(DashboardComponent):
 
         self.root.title.text = (
             "Progress -- total: %(all)s, "
-            "in-memory: %(memory)s, processing: %(processing)s, "
-            "queued: %(queued)s, "
             "waiting: %(waiting)s, "
+            "queued: %(queued)s, "
+            "processing: %(processing)s, "
+            "in-memory: %(memory)s, "
             "erred: %(erred)s" % totals
         )
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3099,6 +3099,10 @@ class TaskProgress(DashboardComponent):
                     <span style="font-size: 14px; font-weight: bold;">Ready:</span>&nbsp;
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@processing</span>
                 </div>
+                <div>
+                    <span style="font-size: 14px; font-weight: bold;">Queued:</span>&nbsp;
+                    <span style="font-size: 10px; font-family: Monaco, monospace;">@queued</span>
+                </div>
                 """,
         )
         self.root.add_tools(hover)
@@ -3112,6 +3116,7 @@ class TaskProgress(DashboardComponent):
             "released": {},
             "processing": {},
             "waiting": {},
+            "queued": {},
         }
 
         for tp in self.scheduler.task_prefixes.values():
@@ -3122,6 +3127,7 @@ class TaskProgress(DashboardComponent):
                 state["released"][tp.name] = active_states["released"]
                 state["processing"][tp.name] = active_states["processing"]
                 state["waiting"][tp.name] = active_states["waiting"]
+                state["queued"][tp.name] = active_states["queued"]
 
         state["all"] = {k: sum(v[k] for v in state.values()) for k in state["memory"]}
 
@@ -3134,7 +3140,7 @@ class TaskProgress(DashboardComponent):
 
         totals = {
             k: sum(state[k].values())
-            for k in ["all", "memory", "erred", "released", "waiting"]
+            for k in ["all", "memory", "erred", "released", "waiting", "queued"]
         }
         totals["processing"] = totals["all"] - sum(
             v for k, v in totals.items() if k != "all"
@@ -3143,6 +3149,7 @@ class TaskProgress(DashboardComponent):
         self.root.title.text = (
             "Progress -- total: %(all)s, "
             "in-memory: %(memory)s, processing: %(processing)s, "
+            "queued: %(queued)s, "
             "waiting: %(waiting)s, "
             "erred: %(erred)s" % totals
         )

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2091,8 +2091,8 @@ class TaskGraph(DashboardComponent):
 
         node_colors = factor_cmap(
             "state",
-            factors=["waiting", "processing", "memory", "released", "erred"],
-            palette=["gray", "green", "red", "blue", "black"],
+            factors=["waiting", "queued", "processing", "memory", "released", "erred"],
+            palette=["gray", "yellow", "green", "red", "blue", "black"],
         )
 
         self.root = figure(title="Task Graph", **kwargs)

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2094,6 +2094,13 @@ class TaskGraph(DashboardComponent):
             factors=["waiting", "processing", "memory", "released", "erred"],
             palette=["gray", "green", "red", "blue", "black"],
         )
+        worker_colors = linear_cmap(
+            "worker",
+            Viridis11,  # TODO larger cmap for more workers
+            low=0,
+            high=11,  # TODO actually set this, and update when workers add/leave!!!
+            nan_color="black",
+        )
 
         self.root = figure(title="Task Graph", **kwargs)
         self.subtitle = Title(text=" ", text_font_style="italic")
@@ -2112,6 +2119,7 @@ class TaskGraph(DashboardComponent):
             x="x",
             y="y",
             size=10,
+            line_color=worker_colors,
             color=node_colors,
             source=self.node_source,
             view=node_view,
@@ -2124,7 +2132,7 @@ class TaskGraph(DashboardComponent):
 
         hover = HoverTool(
             point_policy="follow_mouse",
-            tooltips="<b>@name</b>: @state",
+            tooltips="<b>@name</b>: @state @worker",
             renderers=[rect],
         )
         tap = TapTool(callback=OpenURL(url="info/task/@key.html"), renderers=[rect])
@@ -2174,6 +2182,7 @@ class TaskGraph(DashboardComponent):
             node_name = []
             edge_x = []
             edge_y = []
+            worker = []
 
             x = self.layout.x
             y = self.layout.y
@@ -2191,6 +2200,11 @@ class TaskGraph(DashboardComponent):
                 node_y.append(yy)
                 node_state.append(task.state)
                 node_name.append(task.prefix.name)
+                ws = task.processing_on or (
+                    next(iter(task.who_has)) if task.who_has else None
+                )
+                # TODO don't rely on worker name being int-like; use categorical cmap instead
+                worker.append(int(ws.name) if ws else None)
 
             for a, b in new_edges:
                 try:
@@ -2206,6 +2220,7 @@ class TaskGraph(DashboardComponent):
                 "name": node_name,
                 "key": node_key,
                 "visible": ["True"] * len(node_x),
+                "worker": worker,
             }
             edge = {"x": edge_x, "y": edge_y, "visible": ["True"] * len(edge_x)}
 
@@ -2230,6 +2245,12 @@ class TaskGraph(DashboardComponent):
             self.layout.state_updates = []
             updates = [(i, c) for i, c in state_updates if i < n]
             self.node_source.patch({"state": updates})
+
+        if self.layout.worker_updates:
+            worker_updates = self.layout.worker_updates
+            self.layout.worker_updates = []
+            updates = [(i, c) for i, c in worker_updates if i < n]
+            self.node_source.patch({"worker": updates})
 
         if self.layout.visible_updates:
             updates = self.layout.visible_updates

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2094,13 +2094,6 @@ class TaskGraph(DashboardComponent):
             factors=["waiting", "processing", "memory", "released", "erred"],
             palette=["gray", "green", "red", "blue", "black"],
         )
-        worker_colors = linear_cmap(
-            "worker",
-            Viridis11,  # TODO larger cmap for more workers
-            low=0,
-            high=11,  # TODO actually set this, and update when workers add/leave!!!
-            nan_color="black",
-        )
 
         self.root = figure(title="Task Graph", **kwargs)
         self.subtitle = Title(text=" ", text_font_style="italic")
@@ -2119,7 +2112,6 @@ class TaskGraph(DashboardComponent):
             x="x",
             y="y",
             size=10,
-            line_color=worker_colors,
             color=node_colors,
             source=self.node_source,
             view=node_view,
@@ -2132,7 +2124,7 @@ class TaskGraph(DashboardComponent):
 
         hover = HoverTool(
             point_policy="follow_mouse",
-            tooltips="<b>@name</b>: @state @worker",
+            tooltips="<b>@name</b>: @state",
             renderers=[rect],
         )
         tap = TapTool(callback=OpenURL(url="info/task/@key.html"), renderers=[rect])
@@ -2182,7 +2174,6 @@ class TaskGraph(DashboardComponent):
             node_name = []
             edge_x = []
             edge_y = []
-            worker = []
 
             x = self.layout.x
             y = self.layout.y
@@ -2200,11 +2191,6 @@ class TaskGraph(DashboardComponent):
                 node_y.append(yy)
                 node_state.append(task.state)
                 node_name.append(task.prefix.name)
-                ws = task.processing_on or (
-                    next(iter(task.who_has)) if task.who_has else None
-                )
-                # TODO don't rely on worker name being int-like; use categorical cmap instead
-                worker.append(int(ws.name) if ws else None)
 
             for a, b in new_edges:
                 try:
@@ -2220,7 +2206,6 @@ class TaskGraph(DashboardComponent):
                 "name": node_name,
                 "key": node_key,
                 "visible": ["True"] * len(node_x),
-                "worker": worker,
             }
             edge = {"x": edge_x, "y": edge_y, "visible": ["True"] * len(edge_x)}
 
@@ -2245,12 +2230,6 @@ class TaskGraph(DashboardComponent):
             self.layout.state_updates = []
             updates = [(i, c) for i, c in state_updates if i < n]
             self.node_source.patch({"state": updates})
-
-        if self.layout.worker_updates:
-            worker_updates = self.layout.worker_updates
-            self.layout.worker_updates = []
-            updates = [(i, c) for i, c in worker_updates if i < n]
-            self.node_source.patch({"worker": updates})
 
         if self.layout.visible_updates:
             updates = self.layout.visible_updates

--- a/distributed/diagnostics/graph_layout.py
+++ b/distributed/diagnostics/graph_layout.py
@@ -27,7 +27,6 @@ class GraphLayout(SchedulerPlugin):
         self.new = []
         self.new_edges = []
         self.state_updates = []
-        self.worker_updates = []
         self.visible_updates = []
         self.visible_edge_updates = []
 
@@ -94,18 +93,11 @@ class GraphLayout(SchedulerPlugin):
                 self.new_edges.append(edge)
 
     def transition(self, key, start, finish, *args, **kwargs):
-        task = self.scheduler.tasks[key]
-        idx = self.index[key]
         if finish != "forgotten":
-            self.state_updates.append((idx, finish))
-            ws = (
-                task.queued_on
-                or task.processing_on
-                or (next(iter(task.who_has)) if task.who_has else None)
-            )
-            self.worker_updates.append((idx, int(ws.name) if ws else None))
+            self.state_updates.append((self.index[key], finish))
         else:
-            self.visible_updates.append((idx, "False"))
+            self.visible_updates.append((self.index[key], "False"))
+            task = self.scheduler.tasks[key]
             for dep in task.dependents:
                 edge = (key, dep.key)
                 self.visible_edge_updates.append((self.index_edge.pop(edge), "False"))
@@ -132,7 +124,6 @@ class GraphLayout(SchedulerPlugin):
         self.new_edges = []
         self.visible_updates = []
         self.state_updates = []
-        self.worker_updates = []
         self.visible_edge_updates = []
 
         self.index = {}

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -64,23 +64,29 @@ def progress_quads(msg, nrows=8, ncols=3):
     ...        'memory': {'inc': 2, 'dec': 0, 'add': 1},
     ...        'erred': {'inc': 0, 'dec': 1, 'add': 0},
     ...        'released': {'inc': 1, 'dec': 0, 'add': 1},
-    ...        'processing': {'inc': 1, 'dec': 0, 'add': 2}}
+    ...        'processing': {'inc': 1, 'dec': 0, 'add': 2},
+    ...        'queued': {'inc': 1, 'dec': 0, 'add': 2}}
 
     >>> progress_quads(msg, nrows=2)  # doctest: +SKIP
-    {'name': ['inc', 'add', 'dec'],
-     'left': [0, 0, 1],
-     'right': [0.9, 0.9, 1.9],
-     'top': [0, -1, 0],
-     'bottom': [-.8, -1.8, -.8],
-     'released': [1, 1, 0],
-     'memory': [2, 1, 0],
-     'erred': [0, 0, 1],
-     'processing': [1, 0, 2],
-     'done': ['3 / 5', '2 / 4', '1 / 1'],
-     'released-loc': [.2/.9, .25 / 0.9, 1],
-     'memory-loc': [3 / 5 / .9, .5 / 0.9, 1],
-     'erred-loc': [3 / 5 / .9, .5 / 0.9, 1.9],
-     'processing-loc': [4 / 5, 1 / 1, 1]}}
+    {'all': [5, 4, 1],
+    'memory': [2, 1, 0],
+    'erred': [0, 0, 1],
+    'released': [1, 1, 0],
+    'processing': [1, 2, 0],
+    'queued': [1, 2, 0],
+    'name': ['inc', 'add', 'dec'],
+    'show-name': ['inc', 'add', 'dec'],
+    'left': [0, 0, 1],
+    'right': [0.9, 0.9, 1.9],
+    'top': [0, -1, 0],
+    'bottom': [-0.8, -1.8, -0.8],
+    'color': ['#45BF6F', '#2E6C8E', '#440154'],
+    'released-loc': [0.18, 0.225, 1.0],
+    'memory-loc': [0.54, 0.45, 1.0],
+    'erred-loc': [0.54, 0.45, 1.9],
+    'processing-loc': [0.72, 0.9, 1.9],
+    'queued-loc': [0.9, 1.35, 1.9],
+    'done': ['3 / 5', '2 / 4', '1 / 1']}
     """
     width = 0.9
     names = sorted(msg["all"], key=msg["all"].get, reverse=True)
@@ -100,19 +106,28 @@ def progress_quads(msg, nrows=8, ncols=3):
     d["memory-loc"] = []
     d["erred-loc"] = []
     d["processing-loc"] = []
+    d["queued-loc"] = []
     d["done"] = []
-    for r, m, e, p, a, l in zip(
-        d["released"], d["memory"], d["erred"], d["processing"], d["all"], d["left"]
+    for r, m, e, p, q, a, l in zip(
+        d["released"],
+        d["memory"],
+        d["erred"],
+        d["processing"],
+        d["queued"],
+        d["all"],
+        d["left"],
     ):
         rl = width * r / a + l
         ml = width * (r + m) / a + l
         el = width * (r + m + e) / a + l
         pl = width * (p + r + m + e) / a + l
+        ql = width * (p + r + m + e + q) / a + l
         done = "%d / %d" % (r + m + e, a)
         d["released-loc"].append(rl)
         d["memory-loc"].append(ml)
         d["erred-loc"].append(el)
         d["processing-loc"].append(pl)
+        d["queued-loc"].append(ql)
         d["done"].append(done)
 
     return d

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -118,16 +118,12 @@ properties:
               How frequently to balance worker loads
 
           worker-oversaturation:
-            type:
-            - integer
-            - float
+            type: float
             description: |
-              Controls how many extra root tasks are sent to workers (like a readahead).
+              Controls how many extra root tasks are sent to workers (like a `readahead`).
 
-              As an integer, this many _extra_ root tasks are sent to the worker, beyond that worker's
-              thread count. As a float, `worker-oversaturation * worker.nthreads` _extra_ tasks are sent
-              to the worker beyond its thread count. If `.inf`, all runnable tasks are immediately sent
-              to workers.
+              `floor(worker-oversaturation * worker.nthreads)` _extra_ tasks are sent to the worker
+              beyond its thread count. If `.inf`, all runnable tasks are immediately sent to workers.
 
               Allowing oversaturation means a worker will start running a new root task as soon as
               it completes the previous, even if there is a higher-priority downstream task to run.
@@ -137,8 +133,9 @@ properties:
               This generally comes  at the expense of increased memory usage. It leads to "wider"
               (more breadth-first) execution of the graph.
 
-              Compute-bound workloads benefit from increasing oversaturation. Memory-bound
-              workloads should generally leave `worker-oversaturation` at 0.
+              Compute-bound workloads benefit from oversaturation. Memory-bound workloads should
+              generally leave `worker-oversaturation` at 0, though 0.25-0.5 could slightly improve
+              performance if ample memory is available.
 
           worker-ttl:
             type:

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -117,6 +117,29 @@ properties:
             description: |
               How frequently to balance worker loads
 
+          worker-oversaturation:
+            type:
+            - integer
+            - float
+            description: |
+              Controls how many extra root tasks are sent to workers (like a readahead).
+
+              As an integer, this many _extra_ root tasks are sent to the worker, beyond that worker's
+              thread count. As a float, `worker-oversaturation * worker.nthreads` _extra_ tasks are sent
+              to the worker beyond its thread count. If `.inf`, all runnable tasks are immediately sent
+              to workers.
+
+              Allowing oversaturation means a worker will start running a new root task as soon as
+              it completes the previous, even if there is a higher-priority downstream task to run.
+              This reduces worker idleness, by letting workers do something while waiting for further
+              instructions from the scheduler.
+
+              This generally comes  at the expense of increased memory usage. It leads to "wider"
+              (more breadth-first) execution of the graph.
+
+              Compute-bound workloads benefit from increasing oversaturation. Memory-bound
+              workloads should generally leave `worker-oversaturation` at 0.
+
           worker-ttl:
             type:
             - string

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -22,6 +22,7 @@ distributed:
     events-log-length: 100000
     work-stealing: True     # workers should steal tasks from each other
     work-stealing-interval: 100ms  # Callback time for work stealing
+    worker-oversaturation: 0  # Amount of extra root tasks to send to workers, as fixed count or fraction of nthreads.
     worker-ttl: "5 minutes" # like '60s'. Time to live for workers.  They must heartbeat faster than this
     pickle: True            # Is the scheduler allowed to deserialize arbitrary bytestrings
     preload: []             # Run custom modules with Scheduler

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -22,7 +22,7 @@ distributed:
     events-log-length: 100000
     work-stealing: True     # workers should steal tasks from each other
     work-stealing-interval: 100ms  # Callback time for work stealing
-    worker-oversaturation: 0  # Amount of extra root tasks to send to workers, as fixed count or fraction of nthreads.
+    worker-oversaturation: 0.0  # Send this fraction of nthreads extra root tasks to workers
     worker-ttl: "5 minutes" # like '60s'. Time to live for workers.  They must heartbeat faster than this
     pickle: True            # Is the scheduler allowed to deserialize arbitrary bytestrings
     preload: []             # Run custom modules with Scheduler

--- a/distributed/http/templates/worker-table.html
+++ b/distributed/http/templates/worker-table.html
@@ -6,6 +6,7 @@
         <th> Memory </th>
         <th> Memory use </th>
         <th> Occupancy </th>
+        <th> Queued </th>
         <th> Processing </th>
         <th> In-memory </th>
         <th> Services</th>
@@ -20,6 +21,7 @@
         <td> {{ format_bytes(ws.memory_limit) if ws.memory_limit is not None else "" }} </td>
         <td> <progress class="progress" value="{{ ws.metrics['memory'] }}" max="{{ ws.memory_limit }}"></progress> </td>
         <td> {{ format_time(ws.occupancy) }} </td>
+        <td> {{ len(ws.queued) }} </td>
         <td> {{ len(ws.processing) }} </td>
         <td> {{ len(ws.has_what) }} </td>
         {% if 'dashboard' in ws.services %}

--- a/distributed/http/templates/worker.html
+++ b/distributed/http/templates/worker.html
@@ -41,6 +41,21 @@
             {% end %}
           </table>
         </div>
+        <div class="content">
+          <h2 class="subtitle"> Queued </h2>
+          <table class="table is-striped is-hoverable">
+            <tr>
+                <th> Task </th>
+                <th> Priority </th>
+            </tr>
+            {% for ts in ws.queued.sorted() %}
+            <tr>
+                <td> <a href="../task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a></td>
+                <td> {{ts.priority }} </td>
+            </tr>
+            {% end %}
+          </table>
+        </div>
       </div>
     </div>
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7753,13 +7753,13 @@ def heartbeat_interval(n: int) -> float:
         return n / 200 + 1
 
 
-def worker_saturated(ws: WorkerState, oversaturation_factor: int | float) -> bool:
+def worker_saturated(ws: WorkerState, oversaturation_factor: float) -> bool:
     if math.isinf(oversaturation_factor):
         return False
     nthreads = ws.nthreads
-    if isinstance(oversaturation_factor, float):
-        oversaturation_factor = math.floor(oversaturation_factor * nthreads)
-    return len(ws.processing) >= max(nthreads + oversaturation_factor, 1)
+    return len(ws.processing) >= max(
+        nthreads + int(oversaturation_factor * nthreads), 1
+    )
 
 
 class KilledWorker(Exception):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -320,6 +320,21 @@ def test_oversaturation_factor(oversaturation, expected_task_counts: tuple[int, 
     _test_oversaturation_factor()
 
 
+@gen_cluster(
+    client=True,
+    nthreads=[("", 2)] * 2,
+    timeout=3600,  # TODO remove
+    scheduler_kwargs=dict(  # TODO remove
+        dashboard=True,
+        dashboard_address=":8787",
+    ),
+)
+async def test_queued_tasks_rebalance(c, s, a, b):
+    event = Event()
+    fs = c.map(lambda _: event.wait(), range(100))
+    await c.gather(fs)
+
+
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
 async def test_move_data_over_break_restrictions(client, s, a, b, c):
     [x] = await client.scatter([1], workers=b.address)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -274,7 +274,7 @@ async def test_root_task_overproduction(c, s, *nannies):
         return "x" * size
 
     roots = [
-        big_data(parse_bytes("300 MiB"), dask_key_name=f"root-{i}") for i in range(16)
+        big_data(parse_bytes("350 MiB"), dask_key_name=f"root-{i}") for i in range(16)
     ]
     passthrough = [delayed(slowidentity)(x) for x in roots]
     memory_consumed = [delayed(len)(x) for x in passthrough]

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -288,10 +288,9 @@ async def test_root_task_overproduction(c, s, *nannies):
     "oversaturation, expected_task_counts",
     [
         (1.5, (5, 2)),
-        (1, (3, 2)),
         (1.0, (4, 2)),
-        (0, (2, 1)),
-        (-1, (1, 1)),
+        (0.0, (2, 1)),
+        (-1.0, (1, 1)),
         (float("inf"), (7, 3))
         # ^ depends on root task assignment logic; ok if changes, just needs to add up to 10
     ],

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -16,12 +16,12 @@ from unittest import mock
 import cloudpickle
 import psutil
 import pytest
-from tlz import concat, first, merge, valmap
+from tlz import concat, first, merge, partition, valmap
 from tornado.ioloop import IOLoop
 
 import dask
 from dask import delayed
-from dask.utils import apply, parse_timedelta, stringify, tmpfile, typename
+from dask.utils import apply, parse_bytes, parse_timedelta, stringify, tmpfile, typename
 
 from distributed import (
     CancelledError,
@@ -54,6 +54,7 @@ from distributed.utils_test import (
     raises_with_cause,
     slowadd,
     slowdec,
+    slowidentity,
     slowinc,
     tls_only_security,
     varying,
@@ -243,6 +244,44 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
         assert len(unexpected_transfers) <= 3, unexpected_transfers
 
     test_decide_worker_coschedule_order_neighbors_()
+
+
+@pytest.mark.slow
+@gen_cluster(
+    client=True,
+    nthreads=[("127.0.0.1", 2)] * 2,
+    worker_kwargs={"memory_limit": "1.0GiB"},
+    timeout=3600,  # TODO remove
+    Worker=Nanny,
+    scheduler_kwargs=dict(  # TODO remove
+        dashboard=True,
+        dashboard_address=":8787",
+    ),
+    config={
+        "distributed.worker.memory.target": False,
+        "distributed.worker.memory.spill": False,
+        "distributed.scheduler.work-stealing": False,
+    },
+)
+async def test_root_task_overproduction(c, s, *nannies):
+    """
+    Workload that would run out of memory and kill workers if >2 root tasks were
+    ever in memory at once on a worker.
+    """
+
+    @delayed(pure=True)
+    def big_data(size: int) -> str:
+        return "x" * size
+
+    roots = [
+        big_data(parse_bytes("300 MiB"), dask_key_name=f"root-{i}") for i in range(16)
+    ]
+    passthrough = [delayed(slowidentity)(x) for x in roots]
+    memory_consumed = [delayed(len)(x) for x in passthrough]
+    reduction = [sum(sizes) for sizes in partition(4, memory_consumed)]
+    final = sum(reduction)
+
+    await c.compute(final)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -274,7 +274,7 @@ async def test_root_task_overproduction(c, s, *nannies):
         return "x" * size
 
     roots = [
-        big_data(parse_bytes("300 MiB"), dask_key_name=f"root-{i}") for i in range(16)
+        big_data(parse_bytes("300 MiB"), dask_key_name=f"root-{i}") for i in range(1600)
     ]
     passthrough = [delayed(slowidentity)(x) for x in roots]
     memory_consumed = [delayed(len)(x) for x in passthrough]

--- a/distributed/widgets/templates/worker_state.html.j2
+++ b/distributed/widgets/templates/worker_state.html.j2
@@ -3,3 +3,4 @@
 <span style="color: var(--jp-ui-font-color2, gray)"> status: </span>{{ status }}
 <span style="color: var(--jp-ui-font-color2, gray)"> memory: </span>{{ has_what | length }}
 <span style="color: var(--jp-ui-font-color2, gray)"> processing: </span>{{ processing | length }}
+<span style="color: var(--jp-ui-font-color2, gray)"> queued: </span>{{ queued | length }}


### PR DESCRIPTION
This is an approach for withholding root tasks from workers while preserving neighboring task co-assignment, as discussed in https://github.com/dask/distributed/issues/6560.

This adds:
* A `queued` state on the scheduler. `queued` is like `processing` (task is ready; all dependencies are in memory), but rather than being already sent to a worker, we just track the worker we _plan_ to run it on when that worker has availability.
* A `HeapSet` tracking queued tasks per worker in priority order (scheduler-side).
* Transition logic where each time a task completes on a worker, we try to schedule its next queued task if, after other recommendations have been processed, the worker would still have idle threads. This ensures higher-priority downstream tasks always take precedence over root tasks.
* A `distributed.scheduler.worker-oversaturation` config option to allow some degree of oversaturation (or even undersaturation) if desired. This will be helpful for benchmarking. It also could be a feature flag: if we set the default to `inf`, current behavior would be unchanged.
* Basic dashboard updates to show queued tasks (could do much more here)
* An algorithm for load-balancing queued tasks when a new worker joins. This is just a draft of an idea; I'm not sure it would scale adequately or even if it's the right scheduling approach. It tries to preserve co-assignment ("runs" of subsequent tasks in priority order) even as new workers join.

Due to an unintentional implementation detail, this also avoids https://github.com/dask/distributed/issues/6597 in some very specific situations (see b2e792465ad3c8a6ecc6b9ca6346f82eedaa3ef5 message), but is not in any way actually a fix.

I have not tested this much on real clusters yet. But I _think_ it works. If people like @TomNicholas want to try it out, I'd be curious to hear feedback.

I didn't get around to pushing this up on Friday and I'll be off tomorrow, but I'm pushing it up now in case @fjetter wants to take a look.

Closes #6560

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
