### PR TITLE
Merge `extend-ignore` and `ignore` values for `flake8`

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -134,7 +134,8 @@ def init_once():
     try:
         import rmm
 
-        device_array = lambda n: rmm.DeviceBuffer(size=n)
+        def device_array(n):
+            return rmm.DeviceBuffer(size=n)
 
         if pool_size_str is not None:
             pool_size = parse_bytes(pool_size_str)

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -48,6 +48,7 @@ from bokeh.palettes import Viridis11
 from bokeh.plotting import figure
 from bokeh.themes import Theme
 from bokeh.transform import cumsum, factor_cmap, linear_cmap, stack
+from jinja2 import Environment, FileSystemLoader
 from tlz import curry, pipe, valmap
 from tlz.curried import concat, groupby, map
 from tornado import escape
@@ -88,8 +89,6 @@ else:
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
-
-from jinja2 import Environment, FileSystemLoader
 
 env = Environment(
     loader=FileSystemLoader(

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -19,6 +19,7 @@ from bokeh.models.widgets import DataTable, TableColumn
 from bokeh.palettes import RdBu
 from bokeh.plotting import figure
 from bokeh.themes import Theme
+from jinja2 import Environment, FileSystemLoader
 from tlz import merge, partition_all
 
 from dask.utils import format_bytes, format_time
@@ -35,9 +36,6 @@ from distributed.metrics import time
 from distributed.utils import log_errors
 
 logger = logging.getLogger(__name__)
-
-from jinja2 import Environment, FileSystemLoader
-
 env = Environment(
     loader=FileSystemLoader(
         os.path.join(os.path.dirname(__file__), "..", "..", "http", "templates")

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -25,7 +25,10 @@ def serialize_numpy_ndarray(x, context=None):
     if x.dtype.hasobject or (x.dtype.flags & np.core.multiarray.LIST_PICKLE):
         header = {"pickle": True}
         frames = [None]
-        buffer_callback = lambda f: frames.append(memoryview(f))
+
+        def buffer_callback(f):
+            frames.append(memoryview(f))
+
         frames[0] = pickle.dumps(
             x,
             buffer_callback=buffer_callback,

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -582,7 +582,9 @@ def test_dumps_task():
     d = dumps_task((inc, 1))
     assert set(d) == {"function", "args"}
 
-    f = lambda x, y=2: x + y
+    def f(x, y=2):
+        return x + y
+
     d = dumps_task((apply, f, (1,), {"y": 10}))
     assert cloudpickle.loads(d["function"])(1, 2) == 3
     assert cloudpickle.loads(d["args"]) == (1,)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+from docutils.parsers.rst import directives
+
+# -- Configuration to keep autosummary in sync with autoclass::members ----------------------------------------------
+# Fixes issues/3693
+# See https://stackoverflow.com/questions/20569011/python-sphinx-autosummary-automated-listing-of-member-functions
+from sphinx.ext.autosummary import Autosummary, get_documenter
+from sphinx.util.inspect import safe_getattr
+
+import distributed
+
 #
 # Dask.distributed documentation build configuration file, created by
 # sphinx-quickstart on Tue Oct  6 14:42:44 2015.
@@ -65,7 +75,6 @@ author = "Anaconda, Inc."
 # built documents.
 #
 # The short X.Y version.
-import distributed
 
 version = distributed.__version__
 # The full version, including alpha/beta/rc tags.
@@ -426,15 +435,6 @@ def copy_legacy_redirects(app, docname):
             target_path = app.outdir + "/" + html_src_path
             with open(target_path, "w") as f:
                 f.write(page)
-
-
-from docutils.parsers.rst import directives
-
-# -- Configuration to keep autosummary in sync with autoclass::members ----------------------------------------------
-# Fixes issues/3693
-# See https://stackoverflow.com/questions/20569011/python-sphinx-autosummary-automated-listing-of-member-functions
-from sphinx.ext.autosummary import Autosummary, get_documenter
-from sphinx.util.inspect import safe_getattr
 
 
 class AutoAutoSummary(Autosummary):

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,12 +5,13 @@
 
 # Note: there cannot be spaces after commas here
 exclude = __init__.py,versioneer.py,distributed/_concurrent_futures_thread.py
-extend-ignore =
+ignore =
+    E402, # Module level import not at top of file
     # Ignores below are aligned with black https://github.com/psf/black/blob/main/.flake8
-    E203,       # Whitespace before ':'
-    E266,       # Too many leading '#' for block comment
-    E501,       # Line too long (82 > 79 characters)
-
+    E203, # Whitespace before ':'
+    E266, # Too many leading '#' for block comment
+    E501, # Line too long
+    W503, # Line break occurred before a binary operator
 per-file-ignores =
     **/tests/*:
         # local variable is assigned to but never used

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,14 +3,16 @@
 # https://flake8.readthedocs.io/en/latest/user/configuration.html
 # https://flake8.readthedocs.io/en/latest/user/error-codes.html
 
-# Aligned with black https://github.com/psf/black/blob/main/.flake8
-extend-ignore = E203, E266, E501
 # Note: there cannot be spaces after commas here
 exclude = __init__.py,versioneer.py,distributed/_concurrent_futures_thread.py
 ignore =
     E4,         # Import formatting
     E731,       # Assigning lambda expression
     W503,       # line break before binary operator
+    # Ignores below are aligned with black https://github.com/psf/black/blob/main/.flake8
+    E203,       # Whitespace before ':'
+    E266,       # Too many leading '#' for block comment
+    E501,       # Line too long (82 > 79 characters)
 
 per-file-ignores =
     **/tests/*:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@
 # Note: there cannot be spaces after commas here
 exclude = __init__.py,versioneer.py,distributed/_concurrent_futures_thread.py
 ignore =
-    E402, # Module level import not at top of file
     # Ignores below are aligned with black https://github.com/psf/black/blob/main/.flake8
     E203, # Whitespace before ':'
     E266, # Too many leading '#' for block comment
@@ -14,10 +13,12 @@ ignore =
     W503, # Line break occurred before a binary operator
 per-file-ignores =
     **/tests/*:
-        # local variable is assigned to but never used
-        F841,
-        # Ambiguous variable name
+        # Module level import not at top of file (to silence on pytest.importorskip)
+        E402,
+        # Do not use variables named 'I', 'O', or 'l'
         E741,
+        # Local variable name is assigned to but never used
+        F841,
 
 max-line-length = 88
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,10 +5,7 @@
 
 # Note: there cannot be spaces after commas here
 exclude = __init__.py,versioneer.py,distributed/_concurrent_futures_thread.py
-ignore =
-    E4,         # Import formatting
-    E731,       # Assigning lambda expression
-    W503,       # line break before binary operator
+extend-ignore =
     # Ignores below are aligned with black https://github.com/psf/black/blob/main/.flake8
     E203,       # Whitespace before ':'
     E266,       # Too many leading '#' for block comment

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,8 @@ ignore =
     W503, # Line break occurred before a binary operator
 per-file-ignores =
     **/tests/*:
-        # Module level import not at top of file (to silence on pytest.importorskip)
+        # Module level import not at top of file (to silence on pytest.importorskip) 
+        # See https://github.com/PyCQA/pycodestyle/issues/472
         E402,
         # Do not use variables named 'I', 'O', or 'l'
         E741,


### PR DESCRIPTION
Merges `ignore` and `extend-ignore` config options for `flake8`, as `extend-ignore` makes little sense when `ignore` is also configured and therefore overriding defaults.

This PR
* aligns `ignore` list with `black` `v.4.0.1`
* ignores `E402` in tests to silence errors on `pytest.importorskip` (see https://github.com/PyCQA/pycodestyle/issues/472) 
* fixes any other `flake8` issues resulting in the changes

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
