### PR TITLE
Ensure restart clears taskgroups et al

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -615,10 +615,18 @@ async def test_ready_remove_worker(s, a, b):
 
 @gen_cluster(client=True, Worker=Nanny, timeout=60)
 async def test_restart(c, s, a, b):
+    from distributed.scheduler import TaskState
+
+    before = TaskState._instances
     futures = c.map(inc, range(20))
     await wait(futures)
 
     await s.restart()
+
+    assert TaskState._instances == before
+    assert not s.computations
+    assert not s.task_prefixes
+    assert not s.task_groups
 
     assert len(s.workers) == 2
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -615,15 +615,12 @@ async def test_ready_remove_worker(s, a, b):
 
 @gen_cluster(client=True, Worker=Nanny, timeout=60)
 async def test_restart(c, s, a, b):
-    from distributed.scheduler import TaskState
 
-    before = TaskState._instances
     futures = c.map(inc, range(20))
     await wait(futures)
 
     await s.restart()
 
-    assert TaskState._instances == before
     assert not s.computations
     assert not s.task_prefixes
     assert not s.task_groups


### PR DESCRIPTION
Restart keeps TaskGroups, TaskPrefixes, etc. around.

This can have a non-trivial impact on scheduling, e.g.

- https://github.com/dask/distributed/blob/c15a10e87ca5d03e62f0ad4f38adb63163522979/distributed/scheduler.py#L2648
- https://github.com/dask/distributed/blob/c15a10e87ca5d03e62f0ad4f38adb63163522979/distributed/scheduler.py#L1802-L1805
- https://github.com/dask/distributed/blob/c15a10e87ca5d03e62f0ad4f38adb63163522979/distributed/scheduler.py#L2015-L2022

and there are possibly more collections where this matters. In a perfect world, all mutable state would be encapsulated in a dedicated class of which we could create a new instance in case of a restart but we're very far away from this. I think these are the most important collections to clear.

