### PR TITLE
Remove resumed state

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -851,7 +851,7 @@ async def end_cluster(s, workers):
 def gen_cluster(
     nthreads: list[tuple[str, int] | tuple[str, int, dict]] | None = None,
     scheduler: str = "127.0.0.1",
-    timeout: float = _TEST_TIMEOUT,
+    timeout: float = 2,
     security: Security | dict[str, Any] | None = None,
     Worker: type[ServerNode] = Worker,
     client: bool = False,


### PR DESCRIPTION
The resumed state is exceptionally complicated and a very frequent source of problems. This PR removes the 'resumed' state and the `TaskState.next` attribute.

This PR also deals with the issue of tasks with waiters that transition to error - which is typical, but not exclusive, of the cancelled state - see issues below. The waiters are now sent back to the scheduler.

- Mutually exclusive with #6699
- Mutually exclusive with #6844 
- Closes #6682
- Closes #6689
- Closes #6693
- Closes #6685 
- Closes #6705
# Design

| Events | Main | This PR |
| --- | --- | --- |
| compute[1]<br/>free-keys | status=cancelled<br/>previous=executing<br/>*On completion*: quietly release | (same) |
| fetch[2]<br/>free-keys | status=cancelled<br/>previous=flight<br/>*On completion*: quietly release | (same) |
| compute[1]<br/>free-keys<br/>compute[1] | status=executing | (same) |
| fetch[2]<br/>free-keys<br/>fetch[2] | status=flight | (same)| status=flight<br/>previous=None |
| compute[1]<br/>free-keys<br/>fetch[2] | status=resumed<br/>previous=executing<br/>next=fetch<br/>*On success:* add-keys<br/>*On compute failure:* cluster deadlock (#6689)<br/>*On reschedule:* InvalidTransition (#6685)| status=executing<br/>previous=None<br/>*On success:* task-finished<br/>*On compute failure:* task-erred[5]; reschedule dependents[6]<br/>*On reschedule:* reschedule task and its dependents[6] |
| fetch[2]<br/>free-keys<br/>compute[1] | status=resumed<br/>previous=flight<br/>next=waiting<br/>*On success:* task-finished with bogus metrics<br/>*On peer failure [3]:* transition to waiting<br/>*On (un)pickle failure [4]:* task-erred | status=flight<br/>previous=None<br/>*On success:* add-keys<br/>*On peer failure [3]:* transition to fetch or missing; on the scheduler side, request_who_has reschedules<br/>*On (un)pickle failure [4]:* task-erred|
| fetch[2] | status=flight<br/> *On success:* add-keys<br/>*On peer failure [3]:* transition to fetch or missing<br/>*On (un)pickle failure [4]:* cluster deadlock (#6705) |status=flight<br/> *On success:* add-keys<br/>*On peer failure [3]:* transition to fetch or missing<br/>*On (un)pickle failure [4]:*  task-erred[5] and reschedule dependents[6] |

#### Notes
[1] ComputeTaskEvent(key=\<key\>)
[2] ComputeTaskEvent(who_has={\<key\>: [...]} or AcquireReplicasEvent(who_has={\<key\>: [...]})
[3] GatherDepSuccessEvent without the requested key or GatherDepNetworkFailureEvent
[4] GatherDepFailureEvent, typically caused by a failure to unpickle, or GatherDepSuccessEvent for a task that is larger than 60% max_memory, is thus spilled immediately, and fails to pickle.
[5] The task-erred messages introduce a new scheduler-side use case, where the scheduler receives a task-erred message for a task that is already in memory. At the moment, this use case is a no-op.
- if ts.retries > 0, decrease it by one and, on the reporting worker only, release the task and all its dependents
- if ts.retries = 0, transition the task to erred, release the task on the workers where it is in memory, and release all dependents everywhere.

[6] rescheduling waiters implies introducing a new waiting->rescheduled transition

# TODO 
- The implementation does not fully reflect the above design yet
- Failing tests:
  - FAILED distributed/tests/test_failed_workers.py::test_submit_after_failed_worker_sync
  - FAILED distributed/tests/test_failed_workers.py::test_submit_after_failed_worker_async[False]
  - FAILED distributed/tests/test_worker.py::test_task_flight_compute_oserror - a...
  - The whole test_cancelled_state.py (I didn't look at it yet)
- Write more tests for waiters being sent back to the scheduler
- Ensure all tickets above meet DoD

Regardless of TODOs, this is a gargantuan change which won't go in before @fjetter has come back and has had the time to thoroughly review it.