### PR TITLE
Enable dependabot for gh actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,9 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "weekly"


### PR DESCRIPTION
This enables dependabot for GH actions. We can look into other dependabot configurations in a later PR

xref https://github.com/dask/distributed/pull/7100