### PR TITLE
Update parsing of `FULL_RAPIDS_VER`/`FULL_UCX_PY_VER` in gpuCI updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yaml
+++ b/.github/workflows/update-gpuci.yaml
@@ -42,8 +42,8 @@ jobs:
         run: |
           echo RAPIDS_VER=${{ steps.rapids_current.outputs.RAPIDS_VER_0 }} >> $GITHUB_ENV
           echo UCX_PY_VER=$(curl -sL https://version.gpuci.io/rapids/${{ steps.rapids_current.outputs.RAPIDS_VER_0 }}) >> $GITHUB_ENV
-          echo NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-10} >> $GITHUB_ENV
-          echo NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-10} >> $GITHUB_ENV
+          echo NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-4} >> $GITHUB_ENV
+          echo NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-4} >> $GITHUB_ENV
 
       - name: Update RAPIDS version
         uses: jacobtomlinson/gha-find-replace@v3


### PR DESCRIPTION
Now that cuDF/ucx-py packages have moved their publishing date to the build string, we need to update the updating workflow to parse the new version strings accordingly.

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
