### PR TITLE
Introduce distributed.comm.ucx.environment config slot

### DIFF
--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -78,14 +78,15 @@ async def test_ucx_config(ucx_loop, cleanup):
 
     with dask.config.set(
         {
+            "distributed.comm.ucx": {"nvlink": True},
             "distributed.comm.ucx.environment": {
-                "log-level": "DEBUG",
+                "tls": "all",
                 "memtrack-dest": "stdout",
-            }
+            },
         }
     ):
         ucx_config, ucx_environment = _prepare_ucx_config()
-        assert ucx_environment["UCX_LOG_LEVEL"] == "DEBUG"
+        assert "UCX_TLS" not in ucx_environment
         assert ucx_environment["UCX_MEMTRACK_DEST"] == "stdout"
 
 

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.gpu
 import dask
 
 from distributed import Client
-from distributed.comm.ucx import _scrub_ucx_config
+from distributed.comm.ucx import _prepare_ucx_config
 from distributed.utils import get_ip
 from distributed.utils_test import gen_test, popen
 
@@ -34,7 +34,7 @@ async def test_ucx_config(ucx_loop, cleanup):
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
-        ucx_config = _scrub_ucx_config()
+        ucx_config = _prepare_ucx_config()
         assert ucx_config.get("TLS") == "rc,tcp,cuda_copy,cuda_ipc"
         assert ucx_config.get("SOCKADDR_TLS_PRIORITY") == "tcp"
 
@@ -47,7 +47,7 @@ async def test_ucx_config(ucx_loop, cleanup):
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
-        ucx_config = _scrub_ucx_config()
+        ucx_config = _prepare_ucx_config()
         assert ucx_config.get("TLS") == "rc,tcp"
         assert ucx_config.get("SOCKADDR_TLS_PRIORITY") == "tcp"
 
@@ -60,7 +60,7 @@ async def test_ucx_config(ucx_loop, cleanup):
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
-        ucx_config = _scrub_ucx_config()
+        ucx_config = _prepare_ucx_config()
         assert ucx_config.get("TLS") == "rc,tcp,cuda_copy"
         assert ucx_config.get("SOCKADDR_TLS_PRIORITY") == "rdmacm"
 
@@ -73,8 +73,20 @@ async def test_ucx_config(ucx_loop, cleanup):
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
-        ucx_config = _scrub_ucx_config()
+        ucx_config = _prepare_ucx_config()
         assert ucx_config == {}
+
+    with dask.config.set(
+        {
+            "distributed.comm.ucx.environment": {
+                "log-level": "DEBUG",
+                "memtrack-dest": "stdout",
+            }
+        }
+    ):
+        ucx_config = _prepare_ucx_config()
+        assert ucx_config["LOG_LEVEL"] == "DEBUG"
+        assert ucx_config["MEMTRACK_DEST"] == "stdout"
 
 
 @pytest.mark.flaky(

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -34,7 +34,7 @@ async def test_ucx_config(ucx_loop, cleanup):
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
-        ucx_config = _prepare_ucx_config()
+        ucx_config, _ = _prepare_ucx_config()
         assert ucx_config.get("TLS") == "rc,tcp,cuda_copy,cuda_ipc"
         assert ucx_config.get("SOCKADDR_TLS_PRIORITY") == "tcp"
 
@@ -47,7 +47,7 @@ async def test_ucx_config(ucx_loop, cleanup):
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
-        ucx_config = _prepare_ucx_config()
+        ucx_config, _ = _prepare_ucx_config()
         assert ucx_config.get("TLS") == "rc,tcp"
         assert ucx_config.get("SOCKADDR_TLS_PRIORITY") == "tcp"
 
@@ -60,7 +60,7 @@ async def test_ucx_config(ucx_loop, cleanup):
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
-        ucx_config = _prepare_ucx_config()
+        ucx_config, _ = _prepare_ucx_config()
         assert ucx_config.get("TLS") == "rc,tcp,cuda_copy"
         assert ucx_config.get("SOCKADDR_TLS_PRIORITY") == "rdmacm"
 
@@ -73,7 +73,7 @@ async def test_ucx_config(ucx_loop, cleanup):
     }
 
     with dask.config.set({"distributed.comm.ucx": ucx}):
-        ucx_config = _prepare_ucx_config()
+        ucx_config, _ = _prepare_ucx_config()
         assert ucx_config == {}
 
     with dask.config.set(
@@ -84,9 +84,9 @@ async def test_ucx_config(ucx_loop, cleanup):
             }
         }
     ):
