### PR TITLE
Always raise exception if P2PShuffle's send fails

### DIFF
--- a/distributed/shuffle/_shuffle_extension.py
+++ b/distributed/shuffle/_shuffle_extension.py
@@ -269,6 +269,7 @@ class Shuffle:
         assert not self.transferred, "`inputs_done` called multiple times"
         self.transferred = True
         await self._comm_buffer.flush()
+        self._comm_buffer.raise_on_exception()
 
     def done(self) -> bool:
         return self.transferred and self.output_partitions_left == 0

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -668,15 +668,57 @@ async def test_error_offload(tmpdir, loop_in_thread):
     try:
         await sB.add_partition(dfs[0])
         await sB.add_partition(dfs[1])
-        await sB.barrier()
-        # Fetching from B is not a problem
-        assert len(partitions_for_worker["B"]) == 1
-        await sB.get_output_partition(partitions_for_worker["B"][0])
-
         with pytest.raises(RuntimeError, match="Error during deserialization"):
-            assert len(partitions_for_worker["A"]) == 1
-            # The error should be raised here. Functionally speaking, we're fine
-            # as long as it is raised before we collect the last shard.
-            await sA.get_output_partition(partitions_for_worker["A"][0])
+            await sB.barrier()
+    finally:
+        await asyncio.gather(*[s.close() for s in [sA, sB]])
+
+
+@gen_test()
+async def test_error_send(tmpdir, loop_in_thread):
+    dfs = []
+    rows_per_df = 10
+    n_input_partitions = 1
+    npartitions = 2
+    for ix in range(n_input_partitions):
+        df = pd.DataFrame({"x": range(rows_per_df * ix, rows_per_df * (ix + 1))})
+        df["_partition"] = df.x % npartitions
+        dfs.append(df)
+
+    workers = ["A", "B"]
+
+    worker_for_mapping = {}
+    partitions_for_worker = defaultdict(list)
+
+    for part in range(npartitions):
+        worker_for_mapping[part] = w = get_worker_for(part, workers, npartitions)
+        partitions_for_worker[w].append(part)
+    schema = pa.Schema.from_pandas(dfs[0])
+
+    local_shuffle_pool = ShuffleTestPool()
+
+    class ErrorSend(Shuffle):
+        async def send(self, address: str, shards: list[bytes]) -> None:
+            raise RuntimeError("Error during send")
+
+    sA = local_shuffle_pool.new_shuffle(
+        name="A",
+        worker_for_mapping=worker_for_mapping,
+        schema=schema,
+        directory=tmpdir,
+        loop=loop_in_thread,
+        Shuffle=ErrorSend,
+    )
+    sB = local_shuffle_pool.new_shuffle(
+        name="B",
+        worker_for_mapping=worker_for_mapping,
+        schema=schema,
+        directory=tmpdir,
+        loop=loop_in_thread,
+    )
+    try:
+        await sA.add_partition(dfs[0])
+        with pytest.raises(RuntimeError, match="Error during send"):
+            await sA.barrier()
     finally:
         await asyncio.gather(*[s.close() for s in [sA, sB]])


### PR DESCRIPTION
This PR fixes an issue where the `P2PShuffle` would not raise an exception during `send` causing data loss.

**Reproducer**
A slightly adjusted variant of the added unit test:

```python3
@gen_test()
async def test_error_send(tmpdir, loop_in_thread):
    dfs = []
    rows_per_df = 10
    n_input_partitions = 1
    npartitions = 2
    for ix in range(n_input_partitions):
        df = pd.DataFrame({"x": range(rows_per_df * ix, rows_per_df * (ix + 1))})
        df["_partition"] = df.x % npartitions
        dfs.append(df)

    workers = ["A", "B"]

    worker_for_mapping = {}
    partitions_for_worker = defaultdict(list)

    for part in range(npartitions):
        worker_for_mapping[part] = w = get_worker_for(part, workers, npartitions)
        partitions_for_worker[w].append(part)
    schema = pa.Schema.from_pandas(dfs[0])

    local_shuffle_pool = ShuffleTestPool()

    class ErrorSend(Shuffle):
        async def send(self, address: str, shards: list[bytes]) -> None:
            raise RuntimeError("Error during send")

    sA = local_shuffle_pool.new_shuffle(
        name="A",
        worker_for_mapping=worker_for_mapping,
        schema=schema,
        directory=tmpdir,
        loop=loop_in_thread,
        Shuffle=ErrorSend,
    )
    sB = local_shuffle_pool.new_shuffle(
        name="B",
        worker_for_mapping=worker_for_mapping,
        schema=schema,
        directory=tmpdir,
        loop=loop_in_thread,
    )
    try:
        await sA.add_partition(dfs[0])
        await sA.barrier()
        all_parts = []
        all_parts.append(await sA.get_output_partition(partitions_for_worker["A"][0]))
        all_parts.append(await sB.get_output_partition(partitions_for_worker["B"][0]))
        assert len(pd.concat(dfs)) == len(pd.concat(all_parts))
    finally:
        await asyncio.gather(*[s.close() for s in [sA, sB]])
```
```
FAILED distributed/shuffle/tests/test_shuffle.py::test_error_send - assert 10 == 0
```

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
