### PR TITLE
Allow very fast keys and very expensive transfers as stealing candidates

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1783,7 +1783,7 @@ class StealingEvents(DashboardComponent):
         self.last = 0
         self.source = ColumnDataSource(
             {
-                "time": [time() - 20, time()],
+                "time": [time() - 60, time()],
                 "level": [0, 15],
                 "color": ["white", "white"],
                 "duration": [0, 0],
@@ -1828,7 +1828,7 @@ class StealingEvents(DashboardComponent):
         """Convert a log message to a glyph"""
         total_duration = 0
         for msg in msgs:
-            time, level, key, duration, sat, occ_sat, idl, occ_idl = msg
+            time, level, key, duration, sat, occ_sat, idl, occ_idl = msg[:8]
             total_duration += duration
 
         try:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -238,6 +238,12 @@ class WorkStealing(SchedulerPlugin):
         ws = ts.processing_on
         compute_time = ws.processing[ts]
 
+        if not compute_time:
+            # occupancy/ws.proccessing[ts] is only allowed to be zero for
+            # long running tasks which cannot be stolen
+            assert ts in ws.long_running
+            return None, None
+
         nbytes = ts.get_nbytes_deps()
         transfer_time = nbytes / self.scheduler.bandwidth + LATENCY
         cost_multiplier = transfer_time / compute_time
@@ -245,7 +251,7 @@ class WorkStealing(SchedulerPlugin):
         level = int(round(log2(cost_multiplier) + 6))
         if level < 1:
             level = 1
-        elif level > len(self.cost_multipliers):
+        elif level >= len(self.cost_multipliers):
             return None, None
 
         return cost_multiplier, level

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -237,18 +237,16 @@ class WorkStealing(SchedulerPlugin):
         assert ts.processing_on
         ws = ts.processing_on
         compute_time = ws.processing[ts]
-        if compute_time < 0.005:  # 5ms, just give up
-            return None, None
 
         nbytes = ts.get_nbytes_deps()
         transfer_time = nbytes / self.scheduler.bandwidth + LATENCY
         cost_multiplier = transfer_time / compute_time
-        if cost_multiplier > 100:
-            return None, None
 
         level = int(round(log2(cost_multiplier) + 6))
         if level < 1:
             level = 1
+        elif level > len(self.cost_multipliers):
+            return None, None
 
         return cost_multiplier, level
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1371,14 +1371,15 @@ async def test_steal_very_fast_tasks(c, s, *workers):
     futs = c.compute(results)
     await c.gather(futs)
 
-    max_ = 0
-    rest = 0
+    # The following is an attempt to estimate and assert a roughly uniform data
+    # distribution
+    max_ntasks_on_worker = 0
     for w in workers:
-        ntasks = len(w.data)
-        if ntasks > max_:
-            rest += max_
-            max_ = ntasks
-        else:
-            rest += ntasks
+        ntasks_on_worker = len(w.data)
+        if ntasks_on_worker > max_ntasks_on_worker:
+            max_ntasks_on_worker = ntasks_on_worker
+        assert ntasks_on_worker > ntasks / len(workers) * 0.5
 
-    assert max_ < rest * 2 / 3
+    ntasks_on_other_workers = ntasks - max_ntasks_on_worker
+    nother_workers = len(workers) - 1
+    assert max_ntasks_on_worker < 2 * ntasks_on_other_workers / nother_workers

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -10,6 +10,7 @@ import weakref
 from operator import mul
 from time import sleep
 
+import numpy as np
 import pytest
 from tlz import sliding_window
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1355,7 +1355,7 @@ def test_steal_worker_state(ws_with_running_task):
 @pytest.mark.slow()
 @gen_cluster(nthreads=[("", 1)] * 4, client=True)
 async def test_steal_very_fast_tasks(c, s, *workers):
-    # Ensure that very fast tasks
+    # Ensure that very fast tasks are allowed to be stolen
     root = dask.delayed(lambda n: "x" * n)(
         dask.utils.parse_bytes("1MiB"), dask_key_name="root"
     )
@@ -1371,7 +1371,6 @@ async def test_steal_very_fast_tasks(c, s, *workers):
     futs = c.compute(results)
     await c.gather(futs)
 
-    dat = {}
     max_ = 0
     rest = 0
     for w in workers:
@@ -1381,7 +1380,5 @@ async def test_steal_very_fast_tasks(c, s, *workers):
             max_ = ntasks
         else:
             rest += ntasks
-        dat[w] = len(w.data)
-        assert ntasks > ntasks / len(workers) * 0.5
 
     assert max_ < rest * 2 / 3

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1371,15 +1371,7 @@ async def test_steal_very_fast_tasks(c, s, *workers):
     futs = c.compute(results)
     await c.gather(futs)
 
-    # The following is an attempt to estimate and assert a roughly uniform data
-    # distribution
-    max_ntasks_on_worker = 0
-    for w in workers:
-        ntasks_on_worker = len(w.data)
-        if ntasks_on_worker > max_ntasks_on_worker:
-            max_ntasks_on_worker = ntasks_on_worker
-        assert ntasks_on_worker > ntasks / len(workers) * 0.5
-
-    ntasks_on_other_workers = ntasks - max_ntasks_on_worker
-    nother_workers = len(workers) - 1
-    assert max_ntasks_on_worker < 2 * ntasks_on_other_workers / nother_workers
+    ntasks_per_worker = np.array([len(w.data) for w in workers])
+    ideal = ntasks / len(workers)
+    assert (ntasks_per_worker > ideal * 0.5).all(), (ideal, ntasks_per_worker)
+    assert (ntasks_per_worker < ideal * 1.5).all(), (ideal, ntasks_per_worker)


### PR DESCRIPTION
This is a partial fix for a couple of issues

- https://github.com/dask/distributed/issues/6573
- https://github.com/dask/distributed/issues/5599
- https://github.com/dask/distributed/issues/4471

These issues do report a situation where one worker greedily steals all/most of the keys and the cluster is no longer able to correct course afterwards. This inability to correct the imbalance again is due to these limits on compute time and cost factor.

The unit test provided ensures that indeed the final computation is happening roughly on all workers uniformly.


Unfortunately, this change can have a lot of unknown side effects impacting all kinds of workloads and therefore opens us to the risk of significant regressions for some yet unknown workflows. For instance, we had to blocklist shuffle-split keys because stealing them can cause catastrophic regressions for shuffling.

Apart from causing bad stealing decisions, this change potentially significantly increases the size of the stealable collections such that a single `Stealing.balance` will consume more CPU time.

I still believe this is the right thing to do and I hope that [coiled-runtime](https://github.com/coiled/coiled-runtime) benchmarks would notify us if any standard workflows are significantly impaired.
We will follow up with a couple of other changes that should mitigate this shortly


This change was part of https://github.com/dask/distributed/pull/4920