### PR TITLE
Add Prometheus collector for work-stealing

### DIFF
--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -4,6 +4,7 @@ import toolz
 
 from distributed.http.prometheus import PrometheusCollector
 from distributed.http.scheduler.prometheus.semaphore import SemaphoreMetricCollector
+from distributed.http.scheduler.prometheus.stealing import WorkStealingMetricCollector
 from distributed.http.utils import RequestHandler
 from distributed.scheduler import ALL_TASK_STATES, Scheduler
 
@@ -85,7 +86,11 @@ class SchedulerMetricCollector(PrometheusCollector):
         yield prefix_state_counts
 
 
-COLLECTORS = [SchedulerMetricCollector, SemaphoreMetricCollector]
+COLLECTORS = [
+    SchedulerMetricCollector,
+    SemaphoreMetricCollector,
+    WorkStealingMetricCollector,
+]
 
 
 class PrometheusHandler(RequestHandler):

--- a/distributed/http/scheduler/prometheus/semaphore.py
+++ b/distributed/http/scheduler/prometheus/semaphore.py
@@ -11,8 +11,10 @@ class SemaphoreMetricCollector(PrometheusCollector):
     def collect(self):
         from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
-        sem_ext = self.server.extensions["semaphores"]
-
+        try:
+            sem_ext = self.server.extensions["semaphores"]
+        except KeyError:
+            return
         semaphore_max_leases_family = GaugeMetricFamily(
             self.build_name("max_leases"),
             "Maximum leases allowed per semaphore, this will be constant for each semaphore during its lifetime.",

--- a/distributed/http/scheduler/prometheus/stealing.py
+++ b/distributed/http/scheduler/prometheus/stealing.py
@@ -8,10 +8,14 @@ class WorkStealingMetricCollector(PrometheusCollector):
     def __init__(self, server):
         super().__init__(server)
         self.subsystem = "stealing"
-        self.stealing: WorkStealing = self.server.extensions["stealing"]
 
     def collect(self):
         from prometheus_client.core import CounterMetricFamily
+
+        try:
+            stealing: WorkStealing = self.server.extensions["stealing"]
+        except KeyError:
+            return
 
         stealing_request_count_total = CounterMetricFamily(
             self.build_name("request_count_total"),
@@ -25,13 +29,13 @@ class WorkStealingMetricCollector(PrometheusCollector):
             labels=["cost_multiplier"],
         )
 
-        for level, multiplier in enumerate(self.stealing.cost_multipliers):
+        for level, multiplier in enumerate(stealing.cost_multipliers):
             stealing_request_count_total.add_metric(
-                [str(multiplier)], self.stealing.metrics["request_count_total"][level]
+                [str(multiplier)], stealing.metrics["request_count_total"][level]
             )
 
             stealing_request_cost_total.add_metric(
-                [str(multiplier)], self.stealing.metrics["request_cost_total"][level]
+                [str(multiplier)], stealing.metrics["request_cost_total"][level]
             )
 
         yield stealing_request_count_total

--- a/distributed/http/scheduler/prometheus/stealing.py
+++ b/distributed/http/scheduler/prometheus/stealing.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from distributed.http.prometheus import PrometheusCollector
+from distributed.stealing import WorkStealing
+
+
+class WorkStealingMetricCollector(PrometheusCollector):
+    def __init__(self, server):
+        super().__init__(server)
+        self.subsystem = "stealing"
+        self.stealing: WorkStealing = self.server.extensions["stealing"]
+
+    def collect(self):
+        from prometheus_client.core import CounterMetricFamily
+
+        stealing_request_count_total = CounterMetricFamily(
+            self.build_name("request_count_total"),
+            "Total number of stealing requests per cost multiplier.",
+            labels=["cost_multiplier"],
+        )
+
+        stealing_request_cost_total = CounterMetricFamily(
+            self.build_name("request_cost_total"),
+            "Total cost of stealing requests per cost multiplier.",
+            labels=["cost_multiplier"],
+        )
+
+        for level, multiplier in enumerate(self.stealing.cost_multipliers):
+            stealing_request_count_total.add_metric(
+                [str(multiplier)], self.stealing.metrics["request_count_total"][level]
+            )
+
+            stealing_request_cost_total.add_metric(
+                [str(multiplier)], self.stealing.metrics["request_cost_total"][level]
+            )
+
+        yield stealing_request_count_total
+        yield stealing_request_cost_total

--- a/distributed/http/scheduler/tests/test_semaphore_http.py
+++ b/distributed/http/scheduler/tests/test_semaphore_http.py
@@ -69,3 +69,13 @@ async def test_prometheus(c, s, a, b):
     assert active_metrics.keys() == expected_metrics
     for v in active_metrics.values():
         assert v.samples == []
+
+
+@gen_cluster(
+    client=True, clean_kwargs={"threads": False}, scheduler_kwargs={"extensions": {}}
+)
+async def test_prometheus_without_semaphore_extension(c, s, a, b):
+    pytest.importorskip("prometheus_client")
+
+    active_metrics = await fetch_metrics(s.http_server.port, "dask_semaphore_")
+    assert not active_metrics

--- a/distributed/http/scheduler/tests/test_stealing_http.py
+++ b/distributed/http/scheduler/tests/test_stealing_http.py
@@ -92,3 +92,13 @@ async def test_prometheus_collect_cost_total_by_cost_multipliers(c, s, a, b):
         if event[0] == "request"
     )
     assert count == expected_cost
