### PR TITLE
Enable Active Memory Manager by default

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
         # To avoid hamstringing other people, change 'on: [push, pull_request]' above
         # to just 'on: [push]'; this way the stress test will run exclusively in your
         # branch (https://github.com/<your name>/distributed/actions).
-        # run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        run: [1, 2, 3, 4, 5]
 
     env:
       CONDA_FILE: continuous_integration/environment-${{ matrix.python-version }}.yaml
@@ -55,9 +55,9 @@ jobs:
       - name: Set $TEST_ID
         run: |
           export PARTITION_LABEL=$( echo "${{ matrix.partition }}" | sed "s/ //" )
-          export TEST_ID="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.queuing }}-$PARTITION_LABEL"
+          # export TEST_ID="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.queuing }}-$PARTITION_LABEL"
           # Switch to this version for stress-test:
-          # export TEST_ID="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.queuing }}-$PARTITION_LABEL-${{ matrix.run }}"
+          export TEST_ID="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.queuing }}-$PARTITION_LABEL-${{ matrix.run }}"
           echo "TEST_ID: $TEST_ID"
           echo "TEST_ID=$TEST_ID" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
         # To avoid hamstringing other people, change 'on: [push, pull_request]' above
         # to just 'on: [push]'; this way the stress test will run exclusively in your
         # branch (https://github.com/<your name>/distributed/actions).
-        run: [1, 2, 3, 4, 5]
+        # run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
 
     env:
       CONDA_FILE: continuous_integration/environment-${{ matrix.python-version }}.yaml
@@ -55,9 +55,9 @@ jobs:
       - name: Set $TEST_ID
         run: |
           export PARTITION_LABEL=$( echo "${{ matrix.partition }}" | sed "s/ //" )
-          # export TEST_ID="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.queuing }}-$PARTITION_LABEL"
+          export TEST_ID="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.queuing }}-$PARTITION_LABEL"
           # Switch to this version for stress-test:
-          export TEST_ID="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.queuing }}-$PARTITION_LABEL-${{ matrix.run }}"
+          # export TEST_ID="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.queuing }}-$PARTITION_LABEL-${{ matrix.run }}"
           echo "TEST_ID: $TEST_ID"
           echo "TEST_ID=$TEST_ID" >> $GITHUB_ENV
         shell: bash

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2370,6 +2370,11 @@ class Client(SyncMethodMixin):
         broadcast : bool (defaults to False)
             Whether to send each data element to all workers.
             By default we round-robin based on number of cores.
+
+            .. note::
+               Setting this flag to True is incompatible with the Active Memory
+               Manager's :ref:`ReduceReplicas` policy. If you wish to use it, you must
+               first disable the policy or disable the AMM entirely.
         direct : bool (defaults to automatically check)
             Whether or not to connect directly to the workers, or to ask
             the scheduler to serve as intermediary.  This can also be set when
