### PR TITLE
Fix `P2PShuffle` serialization for categorical data

### DIFF
--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -6,19 +6,21 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
 
-def dump_batch(batch: pa.Buffer, file: BinaryIO, schema: pa.Schema) -> None:
+def dump_table(table: pa.Table, file: BinaryIO) -> None:
     """
-    Dump a batch to file, if we're the first, also write the schema
+    Dump a table to file
 
-    This function is with respect to the open file object
+    Note: This function appends to the file and signals end-of-stream when done.
+    This results in multiple end-of-stream signals in a stream.
 
     See Also
     --------
     load_arrow
     """
-    if file.tell() == 0:
-        file.write(schema.serialize())
-    file.write(batch)
+    import pyarrow as pa
+
+    with pa.ipc.new_stream(file, table.schema) as writer:
+        writer.write_table(table)
 
 
 def load_arrow(file: BinaryIO) -> pa.Table:

--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -32,7 +32,7 @@ def load_partition(file: BinaryIO) -> pa.Table:
     >>> tables = [pa.Table.from_pandas(df), pa.Table.from_pandas(df2)]  # doctest: +SKIP
     >>> with open("myfile", mode="wb") as f:  # doctest: +SKIP
     ...     for table in tables:  # doctest: +SKIP
-    ...         dump_shards(tables, f, schema=t.schema)  # doctest: +SKIP
+    ...         dump_shards(tables, f)  # doctest: +SKIP
 
     >>> with open("myfile", mode="rb") as f:  # doctest: +SKIP
     ...     t = load_partition(f)  # doctest: +SKIP
@@ -56,7 +56,7 @@ def load_partition(file: BinaryIO) -> pa.Table:
         raise
 
 
-def list_of_buffers_to_table(data: list[bytes], schema: pa.Schema) -> pa.Table:
+def list_of_buffers_to_table(data: list[bytes]) -> pa.Table:
     """Convert a list of arrow buffers and a schema to an Arrow Table"""
     import pyarrow as pa
 

--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -62,8 +62,7 @@ def list_of_buffers_to_table(data: list[bytes]) -> pa.Table:
 
     tables = []
     for buffer in data:
-        with pa.ipc.open_stream(pa.py_buffer(buffer)) as reader:
-            tables.append(reader.read_all())
+        tables.append(deserialize_table(buffer))
     return pa.concat_tables(tables)
 
 
@@ -101,3 +100,10 @@ def serialize_table(table: pa.Table) -> bytes:
     with pa.ipc.new_stream(stream, table.schema) as writer:
         writer.write_table(table)
     return stream.getvalue()
+
+
+def deserialize_table(buffer: bytes) -> pa.Table:
+    import pyarrow as pa
+
+    with pa.ipc.open_stream(pa.py_buffer(buffer)) as reader:
+        return reader.read_all()

--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -58,20 +58,12 @@ def load_partition(file: BinaryIO) -> pa.Table:
 
 def list_of_buffers_to_table(data: list[bytes], schema: pa.Schema) -> pa.Table:
     """Convert a list of arrow buffers and a schema to an Arrow Table"""
-    import io
-
     import pyarrow as pa
 
     tables = []
-    assert len(data) == 1
-    buffer = data[0]
-    with io.BytesIO(buffer) as stream:
-        while True:
-            try:
-                with pa.ipc.open_stream(stream) as reader:
-                    tables.append(reader.read_all())
-            except Exception:
-                break
+    for buffer in data:
+        with pa.ipc.open_stream(pa.py_buffer(buffer)) as reader:
+            tables.append(reader.read_all())
     return pa.concat_tables(tables)
 
 

--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -60,10 +60,7 @@ def list_of_buffers_to_table(data: list[bytes]) -> pa.Table:
     """Convert a list of arrow buffers and a schema to an Arrow Table"""
     import pyarrow as pa
 
