### PR TITLE
Cache conda environment between CI test runs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,9 +19,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
 
-    env:
-      CONDA_FILE: continuous_integration/environment-${{ matrix.python-version }}.yaml
-
     strategy:
       fail-fast: false
       matrix:
@@ -47,6 +44,7 @@ jobs:
         # run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
 
     env:
+      CONDA_FILE: continuous_integration/environment-${{ matrix.python-version }}.yaml
       TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}
       # TEST_ID: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.partition-label }}-${{ matrix.run }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,12 +69,20 @@ jobs:
         shell: bash -l {0}
         run: conda config --show
 
+      - name: Check if caching is enabled
+        uses: xarray-contrib/ci-trigger@v1.1
+        id: skip-caching
+        with:
+          keyword: "[skip-caching]"
+
       - name: Get Date
+        if: steps.skip-caching.outputs.triggered != 'true'
         id: get-date
         run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')"
         shell: bash
 
       - name: Cache Conda env
+        if: steps.skip-caching.outputs.triggered != 'true'
         uses: actions/cache@v2
         with:
           path: ${{ env.CONDA }}/envs
@@ -86,7 +94,7 @@ jobs:
 
       - name: Update environment
         run: mamba env update -n dask-distributed -f ${{ env.CONDA_FILE }}
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.skip-caching.outputs.triggered == 'true' || steps.cache.outputs.cache-hit != 'true'
 
       - name: Install
         shell: bash -l {0}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
 
+    env:
+      CONDA_FILE: continuous_integration/environment-${{ matrix.python-version }}.yaml
+
     strategy:
       fail-fast: false
       matrix:
@@ -60,13 +63,30 @@ jobs:
           miniforge-version: latest
           condarc-file: continuous_integration/condarc
           use-mamba: true
-          python-version: ${{ matrix.python-version }}
-          environment-file: continuous_integration/environment-${{ matrix.python-version }}.yaml
           activate-environment: dask-distributed
 
       - name: Show conda options
         shell: bash -l {0}
         run: conda config --show
+
+      - name: Get Date
+        id: get-date
+        run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')"
+        shell: bash
+
+      - name: Cache Conda env
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CONDA }}/envs
+          key: conda-${{ matrix.os }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(env.CONDA_FILE) }}-${{ env.CACHE_NUMBER }}
+        env:
+          # Increase this value to reset cache if continuous_integration/environment-${{ matrix.python-version }}.yaml has not changed
+          CACHE_NUMBER: 0
+        id: cache
+
+      - name: Update environment
+        run: mamba env update -n dask-distributed -f ${{ env.CONDA_FILE }}
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install
         shell: bash -l {0}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,13 +74,13 @@ jobs:
           keyword: "[skip-caching]"
 
       - name: Get Date
-        if: steps.skip-caching.outputs.triggered != 'true'
+        if: steps.skip-caching.outputs.trigger-found != 'true'
         id: get-date
         run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')"
         shell: bash
 
       - name: Cache Conda env
-        if: steps.skip-caching.outputs.triggered != 'true'
+        if: steps.skip-caching.outputs.trigger-found != 'true'
         uses: actions/cache@v2
         with:
           path: ${{ env.CONDA }}/envs
@@ -92,7 +92,7 @@ jobs:
 
       - name: Update environment
         run: mamba env update -n dask-distributed -f ${{ env.CONDA_FILE }}
-        if: steps.skip-caching.outputs.triggered == 'true' || steps.cache.outputs.cache-hit != 'true'
+        if: steps.skip-caching.outputs.trigger-found == 'true' || steps.cache.outputs.cache-hit != 'true'
 
       - name: Install
         shell: bash -l {0}

--- a/distributed/objects.py
+++ b/distributed/objects.py
@@ -28,7 +28,6 @@ class SchedulerInfo(dict):
 
     def _repr_html_(self):
         def _format_dashboard_address(server):
-            # breakpoint()
             try:
                 host = (
                     server["host"]

--- a/distributed/objects.py
+++ b/distributed/objects.py
@@ -28,6 +28,7 @@ class SchedulerInfo(dict):
 
     def _repr_html_(self):
         def _format_dashboard_address(server):
+            # breakpoint()
             try:
                 host = (
                     server["host"]


### PR DESCRIPTION
Closes #6853 

Follows the [steps](https://github.com/conda-incubator/setup-miniconda#caching-environments) outlined in the `setup-miniconda` docs to cache the conda environment between test runs.

Note that (as pointed out by @gjoseph92), since we use unpinned CI dependencies in our environments, it's possible for the cached environment to become outdated - hoping to address this with a triggering keyword that can be added to PRs or commits to skip the caching and install the environment from scratch.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
