### PR TITLE
Use retries for the test report

### DIFF
--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import html
 import io
 import os
@@ -16,6 +17,8 @@ import altair_saver
 import junitparser
 import pandas
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 TOKEN = os.environ.get("GITHUB_TOKEN")
 
@@ -25,6 +28,19 @@ COLORS = {
     "x": "#f2a5a5",
     "s": "#f2ef8f",
 }
+
+
+@contextlib.contextmanager
+def get_session() -> Iterator[requests.Session]:
+    retry_strategy = Retry(
+        status_forcelist=[429, 500, 502, 503, 504],
+        backoff_factor=0.2,
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    with requests.Session() as session:
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        yield session
 
 
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
@@ -77,11 +93,13 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def get_from_github(url: str, params: dict[str, Any]) -> requests.Response:
+def get_from_github(
+    url: str, params: dict[str, Any], session: requests.Session
+) -> requests.Response:
     """
     Make an authenticated request to the GitHub REST API.
     """
-    r = requests.get(url, params=params, headers={"Authorization": f"token {TOKEN}"})
+    r = session.get(url, params=params, headers={"Authorization": f"token {TOKEN}"})
     r.raise_for_status()
     return r
 
@@ -103,17 +121,17 @@ def maybe_get_next_page_path(response: requests.Response) -> str | None:
     return next_page_path
 
 
-def get_jobs(run):
+def get_jobs(run, session):
     with shelve.open("test_report_jobs") as cache:
         url = run["jobs_url"]
         try:
             jobs = cache[url]
         except KeyError:
             params = {"per_page": 100}
-            r = get_from_github(run["jobs_url"], params)
+            r = get_from_github(run["jobs_url"], params, session=session)
             jobs = r.json()["jobs"]
             while next_page := maybe_get_next_page_path(r):
-                r = get_from_github(next_page, params=params)
+                r = get_from_github(next_page, params=params, session=session)
                 jobs.extend(r.json()["jobs"])
             cache[url] = jobs
 
@@ -137,7 +155,7 @@ def get_jobs(run):
 
 
 def get_workflow_run_listing(
-    repo: str, branch: str, event: str, days: int
+    repo: str, branch: str, event: str, days: int, session: requests.Session
 ) -> list[dict]:
     """
     Get a list of workflow runs from GitHub actions.
@@ -145,19 +163,23 @@ def get_workflow_run_listing(
     since = (pandas.Timestamp.now(tz="UTC") - pandas.Timedelta(days=days)).date()
     params = {"per_page": 100, "branch": branch, "event": event, "created": f">{since}"}
     r = get_from_github(
-        f"https://api.github.com/repos/{repo}/actions/runs", params=params
+        f"https://api.github.com/repos/{repo}/actions/runs",
+        params=params,
+        session=session,
     )
     runs = r.json()["workflow_runs"]
     next_page = maybe_get_next_page_path(r)
     while next_page:
-        r = get_from_github(next_page, params)
+        r = get_from_github(next_page, params, session=session)
         runs += r.json()["workflow_runs"]
         next_page = maybe_get_next_page_path(r)
 
     return runs
 
 
-def get_artifacts_for_workflow_run(run_id: str, repo: str) -> list:
+def get_artifacts_for_workflow_run(
+    run_id: str, repo: str, session: requests.Session
+) -> list:
     """
     Get a list of artifacts from GitHub actions
     """
@@ -165,11 +187,12 @@ def get_artifacts_for_workflow_run(run_id: str, repo: str) -> list:
     r = get_from_github(
         f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/artifacts",
         params=params,
+        session=session,
     )
     artifacts = r.json()["artifacts"]
     next_page = maybe_get_next_page_path(r)
     while next_page:
-        r = get_from_github(next_page, params=params)
+        r = get_from_github(next_page, params=params, session=session)
         artifacts += r.json()["artifacts"]
         next_page = maybe_get_next_page_path(r)
 
@@ -185,7 +208,9 @@ def suite_from_name(name: str) -> str:
     return "-".join(name.split("-")[:3])
 
 
-def download_and_parse_artifact(url: str) -> junitparser.JUnitXml | None:
+def download_and_parse_artifact(
+    url: str, session: requests.Session
+) -> junitparser.JUnitXml | None:
     """
     Download the artifact at the url parse it.
     """
@@ -193,7 +218,7 @@ def download_and_parse_artifact(url: str) -> junitparser.JUnitXml | None:
         try:
             xml_raw = cache[url]
         except KeyError:
-            r = get_from_github(url, params={})
+            r = get_from_github(url, params={}, session=session)
             f = zipfile.ZipFile(io.BytesIO(r.content))
             cache[url] = xml_raw = f.read(f.filelist[0].filename)
     try:
@@ -269,76 +294,81 @@ def download_and_parse_artifacts(
 
     print("Getting list of workflow runs...")
     runs = []
-    for event in events:
-        runs += get_workflow_run_listing(
-            repo=repo, branch=branch, event=event, days=max_days
-        )
-
-    # Filter the workflow runs listing to be in the retention period,
-    # and only be test runs (i.e., no linting) that completed.
-    runs = [
-        r
-        for r in runs
-        if (
-            pandas.to_datetime(r["created_at"])
-            > pandas.Timestamp.now(tz="UTC") - pandas.Timedelta(days=max_days)
-            and r["conclusion"] != "cancelled"
-            and r["name"].lower() == "tests"
-        )
-    ]
-    print(f"Found {len(runs)} workflow runs")
-    # Each workflow run processed takes ~10-15 API requests. To avoid being
-    # rate limited by GitHub (1000 requests per hour) we choose just the
-    # most recent N runs. This also keeps the viz size from blowing up.
-    runs = sorted(runs, key=lambda r: r["created_at"])[-max_runs:]
-    print(f"Fetching artifact listing for the {len(runs)} most recent workflow runs")
-
-    for r in runs:
-        artifacts = get_artifacts_for_workflow_run(r["id"], repo=repo)
-        # We also upload timeout reports as artifacts, but we don't want them here.
-        r["artifacts"] = [
-            a
-            for a in artifacts
-            if "timeouts" not in a["name"] and "cluster_dumps" not in a["name"]
-        ]
-
-    nartifacts = sum(len(r["artifacts"]) for r in runs)
-    ndownloaded = 0
-    print(f"Downloading and parsing {nartifacts} artifacts...")
-
-    for r in runs:
-        jobs_df = get_jobs(r)
-        r["dfs"] = []
-        for a in r["artifacts"]:
-            url = a["archive_download_url"]
-            df: pandas.DataFrame | None
-            xml = download_and_parse_artifact(url)
-            if xml is None:
-                continue
-            df = dataframe_from_jxml(cast(Iterable, xml))
-            # Note: we assign a column with the workflow run timestamp rather
-            # than the artifact timestamp so that artifacts triggered under
-            # the same workflow run can be aligned according to the same trigger
-            # time.
-            html_url = jobs_df[jobs_df["suite_name"] == a["name"]].html_url.unique()
-            assert (
-                len(html_url) == 1
-            ), f"Artifact suit name {a['name']} did not match any jobs dataframe {jobs_df['suite_name'].unique()}"
-            html_url = html_url[0]
-            assert html_url is not None
-            df2 = df.assign(
-                name=a["name"],
-                suite=suite_from_name(a["name"]),
-                date=r["created_at"],
-                html_url=html_url,
+    with get_session() as session:
+        for event in events:
+            runs += get_workflow_run_listing(
+                repo=repo, branch=branch, event=event, days=max_days, session=session
             )
 
-            if df2 is not None:
-                yield df2
+        # Filter the workflow runs listing to be in the retention period,
+        # and only be test runs (i.e., no linting) that completed.
+        runs = [
+            r
+            for r in runs
+            if (
+                pandas.to_datetime(r["created_at"])
+                > pandas.Timestamp.now(tz="UTC") - pandas.Timedelta(days=max_days)
+                and r["conclusion"] != "cancelled"
+                and r["name"].lower() == "tests"
+            )
+        ]
+        print(f"Found {len(runs)} workflow runs")
+        # Each workflow run processed takes ~10-15 API requests. To avoid being
+        # rate limited by GitHub (1000 requests per hour) we choose just the
+        # most recent N runs. This also keeps the viz size from blowing up.
+        runs = sorted(runs, key=lambda r: r["created_at"])[-max_runs:]
+        print(
+            f"Fetching artifact listing for the {len(runs)} most recent workflow runs"
+        )
 
-            ndownloaded += 1
-            if ndownloaded and not ndownloaded % 20:
-                print(f"{ndownloaded}... ", end="")
+        for r in runs:
+            artifacts = get_artifacts_for_workflow_run(
+                r["id"], repo=repo, session=session
+            )
+            # We also upload timeout reports as artifacts, but we don't want them here.
+            r["artifacts"] = [
+                a
+                for a in artifacts
+                if "timeouts" not in a["name"] and "cluster_dumps" not in a["name"]
+            ]
+
+        nartifacts = sum(len(r["artifacts"]) for r in runs)
+        ndownloaded = 0
+        print(f"Downloading and parsing {nartifacts} artifacts...")
+
+        for r in runs:
+            jobs_df = get_jobs(r, session=session)
+            r["dfs"] = []
+            for a in r["artifacts"]:
+                url = a["archive_download_url"]
+                df: pandas.DataFrame | None
+                xml = download_and_parse_artifact(url, session=session)
+                if xml is None:
+                    continue
+                df = dataframe_from_jxml(cast(Iterable, xml))
+                # Note: we assign a column with the workflow run timestamp rather
+                # than the artifact timestamp so that artifacts triggered under
+                # the same workflow run can be aligned according to the same trigger
+                # time.
+                html_url = jobs_df[jobs_df["suite_name"] == a["name"]].html_url.unique()
+                assert (
+                    len(html_url) == 1
+                ), f"Artifact suit name {a['name']} did not match any jobs dataframe {jobs_df['suite_name'].unique()}"
+                html_url = html_url[0]
+                assert html_url is not None
+                df2 = df.assign(
+                    name=a["name"],
+                    suite=suite_from_name(a["name"]),
+                    date=r["created_at"],
+                    html_url=html_url,
+                )
+
+                if df2 is not None:
+                    yield df2
+
+                ndownloaded += 1
+                if ndownloaded and not ndownloaded % 20:
+                    print(f"{ndownloaded}... ", end="")
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
Our test reports are failing because of a couple of 503s which we should retry.

This introduces retries and establishes a requests session for everything we're doing. big diff is merely indentation