### PR TITLE
Only use opened queue slots on running workers

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2167,10 +2167,7 @@ class SchedulerState:
                 _task_slots_available(ws, self.WORKER_SATURATION),
             )
             assert ws in self.running, (ws, self.running)
-
-        if self.validate and ws is not None:
             assert self.workers.get(ws.address) is ws
-            assert ws in self.running, (ws, self.running)
 
         return ws
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7878,7 +7878,11 @@ def _exit_processing_common(
     state.release_resources(ts, ws)
 
     # If a slot has opened up for a queued task, schedule it.
-    if state.queued and not _worker_full(ws, state.WORKER_SATURATION):
+    if (
+        state.queued
+        and ws.status == Status.running
+        and not _worker_full(ws, state.WORKER_SATURATION)
+    ):
         qts = state.queued.peek()
         if state.validate:
             assert qts.state == "queued", qts.state


### PR DESCRIPTION
Minor readability and performance improvement that avoids trying to send a queued task to processing when a slot opens on a non-running worker.

This doesn't affect correctness. Currently, a task will be recommended to `processing` and we'll look for a worker for it. Since the worker isn't running, we won't pick it, and the task will stay in `queued`. With this PR, we simply save ourselves doing the search when we know it won't be fruitful.

I haven't come up with a nice way to test this (since it shouldn't affect behavior and the performance difference will be minuscule anyway.) I could look at the scheduler transition logs and assert there's no extra queued->processing->queued transition in this case, but that feels a bit nitpicky for a case that isn't very important.

- [x] Passes `pre-commit run --all-files`
