### PR TITLE
Update `ga-yaml-parser` step in gpuCI updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yaml
+++ b/.github/workflows/update-gpuci.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
 
       - name: Parse current axis YAML
+        id: rapids_current
         uses: the-coding-turtle/ga-yaml-parser@v0.1.2
         with:
           file: continuous_integration/gpuci/axis.yaml
@@ -39,8 +40,8 @@ jobs:
           FULL_RAPIDS_VER: ${{ steps.cudf_latest.outputs.version }}
           FULL_UCX_PY_VER: ${{ steps.ucx_py_latest.outputs.version }}
         run: |
-          echo RAPIDS_VER=$RAPIDS_VER_0 >> $GITHUB_ENV
-          echo UCX_PY_VER=$(curl -sL https://version.gpuci.io/rapids/$RAPIDS_VER_0) >> $GITHUB_ENV
+          echo RAPIDS_VER=${{ steps.rapids_current.outputs.RAPIDS_VER_0 }} >> $GITHUB_ENV
+          echo UCX_PY_VER=$(curl -sL https://version.gpuci.io/rapids/${{ steps.rapids_current.outputs.RAPIDS_VER_0 }}) >> $GITHUB_ENV
           echo NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-10} >> $GITHUB_ENV
           echo NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-10} >> $GITHUB_ENV
 


### PR DESCRIPTION
Looks like the auto-bump of `ga-yaml-parser` changed the behavior of the action, making it so we haven't been running the gpuCI updating workflow in a while; this PR makes modifications that should unblock it.

cc @jrbourbeau 

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
