### PR TITLE
Select queued tasks in stimuli, not transitions

### DIFF
--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -121,7 +121,7 @@ class HeapSet(MutableSet[T]):
         """Iterate over the n smallest elements without removing them.
         This is O(1) for n == 1; O(n*logn) otherwise.
         """
-        if n <= 0:
+        if n <= 0 or not self:
             return  # empty iterator
         if n == 1:
             yield self.peek()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5304,10 +5304,8 @@ class Scheduler(SchedulerState, ServerNode):
 
         self.stimulus_queue_slots_maybe_opened(stimulus_id=stimulus_id)
 
-    def handle_task_erred(self, key: str, worker: str, stimulus_id: str, **msg) -> None:
-        r: tuple = self.stimulus_task_erred(
-            key=key, worker=worker, stimulus_id=stimulus_id, **msg
-        )
+    def handle_task_erred(self, key: str, stimulus_id: str, **msg) -> None:
+        r: tuple = self.stimulus_task_erred(key=key, stimulus_id=stimulus_id, **msg)
         recommendations, client_msgs, worker_msgs = r
         self._transitions(recommendations, client_msgs, worker_msgs, stimulus_id)
         self.send_all(client_msgs, worker_msgs)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4609,23 +4609,22 @@ class Scheduler(SchedulerState, ServerNode):
 
         # TODO: balance workers
 
-    def stimulus_queue_slots_maybe_opened(
-        self, *workers: WorkerState, stimulus_id: str
-    ) -> None:
+    def stimulus_queue_slots_maybe_opened(self, *, stimulus_id: str) -> None:
         """Respond to an event which may have opened a spot on the threadpool of a worker
 
         Selects the appropriate number of tasks from the front of the queue (potentially
         0), and transitions them to ``processing``.
         """
-        # FIXME we'll pick the same tasks for each worker!!! (because this doesn't pop off the queue)
-        recommendations: Recs = {
-            qts.key: "processing"
-            for ws in workers
-            for qts in self._next_queued_tasks_for_worker(ws)
-        }
-        # TODO we already know the worker, pass `ws` as an argument to
-        # `transition_queued_procssing` and bypass `decide_worker`
-        self.transitions(recommendations, stimulus_id)
+        if self.idle_task_count:
+            # FIXME we'll pick the same tasks for each worker!!! (because this doesn't pop off the queue)
+            recommendations: Recs = {
+                qts.key: "processing"
+                for ws in self.idle_task_count
+                for qts in self._next_queued_tasks_for_worker(ws)
+            }
+            # TODO we already know the worker, pass `ws` as an argument to
+            # `transition_queued_procssing` and bypass `decide_worker`
+            self.transitions(recommendations, stimulus_id)
 
     def stimulus_task_finished(self, key=None, worker=None, stimulus_id=None, **kwargs):
         """Mark that a task has finished execution on a particular worker"""
@@ -4951,15 +4950,9 @@ class Scheduler(SchedulerState, ServerNode):
         recommendations: Recs = {}
 
         self._client_releases_keys(keys=keys, cs=cs, recommendations=recommendations)
-        potential_open_workers = {
-            ws for k in recommendations.keys() if (ws := self.tasks[k].processing_on)
-        }
-
         self.transitions(recommendations, stimulus_id)
 
-        self.stimulus_queue_slots_maybe_opened(
-            *potential_open_workers, stimulus_id=stimulus_id
-        )
+        self.stimulus_queue_slots_maybe_opened(stimulus_id=stimulus_id)
 
     def client_heartbeat(self, client=None):
         """Handle heartbeats from Client"""
@@ -5307,9 +5300,7 @@ class Scheduler(SchedulerState, ServerNode):
         self._transitions(recommendations, client_msgs, worker_msgs, stimulus_id)
         self.send_all(client_msgs, worker_msgs)
 
