### PR TITLE
Expand environment variables in security (SSL) configuration.

### DIFF
--- a/distributed/security.py
+++ b/distributed/security.py
@@ -217,6 +217,10 @@ class Security:
             val = kwargs[field]
         else:
             val = dask.config.get(config_name)
+
+        if val is not None:
+            val = val.format(**os.environ)
+
         setattr(self, field, val)
 
     def _set_tls_version_field(self, kwargs, field, config_name, default=None):

--- a/distributed/tests/test_security.py
+++ b/distributed/tests/test_security.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import ssl
 from contextlib import contextmanager
 
@@ -83,6 +84,14 @@ def test_from_config():
     assert sec.tls_scheduler_cert == "scert.pem"
     assert sec.tls_worker_key is None
     assert sec.tls_worker_cert == "wcert.pem"
+
+
+def test_expand_vars():
+    from pathlib import Path
+
+    cert_path = str(Path("{HOME}") / "cert.pem")
+    s = Security(tls_ca_file=cert_path)
+    assert s.tls_ca_file == str(Path(os.environ["HOME"]) / "cert.pem")
 
 
 @pytest.mark.parametrize("min_ver", [None, 1.2, 1.3])


### PR DESCRIPTION
Implements expanding environment variables in the security configuration. This enables both having a centralized configuration and storing the SSL certificates e.g. in the users home directory. This pull request is more general and supersede pull request #7524 .

- [ X] Tests added / passed
- [X ] Passes `pre-commit run --all-files`
