### PR TITLE
reduce max-runs to populate test report cache

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Generate report
         run: |
-          python continuous_integration/scripts/test_report.py --max-days 90 --max-runs 50 --nfails 1 -o test_report.html
-          python continuous_integration/scripts/test_report.py --max-days 7 --max-runs 50 --nfails 2 -o test_short_report.html --title "Test Short Report"
+          python continuous_integration/scripts/test_report.py --max-days 90 --max-runs 20 --nfails 1 -o test_report.html
+          python continuous_integration/scripts/test_report.py --max-days 7 --max-runs 20 --nfails 2 -o test_short_report.html --title "Test Short Report"
           mkdir deploy
           mv test_report.html test_short_report.html deploy/
 


### PR DESCRIPTION
We may need to reduce the number of workflows for a day to allow the cache (introduced in https://github.com/dask/distributed/pull/6937) to be populated