### PR TITLE
Change memory bars color on spilling/paused status

### DIFF
--- a/docs/source/worker-memory.rst
+++ b/docs/source/worker-memory.rst
@@ -134,6 +134,17 @@ spilled
 The sum of managed + unmanaged + unmanaged recent is equal by definition to the process
 memory.
 
+The color of the bars will change as a function of memory usage too:
+
+blue
+    The worker is operating as normal
+orange
+    The worker may be spilling data to disk
+red
+    The worker is paused or retiring
+grey
+    Data that has already been spilled to disk; this is in addition to process memory
+
 
 .. _memtrim:
 


### PR DESCRIPTION
Turn the GUI memory bar for a worker to orange when it passes the target threshold, and to red when it pauses or enters its graceful retirement stage.
The cluster bar changes accordingly to orange if there's at least one worker spilling and to red if there's at least one worker paused or retiring.

**In main:** individual worker bars change to orange when above 50% and to red when above 100%.
The cluster bar changes to orange when the total cluster memory is above 50% and to red when above 100%.

## Demo
```python
import dask
import distributed
import dask.array as da

dask.config.set(
    {
        "distributed.worker.memory.max_spill": "250 MiB",
        "distributed.worker.memory.terminate": False,
    }
)
c = distributed.Client(
    threads_per_worker=4, n_workers=4, memory_limit="4 GiB"
)

rng = da.random.RandomState(0)
a = rng.random((16_000, 16_000), chunks=(4000, 4000))
b = (a @ a.T).sum().round(3)
b.compute()
```
![Peek 2022-08-25 18-12](https://user-images.githubusercontent.com/6213168/186731497-592217ec-454f-49e1-9085-d056021a0077.gif)

