### PR TITLE
Remove redundant use of `with clean():`

### DIFF
--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -25,7 +25,6 @@ from distributed.utils_test import (
     assert_can_connect_locally_4,
     assert_cannot_connect,
     captured_logger,
-    clean,
     gen_test,
     inc,
     raises_with_cause,
@@ -997,10 +996,9 @@ def test_dont_select_closed_worker(loop):
 
 
 def test_client_cluster_synchronous(loop):
-    with clean(threads=False):
-        with Client(loop=loop, processes=False, dashboard_address=":0") as c:
-            assert not c.asynchronous
-            assert not c.cluster.asynchronous
+    with Client(loop=loop, processes=False, dashboard_address=":0") as c:
+        assert not c.asynchronous
+        assert not c.cluster.asynchronous
 
 
 @gen_test()


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
