### PR TITLE
Restore log message about received signals in CLI

### DIFF
--- a/distributed/_signals.py
+++ b/distributed/_signals.py
@@ -14,10 +14,13 @@ async def wait_for_signals(signals: list[signal.Signals]) -> None:
     event = asyncio.Event()
 
     old_handlers: dict[int, Any] = {}
+    caught_signal: int | None = None
 
     def handle_signal(signum, frame):
         # *** Do not log or print anything in here
         # https://stackoverflow.com/questions/45680378/how-to-explain-the-reentrant-runtimeerror-caused-by-printing-in-signal-handlers
+        nonlocal caught_signal
+        caught_signal = signum
         # Restore old signal handler to allow for quicker exit
         # if the user sends the signal again.
         signal.signal(signum, old_handlers[signum])
@@ -28,6 +31,10 @@ async def wait_for_signals(signals: list[signal.Signals]) -> None:
 
     try:
         await event.wait()
+        assert caught_signal
+        logger.info(
+            "Received signal %s (%d)", signal.Signals(caught_signal).name, caught_signal
+        )
     finally:
         for sig in signals:
             signal.signal(sig, old_handlers[sig])

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -549,6 +549,7 @@ def test_signal_handling(loop, sig):
         stdout, stderr = scheduler.communicate()
         logs = stdout.decode().lower()
         assert stderr is None
+        assert sig.name.lower() in logs
         assert scheduler.returncode == 0
         assert "scheduler closing" in logs
         assert "end scheduler" in logs

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -689,6 +689,7 @@ async def test_signal_handling(c, s, nanny, sig):
         stdout, stderr = worker.communicate()
         logs = stdout.decode().lower()
         assert stderr is None
+        assert sig.name.lower() in logs
         assert worker.returncode == 0
         if nanny == "--nanny":
             assert "closing nanny" in logs


### PR DESCRIPTION
This restores the signal log messages that has been removed in https://github.com/dask/distributed/pull/6590 in a safe way

I believe this can be of help debugging something like https://github.com/dask/distributed/pull/6615#issuecomment-1164311459