### PR TITLE
Do not include psutil memory_info in GC duration warning

### DIFF
--- a/distributed/utils_perf.py
+++ b/distributed/utils_perf.py
@@ -181,6 +181,10 @@ class GCDiagnosis:
         # don't waste time measuring them
         if info["generation"] != 2:
             return
+        if phase == "stop":
+            # Stop timer before measuring RSS to avoid this influencing the
+            # measurement
+            self._fractional_timer.stop_timing()
         if self._proc is not None:
             rss = self._proc.memory_info().rss
         else:
@@ -190,7 +194,6 @@ class GCDiagnosis:
             self._gc_rss_before = rss
             return
         assert phase == "stop"
-        self._fractional_timer.stop_timing()
         frac = self._fractional_timer.running_fraction
         if frac is not None and frac >= self._warn_over_frac:
             logger.warning(


### PR DESCRIPTION
The test `test_tick_interval` recently started flaking. It was accompanied by multiple warnings of the GC duration claiming that GC took too long.
While this can certainly be true, I realized that the GC callback is also inspecting process memory. I believe the process memory check actually can be slow-ish and I believe we should not include this in the measurement of the gc callback.

In fact, I'm wondering if this should even be there in the first place. I also wonder if we should implement a similar logic for get_process_memory as we did for gc.collect that ensures it doesn't run too frequently.

cc @crusaderky @gjoseph92 