### PR TITLE
Automatically mark all WorkerState tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -35,5 +35,8 @@ def pytest_collection_modifyitems(config, items):
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
 
+        if "ws" in item.fixturenames:
+            item.add_marker(pytest.mark.workerstate)
+
 
 pytest_plugins = ["distributed.pytest_resourceleaks"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,7 @@ markers =
     ipython: marks tests as exercising IPython
     gpu: marks tests we want to run on GPUs
     leaking: ignore leaked resources; see pytest_resourceleaks.py for usage
+    workerstate: deterministic test for the worker state machine. Automatically applied to all tests that use the 'ws' fixture.
 
 # pytest-timeout settings
 # 'thread' kills off the whole test suite. 'signal' only kills the offending test.


### PR DESCRIPTION
Automatically mark all tests that use the `ws` or the `ws_with_running_task` fixtures.
This allows running all and only such tests with `pytest -m workerstate`.

This in turn will allow, in the future,
- to measure and progressively increase test coverage of `WorkerState._transition_*` using deterministic WorkerState tests only
- to give developers a quick way to retest after changes to the transitions machinery.
