### PR TITLE
Avoid overflow in `statitics.mean`

### DIFF
--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import weakref
-from statistics import mean
 
 import tlz as toolz
 from bokeh.core.properties import without_property_validation
@@ -559,6 +558,9 @@ class SystemMonitor(DashboardComponent):
     @without_property_validation
     @log_errors
     def update(self):
+        def mean(x):
+            return sum(x) / len(x)
+
         self.source.stream(self.get_data(), 1000)
         self.label_source.data["cpu"] = [
             "{}: {:.1f}%".format(f.__name__, f(self.source.data["cpu"]))


### PR DESCRIPTION
I don't know why, but for some reason statistics.mean was overflowing in CI.  See https://github.com/dask/distributed/actions/runs/3741526593/jobs/6351258185

I'm trying a naive implementation instead.  It also happens to be faster and simpler.

```python
In [1]: from statistics import mean

In [2]: x = list(range(1000))

In [3]: %timeit mean(x)
196 µs ± 777 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [4]: %timeit sum(x) / len(x)
4.82 µs ± 15.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
