### PR TITLE
Use `async with Worker` in tests

### DIFF
--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -75,8 +75,8 @@ async def test_add_remove_worker(s):
 
     events[:] = []
     s.remove_plugin(plugin.name)
-    a = await Worker(s.address)
-    await a.close()
+    async with Worker(s.address):
+        pass
     assert events == []
 
 

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -44,11 +44,10 @@ class MyPlugin(WorkerPlugin):
 async def test_create_with_client(c, s):
     await c.register_worker_plugin(MyPlugin(123))
 
-    worker = await Worker(s.address)
-    assert worker._my_plugin_status == "setup"
-    assert worker._my_plugin_data == 123
+    async with Worker(s.address) as worker:
+        assert worker._my_plugin_status == "setup"
+        assert worker._my_plugin_data == 123
 
-    await worker.close()
     assert worker._my_plugin_status == "teardown"
 
 
@@ -57,33 +56,33 @@ async def test_remove_with_client(c, s):
     await c.register_worker_plugin(MyPlugin(123), name="foo")
     await c.register_worker_plugin(MyPlugin(546), name="bar")
 
-    worker = await Worker(s.address)
-    # remove the 'foo' plugin
-    await c.unregister_worker_plugin("foo")
-    assert worker._my_plugin_status == "teardown"
+    async with Worker(s.address) as worker:
+        # remove the 'foo' plugin
+        await c.unregister_worker_plugin("foo")
+        assert worker._my_plugin_status == "teardown"
 
-    # check that on the scheduler registered worker plugins we only have 'bar'
-    assert len(s.worker_plugins) == 1
-    assert "bar" in s.worker_plugins
+        # check that on the scheduler registered worker plugins we only have 'bar'
+        assert len(s.worker_plugins) == 1
+        assert "bar" in s.worker_plugins
 
-    # check on the worker plugins that we only have 'bar'
-    assert len(worker.plugins) == 1
-    assert "bar" in worker.plugins
+        # check on the worker plugins that we only have 'bar'
+        assert len(worker.plugins) == 1
+        assert "bar" in worker.plugins
 
-    # let's remove 'bar' and we should have none worker plugins
-    await c.unregister_worker_plugin("bar")
-    assert worker._my_plugin_status == "teardown"
-    assert not s.worker_plugins
-    assert not worker.plugins
+        # let's remove 'bar' and we should have none worker plugins
+        await c.unregister_worker_plugin("bar")
+        assert worker._my_plugin_status == "teardown"
+        assert not s.worker_plugins
+        assert not worker.plugins
 
 
 @gen_cluster(client=True, nthreads=[])
 async def test_remove_with_client_raises(c, s):
     await c.register_worker_plugin(MyPlugin(123), name="foo")
 
