### PR TITLE
Revamped implementations of remote `print()` and `warn()`, fixing #7095

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -672,7 +672,7 @@ def _handle_warn(event):
             # TypeError makes sense here because it's analogous to calling a
             # function without a required positional argument
             raise TypeError(
-                "_handle_warn: client receive warn a event missing the required "
+                "_handle_warn: client received a warn event missing the required "
                 '"message" argument.'
             )
         warnings.warn(

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7389,10 +7389,6 @@ def test_print_local(capsys):
     out, err = capsys.readouterr()
     assert "Hello!:123\n" == out
 
-    print("Hello!", 123, sep=":", local_too=False)
-    out, err = capsys.readouterr()
-    assert "" == out
-
 
 def _verify_cluster_dump(
     url: str | pathlib.PosixPath, format: str, addresses: set[str]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3233,8 +3233,8 @@ def print(
     to use the default values. If no objects are given, ``print()`` will just
     write ``end``.
 
-    Optional keyword arguments
-    --------------------------
+    Parameters
+    ----------
     sep : str, optional
         String inserted between values, default a space.
     end : str, optional
@@ -3244,8 +3244,8 @@ def print(
     flush : bool, default False
         Whether to forcibly flush the stream.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from dask.distributed import Client, print
     >>> client = distributed.Client(...)
     >>> def worker_function():
@@ -3307,8 +3307,8 @@ def warn(
     ``source`` are ignored by clients because they would not be meaningful in
     the client's thread.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from dask.distributed import Client, warn
     >>> client = Client()
     >>> def do_warn():

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -23,6 +23,8 @@ The client connects to and submits computation to a Dask cluster (such as a :cla
    get_client
    secede
    rejoin
+   print
+   warn
    Reschedule
 
 .. currentmodule:: distributed.recreate_tasks
@@ -184,6 +186,8 @@ Other
 .. autofunction:: distributed.get_client
 .. autofunction:: distributed.secede
 .. autofunction:: distributed.rejoin
+.. autofunction:: distributed.print
+.. autofunction:: distributed.warn
 .. autoclass:: distributed.Reschedule
 .. autoclass:: get_task_stream
 .. autoclass:: get_task_metadata


### PR DESCRIPTION
This PR rewrites the remote `print()` and `warn()` functions to be more correct and better documented, as discussed in #7095, and extending the initial work by @fjetter in #5217. Some notes about the implementation:

- `print()` relies on msgpack to distinguish correctly between string-valued and None-valued arguments. I've special-cased the `file` kwarg to disallow using this function to write to arbitrary file-like objects (because it wouldn't be clear how that should work in the possibly remote client thread), while still allowing a distinction between standard out and standard error.
- `warn()` handles its own serialization of the `message` and `category` arguments into bytes because, if we want it to be truly drop-in, these might be Warning instance objects or classes, which msgpack won't serialize out of the box. See the test function for the various use cases. I feel like the only way this breaks down is if the user does something really bizarre like emit a custom Warning subclass that stores a ton of data in itself.
- `warn()` ignores the `stacklevel` and `source` arguments in the remote client, because the former would be meaningless in the client's thread and the latter would entail serializing an arbitrary object, which I'd rather avoid. 

I've also stuck these functions into the API docs. Assuming this is merged, a good follow-up PR would be to introduce them in the "Debug" page of the main dask docs.