### PR TITLE
Ensure client session is quiet after `cluster.close()` or `client.shutdown()`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1511,10 +1511,10 @@ class Client(SyncMethodMixin):
                     if is_python_shutting_down():
                         return
                     if self.status == "running":
-                        # Don't attempt to reconnect if scheduler comm or cluster are already closed
-                        if self.scheduler_comm.comm.closed() or (
-                            self.cluster
-                            and self.cluster.status in (Status.closed, Status.closing)
+                        # Don't attempt to reconnect if cluster are already closed
+                        if self.cluster and self.cluster.status in (
+                            Status.closed,
+                            Status.closing,
                         ):
                             return
                         logger.info("Client report stream closed to scheduler")

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from collections.abc import Collection, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures._base import DoneAndNotDoneFutures
-from contextlib import contextmanager, suppress
+from contextlib import asynccontextmanager, contextmanager, suppress
 from contextvars import ContextVar
 from functools import partial
 from importlib.metadata import PackageNotFoundError, version
@@ -1286,6 +1286,9 @@ class Client(SyncMethodMixin):
     @log_errors
     async def _reconnect(self):
         assert self.scheduler_comm.comm.closed()
+        # Don't attempt to reconnect if cluster is already closed
+        if self.cluster and self.cluster.status in (Status.closed, Status.closing):
+            return
 
         self.status = "connecting"
         self.scheduler_comm = None
@@ -1441,7 +1444,10 @@ class Client(SyncMethodMixin):
         return self.sync(self._wait_for_workers, n_workers, timeout=timeout)
 
     def _heartbeat(self):
-        if self.scheduler_comm:
+        # Don't send heartbeat if scheduler comm or cluster are already closed
+        if (self.scheduler_comm and not self.scheduler_comm.comm.closed()) or (
+            self.cluster and self.cluster.status not in (Status.closed, Status.closing)
+        ):
             self.scheduler_comm.send({"op": "heartbeat-client"})
 
     def __enter__(self):
@@ -1505,6 +1511,12 @@ class Client(SyncMethodMixin):
                     if is_python_shutting_down():
                         return
                     if self.status == "running":
+                        # Don't attempt to reconnect if scheduler comm or cluster are already closed
+                        if self.scheduler_comm.comm.closed() or (
+                            self.cluster
+                            and self.cluster.status in (Status.closed, Status.closing)
+                        ):
+                            return
                         logger.info("Client report stream closed to scheduler")
                         logger.info("Reconnecting...")
                         self.status = "connecting"
@@ -1538,7 +1550,7 @@ class Client(SyncMethodMixin):
                         logger.exception(e)
                 if breakout:
                     break
-        except CancelledError:
+        except (CancelledError, asyncio.CancelledError):
             pass
 
     def _handle_key_in_memory(self, key=None, type=None, workers=None):
@@ -1588,6 +1600,25 @@ class Client(SyncMethodMixin):
         logger.warning("Scheduler exception:")
         logger.exception(exception)
 
+    @asynccontextmanager
+    async def _wait_for_handle_report_task(self, fast=False):
+        current_task = asyncio.current_task()
+        handle_report_task = self._handle_report_task
+        # Give the scheduler 'stream-closed' message 100ms to come through
+        # This makes the shutdown slightly smoother and quieter
+        if handle_report_task is not None and handle_report_task is not current_task:
+            with suppress(asyncio.CancelledError, TimeoutError):
+                await asyncio.wait_for(asyncio.shield(handle_report_task), 0.1)
+
+            yield
+
+            if (
+                handle_report_task is not None
+                and handle_report_task is not current_task
+            ):
+                with suppress(TimeoutError, asyncio.CancelledError):
+                    await asyncio.wait_for(handle_report_task, 0 if fast else 2)
+
     async def _close(self, fast=False):
         """
         Send close signal and wait until scheduler completes
@@ -1627,45 +1658,27 @@ class Client(SyncMethodMixin):
             ):
                 self._send_to_scheduler({"op": "close-client"})
                 self._send_to_scheduler({"op": "close-stream"})
+            async with self._wait_for_handle_report_task(fast=fast):
+                if (
+                    self.scheduler_comm
+                    and self.scheduler_comm.comm
+                    and not self.scheduler_comm.comm.closed()
+                ):
+                    await self.scheduler_comm.close()
 
-            current_task = asyncio.current_task()
-            handle_report_task = self._handle_report_task
-            # Give the scheduler 'stream-closed' message 100ms to come through
-            # This makes the shutdown slightly smoother and quieter
-            if (
-                handle_report_task is not None
-                and handle_report_task is not current_task
-            ):
-                with suppress(asyncio.CancelledError, TimeoutError):
-                    await asyncio.wait_for(asyncio.shield(handle_report_task), 0.1)
+                for key in list(self.futures):
+                    self._release_key(key=key)
 
-            if (
-                self.scheduler_comm
-                and self.scheduler_comm.comm
-                and not self.scheduler_comm.comm.closed()
-            ):
-                await self.scheduler_comm.close()
+                if self._start_arg is None:
+                    with suppress(AttributeError):
+                        await self.cluster.close()
 
-            for key in list(self.futures):
-                self._release_key(key=key)
+                await self.rpc.close()
 
-            if self._start_arg is None:
-                with suppress(AttributeError):
-                    await self.cluster.close()
+                self.status = "closed"
 
-            await self.rpc.close()
-
-            self.status = "closed"
-
-            if _get_global_client() is self:
-                _set_global_client(None)
-
-            if (
-                handle_report_task is not None
-                and handle_report_task is not current_task
-            ):
-                with suppress(TimeoutError, asyncio.CancelledError):
-                    await asyncio.wait_for(handle_report_task, 0 if fast else 2)
+                if _get_global_client() is self:
+                    _set_global_client(None)
 
             with suppress(AttributeError):
                 await self.scheduler.close_rpc()
@@ -1732,14 +1745,16 @@ class Client(SyncMethodMixin):
     async def _shutdown(self):
         logger.info("Shutting down scheduler from Client")
 
+        self.status = "closing"
         for pc in self._periodic_callbacks.values():
             pc.stop()
-        if self.cluster:
-            await self.cluster.close()
-        else:
-            with suppress(CommClosedError):
-                self.status = "closing"
-                await self.scheduler.terminate()
+
+        async with self._wait_for_handle_report_task(fast=True):
+            if self.cluster:
+                await self.cluster.close()
+            else:
+                with suppress(CommClosedError):
+                    await self.scheduler.terminate()
 
     def shutdown(self):
         """Shut down the connected scheduler and workers

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1749,12 +1749,14 @@ class Client(SyncMethodMixin):
         for pc in self._periodic_callbacks.values():
             pc.stop()
 
-        async with self._wait_for_handle_report_task(fast=True):
+        async with self._wait_for_handle_report_task():
             if self.cluster:
                 await self.cluster.close()
             else:
                 with suppress(CommClosedError):
                     await self.scheduler.terminate()
+
+        await self._close()
 
     def shutdown(self):
         """Shut down the connected scheduler and workers

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6297,6 +6297,7 @@ async def test_shutdown():
 
                 assert s.status == Status.closed
                 assert w.status in {Status.closed, Status.closing}
+                assert c.status == "closed"
 
 
 @gen_test()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6309,6 +6309,8 @@ async def test_shutdown_localcluster():
             await c.shutdown()
 
         assert lc.scheduler.status == Status.closed
+        assert lc.status == Status.closed
+        assert c.status == "closed"
 
 
 @gen_test()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6311,12 +6311,39 @@ async def test_shutdown_localcluster():
 
 
 @gen_test()
-async def test_shutdown_is_clean():
+async def test_shutdown_stops_callbacks():
     async with Scheduler(dashboard_address=":0") as s:
         async with Worker(s.address) as w:
             async with Client(s.address, asynchronous=True) as c:
                 await c.shutdown()
                 assert not any(pc.is_running() for pc in c._periodic_callbacks.values())
+
+
+@gen_test()
+async def test_shutdown_is_quiet_with_cluster():
+    async with LocalCluster(
+        n_workers=1, asynchronous=True, processes=False, dashboard_address=":0"
+    ) as cluster:
+        with captured_logger(logging.getLogger("distributed.client")) as logger:
+            timeout = 0.1
+            async with Client(cluster, asynchronous=True, timeout=timeout) as c:
+                await c.shutdown()
+                await asyncio.sleep(timeout)
+            msg = logger.getvalue().strip()
+            assert msg == "Shutting down scheduler from Client", msg
+
+
+@gen_test()
+async def test_client_is_quiet_cluster_close():
+    async with LocalCluster(
+        n_workers=1, asynchronous=True, processes=False, dashboard_address=":0"
+    ) as cluster:
+        with captured_logger(logging.getLogger("distributed.client")) as logger:
+            timeout = 0.1
+            async with Client(cluster, asynchronous=True, timeout=timeout) as c:
+                await cluster.close()
+                await asyncio.sleep(timeout)
+            assert not logger.getvalue().strip()
 
 
 @gen_test()


### PR DESCRIPTION
This is a follow-up on https://github.com/dask/distributed/pull/7428. Frequently I see users do the following in a notebook

```python
cluster = ...  # Provision some cluster with dask-kubernetes, dask-cloudprovider, coiled, etc.
client = Client(cluster)
...  # do work
cluster.close() 
```

And then after a few seconds an error is printed (highlighted in red) in their notebook

```
distributed.client - ERROR - Failed to reconnect to scheduler after 30.00 seconds, closing client
```

The same type of thing can happen when using `client.shutdown()` instead of `cluster.close()`. 

This PR adds logic to determine if the scheduler/cluster is closing/has already been closed and, if so, don't attempt to reconnect the client to the scheduler, heartbeat, etc. The goal is to avoid scary errors in the user's client session if they're shutting things down in an expected way. 

cc @ncclementi @shughes-uk @dchudz who have run into this before 

EDIT: looks like we have some intentional tests around reconnecting if the connection between the client and scheduler is temporarily lost. This makes sense as we want to be resilient to transient network blips. I've restricted the "don't reconnect" logic to _only_ be if there's a cluster manager associated with the client and the cluster is closing/closed (which seems safe to me). 