### PR TITLE
deprecate passing stopped loops to LoopRunner (and therefore Client/Cluster)

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -122,9 +122,9 @@ class Actor(WrappedKey):
     @property
     def _io_loop(self):
         if self._worker:
-            return self._worker.io_loop
+            return self._worker.loop
         else:
-            return self._client.io_loop
+            return self._client.loop
 
     @property
     def _scheduler_rpc(self):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1366,8 +1366,10 @@ class Client(SyncMethodMixin):
     def __del__(self):
         # If the loop never got assigned, we failed early in the constructor,
         # nothing to do
-        if hasattr(self, "loop"):
-            self.close()
+        if getattr(self, "status", "newly-created") in ["closed", "newly-created"]:
+            return
+
+        self.close()
 
     def _inc_ref(self, key):
         with self._refcount_lock:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -872,7 +872,6 @@ class Client(SyncMethodMixin):
 
         self._asynchronous = asynchronous
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
-        self.io_loop = self.loop = self._loop_runner.loop
         self._connecting_to_scheduler = False
 
         self._gather_keys = None
@@ -943,6 +942,17 @@ class Client(SyncMethodMixin):
         from distributed.recreate_tasks import ReplayTaskClient
 
         ReplayTaskClient(self)
+
+    @property
+    def io_loop(self):
+        warnings.warn(
+            "The io_loop property is deprecated", DeprecationWarning, stacklevel=2
+        )
+        return self._loop_runner.loop
+
+    @property
+    def loop(self):
+        return self._loop_runner.loop
 
     @contextmanager
     def as_current(self):

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -66,7 +66,6 @@ class Cluster(SyncMethodMixin):
         scheduler_sync_interval=1,
     ):
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
-        self.loop = self._loop_runner.loop
 
         self.scheduler_info = {"workers": {}}
         self.periodic_callbacks = {}
@@ -91,6 +90,10 @@ class Cluster(SyncMethodMixin):
             **type(self)._cluster_info,
         }
         self.status = Status.created
+
+    @property
+    def loop(self):
+        return self._loop_runner.loop
 
     @property
     def name(self):

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -670,7 +670,7 @@ async def run_spec(spec: dict[str, Any], *args: Any) -> dict[str, Worker | Nanny
 @atexit.register
 def close_clusters():
     for cluster in list(SpecCluster._instances):
-        if cluster.shutdown_on_close:
+        if getattr(cluster, "shutdown_on_close", False):
             with suppress(gen.TimeoutError, TimeoutError):
-                if cluster.status != Status.closed:
+                if getattr(cluster, "status", Status.closed) != Status.closed:
                     cluster.close(timeout=10)

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -289,6 +289,7 @@ async def test_no_more_workers_than_tasks():
                 assert len(cluster.scheduler.workers) <= 1
 
 
+@pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
 def test_basic_no_loop(cleanup):
     loop = None
     try:

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from tornado.ioloop import IOLoop
 
 from distributed.deploy.cluster import Cluster
 from distributed.utils_test import gen_test
@@ -48,3 +49,19 @@ async def test_cluster_info(loop_in_thread):
     assert "foo" in cluster._cluster_info  # exists before start() called
     with cluster:  # start and stop the cluster to avoid a resource warning
         pass
+
+
+@gen_test()
+async def test_deprecated_loop_properties():
+    class ExampleCluster(Cluster):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.loop = self.io_loop = IOLoop.current()
+
+    with pytest.warns(DeprecationWarning) as warninfo:
+        async with ExampleCluster(asynchronous=True, loop=IOLoop.current()):
+            pass
+
+    assert [(w.category, *w.message.args) for w in warninfo] == [
+        (DeprecationWarning, "setting the loop property is deprecated")
+    ]

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -82,6 +82,7 @@ def test_spec_sync(loop):
             assert result == 11
 
 
+@pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
 def test_loop_started_in_constructor(cleanup):
     # test that SpecCluster.__init__ starts a loop in another thread
     cluster = SpecCluster(worker_spec, scheduler=scheduler, loop=None)

--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import html
 import logging
 import sys
+import warnings
 import weakref
 from contextlib import suppress
 from timeit import default_timer
@@ -111,6 +112,8 @@ class ProgressBar:
 
 
 class TextProgressBar(ProgressBar):
+    __loop: IOLoop | None = None
+
     def __init__(
         self,
         keys,
@@ -122,13 +125,30 @@ class TextProgressBar(ProgressBar):
         start=True,
         **kwargs,
     ):
+        self._loop_runner = loop_runner = LoopRunner(loop=loop)
         super().__init__(keys, scheduler, interval, complete)
         self.width = width
-        self.loop = loop or IOLoop()
 
         if start:
-            loop_runner = LoopRunner(self.loop)
             loop_runner.run_sync(self.listen)
+
+    @property
+    def loop(self) -> IOLoop | None:
+        loop = self.__loop
+        if loop is None:
+            # If the loop is not running when this is called, the LoopRunner.loop
+            # property will raise a DeprecationWarning
+            # However subsequent calls might occur - eg atexit, where a stopped
+            # loop is still acceptable - so we cache access to the loop.
+            self.__loop = loop = self._loop_runner.loop
+        return loop
+
+    @loop.setter
+    def loop(self, value: IOLoop) -> None:
+        warnings.warn(
+            "setting the loop property is deprecated", DeprecationWarning, stacklevel=2
+        )
+        self.__loop = value
 
     def _draw_bar(self, remaining, all, **kwargs):
         frac = (1 - remaining / all) if all else 1.0

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -377,7 +377,7 @@ class Semaphore(SyncMethodMixin):
         except ValueError:
             client = get_client()
             self.scheduler = scheduler_rpc or client.scheduler
-            self.loop = loop or client.io_loop
+            self.loop = loop or client.loop
 
         self.name = name or "semaphore-" + uuid.uuid4().hex
         self.max_leases = max_leases

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5543,7 +5543,11 @@ def test_client_async_before_loop_starts(cleanup):
             pass
 
     with pristine_loop() as loop:
-        client = Client(asynchronous=True, loop=loop)
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"Constructing LoopRunner\(loop=loop\) without a running loop is deprecated",
+        ):
+            client = Client(asynchronous=True, loop=loop)
         assert client.asynchronous
         assert isinstance(client.close(), NoOpAwaitable)
         loop.run_sync(close)  # TODO: client.close() does not unset global client

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2874,6 +2874,7 @@ async def test_startup_close_startup(s, a, b):
     await c.close()
 
 
