### PR TITLE
Update typing for system_monitor after python/typeshed#8829

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,4 +88,4 @@ repos:
           - zict
           - pyarrow
 
-# Increase this by 1 to force-wipe the pre-commit github action cache: 1
+# Increase this by 1 to force-wipe the pre-commit github action cache: 2

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections import deque
-from typing import Any, cast
+from typing import Any
 
 import psutil
 

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections import deque
-from typing import Any
+from typing import Any, cast
 
 import psutil
 
@@ -70,8 +70,7 @@ class SystemMonitor:
             else:
                 if disk_ioc is None:  # pragma: nocover
                     # diskless machine
-                    # FIXME https://github.com/python/typeshed/pull/8829
-                    monitor_disk_io = False  # type: ignore[unreachable]
+                    monitor_disk_io = False
                 else:
                     self._last_disk_io_counters = disk_ioc
                     self.quantities["host_disk_io.read_bps"] = deque(maxlen=maxlen)
@@ -142,7 +141,7 @@ class SystemMonitor:
             self._last_net_io_counters = net_ioc
 
         if self.monitor_disk_io:
-            disk_ioc = psutil.disk_io_counters()
+            disk_ioc = cast(psutil._common.sdiskio, psutil.disk_io_counters())
             last_disk = self._last_disk_io_counters
             result["host_disk_io.read_bps"] = (
                 disk_ioc.read_bytes - last_disk.read_bytes

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -141,7 +141,8 @@ class SystemMonitor:
             self._last_net_io_counters = net_ioc
 
         if self.monitor_disk_io:
-            disk_ioc = cast(psutil._common.sdiskio, psutil.disk_io_counters())
+            disk_ioc = psutil.disk_io_counters()
+            assert disk_ioc is not None
             last_disk = self._last_disk_io_counters
             result["host_disk_io.read_bps"] = (
                 disk_ioc.read_bytes - last_disk.read_bytes


### PR DESCRIPTION
We must now explicitly no-op cast to sdiskio before accessing properties of the disk_io_counters call. This is safe because initialisation logic ensures that we never reach these branches except in the "not None" case.

- [x] Passes `pre-commit run --all-files`

cc @crusaderky.