### PR TITLE
Fix flaky test_scatter_no_workers

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1419,7 +1419,7 @@ async def test_scatter_no_workers(c, s, direct):
     start = time()
     with pytest.raises(TimeoutError):
         await c.scatter(123, timeout=0.1, direct=direct)
-    assert time() < start + 1.5
+    assert time() < start + 5
 
     fut = c.scatter({"y": 2}, timeout=5, direct=direct)
     await asyncio.sleep(0.1)


### PR DESCRIPTION
Fix flaky test when CI decides to take a nap:
https://github.com/dask/distributed/pull/7557/checks?check_run_id=11423389465

```
>       assert time() < start + 1.5
E       assert 1676652426.6656592 < (1676652424.9998777 + 1.5)
E        +  where 1676652426.6656592 = time()
```