### PR TITLE
use `async with Client:` in tests

### DIFF
--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -117,50 +117,47 @@ async def test_adaptive_scale_down_override():
 
 @gen_test()
 async def test_min_max():
-    cluster = await LocalCluster(
+    async with LocalCluster(
         n_workers=0,
         silence_logs=False,
         processes=False,
         dashboard_address=":0",
         asynchronous=True,
         threads_per_worker=1,
-    )
-    try:
+    ) as cluster:
         adapt = cluster.adapt(minimum=1, maximum=2, interval="20 ms", wait_count=10)
-        c = await Client(cluster, asynchronous=True)
+        async with Client(cluster, asynchronous=True) as c:
+            start = time()
+            while not cluster.scheduler.workers:
+                await asyncio.sleep(0.01)
+                assert time() < start + 1
 
-        start = time()
-        while not cluster.scheduler.workers:
-            await asyncio.sleep(0.01)
-            assert time() < start + 1
+            await asyncio.sleep(0.2)
+            assert len(cluster.scheduler.workers) == 1
+            assert len(adapt.log) == 1 and adapt.log[-1][1] == {"status": "up", "n": 1}
 
-        await asyncio.sleep(0.2)
-        assert len(cluster.scheduler.workers) == 1
-        assert len(adapt.log) == 1 and adapt.log[-1][1] == {"status": "up", "n": 1}
+            futures = c.map(slowinc, range(100), delay=0.1)
 
-        futures = c.map(slowinc, range(100), delay=0.1)
+            start = time()
+            while len(cluster.scheduler.workers) < 2:
+                await asyncio.sleep(0.01)
+                assert time() < start + 1
 
-        start = time()
-        while len(cluster.scheduler.workers) < 2:
-            await asyncio.sleep(0.01)
-            assert time() < start + 1
+            assert len(cluster.scheduler.workers) == 2
+            await asyncio.sleep(0.5)
+            assert len(cluster.scheduler.workers) == 2
+            assert len(cluster.workers) == 2
+            assert len(adapt.log) == 2 and all(
+                d["status"] == "up" for _, d in adapt.log
+            )
 
-        assert len(cluster.scheduler.workers) == 2
-        await asyncio.sleep(0.5)
-        assert len(cluster.scheduler.workers) == 2
-        assert len(cluster.workers) == 2
-        assert len(adapt.log) == 2 and all(d["status"] == "up" for _, d in adapt.log)
+            del futures
 
-        del futures
-
-        start = time()
-        while len(cluster.scheduler.workers) != 1:
-            await asyncio.sleep(0.01)
-            assert time() < start + 2
-        assert adapt.log[-1][1]["status"] == "down"
-    finally:
-        await c.close()
-        await cluster.close()
+            start = time()
+            while len(cluster.scheduler.workers) != 1:
+                await asyncio.sleep(0.01)
+                assert time() < start + 2
+            assert adapt.log[-1][1]["status"] == "down"
 
 
 @gen_test()
