### PR TITLE
Revert "TST: Fetch executables from build root. (#2551)" 

### DIFF
--- a/distributed/cli/tests/test_dask_scheduler.py
+++ b/distributed/cli/tests/test_dask_scheduler.py
@@ -596,7 +596,7 @@ def test_signal_handling(loop, sig):
 
 
 @pytest.mark.skipif(WINDOWS, reason="POSIX only")
-def test_deprecated_single_executable(loop):
+def test_single_executable_deprecated(loop):
     port = open_port()
     with popen(
         [

--- a/distributed/cli/tests/test_tls_cli.py
+++ b/distributed/cli/tests/test_tls_cli.py
@@ -43,10 +43,13 @@ def test_basic(loop, requires_default_ports):
 
 def test_sni(loop):
     port = open_port()
-    with popen(["dask-scheduler", "--no-dashboard", f"--port={port}"] + tls_args) as s:
+    with popen(
+        ["dask", "scheduler", "--no-dashboard", f"--port={port}"] + tls_args
+    ) as s:
         with popen(
             [
-                "dask-worker",
+                "dask",
+                "worker",
                 "--no-dashboard",
                 "--scheduler-sni",
                 "localhost",

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3647,7 +3647,7 @@ async def test_reconnect():
     port = open_port()
 
     stack = ExitStack()
-    proc = popen(["dask-scheduler", "--no-dashboard", f"--port={port}"])
+    proc = popen(["dask", "scheduler", "--no-dashboard", f"--port={port}"])
     stack.enter_context(proc)
     async with Client(f"127.0.0.1:{port}", asynchronous=True) as c, Worker(
         f"127.0.0.1:{port}"
@@ -3666,7 +3666,7 @@ async def test_reconnect():
         with pytest.raises(CancelledError):
             await x
 
-        with popen(["dask-scheduler", "--no-dashboard", f"--port={port}"]):
+        with popen(["dask", "scheduler", "--no-dashboard", f"--port={port}"]):
             start = time()
             while c.status != "running":
                 await asyncio.sleep(0.1)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1233,9 +1233,7 @@ def popen(
     if sys.platform.startswith("win"):
         args[0] = os.path.join(sys.prefix, "Scripts", args[0])
     else:
-        args[0] = os.path.join(
-            os.environ.get("DESTDIR", "") + sys.prefix, "bin", args[0]
-        )
+        args[0] = os.path.join(sys.prefix, "bin", args[0])
     with subprocess.Popen(args, **kwargs) as proc:
         try:
             yield proc


### PR DESCRIPTION
The original PR #2551 was implemented (by myself for Fedora packaging) because tests were using distributed's to-be-installed CLI programs. In a `DESTDIR`-based install (i.e., during packaging), this meant they would not directly be in `sys.prefix`.

However, with #6735, the CLI programs are extensions of the `dask` CLI. This program _would_ be pre-installed to `sys.prefix` because it would be there as a dependency, and so tests should no longer apply `DESTDIR`.

The exception to this are the two tests that check the deprecated old CLI. In my case, I haven't completed packaging for Fedora, and don't need to worry about testing the deprecated CLI, so it's okay for me to break that.

Additionally, I have removed the remaining cases of using the deprecated CLI from tests, so that only the 'check deprecations' tests mentioned above use them.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
