### PR TITLE
Expose event loop health metrics in Prometheus

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -394,9 +394,10 @@ class Server:
         self.periodic_callbacks["monitor"] = pc
 
         self._last_tick = time()
+        self._max_tick_duration = 0
         self._tick_counter = 0
-        self._tick_count = 0
-        self._tick_count_last = time()
+        self._last_tick_counter = 0
+        self._last_tick_cycle = time()
         self._tick_interval = parse_timedelta(
             dask.config.get("distributed.admin.tick.interval"), default="ms"
         )
@@ -581,27 +582,32 @@ class Server:
 
     def _measure_tick(self):
         now = time()
-        diff = now - self._last_tick
+        tick_duration = now - self._last_tick
         self._last_tick = now
         self._tick_counter += 1
-        if diff > tick_maximum_delay:
+        # This metric is exposed in Prometheus and is reset there during
+        # collection
+        self._max_tick_duration = max(self._max_tick_duration, tick_duration)
+        if tick_duration > tick_maximum_delay:
             logger.info(
                 "Event loop was unresponsive in %s for %.2fs.  "
                 "This is often caused by long-running GIL-holding "
                 "functions or moving large chunks of data. "
                 "This can cause timeouts and instability.",
                 type(self).__name__,
-                diff,
+                tick_duration,
             )
         if self.digests is not None:
-            self.digests["tick-duration"].add(diff)
+            self.digests["tick-duration"].add(tick_duration)
 
     def _cycle_ticks(self):
         if not self._tick_counter:
             return
-        last, self._tick_count_last = self._tick_count_last, time()
-        count, self._tick_counter = self._tick_counter, 0
-        self._tick_interval_observed = (time() - last) / (count or 1)
+        now = time()
+        last_tick_cycle, self._last_tick_cycle = self._last_tick_cycle, now
+        count = self._tick_counter - self._last_tick_counter
+        self._last_tick_counter = self._tick_counter
+        self._tick_interval_observed = (now - last_tick_cycle) / (count or 1)
 
     @property
     def address(self) -> str:

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -91,7 +91,7 @@ class SchedulerMetricCollector(PrometheusCollector):
 
         now = time()
         max_tick_duration = max(
-            self.server._max_tick_duration, now() - self.server._last_tick
+            self.server._max_tick_duration, now - self.server._last_tick
         )
         self.server._max_tick_duration = 0
         yield GaugeMetricFamily(
@@ -103,6 +103,7 @@ class SchedulerMetricCollector(PrometheusCollector):
         yield CounterMetricFamily(
             self.build_name("tick_count_total"),
             "Total number of ticks observed since the server started",
+            value=self.server._tick_counter,
         )
 
 

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -111,11 +111,11 @@ async def test_prometheus(c, s, a, b):
         "dask_scheduler_tasks_suspicious",
         "dask_scheduler_tasks_forgotten",
         "dask_scheduler_prefix_state_totals",
-        "dask_scheduler_tick_count_total",
+        "dask_scheduler_tick_count",
         "dask_scheduler_tick_duration_maximum_seconds",
     }
 
-    assert active_metrics.keys() == expected_metrics
+    assert set(active_metrics.keys()) == expected_metrics
     assert active_metrics["dask_scheduler_clients"].samples[0].value == 1.0
 
     # request data twice since there once was a case where metrics got registered multiple times resulting in

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -111,6 +111,8 @@ async def test_prometheus(c, s, a, b):
         "dask_scheduler_tasks_suspicious",
         "dask_scheduler_tasks_forgotten",
         "dask_scheduler_prefix_state_totals",
+        "dask_scheduler_tick_count_total",
+        "dask_scheduler_tick_duration_maximum_seconds",
     }
 
     assert active_metrics.keys() == expected_metrics

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from time import time
 from typing import ClassVar
 
 import prometheus_client
@@ -142,6 +143,22 @@ class WorkerMetricCollector(PrometheusCollector):
                 .components[1]
                 .quantile(50),
             )
+
+        now = time()
+        max_tick_duration = max(
+            self.server._max_tick_duration, now() - self.server._last_tick
+        )
+        self.server._max_tick_duration = 0
+        yield GaugeMetricFamily(
+            self.build_name("tick_duration_maximum_seconds"),
+            "Maximum tick duration observed since Prometheus last scraped metrics",
+            value=max_tick_duration,
+        )
+
+        yield CounterMetricFamily(
+            self.build_name("tick_count_total"),
+            "Total number of ticks observed since the server started",
+        )
 
 
 class PrometheusHandler(RequestHandler):

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -146,7 +146,7 @@ class WorkerMetricCollector(PrometheusCollector):
 
         now = time()
         max_tick_duration = max(
-            self.server._max_tick_duration, now() - self.server._last_tick
+            self.server._max_tick_duration, now - self.server._last_tick
         )
         self.server._max_tick_duration = 0
         yield GaugeMetricFamily(
@@ -158,6 +158,7 @@ class WorkerMetricCollector(PrometheusCollector):
         yield CounterMetricFamily(
             self.build_name("tick_count_total"),
             "Total number of ticks observed since the server started",
+            value=self.server._tick_counter,
         )
 
 

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -36,6 +36,8 @@ async def test_prometheus(c, s, a):
         "dask_worker_transfer_outgoing_bytes",
         "dask_worker_transfer_outgoing_count",
         "dask_worker_transfer_outgoing_count_total",
+        "dask_worker_tick_count_total",
+        "dask_worker_tick_duration_maximum_seconds",
     }
 
     try:


### PR DESCRIPTION
* Closes #7307
* Supersedes #7301

This PR adds two metrics for event loop health:

`tick_duration_maximum_seconds` calculates the maximum tick duration observed between two Prometheus scrapes (or the duration since the last observed tick, whichever is larger). This is similar to #7301, but differs in two aspects:
1. We _always_ return a value for the metric, even if we have not observed a tick since the last scraping. This avoids having to deal with missing metrics (https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics) by having an (in my opinion) sane fallback.
2. We calculate the maximum of the actual tick duration measured in `_measure_tick`. This duration is also used in the crick-based metrics. #7301 calculates the maximum of `_tick_interval_observed`. This metric is an average duration over the tick cycle interval. 

`tick_count_total` is the total count of ticks we observed since the server started. This lets us calculate the observed tick rate over time (and this the average duration over time). 

**Notes**:
* The metrics are currently copied across the two collectors. Refactoring this into a unified collector is left for another PR (cc @graingert)
* It might be useful to expose the tick duration in a summary/histogram metric instead of a gauge. However, this would mean tighter coupling with Prometheus or adding abstraction layers. Before we do so, we should sort out whether we want to switch to OpenTelemetry (https://github.com/dask/distributed/issues/7345#issuecomment-1327682242)


- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
