### PR TITLE
test_serialize_numba: Workaround issue with np.empty_like in NumPy 1.23

### DIFF
--- a/distributed/protocol/tests/test_numba.py
+++ b/distributed/protocol/tests/test_numba.py
@@ -31,10 +31,8 @@ def test_serialize_numba(shape, dtype, order, serializers):
     elif serializers[0] == "dask":
         assert all(isinstance(f, memoryview) for f in frames)
 
-    hx = np.empty_like(ary)
-    hy = np.empty_like(ary)
-    x.copy_to_host(hx)
-    y.copy_to_host(hy)
+    hx = x.copy_to_host()
+    hy = y.copy_to_host()
     assert (hx == hy).all()
 
 


### PR DESCRIPTION
In NumPy 1.23, the strides of empty arrays are 0 instead of the item size, due to https://github.com/numpy/numpy/pull/21477 - however, `np.empty_like` seems to create non-zero-strided arrays from a zero-strided empty array, and copying to the host from a device array with zero strides fails a compatibility check in Numba.

This PR works around the issue by calling `copy_to_host()` with no arguments, allowing Numba to create an array on the host that is compatible with the device array - the resulting implementation is functionally equivalent and slightly simpler, so I believe this change could remain permanant rather than requiring a revert later.


- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`