### PR TITLE
Add max version constraint for `dask-core` in nightlies

### DIFF
--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -1,6 +1,7 @@
 {% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
 {% set new_patch = major_minor_patch[2] | int + 1 %}
-{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
+{% set next_release_version = (major_minor_patch[:2] + [new_patch]) | join('.') %}
+{% set version = next_release_version + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
 
 
@@ -22,7 +23,7 @@ requirements:
     - setuptools
   run:
     - python >=3.8
-    - dask-core >={{ dask_version }}
+    - dask-core >={{ dask_version }},<{{ next_release_version }}
     - distributed {{ version }}=*_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
     - cytoolz >=0.8.2
     - numpy >=1.18

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -1,6 +1,7 @@
 {% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
 {% set new_patch = major_minor_patch[2] | int + 1 %}
-{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
+{% set next_release_version = (major_minor_patch[:2] + [new_patch]) | join('.') %}
+{% set version = next_release_version + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
 
 
@@ -31,7 +32,7 @@ requirements:
     - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core >={{ dask_version }}
+    - dask-core >={{ dask_version }},<{{ next_release_version }}
     - jinja2
     - locket >=1.0
     - msgpack-python >=0.6.0


### PR DESCRIPTION
As part of addressing https://github.com/dask/dask/issues/9367, this PR adds a max version constraint to the `dask-core` dependency in our nightly recipes, which effectively forces all nightly `dask` / `distributed` packages to pull nightly `dask-core`.

cc @jakirkham @galipremsagar 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
