### PR TITLE
chore(ci): coverage report fixing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   test:
     # Do not run the schedule job on forks
-    # if: github.repository == 'dask/distributed' || github.event_name != 'schedule'
+    if: github.repository == 'dask/distributed' || github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
 
@@ -186,17 +186,17 @@ jobs:
       #   uses: mxschmitt/action-tmate@v3
 
       - name: where am i
-        command: pwd
+        run: pwd
 
       - name: files
-        command: ls
+        run: ls
 
       # https://community.codecov.com/t/files-missing-from-report/3902/7
       # The coverage file being created records filenames at the distributed/ directory
       # as opposed to root. This is causing filename mismatches in Codecov.
-      # This command edits `coverage.xml` in-file by adding `distributed` to all filenames.
+      # This step edits `coverage.xml` in-file by adding `distributed` to all filenames.
       - name: Prepare coverage report
-        command: sed -i 's/filename="/filename="distributed\//g' coverage.xml
+        run: sed -i 's/filename="/filename="distributed\//g' coverage.xml
 
       - name: Coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   test:
     # Do not run the schedule job on forks
-    if: github.repository == 'dask/distributed' || github.event_name != 'schedule'
+    # if: github.repository == 'dask/distributed' || github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -185,10 +185,21 @@ jobs:
       #   if: ${{ failure() }}
       #   uses: mxschmitt/action-tmate@v3
 
+      - name: where am i
+        command: pwd
+
+      - name: files
+        command: ls
+
+      # https://community.codecov.com/t/files-missing-from-report/3902/7
+      # The coverage file being created records filenames at the distributed/ directory
+      # as opposed to root. This is causing filename mismatches in Codecov.
+      # This command edits `coverage.xml` in-file by adding `distributed` to all filenames.
+      - name: Prepare coverage report
+        command: sed -i 's/filename="/filename="distributed\//g' coverage.xml
+
       - name: Coverage
         uses: codecov/codecov-action@v3
-        with:
-          functionalities: network
 
       - name: Upload test results
         # ensure this runs even if pytest fails

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -192,7 +192,7 @@ jobs:
       - name: Prepare coverage report
         if: ${{ matrix.os != 'windows-latest' }}
         shell: bash -l {0}
-        run: sed -i 's/filename="/filename="distributed\//g' coverage.xml
+        run: sed -i'' -e 's/filename="/filename="distributed\//g' coverage.xml
 
       # Do not upload coverage reports for cron jobs
       - name: Coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -185,21 +185,21 @@ jobs:
       #   if: ${{ failure() }}
       #   uses: mxschmitt/action-tmate@v3
 
-      - name: where am i
-        run: pwd
-
-      - name: files
-        run: ls
-
       # https://community.codecov.com/t/files-missing-from-report/3902/7
       # The coverage file being created records filenames at the distributed/ directory
       # as opposed to root. This is causing filename mismatches in Codecov.
       # This step edits `coverage.xml` in-file by adding `distributed` to all filenames.
       - name: Prepare coverage report
+        if: ${{ matrix.os != 'windows-latest' }}
+        shell: bash -l {0}
         run: sed -i 's/filename="/filename="distributed\//g' coverage.xml
 
+      # Do not upload coverage reports for cron jobs
       - name: Coverage
+        if: github.event_name != 'schedule'
         uses: codecov/codecov-action@v3
+        with:
+          name: ${{ env.TEST_ID }}
 
       - name: Upload test results
         # ensure this runs even if pytest fails


### PR DESCRIPTION
This helps mitigate the issues presented in https://community.codecov.com/t/files-missing-from-report/3902/7 by pretending filenames in the coverage report with `distributed/`.

It is **strongly** recommended to add the `Codecov token` as described in this [post](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954) due to an ongoing issue we are having with rate limits.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`