### PR TITLE
Remove timeout and executor_wait from Worker.close

### DIFF
--- a/distributed/chaos.py
+++ b/distributed/chaos.py
@@ -56,7 +56,7 @@ class KillWorker(WorkerPlugin):
         )
 
     def graceful(self):
-        asyncio.create_task(self.worker.close(nanny=False, executor_wait=False))
+        asyncio.create_task(self.worker.close(nanny=False))
 
     def sys_exit(self):
         sys.exit(0)

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -68,6 +68,8 @@ async def test_add_remove_worker(s):
     await b
     await a.close()
     await b.close()
+    while any(w.address in s.workers for w in [a, b]):
+        await asyncio.sleep(0.01)
 
     assert events == [
         ("add_worker", a.address),
@@ -168,7 +170,10 @@ async def test_async_add_remove_worker(s):
 
     async with Worker(s.address) as a:
         async with Worker(s.address) as b:
-            pass
+            addresses = [a.address, b.address]
+
+    while any(w in s.workers for w in addresses):
+        await asyncio.sleep(0.01)
 
     assert len(events) == 4
     assert set(events) == {

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -804,7 +804,7 @@ class WorkerProcess:
         If the worker process does not terminate within ``timeout`` seconds,
         even after being killed, `asyncio.TimeoutError` is raised.
         """
-        if executor_wait is not None:
+        if executor_wait is not None:  # pragma: nocover
             warnings.warn(
                 "`executor_wait` has no functionality and will be removed in a future version",
                 FutureWarning,

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -925,7 +925,8 @@ async def test_remove_worker(c, s, a, b):
 
     await b.close()
 
-    assert b.address not in s.workers
+    while b.address in s.workers:
+        await asyncio.sleep(0.01)
 
     result = await c.gather(L)
     assert result == list(map(inc, range(20)))

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -13,6 +13,13 @@ from unittest import mock
 
 import psutil
 import pytest
+
+from distributed import Event
+from distributed.diagnostics.plugin import WorkerPlugin
+
+pytestmark = pytest.mark.gpu
+
+from tlz import first, valmap
 from tlz import first
 from tornado.ioloop import IOLoop
 
@@ -781,3 +788,18 @@ async def test_log_event(c, s):
             "traceback_text": "",
         },
     ] == [msg[1] for msg in s.get_events("test-topic4")]
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_worker_thread_does_not_block_shutdown(c, s):
+    event = Event()
+    async with Nanny(s.address):
+
+        def block_forever():
+            event.set()
+            import time
+
+            time.sleep(100000000)
+
+        c.submit(block_forever)
+        await event.wait()

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -9,6 +9,7 @@ import random
 import sys
 import warnings
 from contextlib import suppress
+from time import sleep
 from unittest import mock
 
 import psutil
@@ -797,9 +798,8 @@ async def test_worker_thread_does_not_block_shutdown(c, s):
 
         def block_forever():
             event.set()
-            import time
 
-            time.sleep(100000000)
+            sleep(100000000)
 
         c.submit(block_forever)
         await event.wait()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2475,7 +2475,8 @@ async def test_async_context_manager():
         async with Worker(s.address) as w:
             assert w.status == Status.running
             assert s.workers
-        assert not s.workers
+        while s.workers:
+            await asyncio.sleep(0.1)
 
 
 @gen_test()
@@ -3779,7 +3780,8 @@ async def test_rebalance_dead_recipient(client, s, a, b, c):
     x_ts = s.tasks[x.key]
     y_ts = s.tasks[y.key]
     await c.close()
-    assert s.workers.keys() == {a.address, b.address}
+    while s.workers.keys() != {a.address, b.address}:
+        await asyncio.sleep(0.01)
 
     out = await s._rebalance_move_data(
         [(a_ws, b_ws, x_ts), (a_ws, c_ws, y_ts)], stimulus_id="test"
@@ -3831,7 +3833,8 @@ async def test_delete_worker_data_bad_worker(s, a, b):
     e.g. a sender died in the middle of rebalance()
     """
     await a.close()
-    assert s.workers.keys() == {b.address}
+    while s.workers.keys() != {b.address}:
+        await asyncio.sleep(0.01)
     await s.delete_worker_data(a.address, ["x"], stimulus_id="test")
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -4214,7 +4214,7 @@ async def test_ensure_events_dont_include_taskstate_objects(c, s, a, b):
     while not a.state.tasks:
         await asyncio.sleep(0.1)
 
-    await a.close(executor_wait=False)
+    await a.close()
     await event.set()
     await c.gather(futs)
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1237,7 +1237,7 @@ async def test_steal_worker_dies_same_ip(c, s, w0, w1):
 
     assert victim_ts.processing_on != wsB
 
-    await w_new.close(executor_wait=False)
+    await w_new.close()
     await ev.set()
     await c.gather(futs1)
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3565,6 +3565,9 @@ async def test_broken_comm(c, s, a, b):
 
 @gen_cluster(nthreads=[])
 async def test_do_not_block_event_loop_during_shutdown(s):
+    # An earlier implementation of Close blocked the event loop during
+    # threadpool closing. This was removed by now but closing should not block,
+    # ever, so the test is still OK
     loop = asyncio.get_running_loop()
     called_handler = threading.Event()
     block_handler = threading.Event()
@@ -3591,8 +3594,7 @@ async def test_do_not_block_event_loop_during_shutdown(s):
 
     async def close():
         called_handler.wait()
-        # executor_wait is True by default but we want to be explicit here
-        await w.close(executor_wait=True)
+        await w.close()
 
     await asyncio.gather(block(), close(), set_future())
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -121,7 +121,7 @@ NO_AMM = {"distributed.scheduler.active-memory-manager.start": False}
 
 async def cleanup_global_workers():
     for worker in Worker._instances:
-        await worker.close(executor_wait=False)
+        await worker.close()
 
 
 @pytest.fixture
@@ -1751,7 +1751,7 @@ def check_instances():
 
     for w in Worker._instances:
         with suppress(RuntimeError):  # closed IOLoop
-            w.loop.add_callback(w.close, executor_wait=False)
+            w.loop.add_callback(w.close)
             if w.status in WORKER_ANY_RUNNING:
                 w.loop.add_callback(w.close)
     Worker._instances.clear()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -27,7 +27,6 @@ from collections.abc import (
     MutableMapping,
 )
 from concurrent.futures import Executor
-from contextlib import suppress
 from functools import wraps
 from inspect import isawaitable
 from typing import (
@@ -1648,8 +1647,7 @@ class Worker(BaseWorker, ServerNode):
         self.batched_send({"op": "close-stream"})
 
         if self.batched_stream:
-            with suppress(TimeoutError):
-                await self.batched_stream.close()
+            await self.batched_stream.close()
 
         for executor in self.executors.values():
             if executor is utils._offload_executor:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1531,12 +1531,12 @@ class Worker(BaseWorker, ServerNode):
             logger.info("Stopping worker. Reason: %s", reason)
         if self.status not in WORKER_ANY_RUNNING:
             logger.info("Closed worker has not yet started: %s", self.status)
-        if executor_wait is not None:
+        if executor_wait is not None:  # pragma: nocover
             warnings.warn(
                 "`executor_wait` has no functionality and will be removed in a future version",
                 FutureWarning,
             )
-        if timeout is not None:
+        if timeout is not None:  # pragma: nocover
             warnings.warn(
                 "timeout has no functionality and will be removed in a future version",
                 FutureWarning,

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3777,13 +3777,14 @@ class BaseWorker(abc.ABC):
         """Cancel all asynchronous instructions"""
         if not self._async_instructions:
             return
-        pending = self._async_instructions
-        while pending:
+        pending_to_cancel = self._async_instructions
+        while pending_to_cancel:
             for task in self._async_instructions:
                 task.cancel()
             # async tasks can handle cancellation and could take an arbitrary amount
             # of time to terminate
-            _, pending = await asyncio.wait(self._async_instructions)
+            _, pending = await asyncio.wait(self._async_instructions, timeout=0.1)
+            pending_to_cancel.update(pending)
 
     @abc.abstractmethod
     def batched_send(self, msg: dict[str, Any]) -> None:


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/7318

As you can see, complexity reduces quite a bit. At least locally no tests broke. I could see some resource leakage warnings to be raised in CI, though. Let's see. I don't think any user would be impacted.

I'm still curious about everyones thoughts