+
+
+@gen_cluster(
+    client=True, clean_kwargs={"threads": False}, scheduler_kwargs={"extensions": {}}
+)
+async def test_prometheus_without_stealing_extension(c, s, a, b):
+    pytest.importorskip("prometheus_client")
+
+    active_metrics = await fetch_metrics(s.http_server.port, "dask_stealing_")
+    assert not active_metrics

--- a/distributed/http/scheduler/tests/test_stealing_http.py
+++ b/distributed/http/scheduler/tests/test_stealing_http.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from distributed.client import wait
+from distributed.utils_test import (
+    fetch_metrics,
+    fetch_metrics_sample_names,
+    gen_cluster,
+    slowinc,
+)
+
+
+@gen_cluster(client=True)
+async def test_prometheus(c, s, a, b):
+    pytest.importorskip("prometheus_client")
+    active_metrics = await fetch_metrics_sample_names(
+        s.http_server.port, prefix="dask_stealing_"
+    )
+    expected_metrics = {
+        "dask_stealing_request_count_total",
+        "dask_stealing_request_cost_total",
+    }
+
+    assert active_metrics == expected_metrics
+
+
+@gen_cluster(client=True)
+async def test_prometheus_collect_count_total_by_cost_multipliers(c, s, a, b):
+    pytest.importorskip("prometheus_client")
+
+    async def fetch_metrics_by_cost_multipliers():
+        families = await fetch_metrics(s.http_server.port, prefix="dask_stealing_")
+        active_metrics = {
+            sample.labels["cost_multiplier"]: sample.value
+            for sample in families["dask_stealing_request_count"].samples
+            if sample.name == "dask_stealing_request_count_total"
+        }
+        return active_metrics
+
+    active_metrics = await fetch_metrics_by_cost_multipliers()
+    stealing = s.extensions["stealing"]
+    expected_metrics = {str(multiplier): 0 for multiplier in stealing.cost_multipliers}
+    assert active_metrics == expected_metrics
+
+    futures = c.map(
+        slowinc, range(10), delay=0.1, workers=a.address, allow_other_workers=True
+    )
+    await wait(futures)
+
+    active_metrics = await fetch_metrics_by_cost_multipliers()
+    assert len(active_metrics) == len(stealing.cost_multipliers)
+    count = sum(active_metrics.values())
+    assert count > 0
+    expected_count = sum(
+        len(event[1]) for _, event in s.events["stealing"] if event[0] == "request"
+    )
+    assert count == expected_count
+
+
+@gen_cluster(client=True)
+async def test_prometheus_collect_cost_total_by_cost_multipliers(c, s, a, b):
+    pytest.importorskip("prometheus_client")
+
+    async def fetch_metrics_by_cost_multipliers():
+        families = await fetch_metrics(s.http_server.port, prefix="dask_stealing_")
+        active_metrics = {
+            sample.labels["cost_multiplier"]: sample.value
+            for sample in families["dask_stealing_request_cost"].samples
+            if sample.name == "dask_stealing_request_cost_total"
+        }
+        return active_metrics
+
+    active_metrics = await fetch_metrics_by_cost_multipliers()
+    stealing = s.extensions["stealing"]
+    expected_metrics = {str(multiplier): 0 for multiplier in stealing.cost_multipliers}
+    assert active_metrics == expected_metrics
+
+    futures = c.map(
+        slowinc, range(10), delay=0.1, workers=a.address, allow_other_workers=True
+    )
+    await wait(futures)
+
+    active_metrics = await fetch_metrics_by_cost_multipliers()
+    assert len(active_metrics) == len(stealing.cost_multipliers)
+    count = sum(active_metrics.values())
+    assert count > 0
+    expected_cost = sum(
+        request[3]
+        for _, event in s.events["stealing"]
+        for request in event[1]
+        if event[0] == "request"
+    )
+    assert count == expected_cost

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -78,6 +78,7 @@ class WorkStealing(SchedulerPlugin):
     # { worker state: occupancy }
     in_flight_occupancy: defaultdict[WorkerState, float]
     in_flight_tasks: defaultdict[WorkerState, int]
