### PR TITLE
Remove conditional imports of psutil

### DIFF
--- a/distributed/metrics.py
+++ b/distributed/metrics.py
@@ -5,6 +5,8 @@ import time as timemod
 from collections.abc import Callable
 from functools import wraps
 
+import psutil
+
 from distributed.compatibility import WINDOWS
 
 _empty_namedtuple = collections.namedtuple("_empty_namedtuple", ())
@@ -13,14 +15,8 @@ _empty_namedtuple = collections.namedtuple("_empty_namedtuple", ())
 def _psutil_caller(method_name, default=_empty_namedtuple):
     """
     Return a function calling the given psutil *method_name*,
-    or returning *default* if psutil is not present.
+    or returning *default* if psutil fails.
     """
-    # Import only once to avoid the cost of a failing import at each wrapper() call
-    try:
-        import psutil
-    except ImportError:  # pragma: no cover
-        return default
-
     meth = getattr(psutil, method_name)
 
     @wraps(meth)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -36,6 +36,7 @@ from typing import Any as AnyType
 from typing import ClassVar, Iterator, TypeVar, overload
 
 import click
+import psutil
 import tblib.pickling_support
 
 try:
@@ -200,8 +201,6 @@ def get_ip_interface(ifname):
     ValueError is raised if the interface does no have an IPv4 address
     associated with it.
     """
-    import psutil
-
     net_if_addrs = psutil.net_if_addrs()
 
     if ifname not in net_if_addrs:

--- a/distributed/utils_perf.py
+++ b/distributed/utils_perf.py
@@ -5,6 +5,8 @@ import logging
 import threading
 from collections import deque
 
+import psutil
+
 from dask.utils import format_bytes
 
 from distributed.metrics import thread_time
@@ -147,12 +149,7 @@ class GCDiagnosis:
     def enable(self):
         assert not self._enabled
         self._fractional_timer = FractionalTimer(n_samples=self.N_SAMPLES)
-        try:
-            import psutil
-        except ImportError:
-            self._proc = None
-        else:
-            self._proc = psutil.Process()
+        self._proc = psutil.Process()
 
         cb = self._gc_callback
         assert cb not in gc.callbacks
@@ -181,10 +178,7 @@ class GCDiagnosis:
         # don't waste time measuring them
         if info["generation"] != 2:
             return
-        if self._proc is not None:
-            rss = self._proc.memory_info().rss
-        else:
-            rss = 0
+        rss = self._proc.memory_info().rss
         if phase == "start":
             self._fractional_timer.start_timing()
             self._gc_rss_before = rss


### PR DESCRIPTION
psutil is a mandatory requirement and it's imported at the top of the module in many places. Historically it used to be optional. This PR cleans up a few unnecessary conditional imports.