-        ucx_config = _prepare_ucx_config()
-        assert ucx_config["LOG_LEVEL"] == "DEBUG"
-        assert ucx_config["MEMTRACK_DEST"] == "stdout"
+        ucx_config, ucx_environment = _prepare_ucx_config()
+        assert ucx_environment["UCX_LOG_LEVEL"] == "DEBUG"
+        assert ucx_environment["UCX_MEMTRACK_DEST"] == "stdout"
 
 
 @pytest.mark.flaky(

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -573,9 +573,6 @@ def _prepare_ucx_config():
     # High-level settings in (1) are preferred to settings in (2)
     # Settings in the external environment override both
 
-    # import does not initialize ucp -- this will occur outside this function
-    from ucp import get_config
-
     high_level_options = {}
 
     # if any of the high level flags are set, as long as they are not Null/None,
@@ -633,12 +630,5 @@ def _prepare_ucx_config():
             )
         else:
             environment_options[key] = v
-
-    valid_ucx_vars = set(get_config().keys())
-    for k, v in high_level_options.items():
-        if k not in valid_ucx_vars:
-            logger.debug(
-                f"Key: {k} with value: {v} not a valid UCX configuration option"
-            )
 
     return high_level_options, environment_options

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -11,7 +11,6 @@ import functools
 import logging
 import os
 import struct
-import warnings
 import weakref
 from collections.abc import Awaitable, Callable, Collection
 from typing import TYPE_CHECKING, Any
