### PR TITLE
Allow tornado 6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1
 tblib >= 1.6.0
 toolz >= 0.8.2
-tornado >= 6.0.3, <6.2
+tornado >= 6.0.3, < 6.3
 urllib3
 zict >= 0.1.3
 pyyaml


### PR DESCRIPTION
Trying to upgrade to tornado 6.2. Latest tornado upgrade dates back to 2019: #2547. 
