### PR TITLE
Prometheus: measure how much spilling blocks the event loop 

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -272,11 +272,11 @@ class BaseActorFuture(abc.ABC, Awaitable[_T]):
 
     @abc.abstractmethod
     def result(self, timeout: str | timedelta | float | None = None) -> _T:
-        ...
+        ...  # pragma: nocover
 
     @abc.abstractmethod
     def done(self) -> bool:
-        ...
+        ...  # pragma: nocover
 
     def __repr__(self) -> Literal["<ActorFuture>"]:
         return "<ActorFuture>"

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -91,9 +91,9 @@ class SchedulerMetricCollector(PrometheusCollector):
 
         now = time()
         max_tick_duration = max(
-            self.server._max_tick_duration, now - self.server._last_tick
+            self.server.digests_max["tick_duration"],
+            now - self.server._last_tick,
         )
-        self.server._max_tick_duration = 0
         yield GaugeMetricFamily(
             self.build_name("tick_duration_maximum_seconds"),
             "Maximum tick duration observed since Prometheus last scraped metrics",
@@ -105,6 +105,8 @@ class SchedulerMetricCollector(PrometheusCollector):
             "Total number of ticks observed since the server started",
             value=self.server._tick_counter,
         )
+
+        self.server.digests_max.clear()
 
 
 COLLECTORS = [

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -146,9 +146,9 @@ class WorkerMetricCollector(PrometheusCollector):
 
         now = time()
         max_tick_duration = max(
-            self.server._max_tick_duration, now - self.server._last_tick
+            self.server.digests_max["tick_duration"],
+            now - self.server._last_tick,
         )
-        self.server._max_tick_duration = 0
         yield GaugeMetricFamily(
             self.build_name("tick_duration_maximum_seconds"),
             "Maximum tick duration observed since Prometheus last scraped metrics",
@@ -160,6 +160,38 @@ class WorkerMetricCollector(PrometheusCollector):
             "Total number of ticks observed since the server started",
             value=self.server._tick_counter,
         )
+
+        # This duplicates spill_time_total; however the breakdown is different
+        evloop_blocked_total = CounterMetricFamily(
+            self.build_name("event_loop_blocked_time_total"),
+            "Total time during which the worker's event loop was blocked "
+            "by spill/unspill activity since the latest worker reset",
+            labels=["cause"],
+        )
+        # This is typically higher than spill_time_per_key_max, as multiple keys can be
+        # spilled/unspilled without yielding the event loop
+        evloop_blocked_max = GaugeMetricFamily(
+            self.build_name("event_loop_blocked_time_max"),
+            "Maximum contiguous time during which the worker's event loop was blocked "
+            "by spill/unspill activity since the previous Prometheus poll",
+            labels=["cause"],
+        )
+        for family, digest in (
+            (evloop_blocked_total, self.server.digests_total),
+            (evloop_blocked_max, self.server.digests_max),
+        ):
+            for family_label, digest_label in (
+                ("disk-write-target", "disk-write-target-duration"),
+                ("disk-write-spill", "disk-write-spill-duration"),
+                ("disk-read-execute", "disk-load-duration"),
+                ("disk-read-get-data", "get-data-load-duration"),
+            ):
+                family.add_metric([family_label], digest[digest_label])
+
+        yield evloop_blocked_total
+        yield evloop_blocked_max
+
+        self.server.digests_max.clear()
 
 
 class PrometheusHandler(RequestHandler):

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -163,9 +163,10 @@ class WorkerMetricCollector(PrometheusCollector):
 
         # This duplicates spill_time_total; however the breakdown is different
         evloop_blocked_total = CounterMetricFamily(
-            self.build_name("event_loop_blocked_time_total"),
+            self.build_name("event_loop_blocked_time"),
             "Total time during which the worker's event loop was blocked "
             "by spill/unspill activity since the latest worker reset",
+            unit="seconds",
             labels=["cause"],
         )
         # This is typically higher than spill_time_per_key_max, as multiple keys can be
@@ -174,6 +175,7 @@ class WorkerMetricCollector(PrometheusCollector):
             self.build_name("event_loop_blocked_time_max"),
             "Maximum contiguous time during which the worker's event loop was blocked "
             "by spill/unspill activity since the previous Prometheus poll",
+            unit="seconds",
             labels=["cause"],
         )
         for family, digest in (

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -25,19 +25,21 @@ async def test_prometheus(c, s, a):
         a.http_server.port, prefix="dask_worker_"
     )
     expected_metrics = {
-        "dask_worker_tasks",
         "dask_worker_concurrent_fetch_requests",
-        "dask_worker_threads",
+        "dask_worker_event_loop_blocked_time_max",
+        "dask_worker_event_loop_blocked_time_total",
         "dask_worker_latency_seconds",
         "dask_worker_memory_bytes",
+        "dask_worker_tasks",
+        "dask_worker_tick_count_total",
+        "dask_worker_tick_duration_maximum_seconds",
+        "dask_worker_threads",
         "dask_worker_transfer_incoming_bytes",
         "dask_worker_transfer_incoming_count",
         "dask_worker_transfer_incoming_count_total",
         "dask_worker_transfer_outgoing_bytes",
         "dask_worker_transfer_outgoing_count",
         "dask_worker_transfer_outgoing_count_total",
-        "dask_worker_tick_count_total",
-        "dask_worker_tick_duration_maximum_seconds",
     }
 
     try:
