### PR TITLE
Network occupancy dashboard

### DIFF
--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -6,8 +6,13 @@ import itertools
 import weakref
 from collections import OrderedDict, UserDict
 from collections.abc import Callable, Hashable, Iterator
-from typing import MutableSet  # TODO move to collections.abc (requires Python >=3.9)
-from typing import Any, TypeVar, cast
+from typing import (  # TODO move to collections.abc (requires Python >=3.9)
+    Any,
+    Container,
+    MutableSet,
+    TypeVar,
+    cast,
+)
 
 T = TypeVar("T", bound=Hashable)
 
@@ -245,7 +250,7 @@ class Occupancy:
         self.cpu = 0.0
         self.network = 0.0
 
-    def _to_dict(self) -> dict[str, float]:
+    def _to_dict(self, *, exclude: Container[str] = ()) -> dict[str, float]:
         return {"cpu": self.cpu, "network": self.network}
 
     @property

--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import heapq
 import itertools
 import weakref
@@ -199,3 +200,54 @@ class HeapSet(MutableSet[T]):
         self._data.clear()
         self._heap.clear()
         self._sorted = True
+
+
+# NOTE: only used in Scheduler; if work stealing is ever removed,
+# this could be moved to `scheduler.py`.
+@dataclasses.dataclass
+class Occupancy:
+    cpu: float
+    network: float
+
+    def __add__(self, other: Any) -> Occupancy:
+        if isinstance(other, type(self)):
+            return type(self)(self.cpu + other.cpu, self.network + other.network)
+        return NotImplemented
+
+    def __iadd__(self, other: Any) -> Occupancy:
+        if isinstance(other, type(self)):
+            self.cpu += other.cpu
+            self.network += other.network
+            return self
+        return NotImplemented
+
+    def __sub__(self, other: Any) -> Occupancy:
+        if isinstance(other, type(self)):
+            return type(self)(self.cpu - other.cpu, self.network - other.network)
+        return NotImplemented
+
+    def __isub__(self, other: Any) -> Occupancy:
+        if isinstance(other, type(self)):
+            self.cpu -= other.cpu
+            self.network -= other.network
+            return self
+        return NotImplemented
+
+    def __bool__(self) -> bool:
+        return self.cpu != 0 or self.network != 0
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, type(self)):
+            return self.cpu == other.cpu and self.network == other.network
+        return NotImplemented
+
+    def clear(self) -> None:
+        self.cpu = 0.0
+        self.network = 0.0
+
+    def _to_dict(self) -> dict[str, float]:
+        return {"cpu": self.cpu, "network": self.network}
+
+    @property
+    def total(self) -> float:
+        return self.cpu + self.network

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -163,7 +163,8 @@ class Occupancy(DashboardComponent):
         workers = self.scheduler.workers.values()
 
         y = list(range(len(workers)))
-        occupancy = [ws.occupancy for ws in workers]
+        # TODO split chart by cpu vs network
+        occupancy = [ws.occupancy.total for ws in workers]
         ms = [occ * 1000 for occ in occupancy]
         x = [occ / 500 for occ in occupancy]
         total = sum(occupancy)

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -120,13 +120,14 @@ class Occupancy(DashboardComponent):
         self.scheduler = scheduler
         self.source = ColumnDataSource(
             {
-                "occupancy": [0, 0],
-                "worker": ["a", "b"],
-                "x": [0.0, 0.1],
-                "y": [1, 2],
-                "ms": [1, 2],
-                "color": ["red", "blue"],
-                "escaped_worker": ["a", "b"],
+                "occupancy_network": [],
+                "occupancy_cpu": [],
+                "occupancy_network_ms": [],
+                "occupancy_cpu_ms": [],
+                "worker": [],
+                "y": [],
+                "color": [],
+                "escaped_worker": [],
             }
         )
 
@@ -139,10 +140,14 @@ class Occupancy(DashboardComponent):
             min_border_bottom=50,
             **kwargs,
         )
