### PR TITLE
Make test_idle_timeout_no_workers more robust

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7021,6 +7021,7 @@ class Scheduler(SchedulerState, ServerNode):
                 await self.remove_worker(address=ws.address, stimulus_id=stimulus_id)
 
     def check_idle(self):
+        assert self.idle_timeout
         if self.status in (Status.closing, Status.closed):
             return
 


### PR DESCRIPTION
This test was introduced in https://github.com/dask/distributed/pull/6563 and is unfortunately flaky. If the PC is scheduled once before the task actually arrives at the scheduler, the scheduler will have an `idle_since` set.

I rewrote the test w/out PC and added a bit more logic to it. It works now robustly, at least on my machine