### PR TITLE
Support scheduler preloading

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3548,10 +3548,8 @@ class Scheduler(SchedulerState, ServerNode):
         self.bandwidth_workers = defaultdict(float)
         self.bandwidth_types = defaultdict(float)
 
-        if not preload:
-            preload = dask.config.get("distributed.scheduler.preload")
-        if not preload_argv:
-            preload_argv = dask.config.get("distributed.scheduler.preload-argv")
+        preload = (preload or []) + dask.config.get("distributed.scheduler.preload")
+        preload_argv = (preload_argv or []) + dask.config.get("distributed.scheduler.preload-argv")
         self.preloads = preloading.process_preloads(self, preload, preload_argv)
 
         if isinstance(security, dict):


### PR DESCRIPTION
Closes #7342

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

I need to work out where to add tests (we don't have any for the `dask-scheduler` cli preload functionality?), but this should fix #7342 