### PR TITLE
Prometheus debug log

### DIFF
--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -20,7 +20,7 @@ class WorkerMetricCollector(PrometheusCollector):
             import crick  # noqa: F401
         except ImportError:
             self.crick_available = False
-            self.logger.info(
+            self.logger.debug(
                 "Not all prometheus metrics available are exported. "
                 "Digest-based metrics require crick to be installed"
             )

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -7,20 +7,21 @@ from distributed.http.prometheus import PrometheusCollector
 from distributed.http.utils import RequestHandler
 from distributed.worker import Worker
 
+logger = logging.getLogger("distributed.prometheus.worker")
+
 
 class WorkerMetricCollector(PrometheusCollector):
     server: Worker
 
     def __init__(self, server: Worker):
         super().__init__(server)
-        self.logger = logging.getLogger("distributed.dask_worker")
         self.subsystem = "worker"
         self.crick_available = True
         try:
             import crick  # noqa: F401
         except ImportError:
             self.crick_available = False
-            self.logger.debug(
+            logger.debug(
                 "Not all prometheus metrics available are exported. "
                 "Digest-based metrics require crick to be installed"
             )


### PR DESCRIPTION
I think having crick installed is rather the exception than the rule. I don't think we should spam this message.

I also changed the log name. This would establish a namespace `distributed.prometheus` which is where we could log all prometheus related messages (this is currently the only one afaik)