### PR TITLE
Replace occurences of large delay slowinc with locks

### DIFF
--- a/distributed/diagnostics/memory_sampler.py
+++ b/distributed/diagnostics/memory_sampler.py
@@ -151,7 +151,8 @@ class MemorySampler:
             # Forward-fill NaNs in the middle of a series created either by overlapping
             # sampling time range or by align=True. Do not ffill series beyond their
             # last sample.
-            df = df.ffill().where(~pd.isna(df.bfill()))
+            # FIXME https://github.com/pandas-dev/pandas-stubs/issues/44
+            df = df.ffill().where(~pd.isna(df.bfill()))  # type: ignore
 
         return df
 

--- a/distributed/diagnostics/memory_sampler.py
+++ b/distributed/diagnostics/memory_sampler.py
@@ -151,8 +151,7 @@ class MemorySampler:
             # Forward-fill NaNs in the middle of a series created either by overlapping
             # sampling time range or by align=True. Do not ffill series beyond their
             # last sample.
-            # FIXME https://github.com/pandas-dev/pandas-stubs/issues/44
-            df = df.ffill().where(~pd.isna(df.bfill()))  # type: ignore
+            df = df.ffill().where(~pd.isna(df.bfill()))
 
         return df
 

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -15,42 +15,45 @@ from tornado.httpclient import AsyncHTTPClient, HTTPClientError
 import dask.config
 from dask.sizeof import sizeof
 
+from distributed import Lock
 from distributed.utils import is_valid_xml
-from distributed.utils_test import gen_cluster, inc, slowinc
+from distributed.utils_test import gen_cluster, inc, lock_inc, slowinc
 
 DEFAULT_ROUTES = dask.config.get("distributed.scheduler.http.routes")
 
 
 @gen_cluster(client=True)
 async def test_connect(c, s, a, b):
-    future = c.submit(lambda x: x + 1, 1)
-    x = c.submit(slowinc, 1, delay=1, retries=5)
-    await future
-    http_client = AsyncHTTPClient()
-    for suffix in [
-        "info/main/workers.html",
-        "info/worker/" + url_escape(a.address) + ".html",
-        "info/task/" + url_escape(future.key) + ".html",
-        "info/main/logs.html",
-        "info/logs/" + url_escape(a.address) + ".html",
-        "info/call-stack/" + url_escape(x.key) + ".html",
-        "info/call-stacks/" + url_escape(a.address) + ".html",
-        "json/counts.json",
-        "json/identity.json",
-        "json/index.html",
-        "individual-plots.json",
-        "sitemap.json",
-    ]:
-        response = await http_client.fetch(
-            "http://localhost:%d/%s" % (s.http_server.port, suffix)
-        )
-        assert response.code == 200
-        body = response.body.decode()
-        if suffix.endswith(".json"):
-            json.loads(body)
-        else:
-            assert is_valid_xml(body)
-            assert not re.search("href=./", body)  # no absolute links
+    lock = Lock()
+    async with lock:
+        future = c.submit(lambda x: x + 1, 1)
+        x = c.submit(lock_inc, 1, lock=lock, retries=5)
+        await future
+        http_client = AsyncHTTPClient()
+        for suffix in [
+            "info/main/workers.html",
+            "info/worker/" + url_escape(a.address) + ".html",
+            "info/task/" + url_escape(future.key) + ".html",
+            "info/main/logs.html",
+            "info/logs/" + url_escape(a.address) + ".html",
+            "info/call-stack/" + url_escape(x.key) + ".html",
+            "info/call-stacks/" + url_escape(a.address) + ".html",
+            "json/counts.json",
+            "json/identity.json",
+            "json/index.html",
+            "individual-plots.json",
+            "sitemap.json",
+        ]:
+            response = await http_client.fetch(
+                "http://localhost:%d/%s" % (s.http_server.port, suffix)
+            )
+            assert response.code == 200
+            body = response.body.decode()
+            if suffix.endswith(".json"):
+                json.loads(body)
+            else:
+                assert is_valid_xml(body)
+                assert not re.search("href=./", body)  # no absolute links
 
 
 @gen_cluster(client=True, nthreads=[])

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -531,7 +531,6 @@ async def test_drop_with_paused_workers_with_running_tasks_3_4(c, s, a, b, pause
     assert {ws.address for ws in s.tasks["x"].who_has} == {a.address}
 
 
-# @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[("", 1)] * 3, config=demo_config("drop"))
 async def test_drop_with_paused_workers_with_running_tasks_5(c, s, w1, w2, w3):
     """If there is exactly 1 worker that holds a replica of a task that isn't paused or

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4434,7 +4434,7 @@ async def test_auto_normalize_collection(c, s, a, b):
     assert len(x.dask) == 2
 
     with dask.config.set(optimizations=[c._optimize_insert_futures]):
-        y = x.map_blocks(slowinc, delay=1, dtype=x.dtype)
+        y = x.map_blocks(inc, dtype=x.dtype)
         yy = c.persist(y)
 
         await wait(yy)
@@ -4457,7 +4457,7 @@ def test_auto_normalize_collection_sync(c):
     da = pytest.importorskip("dask.array")
     x = da.ones(10, chunks=5)
 
-    y = x.map_blocks(slowinc, delay=1, dtype=x.dtype)
+    y = x.map_blocks(inc, dtype=x.dtype)
     yy = c.persist(y)
 
     wait(yy)

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -9,9 +9,9 @@ import dask
 from dask import delayed
 from dask.utils import stringify
 
-from distributed import Worker
+from distributed import Lock, Worker
 from distributed.client import wait
-from distributed.utils_test import gen_cluster, inc, slowadd, slowinc
+from distributed.utils_test import gen_cluster, inc, lock_inc, slowadd, slowinc
 
 
 @gen_cluster(
@@ -274,10 +274,11 @@ async def test_set_resources(c, s, a):
     assert a.total_resources["A"] == 2
     assert a.state.available_resources["A"] == 2
     assert s.workers[a.address].resources == {"A": 2}
-
-    future = c.submit(slowinc, 1, delay=1, resources={"A": 1})
-    while a.state.available_resources["A"] == 2:
-        await asyncio.sleep(0.01)
+    lock = Lock()
+    async with lock:
+        future = c.submit(lock_inc, 1, lock=lock, resources={"A": 1})
+        while a.state.available_resources["A"] == 2:
+            await asyncio.sleep(0.01)
 
     await a.set_resources(A=3)
     assert a.total_resources["A"] == 3

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -352,6 +352,11 @@ def slowidentity(*args, **kwargs):
         return args
 
 
+def lock_inc(x, lock):
+    with lock:
+        return x + 1
+
+
 class _UnhashableCallable:
     # FIXME https://github.com/python/mypy/issues/4266
     __hash__ = None  # type: ignore


### PR DESCRIPTION
This replaces all occurrences of slowinc with a delay >=1s with appropriate lock calls or with plain `inc`. This makes these tests more deterministic and gives us a couple of seconds of improved runtime