### PR TITLE
Reverse order of `get_logs()` and `get_worker_logs()`

### DIFF
--- a/distributed/node.py
+++ b/distributed/node.py
@@ -109,12 +109,12 @@ class ServerNode(Server):
 
         Returns
         -------
-        List of tuples containing the log level, message, and (optional) timestamp for each filtered entry
+        List of tuples containing the log level, message, and (optional) timestamp for each filtered entry, newest first
         """
         deque_handler = self._deque_handler
 
         L = []
-        for count, msg in enumerate(deque_handler.deque):
+        for count, msg in enumerate(reversed(deque_handler.deque)):
             if n and count >= n or msg.created < start:
                 break
             if timestamps:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5749,10 +5749,10 @@ async def test_logs_from_worker_submodules(c, s, a):
     await c.run(on_worker)
     logs = await c.get_worker_logs()
     logs = [row[1].partition(" - ")[2] for row in logs[a.worker_address]]
-    assert logs[-3:] == [
-        "distributed.worker - INFO - AAA",
-        "distributed.worker.state_machine - INFO - BBB",
+    assert logs[:3] == [
         "distributed.worker.memory - INFO - CCC",
+        "distributed.worker.state_machine - INFO - BBB",
+        "distributed.worker - INFO - AAA",
     ]
 
     def on_nanny(dask_worker):
@@ -5764,9 +5764,9 @@ async def test_logs_from_worker_submodules(c, s, a):
     await c.run(on_nanny, nanny=True)
     logs = await c.get_worker_logs(nanny=True)
     logs = [row[1].partition(" - ")[2] for row in logs[a.worker_address]]
-    assert logs[-2:] == [
-        "distributed.nanny - INFO - DDD",
+    assert logs[:2] == [
         "distributed.nanny.memory - INFO - EEE",
+        "distributed.nanny - INFO - DDD",
     ]
 
 


### PR DESCRIPTION
Closes #7474 

This PR reverses the order of log messages returned from `ServerNode.get_logs()` so that newest logs are returned first. This was the suggested solution for issue #7474 and makes the behavior of `client.get_worker_logs()` consistent with its docstring. Reversing the order of returned logs also allows the user to correctly filter to the "n" latest logs, which will make `ServerNode.get_logs()` and `client.get_worker_logs()` much more useful for typical cases with more than a handful of log messages. 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
