### PR TITLE
More comprehensive WorkerState task counters

### DIFF
--- a/distributed/dashboard/components/worker.py
+++ b/distributed/dashboard/components/worker.py
@@ -90,7 +90,7 @@ class StateTable(DashboardComponent):
             "Stored": [len(w.data)],
             "Executing": ["%d / %d" % (w.state.executing_count, w.state.nthreads)],
             "Ready": [len(w.state.ready)],
-            "Waiting": [w.state.waiting_for_data_count],
+            "Waiting": [len(w.state.waiting)],
             "Connections": [w.state.transfer_incoming_count],
             "Serving": [len(w._comms)],
         }

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -536,12 +536,10 @@ async def test_WorkerTable_custom_metric_overlap_with_core_metric(c, s, a, b):
     def metric(worker):
         return -999
 
-    a.metrics["executing"] = metric
     a.metrics["cpu"] = metric
     a.metrics["metric"] = metric
     await asyncio.gather(a.heartbeat(), b.heartbeat())
 
-    assert s.workers[a.address].metrics["executing"] != -999
     assert s.workers[a.address].metrics["cpu"] != -999
     assert s.workers[a.address].metrics["metric"] == -999
 

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -71,8 +71,14 @@ async def test_prometheus_collect_task_states(c, s, a):
     assert not a.state.tasks
     active_metrics = await fetch_state_metrics()
     assert active_metrics == {
-        "stored": 0.0,
+        "constrained": 0.0,
         "executing": 0.0,
+        "fetch": 0.0,
+        "flight": 0.0,
+        "long-running": 0.0,
+        "memory": 0.0,
+        "missing": 0.0,
+        "other": 0.0,
         "ready": 0.0,
         "waiting": 0.0,
     }
@@ -86,8 +92,14 @@ async def test_prometheus_collect_task_states(c, s, a):
 
     active_metrics = await fetch_state_metrics()
     assert active_metrics == {
-        "stored": 0.0,
+        "constrained": 0.0,
         "executing": 1.0,
+        "fetch": 0.0,
+        "flight": 0.0,
+        "long-running": 0.0,
+        "memory": 0.0,
+        "missing": 0.0,
+        "other": 0.0,
         "ready": 0.0,
         "waiting": 0.0,
     }
@@ -102,8 +114,14 @@ async def test_prometheus_collect_task_states(c, s, a):
 
     active_metrics = await fetch_state_metrics()
     assert active_metrics == {
-        "stored": 0.0,
+        "constrained": 0.0,
         "executing": 0.0,
+        "fetch": 0.0,
+        "flight": 0.0,
+        "long-running": 0.0,
+        "memory": 0.0,
+        "missing": 0.0,
+        "other": 0.0,
         "ready": 0.0,
         "waiting": 0.0,
     }

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -610,7 +610,7 @@ async def test_clear_events_client_removal(c, s, a, b):
 @gen_cluster(client=True, nthreads=[])
 async def test_add_worker(c, s):
     x = c.submit(inc, 1, key="x")
-    await wait_for_state("x", "no-worker", s)
+    await wait_for_state("x", ("queued", "no-worker"), s)
     s.validate_state()
 
     async with Worker(s.address) as w:

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -987,16 +987,19 @@ async def test_wait_for_state(c, s, a, capsys):
 
     await asyncio.gather(
         wait_for_state("x", "memory", s),
-        wait_for_state("x", "memory", a),
+        wait_for_state("x", {"memory", "other"}, a),
         c.run(wait_for_state, "x", "memory"),
     )
 
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(wait_for_state("x", "bad_state", s), timeout=0.1)
     with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(wait_for_state("x", ("this", "that"), s), timeout=0.1)
+    with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(wait_for_state("y", "memory", s), timeout=0.1)
     assert capsys.readouterr().out == (
         f"tasks[x].state='memory' on {s.address}; expected state='bad_state'\n"
+        f"tasks[x].state='memory' on {s.address}; expected state=('this', 'that')\n"
         f"tasks[y] not found on {s.address}\n"
     )
 

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -703,10 +703,9 @@ async def test_override_data_worker(s):
     async with Worker(s.address, data=UserDict) as w:
         assert type(w.data) is UserDict
 
-    data = UserDict({"x": 1})
+    data = UserDict()
     async with Worker(s.address, data=data) as w:
         assert w.data is data
-        assert w.data == {"x": 1}
 
 
 @gen_cluster(


### PR DESCRIPTION
- Expose a more comprehensive and accurate view of the number of tasks in each state on the worker to the scheduler (through the heartbeat) and to prometheus. Crucially, this PR gives us a measure of network saturation and co-assignment by showing how many tasks are queued up in `fetch` state.
- O(1) count number of tasks in fetch state
- Closes #6319
- Disallow directly writing to Worker.data. I am quite frankly baffled this was possible before. I don't think we should have a deprecation cycle for this?
- Prometheus tasks metric `stored` has been renamed to `memory` CC @ntabris 