### PR TITLE
Allow all hosts in jupyter-server-proxy

### DIFF
--- a/distributed/http/proxy.py
+++ b/distributed/http/proxy.py
@@ -15,6 +15,10 @@ try:
         from a port to any valid endpoint'.
         """
 
+        def __init__(self, *args, **kwargs):
+            kwargs["host_allowlist"] = lambda handler, host: True
+            super().__init__(*args, **kwargs)
+
         def initialize(self, dask_server=None, extra=None):
             self.scheduler = dask_server
             self.extra = extra or {}


### PR DESCRIPTION
Allows the dashboard for remote workers in the bokeh info page to function by modifying `host_allowlist`.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
