### PR TITLE
Improve differentiation between incoming/outgoing connections and transfers

### DIFF
--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -235,7 +235,7 @@ class CommunicatingTimeSeries(DashboardComponent):
         fig = figure(
             title="Communication History",
             x_axis_type="datetime",
-            y_range=[-0.1, worker.state.total_out_connections + 0.5],
+            y_range=[-0.1, worker.state.comm_incoming_limit + 0.5],
             height=150,
             tools="",
             x_range=x_range,

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -114,8 +114,8 @@ class CommunicatingStream(DashboardComponent):
             "total",
         ]
 
-        self.incoming = ColumnDataSource({name: [] for name in names})
-        self.outgoing = ColumnDataSource({name: [] for name in names})
+        self.incoming_transfers = ColumnDataSource({name: [] for name in names})
+        self.outgoing_transfers = ColumnDataSource({name: [] for name in names})
 
         x_range = DataRange1d(range_padding=0)
         y_range = DataRange1d(range_padding=0)
@@ -131,7 +131,7 @@ class CommunicatingStream(DashboardComponent):
         )
 
         fig.rect(
-            source=self.incoming,
+            source=self.incoming_transfers,
             x="middle",
             y="y",
             width="duration",
@@ -140,7 +140,7 @@ class CommunicatingStream(DashboardComponent):
             alpha="alpha",
         )
         fig.rect(
-            source=self.outgoing,
+            source=self.outgoing_transfers,
             x="middle",
             y="y",
             width="duration",
@@ -159,26 +159,30 @@ class CommunicatingStream(DashboardComponent):
 
         self.root = fig
 
-        self.last_incoming = 0
-        self.last_outgoing = 0
+        self.last_incoming_transfer_count = 0
+        self.last_outgoing_transfer_count = 0
         self.who = dict()
 
     @without_property_validation
     @log_errors
     def update(self):
-        outgoing = self.worker.outgoing_transfer_log
-        n = self.worker.outgoing_count - self.last_outgoing
-        outgoing = [outgoing[-i].copy() for i in range(1, n + 1)]
-        self.last_outgoing = self.worker.outgoing_count
+        outgoing_transfer_log = self.worker.outgoing_transfer_log
+        n = self.worker.outgoing_transfer_count - self.last_outgoing_transfer_count
+        outgoing_transfer_log = [
+            outgoing_transfer_log[-i].copy() for i in range(1, n + 1)
+        ]
+        self.last_outgoing_transfer_count = self.worker.outgoing_transfer_count
 
-        incoming = self.worker.incoming_transfer_log
-        n = self.worker.incoming_count - self.last_incoming
-        incoming = [incoming[-i].copy() for i in range(1, n + 1)]
-        self.last_incoming = self.worker.incoming_count
+        incoming_transfer_log = self.worker.incoming_transfer_log
+        n = self.worker.incoming_transfer_count - self.last_incoming_transfer_count
+        incoming_transfer_log = [
+            incoming_transfer_log[-i].copy() for i in range(1, n + 1)
+        ]
+        self.last_incoming_transfer_count = self.worker.incoming_transfer_count
 
         for [msgs, source] in [
-            [incoming, self.incoming],
-            [outgoing, self.outgoing],
+            [incoming_transfer_log, self.incoming_transfers],
+            [outgoing_transfer_log, self.outgoing_transfers],
         ]:
 
             for msg in msgs:

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -180,14 +180,14 @@ class CommunicatingStream(DashboardComponent):
 
         transfer_incoming_log = self.worker.transfer_incoming_log
         n = (
-            self.worker.transfer_incoming_count_total
+            self.worker.state.transfer_incoming_count_total
             - self.last_transfer_incoming_count_total
         )
         transfer_incoming_log = [
             transfer_incoming_log[-i].copy() for i in range(1, n + 1)
         ]
         self.last_transfer_incoming_count_total = (
-            self.worker.transfer_incoming_count_total
+            self.worker.state.transfer_incoming_count_total
         )
 
         for [msgs, source] in [

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -261,7 +261,7 @@ class CommunicatingTimeSeries(DashboardComponent):
             {
                 "x": [time() * 1000],
                 "out": [len(self.worker._comms)],
-                "in": [self.worker.state.incoming_count],
+                "in": [self.worker.state.transfer_incoming_count],
             },
             10000,
         )

--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -114,8 +114,8 @@ class CommunicatingStream(DashboardComponent):
             "total",
         ]
 
-        self.incoming_transfers = ColumnDataSource({name: [] for name in names})
-        self.outgoing_transfers = ColumnDataSource({name: [] for name in names})
+        self.comm_incoming = ColumnDataSource({name: [] for name in names})
+        self.comm_outgoing = ColumnDataSource({name: [] for name in names})
 
         x_range = DataRange1d(range_padding=0)
         y_range = DataRange1d(range_padding=0)
