### PR TITLE
Simplify `Scheduler.restart` logic and raise deliberate exceptions

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3421,11 +3421,12 @@ class Client(SyncMethodMixin):
         if timeout is not None:
             timeout = parse_timedelta(timeout, "s")
 
-        response = await self.scheduler.restart(timeout=timeout)
+        msg = await self.scheduler.restart(timeout=timeout)
 
-        if response["status"] == "error":
-            raise RuntimeError(response["message"])
-        assert response["status"] == "OK", response
+        if msg["status"] == "error":
+            typ, exc, tb = clean_exception(**msg)
+            raise exc.with_traceback(tb)
+        assert msg["status"] == "OK", msg
         return self
 
     def restart(self, timeout=no_default):
@@ -3460,12 +3461,12 @@ class Client(SyncMethodMixin):
         if timeout is not None:
             timeout = parse_timedelta(timeout, "s")
 
-        response = await self.scheduler.restart_workers(
-            workers=workers, timeout=timeout
-        )
-        if response["status"] == "error":
-            raise RuntimeError(response["message"])
-        assert response["status"] == "OK", response
+        msg = await self.scheduler.restart_workers(workers=workers, timeout=timeout)
+
+        if msg["status"] == "error":
+            typ, exc, tb = clean_exception(**msg)
+            raise exc.with_traceback(tb)
+        assert msg["status"] == "OK", msg
         return self
 
     def restart_workers(self, workers, timeout=no_default):

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3421,7 +3421,11 @@ class Client(SyncMethodMixin):
         if timeout is not None:
             timeout = parse_timedelta(timeout, "s")
 
-        await self.scheduler.restart(timeout=timeout)
+        response = await self.scheduler.restart(timeout=timeout)
+
+        if response["status"] == "error":
+            raise RuntimeError(response["message"])
+        assert response["status"] == "OK", response
         return self
 
     def restart(self, timeout=no_default):
@@ -3456,7 +3460,12 @@ class Client(SyncMethodMixin):
         if timeout is not None:
             timeout = parse_timedelta(timeout, "s")
 
-        await self.scheduler.restart_workers(workers=workers, timeout=timeout)
+        response = await self.scheduler.restart_workers(
+            workers=workers, timeout=timeout
+        )
+        if response["status"] == "error":
+            raise RuntimeError(response["message"])
+        assert response["status"] == "OK", response
         return self
 
     def restart_workers(self, workers, timeout=no_default):

--- a/distributed/metrics.py
+++ b/distributed/metrics.py
@@ -98,3 +98,27 @@ try:
     thread_time = timemod.thread_time
 except (AttributeError, OSError):  # pragma: no cover
     thread_time = process_time
+
+
+class CountdownTimer:
+    duration: float | None
+    started_at: float
+
+    def __init__(self, duration: float | None = None):
+        self.duration = duration
+        self.started_at = time()
+
+    @property
+    def elapsed(self) -> float:
+        return time() - self.started_at
+
+    @property
+    def remaining(self) -> float | None:
+        if self.duration is None:
+            return None
+        else:
+            return max(0, self.duration - self.elapsed)
+
+    @property
+    def expired(self) -> bool:
+        return self.remaining == 0

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5824,7 +5824,7 @@ class Scheduler(SchedulerState, ServerNode):
 
             bad_nannies = []
             for nanny, response in zip(nanny_addresses, responses):
-                if isinstance(response, asyncio.TimeoutError):
+                if isinstance(response, TimeoutError):
                     logger.error(
                         "Scheduler timed out trying to restart worker on %s.", nanny
                     )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5696,7 +5696,7 @@ class Scheduler(SchedulerState, ServerNode):
         See Also
         --------
         Client.restart
