### PR TITLE
Meter how long each task prefix stays in each state

### DIFF
--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -23,8 +23,9 @@ async def test_prometheus_api_doc(c, s, a):
     """
     pytest.importorskip("prometheus_client")
 
-    # Some metrics only appear after a task is executed
-    await c.submit(inc, 1)
+    # Some metrics only appear if there are tasks on the cluster
+    fut = c.submit(inc, 1)
+    await fut
     # Semaphore metrics only appear after semaphores are used
     sem = await Semaphore()
     await sem.acquire()

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -42,9 +42,9 @@ class WorkerMetricCollector(PrometheusCollector):
         for state, n in ws.task_counter.current_count(by_prefix=False).items():
             if state == "memory" and hasattr(self.server.data, "slow"):
                 n_spilled = len(self.server.data.slow)
-                if n - n_spilled:
+                if n - n_spilled > 0:
                     tasks.add_metric(["memory"], n - n_spilled)
-                if n_spilled:
+                if n_spilled > 0:
                     tasks.add_metric(["disk"], n_spilled)
             else:
                 tasks.add_metric([state], n)

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 from unittest import mock
 
@@ -10,6 +9,7 @@ from tornado.httpclient import AsyncHTTPClient
 from distributed import Event, Worker, wait
 from distributed.sizeof import sizeof
 from distributed.utils_test import (
+    async_wait_for,
     fetch_metrics,
     fetch_metrics_body,
     fetch_metrics_sample_names,
@@ -20,6 +20,10 @@ from distributed.utils_test import (
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
 async def test_prometheus(c, s, a):
     pytest.importorskip("prometheus_client")
+
+    # We need *some* tasks or dask_worker_tasks won't appear
+    fut = c.submit(lambda: 1)
+    await wait(fut)
 
     active_metrics = await fetch_metrics_sample_names(
         a.http_server.port, prefix="dask_worker_"
@@ -88,22 +92,7 @@ async def test_metrics_when_prometheus_client_not_installed(
 async def test_prometheus_collect_task_states(c, s, a):
     pytest.importorskip("prometheus_client")
 
-    async def assert_metrics(**kwargs):
-        expect = {
-            "constrained": 0,
-            "executing": 0,
-            "fetch": 0,
-            "flight": 0,
-            "long-running": 0,
-            "memory": 0,
-            "disk": 0,
-            "missing": 0,
-            "other": 0,
-            "ready": 0,
-            "waiting": 0,
-        }
-        expect.update(kwargs)
-
+    async def assert_metrics(**expect):
         families = await fetch_metrics(a.http_server.port, prefix="dask_worker_")
         actual = {
             sample.labels["state"]: sample.value
@@ -117,24 +106,29 @@ async def test_prometheus_collect_task_states(c, s, a):
     ev = Event()
 
     # submit a task which should show up in the prometheus scraping
-    future = c.submit(ev.wait)
-    while not a.state.executing:
-        await asyncio.sleep(0.001)
+    fut1 = c.submit(ev.wait)
+    await async_wait_for(lambda: a.state.executing, timeout=5)
 
     await assert_metrics(executing=1)
 
     await ev.set()
-    await c.gather(future)
+    await wait(fut1)
 
     await assert_metrics(memory=1)
+
+    fut2 = c.submit(lambda: 1)
+    await wait(fut2)
+    await assert_metrics(memory=2)
+
     a.data.evict()
-    await assert_metrics(disk=1)
+    await assert_metrics(memory=1, disk=1)
+    a.data.evict()
+    await assert_metrics(disk=2)
 
-    future.release()
+    fut1.release()
+    fut2.release()
 
-    while future.key in a.state.tasks:
-        await asyncio.sleep(0.001)
-
+    await async_wait_for(lambda: not a.state.tasks, timeout=5)
     await assert_metrics()
 
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3426,6 +3426,8 @@ async def test_Worker__to_dict(c, s, a):
         "transition_counter",
         "tasks",
         "data_needed",
+        "task_counts",
+        "task_cumulative_elapsed",
     }
     assert d["tasks"]["x"]["key"] == "x"
     assert d["data"] == {"x": None}

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -1722,8 +1722,8 @@ def test_task_counter(ws):
         # timer accuracy in Windows can be very poor;
         # see awful hack in distributed.metrics
         margin_lo = 0.099 if WINDOWS else 0
-        # sleep() has been observed to have up to 250ms lag on MacOSX GitHub CI
-        margin_hi = 0.4 if MACOS else 0.1
+        # sleep() has been observed to have up to 450ms lag on MacOSX GitHub CI
+        margin_hi = 0.6 if MACOS else 0.1
         assert expect - margin_lo <= actual < expect + margin_hi
 
     sleep(0.1)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1010,7 +1010,7 @@ class Worker(BaseWorker, ServerNode):
             spilled_memory, spilled_disk = 0, 0
 
         out = dict(
-            task_counts=self.state.task_counts,
+            task_counts=self.state.task_counter.current_count(by_prefix=False),
             bandwidth={
                 "total": self.bandwidth,
                 "workers": dict(self.bandwidth_workers),

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3771,10 +3771,8 @@ class TaskCounter:
             False
                 Return mapping of task state -> seconds
         """
-        if self._previous_ts is None:
-            assert not self._current_count
-            assert not self._cumulative_elapsed
-        else:
+        if self._current_count:
+            assert self._previous_ts is not None
             now = monotonic()
             elapsed = now - self._previous_ts
             self._previous_ts = now
@@ -3801,10 +3799,12 @@ class TaskCounter:
             return
 
         now = monotonic()
-        if self._previous_ts is not None:
+        if self._current_count:
+            assert self._previous_ts is not None
             elapsed = now - self._previous_ts
             for k, n_tasks in self._current_count.items():
                 self._cumulative_elapsed[k] += elapsed * n_tasks
+        self._previous_ts = now
 
         for ts, prev_state in prev_states.items():
             if ts.state != "forgotten":
@@ -3826,8 +3826,6 @@ class TaskCounter:
             # will remain in released state and never transition to anything else.
             self._current_count[ts.prefix, ts.state] += 1
         self._new_tasks.clear()
-
-        self._previous_ts = now
 
 
 class DeprecatedWorkerStateAttribute:


### PR DESCRIPTION
- Closes #7412
- Partially closes #7217

Add task metrics:
1. current number of tasks, per task prefix, per task state (on worker), per worker
2. cumulative elapsed time, per task prefix, per task state (on worker), per worker

This differs from similar metrics on the scheduler because it offers much higher granularity of states, e.g. it differentiates between fetch, flight, and no-worker and between waiting and executing.

This should allow us, for example, to:
- appreciate which tasks sit for an abnormal amount of time in waiting state
- appreciate which tasks take an abnormal of time to transfer over the network
- spot tasks that should be transitory and turn out to sit in memory for a long time (and could potentially benefit from `dask.graph_manipulation.clone`)
- notice when the network is saturated (tasks sit in `fetch` state for a long time)
- measure how long it takes for the cluster to heal after the loss of a worker (tasks sit in `no-worker` state)
- how long tasks sit in `cancelled` state before they are cleaned up, releasing resources

As discussed offline, these new metrics are not exported to prometheus for the time being over concerns about cardinality. An opt-in switch is likely in the future.

This PR also introduces cancelled, resumed, released and error task states in Prometheus worker metrics and removes the "other" state.