### PR TITLE
Remove update_graph_hlg

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -468,14 +468,6 @@ class Future(WrappedKey):
         except ValueError:
             c = get_client(address)
         self.__init__(key, c)
-        c._send_to_scheduler(
-            {
-                "op": "update-graph",
-                "tasks": {},
-                "keys": [stringify(self.key)],
-                "client": c.id,
-            }
-        )
 
     def __del__(self):
         try:
@@ -3036,7 +3028,7 @@ class Client(SyncMethodMixin):
 
             self._send_to_scheduler(
                 {
-                    "op": "update-graph-hlg",
+                    "op": "update-graph",
                     "hlg": dsk,
                     "keys": list(map(stringify, keys)),
                     "priority": priority,

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -140,23 +140,6 @@ async def test_multi_progressbar_widget(c, s, a, b):
 
 
 @mock_widget()
-@gen_cluster(client=True)
-async def test_multi_progressbar_widget_intermediates(c, s, a, b):
-    x1 = c.submit(inc, 1, key="x-1")
-    x2 = c.submit(inc, x1, key="x-2")
-    x3 = c.submit(inc, x2, key="x-3")
-    y1 = c.submit(dec, x3)
-    y2 = c.submit(dec, y1)
-    del x1, x2, x3, y1
-
-    p = MultiProgressWidget(["x-1", "x-2", "x-3"], scheduler=s.address)
-    await p.listen()
-
-    assert "x" in p.bars
-    await y2
-
-
-@mock_widget()
 def test_values(client):
     L = [client.submit(inc, i) for i in range(5)]
     wait(L)

--- a/distributed/diagnostics/tests/test_widgets.py
+++ b/distributed/diagnostics/tests/test_widgets.py
@@ -7,11 +7,9 @@ from unittest import mock
 
 import pytest
 from packaging.version import parse as parse_version
-from tlz import valmap
 
 from distributed.client import wait
 from distributed.utils_test import dec, gen_cluster, gen_tls_cluster, inc, throws
-from distributed.worker import dumps_task
 
 ipywidgets = pytest.importorskip("ipywidgets")
 
@@ -142,35 +140,20 @@ async def test_multi_progressbar_widget(c, s, a, b):
 
 
 @mock_widget()
-@gen_cluster()
-async def test_multi_progressbar_widget_after_close(s, a, b):
-    s.update_graph(
-        tasks=valmap(
-            dumps_task,
-            {
-                "x-1": (inc, 1),
-                "x-2": (inc, "x-1"),
-                "x-3": (inc, "x-2"),
-                "y-1": (dec, "x-3"),
-                "y-2": (dec, "y-1"),
-                "e": (throws, "y-2"),
-                "other": (inc, 123),
-            },
-        ),
-        keys=["e"],
-        dependencies={
-            "x-2": {"x-1"},
-            "x-3": {"x-2"},
-            "y-1": {"x-3"},
-            "y-2": {"y-1"},
-            "e": {"y-2"},
-        },
-    )
+@gen_cluster(client=True)
+async def test_multi_progressbar_widget_intermediates(c, s, a, b):
+    x1 = c.submit(inc, 1, key="x-1")
+    x2 = c.submit(inc, x1, key="x-2")
+    x3 = c.submit(inc, x2, key="x-3")
+    y1 = c.submit(dec, x3)
+    y2 = c.submit(dec, y1)
+    del x1, x2, x3, y1
 
     p = MultiProgressWidget(["x-1", "x-2", "x-3"], scheduler=s.address)
     await p.listen()
 
     assert "x" in p.bars
+    await y2
 
 
 @mock_widget()
@@ -232,32 +215,17 @@ def test_progressbar_cancel(client):
 
 
 @mock_widget()
-@gen_cluster()
-async def test_multibar_complete(s, a, b):
-    s.update_graph(
-        tasks=valmap(
-            dumps_task,
-            {
-                "x-1": (inc, 1),
-                "x-2": (inc, "x-1"),
-                "x-3": (inc, "x-2"),
-                "y-1": (dec, "x-3"),
-                "y-2": (dec, "y-1"),
-                "e": (throws, "y-2"),
-                "other": (inc, 123),
-            },
-        ),
-        keys=["e"],
-        dependencies={
-            "x-2": {"x-1"},
-            "x-3": {"x-2"},
-            "y-1": {"x-3"},
-            "y-2": {"y-1"},
-            "e": {"y-2"},
-        },
-    )
+@gen_cluster(client=True)
+async def test_multibar_complete(c, s, a, b):
+    x1 = c.submit(inc, 1, key="x-1")
+    x2 = c.submit(inc, x1, key="x-2")
+    x3 = c.submit(inc, x2, key="x-3")
+    y1 = c.submit(dec, x3, key="y-1")
+    y2 = c.submit(dec, y1, key="y-2")
+    e = c.submit(throws, y2, key="e")
+    other = c.submit(inc, 123, key="other")
 
-    p = MultiProgressWidget(["e"], scheduler=s.address, complete=True)
+    p = MultiProgressWidget([e.key], scheduler=s.address, complete=True)
     await p.listen()
 
     assert p._last_response["all"] == {"x": 3, "y": 2, "e": 1}

--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -166,6 +166,7 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         for barrier_task in barriers:
             if barrier_task.state == "memory":
                 for dt in barrier_task.dependents:
+                    assert dt.worker_restrictions is not None
                     if worker not in dt.worker_restrictions:
                         continue
                     dt.worker_restrictions.clear()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -990,6 +990,7 @@ async def test_ready_remove_worker(c, s, a, b, worker_saturation):
     assert sum(len(w.processing) for w in s.workers.values()) + len(s.queued) == len(
         s.tasks
     )
+    await ev.set()
 
 
 @gen_cluster(client=True, Worker=Nanny, timeout=60)


### PR DESCRIPTION
This removes the two methods update_graph and update_graph_hlg handlers. Now there is only one handler. A subsequent PR will consolidate the two methods.
I took the liberty of adding type annotations which makes the change larger than absolutely necessary but I think it's worth it.
