### PR TITLE
Add `dask spec` CLI

### DIFF
--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -64,6 +64,7 @@ test:
     - dask scheduler --help
     - dask ssh --help
     - dask worker --help
+    - dask spec --help
   requires:
     - pip
 

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -134,7 +134,7 @@ def main(
     jupyter,
     **kwargs,
 ):
-    """Launch a distributed scheduler."""
+    """Launch a Dask scheduler."""
 
     if "dask-scheduler" in sys.argv[0]:
         warnings.warn(

--- a/distributed/cli/dask_spec.py
+++ b/distributed/cli/dask_spec.py
@@ -16,6 +16,7 @@ from distributed.deploy.spec import run_spec
 @click.option("--spec-file", type=str, default=None, help="")
 @click.version_option()
 def main(args: list, spec: str, spec_file: str) -> None:
+    """Launch a Dask process defined by a JSON/YAML specification"""
 
     if spec and spec_file or not spec and not spec_file:
         print("Must specify exactly one of --spec and --spec-file")

--- a/distributed/cli/dask_spec.py
+++ b/distributed/cli/dask_spec.py
@@ -10,7 +10,7 @@ import yaml
 from distributed.deploy.spec import run_spec
 
 
-@click.command(context_settings=dict(ignore_unknown_options=True))
+@click.command(name="spec", context_settings=dict(ignore_unknown_options=True))
 @click.argument("args", nargs=-1)
 @click.option("--spec", type=str, default="", help="")
 @click.option("--spec-file", type=str, default=None, help="")

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("distributed.dask_ssh")
 @click.command(
     name="ssh",
     help=dedent(
-        """Launch a distributed cluster over SSH. A 'dask scheduler' process will run on the
+        """Launch a Dask cluster over SSH. A 'dask scheduler' process will run on the
         first host specified in [HOSTNAMES] or in the hostfile, unless --scheduler is specified
         explicitly. One or more 'dask worker' processes will be run on each host. Use the flag
         --nworkers to adjust how many dask worker process are run on each host and the flag

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -260,7 +260,7 @@ def main(  # type: ignore[no-untyped-def]
     preload_nanny,
     **kwargs,
 ):
-    """Launch a distributed worker attached to an existing SCHEDULER."""
+    """Launch a Dask worker attached to an existing scheduler"""
 
     if "dask-worker" in sys.argv[0]:
         warnings.warn(

--- a/distributed/cli/tests/test_dask_spec.py
+++ b/distributed/cli/tests/test_dask_spec.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-
 import yaml
 
 from distributed import Client
@@ -14,18 +12,16 @@ async def test_text():
     port = open_port()
     with popen(
         [
-            sys.executable,
-            "-m",
-            "distributed.cli.dask_spec",
+            "dask",
+            "spec",
             "--spec",
             '{"cls": "dask.distributed.Scheduler", "opts": {"port": %d}}' % port,
         ]
     ):
         with popen(
             [
-                sys.executable,
-                "-m",
-                "distributed.cli.dask_spec",
+                "dask",
+                "spec",
                 "tcp://localhost:%d" % port,
                 "--spec",
                 '{"cls": "dask.distributed.Worker", "opts": {"nanny": false, "nthreads": 3, "name": "foo"}}',
@@ -52,9 +48,8 @@ async def test_file(c, s, tmp_path):
         )
     with popen(
         [
-            sys.executable,
-            "-m",
-            "distributed.cli.dask_spec",
+            "dask",
+            "spec",
             s.address,
             "--spec-file",
             fn,
@@ -70,9 +65,8 @@ async def test_file(c, s, tmp_path):
 def test_errors():
     with popen(
         [
-            sys.executable,
-            "-m",
-            "distributed.cli.dask_spec",
+            "dask",
+            "spec",
             "--spec",
             '{"foo": "bar"}',
             "--spec-file",
@@ -84,10 +78,7 @@ def test_errors():
         assert "exactly one" in line
         assert "--spec" in line and "--spec-file" in line
 
-    with popen(
-        [sys.executable, "-m", "distributed.cli.dask_spec"],
-        capture_output=True,
-    ) as proc:
+    with popen(["dask", "spec"], capture_output=True) as proc:
         line = proc.stdout.readline().decode()
         assert "exactly one" in line
         assert "--spec" in line and "--spec-file" in line

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         scheduler=distributed.cli.dask_scheduler:main
         worker=distributed.cli.dask_worker:main
         ssh=distributed.cli.dask_ssh:main
+        spec=distributed.cli.dask_spec:main
       """,
     # https://mypy.readthedocs.io/en/latest/installed_packages.html
     zip_safe=False,


### PR DESCRIPTION
Previously we would always use `python -m distributed.cli.dask_spec` because we thought of dask-spec as being internal facing.  It's getting more use in the wild now so we should probably broadcast it a bit more. I'm more comfortable filling up the `dask` CLI namespace than the global namespace with `dask-spec`.

cc @douglasdavis if you have time to review