-    tables = []
-    for buffer in data:
-        tables.append(deserialize_table(buffer))
-    return pa.concat_tables(tables)
+    return pa.concat_tables(deserialize_table(buffer) for buffer in data)
 
 
 def deserialize_schema(data: bytes) -> pa.Schema:

--- a/distributed/shuffle/_buffer.py
+++ b/distributed/shuffle/_buffer.py
@@ -5,13 +5,10 @@ import contextlib
 import logging
 from collections import defaultdict
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Generic, Sized, TypeVar
+from typing import Any, Generic, Sized, TypeVar
 
 from distributed.metrics import time
 from distributed.shuffle._limiter import ResourceLimiter
-
-if TYPE_CHECKING:
-    import pyarrow as pa
 
 logger = logging.getLogger("distributed.shuffle")
 
@@ -96,7 +93,7 @@ class ShardsBuffer(Generic[ShardType]):
             "memory_limit": self.memory_limiter._maxvalue if self.memory_limiter else 0,
         }
 
-    async def process(self, id: str, shards: list[pa.Table], size: int) -> None:
+    async def process(self, id: str, shards: list[ShardType], size: int) -> None:
         try:
             start = time()
             try:

--- a/distributed/shuffle/_comms.py
+++ b/distributed/shuffle/_comms.py
@@ -67,9 +67,4 @@ class CommShardsBuffer(ShardsBuffer):
 
             # Consider boosting total_size a bit here to account for duplication
             with self.time("send"):
-                await self.send(address, [_join_shards(shards)])
-
-
-def _join_shards(shards: list[bytes]) -> bytes:
-    # This is just there for easier profiling
-    return b"".join(shards)
+                await self.send(address, shards)

--- a/distributed/shuffle/_disk.py
+++ b/distributed/shuffle/_disk.py
@@ -116,8 +116,7 @@ class DiskShardsBuffer(ShardsBuffer):
         # TODO: We could consider deleting the file at this point
         if parts:
             self.bytes_read += size
-            assert len(parts) == 1
-            return parts[0]
+            return pa.concat_tables(parts)
         else:
             raise KeyError(id)
 

--- a/distributed/shuffle/_disk.py
+++ b/distributed/shuffle/_disk.py
@@ -93,6 +93,8 @@ class DiskShardsBuffer(ShardsBuffer):
                     # os.fsync(f)  # TODO: maybe?
 
     def read(self, id: int | str) -> pa.Table:
+        import pyarrow as pa
+
         """Read a complete file back into memory"""
         self.raise_on_exception()
         if not self._inputs_done:

--- a/distributed/shuffle/_shuffle_extension.py
+++ b/distributed/shuffle/_shuffle_extension.py
@@ -20,9 +20,9 @@ from distributed.diagnostics.plugin import SchedulerPlugin
 from distributed.protocol import to_serialize
 from distributed.shuffle._arrow import (
     deserialize_schema,
-    dump_table,
+    dump_table_batch,
     list_of_buffers_to_table,
-    load_arrow,
+    load_into_table,
     serialize_table,
 )
 from distributed.shuffle._comms import CommShardsBuffer
@@ -124,12 +124,12 @@ class Shuffle:
         self.worker_for = pd.Series(worker_for, name="_workers").astype("category")
         self.closed = False
 
-        def _dump_table(table: pa.Table, file: BinaryIO) -> None:
-            return dump_table(table, file)
+        def _dump_table_batch(tables: list[pa.Table], file: BinaryIO) -> None:
+            return dump_table_batch(tables, file)
 
         self._disk_buffer = DiskShardsBuffer(
-            dump=_dump_table,
-            load=load_arrow,
+            dump=_dump_table_batch,
+            load=load_into_table,
             directory=directory,
             memory_limiter=memory_limiter_disk,
         )

