### PR TITLE
Show no-worker on task progress bar

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3251,6 +3251,18 @@ class TaskProgress(DashboardComponent):
             fill_alpha=0.35,
             line_alpha=0,
         )
+        self.root.quad(
+            source=self.source,
+            top="top",
+            bottom="bottom",
+            left="queued-loc",
+            right="no-worker-loc",
+            fill_color="red",
+            hatch_pattern="/",
+            hatch_color="black",
+            fill_alpha=0.35,
+            line_alpha=0,
+        )
         self.root.text(
             source=self.source,
             text="show-name",
@@ -3291,6 +3303,10 @@ class TaskProgress(DashboardComponent):
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@queued</span>
                 </div>
                 <div>
+                    <span style="font-size: 14px; font-weight: bold;">No-worker:</span>&nbsp;
+                    <span style="font-size: 10px; font-family: Monaco, monospace;">@no_worker</span>
+                </div>
+                <div>
                     <span style="font-size: 14px; font-weight: bold;">Processing:</span>&nbsp;
                     <span style="font-size: 10px; font-family: Monaco, monospace;">@processing</span>
                 </div>
@@ -3316,6 +3332,7 @@ class TaskProgress(DashboardComponent):
             "processing": {},
             "waiting": {},
             "queued": {},
+            "no_worker": {},
         }
 
         for tp in self.scheduler.task_prefixes.values():
@@ -3327,6 +3344,7 @@ class TaskProgress(DashboardComponent):
                 state["processing"][tp.name] = active_states["processing"]
                 state["waiting"][tp.name] = active_states["waiting"]
                 state["queued"][tp.name] = active_states["queued"]
+                state["no_worker"][tp.name] = active_states["no-worker"]
 
         state["all"] = {k: sum(v[k] for v in state.values()) for k in state["memory"]}
 
@@ -3339,7 +3357,15 @@ class TaskProgress(DashboardComponent):
 
         totals = {
             k: sum(state[k].values())
-            for k in ["all", "memory", "erred", "released", "waiting", "queued"]
+            for k in [
+                "all",
+                "memory",
+                "erred",
+                "released",
+                "waiting",
+                "queued",
+                "no_worker",
+            ]
         }
         totals["processing"] = totals["all"] - sum(
             v for k, v in totals.items() if k != "all"
@@ -3351,6 +3377,7 @@ class TaskProgress(DashboardComponent):
             "queued: %(queued)s, "
             "processing: %(processing)s, "
             "in-memory: %(memory)s, "
+            "no-worker: %(no_worker)s, "
             "erred: %(erred)s" % totals
         )
 

--- a/distributed/diagnostics/progress_stream.py
+++ b/distributed/diagnostics/progress_stream.py
@@ -111,13 +111,15 @@ def progress_quads(msg, nrows=8, ncols=3):
     d["erred-loc"] = []
     d["processing-loc"] = []
     d["queued-loc"] = []
+    d["no-worker-loc"] = []
     d["done"] = []
-    for r, m, e, p, q, a, l in zip(
+    for r, m, e, p, q, nw, a, l in zip(
         d["released"],
         d["memory"],
         d["erred"],
         d["processing"],
         d["queued"],
+        d.get("no_worker", [0] * n),
         d["all"],
         d["left"],
     ):
@@ -126,12 +128,14 @@ def progress_quads(msg, nrows=8, ncols=3):
         el = width * (r + m + e) / a + l
         pl = width * (p + r + m + e) / a + l
         ql = width * (p + r + m + e + q) / a + l
+        nwl = width * (p + r + m + e + q + nw) / a + l
         done = "%d / %d" % (r + m + e, a)
         d["released-loc"].append(rl)
         d["memory-loc"].append(ml)
         d["erred-loc"].append(el)
         d["processing-loc"].append(pl)
         d["queued-loc"].append(ql)
+        d["no-worker-loc"].append(nwl)
         d["done"].append(done)
 
     return d

--- a/distributed/diagnostics/tests/test_progress_stream.py
+++ b/distributed/diagnostics/tests/test_progress_stream.py
@@ -19,6 +19,7 @@ def test_progress_quads():
         "released": {"inc": 1, "dec": 0, "add": 1},
         "processing": {"inc": 1, "dec": 0, "add": 2},
         "queued": {"inc": 1, "dec": 0, "add": 2},
+        "no-worker": {"inc": 1, "dec": 0, "add": 0},
     }
 
     d = progress_quads(msg, nrows=2)
@@ -37,12 +38,14 @@ def test_progress_quads():
         "erred": [0, 0, 1],
         "processing": [1, 2, 0],
         "queued": [1, 2, 0],
+        "no-worker": [1, 0, 0],
         "done": ["3 / 5", "2 / 4", "1 / 1"],
         "released-loc": [0.9 * 1 / 5, 0.25 * 0.9, 1.0],
         "memory-loc": [0.9 * 3 / 5, 0.5 * 0.9, 1.0],
         "erred-loc": [0.9 * 3 / 5, 0.5 * 0.9, 1.9],
         "processing-loc": [0.9 * 4 / 5, 1 * 0.9, 1 * 0.9 + 1],
         "queued-loc": [1 * 0.9, 1.5 * 0.9, 1 * 0.9 + 1],
+        "no-worker-loc": [1 * 0.9, 1.5 * 0.9, 1 * 0.9 + 1],
     }
     assert d == expected
 


### PR DESCRIPTION
Currently there is no feedback at all if there are tasks in no-worker state. This can be perceived as a deadlock which is not nice. This change will show the tasks in a red/black shaded area in the task progress bar such that users have a chance to understand what's going on

Closes https://github.com/dask/distributed/issues/7170

![image](https://user-images.githubusercontent.com/8629629/197207725-83f884ea-9f7c-4814-8e0b-d05cc94e19c9.png)
