### PR TITLE
Use a tempdir path by default instead of cwd for the worker scratch dir

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -5,6 +5,7 @@ import errno
 import logging
 import os
 import shutil
+import tempfile
 import threading
 import uuid
 import warnings
@@ -108,7 +109,6 @@ class Nanny(ServerNode):
         worker_port: int | str | Collection[int] | None = 0,
         nthreads=None,
         loop=None,
-        local_dir=None,
         local_directory=None,
         services=None,
         name=None,
@@ -152,12 +152,10 @@ class Nanny(ServerNode):
         assert isinstance(self.security, Security)
         self.connection_args = self.security.get_connection_args("worker")
 
-        if local_dir is not None:
-            warnings.warn("The local_dir keyword has moved to local_directory")
-            local_directory = local_dir
-
         if local_directory is None:
-            local_directory = dask.config.get("temporary-directory") or os.getcwd()
+            local_directory = (
+                dask.config.get("temporary-directory") or tempfile.gettempdir()
+            )
             self._original_local_dir = local_directory
             local_directory = os.path.join(local_directory, "dask-worker-space")
         else:
@@ -306,12 +304,6 @@ class Nanny(ServerNode):
     @property
     def worker_dir(self):
         return None if self.process is None else self.process.worker_dir
-
-    @property
-    def local_dir(self):
-        """For API compatibility with Nanny"""
-        warnings.warn("The local_dir attribute has moved to local_directory")
-        return self.local_directory
 
     async def start_unsafe(self):
         """Start nanny, start local process, start watching"""

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -10,6 +10,7 @@ import os
 import pathlib
 import random
 import sys
+import tempfile
 import threading
 import warnings
 import weakref
@@ -568,7 +569,9 @@ class Worker(BaseWorker, ServerNode):
             local_directory = local_dir
 
         if not local_directory:
-            local_directory = dask.config.get("temporary-directory") or os.getcwd()
+            local_directory = (
+                dask.config.get("temporary-directory") or tempfile.gettempdir()
+            )
 
         os.makedirs(local_directory, exist_ok=True)
         local_directory = os.path.join(local_directory, "dask-worker-space")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -440,7 +440,6 @@ class Worker(BaseWorker, ServerNode):
         scheduler_file: str | None = None,
         nthreads: int | None = None,
         loop: IOLoop | None = None,  # Deprecated
-        local_dir: None = None,  # Deprecated, use local_directory instead
         local_directory: str | None = None,
         services: dict | None = None,
         name: Any | None = None,
@@ -560,12 +559,6 @@ class Worker(BaseWorker, ServerNode):
         assert profile_cycle_interval
 
         self._setup_logging(logger, wsm_logger)
-
-        if local_dir is not None:
-            warnings.warn(  # type: ignore[unreachable]
-                "The local_dir keyword has moved to local_directory"
-            )
-            local_directory = local_dir
 
         if not local_directory:
             local_directory = (

--- a/docs/source/worker-memory.rst
+++ b/docs/source/worker-memory.rst
@@ -22,7 +22,8 @@ types like NumPy arrays and Pandas dataframes. The sum of the ``sizeof`` of all 
 tracked by Dask is called :ref:`managed memory <memtypes>`.
 
 When the managed memory exceeds 60% of the memory limit (*target threshold*), the worker
-will begin to dump the least recently used data to disk. You can control this location
+will begin to dump the least recently used data to disk. By default, it writes to the
+OS's temporary directory (``/tmp`` in Linux); you can control this location
 with the ``--local-directory`` keyword::
 
    $ dask-worker tcp://scheduler:port --memory-limit="4 GiB" --local-directory /scratch


### PR DESCRIPTION
No point in spamming CWD. If people actually want this for debugging purposes they can provide this as an option but I assume most cases will want to use proper tmpdirs

relates to https://github.com/dask/distributed/issues/6649