### PR TITLE
Restrict `bokeh=3` support

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -7,7 +7,8 @@ dependencies:
   - packaging
   - pip
   - asyncssh
-  - bokeh
+  # Temporary restriction until https://github.com/dask/distributed/issues/7173 is resolved
+  - bokeh<3
   - click
   - cloudpickle
   - coverage

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -7,7 +7,8 @@ dependencies:
   - packaging
   - pip
   - asyncssh
-  - bokeh < 3 # Only tested here
+  # Temporary restriction until https://github.com/dask/distributed/issues/7173 is resolved
+  - bokeh<3
   - click
   - cloudpickle
   - coverage

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -8,7 +8,8 @@ dependencies:
   - packaging
   - pip
   - asyncssh
-  - bokeh
+  # Temporary restriction until https://github.com/dask/distributed/issues/7173 is resolved
+  - bokeh<3
   - click
   - cloudpickle
   - coverage

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - lz4
     - numpy >=1.18
     - pandas >=1.0
-    - bokeh >=2.4.2
+    - bokeh >=2.4.2,<3
     - jinja2
 
   run_constrained:

--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -16,10 +16,10 @@ from distributed.versions import MIN_BOKEH_VERSION
 
 if BOKEH_VERSION < parse_version(MIN_BOKEH_VERSION):
     warnings.warn(
-        f"\nDask needs bokeh >= {MIN_BOKEH_VERSION} for the dashboard."
+        f"\nDask needs bokeh >= {MIN_BOKEH_VERSION}, < 3 for the dashboard."
         "\nContinuing without the dashboard."
     )
-    raise ImportError(f"Dask needs bokeh >= {MIN_BOKEH_VERSION}")
+    raise ImportError(f"Dask needs bokeh >= {MIN_BOKEH_VERSION}, < 3")
 
 
 if BOKEH_VERSION.major < 3:

--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -12,14 +12,19 @@ from packaging.version import parse as parse_version
 import dask
 
 from distributed.dashboard.utils import BOKEH_VERSION
-from distributed.versions import MIN_BOKEH_VERSION
+from distributed.versions import MAX_BOKEH_VERSION, MIN_BOKEH_VERSION
 
-if BOKEH_VERSION < parse_version(MIN_BOKEH_VERSION):
+if BOKEH_VERSION < parse_version(MIN_BOKEH_VERSION) or BOKEH_VERSION > parse_version(
+    MAX_BOKEH_VERSION
+):
     warnings.warn(
         f"\nDask needs bokeh >= {MIN_BOKEH_VERSION}, < 3 for the dashboard."
+        f"\nYou have bokeh=={BOKEH_VERSION}."
         "\nContinuing without the dashboard."
     )
-    raise ImportError(f"Dask needs bokeh >= {MIN_BOKEH_VERSION}, < 3")
+    raise ImportError(
+        f"Dask needs bokeh >= {MIN_BOKEH_VERSION}, < 3, not bokeh=={BOKEH_VERSION}"
+    )
 
 
 if BOKEH_VERSION.major < 3:

--- a/distributed/http/scheduler/missing_bokeh.py
+++ b/distributed/http/scheduler/missing_bokeh.py
@@ -10,8 +10,8 @@ class MissingBokeh(RequestHandler):
     def get(self):
         self.write(
             f"<p>Dask needs bokeh >= {MIN_BOKEH_VERSION}, < 3 for the dashboard.</p>"
-            f"<p>Install with conda: conda install bokeh>={MIN_BOKEH_VERSION},<3</p>"
-            f"<p>Install with pip: pip install bokeh>={MIN_BOKEH_VERSION},<3</p>"
+            f"<p>Install with conda: <code>conda install bokeh>={MIN_BOKEH_VERSION},<3</code></p>"
+            f"<p>Install with pip: <code>pip install bokeh>={MIN_BOKEH_VERSION},<3</code></p>"
         )
 
 

--- a/distributed/http/scheduler/missing_bokeh.py
+++ b/distributed/http/scheduler/missing_bokeh.py
@@ -9,9 +9,9 @@ class MissingBokeh(RequestHandler):
     @log_errors
     def get(self):
         self.write(
-            f"<p>Dask needs bokeh >= {MIN_BOKEH_VERSION} for the dashboard.</p>"
-            f"<p>Install with conda: conda install bokeh>={MIN_BOKEH_VERSION}</p>"
-            f"<p>Install with pip: pip install bokeh>={MIN_BOKEH_VERSION}</p>"
+            f"<p>Dask needs bokeh >= {MIN_BOKEH_VERSION}, < 3 for the dashboard.</p>"
+            f"<p>Install with conda: conda install bokeh>={MIN_BOKEH_VERSION},<3</p>"
+            f"<p>Install with pip: pip install bokeh>={MIN_BOKEH_VERSION},<3</p>"
         )
 
 

--- a/distributed/http/scheduler/tests/test_missing_bokeh.py
+++ b/distributed/http/scheduler/tests/test_missing_bokeh.py
@@ -14,6 +14,12 @@ from distributed.utils_test import gen_test
 @gen_test()
 async def test_missing_bokeh():
     with mock.patch.dict(sys.modules, {"bokeh": None}):
