### PR TITLE
Rewrite test_cancelled_resumed_after_flight_with_dependencies using WorkerState

### DIFF
--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -404,7 +404,7 @@ async def test_cancelled_resumed_after_flight_with_dependencies(c, s, a):
         # Wait for the scheduler to reschedule x on a.
         # We want the comms from the scheduler to reach a before b closes the RPC
         # channel, causing a.gather_dep() to raise OSError.
-        await wait_for_stimulus(a.state, ComputeTaskEvent, key="x")
+        await wait_for_stimulus(ComputeTaskEvent, a, key="x")
 
     # b closed; a.gather_dep() fails. Note that, in the current implementation, x won't
     # be recomputed on a until this happens.

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -960,7 +960,8 @@ async def test_wait_for_stimulus(c, s, a):
     assert not t2.done()
 
     x = c.submit(inc, 1, key="x")
-    await t1
+    ev = await t1
+    assert isinstance(ev, ComputeTaskEvent)
     await wait_for_stimulus(ComputeTaskEvent, a, key="x")
     await c.run(wait_for_stimulus, ComputeTaskEvent, key="x")
     assert not t2.done()

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -953,15 +953,17 @@ async def test_wait_for_state(c, s, a, capsys):
 
 @gen_cluster(client=True, nthreads=[("", 1)])
 async def test_wait_for_stimulus(c, s, a):
-    t1 = asyncio.create_task(wait_for_stimulus(a.state, ComputeTaskEvent))
-    t2 = asyncio.create_task(wait_for_stimulus(a.state, ComputeTaskEvent, key="y"))
+    t1 = asyncio.create_task(wait_for_stimulus(ComputeTaskEvent, a))
+    t2 = asyncio.create_task(wait_for_stimulus(ComputeTaskEvent, a, key="y"))
     await asyncio.sleep(0.05)
     assert not t1.done()
     assert not t2.done()
 
     x = c.submit(inc, 1, key="x")
     await t1
-    await wait_for_stimulus(a.state, ComputeTaskEvent, key="x")
+    await wait_for_stimulus(ComputeTaskEvent, a, key="x")
+    await c.run(wait_for_stimulus, ComputeTaskEvent, key="x")
     assert not t2.done()
+
     y = c.submit(inc, 1, key="y")
     await t2

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -45,9 +45,11 @@ from distributed.utils_test import (
     raises_with_cause,
     tls_only_security,
     wait_for_state,
+    wait_for_stimulus,
 )
 from distributed.worker import fail_hard
 from distributed.worker_state_machine import (
+    ComputeTaskEvent,
     InvalidTaskState,
     InvalidTransition,
     PauseEvent,
@@ -920,7 +922,7 @@ async def test_freeze_batched_send():
         assert e.count == 3
 
 
-@gen_cluster(client=True, nthreads=[("", 1)], timeout=2)
+@gen_cluster(client=True, nthreads=[("", 1)])
 async def test_wait_for_state(c, s, a, capsys):
     ev = Event()
     x = c.submit(lambda ev: ev.wait(), ev, key="x")
@@ -947,3 +949,19 @@ async def test_wait_for_state(c, s, a, capsys):
         f"tasks[x].state='memory' on {s.address}; expected state='bad_state'\n"
         f"tasks[y] not found on {s.address}\n"
     )
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_wait_for_stimulus(c, s, a):
+    t1 = asyncio.create_task(wait_for_stimulus(a.state, ComputeTaskEvent))
+    t2 = asyncio.create_task(wait_for_stimulus(a.state, ComputeTaskEvent, key="y"))
+    await asyncio.sleep(0.05)
+    assert not t1.done()
+    assert not t2.done()
+
+    x = c.submit(inc, 1, key="x")
+    await t1
+    await wait_for_stimulus(a.state, ComputeTaskEvent, key="x")
+    assert not t2.done()
+    y = c.submit(inc, 1, key="y")
+    await t2

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -307,6 +307,29 @@ def test_computetask_to_dict():
     assert ev3.priority == (0,)  # List is automatically converted back to tuple
 
 
+def test_computetask_dummy():
+    ev = ComputeTaskEvent.dummy(key="x", stimulus_id="s")
+    assert ev == ComputeTaskEvent(
+        key="x",
+        who_has={},
+        nbytes={},
+        priority=(0,),
+        duration=1.0,
+        run_spec=None,
+        resource_restrictions={},
+        actor=False,
+        annotations={},
+        stimulus_id="s",
+        function=None,
+        args=None,
+        kwargs=None,
+    )
+
+    # nbytes is generated from who_has if omitted
+    ev2 = ComputeTaskEvent.dummy(key="x", who_has={"y": "127.0.0.1:2"}, stimulus_id="s")
+    assert ev2.nbytes == {"y": 1}
+
+
 def test_updatedata_to_dict():
     """The potentially very large UpdateDataEvent.data is not stored in the log"""
     ev = UpdateDataEvent(
@@ -933,19 +956,10 @@ def test_gather_priority(ws):
             stimulus_id="compute1",
         ),
         # A higher-priority task, even if scheduled later, is fetched first
