### PR TITLE
Set sizing mode on `Tabs` to avoid layout collapse

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -1501,7 +1501,7 @@ class ComputePerKey(DashboardComponent):
         self.wedge_fig = fig2
         tab2 = TabPanel(child=fig2, title="Pie Chart")
 
-        self.root = Tabs(tabs=[tab1, tab2])
+        self.root = Tabs(tabs=[tab1, tab2], sizing_mode="stretch_both")
 
     @without_property_validation
     @log_errors
@@ -4253,7 +4253,11 @@ def status_doc(scheduler, extra, doc):
     tab3 = TabPanel(child=occupancy_root, title="Occupancy")
     tab4 = TabPanel(child=workers_transfer_bytes.root, title="Data Transfer")
 
-    proc_tabs = Tabs(tabs=[tab1, tab2, tab3, tab4], name="processing_tabs")
+    proc_tabs = Tabs(
+        tabs=[tab1, tab2, tab3, tab4],
+        name="processing_tabs",
+        sizing_mode="stretch_both",
+    )
     doc.add_root(proc_tabs)
 
     task_stream = TaskStream(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7590,7 +7590,8 @@ class Scheduler(SchedulerState, ServerNode):
                 scheduler,
                 bandwidth_workers,
                 bandwidth_types,
-            ]
+            ],
+            sizing_mode="stretch_both",
         )
 
         from bokeh.core.templates import get_env


### PR DESCRIPTION
Fixes part of issue #7173.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

![image](https://user-images.githubusercontent.com/27475/205130043-5151d4cc-1a03-40f0-8472-980caa472128.png)