@@ -194,16 +191,14 @@ async def test_adapt_quickly():
     Instead we want to wait a few beats before removing a worker in case the
     user is taking a brief pause between work
     """
-    cluster = await LocalCluster(
+    async with LocalCluster(
         n_workers=0,
         asynchronous=True,
         processes=False,
         silence_logs=False,
         dashboard_address=":0",
-    )
-    client = await Client(cluster, asynchronous=True)
-    adapt = cluster.adapt(interval="20 ms", wait_count=5, maximum=10)
-    try:
+    ) as cluster, Client(cluster, asynchronous=True) as client:
+        adapt = cluster.adapt(interval="20 ms", wait_count=5, maximum=10)
         future = client.submit(slowinc, 1, delay=0.100)
         await wait(future)
         assert len(adapt.log) == 1
@@ -241,9 +236,6 @@ async def test_adapt_quickly():
 
         await asyncio.sleep(0.1)
         assert len(cluster.workers) == 1
-    finally:
-        await client.close()
-        await cluster.close()
 
 
 @gen_test()
@@ -255,20 +247,19 @@ async def test_adapt_down():
         processes=False,
         silence_logs=False,
         dashboard_address=":0",
-    ) as cluster:
-        async with Client(cluster, asynchronous=True) as client:
-            cluster.adapt(interval="20ms", maximum=5)
+    ) as cluster, Client(cluster, asynchronous=True) as client:
+        cluster.adapt(interval="20ms", maximum=5)
 
-            futures = client.map(slowinc, range(1000), delay=0.1)
-            while len(cluster.scheduler.workers) < 5:
-                await asyncio.sleep(0.1)
+        futures = client.map(slowinc, range(1000), delay=0.1)
+        while len(cluster.scheduler.workers) < 5:
+            await asyncio.sleep(0.1)
 
-            cluster.adapt(maximum=2)
+        cluster.adapt(maximum=2)
 
-            start = time()
-            while len(cluster.scheduler.workers) != 2:
-                await asyncio.sleep(0.1)
-                assert time() < start + 60
+        start = time()
+        while len(cluster.scheduler.workers) != 2:
+            await asyncio.sleep(0.1)
+            assert time() < start + 60
 
 
 @gen_test()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6,6 +6,7 @@ import functools
 import gc
 import inspect
 import logging
+import operator
 import os
 import pathlib
 import pickle
@@ -534,17 +535,14 @@ async def test_exceptions(c, s, a, b):
 
 @gen_cluster()
 async def test_gc(s, a, b):
-    c = await Client(s.address, asynchronous=True)
-
-    x = c.submit(inc, 10)
-    await x
-    assert s.tasks[x.key].who_has
-    x.__del__()
-    await async_wait_for(
-        lambda: x.key not in s.tasks or not s.tasks[x.key].who_has, timeout=0.3
-    )
-
-    await c.close()
+    async with Client(s.address, asynchronous=True) as c:
+        x = c.submit(inc, 10)
+        await x
+        assert s.tasks[x.key].who_has
+        x.__del__()
+        await async_wait_for(
+            lambda: x.key not in s.tasks or not s.tasks[x.key].who_has, timeout=0.3
+        )
 
 
 def test_thread(c):
@@ -587,13 +585,12 @@ async def test_gather(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_gather_mismatched_client(c, s, a, b):
-    c2 = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c2:
+        x = c.submit(inc, 10)
+        y = c2.submit(inc, 5)
 
-    x = c.submit(inc, 10)
-    y = c2.submit(inc, 5)
-
-    with pytest.raises(ValueError, match="Futures created by another client"):
-        await c.gather([x, y])
+        with pytest.raises(ValueError, match="Futures created by another client"):
+            await c.gather([x, y])
 
 
 @gen_cluster(client=True)
@@ -1067,20 +1064,16 @@ async def test_map_quotes(c, s, a, b):
 
 @gen_cluster()
 async def test_two_consecutive_clients_share_results(s, a, b):
-    c = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c:
 
-    x = c.submit(random.randint, 0, 1000, pure=True)
-    xx = await x
+        x = c.submit(random.randint, 0, 1000, pure=True)
+        xx = await x
 
-    f = await Client(s.address, asynchronous=True)
+        async with Client(s.address, asynchronous=True) as f:
+            y = f.submit(random.randint, 0, 1000, pure=True)
+            yy = await y
 
-    y = f.submit(random.randint, 0, 1000, pure=True)
-    yy = await y
-
-    assert xx == yy
-
-    await c.close()
-    await f.close()
+            assert xx == yy
 
 
 @gen_cluster(client=True)
@@ -1423,14 +1416,10 @@ async def test_scatter_direct(c, s, a, b):
 
 @gen_cluster()
 async def test_scatter_direct_2(s, a, b):
-    c = await Client(s.address, asynchronous=True, heartbeat_interval=10)
-
-    last = s.clients[c.id].last_seen
-
-    while s.clients[c.id].last_seen == last:
-        await asyncio.sleep(0.10)
-
-    await c.close()
+    async with Client(s.address, asynchronous=True, heartbeat_interval=10) as c:
+        last = s.clients[c.id].last_seen
+        while s.clients[c.id].last_seen == last:
+            await asyncio.sleep(0.10)
 
 
 @gen_cluster(client=True)
@@ -2014,21 +2003,26 @@ async def test_badly_serialized_input_stderr(capsys, c):
     assert future.status == "error"
 
 
-def test_repr(loop):
-    funcs = [str, repr, lambda x: x._repr_html_()]
+@pytest.mark.parametrize(
+    "func",
+    [
+        str,
+        repr,
+        operator.methodcaller("_repr_html_"),
+    ],
+)
+def test_repr(loop, func):
     with cluster(nworkers=3, worker_kwargs={"memory_limit": "2 GiB"}) as (s, [a, b, c]):
         with Client(s["address"], loop=loop) as c:
-            for func in funcs:
-                text = func(c)
-                assert c.scheduler.address in text
-                assert "threads=3" in text or "Total threads: </strong>" in text
-                assert "6.00 GiB" in text
-                if "<table" not in text:
-                    assert len(text) < 80
-
-        for func in funcs:
             text = func(c)
-            assert "No scheduler connected" in text
+            assert c.scheduler.address in text
+            assert "threads=3" in text or "Total threads: </strong>" in text
+            assert "6.00 GiB" in text
+            if "<table" not in text:
+                assert len(text) < 80
+
+        text = func(c)
+        assert "No scheduler connected" in text
 
 
 @gen_cluster(client=True)
@@ -2043,17 +2037,12 @@ async def test_repr_no_memory_limit(c, s, a, b):
 
 @gen_test()
 async def test_repr_localcluster():
-    cluster = await LocalCluster(
+    async with LocalCluster(
         processes=False, dashboard_address=":0", asynchronous=True
-    )
-    client = await Client(cluster, asynchronous=True)
-    try:
+    ) as cluster, Client(cluster, asynchronous=True) as client:
         text = client._repr_html_()
         assert cluster.scheduler.address in text
         assert is_valid_xml(client._repr_html_())
-    finally:
-        await client.close()
-        await cluster.close()
 
 
 @gen_cluster(client=True)
@@ -2176,32 +2165,28 @@ def test_repr_sync(c):
 
 @gen_cluster()
 async def test_multi_client(s, a, b):
-    c = await Client(s.address, asynchronous=True)
-    f = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as f:
+        async with Client(s.address, asynchronous=True) as c:
 
-    assert set(s.client_comms) == {c.id, f.id}
+            assert set(s.client_comms) == {c.id, f.id}
 
-    x = c.submit(inc, 1)
-    y = f.submit(inc, 2)
-    y2 = c.submit(inc, 2)
+            x = c.submit(inc, 1)
+            y = f.submit(inc, 2)
+            y2 = c.submit(inc, 2)
 
-    assert y.key == y2.key
+            assert y.key == y2.key
 
-    await wait([x, y])
+            await wait([x, y])
 
-    assert {ts.key for ts in s.clients[c.id].wants_what} == {x.key, y.key}
-    assert {ts.key for ts in s.clients[f.id].wants_what} == {y.key}
+            assert {ts.key for ts in s.clients[c.id].wants_what} == {x.key, y.key}
+            assert {ts.key for ts in s.clients[f.id].wants_what} == {y.key}
 
-    await c.close()
+        while c.id in s.clients:
+            await asyncio.sleep(0.01)
 
-    while c.id in s.clients:
-        await asyncio.sleep(0.01)
-
-    assert c.id not in s.clients
-    assert c.id not in s.tasks[y.key].who_wants
-    assert x.key not in s.tasks
-
-    await f.close()
+        assert c.id not in s.clients
+        assert c.id not in s.tasks[y.key].who_wants
+        assert x.key not in s.tasks
 
     while s.tasks:
         await asyncio.sleep(0.01)
@@ -2234,42 +2219,39 @@ async def test_cleanup_after_broken_client_connection(s, a, b):
 
 @gen_cluster()
 async def test_multi_garbage_collection(s, a, b):
-    c = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c, Client(
+        s.address, asynchronous=True
+    ) as f:
 
-    f = await Client(s.address, asynchronous=True)
+        x = c.submit(inc, 1)
+        y = f.submit(inc, 2)
+        y2 = c.submit(inc, 2)
 
-    x = c.submit(inc, 1)
-    y = f.submit(inc, 2)
-    y2 = c.submit(inc, 2)
+        assert y.key == y2.key
 
-    assert y.key == y2.key
+        await wait([x, y])
 
-    await wait([x, y])
+        x.__del__()
+        while x.key in a.data or x.key in b.data:
+            await asyncio.sleep(0.01)
 
-    x.__del__()
-    while x.key in a.data or x.key in b.data:
-        await asyncio.sleep(0.01)
+        assert {ts.key for ts in s.clients[c.id].wants_what} == {y.key}
+        assert {ts.key for ts in s.clients[f.id].wants_what} == {y.key}
 
-    assert {ts.key for ts in s.clients[c.id].wants_what} == {y.key}
-    assert {ts.key for ts in s.clients[f.id].wants_what} == {y.key}
+        y.__del__()
+        while x.key in {ts.key for ts in s.clients[f.id].wants_what}:
+            await asyncio.sleep(0.01)
 
-    y.__del__()
-    while x.key in {ts.key for ts in s.clients[f.id].wants_what}:
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.1)
+        assert y.key in a.data or y.key in b.data
+        assert {ts.key for ts in s.clients[c.id].wants_what} == {y.key}
+        assert not s.clients[f.id].wants_what
 
-    await asyncio.sleep(0.1)
-    assert y.key in a.data or y.key in b.data
-    assert {ts.key for ts in s.clients[c.id].wants_what} == {y.key}
-    assert not s.clients[f.id].wants_what
+        y2.__del__()
+        while y.key in a.data or y.key in b.data:
+            await asyncio.sleep(0.01)
 
-    y2.__del__()
-    while y.key in a.data or y.key in b.data:
-        await asyncio.sleep(0.01)
-
-    assert not s.tasks
-
-    await c.close()
-    await f.close()
+        assert not s.tasks
 
 
 @gen_cluster(client=True)
@@ -2868,11 +2850,11 @@ def test_client_num_fds(loop):
 
 @gen_cluster()
 async def test_startup_close_startup(s, a, b):
-    c = await Client(s.address, asynchronous=True)
-    await c.close()
+    async with Client(s.address, asynchronous=True):
+        pass
 
-    c = await Client(s.address, asynchronous=True)
-    await c.close()
+    async with Client(s.address, asynchronous=True):
+        pass
 
 
 @pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
@@ -3570,11 +3552,10 @@ def test_as_completed_next_batch(c):
 
 @gen_cluster(nthreads=[])
 async def test_status(s):
-    c = await Client(s.address, asynchronous=True)
-    assert c.status == "running"
-    x = c.submit(inc, 1)
+    async with Client(s.address, asynchronous=True) as c:
+        assert c.status == "running"
+        x = c.submit(inc, 1)
 
-    await c.close()
     assert c.status == "closed"
 
 
@@ -3627,54 +3608,52 @@ async def test_reconnect():
         s.stop()
         await Server.close(s)
 
-    s = await Scheduler(port=port)
-    w = await Worker(f"127.0.0.1:{port}")
-    c = await Client(f"127.0.0.1:{port}", asynchronous=True)
-    await c.wait_for_workers(1, timeout=10)
-    x = c.submit(inc, 1)
-    assert (await x) == 2
-    await hard_stop(s)
+    async with Scheduler(port=port) as s:
+        async with Client(f"127.0.0.1:{port}", asynchronous=True) as c:
+            async with Worker(f"127.0.0.1:{port}") as w:
+                await c.wait_for_workers(1, timeout=10)
+                x = c.submit(inc, 1)
+                assert (await x) == 2
+                await hard_stop(s)
 
-    start = time()
-    while c.status != "connecting":
-        assert time() < start + 10
-        await asyncio.sleep(0.01)
+                start = time()
+                while c.status != "connecting":
+                    assert time() < start + 10
+                    await asyncio.sleep(0.01)
 
-    assert x.status == "cancelled"
-    with pytest.raises(CancelledError):
-        await x
+                assert x.status == "cancelled"
+                with pytest.raises(CancelledError):
+                    await x
 
-    s = await Scheduler(port=port)
-    start = time()
-    while c.status != "running":
-        await asyncio.sleep(0.1)
-        assert time() < start + 10
+                async with Scheduler(port=port) as s2:
+                    start = time()
+                    while c.status != "running":
+                        await asyncio.sleep(0.1)
+                        assert time() < start + 10
 
-    await w.finished()
-    w = await Worker(f"127.0.0.1:{port}")
+                    await w.finished()
+                    w = await Worker(f"127.0.0.1:{port}")
 
-    start = time()
-    while len(await c.nthreads()) != 1:
-        await asyncio.sleep(0.05)
-        assert time() < start + 10
+                    start = time()
+                    while len(await c.nthreads()) != 1:
+                        await asyncio.sleep(0.05)
+                        assert time() < start + 10
 
-    x = c.submit(inc, 1)
-    assert (await x) == 2
-    await hard_stop(s)
+                    x = c.submit(inc, 1)
+                    assert (await x) == 2
+                    await hard_stop(s2)
 
-    start = time()
-    while True:
-        assert time() < start + 10
-        try:
-            await x
-            assert False
-        except CommClosedError:
-            continue
-        except CancelledError:
-            break
-
-    await w.close()
-    await c._close(fast=True)
+                start = time()
+                while True:
+                    assert time() < start + 10
+                    try:
+                        await x
+                        assert False
+                    except CommClosedError:
+                        continue
+                    except CancelledError:
+                        break
+            await c._close(fast=True)
 
 
 class UnhandledExceptions(Exception):
@@ -3796,46 +3775,44 @@ def test_open_close_many_workers(loop, worker, count, repeat):
 
 @gen_cluster()
 async def test_idempotence(s, a, b):
-    c = await Client(s.address, asynchronous=True)
-    f = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c, Client(
+        s.address, asynchronous=True
+    ) as f:
 
-    # Submit
-    x = c.submit(inc, 1)
-    await x
-    log = list(s.transition_log)
+        # Submit
+        x = c.submit(inc, 1)
+        await x
+        log = list(s.transition_log)
 
-    len_single_submit = len(log)  # see last assert
+        len_single_submit = len(log)  # see last assert
 
-    y = f.submit(inc, 1)
-    assert x.key == y.key
-    await y
-    await asyncio.sleep(0.1)
-    log2 = list(s.transition_log)
-    assert log == log2
+        y = f.submit(inc, 1)
+        assert x.key == y.key
+        await y
+        await asyncio.sleep(0.1)
+        log2 = list(s.transition_log)
+        assert log == log2
 
-    # Error
-    a = c.submit(div, 1, 0)
-    await wait(a)
-    assert a.status == "error"
-    log = list(s.transition_log)
+        # Error
+        a = c.submit(div, 1, 0)
+        await wait(a)
+        assert a.status == "error"
+        log = list(s.transition_log)
 
-    b = f.submit(div, 1, 0)
-    assert a.key == b.key
-    await wait(b)
-    await asyncio.sleep(0.1)
-    log2 = list(s.transition_log)
-    assert log == log2
+        b = f.submit(div, 1, 0)
+        assert a.key == b.key
+        await wait(b)
+        await asyncio.sleep(0.1)
+        log2 = list(s.transition_log)
+        assert log == log2
 
-    s.transition_log.clear()
-    # Simultaneous Submit
-    d = c.submit(inc, 2)
-    e = c.submit(inc, 2)
-    await wait([d, e])
+        s.transition_log.clear()
+        # Simultaneous Submit
+        d = c.submit(inc, 2)
+        e = c.submit(inc, 2)
+        await wait([d, e])
 
-    assert len(s.transition_log) == len_single_submit
-
-    await c.close()
-    await f.close()
+        assert len(s.transition_log) == len_single_submit
 
 
 def test_scheduler_info(c):
@@ -4010,60 +3987,56 @@ async def test_scatter_compute_store_lose_processing(c, s, a, b):
 
 @gen_cluster()
 async def test_serialize_future(s, a, b):
-    c1 = await Client(s.address, asynchronous=True)
-    c2 = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c1, Client(
+        s.address, asynchronous=True
+    ) as c2:
 
-    future = c1.submit(lambda: 1)
-    result = await future
+        future = c1.submit(lambda: 1)
+        result = await future
 
-    for ci in (c1, c2):
-        for ctxman in lambda ci: ci.as_current(), lambda ci: temp_default_client(ci):
-            with ctxman(ci):
-                future2 = pickle.loads(pickle.dumps(future))
-                assert future2.client is ci
-                assert stringify(future2.key) in ci.futures
-                result2 = await future2
-                assert result == result2
-
-    await c1.close()
-    await c2.close()
+        for ci in (c1, c2):
+            for ctxman in lambda ci: ci.as_current(), lambda ci: temp_default_client(
+                ci
+            ):
+                with ctxman(ci):
+                    future2 = pickle.loads(pickle.dumps(future))
+                    assert future2.client is ci
+                    assert stringify(future2.key) in ci.futures
+                    result2 = await future2
+                    assert result == result2
 
 
 @gen_cluster()
 async def test_temp_default_client(s, a, b):
-    c1 = await Client(s.address, asynchronous=True)
-    c2 = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c1, Client(
+        s.address, asynchronous=True
+    ) as c2:
 
-    with temp_default_client(c1):
-        assert default_client() is c1
-        assert default_client(c2) is c2
+        with temp_default_client(c1):
+            assert default_client() is c1
+            assert default_client(c2) is c2
 
-    with temp_default_client(c2):
-        assert default_client() is c2
-        assert default_client(c1) is c1
-
-    await c1.close()
-    await c2.close()
+        with temp_default_client(c2):
+            assert default_client() is c2
+            assert default_client(c1) is c1
 
 
 @gen_cluster(client=True)
 async def test_as_current(c, s, a, b):
-    c1 = await Client(s.address, asynchronous=True)
-    c2 = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c1, Client(
+        s.address, asynchronous=True
+    ) as c2:
 
-    with temp_default_client(c):
-        assert Client.current() is c
-        with pytest.raises(ValueError):
-            Client.current(allow_global=False)
-        with c1.as_current():
-            assert Client.current() is c1
-            assert Client.current(allow_global=True) is c1
-        with c2.as_current():
-            assert Client.current() is c2
-            assert Client.current(allow_global=True) is c2
-
-    await c1.close()
-    await c2.close()
+        with temp_default_client(c):
+            assert Client.current() is c
+            with pytest.raises(ValueError):
+                Client.current(allow_global=False)
+            with c1.as_current():
+                assert Client.current() is c1
+                assert Client.current(allow_global=True) is c1
+            with c2.as_current():
+                assert Client.current() is c2
+                assert Client.current(allow_global=True) is c2
 
 
 def test_as_current_is_thread_local(s, loop):
@@ -4563,14 +4536,27 @@ async def test_client_timeout():
     straight away
     """
     port = open_port()
