### PR TITLE
Cache root-ish-ness for consistency

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1519,14 +1519,13 @@ class SchedulerState:
     tasks: dict[str, TaskState]
 
     #: Tasks in the "queued" state, ordered by priority.
-    #: They should generally be root-ish, but in certain cases may not be.
-    #: They must not have restrictions.
+    #: They are all root-ish.
     #: Always empty if `worker-saturation` is set to `inf`.
     queued: HeapSet[TaskState]
 
     #: Tasks in the "no-worker" state.
     #: They may or may not have restrictions.
-    #: Could contain root-ish tasks even when `worker-saturation` is a finite value.
+    #: Only contains root-ish tasks if `worker-saturation` is set to `inf`.
     unrunnable: set[TaskState]
 
     #: Subset of tasks that exist in memory on more than one worker

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7945,6 +7945,7 @@ def _propagate_released(
     recommendations: Recs,
 ) -> None:
     ts.state = "released"
+    ts._rootish = None
     key = ts.key
 
     if ts.has_lost_dependencies:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -525,7 +525,7 @@ async def test_queued_rootish_changes_while_paused(c, s, a, b):
     config={"distributed.scheduler.work-stealing": False},
 )
 async def test_queued_rootish_changes_scale_up(c, s, a):
-    "Tasks are initially root-ish. After cluster scales, they aren't."
+    "Tasks are initially root-ish. After cluster scales, they don't meet the definition, but still are."
 
     root = c.submit(inc, 1, key="root")
 
@@ -548,9 +548,9 @@ async def test_queued_rootish_changes_scale_up(c, s, a):
         for _ in range(3):
             await stack.enter_async_context(Worker(s.address, nthreads=2))
 
-        if s.is_rootish(s.tasks[fs[0].key]):
+        if not s.is_rootish(s.tasks[fs[0].key]):
             pytest.fail(
-                "Test assumptions have changed; task is still root-ish. Test may no longer be relevant."
+                "Test assumptions have changed; root-ish-ness has flipped. Test may no longer be relevant."
             )
 
         await event.set()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -8,6 +8,7 @@ import operator
 import pickle
 import re
 import sys
+from contextlib import AsyncExitStack
 from itertools import product
 from textwrap import dedent
 from time import sleep
@@ -479,6 +480,84 @@ async def test_queued_remove_add_worker(c, s, a, b):
 
         await event.set()
         await wait(fs)
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 2)] * 2,
+    config={
+        "distributed.worker.memory.pause": False,
+        "distributed.worker.memory.target": False,
+        "distributed.worker.memory.spill": False,
+        "distributed.scheduler.work-stealing": False,
+    },
+)
+async def test_queued_rootish_changes_while_paused(c, s, a, b):
+    "Some tasks are root-ish, some aren't. So both `unrunnable` and `queued` contain non-restricted tasks."
+
+    root = c.submit(inc, 1, key="root")
+    await root
+
+    # manually pause the workers
+    a.status = Status.paused
+    b.status = Status.paused
+
+    await async_wait_for(lambda: not s.running, 5)
+
+    fs = [c.submit(inc, root, key=f"inc-{i}") for i in range(s.total_nthreads * 2 + 1)]
+    # ^ `c.submit` in a for-loop so the first tasks don't look root-ish (`TaskGroup` too
+    # small), then the last one does. So N-1 tasks will go to `no-worker`, and the last
+    # to `queued`. `is_rootish` is just messed up like that.
+
+    await async_wait_for(lambda: len(s.tasks) > len(fs), 5)
+
+    # un-pause
+    a.status = Status.running
+    b.status = Status.running
+    await async_wait_for(lambda: len(s.running) == len(s.workers), 5)
+
+    await c.gather(fs)
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)],
+    config={"distributed.scheduler.work-stealing": False},
+)
+async def test_queued_rootish_changes_scale_up(c, s, a):
+    "Tasks are initially root-ish. After cluster scales, they aren't."
+
+    root = c.submit(inc, 1, key="root")
+
+    event = Event()
+    clog = c.submit(event.wait, key="clog")
+    await wait_for_state(clog.key, "processing", s)
+
+    fs = c.map(inc, [root] * 5, key=[f"inc-{i}" for i in range(5)])
+
+    await async_wait_for(lambda: len(s.tasks) > len(fs), 5)
+
+    if not s.is_rootish(s.tasks[fs[0].key]):
+        pytest.fail(
+            "Test assumptions have changed; task is not root-ish. Test may no longer be relevant."
+        )
+    if math.isfinite(s.WORKER_SATURATION):
+        assert s.queued
+
+    async with AsyncExitStack() as stack:
+        for _ in range(3):
+            await stack.enter_async_context(Worker(s.address, nthreads=2))
+
+        if s.is_rootish(s.tasks[fs[0].key]):
+            pytest.fail(
+                "Test assumptions have changed; task is still root-ish. Test may no longer be relevant."
+            )
+
+        await event.set()
+        await clog
+
+    # Just verify it doesn't deadlock
+    await c.gather(fs)
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])


### PR DESCRIPTION
This is a way of avoiding the consistency issues in #7259 with less thinking. If root-ish-ness can't change, things are simpler.

I don't love having to do this. But hopefully this will be determined statically (and likely cached) anyway: https://github.com/dask/distributed/issues/6922.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