--- a/distributed/shuffle/_shuffle_extension.py
+++ b/distributed/shuffle/_shuffle_extension.py
@@ -23,6 +23,7 @@ from distributed.shuffle._arrow import (
     dump_table,
     list_of_buffers_to_table,
     load_arrow,
+    serialize_table,
 )
 from distributed.shuffle._comms import CommShardsBuffer
 from distributed.shuffle._disk import DiskShardsBuffer
@@ -233,10 +234,7 @@ class Shuffle:
                 self.column,
                 self.worker_for,
             )
-            out = {
-                k: [b.serialize().to_pybytes() for b in t.to_batches()]
-                for k, t in out.items()
-            }
+            out = {k: [serialize_table(t)] for k, t in out.items()}
             return out
 
         out = await self.offload(_)

--- a/distributed/shuffle/_worker_extension.py
+++ b/distributed/shuffle/_worker_extension.py
@@ -203,7 +203,7 @@ class Shuffle:
             raise
 
     def _repartition_buffers(self, data: list[bytes]) -> dict[str, list[pa.Table]]:
-        table = list_of_buffers_to_table(data, self.schema)
+        table = list_of_buffers_to_table(data)
         groups = split_by_partition(table, self.column)
         assert len(table) == sum(map(len, groups.values()))
         del data

--- a/distributed/shuffle/_worker_extension.py
+++ b/distributed/shuffle/_worker_extension.py
@@ -19,9 +19,9 @@ from distributed.core import PooledRPCCall
 from distributed.protocol import to_serialize
 from distributed.shuffle._arrow import (
     deserialize_schema,
-    dump_table_batch,
+    dump_shards,
     list_of_buffers_to_table,
-    load_into_table,
+    load_partition,
     serialize_table,
 )
 from distributed.shuffle._comms import CommShardsBuffer
@@ -123,11 +123,11 @@ class Shuffle:
         self.closed = False
 
         def _dump_table_batch(tables: list[pa.Table], file: BinaryIO) -> None:
-            return dump_table_batch(tables, file)
+            return dump_shards(tables, file)
 
         self._disk_buffer = DiskShardsBuffer(
             dump=_dump_table_batch,
-            load=load_into_table,
+            load=load_partition,
             directory=directory,
             memory_limiter=memory_limiter_disk,
         )

--- a/distributed/shuffle/_worker_extension.py
+++ b/distributed/shuffle/_worker_extension.py
@@ -122,8 +122,6 @@ class Shuffle:
         self.worker_for = pd.Series(worker_for, name="_workers").astype("category")
         self.closed = False
 