-    with dask.config.set({"distributed.comm.timeouts.connect": "10s"}):
-        c = Client(f"127.0.0.1:{port}", asynchronous=True)
-        client_start_fut = asyncio.ensure_future(c)
+    stop_event = asyncio.Event()
+
+    async def run_client():
+        try:
+            async with Client(f"127.0.0.1:{port}", asynchronous=True) as c:
+                return await c.run_on_scheduler(lambda: 123)
+        finally:
+            stop_event.set()
+
+    async def run_scheduler_after_2_seconds():
+        # TODO: start a scheduler that waits for the first connection and
+        # closes it
         await asyncio.sleep(2)
         async with Scheduler(port=port, dashboard_address=":0"):
-            await client_start_fut
-            assert await c.run_on_scheduler(lambda: 123) == 123
-            await c.close()
+            await stop_event.wait()
+
+    with dask.config.set({"distributed.comm.timeouts.connect": "10s"}):
+        assert await asyncio.gather(
+            run_client(),
+            run_scheduler_after_2_seconds(),
+        ) == [123, None]
 
 
 @gen_cluster(client=True)
@@ -4955,14 +4941,14 @@ def test_quiet_client_close_when_cluster_is_closed_before_client(loop):
 
 @gen_cluster()
 async def test_close(s, a, b):
