### PR TITLE
Handle `/metrics` endpoint without `prometheus-client` installed

### DIFF
--- a/distributed/http/prometheus.py
+++ b/distributed/http/prometheus.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from importlib import import_module
+
 import dask.config
+
+from distributed.http.utils import RequestHandler
 
 
 class PrometheusCollector:
@@ -17,3 +21,21 @@ class PrometheusCollector:
             full_name.append(self.subsystem)
         full_name.append(name)
         return "_".join(full_name)
+
+
+class PrometheusNotAvailableHandler(RequestHandler):
+    def get(self):
+        self.write(
+            "# Prometheus is not available, see: https://docs.dask.org/en/stable/how-to/setup-prometheus.html#setup-prometheus-monitoring"
+        )
+        self.set_header("Content-Type", "text/plain; version=0.0.4")
+
+
+def get_metrics_handler(module_name: str, handler_name: str) -> type[RequestHandler]:
+    try:
+        import prometheus_client  # noqa: F401
+    except ModuleNotFoundError:
+        return PrometheusNotAvailableHandler
+    module = import_module(module_name)
+    handler = getattr(module, handler_name)
+    return handler

--- a/distributed/http/prometheus.py
+++ b/distributed/http/prometheus.py
@@ -31,7 +31,9 @@ class PrometheusNotAvailableHandler(RequestHandler):
         self.set_header("Content-Type", "text/plain; version=0.0.4")
 
 
-def get_metrics_handler(module_name: str, handler_name: str) -> type[RequestHandler]:
+def import_metrics_handler(module_name: str, handler_name: str) -> type[RequestHandler]:
+    """Import ``handler_name`` from ``module_name`` if ``prometheus_client``
+    is installed, import the ``PrometheusNotAvailableHandler`` otherwise."""
     try:
         import prometheus_client  # noqa: F401
     except ModuleNotFoundError:

