### PR TITLE
Avoid function calls in argument defaults (`B008`)

### DIFF
--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -184,7 +184,9 @@ class InProc(Comm):
         self._initialized = True
 
     def _get_finalizer(self):
-        def finalize(write_q=self._write_q, write_loop=self._write_loop, r=repr(self)):
+        r = repr(self)
+
+        def finalize(write_q=self._write_q, write_loop=self._write_loop, r=r):
             logger.warning(f"Closing dangling queue in {r}")
             write_loop.add_callback(write_q.put_nowait, _EOF)
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -194,7 +194,9 @@ class TCP(Comm):
         pass
 
     def _get_finalizer(self):
-        def finalize(stream=self.stream, r=repr(self)):
+        r = repr(self)
+
+        def finalize(stream=self.stream, r=r):
             # stream is None if a StreamClosedError is raised during interpreter
             # shutdown
             if stream is not None and not stream.closed():

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -205,7 +205,9 @@ class WS(Comm):
         self._read_extra()
 
     def _get_finalizer(self):
-        def finalize(sock=self.sock, r=repr(self)):
+        r = repr(self)
+
+        def finalize(sock=self.sock, r=r):
             if not sock.close_code:
                 logger.info("Closing dangling websocket in %s", r)
                 sock.close()


### PR DESCRIPTION
Partially addresses pre-commit failures in https://github.com/dask/distributed/pull/6809

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
