### PR TITLE
Fix for bytes/str discrepancy after PyNVML update

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -317,6 +317,8 @@ def _get_memory_total(h):
 def _get_name(h):
     try:
         return pynvml.nvmlDeviceGetName(h).decode()
+    except AttributeError:
+        return pynvml.nvmlDeviceGetName(h)
     except pynvml.NVMLError_NotSupported:
         return None
 


### PR DESCRIPTION
A PyNVML update has changed how some objects were previously returned `bytes` but now return `str`, which is now handled appropriately with this change.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
