### PR TITLE
Revert idle classification when worker-saturation is set

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5339,6 +5339,7 @@ class Scheduler(SchedulerState, ServerNode):
         else:
             self.running.discard(ws)
             self.idle.pop(ws.address, None)
+            self.idle_task_count.pop(ws.address, None)
 
     async def handle_request_refresh_who_has(
         self, keys: Iterable[str], worker: str, stimulus_id: str

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -398,6 +398,7 @@ async def test_queued_paused_new_worker(c, s, a, b):
         await asyncio.sleep(0.01)
 
     assert not s.idle
+    assert not s.idle_task_count
     assert not s.running
 
     async with Worker(s.address, nthreads=2) as w:
@@ -446,6 +447,7 @@ async def test_queued_paused_unpaused(c, s, a, b, queue):
 
     assert not s.running
     assert not s.idle
+    assert not s.idle_task_count
 
     # un-pause
     a.status = Status.running
@@ -455,7 +457,8 @@ async def test_queued_paused_unpaused(c, s, a, b, queue):
 
     if queue:
         assert not s.idle  # workers should have been (or already were) filled
-    # If queuing is disabled, all workers might already be saturated when they un-pause.
+        # If queuing is disabled, all workers might already be saturated when they un-pause.
+        assert not s.idle_task_count
 
     await wait(final)
 


### PR DESCRIPTION
This restores the behavior of the idle set to the behavior before https://github.com/dask/distributed/pull/6614 when worker-saturation is set.

All code paths in the new queuing path will use a different idleness set based on a different definition of idle. 

Closes https://github.com/dask/distributed/issues/7085

ref https://github.com/dask/distributed/pull/7191