### PR TITLE
Remove unused `worker_coroutines`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3007,7 +3007,6 @@ class Scheduler(SchedulerState, ServerNode):
         # Communication state
         self.client_comms = {}
         self.stream_comms = {}
-        self._worker_coroutines = []
 
         # Task state
         tasks = {}
@@ -3334,10 +3333,6 @@ class Scheduler(SchedulerState, ServerNode):
         enable_gc_diagnosis()
 
         self.clear_task_state()
-
-        with suppress(AttributeError):
-            for c in self._worker_coroutines:
-                c.cancel()
 
         for addr in self._start_address:
             await self.listen(
@@ -5187,10 +5182,6 @@ class Scheduler(SchedulerState, ServerNode):
                     )
 
         self.clear_task_state()
-
-        with suppress(AttributeError):
-            for c in self._worker_coroutines:
-                c.cancel()
 
         self.erred_tasks.clear()
         self.computations.clear()

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -272,8 +272,6 @@ def test_secede_without_stealing_issue_1262():
     c, s, a, b, f = secede_test()
 
     assert f == 2
-    # ensure no workers had errors
-    assert all([f.exception() is None for f in s._worker_coroutines])
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
`_worker_coroutines` is unused anywhere AFAICT and seems to just be vestigial

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
