### PR TITLE
Add Jupyter Server to Dask Scheduler

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -85,7 +85,9 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     "jupyter",
     default=False,
     required=False,
-    help="Start a Jupyter Server in the same process",
+    help="Start a Jupyter Server in the same process.  Warning: This will make"
+    "it possible for anyone with access to your dashboard address to run"
+    "Python code",
 )
 @click.option("--show/--no-show", default=False, help="Show web UI [default: --show]")
 @click.option(

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -80,6 +80,13 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
     required=False,
     help="Deprecated.  See --dashboard/--no-dashboard.",
 )
+@click.option(
+    "--jupyter/--no-jupyter",
+    "jupyter",
+    default=False,
+    required=False,
+    help="Start a Jupyter Server in the same process",
+)
 @click.option("--show/--no-show", default=False, help="Show web UI [default: --show]")
 @click.option(
     "--dashboard-prefix", type=str, default="", help="Prefix for the dashboard app"
@@ -132,6 +139,7 @@ def main(
     tls_cert,
     tls_key,
     dashboard_address,
+    jupyter,
     **kwargs,
 ):
     g0, g1, g2 = gc.get_threshold()  # https://github.com/dask/distributed/issues/1653
@@ -195,6 +203,7 @@ def main(
             dashboard=dashboard,
             dashboard_address=dashboard_address,
             http_prefix=dashboard_prefix,
+            jupyter=jupyter,
             **kwargs,
         )
         logger.info("-" * 47)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3009,7 +3009,15 @@ class Scheduler(SchedulerState, ServerNode):
             from traitlets.config import Config
 
             j = ServerApp.instance(
-                config=Config({"ServerApp": {"base_url": "jupyter", "token": ""}})
+                config=Config(
+                    {
+                        "ServerApp": {
+                            "base_url": "jupyter",
+                            "token": "",
+                            "allow_remote_access": True,
+                        }
+                    }
+                )
             )
             j.initialize(
                 new_httpserver=False,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3006,7 +3006,13 @@ class Scheduler(SchedulerState, ServerNode):
             )
         self.jupyter = jupyter
         if self.jupyter:
-            from jupyter_server.serverapp import ServerApp
+            try:
+                from jupyter_server.serverapp import ServerApp
+            except ImportError:
+                raise ImportError(
+                    "In order to use the Dask jupyter option you "
+                    "need to have jupyterlab installed"
+                )
             from traitlets.config import Config
 
             j = ServerApp.instance(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3022,7 +3022,6 @@ class Scheduler(SchedulerState, ServerNode):
             )
             j.initialize(
                 new_httpserver=False,
-                argv=["--ServerApp.base_url=jupyter"],
             )
             self._jupyter_server_application = j
             self.http_application.add_application(j.web_app)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3014,6 +3014,9 @@ class Scheduler(SchedulerState, ServerNode):
                     {
                         "ServerApp": {
                             "base_url": "jupyter",
+                            # SECURITY: in this context we expect this to be safe, as
+                            # if a client can connect to the scheduler they can already
+                            # run arbitrary code.
                             "token": "",
                             "allow_remote_access": True,
                         }

--- a/distributed/shuffle/shuffle_extension.py
+++ b/distributed/shuffle/shuffle_extension.py
@@ -531,7 +531,7 @@ def split_by_worker(
     unique_codes = codes[splits]
     out = {
         # FIXME https://github.com/pandas-dev/pandas-stubs/issues/43
-        worker_for.cat.categories[code]: shard  # type: ignore
+        worker_for.cat.categories[code]: shard
         for code, shard in zip(unique_codes, shards)
     }
     assert sum(map(len, out.values())) == nrows

--- a/distributed/tests/test_jupyter.py
+++ b/distributed/tests/test_jupyter.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("jupyter_server")
+
+from tornado.httpclient import AsyncHTTPClient
+
+from distributed import Scheduler
+from distributed.utils_test import gen_test
+
+
+@gen_test()
+async def test_jupyter_server():
+    async with Scheduler(jupyter=True) as s:
+        http_client = AsyncHTTPClient()
+        response = await http_client.fetch(
+            f"http://localhost:{s.http_server.port}/jupyter/api/status"
+        )
+        assert response.code == 200


### PR DESCRIPTION
This adds an option to start a Jupyter Server in the Dask Scheduler process.

This is admittedly a bit strange, but also convenient when you have a
dask scheduler running and want a quick Jupyter notebook without setting
up separate port forwarding / auth / etc..
This piggybacks on the existing Tornado server application.

This adds a new `Scheduler(jupyter=...)` keyword
and a `dask-scheduler --jupyter` flag.

It's a bit strange, but also pretty lightweight.

Done in collaboration with @Carreau and @zsailer