### PR TITLE
use the loop fixture in more tests

### DIFF
--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -68,9 +68,9 @@ def test_local_cluster_supports_blocked_handlers(loop):
     )
 
 
-def test_close_twice():
-    with LocalCluster(dashboard_address=":0") as cluster:
-        with Client(cluster.scheduler_address) as client:
+def test_close_twice(loop):
+    with LocalCluster(dashboard_address=":0", loop=loop) as cluster:
+        with Client(cluster.scheduler_address, loop=loop) as client:
             f = client.map(inc, range(100))
             client.gather(f)
         with captured_logger("tornado.application") as log:
@@ -81,17 +81,18 @@ def test_close_twice():
         assert not log
 
 
-def test_procs():
+def test_procs(loop):
     with LocalCluster(
         n_workers=2,
         processes=False,
         threads_per_worker=3,
         dashboard_address=":0",
         silence_logs=False,
+        loop=loop,
     ) as c:
         assert len(c.workers) == 2
         assert all(isinstance(w, Worker) for w in c.workers.values())
-        with Client(c.scheduler.address) as e:
+        with Client(c.scheduler.address, loop=loop) as e:
             assert all(w.state.nthreads == 3 for w in c.workers.values())
             assert all(isinstance(w, Worker) for w in c.workers.values())
         repr(c)
@@ -102,10 +103,11 @@ def test_procs():
         threads_per_worker=3,
         dashboard_address=":0",
         silence_logs=False,
+        loop=loop,
     ) as c:
         assert len(c.workers) == 2
         assert all(isinstance(w, Nanny) for w in c.workers.values())
-        with Client(c.scheduler.address) as e:
+        with Client(c.scheduler.address, loop=loop) as e:
             assert all(v == 3 for v in e.nthreads().values())
 
             c.scale(3)
@@ -113,48 +115,56 @@ def test_procs():
         repr(c)
 
 
-def test_move_unserializable_data():
+def test_move_unserializable_data(loop):
     """
     Test that unserializable data is still fine to transfer over inproc
     transports.
     """
     with LocalCluster(
-        processes=False, silence_logs=False, dashboard_address=":0"
+        processes=False, silence_logs=False, dashboard_address=":0", loop=loop
     ) as cluster:
         assert cluster.scheduler_address.startswith("inproc://")
         assert cluster.workers[0].address.startswith("inproc://")
-        with Client(cluster) as client:
+        with Client(cluster, loop=loop) as client:
             lock = Lock()
             x = client.scatter(lock)
             y = client.submit(lambda x: x, x)
             assert y.result() is lock
 
 
-def test_transports_inproc():
+def test_transports_inproc(loop):
     """
     Test the transport chosen by LocalCluster depending on arguments.
     """
     with LocalCluster(
-        n_workers=1, processes=False, silence_logs=False, dashboard_address=":0"
+        n_workers=1,
+        processes=False,
+        silence_logs=False,
+        dashboard_address=":0",
+        loop=loop,
     ) as c:
         assert c.scheduler_address.startswith("inproc://")
         assert c.workers[0].address.startswith("inproc://")
-        with Client(c.scheduler.address) as e:
+        with Client(c.scheduler.address, loop=loop) as e:
             assert e.submit(inc, 4).result() == 5
 
 
-def test_transports_tcp():
+def test_transports_tcp(loop):
     # Have nannies => need TCP
     with LocalCluster(
-        n_workers=1, processes=True, silence_logs=False, dashboard_address=":0"
+        n_workers=1,
+        processes=True,
+        silence_logs=False,
+        dashboard_address=":0",
+        loop=loop,
     ) as c:
         assert c.scheduler_address.startswith("tcp://")
         assert c.workers[0].address.startswith("tcp://")
-        with Client(c.scheduler.address) as e:
+        with Client(c.scheduler.address, loop=loop) as e:
             assert e.submit(inc, 4).result() == 5
 
 
-def test_transports_tcp_port():
+def test_transports_tcp_port(loop):
     port = open_port()
     # Scheduler port specified => need TCP
     with LocalCluster(
@@ -163,11 +173,12 @@ def test_transports_tcp_port():
         scheduler_port=port,
         silence_logs=False,
         dashboard_address=":0",
+        loop=loop,
     ) as c:
 
         assert c.scheduler_address == f"tcp://127.0.0.1:{port}"
         assert c.workers[0].address.startswith("tcp://")
