### PR TITLE
Use functionalities network for codecov

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -187,6 +187,8 @@ jobs:
 
       - name: Coverage
         uses: codecov/codecov-action@v3
+        with:
+          functionalities: network
 
       - name: Upload test results
         # ensure this runs even if pytest fails


### PR DESCRIPTION
For some reason top-level files like scheduler.py or worker.py are not shown in codecov. This affects files that have duplicate filenames in a nested directory (e.g. in dashboard). I asked on the community board of codecov for help, see https://community.codecov.com/t/files-missing-from-report/3902/2

They suggest this might be connected to how they rewrite paths and suggested to enable this functionality to see if it proves things