### PR TITLE
Support tornado 6.2

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -38,7 +38,7 @@ dependencies:
   - sortedcollections
   - tblib
   - toolz
-  - tornado >= 6.0.3
+  - tornado=6.2
   - zict  # overridden by git tip below
   - zstandard >=0.9.0
   - pip:

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -38,7 +38,7 @@ dependencies:
   - sortedcollections
   - tblib
   - toolz
-  - tornado<6.2
+  - tornado >= 6.0.3
   - zict  # overridden by git tip below
   - zstandard >=0.9.0
   - pip:

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -41,7 +41,7 @@ dependencies:
   - sortedcollections
   - tblib
   - toolz
-  - tornado >= 6.0.3
+  - tornado
   - zict
   - zstandard >=0.9.0
   - pip:

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -41,7 +41,7 @@ dependencies:
   - sortedcollections
   - tblib
   - toolz
-  - tornado<6.2
+  - tornado >= 6.0.3
   - zict
   - zstandard >=0.9.0
   - pip:

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -44,7 +44,7 @@ dependencies:
   - tblib
   - toolz
   - torchvision  # Only tested here
-  - tornado >= 6.0.3
+  - tornado
   - zict
   - zstandard >=0.9.0
   - pip:

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -44,7 +44,7 @@ dependencies:
   - tblib
   - toolz
   - torchvision  # Only tested here
-  - tornado<6.2
+  - tornado >= 6.0.3
   - zict
   - zstandard >=0.9.0
   - pip:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - sortedcontainers !=2.0.0,!=2.0.1
     - tblib >=1.6.0
     - toolz >=0.8.2
-    - tornado >=6.0.3,<6.2
+    - tornado >=6.0.3
     - urllib3
     - zict >=0.1.3
   run_constrained:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1
 tblib >= 1.6.0
 toolz >= 0.8.2
-tornado >= 6.0.3, <6.2
+tornado >= 6.0.3
 urllib3
 zict >= 0.1.3
 pyyaml


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/6669


Looks like all of the deprecations were already dealt with