### PR TITLE
Expose transfer-related metrics in `Worker.get_metrics` and `WorkerMetricCollector`

### DIFF
--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -53,6 +53,12 @@ class WorkerMetricCollector(PrometheusCollector):
             value=self.server.latency,
         )
 
+        yield GaugeMetricFamily(
+            self.build_name("comm_reserved_bytes"),
+            "Number of bytes currently reserved for incoming/outgoing data transfers.",
+            value=self.server.state.comm_nbytes,
+        )
+
         # all metrics using digests require crick to be installed
         # the following metrics will export NaN, if the corresponding digests are None
         if self.crick_available:

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -37,7 +37,10 @@ class WorkerMetricCollector(PrometheusCollector):
 
         yield GaugeMetricFamily(
             self.build_name("concurrent_fetch_requests"),
-            "Number of open fetch requests to other workers.",
+            (
+                "[Deprecated: This metric has been renamed to transfer_incoming_count.] "
+                "Number of open fetch requests to other workers."
+            ),
             value=self.server.state.transfer_incoming_count,
         )
 
@@ -54,9 +57,45 @@ class WorkerMetricCollector(PrometheusCollector):
         )
 
         yield GaugeMetricFamily(
-            self.build_name("comm_reserved_bytes"),
-            "Number of bytes currently reserved for incoming/outgoing data transfers.",
-            value=self.server.state.comm_nbytes,
+            self.build_name("transfer_incoming_bytes"),
+            "Total size of open data transfers from other workers.",
+            value=self.server.state.transfer_incoming_bytes,
+        )
+
+        yield GaugeMetricFamily(
+            self.build_name("transfer_incoming_count"),
+            "Number of open data transfers from other workers.",
+            value=self.server.state.transfer_incoming_bytes,
+        )
+
+        yield GaugeMetricFamily(
+            self.build_name("transfer_incoming_count_total"),
+            (
+                "Total number of data transfers from other workers "
+                "since the worker was started."
+            ),
+            value=self.server.state.transfer_incoming_count_total,
+        )
+
+        yield GaugeMetricFamily(
+            self.build_name("transfer_outgoing_bytes"),
+            "Total size of open data transfers to other workers.",
+            value=self.server.transfer_outgoing_bytes,
+        )
+
+        yield GaugeMetricFamily(
+            self.build_name("transfer_outgoing_count"),
+            "Number of open data transfers to other workers.",
+            value=self.server.transfer_outgoing_count,
+        )
+
+        yield GaugeMetricFamily(
+            self.build_name("transfer_outgoing_count_total"),
+            (
+                "Total number of data transfers to other workers "
+                "since the worker was started."
+            ),
+            value=self.server.transfer_outgoing_count_total,
         )
 
         # all metrics using digests require crick to be installed

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -21,6 +21,12 @@ async def test_prometheus(c, s, a):
         "dask_worker_concurrent_fetch_requests",
         "dask_worker_threads",
         "dask_worker_latency_seconds",
+        "dask_worker_transfer_incoming_bytes",
+        "dask_worker_transfer_incoming_count",
+        "dask_worker_transfer_incoming_count_total",
+        "dask_worker_transfer_outgoing_bytes",
+        "dask_worker_transfer_outgoing_count",
+        "dask_worker_transfer_outgoing_count_total",
     }
 
     try:

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -410,7 +410,7 @@ def test_computetask_dummy():
 
     # nbytes is generated from who_has if omitted
     ev2 = ComputeTaskEvent.dummy("x", who_has={"y": "127.0.0.1:2"}, stimulus_id="s")
-    assert ev2.nbytes == {"y": 7}
+    assert ev2.nbytes == {"y": 1}
 
 
 def test_updatedata_to_dict():
@@ -1086,7 +1086,7 @@ def test_gather_priority(ws):
             stimulus_id="unpause",
             worker="127.0.0.7:1",
             to_gather={"y", "x8"},
