### PR TITLE
Ensure client.restart waits for workers to leave and come back

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3493,6 +3493,16 @@ async def test_Client_clears_references_after_restart(c, s, a, b):
         assert key not in c.refcount
 
 
+@pytest.mark.slow
+@gen_cluster(Worker=Nanny, client=True, nthreads=[("", 1)] * 5)
+async def test_restart_waits_for_new_workers(c, s, *workers):
+    initial_workers = set(s.workers)
+    await c.restart()
+    assert len(s.workers) == len(initial_workers)
+    for w in workers:
+        assert w.address not in s.workers
+
+
 @gen_cluster(Worker=Nanny, client=True)
 async def test_restart_timeout_is_logged(c, s, a, b):
     with captured_logger(logging.getLogger("distributed.client")) as logger:


### PR DESCRIPTION
Client should be blocking until the workers are cycled through. At the very least since https://github.com/dask/distributed/pull/6504 we're no longer removing workers immediately from the internal state tracking and therefore client.restart would return immediately before any workers were removed.

This is at the very least an issue since https://github.com/dask/distributed/pull/6504 possibly before. I have a strong suspicion that this is responsible for https://github.com/coiled/coiled-runtime/issues/166
I believe in cases of timeouts of individual nanny restarts, this was a problem before #6504 already