### PR TITLE
Improved test for balancing expensive tasks

### DIFF
--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1376,7 +1376,7 @@ async def test_steal_very_fast_tasks(c, s, *workers):
     [
         pytest.param(10, 5, False, id="not enough work to steal"),
         pytest.param(10, 10, True, id="enough work to steal"),
-        pytest.param(20, 10, False, id="not enough work for increased price"),
+        pytest.param(20, 10, False, id="not enough work for increased cost"),
     ],
 )
 def test_balance_expensive_tasks(cost, ntasks, expect_steal):


### PR DESCRIPTION
Parametrizes and renames `test_balance_steal_communication_heavy_tasks` to make its purpose clearer and to address https://github.com/dask/distributed/pull/7243#discussion_r1016612395
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @crusaderky 