-            total_nbytes=7 + 4 * 2**20,
+            total_nbytes=1 + 4 * 2**20,
         ),
         # Followed by local workers
         GatherDep(
@@ -1114,7 +1114,7 @@ def test_gather_priority(ws):
             total_nbytes=4 * 2**20,
         ),
     ]
-    expected_bytes = 7 + 4 * 2**20 + 4 * 2**20 + 8 * 2**20 + 4 * 2**20
+    expected_bytes = 1 + 4 * 2**20 + 4 * 2**20 + 8 * 2**20 + 4 * 2**20
     assert ws.transfer_incoming_bytes == expected_bytes
     assert ws.transfer_incoming_count == 4
     assert ws.transfer_incoming_count_total == 4

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -387,9 +387,9 @@ class Worker(BaseWorker, ServerNode):
     transfer_outgoing_log: deque[dict[str, Any]]
     #: Total number of data transfers to other workers since the worker was started.
     transfer_outgoing_count_total: int
-    #: Total size of open data transfers to other worker.
+    #: Current total size of open data transfers to other workers
     transfer_outgoing_bytes: int
-    #: Number of open data transfers to other workers.
+    #: Current number of open data transfers to other workers
     transfer_outgoing_count: int
     bandwidth: float
     latency: float
@@ -1708,10 +1708,10 @@ class Worker(BaseWorker, ServerNode):
                     )
 
         msg = {"status": "OK", "data": {k: to_serialize(v) for k, v in data.items()}}
-        bytes_per_task = {
-            k: self.state.tasks[k].nbytes for k in data if k in self.state.tasks
-        }
-        total_bytes = sum(filter(None, bytes_per_task.values()))
+        # Note: `if k in self.data` above guarantees that 
+        # k is in self.state.tasks too and that nbytes is non-None
+        bytes_per_task = {k: self.state.tasks[k].nbytes for k in data}
+        total_bytes = sum(bytes_per_task.values())
         self.transfer_outgoing_bytes += total_bytes
         stop = time()
         if self.digests is not None:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -983,6 +983,7 @@ class Worker(BaseWorker, ServerNode):
                 "memory": spilled_memory,
                 "disk": spilled_disk,
             },
+            comm_reserved_bytes=self.state.comm_nbytes,
             event_loop_interval=self._tick_interval_observed,
         )
         out.update(self.monitor.recent())

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1710,9 +1710,7 @@ class Worker(BaseWorker, ServerNode):
         msg = {"status": "OK", "data": {k: to_serialize(v) for k, v in data.items()}}
         # Note: `if k in self.data` above guarantees that
         # k is in self.state.tasks too and that nbytes is non-None
-        bytes_per_task: dict[str, int] = {
-            k: self.state.tasks[k].nbytes or 0 for k in data
-        }
+        bytes_per_task = {k: self.state.tasks[k].nbytes or 0 for k in data}
         total_bytes = sum(bytes_per_task.values())
         self.transfer_outgoing_bytes += total_bytes
         stop = time()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -385,7 +385,7 @@ class Worker(BaseWorker, ServerNode):
     profile_history: deque[tuple[float, dict[str, Any]]]
     transfer_incoming_log: deque[dict[str, Any]]
     transfer_outgoing_log: deque[dict[str, Any]]
-    #: Total number of data transfers to other workers since the worker was started.
+    #: Total number of data transfers to other workers since the worker was started
     transfer_outgoing_count_total: int
     #: Current total size of open data transfers to other workers
     transfer_outgoing_bytes: int
@@ -1708,9 +1708,11 @@ class Worker(BaseWorker, ServerNode):
                     )
 
         msg = {"status": "OK", "data": {k: to_serialize(v) for k, v in data.items()}}
-        # Note: `if k in self.data` above guarantees that 
+        # Note: `if k in self.data` above guarantees that
         # k is in self.state.tasks too and that nbytes is non-None
