### PR TITLE
Ensure Server.close cannot run concurrently

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -867,7 +867,7 @@ class Server:
             assert comm.closed()
 
     async def close_unsafe(
-        self, timeout: float | None, reason: str | None, **kwargs: Any
+        self, timeout: float | None = None, reason: str | None = None, **kwargs: Any
     ) -> None:
         """Attempt to close the server. This is not idempotent and not protected against concurrent closing attempts.
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3889,7 +3889,9 @@ class Scheduler(SchedulerState, ServerNode):
         setproctitle(f"dask scheduler [{self.address}]")
         return self
 
-    async def close_unsafe(self, timeout: float | None, reason: str | None, **kwargs):
+    async def close_unsafe(
+        self, timeout: float | None = None, reason: str | None = None, **kwargs
+    ):
         """Send cleanup signal to all coroutines then wait until finished
 
         See Also

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3666,7 +3666,9 @@ class BaseWorker(abc.ABC):
                 self._async_instructions.add(task)
                 task.add_done_callback(self._handle_stimulus_from_task)
 
-    async def close_unsafe(self, timeout: float = 30) -> None:
+    async def close_unsafe(
+        self, timeout: float | None = 30, reason: str | None = None
+    ) -> None:
         """Cancel all asynchronous instructions"""
         if not self._async_instructions:
             return

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3666,7 +3666,7 @@ class BaseWorker(abc.ABC):
                 self._async_instructions.add(task)
                 task.add_done_callback(self._handle_stimulus_from_task)
 
-    async def close(self, timeout: float = 30) -> None:
+    async def close_unsafe(self, timeout: float = 30) -> None:
         """Cancel all asynchronous instructions"""
         if not self._async_instructions:
             return


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/7312

There are weird race conditions possible if start and stop is running concurrently. I think we should just prohibit doing this and lock it similarly to how we lock start. I ended up introducing similar close_unsafe methods as I did for the start_unsafe back in https://github.com/dask/distributed/pull/5910