### PR TITLE
Ensure dicts are properly recognized as msgpack serializable

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -822,7 +822,7 @@ def _is_msgpack_serializable(v):
         or typ is float
         or isinstance(v, dict)
         and all(map(_is_msgpack_serializable, v.values()))
-        and all(isinstance(x, str) for x in v.keys())
+        and all(type(x) is str for x in v.keys())
         or isinstance(v, (list, tuple))
         and all(map(_is_msgpack_serializable, v))
     )

--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -817,11 +817,12 @@ def _is_msgpack_serializable(v):
         v is None
         or typ is str
         or typ is bool
+        or typ is bytes
         or typ is int
         or typ is float
         or isinstance(v, dict)
         and all(map(_is_msgpack_serializable, v.values()))
-        and all(typ is str for x in v.keys())
+        and all(isinstance(x, str) for x in v.keys())
         or isinstance(v, (list, tuple))
         and all(map(_is_msgpack_serializable, v))
     )

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -34,7 +34,10 @@ from distributed.protocol import (
     to_serialize,
 )
 from distributed.protocol.compression import default_compression
-from distributed.protocol.serialize import check_dask_serializable
+from distributed.protocol.serialize import (
+    _is_msgpack_serializable,
+    check_dask_serializable,
+)
 from distributed.utils import ensure_memoryview, nbytes
 from distributed.utils_test import NO_AMM, gen_test, inc
 
@@ -626,3 +629,24 @@ async def test_large_pickled_object(c, s, a, b):
     y = await c.scatter(x, workers=[a.worker_address])
     z = c.submit(lambda x: x, y, workers=[b.worker_address])
     await z
+
+
+def test__is_msgpack_serializable():
+    assert _is_msgpack_serializable(None)
+    assert _is_msgpack_serializable("a")
+    assert _is_msgpack_serializable(1)
+    assert _is_msgpack_serializable(1.0)
+    assert _is_msgpack_serializable(b"0")
+    assert _is_msgpack_serializable({"a": "b"})
+    assert _is_msgpack_serializable(["a"])
+    assert _is_msgpack_serializable(("a",))
+
+    class C:
+        def __hash__(self):
+            return 5
+
+    assert not _is_msgpack_serializable(["a", C()])
+    assert not _is_msgpack_serializable(("a", C()))
+    assert not _is_msgpack_serializable(C())
+    assert not _is_msgpack_serializable({C(): "foo"})
+    assert not _is_msgpack_serializable({"foo": C()})


### PR DESCRIPTION
This was already introduces in https://github.com/dask/distributed/pull/3536 pretty sure this is a typo.

This typo effectively prohibited simple dicts without any custom objects to take the fast path since `all(typ is str for x in v.keys())` is always False

similarly, genuine bytes where also misclassified and encoded using a "complex" header.

I doubt that either is a big deal but since this was introduced for cuda I guess smbd from @dask/gpu should be aware.


About the test... ObjectDictSerializer is not tested explicitly anywhere and I chose not to introduce a granular unit test for this, yet. I'm not super happy about the `test__is_msgpack_serializable` but at least for the composite/nested types this adds _some_ value