### PR TITLE
Ignore get_default_shuffle_algorithm linting issue

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -39,12 +39,8 @@ import dask
 import dask.bag as db
 from dask import delayed
 from dask.optimization import SubgraphCallable
-from dask.utils import (
-    get_default_shuffle_algorithm,
-    parse_timedelta,
-    stringify,
-    tmpfile,
-)
+from dask.utils import get_default_shuffle_algorithm  # type: ignore
+from dask.utils import parse_timedelta, stringify, tmpfile
 
 from distributed import (
     CancelledError,


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/7505

We'll need to revert this after the next dask release. Is there a way to tell mypy to use git head?

cc @jrbourbeau 