### PR TITLE
Fix flaky `test_include_communication_in_occupancy`

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1472,7 +1472,12 @@ async def test_balance_many_workers_2(c, s, *workers):
     assert {len(w.has_what) for w in s.workers.values()} == {3}
 
 
-@gen_cluster(client=True)
+@gen_cluster(
+    client=True,
+    worker_kwargs={
+        "heartbeat_interval": "10s",  # prevent worker from updating executing task durations
+    },
+)
 async def test_include_communication_in_occupancy(c, s, a, b):
     x = c.submit(operator.mul, b"0", int(s.bandwidth) * 2, workers=a.address)
     y = c.submit(operator.mul, b"1", int(s.bandwidth * 3), workers=b.address)


### PR DESCRIPTION
This assertion would sometimes fail, and `occ3` would be some number like `0.020008087158203125`
https://github.com/dask/distributed/blob/581b603efcb6905eb14b7d8725d794c2697057c6/distributed/tests/test_scheduler.py#L1506-L1507

On slower CI (macOS), the worker would have a chance to heartbeat before that line, updating the `max_exec_time`. When the duration average is unknown but the `max_exec_time` is known, we use that to calculate occupancy.

Adding an `await asyncio.sleep(0.5)` above that line was a reliable way to make the test always fail.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