--- a/distributed/http/prometheus.py
+++ b/distributed/http/prometheus.py
@@ -40,4 +40,5 @@ def import_metrics_handler(module_name: str, handler_name: str) -> type[RequestH
         return PrometheusNotAvailableHandler
     module = import_module(module_name)
     handler = getattr(module, handler_name)
+    assert issubclass(handler, RequestHandler)
     return handler

--- a/distributed/http/prometheus.py
+++ b/distributed/http/prometheus.py
@@ -26,7 +26,8 @@ class PrometheusCollector:
 class PrometheusNotAvailableHandler(RequestHandler):
     def get(self):
         self.write(
-            "# Prometheus is not available, see: https://docs.dask.org/en/stable/how-to/setup-prometheus.html#setup-prometheus-monitoring"
+            "# Prometheus metrics are not available, see: "
+            "https://docs.dask.org/en/stable/how-to/setup-prometheus.html#setup-prometheus-monitoring"
         )
         self.set_header("Content-Type", "text/plain; version=0.0.4")
 

--- a/distributed/http/scheduler/prometheus/__init__.py
+++ b/distributed/http/scheduler/prometheus/__init__.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from distributed.http.prometheus import get_metrics_handler
+from distributed.http.prometheus import import_metrics_handler
 
 routes: list[tuple] = [
     (
         "/metrics",
-        get_metrics_handler(
+        import_metrics_handler(
             "distributed.http.scheduler.prometheus.core", "PrometheusHandler"
         ),
         {},

--- a/distributed/http/scheduler/prometheus/__init__.py
+++ b/distributed/http/scheduler/prometheus/__init__.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
-from distributed.http.scheduler.prometheus.core import PrometheusHandler
+from distributed.http.prometheus import get_metrics_handler
 
-routes: list[tuple] = [("/metrics", PrometheusHandler, {})]
+routes: list[tuple] = [
+    (
+        "/metrics",
+        get_metrics_handler(
+            "distributed.http.scheduler.prometheus.core", "PrometheusHandler"
+        ),
+        {},
+    )
+]

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import prometheus_client
 import toolz
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
 from distributed.http.prometheus import PrometheusCollector
 from distributed.http.scheduler.prometheus.semaphore import SemaphoreMetricCollector
@@ -15,7 +17,6 @@ class SchedulerMetricCollector(PrometheusCollector):
         self.subsystem = "scheduler"
 
     def collect(self):
-        from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
         yield GaugeMetricFamily(
             self.build_name("clients"),
@@ -97,8 +98,6 @@ class PrometheusHandler(RequestHandler):
     _collectors = None
 
     def __init__(self, *args, dask_server=None, **kwargs):
-        import prometheus_client
-
         super().__init__(*args, dask_server=dask_server, **kwargs)
 
         if PrometheusHandler._collectors:
@@ -116,7 +115,5 @@ class PrometheusHandler(RequestHandler):
             prometheus_client.REGISTRY.register(instantiated_collector)
 
     def get(self):
-        import prometheus_client
-
         self.write(prometheus_client.generate_latest())
         self.set_header("Content-Type", "text/plain; version=0.0.4")

--- a/distributed/http/scheduler/prometheus/semaphore.py
+++ b/distributed/http/scheduler/prometheus/semaphore.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+
 from distributed.http.prometheus import PrometheusCollector
 
 
@@ -9,7 +11,6 @@ class SemaphoreMetricCollector(PrometheusCollector):
         self.subsystem = "semaphore"
 
     def collect(self):
-        from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
         try:
             sem_ext = self.server.extensions["semaphores"]

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from unittest import mock
 
 import aiohttp
 import pytest
@@ -15,13 +16,15 @@ from tornado.httpclient import AsyncHTTPClient, HTTPClientError
 import dask.config
 from dask.sizeof import sizeof
 
-from distributed import Lock
+from distributed import Lock, Scheduler
 from distributed.client import wait
 from distributed.utils import is_valid_xml
 from distributed.utils_test import (
     div,
     fetch_metrics,
+    fetch_metrics_body,
     gen_cluster,
+    gen_test,
     inc,
     lock_inc,
     slowinc,
@@ -116,6 +119,14 @@ async def test_prometheus(c, s, a, b):
     # request data twice since there once was a case where metrics got registered multiple times resulting in
     # prometheus_client errors
     await fetch_metrics(s.http_server.port, "dask_scheduler_")
+
+
+@gen_test()
+async def test_metrics_when_prometheus_client_not_installed():
+    with mock.patch.dict("sys.modules", {"prometheus_client": None}):
+        async with Scheduler(dashboard_address=":0") as s:
+            body = await fetch_metrics_body(s.http_server.port)
+            assert "Prometheus metrics are not available" in body
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -126,7 +126,7 @@ def prometheus_not_available():
     import sys
 
     with mock.patch.dict("sys.modules", {"prometheus_client": None}):
-        del sys.modules["distributed.http.scheduler.prometheus"]
+        sys.modules.pop("distributed.http.scheduler.prometheus", None)
         yield
 
 

--- a/distributed/http/worker/prometheus/__init__.py
+++ b/distributed/http/worker/prometheus/__init__.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
-from distributed.http.worker.prometheus.core import PrometheusHandler
+from distributed.http.prometheus import get_metrics_handler
 
-routes: list[tuple] = [("/metrics", PrometheusHandler, {})]
+routes: list[tuple] = [
+    (
+        "/metrics",
+        get_metrics_handler(
+            "distributed.http.worker.prometheus.core", "PrometheusHandler"
+        ),
+        {},
+    )
+]

--- a/distributed/http/worker/prometheus/__init__.py
+++ b/distributed/http/worker/prometheus/__init__.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from distributed.http.prometheus import get_metrics_handler
+from distributed.http.prometheus import import_metrics_handler
 
 routes: list[tuple] = [
     (
         "/metrics",
-        get_metrics_handler(
+        import_metrics_handler(
             "distributed.http.worker.prometheus.core", "PrometheusHandler"
         ),
         {},

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import logging
 from typing import ClassVar
 
+import prometheus_client
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+
 from distributed.http.prometheus import PrometheusCollector
 from distributed.http.utils import RequestHandler
 from distributed.worker import Worker
@@ -26,7 +29,6 @@ class WorkerMetricCollector(PrometheusCollector):
             )
 
     def collect(self):
-        from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
         ws = self.server.state
 
@@ -145,8 +147,6 @@ class PrometheusHandler(RequestHandler):
     _collector: ClassVar[WorkerMetricCollector | None] = None
 
     def __init__(self, *args, dask_server=None, **kwargs):
-        import prometheus_client
-
         super().__init__(*args, dask_server=dask_server, **kwargs)
 
         if PrometheusHandler._collector:
@@ -160,7 +160,5 @@ class PrometheusHandler(RequestHandler):
         prometheus_client.REGISTRY.register(PrometheusHandler._collector)
 
     def get(self):
-        import prometheus_client
-
         self.write(prometheus_client.generate_latest())
         self.set_header("Content-Type", "text/plain; version=0.0.4")

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -63,7 +63,7 @@ def prometheus_not_available():
     import sys
 
     with mock.patch.dict("sys.modules", {"prometheus_client": None}):
-        del sys.modules["distributed.http.worker.prometheus"]
+        sys.modules.pop("distributed.http.worker.prometheus", None)
         yield
 
 
@@ -71,12 +71,9 @@ def prometheus_not_available():
 async def test_metrics_when_prometheus_client_not_installed(
     c, s, prometheus_not_available
 ):
-    with mock.patch.dict("sys.modules", {"prometheus_client": None}):
-        import distributed
-
-        async with distributed.Worker(s.address) as w:
-            body = await fetch_metrics_body(w.http_server.port)
-            assert "Prometheus metrics are not available" in body
+    async with Worker(s.address) as w:
+        body = await fetch_metrics_body(w.http_server.port)
+        assert "Prometheus metrics are not available" in body
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from unittest import mock
 
 import pytest
 from tornado.httpclient import AsyncHTTPClient
@@ -10,6 +11,7 @@ from distributed import Event, Worker, wait
 from distributed.sizeof import sizeof
 from distributed.utils_test import (
     fetch_metrics,
+    fetch_metrics_body,
     fetch_metrics_sample_names,
     gen_cluster,
 )
@@ -54,6 +56,14 @@ async def test_prometheus(c, s, a):
     # request data twice since there once was a case where metrics got registered
     # multiple times resulting in prometheus_client errors
     await fetch_metrics(a.http_server.port, prefix="dask_worker_")
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_metrics_when_prometheus_client_not_installed(c, s):
+    with mock.patch.dict("sys.modules", {"prometheus_client": None}):
+        async with Worker(s.address) as w:
+            body = await fetch_metrics_body(w.http_server.port)
+            assert "Prometheus metrics are not available" in body
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2481,13 +2481,17 @@ def requires_default_ports(name_of_test):
     yield
 
 
-async def fetch_metrics(port: int, prefix: str | None = None) -> dict[str, Any]:
-    from prometheus_client.parser import text_string_to_metric_families
-
+async def fetch_metrics_body(port: int) -> str:
     http_client = AsyncHTTPClient()
     response = await http_client.fetch(f"http://localhost:{port}/metrics")
     assert response.code == 200
-    txt = response.body.decode("utf8")
+    return response.body.decode("utf8")
+
+
+async def fetch_metrics(port: int, prefix: str | None = None) -> dict[str, Any]:
+    from prometheus_client.parser import text_string_to_metric_families
+
+    txt = await fetch_metrics_body(port)
     families = {
         family.name: family
         for family in text_string_to_metric_families(txt)
@@ -2505,10 +2509,7 @@ async def fetch_metrics_sample_names(port: int, prefix: str | None = None) -> se
     """
     from prometheus_client.parser import text_string_to_metric_families
 
-    http_client = AsyncHTTPClient()
-    response = await http_client.fetch(f"http://localhost:{port}/metrics")
-    assert response.code == 200
-    txt = response.body.decode("utf8")
+    txt = await fetch_metrics_body(port)
     sample_names = set().union(
         *[
             {sample.name for sample in family.samples}


### PR DESCRIPTION
Closes #7220

This PR ensures that the `/metrics` endpoint gracefully handles the `prometheus_client` not being installed and provides information about getting Prometheus set up. Additionally, it makes some simplifications around the imports for the `prometheus_clients` that move them out of frequently-called functions. I'd consider this change a hotfix, we should implement a more structured approach to the `PrometheusHandler` in the future that also allows plugins to add collectors.


- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
