### PR TITLE
Wait for workers to return in `Client.restart`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3322,7 +3322,7 @@ class Client(SyncMethodMixin):
 
     async def _restart(self, timeout=no_default):
         if timeout == no_default:
-            timeout = self._timeout * 2
+            timeout = self._timeout * 4
         if timeout is not None:
             timeout = parse_timedelta(timeout, "s")
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3330,7 +3330,7 @@ class Client(SyncMethodMixin):
         return self
 
     def restart(self, timeout=no_default):
-        """Restart the distributed network
+        """Clear all tasks, restart all workers, and wait for them to return.
 
         This kills all active work, deletes all data on the network, and
         restarts the worker processes.

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3329,13 +3329,20 @@ class Client(SyncMethodMixin):
         await self.scheduler.restart(timeout=timeout)
         return self
 
-    def restart(self, **kwargs):
+    def restart(self, timeout=no_default):
         """Restart the distributed network
 
         This kills all active work, deletes all data on the network, and
         restarts the worker processes.
+
+        Workers without nannies are shut down, hoping an external deployment system
+        will restart them. Therefore, if not using nannies and your deployment system
+        does not automatically restart workers, ``restart`` will just shut down all
+        workers, then time out!
+
+        Raises `TimeoutError` if not all workers come back within ``timeout`` seconds.
         """
-        return self.sync(self._restart, **kwargs)
+        return self.sync(self._restart, timeout=timeout)
 
     async def _upload_large_file(self, local_filename, remote_filename=None):
         if remote_filename is None:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3316,15 +3316,16 @@ class Client(SyncMethodMixin):
         if timeout is not None:
             timeout = parse_timedelta(timeout, "s")
 
-        await self.scheduler.restart(timeout=timeout)
+        try:
+            await self.scheduler.restart(timeout=timeout)
+        finally:
+            for state in self.futures.values():
+                state.cancel()
+            self.futures.clear()
 
-        for state in self.futures.values():
-            state.cancel()
-        self.futures.clear()
-
-        self.generation += 1
-        with self._refcount_lock:
-            self.refcount.clear()
+            self.generation += 1
+            with self._refcount_lock:
+                self.refcount.clear()
 
         return self
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3340,7 +3340,7 @@ class Client(SyncMethodMixin):
 
         After `restart`, all connected workers are new, regardless of whether `TimeoutError`
         was raised. Any workers that failed to shut down in time are removed, and
-        may or many not shut down on their own in the future.
+        may or may not shut down on their own in the future.
 
         Parameters
         ----------
@@ -3353,6 +3353,9 @@ class Client(SyncMethodMixin):
             (default True). Use ``restart(wait_for_workers=False)`` combined with
             `Client.wait_for_workers` for granular control over how many workers to
             wait for.
+        See also
+        ----------
+        Scheduler.restart
         """
         return self.sync(
             self._restart, timeout=timeout, wait_for_workers=wait_for_workers

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -642,10 +642,8 @@ class WorkerProcess:
         """
         enable_proctitle_on_children()
         if self.status == Status.running:
-            logger.info(f"{self.worker_address} - Start called when already running")
             return self.status
         if self.status == Status.starting:
-            logger.info(f"{self.worker_address} - Start called when already starting")
             await self.running.wait()
             return self.status
 
@@ -678,9 +676,7 @@ class WorkerProcess:
         os.environ.update(self.env)
 
         try:
-            logger.info(f"{self.worker_address} - Starting worker process")
             await self.process.start()
-            logger.info(f"{self.worker_address} - Worker process started")
         except OSError:
             logger.exception("Nanny failed to start process", exc_info=True)
             self.process.terminate()
@@ -688,7 +684,6 @@ class WorkerProcess:
             return self.status
         try:
             msg = await self._wait_until_connected(uid)
