### PR TITLE
Handle edge cases between `queued` and `no-worker`

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -8,6 +8,7 @@ import operator
 import pickle
 import re
 import sys
+from contextlib import AsyncExitStack
 from itertools import product
 from textwrap import dedent
 from time import sleep
@@ -479,6 +480,84 @@ async def test_queued_remove_add_worker(c, s, a, b):
 
         await event.set()
         await wait(fs)
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 2)] * 2,
+    config={
+        "distributed.worker.memory.pause": False,
+        "distributed.worker.memory.target": False,
+        "distributed.worker.memory.spill": False,
+        "distributed.scheduler.work-stealing": False,
+    },
+)
+async def test_queued_rootish_changes_while_paused(c, s, a, b):
+    "Some tasks are root-ish, some aren't. So both `unrunnable` and `queued` contain non-restricted tasks."
+
+    root = c.submit(inc, 1, key="root")
+    await root
+
+    # manually pause the workers
+    a.status = Status.paused
+    b.status = Status.paused
+
+    await async_wait_for(lambda: not s.running, 5)
+
+    fs = [c.submit(inc, root, key=f"inc-{i}") for i in range(s.total_nthreads * 2 + 1)]
+    # ^ `c.submit` in a for-loop so the first tasks don't look root-ish (`TaskGroup` too
+    # small), then the last one does. So N-1 tasks will go to `no-worker`, and the last
+    # to `queued`. `is_rootish` is just messed up like that.
+
+    await async_wait_for(lambda: len(s.tasks) > len(fs), 5)
+
+    # un-pause
+    a.status = Status.running
+    b.status = Status.running
+    await async_wait_for(lambda: len(s.running) == len(s.workers), 5)
+
+    await c.gather(fs)
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)],
+    config={"distributed.scheduler.work-stealing": False},
+)
+async def test_queued_rootish_changes_scale_up(c, s, a):
+    "Tasks are initially root-ish. After cluster scales, they aren't."
+
+    root = c.submit(inc, 1, key="root")
+
+    event = Event()
+    clog = c.submit(event.wait, key="clog")
+    await wait_for_state(clog.key, "processing", s)
+
+    fs = c.map(inc, [root] * 5, key=[f"inc-{i}" for i in range(5)])
+
+    await async_wait_for(lambda: len(s.tasks) > len(fs), 5)
+
+    if not s.is_rootish(s.tasks[fs[0].key]):
+        pytest.fail(
+            "Test assumptions have changed; task is not root-ish. Test may no longer be relevant."
+        )
+    if math.isfinite(s.WORKER_SATURATION):
+        assert s.queued
+
+    async with AsyncExitStack() as stack:
+        for _ in range(3):
+            await stack.enter_async_context(Worker(s.address, nthreads=2))
+
+        if s.is_rootish(s.tasks[fs[0].key]):
+            pytest.fail(
+                "Test assumptions have changed; task is still root-ish. Test may no longer be relevant."
+            )
+
+        await event.set()
+        await clog
+
+    # Just verify it doesn't deadlock
+    await c.gather(fs)
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])


### PR DESCRIPTION
While working on https://github.com/dask/distributed/pull/7221, I discovered some edge cases with queuing related to the `queued` vs `no-worker` states, and the fact that `is_rootish` can change. (These edge cases were not created by https://github.com/dask/distributed/pull/7221; that just made it easier to find them since we could remove the almost-dead round-robin code https://github.com/dask/distributed/commit/c9018239266366ef980803c55419b91d4485c3a8.)

When queuing is enabled, and there are no running workers (0 workers, or all paused/retiring):
* If a task is root-ish, it goes into `Scheduler.queued`. Cool.
* Otherwise, if goes into `Scheduler.unrunnable`. Possible issue.

Once worker(s) are running, we schedule tasks in `unrunnable`. By this time, `is_rootish(ts)` may now be True. This happens if the TaskGroup grew, or the cluster shrank, passing the `len(tg) > total_nthreads * 2` cutoff.

`transition_no_worker_processing` used to always assume that tasks in `unrunnable` were non-rootish. This is usually the case (most of the time, they're restricted tasks), but not always.

If we remove the round-robin code path, this case then fails an [assertion](https://github.com/dask/distributed/commit/c9018239266366ef980803c55419b91d4485c3a8#diff-bbcf2e505bf2f9dd0dc25de4582115ee4ed4a6e80997affc7b22122912cc6591R2172). So we should use `decide_worker_rootish_queuing_disabled` versus `decide_worker_non_rootish` depending on whether the task is root-ish or not.

-----

More broadly, it's awkward that `is_rootish` isn't static. https://github.com/dask/distributed/issues/6922 will be very nice once we have it.

I thought about storing root-ish-ness per task (on the first call, `is_rootish` would cache it) so at least it can't change. But I don't think that's necessary, because it doesn't really matter that much which `decide_worker` function we use in this very rare case, so long as the task gets scheduled. I could certainly see going the other way, but I felt better about loosening the assertions in the `decide_worker` functions for now.

cc @fjetter @crusaderky

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`