### PR TITLE
Use `conda-incubator/setup-miniconda@v2.2.0`

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-variant: Mambaforge
           use-mamba: true

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest


### PR DESCRIPTION
Pins to the latest `conda-incubator/setup-miniconda`. As Dependabot already checks for GH Actions updates ( https://github.com/dask/distributed/pull/7101 ), updates to this action version can be handled automatically.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
