### PR TITLE
Coassignment + queuing by divvying up the queue

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2220,6 +2220,8 @@ class SchedulerState:
                 if not (ws := self.decide_worker_rootish_queuing_disabled(ts)):
                     return {ts.key: "no-worker"}, {}, {}
             else:
+                # All rootish tasks go straight to `queued` first.
+                # `stimulus_queue_slots_maybe_opened` will then maybe pop some off later.
                 return {ts.key: "queued"}, {}, {}
         else:
             if not (ws := self.decide_worker_non_rootish(ts)):
@@ -2696,7 +2698,6 @@ class SchedulerState:
                 ws,
                 _task_slots_available(ws, self.WORKER_SATURATION),
             )
-            # TODO assert `ts` meant for `ws`
 
         self.queued.discard(ts)
         worker_msgs: Msgs = self._add_to_processing(ts, ws)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import itertools
 import json
 import logging
 import math
@@ -429,10 +428,6 @@ async def test_queued_release_multiple_workers(c, s, *workers):
         await async_wait_for(lambda: second_batch[0].key in s.tasks, 5)
 
         # All of the second batch should be queued after the first batch
-        assert [ts.key for ts in s.queued.sorted()] == [
-            f.key
-            for f in itertools.chain(first_batch[s.total_nthreads :], second_batch)
-        ]
 
         # Cancel the first batch.
         # Use `Client.close` instead of `del first_batch` because deleting futures sends cancellation
@@ -444,9 +439,7 @@ async def test_queued_release_multiple_workers(c, s, *workers):
         await async_wait_for(lambda: len(s.tasks) == len(second_batch), 5)
 
         # Second batch should move up the queue and start processing
-        assert len(s.queued) == len(second_batch) - s.total_nthreads, list(
-            s.queued.sorted()
-        )
+        assert len(s.queued) == len(second_batch) - s.total_nthreads, list(s.queued)
 
         await event.set()
         await c2.gather(second_batch)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -158,7 +158,7 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
         nthreads=nthreads,
         config={
             "distributed.scheduler.work-stealing": False,
-            "distributed.scheduler.worker-saturation": float("inf"),
+            # "distributed.scheduler.worker-saturation": float("inf"),
         },
     )
     async def test_decide_worker_coschedule_order_neighbors_(c, s, *workers):


### PR DESCRIPTION
An experimental approach to getting co-assignment a la https://github.com/dask/distributed/pull/4967 along with queuing. This turns the queue into a SortedSet (surprisingly little performance impact), then instead of always pulling from the front of the queue, each worker pops from some point along the queue corresponding to its index (at position `ws_idx * tasks_per_worker`).

This doesn't actually work well.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
