### PR TITLE
Add `Client.log_on_scheduler` method to help correlating cluster logs with client-side events.

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4174,6 +4174,15 @@ class Client(SyncMethodMixin):
         """
         return self.sync(self.scheduler.log_event, topic=topic, msg=msg)
 
+    def log_on_scheduler(self, msg: str, *args: Any, level: int = logging.INFO) -> None:
+        """Log 'msg % args' with the integer severity 'level' on the scheduler.
+
+        See Also
+        --------
+        logging.log
+        """
+        return self.sync(self.scheduler.log_message, msg=msg % args, level=level)
+
     def get_events(self, topic: str | None = None):
         """Retrieve structured topic logs
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4175,7 +4175,7 @@ class Client(SyncMethodMixin):
         return self.sync(self.scheduler.log_event, topic=topic, msg=msg)
 
     def log_on_scheduler(self, msg: str, *args: Any, level: int = logging.INFO) -> None:
-        """Log 'msg % args' with the integer severity 'level' on the scheduler.
+        """Log 'msg % args' with the integer severity 'level' on the scheduler
 
         See Also
         --------

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3636,6 +3636,7 @@ class Scheduler(SchedulerState, ServerNode):
             "get_logs": self.get_logs,
             "logs": self.get_logs,
             "worker_logs": self.get_worker_logs,
+            "log_message": self.log_message,
             "log_event": self.log_event,
             "events": self.get_events,
             "nbytes": self.get_nbytes,
@@ -7600,6 +7601,10 @@ class Scheduler(SchedulerState, ServerNode):
             msg={"op": "get_logs", "n": n}, workers=workers, nanny=nanny
         )
         return results
+
+    @staticmethod
+    def log_message(msg: str, level: int = logging.INFO) -> None:
+        logger.log(level, msg)
 
     def log_event(self, topic: str | Collection[str], msg: Any) -> None:
         event = (time(), msg)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7744,3 +7744,12 @@ async def test_wait_for_workers_n_workers_value_check(c, s, a, b, value, excepti
         ctx = nullcontext()
     with ctx:
         await c.wait_for_workers(value)
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_log_message(c, s):
+    with captured_logger("distributed.scheduler", level=logging.INFO) as logger:
+        await c.log_on_scheduler("test info with %s", "parameter", level=logging.INFO)
+        await c.log_on_scheduler("test debug with %s", "parameter", level=logging.DEBUG)
+    assert "test info with parameter" in logger.getvalue()
+    assert "test debug with parameter" not in logger.getvalue()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -4010,3 +4010,12 @@ async def test_count_task_prefix(c, s, a, b):
 
     assert s.task_prefixes["inc"].state_counts["memory"] == 20
     assert s.task_prefixes["inc"].state_counts["erred"] == 0
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_log_message(c, s):
+    with captured_logger("distributed.scheduler", level=logging.INFO) as logger:
+        s.log_message("test info", level=logging.INFO)
+        s.log_message("test debug ", level=logging.DEBUG)
+    assert "test info" in logger.getvalue()
+    assert "test debug" not in logger.getvalue()


### PR DESCRIPTION
This PR adds a `Client.log_on_scheduler` method that logs the provided message in the scheduler's logs. I implemented a similar helper for coiled/coiled-runtime/pull/473 and figured this might be generally helpful to allow users to inject additional timestamped information into the cluster logs. 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
