### PR TITLE
Guarantee worker is restarted if Nanny.kill is called

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -498,7 +498,9 @@ class Server:
         return self.start().__await__()
 
     async def cancel_start(self):
-        self.__startup_task.cancel()
+        if self.__startup_task:
+            self.__startup_task.cancel()
+            await self.started()
 
     async def start_unsafe(self):
         """Attempt to start the server. This is not idempotent and not protected against concurrent startup attempts.

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -351,6 +351,7 @@ class Server:
         self.digests = None
         self._ongoing_background_tasks = AsyncTaskGroup()
         self._event_finished = asyncio.Event()
+        self._event_started = asyncio.Event()
 
         self.listeners = []
         self.io_loop = self.loop = IOLoop.current()
@@ -489,6 +490,9 @@ class Server:
         """Wait until the server has finished"""
         await self._event_finished.wait()
 
+    async def started(self):
+        await self._event_started.wait()
+
     def __await__(self):
         return self.start().__await__()
 
@@ -507,30 +511,32 @@ class Server:
 
     @final
     async def start(self):
-        async with self._startup_lock:
-            if self.status == Status.failed:
-                assert self.__startup_exc is not None
-                raise self.__startup_exc
-            elif self.status != Status.init:
-                return self
-            timeout = getattr(self, "death_timeout", None)
+        if self.status == Status.failed:
+            assert self.__startup_exc is not None
+            raise self.__startup_exc
+        elif self.status != Status.init:
+            return self
 
-            async def _close_on_failure(exc: Exception) -> None:
-                await self.close()
-                self.status = Status.failed
-                self.__startup_exc = exc
+        async def _close_on_failure(exc: Exception) -> None:
+            self._event_started.set()
+            await self.close()
+            self.status = Status.failed
+            self.__startup_exc = exc
 
-            try:
+        timeout = getattr(self, "death_timeout", None)
+        try:
+            async with self._startup_lock:
                 await asyncio.wait_for(self.start_unsafe(), timeout=timeout)
-            except asyncio.TimeoutError as exc:
-                await _close_on_failure(exc)
-                raise asyncio.TimeoutError(
-                    f"{type(self).__name__} start timed out after {timeout}s."
-                ) from exc
-            except Exception as exc:
-                await _close_on_failure(exc)
-                raise RuntimeError(f"{type(self).__name__} failed to start.") from exc
-            self.status = Status.running
+                self._event_started.set()
+                self.status = Status.running
+        except asyncio.TimeoutError as exc:
+            await _close_on_failure(exc)
+            raise asyncio.TimeoutError(
+                f"{type(self).__name__} start timed out after {timeout}s."
+            ) from exc
+        except Exception as exc:
+            await _close_on_failure(exc)
+            raise RuntimeError(f"{type(self).__name__} failed to start.") from exc
         return self
 
     async def __aenter__(self):
@@ -741,7 +747,7 @@ class Server:
         logger.debug("Connection from %r to %s", address, type(self).__name__)
         self._comms[comm] = op
 
-        await self
+        await self.started()
         try:
             while not self.__stopped:
                 try:
@@ -940,6 +946,9 @@ class Server:
             await asyncio.gather(*[comm.close() for comm in list(self._comms)])
         finally:
             self._event_finished.set()
+            logger.debug(
+                f"Closed {type(self).__name__} - {self.address_safe} - {self.id}"
+            )
 
 
 def pingpong(comm):

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -419,6 +419,7 @@ class Server:
         self.io_loop.add_callback(set_thread_ident)
         self._startup_lock = asyncio.Lock()
         self.__startup_exc = None
+        self.__startup_task = None
 
         self.rpc = ConnectionPool(
             limit=connection_limit,
@@ -497,7 +498,7 @@ class Server:
         return self.start().__await__()
 
     async def cancel_start(self):
-        self._startup_task.cancel()
+        self.__startup_task.cancel()
 
     async def start_unsafe(self):
         """Attempt to start the server. This is not idempotent and not protected against concurrent startup attempts.