@@ -3513,11 +3518,16 @@ class Client(SyncMethodMixin):
         """Set replication of futures within network
 
         Copy data onto many workers.  This helps to broadcast frequently
-        accessed data and it helps to improve resilience.
+        accessed data and can improve resilience.
 
         This performs a tree copy of the data throughout the network
         individually on each piece of data.  This operation blocks until
         complete.  It does not guarantee replication of data to future workers.
+
+        .. note::
+           This method is incompatible with the Active Memory Manager's
+           :ref:`ReduceReplicas` policy. If you wish to use it, you must first disable
+           the policy or disable the AMM entirely.
 
         Parameters
         ----------

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -69,8 +69,7 @@ distributed:
       start: true
 
       # Once started, run the AMM cycle every <interval>
-      # TODO REVERT BEFORE MERGING
-      interval: 0.01s
+      interval: 2s
 
       # Memory measure to use. Must be one of the attributes of
       # distributed.scheduler.MemoryState.

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -66,9 +66,10 @@ distributed:
       # Set to true to auto-start the Active Memory Manager on Scheduler start; if false
       # you'll have to either manually start it with client.amm.start() or run it once
       # with client.amm.run_once().
-      start: false
+      start: true
       # Once started, run the AMM cycle every <interval>
-      interval: 2s
+      # TODO REVERT BEFORE MERGING
+      interval: 0.01s
       policies:
         # Policies that should be executed at every cycle. Any additional keys in each
         # object are passed as keyword arguments to the policy constructor.

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -35,7 +35,7 @@ from distributed.protocol import (
 )
 from distributed.protocol.serialize import check_dask_serializable
 from distributed.utils import ensure_memoryview, nbytes
-from distributed.utils_test import gen_test, inc
+from distributed.utils_test import NO_AMM, gen_test, inc
 
 
 class MyObj:
@@ -208,7 +208,7 @@ async def test_object_in_graph(c, s, a, b):
     assert result.data == 123
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_scatter(c, s, a, b):
     o = MyObj(123)
     [future] = await c._scatter([o])

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -20,8 +20,8 @@ from distributed.active_memory_manager import (
 )
 from distributed.core import Status
 from distributed.utils_test import (
-    BlockedGatherDep,
     NO_AMM,
+    BlockedGatherDep,
     assert_story,
     captured_logger,
     gen_cluster,
@@ -1082,7 +1082,7 @@ async def test_dont_replicate_actors(c, s, a, b):
 
 
 @pytest.mark.parametrize("has_proxy", [False, True])
-@gen_cluster(client=True, config=NO_AMM_START)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_RetireWorker_with_actor(c, s, a, b, has_proxy):
     """A worker holding one or more original actor objects cannot be retired"""
     x = c.submit(Counter, key="x", actor=True, workers=[a.address])
@@ -1108,7 +1108,7 @@ async def test_RetireWorker_with_actor(c, s, a, b, has_proxy):
         assert "y" in b.data
 
 
-@gen_cluster(client=True, config=NO_AMM_START)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_RetireWorker_with_actor_proxy(c, s, a, b):
     """A worker holding an Actor proxy object can be retired as normal."""
     x = c.submit(Counter, key="x", actor=True, workers=[a.address])
@@ -1162,7 +1162,6 @@ async def tensordot_stress(c):
 @gen_cluster(
     client=True,
     nthreads=[("", 1)] * 4,
-    Worker=Nanny,
     config=NO_AMM,
 )
 async def test_noamm_stress(c, s, *workers):

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -477,9 +477,7 @@ async def bench_param_server(c, s, *workers):
     print(format_time(end - start))
 
 
-@pytest.mark.slow
-@pytest.mark.flaky(reruns=10, reruns_delay=5)
-@gen_cluster(client=True, timeout=120)
+@gen_cluster(client=True)
 async def test_compute(c, s, a, b):
     @dask.delayed
     def f(n, counter):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -85,6 +85,8 @@ from distributed.utils import (
     tmp_text,
 )
 from distributed.utils_test import (
+    NO_AMM,
+    BlockedGatherDep,
     TaskStateMetadataPlugin,
     _UnhashableCallable,
     async_wait_for,
@@ -112,6 +114,7 @@ from distributed.utils_test import (
     tls_only_security,
     varying,
     wait_for,
+    wait_for_state,
 )
 
 pytestmark = pytest.mark.ci1
@@ -927,7 +930,7 @@ async def test_tokenize_on_futures(c, s, a, b):
 
 
 @pytest.mark.skipif(not LINUX, reason="Need 127.0.0.2 to mean localhost")
-@gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True)
+@gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True, config=NO_AMM)
 async def test_restrictions_submit(c, s, a, b):
     x = c.submit(inc, 1, workers={a.ip})
     y = c.submit(inc, x, workers={b.ip})
@@ -940,7 +943,7 @@ async def test_restrictions_submit(c, s, a, b):
     assert y.key in b.data
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_restrictions_ip_port(c, s, a, b):
     x = c.submit(inc, 1, workers={a.address})
     y = c.submit(inc, x, workers={b.address})
@@ -978,7 +981,7 @@ async def test_restrictions_get(c, s, a, b):
     assert len(b.data) == 0
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_restrictions_get_annotate(c, s, a, b):
     x = 1
     with dask.annotate(workers=a.address):
@@ -1436,7 +1439,7 @@ async def test_scatter_direct_numpy(c, s, a, b):
     assert not s.counters["op"].components[0]["scatter"]
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_scatter_direct_broadcast(c, s, a, b):
     future2 = await c.scatter(456, direct=True, broadcast=True)
     assert future2.key in a.data
@@ -1453,7 +1456,7 @@ async def test_scatter_direct_balanced(c, s, *workers):
     assert sorted(len(w.data) for w in workers) == [0, 1, 1, 1]
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4, config=NO_AMM)
 async def test_scatter_direct_broadcast_target(c, s, *workers):
     futures = await c.scatter([123, 456], direct=True, workers=workers[0].address)
     assert futures[0].key in workers[0].data
@@ -1688,7 +1691,8 @@ async def test_upload_file_egg(c, s, a, b):
                 assert result == (value, value)
 
 
-@gen_cluster(client=True)
+# _upload_large_file internally calls replicate, which makes it incompatible with AMM
+@gen_cluster(client=True, config=NO_AMM)
 async def test_upload_large_file(c, s, a, b):
     assert a.local_directory
     assert b.local_directory
@@ -2258,20 +2262,20 @@ async def test_multi_garbage_collection(s, a, b):
         assert not s.tasks
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test__broadcast(c, s, a, b):
     x, y = await c.scatter([1, 2], broadcast=True)
     assert a.data == b.data == {x.key: 1, y.key: 2}
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4, config=NO_AMM)
 async def test__broadcast_integer(c, s, *workers):
     x, y = await c.scatter([1, 2], broadcast=2)
     assert len(s.tasks[x.key].who_has) == 2
     assert len(s.tasks[y.key].who_has) == 2
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test__broadcast_dict(c, s, a, b):
     d = await c.scatter({"x": 1}, broadcast=True)
     assert a.data == b.data == {"x": 1}
@@ -2892,11 +2896,14 @@ async def test_badly_serialized_exceptions(c, s, a, b):
 # Set rebalance() to work predictably on small amounts of managed memory. By default, it
 # uses optimistic memory, which would only be possible to test by allocating very large
 # amounts of managed memory, so that they would hide variations in unmanaged memory.
-REBALANCE_MANAGED_CONFIG = {
-    "distributed.worker.memory.rebalance.measure": "managed",
-    "distributed.worker.memory.rebalance.sender-min": 0,
-    "distributed.worker.memory.rebalance.sender-recipient-gap": 0,
-}
+REBALANCE_MANAGED_CONFIG = merge(
+    NO_AMM,
+    {
+        "distributed.worker.memory.rebalance.measure": "managed",
+        "distributed.worker.memory.rebalance.sender-min": 0,
+        "distributed.worker.memory.rebalance.sender-recipient-gap": 0,
+    },
+)
 
 
 @gen_cluster(client=True, config=REBALANCE_MANAGED_CONFIG)
@@ -2950,7 +2957,7 @@ def test_rebalance_sync(loop):
             assert len(b.data) == 50
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_rebalance_unprepared(c, s, a, b):
     """Client.rebalance() internally waits for unfinished futures"""
     futures = c.map(slowinc, range(10), delay=0.05, workers=a.address)
@@ -2962,7 +2969,7 @@ async def test_rebalance_unprepared(c, s, a, b):
     s.validate_state()
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_rebalance_raises_on_explicit_missing_data(c, s, a, b):
     """rebalance() raises KeyError if explicitly listed futures disappear"""
     f = Future("x", client=c, state="memory")
@@ -3010,7 +3017,7 @@ async def test_add_worker_after_tasks(c, s):
 
 
 @pytest.mark.skipif(not LINUX, reason="Need 127.0.0.2 to mean localhost")
-@gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True)
+@gen_cluster([("127.0.0.1", 1), ("127.0.0.2", 2)], client=True, config=NO_AMM)
 async def test_workers_register_indirect_data(c, s, a, b):
     [x] = await c.scatter([1], workers=a.address)
     y = c.submit(inc, x, workers=b.ip)
@@ -3032,7 +3039,11 @@ async def test_submit_on_cancelled_future(c, s, a, b):
         c.submit(inc, x)
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
+@gen_cluster(
+    client=True,
+    nthreads=[("127.0.0.1", 1)] * 10,
+    config=NO_AMM,
+)
 async def test_replicate(c, s, *workers):
     [a, b] = await c.scatter([1, 2])
     await s.replicate(keys=[a.key, b.key], n=5)
@@ -3045,7 +3056,7 @@ async def test_replicate(c, s, *workers):
     assert sum(b.key in w.data for w in workers) == 5
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_replicate_tuple_keys(c, s, a, b):
     x = delayed(inc)(1, dask_key_name=("x", 1))
     f = c.persist(x)
@@ -3057,7 +3068,11 @@ async def test_replicate_tuple_keys(c, s, a, b):
     s.validate_state()
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
+@gen_cluster(
+    client=True,
+    nthreads=[("127.0.0.1", 1)] * 10,
+    config=NO_AMM,
+)
 async def test_replicate_workers(c, s, *workers):
 
     [a, b] = await c.scatter([1, 2], workers=[workers[0].address])
@@ -3108,7 +3123,11 @@ class CountSerialization:
         return self.n
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
+@gen_cluster(
+    client=True,
+    nthreads=[("127.0.0.1", 1)] * 10,
+    config=NO_AMM,
+)
 async def test_replicate_tree_branching(c, s, *workers):
     obj = CountSerialization()
     [future] = await c.scatter([obj])
@@ -3118,7 +3137,11 @@ async def test_replicate_tree_branching(c, s, *workers):
     assert max_count > 1
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 10)
+@gen_cluster(
+    client=True,
+    nthreads=[("127.0.0.1", 1)] * 10,
+    config=NO_AMM,
+)
 async def test_client_replicate(c, s, *workers):
     x = c.submit(inc, 1)
     y = c.submit(inc, 2)
@@ -3143,6 +3166,7 @@ async def test_client_replicate(c, s, *workers):
 @gen_cluster(
     client=True,
     nthreads=[("127.0.0.1", 1), ("127.0.0.2", 1), ("127.0.0.2", 1)],
+    config=NO_AMM,
 )
 async def test_client_replicate_host(client, s, a, b, c):
     aws = s.workers[a.address]
@@ -3160,7 +3184,9 @@ async def test_client_replicate_host(client, s, a, b, c):
     assert s.tasks[x.key].who_has == {aws, bws, cws}
 
 
-def test_client_replicate_sync(c):
+def test_client_replicate_sync(client_no_amm):
+    c = client_no_amm
+
     x = c.submit(inc, 1)
     y = c.submit(inc, 2)
     c.replicate([x, y], n=2)
@@ -3227,7 +3253,7 @@ async def test_balanced_with_submit(c, s, *workers):
         assert len(w.data) == 1
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4, config=NO_AMM)
 async def test_balanced_with_submit_and_resident_data(c, s, *workers):
     [x] = await c.scatter([10], broadcast=True)
     L = [c.submit(slowinc, x, pure=False) for i in range(4)]
@@ -3880,7 +3906,11 @@ async def test_lose_scattered_data(c, s, a, b):
     assert x.key not in s.tasks
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
+@gen_cluster(
+    client=True,
+    nthreads=[("127.0.0.1", 1)] * 3,
+    config=NO_AMM,
+)
 async def test_partially_lose_scattered_data(e, s, a, b, c):
     x = await e.scatter(1, workers=a.address)
     await e.replicate(x, n=2)
@@ -3892,22 +3922,22 @@ async def test_partially_lose_scattered_data(e, s, a, b, c):
     assert s.get_task_status(keys=[x.key]) == {x.key: "memory"}
 
 
-@gen_cluster(client=True)
-async def test_scatter_compute_lose(c, s, a, b):
-    [x] = await c.scatter([[1, 2, 3, 4]], workers=a.address)
-    y = c.submit(inc, 1, workers=b.address)
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_scatter_compute_lose(c, s, a):
+    x = (await c.scatter({"x": 1}, workers=[a.address]))["x"]
 
-    z = c.submit(slowadd, x, y, delay=0.2)
-    await asyncio.sleep(0.1)
+    async with BlockedGatherDep(s.address) as b:
+        y = c.submit(inc, x, key="y", workers=[b.address])
+        await wait_for_state("x", "flight", b)
 
-    await a.close()
+        await a.close()
+        b.block_gather_dep.set()
 
-    with pytest.raises(CancelledError):
-        await wait(z)
+        with pytest.raises(CancelledError):
+            await wait(y)
 
-    assert x.status == "cancelled"
-    assert y.status == "finished"
-    assert z.status == "cancelled"
+        assert x.status == "cancelled"
+        assert y.status == "cancelled"
 
 
 @gen_cluster(client=True)
@@ -4092,7 +4122,7 @@ async def test_as_current_is_task_local(s, a, b):
 
 
 @nodebug  # test timing is fragile
-@gen_cluster(nthreads=[("127.0.0.1", 1)] * 3, client=True)
+@gen_cluster(nthreads=[("127.0.0.1", 1)] * 3, client=True, config=NO_AMM)
 async def test_persist_workers_annotate(e, s, a, b, c):
     with dask.annotate(workers=a.address, allow_other_workers=False):
         L1 = [delayed(inc)(i) for i in range(4)]
@@ -4299,10 +4329,13 @@ async def test_weight_occupancy_against_data_movement(c, s, a, b):
 @gen_cluster(
     client=True,
     nthreads=[("127.0.0.1", 1), ("127.0.0.1", 10)],
-    config={
-        "distributed.scheduler.work-stealing": False,
-        "distributed.scheduler.default-task-durations": {"f": "10ms"},
-    },
+    config=merge(
+        NO_AMM,
+        {
+            "distributed.scheduler.work-stealing": False,
+            "distributed.scheduler.default-task-durations": {"f": "10ms"},
+        },
+    ),
 )
 async def test_distribute_tasks_by_nthreads(c, s, a, b):
     def f(x, y=0):
@@ -5845,7 +5878,7 @@ async def test_scatter_error_cancel(c, s, a, b):
 @gen_cluster(
     client=True,
     nthreads=[("", 1)] * 10,
-    config={"distributed.worker.memory.pause": False},
+    config=merge(NO_AMM, {"distributed.worker.memory.pause": False}),
 )
 async def test_scatter_and_replicate_avoid_paused_workers(
     c, s, *workers, workers_arg, direct, broadcast

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -7,10 +7,13 @@ from contextlib import suppress
 from time import sleep
 from unittest import mock
 
+import psutil
 import pytest
-from tlz import first, partition_all
+from tlz import first, merge, partition_all
 
+import dask.config
 from dask import delayed
+from dask.utils import parse_bytes
 
 from distributed import Client, Nanny, profile, wait
 from distributed.comm import CommClosedError
@@ -18,6 +21,7 @@ from distributed.compatibility import MACOS
 from distributed.metrics import time
 from distributed.utils import CancelledError, sync
 from distributed.utils_test import (
+    NO_AMM,
     BlockedGatherDep,
     BlockedGetData,
     async_wait_for,
@@ -235,7 +239,8 @@ async def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
     y = c.submit(inc, 1)
     del x
 
-    # Ensure that the profiler has stopped and released all references to x so that it can be garbage-collected
+    # Ensure that the profiler has stopped and released all references to x so that it
+    # can be garbage-collected
     with profile.lock:
         pass
     await asyncio.sleep(0.1)
@@ -305,16 +310,11 @@ class SlowTransmitData:
         self.data = data
 
     def __reduce__(self):
-        import time
-
-        time.sleep(self.delay)
-        return (SlowTransmitData, (self.delay,))
+        sleep(self.delay)
+        return SlowTransmitData, (self.data, self.delay)
 
     def __sizeof__(self) -> int:
         # Ensure this is offloaded to avoid blocking loop
-        import dask
-        from dask.utils import parse_bytes
-
         return parse_bytes(dask.config.get("distributed.comm.offload")) + 1
 
 
@@ -357,6 +357,7 @@ async def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
 @gen_cluster(
     client=True,
     nthreads=[("127.0.0.1", 1), ("127.0.0.1", 2), ("127.0.0.1", 3)],
+    config=NO_AMM,
 )
 async def test_worker_same_host_replicas_missing(c, s, a, b, x):
     # See GH4784
@@ -462,11 +463,11 @@ async def test_forget_data_not_supposed_to_have(c, s, a):
 
 @gen_cluster(
     client=True,
-    nthreads=[("127.0.0.1", 1) for _ in range(3)],
-    config={"distributed.comm.timeouts.connect": "1s"},
+    nthreads=[("", 1)] * 3,
+    config=merge(NO_AMM, {"distributed.comm.timeouts.connect": "1s"}),
     Worker=Nanny,
 )
-async def test_failing_worker_with_additional_replicas_on_cluster(c, s, *workers):
+async def test_failing_worker_with_additional_replicas_on_cluster(c, s, n0, n1, n2):
     """
     If a worker detects a missing dependency, the scheduler is notified. If no
     other replica is available, the dependency is rescheduled. A reschedule
