### PR TITLE
Avoid signaling outside main thread

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -14,6 +14,7 @@ import os
 import pickle
 import random
 import sys
+import threading
 import uuid
 import warnings
 import weakref
@@ -3352,6 +3353,9 @@ class Scheduler(SchedulerState, ServerNode):
                     }
                 )
             )
+            if threading.current_thread() is not threading.main_thread():
+                ServerApp.init_signal = lambda self: None
+                ServerApp._restore_sigint_handler = lambda self: None
             j.initialize(
                 new_httpserver=False,
             )


### PR DESCRIPTION
Closes #6886

@mrocklin dunno if I was taking @Carreau too literally here but this does resolve the issue (i.e. the example from the issue now succeeds). Not sure if it's bad form to be actually overriding these class methods, maybe we want to subclass or something?