### PR TITLE
Reset state of `ShuffleSchedulerExtension` on restart

### DIFF
--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -227,6 +227,12 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         with contextlib.suppress(KeyError):
             del self.heartbeats[id]
 
+    def restart(self, scheduler: Scheduler) -> None:
+        self.states.clear()
+        self.heartbeats.clear()
+        self.tombstones.clear()
+        self.erred_shuffles.clear()
+
 
 def get_worker_for(output_partition: int, workers: list[str], npartitions: int) -> str:
     "Get the address of the worker which should hold this output partition number"


### PR DESCRIPTION
Fixes issue where forgotten shuffles could not be re-run after a cluster restart

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

