### PR TITLE
utils: has_arg returns True for keyword-only arguments

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -578,6 +578,15 @@ async def test_run_dask_worker(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_run_dask_worker_kwonlyarg(c, s, a, b):
+    def f(*, dask_worker=None):
+        return dask_worker.id
+
+    response = await c._run(f)
+    assert response == {a.address: a.id, b.address: b.id}
+
+
+@gen_cluster(client=True)
 async def test_run_coroutine_dask_worker(c, s, a, b):
     async def f(dask_worker=None):
         await asyncio.sleep(0.001)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -125,7 +125,8 @@ def has_arg(func, argname):
     """
     while True:
         try:
-            if argname in inspect.getfullargspec(func).args:
+            argspec = inspect.getfullargspec(func)
+            if argname in set(argspec.args) | set(argspec.kwonlyargs):
                 return True
         except TypeError:
             break


### PR DESCRIPTION
When using keyword-only arguments, has_arg would previously return
False when presented with:

    def foo(*, bar=None):
        pass

    has_arg(foo, "bar")

This made composition of functions sent to workers via client.run
using functools.partial rather fragile. For example

    def foo(a, dask_worker=None):
        return dask_worker.id

    client.run(partial(foo, 1))   # works
    client.run(partial(foo, a=1)) # fails

In the latter case, the partially applied function has a signature
where dask_worker is a keyword-only argument, in the former it is a
positional argument.

Remove this source of confusion by checking the union of positional
and keyword-only arguments.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
