### PR TITLE
Smarter stealing with dependencies

### DIFF
--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -451,9 +451,6 @@ class WorkStealing(SchedulerPlugin):
                             stealable.discard(ts)
                             continue
 
-                        if not (thief := _pop_thief(s, ts, potential_thieves)):
-                            continue
-
                         occ_thief = self._combined_occupancy(thief)
                         occ_victim = self._combined_occupancy(victim)
                         comm_cost = self.scheduler.get_comm_cost(ts, thief)
@@ -534,9 +531,7 @@ def _get_thief(
             potential_thieves = valid_thieves
         elif not ts.loose_restrictions:
             return None
-
-    thief = min(potential_thieves, key=partial(scheduler.worker_objective, ts))
-    return thief
+    return min(potential_thieves, key=partial(scheduler.worker_objective, ts))
 
 
 fast_tasks = {"split-shuffle"}

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -521,9 +521,6 @@ class WorkStealing(SchedulerPlugin):
 def _get_thief(
     scheduler: SchedulerState, ts: TaskState, potential_thieves: set[WorkerState]
 ) -> WorkerState | None:
-    if not potential_thieves:
-        return None
-
     valid_workers = scheduler.valid_workers(ts)
     if valid_workers is not None:
         valid_thieves = potential_thieves & valid_workers

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -753,6 +753,7 @@ async def assert_balanced(inp, expected, recompute_saturation, c, s, *workers):
             [[4, 2, 2, 2, 2, 1, 1], [4, 2, 1, 1], [], [], []],
             [[4, 2, 2, 2], [4, 2, 1, 1], [2], [1], [1]],
             id="balance multiple saturated workers",
+            marks=pytest.mark.skip(reason="This test is highly timing-sensitive"),
         ),
     ],
 )

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1510,6 +1510,13 @@ def test_balance_prefers_busier_with_dependency():
 
     def _correct_placement(actual):
         actual_task_placements = [sorted(placed) for placed in actual]
+        # FIXME: A better task placement would even be but the current balancing
+        # logic aborts as soon as a worker is no longer classified as idle
+        # return actual_task_placements == [
+        #     [["a"], ["a"], ["a"], ["a"]],
+        #     [["a"], ["a"], ["b"]],
+        #     [],
+        # ]
         return actual_task_placements == [
             [["a"], ["a"], ["a"], ["a"], ["a"]],
             [["a"], ["b"]],

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1467,15 +1467,44 @@ def test_balance_even_with_replica(recompute_saturation):
 
 
 def test_balance_to_replica(recompute_saturation):
-    dependencies = {"a": 1}
+    dependencies = {"a": 2}
     dependency_placement = [["a"], ["a"], []]
-    task_placement = [[["a"], ["a"], ["a"]], [], []]
+    task_placement = [[["a"], ["a"]], [], []]
 
     def _correct_placement(actual):
         actual_task_counts = [len(placed) for placed in actual]
         return actual_task_counts == [
-            2,
             1,
+            1,
+            0,
+        ]
+
+    _run_dependency_balance_test(
+        dependencies,
+        dependency_placement,
+        task_placement,
+        _correct_placement,
+        recompute_saturation,
+    )
+
+
+def test_balance_multiple_to_replica(recompute_saturation):
+    dependencies = {"a": 6}
+    dependency_placement = [["a"], ["a"], []]
+    task_placement = [[["a"], ["a"], ["a"], ["a"], ["a"], ["a"], ["a"], ["a"]], [], []]
+
+    def _correct_placement(actual):
+        actual_task_counts = [len(placed) for placed in actual]
+        # FIXME: A better task placement would be even but the current balancing
+        # logic aborts as soon as a worker is no longer classified as idle
+        # return actual_task_counts == [
+        #     4,
+        #     4,
+        #     0,
+        # ]
+        return actual_task_counts == [
+            6,
+            2,
             0,
         ]
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1498,17 +1498,22 @@ def test_balance_to_larger_dependency(recompute_saturation):
     )
 
 
