### PR TITLE
Nanny(config=...) parameter should overlay global dask config

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -230,7 +230,7 @@ class Nanny(ServerNode):
             {k: str(v) for k, v in env.items()} if env else {},
         )
 
-        self.config = config or dask.config.config
+        self.config = merge(dask.config.config, config or {})
         worker_kwargs.update(
             {
                 "port": worker_port,

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -350,6 +350,15 @@ async def test_environment_variable_pre_post_spawn(c, s, n):
     assert "POST-SPAWN" not in os.environ
 
 
+@gen_cluster(client=True, nthreads=[])
+async def test_config_param_overlays(c, s):
+    with dask.config.set({"test123.foo": 1, "test123.bar": 2}):
+        async with Nanny(s.address, config={"test123.bar": 3, "test123.baz": 4}) as n:
+            out = await c.submit(lambda: dask.config.get("test123"))
+
+    assert out == {"foo": 1, "bar": 3, "baz": 4}
+
+
 @gen_cluster(nthreads=[])
 async def test_local_directory(s):
     with tmpfile() as fn:


### PR DESCRIPTION
As discussed in https://github.com/dask/distributed/pull/7028#issuecomment-1256814311