### PR TITLE
Do not close worker on comm error in heartbeat

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1873,10 +1873,10 @@ async def test_heartbeat_comm_closed(s, monkeypatch):
             monkeypatch.setattr(w.scheduler, "heartbeat_worker", bad_heartbeat_worker)
 
             await w.heartbeat()
-            assert w.status == Status.closed
-            while s.workers:
-                await asyncio.sleep(0.01)
-    assert "Heartbeat to scheduler failed" in logger.getvalue()
+            assert w.status == Status.running
+    logs = logger.getvalue()
+    assert "Failed to communicate with scheduler during heartbeat" in logs
+    assert "Traceback" in logs
 
 
 @gen_cluster(nthreads=[("", 1)], worker_kwargs={"heartbeat_interval": "100s"})

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1237,17 +1237,12 @@ class Worker(BaseWorker, ServerNode):
             )
             self.bandwidth_workers.clear()
             self.bandwidth_types.clear()
-        except CommClosedError:
-            logger.warning("Heartbeat to scheduler failed", exc_info=True)
-            await self.close()
         except OSError as e:
-            # Scheduler is gone. Respect distributed.comm.timeouts.connect
-            if "Timed out trying to connect" in str(e):
-                logger.info("Timed out while trying to connect during heartbeat")
-                await self.close()
-            else:
-                logger.exception(e)
-                raise e
+            logger.exception(e)
+        except Exception as e:
+            logger.exception("Unexpected exception during heartbeat. Closing worker.")
+            await self.close()
+            raise e
         finally:
             self.heartbeat_active = False
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -56,7 +56,6 @@ from distributed.comm.addressing import address_from_user_args
 from distributed.comm.utils import OFFLOAD_THRESHOLD
 from distributed.compatibility import randbytes, to_thread
 from distributed.core import (
-    CommClosedError,
     ConnectionPool,
     Status,
     coerce_to_address,
@@ -1237,8 +1236,8 @@ class Worker(BaseWorker, ServerNode):
             )
             self.bandwidth_workers.clear()
             self.bandwidth_types.clear()
-        except OSError as e:
-            logger.exception(e)
+        except OSError:
+            logger.exception("Failed to communicate with scheduler during heartbeat.")
         except Exception as e:
             logger.exception("Unexpected exception during heartbeat. Closing worker.")
             await self.close()


### PR DESCRIPTION
Supersedes
* #6492

This PR revives #6492 to avoid closing the worker upon heartbeat failure.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
