### PR TITLE
Add text to top of API docs to make sure that users are exposed to LocalCluster

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,6 +7,8 @@ API
 
 **Client**
 
+The client connects to and submits computation to a Dask cluster (such as a :class:`distributed.LocalCluster`)
+
 .. autosummary::
    Client
 


### PR DESCRIPTION
This is pretty straightforward, but the goal is to expose people to `LocalCluster` earlier.
![image](https://user-images.githubusercontent.com/4806877/181108678-76a20add-cfee-49ca-bed7-9c548290cff7.png)


@martindurant I think this is what you were talking about in dev meeting today?