-    c = await Client(s.address, asynchronous=True)
-    future = c.submit(inc, 1)
-    await wait(future)
-    assert c.id in s.clients
-    await c.close()
+    async with Client(s.address, asynchronous=True) as c:
+        future = c.submit(inc, 1)
+        await wait(future)
+        assert c.id in s.clients
+        await c.close()
 
-    while c.id in s.clients or s.tasks:
-        await asyncio.sleep(0.01)
+        while c.id in s.clients or s.tasks:
+            await asyncio.sleep(0.01)
 
 
 def test_threadsafe(c):
@@ -5499,9 +5485,8 @@ async def test_profile_keys(c, s, a, b):
 @gen_cluster()
 async def test_client_with_name(s, a, b):
     with captured_logger("distributed.scheduler") as sio:
-        client = await Client(s.address, asynchronous=True, name="foo")
-        assert "foo" in client.id
-        await client.close()
+        async with Client(s.address, asynchronous=True, name="foo") as client:
+            assert "foo" in client.id
 
     text = sio.getvalue()
     assert "foo" in text
@@ -5521,13 +5506,11 @@ async def test_future_auto_inform(c, s, a, b):
     x = c.submit(inc, 1)
     await wait(x)
 
-    client = await Client(s.address, asynchronous=True)
-    future = Future(x.key, client)
+    async with Client(s.address, asynchronous=True) as client:
+        future = Future(x.key, client)
 
