### PR TITLE
Hold on to z.sum() until test completes

### DIFF
--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -1082,7 +1082,8 @@ async def test_compute_per_key(c, s, a, b):
     await x
     y = await dask.delayed(inc)(1).persist()
     z = (x + x.T) - x.mean(axis=0)
-    await c.compute(z.sum())
+    zsum = z.sum()
+    await c.compute(zsum)
 
     mbk.update()
     http_client = AsyncHTTPClient()


### PR DESCRIPTION
Since we are checking for the presence of z.sum() in the known keys in the dashboard we need to make sure it doesn't get collected. 

Closes #7135 (I hope!)

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
