### PR TITLE
Pickle worker state machine exceptions

### DIFF
--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -34,6 +34,8 @@ from distributed.worker_state_machine import (
     GatherDep,
     GatherDepSuccessEvent,
     Instruction,
+    InvalidTaskState,
+    InvalidTransition,
     PauseEvent,
     RecommendationsConflict,
     RefreshWhoHasEvent,
@@ -44,6 +46,7 @@ from distributed.worker_state_machine import (
     SerializedTask,
     StateMachineEvent,
     TaskState,
+    TransitionCounterMaxExceeded,
     UnpauseEvent,
     UpdateDataEvent,
     merge_recs_instructions,
@@ -192,6 +195,32 @@ def test_WorkerState_pickle(ws):
     ws2 = pickle.loads(pickle.dumps(ws))
     assert ws2.tasks.keys() == {"x", "y"}
     assert ws2.data == {"y": 123}
+
+
+@pytest.mark.parametrize(
+    "cls,kwargs",
+    [
+        (
+            InvalidTransition,
+            dict(key="x", start="released", finish="waiting", story=[]),
+        ),
+        (
+            TransitionCounterMaxExceeded,
+            dict(key="x", start="released", finish="waiting", story=[]),
+        ),
+        (InvalidTaskState, dict(key="x", state="released", story=[])),
+    ],
+)
+@pytest.mark.parametrize("positional", [False, True])
+def test_pickle_exceptions(cls, kwargs, positional):
+    if positional:
+        e = cls(*kwargs.values())
+    else:
+        e = cls(**kwargs)
+    e2 = pickle.loads(pickle.dumps(e))
+    assert type(e2) is type(e)
+    for k, v in kwargs.items():
+        assert getattr(e2, k) == v
 
 
 def traverse_subclasses(cls: type) -> Iterator[type]:

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -130,6 +130,9 @@ class InvalidTransition(Exception):
         self.finish = finish
         self.story = story
 
+    def __reduce__(self) -> tuple[Callable, tuple]:
+        return type(self), (self.key, self.start, self.finish, self.story)
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}: {self.key} :: {self.start}->{self.finish}"
@@ -168,6 +171,9 @@ class InvalidTaskState(Exception):
         self.key = key
         self.state = state
         self.story = story
+
+    def __reduce__(self) -> tuple[Callable, tuple]:
+        return type(self), (self.key, self.state, self.story)
 
     def __repr__(self) -> str:
         return (
@@ -2415,7 +2421,10 @@ class WorkerState:
                 # final
                 ts.state,
                 # new recommendations
-                {ts.key: new for ts, new in recs.items()},
+                {
+                    ts.key: new[0] if isinstance(new, tuple) else new
+                    for ts, new in recs.items()
+                },
                 stimulus_id,
                 time(),
             )


### PR DESCRIPTION
Fix error when `@fail_hard` is triggered:
```
*** TypeError: __init__() missing 3 required positional arguments: 'key', 'state', and 'story'
```

Also prevent the full value or exception of a task to enter the transition log. Note that, as of this PR, this is purely hypothetical - no transitions actually return `{ts: ("memory", value)}, []` _yet_.