-        def _dump_shards(shards: list[pa.Table], file: BinaryIO) -> None:
-            return dump_shards(shards, file)
 
         self._disk_buffer = DiskShardsBuffer(
             dump=_dump_shards,

--- a/distributed/shuffle/_worker_extension.py
+++ b/distributed/shuffle/_worker_extension.py
@@ -9,7 +9,7 @@ import time
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any, BinaryIO, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 import toolz
 
@@ -122,9 +122,8 @@ class Shuffle:
         self.worker_for = pd.Series(worker_for, name="_workers").astype("category")
         self.closed = False
 
-
         self._disk_buffer = DiskShardsBuffer(
-            dump=_dump_shards,
+            dump=dump_shards,
             load=load_partition,
             directory=directory,
             memory_limiter=memory_limiter_disk,

--- a/distributed/shuffle/_worker_extension.py
+++ b/distributed/shuffle/_worker_extension.py
@@ -122,11 +122,11 @@ class Shuffle:
         self.worker_for = pd.Series(worker_for, name="_workers").astype("category")
         self.closed = False
 
-        def _dump_table_batch(tables: list[pa.Table], file: BinaryIO) -> None:
-            return dump_shards(tables, file)
+        def _dump_shards(shards: list[pa.Table], file: BinaryIO) -> None:
+            return dump_shards(shards, file)
 
         self._disk_buffer = DiskShardsBuffer(
-            dump=_dump_table_batch,
+            dump=_dump_shards,
             load=load_partition,
             directory=directory,
             memory_limiter=memory_limiter_disk,

--- a/distributed/shuffle/tests/test_disk_buffer.py
+++ b/distributed/shuffle/tests/test_disk_buffer.py
@@ -10,6 +10,7 @@ from distributed.utils_test import gen_test
 
 
 def dump(data, f):
+    data = b"".join(data)
     f.write(data)
 
 

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -666,7 +666,7 @@ def test_processing_chain():
     workers = ["a", "b", "c"]
     npartitions = 5
 
-    # Test the processing chain with a dataframe that contains all possible dtypes
+    # Test the processing chain with a dataframe that contains all supported dtypes
     df = pd.DataFrame(
         {
             f"col{next(counter)}": pd.array([True, False] * 50, dtype="bool"),

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -730,6 +730,15 @@ def test_processing_chain():
                 [pd.Timestamp.fromtimestamp(1641034800 + i) for i in range(100)],
                 dtype=pd.ArrowDtype(pa.timestamp("ms")),
             ),
+            # FIXME: distributed#7420
+            # f"col{next(counter)}": pd.array(
+            #     ["lorem ipsum"] * 100,
+            #     dtype="string[pyarrow]",
+            # ),
+            # f"col{next(counter)}": pd.array(
+            #     ["lorem ipsum"] * 100,
+            #     dtype=pd.StringDtype("pyarrow"),
+            # ),
         }
     )
     df["_partitions"] = df.col4 % npartitions

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -666,11 +666,12 @@ def test_processing_chain():
     workers = ["a", "b", "c"]
     npartitions = 5
 
+    # FIXME: csingle, cdouble, clongdouble, sparse and object not supported
     # Test the processing chain with a dataframe that contains all supported dtypes
     df = pd.DataFrame(
         {
+            # numpy dtypes
             f"col{next(counter)}": pd.array([True, False] * 50, dtype="bool"),
-            f"col{next(counter)}": pd.array([True, False] * 50, dtype="boolean"),
             f"col{next(counter)}": pd.array(range(100), dtype="int8"),
             f"col{next(counter)}": pd.array(range(100), dtype="int16"),
             f"col{next(counter)}": pd.array(range(100), dtype="int32"),
@@ -682,27 +683,15 @@ def test_processing_chain():
             f"col{next(counter)}": pd.array(range(100), dtype="float16"),
             f"col{next(counter)}": pd.array(range(100), dtype="float32"),
             f"col{next(counter)}": pd.array(range(100), dtype="float64"),
-            # f"col{next(counter)}": pd.array(range(100), dtype="csingle"),
-            # f"col{next(counter)}": pd.array(range(100), dtype="cdouble"),
-            # f"col{next(counter)}": pd.array(range(100), dtype="clongdouble"),
             f"col{next(counter)}": pd.array(
                 [np.datetime64("2022-01-01") + i for i in range(100)],
                 dtype="datetime64",
             ),
             f"col{next(counter)}": pd.array(
-                [np.datetime64("2022-01-01") + i for i in range(100)],
-                dtype=pd.DatetimeTZDtype(tz="UTC"),
-            ),
-            f"col{next(counter)}": pd.array(
                 [np.timedelta64(1, "D") + i for i in range(100)], dtype="timedelta64"
             ),
-            f"col{next(counter)}": pd.array(
-                [pd.Period("2022-01-01", freq="D") + i for i in range(100)],
-                dtype="period[D]",
-            ),
-            f"col{next(counter)}": pd.array(
-                [pd.Interval(left=i, right=i + 2) for i in range(100)], dtype="Interval"
-            ),
+            # Nullable dtypes
+            f"col{next(counter)}": pd.array([True, False] * 50, dtype="boolean"),
             f"col{next(counter)}": pd.array(range(100), dtype="Int8"),
             f"col{next(counter)}": pd.array(range(100), dtype="Int16"),
             f"col{next(counter)}": pd.array(range(100), dtype="Int32"),
@@ -711,18 +700,39 @@ def test_processing_chain():
             f"col{next(counter)}": pd.array(range(100), dtype="UInt16"),
             f"col{next(counter)}": pd.array(range(100), dtype="UInt32"),
             f"col{next(counter)}": pd.array(range(100), dtype="UInt64"),
+            # pandas dtypes
+            f"col{next(counter)}": pd.array(
+                [np.datetime64("2022-01-01") + i for i in range(100)],
+                dtype=pd.DatetimeTZDtype(tz="Europe/Berlin"),
+            ),
+            f"col{next(counter)}": pd.array(
+                [pd.Period("2022-01-01", freq="D") + i for i in range(100)],
+                dtype="period[D]",
+            ),
+            f"col{next(counter)}": pd.array(
+                [pd.Interval(left=i, right=i + 2) for i in range(100)], dtype="Interval"
+            ),
             f"col{next(counter)}": pd.array(["x", "y"] * 50, dtype="category"),
-            # f"col{next(counter)}": pd.array(
-            # [np.nan, np.nan, 1.0, np.nan, np.nan] * 20,
-            # dtype="Sparse[float64]",
-            # ),
             f"col{next(counter)}": pd.array(["lorem ipsum"] * 100, dtype="string"),
-            # f"col{next(counter)}": pd.array(
-            #     [Stub(i) for i in range(100)], dtype="object"
-            # ),
+            # PyArrow dtypes
+            f"col{next(counter)}": pd.array([True, False] * 50, dtype="bool[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="int8[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="int16[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="int32[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="int64[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="uint8[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="uint16[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="uint32[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="uint64[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="float32[pyarrow]"),
+            f"col{next(counter)}": pd.array(range(100), dtype="float64[pyarrow]"),
+            f"col{next(counter)}": pd.array(
+                [pd.Timestamp.fromtimestamp(1641034800 + i) for i in range(100)],
+                dtype=pd.ArrowDtype(pa.timestamp("ms")),
+            ),
         }
     )
-    df["_partitions"] = df.col3 % npartitions
+    df["_partitions"] = df.col4 % npartitions
     schema = pa.Schema.from_pandas(df)
     worker_for = {i: random.choice(workers) for i in list(range(npartitions))}
     worker_for = pd.Series(worker_for, name="_worker").astype("category")

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -30,6 +30,7 @@ from distributed.shuffle._shuffle_extension import (
     get_worker_for,
     list_of_buffers_to_table,
     load_arrow,
+    serialize_table,
     split_by_partition,
     split_by_worker,
 )
@@ -675,10 +676,7 @@ def test_processing_chain():
     assert set(data) == set(worker_for.cat.categories)
     assert sum(map(len, data.values())) == len(df)
 
-    batches = {
-        worker: [b.serialize().to_pybytes() for b in t.to_batches()]
-        for worker, t in data.items()
-    }
+    batches = {worker: [serialize_table(t)] for worker, t in data.items()}
 
     # Typically we communicate to different workers at this stage
     # We then receive them back and reconstute them

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -806,8 +806,13 @@ def test_processing_chain():
         bio.seek(0)
         out[k] = load_partition(bio)
 
-    assert sum(map(len, out.values())) == len(df)
-    assert all(v.to_pandas().dtypes.equals(df.dtypes) for v in out.values())
+    shuffled_df = pd.concat(table.to_pandas() for table in out.values())
+    pd.testing.assert_frame_equal(
+        df,
+        shuffled_df,
+        check_like=True,
+        check_exact=True,
+    )
 
 
 @gen_cluster(client=True)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -27,10 +27,10 @@ from distributed.shuffle._shuffle_extension import (
     Shuffle,
     ShuffleId,
     ShuffleWorkerExtension,
-    dump_table,
+    dump_table_batch,
     get_worker_for,
     list_of_buffers_to_table,
-    load_arrow,
+    load_into_table,
     split_by_partition,
     split_by_worker,
 )
@@ -712,13 +712,12 @@ def test_processing_chain():
 
     for partitions in splits_by_worker.values():
         for partition, tables in partitions.items():
-            for table in tables:
-                dump_table(table, filesystem[partition])
+            dump_table_batch(tables, filesystem[partition])
 
     out = {}
     for k, bio in filesystem.items():
         bio.seek(0)
-        out[k] = load_arrow(bio)
+        out[k] = load_into_table(bio)
 
     assert sum(map(len, out.values())) == len(df)
 

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -29,9 +29,9 @@ from distributed.shuffle._shuffle import ShuffleId, barrier_key
 from distributed.shuffle._worker_extension import (
     Shuffle,
     ShuffleWorkerExtension,
-    dump_table_batch,
+    dump_shards,
     list_of_buffers_to_table,
-    load_into_table,
+    load_partition,
     split_by_partition,
     split_by_worker,
 )
@@ -763,12 +763,12 @@ def test_processing_chain():
 
     for partitions in splits_by_worker.values():
         for partition, tables in partitions.items():
-            dump_table_batch(tables, filesystem[partition])
+            dump_shards(tables, filesystem[partition])
 
     out = {}
     for k, bio in filesystem.items():
         bio.seek(0)
-        out[k] = load_into_table(bio)
+        out[k] = load_partition(bio)
 
     assert sum(map(len, out.values())) == len(df)
     assert all(v.to_pandas().dtypes.equals(df.dtypes) for v in out.values())

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -769,7 +769,7 @@ def test_processing_chain():
     # We then receive them back and reconstute them
 
     by_worker = {
-        worker: list_of_buffers_to_table(list_of_batches, schema)
+        worker: list_of_buffers_to_table(list_of_batches)
         for worker, list_of_batches in batches.items()
     }
     assert sum(map(len, by_worker.values())) == len(df)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -665,6 +665,8 @@ def test_processing_chain():
     counter = count()
     workers = ["a", "b", "c"]
     npartitions = 5
+
+    # Test the processing chain with a dataframe that contains all possible dtypes
     df = pd.DataFrame(
         {
             f"col{next(counter)}": pd.array([True, False] * 50, dtype="bool"),
@@ -684,20 +686,22 @@ def test_processing_chain():
             # f"col{next(counter)}": pd.array(range(100), dtype="cdouble"),
             # f"col{next(counter)}": pd.array(range(100), dtype="clongdouble"),
             f"col{next(counter)}": pd.array(
-                [np.datetime64("2022-01-01")] * 100, dtype="datetime64"
+                [np.datetime64("2022-01-01") + i for i in range(100)],
+                dtype="datetime64",
             ),
             f"col{next(counter)}": pd.array(
-                [np.datetime64("2022-01-01")] * 100,
+                [np.datetime64("2022-01-01") + i for i in range(100)],
                 dtype=pd.DatetimeTZDtype(tz="UTC"),
             ),
             f"col{next(counter)}": pd.array(
-                [np.timedelta64(1, "D")] * 100, dtype="timedelta64"
+                [np.timedelta64(1, "D") + i for i in range(100)], dtype="timedelta64"
             ),
             f"col{next(counter)}": pd.array(
-                [pd.Period("2022-01-01", freq="D")] * 100, dtype="period[D]"
+                [pd.Period("2022-01-01", freq="D") + i for i in range(100)],
+                dtype="period[D]",
             ),
             f"col{next(counter)}": pd.array(
-                [pd.Interval(left=0, right=5)] * 100, dtype="Interval"
+                [pd.Interval(left=i, right=i + 2) for i in range(100)], dtype="Interval"
             ),
             f"col{next(counter)}": pd.array(range(100), dtype="Int8"),
             f"col{next(counter)}": pd.array(range(100), dtype="Int16"),

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -6,6 +6,7 @@ import os
 import random
 import shutil
 from collections import defaultdict
+from itertools import chain
 from typing import Any, Mapping
 from unittest import mock
 
@@ -661,7 +662,10 @@ def test_processing_chain():
     """
     workers = ["a", "b", "c"]
     npartitions = 5
-    df = pd.DataFrame({"x": range(100), "y": range(100)})
+    df = pd.DataFrame(
+        {"x": range(100), "y": range(100), "z": chain(range(50), range(50))}
+    )
+    df["z"] = df["z"].astype("category")
     df["_partitions"] = df.x % npartitions
     schema = pa.Schema.from_pandas(df)
     worker_for = {i: random.choice(workers) for i in list(range(npartitions))}

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -666,7 +666,6 @@ def test_processing_chain():
     workers = ["a", "b", "c"]
     npartitions = 5
 
-    # FIXME: csingle, cdouble, clongdouble, sparse and object not supported
     # Test the processing chain with a dataframe that contains all supported dtypes
     df = pd.DataFrame(
         {
@@ -690,6 +689,10 @@ def test_processing_chain():
             f"col{next(counter)}": pd.array(
                 [np.timedelta64(1, "D") + i for i in range(100)], dtype="timedelta64"
             ),
+            # FIXME: PyArrow does not support complex numbers: https://issues.apache.org/jira/browse/ARROW-638
+            # f"col{next(counter)}": pd.array(range(100), dtype="csingle"),
+            # f"col{next(counter)}": pd.array(range(100), dtype="cdouble"),
+            # f"col{next(counter)}": pd.array(range(100), dtype="clongdouble"),
             # Nullable dtypes
             f"col{next(counter)}": pd.array([True, False] * 50, dtype="boolean"),
             f"col{next(counter)}": pd.array(range(100), dtype="Int8"),
@@ -714,6 +717,11 @@ def test_processing_chain():
             ),
             f"col{next(counter)}": pd.array(["x", "y"] * 50, dtype="category"),
             f"col{next(counter)}": pd.array(["lorem ipsum"] * 100, dtype="string"),
+            # FIXME: PyArrow does not support sparse data: https://issues.apache.org/jira/browse/ARROW-8679
+            # f"col{next(counter)}": pd.array(
+            #     [np.nan, np.nan, 1.0, np.nan, np.nan] * 20,
+            #     dtype="Sparse[float64]",
+            # ),
             # PyArrow dtypes
             f"col{next(counter)}": pd.array([True, False] * 50, dtype="bool[pyarrow]"),
             f"col{next(counter)}": pd.array(range(100), dtype="int8[pyarrow]"),
@@ -738,6 +746,11 @@ def test_processing_chain():
             # f"col{next(counter)}": pd.array(
             #     ["lorem ipsum"] * 100,
             #     dtype=pd.StringDtype("pyarrow"),
+            # ),
+            # custom objects
+            # FIXME: Serializing custom objects is not supported in P2P shuffling
+            # f"col{next(counter)}": pd.array(
+            #     [Stub(i) for i in range(100)], dtype="object"
             # ),
         }
     )

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -657,6 +657,11 @@ def test_processing_chain():
     In practice this takes place on many different workers.
     Here we verify its accuracy in a single threaded situation.
     """
+
+    class Stub:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
     counter = count()
     workers = ["a", "b", "c"]
     npartitions = 5
@@ -709,7 +714,7 @@ def test_processing_chain():
             # ),
             f"col{next(counter)}": pd.array(["lorem ipsum"] * 100, dtype="string"),
             # f"col{next(counter)}": pd.array(
-            #     [object() for _ in range(100)], dtype="object"
+            #     [Stub(i) for i in range(100)], dtype="object"
             # ),
         }
     )


### PR DESCRIPTION
Closes #7400

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