-            logger.info(f"{self.worker_address} - Connected to worker")
         except Exception:
             logger.exception("Failed to connect to process")
             self.status = Status.failed

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -642,8 +642,10 @@ class WorkerProcess:
         """
         enable_proctitle_on_children()
         if self.status == Status.running:
+            logger.info(f"{self.worker_address} - Start called when already running")
             return self.status
         if self.status == Status.starting:
+            logger.info(f"{self.worker_address} - Start called when already starting")
             await self.running.wait()
             return self.status
 
@@ -676,7 +678,9 @@ class WorkerProcess:
         os.environ.update(self.env)
 
         try:
+            logger.info(f"{self.worker_address} - Starting worker process")
             await self.process.start()
+            logger.info(f"{self.worker_address} - Worker process started")
         except OSError:
             logger.exception("Nanny failed to start process", exc_info=True)
             self.process.terminate()
@@ -684,6 +688,7 @@ class WorkerProcess:
             return self.status
         try:
             msg = await self._wait_until_connected(uid)
+            logger.info(f"{self.worker_address} - Connected to worker")
         except Exception:
             logger.exception("Failed to connect to process")
             self.status = Status.failed

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -379,7 +379,7 @@ class Nanny(ServerNode):
         informed
         """
         if self.process is None:
-            return "OK"
+            return
 
         deadline = time() + timeout
         await self.process.kill(timeout=0.8 * (deadline - time()))

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5136,6 +5136,9 @@ class Scheduler(SchedulerState, ServerNode):
             (default True). Use ``restart(wait_for_workers=False)`` combined with
             `Client.wait_for_workers` for granular control over how many workers to
             wait for.
+        See also
+        ----------
+        Client.restart
         """
         stimulus_id = f"restart-{time()}"
 
@@ -5214,7 +5217,7 @@ class Scheduler(SchedulerState, ServerNode):
                 )
 
                 raise TimeoutError(
-                    f"{len(bad_nannies)}/{len(nannies)} worker(s) did not shut down within {timeout}s"
+                    f"{len(bad_nannies)}/{len(nannies)} nanny worker(s) did not shut down within {timeout}s"
                 )
 
         self.log_event([client, "all"], {"action": "restart", "client": client})

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5193,10 +5193,6 @@ class Scheduler(SchedulerState, ServerNode):
                     f"{n_failed}/{len(nannies)} worker(s) did not restart within {timeout}s"
                 )
 
-        with suppress(AttributeError):
-            for c in self._worker_coroutines:
-                c.cancel()
-
         self.log_event([client, "all"], {"action": "restart", "client": client})
         while monotonic() < start + timeout:
             if len(self.workers) >= n_workers:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5228,7 +5228,7 @@ class Scheduler(SchedulerState, ServerNode):
                 # our shut-down workers have come back up. That's fine; workers are interchangeable.
                 if len(self.workers) >= n_workers:
                     return
-                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.2)
             else:
                 msg = (
                     f"Waited for {n_workers} worker(s) to reconnect after restarting, "

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5131,13 +5131,7 @@ class Scheduler(SchedulerState, ServerNode):
         stimulus_id = f"restart-{time()}"
         n_workers = len(self.workers)
 
-        for plugin in list(self.plugins.values()):
-            try:
-                plugin.restart(self)
-            except Exception as e:
-                logger.exception(e)
-
-        logger.info("Send lost future signal to clients")
+        logger.info("Releasing all requested keys")
         for cs in self.clients.values():
             self.client_releases_keys(
                 keys=[ts.key for ts in cs.wants_what],
@@ -5147,6 +5141,12 @@ class Scheduler(SchedulerState, ServerNode):
 
         self.clear_task_state()
         self.report({"op": "restart"})
+
+        for plugin in list(self.plugins.values()):
+            try:
+                plugin.restart(self)
+            except Exception as e:
+                logger.exception(e)
 
         start = time()
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5224,6 +5224,8 @@ class Scheduler(SchedulerState, ServerNode):
 
         if wait_for_workers:
             while monotonic() < start + timeout:
+                # NOTE: if new (unrelated) workers join while we're waiting, we may return before
+                # our shut-down workers have come back up. That's fine; workers are interchangeable.
                 if len(self.workers) >= n_workers:
                     return
                 await asyncio.sleep(0.01)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5126,8 +5126,12 @@ class Scheduler(SchedulerState, ServerNode):
         does not automatically restart workers, ``restart`` will just shut down all
         workers, then time out!
 
-        Raises `TimeoutError` if not all workers come back within ``timeout`` seconds
-        after being shut down.
+        Raises `TimeoutError` if the restart process takes longer than ``timeout``
+        seconds. This could mean not all workers came back within ``timeout`` seconds,
+        or that they didn't shut down in time, or even that connecting to all Nannies
+        took too long. After a `TimeoutError`, the cluster is still usable, but
+        non-restarted workers may still be connected to the cluster, and they may
+        shut themselves down at some point in the future.
         """
         stimulus_id = f"restart-{time()}"
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3045,7 +3045,6 @@ class Scheduler(SchedulerState, ServerNode):
             "client-releases-keys": self.client_releases_keys,
             "heartbeat-client": self.client_heartbeat,
             "close-client": self.remove_client,
