### PR TITLE
User a layer for p2p shuffle

### DIFF
--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -288,10 +288,16 @@ async def test_tail(c, s, a, b):
         dtypes={"x": float, "y": float},
         freq="1 s",
     )
-    shuffled = dd.shuffle.shuffle(df, "x", shuffle="p2p").tail(compute=False)
-    persisted = await shuffled.persist()  # Only ask for one key
+    x = dd.shuffle.shuffle(df, "x", shuffle="p2p")
+    full = await x.persist()
+    ntasks_full = len(s.tasks)
+    del full
+    while s.tasks:
+        await asyncio.sleep(0)
+    partial = await x.tail(compute=False).persist()  # Only ask for one key
 
-    assert len(s.tasks) < df.npartitions * 2
+    assert len(s.tasks) < ntasks_full
+    del partial
 
     clean_worker(a)
     clean_worker(b)
@@ -402,6 +408,7 @@ async def test_restrictions(c, s, a, b):
 @pytest.mark.xfail(reason="Don't clean up forgotten shuffles")
 @gen_cluster(client=True)
 async def test_delete_some_results(c, s, a, b):
+    # FIXME: This works but not reliably. It fails every ~25% of runs
     df = dask.datasets.timeseries(
         start="2000-01-01",
         end="2000-01-10",
@@ -421,7 +428,6 @@ async def test_delete_some_results(c, s, a, b):
     clean_scheduler(s)
 
 
-@pytest.mark.xfail(reason="Don't update ongoing shuffles")
 @gen_cluster(client=True)
 async def test_add_some_results(c, s, a, b):
     df = dask.datasets.timeseries(


### PR DESCRIPTION
This moves the graph generation for p2p shuffling to a layer. The benefit is that we can generate a "new graph" when culling.

This specifically helps with problem cases like Case 2 in https://github.com/dask/distributed/issues/6105

```python
df = ...
x = df.shuffle(on="x")
y = x.partitions[x.npartitions//2].persist()
sleep(0.1)
z = x.persist()
```

as exhibited by test case `test_add_some_results`.

In the above example, `y`, and `z`, will be treated as unique shuffles which makes releasing keys much more straight forward and decouples the problem significantly.

Of course, we may need to submit some data twice but I doubt this is a problem in practice.


FWIW I only inherited from SimpleShuffleLayer because I didn't want to duplicate too much code. It's sufficiently similar to what we need for now to be subclassed