### PR TITLE
Rename managed_in_memory etc. to match GUI

### DIFF
--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -95,9 +95,7 @@ class ActiveMemoryManagerExtension:
             )
         mem = scheduler.memory
         measure_domain = {
-            name
-            for name in dir(mem)
-            if not name.startswith("_") and isinstance(getattr(mem, name), int)
+            name for name in dir(mem) if not name.startswith("_") and name != "sum"
         }
         if not isinstance(measure, str) or measure not in measure_domain:
             raise ValueError(

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -400,10 +400,10 @@ class ClusterMemory(DashboardComponent, MemoryColor):
         color = self._cluster_memory_color()
 
         width = [
-            meminfo.managed_in_memory,
+            meminfo.managed,
             meminfo.unmanaged_old,
             meminfo.unmanaged_recent,
-            meminfo.managed_spilled,
+            meminfo.spilled,
         ]
 
         result = {
@@ -411,18 +411,18 @@ class ClusterMemory(DashboardComponent, MemoryColor):
             "x": [sum(width[:i]) + w / 2 for i, w in enumerate(width)],
             "color": [color, color, color, "grey"],
             "proc_memory": [meminfo.process] * 4,
-            "managed": [meminfo.managed_in_memory] * 4,
+            "managed": [meminfo.managed] * 4,
             "unmanaged_old": [meminfo.unmanaged_old] * 4,
             "unmanaged_recent": [meminfo.unmanaged_recent] * 4,
-            "spilled": [meminfo.managed_spilled] * 4,
+            "spilled": [meminfo.spilled] * 4,
         }
 
-        x_end = max(limit, meminfo.process + meminfo.managed_spilled)
+        x_end = max(limit, meminfo.process + meminfo.spilled)
         self.root.x_range.end = x_end
 
         title = f"Bytes stored: {format_bytes(meminfo.process)}"
-        if meminfo.managed_spilled:
-            title += f" + {format_bytes(meminfo.managed_spilled)} spilled to disk"
+        if meminfo.spilled:
+            title += f" + {format_bytes(meminfo.spilled)} spilled to disk"
         self.root.title.text = title
 
         update(self.source, result)
@@ -541,24 +541,24 @@ class WorkersMemory(DashboardComponent, MemoryColor):
         for ws in workers:
             meminfo = ws.memory
             limit = getattr(ws, "memory_limit", 0)
-            max_limit = max(max_limit, limit, meminfo.process + meminfo.managed_spilled)
+            max_limit = max(max_limit, limit, meminfo.process + meminfo.spilled)
             color_i = self._memory_color(meminfo.process, limit, ws.status)
 
             width += [
-                meminfo.managed_in_memory,
+                meminfo.managed,
                 meminfo.unmanaged_old,
                 meminfo.unmanaged_recent,
-                meminfo.managed_spilled,
+                meminfo.spilled,
             ]
             x += [sum(width[-4:i]) + width[i] / 2 for i in range(-4, 0)]
             color += [color_i, color_i, color_i, "grey"]
 
             # memory info
             procmemory.append(meminfo.process)
-            managed.append(meminfo.managed_in_memory)
+            managed.append(meminfo.managed)
             unmanaged_old.append(meminfo.unmanaged_old)
             unmanaged_recent.append(meminfo.unmanaged_recent)
-            spilled.append(meminfo.managed_spilled)
+            spilled.append(meminfo.spilled)
 
         result = {
             "width": width,
@@ -3539,7 +3539,7 @@ class WorkerTable(DashboardComponent):
             "memory",
             "memory_limit",
             "memory_percent",
-            "memory_managed_in_memory",
+            "memory_managed",
             "memory_unmanaged_old",
             "memory_unmanaged_recent",
             "memory_spilled",
@@ -3569,7 +3569,7 @@ class WorkerTable(DashboardComponent):
             "memory",
             "memory_limit",
             "memory_percent",
-            "memory_managed_in_memory",
+            "memory_managed",
             "memory_unmanaged_old",
             "memory_unmanaged_recent",
             "memory_spilled",
@@ -3582,7 +3582,7 @@ class WorkerTable(DashboardComponent):
         column_title_renames = {
             "memory_limit": "limit",
             "memory_percent": "memory %",
-            "memory_managed_in_memory": "managed",
+            "memory_managed": "managed",
             "memory_unmanaged_old": "unmanaged old",
             "memory_unmanaged_recent": "unmanaged recent",
             "memory_spilled": "spilled",
@@ -3605,7 +3605,7 @@ class WorkerTable(DashboardComponent):
             "memory_percent": NumberFormatter(format="0.0 %"),
             "memory": NumberFormatter(format="0.0 b"),
             "memory_limit": NumberFormatter(format="0.0 b"),
-            "memory_managed_in_memory": NumberFormatter(format="0.0 b"),
+            "memory_managed": NumberFormatter(format="0.0 b"),
             "memory_unmanaged_old": NumberFormatter(format="0.0 b"),
             "memory_unmanaged_recent": NumberFormatter(format="0.0 b"),
             "memory_spilled": NumberFormatter(format="0.0 b"),
@@ -3748,11 +3748,11 @@ class WorkerTable(DashboardComponent):
             else:
                 data["memory_percent"][-1] = ""
             data["memory_limit"][-1] = ws.memory_limit
-            data["memory_managed_in_memory"][-1] = minfo.managed_in_memory
+            data["memory_managed"][-1] = minfo.managed
             data["memory_unmanaged_old"][-1] = minfo.unmanaged_old
             data["memory_unmanaged_recent"][-1] = minfo.unmanaged_recent
             data["memory_unmanaged_recent"][-1] = minfo.unmanaged_recent
-            data["memory_spilled"][-1] = minfo.managed_spilled
+            data["memory_spilled"][-1] = minfo.spilled
             data["cpu"][-1] = ws.metrics["cpu"] / 100.0
             data["cpu_fraction"][-1] = ws.metrics["cpu"] / 100.0 / ws.nthreads
             data["nthreads"][-1] = ws.nthreads

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -321,8 +321,8 @@ async def test_WorkersMemory(c, s, a, b):
     cl.update()
     d = dict(cl.source.data)
     llens = {len(l) for l in d.values()}
-    # There are 2 workers. There is definitely going to be managed_in_memory and
-    # unmanaged_old; there may be unmanaged_new. There won't be managed_spilled.
+    # There are 2 workers. There is definitely going to be managed and
+    # unmanaged_old; there may be unmanaged_new. There won't be spilled.
     # Empty rects are removed.
     assert llens in ({4}, {5}, {6})
     assert all(d["width"])
@@ -340,8 +340,8 @@ async def test_ClusterMemory(c, s, a, b):
     llens = {len(l) for l in d.values()}
     # Unlike WorkersMemory, empty rects here aren't pruned away.
     assert llens == {4}
-    # There is definitely going to be managed_in_memory and
-    # unmanaged_old; there may be unmanaged_new. There won't be managed_spilled.
+    # There is definitely going to be managed and
+    # unmanaged_old; there may be unmanaged_new. There won't be spilled.
     assert any(d["width"])
     assert not all(d["width"])
 

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -299,7 +299,7 @@ properties:
                   - process
                   - optimistic
                   - managed
-                  - managed_in_memory
+                  - managed_total
                 description:
                   One of the attributes of distributed.scheduler.MemoryState
               policies:
@@ -508,7 +508,7 @@ properties:
                       - process
                       - optimistic
                       - managed
-                      - managed_in_memory
+                      - managed_total
                     description: >-
                       Which of the properties of distributed.scheduler.MemoryState
                       should be used for measuring worker memory usage

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -121,7 +121,7 @@ distributed:
         #     Managed by dask (instantaneous) + unmanaged (without any increases
         #     happened in the last <distributed.worker.memory.recent-to-old-time>).
         #     Recommended for use on CPython with large (2MiB+) numpy-based data chunks.
-        # managed_in_memory
+        # managed
         #     Only consider the data allocated by dask in RAM. Recommended if RAM is not
         #     released in a timely fashion back to the OS after the Python objects are
         #     dereferenced, but remains available for reuse by PyMalloc.
@@ -131,7 +131,7 @@ distributed:
         #     underscore) to a low value; refer to the mallopt man page and to the
         #     comments about M_TRIM_THRESHOLD on
         #     https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c
-        # managed
+        # managed_total
         #     Only consider data allocated by dask, including that spilled to disk.
         #     Recommended if disk occupation of the spill file is an issue.
         measure: optimistic

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -357,6 +357,16 @@ class MemoryState:
     def optimistic(self) -> int:
         return self.managed + self.unmanaged_old
 
+    @property
+    def managed_in_memory(self) -> int:
+        warnings.warn("managed_in_memory has been renamed to managed", FutureWarning)
+        return self.managed
+
+    @property
+    def managed_spilled(self) -> int:
+        warnings.warn("managed_spilled has been renamed to spilled", FutureWarning)
+        return self.spilled
+
     def __repr__(self) -> str:
         return (
             f"Process memory (RSS)  : {format_bytes(self.process)}\n"

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -378,14 +378,18 @@ class MemoryState:
 
     def _to_dict(self, *, exclude: Container[str] = ()) -> dict:
         """Dictionary representation for debugging purposes.
-        Not type stable and not intended for roundtrips.
 
         See also
         --------
         Client.dump_cluster_state
         distributed.utils.recursive_to_dict
         """
-        return recursive_to_dict(self, exclude=exclude, members=True)
+        return {
+            k: getattr(self, k)
+            for k in dir(self)
+            if not k.startswith("_")
+            and k not in {"sum", "managed_in_memory", "managed_spilled"}
+        }
 
 
 class WorkerState:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -252,26 +252,26 @@ class MemoryState:
 
     Attributes / properties:
 
-    managed
+    managed_total
         Sum of the output of sizeof() for all dask keys held by the worker in memory,
         plus number of bytes spilled to disk
 
-    managed_in_memory
+    managed
         Sum of the output of sizeof() for the dask keys held in RAM. Note that this may
         be inaccurate, which may cause inaccurate unmanaged memory (see below).
 
-    managed_spilled
+    spilled
         Number of bytes  for the dask keys spilled to the hard drive.
         Note that this is the size on disk; size in memory may be different due to
         compression and inaccuracies in sizeof(). In other words, given the same keys,
-        'managed' will change depending if the keys are in memory or spilled.
+        'managed' will change depending on the keys being in memory or spilled.
 
     process
         Total RSS memory measured by the OS on the worker process.
-        This is always exactly equal to managed_in_memory + unmanaged.
+        This is always exactly equal to managed + unmanaged.
 
     unmanaged
-        process - managed_in_memory. This is the sum of
+        process - managed. This is the sum of
 
         - Python interpreter and modules
         - global variables
@@ -291,33 +291,15 @@ class MemoryState:
         spike.
 
     optimistic
-        managed_in_memory + unmanaged_old; in other words the memory held long-term by
+        managed + unmanaged_old; in other words the memory held long-term by
         the process under the hopeful assumption that all unmanaged_recent memory is a
         temporary spike
-
-    .. note::
-        There is an intentional misalignment in terminology between this class (which is
-        meant for internal / programmatic use) and the memory readings on the GUI (which
-        is aimed at the general public:
-
-        ================= =====================
-        MemoryState       GUI
-        ================= =====================
-        managed           n/a
-        managed_in_memory managed
-        managed_spilled   spilled
-        process           process (RSS); memory
-        unmanaged         n/a
-        unmanaged_old     unmanaged (old)
-        unmanaged_recent  unmanaged (recent)
-        optimistic        n/a
-        ================= =====================
     """
 
     process: int
     unmanaged_old: int
-    managed_in_memory: int
-    managed_spilled: int
+    managed: int
+    spilled: int
 
     __slots__ = tuple(__annotations__)
 
@@ -326,62 +308,62 @@ class MemoryState:
         *,
         process: int,
         unmanaged_old: int,
-        managed_in_memory: int,
-        managed_spilled: int,
+        managed: int,
+        spilled: int,
     ):
         # Some data arrives with the heartbeat, some other arrives in realtime as the
         # tasks progress. Also, sizeof() is not guaranteed to return correct results.
         # This can cause glitches where a partial measure is larger than the whole, so
         # we need to force all numbers to add up exactly by definition.
         self.process = process
-        self.managed_in_memory = min(self.process, managed_in_memory)
-        self.managed_spilled = managed_spilled
+        self.managed = min(self.process, managed)
+        self.spilled = spilled
         # Subtractions between unsigned ints guaranteed by construction to be >= 0
-        self.unmanaged_old = min(unmanaged_old, process - self.managed_in_memory)
+        self.unmanaged_old = min(unmanaged_old, process - self.managed)
 
     @staticmethod
     def sum(*infos: MemoryState) -> MemoryState:
         process = 0
         unmanaged_old = 0
-        managed_in_memory = 0
-        managed_spilled = 0
+        managed = 0
+        spilled = 0
         for ms in infos:
             process += ms.process
             unmanaged_old += ms.unmanaged_old
-            managed_spilled += ms.managed_spilled
-            managed_in_memory += ms.managed_in_memory
+            spilled += ms.spilled
+            managed += ms.managed
         return MemoryState(
             process=process,
             unmanaged_old=unmanaged_old,
-            managed_in_memory=managed_in_memory,
-            managed_spilled=managed_spilled,
+            managed=managed,
+            spilled=spilled,
         )
 
     @property
-    def managed(self) -> int:
-        return self.managed_in_memory + self.managed_spilled
+    def managed_total(self) -> int:
+        return self.managed + self.spilled
 
     @property
     def unmanaged(self) -> int:
         # This is never negative thanks to __init__
-        return self.process - self.managed_in_memory
+        return self.process - self.managed
 
     @property
     def unmanaged_recent(self) -> int:
         # This is never negative thanks to __init__
-        return self.process - self.managed_in_memory - self.unmanaged_old
+        return self.process - self.managed - self.unmanaged_old
 
     @property
     def optimistic(self) -> int:
-        return self.managed_in_memory + self.unmanaged_old
+        return self.managed + self.unmanaged_old
 
     def __repr__(self) -> str:
         return (
             f"Process memory (RSS)  : {format_bytes(self.process)}\n"
-            f"  - managed by Dask   : {format_bytes(self.managed_in_memory)}\n"
+            f"  - managed by Dask   : {format_bytes(self.managed)}\n"
             f"  - unmanaged (old)   : {format_bytes(self.unmanaged_old)}\n"
             f"  - unmanaged (recent): {format_bytes(self.unmanaged_recent)}\n"
-            f"Spilled to disk       : {format_bytes(self.managed_spilled)}\n"
+            f"Spilled to disk       : {format_bytes(self.spilled)}\n"
         )
 
     def _to_dict(self, *, exclude: Container[str] = ()) -> dict:
@@ -622,25 +604,23 @@ class WorkerState:
         from optimistic memory, which is used for heuristics.
 
         Something that is less OK, but also less frequent, is that the sudden deletion
-        of spilled keys will cause a negative blip of managed_in_memory:
+        of spilled keys will cause a negative blip in managed memory:
 
         1. Delete 100MB of spilled data
         2. The updated managed memory *total* reaches the scheduler faster than the
            updated spilled portion
-        3. This causes managed_in_memory to temporarily plummet and be replaced by
-           unmanaged_recent, while managed_spilled remains unaltered
-        4. When the heartbeat arrives, managed_in_memory goes back up, unmanaged_recent
-           goes back down, and managed_spilled goes down by 100MB as it should have to
+        3. This causes the managed memory to temporarily plummet and be replaced by
+           unmanaged_recent, while spilled memory remains unaltered
+        4. When the heartbeat arrives, managed goes back up, unmanaged_recent
+           goes back down, and spilled goes down by 100MB as it should have to
            begin with.
 
         https://github.com/dask/distributed/issues/6002 will let us solve this.
         """
         return MemoryState(
             process=self.metrics["memory"],
-            managed_in_memory=max(
-                0, self.nbytes - self.metrics["spilled_bytes"]["memory"]
-            ),
-            managed_spilled=self.metrics["spilled_bytes"]["disk"],
+            managed=max(0, self.nbytes - self.metrics["spilled_bytes"]["memory"]),
+            spilled=self.metrics["spilled_bytes"]["disk"],
             unmanaged_old=self._memory_unmanaged_old,
         )
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3012,9 +3012,23 @@ def test_memorystate_adds_up(process, unmanaged_old, managed, spilled):
         spilled=spilled,
     )
     assert m.managed + m.unmanaged == m.process
-    assert m.managed + m.spilled == m.managed
+    assert m.managed + m.spilled == m.managed_total
     assert m.unmanaged_old + m.unmanaged_recent == m.unmanaged
     assert m.optimistic + m.unmanaged_recent == m.process
+
+
+def test_memorystate__to_dict():
+    m = MemoryState(process=11, unmanaged_old=2, managed=3, spilled=1)
+    assert m._to_dict() == {
+        "managed": 3,
+        "managed_total": 4,
+        "optimistic": 5,
+        "process": 11,
+        "spilled": 1,
+        "unmanaged": 8,
+        "unmanaged_old": 2,
+        "unmanaged_recent": 6,
+    }
 
 
 _test_leak = []

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2960,6 +2960,11 @@ def test_memorystate():
     assert m.unmanaged_recent == 17
     assert m.optimistic == 83
 
+    with pytest.warns(FutureWarning):
+        assert m.managed_spilled == m.spilled
+    with pytest.warns(FutureWarning):
+        assert m.managed_in_memory == m.managed
+
     assert (
         repr(m)
         == dedent(

--- a/docs/source/worker-memory.rst
+++ b/docs/source/worker-memory.rst
@@ -121,10 +121,10 @@ unmanaged recent
     the ``~/.config/dask/distributed.yaml`` file. If your tasks typically run for longer
     than 30 seconds, it's recommended that you increase this setting accordingly.
 
-    By default, :meth:`distributed.Client.rebalance` and
-    :meth:`distributed.scheduler.Scheduler.rebalance` ignore unmanaged recent memory.
-    This behaviour can also be tweaked using the Dask config - see the methods'
-    documentation.
+    By default, :meth:`distributed.Client.rebalance`,
+    :meth:`distributed.scheduler.Scheduler.rebalance`, and the
+    :doc:`active_memory_manager` ignore unmanaged recent memory. This behaviour can also
+    be tweaked using the Dask config - see the specific components' documentation.
 
 spilled
     managed memory that has been spilled to disk. This is not included in the 'managed'
@@ -158,10 +158,11 @@ Dask — it's actually normal behavior for all processes on Linux and MacOS, and
 consequence of how the low-level memory allocator works (see below for details).
 
 Because Dask makes decisions (spill-to-disk, pause, terminate,
-:meth:`~distributed.Client.rebalance`) based on the worker's memory usage as reported by
-the OS, and is unaware of how much of this memory is actually in use versus empty and
-"hoarded", it can overestimate — sometimes significantly — how much memory the process
-is using and think the worker is running out of memory when in fact it isn't.
+:doc:`active_memory_manager`, :meth:`~distributed.Client.rebalance`) based on the
+worker's memory usage as reported by the OS, and is unaware of how much of this memory
+is actually in use versus empty and "hoarded", it can overestimate — sometimes
+significantly — how much memory the process is using and think the worker is running out
+of memory when in fact it isn't.
 
 More in detail: both the Linux and MacOS memory allocators try to avoid performing a
 `brk`_ kernel call every time the application calls `free`_ by implementing a user-space
@@ -259,10 +260,14 @@ in its decision-making:
 .. code-block:: yaml
 
    distributed:
+     scheduler:
+       active-memory-manager:
+         measure: managed
+
      worker:
        memory:
          rebalance:
-           measure: managed_in_memory
+           measure: managed
          spill: false
          pause: false
          terminate: false


### PR DESCRIPTION
Memory types in the implementation and in the config file are misaligned to the GUI. This causes a great deal of confusion, particularly considering that the config is exposed to the end users.

Rename implementation and dask config to match the GUI:

managed_in_memory -> managed
managed_spilled -> spilled
managed -> managed_total

Also document that the Active Memory Manager uses optimistic memory in the worker memory docs.