### PR TITLE
[DNM] All tasks without dependencies are root-ish

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3048,8 +3048,9 @@ class SchedulerState:
         """
         if ts.resource_restrictions or ts.worker_restrictions or ts.host_restrictions:
             return False
+        if not ts.dependencies:
+            return True
         tg = ts.group
-        # TODO short-circuit to True if `not ts.dependencies`?
         return (
             len(tg) > self.total_nthreads * 2
             and len(tg.dependencies) < 5


### PR DESCRIPTION
If a task doesn't have dependencies, then it's obviously a root task. However, the current logic would only consider it so if the TaskGroup was also 2x larger than the cluster.

That allowed for the awkward case where small groups of root tasks would go down a different code path. It's not clear how much this code path was even used or needed, xref https://github.com/dask/distributed/pull/6974.

Opening this just to see what happens in CI. 

See a little other discussion in https://github.com/dask/distributed/issues/7204#issuecomment-1293854506.

Making this change would help a bit with https://github.com/dask/distributed/issues/7197.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
