### PR TITLE
Fix un/packing for namedtuples with custom constructors

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7933,31 +7933,69 @@ async def test_wait_for_workers_n_workers_value_check(c, s, a, b, value, excepti
         await c.wait_for_workers(value)
 
 
-@gen_cluster(client=True)
-async def test_unpacks_remotedata_namedtuple(c, s, a, b):
-    class NamedTupleAnnotation(namedtuple("BaseAnnotation", field_names="value")):
-        def unwrap(self):
-            return self.value
+class PlainNamedTuple(namedtuple("PlainNamedTuple", "value")):
+    """Namedtuple with a default constructor."""
 
+
+class NewArgsNamedTuple(namedtuple("NewArgsNamedTuple", "ab, c")):
+    """Namedtuple with a custom constructor."""
+
+    def __new__(cls, a, b, c):
+        return super().__new__(cls, f"{a}-{b}", c)
+
+    def __getnewargs__(self):
+        return *self.ab.split("-"), self.c
+
+
+class NewArgsExNamedTuple(namedtuple("NewArgsExNamedTuple", "ab, c, k, v")):
+    """Namedtuple with a custom constructor including keywords-only arguments."""
+
+    def __new__(cls, a, b, c, **kw):
+        return super().__new__(cls, f"{a}-{b}", c, tuple(kw.keys()), tuple(kw.values()))
+
+    def __getnewargs_ex__(self):
+        return (*self.ab.split("-"), self.c), dict(zip(self.k, self.v))
+
+
+@pytest.mark.parametrize(
+    "typ, args, kwargs",
+    [
+        (PlainNamedTuple, ["some-data"], {}),
+        (NewArgsNamedTuple, ["some", "data", "more"], {}),
+        (NewArgsExNamedTuple, ["some", "data", "more"], {"another": "data"}),
+    ],
+)
+@gen_cluster(client=True)
+async def test_unpacks_remotedata_namedtuple(c, s, a, b, typ, args, kwargs):
     def identity(x):
         return x
 
-    outer_future = c.submit(identity, NamedTupleAnnotation("some-data"))
+    outer_future = c.submit(identity, typ(*args, **kwargs))
     result = await outer_future
-    assert result == NamedTupleAnnotation(value="some-data")
+    assert result == typ(*args, **kwargs)
 
 
+@pytest.mark.parametrize(
+    "typ, args, kwargs",
+    [
+        (PlainNamedTuple, [], {}),
+        (NewArgsNamedTuple, ["some", "data"], {}),
+        (NewArgsExNamedTuple, ["some", "data"], {"another": "data"}),
+    ],
+)
 @gen_cluster(client=True)
-async def test_resolves_future_in_namedtuple(c, s, a, b):
-    TestTuple = namedtuple("TestTuple", field_names=["x", "y"])
-
+async def test_resolves_future_in_namedtuple(c, s, a, b, typ, args, kwargs):
     def identity(x):
         return x
 
-    inner_future = c.submit(identity, 1)
-    outer_future = c.submit(identity, TestTuple(x=inner_future, y=2))
+    inner_result = 1
+    inner_future = c.submit(identity, inner_result)
+    kwin, kwout = dict(kwargs), dict(kwargs)
+    if kwargs:
+        kwin["inner"], kwout["inner"] = inner_future, inner_result
+    outer_future = c.submit(identity, typ(*args, inner_future, **kwin))
     result = await outer_future
-    assert result == TestTuple(x=1, y=2)
+    assert result == typ(*args, inner_result, **kwout)
 
 
 @gen_cluster(client=True)

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -6,7 +6,7 @@ import random
 from collections import defaultdict
 from functools import partial
 from itertools import cycle
-from typing import Any
+from typing import Any, Callable
 
 from tlz import concat, drop, groupby, merge
 
@@ -163,6 +163,20 @@ async def scatter_to_workers(nthreads, data, rpc=rpc, report=True):
 collection_types = (tuple, list, set, frozenset)
 
 
+def _namedtuple_packing(o: Any, handler: Callable[..., Any]) -> Any:
+    """Special pack/unpack dispatcher for namedtuples respecting their potential constructors."""
+    assert is_namedtuple_instance(o)
+    typ = type(o)
+    if hasattr(o, "__getnewargs_ex__"):
+        args, kwargs = o.__getnewargs_ex__()
+        handled_args = [handler(item) for item in args]
+        handled_kwargs = {k: handler(v) for k, v in kwargs.items()}
+        return typ(*handled_args, **handled_kwargs)
+    args = o.__getnewargs__() if hasattr(typ, "__getnewargs__") else o
+    handled_args = [handler(item) for item in args]
+    return typ(*handled_args)
+
+
 def _unpack_remotedata_inner(
     o: Any, byte_keys: bool, found_keys: set[WrappedKey]
 ) -> Any:
@@ -202,8 +216,11 @@ def _unpack_remotedata_inner(
                 _unpack_remotedata_inner(item, byte_keys, found_keys) for item in o
             )
     elif is_namedtuple_instance(o):
-        return typ(
-            *[_unpack_remotedata_inner(item, byte_keys, found_keys) for item in o]
+        return _namedtuple_packing(
+            o,
+            partial(
+                _unpack_remotedata_inner, byte_keys=byte_keys, found_keys=found_keys
+            ),
         )
 
     if typ in collection_types:
@@ -292,7 +309,7 @@ def pack_data(o, d, key_types=object):
     elif typ is dict:
         return {k: pack_data(v, d, key_types=key_types) for k, v in o.items()}
     elif is_namedtuple_instance(o):
-        return typ(*[pack_data(x, d, key_types=key_types) for x in o])
+        return _namedtuple_packing(o, partial(pack_data, d=d, key_types=key_types))
     else:
         return o
 


### PR DESCRIPTION
This is a fix for un/packing of namedtuples with custom constructors that's been broken by recently merged #7282 and its followup #7292.

Before #7282, the `_unpack_remotedata_inner` and `pack_data` were taking care of un/packing of a set of specific data *types* (matched using `type(o) is ...`). That was safe, since for each exact type we know its exact constructor signature.

The #7282 attempted to extend the logic for `namedtuple` - this time for any potential *subtypes* (matched using `isinstance(o, tuple)`). It assumes the constructor signature of any of these potential subtypes will match the default `namedtuple` constructor signature. Overriding constructors in subclasses with a custom parent-incompatible signature is, however, a valid principle, which this implementation now prevents (breaking previously working code).

This proposed fix builds on the existing concept of `__getnewargs__()` and `__getnewargs_ex__()` which are typically implemented on namedtuples with custom constructors to keep them serializable.

Example of namedtuple with a custom constructor accompanied with the matching `__getnewargs__`:
```
class CustomNamedTuple(collections.namedtuple('CustomNamedTuple', 'synthetic_field')):
    def __new__(cls, foo, bar):
        return super().__new__(cls, f'{foo}-{bar}')

    def __getnewargs__(self):
        return tuple(self.synthetic_field.split('-'))
```