### PR TITLE
increase timeout in test_quiet_process

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7551,7 +7551,7 @@ def test_quiet_close_process(processes, tmp_path):
         f.write(client_script % processes)
 
     with popen([sys.executable, tmp_path / "script.py"], capture_output=True) as proc:
-        out, err = proc.communicate(timeout=10)
+        out, err = proc.communicate(timeout=60)
 
     assert not out
     assert not err


### PR DESCRIPTION
I believe there is no sane reason to have a timeout here other than to ensure that there is nothing funny happening with the subprocess itself.

The script should fail sooner due to the 30s default connect timeout if something fails and should terminate much sooner if successful. However, apparently 10s are not sufficient to start a process on CI?

Closes XXX (no ticket open but it is frequently failing)