### PR TITLE
Add `ForwardOutput` worker plugin to forward `stdout` and `stderr` to client.

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3784,6 +3784,7 @@ async def test_forward_output(c, s, a, b, capsys):
 
     # After installing, output should be forwarded
     await c.register_worker_plugin(plugin, "forward")
+    await asyncio.sleep(0.1)  # Let setup messages come in
     capsys.readouterr()
 
     await c.submit(print_stdout, "foo", key=next(counter))
@@ -3825,6 +3826,7 @@ async def test_forward_output(c, s, a, b, capsys):
     # Registering the plugin is idempotent
     other_plugin = ForwardOutput()
     await c.register_worker_plugin(other_plugin, "forward")
+    await asyncio.sleep(0.1)  # Let teardown/setup messages come in
     out, err = capsys.readouterr()
 
     await c.submit(print_stdout, "foo", key=next(counter))
@@ -3835,6 +3837,7 @@ async def test_forward_output(c, s, a, b, capsys):
 
     # After unregistering the plugin, we should once again not see any output
     await c.unregister_worker_plugin("forward")
+    await asyncio.sleep(0.1)  # Let teardown messages come in
     capsys.readouterr()
 
     await c.submit(print_stdout, "foo", key=next(counter))

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import importlib
+import itertools
 import logging
 import os
 import sys
@@ -44,7 +45,12 @@ from distributed.comm.registry import backends
 from distributed.compatibility import LINUX, WINDOWS, to_thread
 from distributed.core import CommClosedError, Status, rpc
 from distributed.diagnostics import nvml
-from distributed.diagnostics.plugin import CondaInstall, PackageInstall, PipInstall
+from distributed.diagnostics.plugin import (
+    CondaInstall,
+    ForwardOutput,
+    PackageInstall,
+    PipInstall,
+)
 from distributed.metrics import time
 from distributed.protocol import pickle
 from distributed.scheduler import Scheduler
@@ -3741,3 +3747,93 @@ async def test_worker_log_memory_limit_too_high(s):
         for snippets in expected_snippets:
             # assert any(snip in caplog.text for snip in snippets)
             assert any(snip in caplog.getvalue().lower() for snip in snippets)
+
+
+@gen_cluster(client=True, Worker=Nanny)
+async def test_forward_output(c, s, a, b, capsys):
+    def print_stdout(*args, **kwargs):
+        print(*args, file=sys.stdout, **kwargs)
+
+    def print_stderr(*args, **kwargs):
+        print(*args, file=sys.stderr, **kwargs)
+
+    plugin = ForwardOutput()
+    out, err = capsys.readouterr()
+
+    counter = itertools.count()
+
+    # Without the plugin installed, we should not see any output
+    # Note that we use nannies so workers run in subprocesses
+    await c.submit(print_stdout, "foo", key=next(counter))
+    await c.submit(print_stdout, "bar\n", key=next(counter))
+    await c.submit(print_stdout, "baz", end="", flush=True, key=next(counter))
+    await c.submit(print_stdout, 1, 2, end="\n", sep="\n", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "" == out
+    assert "" == err
+
+    await c.submit(print_stderr, "foo", key=next(counter))
+    await c.submit(print_stderr, "bar\n", key=next(counter))
+    await c.submit(print_stderr, "baz", flush=True, key=next(counter))
+    await c.submit(print_stderr, 1, 2, end="\n", sep="\n", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "" == out
+    assert "" == err
+
+    # After installing, output should be forwarded
+    await c.register_worker_plugin(plugin, "forward")
+    capsys.readouterr()
+
+    await c.submit(print_stdout, "foo", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "foo\n" == out
+    assert "" == err
+
+    await c.submit(print_stdout, "bar\n", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "bar\n\n" == out
+    assert "" == err
+
+    await c.submit(print_stdout, "baz", end="", flush=True, key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "baz" == out
+    assert "" == err
+
+    await c.submit(print_stdout, "first\nsecond", end="", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "first\nsecond" == out
+    assert "" == err
+
+    await c.submit(print_stdout, 1, 2, sep=":", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "1:2\n" == out
+    assert err == ""
+
+    await c.submit(print_stderr, "fatal", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "" == out
+    assert "fatal\n" == err
+
+    # After unregistering the plugin, we should once again not see any output
+    await c.unregister_worker_plugin("forward")
+    capsys.readouterr()
+
+    await c.submit(print_stdout, "foo", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "" == out
+    assert "" == err
+
+    await c.submit(print_stderr, "fatal", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "" == out
+    assert "" == err

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3822,6 +3822,17 @@ async def test_forward_output(c, s, a, b, capsys):
     assert "" == out
     assert "fatal\n" == err
 
+    # Registering the plugin is idempotent
+    other_plugin = ForwardOutput()
+    await c.register_worker_plugin(other_plugin, "forward")
+    out, err = capsys.readouterr()
+
+    await c.submit(print_stdout, "foo", key=next(counter))
+    out, err = capsys.readouterr()
+
+    assert "foo\n" == out
+    assert "" == err
+
     # After unregistering the plugin, we should once again not see any output
     await c.unregister_worker_plugin("forward")
     capsys.readouterr()


### PR DESCRIPTION
This PR adds a `ForwardOutput` worker plugin that forwards all output from `stdout` and `stderr` on all workers to all clients using the internals implemented for `distributed.worker.print`. This plugin is not intended for chatty workloads and may put significant load on the scheduler.

Note that this plugin is related to #7276 but takes a slightly different route as it tries to avoid adding additional client methods that start to bloat the client interface. This comes at the cost of forwarding to **all** clients. This is the same behavior that we already have with `distributed.print()`. Unless somebody is particularly interested in using this plugin in a multi-client environment, I would leave this as is until we have added client plugins that allow adding functionality on the client without the need for dedicated methods. 

* Closes #7202

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
