### PR TITLE
scatter() should not sidestep the worker transition machinery

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2366,7 +2366,7 @@ class Client(SyncMethodMixin):
                     direct = True
 
         if local_worker:  # running within task
-            local_worker.update_data(data=data, report=False)
+            local_worker.update_data(data=data)
 
             await self.scheduler.update_data(
                 who_has={key: [local_worker.address] for key in data},
@@ -2390,7 +2390,7 @@ class Client(SyncMethodMixin):
                     raise ValueError("No valid workers found")
 
                 _, who_has, nbytes = await scatter_to_workers(
-                    nthreads, data2, report=False, rpc=self.rpc
+                    nthreads, data2, rpc=self.rpc
                 )
 
                 await self.scheduler.update_data(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5658,9 +5658,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         assert isinstance(data, dict)
 
-        keys, who_has, nbytes = await scatter_to_workers(
-            nthreads, data, rpc=self.rpc, report=False
-        )
+        keys, who_has, nbytes = await scatter_to_workers(nthreads, data, rpc=self.rpc)
 
         self.update_data(who_has=who_has, nbytes=nbytes, client=client)
 

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -1076,7 +1076,7 @@ def test_cancel_with_dependencies_in_memory(ws, release_dep, done_ev_cls):
 
     Read: https://github.com/dask/distributed/issues/6893"""
     ws.handle_stimulus(
-        UpdateDataEvent(data={"x": 1}, report=False, stimulus_id="s1"),
+        UpdateDataEvent(data={"x": 1}, stimulus_id="s1"),
         ComputeTaskEvent.dummy("y", who_has={"x": [ws.address]}, stimulus_id="s2"),
     )
     assert ws.tasks["x"].state == "memory"

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -18,7 +18,7 @@ from distributed.diagnostics.plugin import WorkerPlugin
 
 pytestmark = pytest.mark.gpu
 
-from tlz import first, valmap
+from tlz import first
 from tornado.ioloop import IOLoop
 
 import dask
@@ -32,6 +32,7 @@ from distributed.metrics import time
 from distributed.protocol.pickle import dumps
 from distributed.utils import TimeoutError, get_mp_context, parse_ports
 from distributed.utils_test import (
+    async_wait_for,
     captured_logger,
     gen_cluster,
     gen_test,
@@ -56,24 +57,22 @@ async def test_nanny_process_failure(c, s):
 
         assert os.path.exists(first_dir)
 
-        ww = rpc(n.worker_address)
-        await ww.update_data(data=valmap(dumps, {"x": 1, "y": 2}))
         pid = n.pid
         assert pid is not None
         with suppress(CommClosedError):
             await c.run(os._exit, 0, workers=[n.worker_address])
 
-        while n.pid == pid:  # wait while process dies and comes back
-            await asyncio.sleep(0.01)
-
-        await asyncio.sleep(1)
-        while not n.is_alive():  # wait while process comes back
-            await asyncio.sleep(0.01)
+        # Wait while process dies
+        await async_wait_for(lambda: n.pid != pid, timeout=5)
+        # Wait while process comes back
+        await async_wait_for(lambda: n.is_alive(), timeout=5)
 
         # assert n.worker_address != original_address  # most likely
 
-        while n.worker_address not in s.workers or n.worker_dir is None:
-            await asyncio.sleep(0.01)
+        await async_wait_for(
+            lambda: n.worker_address in s.workers and n.worker_dir is not None,
+            timeout=5,
+        )
 
         second_dir = n.worker_dir
 
@@ -81,7 +80,6 @@ async def test_nanny_process_failure(c, s):
     assert not os.path.exists(second_dir)
     assert not os.path.exists(first_dir)
     assert first_dir != n.worker_dir
-    await ww.close_rpc()
     s.stop()
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1698,6 +1698,8 @@ async def test_include_communication_in_occupancy(c, s, a, b):
 async def test_new_worker_with_data_rejected(s):
     w = Worker(s.address, nthreads=1)
     w.update_data(data={"x": 0})
+    assert w.state.tasks["x"].state == "memory"
+    assert w.data == {"x": 0}
 
     with captured_logger(
         "distributed.worker", level=logging.WARNING
@@ -1729,6 +1731,8 @@ async def test_worker_arrives_with_processing_data(c, s, a, b):
 
     w = Worker(s.address, nthreads=1)
     w.update_data(data={y.key: 3})
+    assert w.state.tasks[y.key].state == "memory"
+    assert w.data == {y.key: 3}
 
     with pytest.raises(RuntimeError, match="Worker failed to start"):
         await w

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -469,12 +469,7 @@ async def test_plugin_exception():
         with raises_with_cause(
             RuntimeError, "Worker failed to start", ValueError, "Setup failed"
         ):
-            async with Worker(
-                s.address,
-                plugins={
-                    MyPlugin(),
-                },
-            ) as w:
+            async with Worker(s.address, plugins={MyPlugin()}):
                 pass
 
 
@@ -2136,7 +2131,6 @@ async def test_worker_descopes_data(c, s, a):
     assert not C.instances
 
 
-# @pytest.mark.slow
 @gen_cluster(client=True, config=NO_AMM)
 async def test_gather_dep_one_worker_always_busy(c, s, a, b):
     # Ensure that both dependencies for H are on another worker than H itself.
@@ -2178,6 +2172,7 @@ async def test_gather_dep_one_worker_always_busy(c, s, a, b):
         # ourselves. Note that doing so means that B won't know about the existence of
         # the extra replicas until it takes the initiative to invoke scheduler.who_has.
         x.update_data({"f": 2, "g": 3})
+        s.add_keys(worker=x.address, keys=("f", "g"))
         assert await h == 5
 
 

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -168,8 +168,9 @@ def test_WorkerState__to_dict(ws):
             ["x", "released", "fetch", "fetch", {}, "s1"],
             ["gather-dependencies", "127.0.0.1:1235", ["x"], "s1"],
             ["x", "fetch", "flight", "flight", {}, "s1"],
-            ["y", "put-in-memory", "s2"],
             ["y", "receive-from-scatter", "s2"],
+            ["y", "put-in-memory", "s2"],
+            ["y", "released", "memory", "memory", {}, "s2"],
         ],
         "long_running": [],
         "missing_dep_flight": [],
@@ -207,7 +208,7 @@ def test_WorkerState__to_dict(ws):
                 "state": "memory",
             },
         },
-        "transition_counter": 2,
+        "transition_counter": 3,
     }
     assert actual == expect
 

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -116,7 +116,7 @@ class WrappedKey:
 _round_robin_counter = [0]
 
 