-        ComputeTaskEvent(
+        ComputeTaskEvent.dummy(
             key="z",
             who_has={"y": ["127.0.0.7:1"]},
-            nbytes={"y": 1},
             priority=(0,),
-            duration=1.0,
-            run_spec=None,
-            function=None,
-            args=None,
-            kwargs=None,
-            resource_restrictions={},
-            actor=False,
-            annotations={},
             stimulus_id="compute2",
         ),
         UnpauseEvent(stimulus_id="unpause"),

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2443,7 +2443,7 @@ async def wait_for_stimulus(
             for ev in log:
                 if not isinstance(ev, type_):
                     continue
-                if not matches or all(getattr(ev, k) == v for k, v in matches.items()):
+                if all(getattr(ev, k) == v for k, v in matches.items()):
                     return ev
         await asyncio.sleep(interval)
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2435,12 +2435,15 @@ async def wait_for_stimulus(
     **matches: Any,
 ) -> StateMachineEvent:
     """Wait for a specific stimulus to appear in the log of the WorkerState."""
+    last_ev = None
     while True:
-        for ev in ws.stimulus_log:
-            if not isinstance(ev, type_):
-                continue
-            if not matches or all(getattr(ev, k) == v for k, v in matches.items()):
-                return ev
+        if ws.stimulus_log and ws.stimulus_log[-1] is not last_ev:
+            last_ev = ws.stimulus_log[-1]
+            for ev in ws.stimulus_log:
+                if not isinstance(ev, type_):
+                    continue
+                if not matches or all(getattr(ev, k) == v for k, v in matches.items()):
+                    return ev
         await asyncio.sleep(interval)
 
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2428,18 +2428,19 @@ async def wait_for_state(
 
 
 async def wait_for_stimulus(
-    ws: WorkerState,
     type_: type[StateMachineEvent] | tuple[type[StateMachineEvent], ...],
+    dask_worker: Worker,
     *,
     interval: float = 0.01,
     **matches: Any,
 ) -> StateMachineEvent:
     """Wait for a specific stimulus to appear in the log of the WorkerState."""
+    log = dask_worker.state.stimulus_log
     last_ev = None
     while True:
-        if ws.stimulus_log and ws.stimulus_log[-1] is not last_ev:
-            last_ev = ws.stimulus_log[-1]
-            for ev in ws.stimulus_log:
+        if log and log[-1] is not last_ev:
+            last_ev = log[-1]
+            for ev in log:
                 if not isinstance(ev, type_):
                     continue
                 if not matches or all(getattr(ev, k) == v for k, v in matches.items()):

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -73,7 +73,7 @@ from distributed.utils import (
     sync,
 )
 from distributed.worker import WORKER_ANY_RUNNING, Worker
-from distributed.worker_state_machine import InvalidTransition
+from distributed.worker_state_machine import InvalidTransition, StateMachineEvent
 from distributed.worker_state_machine import TaskState as WorkerTaskState
 from distributed.worker_state_machine import WorkerState
 
@@ -2400,6 +2400,9 @@ def freeze_batched_send(bcomm: BatchedSend) -> Iterator[LockedComm]:
 async def wait_for_state(
     key: str, state: str, dask_worker: Worker | Scheduler, *, interval: float = 0.01
 ) -> None:
+    """Wait for a task to appear on a Worker or on the Scheduler and to be in a specific
+    state.
+    """
     if isinstance(dask_worker, Worker):
         tasks = dask_worker.state.tasks
     elif isinstance(dask_worker, Scheduler):
@@ -2422,6 +2425,23 @@ async def wait_for_state(
         # message as an exception wouldn't work.
         print(msg)
         raise
+
+
+async def wait_for_stimulus(
+    ws: WorkerState,
+    type_: type[StateMachineEvent] | tuple[type[StateMachineEvent], ...],
+    *,
+    interval: float = 0.01,
+    **matches: Any,
+) -> StateMachineEvent:
+    """Wait for a specific stimulus to appear in the log of the WorkerState."""
+    while True:
+        for ev in ws.stimulus_log:
+            if not isinstance(ev, type_):
+                continue
+            if not matches or all(getattr(ev, k) == v for k, v in matches.items()):
+                return ev
+        await asyncio.sleep(interval)
 
 
 @pytest.fixture

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -694,6 +694,38 @@ class ComputeTaskEvent(StateMachineEvent):
     def _after_from_dict(self) -> None:
         self.run_spec = SerializedTask(task=None, function=None, args=None, kwargs=None)
 
+    @staticmethod
+    def dummy(
+        *,
+        key: str,
+        who_has: dict[str, Collection[str]] | None = None,
+        nbytes: dict[str, int] | None = None,
+        priority: tuple[int, ...] = (0,),
+        duration: float = 1.0,
+        resource_restrictions: dict[str, float] | None = None,
+        actor: bool = False,
+        annotations: dict | None = None,
+        stimulus_id: str,
+    ) -> ComputeTaskEvent:
+        """Build a dummy event, with most attributes set to a reasonable default.
+        This is a convenience method to be used in unit testing only.
+        """
+        return ComputeTaskEvent(
+            key=key,
+            who_has=who_has or {},
+            nbytes=nbytes or {k: 1 for k in who_has or ()},
+            priority=priority,
+            duration=duration,
+            run_spec=None,
+            function=None,
+            args=None,
+            kwargs=None,
+            resource_restrictions=resource_restrictions or {},
+            actor=actor,
+            annotations=annotations or {},
+            stimulus_id=stimulus_id,
+        )
+
 
 @dataclass
 class ExecuteSuccessEvent(StateMachineEvent):


### PR DESCRIPTION
This makes the test unperturbed by details around worker retirement.
Blocks #6633.

@fjetter I would like your opinion - do you think this is a good use of our new tool, or do you think it lessens the test as we're not testing a substantial amount of scheduler-side behaviour any more?