### PR TITLE
Fix Jupyter security note

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3020,9 +3020,11 @@ class Scheduler(SchedulerState, ServerNode):
                     {
                         "ServerApp": {
                             "base_url": "jupyter",
-                            # SECURITY: in this context we expect this to be safe, as
-                            # if a client can connect to the scheduler they can already
-                            # run arbitrary code.
+                            # SECURITY: We usually expect the dashboard to be a read-only view into
+                            # the scheduler activity. However, by adding an open Jupyter application
+                            # we are allowing arbitrary remote code execution on the scheduler via the
+                            # dashboard server. This option should only be used when the dashboard is
+                            # protected via other means, or when you don't care about cluster security.
                             "token": "",
                             "allow_remote_access": True,
                         }


### PR DESCRIPTION
Following up on an unresolved review thread https://github.com/dask/distributed/pull/6737#discussion_r935299222

Starting Jupyter alongside the scheduler is a security risk if the dashboard has not been secured. Updating the comment with the suggestion from @ian-r-rose to reflect that.