### PR TITLE
Detect mismatching Python version in scheduler

### DIFF
--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -107,16 +107,23 @@ def test_scheduler_additional_irrelevant_package(kwargs_matching):
     assert error_message(**kwargs_matching)["warning"] == ""
 
 
-def test_python_mismatch(kwargs_matching):
-    kwargs_matching["source"]["packages"]["python"] = "0.0.0"
-    msg = error_message(**kwargs_matching)
+def test_python_mismatch(kwargs_matching, node):
+    column_matching = {"source": 1, "scheduler": 2, "workers": 3}
+    i = column_matching.get(node, 3)
+    mismatch_version = "0.0.0"
+    kwargs = kwargs_matching
+    if node in kwargs["workers"]:
+        kwargs["workers"][node]["packages"]["python"] = mismatch_version
+    else:
+        kwargs[node]["packages"]["python"] = mismatch_version
+    msg = error_message(**kwargs)
     assert "Mismatched versions found" in msg["warning"]
     assert "python" in msg["warning"]
     assert (
         "0.0.0"
         in re.search(r"python\s+(?:(?:\|[^|\r\n]*)+\|(?:\r?\n|\r)?)+", msg["warning"])
         .group(0)
-        .split("|")[1]
+        .split("|")[i]
         .strip()
     )
 

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -29,7 +29,7 @@ optional_packages = [
 
 
 # only these scheduler packages will be checked for version mismatch
-scheduler_relevant_packages = {pkg for pkg, _ in required_packages} | {"lz4"}
+scheduler_relevant_packages = {pkg for pkg, _ in required_packages} | {"lz4", "python"}
 
 
 # notes to be displayed for mismatch packages


### PR DESCRIPTION
Detects a mismatching Python version on the scheduler

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
