### PR TITLE
Remove the experimental feature warning for `Semaphore`

### DIFF
--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -272,12 +272,6 @@ class Semaphore(SyncMethodMixin):
 
     .. warning::
 
-        This implementation is still in an experimental state and subtle
-        changes in behavior may occur without any change in the major version
-        of this library.
-
-    .. warning::
-
         This implementation is susceptible to lease overbooking in case of
         lease timeouts. It is advised to monitor log information and adjust
         above configuration options to suitable values for the user application.


### PR DESCRIPTION
This code has been around for 2+ years and I know it's been used in production environments. I feel very comfortable removing this warning. In fact, I think most users will have a better time with this than with the plain Lock

See also https://github.com/dask/distributed/issues/7371