### PR TITLE
Remove ignore annotation-unchecked

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -116,9 +116,6 @@ from distributed.utils_comm import (
 from distributed.utils_perf import disable_gc_diagnosis, enable_gc_diagnosis
 from distributed.variable import VariableExtension
 
-# FIXME improve annotations. See also special treatment in setup.cfg.
-# mypy: disable-error-code=annotation-unchecked
-
 if TYPE_CHECKING:
     # TODO import from typing (requires Python >=3.10)
     from typing_extensions import TypeAlias


### PR DESCRIPTION
Closes #7378
The ignore is only necessary if you remove `allow_incomplete_defs = true` from setup.cfg.