### PR TITLE
P2P: raise RuntimeError if pyarrow version is not sufficient

### DIFF
--- a/distributed/shuffle/__init__.py
+++ b/distributed/shuffle/__init__.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from distributed.shuffle._arrow import check_minimal_arrow_version
 from distributed.shuffle._scheduler_extension import ShuffleSchedulerExtension
 from distributed.shuffle._shuffle import P2PShuffleLayer, rearrange_by_column_p2p
 from distributed.shuffle._worker_extension import ShuffleWorkerExtension
 
 __all__ = [
+    "check_minimal_arrow_version",
     "P2PShuffleLayer",
     "rearrange_by_column_p2p",
     "ShuffleSchedulerExtension",

--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from io import BytesIO
 from typing import TYPE_CHECKING, BinaryIO
 
+from packaging.version import parse
+
 if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
@@ -40,13 +42,13 @@ def check_minimal_arrow_version() -> None:
     minversion = "7.0.0"
     try:
         import pyarrow as pa
-        from packaging.version import parse
-
-        if parse(pa.__version__) >= parse(minversion):
-            return
-        suffix = f" but only found {pa.__version__}"
-    finally:
+    except ImportError:
         raise RuntimeError(f"P2P shuffling requires pyarrow>={minversion}" + suffix)
+
+    if parse(pa.__version__) < parse(minversion):
+        raise RuntimeError(
+            f"P2P shuffling requires pyarrow>={minversion} but only found {pa.__version__}"
+        )
 
 
 def dump_shards(shards: list[bytes], file: BinaryIO) -> None:

--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -37,13 +37,12 @@ def check_minimal_arrow_version() -> None:
     Raises a RuntimeError in case pyarrow is not installed or installed version
     is not recent enough.
     """
-    suffix = ""
     # First version to introduce Table.sort_by
     minversion = "7.0.0"
     try:
         import pyarrow as pa
     except ImportError:
-        raise RuntimeError(f"P2P shuffling requires pyarrow>={minversion}" + suffix)
+        raise RuntimeError(f"P2P shuffling requires pyarrow>={minversion}")
 
     if parse(pa.__version__) < parse(minversion):
         raise RuntimeError(

--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -29,6 +29,12 @@ def check_dtype_support(meta_input: pd.DataFrame) -> None:
 
 
 def check_minimal_arrow_version() -> None:
+    """Verify that the the correct version of pyarrow is installed to support
+    the P2P extension.
+
+    Raises a RuntimeError in case pyarrow is not installed or installed version
+    is not recent enough.
+    """
     suffix = ""
     # First version to introduce Table.sort_by
     minversion = "7.0.0"

--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -28,6 +28,21 @@ def check_dtype_support(meta_input: pd.DataFrame) -> None:
             raise TypeError("p2p does not support sparse data found in column '{name}'")
 
 
+def check_minimal_arrow_version() -> None:
+    suffix = ""
+    # First version to introduce Table.sort_by
+    minversion = "7.0.0"
+    try:
+        import pyarrow as pa
+        from packaging.version import parse
+
+        if parse(pa.__version__) >= parse(minversion):
+            return
+        suffix = f" but only found {pa.__version__}"
+    finally:
+        raise RuntimeError(f"P2P shuffling requires pyarrow>={minversion}" + suffix)
+
+
 def dump_shards(shards: list[bytes], file: BinaryIO) -> None:
     """
     Write multiple shard tables to the file

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -8,6 +8,7 @@ from dask.highlevelgraph import HighLevelGraph
 from dask.layers import SimpleShuffleLayer
 
 from distributed.shuffle._arrow import check_dtype_support
+from distributed.shuffle._arrow import check_minimal_arrow_version
 
 logger = logging.getLogger("distributed.shuffle")
 if TYPE_CHECKING:
@@ -138,6 +139,7 @@ class P2PShuffleLayer(SimpleShuffleLayer):
         parts_out: list | None = None,
         annotations: dict | None = None,
     ):
+        check_minimal_arrow_version()
         annotations = annotations or {}
         annotations.update({"shuffle": lambda key: key[1]})
         super().__init__(

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -7,8 +7,7 @@ from dask.base import tokenize
 from dask.highlevelgraph import HighLevelGraph
 from dask.layers import SimpleShuffleLayer
 
-from distributed.shuffle._arrow import check_dtype_support
-from distributed.shuffle._arrow import check_minimal_arrow_version
+from distributed.shuffle._arrow import check_dtype_support, check_minimal_arrow_version
 
 logger = logging.getLogger("distributed.shuffle")
 if TYPE_CHECKING:


### PR DESCRIPTION
The test is unfortunately never triggered on CI... we don't have a job that installs pandas but not pyarrow.