### PR TITLE
Require Click 7.0+

### DIFF
--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - dask-core {{ dask_version }}
   run:
     - python >=3.8
-    - click >=6.6
+    - click >=7.0
     - cloudpickle >=1.5.0
     - cytoolz >=0.8.2
     - {{ pin_compatible('dask-core', max_pin='x.x.x.x') }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click >= 6.6
+click >= 7.0
 cloudpickle >= 1.5.0
 dask == 2022.10.1
 jinja2


### PR DESCRIPTION
As Dask now includes this requirement and has a minimum of Click 7.0, go ahead and align on that version in Distributed.

xref: https://github.com/dask/dask/pull/9595

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