-        Client.restart_workers
+        Scheduler.restart_workers
         """
         stimulus_id = f"restart-{time()}"
         timer = CountdownTimer(timeout)
@@ -5748,6 +5748,29 @@ class Scheduler(SchedulerState, ServerNode):
             )
 
     async def restart_workers(self, workers: Iterable[str], timeout: float = 30):
+        """
+        Restart a specified set of workers
+
+        If this method takes longer than ``timeout`` seconds or fails,
+        it will raise an ``RuntimeError``. This leaves the workers in an undefined
+        state.
+
+        This methods expects all workers to have nannies to be able to restart them.
+        If workers without nannies exist, ``Scheduler.restart_workers`` will raise a
+        ``RuntimeError`` that lists the workers without nannies. Consider removing
+        those workers and calling ``Scheduler.restart_workers`` again afterward.
+
+        Parameters
+        ----------
+        timeout:
+            Raise `RuntimeError` if ``restart_workers`` takes more than ``timeout``
+            seconds.
+
+        See Also
+        --------
+        Scheduler.restart
+        Client.restart_workers
+        """
         self._expect_nannies(workers)
         logger.debug("Asking nannies to restart workers: %s.", workers)
         await self._restart_workers(workers, timeout)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3513,14 +3513,13 @@ def test_get_returns_early(c):
 
 
 @pytest.mark.slow
-@gen_cluster(client=True)
-async def test_Client_clears_references_after_restart(c, s, a, b):
+@gen_cluster(client=True, Worker=Nanny)
+async def test_client_clears_references_after_restart(c, s, a, b):
     x = c.submit(inc, 1)
     assert x.key in c.refcount
     assert x.key in c.futures
 
-    with pytest.raises(TimeoutError):
-        await c.restart(timeout=5)
+    await c.restart()
 
     assert x.key not in c.refcount
     assert not c.futures

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4874,16 +4874,16 @@ async def test_restart_workers_no_nanny_raises(c, s, a, b):
 
 class SlowKillNanny(Nanny):
     async def kill(self, timeout=2, **kwargs):
-        await asyncio.sleep(2)
+        await asyncio.sleep(3)
         return await super().kill(timeout=timeout)
 
 
 @gen_cluster(client=True, Worker=SlowKillNanny)
 async def test_restart_workers_timeout(c, s, a, b):
-    with pytest.raises(TimeoutError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         await c.restart_workers(workers=[a.worker_address], timeout=0.001)
     msg = str(excinfo.value).lower()
-    assert "workers failed to restart" in msg
+    assert "1/1 worker(s) failed to restart" in msg
     assert a.worker_address in msg
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4865,10 +4865,11 @@ async def test_restart_workers(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_restart_workers_no_nanny_raises(c, s, a, b):
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(RuntimeError) as exc_info:
         await c.restart_workers(workers=[a.address])
-    msg = str(excinfo.value).lower()
-    assert "restarting workers requires a nanny" in msg
+    msg = str(exc_info.value)
+    assert "Expected all workers to have a nanny" in msg
+    assert "1 worker(s) without a nanny" in msg
     assert a.address in msg
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4884,8 +4884,8 @@ async def test_restart_workers_timeout(c, s, a, b):
     with pytest.raises(RuntimeError) as excinfo:
         await c.restart_workers(workers=[a.worker_address], timeout=0.001)
     msg = str(excinfo.value).lower()
-    assert "1/1 worker(s) failed to restart" in msg
-    assert a.worker_address in msg
+    assert "1/1 nannies failed to restart" in msg
+    assert a.address in msg
 
 
 class MyException(Exception):

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -172,7 +172,7 @@ def test_worker_doesnt_await_task_completion(loop):
             future = c.submit(sleep, 100)
             sleep(0.1)
             start = time()
-            c.restart(timeout="5s", wait_for_workers=False)
+            c.restart(timeout="5s")
             stop = time()
             assert stop - start < 10
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1049,43 +1049,6 @@ async def test_restart_nanny_timeout_exceeded(c, s, a, b):
     assert fr.status == "cancelled"
 
 
-@gen_cluster(client=True, nthreads=[("", 1)])
-async def test_restart_worker_rejoins_after_timeout_expired(c, s, a):
-    """
-    We don't want to see an error message like:
-
-    ``Waited for 1 worker(s) to reconnect after restarting, but after 0s, only 1 have returned.``
-
-    If a worker rejoins after our last poll for new workers, but before we raise the error,
-    we shouldn't raise the error.
-    """
-    # We'll use a 0s timeout on the restart, so it always expires.
-    # And we'll use a plugin to block the restart process, and spin up a new worker
-    # in the middle of it.
-
-    class Plugin(SchedulerPlugin):
-        removed = asyncio.Event()
-        proceed = asyncio.Event()
-
-        async def remove_worker(self, *args, **kwargs):
-            self.removed.set()
-            await self.proceed.wait()
-
-    s.add_plugin(Plugin())
-
-    task = asyncio.create_task(c.restart(timeout=0))
-    await Plugin.removed.wait()
-    assert not s.workers
-
-    async with Worker(s.address, nthreads=1) as w:
-        assert len(s.workers) == 1
-        Plugin.proceed.set()
-
-        # New worker has joined, but the timeout has expired (since it was 0).
-        # Still, we should not time out.
-        await task
-
-
 @pytest.mark.slow
 @gen_cluster(client=True, Worker=Nanny)
 async def test_restart_some_nannies_some_not(c, s, a, b):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1026,27 +1026,32 @@ class SlowKillNanny(Nanny):
     config={"distributed.scheduler.allowed-failures": 0},
 )
 async def test_restart_nanny_timeout_exceeded(c, s, a, b):
-    f = c.submit(div, 1, 0)
-    fr = c.submit(inc, 1, resources={"FOO": 1})
-    await wait(f)
-    assert s.erred_tasks
-    assert s.computations
-    assert s.unrunnable
-    assert s.tasks
+    with captured_logger("distributed.scheduler") as logger:
+        f = c.submit(div, 1, 0)
+        fr = c.submit(inc, 1, resources={"FOO": 1})
+        await wait(f)
+        assert s.erred_tasks
+        assert s.computations
+        assert s.unrunnable
+        assert s.tasks
 
-    with pytest.raises(RuntimeError, match=r"2/2 worker\(s\) failed to restart"):
-        await c.restart(timeout="1s")
-    assert a.kill_called.is_set()
-    assert b.kill_called.is_set()
+        with pytest.raises(RuntimeError, match=r"2/2 nannies failed to restart"):
+            await c.restart(timeout="1s")
+        assert a.kill_called.is_set()
+        assert b.kill_called.is_set()
 
-    assert not s.erred_tasks
-    assert not s.computations
-    assert not s.unrunnable
-    assert not s.tasks
+        assert not s.erred_tasks
+        assert not s.computations
+        assert not s.unrunnable
+        assert not s.tasks
 
-    assert not c.futures
-    assert f.status == "cancelled"
-    assert fr.status == "cancelled"
+        assert not c.futures
+        assert f.status == "cancelled"
+        assert fr.status == "cancelled"
+        await asyncio.sleep(5)
+
+    logs = logger.getvalue()
+    print(logs)
 
 
 @pytest.mark.slow

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -946,16 +946,6 @@ async def test_restart_nanny_timeout_exceeded(c, s, a, b):
     assert fr.status == "cancelled"
 
 
-@gen_cluster(client=True, nthreads=[("", 1)] * 2)
-async def test_restart_not_all_workers_return(c, s, a, b):
-    with pytest.raises(TimeoutError, match="Waited for 2 worker"):
-        await c.restart(timeout="1s")
-
-    assert not s.workers
-    assert a.status in (Status.closed, Status.closing)
-    assert b.status in (Status.closed, Status.closing)
-
-
 @gen_cluster(client=True, nthreads=[("", 1)])
 async def test_restart_worker_rejoins_after_timeout_expired(c, s, a):
     """

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -993,17 +993,6 @@ async def test_restart_worker_rejoins_after_timeout_expired(c, s, a):
         await task
 
 
