### PR TITLE
Improve import time - lazy imports for fsspec and urllib3

### DIFF
--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -12,7 +12,6 @@ from types import ModuleType
 from typing import TYPE_CHECKING, cast
 
 import click
-import urllib3
 
 from dask.utils import tmpfile
 
@@ -130,6 +129,9 @@ def _import_module(name: str, file_dir: str | None = None) -> ModuleType:
 def _download_module(url: str) -> ModuleType:
     logger.info("Downloading preload at %s", url)
     assert is_webaddress(url)
+    # This is the only place where urrllib3 is used and it is a relatively heavy
+    # import. Do lazy import to reduce import time
+    import urllib3
 
     with urllib3.PoolManager() as http:
         response = http.request(


### PR DESCRIPTION
After https://github.com/dask/dask/pull/9230 I had a quick look at what is making distributed import slow. 

On my machine, import time after https://github.com/dask/dask/pull/9230 is about 340ms

Delaying these two imports reduces this to about 240ms, i.e. by about 30%

After this change the biggest offenders are

| | |
| ---- | --- |
| tlz | 18% |
| numpy | 16% |
| [_register_transports](https://github.com/dask/distributed/blob/0df863643260dd64f2e89f8236d5d56b3614da4c/distributed/comm/__init__.py#L19-L48) | 12% |
| widget  stuff (distributed.widgets) | 8% |
| Jinja | 6% |
| Config loading | 5.4% |

We may be able to somehow reduce the impact of _register_transports but I think everything else is not really worth bothering with since if we made these imports lazy (if even possible), as soon as we did anything with the library, we'd hit by this penalty.

cluster_dump is a debugging utility module and preload is not necessarily used by everyone so I consider delaying these two modules beneficial