+@pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
 def test_startup_close_startup_sync(loop):
     with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
@@ -5537,6 +5538,7 @@ async def test_future_auto_inform(c, s, a, b):
     await client.close()
 
 
+@pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
 def test_client_async_before_loop_starts(cleanup):
     async def close():
         async with client:
@@ -6846,6 +6848,7 @@ async def test_workers_collection_restriction(c, s, a, b):
     assert a.data and not b.data
 
 
+@pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 async def test_get_client_functions_spawn_clusters(c, s, a):
     # see gh4565

--- a/distributed/tests/test_client_loop.py
+++ b/distributed/tests/test_client_loop.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import contextlib
 
+import pytest
+
 from distributed import Client, LocalCluster
 from distributed.utils import LoopRunner
 
@@ -27,12 +29,14 @@ def _check_cluster_and_client_loop(loop):
 
 
 # Test if Client stops LoopRunner on close.
+@pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
 def test_close_loop_sync_start_new_loop(cleanup):
     with _check_loop_runner():
         _check_cluster_and_client_loop(loop=None)
 
 
 # Test if Client stops LoopRunner on close.
+@pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
 def test_close_loop_sync_use_running_loop(cleanup):
     with _check_loop_runner():
         # Start own loop or use current thread's one.

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -387,25 +387,47 @@ def assert_not_running(loop):
             q.get(timeout=0.02)
 
 
+_loop_not_running_property_warning = functools.partial(
+    pytest.warns,
+    DeprecationWarning,
+    match=r"Accessing the loop property while the loop is not running is deprecated",
+)
+_explicit_loop_is_not_running_warning = functools.partial(
+    pytest.warns,
+    DeprecationWarning,
+    match=r"Constructing LoopRunner\(loop=loop\) without a running loop is deprecated",
+)
+_implicit_loop_is_not_running_warning = functools.partial(
+    pytest.warns,
+    DeprecationWarning,
+    match=r"Constructing a LoopRunner\(asynchronous=True\) without a running loop is deprecated",
+)
+
+
 def test_loop_runner(loop_in_thread):
     # Implicit loop
     loop = IOLoop()
     loop.make_current()
     runner = LoopRunner()
-    assert runner.loop not in (loop, loop_in_thread)
+    with _loop_not_running_property_warning():
+        assert runner.loop not in (loop, loop_in_thread)
     assert not runner.is_started()
-    assert_not_running(runner.loop)
+    with _loop_not_running_property_warning():
+        assert_not_running(runner.loop)
     runner.start()
     assert runner.is_started()
     assert_running(runner.loop)
     runner.stop()
     assert not runner.is_started()
-    assert_not_running(runner.loop)
+    with _loop_not_running_property_warning():
+        assert_not_running(runner.loop)
 
     # Explicit loop
     loop = IOLoop()
-    runner = LoopRunner(loop=loop)
-    assert runner.loop is loop
+    with _explicit_loop_is_not_running_warning():
+        runner = LoopRunner(loop=loop)
+    with _loop_not_running_property_warning():
+        assert runner.loop is loop
     assert not runner.is_started()
     assert_not_running(loop)
     runner.start()
@@ -429,29 +451,39 @@ def test_loop_runner(loop_in_thread):
     # Implicit loop, asynchronous=True
     loop = IOLoop()
     loop.make_current()
