### PR TITLE
Future-proof Bokeh value import

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -11,7 +11,7 @@ from numbers import Number
 from typing import TypeVar
 
 import numpy as np
-from bokeh.core.properties import without_property_validation
+from bokeh.core.properties import value, without_property_validation
 from bokeh.io import curdoc
 from bokeh.layouts import column, row
 from bokeh.models import (
@@ -40,7 +40,6 @@ from bokeh.models import (
     Title,
     VeeHead,
     WheelZoomTool,
-    value,
 )
 from bokeh.models.widgets import DataTable, TableColumn
 from bokeh.models.widgets.markups import Div


### PR DESCRIPTION

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

There is a good chance that we will restore a compatibility import for `value` before Bokeh 3.0 is released, but the right place to import it from is still really `bokeh.core.properties`. This PR moves the import now to future-proof things, regardless. 

A basic smoke test seems to be working fine for me with Bokeh 3.0dev, but some of the unit tests are failing (with Bokeh 3.0dev) for me locally with "internal server error". I am not sure if there is a real problem with the tests, or just my quick testing env is not set-up correctly. We don't see these failures in our CI "downstream" job so I think maybe it is the latter.  It would be helpful if someone on the Dask end can install a 3.0 dev build and run tests to see if tehy see the same thing. cc @jrbourbeau 