### PR TITLE
No longer double count transfer cost in stealing

### DIFF
--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -23,9 +23,11 @@ from distributed.core import Status
 from distributed.metrics import time
 from distributed.system import MEMORY_LIMIT
 from distributed.utils_test import (
+    SizeOf,
     captured_logger,
     freeze_batched_send,
     gen_cluster,
+    gen_nbytes,
     inc,
     nodebug_setup_module,
     nodebug_teardown_module,
@@ -169,13 +171,24 @@ async def test_stop_in_flight(c, s, a, b):
     del futs
     while s.tasks or a.state.tasks or b.state.tasks:
         await asyncio.sleep(0.1)
+    event = Event()
+
+    def block(x, event):
+        event.wait()
+        return x + 1
+
     futs = c.map(
-        slowinc, range(num_tasks), workers=[a.address], allow_other_workers=True
+        block,
+        range(num_tasks),
+        event=event,
+        workers=[a.address],
+        allow_other_workers=True,
     )
     while not len(a.state.tasks) == num_tasks:
         await asyncio.sleep(0.01)
     assert len(b.state.tasks) == 0
     await steal.start()
+    await event.set()
     await c.gather(futs)
     assert len(a.state.tasks) != num_tasks
     assert len(b.state.tasks) != 0
@@ -185,6 +198,7 @@ async def test_stop_in_flight(c, s, a, b):
     client=True,
     nthreads=[("127.0.0.1", 1)] * 2,
     config={"distributed.scheduler.work-stealing-interval": "10ms"},
+    timeout=10,
 )
 async def test_allow_tasks_stolen_before_first_completes(c, s, a, b):
     # https://github.com/dask/distributed/issues/5564
@@ -233,6 +247,7 @@ async def test_allow_tasks_stolen_before_first_completes(c, s, a, b):
         await steal.start()
         # A is still blocked by executing task f-1 so this can only pass if
         # workstealing moves the tasks to B
+        await asyncio.sleep(5)
         await c.gather(more_tasks)
         assert len(b.data) == 10
     await first
@@ -634,19 +649,12 @@ async def assert_balanced(inp, expected, recompute_saturation, c, s, *workers):
 
     counter = itertools.count()
 
-    class Sizeof:
-        def __init__(self, nbytes):
-            self._nbytes = nbytes - 16
-
-        def __sizeof__(self) -> int:
-            return self._nbytes
-
     futures = []
     for w, ts in zip(workers, inp):
         for t in sorted(ts, reverse=True):
             if t:
                 [dat] = await c.scatter(
-                    [Sizeof(int(t * s.bandwidth))], workers=w.address
+                    [SizeOf(int(t * s.bandwidth))], workers=w.address
                 )
             else:
                 dat = 123
@@ -721,7 +729,7 @@ async def assert_balanced(inp, expected, recompute_saturation, c, s, *workers):
         # schedule a task on the threadpool
         (
             [[4, 2, 2, 2, 2, 1, 1], [4, 2, 1, 1], [], [], []],
-            [[4, 2, 2, 2, 2], [4, 2, 1], [1], [1], [1]],
+            [[4, 2, 2, 2], [4, 2, 1, 1], [2], [1], [1]],
         ),
     ],
 )
@@ -750,13 +758,46 @@ async def test_restart(c, s, a, b):
         await asyncio.sleep(0.01)
 
     steal = s.extensions["stealing"]
-    assert any(st for st in steal.stealable_all)
+    # assert any(st for st in steal.stealable_all)
     assert any(x for L in steal.stealable.values() for x in L)
 
     await c.restart()
 
-    assert not any(x for x in steal.stealable_all)
+    # assert not any(x for x in steal.stealable_all)
     assert not any(x for L in steal.stealable.values() for x in L)
+
+
+@gen_cluster(client=True)
+async def test_do_not_steal_communication_heavy_tasks(c, s, a, b):
+    # Never steal unreasonably large tasks
+    steal = s.extensions["stealing"]
+    x = c.submit(gen_nbytes, int(s.bandwidth) * 1000, workers=a.address, pure=False)
+    y = c.submit(gen_nbytes, int(s.bandwidth) * 1000, workers=a.address, pure=False)
+
+    def block_reduce(x, y, event):
+        event.wait()
+        return None
+
+    event = Event()
+    futures = [
+        c.submit(
+            block_reduce,
+            x,
+            y,
+            event=event,
+            pure=False,
+            workers=a.address,
+            allow_other_workers=True,
+        )
+        for i in range(10)
+    ]
+    while not a.state.tasks:
+        await asyncio.sleep(0.1)
+    steal.balance()
+    await steal.stop()
+    await event.set()
+    await c.gather(futures)
+    assert not b.data
 
 
 @gen_cluster(
@@ -765,6 +806,7 @@ async def test_restart(c, s, a, b):
 )
 async def test_steal_communication_heavy_tasks(c, s, a, b):
     steal = s.extensions["stealing"]
+    await steal.stop()
     x = c.submit(mul, b"0", int(s.bandwidth), workers=a.address)
     y = c.submit(mul, b"1", int(s.bandwidth), workers=b.address)
 
@@ -785,10 +827,8 @@ async def test_steal_communication_heavy_tasks(c, s, a, b):
         await asyncio.sleep(0.01)
 
     steal.balance()
-    while steal.in_flight:
-        await asyncio.sleep(0.001)
 