@@ -59,13 +58,13 @@ _warning_suffix = (
 
 
 def _warn_existing_cuda_context(ctx, pid):
-    warnings.warn(
+    logger.warning(
         f"A CUDA context for device {ctx} already exists on process ID {pid}. {_warning_suffix}"
     )
 
 
 def _warn_cuda_context_wrong_device(ctx_expected, ctx_actual, pid):
-    warnings.warn(
+    logger.warning(
         f"Worker with process ID {pid} should have a CUDA context assigned to device "
         f"{ctx_expected}, but instead the CUDA context is on device {ctx_actual}. "
         f"{_warning_suffix}"
@@ -167,7 +166,7 @@ def init_once():
                 )
 
         if pool_size_str is not None:
-            warnings.warn(
+            logger.warning(
                 "Initial RMM pool size defined, but RMM is not available. "
                 "Please consider installing RMM or removing the pool size option."
             )

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -128,9 +128,10 @@ def init_once():
     ucp = _ucp
 
     with patch.dict(os.environ, ucx_environment):
-        # This means that low-level settings in
-        # distributed.comm.ucx.environment
-        # override the high-level ones.
+        # We carefully ensure that ucx_environment only contains things
+        # that don't override ucx_config or existing slots in the
+        # environment, so the user's external environment can safely
+        # override things here.
         ucp.init(options=ucx_config, env_takes_precedence=True)
 
     pool_size_str = dask.config.get("distributed.rmm.pool-size")

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -15,6 +15,7 @@ import warnings
 import weakref
 from collections.abc import Awaitable, Callable, Collection
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 
 import dask
 from dask.utils import parse_bytes
@@ -89,7 +90,7 @@ def init_once():
         return
 
     # remove/process dask.ucx flags for valid ucx options
-    ucx_config = _prepare_ucx_config()
+    ucx_config, ucx_environment = _prepare_ucx_config()
 
     # We ensure the CUDA context is created before initializing UCX. This can't
     # be safely handled externally because communications in Dask start before
@@ -126,7 +127,11 @@ def init_once():
 
     ucp = _ucp
 
-    ucp.init(options=ucx_config, env_takes_precedence=True)
+    with patch.dict(os.environ, ucx_environment):
+        # This means that low-level settings in
+        # distributed.comm.ucx.environment
+        # override the high-level ones.
+        ucp.init(options=ucx_config, env_takes_precedence=True)
 
     pool_size_str = dask.config.get("distributed.rmm.pool-size")
 
@@ -556,14 +561,17 @@ def _prepare_ucx_config():
 
     Returns
     -------
-    dict
-        Options suitable for passing to ``ucp.init``
+    tuple
+        Options suitable for passing to ``ucp.init`` and additional
+        UCX options that will be inserted directly into the environment
+        while calling ``ucp.init``.
     """
 
     # configuration of UCX can happen in two ways:
     # 1) high level on/off flags which correspond to UCX configuration
     # 2) explicitly defined UCX configuration flags in distributed.comm.ucx.environment
     # High-level settings in (1) are preferred to settings in (2)
+    # Settings in the external environment override both
 
     # import does not initialize ucp -- this will occur outside this function
     from ucp import get_config
@@ -606,22 +614,24 @@ def _prepare_ucx_config():
         high_level_options = {"TLS": tls, "SOCKADDR_TLS_PRIORITY": tls_priority}
 
     # Pick up any other ucx environment settings
-    # {"some-name": value} is translated to {"SOME_NAME": value}
+    # {"some-name": value} is translated to {"UCX_SOME_NAME": value}
     def normalise(k):
-        return "_".join(map(str.upper, k.split("-")))
+        return "_".join(map(str.upper, ("UCX", *k.split("-"))))
 
     environment_options = {
-        normalise(k): v
+        key: v
         for k, v in dask.config.get("distributed.comm.ucx.environment", {}).items()
+        # High-level settings take precedence over low-level
+        # environment configuration, as do settings already in the
+        # environment (set externally)
+        if (key := normalise(k)) not in os.environ and key[4:] not in high_level_options
     }
 
-    # High level options override general environment ones.
-    environment_options.update(high_level_options)
     valid_ucx_vars = set(get_config().keys())
-    for k, v in environment_options.items():
+    for k, v in high_level_options.items():
         if k not in valid_ucx_vars:
             logger.debug(
                 f"Key: {k} with value: {v} not a valid UCX configuration option"
             )
 
-    return environment_options
+    return high_level_options, environment_options

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -961,7 +961,21 @@ properties:
                   additional variables for each transport, while ensuring optimal connectivity. When
                   ``True``, a CUDA context will be created on the first device listed in
                   ``CUDA_VISIBLE_DEVICES``.
+              environment:
+                type: object
+                description: |
+                  Mapping for setting arbitrary UCX environment variables.
+                  Names here are translated via the following rules to
+                  map to the relevant UCX environment variable:
+                    - hyphens are replaced with underscores
+                    - words are uppercased
+                    - UCX_ is prepended
+                  So, for example, setting ``some-option=value`` is
+                  equivalent to setting ``UCX_SOME_OPTION=value`` in
+                  the calling environment.
 
+                  For a full list of supported UCX environment
+                  variables, run ``ucx_info -f``.
           tcp:
             type: object
             properties:

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -229,7 +229,9 @@ distributed:
       infiniband: null  # enable Infiniband
       rdmacm: null  # enable RDMACM
       create-cuda-context: null  # create CUDA context before UCX initialization
-
+      environment: {}            # Any other environment settings to
+                                 # be transferred to UCX. Name
+                                 # munging: key-name => UCX_KEY_NAME
     zstd:
       level: 3      # Compression level, between 1 and 22.
       threads: 0    # Threads to use. 0 for single-threaded, -1 to infer from cpu count.

--- a/distributed/tests/test_config.py
+++ b/distributed/tests/test_config.py
@@ -338,13 +338,14 @@ def test_schema_is_complete():
         schema = yaml.safe_load(f)
 
     skip = {
-        "default-task-durations",
-        "bokeh-application",
-        "environ",
-        "pre-spawn-environ",
+        "distributed.scheduler.default-task-durations",
+        "distributed.scheduler.dashboard.bokeh-application",
+        "distributed.nanny.environ",
+        "distributed.nanny.pre-spawn-environ",
+        "distributed.comm.ucx.environment",
     }
 
-    def test_matches(c, s):
+    def test_matches(c, s, root):
         if set(c) != set(s["properties"]):
             raise ValueError(
                 "\nThe distributed.yaml and distributed-schema.yaml files are not in sync.\n"
@@ -359,10 +360,11 @@ def test_schema_is_complete():
                 )
             )
         for k, v in c.items():
-            if isinstance(v, dict) and k not in skip:
-                test_matches(c[k], s["properties"][k])
+            key = f"{root}.{k}" if root else k
+            if isinstance(v, dict) and key not in skip:
+                test_matches(c[k], s["properties"][k], key)
 
-    test_matches(config, schema)
+    test_matches(config, schema, "")
 
 
 def test_uvloop_event_loop():


### PR DESCRIPTION
Can be used for setting arbitrary UCX configuration in addition to the specific high-level options in those cases where one needs fine-grained control over the UCX configuration.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @pentschev, @quasiben 