### PR TITLE
close_worker cleanup

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5970,8 +5970,16 @@ class Scheduler(SchedulerState, ServerNode):
             worker.
         remove: bool (defaults to True)
             Whether or not to remove the worker metadata immediately or else
-            wait for the worker to contact us. If close_workers=False and remove=False,
-            this method just makes sure
+            wait for the worker to contact us.
+
+            If close_workers=False and remove=False, this method just flushes the tasks
+            in memory out of the workers and then returns.
+            If close_workers=True and remove=False, this method will return while the
+            workers are still in the cluster, although they won't accept new tasks.
+            If close_workers=False or for whatever reason a worker doesn't accept the
+            close command, it will be left permanently unable to accept new tasks and
+            it is expected to be closed in some other way.
+
         **kwargs: dict
             Extra options to pass to workers_to_close to determine which
             workers we should drop

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3439,19 +3439,6 @@ class Scheduler(SchedulerState, ServerNode):
         setproctitle("dask-scheduler [closed]")
         disable_gc_diagnosis()
 
-    @log_errors
-    async def close_worker(self, worker: str, stimulus_id: str, safe: bool = False):
-        """Remove a worker from the cluster
-
-        This both removes the worker from our local state and also sends a
-        signal to the worker to shut down.  This works regardless of whether or
-        not the worker has a nanny process restarting it
-        """
-        logger.info("Closing worker %s", worker)
-        self.log_event(worker, {"action": "close-worker"})
-        self.worker_send(worker, {"op": "close"})  # TODO redundant with `remove_worker`
-        await self.remove_worker(address=worker, safe=safe, stimulus_id=stimulus_id)
-
     ###########
     # Stimuli #
     ###########
@@ -4170,16 +4157,38 @@ class Scheduler(SchedulerState, ServerNode):
 
         return tuple(seen)
 
+    def close_worker(self, worker: str) -> None:
+        """Ask a worker to shut itself down. Do not wait for it to take effect.
+        Note that there is no guarantee that the worker will actually accept the
+        command.
+
+        Note that :meth:`remove_worker` sends the same command internally if close=True.
+
+        See also
+        --------
+        retire_workers
+        remove_worker
+        """
+        if worker not in self.workers:
+            return
+
+        logger.info("Closing worker %s", worker)
+        self.log_event(worker, {"action": "close-worker"})
+        self.worker_send(worker, {"op": "close"})
+
     @log_errors
     async def remove_worker(
         self, address: str, *, stimulus_id: str, safe: bool = False, close: bool = True
     ) -> Literal["OK", "already-removed"]:
-        """
-        Remove worker from cluster
+        """Remove worker from cluster.
 
-        We do this when a worker reports that it plans to leave or when it
-        appears to be unresponsive.  This may send its tasks back to a released
-        state.
+        We do this when a worker reports that it plans to leave or when it appears to be
+        unresponsive. This may send its tasks back to a released state.
+
+        See also
+        --------
+        retire_workers
+        close_worker
         """
         if self.status == Status.closed:
             return "already-removed"
@@ -5935,16 +5944,16 @@ class Scheduler(SchedulerState, ServerNode):
     @log_errors
     async def retire_workers(
         self,
-        comm=None,
+        workers: list[str] | None = None,
         *,
-        workers: "list[str] | None" = None,
-        names: "list | None" = None,
+        names: list | None = None,
         close_workers: bool = False,
         remove: bool = True,
         stimulus_id: str | None = None,
-        **kwargs,
-    ) -> dict:
-        """Gracefully retire workers from cluster
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Gracefully retire workers from cluster. Any key that is in memory exclusively
+        on the retired workers is replicated somewhere else.
 
         Parameters
         ----------
@@ -5961,7 +5970,8 @@ class Scheduler(SchedulerState, ServerNode):
             worker.
         remove: bool (defaults to True)
             Whether or not to remove the worker metadata immediately or else
-            wait for the worker to contact us
+            wait for the worker to contact us. If close_workers=False and remove=False,
+            this method just makes sure
         **kwargs: dict
             Extra options to pass to workers_to_close to determine which
             workers we should drop
@@ -5970,6 +5980,11 @@ class Scheduler(SchedulerState, ServerNode):
         -------
         Dictionary mapping worker ID/address to dictionary of information about
         that worker for each retired worker.
+
+        If there are keys that exist in memory only on the workers being retired and it
+        was impossible to replicate them somewhere else (e.g. because there aren't
+        any other running workers), the workers holding such keys won't be retired and
+        won't appear in the returned dict.
 
         See Also
         --------
@@ -6040,7 +6055,7 @@ class Scheduler(SchedulerState, ServerNode):
                             ws,
                             policy,
                             prev_status=prev_status,
-                            close_workers=close_workers,
+                            close=close_workers,
                             remove=remove,
                             stimulus_id=stimulus_id,
                         )
@@ -6067,7 +6082,7 @@ class Scheduler(SchedulerState, ServerNode):
         ws: WorkerState,
         policy: RetireWorker,
         prev_status: Status,
-        close_workers: bool,
+        close: bool,
         remove: bool,
         stimulus_id: str,
     ) -> tuple:  # tuple[str | None, dict]
@@ -6094,14 +6109,12 @@ class Scheduler(SchedulerState, ServerNode):
             "All unique keys on worker %s have been replicated elsewhere", ws.address
         )
 
-        if close_workers and ws.address in self.workers:
-            await self.close_worker(
-                worker=ws.address, safe=True, stimulus_id=stimulus_id
-            )
         if remove:
             await self.remove_worker(
-                address=ws.address, safe=True, stimulus_id=stimulus_id
+                ws.address, safe=True, close=close, stimulus_id=stimulus_id
             )
+        elif close:
+            self.close_worker(ws.address)
 
         logger.info("Retired worker %s", ws.address)
         return ws.address, ws.identity()

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -156,7 +156,7 @@ async def test_flight_to_executing_via_cancelled_resumed(c, s, b):
         await block_compute.acquire()
 
         # Close in scheduler to ensure we transition and reschedule task properly
-        await s.close_worker(worker=a.address, stimulus_id="test")
+        await s.remove_worker(a.address, stimulus_id="test")
         await wait_for_state(fut1.key, "resumed", b)
 
         block_get_data.release()


### PR DESCRIPTION
Closes #6643

Note: this technically breaks public API. However I felt that a deprecation cycle should be overkill as this is pretty obscure functionality that 99% of the users should not even know of.