### PR TITLE
Unskip `test_delete_some_results`

### DIFF
--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1029,7 +1029,6 @@ async def test_restrictions(c, s, a, b):
     assert all(stringify(key) in a.data for key in y.__dask_keys__())
 
 
-@pytest.mark.skip(reason="Fails on CI with unknown cause")
 @gen_cluster(client=True)
 async def test_delete_some_results(c, s, a, b):
     df = dask.datasets.timeseries(


### PR DESCRIPTION
`test_delete_some_results` used to fail on CI for an unknown cause. As mentioned in https://github.com/dask/distributed/pull/7486#issuecomment-1406625887, #7486 should make P2P shuffling robust and implement all necessary changes for #6105 and #7352. If  `test_delete_some_results` does not flake, I consider these solved.
* Closes #6105
* Closes #7352 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
