### PR TITLE
Ensure tests do not leave signalhandlers

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2478,22 +2478,10 @@ def requires_default_ports(name_of_test):
     yield
 
 
-_default_signals = None
-
-
-def _set_default_signals():
-    global _default_signals
-    default_signals = {}
-    for sig in signal.Signals:
-        try:
-            default_signals[sig] = signal.getsignal(sig)
-        except ValueError:
-            break
+_default_signals = {sig: signal.getsignal(sig) for sig in signal.valid_signals()}
 
 
 def assert_default_signal_handlers():
-    if not _default_signals:
-        _set_default_signals()
     assert _default_signals
     for sig, default_handler in _default_signals.items():
         assert (

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2480,10 +2480,16 @@ def requires_default_ports(name_of_test):
 
 _default_signals = {sig: signal.getsignal(sig) for sig in signal.valid_signals()}
 
+_allowed_overrides = {
+    signal.SIGSTOP,  # pytest-timeout
+}
+
 
 def assert_default_signal_handlers():
     assert _default_signals
     for sig, default_handler in _default_signals.items():
+        if sig in _allowed_overrides:
+            continue
         assert (
             signal.getsignal(sig) is default_handler
         ), f"Non-default handler installed for signal {sig}: {signal.getsignal(sig)}"


### PR DESCRIPTION
Before https://github.com/dask/distributed/pull/6205 CLI tests would install non-default signal handlers without removing them again by using the deprecated `install_signal_handlers`.
This was only possible for CLI tests that did not spawn a dedicated subprocess by using the Click `CLIRunner`, e.g. [`test_idle_timeout`](https://github.com/dask/distributed/blob/c11c8ee43cc13709056a600545972995e8162c73/distributed/cli/tests/test_dask_scheduler.py#L413-L419)

With #6205 this was removed by introducing a task that is running `wait_for_signals` and is listening to signals that would restore the original signal handlers again.

This autouse fixture ensure that we are guaranteed to not leave any dangling signal handlers and are using the default ones. If not, we'll see this as an error in the test suite instead of a spurious, unrelated test failure

cc @graingert @hendrikmakait @crusaderky 