### PR TITLE
Fix dump output of parameter-less events

### DIFF
--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -247,7 +247,10 @@ def test_merge_recs_instructions():
         merge_recs_instructions(({x: "memory"}, []), ({x: "released"}, []))
 
 
-def test_event_to_dict():
+def test_event_to_dict_with_annotations():
+    """Test recursive_to_dict(ev), where ev is a subclass of StateMachineEvent that
+    defines its own annotations
+    """
     ev = RescheduleEvent(stimulus_id="test", key="x")
     ev2 = ev.to_loggable(handled=11.22)
     assert ev2 == ev
@@ -257,6 +260,23 @@ def test_event_to_dict():
         "stimulus_id": "test",
         "handled": 11.22,
         "key": "x",
+    }
+    ev3 = StateMachineEvent.from_dict(d)
+    assert ev3 == ev
+
+
+def test_event_to_dict_without_annotations():
+    """Test recursive_to_dict(ev), where ev is a subclass of StateMachineEvent that
+    does not define its own annotations
+    """
+    ev = PauseEvent(stimulus_id="test")
+    ev2 = ev.to_loggable(handled=11.22)
+    assert ev2 == ev
+    d = recursive_to_dict(ev2)
+    assert d == {
+        "cls": "PauseEvent",
+        "stimulus_id": "test",
+        "handled": 11.22,
     }
     ev3 = StateMachineEvent.from_dict(d)
     assert ev3 == ev

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -523,7 +523,14 @@ class StateMachineEvent:
             "stimulus_id": self.stimulus_id,
             "handled": self.handled,
         }
-        info.update({k: getattr(self, k) for k in self.__annotations__})
+        info.update(
+            {
+                k: getattr(self, k)
+                for k in self.__annotations__
+                # Necessary for subclasses that don't define their own annotations
+                if k != "_classes"
+            }
+        )
         info = {k: v for k, v in info.items() if k not in exclude}
         return recursive_to_dict(info, exclude=exclude)
 


### PR DESCRIPTION
Fix glitch in cluster dump:

```yaml
stimulus_log:
    - _classes:
        AcquireReplicasEvent: <class 'distributed.worker_state_machine.AcquireReplicasEvent'>
        AlreadyCancelledEvent: <class 'distributed.worker_state_machine.AlreadyCancelledEvent'>
        CancelComputeEvent: <class 'distributed.worker_state_machine.CancelComputeEvent'>
        ComputeTaskEvent: <class 'distributed.worker_state_machine.ComputeTaskEvent'>
        ExecuteFailureEvent: <class 'distributed.worker_state_machine.ExecuteFailureEvent'>
        ExecuteSuccessEvent: <class 'distributed.worker_state_machine.ExecuteSuccessEvent'>
        FindMissingEvent: <class 'distributed.worker_state_machine.FindMissingEvent'>
        FreeKeysEvent: <class 'distributed.worker_state_machine.FreeKeysEvent'>
        GatherDepBusyEvent: <class 'distributed.worker_state_machine.GatherDepBusyEvent'>
        GatherDepDoneEvent: <class 'distributed.worker_state_machine.GatherDepDoneEvent'>
        GatherDepFailureEvent: <class 'distributed.worker_state_machine.GatherDepFailureEvent'>
        GatherDepNetworkFailureEvent: <class 'distributed.worker_state_machine.GatherDepNetworkFailureEvent'>
        GatherDepSuccessEvent: <class 'distributed.worker_state_machine.GatherDepSuccessEvent'>
        PauseEvent: <class 'distributed.worker_state_machine.PauseEvent'>
        RefreshWhoHasEvent: <class 'distributed.worker_state_machine.RefreshWhoHasEvent'>
        RemoveReplicasEvent: <class 'distributed.worker_state_machine.RemoveReplicasEvent'>
        RescheduleEvent: <class 'distributed.worker_state_machine.RescheduleEvent'>
        RetryBusyWorkerEvent: <class 'distributed.worker_state_machine.RetryBusyWorkerEvent'>
        SecedeEvent: <class 'distributed.worker_state_machine.SecedeEvent'>
        StealRequestEvent: <class 'distributed.worker_state_machine.StealRequestEvent'>
        UnpauseEvent: <class 'distributed.worker_state_machine.UnpauseEvent'>
        UpdateDataEvent: <class 'distributed.worker_state_machine.UpdateDataEvent'>
      cls: PauseEvent
      handled: 1657280902.9988787
      stimulus_id: worker-status-change-1657280902.9988606
```