### PR TITLE
Bump minimum `bokeh` version to 2.4.2

### DIFF
--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -12,7 +12,7 @@ from itertools import chain
 from types import ModuleType
 from typing import Any
 
-MIN_BOKEH_VERSION = "2.1.1"
+MIN_BOKEH_VERSION = "2.4.2"
 
 required_packages = [
     ("dask", lambda p: p.__version__),


### PR DESCRIPTION
This addresses the `ImportError` reported in https://github.com/dask/distributed/issues/7244. I suspect a lot (most?) users are already using `bokeh>=2.4.2` as [`dask` already uses this as the minimum version](https://github.com/conda-forge/dask-feedstock/blob/61c3f7807361df2802c0411770094e2c5c56b838/recipe/meta.yaml#L29). We should start testing our minimum deps (xref https://github.com/dask/distributed/pull/4794) but I think this change is a definite improvement on the current state of things. 

Closes https://github.com/dask/distributed/issues/7244