### PR TITLE
Fix attribute error end cluster

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -971,9 +971,7 @@ def gen_cluster(
             @contextlib.asynccontextmanager
             async def _cluster_factory():
                 workers = []
-                s = False
                 try:
-
                     for _ in range(60):
                         try:
                             s, ws = await start_cluster(
@@ -994,11 +992,13 @@ def gen_cluster(
                         else:
                             workers[:] = ws
                             break
-                    if s is False:
+                    else:
                         raise Exception("Could not start cluster")
-                    yield s, workers
+                    try:
+                        yield s, workers
+                    finally:
+                        await end_cluster(s, workers)
                 finally:
-                    await end_cluster(s, workers)
                     await asyncio.wait_for(cleanup_global_workers(), 1)
 
             async def async_fn():


### PR DESCRIPTION
test_chaos_rechunk is occasionally running into failure during gen_cluster startup.

There are two problems with this

- Upon failure it raises an AttributeError because the scheduler is still the literal `False` when trying to call end_cluster
- I noticed that if we're retrying the cluster creation, there may be unclosed, dangling schedulers and/or workers that were created in start_cluster. I replaced this with an asyncexiststack