@@ -475,34 +476,33 @@ async def test_failing_worker_with_additional_replicas_on_cluster(c, s, *workers
     and correct its state.
     """
 
-    def slow_transfer(x, delay=0.1):
-        return SlowTransmitData(x, delay=delay)
-
     def dummy(*args, **kwargs):
         return
 
-    import psutil
-
-    proc = psutil.Process(workers[1].pid)
+    proc1 = psutil.Process(n1.pid)
     f1 = c.submit(
-        slow_transfer,
+        SlowTransmitData,
         1,
+        delay=0.1,
         key="f1",
-        workers=[workers[0].worker_address],
+        workers=[n0.worker_address],
     )
+    await wait(f1)
+
     # We'll schedule tasks on two workers, s.t. f1 is replicated. We will
     # suspend one of the workers and kill the origin worker of f1 such that a
     # comm failure causes the worker to handle a missing dependency. It will ask
     # the schedule such that it knows that a replica is available on f2 and
     # reschedules the fetch
-    f2 = c.submit(dummy, f1, pure=False, key="f2", workers=[workers[1].worker_address])
-    f3 = c.submit(dummy, f1, pure=False, key="f3", workers=[workers[2].worker_address])
+    f2 = c.submit(dummy, f1, key="f2", workers=[n1.worker_address])
+    f3 = c.submit(dummy, f1, key="f3", workers=[n2.worker_address])
 
-    await wait(f1)
-    proc.suspend()
+    proc1.suspend()
 
     await wait(f3)
-    await workers[0].close()
+    # Because of this line we need to disable AMM; otherwise it could choose to delete
+    # the replicas of f1 on n1 and n2 and keep the one on n0.
+    await n0.close()
 
-    proc.resume()
+    proc1.resume()
     await c.gather([f1, f2, f3])

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -10,7 +10,7 @@ from dask.utils import stringify
 
 from distributed import Lock, Worker
 from distributed.client import wait
-from distributed.utils_test import gen_cluster, inc, lock_inc, slowadd, slowinc
+from distributed.utils_test import NO_AMM, gen_cluster, inc, lock_inc, slowadd, slowinc
 from distributed.worker_state_machine import (
     ComputeTaskEvent,
     Execute,
@@ -133,23 +133,20 @@ async def test_map(c, s, a, b):
 
 @gen_cluster(
     client=True,
-    nthreads=[
-        ("127.0.0.1", 1, {"resources": {"A": 1}}),
-        ("127.0.0.1", 1, {"resources": {"B": 1}}),
-    ],
+    nthreads=[("", 1, {"resources": {"A": 1}}), ("", 1, {"resources": {"B": 1}})],
+    config=NO_AMM,
 )
 async def test_persist(c, s, a, b):
     with dask.annotate(resources={"A": 1}):
-        x = delayed(inc)(1)
+        x = delayed(inc)(1, dask_key_name="x")
     with dask.annotate(resources={"B": 1}):
-        y = delayed(inc)(x)
+        y = delayed(inc)(x, dask_key_name="y")
 
     xx, yy = c.persist([x, y], optimize_graph=False)
-
     await wait([xx, yy])
 
-    assert x.key in a.data
-    assert y.key in b.data
+    assert set(a.data) == {"x"}
+    assert set(b.data) == {"x", "y"}
 
 
 @gen_cluster(

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -43,6 +43,7 @@ from distributed.protocol.pickle import dumps, loads
 from distributed.scheduler import KilledWorker, MemoryState, Scheduler, WorkerState
 from distributed.utils import TimeoutError
 from distributed.utils_test import (
+    NO_AMM,
     BrokenComm,
     async_wait_for,
     captured_logger,
@@ -1344,7 +1345,7 @@ async def test_workers_to_close_grouped(c, s, *workers):
     # Assert that *total* byte count in group determines group priority
     av = await c.scatter("a" * 100, workers=workers[0].address)
     bv = await c.scatter("b" * 75, workers=workers[2].address)
-    bv2 = await c.scatter("b" * 75, workers=workers[3].address)
+    cv = await c.scatter("c" * 75, workers=workers[3].address)
 
     assert set(s.workers_to_close(key=key)) == {workers[0].address, workers[1].address}
 
@@ -1887,7 +1888,7 @@ async def test_retries(c, s, a, b):
     exc_info.match("one")
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3, config=NO_AMM)
 async def test_missing_data_errant_worker(c, s, w1, w2, w3):
     with dask.config.set({"distributed.comm.timeouts.connect": "1s"}):
         np = pytest.importorskip("numpy")
@@ -2415,7 +2416,7 @@ class NoSchedulerDelayWorker(Worker):
         pass
 
 
-@gen_cluster(client=True, Worker=NoSchedulerDelayWorker)
+@gen_cluster(client=True, Worker=NoSchedulerDelayWorker, config=NO_AMM)
 async def test_task_groups(c, s, a, b):
     start = time()
     da = pytest.importorskip("dask.array")
@@ -3106,7 +3107,7 @@ async def assert_ndata(client, by_addr, total=None):
     client=True,
     Worker=Nanny,
     worker_kwargs={"memory_limit": "1 GiB"},
-    config={"distributed.worker.memory.rebalance.sender-min": 0.3},
+    config=merge(NO_AMM, {"distributed.worker.memory.rebalance.sender-min": 0.3}),
 )
 async def test_rebalance(c, s, a, b):
     # We used nannies to have separate processes for each worker
@@ -3136,11 +3137,14 @@ async def test_rebalance(c, s, a, b):
 # Set rebalance() to work predictably on small amounts of managed memory. By default, it
 # uses optimistic memory, which would only be possible to test by allocating very large
 # amounts of managed memory, so that they would hide variations in unmanaged memory.
-REBALANCE_MANAGED_CONFIG = {
-    "distributed.worker.memory.rebalance.measure": "managed",
-    "distributed.worker.memory.rebalance.sender-min": 0,
-    "distributed.worker.memory.rebalance.sender-recipient-gap": 0,
-}
+REBALANCE_MANAGED_CONFIG = merge(
+    NO_AMM,
+    {
+        "distributed.worker.memory.rebalance.measure": "managed",
+        "distributed.worker.memory.rebalance.sender-min": 0,
+        "distributed.worker.memory.rebalance.sender-recipient-gap": 0,
+    },
+)
 
 
 @gen_cluster(client=True, config=REBALANCE_MANAGED_CONFIG)
@@ -3173,14 +3177,14 @@ async def test_rebalance_workers_and_keys(client, s, a, b, c):
         await s.rebalance(workers=["notexist"])
 
 
-@gen_cluster()
+@gen_cluster(config=NO_AMM)
 async def test_rebalance_missing_data1(s, a, b):
     """key never existed"""
     out = await s.rebalance(keys=["notexist"])
     assert out == {"status": "partial-fail", "keys": ["notexist"]}
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_rebalance_missing_data2(c, s, a, b):
     """keys exist but belong to unfinished futures. Unlike Client.rebalance(),
     Scheduler.rebalance() does not wait for unfinished futures.
@@ -3229,7 +3233,7 @@ async def test_rebalance_no_workers(s):
 @gen_cluster(
     client=True,
     worker_kwargs={"memory_limit": 0},
-    config={"distributed.worker.memory.rebalance.measure": "managed"},
+    config=merge(NO_AMM, {"distributed.worker.memory.rebalance.measure": "managed"}),
 )
 async def test_rebalance_no_limit(c, s, a, b):
     futures = await c.scatter(range(100), workers=[a.address])
@@ -3245,11 +3249,14 @@ async def test_rebalance_no_limit(c, s, a, b):
     client=True,
     Worker=Nanny,
     worker_kwargs={"memory_limit": "1000 MiB"},
-    config={
-        "distributed.worker.memory.rebalance.measure": "managed",
-        "distributed.worker.memory.rebalance.sender-min": 0.2,
-        "distributed.worker.memory.rebalance.recipient-max": 0.1,
-    },
+    config=merge(
+        NO_AMM,
+        {
+            "distributed.worker.memory.rebalance.measure": "managed",
+            "distributed.worker.memory.rebalance.sender-min": 0.2,
+            "distributed.worker.memory.rebalance.recipient-max": 0.1,
+        },
+    ),
 )
 async def test_rebalance_no_recipients(c, s, a, b):
     """There are sender workers, but no recipient workers"""
