### PR TITLE
Show actual Job URL on test report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,8 @@ tags
 .mypy_cache/
 
 reports/
-test_report.*
+test_report*.html
+test_report*.db
 test_short_report.html
 
 # Test failures will dump the cluster state in here


### PR DESCRIPTION
By fetching the Jobs info we can show the URL pointing to the actual job (e.g. OSX noci1)

With this PR

https://github.com/dask/distributed/runs/7666177056?check_suite_focus=true

![image](https://user-images.githubusercontent.com/8629629/183079968-19813552-6595-4913-99cc-1d4b37e9b2c3.png)

Without

https://github.com/dask/distributed/actions/runs/2794492651

![image](https://user-images.githubusercontent.com/8629629/183080088-763ba525-5c67-4664-851d-3b31b23bce79.png)

It also reduces the size of the HTML page generated by shrinking the DF before rendering. The HTML grew to 10-20MB already