### PR TITLE
Tell workers when their peers have left (so they don't hang fetching data from them)

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4884,7 +4884,7 @@ class Scheduler(SchedulerState, ServerNode):
             self.bandwidth_workers.pop((address, w), None)
             self.bandwidth_workers.pop((w, address), None)
 
-        async def remove_worker_from_events():
+        async def remove_worker_from_events() -> None:
             # If the worker isn't registered anymore after the delay, remove from events
             if address not in self.workers and address in self.events:
                 del self.events[address]
@@ -5300,7 +5300,9 @@ class Scheduler(SchedulerState, ServerNode):
                 cleanup_delay, remove_client_from_events
             )
 
-    def send_task_to_worker(self, worker, ts: TaskState, duration: float = -1):
+    def send_task_to_worker(
+        self, worker: str, ts: TaskState, duration: float = -1
+    ) -> None:
         """Send a single computational task to a worker"""
         try:
             msg: dict = self._task_to_msg(ts, duration)
@@ -6815,7 +6817,9 @@ class Scheduler(SchedulerState, ServerNode):
         logger.info("Retired worker %s", ws.address)
         return ws.address, ws.identity()
 
-    def add_keys(self, worker=None, keys=(), stimulus_id=None):
+    def add_keys(
+        self, worker=None, keys=(), stimulus_id=None
+    ) -> Literal["OK", "not found"]:
         """
         Learn that a worker has certain keys
 
@@ -6827,7 +6831,7 @@ class Scheduler(SchedulerState, ServerNode):
         ws: WorkerState = self.workers[worker]
         redundant_replicas = []
         for key in keys:
-            ts: TaskState = self.tasks.get(key)
+            ts = self.tasks.get(key)
             if ts is not None and ts.state == "memory":
                 if ws not in ts.who_has:
                     self.add_replica(ts, ws)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4898,6 +4898,16 @@ class Scheduler(SchedulerState, ServerNode):
         )
         logger.debug("Removed worker %s", ws)
 
+        for w in self.workers:
+            self.worker_send(
+                w,
+                {
+                    "op": "remove-worker",
+                    "worker": address,
+                    "stimulus_id": stimulus_id,
+                },
+            )
+
         return "OK"
 
     def stimulus_cancel(

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -267,12 +267,7 @@ def test_flight_cancelled_error(ws):
 @gen_cluster(client=True, nthreads=[("", 1)])
 async def test_in_flight_lost_after_resumed(c, s, b):
     async with BlockedGetData(s.address) as a:
-        fut1 = c.submit(
-            inc,
-            1,
-            workers=[a.address],
-            key="fut1",
-        )
+        fut1 = c.submit(inc, 1, workers=[a.address], key="fut1")
         # Ensure fut1 is in memory but block any further execution afterwards to
         # ensure we control when the recomputation happens
         await wait(fut1)
@@ -281,7 +276,6 @@ async def test_in_flight_lost_after_resumed(c, s, b):
         # This ensures that B already fetches the task, i.e. after this the task
         # is guaranteed to be in flight
         await a.in_get_data.wait()
-        assert fut1.key in b.state.tasks
         assert b.state.tasks[fut1.key].state == "flight"
 
         s.set_restrictions({fut1.key: [a.address, b.address]})

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -13,6 +13,7 @@ from distributed.utils_test import (
     BlockedGetData,
     _LockedCommPool,
     assert_story,
+    async_poll_for,
     gen_cluster,
     inc,
     lock_inc,
@@ -265,16 +266,10 @@ def test_flight_cancelled_error(ws):
 
 @gen_cluster(client=True, nthreads=[("", 1)])
 async def test_in_flight_lost_after_resumed(c, s, b):
-    lock_executing = Lock()
-
-    def block_execution(lock):
-        lock.acquire()
-        return 1
-
     async with BlockedGetData(s.address) as a:
         fut1 = c.submit(
-            block_execution,
-            lock_executing,
+            inc,
+            1,
             workers=[a.address],
             key="fut1",
         )
@@ -294,30 +289,12 @@ async def test_in_flight_lost_after_resumed(c, s, b):
         # to be recomputed on B
         await s.remove_worker(a.address, stimulus_id="foo", close=False, safe=True)
 
-        while not b.state.tasks[fut1.key].state == "resumed":
-            await asyncio.sleep(0.01)
+        await wait_for_state(fut1.key, "resumed", b, interval=0)
 
         fut1.release()
         fut2.release()
 
-        while not b.state.tasks[fut1.key].state == "cancelled":
-            await asyncio.sleep(0.01)
-
-        a.block_get_data.set()
-        while b.state.tasks:
-            await asyncio.sleep(0.01)
-
-    assert_story(
-        b.state.story(fut1.key),
-        expect=[
-            # The initial free-keys is rejected
-            ("free-keys", (fut1.key,)),
-            (fut1.key, "resumed", "released", "cancelled", {}),
-            # After gather_dep receives the data, the task is forgotten
-            (fut1.key, "cancelled", "memory", "released", {fut1.key: "forgotten"}),
-            (fut1.key, "released", "forgotten", "forgotten", {}),
-        ],
-    )
+        await async_poll_for(lambda: not b.state.tasks, timeout=5)
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -4381,7 +4381,8 @@ async def test_tell_workers_when_peers_have_left(c, s, a, b):
         async def gather_dep(self, worker, *args, **kwargs):
             w = workers.pop(worker, None)
             if w is not None and workers:
-                await w.close()
+                w.listener.stop()
+                s.stream_comms[worker].abort()
 
             return await super().gather_dep(worker, *args, **kwargs)
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -4368,6 +4368,10 @@ async def test_submit_dependency_of_erred_task(c, s, a, b):
         await y
 
 
+@pytest.mark.skipif(
+    condition=sys.version_info <= (3, 8),
+    reason="flaky on python 3.8",
+)  # seems related to https://github.com/python/cpython/issues/86296
 @gen_cluster(client=True)
 async def test_tell_workers_when_peers_have_left(c, s, a, b):
     f = (await c.scatter({"f": 1}, workers=[a.address, b.address], broadcast=True))["f"]

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -38,6 +38,7 @@ from distributed.worker_state_machine import (
     ExecuteSuccessEvent,
     FreeKeysEvent,
     GatherDep,
+    GatherDepBusyEvent,
     GatherDepFailureEvent,
     GatherDepNetworkFailureEvent,
     GatherDepSuccessEvent,
@@ -50,8 +51,11 @@ from distributed.worker_state_machine import (
     ReleaseWorkerDataMsg,
     RemoveReplicasEvent,
     RemoveWorkerEvent,
+    RequestRefreshWhoHasMsg,
     RescheduleEvent,
     RescheduleMsg,
+    RetryBusyWorkerEvent,
+    RetryBusyWorkerLater,
     SecedeEvent,
     SerializedTask,
     StateMachineEvent,
@@ -1765,7 +1769,8 @@ def test_task_counter(ws):
     assert_time(elapsed["z", "flight"], 0.25)
 
 
-def test_remove_worker_while_in_flight(ws):
+@pytest.mark.parametrize("outcome", ["fail", "success", "no-key", "busy"])
+def test_remove_worker_while_in_flight(ws, outcome):
     ws2 = "127.0.0.1:2"
     ws.handle_stimulus(
         ComputeTaskEvent.dummy("y", who_has={"x": [ws2]}, stimulus_id="s1"),
@@ -1777,45 +1782,92 @@ def test_remove_worker_while_in_flight(ws):
     assert not ws.tasks["y"].who_has
     assert not ws.has_what
 
-    ws.handle_stimulus(
-        GatherDepNetworkFailureEvent(worker=ws2, total_nbytes=1, stimulus_id="s3")
-    )
-    assert ts.state == "missing"
+    if outcome == "fail":
+        instructions = ws.handle_stimulus(
+            GatherDepNetworkFailureEvent(worker=ws2, total_nbytes=1, stimulus_id="s3")
+        )
+        assert not instructions
+        assert ts.state == "missing"
+    elif outcome == "success":
+        instructions = ws.handle_stimulus(
+            GatherDepSuccessEvent(
+                worker=ws2, total_nbytes=1, data={"x": None}, stimulus_id="s3"
+            )
+        )
+        assert instructions == [
+            AddKeysMsg(stimulus_id="s3", keys=["x"]),
+            Execute(stimulus_id="s3", key="y"),
+        ]
+        assert ts.state == "memory"
+    elif outcome == "no-key":
+        instructions = ws.handle_stimulus(
+            GatherDepSuccessEvent(worker=ws2, total_nbytes=1, data={}, stimulus_id="s3")
+        )
+        assert not instructions
+        assert ts.state == "missing"
+    else:
+        assert outcome == "busy"
+        instructions = ws.handle_stimulus(
+            GatherDepBusyEvent(worker=ws2, total_nbytes=1, stimulus_id="s3")
+        )
+        assert instructions == [
+            RetryBusyWorkerLater(worker=ws2, stimulus_id="s3"),
+            RequestRefreshWhoHasMsg(keys=["x"], stimulus_id="s3"),
+        ]
+        assert ts.state == "missing"
+        instructions = ws.handle_stimulus(
+            RetryBusyWorkerEvent(worker=ws2, stimulus_id="s4")
+        )
+        assert not instructions
+        assert ts.state == "missing"
+
+    assert not ts.who_has
+    assert not ws.has_what
 
 
-def test_remove_worker_unknown_peer(ws):
-    unknown_peer = "127.0.0.1:1"
+def test_remove_worker_while_in_flight_unused_peer(ws):
     ws2 = "127.0.0.1:2"
+    ws3 = "127.0.0.1:3"
     ws.handle_stimulus(
-        ComputeTaskEvent.dummy("y", who_has={"x": [ws2]}, stimulus_id="s1"),
-        RemoveWorkerEvent(worker=unknown_peer, stimulus_id="s2"),
+        AcquireReplicasEvent(who_has={"x": [ws2]}, nbytes={"x": 1}, stimulus_id="s1"),
+        AcquireReplicasEvent(
+            who_has={"y": [ws2, ws3]}, nbytes={"y": 1}, stimulus_id="s2"
+        ),
     )
-    ts = ws.tasks["x"]
+
+    ts = ws.tasks["y"]
     assert ts.state == "flight"
-    assert not ws.data_needed
-    assert not ws.tasks["y"].who_has
-    assert ws.has_what == {ws2: {"x"}}
+    assert ts.who_has == {ws2, ws3}
+    assert ts.coming_from == ws3
+
+    ws.handle_stimulus(RemoveWorkerEvent(worker=ws2, stimulus_id="s3"))
+    assert ts.state == "flight"
+    assert ts.who_has == {ws3}
+    assert ts.coming_from == ws3
 
 
-def test_remove_worker_in_fetch(ws):
+def test_remove_worker_while_in_fetch(ws):
     ws2 = "127.0.0.1:2"
     ws3 = "127.0.0.1:3"
     ws.handle_stimulus(
         AcquireReplicasEvent(
-            who_has={"x": [ws2]},
-            nbytes={"x": 1},
-            stimulus_id="s1",
+            who_has={"x": [ws2], "y": [ws3]}, nbytes={"x": 1, "y": 1}, stimulus_id="s1"
         ),
         AcquireReplicasEvent(
-            who_has={"y": [ws2]},
-            nbytes={"y": 1},
+            who_has={"w": [ws2], "z": [ws2, ws3]},
+            nbytes={"w": 1, "z": 1},
             stimulus_id="s2",
         ),
-        RemoveWorkerEvent(worker=ws2, stimulus_id="s2"),
+        RemoveWorkerEvent(worker=ws2, stimulus_id="s3"),
     )
-    assert ws.tasks["x"].state == "flight"
-    y_ts = ws.tasks["y"]
-    assert y_ts.state == "missing"
-    assert not y_ts.who_has
-    assert not ws.data_needed
-    assert not ws.has_what
+    assert ws.tasks["w"].state == "missing"
+    assert ws.tasks["z"].state == "fetch"
+    assert not ws.tasks["w"].who_has
+    assert ws.tasks["z"].who_has == {ws3}
+    assert {k: list(v) for k, v in ws.data_needed.items()} == {ws3: [ws.tasks["z"]]}
+    assert ws.has_what == {ws3: {"y", "z"}}
+
+
+def test_remove_worker_unknown(ws):
+    ws2 = "127.0.0.1:2"
+    ws.handle_stimulus(RemoveWorkerEvent(worker=ws2, stimulus_id="s3"))

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -1795,3 +1795,27 @@ def test_remove_worker_unknown_peer(ws):
     assert not ws.data_needed
     assert not ws.tasks["y"].who_has
     assert ws.has_what == {ws2: {"x"}}
+
+
+def test_remove_worker_in_fetch(ws):
+    ws2 = "127.0.0.1:2"
+    ws3 = "127.0.0.1:3"
+    ws.handle_stimulus(
+        AcquireReplicasEvent(
+            who_has={"x": [ws2]},
+            nbytes={"x": 1},
+            stimulus_id="s1",
+        ),
+        AcquireReplicasEvent(
+            who_has={"y": [ws2]},
+            nbytes={"y": 1},
+            stimulus_id="s2",
+        ),
+        RemoveWorkerEvent(worker=ws2, stimulus_id="s2"),
+    )
+    assert ws.tasks["x"].state == "flight"
+    y_ts = ws.tasks["y"]
+    assert y_ts.state == "missing"
+    assert not y_ts.who_has
+    assert not ws.data_needed
+    assert not ws.has_what

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -1781,3 +1781,17 @@ def test_remove_worker_while_in_flight(ws):
         GatherDepNetworkFailureEvent(worker=ws2, total_nbytes=1, stimulus_id="s3")
     )
     assert ts.state == "missing"
+
+
+def test_remove_worker_unknown_peer(ws):
+    unknown_peer = "127.0.0.1:1"
+    ws2 = "127.0.0.1:2"
+    ws.handle_stimulus(
+        ComputeTaskEvent.dummy("y", who_has={"x": [ws2]}, stimulus_id="s1"),
+        RemoveWorkerEvent(worker=unknown_peer, stimulus_id="s2"),
+    )
+    ts = ws.tasks["x"]
+    assert ts.state == "flight"
+    assert not ws.data_needed
+    assert not ws.tasks["y"].who_has
+    assert ws.has_what == {ws2: {"x"}}

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -767,7 +767,7 @@ class Worker(BaseWorker, ServerNode):
             "steal-request": self._handle_remote_stimulus(StealRequestEvent),
             "refresh-who-has": self._handle_remote_stimulus(RefreshWhoHasEvent),
             "worker-status-change": self.handle_worker_status_change,
-            "remove-worker": self._remove_worker,
+            "remove-worker": self._handle_remove_worker,
         }
 
         ServerNode.__init__(
@@ -2618,7 +2618,7 @@ class Worker(BaseWorker, ServerNode):
         """
         return self.active_threads[threading.get_ident()]
 
