### PR TITLE
Create new Zstd (De)Compressor for each compression call

### DIFF
--- a/distributed/protocol/compression.py
+++ b/distributed/protocol/compression.py
@@ -81,17 +81,15 @@ with suppress(ImportError):
     if parse_version(zstandard.__version__) < parse_version("0.9.0"):
         raise ImportError("Need zstandard >= 0.9.0")
 
-    zstd_compressor = zstandard.ZstdCompressor(
-        level=dask.config.get("distributed.comm.zstd.level"),
-        threads=dask.config.get("distributed.comm.zstd.threads"),
-    )
-
-    zstd_decompressor = zstandard.ZstdDecompressor()
-
     def zstd_compress(data):
+        zstd_compressor = zstandard.ZstdCompressor(
+            level=dask.config.get("distributed.comm.zstd.level"),
+            threads=dask.config.get("distributed.comm.zstd.threads"),
+        )
         return zstd_compressor.compress(data)
 
     def zstd_decompress(data):
+        zstd_decompressor = zstandard.ZstdDecompressor()
         return zstd_decompressor.decompress(data)
 
     compressions["zstd"] = {"compress": zstd_compress, "decompress": zstd_decompress}

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -149,12 +149,12 @@ def test_compression_thread_safety(lib, compression):
         assert rc == compression
         assert compressions[rc]["decompress"](rd) == payload
 
-    for f in try_converters:
+    for fn in try_converters:
         threads = []
         for _ in range(0, 100):
             start = False
             for _ in range(0, 10):
-                thread = Thread(target=test_compress_decompress)
+                thread = Thread(target=test_compress_decompress, args=(fn,))
                 thread.start()
                 threads.append(thread)
             start = True


### PR DESCRIPTION
The ZstdCompressor and ZstdDecompressor objects are not thread safe to reuse. This commit re-instantiates a new object for each call to compress/decompress and adds a test to ensure this is the case.

The tests run the compress/decompress round trip 100 times, 10 times, and take about 500ms for each compression algo. In my testing this was enough to reproduce issues 90% of the time, while ensuring tests didn't take too long.

Closes #7403.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