-    while future.status != "finished":
-        await asyncio.sleep(0.01)
-
-    await client.close()
+        while future.status != "finished":
+            await asyncio.sleep(0.01)
 
 
 @pytest.mark.filterwarnings("ignore:There is no current event loop:DeprecationWarning")
@@ -5644,13 +5627,10 @@ async def test_avoid_delayed_finalize(c, s, a, b):
 async def test_config_scheduler_address(s, a, b):
     with dask.config.set({"scheduler-address": s.address}):
         with captured_logger("distributed.client") as sio:
-            c = await Client(asynchronous=True)
-            assert c.scheduler.address == s.address
+            async with Client(asynchronous=True) as c:
+                assert c.scheduler.address == s.address
 
-        text = sio.getvalue()
-        assert s.address in text
-
-        await c.close()
+    assert sio.getvalue() == f"Config value `scheduler-address` found: {s.address}\n"
 
 
 @gen_cluster(client=True)
@@ -5681,10 +5661,8 @@ async def test_unhashable_function(c, s, a, b):
 @gen_cluster()
 async def test_client_name(s, a, b):
     with dask.config.set({"client-name": "hello-world"}):
-        c = await Client(s.address, asynchronous=True)
-        assert any("hello-world" in name for name in list(s.clients))
-
-    await c.close()
+        async with Client(s.address, asynchronous=True) as c:
+            assert any("hello-world" in name for name in list(s.clients))
 
 
 def test_client_doesnt_close_given_loop(loop_in_thread, s, a, b):
@@ -5731,12 +5709,10 @@ async def test_client_timeout_2():
         start = time()
         c = Client(f"127.0.0.1:{port}", asynchronous=True)
         with pytest.raises((TimeoutError, IOError)):
-            await c
+            async with c:
+                pass
         stop = time()
-
         assert c.status == "closed"
-        await c.close()
-
         assert stop - start < 1
 
 