@@ -45,7 +47,7 @@ async def test_prometheus(c, s, a):
     except ImportError:
         pass
     else:
-        expected_metrics = expected_metrics.union(
+        expected_metrics.update(
             {
                 "dask_worker_tick_duration_median_seconds",
                 "dask_worker_task_duration_median_seconds",

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -26,8 +26,8 @@ async def test_prometheus(c, s, a):
     )
     expected_metrics = {
         "dask_worker_concurrent_fetch_requests",
-        "dask_worker_event_loop_blocked_time_max",
-        "dask_worker_event_loop_blocked_time_total",
+        "dask_worker_event_loop_blocked_time_max_seconds",
+        "dask_worker_event_loop_blocked_time_seconds_total",
         "dask_worker_latency_seconds",
         "dask_worker_memory_bytes",
         "dask_worker_tasks",

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3459,7 +3459,6 @@ class Scheduler(SchedulerState, ServerNode):
         self.synchronize_worker_interval = parse_timedelta(
             synchronize_worker_interval, default="ms"
         )
-        self.digests = None
         self.service_specs = services or {}
         self.service_kwargs = service_kwargs or {}
         self.services = {}
@@ -4618,8 +4617,7 @@ class Scheduler(SchedulerState, ServerNode):
                 self.report_on_key(ts=ts, client=client)
 
         end = time()
-        if self.digests is not None:
-            self.digests["update-graph-duration"].add(end - start)
+        self.digest_metric("update-graph-duration", end - start)
 
         # TODO: balance workers
 

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -22,6 +22,7 @@ from distributed.utils_test import (
 from distributed.worker_state_machine import (
     AddKeysMsg,
     ComputeTaskEvent,
+    DigestMetric,
     Execute,
     ExecuteFailureEvent,
     ExecuteSuccessEvent,
@@ -690,6 +691,7 @@ def test_workerstate_executing_skips_fetch_on_success(ws_with_running_task):
         ExecuteSuccessEvent.dummy("x", 123, stimulus_id="s3"),
     )
     assert instructions == [
+        DigestMetric(name="compute-duration", value=1.0, stimulus_id="s3"),
         AddKeysMsg(keys=["x"], stimulus_id="s3"),
         Execute(key="y", stimulus_id="s3"),
     ]
@@ -779,6 +781,7 @@ def test_workerstate_flight_failure_to_executing(ws, block_queue):
         )
         assert instructions == [
             Execute(key="z", stimulus_id="s4"),
+            DigestMetric(name="compute-duration", value=1.0, stimulus_id="s6"),
             TaskFinishedMsg.match(key="z", stimulus_id="s6"),
             Execute(key="x", stimulus_id="s6"),
         ]

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -13,6 +13,7 @@ from distributed.client import wait
 from distributed.utils_test import NO_AMM, gen_cluster, inc, lock_inc, slowadd, slowinc
 from distributed.worker_state_machine import (
     ComputeTaskEvent,
+    DigestMetric,
     Execute,
     ExecuteFailureEvent,
     ExecuteSuccessEvent,
@@ -265,6 +266,7 @@ def test_constrained_vs_ready_priority_1(ws, p1, p2, expect_key, swap):
         ExecuteSuccessEvent.dummy("clog", stimulus_id="s3"),
     )
     assert instructions == [
+        DigestMetric(name="compute-duration", value=1.0, stimulus_id="s3"),
         TaskFinishedMsg.match(key="clog", stimulus_id="s3"),
         Execute(key=expect_key, stimulus_id="s3"),
     ]
@@ -299,6 +301,7 @@ def test_constrained_vs_ready_priority_2(ws, p1, p2, expect_key, swap):
         ExecuteSuccessEvent.dummy("clog1", stimulus_id="s3"),
     )
     assert instructions == [
+        DigestMetric(name="compute-duration", value=1.0, stimulus_id="s3"),
         TaskFinishedMsg.match(key="clog1", stimulus_id="s3"),
         Execute(key="x", stimulus_id="s3"),
     ]
@@ -320,10 +323,13 @@ def test_constrained_tasks_respect_priority(ws):
     )
     assert instructions == [
         Execute(key="clog", stimulus_id="clog"),
+        DigestMetric(name="compute-duration", value=1.0, stimulus_id="s4"),
         TaskFinishedMsg.match(key="clog", stimulus_id="s4"),
         Execute(key="x3", stimulus_id="s4"),
+        DigestMetric(name="compute-duration", value=1.0, stimulus_id="s5"),
         TaskFinishedMsg.match(key="x3", stimulus_id="s5"),
         Execute(key="x1", stimulus_id="s5"),
+        DigestMetric(name="compute-duration", value=1.0, stimulus_id="s6"),
         TaskFinishedMsg.match(key="x1", stimulus_id="s6"),
         Execute(key="x2", stimulus_id="s6"),
     ]

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -50,6 +50,7 @@ from distributed.utils_test import (
     slowinc,
 )
 from distributed.worker_state_machine import (
+    DigestMetric,
     ExecuteSuccessEvent,
     FreeKeysEvent,
     StealRequestEvent,
@@ -1340,7 +1341,9 @@ def test_steal_worker_state(ws_with_running_task):
     assert ws.tasks["x"].state == "cancelled"
 
     instructions = ws.handle_stimulus(ExecuteSuccessEvent.dummy("x", stimulus_id="s2"))
-    assert not instructions
+    assert instructions == [
+        DigestMetric(stimulus_id="s2", name="compute-duration", value=1.0)
+    ]
     assert "x" not in ws.tasks
     assert "x" not in ws.data
     assert ws.available_resources == {"R": 1}

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -305,8 +305,18 @@ class WorkerMemoryManager:
             # somewhat of an ugly hack,  DO NOT tweak this without a thorough cycle of
             # stress testing. See: https://github.com/dask/distributed/issues/6110.
             if now - last_yielded > 0.5:
+                # See metrics:
+                # - disk-load-duration
+                # - get-data-load-duration
+                # - disk-write-target-duration
+                # - disk-write-spill-duration
+                worker.digest_metric("disk-write-spill-duration", now - last_yielded)
                 await asyncio.sleep(0)
                 last_yielded = monotonic()
+
+        now = monotonic()
+        if now - last_yielded > 0.005:
+            worker.digest_metric("disk-write-spill-duration", now - last_yielded)
 
         if count:
             self.logger.debug(

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3721,7 +3721,6 @@ class BaseWorker(abc.ABC):
             msgpack-serializable message to send to the scheduler.
             Must have a 'op' key which is registered in Scheduler.stream_handlers.
         """
-        ...
 
     @abc.abstractmethod
     async def gather_dep(
@@ -3745,22 +3744,18 @@ class BaseWorker(abc.ABC):
         total_nbytes : int
             Total number of bytes for all the dependencies in to_gather combined
         """
-        ...
 
     @abc.abstractmethod
     async def execute(self, key: str, *, stimulus_id: str) -> StateMachineEvent:
         """Execute a task"""
-        ...
 
     @abc.abstractmethod
     async def retry_busy_worker_later(self, worker: str) -> StateMachineEvent:
         """Wait some time, then take a peer worker out of busy state"""
-        ...
 
     @abc.abstractmethod
     def digest_metric(self, name: str, value: float) -> None:
         """Log an arbitrary numerical metric"""
-        ...
 
 
 class DeprecatedWorkerStateAttribute:


### PR DESCRIPTION
- Partially closes #7351
- Overhaul Server.digests to include cumulative and local maximum variants that don't require crick
- Measure contiguous time when the event loop is blocked by spill/unspill activity