### PR TITLE
Do not allow for a worker to reject a drop replica request

### DIFF
--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -88,8 +88,6 @@ PROCESSING: set[TaskStateState] = {
     "constrained",
     "executing",
     "long-running",
-    "cancelled",
-    "resumed",
 }
 READY: set[TaskStateState] = {"ready", "constrained"}
 # Valid states for a task that is found in TaskState.waiting_for_data


### PR DESCRIPTION
There appears to be a race where a task is left dangling, i.e. we produce a memory leak 
if a task is being fetched while the downstream task is being cancelled.

Came up during https://github.com/dask/distributed/pull/7486

TODO: Test