### PR TITLE
WIP Remove single-address RPC

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -26,7 +26,7 @@ from distributed.client import (
     performance_report,
     wait,
 )
-from distributed.core import Status, connect, rpc
+from distributed.core import ConnectionPool, Status, connect
 from distributed.deploy import (
     Adaptive,
     LocalCluster,
@@ -118,6 +118,7 @@ __all__ = [
     "Client",
     "CompatibleExecutor",
     "CondaInstall",
+    "ConnectionPool",
     "Environ",
     "Event",
     "Future",
@@ -164,7 +165,6 @@ __all__ = [
     "print",
     "progress",
     "rejoin",
-    "rpc",
     "secede",
     "sync",
     "wait",

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -66,7 +66,6 @@ from distributed.core import (
     Status,
     clean_exception,
     connect,
-    rpc,
 )
 from distributed.diagnostics.plugin import (
     NannyPlugin,
@@ -879,7 +878,7 @@ class Client(SyncMethodMixin):
         if address is not None and kwargs:
             raise ValueError(f"Unexpected keyword arguments: {sorted(kwargs)}")
 
-        if isinstance(address, (rpc, PooledRPCCall)):
+        if isinstance(address, PooledRPCCall):
             self.scheduler = address
         elif isinstance(getattr(address, "scheduler_address", None), str):
             # It's a LocalCluster or LocalCluster-compatible object
@@ -1678,9 +1677,8 @@ class Client(SyncMethodMixin):
 
                 if _get_global_client() is self:
                     _set_global_client(None)
-
-            with suppress(AttributeError):
-                await self.scheduler.close_rpc()
+            if self.scheduler:
+                await self.scheduler.close()
 
             self.scheduler = None
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3747,7 +3747,7 @@ async def test_reconnect_timeout(c, s):
 def test_open_close_many_workers(loop, worker, count, repeat):
     proc = psutil.Process()
 
-    with cluster(nworkers=0, active_rpc_timeout=2) as (s, _):
+    with cluster(nworkers=0) as (s, _):
         gc.collect()
         before = proc.num_fds()
         done = Semaphore(0)

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -249,7 +249,7 @@ async def test_forgotten_futures_dont_clean_up_new_futures(c, s, a, b):
 
 @pytest.mark.slow
 @pytest.mark.flaky(condition=MACOS, reruns=10, reruns_delay=5)
-@gen_cluster(client=True, timeout=60, active_rpc_timeout=10)
+@gen_cluster(client=True, timeout=60)
 async def test_broken_worker_during_computation(c, s, a, b):
     s.allowed_failures = 100
     async with Nanny(s.address, nthreads=2) as n:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -37,7 +37,7 @@ from distributed import (
 )
 from distributed.comm.addressing import parse_host_port
 from distributed.compatibility import LINUX, MACOS, WINDOWS, PeriodicCallback
-from distributed.core import ConnectionPool, Status, clean_exception, connect, rpc
+from distributed.core import ConnectionPool, Status, clean_exception, connect
 from distributed.metrics import time
 from distributed.protocol.pickle import dumps, loads
 from distributed.scheduler import KilledWorker, MemoryState, Scheduler, WorkerState
@@ -711,10 +711,11 @@ async def test_retire_workers_empty(s):
 
 @gen_cluster()
 async def test_server_listens_to_other_ops(s, a, b):
-    async with rpc(s.address) as r:
-        ident = await r.identity()
-        assert ident["type"] == "Scheduler"
-        assert ident["id"].lower().startswith("scheduler")
+    async with ConnectionPool() as rpc:
+        async with rpc(s.address) as r:
+            ident = await r.identity()
+            assert ident["type"] == "Scheduler"
+            assert ident["id"].lower().startswith("scheduler")
 
 
 @gen_cluster()

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -80,7 +80,7 @@ async def test_cancel_stress(c, s, *workers):
 def test_cancel_stress_sync(loop):
     da = pytest.importorskip("dask.array")
     x = da.random.random((50, 50), chunks=(2, 2))
-    with cluster(active_rpc_timeout=10) as (s, [a, b]):
+    with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop) as c:
             x = c.persist(x)
             y = (x.sum(axis=0) + x.sum(axis=1) + 1).std()

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -25,7 +25,7 @@ from distributed import Client, Event, Nanny, Scheduler, Worker, config, default
 from distributed.batched import BatchedSend
 from distributed.comm.core import connect
 from distributed.compatibility import WINDOWS
-from distributed.core import Server, Status, rpc
+from distributed.core import ConnectionPool, Server, Status
 from distributed.metrics import time
 from distributed.tests.test_batched import EchoServer
 from distributed.utils import get_mp_context
@@ -68,8 +68,9 @@ def test_bare_cluster(loop):
 
 def test_cluster(cleanup):
     async def identity():
-        async with rpc(s["address"]) as scheduler_rpc:
-            return await scheduler_rpc.identity()
+        async with ConnectionPool() as rpc:
+            async with rpc(s["address"]) as scheduler_rpc:
+                return await scheduler_rpc.identity()
 
     with cluster() as (s, [a, b]):
         ident = asyncio.run(identity())

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -61,9 +61,8 @@ from distributed.core import (
     coerce_to_address,
     error_message,
     pingpong,
+    send_recv,
 )
-from distributed.core import rpc as RPCType
-from distributed.core import send_recv
 from distributed.diagnostics import nvml
 from distributed.diagnostics.plugin import _get_plugin_name
 from distributed.diskutils import WorkDir, WorkSpace
@@ -1576,7 +1575,6 @@ class Worker(BaseWorker, ServerNode):
                         # otherwise
                         c.close()
 
-        await self.scheduler.close_rpc()
         self._workdir.release()
 
         self.stop_services()
@@ -3474,7 +3472,7 @@ def benchmark_memory(
 
 async def benchmark_network(
     address: str,
-    rpc: ConnectionPool | Callable[[str], RPCType],
+    rpc: ConnectionPool,
     sizes: Iterable[str] = ("1 kiB", "10 kiB", "100 kiB", "1 MiB", "10 MiB", "50 MiB"),
     duration="1 s",
 ) -> dict[str, float]:


### PR DESCRIPTION
Ages ago, the `ConnectionPool` and the `PooledRPCCall` classes where introduced that pool used connections for multiple addresses. The only case we are dedicating a connection to a single purpose is the always-open `BatchedSend` connection that connects Client->Scheduler and Scheduler->Worker. (Right now, there is one more thing in the Cluster implementation handling `_watch_worker_status` but I consider this unnecessary and rather an accident than intended usage).

The predecessor `rpc` which is only pooling a connection by a single address is fading out and is only used in very few places any longer. However, the ConnectionPool + PooledRPCCall is a full replacement of `rpc` and there is no need to maintain both implementations. In fact, most low level tests where only testing the single-address `rpc` class. I don't see a reason maintaining both paths and believe the existence of both is rather confusing for developers.

Removing this is likely a breaking change since `rpc` was exposed as a top-level import. We should consider adding the code back in and add a deprecation warning for a release or two. This PR removes all internal usages

TODO
- [ ] A couple of failing tests
- [ ] Handle deprecation