### PR TITLE
unconditionally import ssl

### DIFF
--- a/distributed/comm/asyncio_tcp.py
+++ b/distributed/comm/asyncio_tcp.py
@@ -5,16 +5,12 @@ import collections
 import logging
 import os
 import socket
+import ssl
 import struct
 import sys
 import weakref
 from itertools import islice
 from typing import Any
-
-try:
-    import ssl
-except ImportError:
-    ssl = None  # type: ignore
 
 import dask
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -136,7 +136,7 @@ def convert_stream_closed_error(obj, exc):
     if exc.real_error is not None:
         # The stream was closed because of an underlying OS error
         exc = exc.real_error
-        if ssl and isinstance(exc, ssl.SSLError):
+        if isinstance(exc, ssl.SSLError):
             if "UNKNOWN_CA" in exc.reason:
                 raise FatalCommClosedError(f"in {obj}: {exc.__class__.__name__}: {exc}")
         raise CommClosedError(f"in {obj}: {exc.__class__.__name__}: {exc}") from exc

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -6,21 +6,15 @@ import errno
 import functools
 import logging
 import socket
+import ssl
 import struct
 import sys
 import weakref
 from ssl import SSLCertVerificationError, SSLError
 from typing import Any, ClassVar
 
-from tornado import gen
-
-try:
-    import ssl
-except ImportError:
-    ssl = None  # type: ignore
-
 from tlz import sliding_window
-from tornado import netutil
+from tornado import gen, netutil
 from tornado.iostream import IOStream, StreamClosedError
 from tornado.tcpclient import TCPClient
 from tornado.tcpserver import TCPServer

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import ssl
 import warnings
 import weakref
 from contextlib import suppress
@@ -131,8 +132,6 @@ class ServerNode(Server):
         tls_cert = dask.config.get("distributed.scheduler.dashboard.tls.cert")
         tls_ca_file = dask.config.get("distributed.scheduler.dashboard.tls.ca-file")
         if tls_cert:
-            import ssl
-
             ssl_options = ssl.create_default_context(
                 cafile=tls_ca_file, purpose=ssl.Purpose.CLIENT_AUTH
             )

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -2,19 +2,10 @@ from __future__ import annotations
 
 import datetime
 import os
+import ssl
 import sys
 import tempfile
 import warnings
-
-try:
-    import ssl
-except ImportError:
-    ssl = None  # type: ignore
-
-try:
-    from ssl import OPENSSL_VERSION_INFO as _OPENSSL_VERSION_INFO
-except ImportError:
-    _OPENSSL_VERSION_INFO = (0, 0, 0, 0, 0)
 
 import dask
 from dask.widgets import get_template
@@ -22,7 +13,7 @@ from dask.widgets import get_template
 __all__ = ("Security",)
 
 
-if sys.version_info >= (3, 10) or _OPENSSL_VERSION_INFO >= (1, 1, 0, 7):
+if sys.version_info >= (3, 10) or ssl.OPENSSL_VERSION_INFO >= (1, 1, 0, 7):
     # The OP_NO_SSL* and OP_NO_TLS* become deprecated in favor of
     # 'SSLContext.minimum_version' from Python 3.7 onwards, however
     # this attribute is not available unless the ssl module is compiled
@@ -121,7 +112,7 @@ class Security:
     )
 
     def __init__(self, require_encryption=None, **kwargs):
-        if _OPENSSL_VERSION_INFO < (1, 1, 1):
+        if ssl.OPENSSL_VERSION_INFO < (1, 1, 1):
             warnings.warn(
                 f"support for {ssl.OPENSSL_VERSION} is deprecated,"
                 " and will be removed in a future release",

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
+import ssl
 from contextlib import contextmanager
-
-try:
-    import ssl
-except ImportError:
-    ssl = None  # type: ignore
 
 import pytest
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -16,6 +16,7 @@ import os
 import re
 import signal
 import socket
+import ssl
 import subprocess
 import sys
 import tempfile
@@ -76,11 +77,6 @@ from distributed.worker import WORKER_ANY_RUNNING, Worker
 from distributed.worker_state_machine import InvalidTransition, StateMachineEvent
 from distributed.worker_state_machine import TaskState as WorkerTaskState
 from distributed.worker_state_machine import WorkerState
-
-try:
-    import ssl
-except ImportError:
-    ssl = None  # type: ignore
 
 try:
     import dask.array  # register config


### PR DESCRIPTION
tornado imports ssl unconditionally since v6.0.0b1 [tornadoweb/tornado@`e1d24ac` (#2443)](https://github.com/tornadoweb/tornado/pull/2443/commits/e1d24ac6f03e28aa66789c49bc7e917990e7a9bb)

originally introduced in https://github.com/dask/distributed/pull/1570

and this is already unsupported due to an unconditional import in distributed.comm.ws:

```
 graingert@superjacent  ~/projects/distributed   main  python
Python 3.10.4 | packaged by conda-forge | (main, Mar 24 2022, 17:38:57) [GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.modules["ssl"] = None
>>> import distributed
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/graingert/projects/distributed/distributed/__init__.py", line 15, in <module>
    from distributed.actor import Actor, ActorFuture, BaseActorFuture
  File "/home/graingert/projects/distributed/distributed/actor.py", line 14, in <module>
    from distributed.client import Future
  File "/home/graingert/projects/distributed/distributed/client.py", line 54, in <module>
    from distributed import cluster_dump, preloading
  File "/home/graingert/projects/distributed/distributed/preloading.py", line 19, in <module>
    from distributed.core import Server
  File "/home/graingert/projects/distributed/distributed/core.py", line 28, in <module>
    from distributed.comm import (
  File "/home/graingert/projects/distributed/distributed/comm/__init__.py", line 48, in <module>
    _register_transports()
  File "/home/graingert/projects/distributed/distributed/comm/__init__.py", line 22, in _register_transports
    from distributed.comm import inproc, ws
  File "/home/graingert/projects/distributed/distributed/comm/ws.py", line 9, in <module>
    from ssl import SSLError
ModuleNotFoundError: import of ssl halted; None in sys.modules
>>> 
```

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
