### PR TITLE
Avoid parsing `sys.argv` when starting `jupyter` server

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3509,7 +3509,8 @@ class Scheduler(SchedulerState, ServerNode):
                 )
             )
             j.initialize(
-                new_httpserver=False, argv=[]
+                new_httpserver=False,
+                argv=[],
             )
             self._jupyter_server_application = j
             self.http_application.add_application(j.web_app)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3509,7 +3509,7 @@ class Scheduler(SchedulerState, ServerNode):
                 )
             )
             j.initialize(
-                new_httpserver=False,
+                new_httpserver=False, argv=[]
             )
             self._jupyter_server_application = j
             self.http_application.add_application(j.web_app)

--- a/distributed/tests/test_jupyter.py
+++ b/distributed/tests/test_jupyter.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import pytest
+
+pytest.importorskip("requests")
+
 import requests
 
 from distributed import Client

--- a/distributed/tests/test_jupyter.py
+++ b/distributed/tests/test_jupyter.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import pytest
+import requests
+
+from distributed import Client
 
 pytest.importorskip("jupyter_server")
 
 from tornado.httpclient import AsyncHTTPClient
 
 from distributed import Scheduler
-from distributed.utils_test import gen_test
+from distributed.utils import open_port
+from distributed.utils_test import gen_test, popen
 
 
 @gen_test()
@@ -18,3 +22,22 @@ async def test_jupyter_server():
             f"http://localhost:{s.http_server.port}/jupyter/api/status"
         )
         assert response.code == 200
+
+
+@pytest.mark.slow
+def test_jupyter_cli(loop):
+    port = open_port()
+    with popen(
+        [
+            "dask",
+            "scheduler",
+            "--jupyter",
+            "--no-dashboard",
+            "--host",
+            f"127.0.0.1:{port}",
+        ],
+        capture_output=True,
+    ):
+        with Client(f"127.0.0.1:{port}", loop=loop):
+            response = requests.get("http://127.0.0.1:8787/jupyter/api/status")
+            assert response.status_code == 200


### PR DESCRIPTION
Closes #7569.

`initialize` forwards an `argv` along to `jupyter_core.application.JupyterApp`, if it's not passed then it goes and grabs `sys.argv` which causes the linked issue. So the simplest fix seems to be to explicitly pass no arguments to avoid this behavior. If for some reason we do want to forward along args then we could just pop `--jupyter` from the list, either seems fine to me....?

cc @mrocklin @Carreau 