### PR TITLE
Ignore numpy bool8 deprecation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,7 @@ filterwarnings =
     ignore:(?s)Exception ignored in. <function Client\.__del__.*RuntimeError. IOLoop is closed:pytest.PytestUnraisableExceptionWarning
     ignore:notifyAll\(\) is deprecated, use notify_all\(\) instead:DeprecationWarning:paramiko
     ignore:setDaemon\(\) is deprecated, set the daemon attribute instead:DeprecationWarning:paramiko
+    ignore:`np.bool8` is a deprecated alias for `np.bool_`
 minversion = 6
 markers =
     ci1: marks tests as belonging to 1 out of 2 partitions to run on CI ('-m "not ci1"' for second partition)


### PR DESCRIPTION
Fixes https://github.com/dask/distributed/issues/7422

Fixed upstream in https://github.com/bokeh/bokeh/issues/12689

This is killing CI right now.  A PR is submitted upstream.  We should revert that once that change is released.