### PR TITLE
Don't use `bokeh` `Figure` in tests

### DIFF
--- a/distributed/diagnostics/tests/test_task_stream.py
+++ b/distributed/diagnostics/tests/test_task_stream.py
@@ -133,18 +133,18 @@ def test_client_sync(client):
 
 @gen_cluster(client=True)
 async def test_get_task_stream_plot(c, s, a, b):
-    bokeh = pytest.importorskip("bokeh")
+    bkm = pytest.importorskip("bokeh.models")
     await c.get_task_stream()
 
     futures = c.map(slowinc, range(10), delay=0.1)
     await wait(futures)
 
     data, figure = await c.get_task_stream(plot=True)
-    assert isinstance(figure, bokeh.plotting.Figure)
+    assert isinstance(figure, bkm.Plot)
 
 
 def test_get_task_stream_save(client, tmpdir):
-    bokeh = pytest.importorskip("bokeh")
+    bkm = pytest.importorskip("bokeh.models")
     tmpdir = str(tmpdir)
     fn = os.path.join(tmpdir, "foo.html")
 
@@ -155,4 +155,4 @@ def test_get_task_stream_save(client, tmpdir):
     assert "inc" in data
     assert "bokeh" in data
 
-    assert isinstance(ts.figure, bokeh.plotting.Figure)
+    assert isinstance(ts.figure, bkm.Plot)


### PR DESCRIPTION
cc @jrbourbeau 

This PR removes the use of `bokeh.plotting.Figure` in tests, since `Figure` will be removed in Bokeh 3.0

I edited this in the GH web UI, and have not actually run anything, so we will see how this goes. 
