### PR TITLE
Check ContextVar in default_client

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,6 +107,11 @@ jobs:
         run: mamba env update -n dask-distributed -f ${{ env.CONDA_FILE }}
         if: steps.skip-caching.outputs.trigger-found == 'true' || steps.cache.outputs.cache-hit != 'true'
 
+      - name: Install Dev Dask
+        shell: bash -l {0}
+        run: |
+          python -m pip install --no-deps git+https://github.com/mrocklin/dask@default-client-scheduler
+
       - name: Install
         shell: bash -l {0}
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,11 +107,6 @@ jobs:
         run: mamba env update -n dask-distributed -f ${{ env.CONDA_FILE }}
         if: steps.skip-caching.outputs.trigger-found == 'true' || steps.cache.outputs.cache-hit != 'true'
 
-      - name: Install Dev Dask
-        shell: bash -l {0}
-        run: |
-          python -m pip install --no-deps git+https://github.com/mrocklin/dask@default-client-scheduler
-
       - name: Install
         shell: bash -l {0}
         run: |

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -115,7 +115,7 @@ _global_clients: weakref.WeakValueDictionary[
 ] = weakref.WeakValueDictionary()
 _global_client_index = [0]
 
-_current_client = ContextVar("_current_client", default=None)
+_current_client: ContextVar[Client | None] = ContextVar("_current_client", default=None)
 
 DEFAULT_EXTENSIONS = {
     "pubsub": PubSubClientExtension,

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -123,6 +123,9 @@ DEFAULT_EXTENSIONS = {
 
 
 def _get_global_client() -> Client | None:
+    c = _current_client.get()
+    if c:
+        return c
     L = sorted(list(_global_clients), reverse=True)
     for k in L:
         c = _global_clients[k]

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4095,6 +4095,7 @@ def test_as_current_is_thread_local(s, loop):
                     # This line runs only when all parties are inside the
                     # context manager
                     assert Client.current(allow_global=False) is c
+                    assert default_client() is c
                 finally:
                     cm_before_exit.wait()
 


### PR DESCRIPTION
Previously default_client would iterate through the list of clients for the most recent.  Now it checks the ContextVar first.  This means that default_client will be more thread-aware.

This is particularly helpful when using `wait` in a context with multiple clients in multiple threads, a workflow that shows up in large scale XGBoost workloads.

Also, I noticed that mypy was sad with this change, which I wouldn't quite understand.  This didn't pass pre-commit on my machine.

cc @dankerrigan 