### PR TITLE
Remove the Incorrect-Sizeof-Warning

### DIFF
--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -1154,36 +1154,3 @@ async def test_deprecated_params(s, name):
     with pytest.warns(FutureWarning, match=name):
         async with Worker(s.address, **{name: 0.789}) as a:
             assert getattr(a.memory_manager, name) == 0.789
-
-
-@gen_cluster(
-    client=True,
-    config={"distributed.worker.memory.target": False},
-    worker_kwargs={"heartbeat_interval": "10ms"},
-)
-async def test_warn_on_sizeof_overestimate(c, s, a, b):
-    class C:
-        def __sizeof__(self):
-            return 2**40
-
-    with captured_logger("distributed.worker") as log:
-        x = c.submit(C)
-        # Wait for heartbeat
-        while "exceeds process memory" not in log.getvalue():
-            await asyncio.sleep(0.01)
-
-
-@gen_cluster(client=True, worker_kwargs={"heartbeat_interval": "10ms"})
-async def test_warn_on_sizeof_overestimate_spill(c, s, a, b):
-    class C:
-        def __sizeof__(self):
-            return 2**40
-
-    with captured_logger("distributed.worker") as log:
-        x = c.submit(C)
-        # Wait for heartbeat
-        while not s.memory.spilled:
-            await asyncio.sleep(0.01)
-
-    # Measure managed, not managed+spilled
-    assert "exceeds process memory" not in log.getvalue()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1050,23 +1050,6 @@ class Worker(BaseWorker, ServerNode):
             except Exception:  # TODO: log error once
                 pass
 
-        managed = out["managed_bytes"] - out["spilled_bytes"]["memory"]
-        if managed > out["memory"]:
-            # Maybe the new managed memory was added after the latest monitor run
-            out["memory"] = self.monitor.get_process_memory()
-        if managed > out["memory"] and dask.config.get(
-            "distributed.worker.sizeof-warning", default=True
-        ):
-            logger.warning(
-                "Managed memory (%s) exceeds process memory (%s); this will cause "
-                "premature spilling as well as malfunctions in several heuristics. "
-                "Please ensure that sizeof() returns accurate outputs for your data. "
-                "To disable this warning, set distributed.worker.sizeof-warning=False. "
-                "Read more: https://distributed.dask.org/en/stable/worker-memory.html",
-                format_bytes(managed),
-                format_bytes(out["memory"]),
-            )
-
         return out
 
     async def get_startup_information(self):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1054,11 +1054,14 @@ class Worker(BaseWorker, ServerNode):
         if managed > out["memory"]:
             # Maybe the new managed memory was added after the latest monitor run
             out["memory"] = self.monitor.get_process_memory()
-        if managed > out["memory"]:
+        if managed > out["memory"] and dask.config.get(
+            "distributed.worker.sizeof-warning", default=True
+        ):
             logger.warning(
                 "Managed memory (%s) exceeds process memory (%s); this will cause "
                 "premature spilling as well as malfunctions in several heuristics. "
                 "Please ensure that sizeof() returns accurate outputs for your data. "
+                "To disable this warning, set distributed.worker.sizeof-warning=False. "
                 "Read more: https://distributed.dask.org/en/stable/worker-memory.html",
                 format_bytes(managed),
                 format_bytes(out["memory"]),


### PR DESCRIPTION
Rolling back #7419 and co.

~~Adding the config `distributed.worker.sizeof-warning` to disable the warning introduced by #7419.~~

This warning is not reliable when dealing with CUDA objects.  E.g. `sizeof()` of a cuDF dataframe returns the size of the device memory not main memory.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
