### PR TITLE
Separation of concerns between Shuffle and WorkerShuffle

### DIFF
--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -1126,9 +1126,6 @@ async def test_shuffling(c, s, a, b):
         ss.update()
         await asyncio.sleep(0.1)
         assert time() < start + 5
-    # FIXME: If this is still running while the test is running, this raises
-    # awkward CancelledErrors
-    await df2
 
 
 @gen_cluster(client=True, scheduler_kwargs={"dashboard": True}, timeout=60)

--- a/distributed/shuffle/_multi_comm.py
+++ b/distributed/shuffle/_multi_comm.py
@@ -64,7 +64,6 @@ class MultiComm:
     def __init__(
         self,
         send: Callable[[str, list[bytes]], Awaitable[None]],
-        loop: asyncio.AbstractEventLoop | None = None,
     ):
         self.send = send
         self.shards: dict[str, list[bytes]] = defaultdict(list)
@@ -75,7 +74,7 @@ class MultiComm:
         self._futures: set[asyncio.Task] = set()
         self._done = False
         self.diagnostics: dict[str, float] = defaultdict(float)
-        self._loop = loop or asyncio.get_event_loop()
+        self._loop = asyncio.get_event_loop()
 
         self._communicate_task = asyncio.create_task(self.communicate())
         self._exception: Exception | None = None

--- a/distributed/shuffle/_multi_file.py
+++ b/distributed/shuffle/_multi_file.py
@@ -167,6 +167,7 @@ class MultiFile:
 
             while not self._done:
                 with self.time("idle"):
+                    await self._maybe_raise_exception()
                     if not self.shards:
                         await asyncio.sleep(0.1)
                         continue

--- a/distributed/shuffle/_multi_file.py
+++ b/distributed/shuffle/_multi_file.py
@@ -262,6 +262,7 @@ class MultiFile:
             await asyncio.gather(*self._futures)
             raise self._exception
         while self.shards:
+            # If an exception arises while we're sleeping here we deadlock
             await asyncio.sleep(0.05)
 
         await asyncio.gather(*self._futures)

--- a/distributed/shuffle/_multi_file.py
+++ b/distributed/shuffle/_multi_file.py
@@ -72,7 +72,6 @@ class MultiFile:
         dump: Callable[[Any, BinaryIO], None] = pickle.dump,
         load: Callable[[BinaryIO], Any] = pickle.load,
         sizeof: Callable[[list[pa.Table]], int] = sizeof,
-        loop: object = None,
     ):
         self.directory = pathlib.Path(directory)
         if not os.path.exists(self.directory):
@@ -96,7 +95,7 @@ class MultiFile:
         self.diagnostics = defaultdict(float)
 
         self._communicate_future = asyncio.create_task(self.communicate())
-        self._loop = loop or asyncio.get_event_loop()
+        self._loop = asyncio.get_event_loop()
         self._exception = None
 
     @property

--- a/distributed/shuffle/_multi_file.py
+++ b/distributed/shuffle/_multi_file.py
@@ -233,10 +233,12 @@ class MultiFile:
             async with self.condition:
                 self.condition.notify()
 
-    def read(self, id: int) -> pa.Table:
+    def read(self, id: int | str) -> pa.Table:
         """Read a complete file back into memory"""
         if self._exception:
             raise self._exception
+        if not self._done:
+            raise RuntimeError("Tried to read from file before done.")
         parts = []
 
         try:

--- a/distributed/shuffle/_multi_file.py
+++ b/distributed/shuffle/_multi_file.py
@@ -12,6 +12,8 @@ from collections import defaultdict
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any, BinaryIO
 
+from tornado.ioloop import IOLoop
+
 from dask.sizeof import sizeof
 from dask.utils import parse_bytes
 
