### PR TITLE
Don't force recursing into python collections when serializing objects.

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -268,7 +268,7 @@ def serialize(  # type: ignore[no-untyped-def]
             serializers=serializers,
             on_error=on_error,
             context=context,
-            iterate_collection=True,
+            iterate_collection=iterate_collection,
         )
 
     # Note: don't use isinstance(), as it would match subclasses


### PR DESCRIPTION
Looking at #6368 and dask/dask#9411, and seeing what this breaks

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
