### PR TITLE
Only set 5s connect timeout in `gen_cluster` tests

### DIFF
--- a/distributed/config.py
+++ b/distributed/config.py
@@ -80,7 +80,7 @@ def _initialize_logging_old_style(config):
         }
     """
     loggers = {  # default values
-        "distributed": "info",
+        "distributed": "debug",
         "distributed.client": "warning",
         "bokeh": "error",
         "tornado": "critical",

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -80,7 +80,7 @@ def _initialize_logging_old_style(config):
         }
     """
     loggers = {  # default values
-        "distributed": "debug",
+        "distributed": "info",
         "distributed.client": "warning",
         "bokeh": "error",
         "tornado": "critical",

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -42,7 +42,6 @@ def test_submit_after_failed_worker_sync(loop):
             a["proc"]().terminate()
             total = c.submit(sum, L)
             assert total.result() == sum(map(inc, range(10)))
-    assert False
 
 
 @pytest.mark.slow()

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import random
 from contextlib import suppress
@@ -36,6 +37,7 @@ pytestmark = pytest.mark.ci1
 @pytest.mark.slow()
 def test_submit_after_failed_worker_sync(loop):
     with cluster() as (s, [a, b]):
+        logging.getLogger("distributed").setLevel("DEBUG")
         with Client(s["address"], loop=loop) as c:
             L = c.map(inc, range(10))
             wait(L)
@@ -74,6 +76,7 @@ async def test_submit_after_failed_worker(c, s, a, b):
 @pytest.mark.slow
 def test_gather_after_failed_worker(loop):
     with cluster() as (s, [a, b]):
+        logging.getLogger("distributed").setLevel("DEBUG")
         with Client(s["address"], loop=loop) as c:
             L = c.map(inc, range(10))
             wait(L)
@@ -144,6 +147,7 @@ async def test_restart_cleared(c, s, a, b):
 
 def test_restart_sync(loop):
     with cluster(nanny=True) as (s, [a, b]):
+        logging.getLogger("distributed").setLevel("DEBUG")
         with Client(s["address"], loop=loop) as c:
             x = c.submit(div, 1, 2)
             x.result()
@@ -163,6 +167,7 @@ def test_restart_sync(loop):
 
 def test_worker_doesnt_await_task_completion(loop):
     with cluster(nanny=True, nworkers=1) as (s, [w]):
+        logging.getLogger("distributed").setLevel("DEBUG")
         with Client(s["address"], loop=loop) as c:
             future = c.submit(sleep, 100)
             sleep(0.1)

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
 import random
 from contextlib import suppress
@@ -37,7 +36,6 @@ pytestmark = pytest.mark.ci1
 @pytest.mark.slow()
 def test_submit_after_failed_worker_sync(loop):
     with cluster() as (s, [a, b]):
-        logging.getLogger("distributed").setLevel("DEBUG")
         with Client(s["address"], loop=loop) as c:
             L = c.map(inc, range(10))
             wait(L)
@@ -76,7 +74,6 @@ async def test_submit_after_failed_worker(c, s, a, b):
 @pytest.mark.slow
 def test_gather_after_failed_worker(loop):
     with cluster() as (s, [a, b]):
-        logging.getLogger("distributed").setLevel("DEBUG")
         with Client(s["address"], loop=loop) as c:
             L = c.map(inc, range(10))
             wait(L)
@@ -147,7 +144,6 @@ async def test_restart_cleared(c, s, a, b):
 
 def test_restart_sync(loop):
     with cluster(nanny=True) as (s, [a, b]):
-        logging.getLogger("distributed").setLevel("DEBUG")
         with Client(s["address"], loop=loop) as c:
             x = c.submit(div, 1, 2)
             x.result()
@@ -167,7 +163,6 @@ def test_restart_sync(loop):
 
 def test_worker_doesnt_await_task_completion(loop):
     with cluster(nanny=True, nworkers=1) as (s, [w]):
-        logging.getLogger("distributed").setLevel("DEBUG")
         with Client(s["address"], loop=loop) as c:
             future = c.submit(sleep, 100)
             sleep(0.1)

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -42,6 +42,7 @@ def test_submit_after_failed_worker_sync(loop):
             a["proc"]().terminate()
             total = c.submit(sum, L)
             assert total.result() == sum(map(inc, range(10)))
+    assert False
 
 
 @pytest.mark.slow()

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -167,9 +167,9 @@ def test_worker_doesnt_await_task_completion(loop):
             future = c.submit(sleep, 100)
             sleep(0.1)
             start = time()
-            c.restart()
+            c.restart(timeout="5s", wait_for_workers=False)
             stop = time()
-            assert stop - start < 20
+            assert stop - start < 10
 
 
 @gen_cluster(Worker=Nanny, timeout=60)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -152,7 +152,7 @@ def loop_in_thread(cleanup):
     loop_started = concurrent.futures.Future()
     with concurrent.futures.ThreadPoolExecutor(
         1, thread_name_prefix="test IOLoop"
-    ) as tpe, set_default_test_config():
+    ) as tpe, default_test_config():
 
         async def run():
             io_loop = IOLoop.current()
