### PR TITLE
Remove `tornado` max version from nightly recipe

### DIFF
--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - sortedcontainers !=2.0.0,!=2.0.1
     - tblib >=1.6.0
     - toolz >=0.10.0
-    - tornado >=6.0.3,<6.2
+    - tornado >=6.0.3
     - urllib3
     - zict >=0.1.3
   run_constrained:


### PR DESCRIPTION
Looks like this was missed in https://github.com/dask/distributed/pull/7286; makes the constraints of the nightly `distributed` packages consistent with the stable release.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