@@ -529,11 +530,11 @@ class Server:
         timeout = getattr(self, "death_timeout", None)
         try:
             async with self._startup_lock:
-                self._startup_task = asyncio.create_task(self.start_unsafe())
-                self._startup_task.add_done_callback(
+                self.__startup_task = asyncio.create_task(self.start_unsafe())
+                self.__startup_task.add_done_callback(
                     lambda _: self._event_started.set()
                 )
-                await asyncio.wait_for(self._startup_task, timeout=timeout)
+                await asyncio.wait_for(self.__startup_task, timeout=timeout)
                 self.status = Status.running
         except asyncio.TimeoutError as exc:
             await _close_on_failure(exc)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -584,7 +584,6 @@ class Nanny(ServerNode):
         # status to closing
         logger.info("Closing Nanny at %r. Reason: %s", self.address_safe, reason)
         await self.cancel_start()
-        await self.started()
 
         self.status = Status.closing
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -13,10 +13,10 @@ import threading
 import uuid
 import warnings
 import weakref
+from collections import defaultdict
 from collections.abc import Collection
 from inspect import isawaitable
 from queue import Empty
-from time import sleep as sync_sleep
 from typing import TYPE_CHECKING, Callable, ClassVar, Literal
 
 from toolz import merge
@@ -119,6 +119,7 @@ class Nanny(ServerNode):
     # Inputs to parse_ports()
     _given_worker_port: int | str | Collection[int] | None
     _start_port: int | str | Collection[int] | None
+    _process_callback_received: defaultdict[WorkerProcess, asyncio.Event]
 
     def __init__(  # type: ignore[no-untyped-def]
         self,
@@ -222,6 +223,9 @@ class Nanny(ServerNode):
         self.reconnect = reconnect
         self.validate = validate
         self.resources = resources
+
+        self._instantiate_lock = asyncio.Lock()
+        self._process_callback_received = defaultdict(asyncio.Event)
 
         self.Worker = Worker if worker_class is None else worker_class
 
@@ -385,66 +389,50 @@ class Nanny(ServerNode):
             return
 
         deadline = time() + timeout
-        await self.process.kill(reason=reason, timeout=0.8 * (deadline - time()))
+        proc = self.process
+        await proc.kill(reason=reason, timeout=0.8 * (deadline - time()))
+        assert proc.status in (Status.stopped, Status.failed), proc.status
+        assert proc.stopped.is_set()
+        await self._process_callback_received[proc].wait()
+        assert self.process is not proc
 
     async def instantiate(self) -> Status:
         """Start a local worker process
 
         Blocks until the process is up and the scheduler is properly informed
         """
-        if self.process is None:
-            worker_kwargs = dict(
-                scheduler_ip=self.scheduler_addr,
-                nthreads=self.nthreads,
-                local_directory=self._original_local_dir,
-                services=self.services,
-                nanny=self.address,
-                name=self.name,
-                memory_limit=self.memory_manager.memory_limit,
-                resources=self.resources,
-                validate=self.validate,
-                silence_logs=self.silence_logs,
-                death_timeout=self.death_timeout,
-                preload=self.preload,
-                preload_argv=self.preload_argv,
-                security=self.security,
-                contact_address=self.contact_address,
-            )
-            worker_kwargs.update(self.worker_kwargs)
-            self.process = WorkerProcess(
-                worker_kwargs=worker_kwargs,
-                silence_logs=self.silence_logs,
-                on_exit=self._on_worker_exit_sync,
-                worker=self.Worker,
-                env=self.env,
-                pre_spawn_env=self.pre_spawn_env,
-                config=self.config,
-            )
-
-        if self.death_timeout:
-            try:
-                result = await asyncio.wait_for(
-                    self.process.start(), self.death_timeout
+        # The lock is required since there are many possible race conditions due
+        # to the worker exit callback
+        async with self._instantiate_lock:
+            if self.process is None:
+                worker_kwargs = dict(
+                    scheduler_ip=self.scheduler_addr,
+                    nthreads=self.nthreads,
+                    local_directory=self._original_local_dir,
+                    services=self.services,
+                    nanny=self.address,
+                    name=self.name,
+                    memory_limit=self.memory_manager.memory_limit,
+                    resources=self.resources,
+                    validate=self.validate,
+                    silence_logs=self.silence_logs,
+                    death_timeout=self.death_timeout,
+                    preload=self.preload,
+                    preload_argv=self.preload_argv,
+                    security=self.security,
+                    contact_address=self.contact_address,
                 )
-            except asyncio.TimeoutError:
-                logger.error(
-                    "Timed out connecting Nanny '%s' to scheduler '%s'",
-                    self,
-                    self.scheduler_addr,
+                worker_kwargs.update(self.worker_kwargs)
+                self.process = WorkerProcess(
+                    worker_kwargs=worker_kwargs,
+                    silence_logs=self.silence_logs,
+                    on_exit=self._on_worker_exit_sync,
+                    worker=self.Worker,
+                    env=self.env,
+                    pre_spawn_env=self.pre_spawn_env,
+                    config=self.config,
                 )
-                await self.close(
-                    timeout=self.death_timeout, reason="nanny-instantiate-timeout"
-                )
-                raise
-
-        else:
-            try:
-                result = await self.process.start()
-            except Exception:
-                logger.error("Failed to start process", exc_info=True)
-                await self.close(reason="nanny-instantiate-failed")
-                raise
-        return result
+            return await self.process.start()
 
     @log_errors
     async def plugin_add(self, plugin=None, name=None):
@@ -519,6 +507,9 @@ class Nanny(ServerNode):
 
     @log_errors
     async def _on_worker_exit(self, exitcode):
+        assert self.process
+        self._process_callback_received[self.process].set()
+        self.process = None
         if self.status not in (
             Status.init,
             Status.closing,
@@ -550,6 +541,8 @@ class Nanny(ServerNode):
             logger.error(
                 "Failed to restart worker after its process exited", exc_info=True
             )
+            await self.close(reason="worker-failed-restart")
+            raise
 
     @property
     def pid(self):
@@ -578,11 +571,14 @@ class Nanny(ServerNode):
         """
         if self.status == Status.closing:
             await self.finished()
-            assert self.status == Status.closed
+            assert self.status in (Status.closed, Status.failed)
 
-        if self.status == Status.closed:
+        if self.status in (Status.closed, Status.failed):
             return "OK"
 
+        # Make sure we're not colliding with the startup coro when setting the
+        # status to closing
+        await self.started()
         self.status = Status.closing
         logger.info("Closing Nanny at %r. Reason: %s", self.address_safe, reason)
 
@@ -726,6 +722,7 @@ class WorkerProcess:
         self.running.set()
 
         init_q.close()
+        init_q.join_thread()
 
         return self.status
 
@@ -817,22 +814,20 @@ class WorkerProcess:
                 "reason": reason,
             }
         )
-        await asyncio.sleep(0)  # otherwise we get broken pipe errors
         queue.close()
+        queue.join_thread()
         del queue
 
         try:
             try:
                 await process.join(wait_timeout)
-                return
             except asyncio.TimeoutError:
-                pass
-
-            logger.warning(
-                f"Worker process still alive after {wait_timeout} seconds, killing"
-            )
-            await process.kill()
-            await process.join(max(0, deadline - time()))
+                logger.warning(
+                    f"Worker process still alive after {wait_timeout} seconds, killing"
+                )
+                await process.kill()
+                await process.join(max(0, deadline - time()))
+            await self.stopped.wait()
         except ValueError as e:
             if "invalid operation on closed AsyncProcess" in str(e):
                 return
@@ -934,6 +929,7 @@ class WorkerProcess:
                             }
                         )
                         init_result_q.close()
+                        init_result_q.join_thread()
                         await worker.finished()
                         logger.info("Worker closed")
             except Exception as e:
@@ -943,14 +939,7 @@ class WorkerProcess:
                 logger.exception(f"Failed to {failure_type} worker")
                 init_result_q.put({"uid": uid, "exception": e})
                 init_result_q.close()
-                # If we hit an exception here we need to wait for a least
-                # one interval for the outside to pick up this message.
-                # Otherwise we arrive in a race condition where the process
-                # cleanup wipes the queue before the exception can be
-                # properly handled. See also
-                # WorkerProcess._wait_until_connected (the 3 is for good
-                # measure)
-                sync_sleep(cls._init_msg_interval * 3)
+                init_result_q.join_thread()
 
         with contextlib.ExitStack() as stack:
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -788,13 +788,20 @@ class WorkerProcess:
         """
         deadline = time() + timeout
 
+        # If the process is not properly up it will not watch the closing queue
+        # and we may end up leaking this process.
+        # Therefore wait for it to be properly started before killing it.
+        if self.status == Status.starting:
+            await self.running.wait()
+
         if self.status == Status.stopped:
             return
+
         if self.status == Status.stopping:
             await self.stopped.wait()
             return
+
         assert self.status in (
-            Status.starting,
             Status.running,
             Status.failed,  # process failed to start, but hasn't been joined yet
         ), self.status

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3958,7 +3958,9 @@ class Scheduler(SchedulerState, ServerNode):
         await asyncio.gather(
             *[log_errors(plugin.before_close) for plugin in list(self.plugins.values())]
         )
-
+        # Make sure we're not colliding with the startup coro when setting the
+        # status to closing
+        await self.started()
         self.status = Status.closing
 
         logger.info("Scheduler closing...")

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -554,7 +554,7 @@ async def test_worker_start_exception(s):
 )
 @gen_cluster(nthreads=[])
 async def test_worker_start_exception_after_restart(s, api):
-    async with Nanny(s.address, death_timeout="2s") as nanny:
+    async with Nanny(s.address, death_timeout="5s") as nanny:
         # Stop the listener on the scheduler, i.e. do not allow any new incoming
         # connections. The restarting workers will fail while trying to attempt
         # connection

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -554,16 +554,11 @@ async def test_worker_start_exception(s):
 )
 @gen_cluster(nthreads=[])
 async def test_worker_start_exception_after_restart(s, api):
-    async with Nanny(s.address) as nanny:
-        # A restart should fail
-        nanny.worker_kwargs.update(
-            {
-                "scheduler_port": -1234,
-                "nthreads": -42,
-                "port": -9876,
-                "protocol": "doesnt-exit",
-            }
-        )
+    async with Nanny(s.address, death_timeout="2s") as nanny:
+        # Stop the listener on the scheduler, i.e. do not allow any new incoming
+        # connections. The restarting workers will fail while trying to attempt
+        # connection
+        s.stop()
         if api == "kill":
             # Kill is not immediately restarting the process and is therefore
             # not raising an exception and we need to wait

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1519,7 +1519,6 @@ class Worker(BaseWorker, ServerNode):
         # Make sure we're not colliding with the startup coro when setting the
         # status to closing
         await self.cancel_start()
-        await self.started()
         self.status = Status.closing
 
         # Stop callbacks before giving up control in any `await`.

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1516,6 +1516,9 @@ class Worker(BaseWorker, ServerNode):
             logger.info("Closed worker has not yet started: %s", self.status)
         if not executor_wait:
             logger.info("Not waiting on executor to close")
+        # Make sure we're not colliding with the startup coro when setting the
+        # status to closing
+        await self.started()
         self.status = Status.closing
 
         # Stop callbacks before giving up control in any `await`.

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1518,6 +1518,7 @@ class Worker(BaseWorker, ServerNode):
             logger.info("Not waiting on executor to close")
         # Make sure we're not colliding with the startup coro when setting the
         # status to closing
+        await self.cancel_start()
         await self.started()
         self.status = Status.closing
 


### PR DESCRIPTION
This closes https://github.com/dask/distributed/issues/7312 a race condition that might kill a nanny if it shuts down a worker even though it's supposed to by restarted.

It does feel like a bandaid since the closing is still extremely complicated but I'd like to fix the behavior first before cleaning anything up

Closes https://github.com/dask/distributed/issues/6311 (at least one of the problems with the test)

xref https://github.com/dask/distributed/issues/7321, https://github.com/dask/distributed/pull/7320