### PR TITLE
DNM: Tracing Dask with OpenTelemetry

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -21,7 +21,6 @@ from distributed.proctitle import (
 
 logger = logging.getLogger("distributed.scheduler")
 
-
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1535,6 +1535,7 @@ class Client(SyncMethodMixin):
                         raise exc.with_traceback(tb)
 
                     op = msg.pop("op")
+                    msg.pop("otel_context")
 
                     if op == "close" or op == "stream-closed":
                         breakout = True

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -14,7 +14,6 @@ from collections import defaultdict, deque
 from collections.abc import Container, Coroutine
 from enum import Enum
 from functools import partial
-from time import time_ns
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, TypedDict, TypeVar, final
 
 import tblib
@@ -749,7 +748,6 @@ class Server:
         await self
         try:
             while not self.__stopped:
-                start_time = time_ns()
                 try:
                     msg = await comm.read()
                     logger.debug("Message from %r: %s", address, msg)
@@ -784,7 +782,7 @@ class Server:
                 carrier = msg.pop("otel_context", None)
                 context = propagate.extract(carrier) if carrier is not None else None
                 with tracer.start_as_current_span(
-                    f"COMM HANDLER: {op}", context=context, start_time=start_time
+                    f"COMM HANDLER: {op}", context=context
                 ):
                     if self.counters is not None:
                         self.counters["op"].add(op)
@@ -884,7 +882,6 @@ class Server:
         closed = False
         try:
             while not closed:
-                start_time = time_ns()
                 try:
                     msgs = await comm.read()
                 # If another coroutine has closed the comm, stop handling the stream.
@@ -918,21 +915,19 @@ class Server:
                         if iscoroutinefunction(handler):
 
                             async def instrumented_handler(
-                                handler, op, context, start_time, kwargs
+                                handler, op, context, kwargs
                             ):
                                 with tracer.start_as_current_span(
                                     f"STREAM HANDLER: {op}",
                                     context=context,
-                                    start_time=start_time,
                                 ):
-                                    return await handler(kwargs)
+                                    return await handler(**kwargs)
 
                             self._ongoing_background_tasks.call_soon(
                                 instrumented_handler,
                                 handler,
                                 op,
                                 context,
-                                start_time,
                                 merge(extra, msg),
                             )
                             await asyncio.sleep(0)
@@ -940,7 +935,6 @@ class Server:
                             with tracer.start_as_current_span(
                                 f"STREAM HANDLER: {op}",
                                 context=context,
-                                start_time=start_time,
                             ):
                                 handler(**merge(extra, msg))
                     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ dask == 2023.1.0
 jinja2 >= 2.10.3
 locket >= 1.0.0
 msgpack >= 1.0.0
+opentelemetry-api >= 1.15.0
 packaging >= 20.0
 psutil >= 5.7.0
 pyyaml >= 5.3.1


### PR DESCRIPTION
# DO NOT MERGE

This PR showcases basic support for tracing Dask handlers with OpenTelemetry. For a version that adds traces to most (if not all) places where stimuli are generated, see `hendrikmakait:opentelemetry-prototype`.

**TODO**
* [ ] Setup instructions
* [ ] How to run
* [ ] Add example screenshot