### PR TITLE
Drop comparison of versions against all clients

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3754,7 +3754,7 @@ class Scheduler(SchedulerState, ServerNode):
             version_module.get_versions(),
             {w: ws.versions for w, ws in self.workers.items()},
             versions,
-            source_name=f"worker {ws.server_id}",
+            source_name=f"Current worker: {ws.server_id}",
         )
         msg.update(version_warning)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3754,7 +3754,7 @@ class Scheduler(SchedulerState, ServerNode):
             version_module.get_versions(),
             {w: ws.versions for w, ws in self.workers.items()},
             versions,
-            source_name=f"Current worker: {ws.server_id}",
+            source_name=str(ws.server_id),
         )
         msg.update(version_warning)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3752,12 +3752,9 @@ class Scheduler(SchedulerState, ServerNode):
 
         version_warning = version_module.error_message(
             version_module.get_versions(),
-            merge(
-                {w: ws.versions for w, ws in self.workers.items()},
-                {c: cs.versions for c, cs in self.clients.items() if cs.versions},
-            ),
+            {w: ws.versions for w, ws in self.workers.items()},
             versions,
-            client_name="This Worker",
+            source_name=f"worker {ws.server_id}",
         )
         msg.update(version_warning)
 

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -105,7 +105,7 @@ def get_package_info(
     return pversions
 
 
-def error_message(scheduler, workers, source, source_name="client"):
+def error_message(scheduler, workers, source, source_name="Client"):
     from distributed.utils import asciitable
 
     source = source.get("packages") if source else "UNKNOWN"
@@ -155,7 +155,7 @@ def error_message(scheduler, workers, source, source_name="client"):
     out = {"warning": "", "error": ""}
 
     if errs:
-        err_table = asciitable(["Package", source_name, "scheduler", "workers"], errs)
+        err_table = asciitable(["Package", source_name, "Scheduler", "Workers"], errs)
         err_msg = f"Mismatched versions found\n\n{err_table}"
         if notes:
             err_msg += "\nNotes: \n{}".format("\n".join(notes))

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -105,15 +105,15 @@ def get_package_info(
     return pversions
 
 
-def error_message(scheduler, workers, client, client_name="client"):
+def error_message(scheduler, workers, source, source_name="client"):
     from distributed.utils import asciitable
 
-    client = client.get("packages") if client else "UNKNOWN"
+    source = source.get("packages") if source else "UNKNOWN"
     scheduler = scheduler.get("packages") if scheduler else "UNKNOWN"
     workers = {k: v.get("packages") if v else "UNKNOWN" for k, v in workers.items()}
 
     packages = set()
-    packages.update(client)
+    packages.update(source)
     packages.update(scheduler)
     for worker in workers:
         packages.update(workers.get(worker))
@@ -128,10 +128,10 @@ def error_message(scheduler, workers, client, client_name="client"):
         if pkg in scheduler_relevant_packages:
             versions.add(scheduler_version)
 
-        client_version = (
-            client.get(pkg, "MISSING") if isinstance(client, dict) else client
+        source_version = (
+            source.get(pkg, "MISSING") if isinstance(source, dict) else source
         )
-        versions.add(client_version)
+        versions.add(source_version)
 
         worker_versions = {
             workers[w].get(pkg, "MISSING")
@@ -148,14 +148,14 @@ def error_message(scheduler, workers, client, client_name="client"):
         elif len(worker_versions) == 0:
             worker_versions = None
 
-        errs.append((pkg, client_version, scheduler_version, worker_versions))
+        errs.append((pkg, source_version, scheduler_version, worker_versions))
         if pkg in notes_mismatch_package.keys():
             notes.append(f"-  {pkg}: {notes_mismatch_package[pkg]}")
 
     out = {"warning": "", "error": ""}
 
     if errs:
-        err_table = asciitable(["Package", client_name, "scheduler", "workers"], errs)
+        err_table = asciitable(["Package", source_name, "scheduler", "workers"], errs)
         err_msg = f"Mismatched versions found\n\n{err_table}"
         if notes:
             err_msg += "\nNotes: \n{}".format("\n".join(notes))


### PR DESCRIPTION
Closes #6536 

New logged warning (in `test_version_warning_in_cluster`):
```
2022-08-10 15:42:31,352 - distributed.worker - WARNING - Mismatched versions found

+---------+---------------------------------------------+----------------------+-----------------------------------+
| Package | Worker-5a4690f1-71ca-4c19-9b3b-22ac5c13674a | Scheduler            | Workers                           |
+---------+---------------------------------------------+----------------------+-----------------------------------+
| dask    | 2022.8.0+5.gf7fd6c48                        | 2022.8.0+5.gf7fd6c48 | {'2022.8.0+5.gf7fd6c48', '0.0.0'} |
+---------+---------------------------------------------+----------------------+-----------------------------------+
```

**Out of scope:**
* Enabling `Client.get_versions` to check versions against all other clients (follow-up issue: #6868)


- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
