### PR TITLE
memory_manager: Optionally provide local directory to data constructor

### DIFF
--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -97,6 +97,51 @@ async def test_dict_data_if_no_spill_to_disk(s, w):
     assert type(w.data) is dict
 
 
+class WorkerData(dict):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.kwargs = kwargs
+
+
+class WorkerDataLocalDirectory(dict):
+    def __init__(self, worker_local_directory, **kwargs):
+        super().__init__()
+        self.local_directory = worker_local_directory
+        self.kwargs = kwargs
+
+
+@gen_cluster(
+    nthreads=[("", 1)], Worker=Worker, worker_kwargs={"data": WorkerDataLocalDirectory}
+)
+async def test_worker_data_callable_local_directory(s, w):
+    assert type(w.memory_manager.data) is WorkerDataLocalDirectory
+    assert w.memory_manager.data.local_directory == w.local_directory
+
+
+@gen_cluster(
+    nthreads=[("", 1)],
+    Worker=Worker,
+    worker_kwargs={"data": (WorkerDataLocalDirectory, {"a": "b"})},
+)
+async def test_worker_data_callable_local_directory_kwargs(s, w):
+    assert type(w.memory_manager.data) is WorkerDataLocalDirectory
+    assert w.memory_manager.data.local_directory == w.local_directory
+    assert w.memory_manager.data.kwargs == {"a": "b"}
+
+
+@gen_cluster(nthreads=[("", 1)], Worker=Worker, worker_kwargs={"data": WorkerData})
+async def test_worker_data_callable(s, w):
+    assert type(w.memory_manager.data) is WorkerData
+
+
+@gen_cluster(
+    nthreads=[("", 1)], Worker=Worker, worker_kwargs={"data": (WorkerData, {"a": "b"})}
+)
+async def test_worker_data_callable_kwargs(s, w):
+    assert type(w.memory_manager.data) is WorkerData
+    assert w.memory_manager.data.kwargs == {"a": "b"}
+
+
 class CustomError(Exception):
     pass
 

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -129,11 +129,6 @@ async def test_worker_data_callable_local_directory_kwargs(s, w):
     assert w.memory_manager.data.kwargs == {"a": "b"}
 
 
-@gen_cluster(nthreads=[("", 1)], Worker=Worker, worker_kwargs={"data": WorkerData})
-async def test_worker_data_callable(s, w):
-    assert type(w.memory_manager.data) is WorkerData
-
-
 @gen_cluster(
     nthreads=[("", 1)], Worker=Worker, worker_kwargs={"data": (WorkerData, {"a": "b"})}
 )

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -303,7 +303,12 @@ class Worker(BaseWorker, ServerNode):
     scheduler_file: str, optional
     host: str, optional
     data: MutableMapping, type, None
-        The object to use for storage, builds a disk-backed LRU dict by default
+        The object to use for storage, builds a disk-backed LRU dict by default.
+
+        If a callable to construct the storage object is provided, it
+        will receive the worker's attr:``local_directory`` as an
+        argument if the calling signature has an argument named
+        ``worker_local_directory``.
     nthreads: int, optional
     local_directory: str, optional
         Directory where we place local resources
@@ -484,6 +489,8 @@ class Worker(BaseWorker, ServerNode):
         data: (
             MutableMapping[str, Any]  # pre-initialised
             | Callable[[], MutableMapping[str, Any]]  # constructor
+            # constructor receiving self.local_directory
+            | Callable[[str], MutableMapping[str, Any]]
             | tuple[
                 Callable[..., MutableMapping[str, Any]], dict[str, Any]
             ]  # (constructor, kwargs to constructor)

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -67,9 +67,8 @@ class WorkerMemoryManager:
     Notes
     -----
 
-    If the ``data`` argument is a callable and has a named parameter
-    ``worker_local_directory`` it will be passed the location of the
-    worker's :attr:`~distributed.worker.Worker.local_directory`.
+    If data is a callable and has the argument ``worker_local_directory`` in its
+    signature, it will be filled with the worker's attr:``local_directory``.
 
     """
 

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -25,10 +25,17 @@ import logging
 import os
 import sys
 import warnings
-from collections.abc import Callable, MutableMapping
 from contextlib import suppress
 from functools import partial
-from typing import TYPE_CHECKING, Any, Container, Literal, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Container,
+    Literal,
+    MutableMapping,
+    cast,
+)
 
 import psutil
 from tornado.ioloop import PeriodicCallback


### PR DESCRIPTION
If a third party provides a callable constructor for the data attribute, it is likely that they will want to know the worker's local directory. Closes #7151.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
