### PR TITLE
Default dashboard address configurable

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -61,8 +61,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--dashboard-address",
     type=str,
-    default=":8787",
-    show_default=True,
+    default=None,
     help="Address on which to listen for diagnostics dashboard",
 )
 @click.option(

--- a/distributed/cli/tests/conftest.py
+++ b/distributed/cli/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from distributed.utils import open_port
+
+
+@pytest.fixture(scope="module")
+def default_dashboard_port():
+    return open_port()

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -179,6 +179,9 @@ properties:
               Configuration options for Dask's real-time dashboard
 
             properties:
+              default-port:
+                type: object
+                description: The default port for the dashboard and HTTP server
               status:
                 type: object
                 description: The main status page of the dashboard

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -32,6 +32,7 @@ distributed:
       split-shuffle: 1us
     validate: False         # Check scheduler state at every step for debugging
     dashboard:
+      default-port: 8787
       status:
         task-stream-length: 1000
       tasks:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2974,7 +2974,13 @@ class Scheduler(SchedulerState, ServerNode):
         routes = get_handlers(
             server=self, modules=http_server_modules, prefix=http_prefix
         )
-        self.start_http_server(routes, dashboard_address, default_port=8787)
+        self.start_http_server(
+            routes,
+            dashboard_address,
+            default_port=dask.config.get(
+                "distributed.scheduler.dashboard.default-port"
+            ),
+        )
         if show_dashboard:
             distributed.dashboard.scheduler.connect(
                 self.http_application, self.http_server, self, prefix=http_prefix


### PR DESCRIPTION
This complements https://github.com/dask/distributed/pull/6591

The default port for the dashboard or http server is hard coded to 8787. If this port is available, great. However, if a test doesn't properly cleanup after itself all following tests that are hard coded against this port for whatever reason are doomed to fail. We have a couple of these cascading failures on CI lately

This PR introduces a couple of changes
- Allow the default port to be configurable. This is mostly useful for tests
- Set the default port to :0 such that all tests that don't really care about it use the kernel to get a suitable port w/out risk of collision
- I extended our test setup with a couple of fixtures to allow certain tests to override this, e.g. if they specifically want to test against the dashboard port they can use `open_port`. I didn't want to use open_port for _all_ tests. Maybe that's paranoid?
- our magical popen will now automatically forward the local environment and respect config changes to dask.config by creating a new config file for that process


If we do not wan to have this kind of fixture magic in here, I can simplify this to use open_port all the time.