### PR TITLE
Remove cancelled, resumed, and long-running states

### DIFF
--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -14,6 +14,7 @@ from distributed.utils_test import gen_cluster, inc, lock_inc, slowadd, slowinc
 from distributed.worker_state_machine import (
     ComputeTaskEvent,
     Execute,
+    ExecuteFailureEvent,
     ExecuteSuccessEvent,
     FreeKeysEvent,
     TaskFinishedMsg,
@@ -508,3 +509,78 @@ async def test_resources_from_python_override_config(c, s, a, b):
     info = c.scheduler_info()
     for worker in [a, b]:
         assert info["workers"][worker.address]["resources"] == {"my_resources": 10}
+
+
+@pytest.mark.parametrize("done_ev_cls", [ExecuteSuccessEvent, ExecuteFailureEvent])
+def test_cancel_with_resources(ws_with_running_task, done_ev_cls):
+    """Test transition loop of a task with resources:
+
+    executing -> (cancel task) -> released -> (complete execution)
+    """
+    ws = ws_with_running_task
+    assert ws.tasks["x"].state == "executing"
+    assert ws.available_resources == {"R": 0}
+
+    ws.handle_stimulus(FreeKeysEvent(keys=["x"], stimulus_id="s1"))
+    assert ws.tasks["x"].state == "released"
+    assert ws.available_resources == {"R": 0}
+
+    ws.handle_stimulus(done_ev_cls.dummy("x", stimulus_id="s2"))
+    assert "x" not in ws.tasks
+    assert ws.available_resources == {"R": 1}
+
+
+@pytest.mark.parametrize("done_ev_cls", [ExecuteSuccessEvent, ExecuteFailureEvent])
+def test_cancel_then_flight_with_resources(ws_with_running_task, done_ev_cls):
+    """Test transition loop of a task with resources:
+
+    executing -> (cancel task) -> released -> fetch -> flight -> (complete execution)
+    """
+    ws = ws_with_running_task
+    ws2 = "127.0.0.1:2"
+    assert ws.available_resources == {"R": 0}
+    ws.handle_stimulus(FreeKeysEvent(keys=["x"], stimulus_id="s1"))
+    assert ws.tasks["x"].state == "released"
+    assert ws.available_resources == {"R": 0}
+
+    ws.handle_stimulus(
+        ComputeTaskEvent.dummy("y", who_has={"x": [ws2]}, stimulus_id="s2")
+    )
+    assert ws.tasks["x"].state == "flight"
+    assert ws.available_resources == {"R": 0}
+
+    ws.handle_stimulus(done_ev_cls.dummy("x", stimulus_id="s3"))
+    assert ws.tasks["x"].state == "flight"
+    assert ws.available_resources == {"R": 1}
+
+
+@pytest.mark.parametrize(
+    "done_ev_cls,done_status",
+    [(ExecuteSuccessEvent, "memory"), (ExecuteFailureEvent, "error")],
+)
+def test_resume_with_different_resources(ws, done_ev_cls, done_status):
+    """A task with resources is cancelled and then resumed to the same state, but with
+    different resources. This is actually possible in case of manual cancellation from
+    the client, followed by resubmit.
+    """
+    ws.total_resources = {"R": 1}
+    ws.available_resources = {"R": 1}
+
+    ws.handle_stimulus(
+        ComputeTaskEvent.dummy("x", stimulus_id="s2", resource_restrictions={"R": 0.2})
+    )
+    assert ws.tasks["x"].state == "executing"
+    assert ws.available_resources == {"R": 0.8}
+
+    ws.handle_stimulus(FreeKeysEvent(keys=["x"], stimulus_id="s2"))
+    assert ws.tasks["x"].state == "released"
+    assert ws.available_resources == {"R": 0.8}
+
+    instructions = ws.handle_stimulus(
+        ComputeTaskEvent.dummy("x", stimulus_id="s3", resource_restrictions={"R": 0.3})
+    )
+    assert not instructions
+    assert ws.available_resources == {"R": 0.8}
+    ws.handle_stimulus(done_ev_cls.dummy(key="x", stimulus_id="s4"))
+    assert ws.tasks["x"].state == done_status
+    assert ws.available_resources == {"R": 1}

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1330,7 +1330,7 @@ def test_steal_worker_state(ws_with_running_task):
 
     ws.handle_stimulus(FreeKeysEvent(keys=["x"], stimulus_id="s1"))
     assert ws.available_resources == {"R": 0}
-    assert ws.tasks["x"].state == "cancelled"
+    assert ws.tasks["x"].state == "released"
 
     instructions = ws.handle_stimulus(ExecuteSuccessEvent.dummy("x", stimulus_id="s2"))
     assert not instructions

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3221,7 +3221,7 @@ async def test_gather_dep_cancelled_rescheduled(c, s):
             while fut4.key in b.state.tasks:
                 await asyncio.sleep(0)
 
-            assert b.state.tasks[fut2.key].state == "cancelled"
+            assert b.state.tasks[fut2.key].state == "released"
 
             b.block_gather_dep.set()
             await a.in_get_data.wait()
@@ -3259,7 +3259,7 @@ async def test_gather_dep_do_not_handle_response_of_not_requested_tasks(c, s, a)
         while fut4.key in b.state.tasks:
             await asyncio.sleep(0.01)
 
-        assert b.state.tasks[fut2.key].state == "cancelled"
+        assert b.state.tasks[fut2.key].state == "released"
 
         b.block_gather_dep.set()
 
@@ -3287,7 +3287,7 @@ async def test_gather_dep_no_longer_in_flight_tasks(c, s, a):
         while fut2.key in b.state.tasks:
             await asyncio.sleep(0.01)
 
-        assert b.state.tasks[fut1.key].state == "cancelled"
+        assert b.state.tasks[fut1.key].state == "released"
 
         b.block_gather_dep.set()
         while fut2.key in b.state.tasks:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2236,11 +2236,15 @@ class BlockedExecute(Worker):
 
         super().__init__(*args, **kwargs)
 
-    async def execute(self, key: str, *, stimulus_id: str) -> StateMachineEvent:
+    async def execute(
+        self, key: str, *, priority: tuple[int, ...], stimulus_id: str
+    ) -> StateMachineEvent:
         self.in_execute.set()
         await self.block_execute.wait()
         try:
-            return await super().execute(key, stimulus_id=stimulus_id)
+            return await super().execute(
+                key, priority=priority, stimulus_id=stimulus_id
+            )
         finally:
             self.in_execute_exit.set()
             await self.block_execute_exit.wait()
@@ -2391,7 +2395,7 @@ def ws_with_running_task(ws, request):
         ws.handle_stimulus(
             SecedeEvent(key="x", compute_duration=1.0, stimulus_id="secede")
         )
-    assert ws.tasks["x"].state == request.param
+    assert ws.tasks["x"].state == "executing"
     yield ws
 
 


### PR DESCRIPTION
- Mutually exclusive with #6699 
- Mutually exclusive with #6716 
- Closes #6682
- Closes #6689
- Closes #6693
- Closes #6685 
- Closes #6708
- Closes #6709 
- Closes #6877
- Out of scope: #6705 

This is an even more aggressive redesign than #6699 and #6716.

Remove the `long-running` state. A seceded task is distinguished from an executing one exclusively by being in the `WorkerState.long_running` set instead of the `executing` set.

Remove the `cancelled` state. Instead, a cancelled task simply transitions to other states, while remaining in the `executing`, `long_running`, or `in_flight_tasks` sets. A task will not transition to `forgotten` for as long as it is in one of the three above sets.

Remove the `resumed` state. Instead,
- If a task is recommended to transition to `ready`, but it is already in either the `executing` or the `long_running` sets, it transitions back to `executing` instead
- If a task is recommended to transition to `fetch`, but it is already in the `in_flight_tasks` set, it transitions back to `flight` instead

All end events for Execute and GatherDep:
-  work as normal exclusively if the task is still in `executing` or `flight` state respectively
- recommend a transition to `forgotten` if the task is in `released` state
- otherwise, they do nothing besides cleaning up and kicking off the next ensure_computing/ensure_communicating.

At any given moment, there may be both an Execute and a GatherDep instruction for the same task, running at the same time.
If the Execute instruction finishes while the task is in flight, it will be a no-op, and vice versa. This means we no longer have to worry about mismatched end events.

Remove the `previous`, `next`, and `done` TaskState attributes.

### TODO
- Ensure all tickets above meet DoD
- Failing tests in distributed/tests/test_cancelled_state.py