-            "restart": self.restart,
             "subscribe-topic": self.subscribe_topic,
             "unsubscribe-topic": self.unsubscribe_topic,
         }
@@ -3082,6 +3081,7 @@ class Scheduler(SchedulerState, ServerNode):
             "rebalance": self.rebalance,
             "replicate": self.replicate,
             "run_function": self.run_function,
+            "restart": self.restart,
             "update_data": self.update_data,
             "set_resources": self.add_resources,
             "retire_workers": self.retire_workers,
@@ -5176,8 +5176,6 @@ class Scheduler(SchedulerState, ServerNode):
                 f"Waited for {n_workers} worker(s) to reconnect after restarting, "
                 f"but after {timeout}s, only {len(self.workers)} have returned."
             )
-
-        self.report({"op": "restart"})
 
     async def broadcast(
         self,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5139,6 +5139,8 @@ class Scheduler(SchedulerState, ServerNode):
             )
 
         self.clear_task_state()
+        self.erred_tasks.clear()
+        self.computations.clear()
         self.report({"op": "restart"})
 
         for plugin in list(self.plugins.values()):
@@ -5184,9 +5186,6 @@ class Scheduler(SchedulerState, ServerNode):
             with suppress(AttributeError):
                 for c in self._worker_coroutines:
                     c.cancel()
-
-            self.erred_tasks.clear()
-            self.computations.clear()
 
             self.log_event([client, "all"], {"action": "restart", "client": client})
             while len(self.workers) < n_workers:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5181,10 +5181,7 @@ class Scheduler(SchedulerState, ServerNode):
 
             resps = await asyncio.wait_for(
                 asyncio.gather(
-                    *(
-                        nanny.restart(close=True, timeout=timeout * 0.8)
-                        for nanny in nannies
-                    )
+                    *(nanny.restart(close=True, timeout=timeout) for nanny in nannies)
                 ),
                 timeout,
             )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5123,7 +5123,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         After `restart`, all connected workers are new, regardless of whether `TimeoutError`
         was raised. Any workers that failed to shut down in time are removed, and
