### PR TITLE
RFC Respect needs_what in worker_objective

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3029,7 +3029,9 @@ class SchedulerState:
         Minimize expected start time.  If a tie then break with data storage.
         """
         comm_bytes = sum(
-            dts.get_nbytes() for dts in ts.dependencies if ws not in dts.who_has
+            dts.get_nbytes()
+            for dts in ts.dependencies
+            if ws not in dts.who_has and dts not in ws.needs_what
         )
 
         stack_time = ws.occupancy / ws.nthreads


### PR DESCRIPTION
I think we should not count the comm_bytes in the worker objective if the task is supposed to be transferred to this worker, anyhow. In theory, I suspect this should reduce overall number of replicas on a cluster.

cc @crusaderky @gjoseph92 