### PR TITLE
Track reason of workers closing and restarting

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -307,7 +307,9 @@ class PackageInstall(WorkerPlugin, abc.ABC):
             if self.restart and worker.nanny and not await self._is_restarted(worker):
                 logger.info("Restarting worker to refresh interpreter.")
                 await self._set_restarted(worker)
-                worker.loop.add_callback(worker.close_gracefully, restart=True)
+                worker.loop.add_callback(
+                    worker.close_gracefully, restart=True, reason=f"{self.name}-setup"
+                )
 
     @abc.abstractmethod
     def install(self) -> None:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -256,7 +256,7 @@ class Nanny(ServerNode):
         handlers = {
             "instantiate": self.instantiate,
             "kill": self.kill,
-            "restart": self.restart,  # TODO: Remove since this is not being used anywhere
+            "restart": self.restart,
             "get_logs": self.get_logs,
             # cannot call it 'close' on the rpc side for naming conflict
             "terminate": self.close,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -543,7 +543,7 @@ class Nanny(ServerNode):
                 logger.warning("Restarting worker")
                 await self.instantiate()
             elif self.status == Status.closing_gracefully:
-                await self.close(reason="nanny-closing-gracefully")
+                await self.close(reason="nanny-close-gracefully")
 
         except Exception:
             logger.error(

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -256,7 +256,7 @@ class Nanny(ServerNode):
         handlers = {
             "instantiate": self.instantiate,
             "kill": self.kill,
-            "restart": self.restart,  # TODO: Is this being used anywhere?
+            "restart": self.restart,
             # cannot call it 'close' on the rpc side for naming conflict
             "get_logs": self.get_logs,
             "terminate": self.close,
@@ -805,6 +805,7 @@ class WorkerProcess:
                 "op": "stop",
                 "timeout": wait_timeout,
                 "executor_wait": executor_wait,
+                "reason": reason,
             }
         )
         await asyncio.sleep(0)  # otherwise we get broken pipe errors
@@ -877,12 +878,13 @@ class WorkerProcess:
             loop.make_current()
             worker = Worker(**worker_kwargs)
 
-            async def do_stop(timeout=5, executor_wait=True):
+            async def do_stop(timeout=5, executor_wait=True, reason=None):
                 try:
                     await worker.close(
                         nanny=False,
                         executor_wait=executor_wait,
                         timeout=timeout,
+                        reason=reason,
                     )
                 finally:
                     loop.stop()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -464,7 +464,7 @@ class Nanny(ServerNode):
                 msg = error_message(e)
                 return msg
         if getattr(plugin, "restart", False):
-            await self.restart(reason=f"Nanny plugin {name} requested restart.")
+            await self.restart(reason=f"Nanny plugin {name} requests restart.")
 
         return {"status": "OK"}
 
@@ -594,7 +594,7 @@ class Nanny(ServerNode):
         self.stop()
         try:
             if self.process is not None:
-                await self.kill(timeout=timeout)
+                await self.kill(timeout=timeout, reason="Nanny is closing.")
         except Exception:
             logger.exception("Error in Nanny killing Worker subprocess")
         self.process = None

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -558,14 +558,16 @@ class Nanny(ServerNode):
         warnings.warn("Worker._close has moved to Worker.close", stacklevel=2)
         return self.close(*args, **kwargs)
 
-    # TODO: Include reason
-    def close_gracefully(self):
+    def close_gracefully(self, reason: str = "nanny-close-gracefully") -> None:
         """
         A signal that we shouldn't try to restart workers if they go away
 
         This is used as part of the cluster shutdown process.
         """
         self.status = Status.closing_gracefully
+        logger.info(
+            "Closing Nanny gracefully at %r. Reason: %s", self.address_safe, reason
+        )
 
     async def close(
         self, timeout: float = 5, reason: str = "nanny-close"

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -373,7 +373,7 @@ class Nanny(ServerNode):
 
         return self
 
-    async def kill(self, timeout: float = 2, reason: str = "unknown") -> None:
+    async def kill(self, timeout: float = 2, reason: str | None = None) -> None:
         """Kill the local worker process
 
         Blocks until both the process is down and the scheduler is properly
@@ -484,7 +484,7 @@ class Nanny(ServerNode):
         return {"status": "OK"}
 
     async def restart(
-        self, timeout: float = 30, reason: str = "unknown"
+        self, timeout: float = 30, reason: str | None = None
     ) -> Literal["OK", "timed out"]:
         async def _():
             if self.process is not None:
@@ -767,7 +767,7 @@ class WorkerProcess:
                 self.on_exit(r)
 
     async def kill(
-        self, reason: str, timeout: float = 2, executor_wait: bool = True
+        self, timeout: float = 2, executor_wait: bool = True, reason: str | None = None
     ) -> None:
         """
         Ensure the worker process is stopped, waiting at most
@@ -791,7 +791,7 @@ class WorkerProcess:
             Status.failed,  # process failed to start, but hasn't been joined yet
         ), self.status
         self.status = Status.stopping
-        logger.info("Nanny asking worker to close. Reason: %", reason)
+        logger.info("Nanny asking worker to close. Reason: %s", reason)
 
         process = self.process
         assert process

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -256,9 +256,9 @@ class Nanny(ServerNode):
         handlers = {
             "instantiate": self.instantiate,
             "kill": self.kill,
-            "restart": self.restart,
-            # cannot call it 'close' on the rpc side for naming conflict
+            "restart": self.restart,  # TODO: Remove since this is not being used anywhere
             "get_logs": self.get_logs,
+            # cannot call it 'close' on the rpc side for naming conflict
             "terminate": self.close,
             "close_gracefully": self.close_gracefully,
             "run": self.run,

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -110,7 +110,7 @@ class Nanny(ServerNode):
     """
 
     _instances: ClassVar[weakref.WeakSet[Nanny]] = weakref.WeakSet()
-    process = None
+    process: WorkerProcess | None
     memory_manager: NannyMemoryManager
 
     env: dict[str, str]
@@ -162,6 +162,7 @@ class Nanny(ServerNode):
                 stacklevel=2,
             )
 
+        self.process = None
         self._setup_logging(logger)
         self.loop = self.io_loop = IOLoop.current()
 
@@ -617,6 +618,7 @@ class WorkerProcess:
     running: asyncio.Event
     stopped: asyncio.Event
 
+    process: AsyncProcess | None
     env: dict[str, str]
     pre_spawn_env: dict[str, str]
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5751,7 +5751,10 @@ class Scheduler(SchedulerState, ServerNode):
                         # FIXME does not raise if the process fails to shut down,
                         # see https://github.com/dask/distributed/pull/6427/files#r894917424
                         # NOTE: Nanny will automatically restart worker process when it's killed
-                        nanny.kill(timeout=timeout),
+                        nanny.kill(
+                            reason="Scheduler is restarting all workers.",
+                            timeout=timeout,
+                        ),
                         timeout,
                     )
                     for nanny in nannies

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3981,7 +3981,7 @@ class Scheduler(SchedulerState, ServerNode):
             if not comm.closed():
                 # This closes the Worker and ensures that if a Nanny is around,
                 # it is closed as well
-                comm.send({"op": "close", "reason": "Scheduler is closing."})
+                comm.send({"op": "close", "reason": "scheduler-close"})
                 comm.send({"op": "close-stream"})
                 # ^ TODO remove? `Worker.close` will close the stream anyway.
             with suppress(AttributeError):
@@ -4729,9 +4729,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         logger.info("Closing worker %s", worker)
         self.log_event(worker, {"action": "close-worker"})
-        self.worker_send(
-            worker, {"op": "close", "reason": "Scheduler asks worker to close."}
-        )
+        self.worker_send(worker, {"op": "close", "reason": "scheduler-close-worker"})
 
     @log_errors
     async def remove_worker(
@@ -4771,7 +4769,7 @@ class Scheduler(SchedulerState, ServerNode):
         if close:
             with suppress(AttributeError, CommClosedError):
                 self.stream_comms[address].send(
-                    {"op": "close", "reason": "Scheduler removes worker."}
+                    {"op": "close", "reason": "scheduler-remove-worker"}
                 )
 
         self.remove_resources(address)
@@ -5756,7 +5754,7 @@ class Scheduler(SchedulerState, ServerNode):
                         # see https://github.com/dask/distributed/pull/6427/files#r894917424
                         # NOTE: Nanny will automatically restart worker process when it's killed
                         nanny.kill(
-                            reason="Scheduler restarts all workers.",
+                            reason="scheduler-restart",
                             timeout=timeout,
                         ),
                         timeout,

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -113,12 +113,14 @@ async def test_no_hang_when_scheduler_closes(s, a, b):
     Worker=Nanny, nthreads=[("127.0.0.1", 1)], worker_kwargs={"reconnect": False}
 )
 async def test_close_on_disconnect(s, w):
-    await s.close()
+    with captured_logger("distributed.nanny") as logger:
+        await s.close()
 
-    start = time()
-    while w.status != Status.closed:
-        await asyncio.sleep(0.05)
-        assert time() < start + 9
+        start = time()
+        while w.status != Status.closed:
+            await asyncio.sleep(0.05)
+            assert time() < start + 9
+    assert "Reason: scheduler-close" in logger.getvalue()
 
 
 class Something(Worker):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -917,12 +917,12 @@ class SlowKillNanny(Nanny):
         self.kill_called = asyncio.Event()
         super().__init__(*args, **kwargs)
 
-    async def kill(self, *, timeout):
+    async def kill(self, *, timeout, reason=None):
         self.kill_called.set()
         print("kill called")
         await asyncio.wait_for(self.kill_proceed.wait(), timeout)
         print("kill proceed")
-        return await super().kill(timeout=timeout)
+        return await super().kill(timeout=timeout, reason=reason)
 
 
 @gen_cluster(client=True, Worker=SlowKillNanny, nthreads=[("", 1)] * 2)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -869,8 +869,9 @@ async def test_restart(c, s, a, b):
     with captured_logger("distributed.scheduler") as caplog:
         futures = c.map(inc, range(20))
         await wait(futures)
-
-        await s.restart()
+        with captured_logger("distributed.nanny") as nanny_logger:
+            await s.restart()
+        assert "Reason: scheduler-restart" in nanny_logger.getvalue()
 
         assert not s.computations
         assert not s.task_prefixes

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -839,6 +839,8 @@ def test_fail_hard(sync):
 
                 while a.status != Status.closed:
                     await asyncio.sleep(0.01)
+            method_name = "fail_sync" if sync else "fail_async"
+            assert f"worker-{method_name}-fail-hard" in logger.getvalue()
 
         test_done = True
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1505,7 +1505,9 @@ async def test_close_gracefully(c, s, a, b):
 
     assert any(ts for ts in b.state.tasks.values() if ts.state == "executing")
 
-    await b.close_gracefully()
+    with captured_logger("distributed.worker") as logger:
+        await b.close_gracefully(reason="foo")
+    assert "Reason: foo" in logger.getvalue()
 
     assert b.status == Status.closed
     assert b.address not in s.workers

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1260,7 +1260,7 @@ class Worker(BaseWorker, ServerNode):
             self.address,
             self.status,
         )
-        await self.close()
+        await self.close(reason="worker-handle-scheduler-connection-broken")
 
     async def upload_file(
         self, filename: str, data: str | bytes, load: bool = True

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1542,7 +1542,7 @@ class Worker(BaseWorker, ServerNode):
 
         if nanny and self.nanny:
             with self.rpc(self.nanny) as r:
-                await r.close_gracefully()
+                await r.close_gracefully(reason=reason)
 
         setproctitle("dask worker [closing]")
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -207,7 +207,10 @@ async def _force_close(self):
     2.  If it doesn't, log and kill the process
     """
     try:
-        await asyncio.wait_for(self.close(nanny=False, executor_wait=False), 30)
+        await asyncio.wait_for(
+            self.close(nanny=False, executor_wait=False, reason="Worker failed hard."),
+            30,
+        )
     except (KeyboardInterrupt, SystemExit):  # pragma: nocover
         raise
     except BaseException:  # pragma: nocover
@@ -1455,7 +1458,7 @@ class Worker(BaseWorker, ServerNode):
         timeout: float = 30,
         executor_wait: bool = True,
         nanny: bool = True,
-        reason: str = "unknown",
+        reason: str | None = None,
     ) -> str | None:
         """Close the worker
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1508,7 +1508,7 @@ class Worker(BaseWorker, ServerNode):
         disable_gc_diagnosis()
 
         try:
-            logger.info("Stopping worker at %s. Reason: ", self.address, reason)
+            logger.info("Stopping worker at %s. Reason: %s", self.address, reason)
         except ValueError:  # address not available if already closed
             logger.info("Stopping worker. Reason: %s", reason)
         if self.status not in WORKER_ANY_RUNNING:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1635,7 +1635,9 @@ class Worker(BaseWorker, ServerNode):
         setproctitle("dask worker [closed]")
         return "OK"
 
-    async def close_gracefully(self, reason="worker-close-gracefully"):
+    async def close_gracefully(
+        self, restart=None, reason: str = "worker-close-gracefully"
+    ):
         """Gracefully shut down a worker
 
         This first informs the scheduler that we're shutting down, and asks it
@@ -1657,7 +1659,9 @@ class Worker(BaseWorker, ServerNode):
             remove=False,
             stimulus_id=f"worker-close-gracefully-{time()}",
         )
-        await self.close(nanny=not self.lifetime_restart, reason=reason)
+        if restart is None:
+            restart = self.lifetime_restart
+        await self.close(nanny=not restart, reason=reason)
 
     async def wait_until_closed(self):
         warnings.warn("wait_until_closed has moved to finished()")


### PR DESCRIPTION
This PR adds a `reason` kwarg to multiple places where we close/kill/restart workers to provide better insights into the causes of those.

_Note:_

This basically implements a poor man's of tracing, we may want to look into #6201, #4762 and #4718 to improve upon this with less manual repetition.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
