### PR TITLE
Improve `check_thread_leak` output

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -16,7 +16,6 @@ from unittest import mock
 
 import pytest
 import yaml
-from _pytest.outcomes import Failed
 from tornado import gen
 
 import dask.config
@@ -766,7 +765,9 @@ def test_check_thread_leak():
 
     t2 = t3 = None
     try:
-        with pytest.raises(Failed, match=r"2 thread\(s\) were leaked") as exc:
+        with pytest.raises(
+            pytest.fail.Exception, match=r"2 thread\(s\) were leaked"
+        ) as exc:
             with check_thread_leak():
                 t2 = threading.Thread(target=lambda: (event.wait(), "two"))
                 t2.start()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1750,15 +1750,21 @@ def check_thread_leak():
             # Raise an error with information about leaked threads
             from distributed import profile
 
-            lines: list[str] = [f"{len(bad_threads)} thread(s) were leaked from test\n"]
-            for i, thread in enumerate(bad_threads, 1):
-                lines.append(
-                    f"------ Call stack of leaked thread {i}/{len(bad_threads)}: {thread} ------"
-                )
-                lines.append(
-                    "".join(profile.call_stack(sys._current_frames()[thread.ident]))
-                    # NOTE: `call_stack` already adds newlines
-                )
+            frames = sys._current_frames()
+            try:
+                lines: list[str] = [
+                    f"{len(bad_threads)} thread(s) were leaked from test\n"
+                ]
+                for i, thread in enumerate(bad_threads, 1):
+                    lines.append(
+                        f"------ Call stack of leaked thread {i}/{len(bad_threads)}: {thread} ------"
+                    )
+                    lines.append(
+                        "".join(profile.call_stack(frames[thread.ident]))
+                        # NOTE: `call_stack` already adds newlines
+                    )
+            finally:
+                del frames
 
             pytest.fail("\n".join(lines), pytrace=False)
 


### PR DESCRIPTION
This should aid in debugging #6796.

This now gives output like:
```
2 thread(s) were leaked from test

------ Call stack of leaked thread 1/2: <Thread(Thread-3, started 123145522995200)> ------
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 912, in _bootstrap
        self._bootstrap_inner()
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 954, in _bootstrap_inner
        self.run()
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 892, in run
        self._target(*self._args, **self._kwargs)
  File "/Users/gabe/dev/distributed/distributed/tests/test_utils_test.py", line 770, in <lambda>
        t2 = threading.Thread(target=lambda: (event.wait(), "two"))
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 574, in wait
        signaled = self._cond.wait(timeout)
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 312, in wait
        waiter.acquire()

------ Call stack of leaked thread 2/2: <Thread(Thread-4, started 123145539784704)> ------
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 912, in _bootstrap
        self._bootstrap_inner()
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 954, in _bootstrap_inner
        self.run()
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 892, in run
        self._target(*self._args, **self._kwargs)
  File "/Users/gabe/dev/distributed/distributed/tests/test_utils_test.py", line 772, in <lambda>
        t3 = threading.Thread(target=lambda: (event.wait(), "three"))
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 574, in wait
        signaled = self._cond.wait(timeout)
  File "/Users/gabe/miniconda3/envs/dask-distributed/lib/python3.9/threading.py", line 312, in wait
        waiter.acquire()
```

Instead of:
```
>               assert False, (bad_thread, call_stacks)
E               AssertionError: (<Thread(asyncio_4, started daemon 123145657024512)>, ['  File "/Users/runner/miniconda3/envs/dask-distributed/lib/pyt...ibuted/lib/python3.10/concurrent/futures/thread.py", line 81, in _worker
E                 \twork_item = work_queue.get(block=True)
E                 '])
E               assert False
```
which was truncating the traceback and not giving much useful information.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
