### PR TITLE
Inserting memory_limit parameter within LocalCluster docstring

### DIFF
--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -32,12 +32,15 @@ class LocalCluster(SpecCluster):
         Number of workers to start
     memory_limit: str, float, int, or None, default "auto"
         Sets the memory limit *per worker*.
+
         Notes regarding argument data type:
-        If None or 0, no limit is applied.
-        If "auto", the total system memory is split evenly between the workers.
-        If a float, that fraction of the system memory is used *per worker*.
-        If a string giving a number of bytes (like ``"1GiB"``), that amount is used *per worker*.
-        If an int, that number of bytes is used *per worker*.
+
+        * If None or 0, no limit is applied.
+        * If "auto", the total system memory is split evenly between the workers.
+        * If a float, that fraction of the system memory is used *per worker*.
+        * If a string giving a number of bytes (like ``"1GiB"``), that amount is used *per worker*.
+        * If an int, that number of bytes is used *per worker*.
+
         Note that the limit will only be enforced when ``processes=True``, and the limit is only
         enforced on a best-effort basis — it's still possible for workers to exceed this limit.
     processes: bool
@@ -110,7 +113,6 @@ class LocalCluster(SpecCluster):
     def __init__(
         self,
         name=None,
-        memory_limit=None,
         n_workers=None,
         threads_per_worker=None,
         processes=None,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -30,6 +30,8 @@ class LocalCluster(SpecCluster):
     ----------
     n_workers: int
         Number of workers to start
+    memory_limit: str
+        Sets the memory limit per worker. Cannot exceed the total memory available.
     processes: bool
         Whether to use processes (True) or threads (False).  Defaults to True, unless
         worker_class=Worker, in which case it defaults to False.

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -30,8 +30,11 @@ class LocalCluster(SpecCluster):
     ----------
     n_workers: int
         Number of workers to start
-    memory_limit: str
-        Sets the memory limit per worker. Cannot exceed the total memory available.
+    memory_limit: str, float, int, or None, default "auto"
+        Sets the memory limit *per worker*.
+        
+        Note that the limit will only be enforced when ``processes=True``, and the limit is only
+        enforced on a best-effort basis — it's still possible for workers to exceed this limit.
     processes: bool
         Whether to use processes (True) or threads (False).  Defaults to True, unless
         worker_class=Worker, in which case it defaults to False.

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -32,6 +32,11 @@ class LocalCluster(SpecCluster):
         Number of workers to start
     memory_limit: str, float, int, or None, default "auto"
         Sets the memory limit *per worker*.
+        Notes regarding argument data type: If None or 0, no limit is applied.
+        If "auto", the total system memory is split evenly between the workers.
+        If a float, that fraction of the system memory is used *per worker*.
+        If a string giving a number of bytes (like ``"1GiB"``), that amount is used *per worker*.
+        If an int, that number of bytes is used *per worker*.
         Note that the limit will only be enforced when ``processes=True``, and the limit is only
         enforced on a best-effort basis — it's still possible for workers to exceed this limit.
     processes: bool

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -32,7 +32,7 @@ class LocalCluster(SpecCluster):
         Number of workers to start
     memory_limit: str, float, int, or None, default "auto"
         Sets the memory limit *per worker*.
-        Notes regarding argument data type: 
+        Notes regarding argument data type:
         If None or 0, no limit is applied.
         If "auto", the total system memory is split evenly between the workers.
         If a float, that fraction of the system memory is used *per worker*.
@@ -110,6 +110,7 @@ class LocalCluster(SpecCluster):
     def __init__(
         self,
         name=None,
+        memory_limit=None,
         n_workers=None,
         threads_per_worker=None,
         processes=None,

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -32,7 +32,8 @@ class LocalCluster(SpecCluster):
         Number of workers to start
     memory_limit: str, float, int, or None, default "auto"
         Sets the memory limit *per worker*.
-        Notes regarding argument data type: If None or 0, no limit is applied.
+        Notes regarding argument data type: 
+        If None or 0, no limit is applied.
         If "auto", the total system memory is split evenly between the workers.
         If a float, that fraction of the system memory is used *per worker*.
         If a string giving a number of bytes (like ``"1GiB"``), that amount is used *per worker*.

--- a/distributed/deploy/local.py
+++ b/distributed/deploy/local.py
@@ -32,7 +32,6 @@ class LocalCluster(SpecCluster):
         Number of workers to start
     memory_limit: str, float, int, or None, default "auto"
         Sets the memory limit *per worker*.
-        
         Note that the limit will only be enforced when ``processes=True``, and the limit is only
         enforced on a best-effort basis — it's still possible for workers to exceed this limit.
     processes: bool


### PR DESCRIPTION
Insert memory_limit parameter into the LocalCluster docstring and adding notes that the argument:
- Sets memory limit per worker
- Cannot exceed the total memory available

Closes #8224

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
