### PR TITLE
Schedule from queue in batches to improve co-assignment

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1328,7 +1328,7 @@ class TaskState:
 
     def __init__(self, key: str, run_spec: object, state: TaskStateState):
         self.key = key
-        self._hash = hash(key)
+        self._hash = hash(id(self))
         self.run_spec = run_spec
         self._state = state
         self.exception = None
@@ -1366,7 +1366,7 @@ class TaskState:
         return self._hash
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, TaskState) and self.key == other.key
+        return self is other
 
     @property
     def state(self) -> TaskStateState:


### PR DESCRIPTION
An experimental approach to getting co-assignment along with queuing. Rather than scheduling a new task every time a thread opens up on a worker, we basically wait until all the threads are idle on a worker, then schedule a batch of `nthreads` queued tasks at once.

This "works" in that it improves co-assignment and reduces data transfer while maintaining low memory footprint, but it's slow.

Benchmarks: https://observablehq.com/@gjoseph92/snakebench?commits=6bb123e&commits=6215b2b&measure=duration&groupby=branch&show=passed&everygroup=true

runtime
![zchart](https://user-images.githubusercontent.com/3309802/219486588-9e382d7e-8819-4f4a-b070-8f539740c347.png)

memory
![zchart (1)](https://user-images.githubusercontent.com/3309802/219486616-a1e30199-6251-4856-916f-517c7acfe8e5.png)

data transfer
![zchart (2)](https://user-images.githubusercontent.com/3309802/219486651-6d3bc947-6908-4db1-9847-c048904b3cb5.png)


- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
