### PR TITLE
Use safe temp directory in gen_cluster

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1070,7 +1070,7 @@ def gen_cluster(
         def test_func(*outer_args, **kwargs):
             async def async_fn():
                 result = None
-                with tempfile.TemporaryDirectory() as tmpdir:
+                with _SafeTemporaryDirectory() as tmpdir:
                     config2 = merge({"temporary-directory": tmpdir}, config)
                     with dask.config.set(config2):
                         workers = []


### PR DESCRIPTION
There is also the proposal (https://github.com/dask/distributed/pull/6630) to use the pytest tmpdir_factory fixture instead of tempfile. I'm investigating this right now but we introduced this hotfix for the cluster fixture already and I don't see a reason why gen_cluster shouldn't do the same