### PR TITLE
[WIP] Use of new dask CLI : job submission

### DIFF
--- a/distributed/cli/dask_job.py
+++ b/distributed/cli/dask_job.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+import atexit
+import gc
+import logging
+import os
+import re
+import sys
+import stat
+import warnings
+import subprocess 
+from pathlib import Path
+
+import click
+
+from distributed  import Client
+from dask_ctl import get_cluster
+
+
+@click.group
+def job():
+    ...
+
+
+@job.command()
+@click.argument("name")
+@click.argument("path", type=Path)
+@click.option("--run-on-scheduler", type=bool, )
+def submit(name, path):
+    cluster = get_cluster(name)
+    client = Client(cluster)
+
+    with open(path, 'r') as f:
+        script = f.read()
+
+    def runscript():
+        # TODO: use a tempfile
+        filepath = '/tmp/tmpfile'
+        with open(filepath, 'w') as f:
+            f.write(script)
+
+        st = os.stat(filepath)
+        os.chmod(filepath, st.st_mode | stat.S_IEXEC | stat.S_IREAD)
+
+        # TODO: need to set DASK_SCHEDULER_ADDRESS env variable in call to execute
+        # for our script; should be the address of the scheduler
+        # might need to use another approach in subprocess for this
+        return subprocess.check_output(filepath)
+
+    result = client.run_on_scheduler(runscript)
+    print(result)
+
+
+@job.command()
+def gather():
+    ...
+
+

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("distributed.scheduler")
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 
-@click.command(context_settings=dict(ignore_unknown_options=True))
+@click.command(name="scheduler", context_settings=dict(ignore_unknown_options=True))
 @click.option("--host", type=str, default="", help="URI, IP or hostname of this server")
 @click.option("--port", type=int, default=None, help="Serving port")
 @click.option(

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -13,13 +13,14 @@ logger = logging.getLogger("distributed.dask_ssh")
 
 
 @click.command(
+    name="ssh",
     help=dedent(
         """Launch a distributed cluster over SSH. A 'dask-scheduler' process will run on the
         first host specified in [HOSTNAMES] or in the hostfile, unless --scheduler is specified
         explicitly. One or more 'dask-worker' processes will be run on each host. Use the flag
         --nworkers to adjust how many dask-worker process are run on each host and the flag
         --nthreads to adjust how many CPUs are used by each dask-worker process."""
-    )
+    ),
 )
 @click.option(
     "--scheduler",

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -35,7 +35,7 @@ logger = logging.getLogger("distributed.dask_worker")
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 
-@click.command(context_settings=dict(ignore_unknown_options=True))
+@click.command(name="worker", context_settings=dict(ignore_unknown_options=True))
 @click.argument("scheduler", type=str, required=False)
 @click.option(
     "--tls-ca-file",

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,10 @@ setup(
         dask-ssh=distributed.cli.dask_ssh:main
         dask-scheduler=distributed.cli.dask_scheduler:main
         dask-worker=distributed.cli.dask_worker:main
+        [dask_cli]
+        scheduler=distributed.cli.dask_scheduler:main
+        worker=distributed.cli.dask_worker:main
+        ssh=distributed.cli.dask_ssh:main
       """,
     # https://mypy.readthedocs.io/en/latest/installed_packages.html
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         scheduler=distributed.cli.dask_scheduler:main
         worker=distributed.cli.dask_worker:main
         ssh=distributed.cli.dask_ssh:main
+        job=distributed.cli.dask_job:job
       """,
     # https://mypy.readthedocs.io/en/latest/installed_packages.html
     zip_safe=False,


### PR DESCRIPTION
Initial commit for structure and basic implementation of `dask job submit`. This is intended to consume a python script as:

```python
dask job submit <cluster-name> <script-path>
```

There are potentially two different usage patterns we are anticipating:
- the script features use of a `dask` collection or builds `delayed` objects and calls `<object>.compute()`; this should use the `dask` cluster to execute all `.compute` calls.
- the script features no `dask`-isms at all, but is intended to be a single worker job as if the script were just a function submitted via `client.submit`.

It may make sense for these two patterns to be served by two different subcommands. Exploring that here to settle on an approach.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