@@ -3267,7 +3274,7 @@ async def test_rebalance_no_recipients(c, s, a, b):
     nthreads=[("", 1)] * 3,
     client=True,
     worker_kwargs={"memory_limit": 0},
-    config={"distributed.worker.memory.rebalance.measure": "managed"},
+    config=merge(NO_AMM, {"distributed.worker.memory.rebalance.measure": "managed"}),
 )
 async def test_rebalance_skip_recipient(client, s, a, b, c):
     """A recipient is skipped because it already holds a copy of the key to be sent"""
@@ -3282,7 +3289,7 @@ async def test_rebalance_skip_recipient(client, s, a, b, c):
 @gen_cluster(
     client=True,
     worker_kwargs={"memory_limit": 0},
-    config={"distributed.worker.memory.rebalance.measure": "managed"},
+    config=merge(NO_AMM, {"distributed.worker.memory.rebalance.measure": "managed"}),
 )
 async def test_rebalance_skip_all_recipients(c, s, a, b):
     """All recipients are skipped because they already hold copies"""
@@ -3298,7 +3305,7 @@ async def test_rebalance_skip_all_recipients(c, s, a, b):
     client=True,
     Worker=Nanny,
     worker_kwargs={"memory_limit": "1000 MiB"},
-    config={"distributed.worker.memory.rebalance.measure": "managed"},
+    config=merge(NO_AMM, {"distributed.worker.memory.rebalance.measure": "managed"}),
 )
 async def test_rebalance_sender_below_mean(c, s, *_):
     """A task remains on the sender because moving it would send it below the mean"""