@@ -5751,8 +5727,8 @@ async def test_client_active_bad_port():
     with dask.config.set({"distributed.comm.timeouts.connect": "10ms"}):
         c = Client("127.0.0.1:8080", asynchronous=True)
         with pytest.raises((TimeoutError, IOError)):
-            await c
-        await c._close(fast=True)
+            async with c:
+                pass
     http_server.stop()
 
 
@@ -5794,50 +5770,45 @@ async def test_turn_off_pickle(c, s, a, b, direct):
 async def test_de_serialization(s, a, b):
     np = pytest.importorskip("numpy")
 
-    c = await Client(
+    async with Client(
         s.address,
         asynchronous=True,
         serializers=["msgpack", "pickle"],
         deserializers=["msgpack"],
-    )
-    try:
+    ) as c:
         # Can send complex data
         future = await c.scatter(np.ones(5))
 
         # But can not retrieve it
         with pytest.raises(TypeError):
             result = await future
-    finally:
-        await c.close()
 
 
 @gen_cluster()
 async def test_de_serialization_none(s, a, b):
     np = pytest.importorskip("numpy")
 
-    c = await Client(s.address, asynchronous=True, deserializers=["msgpack"])
-    try:
+    async with Client(s.address, asynchronous=True, deserializers=["msgpack"]) as c:
         # Can send complex data
         future = await c.scatter(np.ones(5))
 
         # But can not retrieve it
         with pytest.raises(TypeError):
             result = await future
-    finally:
-        await c.close()
 
 
 @gen_cluster()
 async def test_client_repr_closed(s, a, b):
-    c = await Client(s.address, asynchronous=True)
-    await c.close()
-    c._repr_html_()
+    async with Client(s.address, asynchronous=True) as c:
+        pass
+    assert "No scheduler connected." in c._repr_html_()
 
 
+@pytest.mark.skip
 def test_client_repr_closed_sync(loop):
     with Client(loop=loop, processes=False, dashboard_address=":0") as c:
         pass
-    c._repr_html_()
+    assert "No scheduler connected." in c._repr_html_()
 
 
 @pytest.mark.xfail(reason="https://github.com/dask/dask/pull/6807")
@@ -5917,13 +5888,11 @@ def test_no_threads_lingering():
 
 @gen_cluster()
 async def test_direct_async(s, a, b):
-    c = await Client(s.address, asynchronous=True, direct_to_workers=True)
-    assert c.direct_to_workers
-    await c.close()
+    async with Client(s.address, asynchronous=True, direct_to_workers=True) as c:
+        assert c.direct_to_workers
 
-    c = await Client(s.address, asynchronous=True, direct_to_workers=False)
-    assert not c.direct_to_workers
-    await c.close()
+    async with Client(s.address, asynchronous=True, direct_to_workers=False) as c:
+        assert not c.direct_to_workers
 
 
 def test_direct_sync(c):
@@ -5937,17 +5906,15 @@ def test_direct_sync(c):
 
 @gen_cluster()
 async def test_mixing_clients(s, a, b):
-    c1 = await Client(s.address, asynchronous=True)
-    c2 = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c1, Client(
+        s.address, asynchronous=True
+    ) as c2:
 
-    future = c1.submit(inc, 1)
-    with pytest.raises(ValueError):
-        c2.submit(inc, future)
+        future = c1.submit(inc, 1)
+        with pytest.raises(ValueError):
+            c2.submit(inc, future)
 
-    assert not c2.futures  # Don't create Futures on second Client
-
-    await c1.close()
-    await c2.close()
+        assert not c2.futures  # Don't create Futures on second Client
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -15,28 +15,25 @@ from distributed.utils_test import gen_cluster, inc
 
 @gen_cluster()
 async def test_publish_simple(s, a, b):
-    c = Client(s.address, asynchronous=True)
-    f = Client(s.address, asynchronous=True)
-    await asyncio.gather(c, f)
-
-    data = await c.scatter(range(3))
-    await c.publish_dataset(data=data)
-    assert "data" in s.extensions["publish"].datasets
-    assert isinstance(s.extensions["publish"].datasets["data"]["data"], Serialized)
-
-    with pytest.raises(KeyError) as exc_info:
+    async with Client(s.address, asynchronous=True) as c, Client(
+        s.address, asynchronous=True
+    ) as f:
+        data = await c.scatter(range(3))
         await c.publish_dataset(data=data)
+        assert "data" in s.extensions["publish"].datasets
+        assert isinstance(s.extensions["publish"].datasets["data"]["data"], Serialized)
 
-    assert "exists" in str(exc_info.value)
-    assert "data" in str(exc_info.value)
+        with pytest.raises(KeyError) as exc_info:
+            await c.publish_dataset(data=data)
 
-    result = await c.scheduler.publish_list()
-    assert result == ("data",)
+        assert "exists" in str(exc_info.value)
+        assert "data" in str(exc_info.value)
 
-    result = await f.scheduler.publish_list()
-    assert result == ("data",)
+        result = await c.scheduler.publish_list()
+        assert result == ("data",)
 
-    await asyncio.gather(c.close(), f.close())
+        result = await f.scheduler.publish_list()
+        assert result == ("data",)
 
 
 @gen_cluster()
@@ -56,29 +53,27 @@ async def test_publish_non_string_key(s, a, b):
 
 @gen_cluster()
 async def test_publish_roundtrip(s, a, b):
-    c = await Client(s.address, asynchronous=True)
-    f = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c, Client(
+        s.address, asynchronous=True
+    ) as f:
 
-    data = await c.scatter([0, 1, 2])
-    await c.publish_dataset(data=data)
+        data = await c.scatter([0, 1, 2])
+        await c.publish_dataset(data=data)
 
