### PR TITLE
Update coverage upload action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -186,7 +186,7 @@ jobs:
       #   uses: mxschmitt/action-tmate@v3
 
       - name: Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
       - name: Upload test results
         # ensure this runs even if pytest fails


### PR DESCRIPTION
v1 is apparently deprecated.

I noticed important files like scheudler.py or worker.py to be missing in the report. I have no idea if this is connected but it's worth a shot