-        self.stimulus_queue_slots_maybe_opened(
-            self.workers[worker], stimulus_id=stimulus_id
-        )
+        self.stimulus_queue_slots_maybe_opened(stimulus_id=stimulus_id)
 
     def handle_task_erred(self, key: str, worker: str, stimulus_id: str, **msg) -> None:
         r: tuple = self.stimulus_task_erred(
@@ -5319,9 +5310,7 @@ class Scheduler(SchedulerState, ServerNode):
         self._transitions(recommendations, client_msgs, worker_msgs, stimulus_id)
         self.send_all(client_msgs, worker_msgs)
 
-        self.stimulus_queue_slots_maybe_opened(
-            self.workers[worker], stimulus_id=stimulus_id
-        )
+        self.stimulus_queue_slots_maybe_opened(stimulus_id=stimulus_id)
 
     def release_worker_data(self, key: str, worker: str, stimulus_id: str) -> None:
         ts = self.tasks.get(key)
@@ -5364,7 +5353,7 @@ class Scheduler(SchedulerState, ServerNode):
         ws.add_to_long_running(ts)
         self.check_idle_saturated(ws)
 
-        self.stimulus_queue_slots_maybe_opened(ws, stimulus_id=stimulus_id)
+        self.stimulus_queue_slots_maybe_opened(stimulus_id=stimulus_id)
 
     def handle_worker_status_change(
         self, status: str | Status, worker: str | WorkerState, stimulus_id: str

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4593,7 +4593,7 @@ class Scheduler(SchedulerState, ServerNode):
         # TODO: balance workers
 
     def stimulus_queue_slots_maybe_opened(self, *, stimulus_id: str) -> None:
-        """Respond to an event which may have opened a spot on the threadpool of a worker
+        """Respond to an event which may have opened spots on worker threadpools
 
         Selects the appropriate number of tasks from the front of the queue according to
         the total number of task slots available on workers (potentially 0), and

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -148,8 +148,14 @@ def test_heapset():
     assert list(heap.peekn(1)) == [cx]
     heap.remove(cw)
     assert list(heap.peekn(1)) == [cx]
+    heap.remove(cx)
+    assert list(heap.peekn(-1)) == []
+    assert list(heap.peekn(0)) == []
+    assert list(heap.peekn(1)) == []
+    assert list(heap.peekn(2)) == []
 
     # Test resilience to failure in key()
+    heap.add(cx)
     bad_key = C("bad_key", 0)
     del bad_key.i
     with pytest.raises(AttributeError):

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -383,6 +383,17 @@ async def test_forget_tasks_while_processing(c, s, a, b):
     assert not s.tasks
 
 
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_restart_while_processing(c, s, a, b):
+    events = [Event() for _ in range(10)]
+
+    futures = c.map(Event.wait, events)
+    await events[0].set()
+    await futures[0]
+    await c.restart()
+    assert not s.tasks
+
+
 @gen_cluster(
     client=True,
     nthreads=[("", 1)] * 3,

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -411,7 +411,8 @@ async def test_queued_release_multiple_workers(c, s, *workers):
 
         # All of the second batch should be queued after the first batch
         assert [ts.key for ts in s.queued.sorted()] == [
-            f.key for f in itertools.chain(first_batch[3:], second_batch)
+            f.key
+            for f in itertools.chain(first_batch[s.total_nthreads :], second_batch)
         ]
 
         # Cancel the first batch.
@@ -424,7 +425,9 @@ async def test_queued_release_multiple_workers(c, s, *workers):
         await async_wait_for(lambda: len(s.tasks) == len(second_batch), 5)
 
         # Second batch should move up the queue and start processing
-        assert len(s.queued) == len(second_batch) - 3, list(s.queued.sorted())
+        assert len(s.queued) == len(second_batch) - s.total_nthreads, list(
+            s.queued.sorted()
+        )
 
         await event.set()
         await c2.gather(second_batch)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -383,6 +383,7 @@ async def test_forget_tasks_while_processing(c, s, a, b):
     assert not s.tasks
 
 
+@pytest.mark.slow
 @gen_cluster(client=True, nthreads=[("", 1)], Worker=Nanny)
 async def test_restart_while_processing(c, s, a, b):
     events = [Event() for _ in range(10)]
@@ -390,6 +391,7 @@ async def test_restart_while_processing(c, s, a, b):
     futures = c.map(Event.wait, events)
     await events[0].set()
     await futures[0]
+    # TODO slow because worker waits a while for the task to finish
     await c.restart()
     assert not s.tasks
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 import json
 import logging
 import math
@@ -86,14 +87,14 @@ async def test_administration(s, a, b):
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 async def test_respect_data_in_memory(c, s, a):
-    x = delayed(inc)(1)
-    y = delayed(inc)(x)
+    x = delayed(inc)(1, dask_key_name="x")
+    y = delayed(inc)(x, dask_key_name="y")
     f = c.persist(y)
     await wait([f])
 
     assert s.tasks[y.key].who_has == {s.workers[a.address]}
 
-    z = delayed(operator.add)(x, y)
+    z = delayed(operator.add)(x, y, dask_key_name="z")
     f2 = c.persist(z)
     while f2.key not in s.tasks or not s.tasks[f2.key]:
         assert s.tasks[y.key].who_has
@@ -369,6 +370,58 @@ async def test_graph_execution_width(c, s, *workers):
     # NOTE: the max should normally equal `total_nthreads`. But some macOS CI machines
     # are slow enough that they aren't able to reach the full parallelism of 8 threads.
     assert max(Refcount.log) <= s.total_nthreads
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_forget_tasks_while_processing(c, s, a, b):
+    events = [Event() for _ in range(10)]
+
+    futures = c.map(Event.wait, events)
+    await events[0].set()
+    await futures[0]
+    await c.close()
+    assert not s.tasks
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)],
+    config={"distributed.scheduler.worker-saturation": 1.0},
+)
+async def test_queued_release(c, s, a):
+    event = Event()
+
+    rootish_threshold = s.total_nthreads * 2 + 1
+
+    first_batch = c.map(
+        lambda i: event.wait(),
+        range(rootish_threshold),
+        key=[f"first-{i}" for i in range(rootish_threshold)],
+    )
+    await async_wait_for(lambda: s.queued, 5)
+
+    second_batch = c.map(
+        lambda i: event.wait(),
+        range(rootish_threshold),
+        key=[f"second-{i}" for i in range(rootish_threshold)],
+        fifo_timeout=0,
+    )
+    await async_wait_for(lambda: second_batch[0].key in s.tasks, 5)
+
+    # All of the second batch should be queued after the first batch
+    assert [ts.key for ts in s.queued.sorted()] == [
+        f.key for f in itertools.chain(first_batch[1:], second_batch)
+    ]
+
+    # Cancel the first batch
+    del first_batch
+    await async_wait_for(lambda: len(s.tasks) == len(second_batch), 5)
+
+    # Second batch should move up the queue and start processing
+    assert len(s.queued) == len(second_batch) - 1, list(s.queued.sorted())
+
+    await event.set()
+    await c.gather(second_batch)
 
 
 @gen_cluster(
@@ -4237,7 +4290,7 @@ async def test_deadlock_resubmit_queued_tasks_fast(c, s, a, rootish):
             await asyncio.sleep(0.005)
         assert_rootish()
         if rootish:
-            assert all(s.tasks[k] in s.queued for k in keys)
+            assert all(s.tasks[k] in s.queued for k in keys), [s.tasks[k] for k in keys]
         await block.set()
         # At this point we need/want to wait for the task-finished message to
         # arrive on the scheduler. There is no proper hook to wait, therefore we

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -383,7 +383,7 @@ async def test_forget_tasks_while_processing(c, s, a, b):
     assert not s.tasks
 
 
-@gen_cluster(client=True, nthreads=[("", 1)])
+@gen_cluster(client=True, nthreads=[("", 1)], Worker=Nanny)
 async def test_restart_while_processing(c, s, a, b):
     events = [Event() for _ in range(10)]
 


### PR DESCRIPTION
Before, we selected new queued tasks as part of transitions: when one task exited `processing`, we recommended another task from `queued->processing`. Now, we select queued tasks in response to stimuli: first we do one cycle of transitions as usual, then check if there are open threads, and only then do a second cycle of transitions moving tasks from `queued->processing`.

By moving the `queued->processing` transition after any possible `queued->released` transition, this ensures we won't accidentally overwrite the `queued->released` recommendation (#7396).

See discussion in https://github.com/dask/distributed/issues/7396#issuecomment-1349175707.

Closes https://github.com/dask/distributed/issues/7396, closes https://github.com/dask/distributed/issues/7401, closes https://github.com/dask/distributed/issues/7398.

cc @fjetter @crusaderky

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