-    def _remove_worker(self, worker: str, stimulus_id: str) -> None:
+    def _handle_remove_worker(self, worker: str, stimulus_id: str) -> None:
         self.rpc.remove(worker)
         self.handle_stimulus(RemoveWorkerEvent(worker=worker, stimulus_id=stimulus_id))
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -766,6 +766,7 @@ class Worker(BaseWorker, ServerNode):
             "steal-request": self._handle_remote_stimulus(StealRequestEvent),
             "refresh-who-has": self._handle_remote_stimulus(RefreshWhoHasEvent),
             "worker-status-change": self.handle_worker_status_change,
+            "remove-worker": self._remove_worker,
         }
 
         ServerNode.__init__(
@@ -2615,6 +2616,9 @@ class Worker(BaseWorker, ServerNode):
         get_worker
         """
         return self.active_threads[threading.get_ident()]
+
+    def _remove_worker(self, worker: str, stimulus_id: str) -> None:
+        self.rpc.remove(worker)
 
     def validate_state(self) -> None:
         try:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -138,6 +138,7 @@ from distributed.worker_state_machine import (
     PauseEvent,
     RefreshWhoHasEvent,
     RemoveReplicasEvent,
+    RemoveWorkerEvent,
     RescheduleEvent,
     RetryBusyWorkerEvent,
     SecedeEvent,
@@ -2619,6 +2620,7 @@ class Worker(BaseWorker, ServerNode):
 
     def _remove_worker(self, worker: str, stimulus_id: str) -> None:
         self.rpc.remove(worker)
+        self.handle_stimulus(RemoveWorkerEvent(worker=worker, stimulus_id=stimulus_id))
 
     def validate_state(self) -> None:
         try:

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -2951,7 +2951,8 @@ class WorkerState:
                     assert ts.state != "fetch"
                     assert ts not in self.data_needed[ev.worker]
                 ts.who_has.discard(ev.worker)
-                self.has_what[ev.worker].discard(ts.key)
+                if ev.worker in self.has_what:
+                    self.has_what[ev.worker].discard(ts.key)
                 recommendations[ts] = "fetch"
 
         return recommendations, []


### PR DESCRIPTION
Closes #6790

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
