### PR TITLE
Use dask git tip for mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,9 +58,9 @@ repos:
           - types-setuptools
           # Typed libraries
           - click
-          - dask
           - numpy
           - pytest
           - tornado
-          - zict
           - pyarrow
+          - git+https://github.com/dask/dask
+          - git+https://github.com/dask/zict


### PR DESCRIPTION
Fixes mypy failure due to a change in dask since the latest release:

```
distributed/tests/test_client.py:42: error: Module "dask.utils" has no attribute "get_default_shuffle_algorithm"  [attr-defined]
```