### PR TITLE
Add support for unpacking namedtuples in remote data

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -19,7 +19,7 @@ import types
 import warnings
 import weakref
 import zipfile
-from collections import deque
+from collections import deque, namedtuple
 from collections.abc import Generator
 from contextlib import ExitStack, contextmanager, nullcontext
 from functools import partial
@@ -28,7 +28,6 @@ from threading import Semaphore
 from time import sleep
 from typing import Any
 from unittest import mock
-from collections import namedtuple
 
 import psutil
 import pytest
@@ -7844,6 +7843,7 @@ async def test_wait_for_workers_n_workers_value_check(c, s, a, b, value, excepti
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 1)
 async def test_unpacks_remotedata_namedtuple(c, s, a):
     Point = namedtuple("Point", "x y")
+
     def f():
         return Point(2, 4)
 
@@ -7853,13 +7853,12 @@ async def test_unpacks_remotedata_namedtuple(c, s, a):
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 1)
 async def test_unpacks_remotedata_namedtuple_inherited(c, s, a):
-    class NamedTupleAnnotation(
-        namedtuple("BaseAnnotation", field_names="value")
-    ):
+    class NamedTupleAnnotation(namedtuple("BaseAnnotation", field_names="value")):
         def unwrap(self):
             return self.value
 
     string = "my_value"
+
     def f():
         return NamedTupleAnnotation(value=string)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7840,27 +7840,15 @@ async def test_wait_for_workers_n_workers_value_check(c, s, a, b, value, excepti
         await c.wait_for_workers(value)
 
 
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 1)
-async def test_unpacks_remotedata_namedtuple(c, s, a):
-    Point = namedtuple("Point", "x y")
-
-    def f():
-        return Point(2, 4)
-
-    result = await c.submit(f)
-    assert result == Point(2, 4)
-
-
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 1)
-async def test_unpacks_remotedata_namedtuple_inherited(c, s, a):
+@gen_cluster(client=True)
+async def test_unpacks_remotedata_namedtuple(c, s, a, b):
     class NamedTupleAnnotation(namedtuple("BaseAnnotation", field_names="value")):
         def unwrap(self):
             return self.value
 
-    string = "my_value"
+    def identity(x):
+        return x
 
-    def f():
-        return NamedTupleAnnotation(value=string)
-
-    result = await c.submit(f)
-    assert result == NamedTupleAnnotation(string)
+    outer_future = c.submit(identity, NamedTupleAnnotation("some-data"))
+    result = await outer_future
+    assert result == NamedTupleAnnotation(value="some-data")

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -11,7 +11,7 @@ from tlz import concat, drop, groupby, merge
 
 import dask.config
 from dask.optimization import SubgraphCallable
-from dask.utils import parse_timedelta, stringify
+from dask.utils import parse_timedelta, stringify, is_namedtuple_instance
 
 from distributed.core import rpc
 from distributed.utils import All
@@ -223,6 +223,9 @@ def unpack_remotedata(o, byte_keys=False, myset=None):
                 return o
         else:
             return tuple(unpack_remotedata(item, byte_keys, myset) for item in o)
+    elif is_namedtuple_instance(o):
+        return typ(*[unpack_remotedata(item, byte_keys, myset) for item in o])
+
     if typ in collection_types:
         if not o:
             return o

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -11,7 +11,7 @@ from tlz import concat, drop, groupby, merge
 
 import dask.config
 from dask.optimization import SubgraphCallable
-from dask.utils import parse_timedelta, stringify, is_namedtuple_instance
+from dask.utils import is_namedtuple_instance, parse_timedelta, stringify
 
 from distributed.core import rpc
 from distributed.utils import All


### PR DESCRIPTION

This PR adds support for unpacking namedtuples in unpack_remotedata, similar to https://github.com/dask/dask/pull/9361/files

A step towards closing https://github.com/PrefectHQ/prefect-dask/issues/43

cc: @madkinsz 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
