### PR TITLE
Deprecate `cleanup` fixture; replace with `gonna_run_dask` fixture

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -226,7 +226,7 @@ async def test_ping_pong_cupy(ucx_loop, shape):
 @pytest.mark.slow
 @pytest.mark.parametrize("n", [int(1e9), int(2.5e9)])
 @gen_test()
-async def test_large_cupy(ucx_loop, n, cleanup):
+async def test_large_cupy(ucx_loop, n, gonna_run_dask):
     cupy = pytest.importorskip("cupy")
     com, serv_com = await get_comm_pair()
 
@@ -262,7 +262,7 @@ async def test_ping_pong_numba(ucx_loop):
 
 @pytest.mark.parametrize("processes", [True, False])
 @gen_test()
-async def test_ucx_localcluster(ucx_loop, processes, cleanup):
+async def test_ucx_localcluster(ucx_loop, processes, gonna_run_dask):
     async with LocalCluster(
         protocol="ucx",
         host=HOST,
@@ -352,7 +352,7 @@ async def test_transpose(
 
 @pytest.mark.parametrize("port", [0, 1234])
 @gen_test()
-async def test_ucx_protocol(ucx_loop, cleanup, port):
+async def test_ucx_protocol(ucx_loop, gonna_run_dask, port):
     async with Scheduler(protocol="ucx", port=port, dashboard_address=":0") as s:
         assert s.address.startswith("ucx://")
 

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -24,7 +24,7 @@ rmm = pytest.importorskip("rmm")
 
 
 @gen_test()
-async def test_ucx_config(ucx_loop, cleanup):
+async def test_ucx_config(ucx_loop):
     ucx = {
         "nvlink": True,
         "infiniband": True,
@@ -81,7 +81,7 @@ async def test_ucx_config(ucx_loop, cleanup):
     reruns=10,
     reruns_delay=5,
 )
-def test_ucx_config_w_env_var(ucx_loop, cleanup, loop):
+def test_ucx_config_w_env_var(ucx_loop, loop):
     env = os.environ.copy()
     env["DASK_RMM__POOL_SIZE"] = "1000.00 MB"
 

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -290,7 +290,7 @@ async def test_no_more_workers_than_tasks():
 
 
 @pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
-def test_basic_no_loop(cleanup):
+def test_basic_no_loop(gonna_run_dask):
     loop = None
     try:
         with LocalCluster(

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -83,7 +83,7 @@ def test_spec_sync(loop):
 
 
 @pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
-def test_loop_started_in_constructor(cleanup):
+def test_loop_started_in_constructor(gonna_run_dask):
     # test that SpecCluster.__init__ starts a loop in another thread
     cluster = SpecCluster(worker_spec, scheduler=scheduler, loop=None)
     try:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5532,7 +5532,7 @@ async def test_future_auto_inform(c, s, a, b):
 
 
 @pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
-def test_client_async_before_loop_starts(cleanup):
+def test_client_async_before_loop_starts(gonna_run_dask):
     async def close():
         async with client:
             pass

--- a/distributed/tests/test_client_loop.py
+++ b/distributed/tests/test_client_loop.py
@@ -30,14 +30,14 @@ def _check_cluster_and_client_loop(loop):
 
 # Test if Client stops LoopRunner on close.
 @pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
-def test_close_loop_sync_start_new_loop(cleanup):
+def test_close_loop_sync_start_new_loop(gonna_run_dask):
     with _check_loop_runner():
         _check_cluster_and_client_loop(loop=None)
 
 
 # Test if Client stops LoopRunner on close.
 @pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
-def test_close_loop_sync_use_running_loop(cleanup):
+def test_close_loop_sync_use_running_loop(gonna_run_dask):
     with _check_loop_runner():
         # Start own loop or use current thread's one.
         loop_runner = LoopRunner()

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -482,7 +482,7 @@ async def test_metrics(c, s, a, b):
     assert actual == expected
 
 
-def test_threadpoolworkers_pick_correct_ioloop(cleanup, loop):
+def test_threadpoolworkers_pick_correct_ioloop(loop):
     # gh4057
 
     # About picking appropriate values for the various timings

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -60,7 +60,7 @@ async def test_gather_from_workers_permissive_flaky(c, s, a, b):
     assert bad_workers == [a.address]
 
 
-def test_retry_no_exception(cleanup):
+def test_retry_no_exception():
     n_calls = 0
     retval = object()
 
@@ -76,7 +76,7 @@ def test_retry_no_exception(cleanup):
     assert n_calls == 1
 
 
-def test_retry0_raises_immediately(cleanup):
+def test_retry0_raises_immediately():
     # test that using max_reties=0 raises after 1 call
 
     n_calls = 0
@@ -95,7 +95,7 @@ def test_retry0_raises_immediately(cleanup):
     assert n_calls == 1
 
 
-def test_retry_does_retry_and_sleep(cleanup):
+def test_retry_does_retry_and_sleep():
     # test the retry and sleep pattern of `retry`
     n_calls = 0
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -63,7 +63,7 @@ def test_bare_cluster(loop):
         pass
 
 
-def test_cluster(cleanup):
+def test_cluster():
     async def identity():
         async with rpc(s["address"]) as scheduler_rpc:
             return await scheduler_rpc.identity()

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -69,7 +69,7 @@ def test_instruction_match():
     assert i != RescheduleMsg.match(key="x")
 
 
-def test_TaskState_tracking(cleanup):
+def test_TaskState_tracking():
     gc.collect()
     x = TaskState("x")
     assert len(TaskState._instances) == 1

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -722,7 +722,7 @@ def gen_test(
     def _(func):
         @functools.wraps(func)
         @config_for_cluster_tests()
-        @clean(**clean_kwargs)
+        @_check_clean(**clean_kwargs)
         def test_func(*args, **kwargs):
             if not iscoroutinefunction(func):
                 raise RuntimeError("gen_test only works for coroutine functions.")
@@ -926,7 +926,7 @@ def gen_cluster(
 
         @functools.wraps(func)
         @config_for_cluster_tests(**{"distributed.comm.timeouts.connect": "5s"})
-        @clean(**clean_kwargs)
+        @_check_clean(**clean_kwargs)
         def test_func(*outer_args, **kwargs):
             async def async_fn():
                 result = None
@@ -1770,7 +1770,8 @@ def config_for_cluster_tests(**extra_config):
 
 
 @contextmanager
-def clean(threads=True, instances=True, processes=True):
+def _check_clean(threads=True, instances=True, processes=True):
+    "Verify resources were not leaked. Use the `cleanup` fixture instead."
     asyncio.set_event_loop(None)
     with check_thread_leak() if threads else nullcontext():
         with check_process_leak(check=processes):
@@ -1780,7 +1781,7 @@ def clean(threads=True, instances=True, processes=True):
 
 @pytest.fixture
 def cleanup():
-    with clean():
+    with _check_clean():
         yield
 
 


### PR DESCRIPTION
Addresses https://github.com/dask/distributed/pull/6822#discussion_r940276267, where some tests were using the `cleanup` fixture for its behavior setting default config values (such as disabling the profiler).

I didn't like that muddying of concerns. `cleanup` should just assert that things aren't leaked. If you want config values, that should be separate IMO.

`cleanup` seemed to be currently used like "throw this in whenever you're going to launch a dask cluster, can't hurt". I just don't like the naming of that, so this adds a new `gonna_run_dask` fixture for convenience, which combines `cleanup` + `config_for_cluster_tests` (which is exactly what `cleanup` used to be be before #6822).

This deprecates the `cleanup` fixture right now and raises an error pointing you to `gonna_run_dask`. Maybe that's a bad idea? I just didn't see many/any standalone uses of `cleanup` that actually seemed necessary (either in things that weren't making threads/processes, or already were using `loop`, which runs cleanup itself).

This would break things for any downstream projects using `cleanup` directly.

cc @graingert

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
