### PR TITLE
log the worker name if set

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1370,6 +1370,9 @@ class Worker(BaseWorker, ServerNode):
 
         logger.info("      Start worker at: %26s", self.address)
         logger.info("         Listening to: %26s", listening_address)
+        if self.name != self.address_safe:
+            # only if name was not None
+            logger.info("          Worker name: %26s", self.name)
         for k, v in self.service_ports.items():
             logger.info("  {:>16} at: {:>26}".format(k, self.ip + ":" + str(v)))
         logger.info("Waiting to connect to: %26s", self.scheduler.address)


### PR DESCRIPTION
This is useful for debugging, especially in the context of dask-jobqueue when inspecting the log of a job.

This will result in something like this:
```
2022-08-08 13:40:39,274 - distributed.worker - INFO -       Start worker at:     tcp://172.18.0.3:42825
2022-08-08 13:40:39,274 - distributed.worker - INFO -           Worker name:          HTCondorCluster-0
2022-08-08 13:40:39,275 - distributed.worker - INFO -          Listening to:     tcp://172.18.0.3:42825
```



See also dask/dask-jobqueue#571

- [ ] Tests added / passed (Change should be irrelevant for tests)
- [x] Passes `pre-commit run --all-files`
