### PR TITLE
Add environment variable formatting to temp dir

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -174,8 +174,7 @@ class Nanny(ServerNode):
 
         if local_directory is None:
             local_directory = (
-                dask.config.get("temporary-directory").format(**os.environ)
-                or tempfile.gettempdir()
+                dask.config.get("temporary-directory") or tempfile.gettempdir()
             )
             self._original_local_dir = local_directory
             local_directory = os.path.join(local_directory, "dask-worker-space")
@@ -184,7 +183,7 @@ class Nanny(ServerNode):
 
         # Create directory if it doesn't exist and test for write access.
         # In case of PermissionError, change the name.
-        self.local_directory = WorkSpace(local_directory).base_dir
+        self.local_directory = WorkSpace(local_directory.format(**os.environ)).base_dir
 
         self.preload = preload
         if self.preload is None:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -174,7 +174,8 @@ class Nanny(ServerNode):
 
         if local_directory is None:
             local_directory = (
-                dask.config.get("temporary-directory") or tempfile.gettempdir()
+                dask.config.get("temporary-directory").format(**os.environ)
+                or tempfile.gettempdir()
             )
             self._original_local_dir = local_directory
             local_directory = os.path.join(local_directory, "dask-worker-space")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -579,7 +579,8 @@ class Worker(BaseWorker, ServerNode):
 
         if not local_directory:
             local_directory = (
-                dask.config.get("temporary-directory") or tempfile.gettempdir()
+                dask.config.get("temporary-directory").format(**os.environ)
+                or tempfile.gettempdir()
             )
         local_directory = os.path.join(local_directory, "dask-worker-space")
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -579,10 +579,11 @@ class Worker(BaseWorker, ServerNode):
 
         if not local_directory:
             local_directory = (
-                dask.config.get("temporary-directory").format(**os.environ)
-                or tempfile.gettempdir()
+                dask.config.get("temporary-directory") or tempfile.gettempdir()
             )
-        local_directory = os.path.join(local_directory, "dask-worker-space")
+        local_directory = os.path.join(
+            local_directory.format(**os.environ), "dask-worker-space"
+        )
 
         with warn_on_duration(
             "1s",


### PR DESCRIPTION
In https://github.com/dask/distributed/issues/7491#issuecomment-1398222672 @michaelaye asked about being able to substitute environment variables in the `temporary-directory` config.

Seemed like a small lift so thought I'd throw in a PR.

It uses Python string formatting so you could set config like this.

```yaml
temporary-directory: {LOCALNODE}/{USER}/dask_tmp
```

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
