### PR TITLE
Fix two potentially flaky queuing tests

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -294,7 +294,6 @@ async def test_graph_execution_width(c, s, *workers):
     assert max(Refcount.log) <= s.total_nthreads
 
 
-@pytest.mark.parametrize("queue", [True, False])
 @gen_cluster(
     client=True,
     nthreads=[("", 2)] * 2,
@@ -303,14 +302,10 @@ async def test_graph_execution_width(c, s, *workers):
         "distributed.worker.memory.target": False,
         "distributed.worker.memory.spill": False,
         "distributed.scheduler.work-stealing": False,
+        "distributed.scheduler.worker-saturation": 1.0,
     },
 )
-async def test_queued_paused_new_worker(c, s, a, b, queue):
-    if queue:
-        s.WORKER_SATURATION = 1.0
-    else:
-        s.WORKER_SATURATION = float("inf")
-
+async def test_queued_paused_new_worker(c, s, a, b):
     f1s = c.map(slowinc, range(16))
     f2s = c.map(slowinc, f1s)
     final = c.submit(sum, *f2s)
@@ -383,7 +378,9 @@ async def test_queued_paused_unpaused(c, s, a, b, queue):
     while not s.running:
         await asyncio.sleep(0.01)
 
-    assert not s.idle  # workers should have been (or already were) filled
+    if queue:
+        assert not s.idle  # workers should have been (or already were) filled
+    # If queuing is disabled, all workers might already be saturated when they un-pause.
 
     await wait(final)
 


### PR DESCRIPTION
`test_queued_paused_new_worker` didn't really make sense to run with queuing disabled _and_ work-stealing disabled. It was probably a bit of a race condition that it would pass at all: the workers would finish a task after pausing, causing downstream tasks to try to schedule, causing `decide_worker_non_rootish` to put then in `no-worker` since all workers were paused. When a new worker joined, those downstream tasks would be scheduled on them, which is actually rather bad scheduling, since it would require transferring the inputs from the paused workers. I've skipped this one for non-queuing cases entirely.

`test_queued_paused_unpaused` assumed that the workers would not be saturated when they un-paused. This is a valid assumption with queueing on, but not without. This failed at least once in CI: https://github.com/dask/distributed/actions/runs/3174241165/jobs/5170792765#step:18:1320

cc @fjetter @crusaderky @hendrikmakait 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
