### PR TITLE
Improve `upload_file` API documentation

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3441,8 +3441,11 @@ class Client(SyncMethodMixin):
         """Upload local package to workers
 
         This sends a local file up to all worker nodes.  This file is placed
-        into a temporary directory on Python's system path so any .py,  .egg
-        or .zip  files will be importable.
+        into the working directory of the running worker, see config option
+        `temporary-directory` (defaults to `tempfile.gettempdir`).
+
+        This directory will be added to the Python's system path so any .py,
+        .egg or .zip  files will be importable.
 
         Parameters
         ----------

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3442,7 +3442,7 @@ class Client(SyncMethodMixin):
 
         This sends a local file up to all worker nodes.  This file is placed
         into the working directory of the running worker, see config option
-        `temporary-directory` (defaults to `tempfile.gettempdir`).
+        ``temporary-directory`` (defaults to :py:func:`tempfile.gettempdir`).
 
         This directory will be added to the Python's system path so any .py,
         .egg or .zip  files will be importable.


### PR DESCRIPTION
This clarifies where this temporary directory is created to provide better transparency about which directory is added to the python path.

