### PR TITLE
Reject non-string column names in P2P shuffle

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -79,6 +79,11 @@ def rearrange_by_column_p2p(
     token = tokenize(df, column, npartitions)
 
     empty = df._meta.copy()
+    if any(not isinstance(c, str) for c in empty.columns):
+        unsupported = {c: type(c) for c in empty.columns if not isinstance(c, str)}
+        raise TypeError(
+            f"p2p requires all column names to be str, found: {unsupported}",
+        )
     for c, dt in empty.dtypes.items():
         if dt == object:
             empty[c] = empty[c].astype(

--- a/distributed/shuffle/tests/test_graph.py
+++ b/distributed/shuffle/tests/test_graph.py
@@ -29,6 +29,12 @@ def test_basic(client):
     # ^ NOTE: this works because `assert_eq` sorts the rows before comparing
 
 
+def test_raise_on_non_string_column_name():
+    df = dd.from_pandas(pd.DataFrame({"a": range(10), 1: range(10)}), npartitions=5)
+    with pytest.raises(TypeError, match="p2p requires all column names to be str"):
+        df.shuffle("x", shuffle="p2p")
+
+
 @gen_cluster([("", 2)] * 4, client=True)
 async def test_basic_state(c, s, *workers):
     df = dd.demo.make_timeseries(freq="15D", partition_freq="30D")

--- a/distributed/shuffle/tests/test_graph.py
+++ b/distributed/shuffle/tests/test_graph.py
@@ -32,7 +32,12 @@ def test_basic(client):
 def test_raise_on_non_string_column_name():
     df = dd.from_pandas(pd.DataFrame({"a": range(10), 1: range(10)}), npartitions=5)
     with pytest.raises(TypeError, match="p2p requires all column names to be str"):
-        df.shuffle("x", shuffle="p2p")
+        df.shuffle("a", shuffle="p2p")
+
+
+def test_does_not_raise_on_stringified_numeric_column_name():
+    df = dd.from_pandas(pd.DataFrame({"a": range(10), "1": range(10)}), npartitions=5)
+    df.shuffle("a", shuffle="p2p")
 
 
 @gen_cluster([("", 2)] * 4, client=True)


### PR DESCRIPTION
PyArrow silently coerces column names to `str` which causes non-string column names not to roundtrip in P2P shuffling. This PR rejects non-string column names and leaves it up to the user to coerce column names to `str` or choose a different shuffle.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
