### PR TITLE
Reduce max-runs in test reports

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Generate report
         run: |
-          python continuous_integration/scripts/test_report.py --max-days 90 --max-runs 50 --nfails 1 -o test_report.html
-          python continuous_integration/scripts/test_report.py --max-days 7 --max-runs 50 --nfails 2 -o test_short_report.html --title "Test Short Report"
+          python continuous_integration/scripts/test_report.py --max-days 90 --max-runs 30 --nfails 1 -o test_report.html
+          python continuous_integration/scripts/test_report.py --max-days 7 --max-runs 30 --nfails 2 -o test_short_report.html --title "Test Short Report"
           mkdir deploy
           mv test_report.html test_short_report.html deploy/
 


### PR DESCRIPTION
We're constantly hitting rate limiting errors since the 50 runs require us recently to download about 1k artifacts. Since every CI run fails, we never actually succeeded in building a cache.

We should reduce this limit for a while until we have some runs cached