-        rect = self.root.rect(
-            source=self.source, x="x", width="ms", y="y", height=0.9, color="color"
+        self.root.hbar_stack(
+            ["occupancy_network_ms", "occupancy_cpu_ms"],
+            source=self.source,
+            y="y",
+            height=0.9,
+            fill_alpha=[0.8, 1.0],
+            color="color",
         )
-        rect.nonselection_glyph = None
 
         self.root.xaxis.minor_tick_line_alpha = 0
         self.root.yaxis.visible = False
@@ -153,7 +158,9 @@ class Occupancy(DashboardComponent):
         tap = TapTool(callback=OpenURL(url="./info/worker/@escaped_worker.html"))
 
         hover = HoverTool()
-        hover.tooltips = "@worker : @occupancy s."
+        hover.tooltips = (
+            "@worker : network: @occupancy_network s, cpu: @occupancy_cpu s."
+        )
         hover.point_policy = "follow_mouse"
         self.root.add_tools(hover, tap)
 
@@ -163,11 +170,14 @@ class Occupancy(DashboardComponent):
         workers = self.scheduler.workers.values()
 
         y = list(range(len(workers)))
-        # TODO split chart by cpu vs network
-        occupancy = [ws.occupancy.total for ws in workers]
-        ms = [occ * 1000 for occ in occupancy]
-        x = [occ / 500 for occ in occupancy]
-        total = sum(occupancy)
+        occupancy_network, occupancy_cpu = zip(
+            *((ws.occupancy.network, ws.occupancy.cpu) for ws in workers)
+        )
+        occupancy_network = np.array(occupancy_network)
+        occupancy_cpu = np.array(occupancy_cpu)
+        total_network = occupancy_network.sum()
+        total_cpu = occupancy_cpu.sum()
+        total = total_network + total_cpu
         color = []
         for ws in workers:
             if ws in self.scheduler.idle:
@@ -179,20 +189,22 @@ class Occupancy(DashboardComponent):
 
         if total:
             self.root.title.text = (
-                f"Occupancy -- total time: {format_time(total)} "
-                f"wall time: {format_time(total / self.scheduler.total_nthreads)}"
+                f"Total time: {format_time(total)}, "
+                f"wall time: {format_time(total / self.scheduler.total_nthreads)}, "
+                f"{total_network / total:.0%} network"
             )
         else:
             self.root.title.text = "Occupancy"
 
-        if occupancy:
+        if workers:
             result = {
-                "occupancy": occupancy,
+                "occupancy_network": occupancy_network,
+                "occupancy_cpu": occupancy_cpu,
+                "occupancy_network_ms": occupancy_network * 1000,
+                "occupancy_cpu_ms": occupancy_cpu * 1000,
                 "worker": [ws.address for ws in workers],
-                "ms": ms,
                 "color": color,
                 "escaped_worker": [escape.url_escape(ws.address) for ws in workers],
-                "x": x,
                 "y": y,
             }
 

--- a/distributed/http/templates/worker-table.html
+++ b/distributed/http/templates/worker-table.html
@@ -5,7 +5,8 @@
         <th> Cores </th>
         <th> Memory </th>
         <th> Memory use </th>
-        <th> Occupancy </th>
+        <th> Network Occupancy </th>
+        <th> CPU Occupancy </th>
         <th> Processing </th>
         <th> In-memory </th>
         <th> Services</th>
@@ -19,7 +20,8 @@
         <td> {{ ws.nthreads }} </td>
         <td> {{ format_bytes(ws.memory_limit) if ws.memory_limit is not None else "" }} </td>
         <td> <progress class="progress" value="{{ ws.metrics['memory'] }}" max="{{ ws.memory_limit }}"></progress> </td>
-        <td> {{ format_time(ws.occupancy) }} </td>
+        <td> {{ format_time(ws.occupancy.network) }} </td>
+        <td> {{ format_time(ws.occupancy.cpu) }} </td>
         <td> {{ len(ws.processing) }} </td>
         <td> {{ len(ws.has_what) }} </td>
         {% if 'dashboard' in ws.services %}

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -65,7 +65,7 @@ from distributed import versions as version_module
 from distributed._stories import scheduler_story
 from distributed.active_memory_manager import ActiveMemoryManagerExtension, RetireWorker
 from distributed.batched import BatchedSend
-from distributed.collections import HeapSet
+from distributed.collections import HeapSet, Occupancy
 from distributed.comm import (
     Comm,
     CommClosedError,
@@ -384,48 +384,6 @@ class MemoryState:
         distributed.utils.recursive_to_dict
         """
         return recursive_to_dict(self, exclude=exclude, members=True)
-
-
-@dataclasses.dataclass
-class Occupancy:
-    cpu: float
-    network: float
-
-    def __add__(self, other) -> Occupancy:
-        if isinstance(other, type(self)):
-            return type(self)(self.cpu + other.cpu, self.network + other.network)
-        return NotImplemented
-
-    def __iadd__(self, other):
-        if isinstance(other, type(self)):
-            self.cpu += other.cpu
-            self.network += other.network
-        return NotImplemented
-
-    def __sub__(self, other) -> Occupancy:
-        if isinstance(other, type(self)):
-            return type(self)(self.cpu - other.cpu, self.network - other.network)
-        return NotImplemented
-
-    def __isub__(self, other):
-        if isinstance(other, type(self)):
-            self.cpu -= other.cpu
-            self.network -= other.network
-        return NotImplemented
-
-    def __bool__(self) -> bool:
-        return self.cpu != 0 or self.network != 0
-
-    def clear(self) -> None:
-        self.cpu = 0.0
-        self.network = 0.0
-
-    def _to_dict(self) -> dict[str, float]:
-        return {"cpu": self.cpu, "network": self.network}
-
-    @property
-    def total(self) -> float:
-        return self.cpu + self.network
 
 
 class WorkerState:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -408,7 +408,7 @@ class WorkStealing(SchedulerPlugin):
                         start,
                         level,
                         ts.key,
-                        duration,
+                        duration_total,
                         victim.address,
                         occ_victim,
                         thief.address,

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -14,10 +14,10 @@ from tornado.ioloop import PeriodicCallback
 import dask
 from dask.utils import parse_timedelta
 
+from distributed.collections import Occupancy
 from distributed.comm.addressing import get_address_host
 from distributed.core import CommClosedError, Status
 from distributed.diagnostics.plugin import SchedulerPlugin
-from distributed.scheduler import Occupancy
 from distributed.utils import log_errors, recursive_to_dict
 
 if TYPE_CHECKING:

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -1034,7 +1034,7 @@ async def test_secede_cancelled_or_resumed_scheduler(c, s, a):
     await ev1.wait()
     ts = a.state.tasks["x"]
     assert ts.state == "executing"
-    assert sum(ws.processing.values()) > 0
+    assert any(ws.processing.values())
 
     x.release()
     await wait_for_state("x", "cancelled", a)
@@ -1050,7 +1050,7 @@ async def test_secede_cancelled_or_resumed_scheduler(c, s, a):
 
     # Test that the scheduler receives a delayed {op: long-running}
     assert ws.processing
-    while sum(ws.processing.values()):
+    while any(ws.processing.values()):
         await asyncio.sleep(0.1)
     assert ws.processing
 

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -7,7 +7,7 @@ import random
 
 import pytest
 
-from distributed.collections import LRU, HeapSet
+from distributed.collections import LRU, HeapSet, Occupancy
 
 
 def test_lru():
@@ -339,3 +339,38 @@ def test_heapset_sort_duplicate():
     heap.add(c1)
 
     assert list(heap.sorted()) == [c1, c2]
+
+
+def test_occupancy():
+    ozero = Occupancy(0, 0)
+    assert not ozero
+    assert not ozero.total
+    assert ozero == ozero
+
+    o1_0 = Occupancy(1, 0)
+    assert o1_0
+    assert o1_0.total == 1
+    assert ozero != o1_0
+    assert o1_0 + ozero == o1_0
+
+    o0_1 = Occupancy(0, 1)
+    o1_1 = o0_1 + o1_0
+    assert o1_1.total == 2
+    assert o1_1 == o1_0 + o0_1
+
+    assert o1_1 - o0_1 == o1_0
+
+    mut = Occupancy(0, 0)
+    mut += ozero
+    assert not mut
+    mut += o1_0
+    assert mut == o1_0
+    mut += o1_0
+    assert mut == Occupancy(2, 0)
+
+    mut -= o0_1
+    assert mut == Occupancy(2, -1)
+    assert mut.total == 1
+
+    mut.clear()
+    assert mut == ozero

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1128,7 +1128,7 @@ async def test_steal_reschedule_reset_in_flight_occupancy(c, s, *workers):
 
     del futs1
 
-    assert all(v == 0 for v in steal.in_flight_occupancy.values())
+    assert all(not v for v in steal.in_flight_occupancy.values())
 
 
 @gen_cluster(


### PR DESCRIPTION
Displays network occupancy in a lighter shade, CPU darker on the occupancy dashboard:

![network-occupancy](https://user-images.githubusercontent.com/3309802/189011369-7a15016e-7726-4436-819f-370b690a1495.gif)

The tick mark seem broken (values wrap around at 1000ms), but they're also broken on main. I don't know enough bokeh to know why.

Currently includes https://github.com/dask/distributed/pull/7020; will rebase once that's merged.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
