### PR TITLE
Stop `Client` periodic callbacks during `shutdown()`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1731,6 +1731,9 @@ class Client(SyncMethodMixin):
 
     async def _shutdown(self):
         logger.info("Shutting down scheduler from Client")
+
+        for pc in self._periodic_callbacks.values():
+            pc.stop()
         if self.cluster:
             await self.cluster.close()
         else:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6311,6 +6311,15 @@ async def test_shutdown_localcluster():
 
 
 @gen_test()
+async def test_shutdown_is_clean():
+    async with Scheduler(dashboard_address=":0") as s:
+        async with Worker(s.address) as w:
+            async with Client(s.address, asynchronous=True) as c:
+                await c.shutdown()
+                assert not any(pc.is_running() for pc in c._periodic_callbacks.values())
+
+
+@gen_test()
 async def test_config_inherited_by_subprocess():
     with dask.config.set(foo=100):
         async with LocalCluster(


### PR DESCRIPTION
Currently `Client.shutdown()` doesn't stop periodic callbacks that talk to the scheduler

https://github.com/dask/distributed/blob/83bb08024a7c72ec3b074206d797dbeb0ce444aa/distributed/client.py#L940-L946

which result in a bunch of noise in user's Python session 

```python
In [1]: from distributed import Client

In [2]: c = Client("localhost:8786")

In [3]: c.shutdown()

In [4]: 2022-12-21 11:37:55,652 - tornado.application - ERROR - Exception in callback <bound method Client._heartbeat of <Client: 'tcp://192.168.1.163:8786' processes=1 threads=8, memory=16.00 GiB>>
Traceback (most recent call last):
  File "/Users/james/projects/dask/distributed/distributed/compatibility.py", line 161, in _run
    val = self.callback()
  File "/Users/james/projects/dask/distributed/distributed/client.py", line 1445, in _heartbeat
    self.scheduler_comm.send({"op": "heartbeat-client"})
  File "/Users/james/projects/dask/distributed/distributed/batched.py", line 156, in send
    raise CommClosedError(f"Comm {self.comm!r} already closed.")
distributed.comm.core.CommClosedError: Comm <TCP (closed) Client->Scheduler local=tcp://[::1]:64081 remote=tcp://localhost:8786> already closed.
2022-12-21 11:38:00,653 - tornado.application - ERROR - Exception in callback <bound method Client._heartbeat of <Client: 'tcp://192.168.1.163:8786' processes=1 threads=8, memory=16.00 GiB>>
Traceback (most recent call last):
  File "/Users/james/projects/dask/distributed/distributed/compatibility.py", line 161, in _run
    val = self.callback()
  File "/Users/james/projects/dask/distributed/distributed/client.py", line 1445, in _heartbeat
    self.scheduler_comm.send({"op": "heartbeat-client"})
  File "/Users/james/projects/dask/distributed/distributed/batched.py", line 156, in send
    raise CommClosedError(f"Comm {self.comm!r} already closed.")
distributed.comm.core.CommClosedError: Comm <TCP (closed) Client->Scheduler local=tcp://[::1]:64081 remote=tcp://localhost:8786> already closed.
2022-12-21 11:38:05,652 - tornado.application - ERROR - Exception in callback <bound method Client._heartbeat of <Client: 'tcp://192.168.1.163:8786' processes=1 threads=8, memory=16.00 GiB>>
Traceback (most recent call last):
  File "/Users/james/projects/dask/distributed/distributed/compatibility.py", line 161, in _run
    val = self.callback()
  File "/Users/james/projects/dask/distributed/distributed/client.py", line 1445, in _heartbeat
    self.scheduler_comm.send({"op": "heartbeat-client"})
  File "/Users/james/projects/dask/distributed/distributed/batched.py", line 156, in send
    raise CommClosedError(f"Comm {self.comm!r} already closed.")
...
...
...
```

due to `shutdown()` closing the scheduler (and workers) the client is connected to. 

There's probably more we can do here https://github.com/dask/distributed/issues/7192#issuecomment-1292601669, but this seems like a reasonable first step. 

cc @kmpaul and @dchudz who have run into this 