### PR TITLE
Add descriptive error message to assert in `WorkerState._transition_cancelled_error`

### DIFF
--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1918,7 +1918,10 @@ class WorkerState:
         *,
         stimulus_id: str,
     ) -> RecsInstrs:
-        assert ts.previous in ("executing", "long-running")
+        assert ts.previous in (
+            "executing",
+            "long-running",
+        ), f"Expected 'executing' or 'long-running'; got '{ts.previous}'"
         recs, instructions = self._transition_executing_error(
             ts,
             exception,


### PR DESCRIPTION
This PR adds a descriptive error message to the assert statement in `WorkerState._transition_cancelled_error` to be able to see the actual `ts.previous`.

For context: When scaling up `tensordot_stress` in coiled/coiled-runtime#229 I ran into the assert statement which returned a not-so-helpful 
```
Aug 11 10:00:05 ip-10-0-3-173 cloud-init[1264]:     assert ts.previous in ("executing", "long-running")
Aug 11 10:00:05 ip-10-0-3-173 cloud-init[1264]: AssertionError
```

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
