### PR TITLE
Increase timeouts in test_asyncprocess::test_simple

### DIFF
--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -96,7 +96,7 @@ async def test_simple():
     t1 = time()
     await proc.join(timeout=30)
     dt = time() - t1
-    assert dt <= 1.0
+    assert dt <= 10
     assert not proc.is_alive()
     assert proc.pid is not None
     assert proc.exitcode == 0
@@ -105,7 +105,7 @@ async def test_simple():
     t1 = time()
     await proc.join()
     dt = time() - t1
-    assert dt <= 0.6
+    assert dt <= 2
 
     del proc
 
@@ -140,7 +140,7 @@ async def test_simple():
         await asyncio.sleep(0.01)
         gc.collect()
         dt = time() - t1
-        assert dt < 2.0
+        assert dt < 5.0
 
 
 @gen_test()


### PR DESCRIPTION
This test flaked over in https://github.com/dask/distributed/pull/6991

The functionality appeared to be OK but the process join took ~6 seconds which tripped the `assert dt <= 1.0`. I simply increased all timeouts a bit
