### PR TITLE
Ignore warning for unclose SSHCluster in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ ignore =
     W503, # Line break occurred before a binary operator
 per-file-ignores =
     **/tests/*:
-        # Module level import not at top of file (to silence on pytest.importorskip) 
+        # Module level import not at top of file (to silence on pytest.importorskip)
         # See https://github.com/PyCQA/pycodestyle/issues/472
         E402,
         # Do not use variables named 'I', 'O', or 'l'
@@ -63,6 +63,7 @@ filterwarnings =
     ignore:unclosed file <_io.TextIOWrapper.*:ResourceWarning
     ignore:unclosed transport <_SelectorSocketTransport.*:ResourceWarning
     ignore:unclosed transport <asyncio\.sslproto\..*:ResourceWarning
+    ignore:unclosed cluster SSHCluster.*:ResourceWarning
     ignore:Couldn't detect a suitable IP address for reaching '2001.4860.4860..8888', defaulting to hostname. \[Errno 65\] No route to host:RuntimeWarning
     ignore:Dashboard and Scheduler are using the same server on port.*:RuntimeWarning
     ignore:coroutine 'BaseTCPConnector.connect' was never awaited:RuntimeWarning


### PR DESCRIPTION
I don't think this is worth raising.

Closes https://github.com/dask/distributed/issues/6771
Closes https://github.com/dask/distributed/issues/6653