### PR TITLE
metrics.monotonic() is not monotonic on Windows

### DIFF
--- a/distributed/shuffle/_limiter.py
+++ b/distributed/shuffle/_limiter.py
@@ -44,7 +44,7 @@ class ResourceLimiter:
     async def wait_for_available(self) -> None:
         """Block until the counter drops below maxvalue"""
         start = time()
-        duration = 0
+        duration = 0.0
         try:
             if self.available():
                 return

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1219,7 +1219,7 @@ class Worker(BaseWorker, ServerNode):
                 now=start,
                 metrics=await self.get_metrics(),
                 executing={
-                    key: start - self.state.tasks[key].start_time
+                    key: start - cast(float, self.state.tasks[key].start_time)
                     for key in self.active_keys
                     if key in self.state.tasks
                 },


### PR DESCRIPTION
Every 10 minutes, the monotonic timer can go backwards a few milliseconds. This leads to unit test failures such as

```python
t0 = monotonic()
sleep(0.2)
t1 = monotonic()
assert 0.2 <= t1 - t0

AssertionError:
assert 0.2 <= 0.19631620000018302
```