### PR TITLE
Deprecate default value for Client.wait_for_workers

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1375,8 +1375,8 @@ class Client(SyncMethodMixin):
         """
         if n_workers is no_default:
             warnings.warn(
-                "Client.wait_for_workers requires passing the argument `n_workers`. Not passing any argument will no longer be supported in future versions.",
-                DeprecationWarning,
+                "Please specify the `n_workers` argument when using `Client.wait_for_workers`. Not specifying `n_workers` will no longer be supported in future versions.",
+                FutureWarning,
             )
             n_workers = 0
         elif not isinstance(n_workers, int) or n_workers < 1:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1329,7 +1329,9 @@ class Client(SyncMethodMixin):
         except OSError:
             logger.debug("Not able to query scheduler for identity")
 
-    async def _wait_for_workers(self, n_workers=0, timeout=None):
+    async def _wait_for_workers(
+        self, n_workers: int, timeout: float | None = None
+    ) -> None:
         info = await self.scheduler.identity()
         self._scheduler_identity = SchedulerInfo(info)
         if timeout:
@@ -1346,7 +1348,7 @@ class Client(SyncMethodMixin):
                 ]
             )
 
-        while n_workers and running_workers(info) < n_workers:
+        while running_workers(info) < n_workers:
             if deadline and time() > deadline:
                 raise TimeoutError(
                     "Only %d/%d workers arrived after %s"
@@ -1356,7 +1358,11 @@ class Client(SyncMethodMixin):
             info = await self.scheduler.identity()
             self._scheduler_identity = SchedulerInfo(info)
 
-    def wait_for_workers(self, n_workers=0, timeout=None):
+    def wait_for_workers(
+        self,
+        n_workers: int | str = no_default,
+        timeout: float | None = None,
+    ) -> None:
         """Blocking call to wait for n workers before continuing
 
         Parameters
@@ -1367,6 +1373,16 @@ class Client(SyncMethodMixin):
             Time in seconds after which to raise a
             ``dask.distributed.TimeoutError``
         """
+        if n_workers is no_default:
+            warnings.warn(
+                "Client.wait_for_workers requires passing the argument `n_workers`. Not passing any argument will no longer be supported in future versions.",
+                DeprecationWarning,
+            )
+            n_workers = 0
+        elif not isinstance(n_workers, int) or n_workers < 1:
+            raise ValueError(
+                f"`n_workers` must be a positive integer. Instead got {n_workers}."
+            )
         return self.sync(self._wait_for_workers, n_workers, timeout=timeout)
 
     def _heartbeat(self):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7538,3 +7538,29 @@ async def test_deprecated_loop_properties(s):
         (DeprecationWarning, "The io_loop property is deprecated"),
         (DeprecationWarning, "setting the loop property is deprecated"),
     ]
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_wait_for_workers_no_default(c, s):
+    with pytest.warns(DeprecationWarning, match=r"require.*n_workers"):
+        await c.wait_for_workers()
+
+
+@pytest.mark.parametrize(
+    "value, exception",
+    [
+        (None, ValueError),
+        (0, ValueError),
+        (1.0, ValueError),
+        (1, None),
+        (2, None),
+    ],
+)
+@gen_cluster(client=True)
+async def test_wait_for_workers_n_workers_value_check(c, s, a, b, value, exception):
+    if exception:
+        ctx = pytest.raises(exception)
+    else:
+        ctx = nullcontext()
+    with ctx:
+        await c.wait_for_workers(value)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7542,7 +7542,7 @@ async def test_deprecated_loop_properties(s):
 
 @gen_cluster(client=True, nthreads=[])
 async def test_wait_for_workers_no_default(c, s):
-    with pytest.warns(DeprecationWarning, match=r"require.*n_workers"):
+    with pytest.warns(FutureWarning, match=r"require.*n_workers"):
         await c.wait_for_workers()
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7542,7 +7542,10 @@ async def test_deprecated_loop_properties(s):
 
 @gen_cluster(client=True, nthreads=[])
 async def test_wait_for_workers_no_default(c, s):
-    with pytest.warns(FutureWarning, match=r"require.*n_workers"):
+    with pytest.warns(
+        FutureWarning,
+        match="specify the `n_workers` argument when using `Client.wait_for_workers`",
+    ):
         await c.wait_for_workers()
 
 


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/6900