### PR TITLE
[Test] Ensure relative memory limits work as percentage of system memory

### DIFF
--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -59,6 +59,14 @@ async def test_parse_memory_limit_worker(s, w):
     assert w.memory_manager.memory_limit == 2e9
 
 
+@gen_cluster(nthreads=[("", 1)], worker_kwargs={"memory_limit": "0.5"})
+async def test_parse_memory_limit_worker_relative(s, w):
+    assert w.memory_manager.memory_limit > 0.5
+    assert w.memory_manager.memory_limit == pytest.approx(
+        distributed.system.MEMORY_LIMIT * 0.5
+    )
+
+
 @gen_cluster(
     client=True,
     nthreads=[("", 1)],


### PR DESCRIPTION
I stumbled over this feature and was a bit surprised by it. Never saw a relative memory limit before and I think we're not explicitly testing it anywhere.

Adding this test to make sure this is not accidentally removed