### PR TITLE
Remove duplicated code when validating in_flight_tasks

### DIFF
--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3262,11 +3262,6 @@ class WorkerState:
             assert ts.state == "ready"
         for ts in self.constrained:
             assert ts.state == "constrained"
-        # FIXME https://github.com/dask/distributed/issues/6708
-        # for ts in self.in_flight_tasks:
-        #     assert ts.state == "flight" or (
-        #         ts.state in ("cancelled", "resumed") and ts.previous == "flight"
-        #     )
         for ts in self.executing:
             assert ts.state == "executing" or (
                 ts.state in ("cancelled", "resumed") and ts.previous == "executing"


### PR DESCRIPTION
Remove duplicated, commented out checks that already happen a few lines below
Closes #6708