### PR TITLE
Add `distributed.print` and `distributed.warn` to API docs

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3198,8 +3198,10 @@ def add_gpu_metrics():
 
 def print(*args, **kwargs):
     """Dask print function
-    This prints both wherever this function is run, and also in the user's
-    client session
+
+    This is a wrapper around Python's built-in :external+python:py:func:`print` function
+    that prints both wherever this function is run, and also in the user's
+    client session.
     """
     try:
         worker = get_worker()
@@ -3217,8 +3219,10 @@ def print(*args, **kwargs):
 
 def warn(*args, **kwargs):
     """Dask warn function
-    This raises a warning both wherever this function is run, and also
-    in the user's client session
+
+    This is a wrapper around Python's built-in :py:func:`warnings.warn` function
+    that emits a warning both wherever this function is run, and also
+    in the user's client session.
     """
     try:
         worker = get_worker()

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -66,6 +66,8 @@ The client connects to and submits computation to a Dask cluster (such as a :cla
    get_task_stream
    get_task_metadata
    performance_report
+   print
+   warn
 
 
 **Utilities**
@@ -188,6 +190,8 @@ Other
 .. autoclass:: get_task_stream
 .. autoclass:: get_task_metadata
 .. autoclass:: performance_report
+.. autofunction:: distributed.print
+.. autofunction:: distributed.warn
 
 
 Utilities


### PR DESCRIPTION
Following up on https://github.com/dask/distributed/pull/5217, this PR adds `distributed.print` and `distributed.warn` to the API docs 