### PR TITLE
Bump `toolz` minimum version to `0.10.0`

### DIFF
--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - python >=3.8
     - click >=7.0
     - cloudpickle >=1.5.0
-    - cytoolz >=0.8.2
+    - cytoolz >=0.10.0
     - {{ pin_compatible('dask-core', max_pin='x.x.x.x') }}
     - jinja2
     - locket >=1.0.0
@@ -41,7 +41,7 @@ requirements:
     - pyyaml
     - sortedcontainers !=2.0.0,!=2.0.1
     - tblib >=1.6.0
-    - toolz >=0.8.2
+    - toolz >=0.10.0
     - tornado >=6.0.3,<6.2
     - urllib3
     - zict >=0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ packaging >= 20.0
 psutil >= 5.0
 sortedcontainers !=2.0.0, !=2.0.1
 tblib >= 1.6.0
-toolz >= 0.8.2
+toolz >= 0.10.0
 tornado >= 6.0.3, <6.2
 urllib3
 zict >= 0.1.3


### PR DESCRIPTION
`peekn` (imported [here](https://github.com/dask/distributed/blob/1e078f4afddad96e087cc6f8c23a40d4ae595017/distributed/worker_state_machine.py#L28)) is not provided until `toolz >= 0.10.0`. Therefore, I bumped the requirement of toolz.