### PR TITLE
Add factorization utility

### DIFF
--- a/distributed/deploy/utils.py
+++ b/distributed/deploy/utils.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import math
 
 from dask.system import CPU_COUNT
-from dask.utils import factors
+
+
+def _factors(n: int) -> set[int]:
+    """Return the factors of an integer
+    https://stackoverflow.com/a/6800214/616616
+    """
+    seq = ([i, n // i] for i in range(1, int(pow(n, 0.5) + 1)) if n % i == 0)
+    return {j for item in seq for j in item}
 
 
 def nprocesses_nthreads(n=CPU_COUNT):
@@ -29,6 +36,6 @@ def nprocesses_nthreads(n=CPU_COUNT):
     if n <= 4:
         processes = n
     else:
-        processes = min(f for f in factors(n) if f >= math.sqrt(n))
+        processes = min(f for f in _factors(n) if f >= math.sqrt(n))
     threads = n // processes
     return (processes, threads)


### PR DESCRIPTION
In https://github.com/dask/dask/pull/9507 we're removing the `factors` utility from `dask/dask`. This PR moves that logic into `distributed` since it's used in `nprocesses_nthreads`

cc @ian-r-rose 