### PR TITLE
Move P2P barrier logic to scheduler extension

### DIFF
--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -26,7 +26,6 @@ class ShuffleState:
     schema: bytes
     column: str
     output_workers: set[str]
-    completed_workers: set[str]
     participating_workers: set[str]
 
 
@@ -51,8 +50,8 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         self.scheduler = scheduler
         self.scheduler.handlers.update(
             {
+                "shuffle_barrier": self.barrier,
                 "shuffle_get": self.get,
-                "shuffle_get_participating_workers": self.get_participating_workers,
             }
         )
         self.heartbeats = defaultdict(lambda: defaultdict(dict))
@@ -62,6 +61,13 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
 
     def shuffle_ids(self) -> set[ShuffleId]:
         return set(self.states)
+
+    async def barrier(self, id: ShuffleId, run_id: int) -> None:
+        shuffle = self.states[id]
+        msg = {"op": "shuffle_inputs_done", "shuffle_id": id, "run_id": run_id}
+        await self.scheduler.broadcast(
+            msg=msg, workers=list(shuffle.participating_workers)
+        )
 
     def heartbeat(self, ws: WorkerState, data: dict) -> None:
         for shuffle_id, d in data.items():
@@ -106,7 +112,6 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
                 schema=schema,
                 column=column,
                 output_workers=output_workers,
-                completed_workers=set(),
                 participating_workers=output_workers.copy(),
             )
             self.states[id] = state
@@ -121,9 +126,6 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
             "schema": state.schema,
             "output_workers": state.output_workers,
         }
-
-    def get_participating_workers(self, id: ShuffleId) -> list[str]:
-        return list(self.states[id].participating_workers)
 
     def remove_worker(self, scheduler: Scheduler, worker: str) -> None:
         from time import time

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1102,7 +1102,7 @@ class ShuffleTestPool:
     def __call__(self, addr: str, *args: Any, **kwargs: Any) -> PooledRPCShuffle:
         return PooledRPCShuffle(self.shuffles[addr])
 
-    async def fake_barrier(self, id, run_id):
+    async def shuffle_barrier(self, id, run_id):
         out = {}
         for addr, s in self.shuffles.items():
             out[addr] = await s.inputs_done()
@@ -1123,7 +1123,7 @@ class ShuffleTestPool:
             local_address=name,
             nthreads=2,
             rpc=self,
-            barrier=self.fake_barrier,
+            scheduler=self,
             memory_limiter_disk=ResourceLimiter(10000000),
             memory_limiter_comms=ResourceLimiter(10000000),
         )

--- a/distributed/shuffle/tests/test_shuffle_extension.py
+++ b/distributed/shuffle/tests/test_shuffle_extension.py
@@ -35,10 +35,8 @@ async def test_installation_on_worker(s, a):
 async def test_installation_on_scheduler(s, a):
     ext = s.extensions["shuffle"]
     assert isinstance(ext, ShuffleSchedulerExtension)
+    assert s.handlers["shuffle_barrier"] == ext.barrier
     assert s.handlers["shuffle_get"] == ext.get
-    assert (
-        s.handlers["shuffle_get_participating_workers"] == ext.get_participating_workers
-    )
 
 
 def test_split_by_worker():

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -57,6 +57,7 @@ from distributed.comm.utils import OFFLOAD_THRESHOLD
 from distributed.compatibility import PeriodicCallback, randbytes, to_thread
 from distributed.core import (
     ConnectionPool,
+    PooledRPCCall,
     Status,
     coerce_to_address,
     error_message,
@@ -266,7 +267,7 @@ class Worker(BaseWorker, ServerNode):
         executor.
     * **local_directory:** ``path``:
         Path on local machine to store temporary files
-    * **scheduler:** ``rpc``:
+    * **scheduler:** ``PooledRPCCall``:
         Location of scheduler.  See ``.ip/.port`` attributes.
     * **name:** ``string``:
         Alias
@@ -437,7 +438,7 @@ class Worker(BaseWorker, ServerNode):
     metrics: dict[str, Callable[[Worker], Any]]
     startup_information: dict[str, Callable[[Worker], Any]]
     low_level_profiler: bool
-    scheduler: Any
+    scheduler: PooledRPCCall
     execution_state: dict[str, Any]
     plugins: dict[str, WorkerPlugin]
     _pending_plugins: tuple[WorkerPlugin, ...]


### PR DESCRIPTION
Some minor refactoring that moves the barrier logic to the scheduler instead of going back and forth between scheduler and workers.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
