### PR TITLE
Pin tornado<6.2 on conda recipes

### DIFF
--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - sortedcontainers !=2.0.0,!=2.0.1
     - tblib >=1.6.0
     - toolz >=0.8.2
-    - tornado >=6.0.3
+    - tornado >=6.0.3,<6.2
     - urllib3
     - zict >=0.1.3
   run_constrained:


### PR DESCRIPTION
https://github.com/dask/distributed/pull/6668 missed pinning tornado on conda recipes, nightly builds still pick tornado 6.2. This PR adds the missing pin.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
