### PR TITLE
Fix worker startup in IPv6 only environment

### DIFF
--- a/distributed/comm/asyncio_tcp.py
+++ b/distributed/comm/asyncio_tcp.py
@@ -552,12 +552,12 @@ class TCPListener(Listener):
         comm_handler,
         deserialize=True,
         allow_offload=True,
-        default_host=None,
+        remote_host=None,
         default_port=0,
         **kwargs,
     ):
         self.ip, self.port = parse_host_port(address, default_port)
-        self.default_host = default_host
+        self.remote_host = remote_host
         self.comm_handler = comm_handler
         self.deserialize = deserialize
         self.allow_offload = allow_offload
@@ -712,7 +712,7 @@ class TCPListener(Listener):
         The contact address as a string.
         """
         host, port = self.get_host_port()
-        host = ensure_concrete_host(host, default_host=self.default_host)
+        host = ensure_concrete_host(host, remote_host=self.remote_host)
         return self.prefix + unparse_host_port(host, port)
 
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -553,13 +553,13 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         comm_handler,
         deserialize=True,
         allow_offload=True,
-        default_host=None,
+        remote_host=None,
         default_port=0,
         **connection_args,
     ):
         self._check_encryption(address, connection_args)
         self.ip, self.port = parse_host_port(address, default_port)
-        self.default_host = default_host
+        self.remote_host = remote_host
         self.comm_handler = comm_handler
         self.deserialize = deserialize
         self.allow_offload = allow_offload
@@ -645,7 +645,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         The contact address as a string.
         """
         host, port = self.get_host_port()
-        host = ensure_concrete_host(host, default_host=self.default_host)
+        host = ensure_concrete_host(host, remote_host=self.remote_host)
         return self.prefix + unparse_host_port(host, port)
 
 

--- a/distributed/comm/utils.py
+++ b/distributed/comm/utils.py
@@ -135,14 +135,14 @@ def get_tcp_server_address(tcp_server):
     return get_tcp_server_addresses(tcp_server)[0]
 
 
-def ensure_concrete_host(host, default_host=None):
+def ensure_concrete_host(host, remote_host=None):
     """
     Ensure the given host string (or IP) denotes a concrete host, not a
     wildcard listening address.
     """
     if host in ("0.0.0.0", ""):
-        return default_host or get_ip()
+        return get_ip(remote_host)
     elif host == "::":
-        return default_host or get_ipv6()
+        return get_ipv6(remote_host)
     else:
         return host

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -152,6 +152,7 @@ def get_fileno_limit():
         return 512
 
 
+# toolz.memoize ignores kwargs, so pass all arguments positionally
 @toolz.memoize
 def _get_ip(host, port, family):
     # By using a UDP socket, we don't actually try to connect but
@@ -182,14 +183,14 @@ def get_ip(host="8.8.8.8", port=80):
     *host* defaults to a well-known Internet host (one of Google's public
     DNS servers).
     """
-    return _get_ip(host, port, family=socket.AF_INET)
+    return _get_ip(host, port, socket.AF_INET)
 
 
 def get_ipv6(host="2001:4860:4860::8888", port=80):
     """
     The same as get_ip(), but for IPv6.
     """
-    return _get_ip(host, port, family=socket.AF_INET6)
+    return _get_ip(host, port, socket.AF_INET6)
 
 
 def get_ip_interface(ifname):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -152,7 +152,7 @@ def get_fileno_limit():
         return 512
 
 
-# toolz.memoize ignores kwargs, so pass all arguments positionally
+# toolz.memoize ignores kwargs, so pass all arguments positionally
 @toolz.memoize
 def _get_ip(host, port, family):
     # By using a UDP socket, we don't actually try to connect but
@@ -176,21 +176,21 @@ def _get_ip(host, port, family):
         sock.close()
 
 
-def get_ip(host="8.8.8.8", port=80):
+def get_ip(host=None, port=80):
     """
     Get the local IP address through which the *host* is reachable.
 
     *host* defaults to a well-known Internet host (one of Google's public
     DNS servers).
     """
-    return _get_ip(host, port, socket.AF_INET)
+    return _get_ip(host or "8.8.8.8", port, socket.AF_INET)
 
 
-def get_ipv6(host="2001:4860:4860::8888", port=80):
+def get_ipv6(host=None, port=80):
     """
     The same as get_ip(), but for IPv6.
     """
-    return _get_ip(host, port, socket.AF_INET6)
+    return _get_ip(host or "2001:4860:4860::8888", port, socket.AF_INET6)
 
 
 def get_ip_interface(ifname):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -81,7 +81,6 @@ from distributed.threadpoolexecutor import secede as tpe_secede
 from distributed.utils import (
     TimeoutError,
     _maybe_complex,
-    get_ip,
     has_arg,
     import_file,
     in_async_call,
@@ -1354,9 +1353,7 @@ class Worker(BaseWorker, ServerNode):
             kwargs = self.security.get_listen_args("worker")
             if self._protocol in ("tcp", "tls"):
                 kwargs = kwargs.copy()
-                kwargs["default_host"] = get_ip(
-                    get_address_host(self.scheduler.address)
-                )
+                kwargs["remote_host"] = get_address_host(self.scheduler.address)
             try:
                 await self.listen(start_address, **kwargs)
             except OSError as e:


### PR DESCRIPTION
Closes #6965. With this patch, if the worker is started with the option `--host tcp://[::]:9000`, it starts up an executes a simple task successfully.

Rather than resolving the interface to use on worker startup, save the local listener host and the remote host we want to connect to (in this case, the scheduler). Then, this is lazily resolved to an interface in the TCP connector.

In the long run, I think `get_ip` and `get_ipv6` should be deprecated in favour of a common function that tries IPv6 and falls back to v4 if unavailable. 

No tests were added for this, as discussed on Slack it is not currently possible to test IPv6 only environments on github actions. This was tested manually by spinning up a cluster with the Dask Kubernetes operator on an IPv6-only cluster. 

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