-        bytes_per_task = {k: self.state.tasks[k].nbytes for k in data}
+        bytes_per_task: dict[str, int] = {
+            k: self.state.tasks[k].nbytes or 0 for k in data
+        }
         total_bytes = sum(bytes_per_task.values())
         self.transfer_outgoing_bytes += total_bytes
         stop = time()

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1149,7 +1149,7 @@ class WorkerState:
     #: dependencies until the current query returns.
     in_flight_workers: dict[str, set[str]]
 
-    #: Total size of open data transfers from other workers.
+    #: Current total size of open data transfers from other workers
     transfer_incoming_bytes: int
 
     #: Maximum number of concurrent incoming data transfers from other workers.
@@ -1364,7 +1364,7 @@ class WorkerState:
 
     @property
     def transfer_incoming_count(self) -> int:
-        """Number of open data transfers from other workers.
+        """Current number of open data transfers from other workers.
 
         See also
         --------

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -794,7 +794,7 @@ class ComputeTaskEvent(StateMachineEvent):
         return ComputeTaskEvent(
             key=key,
             who_has=who_has or {},
-            nbytes=nbytes or {k: 1 for k in who_has or ()},
+            nbytes=nbytes or {k: 7 for k in who_has or ()},
             priority=priority,
             duration=duration,
             run_spec=None,

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1149,14 +1149,14 @@ class WorkerState:
     #: dependencies until the current query returns.
     in_flight_workers: dict[str, set[str]]
 
-    #: The total size of incoming data transfers for in-flight tasks.
+    #: Total size of open data transfers from other workers.
     transfer_incoming_bytes: int
 
-    #: The maximum number of concurrent incoming data transfers from other workers.
+    #: Maximum number of concurrent incoming data transfers from other workers.
     #: See also :attr:`distributed.worker.Worker.transfer_outgoing_count_limit`.
     transfer_incoming_count_limit: int
 
-    #: Number of total data transfers from other workers since the worker was started.
+    #: Total number of data transfers from other workers since the worker was started.
     transfer_incoming_count_total: int
 
     #: Ignore :attr:`transfer_incoming_count_limit` as long as :attr:`transfer_incoming_bytes` is
@@ -1354,7 +1354,7 @@ class WorkerState:
 
     @property
     def in_flight_tasks_count(self) -> int:
-        """Count of tasks currently being replicated from other workers to this one.
+        """Number of tasks currently being replicated from other workers to this one.
 
         See also
         --------
@@ -1364,7 +1364,7 @@ class WorkerState:
 
     @property
     def transfer_incoming_count(self) -> int:
-        """Count of open data transfers from other workers.
+        """Number of open data transfers from other workers.
 
         See also
         --------
@@ -1529,6 +1529,7 @@ class WorkerState:
             )
 
             self.in_flight_workers[worker] = to_gather_keys
+            self.transfer_incoming_count_total += 1
             self.transfer_incoming_bytes += total_nbytes
             if (
                 self.transfer_incoming_count >= self.transfer_incoming_count_limit
@@ -2845,7 +2846,6 @@ class WorkerState:
         _execute_done_common
         """
         self.transfer_incoming_bytes -= ev.total_nbytes
-        self.transfer_incoming_count_total += 1
         keys = self.in_flight_workers.pop(ev.worker)
         for key in keys:
             ts = self.tasks[key]

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -794,7 +794,7 @@ class ComputeTaskEvent(StateMachineEvent):
         return ComputeTaskEvent(
             key=key,
             who_has=who_has or {},
-            nbytes=nbytes or {k: 7 for k in who_has or ()},
+            nbytes=nbytes or {k: 1 for k in who_has or ()},
             priority=priority,
             duration=duration,
             run_spec=None,


### PR DESCRIPTION
Closes #6892

* Adds transfer-related metrics in `Worker.get_metrics` and `WorkerMetricCollector`
* Adds testing for `transfer_incoming_*` metrics

**Out of scope:**
* Dashboard component for `transfer_incoming_bytes` and `transfer_outgoing_bytes` to be added in a follow-up PR 

**Notes**:
* `outgoing` metrics appear to be rather awkward to test since the timing needs to be "just right".

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
