### PR TITLE
Failure to spill breaks available resources

### DIFF
--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -606,11 +606,10 @@ def test_workerstate_executing_skips_fetch_on_success(ws_with_running_task):
         ComputeTaskEvent.dummy("y", who_has={"x": [ws2]}, stimulus_id="s2"),
         ExecuteSuccessEvent.dummy("x", 123, stimulus_id="s3"),
     )
-    assert len(instructions) == 2
-    assert isinstance(instructions[0], TaskFinishedMsg)
-    assert instructions[0].key == "x"
-    assert instructions[0].stimulus_id == "s3"
-    assert instructions[1] == Execute(key="y", stimulus_id="s3")
+    assert instructions == [
+        TaskFinishedMsg.match(key="x", stimulus_id="s3"),
+        Execute(key="y", stimulus_id="s3"),
+    ]
     assert ws.tasks["x"].state == "memory"
     assert ws.data["x"] == 123
 
@@ -662,12 +661,10 @@ def test_workerstate_flight_skips_executing_on_success(ws):
             worker=ws2, total_nbytes=1, data={"x": 123}, stimulus_id="s4"
         ),
     )
-    assert len(instructions) == 2
-    assert instructions[0] == GatherDep(
-        worker=ws2, to_gather={"x"}, total_nbytes=1, stimulus_id="s1"
-    )
-    assert isinstance(instructions[1], TaskFinishedMsg)
-    assert instructions[1].stimulus_id == "s4"
+    assert instructions == [
+        GatherDep(worker=ws2, to_gather={"x"}, total_nbytes=1, stimulus_id="s1"),
+        TaskFinishedMsg.match(key="x", stimulus_id="s4"),
+    ]
     assert ws.tasks["x"].state == "memory"
     assert ws.data["x"] == 123
 

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -109,7 +109,12 @@ async def test_fail_to_pickle_execute_1(c, s, a, b):
     larger than target. The data is lost and the task is marked as failed; the worker
     remains in usable condition.
 
-    See also test_workerstate_fail_to_pickle_1
+    See also
+    --------
+    test_workerstate_fail_to_pickle_execute_1
+    test_workerstate_fail_to_pickle_flight
+    test_fail_to_pickle_execute_2
+    test_fail_to_pickle_spill
     """
     x = c.submit(FailToPickle, reported_size=100e9, key="x")
     await wait(x)
@@ -128,8 +133,14 @@ class FailStoreDict(UserDict):
 
 
 def test_workerstate_fail_to_pickle_execute_1(ws_with_running_task):
-    """Same as test_fail_to_pickle_target_execute_1, but testing the WorkerState in
-    isolation.
+    """Same as test_fail_to_pickle_target_execute_1
+
+    See also
+    --------
+    test_fail_to_pickle_execute_1
+    test_workerstate_fail_to_pickle_flight
+    test_fail_to_pickle_execute_2
+    test_fail_to_pickle_spill
     """
     ws = ws_with_running_task
     assert not ws.data
@@ -147,6 +158,13 @@ def test_workerstate_fail_to_pickle_flight(ws):
     """Same as test_workerstate_fail_to_pickle_execute_1, but the task was
     computed on another host and for whatever reason it did not fail to pickle when it
     was sent over the network.
+
+    See also
+    --------
+    test_fail_to_pickle_execute_1
+    test_workerstate_fail_to_pickle_execute_1
+    test_fail_to_pickle_execute_2
+    test_fail_to_pickle_spill
 
     See also test_worker_state_machine.py::test_gather_dep_failure, where the task
     instead fails to unpickle when leaving the network stack.
@@ -187,6 +205,13 @@ async def test_fail_to_pickle_execute_2(c, s, a):
     """Test failure to spill triggered by computing a key which is individually smaller
     than target, so it is not spilled immediately. The data is retained and the task is
     NOT marked as failed; the worker remains in usable condition.