-    assert any(
-        cs.client_key == "published-data" for cs in s.tasks[data[0].key].who_wants
-    )
-    result = await f.get_dataset(name="data")
+        assert any(
+            cs.client_key == "published-data" for cs in s.tasks[data[0].key].who_wants
+        )
+        result = await f.get_dataset(name="data")
 
-    assert len(result) == len(data)
-    out = await f.gather(result)
-    assert out == [0, 1, 2]
+        assert len(result) == len(data)
+        out = await f.gather(result)
+        assert out == [0, 1, 2]
 
-    with pytest.raises(KeyError) as exc_info:
-        await f.get_dataset(name="nonexistent")
+        with pytest.raises(KeyError) as exc_info:
+            await f.get_dataset(name="nonexistent")
 
-    assert "not found" in str(exc_info.value)
-    assert "nonexistent" in str(exc_info.value)
-
-    await c.close()
-    await f.close()
+        assert "not found" in str(exc_info.value)
+        assert "nonexistent" in str(exc_info.value)
 
 
 @gen_cluster(client=True)
@@ -154,29 +149,30 @@ def test_unpublish_multiple_datasets_sync(client):
 @gen_cluster()
 async def test_publish_bag(s, a, b):
     db = pytest.importorskip("dask.bag")
-    c = await Client(s.address, asynchronous=True)
-    f = await Client(s.address, asynchronous=True)
+    async with Client(s.address, asynchronous=True) as c, Client(
+        s.address, asynchronous=True
+    ) as f:
 
-    bag = db.from_sequence([0, 1, 2])
-    bagp = c.persist(bag)
+        bag = db.from_sequence([0, 1, 2])
+        bagp = c.persist(bag)
 
-    assert len(futures_of(bagp)) == 3
-    keys = {f.key for f in futures_of(bagp)}
-    assert keys == set(bag.dask)
+        assert len(futures_of(bagp)) == 3
+        keys = {f.key for f in futures_of(bagp)}
+        assert keys == set(bag.dask)
 
-    await c.publish_dataset(data=bagp)
+        await c.publish_dataset(data=bagp)
 
-    # check that serialization didn't affect original bag's dask
-    assert len(futures_of(bagp)) == 3
+        # check that serialization didn't affect original bag's dask
+        assert len(futures_of(bagp)) == 3
 
-    result = await f.get_dataset("data")
-    assert set(result.dask.keys()) == set(bagp.dask.keys())
-    assert {f.key for f in result.dask.values()} == {f.key for f in bagp.dask.values()}
+        result = await f.get_dataset("data")
+        assert set(result.dask.keys()) == set(bagp.dask.keys())
+        assert {f.key for f in result.dask.values()} == {
+            f.key for f in bagp.dask.values()
+        }
 
-    out = await f.compute(result)
-    assert out == [0, 1, 2]
-    await c.close()
-    await f.close()
+        out = await f.compute(result)
+        assert out == [0, 1, 2]
 
 
 def test_datasets_setitem(client):

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -70,22 +70,20 @@ def test_sync(client):
 
 @gen_cluster()
 async def test_hold_futures(s, a, b):
-    c1 = await Client(s.address, asynchronous=True)
-    future = c1.submit(lambda x: x + 1, 10)
-    q1 = await Queue("q")
-    await q1.put(future)
-    del q1
-    await c1.close()
+    async with Client(s.address, asynchronous=True) as c1:
+        future = c1.submit(lambda x: x + 1, 10)
+        q1 = await Queue("q")
+        await q1.put(future)
+        del q1
 
     await asyncio.sleep(0.1)
 
-    c2 = await Client(s.address, asynchronous=True)
-    q2 = await Queue("q")
-    future2 = await q2.get()
-    result = await future2
+    async with Client(s.address, asynchronous=True) as c1:
+        q2 = await Queue("q")
+        future2 = await q2.get()
+        result = await future2
 
-    assert result == 11
-    await c2.close()
+        assert result == 11
 
 
 @pytest.mark.skip(reason="getting same client from main thread")
@@ -193,31 +191,29 @@ async def test_Future_knows_status_immediately(c, s, a, b):
     q = await Queue("q")
     await q.put(x)
 
-    c2 = await Client(s.address, asynchronous=True)
-    q2 = await Queue("q", client=c2)
-    future = await q2.get()
-    assert future.status == "finished"
+    async with Client(s.address, asynchronous=True) as c2:
+        q2 = await Queue("q", client=c2)
+        future = await q2.get()
+        assert future.status == "finished"
 
-    x = c.submit(div, 1, 0)
-    await wait(x)
-    await q.put(x)
+        x = c.submit(div, 1, 0)
+        await wait(x)
+        await q.put(x)
 
-    future2 = await q2.get()
-    assert future2.status == "error"
-    with pytest.raises(Exception):
-        await future2
-
-    start = time()
-    while True:  # we learn about the true error eventually
-        try:
+        future2 = await q2.get()
+        assert future2.status == "error"
+        with pytest.raises(Exception):
             await future2
-        except ZeroDivisionError:
-            break
-        except Exception:
-            assert time() < start + 5
-            await asyncio.sleep(0.05)
 
-    await c2.close()
+        start = time()
+        while True:  # we learn about the true error eventually
+            try:
+                await future2
+            except ZeroDivisionError:
+                break
+            except Exception:
+                assert time() < start + 5
+                await asyncio.sleep(0.05)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1416,14 +1416,13 @@ async def test_fifo_submission(c, s, w):
 @gen_test()
 async def test_scheduler_file():
     with tmpfile() as fn:
