### PR TITLE
Expose managed/unmanaged/spilled memory to Prometheus

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3510,7 +3510,11 @@ class WorkerTable(DashboardComponent):
         "in_memory",
         "ready",
         "time",
-        "spilled_nbytes",
+        # Use scheduler.WorkerState.memory.managed instead of
+        # scheduler.WorkerState.metrics["managed_bytes"]; the two measures are slightly
+        # different. See explanation in scheduler.WorkerState.memory().
+        "managed_bytes",
+        "spilled_bytes",
     }
 
     def __init__(self, scheduler, width=800, **kwargs):

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -71,7 +71,7 @@ class WorkerMetricCollector(PrometheusCollector):
             labels=["type"],
         )
         memory.add_metric(["managed"], managed_memory)
-        memory.add_metric(["unmanaged"], max(0, process_memory - managed_memory))
+        memory.add_metric(["unmanaged"], process_memory - managed_memory)
         memory.add_metric(["spilled"], spilled_disk)
         yield memory
 

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -66,7 +66,7 @@ class WorkerMetricCollector(PrometheusCollector):
         process_memory = self.server.monitor.get_process_memory()
 
         memory = GaugeMetricFamily(
-            self.build_name("memory"),
+            self.build_name("memory_bytes"),
             "Memory breakdown",
             labels=["type"],
         )

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -62,8 +62,8 @@ class WorkerMetricCollector(PrometheusCollector):
             spilled_memory, spilled_disk = self.server.data.spilled_total
         except AttributeError:
             spilled_memory, spilled_disk = 0, 0  # spilling is disabled
-        managed_memory = self.server.state.nbytes - spilled_memory
         process_memory = self.server.monitor.get_process_memory()
+        managed_memory = min(process_memory, self.server.state.nbytes - spilled_memory)
 
         memory = GaugeMetricFamily(
             self.build_name("memory_bytes"),

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -23,7 +23,7 @@ async def test_prometheus(c, s, a):
         "dask_worker_concurrent_fetch_requests",
         "dask_worker_threads",
         "dask_worker_latency_seconds",
-        "dask_worker_memory",
+        "dask_worker_memory_bytes",
         "dask_worker_transfer_incoming_bytes",
         "dask_worker_transfer_incoming_count",
         "dask_worker_transfer_incoming_count_total",
@@ -64,7 +64,6 @@ async def test_prometheus_collect_task_states(c, s, a):
         }
         return active_metrics
 
-    expected_metrics = {"stored", "executing", "ready", "waiting"}
     assert not a.state.tasks
     active_metrics = await fetch_state_metrics()
     assert active_metrics == {
@@ -143,7 +142,7 @@ async def test_prometheus_collect_memory_metrics(c, s, spill):
         families = await fetch_metrics(w.http_server.port, prefix="dask_worker_")
         active_metrics = {
             sample.labels["type"]: sample.value
-            for sample in families["dask_worker_memory"].samples
+            for sample in families["dask_worker_memory_bytes"].samples
         }
         assert active_metrics.keys() == {"managed", "unmanaged", "spilled"}
         return active_metrics

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -6,8 +6,6 @@ import json
 import pytest
 from tornado.httpclient import AsyncHTTPClient
 
-import dask.config
-
 from distributed import Event, Worker, wait
 from distributed.sizeof import sizeof
 from distributed.utils_test import fetch_metrics, gen_cluster
@@ -133,47 +131,90 @@ async def test_sitemap(s, a, b):
     assert "/statics/css/base.css" in out["paths"]
 
 
-@pytest.mark.parametrize("spill", [False, True])
-@gen_cluster(client=True, nthreads=[])
-async def test_prometheus_collect_memory_metrics(c, s, spill):
+async def fetch_memory_metrics(w: Worker) -> dict[str, float]:
+    families = await fetch_metrics(w.http_server.port, prefix="dask_worker_")
+    active_metrics = {
+        sample.labels["type"]: sample.value
+        for sample in families["dask_worker_memory_bytes"].samples
+    }
+    assert active_metrics.keys() == {"managed", "unmanaged", "spilled"}
+    return active_metrics
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_prometheus_collect_memory_metrics(c, s, a):
     pytest.importorskip("prometheus_client")
 
-    async def fetch_memory_metrics(w):
-        families = await fetch_metrics(w.http_server.port, prefix="dask_worker_")
-        active_metrics = {
-            sample.labels["type"]: sample.value
-            for sample in families["dask_worker_memory_bytes"].samples
-        }
-        assert active_metrics.keys() == {"managed", "unmanaged", "spilled"}
-        return active_metrics
+    metrics = await fetch_memory_metrics(a)
+    assert metrics["managed"] == 0
+    assert metrics["spilled"] == 0
+    assert metrics["unmanaged"] > 50 * 2**20
 
-    if spill:
-        config = {}
-    else:
-        config = {
-            "distributed.worker.memory.target": False,
-            "distributed.worker.memory.spill": False,
-        }
+    x = c.submit(lambda: "foo", key="x")
+    await wait(x)
+    metrics = await fetch_memory_metrics(a)
+    assert metrics["managed"] == sizeof("foo")
+    assert metrics["spilled"] == 0
 
-    with dask.config.set(config):
-        async with Worker(s.address) as w:
-            metrics = await fetch_memory_metrics(w)
-            assert metrics["managed"] == 0
-            assert metrics["spilled"] == 0
-            assert metrics["unmanaged"] > 0
+    a.data.evict()
+    metrics = await fetch_memory_metrics(a)
+    assert metrics["managed"] == 0
+    assert metrics["spilled"] > 0
+    assert metrics["spilled"] != sizeof("foo")  # pickled bytes
 
-            x = c.submit(lambda: "foo", key="x")
-            await wait(x)
-            metrics = await fetch_memory_metrics(w)
-            assert metrics["managed"] == sizeof("foo")
-            assert metrics["spilled"] == 0
 
-            if spill:
-                w.data.evict()
-                metrics = await fetch_memory_metrics(w)
-                assert metrics["managed"] == 0
-                assert metrics["spilled"] > 0
-                assert metrics["spilled"] != sizeof("foo")  # pickled bytes
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)],
+    config={
+        "distributed.worker.memory.target": False,
+        "distributed.worker.memory.spill": False,
+    },
+)
+async def test_prometheus_collect_memory_metrics_spill_disabled(c, s, a):
+    pytest.importorskip("prometheus_client")
+    assert isinstance(a.data, dict)
 
