### PR TITLE
Expand ~ in SSL certificate paths.

### DIFF
--- a/distributed/security.py
+++ b/distributed/security.py
@@ -218,7 +218,7 @@ class Security:
         else:
             val = dask.config.get(config_name)
 
-        if not val is None:
+        if val is not None:
             val = os.path.abspath(os.path.expanduser(val))
 
         setattr(self, field, val)

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -217,6 +217,10 @@ class Security:
             val = kwargs[field]
         else:
             val = dask.config.get(config_name)
+
+        if not val is None:
+            val = os.path.abspath(os.path.expanduser(val))
+
         setattr(self, field, val)
 
     def _set_tls_version_field(self, kwargs, field, config_name, default=None):
@@ -257,7 +261,7 @@ class Security:
                 if isinstance(val, str) and "\n" in val:
                     attr[k] = "Temporary (In-memory)"
                 elif isinstance(val, str):
-                    attr[k] = f"Local ({os.path.abspath(os.path.expanduser(val))})"
+                    attr[k] = f"Local ({val})"
                 else:
                     attr[k] = val
 

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -219,7 +219,7 @@ class Security:
             val = dask.config.get(config_name)
 
         if val is not None:
-            val = os.path.abspath(os.path.expanduser(val))
+            val = os.path.expanduser(val)
 
         setattr(self, field, val)
 
@@ -261,7 +261,7 @@ class Security:
                 if isinstance(val, str) and "\n" in val:
                     attr[k] = "Temporary (In-memory)"
                 elif isinstance(val, str):
-                    attr[k] = f"Local ({val})"
+                    attr[k] = f"Local ({os.path.abspath(val)})"
                 else:
                     attr[k] = val
 

--- a/distributed/security.py
+++ b/distributed/security.py
@@ -257,7 +257,7 @@ class Security:
                 if isinstance(val, str) and "\n" in val:
                     attr[k] = "Temporary (In-memory)"
                 elif isinstance(val, str):
-                    attr[k] = f"Local ({os.path.abspath(val)})"
+                    attr[k] = f"Local ({os.path.abspath(os.path.expanduser(val))})"
                 else:
                     attr[k] = val
 

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -84,10 +84,13 @@ def test_from_config():
     assert sec.tls_worker_key is None
     assert sec.tls_worker_cert == "wcert.pem"
 
+
 def test_path_from_config():
     from pathlib import Path
-    s = Security(tls_ca_file='~/test/fisk.pem')
-    assert s.tls_ca_file == str(Path.home() / 'test' / 'fisk.pem')
+
+    s = Security(tls_ca_file="~/test/fisk.pem")
+    assert s.tls_ca_file == str(Path.home() / "test" / "fisk.pem")
+
 
 @pytest.mark.parametrize("min_ver", [None, 1.2, 1.3])
 @pytest.mark.parametrize("max_ver", [None, 1.2, 1.3])

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -88,8 +88,8 @@ def test_from_config():
 def test_path_from_config():
     from pathlib import Path
 
-    s = Security(tls_ca_file="~/test/fisk.pem")
-    assert s.tls_ca_file == str(Path.home() / "test" / "fisk.pem")
+    s = Security(tls_ca_file="~/cert.pem")
+    assert s.tls_ca_file == str(Path.home() / "cert.pem")
 
 
 @pytest.mark.parametrize("min_ver", [None, 1.2, 1.3])

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -88,7 +88,8 @@ def test_from_config():
 def test_path_from_config():
     from pathlib import Path
 
-    s = Security(tls_ca_file="~/cert.pem")
+    cert_path = str(Path("~") / "cert.pem")
+    s = Security(tls_ca_file=cert_path)
     assert s.tls_ca_file == str(Path.home() / "cert.pem")
 
 

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -84,6 +84,10 @@ def test_from_config():
     assert sec.tls_worker_key is None
     assert sec.tls_worker_cert == "wcert.pem"
 
+def test_path_from_config():
+    from pathlib import Path
+    s = Security(tls_ca_file='~/test/fisk.pem')
+    assert s.tls_ca_file == str(Path.home() / 'test' / 'fisk.pem')
 
 @pytest.mark.parametrize("min_ver", [None, 1.2, 1.3])
 @pytest.mark.parametrize("max_ver", [None, 1.2, 1.3])


### PR DESCRIPTION
Expand "~" in the SSL certificate paths. This simplifies a multi-user configuration where each user have SSL certificates generated in their respective home directory.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
