### PR TITLE
Add test for using annotations with `client.submit` and `client.map`

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6999,6 +6999,7 @@ async def test_annotations_submit_map(c, s, a, b):
 
     assert all([{"foo": 1} == ts.resource_restrictions for ts in s.tasks.values()])
     assert all([{"resources": {"foo": 1}} == ts.annotations for ts in s.tasks.values()])
+    assert not b.state.tasks
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
As pointed out in https://github.com/dask/distributed/issues/7397, we document that users can mix `dask.annotate(...)` and `client.submit` / `client.map`, but don't have test coverage for this case (at least not that I saw). This PR adds a corresponding test. 

Closes https://github.com/dask/distributed/issues/7397