### PR TITLE
Improve documentation of `message-bytes-limit`

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -349,7 +349,12 @@ properties:
                   - string
                   - integer
                 description: |
-                  The maximum size of a message sent between workers
+                  The maximum amount of data for a worker to request from another in a single ``GatherDep``
+
+                  Tasks are gathered in batches, and if the first task in a batch is larger than this value,
+                  the task will still be gathered to ensure progress. Hence, this limit is not absolute. 
+                  Note that this limit applies to a single ``GatherDep`` and a worker may gather data from 
+                  multiple workers in parallel.
           connections:
             type: object
             description: |

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -349,11 +349,11 @@ properties:
                   - string
                   - integer
                 description: |
-                  The maximum amount of data for a worker to request from another in a single gather operation.
+                  The maximum amount of data for a worker to request from another in a single gather operation
 
                   Tasks are gathered in batches, and if the first task in a batch is larger than this value,
                   the task will still be gathered to ensure progress. Hence, this limit is not absolute. 
-                  Note that this limit applies to a single gather operation and a worker may gather data from 
+                  Note that this limit applies to a single gather operation and a worker may gather data from
                   multiple workers in parallel.
           connections:
             type: object

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -349,11 +349,11 @@ properties:
                   - string
                   - integer
                 description: |
-                  The maximum amount of data for a worker to request from another in a single ``GatherDep``
+                  The maximum amount of data for a worker to request from another in a single gather operation.
 
                   Tasks are gathered in batches, and if the first task in a batch is larger than this value,
                   the task will still be gathered to ensure progress. Hence, this limit is not absolute. 
-                  Note that this limit applies to a single ``GatherDep`` and a worker may gather data from 
+                  Note that this limit applies to a single gather operation and a worker may gather data from 
                   multiple workers in parallel.
           connections:
             type: object

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1547,7 +1547,7 @@ class WorkerState:
 
             # A single invocation of _ensure_communicating may generate up to one
             # GatherDep instruction per worker. Multiple tasks from the same worker may
-            # be clustered in the same instruction by _select_keys_for_gather. But once
+            # be batched in the same instruction by _select_keys_for_gather. But once
             # a worker has been selected for a GatherDep and added to in_flight_workers,
             # it won't be selected again until the gather completes.
             instructions.append(

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1126,10 +1126,11 @@ class WorkerState:
     #: multiple entries in :attr:`~TaskState.who_has` will appear multiple times here.
     data_needed: defaultdict[str, HeapSet[TaskState]]
 
-    #: Number of bytes to fetch from the same worker in a single call to
-    #: :meth:`BaseWorker.gather_dep`. Multiple small tasks that can be fetched from the
-    #: same worker will be clustered in a single instruction as long as their combined
-    #: size doesn't exceed this value.
+    #: Number of bytes to gather from the same worker in a single call to
+    #: :meth:`BaseWorker.gather_dep`. Multiple small tasks that can be gathered from the
+    #: same worker will be batched in a single instruction as long as their combined
+    #: size doesn't exceed this value. If the first task to be gathered exceeds this
+    # limit, it will still be gathered to ensure progress. Hence, this limit is not absolute.
     transfer_message_bytes_limit: float
 
     #: All and only tasks with ``TaskState.state == 'missing'``.


### PR DESCRIPTION
Addresses
* https://github.com/dask/distributed/pull/7074#discussion_r981070853

**Note**
It just occurred to me that it might be even better to rename `message-bytes-limit` to `gather-bytes-limit` and `transfer_message_bytes_limit` to `transfer_gather_bytes_limit` to highlight their intention, but I don't want to keep changing names all the time.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @wence-, @crusaderky 