-            else:
-                assert isinstance(w.data, dict)
+    metrics = await fetch_memory_metrics(a)
+    assert metrics["managed"] == 0
+    assert metrics["spilled"] == 0
+    assert metrics["unmanaged"] > 50 * 2**20
+
+    x = c.submit(lambda: "foo", key="x")
+    await wait(x)
+    metrics = await fetch_memory_metrics(a)
+    assert metrics["managed"] == sizeof("foo")
+    assert metrics["spilled"] == 0
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)],
+    config={
+        "distributed.worker.memory.target": False,
+        "distributed.worker.memory.spill": False,
+    },
+)
+async def test_prometheus_collect_memory_metrics_bogus_sizeof(c, s, a):
+    """Test that managed memory never goes above process memory and that unmanaged
+    memory never goes below 0, no matter how large the output of sizeof() is
+    """
+    pytest.importorskip("prometheus_client")
+
+    metrics = await fetch_memory_metrics(a)
+    assert metrics["managed"] == 0
+    assert metrics["unmanaged"] > 50 * 2**20
+    assert metrics["spilled"] == 0
+
+    class C:
+        def __sizeof__(self):
+            return 2**40
+
+    x = c.submit(C, key="x")
+    await wait(x)
+    assert a.state.nbytes > 2**40
+
+    metrics = await fetch_memory_metrics(a)
+    assert 50 * 2**20 < metrics["managed"] < 100 * 2**30  # capped to process memory
+    assert metrics["unmanaged"] == 0  # floored to 0
+    assert metrics["spilled"] == 0

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -605,8 +605,8 @@ class WorkerState:
         4. When the heartbeat arrives, process memory goes down and so does the
            unmanaged_recent.
 