@@ -3317,10 +3324,13 @@ async def test_rebalance_sender_below_mean(c, s, *_):
     client=True,
     Worker=Nanny,
     worker_kwargs={"memory_limit": "1000 MiB"},
-    config={
-        "distributed.worker.memory.rebalance.measure": "managed",
-        "distributed.worker.memory.rebalance.sender-min": 0.3,
-    },
+    config=merge(
+        NO_AMM,
+        {
+            "distributed.worker.memory.rebalance.measure": "managed",
+            "distributed.worker.memory.rebalance.sender-min": 0.3,
+        },
+    ),
 )
 async def test_rebalance_least_recently_inserted_sender_min(c, s, *_):
     """
@@ -3423,7 +3433,7 @@ async def test_gather_on_worker_key_not_on_sender_replicated(
     assert c.data[x.key] == "x"
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3)
+@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 3, config=NO_AMM)
 async def test_gather_on_worker_duplicate_task(client, s, a, b, c):
     """Race condition where the recipient worker receives the same task twice.
     Test that the task nbytes are not double-counted on the recipient.
@@ -3448,7 +3458,10 @@ async def test_gather_on_worker_duplicate_task(client, s, a, b, c):
 
 
 @gen_cluster(
-    client=True, nthreads=[("127.0.0.1", 1)] * 3, scheduler_kwargs={"timeout": "100ms"}
+    client=True,
+    nthreads=[("127.0.0.1", 1)] * 3,
+    scheduler_kwargs={"timeout": "100ms"},
+    config=NO_AMM,
 )
 async def test_rebalance_dead_recipient(client, s, a, b, c):
     """A key fails to be rebalanced due to recipient failure.
@@ -3473,7 +3486,7 @@ async def test_rebalance_dead_recipient(client, s, a, b, c):
     assert await client.has_what() == {a.address: (y.key,), b.address: (x.key,)}
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_delete_worker_data(c, s, a, b):
     # delete only copy of x
     # delete one of the copies of y

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -557,8 +557,9 @@ async def test_release_retry(c, s, a, b):
     },
 )
 async def test_release_failure(c, s, a, b):
-    """Don't raise even if release fails: lease will be cleaned up by the lease-validation after
-    a specified interval anyways (see config parameters used)."""
+    """Don't raise even if release fails: lease will be cleaned up by the
+    lease-validation after a specified interval anyway (see config parameters used).
+    """
 
     with dask.config.set({"distributed.comm.retry.count": 1}):
         pool = await FlakyConnectionPool(failing_connections=5)

--- a/distributed/tests/test_stories.py
+++ b/distributed/tests/test_stories.py
@@ -6,7 +6,13 @@ import dask
 
 from distributed import Worker
 from distributed.comm import CommClosedError
-from distributed.utils_test import assert_story, assert_valid_story, gen_cluster, inc
+from distributed.utils_test import (
+    NO_AMM,
+    assert_story,
+    assert_valid_story,
+    gen_cluster,
+    inc,
+)
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
@@ -124,7 +130,7 @@ async def test_client_story_failed_worker(c, s, a, b, on_error):
         raise ValueError(on_error)
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_worker_story_with_deps(c, s, a, b):
     """
     Assert that the structure of the story does not change unintentionally and

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -17,6 +17,7 @@ from distributed.compatibility import WINDOWS
 from distributed.metrics import time
 from distributed.utils import CancelledError
 from distributed.utils_test import (
+    NO_AMM,
     bump_rlimit,
     cluster,
     gen_cluster,
@@ -122,7 +123,11 @@ async def test_stress_creation_and_deletion(c, s):
         assert await c.compute(z) == 8000884.93
 
 
-@gen_cluster(nthreads=[("", 1)] * 10, client=True)
+@gen_cluster(
+    nthreads=[("", 1)] * 10,
+    client=True,
+    config=NO_AMM,
+)
 async def test_stress_scatter_death(c, s, *workers):
     s.allowed_failures = 1000
     np = pytest.importorskip("numpy")

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -6,10 +6,13 @@ from __future__ import annotations
 
 import asyncio
 
+from tlz import merge
+
 from distributed import Client, Nanny, Queue, Scheduler, Worker, wait, worker_client
 from distributed.core import Status
 from distributed.metrics import time
 from distributed.utils_test import (
+    NO_AMM,
     double,
     gen_test,
     gen_tls_cluster,
@@ -101,11 +104,14 @@ async def test_nanny(c, s, a, b):
 
 @gen_tls_cluster(
     client=True,
-    config={
-        "distributed.worker.memory.rebalance.measure": "managed",
-        "distributed.worker.memory.rebalance.sender-min": 0,
-        "distributed.worker.memory.rebalance.sender-recipient-gap": 0,
-    },
+    config=merge(
+        NO_AMM,
+        {
+            "distributed.worker.memory.rebalance.measure": "managed",
+            "distributed.worker.memory.rebalance.sender-min": 0,
+            "distributed.worker.memory.rebalance.sender-recipient-gap": 0,
+        },
+    ),
 )
 async def test_rebalance(c, s, a, b):
     """Test Client.rebalance(). This test is just to test the TLS Client wrapper around

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -11,6 +11,7 @@ from time import sleep
 
 import psutil
 import pytest
+from tlz import merge
 
 import dask.config
 
@@ -20,7 +21,13 @@ from distributed.compatibility import MACOS, WINDOWS
 from distributed.core import Status
 from distributed.metrics import monotonic
 from distributed.spill import has_zict_210
-from distributed.utils_test import captured_logger, gen_cluster, inc, wait_for_state
+from distributed.utils_test import (
+    NO_AMM,
+    captured_logger,
+    gen_cluster,
+    inc,
+    wait_for_state,
+)
 from distributed.worker_memory import parse_memory_limit
 from distributed.worker_state_machine import (
     ComputeTaskEvent,
@@ -589,11 +596,14 @@ async def test_pause_executor_with_memory_monitor(c, s, a):
 @gen_cluster(
     client=True,
     nthreads=[("", 1), ("", 1)],
-    config={
-        "distributed.worker.memory.target": False,
-        "distributed.worker.memory.spill": False,
-        "distributed.worker.memory.pause": False,
-    },
+    config=merge(
+        NO_AMM,
+        {
+            "distributed.worker.memory.target": False,
+            "distributed.worker.memory.spill": False,
+            "distributed.worker.memory.pause": False,
+        },
+    ),
 )
 async def test_pause_prevents_deps_fetch(c, s, a, b):
     """A worker is paused while there are dependencies ready to fetch, but all other

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -17,6 +17,7 @@ from distributed.protocol.serialize import Serialize
 from distributed.scheduler import TaskState as SchedulerTaskState
 from distributed.utils import recursive_to_dict
 from distributed.utils_test import (
+    NO_AMM,
     _LockedCommPool,
     assert_story,
     freeze_data_fetching,
@@ -598,7 +599,11 @@ async def test_fetch_via_amm_to_compute(c, s, a, b):
 
 
 @pytest.mark.parametrize("as_deps", [False, True])
-@gen_cluster(client=True, nthreads=[("", 1)] * 3)
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)] * 3,
+    config=NO_AMM,
+)
 async def test_lose_replica_during_fetch(c, s, w1, w2, w3, as_deps):
     """
     as_deps=True
@@ -779,7 +784,7 @@ async def test_cancelled_while_in_flight(c, s, a, b):
         await asyncio.sleep(0.01)
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, config=NO_AMM)
 async def test_in_memory_while_in_flight(c, s, a, b):
     """
     1. A client scatters x to a

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -112,6 +112,9 @@ logging_levels = {
 _TEST_TIMEOUT = 30
 _offload_executor.submit(lambda: None).result()  # create thread during import
 
+# Dask configuration to completely disable the Active Memory Manager.
+# This is typically used with @gen_cluster(config=NO_AMM)
+# or @gen_cluster(config=merge(NO_AMM, {<more config options})).
 NO_AMM = {"distributed.scheduler.active-memory-manager.start": False}
 
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -535,18 +535,20 @@ def client(loop, cluster_fixture):
 
 @pytest.fixture
 def client_no_amm(client):
-    """Let a sync test that relies on the Active Memory Manager (AMM) to run wether
-    the AMM is enabled or not in the dask config
+    """Sync client with the Active Memory Manager (AMM) turned off.
+    This works regardless of the AMM being on or off in the dask config.
     """
     before = client.amm.running()
     if before:
         client.amm.stop()  # pragma: nocover
 
     yield client
-    assert not client.amm.running()
 
-    if before:
+    after = client.amm.running()
+    if before and not after:
         client.amm.start()  # pragma: nocover
+    elif not before and after:
+        client.amm.stop()  # pragma: nocover
 
 
 # Compatibility. A lot of tests simply use `c` as fixture name

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -550,8 +550,8 @@ def client_no_amm(client):
     after = client.amm.running()
     if before and not after:
         client.amm.start()  # pragma: nocover
-    elif not before and after:
-        client.amm.stop()  # pragma: nocover
+    elif not before and after:  # pragma: nocover
+        client.amm.stop()
 
 
 # Compatibility. A lot of tests simply use `c` as fixture name
@@ -698,7 +698,7 @@ def cluster(
                         nthreads = await s.ncores_running()
                         if len(nthreads) == nworkers:
                             break
-                        if time() - start > 5:
+                        if time() - start > 5:  # pragma: nocover
                             raise Exception("Timeout on cluster creation")
 
             _run_and_close_tornado(wait_for_workers)

--- a/docs/source/active_memory_manager.rst
+++ b/docs/source/active_memory_manager.rst
@@ -27,7 +27,8 @@ causes increased overall memory usage across the cluster.
 
 Enabling the Active Memory Manager
 ----------------------------------
-The AMM can be enabled through the :doc:`Dask configuration file <configuration>`:
+The AMM is enabled by default. It can be disabled or tweaked through the :doc:`Dask
+configuration file <configuration>`:
 
 .. code-block:: yaml
 
@@ -94,6 +95,9 @@ config and see if it is fit for purpose for you before you tweak individual poli
 
 Built-in policies
 -----------------
+
+.. _ReduceReplicas:
+
 ReduceReplicas
 ++++++++++++++
 class
@@ -112,6 +116,30 @@ computation, this policy drops all excess replicas.
    run this policy, it will delete all replicas but one (but not necessarily the new
    ones).
 
+RetireWorker
+++++++++++++
+class
+    :class:`distributed.active_memory_manager.RetireWorker`
+parameters
+    address : str
+        The address of the worker being retired.
+
+This is a special policy, which should never appear in the Dask configuration file.
+
+It is injected on the fly by :meth:`distributed.Client.retire_workers` and whenever
+an adaptive cluster is being scaled down.
+This policy supervises moving all tasks, that are in memory exclusively on the worker
+being retired, to different workers. Once the worker does not uniquely hold the data for
+any task, this policy uninstall itself automatically from the Active Memory Manager and
+the worker is shut down.
+
+If multiple workers are being retired at the same time, there will be multiple instances
+of this policy installed in the AMM.
+
+If the Active Memory Manager is disabled, :meth:`distributed.Client.retire_workers` and
+adaptive scaling will start a temporary one, install this policy into it, and then shut
+it down once it's finished.
+
 
 Custom policies
 ---------------
@@ -126,7 +154,8 @@ define two methods:
 ``run``
     This method accepts no parameters and is invoked by the AMM every 2 seconds (or
     whatever the AMM interval is).
-    It must yield zero or more of the following :class:`~distributed.active_memory_manager.Suggestion` namedtuples:
+    It must yield zero or more of the following
+    :class:`~distributed.active_memory_manager.Suggestion` namedtuples:
 
     ``yield Suggestion("replicate", <TaskState>)``
         Create one replica of the target task on the worker with the lowest memory usage

--- a/docs/source/active_memory_manager.rst
+++ b/docs/source/active_memory_manager.rst
@@ -132,7 +132,7 @@ It is injected on the fly by :meth:`distributed.Client.retire_workers` and whene
 an adaptive cluster is being scaled down.
 This policy supervises moving all tasks, that are in memory exclusively on the worker
 being retired, to different workers. Once the worker does not uniquely hold the data for
-any task, this policy uninstall itself automatically from the Active Memory Manager and
+any task, this policy uninstalls itself automatically from the Active Memory Manager and
 the worker is shut down.
 
 If multiple workers are being retired at the same time, there will be multiple instances

--- a/docs/source/resilience.rst
+++ b/docs/source/resilience.rst
@@ -48,12 +48,13 @@ This has some fail cases.
     causes a segmentation fault, then that bad function will repeatedly be
     called on other workers.  This function will be marked as "bad" after it
     kills a fixed number of workers (defaults to three).
-3.  Data sent out directly to the workers via a call to ``scatter()`` (instead
-    of being created from a Dask task graph via other Dask functions) is not
-    kept in the scheduler, as it is often quite large, and so the loss of this
-    data is irreparable.  You may wish to call ``Client.replicate`` on the data
-    with a suitable replication factor to ensure that it remains long-lived or
-    else back the data off of some resilient store, like a file system.
+3.  Data sent out directly to the workers via a call to
+    :meth:`~distributed.client.Client.scatter` (instead of being created from a Dask
+    task graph via other Dask functions) is not kept in the scheduler, as it is often
+    quite large, and so the loss of this data is irreparable. You may wish to call
+    :meth:`~distributed.client.Client.replicate` on the data with a suitable replication
+    factor to ensure that it remains long-lived or else back the data off of some
+    resilient store, like a file system.
 
 
 Hardware Failures

--- a/docs/source/resilience.rst
+++ b/docs/source/resilience.rst
@@ -53,7 +53,7 @@ This has some fail cases.
     task graph via other Dask functions) is not kept in the scheduler, as it is often
     quite large, and so the loss of this data is irreparable. You may wish to call
     :meth:`~distributed.client.Client.replicate` on the data with a suitable replication
-    factor to ensure that it remains long-lived or else back the data off of some
+    factor to ensure that it remains long-lived or else back the data off on some
     resilient store, like a file system.
 
 


### PR DESCRIPTION
This PR
- enables the AMM ReduceReplicas policy globally
- changes client.retire_workers and adaptive downscaling from spinning up a temporary AMM instance to using the permanent one.
- explicitly disables AMM in 80 tests that perform assertions around replicas, call replicate() or scatter(broadcast=True), etc.

Evidence that the Active Memory Manager is universally desirable:
https://github.com/coiled/coiled-runtime/issues/140