@@ -131,7 +131,7 @@ class CommunicatingStream(DashboardComponent):
         )
 
         fig.rect(
-            source=self.incoming_transfers,
+            source=self.comm_incoming,
             x="middle",
             y="y",
             width="duration",
@@ -140,7 +140,7 @@ class CommunicatingStream(DashboardComponent):
             alpha="alpha",
         )
         fig.rect(
-            source=self.outgoing_transfers,
+            source=self.comm_outgoing,
             x="middle",
             y="y",
             width="duration",
@@ -166,33 +166,29 @@ class CommunicatingStream(DashboardComponent):
     @without_property_validation
     @log_errors
     def update(self):
-        outgoing_transfer_log = self.worker.outgoing_transfer_log
+        comm_outgoing_log = self.worker.comm_outgoing_log
         n = (
             self.worker.comm_outgoing_cumulative_count
             - self.last_comm_outgoing_cumulative_count
         )
-        outgoing_transfer_log = [
-            outgoing_transfer_log[-i].copy() for i in range(1, n + 1)
-        ]
+        comm_outgoing_log = [comm_outgoing_log[-i].copy() for i in range(1, n + 1)]
         self.last_comm_outgoing_cumulative_count = (
             self.worker.comm_outgoing_cumulative_count
         )
 
-        incoming_transfer_log = self.worker.incoming_transfer_log
+        comm_incoming_log = self.worker.comm_incoming_log
         n = (
             self.worker.comm_incoming_cumulative_count
             - self.last_comm_incoming_cumulative_count
         )
-        incoming_transfer_log = [
-            incoming_transfer_log[-i].copy() for i in range(1, n + 1)
-        ]
+        comm_incoming_log = [comm_incoming_log[-i].copy() for i in range(1, n + 1)]
         self.last_comm_incoming_cumulative_count = (
             self.worker.comm_incoming_cumulative_count
         )
 
         for [msgs, source] in [
-            [incoming_transfer_log, self.incoming_transfers],
-            [outgoing_transfer_log, self.outgoing_transfers],
+            [comm_incoming_log, self.comm_incoming],
+            [comm_outgoing_log, self.comm_outgoing],
         ]:
 
             for msg in msgs:

--- a/distributed/dashboard/tests/test_worker_bokeh.py
+++ b/distributed/dashboard/tests/test_worker_bokeh.py
@@ -142,11 +142,11 @@ async def test_CommunicatingStream(c, s, a, b):
     aa.update()
     bb.update()
 
-    assert len(first(aa.outgoing.data.values())) and len(
-        first(bb.outgoing.data.values())
+    assert len(first(aa.outgoing_transfers.data.values())) and len(
+        first(bb.outgoing_transfers.data.values())
     )
-    assert len(first(aa.incoming.data.values())) and len(
-        first(bb.incoming.data.values())
+    assert len(first(aa.incoming_transfers.data.values())) and len(
+        first(bb.incoming_transfers.data.values())
     )
 
 

--- a/distributed/dashboard/tests/test_worker_bokeh.py
+++ b/distributed/dashboard/tests/test_worker_bokeh.py
@@ -142,11 +142,11 @@ async def test_CommunicatingStream(c, s, a, b):
     aa.update()
     bb.update()
 
-    assert len(first(aa.outgoing_transfers.data.values())) and len(
-        first(bb.outgoing_transfers.data.values())
+    assert len(first(aa.transfer_outgoing.data.values())) and len(
+        first(bb.transfer_outgoing.data.values())
     )
-    assert len(first(aa.incoming_transfers.data.values())) and len(
-        first(bb.incoming_transfers.data.values())
+    assert len(first(aa.transfer_incoming.data.values())) and len(
+        first(bb.transfer_incoming.data.values())
     )
 
 

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -37,7 +37,7 @@ class WorkerMetricCollector(PrometheusCollector):
         yield GaugeMetricFamily(
             self.build_name("concurrent_fetch_requests"),
             "Number of open fetch requests to other workers.",
-            value=self.server.state.comm_incoming_count,
+            value=self.server.state.transfer_incoming_count,
         )
 
         yield GaugeMetricFamily(

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -37,7 +37,7 @@ class WorkerMetricCollector(PrometheusCollector):
         yield GaugeMetricFamily(
             self.build_name("concurrent_fetch_requests"),
             "Number of open fetch requests to other workers.",
-            value=len(self.server.state.in_flight_workers),
+            value=self.server.state.comm_incoming_count,
         )
 
         yield GaugeMetricFamily(

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -647,7 +647,7 @@ async def test_gather_skip(c, s, a):
 async def test_limit_concurrent_gathering(c, s, a, b):
     futures = c.map(inc, range(100))
     await c.gather(futures)
-    assert len(a.outgoing_transfer_log) + len(b.outgoing_transfer_log) < 100
+    assert len(a.comm_outgoing_log) + len(b.comm_outgoing_log) < 100
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -647,7 +647,7 @@ async def test_gather_skip(c, s, a):
 async def test_limit_concurrent_gathering(c, s, a, b):
     futures = c.map(inc, range(100))
     await c.gather(futures)
-    assert len(a.comm_outgoing_log) + len(b.comm_outgoing_log) < 100
+    assert len(a.transfer_outgoing_log) + len(b.transfer_outgoing_log) < 100
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -232,7 +232,7 @@ async def test_nanny_timeout(c, s, a):
     clean_kwargs={"threads": False},
     config={"distributed.worker.memory.pause": False},
 )
-async def test_throttle_incoming_connections(c, s, a, *other_workers):
+async def test_throttle_outgoing_transfers(c, s, a, *other_workers):
     # Put a bunch of small data on worker a
     logging.getLogger("distributed.worker").setLevel(logging.DEBUG)
     remote_data = c.map(

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -241,7 +241,7 @@ async def test_throttle_incoming_connections(c, s, a, *other_workers):
     await wait(remote_data)
 
     a.status = Status.paused
-    a.comm_outgoing_count = 2
+    a.transfer_outgoing_count = 2
 
     requests = [
         await a.get_data(await w.rpc.connect(w.address), keys=[f.key], who=w.address)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -232,7 +232,7 @@ async def test_nanny_timeout(c, s, a):
     clean_kwargs={"threads": False},
     config={"distributed.worker.memory.pause": False},
 )
-async def test_throttle_outgoing_connections(c, s, a, *other_workers):
+async def test_throttle_incoming_connections(c, s, a, *other_workers):
     # Put a bunch of small data on worker a
     logging.getLogger("distributed.worker").setLevel(logging.DEBUG)
     remote_data = c.map(
@@ -241,7 +241,7 @@ async def test_throttle_outgoing_connections(c, s, a, *other_workers):
     await wait(remote_data)
 
     a.status = Status.paused
-    a.outgoing_current_count = 2
+    a.current_outgoing_transfer_count = 2
 
     requests = [
         await a.get_data(await w.rpc.connect(w.address), keys=[f.key], who=w.address)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -241,7 +241,7 @@ async def test_throttle_incoming_connections(c, s, a, *other_workers):
     await wait(remote_data)
 
     a.status = Status.paused
-    a.current_outgoing_transfer_count = 2
+    a.comm_outgoing_count = 2
 
     requests = [
         await a.get_data(await w.rpc.connect(w.address), keys=[f.key], who=w.address)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -227,7 +227,7 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
         # Check that there were few transfers
         unexpected_transfers = []
         for worker in workers:
-            for log in worker.comm_incoming_log:
+            for log in worker.transfer_incoming_log:
                 keys = log["keys"]
                 # The root-ish tasks should never be transferred
                 assert not any(k.startswith("random") for k in keys), keys

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -227,7 +227,7 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
         # Check that there were few transfers
         unexpected_transfers = []
         for worker in workers:
-            for log in worker.incoming_transfer_log:
+            for log in worker.comm_incoming_log:
                 keys = log["keys"]
                 # The root-ish tasks should never be transferred
                 assert not any(k.startswith("random") for k in keys), keys

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3564,13 +3564,6 @@ async def test_execute_preamble_abort_retirement(c, s):
 @gen_cluster()
 async def test_deprecation_of_renamed_worker_attributes(s, a, b):
     msg = (
-        "The `Worker.incoming_count` attribute has been renamed to "
-        "`Worker.transfer_incoming_count_total`"
-    )
-    with pytest.warns(DeprecationWarning, match=msg):
-        assert a.incoming_count == a.transfer_incoming_count_total
-
-    msg = (
         "The `Worker.outgoing_count` attribute has been renamed to "
         "`Worker.transfer_outgoing_count_total`"
     )

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3559,3 +3559,27 @@ async def test_execute_preamble_abort_retirement(c, s):
 
         # Test that y does not get stuck.
         assert await y == 2
+
+
+@gen_cluster()
+async def test_deprecation_of_renamed_worker_attributes(s, a, b):
+    msg = (
+        "The `Worker.incoming_count` attribute has been renamed to "
+        "`Worker.incoming_transfer_count`"
+    )
+    with pytest.warns(DeprecationWarning, match=msg):
+        assert a.incoming_count == a.incoming_transfer_count
+
+    msg = (
+        "The `Worker.outgoing_count` attribute has been renamed to "
+        "`Worker.outgoing_transfer_count`"
+    )
+    with pytest.warns(DeprecationWarning, match=msg):
+        assert a.outgoing_count == a.outgoing_transfer_count
+
+    msg = (
+        "The `Worker.outgoing_current_count` attribute has been renamed to "
+        "`Worker.current_outgoing_transfer_count`"
+    )
+    with pytest.warns(DeprecationWarning, match=msg):
+        assert a.outgoing_current_count == a.current_outgoing_transfer_count

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1967,7 +1967,7 @@ async def test_gather_dep_one_worker_always_busy(c, s, a, b):
     # We will block A for any outgoing communication. This simulates an
     # overloaded worker which will always return "busy" for get_data requests,
     # effectively blocking H indefinitely
-    a.outgoing_current_count = 10000000
+    a.current_outgoing_transfer_count = 10000000
 
     h = c.submit(add, f, g, key="h", workers=[b.address])
 
@@ -2029,7 +2029,7 @@ async def test_gather_dep_from_remote_workers_if_all_local_workers_are_busy(
         )
     )["f"]
     for w in lws:
-        w.outgoing_current_count = 10000000
+        w.current_outgoing_transfer_count = 10000000
 
     g = c.submit(inc, f, key="g", workers=[a.address])
     assert await g == 2

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1247,7 +1247,7 @@ async def test_wait_for_outgoing(c, s, a, b):
 
     assert len(b.transfer_incoming_log) == len(a.transfer_outgoing_log) == 1
     bb = b.transfer_incoming_log[0]["duration"]
-    aa = a.transfer_incoming_log[0]["duration"]
+    aa = a.outgoing_transfer_log[0]["duration"]
     ratio = aa / bb
 
     assert 1 / 3 < ratio < 3
@@ -2726,7 +2726,7 @@ async def test_acquire_replicas_same_channel(c, s, a, b):
                 ("request-dep", a.address, {fut.key}),
             ],
         )
-        assert any(fut.key in msg["keys"] for msg in b.transfer_outgoing_log)
+        assert any(fut.key in msg["keys"] for msg in b.incoming_transfer_log)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -764,7 +764,7 @@ async def test_gather_many_small(c, s, a, *snd_workers, as_deps):
     concurrent outgoing connections. If multiple small fetches from the same worker are
     scheduled all at once, they will result in a single call to gather_dep.
     """
-    a.state.total_out_connections = 2
+    a.state.comm_incoming_limit = 2
     futures = await c.scatter(
         {f"x{i}": i for i in range(100)},
         workers=[w.address for w in snd_workers],
@@ -3036,7 +3036,7 @@ async def test_missing_released_zombie_tasks(c, s, a, b):
     Ensure that no fetch/flight tasks are left in the task dict of a
     worker after everything was released
     """
-    a.total_in_connections = 0
+    a.comm_outgoing_limit = 0
     f1 = c.submit(inc, 1, key="f1", workers=[a.address])
     f2 = c.submit(inc, f1, key="f2", workers=[b.address])
     key = f1.key

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2730,7 +2730,7 @@ async def test_acquire_replicas_same_channel(c, s, a, b):
                 ("request-dep", a.address, {fut.key}),
             ],
         )
-        assert any(fut.key in msg["keys"] for msg in b.incoming_transfer_log)
+        assert any(fut.key in msg["keys"] for msg in b.transfer_incoming_log)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -673,7 +673,7 @@ async def test_fetch_to_missing_on_busy(c, s, a, b):
     x = c.submit(inc, 1, key="x", workers=[b.address])
     await x
 
-    b.total_in_connections = 0
+    b.comm_outgoing_limit = 0
     # Crucially, unlike with `c.submit(inc, x, workers=[a.address])`, the scheduler
     # doesn't keep track of acquire-replicas requests, so it won't proactively inform a
     # when we call remove_worker later on
@@ -923,7 +923,7 @@ async def test_fetch_to_missing_on_refresh_who_has(c, s, w1, w2, w3):
     x = c.submit(inc, 1, key="x", workers=[w1.address])
     y = c.submit(inc, 2, key="y", workers=[w1.address])
     await wait([x, y])
-    w1.total_in_connections = 0
+    w1.comm_outgoing_limit = 0
     s.request_acquire_replicas(w3.address, ["x", "y"], stimulus_id="test1")
 
     # The tasks will now flip-flop between fetch and flight every 150ms
@@ -1040,7 +1040,7 @@ def test_gather_priority(ws):
     3. in case of tie, from the worker with the most tasks queued
     4. in case of tie, from a random worker (which is actually deterministic).
     """
-    ws.total_out_connections = 4
+    ws.comm_incoming_limit = 4
 
     instructions = ws.handle_stimulus(
         PauseEvent(stimulus_id="pause"),
@@ -1060,7 +1060,7 @@ def test_gather_priority(ws):
                 # This will be fetched first because it's on the same worker as y
                 "x8": ["127.0.0.7:1"],
             },
-            # Substantial nbytes prevents total_out_connections to be overridden by
+            # Substantial nbytes prevents comm_incoming_limit to be overridden by
             # comm_threshold_bytes, but it's less than target_message_size
             nbytes={f"x{i}": 4 * 2**20 for i in range(1, 9)},
             stimulus_id="compute1",

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -985,17 +985,17 @@ async def test_fetch_to_missing_on_network_failure(c, s, a):
 
 @gen_cluster()
 async def test_deprecated_worker_attributes(s, a, b):
-    n = a.state.transfer_incoming_throttle_size_threshold
+    n = a.state.target_message_size
     msg = (
-        "The `Worker.comm_threshold_bytes` attribute has been moved to "
-        "`Worker.state.transfer_incoming_throttle_size_threshold`"
+        "The `Worker.target_message_size` attribute has been moved to "
+        "`Worker.state.target_message_size`"
     )
     with pytest.warns(FutureWarning, match=msg):
-        assert a.comm_threshold_bytes == n
+        assert a.target_message_size == n
     with pytest.warns(FutureWarning, match=msg):
-        a.comm_threshold_bytes += 1
-        assert a.comm_threshold_bytes == n + 1
-    assert a.state.transfer_incoming_throttle_size_threshold == n + 1
+        a.target_message_size += 1
+        assert a.target_message_size == n + 1
+    assert a.state.target_message_size == n + 1
 
     # Old and new names differ
     msg = (

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -1061,7 +1061,7 @@ def test_gather_priority(ws):
                 "x8": ["127.0.0.7:1"],
             },
             # Substantial nbytes prevents transfer_incoming_count_limit to be overridden by
-            # transfer_incoming_throttle_size_threshold, but it's less than target_message_size
+            # transfer_incoming_bytes_throttle_threshold, but it's less than target_message_size
             nbytes={f"x{i}": 4 * 2**20 for i in range(1, 9)},
             stimulus_id="compute1",
         ),

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -985,17 +985,17 @@ async def test_fetch_to_missing_on_network_failure(c, s, a):
 
 @gen_cluster()
 async def test_deprecated_worker_attributes(s, a, b):
-    n = a.state.target_message_size
+    n = a.state.generation
     msg = (
-        "The `Worker.target_message_size` attribute has been moved to "
-        "`Worker.state.target_message_size`"
+        "The `Worker.generation` attribute has been moved to "
+        "`Worker.state.generation`"
     )
     with pytest.warns(FutureWarning, match=msg):
-        assert a.target_message_size == n
+        assert a.generation == n
     with pytest.warns(FutureWarning, match=msg):
-        a.target_message_size += 1
-        assert a.target_message_size == n + 1
-    assert a.state.target_message_size == n + 1
+        a.generation -= 1
+        assert a.generation == n - 1
+    assert a.state.generation == n - 1
 
     # Old and new names differ
     msg = (
@@ -1012,7 +1012,7 @@ async def test_deprecated_worker_attributes(s, a, b):
 @pytest.mark.parametrize(
     "nbytes,n_in_flight",
     [
-        # Note: target_message_size = 50e6 bytes
+        # Note: transfer_message_target_bytes = 50e6 bytes
         (int(10e6), 3),
         (int(20e6), 2),
         (int(30e6), 1),
@@ -1060,8 +1060,9 @@ def test_gather_priority(ws):
                 # This will be fetched first because it's on the same worker as y
                 "x8": ["127.0.0.7:1"],
             },
-            # Substantial nbytes prevents transfer_incoming_count_limit to be overridden by
-            # transfer_incoming_bytes_throttle_threshold, but it's less than target_message_size
+            # Substantial nbytes prevents transfer_incoming_count_limit to be
+            # overridden by transfer_incoming_bytes_throttle_threshold,
+            # but it's less than transfer_message_target_bytes
             nbytes={f"x{i}": 4 * 2**20 for i in range(1, 9)},
             stimulus_id="compute1",
         ),

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2281,13 +2281,13 @@ def freeze_data_fetching(w: Worker, *, jump_start: bool = False) -> Iterator[Non
         If True, trigger ensure_communicating on exit; this simulates e.g. an unrelated
         worker moving out of in_flight_workers.
     """
-    old_out_connections = w.state.comm_incoming_limit
-    old_comm_threshold = w.state.comm_threshold_bytes
-    w.state.comm_incoming_limit = 0
-    w.state.comm_threshold_bytes = 0
+    old_out_connections = w.state.transfer_incoming_count_limit
+    old_comm_threshold = w.state.transfer_incoming_throttle_size_threshold
+    w.state.transfer_incoming_count_limit = 0
+    w.state.transfer_incoming_throttle_size_threshold = 0
     yield
-    w.state.comm_incoming_limit = old_out_connections
-    w.state.comm_threshold_bytes = old_comm_threshold
+    w.state.transfer_incoming_count_limit = old_out_connections
+    w.state.transfer_incoming_throttle_size_threshold = old_comm_threshold
     if jump_start:
         w.status = Status.paused
         w.status = Status.running

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2281,12 +2281,12 @@ def freeze_data_fetching(w: Worker, *, jump_start: bool = False) -> Iterator[Non
         If True, trigger ensure_communicating on exit; this simulates e.g. an unrelated
         worker moving out of in_flight_workers.
     """
-    old_out_connections = w.state.total_out_connections
+    old_out_connections = w.state.comm_incoming_limit
     old_comm_threshold = w.state.comm_threshold_bytes
-    w.state.total_out_connections = 0
+    w.state.comm_incoming_limit = 0
     w.state.comm_threshold_bytes = 0
     yield
-    w.state.total_out_connections = old_out_connections
+    w.state.comm_incoming_limit = old_out_connections
     w.state.comm_threshold_bytes = old_comm_threshold
     if jump_start:
         w.status = Status.paused

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2281,8 +2281,8 @@ def freeze_data_fetching(w: Worker, *, jump_start: bool = False) -> Iterator[Non
         If True, trigger ensure_communicating on exit; this simulates e.g. an unrelated
         worker moving out of in_flight_workers.
     """
-    old_out_connections = w.state.transfer_incoming_count_limit
-    old_comm_threshold = w.state.transfer_incoming_bytes_throttle_threshold
+    old_count_limit = w.state.transfer_incoming_count_limit
+    old_threshold = w.state.transfer_incoming_bytes_throttle_threshold
     w.state.transfer_incoming_count_limit = 0
     w.state.transfer_incoming_bytes_throttle_threshold = 0
     yield

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2286,8 +2286,8 @@ def freeze_data_fetching(w: Worker, *, jump_start: bool = False) -> Iterator[Non
     w.state.transfer_incoming_count_limit = 0
     w.state.transfer_incoming_bytes_throttle_threshold = 0
     yield
-    w.state.transfer_incoming_count_limit = old_out_connections
-    w.state.transfer_incoming_bytes_throttle_threshold = old_comm_threshold
+    w.state.transfer_incoming_count_limit = old_count_limit
+    w.state.transfer_incoming_bytes_throttle_threshold = old_threshold
     if jump_start:
         w.status = Status.paused
         w.status = Status.running

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2282,12 +2282,12 @@ def freeze_data_fetching(w: Worker, *, jump_start: bool = False) -> Iterator[Non
         worker moving out of in_flight_workers.
     """
     old_out_connections = w.state.transfer_incoming_count_limit
-    old_comm_threshold = w.state.transfer_incoming_throttle_size_threshold
+    old_comm_threshold = w.state.transfer_incoming_bytes_throttle_threshold
     w.state.transfer_incoming_count_limit = 0
-    w.state.transfer_incoming_throttle_size_threshold = 0
+    w.state.transfer_incoming_bytes_throttle_threshold = 0
     yield
     w.state.transfer_incoming_count_limit = old_out_connections
-    w.state.transfer_incoming_throttle_size_threshold = old_comm_threshold
+    w.state.transfer_incoming_bytes_throttle_threshold = old_comm_threshold
     if jump_start:
         w.status = Status.paused
         w.status = Status.running

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -872,7 +872,9 @@ class Worker(BaseWorker, ServerNode):
     story = DeprecatedWorkerStateAttribute()
     ready = DeprecatedWorkerStateAttribute()
     tasks = DeprecatedWorkerStateAttribute()
-    target_message_size = DeprecatedWorkerStateAttribute()
+    target_message_size = DeprecatedWorkerStateAttribute(
+        target="transfer_message_target_bytes"
+    )
     total_out_connections = DeprecatedWorkerStateAttribute(
         target="transfer_incoming_count_limit"
     )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2589,7 +2589,7 @@ class Worker(BaseWorker, ServerNode):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.transfer_outgoing_log
+        return self.transfer_outgoing_count_limit
 
 
 def get_worker() -> Worker:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -387,7 +387,7 @@ class Worker(BaseWorker, ServerNode):
     outgoing_transfer_log: deque[dict[str, Any]]
     incoming_transfer_count: int
     outgoing_transfer_count: int
-    current_outgoing_tranfer_count: int
+    current_outgoing_transfer_count: int
     bandwidth: float
     latency: float
     profile_cycle_interval: float
@@ -543,7 +543,7 @@ class Worker(BaseWorker, ServerNode):
         self.incoming_transfer_count = 0
         self.outgoing_transfer_log = deque(maxlen=100000)
         self.outgoing_transfer_count = 0
-        self.current_outgoing_tranfer_count = 0
+        self.current_outgoing_transfer_count = 0
         self.bandwidth = parse_bytes(dask.config.get("distributed.scheduler.bandwidth"))
         self.bandwidth_workers = defaultdict(
             lambda: (0, 0)
@@ -1659,20 +1659,20 @@ class Worker(BaseWorker, ServerNode):
 
         if (
             max_connections is not False
-            and self.current_outgoing_tranfer_count >= max_connections
+            and self.current_outgoing_transfer_count >= max_connections
         ):
             logger.debug(
                 "Worker %s has too many open connections to respond to data request "
                 "from %s (%d/%d).%s",
                 self.address,
                 who,
-                self.current_outgoing_tranfer_count,
+                self.current_outgoing_transfer_count,
                 max_connections,
                 throttle_msg,
             )
             return {"status": "busy"}
 
-        self.current_outgoing_tranfer_count += 1
+        self.current_outgoing_transfer_count += 1
         data = {k: self.data[k] for k in keys if k in self.data}
 
         if len(data) < len(keys):
@@ -1704,7 +1704,7 @@ class Worker(BaseWorker, ServerNode):
             comm.abort()
             raise
         finally:
-            self.current_outgoing_tranfer_count -= 1
+            self.current_outgoing_transfer_count -= 1
         stop = time()
         if self.digests is not None:
             self.digests["get-data-send-duration"].add(stop - start)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2533,6 +2533,36 @@ class Worker(BaseWorker, ServerNode):
 
             raise
 
+    @property
+    def incoming_count(self):
+        warnings.warn(
+            "The `Worker.incoming_count` attribute has been renamed to "
+            "`Worker.incoming_transfer_count`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.incoming_transfer_count
+
+    @property
+    def outgoing_count(self):
+        warnings.warn(
+            "The `Worker.outgoing_count` attribute has been renamed to "
+            "`Worker.outgoing_transfer_count`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.outgoing_transfer_count
+
+    @property
+    def outgoing_current_count(self):
+        warnings.warn(
+            "The `Worker.outgoing_current_count` attribute has been renamed to "
+            "`Worker.current_outgoing_transfer_count`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.current_outgoing_transfer_count
+
 
 def get_worker() -> Worker:
     """Get the worker currently running this task

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -859,6 +859,9 @@ class Worker(BaseWorker, ServerNode):
     executing_count = DeprecatedWorkerStateAttribute()
     generation = DeprecatedWorkerStateAttribute()
     has_what = DeprecatedWorkerStateAttribute()
+    incoming_count = DeprecatedWorkerStateAttribute(
+        target="transfer_incoming_count_total"
+    )
     in_flight_tasks = DeprecatedWorkerStateAttribute(target="in_flight_tasks_count")
     in_flight_workers = DeprecatedWorkerStateAttribute()
     log = DeprecatedWorkerStateAttribute()
@@ -2573,6 +2576,16 @@ class Worker(BaseWorker, ServerNode):
         warnings.warn(
             "The `Worker.outgoing_transfer_log` attribute has been renamed to "
             "`Worker.transfer_outgoing_log`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.transfer_outgoing_log
+
+    @property
+    def total_in_connections(self):
+        warnings.warn(
+            "The `Worker.total_in_connections` attribute has been renamed to "
+            "`Worker.transfer_outgoing_count_limit`",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -851,7 +851,7 @@ class Worker(BaseWorker, ServerNode):
     busy_workers = DeprecatedWorkerStateAttribute()
     comm_nbytes = DeprecatedWorkerStateAttribute(target="transfer_incoming_bytes")
     comm_threshold_bytes = DeprecatedWorkerStateAttribute(
-        target="transfer_incoming_throttle_size_threshold"
+        target="transfer_incoming_bytes_throttle_threshold"
     )
     constrained = DeprecatedWorkerStateAttribute()
     data_needed_per_worker = DeprecatedWorkerStateAttribute(target="data_needed")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -385,8 +385,6 @@ class Worker(BaseWorker, ServerNode):
     profile_history: deque[tuple[float, dict[str, Any]]]
     transfer_incoming_log: deque[dict[str, Any]]
     transfer_outgoing_log: deque[dict[str, Any]]
-    #: Number of total data transfers from other workers.
-    transfer_incoming_count_total: int
     #: Number of total data transfers to other workers.
     transfer_outgoing_count_total: int
     #: Number of open data transfers to other workers.
@@ -543,7 +541,6 @@ class Worker(BaseWorker, ServerNode):
             validate = dask.config.get("distributed.scheduler.validate")
 
         self.transfer_incoming_log = deque(maxlen=100000)
-        self.transfer_incoming_count_total = 0
         self.transfer_outgoing_log = deque(maxlen=100000)
         self.transfer_outgoing_count_total = 0
         self.transfer_outgoing_count = 0
@@ -1964,7 +1961,6 @@ class Worker(BaseWorker, ServerNode):
             self.digests["transfer-bandwidth"].add(total_bytes / duration)
             self.digests["transfer-duration"].add(duration)
         self.counters["transfer-count"].add(len(data))
-        self.transfer_incoming_count_total += 1
 
     @fail_hard
     async def gather_dep(
@@ -2541,16 +2537,6 @@ class Worker(BaseWorker, ServerNode):
                 self.log_event(topic, msg)
 
             raise
-
-    @property
-    def incoming_count(self):
-        warnings.warn(
-            "The `Worker.incoming_count` attribute has been renamed to "
-            "`Worker.transfer_incoming_count_total`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.transfer_incoming_count_total
 
     @property
     def incoming_transfer_log(self):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -385,8 +385,11 @@ class Worker(BaseWorker, ServerNode):
     profile_history: deque[tuple[float, dict[str, Any]]]
     incoming_transfer_log: deque[dict[str, Any]]
     outgoing_transfer_log: deque[dict[str, Any]]
+    #: Number of total communications used to transfer data to other workers.
     comm_incoming_cumulative_count: int
+    #: Number of total communications used to transfer data to other workers.
     comm_outgoing_cumulative_count: int
+    #: Number of open communications used to transfer data to other workers.
     comm_outgoing_count: int
     bandwidth: float
     latency: float
@@ -1653,7 +1656,9 @@ class Worker(BaseWorker, ServerNode):
 
         if self.status == Status.paused:
             max_connections = 1
-            throttle_msg = " Throttling incoming connections because worker is paused."
+            throttle_msg = (
+                " Throttling outgoing data transfers because worker is paused."
+            )
         else:
             throttle_msg = ""
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1143,7 +1143,7 @@ class WorkerState:
     #: The total number of bytes in flight
     comm_nbytes: int
 
-    #: The maximum number of concurrent incoming requests for data.
+    #: The maximum number of concurrent outgoing requests for data.
     #: See also :attr:`distributed.worker.Worker.total_in_connections`.
     total_out_connections: int
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1147,6 +1147,9 @@ class WorkerState:
     #: See also :attr:`distributed.worker.Worker.transfer_outgoing_count_limit`.
     transfer_incoming_count_limit: int
 
+    #: Number of total data transfers from other workers.
+    transfer_incoming_count_total: int
+
     #: Ignore :attr:`transfer_incoming_count_limit` as long as :attr:`transfer_incoming_bytes` is
     #: less than this value.
     transfer_incoming_throttle_size_threshold: int
@@ -1265,6 +1268,7 @@ class WorkerState:
         self.in_flight_workers = {}
         self.busy_workers = set()
         self.transfer_incoming_count_limit = transfer_incoming_count_limit
+        self.transfer_incoming_count_total = 0
         self.transfer_incoming_throttle_size_threshold = int(10e6)
         self.transfer_incoming_bytes = 0
         self.missing_dep_flight = set()
@@ -2768,6 +2772,7 @@ class WorkerState:
         _execute_done_common
         """
         self.transfer_incoming_bytes -= ev.total_nbytes
+        self.transfer_incoming_count_total += 1
         keys = self.in_flight_workers.pop(ev.worker)
         for key in keys:
             ts = self.tasks[key]

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1147,7 +1147,7 @@ class WorkerState:
     #: See also :attr:`distributed.worker.Worker.transfer_outgoing_count_limit`.
     transfer_incoming_count_limit: int
 
-    #: Number of total data transfers from other workers.
+    #: Number of total data transfers from other workers since the worker was started.
     transfer_incoming_count_total: int
 
     #: Ignore :attr:`transfer_incoming_count_limit` as long as :attr:`transfer_incoming_bytes` is

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1351,7 +1351,7 @@ class WorkerState:
 
     @property
     def comm_incoming_count(self) -> int:
-        """Count of connections currently being used to receive data from other workers.
+        """Count of open communications used to receive data from other workers.
 
         See also
         --------

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1152,7 +1152,7 @@ class WorkerState:
 
     #: Ignore :attr:`transfer_incoming_count_limit` as long as :attr:`transfer_incoming_bytes` is
     #: less than this value.
-    transfer_incoming_throttle_size_threshold: int
+    transfer_incoming_bytes_throttle_threshold: int
 
     #: Peer workers that recently returned a busy status. Workers in this set won't be
     #: asked for additional dependencies for some time.
@@ -1269,7 +1269,7 @@ class WorkerState:
         self.busy_workers = set()
         self.transfer_incoming_count_limit = transfer_incoming_count_limit
         self.transfer_incoming_count_total = 0
-        self.transfer_incoming_throttle_size_threshold = int(10e6)
+        self.transfer_incoming_bytes_throttle_threshold = int(10e6)
         self.transfer_incoming_bytes = 0
         self.missing_dep_flight = set()
         self.generation = 0
@@ -1468,7 +1468,7 @@ class WorkerState:
         if (
             self.transfer_incoming_count >= self.transfer_incoming_count_limit
             and self.transfer_incoming_bytes
-            >= self.transfer_incoming_throttle_size_threshold
+            >= self.transfer_incoming_bytes_throttle_threshold
         ):
             return {}, []
 
@@ -1524,7 +1524,7 @@ class WorkerState:
             if (
                 self.transfer_incoming_count >= self.transfer_incoming_count_limit
                 and self.transfer_incoming_bytes
-                >= self.transfer_incoming_throttle_size_threshold
+                >= self.transfer_incoming_bytes_throttle_threshold
             ):
                 break
 

--- a/docs/source/diagnosing-performance.rst
+++ b/docs/source/diagnosing-performance.rst
@@ -95,7 +95,7 @@ Bandwidth
 ---------
 
 Dask workers track every incoming and outgoing transfer in the
-``Worker.comm_outgoing_log`` and ``Worker.comm_incoming_log``
+``Worker.transfer_outgoing_log`` and ``Worker.transfer_incoming_log``
 attributes including
 
 1.  Total bytes transferred
@@ -110,8 +110,8 @@ command on the workers:
 
 .. code-block:: python
 
-   client.run(lambda dask_worker: dask_worker.comm_outgoing_log)
-   client.run(lambda dask_worker: dask_worker.comm_incoming_log)
+   client.run(lambda dask_worker: dask_worker.transfer_outgoing_log)
+   client.run(lambda dask_worker: dask_worker.transfer_incoming_log)
 
 
 Performance Reports

--- a/docs/source/diagnosing-performance.rst
+++ b/docs/source/diagnosing-performance.rst
@@ -95,7 +95,7 @@ Bandwidth
 ---------
 
 Dask workers track every incoming and outgoing transfer in the
-``Worker.outgoing_transfer_log`` and ``Worker.incoming_transfer_log``
+``Worker.comm_outgoing_log`` and ``Worker.comm_incoming_log``
 attributes including
 
 1.  Total bytes transferred
@@ -110,8 +110,8 @@ command on the workers:
 
 .. code-block:: python
 
-   client.run(lambda dask_worker: dask_worker.outgoing_transfer_log)
-   client.run(lambda dask_worker: dask_worker.incoming_transfer_log)
+   client.run(lambda dask_worker: dask_worker.comm_outgoing_log)
+   client.run(lambda dask_worker: dask_worker.comm_incoming_log)
 
 
 Performance Reports


### PR DESCRIPTION
The unclear differentiation between incoming/outgoing connections and transfers has made it difficult for me to understand what we are doing. In addition, there were two mistakes in docstrings/messages that we fix.

Following https://github.com/dask/distributed/pull/6936#issuecomment-1230513291 while assuming some small liberties, this PR now implements the following changes:

main | new | notes
-- | -- | --
WorkerState.comm_nbytes | WorkerState.transfer_incoming_bytes |  
(new property) | WorkerState.transfer_incoming_count | len(self.in_flight_workers)
WorkerState.total_out_connections | WorkerState.transfer_incoming_count_limit |  
WorkerState.comm_threshold_bytes | WorkerState.transfer_incoming_bytes_throttle_threshold |  
WorkerState.target_message_size | WorkerState.transfer_message_target_bytes | 
Worker.outgoing_current_count | Worker.transfer_outgoing_count |  
(new attribute) | Worker.transfer_outgoing_bytes |  
Worker.incoming_count | WorkerState.transfer_incoming_count_total | Moved to WorkerState
Worker.outgoing_count | Worker.transfer_outgoing_count_total |  
Worker.total_in_connections | Worker.transfer_outgoing_count_limit |
Worker.incoming_transfer_log | Worker.transfer_incoming_log |
Worker.outgoing_transfer_log | Worker.transfer_outgoing_log |

**Notes:**
* Skip `current` suffix
* Use `total` suffix to highlight _cumulative sums_. 
    * shorter than `cumulative`
    * if it's not `total`, it's _current_
* The abundance `transfer_`-prefixed variables might indicate a missing abstraction

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
