### PR TITLE
[WIP] Dispatch some lists

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -215,7 +215,8 @@ def _infer_if_iterate_over_list(x):
             ):
             # Sometimes we get strings that are actually tuples
             # which are part of the task graph.  We need to serialize
-            # these recursively.
+            # these recursively.  We assume that all the items in the
+            # list are from the task graph
             return True
         if all((type(i) is type(first_val)) for i in iseq):
             return False

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -199,7 +199,7 @@ register_serialization_family("msgpack", msgpack_dumps, msgpack_loads)
 register_serialization_family("error", None, serialization_error_loads)
 
 
-def _infer_if_iterate_over_list(x):
+def infer_if_recurse_to_serialize_list(x):
     try:
         _ = list(set(x))
         iseq = iter(x)
@@ -232,7 +232,7 @@ def _infer_if_iterate_over_list(x):
 def check_dask_serializable(x):
     if type(x) in (list, set, tuple) and len(x):
         if type(x) is list:
-            return _infer_if_iterate_over_list(x)
+            return infer_if_recurse_to_serialize_list(x)
         else:
             return check_dask_serializable(next(iter(x)))
     elif type(x) is dict and len(x):
@@ -298,7 +298,7 @@ def serialize(  # type: ignore[no-untyped-def]
         iterate_collection is None and
         serializers is None
     ):
-        iterate_collection = _infer_if_iterate_over_list(x)
+        iterate_collection = infer_if_recurse_to_serialize_list(x)
 
     if serializers is None:
         serializers = ("dask", "pickle")  # TODO: get from configuration

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -523,8 +523,8 @@ async def test_frame_split():
     "data,is_serializable",
     [
         ([], True),
-        ([[0,0], [0,0]], False),
-        ([[], []], False),
+        ([[0,0], [0,0]], True),
+        ([[], []], True),
         ({}, False),
         ({i: i for i in range(10)}, False),
         (set(range(10)), False),

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -64,7 +64,6 @@ register_serialization(MyObj, serialize_myobj, deserialize_myobj)
     ])
 def test_dumps_serialize(input, expected):
     header, frames = serialize(input)
-    print(header)
 
     assert header.get("serializer") == expected
     assert len(frames) == 1


### PR DESCRIPTION
- Closes #6368 
- Related to:  #6940 

- [ ] Tests added / passed
- [X ] Passes `pre-commit run --all-files`

Using the reproducer from @adbreind in #6368 as a starting point for:

```
from distributed import Client, LocalCluster
from time import time
import numpy as np


def run_test():
    runtime = []
    def foo():
        return [1.5] * 1_000_000

    # with LocalCluster(n_workers=2, threads_per_worker=1, memory_limit='8GiB') as cluster:
    for i in range(5):
        with Client() as client:
            s = time()
            res = client.submit(foo).result()
            runtime.append(time() - s)
    print(f"Run time (in seconds) for 5 runs is: {runtime}, and mean runtime:  {np.mean(runtime)} seconds")

if __name__ == "__main__":
    run_test()
```

On current main, I get:
`Run time (in seconds) for 5 runs is: [13.804176807403564, 13.784174680709839, 13.835507869720459, 13.706598997116089, 13.749552011489868], and mean runtime:  13.776002073287964 seconds`

While on this branch, I get:
`Run time (in seconds) for 5 runs is: [0.15462398529052734, 0.1298370361328125, 0.1314990520477295, 0.13030385971069336, 0.12935090065002441], and mean runtime:  0.13512296676635743 seconds`

What is happening?
When serializing collections, we prefer to use pickle and recurse into the collections, serializing each object in the collection separately.  This decision was [motivated by Blockwise-IO work ](https://github.com/dask/distributed/pull/4641)as described by @rjzamora.  While it makes sense, it also has the unfortunate consequence of making it expensive to serialize collections in general.

Here we create a `Dispatch()` method for lists that converts a list to a numpy array, which can then be serialized.  We add `infer_if_recurse_to_serialize_list`.  Now that lists can be serialized recursively using `pickle`, or with `dask_serialize`, we offload the decision about whether to `iterate_collection` to`infer_if_recurse_to_serialize_list`.

We also need to handle the case where a `Serialize` object must itself be serialized.  To handle this, we add an `iterate_collection` attribute.