### PR TITLE
Set `lifetime-stagger` default value to `None`

### DIFF
--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -203,8 +203,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--lifetime-restart/--no-lifetime-restart",
     "lifetime_restart",
-    default=False,
-    show_default=True,
+    default=None,
     required=False,
     help="Whether or not to restart the worker after the lifetime lapses. "
     "This assumes that you are using the --lifetime and --nanny keywords",

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -190,8 +190,7 @@ pem_file_option_type = click.Path(exists=True, resolve_path=True)
 @click.option(
     "--lifetime-stagger",
     type=str,
-    default="0 seconds",
-    show_default=True,
+    default=None,
     help="Random amount by which to stagger lifetime values",
 )
 @click.option(

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -620,7 +620,7 @@ async def test_set_lifetime_stagger_via_env_var(c, s):
     with popen(["dask", "worker", s.address], env=env), popen(
         ["dask", "worker", s.address], env=env
     ):
-        await c.wait_for_workers(1)
+        await c.wait_for_workers(2)
         [lifetime1, lifetime2] = (
             await c.run(lambda dask_worker: dask_worker.lifetime)
         ).values()


### PR DESCRIPTION
Sets `lifetime-stagger` CLI default to `None` (instead of 0 seconds), to allow overrides through config file or environment variables.

Closes #7444

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
