### PR TITLE
Fix typo in `client.run()` docstring

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2885,7 +2885,7 @@ class Client(SyncMethodMixin):
         >>> def get_status(dask_worker):
         ...     return dask_worker.status
 
-        >>> c.run(get_hostname)  # doctest: +SKIP
+        >>> c.run(get_status)  # doctest: +SKIP
         {'192.168.0.100:9000': 'running',
          '192.168.0.101:9000': 'running}
 


### PR DESCRIPTION
This fixes a typo in the `client.run()` docstring.
This is my first PR in this repo, so please let me know if there's anything I should be adding here to smoothen the process.

- [ ] Tests added / passed
- [X] Passes `pre-commit run --all-files`
