### PR TITLE
Restore `bokeh` as optional dependency with default cluster setup

### DIFF
--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -12,15 +12,14 @@ from packaging.version import parse as parse_version
 import dask
 
 from distributed.dashboard.utils import BOKEH_VERSION
+from distributed.versions import MIN_BOKEH_VERSION
 
-_min_bokeh_version = "2.1.1"
-
-if BOKEH_VERSION < parse_version(_min_bokeh_version):
+if BOKEH_VERSION < parse_version(MIN_BOKEH_VERSION):
     warnings.warn(
-        f"\nDask needs bokeh >= {_min_bokeh_version}, < 3 for the dashboard."
+        f"\nDask needs bokeh >= {MIN_BOKEH_VERSION}, < 3 for the dashboard."
         "\nContinuing without the dashboard."
     )
-    raise ImportError(f"Dask needs bokeh >= {_min_bokeh_version}, < 3")
+    raise ImportError(f"Dask needs bokeh >= {MIN_BOKEH_VERSION}, < 3")
 
 
 def BokehApplication(applications, server, prefix="/", template_variables=None):

--- a/distributed/http/scheduler/missing_bokeh.py
+++ b/distributed/http/scheduler/missing_bokeh.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from distributed.dashboard.core import _min_bokeh_version
 from distributed.http.utils import RequestHandler, redirect
 from distributed.utils import log_errors
+from distributed.versions import MIN_BOKEH_VERSION
 
 
 class MissingBokeh(RequestHandler):
     @log_errors
     def get(self):
         self.write(
-            f"<p>Dask needs bokeh >= {_min_bokeh_version}, < 3 for the dashboard.</p>"
-            f"<p>Install with conda: conda install bokeh>={_min_bokeh_version},<3</p>"
-            f"<p>Install with pip: pip install bokeh>={_min_bokeh_version},<3</p>"
+            f"<p>Dask needs bokeh >= {MIN_BOKEH_VERSION}, < 3 for the dashboard.</p>"
+            f"<p>Install with conda: conda install bokeh>={MIN_BOKEH_VERSION},<3</p>"
+            f"<p>Install with pip: pip install bokeh>={MIN_BOKEH_VERSION},<3</p>"
         )
 
 

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -12,6 +12,8 @@ from itertools import chain
 from types import ModuleType
 from typing import Any
 
+MIN_BOKEH_VERSION = "2.1.1"
+
 required_packages = [
     ("dask", lambda p: p.__version__),
     ("distributed", lambda p: p.__version__),


### PR DESCRIPTION
Closes #7227

- [ ] Tests added / passed
  - To test this functionality, we'd need to add an environment without bokeh installed, which would be nice to do, but beyond the intended scope of this PR
- [X] Passes `pre-commit run --all-files`

## Goal

Restoring the bokeh as an optional dependency. 

## Details

- Prior to #7172 , the `bokeh` package was an optional dependency. (In the sense that you could start a cluster without bokeh installed)
  - In the most recent release (`2022.10.1`), `bokeh` became a required depdency due to the import of `distributed.dashboard.core` in `missing_bokeh` which raises an ImportError if bokeh is not installed. 
    - Not _strictly_ required, since the dashboard can be disabled by passing `dashboard_address=None` to the constructor of the Cluster. Which allows use of `distributed==2022.10.1` without bokeh installed. 

This PR moves the min bokeh variable to a different module that doesn't import code from the dashboard. 