### PR TITLE
Log exceptions in P2P shuffle tasks

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -50,6 +50,8 @@ def shuffle_transfer(
         )
     except Exception:
         msg = f"shuffle_transfer failed during shuffle {id}"
+        # FIXME: Use exception chaining instead of logging the traceback.
+        #  This has previously led to spurious recursion errors
         logger.error(msg, exc_info=True)
         raise RuntimeError(msg)
 
@@ -61,6 +63,8 @@ def shuffle_unpack(
         return _get_worker_extension().get_output_partition(id, output_partition)
     except Exception:
         msg = f"shuffle_unpack failed during shuffle {id}"
+        # FIXME: Use exception chaining instead of logging the traceback.
+        #  This has previously led to spurious recursion errors
         logger.error(msg, exc_info=True)
         raise RuntimeError(msg)
 
@@ -70,6 +74,8 @@ def shuffle_barrier(id: ShuffleId, transfers: list[None]) -> None:
         return _get_worker_extension().barrier(id)
     except Exception:
         msg = f"shuffle_barrier failed during shuffle {id}"
+        # FIXME: Use exception chaining instead of logging the traceback.
+        #  This has previously led to spurious recursion errors
         logger.error(msg, exc_info=True)
         raise RuntimeError(msg)
 

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -48,7 +48,8 @@ def shuffle_transfer(
         _get_worker_extension().add_partition(
             input, id, npartitions=npartitions, column=column
         )
-    except Exception:
+    except Exception as e:
+        logger.exception(e)
         raise RuntimeError(f"shuffle_transfer failed during shuffle {id}")
 
 
@@ -57,14 +58,16 @@ def shuffle_unpack(
 ) -> pd.DataFrame:
     try:
         return _get_worker_extension().get_output_partition(id, output_partition)
-    except Exception:
+    except Exception as e:
+        logger.exception(e)
         raise RuntimeError(f"shuffle_unpack failed during shuffle {id}")
 
 
 def shuffle_barrier(id: ShuffleId, transfers: list[None]) -> None:
     try:
         return _get_worker_extension().barrier(id)
-    except Exception:
+    except Exception as e:
+        logger.exception(e)
         raise RuntimeError(f"shuffle_barrier failed during shuffle {id}")
 
 

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -48,9 +48,10 @@ def shuffle_transfer(
         _get_worker_extension().add_partition(
             input, id, npartitions=npartitions, column=column
         )
-    except Exception as e:
-        logger.exception(e)
-        raise RuntimeError(f"shuffle_transfer failed during shuffle {id}")
+    except Exception:
+        msg = f"shuffle_transfer failed during shuffle {id}"
+        logger.error(msg, exc_info=True)
+        raise RuntimeError(msg)
 
 
 def shuffle_unpack(
@@ -58,17 +59,19 @@ def shuffle_unpack(
 ) -> pd.DataFrame:
     try:
         return _get_worker_extension().get_output_partition(id, output_partition)
-    except Exception as e:
-        logger.exception(e)
-        raise RuntimeError(f"shuffle_unpack failed during shuffle {id}")
+    except Exception:
+        msg = f"shuffle_unpack failed during shuffle {id}"
+        logger.error(msg, exc_info=True)
+        raise RuntimeError(msg)
 
 
 def shuffle_barrier(id: ShuffleId, transfers: list[None]) -> None:
     try:
         return _get_worker_extension().barrier(id)
-    except Exception as e:
-        logger.exception(e)
-        raise RuntimeError(f"shuffle_barrier failed during shuffle {id}")
+    except Exception:
+        msg = f"shuffle_barrier failed during shuffle {id}"
+        logger.error(msg, exc_info=True)
+        raise RuntimeError(msg)
 
 
 def rearrange_by_column_p2p(


### PR DESCRIPTION
Logs the traceback of the caught exception for better observability. Previously, traceback information had been lost.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
