### PR TITLE
`stimulus_task_erred` is no-op when task-erred is not coming from the worker the task is actually processing on

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2319,7 +2319,7 @@ class SchedulerState:
             if self.validate:
                 assert cause or ts.exception_blame
                 assert ts.processing_on
-                assert ts.processing_on == worker
+                assert ts.processing_on.address == worker
                 assert not ts.who_has
                 assert not ts.waiting_on
 
@@ -4182,7 +4182,7 @@ class Scheduler(SchedulerState, ServerNode):
         logger.debug("Stimulus task erred %s, %s", key, worker)
 
         ts: TaskState = self.tasks.get(key)
-        if ts is None or ts.state != "processing" or ts.processing_on != worker:
+        if ts is None or ts.state != "processing" or ts.processing_on.address != worker:
             return {}, {}, {}
 
         if ts.retries > 0:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2304,6 +2304,7 @@ class SchedulerState:
         traceback=None,
         exception_text: str | None = None,
         traceback_text: str | None = None,
+        worker: str | None = None,
         **kwargs,
     ):
         ws: WorkerState
@@ -2318,6 +2319,7 @@ class SchedulerState:
             if self.validate:
                 assert cause or ts.exception_blame
                 assert ts.processing_on
+                assert ts.processing_on == worker
                 assert not ts.who_has
                 assert not ts.waiting_on
 
@@ -4180,7 +4182,7 @@ class Scheduler(SchedulerState, ServerNode):
         logger.debug("Stimulus task erred %s, %s", key, worker)
 
         ts: TaskState = self.tasks.get(key)
-        if ts is None or ts.state != "processing":
+        if ts is None or ts.state != "processing" or ts.processing_on != worker:
             return {}, {}, {}
 
         if ts.retries > 0:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2319,7 +2319,8 @@ class SchedulerState:
             if self.validate:
                 assert cause or ts.exception_blame
                 assert ts.processing_on
-                assert ts.processing_on.address == worker
+                if worker is not None:
+                    assert ts.processing_on.address == worker
                 assert not ts.who_has
                 assert not ts.waiting_on
 


### PR DESCRIPTION
Adds the missing commit from https://github.com/dask/distributed/pull/6884#issuecomment-1225226551.

**Notes**
* The additional checks are instances of #6392, but without passing around IDs or `WorkerState` objects, that's all we can do here.
* See discussion around https://github.com/dask/distributed/pull/6884#issuecomment-1224775494

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @fjetter, @gjoseph92 