-        may or many not shut down on their own in the future.
+        may or may not shut down on their own in the future.
 
         Parameters
         ----------

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5119,7 +5119,7 @@ class Scheduler(SchedulerState, ServerNode):
     @log_errors
     async def restart(self, client=None, timeout=30):
         """
-        Restart all workers. Reset local state.
+        Restart all workers. Reset local state. Wait for workers to return.
 
         Workers without nannies are shut down, hoping an external deployment system
         will restart them. Therefore, if not using nannies and your deployment system

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5126,12 +5126,8 @@ class Scheduler(SchedulerState, ServerNode):
         does not automatically restart workers, ``restart`` will just shut down all
         workers, then time out!
 
-        Raises `TimeoutError` if the restart process takes longer than ``timeout``
-        seconds. This could mean not all workers came back within ``timeout`` seconds,
-        or that they didn't shut down in time, or even that connecting to all Nannies
-        took too long. After a `TimeoutError`, the cluster is still usable, but
-        non-restarted workers may still be connected to the cluster, and they may
-        shut themselves down at some point in the future.
+        Raises `TimeoutError` if not all workers come back within ``timeout`` seconds
+        after being shut down.
         """
         stimulus_id = f"restart-{time()}"
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5121,10 +5121,10 @@ class Scheduler(SchedulerState, ServerNode):
         """
         Restart all workers. Reset local state.
 
-        Workers without nannies are shut down (assuming an external deployment system
-        may restart them). Therefore, if not using nannies and your deployment system
+        Workers without nannies are shut down, hoping an external deployment system
+        will restart them. Therefore, if not using nannies and your deployment system
         does not automatically restart workers, ``restart`` will just shut down all
-        workers!
+        workers, then time out!
 
         Raises `TimeoutError` if not all workers come back within ``timeout`` seconds.
         """

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5146,6 +5146,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
 
         self.clear_task_state()
+        self.report({"op": "restart"})
 
         start = time()
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3493,16 +3493,6 @@ async def test_Client_clears_references_after_restart(c, s, a, b):
         assert key not in c.refcount
 
 
-@pytest.mark.slow
-@gen_cluster(Worker=Nanny, client=True, nthreads=[("", 1)] * 5)
-async def test_restart_waits_for_new_workers(c, s, *workers):
-    initial_workers = set(s.workers)
-    await c.restart()
-    assert len(s.workers) == len(initial_workers)
-    for w in workers:
-        assert w.address not in s.workers
-
-
 @gen_cluster(Worker=Nanny, client=True)
 async def test_restart_timeout_is_logged(c, s, a, b):
     with captured_logger(logging.getLogger("distributed.client")) as logger:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3493,6 +3493,16 @@ async def test_Client_clears_references_after_restart(c, s, a, b):
         assert key not in c.refcount
 
 
+@pytest.mark.slow
+@gen_cluster(Worker=Nanny, client=True, nthreads=[("", 1)] * 5)
+async def test_restart_waits_for_new_workers(c, s, *workers):
+    initial_workers = set(s.workers)
+    await c.restart()
+    assert len(s.workers) == len(initial_workers)
+    for w in workers:
+        assert w.address not in s.workers
+
+
 @gen_cluster(Worker=Nanny, client=True)
 async def test_restart_timeout_is_logged(c, s, a, b):
     with captured_logger(logging.getLogger("distributed.client")) as logger:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3478,13 +3478,17 @@ def test_get_returns_early(c):
 
 
 @pytest.mark.slow
-@gen_cluster(Worker=Nanny, client=True, timeout=60)
+@gen_cluster(client=True)
 async def test_Client_clears_references_after_restart(c, s, a, b):
     x = c.submit(inc, 1)
     assert x.key in c.refcount
+    assert x.key in c.futures
 
-    await c.restart()
+    with pytest.raises(TimeoutError):
+        await c.restart(timeout=5)
+
     assert x.key not in c.refcount
+    assert not c.futures
 
     key = x.key
     del x

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3493,14 +3493,6 @@ async def test_Client_clears_references_after_restart(c, s, a, b):
         assert key not in c.refcount
 
 
