### PR TITLE
Only close scheduler in SpecCluster if it exists

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -431,7 +431,8 @@ class SpecCluster(Cluster):
             else:
                 logger.warning("Cluster closed without starting up")
 
-            await self.scheduler.close()
+            if self.scheduler:
+                await self.scheduler.close()
             for w in self._created:
                 assert w.status in {
                     Status.closing,


### PR DESCRIPTION
In failure cases the scheduler may not have been created but close is
still called, providing a traceback like the following:

```python-traceback
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mrocklin/workspace/distributed/distributed/deploy/spec.py", line 275, in __init__
    self.sync(self._start)
  File "/home/mrocklin/workspace/distributed/distributed/utils.py", line 338, in sync
    return sync(
  File "/home/mrocklin/workspace/distributed/distributed/utils.py", line 405, in sync
    raise exc.with_traceback(tb)
  File "/home/mrocklin/workspace/distributed/distributed/utils.py", line 378, in f
    result = yield future
  File "/home/mrocklin/mambaforge/lib/python3.9/site-packages/tornado/gen.py", line 762, in run
    value = future.result()
  File "/home/mrocklin/workspace/distributed/distributed/deploy/spec.py", line 318, in _start
    await self._close()
  File "/home/mrocklin/workspace/distributed/distributed/deploy/spec.py", line 434, in _close
    await self.scheduler.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

This wasn't really an issue (things were already broken) but makes
tracking down the real issue more of a pain.

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
