### PR TITLE
Bind UCX listener to specific IP address

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -357,6 +357,15 @@ async def test_ucx_protocol(ucx_loop, cleanup, port):
         assert s.address.startswith("ucx://")
 
 
+@gen_test()
+async def test_ucx_listener_ip(ucx_loop, cleanup):
+    async with Scheduler(
+        protocol="ucx", interface="localhost", dashboard_address=":0"
+    ) as s:
+        assert s.address.startswith("ucx://127.0.0.1")
+        assert s.listener.ucp.server.ip == "127.0.0.1"
+
+
 @pytest.mark.skipif(
     not hasattr(ucp.exceptions, "UCXUnreachable"),
     reason="Requires UCX-Py support for UCXUnreachable exception",

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -472,7 +472,9 @@ class UCXListener(Listener):
                 await self.comm_handler(ucx)
 
         init_once()
-        self.ucp_server = ucp.create_listener(serve_forever, port=self._input_port)
+        self.ucp_server = ucp.create_listener(
+            serve_forever, port=self._input_port, ip_address=self.ip
+        )
 
     def stop(self):
         self.ucp_server = None


### PR DESCRIPTION
This change ensures that the IP address as is actually bound to in UCX's listener. Regardless of `--interface`, the UCX backend is currently binding to `0.0.0.0`, as that functionality was previously unimplemented.

Depends on https://github.com/rapidsai/ucx-py/pull/871 (currently blocked).

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
