### PR TITLE
Minor polish in github actions

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
     name: pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
         with:
-          # Needed by versioneer.
-          # Must be higher than the number of commits since the latest release.
-          fetch-depth: 200
+          # Fetch the whole git history.
+          # Needed by GIT_DESCRIBE_NUMBER in the conda recipes.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -26,15 +26,20 @@ jobs:
     name: Build (and upload)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - name: Checkout source
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          # Needed by versioneer.
+          # Must be higher than the number of commits since the latest release.
+          fetch-depth: 200
+
       - name: Set up Python
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: 3.8
+
       - name: Install dependencies
         run: |
           mamba install boa conda-verify
@@ -42,6 +47,7 @@ jobs:
           which python
           pip list
           mamba list
+
       - name: Build conda packages
         run: |
           # suffix for pre-release package versions
@@ -64,6 +70,7 @@ jobs:
                            --channel dask/label/dev \
                            --no-anaconda-upload \
                            --output-folder .
+
       - name: Upload conda packages
         if: |
           github.event_name == 'push'

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -19,10 +19,10 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,12 +69,14 @@ jobs:
         shell: bash
 
       - name: Checkout source
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          # Needed by versioneer.
+          # Must be higher than the number of commits since the latest release.
+          fetch-depth: 200
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,9 +71,8 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
         with:
-          # Needed by versioneer.
-          # Must be higher than the number of commits since the latest release.
-          fetch-depth: 200
+          # Fetch the whole git history. Needed by versioneer.
+          fetch-depth: 0
 
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/update-gpuci.yaml
+++ b/.github/workflows/update-gpuci.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'dask/distributed'
 
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3
 
       - name: Parse current axis YAML
         id: rapids_current


### PR DESCRIPTION
Recently github CI bandwidth during checkout has slown down to a crawl, resulting in minutes or even hours to complete checkout.
This is an attempt to speed it up.

- Related: https://github.com/coiled/coiled-runtime/pull/663

[EDIT] This attempted to set `fetch-depth: 200`, but neither versioneer nor the conda recipes like it. Rescoped the PR to salvage the good bits.