### PR TITLE
Fix flaky test_wall_clock

### DIFF
--- a/distributed/tests/test_metrics.py
+++ b/distributed/tests/test_metrics.py
@@ -16,7 +16,7 @@ def test_wall_clock(name):
         # Resolution
         deltas = [sj - si for si, sj in zip(samples[:-1], samples[1:])]
         assert min(deltas) >= 0.0, deltas
-        assert max(deltas) <= 0.001, deltas
+        assert max(deltas) <= 0.005, deltas
         assert any(0.0 < d < 0.0001 for d in deltas), deltas
         # Close to time.time() / time.monotonic()
         assert t - 0.5 < samples[0] < t + 0.5


### PR DESCRIPTION
https://github.com/dask/distributed/runs/7788208025?check_suite_focus=true

```
>           assert max(deltas) <= 0.001, deltas
E           AssertionError: [0.0012852999998358428, 3.499999820633093e-06, 1.7000002117129043e-06, 1.500000053056283e-06, 1.99999976757681e-06, 1.5999999050109182e-06, ...]
E           assert 0.0012852999998358428 <= 0.001
E            +  where 0.0012852999998358428 = max([0.0012852999998358428, 3.499999820633093e-06, 1.7000002117129043e-06, 1.500000053056283e-06, 1.99999976757681e-06, 1.5999999050109182e-06, ...])
```