### PR TITLE
Update nightly recipes with CLI tests, dependency changes

### DIFF
--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -1,7 +1,6 @@
 {% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
 {% set new_patch = major_minor_patch[2] | int + 1 %}
-{% set next_release_version = (major_minor_patch[:2] + [new_patch]) | join('.') %}
-{% set version = next_release_version + environ.get('VERSION_SUFFIX', '') %}
+{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
 
 
@@ -20,10 +19,12 @@ build:
 requirements:
   host:
     - python >=3.8
+    - dask-core {{ dask_version }}
+    - distributed {{ version }}
   run:
     - python >=3.8
-    - dask-core >={{ dask_version }},<{{ next_release_version }}
-    - distributed {{ version }}=*_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+    - {{ pin_compatible('dask-core', max_pin='x.x.x.x') }}
+    - {{ pin_compatible('distributed', exact=True) }}
     - cytoolz >=0.8.2
     - lz4
     - numpy >=1.18

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -20,15 +20,15 @@ build:
 requirements:
   host:
     - python >=3.8
-    - setuptools
   run:
     - python >=3.8
     - dask-core >={{ dask_version }},<{{ next_release_version }}
     - distributed {{ version }}=*_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
     - cytoolz >=0.8.2
+    - lz4
     - numpy >=1.18
     - pandas >=1.0
-    - bokeh >=2.1.1
+    - bokeh >=2.4.2
     - jinja2
 
   run_constrained:
@@ -46,6 +46,10 @@ test:
     - dask.diagnostics
     - dask.distributed
     - distributed
+    
+  commands:
+    - dask --version
+    - dask info versions
 
 about:
   home: https://dask.org/

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -16,7 +16,7 @@ build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   noarch: python
-  script: python -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   entry_points:
     # Old style CLI
     - dask-scheduler = distributed.cli.dask_scheduler:main

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -1,7 +1,6 @@
 {% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
 {% set new_patch = major_minor_patch[2] | int + 1 %}
-{% set next_release_version = (major_minor_patch[:2] + [new_patch]) | join('.') %}
-{% set version = next_release_version + environ.get('VERSION_SUFFIX', '') %}
+{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
 
 
@@ -27,12 +26,13 @@ requirements:
   host:
     - python >=3.8
     - pip
+    - dask-core {{ dask_version }}
   run:
     - python >=3.8
     - click >=6.6
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
-    - dask-core >={{ dask_version }},<{{ next_release_version }}
+    - {{ pin_compatible('dask-core', max_pin='x.x.x.x') }}
     - jinja2
     - locket >=1.0.0
     - msgpack-python >=0.6.0

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -18,6 +18,7 @@ build:
   noarch: python
   script: python -m pip install . -vv --no-deps
   entry_points:
+    # Old style CLI
     - dask-scheduler = distributed.cli.dask_scheduler:main
     - dask-ssh = distributed.cli.dask_ssh:main
     - dask-worker = distributed.cli.dask_worker:main
@@ -26,7 +27,6 @@ requirements:
   host:
     - python >=3.8
     - pip
-    - setuptools
   run:
     - python >=3.8
     - click >=6.6
@@ -34,7 +34,7 @@ requirements:
     - cytoolz >=0.8.2
     - dask-core >={{ dask_version }},<{{ next_release_version }}
     - jinja2
-    - locket >=1.0
+    - locket >=1.0.0
     - msgpack-python >=0.6.0
     - packaging >=20.0
     - psutil >=5.0
@@ -61,6 +61,9 @@ test:
     - dask-scheduler --help
     - dask-ssh --help
     - dask-worker --help
+    - dask scheduler --help
+    - dask ssh --help
+    - dask worker --help
   requires:
     - pip
 


### PR DESCRIPTION
Follows up on https://github.com/dask/dask/pull/9600 by adding the relevant CLI tests to the `distributed` and `dask` nightly recipes, as well as making some changes to dependency pinnings so that they are consistent with the conda-forge recipes.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
