### PR TITLE
[DNM] Scheduler: process new recommendations immediately

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1705,6 +1705,10 @@ class SchedulerState:
             new = self._transition(key, finish, stimulus_id)
             new_recs, new_cmsgs, new_wmsgs = new
 
+            # Put recommendations at end of dict, so they're processed in the next cycle
+            for k in new_recs:
+                if k != key:
+                    recommendations.pop(k, None)
             recommendations.update(new_recs)
             for c, new_msgs in new_cmsgs.items():
                 msgs = client_msgs.get(c)


### PR DESCRIPTION
Testing this change in CI to see what fails. Subtle but significant: _all_ recommendations from a transition move to the front of the recommendations queue. Previously, only recommendations for the current key, or for keys with no recommendations yet, would be processed on the next cycles. If a key already had a recommendation, the recommendation would be updated, but still processed in the original (priority) order.

If this works, it could be used for co-assignment with queuing.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
