### PR TITLE
Update codecov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,14 +4,15 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "85...100"
+  range: "92...100"
 
   status:
     project:
       default:
-        target: 85%
-        threshold: 1%
-    patch: no
-    changes: no
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: 100%
 
 comment: off


### PR DESCRIPTION
This updates the code coverage settings to something more tangible

- Project wide coverage is set to auto with a threshold of 0.5%. This actually covers all changes in our recent history. We've had ups and downs but no down was higher than 0.5% and if it was, it should warrant another look.
- Patch to 100%. This means that the entire diff has to be covered. I think this is a sane setting overall but it may cause trouble, e.g. if one just reindents certain code passages. Looking at recent changes, some PR would've failed, most would've been successful. This might sting a bit but I'm sure this would improve our discipline about testing

We currently do not define any branch protection rules so even if these would fail, we could still go ahead and merge things but it would be a more aware decision.

if any of this feels too intrusive we can adjust further. E.g. if dashboard changes frequently are an issue because testability is not great, we can introduce [flags](https://docs.codecov.com/docs/flags) and set these parameters differently

My motivation for this is mostly because I stumbled over dead code in the past weeks that could've been avoided by these checks. Some of it is cosmetic/tech debt others are actual regressions.

Note: I think these changes are not reflected on this PR but would only be active once merged


Thoughts?

@crusaderky @jrbourbeau @gjoseph92 @hendrikmakait @jakirkham 