### PR TITLE
Log if closing an executor is not possible in thread

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7516,6 +7516,7 @@ if __name__ == "__main__":
 """
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("processes", [True, False])
 def test_quiet_close_process(processes, tmp_path):
     with open(tmp_path / "script.py", mode="w") as f:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1556,6 +1556,11 @@ class Worker(BaseWorker, ServerNode):
             try:
                 await to_thread(_close)
             except RuntimeError:  # Are we shutting down the process?
+                logger.error(
+                    "Could not close executor %r by dispatching to thread. Trying synchronously.",
+                    executor,
+                    exc_info=True,
+                )
                 _close()  # Just run it directly
 
         self.stop()


### PR DESCRIPTION
This should only happen if the process is actually tearing down. If we hit this exception for any other reason, I would like to know
