### PR TITLE
Catch `BaseException` on UCX read error

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -367,3 +367,13 @@ async def test_ucx_unreachable(
 ):
     with pytest.raises(OSError, match="Timed out trying to connect to"):
         await Client("ucx://255.255.255.255:12345", timeout=1, asynchronous=True)
+
+
+@gen_test()
+async def test_comm_closed_on_read_error():
+    reader, writer = await get_comm_pair()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(reader.read(), 0.01)
+
+    assert reader.closed()

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -331,7 +331,7 @@ class UCX(Comm):
             # (See also https://github.com/dask/distributed/pull/6574).
             self.abort()
             raise CommClosedError("Connection closed by writer.\n"
-                                  "Inner exception: {e!r}")
+                                  f"Inner exception: {e!r}")
         else:
             # Recv frames
             frames = [

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -325,10 +325,10 @@ class UCX(Comm):
             await self.ep.recv(header)
             header = struct.unpack(header_fmt, header)
             cuda_frames, sizes = header[:nframes], header[nframes:]
-        except (
-            ucp.exceptions.UCXCloseError,
-            ucp.exceptions.UCXCanceled,
-        ) + (getattr(ucp.exceptions, "UCXConnectionReset", ()),):
+        except BaseException:
+            # In addition to UCX exceptions, may be CancelledError or a another
+            # "low-level" exception. The only safe thing to do is to abort.
+            # (See also https://github.com/dask/distributed/pull/6574).
             self.abort()
             raise CommClosedError("Connection closed by writer")
         else:

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -330,8 +330,9 @@ class UCX(Comm):
             # "low-level" exception. The only safe thing to do is to abort.
             # (See also https://github.com/dask/distributed/pull/6574).
             self.abort()
-            raise CommClosedError("Connection closed by writer.\n"
-                                  f"Inner exception: {e!r}")
+            raise CommClosedError(
+                f"Connection closed by writer.\nInner exception: {e!r}"
+            )
         else:
             # Recv frames
             frames = [

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -325,12 +325,13 @@ class UCX(Comm):
             await self.ep.recv(header)
             header = struct.unpack(header_fmt, header)
             cuda_frames, sizes = header[:nframes], header[nframes:]
-        except BaseException:
+        except BaseException as e:
             # In addition to UCX exceptions, may be CancelledError or a another
             # "low-level" exception. The only safe thing to do is to abort.
             # (See also https://github.com/dask/distributed/pull/6574).
             self.abort()
-            raise CommClosedError("Connection closed by writer")
+            raise CommClosedError("Connection closed by writer.\n"
+                                  "Inner exception: {e!r}")
         else:
             # Recv frames
             frames = [


### PR DESCRIPTION
This change will ensure `CancelledError`s are catched upon shutting down the Dask cluster, which may otherwise raise various errors.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