-    worker = await Worker(s.address)
-    with pytest.raises(ValueError, match="bar"):
-        await c.unregister_worker_plugin("bar")
+    async with Worker(s.address):
+        with pytest.raises(ValueError, match="bar"):
+            await c.unregister_worker_plugin("bar")
 
 
 @gen_cluster(client=True, worker_kwargs={"plugins": [MyPlugin(5)]})

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -399,7 +399,7 @@ async def test_cancelled_resumed_after_flight_with_dependencies(c, s, a):
     See https://github.com/dask/distributed/pull/6327#discussion_r872231090
     See test_cancelled_resumed_after_flight_with_dependencies_workerstate below.
     """
-    async with await BlockedGetData(s.address) as b:
+    async with BlockedGetData(s.address) as b:
         x = c.submit(inc, 1, key="x", workers=[b.address], allow_other_workers=True)
         y = c.submit(inc, x, key="y", workers=[a.address])
         await b.in_get_data.wait()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -874,15 +874,13 @@ async def test_broadcast_deprecation(s, a, b):
 
 @gen_cluster(nthreads=[])
 async def test_worker_name(s):
-    w = await Worker(s.address, name="alice")
-    assert s.workers[w.address].name == "alice"
-    assert s.aliases["alice"] == w.address
+    async with Worker(s.address, name="alice") as w:
+        assert s.workers[w.address].name == "alice"
+        assert s.aliases["alice"] == w.address
 
-    with raises_with_cause(RuntimeError, None, ValueError, None):
-        w2 = await Worker(s.address, name="alice")
-        await w2.close()
-
-    await w.close()
+        with raises_with_cause(RuntimeError, None, ValueError, None):
+            async with Worker(s.address, name="alice"):
+                pass
 
 
 @gen_cluster(nthreads=[])
@@ -1016,10 +1014,8 @@ async def test_scatter_no_workers(c, s, direct):
 
 @gen_cluster(nthreads=[])
 async def test_scheduler_sees_memory_limits(s):
-    w = await Worker(s.address, nthreads=3, memory_limit=12345)
-
-    assert s.workers[w.address].memory_limit == 12345
-    await w.close()
+    async with Worker(s.address, nthreads=3, memory_limit=12345) as w:
+        assert s.workers[w.address].memory_limit == 12345
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -405,15 +405,14 @@ async def test_oversubscribing_leases(c, s, a, b):
         client = get_client()
         client.set_metadata("release", True)
 
-    observer = await Worker(s.address)
+    async with Worker(s.address) as observer:
+        futures = c.map(
+            guaranteed_lease_timeout, range(2), sem=sem, workers=[a.address, b.address]
+        )
+        fut_observe = c.submit(observe_state, sem=sem, workers=[observer.address])
 
-    futures = c.map(
-        guaranteed_lease_timeout, range(2), sem=sem, workers=[a.address, b.address]
-    )
-    fut_observe = c.submit(observe_state, sem=sem, workers=[observer.address])
-
-    with captured_logger("distributed.semaphore", level=logging.DEBUG) as caplog:
-        payload, observer = await c.gather([futures, fut_observe])
+        with captured_logger("distributed.semaphore", level=logging.DEBUG) as caplog:
+            payload, _ = await c.gather([futures, fut_observe])
 
     logs = caplog.getvalue().split("\n")
     timeouts = [log for log in logs if "timed out" in log]

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1229,9 +1229,8 @@ def test_get_worker_name(client):
 @gen_cluster(nthreads=[], client=True)
 async def test_scheduler_address_config(c, s):
     with dask.config.set({"scheduler-address": s.address}):
-        worker = await Worker()
-        assert worker.scheduler.address == s.address
-    await worker.close()
+        async with Worker() as w:
+            assert w.scheduler.address == s.address
 
 
 @pytest.mark.xfail(reason="very high flakiness")
@@ -1323,10 +1322,9 @@ async def test_register_worker_callbacks(c, s, a, b):
     assert list(result.values()) == [False] * 2
 
     # Start a worker and check that startup is not run
-    worker = await Worker(s.address)
-    result = await c.run(test_import, workers=[worker.address])
-    assert list(result.values()) == [False]
-    await worker.close()
+    async with Worker(s.address) as worker:
+        result = await c.run(test_import, workers=[worker.address])
+        assert list(result.values()) == [False]
 
     # Add a plugin function
     response = await c.register_worker_callbacks(setup=mystartup)
@@ -1336,11 +1334,10 @@ async def test_register_worker_callbacks(c, s, a, b):
     result = await c.run(test_import)
     assert list(result.values()) == [True] * 2
 
-    # Start a worker and check it is ran on it
-    worker = await Worker(s.address)
-    result = await c.run(test_import, workers=[worker.address])
-    assert list(result.values()) == [True]
-    await worker.close()
+    # Start a worker and check it is run on it
+    async with Worker(s.address) as worker:
+        result = await c.run(test_import, workers=[worker.address])
+        assert list(result.values()) == [True]
 
     # Register another plugin function
     response = await c.register_worker_callbacks(setup=mystartup2)
@@ -1350,13 +1347,12 @@ async def test_register_worker_callbacks(c, s, a, b):
     result = await c.run(test_startup2)
     assert list(result.values()) == [True] * 2
 
-    # Start a worker and check it is ran on it
-    worker = await Worker(s.address)
-    result = await c.run(test_import, workers=[worker.address])
-    assert list(result.values()) == [True]
-    result = await c.run(test_startup2, workers=[worker.address])
-    assert list(result.values()) == [True]
-    await worker.close()
+    # Start a worker and check it is run on it
+    async with Worker(s.address) as worker:
+        result = await c.run(test_import, workers=[worker.address])
+        assert list(result.values()) == [True]
+        result = await c.run(test_startup2, workers=[worker.address])
+        assert list(result.values()) == [True]
 
 
 @gen_cluster(client=True)
@@ -1368,30 +1364,28 @@ async def test_register_worker_callbacks_err(c, s, a, b):
 @gen_cluster(nthreads=[])
 async def test_local_directory(s, tmp_path):
     with dask.config.set(temporary_directory=str(tmp_path)):
-        w = await Worker(s.address)
-        assert w.local_directory.startswith(str(tmp_path))
-        assert "dask-worker-space" in w.local_directory
+        async with Worker(s.address) as w:
+            assert w.local_directory.startswith(str(tmp_path))
+            assert "dask-worker-space" in w.local_directory
 
 
 @gen_cluster(nthreads=[])
 async def test_local_directory_make_new_directory(s, tmp_path):
-    w = await Worker(s.address, local_directory=str(tmp_path / "foo" / "bar"))
-    assert w.local_directory.startswith(str(tmp_path))
-    assert "foo" in w.local_directory
-    assert "dask-worker-space" in w.local_directory
+    async with Worker(s.address, local_directory=str(tmp_path / "foo" / "bar")) as w:
+        assert w.local_directory.startswith(str(tmp_path))
+        assert "foo" in w.local_directory
+        assert "dask-worker-space" in w.local_directory
 
 
 @pytest.mark.skipif(not LINUX, reason="Need 127.0.0.2 to mean localhost")
 @gen_cluster(nthreads=[], client=True)
 async def test_host_address(c, s):
-    w = await Worker(s.address, host="127.0.0.2")
-    assert "127.0.0.2" in w.address
-    await w.close()
+    async with Worker(s.address, host="127.0.0.2") as w:
+        assert "127.0.0.2" in w.address
 
-    n = await Nanny(s.address, host="127.0.0.3")
-    assert "127.0.0.3" in n.address
-    assert "127.0.0.3" in n.worker_address
-    await n.close()
+    async with Nanny(s.address, host="127.0.0.3") as n:
+        assert "127.0.0.3" in n.address
+        assert "127.0.0.3" in n.worker_address
 
 
 @pytest.mark.parametrize("Worker", [Worker, Nanny])
@@ -1624,13 +1618,13 @@ async def test_bad_metrics(s):
 
 @gen_cluster(nthreads=[])
 async def test_bad_startup(s):
+    """Bad startup functions do not cause the Worker to fail"""
+
     def bad_startup(w):
         raise Exception("Hello")
 
-    try:
-        await Worker(s.address, startup_information={"bad": bad_startup})
-    except Exception:
-        pytest.fail("Startup exception was raised")
+    async with Worker(s.address, startup_information={"bad": bad_startup}):
+        pass
 
 
 @gen_cluster(client=True)
@@ -1682,7 +1676,7 @@ async def test_pip_install_fails(c, s, a, b):
 
 @gen_cluster(nthreads=[])
 async def test_update_latency(s):
-    async with await Worker(s.address) as w:
+    async with Worker(s.address) as w:
         original = w.latency
         await w.heartbeat()
         assert original != w.latency
@@ -1727,7 +1721,7 @@ async def test_heartbeat_comm_closed(s, monkeypatch):
         def bad_heartbeat_worker(*args, **kwargs):
             raise CommClosedError()
 
-        async with await Worker(s.address) as w:
+        async with Worker(s.address) as w:
             # Trigger CommClosedError during worker heartbeat
             monkeypatch.setattr(w.scheduler, "heartbeat_worker", bad_heartbeat_worker)
 
@@ -1835,7 +1829,7 @@ async def test_bad_local_directory(s):
 
 @gen_cluster(client=True, nthreads=[])
 async def test_taskstate_metadata(c, s):
-    async with await Worker(s.address) as a:
+    async with Worker(s.address) as a:
         await c.register_worker_plugin(TaskStateMetadataPlugin())
 
         f = c.submit(inc, 1)


### PR DESCRIPTION
I found several tests where Worker objects where not closed before the end of the test.
I did a carpet replace of `await Worker` with `async with Worker` just as a matter of hygene.