### PR TITLE
Fix dependencies that should point to `dask/dask`

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -42,7 +42,7 @@ dependencies:
   - zict  # overridden by git tip below
   - zstandard >=0.9.0
   - pip:
-      - git+https://github.com/douglasdavis/dask@new-cli
+      - git+https://github.com/dask/dask
       - git+https://github.com/dask/s3fs
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -45,6 +45,6 @@ dependencies:
   - zict
   - zstandard >=0.9.0
   - pip:
-      - git+https://github.com/douglasdavis/dask@new-cli
+      - git+https://github.com/dask/dask
       - git+https://github.com/jcrist/crick  # Only tested here
       - keras

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -48,5 +48,5 @@ dependencies:
   - zict
   - zstandard >=0.9.0
   - pip:
-      - git+https://github.com/douglasdavis/dask@new-cli
+      - git+https://github.com/dask/dask
       - keras

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -38,7 +38,7 @@ gpuci_logger "Activate conda env"
 conda activate dask
 
 gpuci_logger "Install dask"
-python -m pip install git+https://github.com/douglasdavis/dask@new-cli
+python -m pip install git+https://github.com/dask/dask
 
 gpuci_logger "Install distributed"
 python -m pip install -e .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ numpydoc
 tornado
 toolz
 cloudpickle
-git+https://github.com/douglasdavis/dask@new-cli
+git+https://github.com/dask/dask
 sphinx
 dask-sphinx-theme>=3.0.0
 sphinx-click

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click >= 6.6
 cloudpickle >= 1.5.0
-dask @ git+https://github.com/douglasdavis/dask@new-cli
+dask == 2022.9.2
 jinja2
 locket >= 1.0.0
 msgpack >= 0.6.0


### PR DESCRIPTION
I accidentally merged https://github.com/dask/distributed/pull/6735 too soon. We should have reverted the temporary changes that pointed to @douglasdavis's branch. This PR reverts back to pointing to `dask/dask`

cc @douglasdavis 