### PR TITLE
Improve `KilledWorker` message users see

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8224,7 +8224,7 @@ class KilledWorker(Exception):
     def __str__(self) -> str:
         return (
             f"Attempted to run task {self.task} on {self.allowed_failures} different "
-            "workers but was unsuccessful. The last worker to attempt to run the task was "
+            "workers but was unsuccessful. The last worker that attempt to run the task was "
             f"{self.last_worker.address}. Inspecting worker logs is often a good next step "
             "to diagnose what went wrong. For more information see "
             "https://distributed.dask.org/en/stable/killed.html."

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8224,7 +8224,7 @@ class KilledWorker(Exception):
     def __str__(self) -> str:
         return (
             f"Attempted to run task {self.task} on {self.allowed_failures} different "
-            "workers but was unsuccessful. The last worker that attempt to run the task was "
+            "workers but was unsuccessful. The last worker that attempted to run the task was "
             f"{self.last_worker.address}. Inspecting worker logs is often a good next step "
             "to diagnose what went wrong. For more information see "
             "https://distributed.dask.org/en/stable/killed.html."

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8224,10 +8224,10 @@ class KilledWorker(Exception):
     def __str__(self) -> str:
         return (
             f"Attempted to run task {self.task} on {self.allowed_failures} different "
-            "workers but was unsuccessful. The last worker that attempted to run the task was "
-            f"{self.last_worker.address}. Inspecting worker logs is often a good next step "
-            "to diagnose what went wrong. For more information see "
-            "https://distributed.dask.org/en/stable/killed.html."
+            "workers, but all those workers died while running it. "
+            f"The last worker that attempt to run the task was {self.last_worker.address}. "
+            "Inspecting worker logs is often a good next step to diagnose what went wrong. "
+            "For more information see https://distributed.dask.org/en/stable/killed.html."
         )
 
 


### PR DESCRIPTION
`KilledWorker` errors can be confusing for users. I've seen users get stuck not knowing what to do next or how to figure out what went wrong. I think we can improve the message that users see when a `KilledWorker` error happens.

For example, today users see a message like:

```
distributed.scheduler.KilledWorker: ('lambda-cb8ded4d38da167aa54baad8748eeb0e', <WorkerState
'tcp://192.168.1.163:52441', status: closed, memory: 0, processing: 1>)
```

This PR updates that message to be something like the following:

```
distributed.scheduler.KilledWorker: Attempted to run task lambda-cb8ded4d38da167aa54baad8748eeb0e
on 3 different workers but was unsuccessful. The last worker to attempt to run the task
was tcp://192.168.1.163:52408. Inspecting worker logs is often a good next step to diagnose what
went wrong. For more information see https://distributed.dask.org/en/stable/killed.html.
```

Just pushing up a quick WIP PR for early feedback

cc @ian-r-rose @gjoseph92 who may have thoughts

EDIT: I like the new message because it both gives more context about what happened on the cluster and gives a next step for users to try (e.g. look at worker logs or the relevant documentation page)