-    assert s.workers[b.address].processing
+    await steal.stop()
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -19,6 +19,7 @@ import yaml
 from tornado import gen
 
 import dask.config
+from dask.sizeof import sizeof
 
 from distributed import Client, Event, Nanny, Scheduler, Worker, config, default_client
 from distributed.batched import BatchedSend
@@ -29,6 +30,7 @@ from distributed.metrics import time
 from distributed.tests.test_batched import EchoServer
 from distributed.utils import get_mp_context
 from distributed.utils_test import (
+    SizeOf,
     _LockedCommPool,
     _UnhashableCallable,
     assert_story,
@@ -39,6 +41,7 @@ from distributed.utils_test import (
     dump_cluster_state,
     freeze_batched_send,
     gen_cluster,
+    gen_nbytes,
     gen_test,
     inc,
     new_config,
@@ -1024,3 +1027,10 @@ def test_ws_with_running_task(ws_with_running_task):
     assert ws.available_resources == {"R": 0}
     assert ws.total_resources == {"R": 1}
     assert ts.state in ("executing", "long-running")
+
+
+@pytest.mark.parametrize("nbytes", [0, 1, 1234.567])
+def test_sizeof(nbytes):
+    assert sizeof(SizeOf(nbytes)) == nbytes
+    assert isinstance(gen_nbytes(nbytes), SizeOf)
+    assert sizeof(gen_nbytes(nbytes)) == nbytes

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1029,8 +1029,21 @@ def test_ws_with_running_task(ws_with_running_task):
     assert ts.state in ("executing", "long-running")
 
 
-@pytest.mark.parametrize("nbytes", [0, 1, 1234.567])
-def test_sizeof(nbytes):
-    assert sizeof(SizeOf(nbytes)) == nbytes
-    assert isinstance(gen_nbytes(nbytes), SizeOf)
-    assert sizeof(gen_nbytes(nbytes)) == nbytes
+def test_sizeof():
+    assert sizeof(SizeOf(100)) == 100
+    assert isinstance(gen_nbytes(100), SizeOf)
+    assert sizeof(gen_nbytes(100)) == 100
+
+
+@pytest.mark.parametrize(
+    "input, exc, msg",
+    [
+        (12345.0, TypeError, "Expected integer"),
+        (-1, ValueError, "larger than"),
+        (0, ValueError, "larger than"),
+        (10, ValueError, "larger than"),
+    ],
+)
+def test_sizeof_error(input, exc, msg):
+    with pytest.raises(exc, match=msg):
+        SizeOf(input)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -37,6 +37,7 @@ from tornado.httpclient import AsyncHTTPClient
 from tornado.ioloop import IOLoop
 
 import dask
+from dask.sizeof import sizeof
 
 from distributed import Scheduler, system
 from distributed import versions as version_module
@@ -2458,3 +2459,20 @@ async def fetch_metrics(port: int, prefix: str | None = None) -> dict[str, Any]:
         if prefix is None or family.name.startswith(prefix)
     }
     return families
+
+
+class SizeOf:
+    """
+    An object that returns exactly nbytes when inspected by dask.sizeof.sizeof
+    """
+
+    def __init__(self, nbytes: float) -> None:
+        self._nbytes = nbytes - sizeof(object())
+
+    def __sizeof__(self) -> int:
+        return self._nbytes
+
+
+def gen_nbytes(nbytes: float) -> SizeOf:
+    """A function that emulates exactly nbytes on the worker data structure."""
+    return SizeOf(nbytes)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2466,13 +2466,20 @@ class SizeOf:
     An object that returns exactly nbytes when inspected by dask.sizeof.sizeof
     """
 
-    def __init__(self, nbytes: float) -> None:
-        self._nbytes = nbytes - sizeof(object())
+    def __init__(self, nbytes: int) -> None:
+        if not isinstance(nbytes, int):
+            raise TypeError(f"Expected integer for nbytes but got {type(nbytes)}")
+        size_obj = sizeof(object())
+        if nbytes < size_obj:
+            raise ValueError(
+                f"Expected a value larger than {size_obj} integer but got {nbytes}."
+            )
+        self._nbytes = nbytes - size_obj
 
     def __sizeof__(self) -> int:
         return self._nbytes
 
 
-def gen_nbytes(nbytes: float) -> SizeOf:
+def gen_nbytes(nbytes: int) -> SizeOf:
     """A function that emulates exactly nbytes on the worker data structure."""
     return SizeOf(nbytes)


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/7002

Address the work stealing component of https://github.com/dask/distributed/issues/7003


The steal_ratio calculation now uses genuine compute time instead of occupancy to calculate the steal_ratio. This means that the cost calculation and classification there is truly independent of the worker the task is sitting on as it is supposed to be. The steal_ratio is merely a pre-sorting and filtering step before the actual stealing decision is computed.

To account for this offset and keep existing tests happy (which are valid, see e.g. `test_steal_communication_heavy_tasks`) the actual decision logic had to be adjusted as well to account for this drift.

At the same time I removed the stealing from public logic. After the fixes above this is no longer required and simply adds to complexity.

To fix https://github.com/dask/distributed/issues/7002 the balance loop now maintains a set of `potential_thiefs` that is emptied accordingly, i.e. we no longer depend on an update on the scheduler data structure.
At the very end of a loop, the scheduler is updated with the information accordingly.

TODO:
- More tests
- Look into refactoring the idle classification