### PR TITLE
Support `asynchronous` option in `get_client()`

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2615,7 +2615,9 @@ def get_client(address=None, timeout=None, resolve_address=True, asynchronous=Fa
         client = Client.current()  # TODO: assumes the same scheduler
     except ValueError:
         client = None
-    if client and (not address or client.scheduler.address == address):
+    if client and (not address or not client.scheduler or client.scheduler.address == address):
+        # Client may not have yet been awaited on if get_client() was
+        # previously called with asynchronous=True
         return client
     elif address:
         return Client(address, timeout=timeout, asynchronous=asynchronous)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2555,7 +2555,7 @@ def get_worker() -> Worker:
             raise ValueError("No workers found")
 
 
-def get_client(address=None, timeout=None, resolve_address=True) -> Client:
+def get_client(address=None, timeout=None, resolve_address=True, asynchronous=False) -> Client:
     """Get a client while within a task.
 
     This client connects to the same scheduler to which the worker is connected
@@ -2618,7 +2618,7 @@ def get_client(address=None, timeout=None, resolve_address=True) -> Client:
     if client and (not address or client.scheduler.address == address):
         return client
     elif address:
-        return Client(address, timeout=timeout)
+        return Client(address, timeout=timeout, asynchronous=asynchronous)
     else:
         raise ValueError("No global client found and no address provided")
 


### PR DESCRIPTION
Closes #6723 .

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
