### PR TITLE
Respect death timeout when waiting for scheduler file

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -201,8 +201,9 @@ class Nanny(ServerNode):
             self, preload_nanny, preload_nanny_argv, file_dir=self.local_directory
         )
 
+        self.death_timeout = parse_timedelta(death_timeout)
         if scheduler_file:
-            cfg = json_load_robust(scheduler_file)
+            cfg = json_load_robust(scheduler_file, timeout=self.death_timeout)
             self.scheduler_addr = cfg["address"]
         elif scheduler_ip is None and dask.config.get("scheduler-address"):
             self.scheduler_addr = dask.config.get("scheduler-address")
@@ -221,7 +222,6 @@ class Nanny(ServerNode):
         self.reconnect = reconnect
         self.validate = validate
         self.resources = resources
-        self.death_timeout = parse_timedelta(death_timeout)
 
         self.Worker = Worker if worker_class is None else worker_class
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1101,19 +1101,21 @@ def nbytes(frame, _bytes_like=(bytes, bytearray)):
             return len(frame)
 
 
-def json_load_robust(fn, load=json.load):
+def json_load_robust(fn, load=json.load, timeout=None):
     """Reads a JSON file from disk that may be being written as we read"""
-    while not os.path.exists(fn):
-        sleep(0.01)
-    for _ in range(10):
-        try:
-            with open(fn) as f:
-                cfg = load(f)
-            if cfg:
-                return cfg
-        except (ValueError, KeyError):  # race with writing process
-            pass
+    deadline = Deadline.after(timeout)
+    while not deadline.expires or deadline.remaining:
+        if os.path.exists(fn):
+            try:
+                with open(fn) as f:
+                    cfg = load(f)
+                if cfg:
+                    return cfg
+            except (ValueError, KeyError):  # race with writing process
+                pass
         sleep(0.1)
+    else:
+        raise TimeoutError(f"Could not load file after {timeout}s.")
 
 
 class DequeHandler(logging.Handler):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -601,8 +601,9 @@ class Worker(BaseWorker, ServerNode):
             self, preload, preload_argv, file_dir=self.local_directory
         )
 
+        self.death_timeout = parse_timedelta(death_timeout)
         if scheduler_file:
-            cfg = json_load_robust(scheduler_file)
+            cfg = json_load_robust(scheduler_file, timeout=self.death_timeout)
             scheduler_addr = cfg["address"]
         elif scheduler_ip is None and dask.config.get("scheduler-address", None):
             scheduler_addr = dask.config.get("scheduler-address")
@@ -635,8 +636,6 @@ class Worker(BaseWorker, ServerNode):
         if resources is None:
             resources = dask.config.get("distributed.worker.resources")
             assert isinstance(resources, dict)
-
-        self.death_timeout = parse_timedelta(death_timeout)
 
         self.extensions = {}
         if silence_logs:


### PR DESCRIPTION
If the directory never gets created (e.g. a typo), this will wait indefinitely. Instead, it should timeout at some point. I think reusing the death_timeout is appropriate. I doubt users will want to fine granularly control this timeout but rather want to make sure that a startup is not stuck indefinitely