### PR TITLE
Automatically configure all tests using autouse fixture

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -697,7 +697,7 @@ def cluster(
     ws = weakref.WeakSet()
     enable_proctitle_on_children()
 
-    with check_process_leak(check=True), check_instances():
+    with check_process_leak(check=True), check_instances(), _reconfigure():
         if nanny:
             _run_worker = run_nanny
         else:
@@ -1878,8 +1878,8 @@ def check_instances():
     DequeHandler.clear_all_instances()
 
 
-@pytest.fixture(autouse=True)
-def autoconfigure():
+@contextmanager
+def _reconfigure():
     reset_config()
 
     with dask.config.set(
@@ -2495,3 +2495,9 @@ def requires_default_ports(name_of_test):
         raise TimeoutError(f"Default ports didn't open up in time for {name_of_test}")
 
     yield
+
+
+@pytest.fixture(autouse=True)
+def autoconfigure():
+    with _reconfigure():
+        yield

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -697,7 +697,7 @@ def cluster(
     ws = weakref.WeakSet()
     enable_proctitle_on_children()
 
-    with check_process_leak(check=True), check_instances(), _reconfigure():
+    with check_process_leak(check=True), check_instances():
         if nanny:
             _run_worker = run_nanny
         else:
@@ -1878,8 +1878,8 @@ def check_instances():
     DequeHandler.clear_all_instances()
 
 
-@contextmanager
-def _reconfigure():
+@pytest.fixture(autouse=True)
+def autoconfigure_test():
     reset_config()
 
     with dask.config.set(
@@ -1904,8 +1904,7 @@ def clean(threads=True, instances=True, processes=True):
     with check_thread_leak() if threads else nullcontext():
         with check_process_leak(check=processes):
             with check_instances() if instances else nullcontext():
-                with _reconfigure():
-                    yield
+                yield
 
 
 @pytest.fixture

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1879,7 +1879,7 @@ def check_instances():
 
 
 @pytest.fixture(autouse=True)
-def autoconfigure_test():
+def autoconfigure():
     reset_config()
 
     with dask.config.set(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1904,7 +1904,8 @@ def clean(threads=True, instances=True, processes=True):
     with check_thread_leak() if threads else nullcontext():
         with check_process_leak(check=processes):
             with check_instances() if instances else nullcontext():
-                yield
+                with _reconfigure():
+                    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #6498 

This PR effectively turns `_reconfigure` into an `autouse` fixture that resets the configuration for each test. As a caveat, in some tests `_reconfigure()` is now run twice, but this should not cause any issues.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
