### PR TITLE
Human-readable formatting for disk I/O on `/workers`

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3366,8 +3366,10 @@ class WorkerTable(DashboardComponent):
             "memory_unmanaged_recent": "unmanaged recent",
             "memory_spilled": "spilled",
             "num_fds": "# fds",
-            "read_bytes": "read",
-            "write_bytes": "write",
+            "read_bytes": "net read",
+            "write_bytes": "net write",
+            "read_bytes_disk": "disk read",
+            "write_bytes_disk": "disk write",
         }
 
         self.source = ColumnDataSource({k: [] for k in self.names})
@@ -3390,6 +3392,8 @@ class WorkerTable(DashboardComponent):
             "write_bytes": NumberFormatter(format="0 b"),
             "num_fds": NumberFormatter(format="0"),
             "nthreads": NumberFormatter(format="0"),
+            "read_bytes_disk": NumberFormatter(format="0 b"),
+            "write_bytes_disk": NumberFormatter(format="0 b"),
         }
 
         table = DataTable(
@@ -3419,6 +3423,12 @@ class WorkerTable(DashboardComponent):
             width=width,
             index_position=None,
         )
+
+        for name in extra_names:
+            if name in formatters:
+                extra_table.columns[extra_names.index(name)].formatter = formatters[
+                    name
+                ]
 
         hover = HoverTool(
             point_policy="follow_mouse",


### PR DESCRIPTION
This PR adds formatting for the disk I/O statistics shown on `/workers` and renames columns in the two tables to better differentiate between network and disk I/O.

**Out of scope:**
* I think that, ideally, we would want to have one dedicated table for all I/O metrics but this is out of scope for this PR.

Before (changes highlighted in red):
![annotated-previous-formatting](https://user-images.githubusercontent.com/2699097/183056329-0ec5e320-91cd-4924-93a6-1590b73cdff3.png)

After:
![human-readable-disk-io](https://user-images.githubusercontent.com/2699097/183055783-13c94885-9345-4efb-b09c-704a59555831.png)

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
