### PR TITLE
RFC Sign every compute task with a unique counter to correlated responses

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4654,6 +4654,7 @@ class Scheduler(SchedulerState, ServerNode):
                     "op": "free-keys",
                     "keys": [key],
                     "stimulus_id": stimulus_id,
+                    "attempts": [attempt],
                 }
             ]
         elif ts.state == "memory":

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -363,6 +363,7 @@ def test_computetask_to_dict():
         function=b"blob",
         args=b"blob",
         kwargs=None,
+        attempt=5,
     )
     assert ev.run_spec == SerializedTask(function=b"blob", args=b"blob")
     ev2 = ev.to_loggable(handled=11.22)
@@ -386,6 +387,7 @@ def test_computetask_to_dict():
         "function": None,
         "args": None,
         "kwargs": None,
+        "attempt": 5,
     }
     ev3 = StateMachineEvent.from_dict(d)
     assert isinstance(ev3, ComputeTaskEvent)
@@ -409,6 +411,7 @@ def test_computetask_dummy():
         function=None,
         args=None,
         kwargs=None,
+        attempt=0,
     )
 
     # nbytes is generated from who_has if omitted

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -114,6 +114,7 @@ from distributed.worker_state_machine import (
     ExecuteFailureEvent,
     ExecuteSuccessEvent,
     FindMissingEvent,
+    FreeKeyByAttemptEvent,
     FreeKeysEvent,
     GatherDepBusyEvent,
     GatherDepFailureEvent,
@@ -735,6 +736,7 @@ class Worker(BaseWorker, ServerNode):
             "acquire-replicas": self._handle_remote_stimulus(AcquireReplicasEvent),
             "compute-task": self._handle_remote_stimulus(ComputeTaskEvent),
             "free-keys": self._handle_remote_stimulus(FreeKeysEvent),
+            "free_keys_attempt": self._handle_remote_stimulus(FreeKeyByAttemptEvent),
             "remove-replicas": self._handle_remote_stimulus(RemoveReplicasEvent),
             "steal-request": self._handle_remote_stimulus(StealRequestEvent),
             "refresh-who-has": self._handle_remote_stimulus(RefreshWhoHasEvent),
@@ -2240,6 +2242,7 @@ class Worker(BaseWorker, ServerNode):
 
         # The key *must* be in the worker state thanks to the cancelled state
         ts = self.state.tasks[key]
+        execution_attempt = ts.attempt
 
         try:
             function, args, kwargs = await self._maybe_deserialize_task(ts)
@@ -2316,6 +2319,7 @@ class Worker(BaseWorker, ServerNode):
                     stop=result["stop"],
                     nbytes=result["nbytes"],
                     type=result["type"],
+                    attempt=execution_attempt,
                     stimulus_id=f"task-finished-{time()}",
                 )
 


### PR DESCRIPTION
This was proposed in the context of shuffle resilience, see https://github.com/dask/distributed/issues/6105 and primarily https://github.com/dask/distributed/issues/7353

This introduces a new unique counter in the TaskState objects that counts attempts of assigning the task to a worker. This attempt counter is unique and is used to _sign_ the `compute-task` message. The Worker is expected to respond _sign_ the response accordingly. The scheduler in turn can use this to correlate `task-finished` messages with the sent compute messages and can intentionally reject/accept a response.

In an ancient version of this code base we had a similar check at this position where we verified that a task-finished message would originate from the worker the task is `processing_on`. I don't exactly remember what happened to this check but I cannot find it any longer. This is a different take on this but practically the same functionality.