+
+    See also
+    --------
+    test_fail_to_pickle_execute_1
+    test_workerstate_fail_to_pickle_execute_1
+    test_workerstate_fail_to_pickle_flight
+    test_fail_to_pickle_spill
     """
     x = c.submit(FailToPickle, reported_size=256, key="x")
     await wait(x)
@@ -217,7 +242,15 @@ async def test_fail_to_pickle_execute_2(c, s, a):
     },
 )
 async def test_fail_to_pickle_spill(c, s, a):
-    """Test failure to evict a key, triggered by the spill threshold"""
+    """Test failure to evict a key, triggered by the spill threshold.
+
+    See also
+    --------
+    test_fail_to_pickle_execute_1
+    test_workerstate_fail_to_pickle_execute_1
+    test_workerstate_fail_to_pickle_flight
+    test_fail_to_pickle_execute_2
+    """
     a.monitor.get_process_memory = lambda: 701 if a.data.fast else 0
 
     with captured_logger(logging.getLogger("distributed.spill")) as logs:

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -22,6 +22,13 @@ from distributed.metrics import monotonic
 from distributed.spill import has_zict_210
 from distributed.utils_test import captured_logger, gen_cluster, inc
 from distributed.worker_memory import parse_memory_limit
+from distributed.worker_state_machine import (
+    ComputeTaskEvent,
+    ExecuteSuccessEvent,
+    GatherDep,
+    GatherDepSuccessEvent,
+    TaskErredMsg,
+)
 
 requires_zict_210 = pytest.mark.skipif(
     not has_zict_210,
@@ -97,10 +104,12 @@ async def assert_basic_futures(c: Client) -> None:
 
 
 @gen_cluster(client=True)
-async def test_fail_to_pickle_target_1(c, s, a, b):
-    """Test failure to serialize triggered by key which is individually larger
-    than target. The data is lost and the task is marked as failed;
-    the worker remains in usable condition.
+async def test_fail_to_pickle_execute_1(c, s, a, b):
+    """Test failure to serialize triggered by computing a key which is individually
+    larger than target. The data is lost and the task is marked as failed; the worker
+    remains in usable condition.
+
+    See also test_workerstate_fail_to_pickle_1
     """
     x = c.submit(FailToPickle, reported_size=100e9, key="x")
     await wait(x)
@@ -113,6 +122,57 @@ async def test_fail_to_pickle_target_1(c, s, a, b):
     await assert_basic_futures(c)
 
 
+class FailStoreDict(UserDict):
+    def __setitem__(self, key, value):
+        raise CustomError()
+
+
+def test_workerstate_fail_to_pickle_execute_1(ws_with_running_task):
+    """Same as test_fail_to_pickle_target_execute_1, but testing the WorkerState in
+    isolation.
+    """
+    ws = ws_with_running_task
+    assert not ws.data
+    ws.data = FailStoreDict()
+
+    instructions = ws.handle_stimulus(
+        ExecuteSuccessEvent.dummy("x", None, stimulus_id="s1")
+    )
+    assert instructions == [TaskErredMsg.match(key="x", stimulus_id="s1")]
+    assert ws.tasks["x"].state == "error"
+
+
+@pytest.mark.xfail(reason="https://github.com/dask/distributed/issues/6705")
+def test_workerstate_fail_to_pickle_flight(ws):
+    """Same as test_workerstate_fail_to_pickle_execute_1, but the task was
+    computed on another host and for whatever reason it did not fail to pickle when it
+    was sent over the network.
+
+    See also test_worker_state_machine.py::test_gather_dep_failure, where the task
+    instead fails to unpickle when leaving the network stack.
+    """
+    assert not ws.data
+    ws.data = FailStoreDict()
+    ws.total_resources = {"R": 1}
+    ws.available_resources = {"R": 1}
+    ws2 = "127.0.0.1:2"
+
+    instructions = ws.handle_stimulus(
+        ComputeTaskEvent.dummy(
+            "y", who_has={"x": [ws2]}, resource_restrictions={"R": 1}, stimulus_id="s1"
+        ),
+        GatherDepSuccessEvent(
+            worker=ws2, total_nbytes=1, data={"x": 123}, stimulus_id="s2"
+        ),
+    )
+    assert instructions == [
+        GatherDep(worker=ws2, to_gather={"x"}, total_nbytes=1, stimulus_id="s1"),
+        TaskErredMsg.match(key="x", stimulus_id="s2"),
+    ]
+    assert ws.tasks["x"].state == "error"
+    assert ws.tasks["y"].state == "waiting"  # Not constrained
+
+
 @gen_cluster(
     client=True,
     nthreads=[("", 1)],
@@ -123,10 +183,10 @@ async def test_fail_to_pickle_target_1(c, s, a, b):
         "distributed.worker.memory.pause": False,
     },
 )