-        with Client(c.scheduler.address) as e:
+        with Client(c.scheduler.address, loop=loop) as e:
             assert e.submit(inc, 4).result() == 5
 
 
@@ -273,7 +284,7 @@ def test_Client_kwargs(loop):
 
 
 def test_Client_unused_kwargs_with_cluster(loop):
-    with LocalCluster(dashboard_address=":0") as cluster:
+    with LocalCluster(dashboard_address=":0", loop=loop) as cluster:
         with pytest.raises(Exception) as argexcept:
             c = Client(cluster, n_workers=2, dashboard_port=8000, silence_logs=None)
         assert (
@@ -411,27 +422,37 @@ async def test_memory_limit_none():
         assert w.memory_manager.memory_limit is None
 
 
-def test_cleanup():
-    with clean(threads=False):
-        c = LocalCluster(n_workers=2, silence_logs=False, dashboard_address=":0")
-        port = c.scheduler.port
-        c.close()
-        c2 = LocalCluster(
-            n_workers=2, scheduler_port=port, silence_logs=False, dashboard_address=":0"
-        )
-        c2.close()
+def test_cleanup(loop):
+    c = LocalCluster(n_workers=2, silence_logs=False, dashboard_address=":0", loop=loop)
+    port = c.scheduler.port
+    c.close()
+    c2 = LocalCluster(
+        n_workers=2,
+        scheduler_port=port,
+        silence_logs=False,
+        dashboard_address=":0",
+        loop=loop,
+    )
+    c2.close()
 
 
-def test_repeated():
-    with clean(threads=False):
-        with LocalCluster(
-            n_workers=0, scheduler_port=8448, silence_logs=False, dashboard_address=":0"
-        ):
-            pass
-        with LocalCluster(
-            n_workers=0, scheduler_port=8448, silence_logs=False, dashboard_address=":0"
-        ):
-            pass
+def test_repeated(loop):
+    with LocalCluster(
+        n_workers=0,
+        scheduler_port=8448,
+        silence_logs=False,
+        dashboard_address=":0",
+        loop=loop,
+    ):
+        pass
+    with LocalCluster(
+        n_workers=0,
+        scheduler_port=8448,
+        silence_logs=False,
+        dashboard_address=":0",
+        loop=loop,
+    ):
+        pass
 
 
 @pytest.mark.parametrize("processes", [True, False])
@@ -600,11 +621,13 @@ def test_io_loop_periodic_callbacks(loop):
                 assert pc.io_loop is loop
 
 
-def test_logging():
+def test_logging(loop):
     """
     Workers and scheduler have logs even when silenced
     """
-    with LocalCluster(n_workers=1, processes=False, dashboard_address=":0") as c:
+    with LocalCluster(
+        n_workers=1, processes=False, dashboard_address=":0", loop=loop
+    ) as c:
         assert c.scheduler._deque_handler.deque
         assert c.workers[0]._deque_handler.deque
 
@@ -949,27 +972,26 @@ def test_starts_up_sync(loop):
         cluster.close()
 
 
-def test_dont_select_closed_worker():
+def test_dont_select_closed_worker(loop):
     # Make sure distributed does not try to reuse a client from a
     # closed cluster (https://github.com/dask/distributed/issues/2840).
-    with clean(threads=False):
-        cluster = LocalCluster(n_workers=0, dashboard_address=":0")
-        c = Client(cluster)
-        cluster.scale(2)
-        assert c == get_client()
+    cluster = LocalCluster(n_workers=0, dashboard_address=":0", loop=loop)
+    c = Client(cluster)
+    cluster.scale(2)
+    assert c == get_client()
 
-        c.close()
-        cluster.close()
+    c.close()
+    cluster.close()
 
-        cluster2 = LocalCluster(n_workers=0, dashboard_address=":0")
-        c2 = Client(cluster2)
-        cluster2.scale(2)
+    cluster2 = LocalCluster(n_workers=0, dashboard_address=":0", loop=loop)
+    c2 = Client(cluster2)
+    cluster2.scale(2)
 
-        current_client = get_client()
-        assert c2 == current_client
+    current_client = get_client()
+    assert c2 == current_client
 
-        cluster2.close()
-        c2.close()
+    cluster2.close()
+    c2.close()
 
 
 def test_client_cluster_synchronous(loop):
@@ -1233,18 +1255,13 @@ class MyPlugin:
 
 
 @pytest.mark.slow
-@gen_test(
-    clean_kwargs={
-        # FIXME: This doesn't close the LoopRunner properly, leaving a thread around
-        "threads": False
-    }
-)
-async def test_localcluster_start_exception():
+def test_localcluster_start_exception(loop):
     with raises_with_cause(RuntimeError, None, ImportError, "my_nonexistent_library"):
-        async with LocalCluster(
+        with LocalCluster(
             n_workers=1,
             threads_per_worker=1,
             processes=True,
             plugins={MyPlugin()},
+            loop=loop,
         ):
-            return
+            pass

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -81,7 +81,8 @@ def test_close_twice(loop):
         assert not log
 
 
-def test_procs(loop):
+def test_procs(loop_in_thread):
+    loop = loop_in_thread
     with LocalCluster(
         n_workers=2,
         processes=False,
@@ -436,7 +437,8 @@ def test_cleanup(loop):
     c2.close()
 
 
-def test_repeated(loop):
+def test_repeated(loop_in_thread):
+    loop = loop_in_thread
     with LocalCluster(
         n_workers=0,
         scheduler_port=8448,

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -82,9 +82,14 @@ def test_spec_sync(loop):
             assert result == 11
 
 
-def test_loop_started():
-    with SpecCluster(worker_spec, scheduler=scheduler):
-        pass
+def test_loop_started_in_constructor(cleanup):
+    # test that SpecCluster.__init__ starts a loop in another thread
+    cluster = SpecCluster(worker_spec, scheduler=scheduler, loop=None)
+    try:
+        assert cluster.loop.asyncio_loop.is_running()
+    finally:
+        with cluster:
+            pass
 
 
 @gen_test()

--- a/distributed/diagnostics/tests/test_progressbar.py
+++ b/distributed/diagnostics/tests/test_progressbar.py
@@ -9,7 +9,7 @@ from distributed.utils_test import div, gen_cluster, inc
 
 def test_text_progressbar(capsys, client):
     futures = client.map(inc, range(10))
-    p = TextProgressBar(futures, interval=0.01, complete=True)
+    p = TextProgressBar(futures, interval=0.01, complete=True, loop=client.loop)
     client.gather(futures)
 
     start = time()
@@ -59,10 +59,10 @@ def test_progress_function(client, capsys):
     f = client.submit(lambda: 1)
     g = client.submit(lambda: 2)
 
-    progress([[f], [[g]]], notebook=False)
+    progress([[f], [[g]]], notebook=False, loop=client.loop)
     check_bar_completed(capsys)
 
-    progress(f)
+    progress(f, loop=client.loop)
     check_bar_completed(capsys)
 
 
@@ -70,5 +70,5 @@ def test_progress_function_w_kwargs(client, capsys):
     f = client.submit(lambda: 1)
     g = client.submit(lambda: 2)
 
-    progress(f, interval="20ms")
+    progress(f, interval="20ms", loop=client.loop)
     check_bar_completed(capsys)

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -633,21 +633,21 @@ def test_worker_actor_handle_is_weakref_from_compute_sync(client):
         assert time() < start + 30
 
 
-def test_one_thread_deadlock():
+def test_one_thread_deadlock(loop):
     class UsesCounter:
         # An actor whose method argument is another actor
 
         def do_inc(self, ac):
             return ac.increment().result()
 
-    with cluster(nworkers=1) as (cl, _), Client(cl["address"]) as client:
+    with cluster(nworkers=1) as (cl, _), Client(cl["address"], loop=loop) as client:
         ac = client.submit(Counter, actor=True).result()
         ac2 = client.submit(UsesCounter, actor=True).result()
 
         assert ac2.do_inc(ac).result() == 1
 
 
-def test_one_thread_deadlock_timeout():
+def test_one_thread_deadlock_timeout(loop):
     class UsesCounter:
         # An actor whose method argument is another actor
 
@@ -656,21 +656,21 @@ def test_one_thread_deadlock_timeout():
             # cannot expire
             return ac.increment().result(timeout=0.001)
 
-    with cluster(nworkers=1) as (cl, _), Client(cl["address"]) as client:
+    with cluster(nworkers=1) as (cl, _), Client(cl["address"], loop=loop) as client:
         ac = client.submit(Counter, actor=True).result()
         ac2 = client.submit(UsesCounter, actor=True).result()
 
         assert ac2.do_inc(ac).result() == 1
 
 
-def test_one_thread_deadlock_sync_client():
+def test_one_thread_deadlock_sync_client(loop):
     class UsesCounter:
         # An actor whose method argument is another actor
 
         def do_inc(self, ac):
             return get_client().sync(ac.increment)
 
-    with cluster(nworkers=1) as (cl, _), Client(cl["address"]) as client:
+    with cluster(nworkers=1) as (cl, _), Client(cl["address"], loop=loop) as client:
         ac = client.submit(Counter, actor=True).result()
         ac2 = client.submit(UsesCounter, actor=True).result()
 
@@ -691,7 +691,7 @@ async def test_async_deadlock(client, s, a):
     assert (await ac2.ado_inc(ac)) == 1
 
 
-def test_exception():
+def test_exception(loop):
     class MyException(Exception):
         pass
 
@@ -703,7 +703,7 @@ def test_exception():
         def prop(self):
             raise MyException
 
-    with cluster(nworkers=2) as (cl, w), Client(cl["address"]) as client:
+    with cluster(nworkers=2) as (cl, w), Client(cl["address"], loop=loop) as client:
         ac = client.submit(Broken, actor=True).result()
         acfut = ac.method()
         with pytest.raises(MyException):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1232,7 +1232,8 @@ async def test_get_releases_data(c, s, a, b):
         await asyncio.sleep(0.01)
 
 
-def test_current(s, a, b, loop):
+def test_current(s, a, b, loop_in_thread):
+    loop = loop_in_thread
     with Client(s["address"], loop=loop) as c:
         assert Client.current() is c
     with pytest.raises(
@@ -3292,7 +3293,8 @@ async def test_cancel_clears_processing(c, s, *workers):
     s.validate_state()
 
 
-def test_default_get(loop):
+def test_default_get(loop_in_thread):
+    loop = loop_in_thread
     with cluster() as (s, [a, b]):
         pre_get = dask.base.get_scheduler()
         pytest.raises(KeyError, dask.config.get, "shuffle")

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1226,18 +1226,30 @@ async def test_get_releases_data(c, s, a, b):
         await asyncio.sleep(0.01)
 
 
-def test_current(s, a, b):
-    with Client(s["address"]) as c:
+def test_current(s, a, b, loop):
+    with Client(s["address"], loop=loop) as c:
         assert Client.current() is c
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"No clients found"
+        r"\nStart a client and point it to the scheduler address"
+        r"\n  from distributed import Client"
+        r"\n  client = Client\('ip-addr-of-scheduler:8786'\)",
+    ):
         Client.current()
-    with Client(s["address"]) as c:
+    with Client(s["address"], loop=loop) as c:
         assert Client.current() is c
 
 
 def test_global_clients(loop):
     assert _get_global_client() is None
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"No clients found"
+        r"\nStart a client and point it to the scheduler address"
+        r"\n  from distributed import Client"
+        r"\n  client = Client\('ip-addr-of-scheduler:8786'\)",
+    ):
         default_client()
     with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
@@ -1893,20 +1905,18 @@ async def test_allow_restrictions(c, s, a, b):
         c.map(inc, [20], workers="127.0.0.1", allow_other_workers="Hello!")
 
 
-def test_bad_address():
+def test_bad_address(loop):
     with pytest.raises(OSError, match="connect"):
-        Client("123.123.123.123:1234", timeout=0.1)
+        Client("123.123.123.123:1234", timeout=0.1, loop=loop)
     with pytest.raises(OSError, match="connect"):
-        Client("127.0.0.1:1234", timeout=0.1)
+        Client("127.0.0.1:1234", timeout=0.1, loop=loop)
 
 
 def test_informative_error_on_cluster_type():
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(
+        TypeError, match=r"Scheduler address must be a string or a Cluster instance"
+    ):
         Client(LocalCluster)
-
-    assert "Scheduler address must be a string or a Cluster instance" in str(
-        exc_info.value
-    )
 
 
 @gen_cluster(client=True)
@@ -2861,12 +2871,12 @@ def test_startup_close_startup_sync(loop):
     with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
             sleep(0.1)
-        with Client(s["address"]) as c:
+        with Client(s["address"], loop=None) as c:
             pass
-        with Client(s["address"]) as c:
+        with Client(s["address"], loop=None) as c:
             pass
         sleep(0.1)
-        with Client(s["address"]) as c:
+        with Client(s["address"], loop=None) as c:
             pass
 
 
@@ -2928,9 +2938,11 @@ async def test_rebalance_workers_and_keys(client, s, a, b, c):
         await client.rebalance(workers=["notexist"])
 
 
-def test_rebalance_sync():
+def test_rebalance_sync(loop):
     with dask.config.set(REBALANCE_MANAGED_CONFIG):
-        with Client(n_workers=2, processes=False, dashboard_address=":0") as c:
+        with Client(
+            n_workers=2, processes=False, dashboard_address=":0", loop=loop
+        ) as c:
             s = c.cluster.scheduler
             a = c.cluster.workers[0]
             b = c.cluster.workers[1]
@@ -3274,39 +3286,39 @@ async def test_cancel_clears_processing(c, s, *workers):
     s.validate_state()
 
 
-def test_default_get():
+def test_default_get(loop):
     with cluster() as (s, [a, b]):
         pre_get = dask.base.get_scheduler()
         pytest.raises(KeyError, dask.config.get, "shuffle")
-        with Client(s["address"], set_as_default=True) as c:
+        with Client(s["address"], set_as_default=True, loop=loop) as c:
             assert dask.base.get_scheduler() == c.get
             assert dask.config.get("shuffle") == "tasks"
 
         assert dask.base.get_scheduler() == pre_get
         pytest.raises(KeyError, dask.config.get, "shuffle")
 
-        c = Client(s["address"], set_as_default=False)
+        c = Client(s["address"], set_as_default=False, loop=loop)
         assert dask.base.get_scheduler() == pre_get
         pytest.raises(KeyError, dask.config.get, "shuffle")
         c.close()
 
-        c = Client(s["address"], set_as_default=True)
+        c = Client(s["address"], set_as_default=True, loop=loop)
         assert dask.config.get("shuffle") == "tasks"
         assert dask.base.get_scheduler() == c.get
         c.close()
         assert dask.base.get_scheduler() == pre_get
         pytest.raises(KeyError, dask.config.get, "shuffle")
 
-        with Client(s["address"]) as c:
+        with Client(s["address"], loop=loop) as c:
             assert dask.base.get_scheduler() == c.get
 
-        with Client(s["address"], set_as_default=False) as c:
+        with Client(s["address"], set_as_default=False, loop=loop) as c:
             assert dask.base.get_scheduler() != c.get
         assert dask.base.get_scheduler() != c.get
 
-        with Client(s["address"], set_as_default=True) as c1:
+        with Client(s["address"], set_as_default=True, loop=loop) as c1:
             assert dask.base.get_scheduler() == c1.get
-            with Client(s["address"], set_as_default=True) as c2:
+            with Client(s["address"], set_as_default=True, loop=loop) as c2:
                 assert dask.base.get_scheduler() == c2.get
             assert dask.base.get_scheduler() == c1.get
         assert dask.base.get_scheduler() == pre_get
@@ -3831,11 +3843,11 @@ def test_scheduler_info(c):
     assert isinstance(info["started"], float)
 
 
-def test_write_scheduler_file(c):
+def test_write_scheduler_file(c, loop):
     info = c.scheduler_info()
     with tmpfile("json") as scheduler_file:
         c.write_scheduler_file(scheduler_file)
-        with Client(scheduler_file=scheduler_file) as c2:
+        with Client(scheduler_file=scheduler_file, loop=loop) as c2:
             info2 = c2.scheduler_info()
             assert c.scheduler.address == c2.scheduler.address
 
@@ -5517,7 +5529,7 @@ async def test_future_auto_inform(c, s, a, b):
     await client.close()
 
 
-def test_client_async_before_loop_starts():
+def test_client_async_before_loop_starts(cleanup):
     with pristine_loop() as loop:
         client = Client(asynchronous=True, loop=loop)
         assert client.asynchronous

--- a/distributed/tests/test_client_loop.py
+++ b/distributed/tests/test_client_loop.py
@@ -1,37 +1,46 @@
 from __future__ import annotations
 
-import pytest
+import contextlib
 
 from distributed import Client, LocalCluster
 from distributed.utils import LoopRunner
 
 
-# Test if Client stops LoopRunner on close.
-@pytest.mark.parametrize("with_own_loop", [True, False])
-def test_close_loop_sync(with_own_loop):
-    loop_runner = loop = None
-
-    # Setup simple cluster with one threaded worker.
-    # Complex setup is not required here since we test only IO loop teardown.
-    cluster_params = dict(n_workers=1, dashboard_address=":0", processes=False)
-
+@contextlib.contextmanager
+def _check_loop_runner():
     loops_before = LoopRunner._all_loops.copy()
-
-    # Start own loop or use current thread's one.
-    if with_own_loop:
-        loop_runner = LoopRunner()
-        loop_runner.start()
-        loop = loop_runner.loop
-
-    with LocalCluster(loop=loop, **cluster_params) as cluster:
-        with Client(cluster, loop=loop) as client:
-            client.run(max, 1, 2)
-
-    # own loop must be explicitly stopped.
-    if with_own_loop:
-        loop_runner.stop()
-
+    yield
     # Internal loops registry must the same as before cluster running.
     # This means loop runners in LocalCluster and Client correctly stopped.
     # See LoopRunner._stop_unlocked().
     assert loops_before == LoopRunner._all_loops
+
+
+def _check_cluster_and_client_loop(loop):
+    # Setup simple cluster with one threaded worker.
+    # Complex setup is not required here since we test only IO loop teardown.
+    with LocalCluster(
+        loop=loop, n_workers=1, dashboard_address=":0", processes=False
+    ) as cluster:
+        with Client(cluster, loop=loop) as client:
+            client.run(max, 1, 2)
+
+
+# Test if Client stops LoopRunner on close.
+def test_close_loop_sync_start_new_loop(cleanup):
+    with _check_loop_runner():
+        _check_cluster_and_client_loop(loop=None)
+
+
+# Test if Client stops LoopRunner on close.
+def test_close_loop_sync_use_running_loop(cleanup):
+    with _check_loop_runner():
+        # Start own loop or use current thread's one.
+        loop_runner = LoopRunner()
+        loop_runner.start()
+
+        try:
+            _check_cluster_and_client_loop(loop=loop_runner.loop)
+        finally:
+            # own loop must be explicitly stopped.
+            loop_runner.stop()

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -129,13 +129,13 @@ async def test_async_ctx(s, a, b):
 
 
 @pytest.mark.slow
-def test_worker_dies():
+def test_worker_dies(loop):
     with cluster(
         config={
             "distributed.scheduler.locks.lease-timeout": "0.1s",
         }
     ) as (scheduler, workers):
-        with Client(scheduler["address"]) as client:
+        with Client(scheduler["address"], loop=loop) as client:
             sem = Semaphore(name="x", max_leases=1)
 
             def f(x, sem, kill_address):
@@ -481,7 +481,7 @@ async def test_metrics(c, s, a, b):
     assert actual == expected
 
 
-def test_threadpoolworkers_pick_correct_ioloop(cleanup):
+def test_threadpoolworkers_pick_correct_ioloop(cleanup, loop):
     # gh4057
 
     # About picking appropriate values for the various timings
@@ -504,9 +504,10 @@ def test_threadpoolworkers_pick_correct_ioloop(cleanup):
         }
     ):
         with Client(
-            processes=False, dashboard_address=":0", threads_per_worker=4
+            processes=False, dashboard_address=":0", threads_per_worker=4, loop=loop
         ) as client:
-            sem = Semaphore(max_leases=1, name="database")
+            sem = Semaphore(max_leases=1, name="database", loop=None)
+            assert sem.loop is loop
             protected_resource = []
 
             def access_limited(val, sem):
@@ -520,6 +521,7 @@ def test_threadpoolworkers_pick_correct_ioloop(cleanup):
                     protected_resource.remove(val)
 
             client.gather(client.map(access_limited, range(10), sem=sem))
+            assert sem.refresh_callback.io_loop is loop
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
Refs #6163 

This allows us to make sure the tornado loop is cleaned up after interacting with LoopRunner

* avoid loop fixture in test_basic_no_loop

this test intentionally passes loop=None and currently results
in a "No running loop" deprecation warning

* split test_client_loop tests into two