-@gen_cluster(client=True, nthreads=[("", 1)] * 2)
-async def test_restart_no_wait_for_workers(c, s, a, b):
-    await c.restart(timeout="1s", wait_for_workers=False)
-
-    assert not s.workers
-    # Workers are not immediately closed because of https://github.com/dask/distributed/issues/6390
-    # (the message is still waiting in the BatchedSend)
-    await a.finished()
-    await b.finished()
-
-
 @pytest.mark.slow
 @gen_cluster(client=True, Worker=Nanny)
 async def test_restart_some_nannies_some_not(c, s, a, b):
@@ -1011,15 +1000,12 @@ async def test_restart_some_nannies_some_not(c, s, a, b):
     async with Worker(s.address, nthreads=1) as w:
         await c.wait_for_workers(3)
 
-        # FIXME how to make this not always take 20s if the nannies do restart quickly?
-        with pytest.raises(TimeoutError, match=r"The 1 worker\(s\) not using Nannies"):
-            await c.restart(timeout="20s")
+        with pytest.raises(
+            RuntimeError, match=r"Expected all workers to have a nanny"
+        ) as e:
+            await c.restart()
 
-        assert w.status == Status.closed
-
-        assert len(s.workers) == 2
-        assert set(s.workers).isdisjoint(original_addrs)
-        assert w.address not in s.workers
+    assert w.address in e.value.args[1]
 
 
 @gen_cluster(

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -909,9 +909,9 @@ async def test_restart_waits_for_new_workers(c, s, *workers):
 async def test_restart_no_nannies(c, s, a, b):
     with pytest.raises(
         RuntimeError, match=r"Expected all workers to have a nanny"
-    ) as e:
+    ) as exc_info:
         await c.restart()
-    assert set(s.workers.keys()) == set(e.value.args[1].keys())
+    assert set(s.workers.keys()) == set(exc_info.value.args[1])
 
 
 class SlowKillNanny(Nanny):


### PR DESCRIPTION
Supersedes #7184 
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
