### PR TITLE
Errors when setting TCP timeouts log as error

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -112,7 +112,7 @@ def set_tcp_timeout(comm):
             TCP_USER_TIMEOUT = 18  # since Linux 2.6.37
             sock.setsockopt(socket.SOL_TCP, TCP_USER_TIMEOUT, timeout * 1000)
     except OSError as e:
-        logger.warning("Could not set timeout on TCP stream: %s", e)
+        logger.error("Could not set timeout on TCP stream: %s", e)
 
 
 def get_stream_address(comm):

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -111,8 +111,8 @@ def set_tcp_timeout(comm):
             logger.debug("Setting TCP user timeout: %d ms", timeout * 1000)
             TCP_USER_TIMEOUT = 18  # since Linux 2.6.37
             sock.setsockopt(socket.SOL_TCP, TCP_USER_TIMEOUT, timeout * 1000)
-    except OSError as e:
-        logger.error("Could not set timeout on TCP stream: %s", e)
+    except OSError:
+        logger.exception("Could not set timeout on TCP stream.")
 
 
 def get_stream_address(comm):


### PR DESCRIPTION
We're relying on the tcp timeouts for us to detect dead remotes. Dask can still function in ordinary environments which is why this should not raise but an error log with a traceback feels to be appropriate.

The current log could return something unhelpful like

`2022-10-19 18:14:12,620 - distributed.comm.tcp - WARNING - Could not set timeout on TCP stream: [Errno 22] Invalid argument`

cc @hendrikmakait 