### PR TITLE
Revert "Fix co-assignment for binary operations"

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -250,21 +250,6 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
     test_decide_worker_coschedule_order_neighbors_()
 
 
-@pytest.mark.parametrize("ngroups", [1, 2, 3, 5])
-@gen_cluster(
-    client=True,
-    nthreads=[("", 1), ("", 1)],
-)
-async def test_decide_worker_coschedule_order_binary_op(c, s, a, b, ngroups):
-    roots = [[delayed(i, name=f"x-{n}-{i}") for i in range(8)] for n in range(ngroups)]
-    zs = [sum(rs) for rs in zip(*roots)]
-
-    await c.gather(c.compute(zs))
-
-    assert not a.transfer_incoming_log, [l["keys"] for l in a.transfer_incoming_log]
-    assert not b.transfer_incoming_log, [l["keys"] for l in b.transfer_incoming_log]
-
-
 @pytest.mark.slow
 @gen_cluster(
     nthreads=[("", 2)] * 4,


### PR DESCRIPTION
This reverts commit 7ebd1d99240448eebc346370ce73dece78c92e0d.

Re-opens https://github.com/dask/distributed/issues/6597. See https://github.com/coiled/coiled-runtime/issues/295 for motivation.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
