### PR TITLE
Improve exception catching in UCX communication

### DIFF
--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -327,7 +327,7 @@ class UCX(Comm):
             header = struct.unpack(header_fmt, header)
             cuda_frames, sizes = header[:nframes], header[nframes:]
         except BaseException as e:
-            # In addition to UCX exceptions, may be CancelledError or a another
+            # In addition to UCX exceptions, may be CancelledError or another
             # "low-level" exception. The only safe thing to do is to abort.
             # (See also https://github.com/dask/distributed/pull/6574).
             self.abort()
@@ -357,7 +357,7 @@ class UCX(Comm):
                 for each_frame in recv_frames:
                     await self.ep.recv(each_frame)
             except BaseException as e:
-                # In addition to UCX exceptions, may be CancelledError or a another
+                # In addition to UCX exceptions, may be CancelledError or another
                 # "low-level" exception. The only safe thing to do is to abort.
                 # (See also https://github.com/dask/distributed/pull/6574).
                 self.abort()

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -352,8 +352,17 @@ class UCX(Comm):
             if any(cuda_recv_frames):
                 synchronize_stream(0)
 
-            for each_frame in recv_frames:
-                await self.ep.recv(each_frame)
+            try:
+                for each_frame in recv_frames:
+                    await self.ep.recv(each_frame)
+            except BaseException as e:
+                # In addition to UCX exceptions, may be CancelledError or a another
+                # "low-level" exception. The only safe thing to do is to abort.
+                # (See also https://github.com/dask/distributed/pull/6574).
+                self.abort()
+                raise CommClosedError(
+                    f"Connection closed by writer.\nInner exception: {e!r}"
+                )
             msg = await from_frames(
                 frames,
                 deserialize=self.deserialize,


### PR DESCRIPTION
Closes #7130

As was previously discussed in #6996, some of the exception catching could be improved for both read and write tasks which are now addressed by the changes contained here.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
