### PR TITLE
Consistent worker selection for no-deps cases

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2097,7 +2097,7 @@ class SchedulerState:
         else:
             # Last-used worker is full, unknown, retiring, or paused;
             # pick a new worker for the next few tasks
-            ws = min(pool, key=partial(self.worker_objective, ts))
+            ws = min(pool, key=self.worker_objective_no_deps)
             tg.last_worker_tasks_left = math.floor(
                 (len(tg) / self.total_nthreads) * ws.nthreads
             )
@@ -2152,7 +2152,7 @@ class SchedulerState:
 
         # Just pick the least busy worker.
         # NOTE: this will lead to worst-case scheduling with regards to co-assignment.
-        ws = min(self.idle.values(), key=lambda ws: len(ws.processing) / ws.nthreads)
+        ws = min(self.idle.values(), key=self.worker_objective_no_deps)
         if self.validate:
             assert not _worker_full(ws, self.WORKER_SATURATION), (
                 ws,
@@ -2212,18 +2212,17 @@ class SchedulerState:
             wp_vals = cast("Sequence[WorkerState]", worker_pool.values())
             n_workers: int = len(wp_vals)
             if n_workers < 20:  # smart but linear in small case
-                ws = min(wp_vals, key=operator.attrgetter("occupancy"))
+                ws = min(wp_vals, key=self.worker_objective_no_deps)
                 assert ws
-                if ws.occupancy == 0:
+                if sum(self.worker_objective_no_deps(ws)) == 0:
                     # special case to use round-robin; linear search
-                    # for next worker with zero occupancy (or just
-                    # land back where we started).
+                    # for next empty worker (or just land back where we started).
                     wp_i: WorkerState
                     start: int = self.n_tasks % n_workers
                     i: int
                     for i in range(n_workers):
                         wp_i = wp_vals[(i + start) % n_workers]
-                        if wp_i.occupancy == 0:
+                        if sum(self.worker_objective_no_deps(wp_i)) == 0:
                             ws = wp_i
                             break
             else:  # dumb but fast in large case
@@ -3234,6 +3233,17 @@ class SchedulerState:
             return (len(ws.actors), start_time, ws.nbytes)
         else:
             return (start_time, ws.nbytes)
+
+    def worker_objective_no_deps(self, ws: WorkerState) -> tuple[float, float]:
+        """
+        Objective function to determine the least-busy worker.
+
+        Meant for use with tasks where dependencies are not relevant for scheduling
+        (no dependencies, or widely-shared).
+
+        Minimize worker occupancy. If a tie then break with data storage.
+        """
+        return (ws.occupancy / ws.nthreads, ws.nbytes / ws.memory_limit or 1)
 
     def add_replica(self, ts: TaskState, ws: WorkerState):
         """Note that a worker holds a replica of a task with state='memory'"""


### PR DESCRIPTION
This consolidates the logic used in three different cases into one objective function. In `decide_worker_rootish_queuing_disabled`, `decide_worker_rootish_queuing_enabled`, and the no-dependencies case of `decide_worker_non_rootish`, we're selecting the best worker just based on how busy it is, without regard to where dependencies are.

These three cases had subtly different criteria for picking the best worker. By switching to use the same objective function everywhere, we smooth over the edge cases caused by the changed definition of `idle` and https://github.com/dask/distributed/issues/7274.

The one downside is using `occupancy` as the objective. It can be quite expensive: https://github.com/dask/distributed/issues/7256.

Supersedes https://github.com/dask/distributed/pull/7248

Closes #7197

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