@@ -69,6 +71,7 @@ class MultiFile:
     def __init__(
         self,
         directory: str,
+        loop: IOLoop,
         dump: Callable[[Any, BinaryIO], None] = pickle.dump,
         load: Callable[[BinaryIO], Any] = pickle.load,
         sizeof: Callable[[list[pa.Table]], int] = sizeof,
@@ -95,7 +98,7 @@ class MultiFile:
         self.diagnostics = defaultdict(float)
 
         self._communicate_future = asyncio.create_task(self.communicate())
-        self._loop = asyncio.get_event_loop()
+        self._loop = loop
         self._exception = None
 
     @property

--- a/distributed/shuffle/_shuffle_extension.py
+++ b/distributed/shuffle/_shuffle_extension.py
@@ -592,8 +592,6 @@ class ShuffleSchedulerExtension:
                 mapping[part] = worker
                 output_workers.add(worker)
                 self.scheduler.set_restrictions({ts.key: {worker}})
-                # ts.worker_restrictions = {worker}  # TODO: once cython is
-                # gone
 
             self.worker_for[id] = mapping
             self.schemas[id] = schema

--- a/distributed/shuffle/tests/test_multi_comm.py
+++ b/distributed/shuffle/tests/test_multi_comm.py
@@ -4,6 +4,7 @@ import asyncio
 from collections import defaultdict
 
 import pytest
+from tornado.ioloop import IOLoop
 
 from distributed.shuffle._multi_comm import MultiComm
 from distributed.utils_test import gen_test
@@ -16,7 +17,7 @@ async def test_basic(tmp_path):
     async def send(address, shards):
         d[address].extend(shards)
 
-    mc = MultiComm(send=send)
+    mc = MultiComm(send=send, loop=IOLoop.current())
     mc.put({"x": [b"0" * 1000], "y": [b"1" * 500]})
     mc.put({"x": [b"0" * 1000], "y": [b"1" * 500]})
 
@@ -33,7 +34,7 @@ async def test_exceptions(tmp_path):
     async def send(address, shards):
         raise Exception(123)
 
-    mc = MultiComm(send=send)
+    mc = MultiComm(send=send, loop=IOLoop.current())
     mc.put({"x": [b"0" * 1000], "y": [b"1" * 500]})
 
     while not mc._exception:
@@ -44,3 +45,32 @@ async def test_exceptions(tmp_path):
 
     with pytest.raises(Exception, match="123"):
         await mc.flush()
+
+    await mc.close()
+
+
+@gen_test()
+async def test_slow_send(tmpdir):
+    block_send = asyncio.Event()
+    block_send.set()
+    sending_first = asyncio.Event()
+    d = defaultdict(list)
+
+    async def send(address, shards):
+        await block_send.wait()
+        d[address].extend(shards)
+        sending_first.set()
+
+    mc = MultiComm(send=send, loop=IOLoop.current())
+    mc.max_connections = 1
+    mc.put({"x": [b"0"], "y": [b"1"]})
+    mc.put({"x": [b"0"], "y": [b"1"]})
+    flush_task = asyncio.create_task(mc.flush())
+    await sending_first.wait()
+    block_send.clear()
+
+    with pytest.raises(RuntimeError):
+        mc.put({"x": [b"2"], "y": [b"2"]})
+        await flush_task
+
+    assert [b"2" not in shard for shard in d["x"]]

--- a/distributed/shuffle/tests/test_multi_comm.py
+++ b/distributed/shuffle/tests/test_multi_comm.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
+import math
 from collections import defaultdict
 
 import pytest
@@ -74,3 +76,71 @@ async def test_slow_send(tmpdir):
         await flush_task
 
     assert [b"2" not in shard for shard in d["x"]]
+
+
+def gen_bytes(percentage: float) -> bytes:
+    num_bytes = int(math.floor(percentage * MultiComm.memory_limit))
+    return b"0" * num_bytes
+
+
+@pytest.mark.parametrize("explicit_flush", [True, False])
+@gen_test()
+async def test_concurrent_puts(explicit_flush):
+    d = defaultdict(list)
+
+    async def send(address, shards):
+        d[address].extend(shards)
+
+    frac = 0.1
+    nshards = 10
+    nputs = 20
+    payload = {x: [gen_bytes(frac)] for x in range(nshards)}
+    with concurrent.futures.ThreadPoolExecutor(
+        2, thread_name_prefix="test IOLoop"
+    ) as tpe:
+        async with MultiComm(send=send, loop=IOLoop.current()) as mc:
+            loop = asyncio.get_running_loop()
+            futs = [loop.run_in_executor(tpe, mc.put, payload) for _ in range(nputs)]
+
+            await asyncio.gather(*futs)
+            if explicit_flush:
+                await mc.flush()
+
+                assert not mc.shards
+                assert not mc.sizes
+
+        assert not mc.shards
+        assert not mc.sizes
+        assert len(d) == 10
+        assert sum(map(len, d[0])) == len(gen_bytes(frac)) * nputs
+
+
+@gen_test()
+async def test_concurrent_puts_error():
+    d = defaultdict(list)
+
+    counter = 0
+
+    async def send(address, shards):
+        nonlocal counter
+        counter += 1
+        if counter == 5:
+            raise OSError("error during send")
+        d[address].extend(shards)
+
+    frac = 0.1
+    nshards = 10
+    nputs = 20
+    payload = {x: [gen_bytes(frac)] for x in range(nshards)}
+    with concurrent.futures.ThreadPoolExecutor(
+        2, thread_name_prefix="test IOLoop"
+    ) as tpe:
+        async with MultiComm(send=send, loop=IOLoop.current()) as mc:
+            loop = asyncio.get_running_loop()
+            futs = [loop.run_in_executor(tpe, mc.put, payload) for _ in range(nputs)]
+
+            with pytest.raises(OSError, match="error during send"):
+                await asyncio.gather(*futs)
+
+    assert not mc.shards
+    assert not mc.sizes

--- a/distributed/shuffle/tests/test_multi_file.py
+++ b/distributed/shuffle/tests/test_multi_file.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 
 import pytest
+from tornado.ioloop import IOLoop
 
 from distributed.shuffle._multi_file import MultiFile
 from distributed.utils_test import gen_test
@@ -22,7 +23,9 @@ def load(f):
 
 @gen_test()
 async def test_basic(tmp_path):
-    async with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
+    async with MultiFile(
+        directory=tmp_path, dump=dump, load=load, loop=IOLoop.current()
+    ) as mf:
         await mf.put({"x": [b"0" * 1000], "y": [b"1" * 500]})
         await mf.put({"x": [b"0" * 1000], "y": [b"1" * 500]})
 
@@ -40,7 +43,9 @@ async def test_basic(tmp_path):
 @pytest.mark.parametrize("count", [2, 100, 1000])
 @gen_test()
 async def test_many(tmp_path, count):
-    async with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
+    async with MultiFile(
+        directory=tmp_path, dump=dump, load=load, loop=IOLoop.current()
+    ) as mf:
         d = {i: [str(i).encode() * 100] for i in range(count)}
 
         for _ in range(10):
@@ -60,7 +65,9 @@ async def test_exceptions(tmp_path):
     def dump(data, f):
         raise Exception(123)
 
-    async with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
+    async with MultiFile(
+        directory=tmp_path, dump=dump, load=load, loop=IOLoop.current()
+    ) as mf:
         await mf.put({"x": [b"0" * 1000], "y": [b"1" * 500]})
 
         while not mf._exception:
@@ -71,3 +78,46 @@ async def test_exceptions(tmp_path):
 
         with pytest.raises(Exception, match="123"):
             await mf.flush()
+
+
+@gen_test()
+async def test_buffer_too_many_concurrent_files(tmp_path):
+    pass
+
+
+@pytest.mark.parametrize(
+    "explicit_flush",
+    [
+        True,
+        False,
+    ],
+)
+@gen_test()
+async def test_high_pressure_flush_with_exception(tmp_path, explicit_flush):
+    counter = 0
+    payload = {f"shard-{ix}": [f"shard-{ix}".encode() * 100] for ix in range(100)}
+
+    def dump_broken(data, f):
+        nonlocal counter
+        if counter > MultiFile.concurrent_files:
+            raise Exception(123)
+        counter += 1
+        dump(data, f)
+
+    # Something here should raise...
+    with pytest.raises(Exception, match="123"):
+        async with MultiFile(
+            directory=tmp_path, dump=dump_broken, load=load, loop=IOLoop.current()
+        ) as mf:
+            tasks = []
+            for _ in range(10):
+                tasks.append(asyncio.create_task(mf.put(payload)))
+
+            # Wait until things are actually queued up.
+            # This is when there is no slot on the queue available anymore
+            # but there are still shards around
+            while not (mf.shards and mf.queue.empty()):
+                await asyncio.sleep(0)
+            if explicit_flush:
+                # Flushing while this happens is a bad idea and deadlocks atm
+                await mf.flush()

--- a/distributed/shuffle/tests/test_multi_file.py
+++ b/distributed/shuffle/tests/test_multi_file.py
@@ -22,7 +22,7 @@ def load(f):
 
 @gen_test()
 async def test_basic(tmp_path):
-    with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
+    async with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
         await mf.put({"x": [b"0" * 1000], "y": [b"1" * 500]})
         await mf.put({"x": [b"0" * 1000], "y": [b"1" * 500]})
 
@@ -40,7 +40,7 @@ async def test_basic(tmp_path):
 @pytest.mark.parametrize("count", [2, 100, 1000])
 @gen_test()
 async def test_many(tmp_path, count):
-    with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
+    async with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
         d = {i: [str(i).encode() * 100] for i in range(count)}
 
         for _ in range(10):
@@ -60,7 +60,7 @@ async def test_exceptions(tmp_path):
     def dump(data, f):
         raise Exception(123)
 
-    with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
+    async with MultiFile(directory=tmp_path, dump=dump, load=load) as mf:
         await mf.put({"x": [b"0" * 1000], "y": [b"1" * 500]})
 
         while not mf._exception:

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -451,6 +451,7 @@ async def test_add_some_results(c, s, a, b):
     clean_scheduler(s)
 
 
+@pytest.mark.slow
 @gen_cluster(client=True)
 async def test_clean_after_close(c, s, a, b):
     df = dask.datasets.timeseries(

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -120,7 +120,7 @@ async def test_bad_disk(c, s, a, b):
     # clean_scheduler(s)
 
 
-@pytest.mark.xfail
+@pytest.mark.skip
 @pytest.mark.slow
 @gen_cluster(client=True)
 async def test_crashed_worker(c, s, a, b):


### PR DESCRIPTION
Builds on https://github.com/dask/distributed/pull/7186

This PR refactors the Worker extension and the Shuffle class to have stricter separation of concerns.

Specifically,

Shuffle is responsible for all splitting, sending, flushing, receiving, etc. and is sole owner of associated resources (e.g. comms, buffers, threads, background tasks, etc.). It is entirely asynchronous and not intended to be interacted with directly. This is basically agnostic of what a worker even is.

The extension otoh is the interface between worker and the shuffle instance. It routes RPC calls to the shuffle and exposes synchronous methods to be called in the worker thread. It also is responsible to communicate with the scheduler.

----

Additional changes include some fixes around concurrency. Particularly this should close https://github.com/dask/distributed/issues/6277 (See test_shuffle.py `test_error_offload` and `test_slow_offload`)
The gist is that the shuffle/extension did not wait for threads to complete when flushing (or rather it didn't wait for the receives to finish when flushing)