### PR TITLE
Pin tornado to <6.2

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -38,7 +38,7 @@ dependencies:
   - sortedcollections
   - tblib
   - toolz
-  - tornado
+  - tornado<6.2
   - zict  # overridden by git tip below
   - zstandard >=0.9.0
   - pip:

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -40,7 +40,7 @@ dependencies:
   - sortedcollections
   - tblib
   - toolz
-  - tornado
+  - tornado<6.2
   - zict
   - zstandard >=0.9.0
   - pip:

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -44,7 +44,7 @@ dependencies:
   - tblib
   - toolz
   - torchvision  # Only tested here
-  - tornado
+  - tornado<6.2
   - zict
   - zstandard >=0.9.0
   - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1
 tblib >= 1.6.0
 toolz >= 0.8.2
-tornado >= 6.0.3
+tornado >= 6.0.3, <6.2
 urllib3
 zict >= 0.1.3
 pyyaml


### PR DESCRIPTION
Tornado 6.2 was just released and we're hitting a few issues on CI.

This pins the library until we can resolve the problems