### PR TITLE
Remove  superfluous `ShuffleSchedulerExtension.barriers`

### DIFF
--- a/distributed/shuffle/_shuffle_extension.py
+++ b/distributed/shuffle/_shuffle_extension.py
@@ -643,6 +643,10 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         return "shuffle-barrier-" + shuffle_id
 
     @classmethod
+    def _is_barrier_key(cls, key: str) -> bool:
+        return key.startswith("shuffle-barrier-")
+
+    @classmethod
     def id_from_key(cls, key: str) -> ShuffleId:
         assert key.startswith("shuffle-barrier-")
         return ShuffleId(key.replace("shuffle-barrier-", ""))
@@ -766,10 +770,9 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
     ) -> None:
         if finish != "forgotten":
             return
-        try:
-            shuffle_id = self.id_from_key(key)
-        except AssertionError:
+        if not self._is_barrier_key(key):
             return
+        shuffle_id = self.id_from_key(key)
         if shuffle_id not in self.worker_for:
             return
 

--- a/distributed/shuffle/_shuffle_extension.py
+++ b/distributed/shuffle/_shuffle_extension.py
@@ -643,10 +643,6 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         return "shuffle-barrier-" + shuffle_id
 
     @classmethod
-    def _is_barrier_key(cls, key: str) -> bool:
-        return key.startswith("shuffle-barrier-")
-
-    @classmethod
     def id_from_key(cls, key: str) -> ShuffleId:
         assert key.startswith("shuffle-barrier-")
         return ShuffleId(key.replace("shuffle-barrier-", ""))
@@ -770,7 +766,7 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
     ) -> None:
         if finish != "forgotten":
             return
-        if not self._is_barrier_key(key):
+        if not key.startswith("shuffle-barrier-"):
             return
         shuffle_id = self.id_from_key(key)
         if shuffle_id not in self.worker_for:

--- a/distributed/shuffle/_shuffle_extension.py
+++ b/distributed/shuffle/_shuffle_extension.py
@@ -644,7 +644,7 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
 
     @classmethod
     def id_from_key(cls, key: str) -> ShuffleId:
-        assert "shuffle-barrier-" in key
+        assert key.startswith("shuffle-barrier-")
         return ShuffleId(key.replace("shuffle-barrier-", ""))
 
     def get(
@@ -766,7 +766,10 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
     ) -> None:
         if finish != "forgotten":
             return
-        shuffle_id = self.id_from_key(key)
+        try:
+            shuffle_id = self.id_from_key(key)
+        except AssertionError:
+            return
         if shuffle_id not in self.worker_for:
             return
 

--- a/distributed/shuffle/_shuffle_extension.py
+++ b/distributed/shuffle/_shuffle_extension.py
@@ -609,7 +609,6 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
     participating_workers: dict[ShuffleId, set[str]]
     tombstones: set[ShuffleId]
     erred_shuffles: dict[ShuffleId, Exception]
-    barriers: dict[ShuffleId, str]
 
     def __init__(self, scheduler: Scheduler):
         self.scheduler = scheduler
@@ -629,7 +628,6 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         self.participating_workers = {}
         self.tombstones = set()
         self.erred_shuffles = {}
-        self.barriers = {}
         self.scheduler.add_plugin(self)
 
     def shuffle_ids(self) -> set[ShuffleId]:
@@ -674,7 +672,6 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
             output_workers = set()
 
             name = self.barrier_key(id)
-            self.barriers[id] = name
             mapping = {}
 
             for ts in self.scheduler.tasks[name].dependents:
@@ -724,7 +721,7 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
             contact_workers = shuffle_workers.copy()
             contact_workers.discard(worker)
             affected_shuffles.add(shuffle_id)
-            name = self.barriers[shuffle_id]
+            name = self.barrier_key(shuffle_id)
             barrier_task = self.scheduler.tasks.get(name)
             if barrier_task:
                 barriers.append(barrier_task)
@@ -769,11 +766,10 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
     ) -> None:
         if finish != "forgotten":
             return
-        if key not in self.barriers.values():
-
+        shuffle_id = self.id_from_key(key)
+        if shuffle_id not in self.worker_for:
             return
 
-        shuffle_id = ShuffleSchedulerExtension.id_from_key(key)
         participating_workers = self.participating_workers[shuffle_id]
         worker_msgs = {
             worker: [
@@ -806,7 +802,6 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         del self.completed_workers[id]
         del self.participating_workers[id]
         self.erred_shuffles.pop(id, None)
-        del self.barriers[id]
         with contextlib.suppress(KeyError):
             del self.heartbeats[id]
 


### PR DESCRIPTION
The use of the `ShuffleSchedulerExtension.barriers` dictionary can be replaced by the use of existing state-tracking collections and class-level key-generation methods.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
