### PR TITLE
Handle failing `plugin.start()` calls during scheduler start

### DIFF
--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -245,3 +245,26 @@ async def test_closing_errors_ok(c, s, a, b, capsys):
     assert "BEFORE_CLOSE" in text
     text = logger.getvalue()
     assert "AFTER_CLOSE" in text
+
+
+@gen_test()
+async def test_start_errors_ok(capsys):
+    class OK(SchedulerPlugin):
+        async def start(self, scheduler):
+            print("foo")
+
+    class Bad(SchedulerPlugin):
+        async def start(self, scheduler):
+            raise RuntimeError("bar")
+
+    s = Scheduler(dashboard_address=":0", plugins=[OK(), Bad()])
+
+    with captured_logger(logging.getLogger("distributed.scheduler")) as logger:
+        await s.start()
+
+    out, _ = capsys.readouterr()
+    assert "foo" in out
+
+    text = logger.getvalue()
+    assert "RuntimeError" in text
+    assert "bar" in text

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3417,8 +3417,14 @@ class Scheduler(SchedulerState, ServerNode):
                 await self.listen("tcp://localhost:0")
             os.environ["DASK_SCHEDULER_ADDRESS"] = self.listeners[-1].contact_address
 
+        async def log_errors(func, scheduler):
+            try:
+                await func(scheduler)
+            except Exception:
+                logger.exception("Plugin call failed during scheduler.start")
+
         await asyncio.gather(
-            *[plugin.start(self) for plugin in list(self.plugins.values())]
+            *[log_errors(plugin.start, self) for plugin in list(self.plugins.values())]
         )
 
         self.start_periodic_callbacks()


### PR DESCRIPTION
Today I ran into an issue where a cluster scheduler failed to start due to a `plugin.start` failure from an HTTP error. Similar to https://github.com/dask/distributed/pull/6450, this PR makes it so we log `plugin.start` errors and continue to start the scheduler. 