### PR TITLE
Fix typos in P2P shuffle code

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -145,9 +145,9 @@ class P2PShuffleLayer(SimpleShuffleLayer):
         dsk: dict[tuple | str, tuple] = {}
         barrier_key = "shuffle-barrier-" + token
         name = "shuffle-transfer-" + token
-        tranfer_keys = list()
+        transfer_keys = list()
         for i in range(self.npartitions_input):
-            tranfer_keys.append((name, i))
+            transfer_keys.append((name, i))
             dsk[(name, i)] = (
                 shuffle_transfer,
                 (self.name_input, i),
@@ -156,7 +156,7 @@ class P2PShuffleLayer(SimpleShuffleLayer):
                 self.column,
             )
 
-        dsk[barrier_key] = (shuffle_barrier, token, tranfer_keys)
+        dsk[barrier_key] = (shuffle_barrier, token, transfer_keys)
 
         name = self.name
         for part_out in self.parts_out:

--- a/distributed/shuffle/_shuffle_extension.py
+++ b/distributed/shuffle/_shuffle_extension.py
@@ -324,7 +324,7 @@ class ShuffleWorkerExtension:
         data: list[bytes],
     ) -> None:
         """
-        Hander: Receive an incoming shard of data from a peer worker.
+        Handler: Receive an incoming shard of data from a peer worker.
         Using an unknown ``shuffle_id`` is an error.
         """
         shuffle = await self._get_shuffle(shuffle_id)


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