-async def test_fail_to_pickle_target_2(c, s, a):
-    """Test failure to spill triggered by key which is individually smaller
-    than target, so it is not spilled immediately. The data is retained and
-    the task is NOT marked as failed; the worker remains in usable condition.
+async def test_fail_to_pickle_execute_2(c, s, a):
+    """Test failure to spill triggered by computing a key which is individually smaller
+    than target, so it is not spilled immediately. The data is retained and the task is
+    NOT marked as failed; the worker remains in usable condition.
     """
     x = c.submit(FailToPickle, reported_size=256, key="x")
     await wait(x)

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -32,6 +32,7 @@ from distributed.worker_state_machine import (
     ExecuteSuccessEvent,
     FreeKeysEvent,
     GatherDep,
+    GatherDepFailureEvent,
     GatherDepSuccessEvent,
     Instruction,
     PauseEvent,
@@ -43,6 +44,7 @@ from distributed.worker_state_machine import (
     SecedeEvent,
     SerializedTask,
     StateMachineEvent,
+    TaskErredMsg,
     TaskState,
     UnpauseEvent,
     UpdateDataEvent,
@@ -1226,3 +1228,26 @@ def test_done_resumed_task_not_in_all_running_tasks(
     ts = ws.tasks["x"]
     assert ts.state == done_status
     assert ts not in ws.all_running_tasks
+
+
+@pytest.mark.xfail(reason="https://github.com/dask/distributed/issues/6705")
+def test_gather_dep_failure(ws):
+    """Simulate a task failing to unpickle when it reaches the destination worker after
+    a flight.
+
+    See also test_worker_memory.py::test_workerstate_fail_to_pickle_flight,
+    where the task instead is gathered successfully, but fails to spill.
+    """
+    ws2 = "127.0.0.1:2"
+    instructions = ws.handle_stimulus(
+        ComputeTaskEvent.dummy("y", who_has={"x": [ws2]}, stimulus_id="s1"),
+        GatherDepFailureEvent.from_exception(
+            Exception(), worker=ws2, total_nbytes=1, stimulus_id="s2"
+        ),
+    )
+    assert instructions == [
+        GatherDep(worker=ws2, to_gather={"x"}, total_nbytes=1, stimulus_id="s1"),
+        TaskErredMsg.match(key="x", stimulus_id="s2"),
+    ]
+    assert ws.tasks["x"].state == "error"
+    assert ws.tasks["y"].state == "waiting"  # Not ready

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -369,7 +369,7 @@ class Instruction:
 
 
 class _InstructionMatch:
-    """Dummy class, to be used to test an instructions list.
+    """Utility class, to be used to test an instructions list.
     See :meth:`Instruction.match`.
     """
 
@@ -383,7 +383,7 @@ class _InstructionMatch:
     def __repr__(self) -> str:
         cls_str = self.cls.__name__
         kwargs_str = ", ".join(f"{k}={v}" for k, v in self.kwargs.items())
-        return f"{cls_str}({kwargs_str}) (dummy match)"
+        return f"{cls_str}({kwargs_str}) (partial match)"
 
     def __eq__(self, other: object) -> bool:
         if type(other) is not self.cls:

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -2126,12 +2126,6 @@ class WorkerState:
                 f"Tried to transition task {ts} to `memory` without data available"
             )
 
-        self._release_resources(ts)
-        self.executing.discard(ts)
-        self.long_running.discard(ts)
-        self.in_flight_tasks.discard(ts)
-        ts.coming_from = None
-
         instructions: Instructions = []
         try:
             recs = self._put_key_in_memory(ts, value, stimulus_id=stimulus_id)
@@ -2139,6 +2133,12 @@ class WorkerState:
             msg = error_message(e)
             recs = {ts: tuple(msg.values())}
         else:
+            self._release_resources(ts)
+            self.executing.discard(ts)
+            self.long_running.discard(ts)
+            self.in_flight_tasks.discard(ts)
+            ts.coming_from = None
+
             if self.validate:
                 assert ts.key in self.data or ts.key in self.actors
             instructions.append(


### PR DESCRIPTION
- Blocked by and incorporates #6704
- Follow-up: #6705

A task finishes its computation successfully, returning an output that is individually larger than 60% of memory_limit.
The task is spilled immediately to disk; however it fails to pickle (this is not the same as OSError, which is handled transparently by the `SpillBuffer`).
The task is marked as having status=error.

This PR fixes a bug where, if the task was using resources, the resources are returned twice, causing available_resources to become higher than total_resources.