### PR TITLE
Backport tornado PeriodicCallback

### DIFF
--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -12,11 +12,10 @@ from collections import defaultdict
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
-from tornado.ioloop import PeriodicCallback
-
 import dask
 from dask.utils import parse_timedelta
 
+from distributed.compatibility import PeriodicCallback
 from distributed.core import Status
 from distributed.metrics import time
 from distributed.utils import import_term, log_errors

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -49,13 +49,14 @@ try:
 except ImportError:
     single_key = first
 from tornado import gen
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import IOLoop
 
 import distributed.utils
 from distributed import cluster_dump, preloading
 from distributed import versions as version_module
 from distributed.batched import BatchedSend
 from distributed.cfexecutor import ClientExecutor
+from distributed.compatibility import PeriodicCallback
 from distributed.core import (
     CommClosedError,
     ConnectionPool,

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -55,7 +55,7 @@ else:
             return secrets.token_bytes(size)
 
 
-if tornado.version_info >= (6, 2):
+if tornado.version_info >= (6, 2, 0, 0):
     from tornado.ioloop import PeriodicCallback
 else:
     # Backport from https://github.com/tornadoweb/tornado/blob/a4f08a31a348445094d1efa17880ed5472db9f7d/tornado/ioloop.py#L838-L962

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 import sys
 
+import tornado
+
 logging_names: dict[str | int, int | str] = {}
 logging_names.update(logging._levelToName)  # type: ignore
 logging_names.update(logging._nameToLevel)  # type: ignore
@@ -51,3 +53,151 @@ else:
 
         def randbytes(size):
             return secrets.token_bytes(size)
+
+
+if tornado.version_info >= (6, 2):
+    from tornado.ioloop import PeriodicCallback
+else:
+    # Backport from https://github.com/tornadoweb/tornado/blob/a4f08a31a348445094d1efa17880ed5472db9f7d/tornado/ioloop.py#L838-L962
+    # License https://github.com/tornadoweb/tornado/blob/v6.2.0/LICENSE
+    # Includes minor modifications to source code to pass linting
+
+    # This backport ensures that async callbacks are not overlapping if a run
+    # takes longer than the interval
+    import datetime
+    import math
+    import random
+    from inspect import isawaitable
+    from typing import Awaitable, Callable
+
+    from tornado.ioloop import IOLoop
+    from tornado.log import app_log
+
+    class PeriodicCallback:  # type: ignore[no-redef]
+        """Schedules the given callback to be called periodically.
+
+        The callback is called every ``callback_time`` milliseconds when
+        ``callback_time`` is a float. Note that the timeout is given in
+        milliseconds, while most other time-related functions in Tornado use
+        seconds. ``callback_time`` may alternatively be given as a
+        `datetime.timedelta` object.
+
+        If ``jitter`` is specified, each callback time will be randomly selected
+        within a window of ``jitter * callback_time`` milliseconds.
+        Jitter can be used to reduce alignment of events with similar periods.
+        A jitter of 0.1 means allowing a 10% variation in callback time.
+        The window is centered on ``callback_time`` so the total number of calls
+        within a given interval should not be significantly affected by adding
+        jitter.
+
+        If the callback runs for longer than ``callback_time`` milliseconds,
+        subsequent invocations will be skipped to get back on schedule.
+
+        `start` must be called after the `PeriodicCallback` is created.
+
+        .. versionchanged:: 5.0
+        The ``io_loop`` argument (deprecated since version 4.1) has been removed.
+
+        .. versionchanged:: 5.1
+        The ``jitter`` argument is added.
+
+        .. versionchanged:: 6.2
+        If the ``callback`` argument is a coroutine, and a callback runs for
+        longer than ``callback_time``, subsequent invocations will be skipped.
+        Previously this was only true for regular functions, not coroutines,
+        which were "fire-and-forget" for `PeriodicCallback`.
+
+        The ``callback_time`` argument now accepts `datetime.timedelta` objects,
+        in addition to the previous numeric milliseconds.
+        """
+
+        def __init__(
+            self,
+            callback: Callable[[], Awaitable | None],
+            callback_time: datetime.timedelta | float,
+            jitter: float = 0,
+        ) -> None:
+            self.callback = callback
+            if isinstance(callback_time, datetime.timedelta):
+                self.callback_time = callback_time / datetime.timedelta(milliseconds=1)
+            else:
+                if callback_time <= 0:
+                    raise ValueError(
+                        "Periodic callback must have a positive callback_time"
+                    )
+                self.callback_time = callback_time
+            self.jitter = jitter
+            self._running = False
+            self._timeout = None  # type: object
+
+        def start(self) -> None:
+            """Starts the timer."""
+            # Looking up the IOLoop here allows to first instantiate the
+            # PeriodicCallback in another thread, then start it using
+            # IOLoop.add_callback().
+            self.io_loop = IOLoop.current()
+            self._running = True
+            self._next_timeout = self.io_loop.time()
+            self._schedule_next()
+
+        def stop(self) -> None:
+            """Stops the timer."""
+            self._running = False
+            if self._timeout is not None:
+                self.io_loop.remove_timeout(self._timeout)
+                self._timeout = None
+
+        def is_running(self) -> bool:
+            """Returns ``True`` if this `.PeriodicCallback` has been started.
+
+            .. versionadded:: 4.1
+            """
+            return self._running
+
+        async def _run(self) -> None:
+            if not self._running:
+                return
+            try:
+                val = self.callback()
+                if val is not None and isawaitable(val):
+                    await val
+            except Exception:
+                app_log.error("Exception in callback %r", self.callback, exc_info=True)
+            finally:
+                self._schedule_next()
+
+        def _schedule_next(self) -> None:
+            if self._running:
+                self._update_next(self.io_loop.time())
+                self._timeout = self.io_loop.add_timeout(self._next_timeout, self._run)
+
+        def _update_next(self, current_time: float) -> None:
+            callback_time_sec = self.callback_time / 1000.0
+            if self.jitter:
+                # apply jitter fraction
+                callback_time_sec *= 1 + (self.jitter * (random.random() - 0.5))
+            if self._next_timeout <= current_time:
+                # The period should be measured from the start of one call
+                # to the start of the next. If one call takes too long,
+                # skip cycles to get back to a multiple of the original
+                # schedule.
+                self._next_timeout += (
+                    math.floor((current_time - self._next_timeout) / callback_time_sec)
+                    + 1
+                ) * callback_time_sec
+            else:
+                # If the clock moved backwards, ensure we advance the next
+                # timeout instead of recomputing the same value again.
+                # This may result in long gaps between callbacks if the
+                # clock jumps backwards by a lot, but the far more common
+                # scenario is a small NTP adjustment that should just be
+                # ignored.
+                #
+                # Note that on some systems if time.time() runs slower
+                # than time.monotonic() (most common on windows), we
+                # effectively experience a small backwards time jump on
+                # every iteration because PeriodicCallback uses
+                # time.time() while asyncio schedules callbacks using
+                # time.monotonic().
+                # https://github.com/tornadoweb/tornado/issues/2333
+                self._next_timeout += callback_time_sec

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, TypedDict, TypeVar, f
 
 import tblib
 from tlz import merge
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import IOLoop
 
 import dask
 from dask.utils import parse_timedelta
@@ -34,6 +34,7 @@ from distributed.comm import (
     normalize_address,
     unparse_host_port,
 )
+from distributed.compatibility import PeriodicCallback
 from distributed.metrics import time
 from distributed.system_monitor import SystemMonitor
 from distributed.utils import (

--- a/distributed/counter.py
+++ b/distributed/counter.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from collections import defaultdict
 
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import IOLoop
+
+from distributed.compatibility import PeriodicCallback
 
 try:
     from crick import TDigest

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -8,10 +8,11 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, cast
 
 import tlz as toolz
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import IOLoop
 
 from dask.utils import parse_timedelta
 
+from distributed.compatibility import PeriodicCallback
 from distributed.metrics import time
 
 if TYPE_CHECKING:

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -10,12 +10,13 @@ from inspect import isawaitable
 from typing import Any
 
 from packaging.version import parse as parse_version
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import IOLoop
 
 import dask.config
 from dask.utils import _deprecated, format_bytes, parse_timedelta, typename
 from dask.widgets import get_template
 
+from distributed.compatibility import PeriodicCallback
 from distributed.core import Status
 from distributed.deploy.adaptive import Adaptive
 from distributed.objects import SchedulerInfo

--- a/distributed/diagnostics/memory_sampler.py
+++ b/distributed/diagnostics/memory_sampler.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 
-from tornado.ioloop import PeriodicCallback
+from distributed.compatibility import PeriodicCallback
 
 if TYPE_CHECKING:
     # Optional runtime dependencies

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -47,7 +47,7 @@ from tlz import (
     second,
     valmap,
 )
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import IOLoop
 
 import dask
 from dask.highlevelgraph import HighLevelGraph
@@ -76,6 +76,7 @@ from distributed.comm import (
     unparse_host_port,
 )
 from distributed.comm.addressing import addresses_from_user_args
+from distributed.compatibility import PeriodicCallback
 from distributed.core import Status, clean_exception, rpc, send_recv
 from distributed.diagnostics.memory_sampler import MemorySamplerExtension
 from distributed.diagnostics.plugin import SchedulerPlugin, _get_plugin_name

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -7,11 +7,10 @@ import warnings
 from asyncio import TimeoutError
 from collections import defaultdict, deque
 
-from tornado.ioloop import PeriodicCallback
-
 import dask
 from dask.utils import parse_timedelta
 
+from distributed.compatibility import PeriodicCallback
 from distributed.metrics import time
 from distributed.utils import SyncMethodMixin, log_errors
 from distributed.utils_comm import retry_operation

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -10,11 +10,11 @@ from time import time
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from tlz import topk
-from tornado.ioloop import PeriodicCallback
 
 import dask
 from dask.utils import parse_timedelta
 
+from distributed.compatibility import PeriodicCallback
 from distributed.core import CommClosedError
 from distributed.diagnostics.plugin import SchedulerPlugin
 from distributed.utils import log_errors, recursive_to_dict

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -422,8 +422,6 @@ async def test_worker_time_to_live(c, s, a, b):
     assert set(s.workers) == {a.address, b.address}
 
     a.periodic_callbacks["heartbeat"].stop()
-    while a.heartbeat_active:
-        await asyncio.sleep(0.01)
 
     start = time()
     while set(s.workers) == {a.address, b.address}:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -17,7 +17,7 @@ import cloudpickle
 import psutil
 import pytest
 from tlz import concat, first, merge, valmap
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import IOLoop
 
 import dask
 from dask import delayed
@@ -35,7 +35,7 @@ from distributed import (
     wait,
 )
 from distributed.comm.addressing import parse_host_port
-from distributed.compatibility import LINUX, MACOS, WINDOWS
+from distributed.compatibility import LINUX, MACOS, WINDOWS, PeriodicCallback
 from distributed.core import ConnectionPool, Status, clean_exception, connect, rpc
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps, loads

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -31,7 +31,7 @@ from inspect import isawaitable
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TextIO, TypeVar, cast
 
 from tlz import first, keymap, pluck
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import IOLoop
 
 import dask
 from dask.core import istask
@@ -54,7 +54,7 @@ from distributed.comm import Comm, connect, get_address_host, parse_address
 from distributed.comm import resolve_address as comm_resolve_address
 from distributed.comm.addressing import address_from_user_args
 from distributed.comm.utils import OFFLOAD_THRESHOLD
-from distributed.compatibility import randbytes, to_thread
+from distributed.compatibility import PeriodicCallback, randbytes, to_thread
 from distributed.core import (
     ConnectionPool,
     Status,

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -160,18 +160,12 @@ class WorkerMemoryManager:
         If process memory rises above the pause threshold (80%), stop execution of new
         tasks.
         """
-        if self._memory_monitoring:
-            return
-        self._memory_monitoring = True
-        try:
-            # Don't use psutil directly; instead read from the same API that is used
-            # to send info to the Scheduler (e.g. for the benefit of Active Memory
-            # Manager) and which can be easily mocked in unit tests.
-            memory = worker.monitor.get_process_memory()
-            self._maybe_pause_or_unpause(worker, memory)
-            await self._maybe_spill(worker, memory)
-        finally:
-            self._memory_monitoring = False
+        # Don't use psutil directly; instead read from the same API that is used
+        # to send info to the Scheduler (e.g. for the benefit of Active Memory
+        # Manager) and which can be easily mocked in unit tests.
+        memory = worker.monitor.get_process_memory()
+        self._maybe_pause_or_unpause(worker, memory)
+        await self._maybe_spill(worker, memory)
 
     def _maybe_pause_or_unpause(self, worker: Worker, memory: int) -> None:
         if self.memory_pause_fraction is False:

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -60,7 +60,6 @@ class WorkerMemoryManager:
     memory_pause_fraction: float | Literal[False]
     max_spill: int | Literal[False]
     memory_monitor_interval: float
-    _memory_monitoring: bool
     _throttled_gc: ThrottledGC
 
     def __init__(
@@ -128,8 +127,6 @@ class WorkerMemoryManager:
             )
         else:
             self.data = {}
-
-        self._memory_monitoring = False
 
         self.memory_monitor_interval = parse_timedelta(
             dask.config.get("distributed.worker.memory.monitor-interval"),

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -31,14 +31,13 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Container, Literal, cast
 
 import psutil
-from tornado.ioloop import PeriodicCallback
 
 import dask.config
 from dask.system import CPU_COUNT
 from dask.utils import format_bytes, parse_bytes, parse_timedelta
 
 from distributed import system
-from distributed.compatibility import WINDOWS
+from distributed.compatibility import WINDOWS, PeriodicCallback
 from distributed.core import Status
 from distributed.metrics import monotonic
 from distributed.spill import ManualEvictProto, SpillBuffer


### PR DESCRIPTION
The PeriodicCallback of tornado versions below 6.2 is known to schedule too many callbacks if the callback is asynchronous and if a single invocation is running longer than the provided interval.

The newer version has much cleaner semantics and guarantees that the new one is only scheduled after the callback is finished.

Specifically the `Client._update_scheduler_info` callback was not aware of this and ran every two seconds. This coroutine accessed the client comm pool to connect to the scheduler and get some meta data. If the scheduler is not responsive, this causes a new update_scheduler_info to be launched every two seconds and since the commpool is typically empty/in use, every invocation will create a new connection.
This is problematic if the event loop of the scheduler is blocked since during this time every new connection attempt will wait, i.e. 10s blocked event loop on the scheduler will cause at least 5 new connections to be opened.
The scheduler event loop is currently known to be blocked when receiving a new graph since it is requiring CPU cycles to unpack, order, etc.
While this is a weird problem, I don't expect this to cause many real world issues unless *many* clients are connected to the scheduler when its event loop is blocked.

Instead of fixing the update_scheduler_info I went ahead and backported the PeriodicCallback from the newer version. This also allows us to get rid of a bit of concurrency control for other async PCs.

cc @hendrikmakait 