### PR TITLE
Avoid unused loop control variable or name them `_` (`B007`)

### DIFF
--- a/distributed/_version.py
+++ b/distributed/_version.py
@@ -113,7 +113,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     """
     rootdirs = []
 
-    for i in range(3):
+    for _ in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
             return {
@@ -520,7 +520,7 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split("/"):
+        for _ in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
         return {

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1153,7 +1153,7 @@ class Client(SyncMethodMixin):
         elif self.scheduler_file is not None:
             while not os.path.exists(self.scheduler_file):
                 await asyncio.sleep(0.01)
-            for i in range(10):
+            for _ in range(10):
                 try:
                     with open(self.scheduler_file) as f:
                         cfg = json.load(f)

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -519,7 +519,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         self.tcp_server = TCPServer(max_buffer_size=MAX_BUFFER_SIZE, **self.server_args)
         self.tcp_server.handle_stream = self._handle_stream
         backlog = int(dask.config.get("distributed.comm.socket-backlog"))
-        for i in range(5):
+        for _ in range(5):
             try:
                 # When shuffling data between workers, there can
                 # really be O(cluster size) connection requests

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -337,7 +337,7 @@ async def test_comm_failure_threading(tcp):
 
     async def sleep_for_60ms():
         max_thread_count = 0
-        for x in range(60):
+        for _ in range(60):
             await asyncio.sleep(0.001)
             thread_count = threading.active_count()
             if thread_count > max_thread_count:
@@ -379,7 +379,7 @@ async def check_inproc_specific(run_client):
         try:
             assert comm.peer_address.startswith("inproc://" + addr_head)
             client_addresses.add(comm.peer_address)
-            for i in range(N_MSGS):
+            for _ in range(N_MSGS):
                 msg = await comm.read()
                 msg["op"] = "pong"
                 await comm.write(msg)
@@ -399,7 +399,7 @@ async def check_inproc_specific(run_client):
             comm = await connect(listener.contact_address)
             try:
                 assert comm.peer_address == "inproc://" + listener_addr
-                for i in range(N_MSGS):
+                for _ in range(N_MSGS):
                     await comm.write({"op": "ping", "data": key})
                     if delay:
                         await asyncio.sleep(delay)
@@ -1020,7 +1020,7 @@ async def check_many_listeners(addr):
     listeners = []
     N = 100
 
-    for i in range(N):
+    for _ in range(N):
         listener = await listen(addr, handle_comm)
         listeners.append(listener)
 

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -300,7 +300,7 @@ async def test_stress(
             x = x.persist()
             await wait(x)
 
-            for i in range(10):
+            for _ in range(10):
                 x = x.rechunk((chunksize, -1))
                 x = x.rechunk((-1, chunksize))
                 x = x.persist()

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1399,7 +1399,7 @@ class ConnectionPool:
             self.active,
             len(self._connecting),
         )
-        for addr, comms in self.available.items():
+        for comms in self.available.values():
             for comm in comms:
                 IOLoop.current().add_callback(comm.close)
                 self.semaphore.release()

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1440,7 +1440,7 @@ class AggregateAction(DashboardComponent):
     def update(self):
         agg_times = defaultdict(float)
 
-        for key, ts in self.scheduler.task_prefixes.items():
+        for ts in self.scheduler.task_prefixes.values():
             for action, t in ts.all_durations.items():
                 agg_times[action] += t
 
@@ -2539,7 +2539,7 @@ class TaskGroupGraph(DashboardComponent):
 
         durations = set()
         nbytes = set()
-        for key, tg in self.scheduler.task_groups.items():
+        for tg in self.scheduler.task_groups.values():
 
             if tg.duration and tg.nbytes_total:
                 durations.add(tg.duration)
@@ -3495,8 +3495,8 @@ class WorkerTable(DashboardComponent):
     @without_property_validation
     def update(self):
         data = {name: [] for name in self.names + self.extra_names}
-        for i, (addr, ws) in enumerate(
-            sorted(self.scheduler.workers.items(), key=lambda kv: str(kv[1].name))
+        for i, ws in enumerate(
+            sorted(self.scheduler.workers.values(), key=lambda ws: str(ws.name))
         ):
             minfo = ws.memory
 

--- a/distributed/deploy/old_ssh.py
+++ b/distributed/deploy/old_ssh.py
@@ -428,7 +428,7 @@ class SSHCluster:
 
         # Start worker nodes
         self.workers = []
-        for i, addr in enumerate(worker_addrs):
+        for addr in worker_addrs:
             self.add_worker(addr)
 
     @gen.coroutine

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -74,7 +74,7 @@ async def test_adaptive_local_cluster_multi_workers():
                 await asyncio.sleep(0.01)
 
             # no workers for a while
-            for i in range(10):
+            for _ in range(10):
                 assert not cluster.scheduler.workers
                 await asyncio.sleep(0.05)
 
@@ -236,7 +236,7 @@ async def test_adapt_quickly():
 
         # Don't scale up for large sequential computations
         x = await client.scatter(1)
-        for i in range(100):
+        for _ in range(100):
             x = client.submit(slowinc, x)
 
         await asyncio.sleep(0.1)

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -464,7 +464,7 @@ async def test_MultiWorker():
 
             adapt = cluster.adapt(minimum=0, maximum=4)
 
-            for i in range(adapt.wait_count):  # relax down to 0 workers
+            for _ in range(adapt.wait_count):  # relax down to 0 workers
                 await adapt.adapt()
             await cluster
             assert not s.workers

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -63,7 +63,7 @@ async def test_progress_stream(c, s, a, b):
     futures = c.map(div, [1] * 10, range(10))
 
     x = 1
-    for i in range(5):
+    for _ in range(5):
         x = delayed(inc)(x)
     future = c.compute(x)
 

--- a/distributed/http/routing.py
+++ b/distributed/http/routing.py
@@ -20,7 +20,7 @@ def _descend_routes(router, routers=None, out=None):
             if issubclass(rule.target, tornado.web.StaticFileHandler):
                 prefix = rule.matcher.regex.pattern.rstrip("(.*)$").rstrip("/")
                 path = rule.target_kwargs["path"]
-                for d, dirs, files in os.walk(path):
+                for d, _, files in os.walk(path):
                     for fn in files:
                         fullpath = d + "/" + fn
                         ourpath = fullpath.replace(path, prefix).replace("\\", "/")

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -450,7 +450,7 @@ async def test_profile_nested_sizeof():
     original = outer = {}
     inner = {}
 
-    for i in range(n):
+    for _ in range(n):
         outer["children"] = inner
         outer, inner = inner, {}
 

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -110,7 +110,7 @@ class QueueExtension:
                         "integer batch sizes and timeouts"
                     )
                     raise NotImplementedError(msg)
-                for i in range(batch):
+                for _ in range(batch):
                     record = await q.get()
                     out.append(record)
             out = [process(o) for o in out]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6724,7 +6724,7 @@ class Scheduler(SchedulerState, ServerNode):
 
     def remove_resources(self, worker):
         ws: WorkerState = self.workers[worker]
-        for resource, quantity in ws.resources.items():
+        for resource in ws.resources:
             dr: dict = self.resources.get(resource, None)
             if dr is None:
                 self.resources[resource] = dr = {}
@@ -6849,7 +6849,7 @@ class Scheduler(SchedulerState, ServerNode):
             tt = t // dt * dt
             if tt > last:
                 last = tt
-                for k, v in keys.items():
+                for v in keys.values():
                     v.append([tt, 0])
             for k, v in d.items():
                 keys[k][-1][1] += v
@@ -7107,7 +7107,7 @@ class Scheduler(SchedulerState, ServerNode):
                     workers: list = list(self.workers.values())
                     nworkers: int = len(workers)
                     i: int
-                    for i in range(nworkers):
+                    for _ in range(nworkers):
                         ws: WorkerState = workers[worker_index % nworkers]
                         worker_index += 1
                         try:

--- a/distributed/shuffle/tests/test_multi_file.py
+++ b/distributed/shuffle/tests/test_multi_file.py
@@ -43,7 +43,7 @@ async def test_many(tmp_path, count):
     with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
         d = {i: [str(i).encode() * 100] for i in range(count)}
 
-        for i in range(10):
+        for _ in range(10):
             await mf.put(d)
 
         await mf.flush()

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -236,7 +236,7 @@ def test_processing_chain():
 
     filesystem = defaultdict(io.BytesIO)
 
-    for worker, partitions in splits_by_worker.items():
+    for partitions in splits_by_worker.values():
         for partition, batches in partitions.items():
             for batch in batches:
                 dump_batch(batch, filesystem[partition], schema)

--- a/distributed/tests/make_tls_certs.py
+++ b/distributed/tests/make_tls_certs.py
@@ -74,7 +74,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 def make_cert_key(hostname, sign=False):
     print("creating cert for " + hostname)
     tempnames = []
-    for i in range(3):
+    for _ in range(3):
         with tempfile.NamedTemporaryFile(delete=False) as f:
             tempnames.append(f.name)
     req_file, cert_file, key_file = tempnames

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -298,7 +298,7 @@ async def test_failed_worker(c, s, a, b):
 async def bench(c, s, a, b):
     counter = await c.submit(Counter, actor=True)
 
-    for i in range(1000):
+    for _ in range(1000):
         await counter.increment()
 
 
@@ -357,7 +357,7 @@ async def test_many_computations(c, s, a, b):
     counter = await c.submit(Counter, actor=True)
 
     def add(n, counter):
-        for i in range(n):
+        for _ in range(n):
             counter.increment().result()
 
     futures = c.map(add, range(10), counter=counter)
@@ -383,7 +383,7 @@ async def test_thread_safety(c, s, a, b):
             assert self.n == 0
             self.n += 1
 
-            for i in range(20):
+            for _ in range(20):
                 sleep(0.002)
                 assert self.n == 1
             self.n = 0
@@ -484,7 +484,7 @@ async def test_compute(c, s, a, b):
     @dask.delayed
     def f(n, counter):
         assert isinstance(counter, Actor)
-        for i in range(n):
+        for _ in range(n):
             counter.increment().result()
 
     @dask.delayed
@@ -506,7 +506,7 @@ def test_compute_sync(client):
     @dask.delayed
     def f(n, counter):
         assert isinstance(counter, Actor), type(counter)
-        for i in range(n):
+        for _ in range(n):
             counter.increment().result()
 
     @dask.delayed
@@ -544,7 +544,7 @@ async def test_actors_in_profile(c, s, a):
 
     sleeper = await c.submit(Sleeper, actor=True)
 
-    for i in range(5):
+    for _ in range(5):
         await sleeper.sleep(0.200)
         if (
             list(a.profile_recent["children"])[0].startswith("sleep")

--- a/distributed/tests/test_client_executor.py
+++ b/distributed/tests/test_client_executor.py
@@ -152,7 +152,7 @@ def test_map(client):
         N = 10
         # Not consuming the iterator will cancel remaining tasks
         it = e.map(slowinc, range(N), [0.3] * N)
-        for x in take(2, it):
+        for _ in take(2, it):
             pass
         # Some tasks still processing
         assert number_of_processing_tasks(client) > 0

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -86,7 +86,7 @@ def test_async_task_group_initialization():
 
 
 async def _wait_for_n_loop_cycles(n):
-    for i in range(n):
+    for _ in range(n):
         await asyncio.sleep(0)
 
 
@@ -538,14 +538,14 @@ async def test_rpc_message_lifetime_inproc():
 
 async def check_rpc_with_many_connections(listen_arg):
     async def g():
-        for i in range(10):
+        for _ in range(10):
             await remote.ping()
 
     server = await Server({"ping": pingpong})
     await server.listen(listen_arg)
 
     async with rpc(server.address) as remote:
-        for i in range(10):
+        for _ in range(10):
             await g()
 
         server.stop()
@@ -936,7 +936,7 @@ async def test_counters():
         await server.listen("tcp://")
 
         async with rpc(server.address) as r:
-            for i in range(2):
+            for _ in range(2):
                 await r.identity()
             with pytest.raises(ZeroDivisionError):
                 await r.div(x=1, y=0)

--- a/distributed/tests/test_counter.py
+++ b/distributed/tests/test_counter.py
@@ -44,6 +44,6 @@ def test_counter(loop):
     c = Counter(loop=loop)
     c.add(1)
 
-    for i in range(5):
+    for _ in range(5):
         c.shift()
         assert abs(sum(cc[1] for cc in c.components) - 1) < 1e-13

--- a/distributed/tests/test_diskutils.py
+++ b/distributed/tests/test_diskutils.py
@@ -24,7 +24,7 @@ from distributed.utils_test import captured_logger
 
 def assert_directory_contents(dir_path, expected, trials=2):
     expected = [os.path.join(dir_path, p) for p in expected]
-    for i in range(trials):
+    for _ in range(trials):
         actual = [
             os.path.join(dir_path, p)
             for p in os.listdir(dir_path)

--- a/distributed/tests/test_metrics.py
+++ b/distributed/tests/test_metrics.py
@@ -9,7 +9,7 @@ from distributed import metrics
 
 @pytest.mark.parametrize("name", ["time", "monotonic"])
 def test_wall_clock(name):
-    for i in range(3):
+    for _ in range(3):
         time.sleep(0.01)
         t = getattr(time, name)()
         samples = [getattr(metrics, name)() for _ in range(100)]

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -176,7 +176,7 @@ async def test_num_fds(s):
 
     before = proc.num_fds()
 
-    for i in range(3):
+    for _ in range(3):
         async with Nanny(s.address):
             await asyncio.sleep(0.1)
 

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -34,7 +34,7 @@ def test_basic():
         sleep(0.02)
 
     def test_f():
-        for i in range(100):
+        for _ in range(100):
             test_g()
             test_h()
 
@@ -44,7 +44,7 @@ def test_basic():
 
     state = create()
 
-    for i in range(100):
+    for _ in range(100):
         sleep(0.02)
         frame = sys._current_frames()[thread.ident]
         process(frame, None, state)
@@ -75,7 +75,7 @@ def test_basic_low_level():
 
     state = create()
 
-    for i in range(100):
+    for _ in range(100):
         sleep(0.02)
         frame = sys._current_frames()[threading.get_ident()]
         llframes = {threading.get_ident(): ll_get_stack(threading.get_ident())}

--- a/distributed/tests/test_pubsub.py
+++ b/distributed/tests/test_pubsub.py
@@ -32,7 +32,7 @@ async def test_speed(c, s, a, b):
         if start:
             pub.put(msg)  # other sub may not have started yet
 
-        for i in range(n):
+        for _ in range(n):
             msg = next(sub)
             pub.put(msg)
             # if i % 100 == 0:
@@ -85,7 +85,7 @@ async def test_client_worker(c, s, a, b):
     await wait(futures)
 
     L = []
-    for i in range(10):
+    for _ in range(10):
         result = await sub.get()
         L.append(result)
 

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -145,12 +145,12 @@ async def test_same_futures(c, s, a, b):
     q = Queue("x")
     future = await c.scatter(123)
 
-    for i in range(5):
+    for _ in range(5):
         await q.put(future)
 
     assert {ts.key for ts in s.clients["queue-x"].wants_what} == {future.key}
 
-    for i in range(4):
+    for _ in range(4):
         future2 = await q.get()
         assert {ts.key for ts in s.clients["queue-x"].wants_what} == {future.key}
         await asyncio.sleep(0.05)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -200,7 +200,7 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
         # Check that each chunk-row of the array is (mostly) stored on the same worker
         primary_worker_key_fractions = []
         secondary_worker_key_fractions = []
-        for i, keys in enumerate(x.__dask_keys__()):
+        for keys in x.__dask_keys__():
             # Iterate along rows of the array.
             keys = {stringify(k) for k in keys}
 
@@ -428,7 +428,7 @@ async def test_feed(s, a, b):
     comm = await connect(s.address)
     await comm.write({"op": "feed", "function": dumps(func), "interval": 0.01})
 
-    for i in range(5):
+    for _ in range(5):
         response = await comm.read()
         expected = dict(s.workers)
         assert cloudpickle.loads(response) == expected
@@ -459,7 +459,7 @@ async def test_feed_setup_teardown(s, a, b):
         }
     )
 
-    for i in range(5):
+    for _ in range(5):
         response = await comm.read()
         assert response == "OK"
 
@@ -483,7 +483,7 @@ async def test_feed_large_bytestring(s, a, b):
     comm = await connect(s.address)
     await comm.write({"op": "feed", "function": dumps(func), "interval": 0.05})
 
-    for i in range(5):
+    for _ in range(5):
         response = await comm.read()
         assert response is True
 
@@ -1125,7 +1125,7 @@ async def test_file_descriptors(c, s):
     await c.close()
 
     assert not s.rpc.open
-    for addr, occ in c.rpc.occupied.items():
+    for occ in c.rpc.occupied.values():
         for comm in occ:
             assert comm.closed() or comm.peer_address != s.address, comm
     assert not s.stream_comms
@@ -1330,7 +1330,7 @@ async def test_close_nanny(s, a, b):
     assert not a.is_alive()
     assert a.pid is None
 
-    for i in range(10):
+    for _ in range(10):
         await asyncio.sleep(0.1)
         assert len(s.workers) == 1
         assert not a.is_alive()
@@ -2401,7 +2401,7 @@ async def test_retire_state_change(c, s, a, b):
     y = c.map(lambda x: x**2, range(10))
     await c.scatter(y)
     coros = []
-    for x in range(2):
+    for _ in range(2):
         v = c.map(lambda i: i * np.random.randint(1000), y)
         k = c.map(lambda i: i * np.random.randint(1000), v)
         foo = c.map(lambda j: j * 6, k)

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -674,7 +674,7 @@ async def assert_balanced(inp, expected, c, s, *workers):
     while len([ts for ts in s.tasks.values() if ts.processing_on]) < len(futures):
         await asyncio.sleep(0.001)
 
-    for i in range(10):
+    for _ in range(10):
         steal.balance()
 
         while steal.in_flight:
@@ -955,7 +955,7 @@ async def test_cleanup_repeated_tasks(c, s, a, b):
 async def test_lose_task(c, s, a, b):
     with captured_logger("distributed.stealing") as log:
         s.periodic_callbacks["stealing"].interval = 1
-        for i in range(100):
+        for _ in range(100):
             futures = c.map(
                 slowinc,
                 range(10),

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -51,7 +51,7 @@ def test_stress_gc(loop, func, n):
     with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
             x = c.submit(func, 1)
-            for i in range(n):
+            for _ in range(n):
                 x = c.submit(func, x)
 
             assert x.result() == n + 2
@@ -66,7 +66,7 @@ async def test_cancel_stress(c, s, *workers):
     await wait([x])
     y = (x.sum(axis=0) + x.sum(axis=1) + 1).std()
     n_todo = len(y.dask) - len(x.dask)
-    for i in range(5):
+    for _ in range(5):
         f = c.compute(y)
         while (
             len([ts for ts in s.tasks.values() if ts.waiting_on])
@@ -84,7 +84,7 @@ def test_cancel_stress_sync(loop):
             x = c.persist(x)
             y = (x.sum(axis=0) + x.sum(axis=1) + 1).std()
             wait(x)
-            for i in range(5):
+            for _ in range(5):
                 f = c.compute(y)
                 sleep(random.random())
                 c.cancel(f)
@@ -199,7 +199,7 @@ async def test_stress_steal(c, s, *workers):
 
     dinc = delayed(slowinc)
     L = [delayed(slowinc)(i, delay=0.005) for i in range(100)]
-    for i in range(5):
+    for _ in range(5):
         L = [delayed(slowsum)(part, delay=0.005) for part in sliding_window(5, L)]
 
     total = delayed(sum)(L)
@@ -207,7 +207,7 @@ async def test_stress_steal(c, s, *workers):
 
     while future.status != "finished":
         await asyncio.sleep(0.1)
-        for i in range(3):
+        for _ in range(3):
             a = random.choice(workers)
             b = random.choice(workers)
             if a is not b:
@@ -227,7 +227,7 @@ async def test_stress_steal(c, s, *workers):
 async def test_close_connections(c, s, *workers):
     da = pytest.importorskip("dask.array")
     x = da.random.random(size=(1000, 1000), chunks=(1000, 1))
-    for i in range(3):
+    for _ in range(3):
         x = x.rechunk((1, 1000))
         x = x.rechunk((1000, 1))
 

--- a/distributed/tests/test_system_monitor.py
+++ b/distributed/tests/test_system_monitor.py
@@ -29,7 +29,7 @@ def test_count():
     sm.update()
     assert sm.count == 2
 
-    for i in range(10):
+    for _ in range(10):
         sm.update()
 
     assert sm.count == 12
@@ -50,7 +50,7 @@ def test_range_query():
     assert all(len(v) == 4 for v in sm.range_query(0).values())
     assert all(len(v) == 3 for v in sm.range_query(1).values())
 
-    for i in range(10):
+    for _ in range(10):
         sm.update()
 
     assert all(len(v) == 4 for v in sm.range_query(10).values())

--- a/distributed/tests/test_threadpoolexecutor.py
+++ b/distributed/tests/test_threadpoolexecutor.py
@@ -122,7 +122,7 @@ def test_rejoin_idempotent():
 
         def f():
             secede()
-            for i in range(5):
+            for _ in range(5):
                 rejoin()
             return 1
 

--- a/distributed/tests/test_utils_perf.py
+++ b/distributed/tests/test_utils_perf.py
@@ -48,7 +48,7 @@ def test_fractional_timer():
 
     timer = RandomTimer()
     ft = FractionalTimer(n_samples=N, timer=timer)
-    for i in range(N):
+    for _ in range(N):
         ft.start_timing()
         ft.stop_timing()
     assert len(timer.timings) == N * 2
@@ -60,7 +60,7 @@ def test_fractional_timer():
     assert ft.running_fraction is not None
     check_fraction(timer, ft)
 
-    for i in range(N * 10):
+    for _ in range(N * 10):
         ft.start_timing()
         ft.stop_timing()
         check_fraction(timer, ft)
@@ -90,7 +90,7 @@ def test_gc_diagnosis_cpu_time():
 
     with enable_gc_diagnosis_and_log(diag, level="WARN") as sio:
         # Spend some CPU time doing only full GCs
-        for i in range(diag.N_SAMPLES):
+        for _ in range(diag.N_SAMPLES):
             gc.collect()
         assert not sio.getvalue()
         gc.collect()
@@ -104,7 +104,7 @@ def test_gc_diagnosis_cpu_time():
 
     with enable_gc_diagnosis_and_log(diag, level="WARN") as sio:
         # Spend half the CPU time doing full GCs
-        for i in range(diag.N_SAMPLES + 1):
+        for _ in range(diag.N_SAMPLES + 1):
             t1 = thread_time()
             gc.collect()
             dt = thread_time() - t1

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -741,7 +741,7 @@ async def test_restrictions(c, s, a, b):
 @gen_cluster(client=True)
 async def test_clean_nbytes(c, s, a, b):
     L = [delayed(inc)(i) for i in range(10)]
-    for i in range(5):
+    for _ in range(5):
         L = [delayed(add)(x, y) for x, y in sliding_window(2, L)]
     total = delayed(sum)(L)
 

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -206,7 +206,7 @@ def test_dont_override_default_get(loop):
         loop=loop, processes=False, set_as_default=True, dashboard_address=":0"
     ) as c:
         assert dask.base.get_scheduler() == c.get
-        for i in range(2):
+        for _ in range(2):
             b2.compute()
 
         assert dask.base.get_scheduler() == c.get

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1141,7 +1141,7 @@ def json_load_robust(fn, load=json.load):
     """Reads a JSON file from disk that may be being written as we read"""
     while not os.path.exists(fn):
         sleep(0.01)
-    for i in range(10):
+    for _ in range(10):
         try:
             with open(fn) as f:
                 cfg = load(f)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -491,10 +491,10 @@ def run_scheduler(q, nputs, config, port=0, **kwargs):
                     validate=True, host="127.0.0.1", port=port, **kwargs
                 )
             except Exception as exc:
-                for i in range(nputs):
+                for _ in range(nputs):
                     q.put(exc)
             else:
-                for i in range(nputs):
+                for _ in range(nputs):
                     q.put(scheduler.address)
                 await scheduler.finished()
 
@@ -937,7 +937,7 @@ def check_invalid_worker_transitions(s: Scheduler) -> None:
     if not s.events.get("invalid-worker-transition"):
         return
 
-    for timestamp, msg in s.events["invalid-worker-transition"]:
+    for _, msg in s.events["invalid-worker-transition"]:
         worker = msg.pop("worker")
         print("Worker:", worker)
         print(InvalidTransition(**msg))
@@ -951,7 +951,7 @@ def check_invalid_task_states(s: Scheduler) -> None:
     if not s.events.get("invalid-worker-task-state"):
         return
 
-    for timestamp, msg in s.events["invalid-worker-task-state"]:
+    for _, msg in s.events["invalid-worker-task-state"]:
         print("Worker:", msg["worker"])
         print("State:", msg["state"])
         for line in msg["story"]:
@@ -964,7 +964,7 @@ def check_worker_fail_hard(s: Scheduler) -> None:
     if not s.events.get("worker-fail-hard"):
         return
 
-    for timestamp, msg in s.events["worker-fail-hard"]:
+    for _, msg in s.events["worker-fail-hard"]:
         msg = msg.copy()
         worker = msg.pop("worker")
         msg["exception"] = deserialize(msg["exception"].header, msg["exception"].frames)
@@ -1869,7 +1869,7 @@ def check_instances():
         assert time() < start + 10
     Worker._initialized_clients.clear()
 
-    for i in range(5):
+    for _ in range(5):
         if all(c.closed() for c in Comm._instances):
             break
         else:


### PR DESCRIPTION
Partially addresses pre-commit failures in https://github.com/dask/distributed/pull/6809

**Note:**

I'm a bit torn when it comes to this rule. In a number of instances, it improved the code by removing unnecessary variables, but in other instances, the value of `for _ in range(N)` over `for i in range(N)` is marginal and may be considered an unnecessary restriction by some developers.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
