### PR TITLE
Rate limit some log messages

### DIFF
--- a/distributed/tests/test_config.py
+++ b/distributed/tests/test_config.py
@@ -283,7 +283,7 @@ def test_rate_limited_logger_many_tags():
             logger.info(i, "x")  # All muted
         assert len(logger._prev_set) == len(logger._prev_heap) == 120
 
-        sleep(0.1)
+        sleep(0.2)
         logger.info(0, "x")  # Event that will flush obsolete tags away
         assert len(logger._prev_set) == len(logger._prev_heap) == 1
     assert len(log.getvalue().splitlines()) == 121

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import array
-import logging
 import os
 import random
 import uuid
@@ -13,7 +12,7 @@ from dask.sizeof import sizeof
 
 from distributed import profile
 from distributed.compatibility import WINDOWS
-from distributed.spill import SpillBuffer, has_zict_220
+from distributed.spill import SpillBuffer, has_zict_220, rl_logger
 from distributed.utils_test import captured_logger
 
 requires_zict_220 = pytest.mark.skipif(
@@ -128,7 +127,7 @@ def test_disk_size_calculation(tmp_path):
 
 def test_spillbuffer_maxlim(tmp_path_factory):
     buf_dir = tmp_path_factory.mktemp("buf")
-    buf = SpillBuffer(str(buf_dir), target=200, max_spill=600, min_log_interval=0)
+    buf = SpillBuffer(str(buf_dir), target=200, max_spill=600)
 
     a, b, c, d, e = "a" * 200, "b" * 100, "c" * 99, "d" * 199, "e" * 98
 
@@ -150,7 +149,8 @@ def test_spillbuffer_maxlim(tmp_path_factory):
     # size of e < target but e+c > target, this will trigger movement of c to slow
     # but the max spill limit prevents it. Resulting in e remaining in fast
 
-    with captured_logger(logging.getLogger("distributed.spill")) as logs_e:
+    rl_logger.clear()
+    with captured_logger("distributed.spill") as logs_e:
         buf["e"] = e
 
     assert "disk reached capacity" in logs_e.getvalue()
@@ -159,7 +159,8 @@ def test_spillbuffer_maxlim(tmp_path_factory):
     # size of d > target, d should go to slow but slow reached the max_spill limit then
     # d will end up on fast with c (which can't be move to slow because it won't fit
     # either)
-    with captured_logger(logging.getLogger("distributed.spill")) as logs_d:
+    rl_logger.clear()
+    with captured_logger("distributed.spill") as logs_d:
         buf["d"] = d
 
     assert "disk reached capacity" in logs_d.getvalue()
@@ -176,7 +177,8 @@ def test_spillbuffer_maxlim(tmp_path_factory):
     unlimited_buf["a_large"] = a_large
     assert psize(unlimited_buf_dir, a_large=a_large)[1] > 600
 
-    with captured_logger(logging.getLogger("distributed.spill")) as logs_alarge:
+    rl_logger.clear()
+    with captured_logger("distributed.spill") as logs_alarge:
         buf["a"] = a_large
 
     assert "disk reached capacity" in logs_alarge.getvalue()
@@ -186,7 +188,8 @@ def test_spillbuffer_maxlim(tmp_path_factory):
     # max_spill
 
     d_large = "d" * 501
-    with captured_logger(logging.getLogger("distributed.spill")) as logs_dlarge:
+    rl_logger.clear()
+    with captured_logger("distributed.spill") as logs_dlarge:
         buf["d"] = d_large
 
     assert "disk reached capacity" in logs_dlarge.getvalue()
@@ -209,14 +212,15 @@ class Bad:
 
 
 def test_spillbuffer_fail_to_serialize(tmp_path):
-    buf = SpillBuffer(str(tmp_path), target=200, max_spill=600, min_log_interval=0)
+    buf = SpillBuffer(str(tmp_path), target=200, max_spill=600)
 
     # bad data individually larger than spill threshold target 200
     a = Bad(size=201)
 
     # Exception caught in the worker
+    rl_logger.clear()
     with pytest.raises(TypeError, match="Could not serialize"):
-        with captured_logger(logging.getLogger("distributed.spill")) as logs_bad_key:
+        with captured_logger("distributed.spill") as logs_bad_key:
             buf["a"] = a
 
     # spill.py must remain silent because we're already logging in worker.py
@@ -229,7 +233,8 @@ def test_spillbuffer_fail_to_serialize(tmp_path):
     assert_buf(buf, tmp_path, {"b": b}, {})
 
     c = "c" * 100
-    with captured_logger(logging.getLogger("distributed.spill")) as logs_bad_key_mem:
+    rl_logger.clear()
+    with captured_logger("distributed.spill") as logs_bad_key_mem:
         # This will go to fast and try to kick b out,
         # but keep b in fast since it's not pickable
         buf["c"] = c
@@ -243,7 +248,7 @@ def test_spillbuffer_fail_to_serialize(tmp_path):
 
 @pytest.mark.skipif(WINDOWS, reason="Needs chmod")
 def test_spillbuffer_oserror(tmp_path):
-    buf = SpillBuffer(str(tmp_path), target=200, max_spill=800, min_log_interval=0)
+    buf = SpillBuffer(str(tmp_path), target=200, max_spill=800)
 
     a, b, c, d = (
         "a" * 200,
@@ -262,7 +267,8 @@ def test_spillbuffer_oserror(tmp_path):
     os.chmod(tmp_path, 0o555)
 
     # Add key > than target
-    with captured_logger(logging.getLogger("distributed.spill")) as logs_oserror_slow:
+    rl_logger.clear()
+    with captured_logger("distributed.spill") as logs_oserror_slow:
         buf["c"] = c
 
     assert "Spill to disk failed" in logs_oserror_slow.getvalue()
@@ -273,7 +279,8 @@ def test_spillbuffer_oserror(tmp_path):
 
     # add key to fast which is smaller than target but when added it triggers spill,
     # which triggers OSError
-    with captured_logger(logging.getLogger("distributed.spill")) as logs_oserror_evict:
+    rl_logger.clear()
+    with captured_logger("distributed.spill") as logs_oserror_evict:
         buf["d"] = d
 
     assert "Spill to disk failed" in logs_oserror_evict.getvalue()
@@ -281,7 +288,7 @@ def test_spillbuffer_oserror(tmp_path):
 
 
 def test_spillbuffer_evict(tmp_path):
-    buf = SpillBuffer(str(tmp_path), target=300, min_log_interval=0)
+    buf = SpillBuffer(str(tmp_path), target=300)
 
     bad = Bad(size=100)
     a = "a" * 100
@@ -298,7 +305,8 @@ def test_spillbuffer_evict(tmp_path):
     assert_buf(buf, tmp_path, {"bad": bad}, {"a": a})
 
     # unsuccessful eviction
-    with captured_logger(logging.getLogger("distributed.spill")) as logs_evict_key:
+    rl_logger.clear()
+    with captured_logger("distributed.spill") as logs_evict_key:
         weight = buf.evict()
     assert weight == -1
 

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -336,8 +336,11 @@ class WorkerMemoryManager:
             )
 
     def _to_dict(self, *, exclude: Container[str] = ()) -> dict:
-        info = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
-        del info["logger"]
+        info = {
+            k: v
+            for k, v in self.__dict__.items()
+            if not k.startswith("_") and k not in ("logger", "rl_logger")
+        }
         info["data"] = dict.fromkeys(self.data)
         return info
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1468,7 +1468,6 @@ class WorkerState:
         who_has)
         This is idempotent
         """
-        logger.debug("Purge task: %s", ts)
         key = ts.key
         self.data.pop(key, None)
         self.actors.pop(key, None)


### PR DESCRIPTION
- Closes #7493
- Reduce the frequency of the following log messages to no more than once every 10 seconds per worker:
  - Worker is at 80% memory usage. Pausing worker.
  - Worker is at 79% memory usage. Resuming worker.
  - Unmanaged memory use is high. This may indicate a memory leak or the memory may not be released to the OS; see https://distributed.dask.org/en/latest/worker-memory.html#memory-not-released-back-to-the-os for more information. 
- Increase rate limiting in distributed.spill from 2 to 10 seconds.

## Demo
```bash
$ export DASK_DISTRIBUTED__WORKER__MEMORY__TARGET=False
$ export DASK_DISTRIBUTED__WORKER__MEMORY__SPILL=0.001
$ dask-worker localhost:8786

2023-02-02 14:52:56,596 - distributed.core - INFO - Starting established connection to tcp://localhost:8786
2023-02-02 14:52:56,697 - distributed.worker.memory - WARNING - Unmanaged memory use is high. This may indicate a memory leak or the memory may not be released to the OS; see https://distributed.dask.org/en/latest/worker-memory.html#memory-not-released-back-to-the-os for more information. -- Unmanaged memory: 156.64 MiB -- Worker memory limit: 62.75 GiB
2023-02-02 14:53:06,797 - distributed.worker.memory - WARNING - Unmanaged memory use is high. This may indicate a memory leak or the memory may not be released to the OS; see https://distributed.dask.org/en/latest/worker-memory.html#memory-not-released-back-to-the-os for more information. -- Unmanaged memory: 156.75 MiB -- Worker memory limit: 62.75 GiB
```
