### PR TITLE
Add max tick metric to prometheus

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -401,6 +401,9 @@ class Server:
             dask.config.get("distributed.admin.tick.interval"), default="ms"
         )
         self._tick_interval_observed = self._tick_interval
+        # This metric is exposed in prometheus and is reset there during
+        # collection
+        self._max_tick_interval_observed = self._tick_interval
         self.periodic_callbacks["tick"] = PeriodicCallback(
             self._measure_tick, self._tick_interval * 1000
         )
@@ -561,6 +564,9 @@ class Server:
         last, self._tick_count_last = self._tick_count_last, time()
         count, self._tick_counter = self._tick_counter, 0
         self._tick_interval_observed = (time() - last) / (count or 1)
+        self._max_tick_interval_observed = max(
+            self._tick_interval_observed, self._max_tick_interval_observed
+        )
 
     @property
     def address(self) -> str:

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -85,6 +85,14 @@ class SchedulerMetricCollector(PrometheusCollector):
                 prefix_state_counts.add_metric([tp.name, state], count)
         yield prefix_state_counts
 
+        if self.server._max_tick_interval_observed != 0:
+            yield GaugeMetricFamily(
+                self.build_name("max_tick_interval"),
+                "Maximum tick interval observed.",
+                value=self.server._max_tick_interval_observed,
+            )
+        self.server._max_tick_interval_observed = 0
+
 
 COLLECTORS = [
     SchedulerMetricCollector,

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -139,6 +139,13 @@ class WorkerMetricCollector(PrometheusCollector):
                 .components[1]
                 .quantile(50),
             )
+        if self.server._max_tick_interval_observed != 0:
+            yield GaugeMetricFamily(
+                self.build_name("max_tick_interval"),
+                "Maximum tick interval observed.",
+                value=self.server._max_tick_interval_observed,
+            )
+        self.server._max_tick_interval_observed = 0
 
 
 class PrometheusHandler(RequestHandler):


### PR DESCRIPTION
Event loop health is an important metric to assess overall cluster health. We're only exporting metrics to prometheus in case crick is installed. This PR suggests to export the maximum observed value during /metric collections to get a similar view. To make this properly work we need to manage state, i.e. this counter is reset by the prometheus collector. I think this is a bit ugly but worth it

cc @hendrikmakait @ntabris 