-@gen_cluster(Worker=Nanny, client=True)
-async def test_restart_timeout_is_logged(c, s, a, b):
-    with captured_logger(logging.getLogger("distributed.client")) as logger:
-        await c.restart(timeout="0.5s")
-    text = logger.getvalue()
-    assert "Restart timed out after 0.50 seconds" in text
-
-
 def test_get_stops_work_after_error(c):
     with pytest.raises(RuntimeError):
         c.get({"x": (throws, 1), "y": (sleep, 1.5)}, ["x", "y"])

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -92,7 +92,6 @@ from distributed.utils_test import (
     double,
     gen_cluster,
     gen_test,
-    geninc,
     get_cert,
     inc,
     map_varying,
@@ -2662,13 +2661,13 @@ def test_run_sync(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_run_coroutine(c, s, a, b):
-    results = await c.run(geninc, 1, delay=0.05)
+    results = await c.run(asyncinc, 1, delay=0.05)
     assert results == {a.address: 2, b.address: 2}
 
-    results = await c.run(geninc, 1, delay=0.05, workers=[a.address])
+    results = await c.run(asyncinc, 1, delay=0.05, workers=[a.address])
     assert results == {a.address: 2}
 
-    results = await c.run(geninc, 1, workers=[])
+    results = await c.run(asyncinc, 1, workers=[])
     assert results == {}
 
     with pytest.raises(RuntimeError, match="hello"):
@@ -2679,14 +2678,14 @@ async def test_run_coroutine(c, s, a, b):
 
 
 def test_run_coroutine_sync(c, s, a, b):
-    result = c.run(geninc, 2, delay=0.01)
+    result = c.run(asyncinc, 2, delay=0.01)
     assert result == {a["address"]: 3, b["address"]: 3}
 
-    result = c.run(geninc, 2, workers=[a["address"]])
+    result = c.run(asyncinc, 2, workers=[a["address"]])
     assert result == {a["address"]: 3}
 
     t1 = time()
-    result = c.run(geninc, 2, delay=10, wait=False)
+    result = c.run(asyncinc, 2, delay=10, wait=False)
     t2 = time()
     assert result is None
     assert t2 - t1 <= 1.0

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -656,7 +656,9 @@ class SlowRestartNanny(Nanny):
 
 @gen_cluster(client=True, Worker=SlowRestartNanny, nthreads=[("", 1)] * 2)
 async def test_restart_nanny_timeout_exceeded(c, s, a, b):
-    with pytest.raises(TimeoutError, match=r"2 worker\(s\) did not restart within 1s"):
+    with pytest.raises(
+        TimeoutError, match="Restarting 2 workers did not complete in 1s"
+    ):
         await c.restart(timeout="1s")
     assert a.restart_called.is_set()
     assert b.restart_called.is_set()
@@ -664,7 +666,9 @@ async def test_restart_nanny_timeout_exceeded(c, s, a, b):
 
 @gen_cluster(client=True, nthreads=[("", 1)] * 2)
 async def test_restart_not_all_workers_return(c, s, a, b):
-    with pytest.raises(TimeoutError, match=r"after 1s, only 0 have returned"):
+    with pytest.raises(
+        TimeoutError, match="Restarting 2 workers did not complete in 1s"
+    ):
         await c.restart(timeout="1s")
 
 
@@ -677,7 +681,9 @@ async def test_restart_some_nannies_some_not(c, s, a, b):
         await c.wait_for_workers(3)
 
         # FIXME how to make this not always take 20s if the nannies do restart quickly?
-        with pytest.raises(TimeoutError, match="after 20s, only 2 have returned"):
+        with pytest.raises(
+            TimeoutError, match="Restarting 3 workers did not complete in 20s"
+        ):
             await c.restart(timeout="20s")
 
         assert w.status == Status.closed

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -675,7 +675,7 @@ async def test_restart_nanny_timeout_exceeded(c, s, a, b):
     assert s.tasks
 
     with pytest.raises(
-        TimeoutError, match=r"2/2 worker\(s\) did not shut down within 1s"
+        TimeoutError, match=r"2/2 nanny worker\(s\) did not shut down within 1s"
     ):
         await c.restart(timeout="1s")
     assert a.kill_called.is_set()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -668,6 +668,7 @@ async def test_restart_not_all_workers_return(c, s, a, b):
         await c.restart(timeout="1s")
 
 
+@pytest.mark.slow
 @gen_cluster(client=True, Worker=Nanny)
 async def test_restart_some_nannies_some_not(c, s, a, b):
     original_procs = {a.process.process, b.process.process}
@@ -675,8 +676,9 @@ async def test_restart_some_nannies_some_not(c, s, a, b):
     async with Worker(s.address, nthreads=1) as w:
         await c.wait_for_workers(3)
 
-        with pytest.raises(TimeoutError, match="after 5s, only 2 have returned"):
-            await c.restart(timeout="5s")
+        # FIXME how to make this not always take 20s if the nannies do restart quickly?
+        with pytest.raises(TimeoutError, match="after 20s, only 2 have returned"):
+            await c.restart(timeout="20s")
 
         assert w.status == Status.closed
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -430,11 +430,6 @@ def map_varying(itemslists):
     return apply, list(map(varying, itemslists))
 
 
-async def geninc(x, delay=0.02):
-    await asyncio.sleep(delay)
-    return x + 1
-
-
 async def asyncinc(x, delay=0.02):
     await asyncio.sleep(delay)
     return x + 1

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1520,7 +1520,10 @@ class Worker(BaseWorker, ServerNode):
                         # otherwise
                         c.close()
 
+        logger.info(f"{self.address} - Clients closed")
+
         await self.scheduler.close_rpc()
+        logger.info(f"{self.address} - Scheduler RPC closed")
         self._workdir.release()
 
         self.stop_services()
@@ -1538,26 +1541,32 @@ class Worker(BaseWorker, ServerNode):
             with suppress(TimeoutError):
                 await self.batched_stream.close(timedelta(seconds=timeout))
 
+        logger.info(f"{self.address} - Batched stream to scheduler closed")
+
         for executor in self.executors.values():
             if executor is utils._offload_executor:
                 continue  # Never shutdown the offload executor
 
             def _close(wait):
+                logger.info(f"{self.address} - Closing {executor}, {wait=}, {timeout=}")
                 if isinstance(executor, ThreadPoolExecutor):
                     executor._work_queue.queue.clear()
                     executor.shutdown(wait=wait, timeout=timeout)
                 else:
                     executor.shutdown(wait=wait)
+                logger.info(f"{self.address} - {executor} closed")
 
             # Waiting for the shutdown can block the event loop causing
             # weird deadlocks particularly if the task that is executing in
             # the thread is waiting for a server reply, e.g. when using
             # worker clients, semaphores, etc.
             if is_python_shutting_down():
+                logger.info(f"{self.address} - Python is shutting down")
                 # If we're shutting down there is no need to wait for daemon
                 # threads to finish
                 _close(wait=False)
             else:
+                logger.info(f"{self.address} - Python is not shutting down")
                 try:
                     await to_thread(_close, wait=executor_wait)
                 except RuntimeError:  # Are we shutting down the process?
@@ -1569,12 +1578,15 @@ class Worker(BaseWorker, ServerNode):
                     _close(wait=executor_wait)  # Just run it directly
 
         self.stop()
+        logger.info(f"{self.address} - Server stop")
         await self.rpc.close()
+        logger.info(f"{self.address} - RPC closed")
 
         self.status = Status.closed
         await ServerNode.close(self)
 
         setproctitle("dask-worker [closed]")
+        logger.info(f"{self.address} - Worker closed successfully")
         return "OK"
 
     async def close_gracefully(self, restart=None):


### PR DESCRIPTION
Taking over #6637 since Florian and Hendrik are out.

This goes a step further and resolves the inconsistent treatment of nanny vs non-nanny workers. Now we wait for all workers to come back, even if they don't have nannies. This may not actually be a good idea; at the least, it's a breaking change.

It also refactors the calling of `Scheduler.restart` into an RPC versus a bulk comms call-response (an odd pattern).

Closes #6637

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