-async def scatter_to_workers(nthreads, data, rpc=rpc, report=True):
+async def scatter_to_workers(nthreads, data, rpc=rpc):
     """Scatter data directly to workers
 
     This distributes data in a round-robin fashion to a set of workers based on
@@ -140,15 +140,7 @@ async def scatter_to_workers(nthreads, data, rpc=rpc, report=True):
 
     rpcs = {addr: rpc(addr) for addr in d}
     try:
-        out = await All(
-            [
-                rpcs[address].update_data(
-                    data=v,
-                    report=report,
-                )
-                for address, v in d.items()
-            ]
-        )
+        out = await All([rpcs[address].update_data(data=v) for address, v in d.items()])
     finally:
         for r in rpcs.values():
             await r.close_rpc()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1304,7 +1304,7 @@ class Worker(BaseWorker, ServerNode):
         result, missing_keys, missing_workers = await gather_from_workers(
             who_has, rpc=self.rpc, who=self.address
         )
-        self.update_data(data=result, report=False)
+        self.update_data(data=result)
         if missing_keys:
             logger.warning(
                 "Could not find data: %s on workers: %s (who_has: %s)",
@@ -1804,16 +1804,11 @@ class Worker(BaseWorker, ServerNode):
     def update_data(
         self,
         data: dict[str, object],
-        report: bool = True,
         stimulus_id: str | None = None,
     ) -> dict[str, Any]:
-        self.handle_stimulus(
-            UpdateDataEvent(
-                data=data,
-                report=report,
-                stimulus_id=stimulus_id or f"update-data-{time()}",
-            )
-        )
+        if stimulus_id is None:
+            stimulus_id = f"update-data-{time()}"
+        self.handle_stimulus(UpdateDataEvent(data=data, stimulus_id=stimulus_id))
         return {"nbytes": {k: sizeof(v) for k, v in data.items()}, "status": "OK"}
 
     async def set_resources(self, **resources: float) -> None:


### PR DESCRIPTION
Normally, a task is created in released state and then goes through the transition machinery to get into memory.
When a scattered key lands on the worker, it completely sidesteps transitions and appears immediately in memory.
This PR aligns scatter to tasks going into memory from flight or executing, making `_transition_to_memory` the one and only code path that inserts keys in `Worker.data`.

Additionally, this PR removes the report flag, which was set to True only in a handful of unit tests that created artificial use cases.