+    metrics: dict[str, dict[int, float]]
     _in_flight_event: asyncio.Event
     _request_counter: int
 
@@ -104,15 +105,19 @@ class WorkStealing(SchedulerPlugin):
         self.in_flight_occupancy = defaultdict(lambda: 0)
         self.in_flight_tasks = defaultdict(lambda: 0)
         self._in_flight_event = asyncio.Event()
+        self.metrics = {
+            "request_count_total": defaultdict(lambda: 0),
+            "request_cost_total": defaultdict(lambda: 0),
+        }
         self._request_counter = 0
         self.scheduler.stream_handlers["steal-response"] = self.move_task_confirm
 
     async def start(self, scheduler: Any = None) -> None:
         """Start the background coroutine to balance the tasks on the cluster.
         Idempotent.
-        The scheduler argument is ignored. It is merely required to satisify the
-        plugin interface. Since this class is simultaneouly an extension, the
-        scheudler instance is already registered during initialization
+        The scheduler argument is ignored. It is merely required to satisfy the
+        plugin interface. Since this class is simultaneously an extension, the
+        scheduler instance is already registered during initialization
         """
         if "stealing" in self.scheduler.periodic_callbacks:
             return
@@ -455,18 +460,21 @@ class WorkStealing(SchedulerPlugin):
                             <= occ_victim - (comm_cost_victim + compute) / 2
                         ):
                             self.move_task_request(ts, victim, thief)
+                            cost = compute + comm_cost_victim
                             log.append(
                                 (
                                     start,
                                     level,
                                     ts.key,
-                                    comm_cost_victim + compute,
+                                    cost,
                                     victim.address,
                                     occ_victim,
                                     thief.address,
                                     occ_thief,
                                 )
                             )
+                            self.metrics["request_count_total"][level] += 1
+                            self.metrics["request_cost_total"][level] += cost
 
                             occ_thief = self._combined_occupancy(thief)
                             nproc_thief = self._combined_nprocessing(thief)


### PR DESCRIPTION
This PR adds a Prometheus collector for work-stealing that exposes the count and cost of stealing requests. It also fixes a bug with the Prometheus endpoint if the `Semaphore` extension is not available. 
 
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
