### PR TITLE
Track CPU and network occupancy separately

### DIFF
--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -6,8 +6,13 @@ import itertools
 import weakref
 from collections import OrderedDict, UserDict
 from collections.abc import Callable, Hashable, Iterator
-from typing import MutableSet  # TODO move to collections.abc (requires Python >=3.9)
-from typing import Any, TypeVar, cast
+from typing import (  # TODO move to collections.abc (requires Python >=3.9)
+    Any,
+    Container,
+    MutableSet,
+    TypeVar,
+    cast,
+)
 
 T = TypeVar("T", bound=Hashable)
 
@@ -245,7 +250,7 @@ class Occupancy:
         self.cpu = 0.0
         self.network = 0.0
 
-    def _to_dict(self) -> dict[str, float]:
+    def _to_dict(self, *, exclude: Container[str] = ()) -> dict[str, float]:
         return {"cpu": self.cpu, "network": self.network}
 
     @property

--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import heapq
 import itertools
 import weakref
@@ -199,3 +200,54 @@ class HeapSet(MutableSet[T]):
         self._data.clear()
         self._heap.clear()
         self._sorted = True
+
+
+# NOTE: only used in Scheduler; if work stealing is ever removed,
+# this could be moved to `scheduler.py`.
+@dataclasses.dataclass
+class Occupancy:
+    cpu: float
+    network: float
+
+    def __add__(self, other: Any) -> Occupancy:
+        if isinstance(other, type(self)):
+            return type(self)(self.cpu + other.cpu, self.network + other.network)
+        return NotImplemented
+
+    def __iadd__(self, other: Any) -> Occupancy:
+        if isinstance(other, type(self)):
+            self.cpu += other.cpu
+            self.network += other.network
+            return self
+        return NotImplemented
+
+    def __sub__(self, other: Any) -> Occupancy:
+        if isinstance(other, type(self)):
+            return type(self)(self.cpu - other.cpu, self.network - other.network)
+        return NotImplemented
+
+    def __isub__(self, other: Any) -> Occupancy:
+        if isinstance(other, type(self)):
+            self.cpu -= other.cpu
+            self.network -= other.network
+            return self
+        return NotImplemented
+
+    def __bool__(self) -> bool:
+        return self.cpu != 0 or self.network != 0
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, type(self)):
+            return self.cpu == other.cpu and self.network == other.network
+        return NotImplemented
+
+    def clear(self) -> None:
+        self.cpu = 0.0
+        self.network = 0.0
+
+    def _to_dict(self) -> dict[str, float]:
+        return {"cpu": self.cpu, "network": self.network}
+
+    @property
+    def total(self) -> float:
+        return self.cpu + self.network

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -163,7 +163,8 @@ class Occupancy(DashboardComponent):
         workers = self.scheduler.workers.values()
 
         y = list(range(len(workers)))
-        occupancy = [ws.occupancy for ws in workers]
+        # TODO split chart by cpu vs network
+        occupancy = [ws.occupancy.total for ws in workers]
         ms = [occ * 1000 for occ in occupancy]
         x = [occ / 500 for occ in occupancy]
         total = sum(occupancy)

--- a/distributed/http/templates/worker-table.html
+++ b/distributed/http/templates/worker-table.html
@@ -5,7 +5,8 @@
         <th> Cores </th>
         <th> Memory </th>
         <th> Memory use </th>
-        <th> Occupancy </th>
+        <th> Network Occupancy </th>
+        <th> CPU Occupancy </th>
         <th> Processing </th>
         <th> In-memory </th>
         <th> Services</th>
@@ -19,7 +20,8 @@
         <td> {{ ws.nthreads }} </td>
         <td> {{ format_bytes(ws.memory_limit) if ws.memory_limit is not None else "" }} </td>
         <td> <progress class="progress" value="{{ ws.metrics['memory'] }}" max="{{ ws.memory_limit }}"></progress> </td>
-        <td> {{ format_time(ws.occupancy) }} </td>
+        <td> {{ format_time(ws.occupancy.network) }} </td>
+        <td> {{ format_time(ws.occupancy.cpu) }} </td>
         <td> {{ len(ws.processing) }} </td>
         <td> {{ len(ws.has_what) }} </td>
         {% if 'dashboard' in ws.services %}

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -65,7 +65,7 @@ from distributed import versions as version_module
 from distributed._stories import scheduler_story
 from distributed.active_memory_manager import ActiveMemoryManagerExtension, RetireWorker
 from distributed.batched import BatchedSend