+        # NOTE: mocking here is fiddly; if any of these get refactored or import order
+        # changes, this may break.
+        sys.modules.pop("distributed.dashboard.scheduler", None)
+        sys.modules.pop("distributed.dashboard.core", None)
+        sys.modules.pop("distributed.dashboard.utils", None)
+
         async with Scheduler(dashboard_address=":0") as s:
             http_client = AsyncHTTPClient()
             response = await http_client.fetch(
@@ -28,37 +34,41 @@ async def test_missing_bokeh():
 async def test_bokeh_version_too_low():
     pytest.importorskip("bokeh")
 
-    import distributed.dashboard.utils
+    with mock.patch.dict(sys.modules):
+        # Remove these imports, so when the scheduler imports
+        # `distributed.dashboard.scheduler`, it has to re-import `dashboard.core`, which
+        # is where the bokeh version detection happens at import time, via
+        # `dashboard.utils.BOKEH_VERSION`.
+        sys.modules.pop("distributed.dashboard.scheduler", None)
+        sys.modules.pop("distributed.dashboard.core", None)
 
-    with mock.patch.object(
-        distributed.dashboard.utils, "BOKEH_VERSION", Version("1.4.0")
-    ):
-        with pytest.warns(UserWarning, match="1.4.0"):
-            async with Scheduler(dashboard_address=":0") as s:
-                http_client = AsyncHTTPClient()
-                response = await http_client.fetch(
-                    f"http://localhost:{s.http_server.port}/status"
-                )
-                assert response.code == 200
-                body = response.body.decode()
-                assert "Dask needs bokeh" in body
+        with mock.patch("distributed.dashboard.utils.BOKEH_VERSION", Version("1.4.0")):
+            with pytest.warns(UserWarning, match="1.4.0"):
+                async with Scheduler(dashboard_address=":0") as s:
+                    http_client = AsyncHTTPClient()
+                    response = await http_client.fetch(
+                        f"http://localhost:{s.http_server.port}/status"
+                    )
+                    assert response.code == 200
+                    body = response.body.decode()
+                    assert "Dask needs bokeh" in body
 
 
 @gen_test()
 async def test_bokeh_version_too_high():
     pytest.importorskip("bokeh")
 
-    import distributed.dashboard.utils
+    with mock.patch.dict(sys.modules):
+        sys.modules.pop("distributed.dashboard.scheduler", None)
+        sys.modules.pop("distributed.dashboard.core", None)
 
-    with mock.patch.object(
-        distributed.dashboard.utils, "BOKEH_VERSION", Version("3.0.1")
-    ):
-        with pytest.warns(UserWarning, match="3.0.1"):
-            async with Scheduler(dashboard_address=":0") as s:
-                http_client = AsyncHTTPClient()
-                response = await http_client.fetch(
-                    f"http://localhost:{s.http_server.port}/status"
-                )
-                assert response.code == 200
-                body = response.body.decode()
-                assert "Dask needs bokeh" in body
+        with mock.patch("distributed.dashboard.utils.BOKEH_VERSION", Version("3.0.1")):
+            with pytest.warns(UserWarning, match="3.0.1"):
+                async with Scheduler(dashboard_address=":0") as s:
+                    http_client = AsyncHTTPClient()
+                    response = await http_client.fetch(
+                        f"http://localhost:{s.http_server.port}/status"
+                    )
+                    assert response.code == 200
+                    body = response.body.decode()
+                    assert "Dask needs bokeh" in body

--- a/distributed/http/scheduler/tests/test_missing_bokeh.py
+++ b/distributed/http/scheduler/tests/test_missing_bokeh.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+from packaging.version import Version
+from tornado.httpclient import AsyncHTTPClient
+
+from distributed import Scheduler
+from distributed.utils_test import gen_test
+
+
+@gen_test()
+async def test_missing_bokeh():
+    with mock.patch.dict(sys.modules, {"bokeh": None}):
+        async with Scheduler(dashboard_address=":0") as s:
+            http_client = AsyncHTTPClient()
+            response = await http_client.fetch(
+                f"http://localhost:{s.http_server.port}/status"
+            )
+            assert response.code == 200
+            body = response.body.decode()
+            assert "Dask needs bokeh" in body
+
+
+@gen_test()
+async def test_bokeh_version_too_low():
+    pytest.importorskip("bokeh")
+
+    import distributed.dashboard.utils
+
+    with mock.patch.object(
+        distributed.dashboard.utils, "BOKEH_VERSION", Version("1.4.0")
+    ):
+        with pytest.warns(UserWarning, match="1.4.0"):
+            async with Scheduler(dashboard_address=":0") as s:
+                http_client = AsyncHTTPClient()
+                response = await http_client.fetch(
+                    f"http://localhost:{s.http_server.port}/status"
+                )
+                assert response.code == 200
+                body = response.body.decode()
+                assert "Dask needs bokeh" in body
+
+
+@gen_test()
+async def test_bokeh_version_too_high():
+    pytest.importorskip("bokeh")
+
+    import distributed.dashboard.utils
+
+    with mock.patch.object(
+        distributed.dashboard.utils, "BOKEH_VERSION", Version("3.0.1")
+    ):
+        with pytest.warns(UserWarning, match="3.0.1"):
+            async with Scheduler(dashboard_address=":0") as s:
+                http_client = AsyncHTTPClient()
+                response = await http_client.fetch(
+                    f"http://localhost:{s.http_server.port}/status"
+                )
+                assert response.code == 200
+                body = response.body.decode()
+                assert "Dask needs bokeh" in body

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -13,6 +13,7 @@ from types import ModuleType
 from typing import Any
 
 MIN_BOKEH_VERSION = "2.4.2"
+MAX_BOKEH_VERSION = "2.4.3"
 
 required_packages = [
     ("dask", lambda p: p.__version__),


### PR DESCRIPTION
See discussion in https://github.com/dask/distributed/issues/7327

* reverts YAML changes from https://github.com/dask/distributed/pull/5648
* adds `< 3` back into error messages
* adds an explicit check that the bokeh version is < 3, and does not show the dashboard otherwise. **This is new. I would rather not show the dashboard at all and tell users why than silently show something misleading.**
* adds tests for dashboard behavior with different bokeh versions. I couldn't find any; maybe there are some and I just didn't know where they were?

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
