### PR TITLE
Naming conventions for Prometheus counters

### DIFF
--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -77,7 +77,7 @@ class SchedulerMetricCollector(PrometheusCollector):
         yield tasks
 
         prefix_state_counts = CounterMetricFamily(
-            self.build_name("prefix_state_totals"),
+            self.build_name("prefix_state"),
             "Accumulated count of task prefix in each state",
             labels=["task_prefix_name", "state"],
         )

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -101,7 +101,7 @@ class SchedulerMetricCollector(PrometheusCollector):
         )
 
         yield CounterMetricFamily(
-            self.build_name("tick_count_total"),
+            self.build_name("tick_count"),
             "Total number of ticks observed since the server started",
             value=self.server._tick_counter,
         )

--- a/distributed/http/scheduler/prometheus/semaphore.py
+++ b/distributed/http/scheduler/prometheus/semaphore.py
@@ -49,7 +49,7 @@ class SemaphoreMetricCollector(PrometheusCollector):
         )
 
         semaphore_average_pending_lease_time = GaugeMetricFamily(
-            self.build_name("average_pending_lease_time"),
+            self.build_name("average_pending_lease_time_seconds"),
             "Exponential moving average of the time it took to acquire a lease "
             "per semaphore\n"
             "Note: This only includes time spent on scheduler side, "
@@ -57,7 +57,6 @@ class SemaphoreMetricCollector(PrometheusCollector):
             "Note: This average is calculated based on order of leases instead "
             "of time of lease acquisition.",
             labels=["name"],
-            unit="s",
         )
 
         for semaphore_name, semaphore_max_leases in sem_ext.max_leases.items():

--- a/distributed/http/scheduler/prometheus/stealing.py
+++ b/distributed/http/scheduler/prometheus/stealing.py
@@ -25,13 +25,13 @@ class WorkStealingMetricCollector(PrometheusCollector):
 
         stealing_request_count_total = CounterMetricFamily(
             self.build_name("request_count"),
-            "Total number of stealing requests per cost multiplier.",
+            "Total number of stealing requests per cost multiplier",
             labels=["cost_multiplier"],
         )
 
         stealing_request_cost_total = CounterMetricFamily(
             self.build_name("request_cost"),
-            "Total cost of stealing requests per cost multiplier.",
+            "Total cost of stealing requests per cost multiplier",
             labels=["cost_multiplier"],
         )
 

--- a/distributed/http/scheduler/prometheus/stealing.py
+++ b/distributed/http/scheduler/prometheus/stealing.py
@@ -25,13 +25,13 @@ class WorkStealingMetricCollector(PrometheusCollector):
 
         stealing_request_count_total = CounterMetricFamily(
             self.build_name("request_count"),
-            "Total number of stealing requests per cost multiplier",
+            "Total number of stealing requests",
             labels=["cost_multiplier"],
         )
 
         stealing_request_cost_total = CounterMetricFamily(
             self.build_name("request_cost"),
-            "Total cost of stealing requests per cost multiplier",
+            "Total cost of stealing requests",
             labels=["cost_multiplier"],
         )
 

--- a/distributed/http/scheduler/prometheus/stealing.py
+++ b/distributed/http/scheduler/prometheus/stealing.py
@@ -24,13 +24,13 @@ class WorkStealingMetricCollector(PrometheusCollector):
             return
 
         stealing_request_count_total = CounterMetricFamily(
-            self.build_name("request_count_total"),
+            self.build_name("request_count"),
             "Total number of stealing requests per cost multiplier.",
             labels=["cost_multiplier"],
         )
 
         stealing_request_cost_total = CounterMetricFamily(
-            self.build_name("request_cost_total"),
+            self.build_name("request_cost"),
             "Total cost of stealing requests per cost multiplier.",
             labels=["cost_multiplier"],
         )

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -110,7 +110,7 @@ async def test_prometheus(c, s, a, b):
         "dask_scheduler_tasks",
         "dask_scheduler_tasks_suspicious",
         "dask_scheduler_tasks_forgotten",
-        "dask_scheduler_prefix_state_totals",
+        "dask_scheduler_prefix_state",
     }
 
     assert active_metrics.keys() == expected_metrics
@@ -213,7 +213,7 @@ async def test_prometheus_collect_task_prefix_counts(c, s, a, b):
 
         prefix_state_counts = {
             (sample.labels["task_prefix_name"], sample.labels["state"]): sample.value
-            for sample in families["dask_scheduler_prefix_state_totals"].samples
+            for sample in families["dask_scheduler_prefix_state"].samples
         }
 
         return prefix_state_counts

--- a/distributed/http/scheduler/tests/test_semaphore_http.py
+++ b/distributed/http/scheduler/tests/test_semaphore_http.py
@@ -45,7 +45,9 @@ async def test_prometheus(c, s, a, b):
     assert active_metrics["dask_semaphore_max_leases"].samples[0].value == 2
     assert active_metrics["dask_semaphore_active_leases"].samples[0].value == 1
     assert (
-        active_metrics["dask_semaphore_average_pending_lease_time_s"].samples[0].value
+        active_metrics["dask_semaphore_average_pending_lease_time_seconds"]
+        .samples[0]
+        .value
         > 0
     )
     assert active_metrics["dask_semaphore_acquire"].samples[0].value == 1
@@ -57,7 +59,9 @@ async def test_prometheus(c, s, a, b):
     assert active_metrics["dask_semaphore_max_leases"].samples[0].value == 2
     assert active_metrics["dask_semaphore_active_leases"].samples[0].value == 0
     assert (
-        active_metrics["dask_semaphore_average_pending_lease_time_s"].samples[0].value
+        active_metrics["dask_semaphore_average_pending_lease_time_seconds"]
+        .samples[0]
+        .value
         > 0
     )
     assert active_metrics["dask_semaphore_acquire"].samples[0].value == 1

--- a/distributed/http/scheduler/tests/test_semaphore_http.py
+++ b/distributed/http/scheduler/tests/test_semaphore_http.py
@@ -18,7 +18,7 @@ async def test_prometheus(c, s, a, b):
         "dask_semaphore_pending_leases",
         "dask_semaphore_acquire",
         "dask_semaphore_release",
-        "dask_semaphore_average_pending_lease_time_s",
+        "dask_semaphore_average_pending_lease_time_seconds",
     }
 
     assert active_metrics.keys() == expected_metrics

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -92,7 +92,7 @@ class WorkerMetricCollector(PrometheusCollector):
         )
 
         yield CounterMetricFamily(
-            self.build_name("transfer_incoming_count_total"),
+            self.build_name("transfer_incoming_count"),
             (
                 "Total number of data transfers from other workers "
                 "since the worker was started"
@@ -112,7 +112,7 @@ class WorkerMetricCollector(PrometheusCollector):
         )
 
         yield CounterMetricFamily(
-            self.build_name("transfer_outgoing_count_total"),
+            self.build_name("transfer_outgoing_count"),
             (
                 "Total number of data transfers to other workers "
                 "since the worker was started"


### PR DESCRIPTION
Follows the OpenMetrics specification (https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#suffixes) and avoids `_total` suffixes on metric families which will be automatically added to `Counter`s (https://github.com/prometheus/client_python#counter). This makes it easier to follow the rules applied to Prometheus metric names and helps resolve issues in dask/dask/pull/9696.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
