### PR TITLE
Queuing: lowest-memory worker as tiebreaker

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2124,9 +2124,12 @@ class SchedulerState:
             # All workers busy? Task gets/stays queued.
             return None
 
-        # Just pick the least busy worker.
+        # Just pick the least busy worker. Use the lowest-RSS worker in a tie.
         # NOTE: this will lead to worst-case scheduling with regards to co-assignment.
-        ws = min(self.idle.values(), key=lambda ws: len(ws.processing) / ws.nthreads)
+        ws = min(
+            self.idle.values(),
+            key=lambda ws: (len(ws.processing) / ws.nthreads, ws.memory.process),
+        )
         if self.validate:
             assert not _worker_full(ws, self.WORKER_SATURATION), (
                 ws,


### PR DESCRIPTION
This could be another way of approaching https://github.com/dask/distributed/issues/7197 in a practical sense. AFAIU the point of the round-robin behavior is that maybe, if you keep re-using the same worker, its memory will slowly creep up (if you're running a task that leaks memory or something)? So if we just use memory as a tie-breaker, you'd probably get round-robin in practice on an idle cluster.

Would need to add a simple test.

Closes #7197

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
