### PR TITLE
Remove sortedcontainers

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -34,7 +34,6 @@ from numbers import Number
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast, overload
 
 import psutil
-from sortedcontainers import SortedSet
 from tlz import (
     first,
     groupby,
@@ -854,7 +853,7 @@ class Computation:
 
     start: float
     groups: set[TaskGroup]
-    code: SortedSet
+    code: dict[str, None]  # a sorted set
     id: uuid.UUID
 
     __slots__ = tuple(__annotations__)
@@ -862,7 +861,7 @@ class Computation:
     def __init__(self):
         self.start = time()
         self.groups = set()
-        self.code = SortedSet()
+        self.code = {}
         self.id = uuid.uuid4()
 
     @property
@@ -4268,8 +4267,8 @@ class Scheduler(SchedulerState, ServerNode):
             computation = Computation()
             self.computations.append(computation)
 
-        if code and code not in computation.code:  # add new code blocks
-            computation.code.add(code)
+        if code:  # add new code blocks
+            computation.code.setdefault(code, None)
 
         n = 0
         while len(tasks) != n:  # walk through new tasks, cancel any bad deps

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -34,7 +34,7 @@ from numbers import Number
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast, overload
 
 import psutil
-from sortedcontainers import SortedDict, SortedSet
+from sortedcontainers import SortedSet
 from tlz import (
     first,
     groupby,
@@ -1485,7 +1485,6 @@ class SchedulerState:
     #######################
 
     #: Workers currently connected to the scheduler
-    #: (actually a SortedDict, but the sortedcontainers package isn't annotated)
     workers: dict[str, WorkerState]
     #: Worker {name: address}
     aliases: dict[Hashable, str]
@@ -1575,7 +1574,7 @@ class SchedulerState:
         self,
         aliases: dict[Hashable, str],
         clients: dict[str, ClientState],
-        workers: SortedDict[str, WorkerState],
+        workers: dict[str, WorkerState],
         host_info: dict[str, dict[str, Any]],
         resources: dict[str, dict[str, float]],
         tasks: dict[str, TaskState],
@@ -3458,7 +3457,7 @@ class Scheduler(SchedulerState, ServerNode):
         clients = {}
 
         # Worker state
-        workers = SortedDict()
+        workers = {}
 
         host_info = {}
         resources = {}

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -400,7 +400,7 @@ class WorkStealing(SchedulerPlugin):
         with log_errors():
             i = 0
             # Paused and closing workers must never become thieves
-            potential_thieves = set(s.idle.values())
+            potential_thieves = s.idle.copy()
             if not potential_thieves or len(potential_thieves) == len(s.workers):
                 return
             victim: WorkerState | None

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6985,7 +6985,7 @@ def test_computation_object_code_dask_compute(client):
         assert len(computations) == 1
         comp = computations[0]
         assert len(comp.code) == 1
-        return comp.code[0]
+        return first(comp.code)
 
     code = client.run_on_scheduler(fetch_comp_code)
 
@@ -7005,7 +7005,7 @@ def test_computation_object_code_not_available(client):
         assert len(computations) == 1
         comp = computations[0]
         assert len(comp.code) == 1
-        return comp.code[0]
+        return first(comp.code)
 
     code = client.run_on_scheduler(fetch_comp_code)
     assert code == "<Code not available>"
@@ -7026,7 +7026,7 @@ async def test_computation_object_code_dask_persist(c, s, a, b):
     comp = computations[0]
     assert len(comp.code) == 1
 
-    assert comp.code[0] == test_function_code
+    assert first(comp.code) == test_function_code
 
 
 @gen_cluster(client=True)
@@ -7047,7 +7047,7 @@ async def test_computation_object_code_client_submit_simple(c, s, a, b):
 
     assert len(comp.code) == 1
 
-    assert comp.code[0] == test_function_code
+    assert first(comp.code) == test_function_code
 
 
 @gen_cluster(client=True)
@@ -7069,7 +7069,7 @@ async def test_computation_object_code_client_submit_list_comp(c, s, a, b):
     # Code is deduplicated
     assert len(comp.code) == 1
 
-    assert comp.code[0] == test_function_code
+    assert first(comp.code) == test_function_code
 
 
 @gen_cluster(client=True)
@@ -7091,7 +7091,7 @@ async def test_computation_object_code_client_submit_dict_comp(c, s, a, b):
     # Code is deduplicated
     assert len(comp.code) == 1
 
-    assert comp.code[0] == test_function_code
+    assert first(comp.code) == test_function_code
 
 
 @gen_cluster(client=True)
@@ -7109,7 +7109,7 @@ async def test_computation_object_code_client_map(c, s, a, b):
     comp = computations[0]
     assert len(comp.code) == 1
 
-    assert comp.code[0] == test_function_code
+    assert first(comp.code) == test_function_code
 
 
 @gen_cluster(client=True)
@@ -7127,7 +7127,7 @@ async def test_computation_object_code_client_compute(c, s, a, b):
     comp = computations[0]
     assert len(comp.code) == 1
 
-    assert comp.code[0] == test_function_code
+    assert first(comp.code) == test_function_code
 
 
 @gen_cluster(client=True, Worker=Nanny)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ locket >= 1.0.0
 msgpack >= 0.6.0
 packaging >= 20.0
 psutil >= 5.0
-sortedcontainers !=2.0.0, !=2.0.1
 tblib >= 1.6.0
 toolz >= 0.8.2
 tornado >= 6.0.3, <6.2


### PR DESCRIPTION
This makes `Scheduler.workers` and `Scheduler.idle` no longer sorted. Sorted containers are a bit slower than their plain equivalents. Most importantly, iterating over them (which we do in plenty of places) is O(nlogn) instead of O(n).

In practice, actual performance is probably worse; I found iteration to be 10x slower in microbenchmarks: https://github.com/dask/distributed/pull/4925#discussion_r654679224.

This would only be done after https://github.com/dask/distributed/pull/7221. The only code relying on these collections being sorted is the old no-deps `decide_worker` logic, which would be unreachable after that PR.

I took this to the extreme and entirely removed the `sortedcontainers` dependency. If we wanted to be more conservative, we could only do 2b8ebf1a384cf9e5bd978602bf72b0ee19e732e2 (I think we should absolutely do this at least if we merge #7221).

@fjetter @crusaderky

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
