### PR TITLE
Round-robin empty workers with queueing enabled

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2129,7 +2129,9 @@ class SchedulerState:
         empties: list[WorkerState] = []
         min_ws: WorkerState | None = None
         min_v: float | None = None
-        for cws in self.idle.values():
+        for cws in dict.values(self.idle):
+            # ^ micro-optimization: `SortedDict` inherits from plain `dict`; iterating
+            # in non-sorted order is 10x faster and order doesn't matter here.
             v = len(cws.processing) / cws.nthreads
             if min_v is None or v < min_v:
                 min_v = v


### PR DESCRIPTION
With queuing enabled, when multiple workers have 0 tasks, rather than always picking the first of the empty workers each time, this implements round-robin logic. This ensures that when you're occasionally submitting a few tasks to an idle cluster, the same workers aren't used each time.

See https://github.com/dask/distributed/issues/4637, https://github.com/dask/distributed/pull/4638 for equivalent behavior with queuing disabled.

Requires https://github.com/dask/distributed/pull/7221.

Closes #7197.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