-        s = await Scheduler(scheduler_file=fn, dashboard_address=":0")
-        with open(fn) as f:
-            data = json.load(f)
-        assert data["address"] == s.address
+        async with Scheduler(scheduler_file=fn, dashboard_address=":0") as s:
+            with open(fn) as f:
+                data = json.load(f)
+            assert data["address"] == s.address
 
-        c = await Client(scheduler_file=fn, loop=s.loop, asynchronous=True)
-        await c.close()
-        await s.close()
+            async with Client(scheduler_file=fn, loop=s.loop, asynchronous=True):
+                pass
 
 
 @pytest.mark.parametrize(

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -273,11 +273,9 @@ def test_new_config():
 def test_lingering_client():
     @gen_cluster()
     async def f(s, a, b):
-        with pytest.warns(
-            DeprecationWarning,
-            match=r"await Client\(\) is deprecated, use async with Client\(\)",
-        ):
-            await Client(s.address, asynchronous=True)
+        # TODO: force async-with here?
+        # see https://github.com/dask/distributed/issues/6616
+        await Client(s.address, asynchronous=True)
 
     f()
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -273,7 +273,11 @@ def test_new_config():
 def test_lingering_client():
     @gen_cluster()
     async def f(s, a, b):
-        await Client(s.address, asynchronous=True)
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"await Client\(\) is deprecated, use async with Client\(\)",
+        ):
+            await Client(s.address, asynchronous=True)
 
     f()
 
@@ -282,6 +286,7 @@ def test_lingering_client():
 
 
 def test_lingering_client_2(loop):
+    # assert where the client went
     with cluster() as (s, [a, b]):
         client = Client(s["address"], loop=loop)
 

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -284,7 +284,7 @@ def test_lingering_client():
 
 
 def test_lingering_client_2(loop):
-    # assert where the client went
+    # TODO: assert where the client went
     with cluster() as (s, [a, b]):
         client = Client(s["address"], loop=loop)
 

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -95,22 +95,20 @@ def test_sync(client):
 
 @gen_cluster()
 async def test_hold_futures(s, a, b):
-    c1 = await Client(s.address, asynchronous=True)
-    future = c1.submit(lambda x: x + 1, 10)
-    x1 = Variable("x")
-    await x1.set(future)
-    del x1
-    await c1.close()
+    async with Client(s.address, asynchronous=True) as c1:
+        future = c1.submit(lambda x: x + 1, 10)
+        x1 = Variable("x")
+        await x1.set(future)
+        del x1
 
     await asyncio.sleep(0.1)
 
-    c2 = await Client(s.address, asynchronous=True)
-    x2 = Variable("x")
-    future2 = await x2.get()
-    result = await future2
+    async with Client(s.address, asynchronous=True) as c2:
+        x2 = Variable("x")
+        future2 = await x2.get()
+        result = await future2
 
-    assert result == 11
-    await c2.close()
+        assert result == 11
 
 
 @gen_cluster(client=True)
@@ -228,31 +226,29 @@ async def test_Future_knows_status_immediately(c, s, a, b):
     v = Variable("x")
     await v.set(x)
 
-    c2 = await Client(s.address, asynchronous=True)
-    v2 = Variable("x", client=c2)
-    future = await v2.get()
-    assert future.status == "finished"
+    async with Client(s.address, asynchronous=True) as c2:
+        v2 = Variable("x", client=c2)
+        future = await v2.get()
+        assert future.status == "finished"
 
-    x = c.submit(div, 1, 0)
-    await wait(x)
-    await v.set(x)
+        x = c.submit(div, 1, 0)
+        await wait(x)
+        await v.set(x)
 
-    future2 = await v2.get()
-    assert future2.status == "error"
-    with pytest.raises(Exception):
-        await future2
-
-    start = time()
-    while True:  # we learn about the true error eventually
-        try:
+        future2 = await v2.get()
+        assert future2.status == "error"
+        with pytest.raises(Exception):
             await future2
-        except ZeroDivisionError:
-            break
-        except Exception:
-            assert time() < start + 5
-            await asyncio.sleep(0.05)
 
-    await c2.close()
+        start = time()
+        while True:  # we learn about the true error eventually
+            try:
+                await future2
+            except ZeroDivisionError:
+                break
+            except Exception:
+                assert time() < start + 5
+                await asyncio.sleep(0.05)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1019,7 +1019,10 @@ def test_get_client_sync(client):
 @gen_cluster(client=True)
 async def test_get_client_coroutine(c, s, a, b):
     async def f():
-        client = await get_client()
+        # TODO: `await get_client()` raises a deprecation warning to use
+        # `async with get_client()` and that will kill the workers' client
+        # if you do that. We really don't want users to do that.
+        client = get_client()
         future = client.submit(inc, 10)
         result = await future
         return result

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1019,9 +1019,10 @@ def test_get_client_sync(client):
 @gen_cluster(client=True)
 async def test_get_client_coroutine(c, s, a, b):
     async def f():
-        # TODO: `await get_client()` raises a deprecation warning to use
-        # `async with get_client()` and that will kill the workers' client
+        # TODO: the existence of `await get_client()` implies the possibility
+        # of `async with get_client()` and that will kill the workers' client
         # if you do that. We really don't want users to do that.
+        # https://github.com/dask/distributed/pull/6921/
         client = get_client()
         future = client.submit(inc, 10)
         result = await future


### PR DESCRIPTION
This is just the refactors extracted from https://github.com/dask/distributed/pull/6836

This should make it easier to do optimizations like https://github.com/dask/distributed/pull/6920 so when a failure happens we can propagate it quickly and close the Client

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
