### PR TITLE
CI: Fetch all artifacts

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -29,7 +29,7 @@ jobs:
 
           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
 
-          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          gh api --paginate "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
           do
             IFS=$'\t' read name url <<< "$artifact"
             gh api $url > "$name.zip"


### PR DESCRIPTION
The "Publish test results" workflow downloads artifacts of the triggering workflow. **Unfortunately, only the first 30 artifacts are fetched.** The `--paginate` argument makes GitHub CLI iterate through all pages and thus fetch all artifacts.

Sorry for causing this issue and thanks for using my action.