### PR TITLE
[WIP] Set `OPENBLAS_NUM_THREADS` by default

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -191,6 +191,7 @@ distributed:
       # Numpy configuration
       OMP_NUM_THREADS: 1
       MKL_NUM_THREADS: 1
+      OPENBLAS_NUM_THREADS: 1
 
   client:
     heartbeat: 5s  # Interval between client heartbeats


### PR DESCRIPTION
In https://docs.dask.org/en/stable/array-best-practices.html#avoid-oversubscribing-threads we recommend setting 

```bash
export OMP_NUM_THREADS=1
export MKL_NUM_THREADS=1
export OPENBLAS_NUM_THREADS=1
```

to avoid oversubscribing worker threads. 

Today we set `OMP_NUM_THREADS` and `MKL_NUM_THREADS` by default (when using a nanny) 

https://github.com/dask/distributed/blob/6ac679e473fa5189b69328889a6cdca30f2ba5d0/distributed/distributed.yaml#L191-L193

So users get good defaults by default. Should we also set `OPENBLAS_NUM_THREADS`? 

cc @crusaderky in case you have thoughts here 