-    runner = LoopRunner(asynchronous=True)
-    assert runner.loop is loop
+    with _implicit_loop_is_not_running_warning():
+        runner = LoopRunner(asynchronous=True)
+    with _loop_not_running_property_warning():
+        assert runner.loop is loop
     assert not runner.is_started()
-    assert_not_running(runner.loop)
+    with _loop_not_running_property_warning():
+        assert_not_running(runner.loop)
     runner.start()
     assert runner.is_started()
-    assert_not_running(runner.loop)
+    with _loop_not_running_property_warning():
+        assert_not_running(runner.loop)
     runner.stop()
     assert not runner.is_started()
-    assert_not_running(runner.loop)
+    with _loop_not_running_property_warning():
+        assert_not_running(runner.loop)
 
     # Explicit loop, asynchronous=True
     loop = IOLoop()
-    runner = LoopRunner(loop=loop, asynchronous=True)
-    assert runner.loop is loop
+    with _explicit_loop_is_not_running_warning():
+        runner = LoopRunner(loop=loop, asynchronous=True)
+    with _loop_not_running_property_warning():
+        assert runner.loop is loop
     assert not runner.is_started()
-    assert_not_running(runner.loop)
+    with _loop_not_running_property_warning():
+        assert_not_running(runner.loop)
     runner.start()
     assert runner.is_started()
-    assert_not_running(runner.loop)
+    with _loop_not_running_property_warning():
+        assert_not_running(runner.loop)
     runner.stop()
     assert not runner.is_started()
-    assert_not_running(runner.loop)
+    with _loop_not_running_property_warning():
+        assert_not_running(runner.loop)
 
 
 def test_two_loop_runners(loop_in_thread):
@@ -459,8 +491,10 @@ def test_two_loop_runners(loop_in_thread):
 
     # ABCCBA
     loop = IOLoop()
-    a = LoopRunner(loop=loop)
-    b = LoopRunner(loop=loop)
+    with _explicit_loop_is_not_running_warning():
+        a = LoopRunner(loop=loop)
+    with _explicit_loop_is_not_running_warning():
+        b = LoopRunner(loop=loop)
     assert_not_running(loop)
     a.start()
     assert_running(loop)
@@ -478,8 +512,10 @@ def test_two_loop_runners(loop_in_thread):
 
     # ABCABC
     loop = IOLoop()
-    a = LoopRunner(loop=loop)
-    b = LoopRunner(loop=loop)
+    with _explicit_loop_is_not_running_warning():
+        a = LoopRunner(loop=loop)
+    with _explicit_loop_is_not_running_warning():
+        b = LoopRunner(loop=loop)
     assert_not_running(loop)
     a.start()
     assert_running(loop)

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -404,6 +404,7 @@ _implicit_loop_is_not_running_warning = functools.partial(
 )
 
 
+@pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
 def test_loop_runner(loop_in_thread):
     # Implicit loop
     loop = IOLoop()
@@ -486,6 +487,7 @@ def test_loop_runner(loop_in_thread):
         assert_not_running(runner.loop)
 
 
+@pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
 def test_two_loop_runners(loop_in_thread):
     # Loop runners tied to the same loop should cooperate
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -433,12 +433,26 @@ class LoopRunner:
     def __init__(self, loop=None, asynchronous=False):
         if loop is None:
             if asynchronous:
+                try:
+                    asyncio.get_running_loop()
+                except RuntimeError:
+                    warnings.warn(
+                        "Constructing a LoopRunner(asynchronous=True) without a running loop is deprecated",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
                 self._loop = IOLoop.current()
             else:
                 # We're expecting the loop to run in another thread,
                 # avoid re-using this thread's assigned loop
                 self._loop = IOLoop()
         else:
+            if not loop.asyncio_loop.is_running():
+                warnings.warn(
+                    "Constructing LoopRunner(loop=loop) without a running loop is deprecated",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             self._loop = loop
         self._asynchronous = asynchronous
         self._loop_thread = None
@@ -569,6 +583,13 @@ class LoopRunner:
 
     @property
     def loop(self):
+        loop = self._loop
+        if not loop.asyncio_loop.is_running():
+            warnings.warn(
+                "Accessing the loop property while the loop is not running is deprecated",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self._loop
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ addopts =
 filterwarnings =
     error
     ignore:Please use `dok_matrix` from the `scipy\.sparse` namespace, the `scipy\.sparse\.dok` namespace is deprecated.:DeprecationWarning
-    ignore:There is no current event loop:DeprecationWarning
     ignore:elementwise comparison failed. this will raise an error in the future:DeprecationWarning
     ignore:unclosed <socket\.socket.*:ResourceWarning
     ignore:unclosed context <zmq\.asyncio\.Context\(\).*:ResourceWarning


### PR DESCRIPTION
Refs #6163

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
