### PR TITLE
Improve robustness of helper functions in `test_steal`

### DIFF
--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -713,6 +713,7 @@ async def assert_balanced(inp, expected, c, s, *workers):
     # on first try and will need a second try to correct its mistake
     for _ in range(2):
         steal.balance()
+        # steal.stop() ensures that all in-flight stealing requests have been resolved
         await steal.stop()
 
     await ev.set()

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -721,7 +721,7 @@ async def assert_balanced(inp, expected, c, s, *workers):
 
     result = [
         sorted(
-            # Exclude input data encoded with ``SizeOf``
+            # The name of input data starts with ``SizeOf``
             (int(key_split(t)) for t in w.data.keys() if not t.startswith("SizeOf")),
             reverse=True,
         )


### PR DESCRIPTION
Inspired by #7250.

cc @crusaderky 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
