### PR TITLE
Log the actual duration to create a directory

### DIFF
--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -552,7 +552,16 @@ def test_warn_on_duration():
             sleep(0.100)
 
     assert record
-    assert any("foo" in str(rec.message) for rec in record)
+
+    with pytest.warns(UserWarning) as record:
+        with warn_on_duration("1ms", "{duration:.4f}"):
+            start = time()
+            sleep(0.100)
+            measured = time() - start
+
+    assert record
+    assert len(record) == 1
+    assert float(str(record[0].message)) >= float(str(f"{measured:.4f}"))
 
 
 def test_logs():

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -24,6 +24,7 @@ from collections.abc import Callable, Collection, Container, KeysView, ValuesVie
 from concurrent.futures import CancelledError, ThreadPoolExecutor  # noqa: F401
 from contextlib import contextmanager, suppress
 from contextvars import ContextVar
+from datetime import timedelta
 from functools import wraps
 from hashlib import md5
 from importlib.util import cache_from_source
@@ -32,7 +33,7 @@ from time import sleep
 from types import ModuleType
 from typing import TYPE_CHECKING
 from typing import Any as AnyType
-from typing import ClassVar, TypeVar, overload
+from typing import ClassVar, Iterator, TypeVar, overload
 
 import click
 import tblib.pickling_support
@@ -1253,12 +1254,19 @@ def iscoroutinefunction(f):
 
 
 @contextmanager
-def warn_on_duration(duration, msg):
+def warn_on_duration(duration: str | float | timedelta, msg: str) -> Iterator[None]:
+    """Generate a UserWarning if the operation in this context takes longer than
+    *duration* and print *msg*
+
+    The message may include a format string `{duration}` which will be formatted
+    to include the actual duration it took
+    """
     start = time()
     yield
     stop = time()
-    if stop - start > _parse_timedelta(duration):
-        warnings.warn(msg, stacklevel=2)
+    diff = stop - start
+    if diff > _parse_timedelta(duration):
+        warnings.warn(msg.format(duration=diff), stacklevel=2)
 
 
 def format_dashboard_link(host, port):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -574,7 +574,7 @@ class Worker(BaseWorker, ServerNode):
 
         with warn_on_duration(
             "1s",
-            "Creating scratch directories is taking a surprisingly long time. "
+            "Creating scratch directories is taking a surprisingly long time. ({duration:.2f}s) "
             "This is often due to running workers on a network file system. "
             "Consider specifying a local-directory to point workers to write "
             "scratch data to a local disk.",


### PR DESCRIPTION
We see this log message quite frequently on CI lately. I think having the actual duration included in the warning can be helpful to understand e.g. if a worker startup times out exclusively due to slow disk