### PR TITLE
Expose setting multiple protocols and ports via the dask-scheduler CLI

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -131,6 +131,7 @@ def main(
     host,
     port,
     protocol,
+    interface,
     bokeh_port,
     show,
     dashboard,
@@ -162,6 +163,9 @@ def main(
             "The --bokeh/--no-bokeh flag has been renamed to --dashboard/--no-dashboard. "
         )
         dashboard = bokeh
+
+    if interface and "," in interface:
+        interface = interface.split(",")
 
     if protocol and "," in protocol:
         protocol = protocol.split(",")
@@ -222,6 +226,7 @@ def main(
             host=host,
             port=port,
             protocol=protocol,
+            interface=interface,
             dashboard=dashboard,
             dashboard_address=dashboard_address,
             http_prefix=dashboard_prefix,

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -27,7 +27,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 @click.command(context_settings=dict(ignore_unknown_options=True))
 @click.option("--host", type=str, default="", help="URI, IP or hostname of this server")
-@click.option("--port", type=int, default=None, help="Serving port")
+@click.option("--port", type=str, default=None, help="Serving port")
 @click.option(
     "--interface",
     type=str,
@@ -130,6 +130,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 def main(
     host,
     port,
+    protocol,
     bokeh_port,
     show,
     dashboard,
@@ -162,8 +163,26 @@ def main(
         )
         dashboard = bokeh
 
+    if protocol and "," in protocol:
+        protocol = protocol.split(",")
+
+    if port:
+        if "," in port:
+            port = [int(p) for p in port.split(",")]
+        else:
+            port = int(port)
+
     if port is None and (not host or not re.search(r":\d", host)):
-        port = 8786
+        if isinstance(protocol, list):
+            port = [8786] + [0] * (len(protocol) - 1)
+        else:
+            port = 8786
+
+    if isinstance(protocol, list) or isinstance(port, list):
+        if (not isinstance(protocol, list) or not isinstance(port, list)) or len(
+            port
+        ) != len(protocol):
+            raise ValueError("--protocol and --port must both be lists of equal length")
 
     sec = {
         k: v
@@ -202,6 +221,7 @@ def main(
             security=sec,
             host=host,
             port=port,
+            protocol=protocol,
             dashboard=dashboard,
             dashboard_address=dashboard_address,
             http_prefix=dashboard_prefix,

--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -131,6 +131,22 @@ def test_dashboard_non_standard_ports(loop):
         requests.get(f"http://localhost:{port2}/status/")
 
 
+def test_multiple_protocols(loop):
+    port1 = open_port()
+    port2 = open_port()
+    with popen(
+        [
+            "dask-scheduler",
+            "--protocol=tcp,ws",
+            f"--port={port1},{port2}",
+        ]
+    ) as _:
+        with Client(f"tcp://127.0.0.1:{port1}", loop=loop):
+            pass
+        with Client(f"ws://127.0.0.1:{port2}", loop=loop):
+            pass
+
+
 @pytest.mark.skipif(not LINUX, reason="Need 127.0.0.2 to mean localhost")
 def test_dashboard_allowlist(loop):
     pytest.importorskip("bokeh")


### PR DESCRIPTION
Closes #6891 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

In #6891 @mrocklin mentioned that `Scheduler` can take a list for `protocol` and `port`. This PR updates the `dask-scheduler` CLI to also allow lists. Users can optionally specify a comma-separated list for each.

```console
$ dask-scheduler                                   
2022-08-17 11:54:30,973 - distributed.scheduler - INFO -   Scheduler at:   tcp://10.51.100.80:8786

$ dask-scheduler --protocol ws                     
2022-08-17 11:56:14,423 - distributed.scheduler - INFO -   Scheduler at:    ws://10.51.100.80:8786

$ dask-scheduler --protocol tcp,ws                            
2022-08-17 11:55:00,675 - distributed.scheduler - INFO -   Scheduler at:   tcp://10.51.100.80:8786
2022-08-17 11:55:00,675 - distributed.scheduler - INFO -   Scheduler at:   ws://10.51.100.80:52663

$ dask-scheduler --protocol tcp,ws --port 8786,8788
2022-08-17 11:55:24,119 - distributed.scheduler - INFO -   Scheduler at:   tcp://10.51.100.80:8786
2022-08-17 11:55:24,119 - distributed.scheduler - INFO -   Scheduler at:    ws://10.51.100.80:8788
```