-from distributed.collections import HeapSet
+from distributed.collections import HeapSet, Occupancy
 from distributed.comm import (
     Comm,
     CommClosedError,
@@ -384,48 +384,6 @@ class MemoryState:
         distributed.utils.recursive_to_dict
         """
         return recursive_to_dict(self, exclude=exclude, members=True)
-
-
-@dataclasses.dataclass
-class Occupancy:
-    cpu: float
-    network: float
-
-    def __add__(self, other) -> Occupancy:
-        if isinstance(other, type(self)):
-            return type(self)(self.cpu + other.cpu, self.network + other.network)
-        return NotImplemented
-
-    def __iadd__(self, other):
-        if isinstance(other, type(self)):
-            self.cpu += other.cpu
-            self.network += other.network
-        return NotImplemented
-
-    def __sub__(self, other) -> Occupancy:
-        if isinstance(other, type(self)):
-            return type(self)(self.cpu - other.cpu, self.network - other.network)
-        return NotImplemented
-
-    def __isub__(self, other):
-        if isinstance(other, type(self)):
-            self.cpu -= other.cpu
-            self.network -= other.network
-        return NotImplemented
-
-    def __bool__(self) -> bool:
-        return self.cpu != 0 or self.network != 0
-
-    def clear(self) -> None:
-        self.cpu = 0.0
-        self.network = 0.0
-
-    def _to_dict(self) -> dict[str, float]:
-        return {"cpu": self.cpu, "network": self.network}
-
-    @property
-    def total(self) -> float:
-        return self.cpu + self.network
 
 
 class WorkerState:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2847,7 +2847,11 @@ class SchedulerState:
         cpu = self.get_task_duration(ts)
         if exec_time > 2 * cpu:
             cpu = 2 * exec_time
-        network = self.get_comm_cost(ts, ws)
+            # FIXME this matches existing behavior but is clearly bizarre
+            # https://github.com/dask/distributed/issues/7003
+            network = 0.0
+        else:
+            network = self.get_comm_cost(ts, ws)
 
         old = ws.processing.get(ts, Occupancy(0, 0))
         ws.processing[ts] = new = Occupancy(cpu, network)

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -408,7 +408,7 @@ class WorkStealing(SchedulerPlugin):
                         start,
                         level,
                         ts.key,
-                        duration,
+                        duration_total,
                         victim.address,
                         occ_victim,
                         thief.address,

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -14,10 +14,10 @@ from tornado.ioloop import PeriodicCallback
 import dask
 from dask.utils import parse_timedelta
 
+from distributed.collections import Occupancy
 from distributed.comm.addressing import get_address_host
 from distributed.core import CommClosedError, Status
 from distributed.diagnostics.plugin import SchedulerPlugin
-from distributed.scheduler import Occupancy
 from distributed.utils import log_errors, recursive_to_dict
 
 if TYPE_CHECKING:

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -1034,7 +1034,7 @@ async def test_secede_cancelled_or_resumed_scheduler(c, s, a):
     await ev1.wait()
     ts = a.state.tasks["x"]
     assert ts.state == "executing"
-    assert sum(ws.processing.values()) > 0
+    assert any(ws.processing.values())
 
     x.release()
     await wait_for_state("x", "cancelled", a)
@@ -1050,7 +1050,7 @@ async def test_secede_cancelled_or_resumed_scheduler(c, s, a):
 
     # Test that the scheduler receives a delayed {op: long-running}
     assert ws.processing
-    while sum(ws.processing.values()):
+    while any(ws.processing.values()):
         await asyncio.sleep(0.1)
     assert ws.processing
 

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -7,7 +7,7 @@ import random
 
 import pytest
 
-from distributed.collections import LRU, HeapSet
+from distributed.collections import LRU, HeapSet, Occupancy
 
 
 def test_lru():
@@ -339,3 +339,38 @@ def test_heapset_sort_duplicate():
     heap.add(c1)
 
     assert list(heap.sorted()) == [c1, c2]
+
+
+def test_occupancy():
+    ozero = Occupancy(0, 0)
+    assert not ozero
+    assert not ozero.total
+    assert ozero == ozero
+
+    o1_0 = Occupancy(1, 0)
+    assert o1_0
+    assert o1_0.total == 1
+    assert ozero != o1_0
+    assert o1_0 + ozero == o1_0
+
+    o0_1 = Occupancy(0, 1)
+    o1_1 = o0_1 + o1_0
+    assert o1_1.total == 2
+    assert o1_1 == o1_0 + o0_1
+
+    assert o1_1 - o0_1 == o1_0
+
+    mut = Occupancy(0, 0)
+    mut += ozero
+    assert not mut
+    mut += o1_0
+    assert mut == o1_0
+    mut += o1_0
+    assert mut == Occupancy(2, 0)
+
+    mut -= o0_1
+    assert mut == Occupancy(2, -1)
+    assert mut.total == 1
+
+    mut.clear()
+    assert mut == ozero

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -374,3 +374,13 @@ def test_occupancy():
 
     mut.clear()
     assert mut == ozero
+
+    assert not mut == 1
+    with pytest.raises(TypeError):
+        mut + 1
+    with pytest.raises(TypeError):
+        mut - 1
+    with pytest.raises(TypeError):
+        mut += 1
+    with pytest.raises(TypeError):
+        mut -= 1

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1128,7 +1128,7 @@ async def test_steal_reschedule_reset_in_flight_occupancy(c, s, *workers):
 
     del futs1
 
-    assert all(v == 0 for v in steal.in_flight_occupancy.values())
+    assert all(not v for v in steal.in_flight_occupancy.values())
 
 
 @gen_cluster(


### PR DESCRIPTION
Closes #7004.

Step towards #7003. This notes, but does not fix, the places where we're currently double-counting occupancy. First we should get this PR in and verify it doesn't change any behavior. Then, we can benchmark how a few lines of changes fixing the double-counting affects performance. At the same time, we can update the dashboard to display both measures separately.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
