### PR TITLE
Round up `saturation-factor`

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -125,6 +125,8 @@ properties:
 
               Up to worker-saturation * nthreads root tasks are sent to a
               worker at a time. If `.inf`, all runnable tasks are immediately sent to workers.
+              The target number is rounded up, so any `worker-saturation` value > 1.0 guarantees
+              at least one extra task will be sent to workers.
 
               Allowing oversaturation (> 1.0) means a worker may start running a new root task as
               soon as it completes the previous, even if there is a higher-priority downstream task
@@ -360,7 +362,7 @@ properties:
                   The maximum amount of data for a worker to request from another in a single gather operation
 
                   Tasks are gathered in batches, and if the first task in a batch is larger than this value,
-                  the task will still be gathered to ensure progress. Hence, this limit is not absolute. 
+                  the task will still be gathered to ensure progress. Hence, this limit is not absolute.
                   Note that this limit applies to a single gather operation and a worker may gather data from
                   multiple workers in parallel.
           connections:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8199,7 +8199,7 @@ def _task_slots_available(ws: WorkerState, saturation_factor: float) -> int:
     "Number of tasks that can be sent to this worker without oversaturating it"
     assert not math.isinf(saturation_factor)
     nthreads = ws.nthreads
-    return max(int(saturation_factor * nthreads), 1) - (
+    return max(math.ceil(saturation_factor * nthreads), 1) - (
         len(ws.processing) - len(ws.long_running)
     )
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -413,9 +413,10 @@ async def test_queued_remove_add_worker(c, s, a, b):
 @pytest.mark.parametrize(
     "saturation_config, expected_task_counts",
     [
-        (2.5, (5, 2)),
-        ("2.5", (5, 2)),
+        (2.5, (5, 3)),
+        ("2.5", (5, 3)),
         (2.0, (4, 2)),
+        (1.1, (3, 2)),
         (1.0, (2, 1)),
         (-1.0, (1, 1)),
         (float("inf"), (6, 4))


### PR DESCRIPTION
This would ensure that any `worker-saturation` value > 1.0 will always result in a worker being oversaturated with at least one task, even for a single-threaded worker.

We don't see a strong signal either way in benchmarking that increasing the saturation factor helps runtime. But consensus is currently that submitting 0 extra tasks to workers feels too radical as an initial change.

For clusters where scheduler<->worker latency is relatively high, giving workers an extra task might make more of a difference than we see in our benchmarks.

Or if data access is very slow, getting a head start and overlapping communication (to a database, S3, etc.) with computation might be more beneficial.

I'm personally still on the fence about this (because it certainly can increase memory usage, but we don't have strong evidence it affects runtime, and it's a little more complicated to explain), but staying a little closer to current behavior seems okay for now.

cc @crusaderky @fjetter @hendrikmakait 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
