### PR TITLE
Fix pre-commit fails with recent versions of mypy and pandas

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -11,6 +11,8 @@ jobs:
     name: pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,13 @@ repos:
       - id: isort
         language_version: python3
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v2.38.2
     hooks:
       - id: pyupgrade
         args:
           - --py38-plus
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black
         language_version: python3
@@ -33,7 +33,7 @@ repos:
         additional_dependencies:
         # NOTE: autoupdate does not pick up flake8-bugbear since it is a transitive
         #  dependency. Make sure to update flake8-bugbear manually on a regular basis.
-          - flake8-bugbear==22.7.1
+          - flake8-bugbear==22.9.23
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.971
     hooks:
@@ -43,7 +43,7 @@ repos:
         args: [--warn-unused-configs]
         additional_dependencies:
           # Type stubs
-          - pandas-stubs >=1.4.3.220704
+          - pandas-stubs
           - types-docutils
           - types-requests
           - types-paramiko
@@ -55,6 +55,8 @@ repos:
           - dask
           - numpy
           - pytest
-          - tornado >=6.2
+          - tornado
           - zict
           - pyarrow
+
+# Increase this by 1 to force-wipe the pre-commit github action cache: 1

--- a/distributed/diagnostics/memory_sampler.py
+++ b/distributed/diagnostics/memory_sampler.py
@@ -4,7 +4,7 @@ import uuid
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from tornado.ioloop import PeriodicCallback
 
@@ -142,7 +142,7 @@ class MemorySampler:
             s.name = label
             if align:
                 # convert datetime to timedelta from the first sample
-                s.index -= s.index[0]
+                s.index -= cast(pd.Timestamp, s.index[0])
             ss[label] = s
 
         df = pd.DataFrame(ss)


### PR DESCRIPTION
1. Fix:
> /home/runner/.cache/pre-commit/repobd6_h4eo/py_env-python3.10/lib/python3.10/site-packages/numpy/__init__.pyi:636:
> error: Positional-only parameters are only supported in Python 3.8 and greater  [syntax]


2. Fix mypy failure in memory-sampler.py after upgrading to pandas-1.5.0.
