### PR TITLE
Include button for launching jupyterlab layout in repr

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -22,10 +22,12 @@ from concurrent.futures._base import DoneAndNotDoneFutures
 from contextlib import contextmanager, suppress
 from contextvars import ContextVar
 from functools import partial
+from importlib.metadata import PackageNotFoundError, version
 from numbers import Number
 from queue import Queue as pyQueue
 from typing import Any, ClassVar, Coroutine, Literal, Sequence, TypedDict
 
+from packaging.version import parse as parse_version
 from tlz import first, groupby, keymap, merge, partition_all, valmap
 
 import dask
@@ -1146,11 +1148,9 @@ class Client(SyncMethodMixin):
 
     def _repr_html_(self):
         try:
-            import dask_labextension  # noqa: F401
-
-            # TODO: also guard with version check
-            JUPYTERLAB = True
-        except ImportError:
+            dle_version = parse_version(version("dask-labextension"))
+            JUPYTERLAB = False if dle_version < parse_version("6.0.0") else True
+        except PackageNotFoundError:
             JUPYTERLAB = False
 
         scheduler, info = self._get_scheduler_info()

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1145,6 +1145,14 @@ class Client(SyncMethodMixin):
             return f"<{self.__class__.__name__}: No scheduler connected>"
 
     def _repr_html_(self):
+        try:
+            import dask_labextension  # noqa: F401
+
+            # TODO: also guard with version check
+            JUPYTERLAB = True
+        except ImportError:
+            JUPYTERLAB = False
+
         scheduler, info = self._get_scheduler_info()
 
         return get_template("client.html.j2").render(
@@ -1154,6 +1162,7 @@ class Client(SyncMethodMixin):
             cluster=self.cluster,
             scheduler_file=self.scheduler_file,
             dashboard_link=self.dashboard_link,
+            jupyterlab=JUPYTERLAB,
         )
 
     def start(self, **kwargs):

--- a/distributed/widgets/templates/client.html.j2
+++ b/distributed/widgets/templates/client.html.j2
@@ -29,6 +29,12 @@
 
         </table>
 
+        {% if jupyterlab %}
+            <button style="margin-bottom: 12px;" data-commandlinker-command="dask:populate-and-launch-layout" data-commandlinker-args='{"url": "{{ dashboard_link }}" }'>
+                Launch dashboard in JupyterLab
+            </button>
+        {% endif %}
+
         {% if scheduler is none %}
             <p>No scheduler connected.</p>
         {% elif cluster %}


### PR DESCRIPTION
This is an experimental UI element to help ease dashboard setup in a JupyterLab environment. Doesn't make sense to merge without a paired release of `dask-labextension`, but opening for discussion/visibility.

![dask-layout-2](https://user-images.githubusercontent.com/5728311/200048008-f64eadf3-febd-4d00-a269-0d84d3821010.gif)

Edit: this is now ready for review, and works with `dask-labextension==6.0.0`.