### PR TITLE
[DNM] `queued`<->`no-worker` transitions

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2032,20 +2032,20 @@ class SchedulerState:
     def transition_no_worker_processing(self, key, stimulus_id):
         try:
             ts: TaskState = self.tasks[key]
-            recommendations: Recs = {}
-            client_msgs: dict = {}
-            worker_msgs: dict = {}
 
             if self.validate:
                 assert not ts.actor, f"Actors can't be in `no-worker`: {ts}"
                 assert ts in self.unrunnable
 
-            if ws := self.decide_worker_non_rootish(ts):
-                self.unrunnable.discard(ts)
-                worker_msgs = _add_to_processing(self, ts, ws)
-            # If no worker, task just stays in `no-worker`
+            ws, state = self.decide_worker_and_next_state(ts)
+            if not ws:
+                return {key: state}, {}, {}
 
-            return recommendations, client_msgs, worker_msgs
+            if self.validate:
+                assert state == "processing", state
+
+            self.unrunnable.discard(ts)
+            return {}, {}, _add_to_processing(self, ts, ws)
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2054,7 +2054,7 @@ class SchedulerState:
                 pdb.set_trace()
             raise
 
-    def decide_worker_rootish_queuing_disabled(
+    def _decide_worker_rootish_queuing_disabled(
         self, ts: TaskState
     ) -> WorkerState | None:
         """Pick a worker for a runnable root-ish task, without queuing.
@@ -2114,7 +2114,7 @@ class SchedulerState:
 
         return ws
 
-    def decide_worker_rootish_queuing_enabled(self) -> WorkerState | None:
+    def _decide_worker_rootish_queuing_enabled(self) -> WorkerState | None:
         """Pick a worker for a runnable root-ish task, if not all are busy.
 
         Picks the least-busy worker out of the ``idle`` workers (idle workers have fewer
@@ -2166,7 +2166,7 @@ class SchedulerState:
 
         return ws
 
-    def decide_worker_non_rootish(self, ts: TaskState) -> WorkerState | None:
+    def _decide_worker_non_rootish(self, ts: TaskState) -> WorkerState | None:
         """Pick a worker for a runnable non-root task, considering dependencies and restrictions.
 
         Out of eligible workers holding dependencies of ``ts``, selects the worker
@@ -2235,6 +2235,32 @@ class SchedulerState:
 
         return ws
 
+    def decide_worker_and_next_state(
+        self, ts: TaskState
+    ) -> tuple[WorkerState | None, Literal["queued", "no-worker", "processing"]]:
+        """Pick a worker for a runnable task.
+
+        Selects an appropriate worker to run the task (or None), based on whether the
+        task is root-ish or not and whether queuing is enabled. Also returns the next
+        state the task should go do. If the worker is not None, the state will be
+        ``processing``.
+        """
+        if self.is_rootish(ts):
+            # NOTE: having two root-ish methods is temporary. When the feature flag is removed,
+            # there should only be one, which combines co-assignment and queuing.
+            # Eventually, special-casing root tasks might be removed entirely, with better heuristics.
+            if math.isinf(self.WORKER_SATURATION):
+                if not (ws := self._decide_worker_rootish_queuing_disabled(ts)):
+                    return None, "no-worker"
+            else:
+                if not (ws := self._decide_worker_rootish_queuing_enabled()):
+                    return None, "queued"
+        else:
+            if not (ws := self._decide_worker_non_rootish(ts)):
+                return None, "no-worker"
+
+        return ws, "processing"
+
     def transition_waiting_processing(self, key, stimulus_id):
         """Possibly schedule a ready task. This is the primary dispatch for ready tasks.
 
@@ -2244,22 +2270,14 @@ class SchedulerState:
         try:
             ts: TaskState = self.tasks[key]
 
-            if self.is_rootish(ts):
-                # NOTE: having two root-ish methods is temporary. When the feature flag is removed,
-                # there should only be one, which combines co-assignment and queuing.
-                # Eventually, special-casing root tasks might be removed entirely, with better heuristics.
-                if math.isinf(self.WORKER_SATURATION):
-                    if not (ws := self.decide_worker_rootish_queuing_disabled(ts)):
-                        return {ts.key: "no-worker"}, {}, {}
-                else:
-                    if not (ws := self.decide_worker_rootish_queuing_enabled()):
-                        return {ts.key: "queued"}, {}, {}
-            else:
-                if not (ws := self.decide_worker_non_rootish(ts)):
-                    return {ts.key: "no-worker"}, {}, {}
+            ws, state = self.decide_worker_and_next_state(ts)
+            if not ws:
+                return {key: state}, {}, {}
 
-            worker_msgs = _add_to_processing(self, ts, ws)
-            return {}, {}, worker_msgs
+            if self.validate:
+                assert state == "processing", state
+
+            return {}, {}, _add_to_processing(self, ts, ws)
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:
@@ -2854,20 +2872,21 @@ class SchedulerState:
     def transition_queued_processing(self, key, stimulus_id):
         try:
             ts: TaskState = self.tasks[key]
-            recommendations: Recs = {}
-            client_msgs: dict = {}
-            worker_msgs: dict = {}
 
             if self.validate:
                 assert not ts.actor, f"Actors can't be queued: {ts}"
                 assert ts in self.queued
 
-            if ws := self.decide_worker_rootish_queuing_enabled():
-                self.queued.discard(ts)
-                worker_msgs = _add_to_processing(self, ts, ws)
-            # If no worker, task just stays `queued`
+            ws, state = self.decide_worker_and_next_state(ts)
+            if not ws:
+                return {key: state}, {}, {}
 
-            return recommendations, client_msgs, worker_msgs
+            if self.validate:
+                assert state == "processing", state
+
+            self.queued.discard(ts)
+            return {}, {}, _add_to_processing(self, ts, ws)
+
         except Exception as e:
             logger.exception(e)
             if LOG_PDB:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3030,7 +3030,12 @@ class SchedulerState:
         Root-ish tasks are part of a group that's much larger than the cluster,
         and have few or no dependencies.
         """
-        if ts.resource_restrictions or ts.worker_restrictions or ts.host_restrictions:
+        if (
+            ts.resource_restrictions
+            or ts.worker_restrictions
+            or ts.host_restrictions
+            or ts.actor
+        ):
             return False
         tg = ts.group
         # TODO short-circuit to True if `not ts.dependencies`?

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2888,6 +2888,7 @@ class SchedulerState:
             raise
 
     def transition_queued_no_worker(self, key, stimulus_id):
+        # FIXME this transition may be unreachable?
         try:
             ts: TaskState = self.tasks[key]
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -8,6 +8,7 @@ import operator
 import pickle
 import re
 import sys
+from contextlib import AsyncExitStack
 from itertools import product
 from textwrap import dedent
 from time import sleep
@@ -479,6 +480,84 @@ async def test_queued_remove_add_worker(c, s, a, b):
 
         await event.set()
         await wait(fs)
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 2)] * 2,
+    config={
+        "distributed.worker.memory.pause": False,
+        "distributed.worker.memory.target": False,
+        "distributed.worker.memory.spill": False,
+        "distributed.scheduler.work-stealing": False,
+    },
+)
+async def test_queued_rootish_changes_while_paused(c, s, a, b):
+    "Some tasks are root-ish, some aren't. So both `unrunnable` and `queued` contain non-restricted tasks."
+
+    root = c.submit(inc, 1, key="root")
+    await root
+
+    # manually pause the workers
+    a.status = Status.paused
+    b.status = Status.paused
+
+    await async_wait_for(lambda: not s.running, 5)
+
+    fs = [c.submit(inc, root, key=f"inc-{i}") for i in range(s.total_nthreads * 2 + 1)]
+    # ^ `c.submit` in a for-loop so the first tasks don't look root-ish (`TaskGroup` too
+    # small), then the last one does. So N-1 tasks will go to `no-worker`, and the last
+    # to `queued`. `is_rootish` is just messed up like that.
+
+    await async_wait_for(lambda: len(s.tasks) > len(fs), 5)
+
+    # un-pause
+    a.status = Status.running
+    b.status = Status.running
+    await async_wait_for(lambda: len(s.running) == len(s.workers), 5)
+
+    await c.gather(fs)
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)],
+    config={"distributed.scheduler.work-stealing": False},
+)
+async def test_queued_rootish_changes_scale_up(c, s, a):
+    "Tasks are initially root-ish. After cluster scales, they aren't."
+
+    root = c.submit(inc, 1, key="root")
+
+    event = Event()
+    clog = c.submit(event.wait, key="clog")
+    await wait_for_state(clog.key, "processing", s)
+
+    fs = c.map(inc, [root] * 5, key=[f"inc-{i}" for i in range(5)])
+
+    await async_wait_for(lambda: len(s.tasks) > len(fs), 5)
+
+    if not s.is_rootish(s.tasks[fs[0].key]):
+        pytest.fail(
+            "Test assumptions have changed; task is not root-ish. Test may no longer be relevant."
+        )
+    if math.isfinite(s.WORKER_SATURATION):
+        assert s.queued
+
+    async with AsyncExitStack() as stack:
+        for _ in range(3):
+            await stack.enter_async_context(Worker(s.address, nthreads=2))
+
+        if s.is_rootish(s.tasks[fs[0].key]):
+            pytest.fail(
+                "Test assumptions have changed; task is still root-ish. Test may no longer be relevant."
+            )
+
+        await event.set()
+        await clog
+
+    # Just verify it doesn't deadlock
+    await c.gather(fs)
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])


### PR DESCRIPTION
Yet another approach to https://github.com/dask/distributed/pull/7259. See https://github.com/dask/distributed/pull/7259#issuecomment-1305962579.

* Adds an overall `decide_worker_or_next_state` function, which picks the appropriate `decide_worker` function for the task (based on root-ish-ness and worker-saturation setting) and either returns a worker, or the state the task should transition to if no worker is available
* Adds transitions between the `queued` and `no-worker` states. These can only occur when we try to schedule a task in one of those states, no workers are available, _and_ the root-ish-ness status has flipped.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