-        This is OK - one of the main reasons for the unmanged_recent / unmanaged_old
-        split is exactly to concentrate all the noise in unmanged_recent and exclude it
+        This is OK - one of the main reasons for the unmanaged_recent / unmanaged_old
+        split is exactly to concentrate all the noise in unmanaged_recent and exclude it
         from optimistic memory, which is used for heuristics.
         """
         return MemoryState(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -567,15 +567,59 @@ class WorkerState:
 
     @property
     def memory(self) -> MemoryState:
+        """Polished memory metrics for the worker.
+
+        **Design note on managed memory**
+
+        There are two measures available for managed memory:
+
+        - ``self.nbytes``
+        - ``self.metrics["managed_bytes"]``
+
+        At rest, the two numbers must be identical. However, ``self.nbytes`` is
+        immediately updated through the batched comms as soon as each task lands in
+        memory on the worker; ``self.metrics["managed_bytes"]`` instead is updated by
+        the heartbeat, which can lag several seconds behind.
+
+        Below we are mixing likely newer managed memory info from ``self.nbytes`` with
+        process and spilled memory from the heartbeat. This is deliberate, so that
+        managed memory total is updated more frequently.
+
+        Managed memory directly and immediately contributes to optimistic memory, which
+        is in turn used in Active Memory Manager heuristics (at the moment of writing;
+        more uses will likely be added in the future). So it's important to have it
+        up to date; much more than it is for process memory.
+
+        Having up-to-date managed memory info as soon as the scheduler learns about
+        task completion also substantially simplifies unit tests.
+
+        The flip side of this design is that it may cause some noise in the
+        unmanaged_recent measure. e.g.:
+
+        1. Delete 100MB of managed data
+        2. The updated managed memory reaches the scheduler faster than the
+           updated process memory
+        3. There's a blip where the scheduler thinks that there's a sudden 100MB
+           increase in unmanaged_recent, since process memory hasn't changed but managed
+           memory has decreased by 100MB
+        4. When the heartbeat arrives, process memory goes down and so does the
+           unmanaged_recent.
+
+        This is OK - one of the main reasons for the unmanged_recent / unmanaged_old
+        split is exactly to concentrate all the noise in unmanged_recent and exclude it
+        from optimistic memory, which is used for heuristics.
+        """
         return MemoryState(
             # metrics["memory"] is None if the worker sent a heartbeat before its
             # SystemMonitor ever had a chance to run
             process=self.metrics["memory"] or 0,
-            # self.nbytes is instantaneous; metrics may lag behind by a heartbeat
+            # Since the two measures are misaligned in time, the sudden deletion of
+            # spilled keys may result in a temporary blip where managed_in_memory goes
+            # into negative territory.
             managed_in_memory=max(
-                0, self.nbytes - self.metrics["spilled_nbytes"]["memory"]
+                0, self.nbytes - self.metrics["spilled_bytes"]["memory"]
             ),
-            managed_spilled=self.metrics["spilled_nbytes"]["disk"],
+            managed_spilled=self.metrics["spilled_bytes"]["disk"],
             unmanaged_old=self._memory_unmanaged_old,
         )
 
@@ -3922,8 +3966,7 @@ class Scheduler(SchedulerState, ServerNode):
         # ws._nbytes is updated at a different time and sizeof() may not be accurate,
         # so size may be (temporarily) negative; floor it to zero.
         size = max(
-            0,
-            metrics["memory"] - ws.nbytes + metrics["spilled_nbytes"]["memory"],
+            0, metrics["memory"] - ws.nbytes + metrics["spilled_bytes"]["memory"]
         )
 
         ws._memory_unmanaged_history.append((local_now, size))

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -624,12 +624,7 @@ class WorkerState:
         https://github.com/dask/distributed/issues/6002 will let us solve this.
         """
         return MemoryState(
-            # metrics["memory"] is None if the worker sent a heartbeat before its
-            # SystemMonitor ever had a chance to run
-            process=self.metrics["memory"] or 0,
-            # Since the two measures are misaligned in time, the sudden deletion of
-            # spilled keys may result in a temporary blip where managed_in_memory goes
-            # into negative territory.
+            process=self.metrics["memory"],
             managed_in_memory=max(
                 0, self.nbytes - self.metrics["spilled_bytes"]["memory"]
             ),

--- a/distributed/widgets/templates/scheduler_info.html.j2
+++ b/distributed/widgets/templates/scheduler_info.html.j2
@@ -116,7 +116,7 @@
                             <strong>Memory usage: </strong> {{ worker["metrics"]["memory"] | format_bytes}}
                         </td>
                         <td style="text-align: left;">
-                            <strong>Spilled bytes: </strong> {{ worker["metrics"]["spilled_nbytes"]["disk"] | format_bytes }}
+                            <strong>Spilled bytes: </strong> {{ worker["metrics"]["spilled_bytes"]["disk"] | format_bytes }}
                         </td>
                     </tr>
                     <tr>

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1000,7 +1000,8 @@ class Worker(BaseWorker, ServerNode):
                 "workers": dict(self.bandwidth_workers),
                 "types": keymap(typename, self.bandwidth_types),
             },
-            spilled_nbytes={
+            managed_bytes=self.state.nbytes,
+            spilled_bytes={
                 "memory": spilled_memory,
                 "disk": spilled_disk,
             },


### PR DESCRIPTION
It could also lead to some interesting discussion in the future about how impactful is the bulk comms vs. heartbeat lag on AMM decisions, as the two measures for managed memory are now available side by side on the Scheduler.

CC @ntabris 