### PR TITLE
Dask config item for always showing GPU in scheduler dashboard menu

### DIFF
--- a/distributed/dashboard/scheduler.py
+++ b/distributed/dashboard/scheduler.py
@@ -6,6 +6,8 @@ from tlz import memoize
 from tornado import web
 from tornado.ioloop import IOLoop
 
+import dask
+
 from distributed.dashboard.components.nvml import (
     gpu_doc,
     gpu_memory_doc,
@@ -126,7 +128,12 @@ def template_variables():
             "workers",
             "tasks",
             "system",
-            *(["gpu"] if device_get_count() > 0 else []),
+            *(
+                ["gpu"]
+                if dask.config.get("distributed.dashboard.always_show_gpu", False)
+                or device_get_count() > 0
+                else []
+            ),
             "profile",
             "graph",
             "groups",

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -276,6 +276,7 @@ distributed:
     graph-max-items: 5000  # maximum number of tasks to try to plot in graph view
     prometheus:
       namespace: "dask"
+    always-show-gpu: False
 
   ##################
   # Administrative #


### PR DESCRIPTION
Currently the scheduler dashboard only shows GPU in menu if there's
a GPU on the scheduler, regardless of whether workers have GPUs.
For deployments where we know in advance that we'll have GPUs we want
to monitor on workers, it would be nice to have a way to force the
scheduler dashboard to show this menu item.

Easy to test locally by running `DASK_DISTRIBUTED__DASHBOARD__ALWAYS_SHOW_GPU=1 dask-scheduler`

- [ ] Tests added / passed (**I think there's no existing test coverage for dashboard menu—should there be?**)
- [x] Passes `pre-commit run --all-files`
