### PR TITLE
do not interact with the event loop when the cluster is garbage collected

### DIFF
--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -6,41 +6,43 @@ from distributed.utils_test import gen_test
 
 @gen_test()
 async def test_eq():
-    clusterA = Cluster(asynchronous=True, name="A")
-    clusterA2 = Cluster(asynchronous=True, name="A2")
-    clusterB = Cluster(asynchronous=True, name="B")
-    assert clusterA != "A"
-    assert not (clusterA == "A")
-    assert clusterA == clusterA
-    assert not (clusterA != clusterA)
-    assert clusterA != clusterA2
-    assert not (clusterA == clusterA2)
-    assert clusterA != clusterB
-    assert not (clusterA == clusterB)
+    async with Cluster(asynchronous=True, name="A") as clusterA, Cluster(
+        asynchronous=True, name="A2"
+    ) as clusterA2, Cluster(asynchronous=True, name="B") as clusterB:
+        assert clusterA != "A"
+        assert not (clusterA == "A")
+        assert clusterA == clusterA
+        assert not (clusterA != clusterA)
+        assert clusterA != clusterA2
+        assert not (clusterA == clusterA2)
+        assert clusterA != clusterB
+        assert not (clusterA == clusterB)
 
 
 @gen_test()
 async def test_repr():
-    cluster = Cluster(asynchronous=True, name="A")
-    assert cluster.scheduler_address == "<Not Connected>"
-    res = repr(cluster)
-    expected = "Cluster(A, '<Not Connected>', workers=0, threads=0, memory=0 B)"
-    assert res == expected
+    async with Cluster(asynchronous=True, name="A") as cluster:
+        assert cluster.scheduler_address == "<Not Connected>"
+        res = repr(cluster)
+        expected = "Cluster(A, '<Not Connected>', workers=0, threads=0, memory=0 B)"
+        assert res == expected
 
 
 @gen_test()
 async def test_logs_deprecated():
-    cluster = Cluster(asynchronous=True)
-    with pytest.warns(FutureWarning, match="get_logs"):
-        cluster.logs()
+    async with Cluster(asynchronous=True) as cluster:
+        with pytest.warns(FutureWarning, match="get_logs"):
+            cluster.logs()
 
 
 @gen_test()
-async def test_cluster_info():
+async def test_cluster_info(loop_in_thread):
     class FooCluster(Cluster):
         def __init__(self):
             self._cluster_info["foo"] = "bar"
-            super().__init__(asynchronous=False)
+            super().__init__(asynchronous=False, loop=loop_in_thread)
 
     cluster = FooCluster()
-    assert "foo" in cluster._cluster_info
+    assert "foo" in cluster._cluster_info  # exists before start() called
+    with cluster:  # start and stop the cluster to avoid a resource warning
+        pass


### PR DESCRIPTION
if the cluster is started async then the event loop keeps a hard reference
to the cluster via PeriodicCallbacks, so the cluster can only be garbage
collected when the loop is closed and the callbacks are cleared.

if the cluster is started sync the event loop is only closed when the
cluster is closed because the event loop is running in a daemon thread

a `ResourceWarning` is added so it's possible to detect a missing `async with Cluster(` in tests

refs https://github.com/dask/distributed/issues/6163

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