@@ -672,7 +672,7 @@ def cluster(
     ws = weakref.WeakSet()
     enable_proctitle_on_children()
 
-    with check_process_leak(check=True), check_instances(), set_default_test_config():
+    with check_process_leak(check=True), check_instances(), default_test_config():
         if nanny:
             _run_worker = run_nanny
         else:
@@ -835,7 +835,7 @@ def gen_test(
 
     def _(func):
         @functools.wraps(func)
-        @set_default_test_config()
+        @default_test_config()
         @clean(**clean_kwargs)
         def test_func(*args, **kwargs):
             if not iscoroutinefunction(func):
@@ -1039,7 +1039,7 @@ def gen_cluster(
             raise RuntimeError("gen_cluster only works for coroutine functions.")
 
         @functools.wraps(func)
-        @set_default_test_config(**{"distributed.comm.timeouts.connect": "5s"})
+        @default_test_config(**{"distributed.comm.timeouts.connect": "5s"})
         @clean(**clean_kwargs)
         def test_func(*outer_args, **kwargs):
             async def async_fn():
@@ -1882,7 +1882,7 @@ def check_instances():
 
 
 @contextmanager
-def set_default_test_config(**extra_config):
+def default_test_config(**extra_config):
     reset_config()
 
     with dask.config.set(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -787,7 +787,9 @@ async def disconnect(addr, timeout=3, rpc_kwargs=None):
     rpc_kwargs = rpc_kwargs or {}
 
     async def do_disconnect():
+        logger.info(f"Disconnecting {addr}")
         async with rpc(addr, **rpc_kwargs) as w:
+            logger.info(f"Disconnecting {addr} - RPC connected")
             # If the worker was killed hard (e.g. sigterm) during test runtime,
             # we do not know at this point and may not be able to connect
             with suppress(EnvironmentError, CommClosedError):
@@ -795,11 +797,13 @@ async def disconnect(addr, timeout=3, rpc_kwargs=None):
                 # worker before a reply can be made and we will always trigger
                 # the timeout
                 await w.terminate(reply=False)
+                logger.info(f"Disconnecting {addr} - sent terminate")
 
     await asyncio.wait_for(do_disconnect(), timeout=timeout)
 
 
 async def disconnect_all(addresses, timeout=3, rpc_kwargs=None):
+    logger.info(f"Disconnecting {addresses}")
     await asyncio.gather(*(disconnect(addr, timeout, rpc_kwargs) for addr in addresses))
 
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -787,9 +787,7 @@ async def disconnect(addr, timeout=3, rpc_kwargs=None):
     rpc_kwargs = rpc_kwargs or {}
 
     async def do_disconnect():
-        logger.info(f"Disconnecting {addr}")
         async with rpc(addr, **rpc_kwargs) as w:
-            logger.info(f"Disconnecting {addr} - RPC connected")
             # If the worker was killed hard (e.g. sigterm) during test runtime,
             # we do not know at this point and may not be able to connect
             with suppress(EnvironmentError, CommClosedError):
@@ -797,13 +795,11 @@ async def disconnect(addr, timeout=3, rpc_kwargs=None):
                 # worker before a reply can be made and we will always trigger
                 # the timeout
                 await w.terminate(reply=False)
-                logger.info(f"Disconnecting {addr} - sent terminate")
 
     await asyncio.wait_for(do_disconnect(), timeout=timeout)
 
 
 async def disconnect_all(addresses, timeout=3, rpc_kwargs=None):
-    logger.info(f"Disconnecting {addresses}")
     await asyncio.gather(*(disconnect(addr, timeout, rpc_kwargs) for addr in addresses))
 
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -152,7 +152,7 @@ def loop_in_thread(cleanup):
     loop_started = concurrent.futures.Future()
     with concurrent.futures.ThreadPoolExecutor(
         1, thread_name_prefix="test IOLoop"
-    ) as tpe, default_test_config():
+    ) as tpe, config_for_cluster_tests():
 
         async def run():
             io_loop = IOLoop.current()
@@ -672,7 +672,7 @@ def cluster(
     ws = weakref.WeakSet()
     enable_proctitle_on_children()
 
-    with check_process_leak(check=True), check_instances(), default_test_config():
+    with check_process_leak(check=True), check_instances(), config_for_cluster_tests():
         if nanny:
             _run_worker = run_nanny
         else:
@@ -839,7 +839,7 @@ def gen_test(
 
     def _(func):
         @functools.wraps(func)
-        @default_test_config()
+        @config_for_cluster_tests()
         @clean(**clean_kwargs)
         def test_func(*args, **kwargs):
             if not iscoroutinefunction(func):
@@ -1043,7 +1043,7 @@ def gen_cluster(
             raise RuntimeError("gen_cluster only works for coroutine functions.")
 
         @functools.wraps(func)
-        @default_test_config(**{"distributed.comm.timeouts.connect": "5s"})
+        @config_for_cluster_tests(**{"distributed.comm.timeouts.connect": "5s"})
         @clean(**clean_kwargs)
         def test_func(*outer_args, **kwargs):
             async def async_fn():
@@ -1886,7 +1886,8 @@ def check_instances():
 
 
 @contextmanager
-def default_test_config(**extra_config):
+def config_for_cluster_tests(**extra_config):
+    "Set recommended config values for tests that create or interact with clusters."
     reset_config()
 
     with dask.config.set(


### PR DESCRIPTION
This subtly refactors (and renames) the use of the `_reconfigure` contextmanager, which is used to set some dask config defaults. Rather than calling `_reconfigure` within `clean`, we separate it out (since its job is different) and call it manually in the `gen_cluster`, `gen_test`, and `loop` fixtures.

We also remove the `"distributed.comm.timeouts.connect": "5s"` default timeout, _except_ for in `gen_cluster`, since that's the only test setup where we can be confident the scheduler isn't running in a subprocess (which could take >5s to start). I'm not even sure what the value is in keeping this timeout for `gen_cluster`, but it shouldn't hurt either, so I left it for now.

See explanation in https://github.com/dask/distributed/issues/6731#issuecomment-1203407451.

- [x] Passes `pre-commit run --all-files`

Closes https://github.com/dask/distributed/issues/6731
* Closes #6751
* Closes #6752
* Closes #6395
* Closes #6753
* Closes #6754
* Closes #6755
* Closes #6759
* Closes #6760
* Closes #6761
* Closes #6762
* Closes #6763
* Closes #6764
* Closes #6765
* Closes #6773