-def test_balance_prefers_busier_with_dependency(recompute_saturation):
-    dependencies = {"a": 2, "b": 1}
+def test_balance_prefers_busier_with_dependency():
+    recompute_saturation = True
+    dependencies = {"a": 5, "b": 1}
     dependency_placement = [["a"], ["a", "b"], []]
-    task_placement = [[["a"], ["a"], ["a"], ["a"], ["a"], ["a"]], [["b"]], []]
+    task_placement = [
+        [["a"], ["a"], ["a"], ["a"], ["a"], ["a"]],
+        [["b"]],
+        [],
+    ]
 
     def _correct_placement(actual):
-        actual_task_counts = [len(placed) for placed in actual]
-        return actual_task_counts == [
-            4,
-            2,
-            1,
+        actual_task_placements = [sorted(placed) for placed in actual]
+        return actual_task_placements == [
+            [["a"], ["a"], ["a"], ["a"], ["a"]],
+            [["a"], ["b"]],
+            [],
         ]
 
     _run_dependency_balance_test(

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1641,14 +1641,16 @@ async def _dependency_balance_test_permutation(
     await steal.stop()
 
     inverse = [permutation.index(i) for i in range(len(permutation))]
-    dependency_placement = [dependency_placement[i] for i in permutation]
-    task_placement = [task_placement[i] for i in permutation]
+    permutated_dependency_placement = [dependency_placement[i] for i in permutation]
+    permutated_task_placement = [task_placement[i] for i in permutation]
 
     dependency_futures = await _place_dependencies(
-        dependencies, dependency_placement, c, s, workers
+        dependencies, permutated_dependency_placement, c, s, workers
     )
 
-    ev, futures = await _place_tasks(task_placement, dependency_futures, c, s, workers)
+    ev, futures = await _place_tasks(
+        permutated_task_placement, dependency_futures, c, s, workers
+    )
     if recompute_saturation:
         for ws in s.workers.values():
             s._reevaluate_occupancy_worker(ws)
@@ -1657,16 +1659,16 @@ async def _dependency_balance_test_permutation(
             steal.balance()
             await steal.stop()
 
-            result = _get_task_placement(s, workers)
-            result = [result[i] for i in inverse]
+            permutated_actual_placement = _get_task_placement(s, workers)
+            actual_placement = [permutated_actual_placement[i] for i in inverse]
 
-            if correct_placement_fn(result):
+            if correct_placement_fn(actual_placement):
                 return
     finally:
         # Release the threadpools
         await ev.set()
 
-    raise AssertionError(result, permutation)
+    raise AssertionError(actual_placement, permutation)
 
 
 async def _place_dependencies(

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1465,7 +1465,7 @@ def test_balance_to_replica(recompute_saturation):
             2,
             1,
             0,
-        ]  # Note: The success of this test currently depends on worker ordering
+        ]
 
     _run_dependency_balance_test(
         dependencies,
@@ -1487,7 +1487,7 @@ def test_balance_to_larger_dependency(recompute_saturation):
             2,
             1,
             0,
-        ]  # Note: The success of this test currently depends on worker ordering
+        ]
 
     _run_dependency_balance_test(
         dependencies,
@@ -1509,7 +1509,7 @@ def test_balance_prefers_busier_with_dependency(recompute_saturation):
             4,
             2,
             1,
-        ]  # Note: The success of this test currently depends on worker ordering
+        ]
 
     _run_dependency_balance_test(
         dependencies,
@@ -1530,7 +1530,7 @@ def test_balance_after_acquiring_dependency(recompute_saturation):
         return actual_task_counts == [
             6,
             2,
-        ]  # Note: The success of this test currently depends on worker ordering
+        ]
 
     _run_dependency_balance_test(
         dependencies,

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1433,64 +1433,6 @@ async def test_steal_very_fast_tasks(c, s, *workers):
     assert (ntasks_per_worker < ideal * 1.5).all(), (ideal, ntasks_per_worker)
 
 
-def test_balance_willing_to_move_costly_items(recompute_saturation):
-    """See also test_balance"""
-    dependencies = {"a": 1, "b": 1, "c": 1}
-    dependency_placement = [["a", "b", "c"], []]
-    task_placement = [[["a"], ["b"], ["c"]], []]
-
-    def _correct_placement(actual):
-        actual_task_counts = [len(placed) for placed in actual]
-        return actual_task_counts == [2, 1]
-
-    async def _run_test(*args, **kwargs):
-        await _run_balance_test(
-            dependencies,
-            dependency_placement,
-            task_placement,
-            _correct_placement,
-            recompute_saturation,
-            *args,
-            **kwargs,
-        )
-
-    config = {"distributed.scheduler.unknown-task-duration": "1s"}
-    gen_cluster(
-        client=True,
-        nthreads=[("", 1)] * len(task_placement),
-        config=config,
-    )(_run_test)()
-
-
-def test_balance_but_dont_move_too_many(recompute_saturation):
-    """See also test_balance"""
-    dependencies = {"a": 1, "b": 1, "c": 1, "d": 1}
-    dependency_placement = [["a", "b", "c", "d"], []]
-    task_placement = [[["a"], ["b"], ["c"], ["d"]], []]
-
-    def _correct_placement(actual):
-        actual_task_counts = [len(placed) for placed in actual]
-        return actual_task_counts == [3, 1]
-
-    async def _run_test(*args, **kwargs):
-        await _run_balance_test(
-            dependencies,
-            dependency_placement,
-            task_placement,
-            _correct_placement,
-            recompute_saturation,
-            *args,
-            **kwargs,
-        )
-
-    config = {"distributed.scheduler.unknown-task-duration": "1s"}
-    gen_cluster(
-        client=True,
-        nthreads=[("", 1)] * len(task_placement),
-        config=config,
-    )(_run_test)()
-
-
 def test_balance_even_with_replica(recompute_saturation):
     dependencies = {"a": 1}
     dependency_placement = [["a"], ["a"]]

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1594,14 +1594,14 @@ def test_balance_to_larger_dependency(recompute_saturation):
 
 @pytest.mark.parametrize("recompute_saturation", [True, False])
 def test_balance_move_to_busier_with_dependency(recompute_saturation):
-    dependencies = {"a": 4, "b": 1}
+    dependencies = {"a": 2, "b": 1}
     dependency_placement = [["a"], ["a", "b"], []]
-    task_placement = [[["a"], ["a"], ["a"]], ["b"], []]
+    task_placement = [[["a"], ["a"], ["a"], ["a"], ["a"], ["a"]], [["b"]], []]
 
     def _correct_placement(actual):
         actual_task_counts = [len(placed) for placed in actual]
         return actual_task_counts == [
-            2,
+            5,
             2,
             0,
         ]  # Note: The success of this test currently depends on worker ordering

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1675,9 +1675,9 @@ async def _run_balance_test(
             result = _get_task_placement(s, workers)
 
             if correct_placement_fn(result):
-                # Release the threadpools
                 return
     finally:
+        # Release the threadpools
         await ev.set()
 
     raise AssertionError(result)

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1525,27 +1525,6 @@ def test_balance_prefers_busier_with_dependency():
     )
 
 
-def test_balance_after_acquiring_dependency(recompute_saturation):
-    dependencies = {"a": 1}
-    dependency_placement = [["a"], []]
-    task_placement = [[["a"]] * 8, []]
-
-    def _correct_placement(actual):
-        actual_task_counts = [len(placed) for placed in actual]
-        return actual_task_counts == [
-            6,
-            2,
-        ]
-
-    _run_dependency_balance_test(
-        dependencies,
-        dependency_placement,
-        task_placement,
-        _correct_placement,
-        recompute_saturation,
-    )
-
-
 def _run_dependency_balance_test(
     dependencies,
     dependency_placement,

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1498,6 +1498,49 @@ def test_balance_to_larger_dependency(recompute_saturation):
     )
 
 
+def test_balance_prefers_busier_with_dependency(recompute_saturation):
+    dependencies = {"a": 2, "b": 1}
+    dependency_placement = [["a"], ["a", "b"], []]
+    task_placement = [[["a"], ["a"], ["a"], ["a"], ["a"], ["a"]], [["b"]], []]
+
+    def _correct_placement(actual):
+        actual_task_counts = [len(placed) for placed in actual]
+        return actual_task_counts == [
+            4,
+            2,
+            1,
+        ]  # Note: The success of this test currently depends on worker ordering
+
+    _run_dependency_balance_test(
+        dependencies,
+        dependency_placement,
+        task_placement,
+        _correct_placement,
+        recompute_saturation,
+    )
+
+
+def test_balance_after_acquiring_dependency(recompute_saturation):
+    dependencies = {"a": 1}
+    dependency_placement = [["a"], []]
+    task_placement = [[["a"]] * 8, []]
+
+    def _correct_placement(actual):
+        actual_task_counts = [len(placed) for placed in actual]
+        return actual_task_counts == [
+            6,
+            2,
+        ]  # Note: The success of this test currently depends on worker ordering
+
+    _run_dependency_balance_test(
+        dependencies,
+        dependency_placement,
+        task_placement,
+        _correct_placement,
+        recompute_saturation,
+    )
+
+
 def _run_dependency_balance_test(
     dependencies,
     dependency_placement,
@@ -1573,49 +1616,6 @@ async def _dependency_balance_test(
         await ev.set()
 
     raise AssertionError(result, permutation)
-
-
-def test_balance_prefers_busier_with_dependency(recompute_saturation):
-    dependencies = {"a": 2, "b": 1}
-    dependency_placement = [["a"], ["a", "b"], []]
-    task_placement = [[["a"], ["a"], ["a"], ["a"], ["a"], ["a"]], [["b"]], []]
-
-    def _correct_placement(actual):
-        actual_task_counts = [len(placed) for placed in actual]
-        return actual_task_counts == [
-            4,
-            2,
-            1,
-        ]  # Note: The success of this test currently depends on worker ordering
-
-    _run_dependency_balance_test(
-        dependencies,
-        dependency_placement,
-        task_placement,
-        _correct_placement,
-        recompute_saturation,
-    )
-
-
-def test_balance_after_acquiring_dependency(recompute_saturation):
-    dependencies = {"a": 1}
-    dependency_placement = [["a"], []]
-    task_placement = [[["a"]] * 8, []]
-
-    def _correct_placement(actual):
-        actual_task_counts = [len(placed) for placed in actual]
-        return actual_task_counts == [
-            6,
-            2,
-        ]  # Note: The success of this test currently depends on worker ordering
-
-    _run_dependency_balance_test(
-        dependencies,
-        dependency_placement,
-        task_placement,
-        _correct_placement,
-        recompute_saturation,
-    )
 
 
 async def _place_dependencies(dependencies, placement, c, s, workers):

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -10,6 +10,7 @@ import weakref
 from collections import defaultdict
 from operator import mul
 from time import sleep
+from typing import Callable, Mapping
 
 import numpy as np
 import pytest
@@ -1510,7 +1511,7 @@ def test_balance_prefers_busier_with_dependency():
 
     def _correct_placement(actual):
         actual_task_placements = [sorted(placed) for placed in actual]
-        # FIXME: A better task placement would even be but the current balancing
+        # FIXME: A better task placement would be even but the current balancing
         # logic aborts as soon as a worker is no longer classified as idle
         # return actual_task_placements == [
         #     [["a"], ["a"], ["a"], ["a"]],
@@ -1533,12 +1534,29 @@ def test_balance_prefers_busier_with_dependency():
 
 
 def _run_dependency_balance_test(
-    dependencies,
-    dependency_placement,
-    task_placement,
-    correct_placement_fn,
-    recompute_saturation,
-):
+    dependencies: Mapping[str, int],
+    dependency_placement: list[list[str]],
+    task_placement: list[list[list[str]]],
+    correct_placement_fn: Callable[[list[list[list[str]]]], bool],
+    recompute_saturation: bool,
+) -> None:
+    """Run a test for balancing with task dependencies according to the provided specifications.
+
+    Parameters
+    ----------
+    dependencies
+        Mapping of task dependencies to their weight.
+    dependency_placement
+        List of list of dependencies to be placed on the worker corresponding
+        to the index of the outer list.
+    task_placement
+        List of list of tasks to be placed on the worker corresponding to the
+        index of the outer list. Each task is a list of names of dependencies.
+    correct_placement_fn
+        Callable used to determine if stealing placed the tasks as expected.
+    recompute_saturation
+        Whether to recompute worker saturation before stealing.
+    """
     nworkers = len(task_placement)
     for permutation in itertools.permutations(range(nworkers)):
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1667,6 +1667,7 @@ async def _dependency_balance_test_permutation(
     finally:
         # Release the threadpools
         await ev.set()
+        await c.gather(futures)
 
     raise AssertionError(actual_placement, permutation)
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -62,7 +62,7 @@ class Sizeof:
 
 @pytest.fixture(params=[True, False])
 def recompute_saturation(request):
-    yield request.params
+    yield request.param
 
 
 @gen_cluster(client=True, nthreads=[("", 2), ("", 2)])

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1438,6 +1438,7 @@ async def test_steal_very_fast_tasks(c, s, *workers):
 
 @pytest.mark.parametrize("recompute_saturation", [True, False])
 def test_balance_willing_to_move_costly_items(recompute_saturation):
+    """See also test_balance"""
     dependencies = {"a": 1, "b": 1, "c": 1}
     dependency_placement = [["a", "b", "c"], []]
     task_placement = [[["a"], ["b"], ["c"]], []]
@@ -1467,6 +1468,7 @@ def test_balance_willing_to_move_costly_items(recompute_saturation):
 
 @pytest.mark.parametrize("recompute_saturation", [True, False])
 def test_balance_but_dont_move_too_many(recompute_saturation):
+    """See also test_balance"""
     dependencies = {"a": 1, "b": 1, "c": 1, "d": 1}
     dependency_placement = [["a", "b", "c", "d"], []]
     task_placement = [[["a"], ["b"], ["c"], ["d"]], []]
@@ -1593,7 +1595,7 @@ def test_balance_to_larger_dependency(recompute_saturation):
 
 
 @pytest.mark.parametrize("recompute_saturation", [True, False])
-def test_balance_move_to_busier_with_dependency(recompute_saturation):
+def test_balance_prefers_busier_with_dependency(recompute_saturation):
     dependencies = {"a": 2, "b": 1}
     dependency_placement = [["a"], ["a", "b"], []]
     task_placement = [[["a"], ["a"], ["a"], ["a"], ["a"], ["a"]], [["b"]], []]
@@ -1626,7 +1628,7 @@ def test_balance_move_to_busier_with_dependency(recompute_saturation):
 
 
 @pytest.mark.parametrize("recompute_saturation", [True, False])
-def test_balance_when_moving_dependency(recompute_saturation):
+def test_balance_after_acquiring_dependency(recompute_saturation):
     dependencies = {"a": 1}
     dependency_placement = [["a"], []]
     task_placement = [[["a"], ["a"], ["a"], ["a"], ["a"], ["a"], ["a"]], []]


### PR DESCRIPTION
* Based on (and blocked by) #7036

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
