### PR TITLE
Update minimum `bokeh` version message

### DIFF
--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -12,12 +12,14 @@ from packaging.version import parse as parse_version
 
 import dask
 
-if parse_version(bokeh.__version__) < parse_version("2.1.1"):
+_min_bokeh_version = "2.1.1"
+
+if parse_version(bokeh.__version__) < parse_version(_min_bokeh_version):
     warnings.warn(
-        "\nDask needs bokeh >= 2.1.1 for the dashboard."
+        f"\nDask needs bokeh >= {_min_bokeh_version} for the dashboard."
         "\nContinuing without the dashboard."
     )
-    raise ImportError("Dask needs bokeh >= 2.1.1")
+    raise ImportError(f"Dask needs bokeh >= {_min_bokeh_version}")
 
 
 def BokehApplication(applications, server, prefix="/", template_variables=None):

--- a/distributed/http/scheduler/missing_bokeh.py
+++ b/distributed/http/scheduler/missing_bokeh.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from distributed.dashboard.core import _min_bokeh_version
 from distributed.http.utils import RequestHandler, redirect
 from distributed.utils import log_errors
 
@@ -8,9 +9,9 @@ class MissingBokeh(RequestHandler):
     @log_errors
     def get(self):
         self.write(
-            "<p>Dask needs bokeh >= 2.1.1 for the dashboard.</p>"
-            "<p>Install with conda: conda install bokeh>=1.0</p>"
-            "<p>Install with pip: pip install bokeh>=2.1.1</p>"
+            f"<p>Dask needs bokeh >= {_min_bokeh_version} for the dashboard.</p>"
+            f"<p>Install with conda: conda install bokeh>={_min_bokeh_version}</p>"
+            f"<p>Install with pip: pip install bokeh>={_min_bokeh_version}</p>"
         )
 
 


### PR DESCRIPTION
Currently we're giving conflicting version for installing with `conda` (1.0) and `pip` (2.1.1). This PR makes it so we specify the minimum `bokeh` version once and then use that value where needed. 