### PR TITLE
Unpickle objects safely

### DIFF
--- a/distributed/event.py
+++ b/distributed/event.py
@@ -8,9 +8,8 @@ from contextlib import suppress
 
 from dask.utils import parse_timedelta
 
-from distributed.client import Client
 from distributed.utils import TimeoutError, log_errors
-from distributed.worker import get_worker
+from distributed.worker import get_client
 
 logger = logging.getLogger(__name__)
 
@@ -180,10 +179,9 @@ class Event:
 
     def __init__(self, name=None, client=None):
         try:
-            self.client = client or Client.current()
+            self.client = client or get_client()
         except ValueError:
-            # Initialise new client
-            self.client = get_worker().client
+            self.client = None
         self.name = name or "event-" + uuid.uuid4().hex
 
     def __await__(self):
@@ -200,6 +198,14 @@ class Event:
             return self
 
         return _().__await__()
+
+    def _verify_running(self):
+        if not self.client:
+            raise RuntimeError(
+                f"{type(self)} object not properly initialized. This can happen"
+                " if the object is being deserialized outside of the context of"
+                " a Client or Worker."
+            )
 
     def wait(self, timeout=None):
         """Wait until the event is set.
@@ -221,6 +227,7 @@ class Event:
         -------
         True if the event was set of false, if a timeout happened
         """
+        self._verify_running()
         timeout = parse_timedelta(timeout)
 
         result = self.client.sync(
@@ -233,6 +240,7 @@ class Event:
 
         All waiters will now block.
         """
+        self._verify_running()
         return self.client.sync(self.client.scheduler.event_clear, name=self.name)
 
     def set(self):
@@ -240,11 +248,13 @@ class Event:
 
         All waiters will now be released.
         """
+        self._verify_running()
         result = self.client.sync(self.client.scheduler.event_set, name=self.name)
         return result
 
     def is_set(self):
         """Check if the event is set"""
+        self._verify_running()
         result = self.client.sync(self.client.scheduler.event_is_set, name=self.name)
         return result
 

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -345,15 +345,19 @@ class Semaphore(SyncMethodMixin):
         loop=None,
     ):
         try:
-            worker = get_worker()
-            self.scheduler = scheduler_rpc or worker.scheduler
-            self.loop = loop or worker.loop
+            try:
+                worker = get_worker()
+                self.scheduler = scheduler_rpc or worker.scheduler
+                self.loop = loop or worker.loop
 
+            except ValueError:
+                client = get_client()
+                self.scheduler = scheduler_rpc or client.scheduler
+                self.loop = loop or client.loop
         except ValueError:
-            client = get_client()
-            self.scheduler = scheduler_rpc or client.scheduler
-            self.loop = loop or client.loop
-
+            # This happens if this is deserialized on the scheduler
+            self.scheduler = None
+            self.loop = None
         self.name = name or "semaphore-" + uuid.uuid4().hex
         self.max_leases = max_leases
         self.id = uuid.uuid4().hex
@@ -381,7 +385,12 @@ class Semaphore(SyncMethodMixin):
 
         # Need to start the callback using IOLoop.add_callback to ensure that the
         # PC uses the correct event loop.
-        self.loop.add_callback(pc.start)
+        if self.loop is not None:
+            self.loop.add_callback(pc.start)
+
+    def _verify_running(self):
+        if not self.scheduler or not self.loop:
+            raise RuntimeError("Semaphore object not properly initialized.")
 
     async def _register(self):
         await retry_operation(
@@ -453,6 +462,7 @@ class Semaphore(SyncMethodMixin):
             Instead of number of seconds, it is also possible to specify
             a timedelta in string format, e.g. "200ms".
         """
+        self._verify_running()
         timeout = parse_timedelta(timeout)
         return self.sync(self._acquire, timeout=timeout)
 
@@ -486,6 +496,7 @@ class Semaphore(SyncMethodMixin):
             immediately, but it will always be automatically released after a specific interval configured using
             "distributed.scheduler.locks.lease-validation-interval" and "distributed.scheduler.locks.lease-timeout".
         """
+        self._verify_running()
         if not self._leases:
             raise RuntimeError("Released too often")
 
@@ -498,9 +509,11 @@ class Semaphore(SyncMethodMixin):
         """
         Return the number of currently registered leases.
         """
+        self._verify_running()
         return self.sync(self.scheduler.semaphore_value, name=self.name)
 
     def __enter__(self):
+        self._verify_running()
         self.acquire()
         return self
 
@@ -508,6 +521,7 @@ class Semaphore(SyncMethodMixin):
         self.release()
 
     async def __aenter__(self):
+        self._verify_running()
         await self.acquire()
         return self
 
@@ -528,6 +542,7 @@ class Semaphore(SyncMethodMixin):
         )
 
     def close(self):
+        self._verify_running()
         self.refresh_callback.stop()
         return self.sync(self.scheduler.semaphore_close, name=self.name)
 

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -390,7 +390,9 @@ class Semaphore(SyncMethodMixin):
 
     def _verify_running(self):
         if not self.scheduler or not self.loop:
-            raise RuntimeError("Semaphore object not properly initialized.")
+            raise RuntimeError(
+                f"{type(self)} object not properly initialized. This can happen if the object is being deserialized outside of the context of a Client or Worker."
+            )
 
     async def _register(self):
         await retry_operation(

--- a/distributed/tests/test_events.py
+++ b/distributed/tests/test_events.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import pickle
 from datetime import timedelta
 
-from distributed import Event
+import pytest
+
+from distributed import Client, Event
 from distributed.utils_test import gen_cluster
 
 
@@ -220,3 +222,33 @@ async def test_two_events_on_workers(c, s, a, b):
 
     assert not s.extensions["events"]._events
     assert not s.extensions["events"]._waiter_count
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_unpickle_without_client(c, s):
+    """Ensure that the object properly pickle roundtrips even if no client, worker, etc. is active in the given context.
+
+    This typically happens if the object is being deserialized on the scheduler.
+    """
+    obj = await Event()
+    pickled = pickle.dumps(obj)
+    await c.close()
+
+    # We do not want to initialize a client during unpickling
+    with pytest.raises(ValueError):
+        Client.current()
+
+    obj2 = pickle.loads(pickled)
+
+    with pytest.raises(ValueError):
+        Client.current()
+
+    assert obj2.client is None
+
+    with pytest.raises(RuntimeError, match="not properly initialized"):
+        await obj2.set()
+
+    async with Client(s.address, asynchronous=True):
+        obj3 = pickle.loads(pickled)
+        await obj3.set()
+        await obj3.wait()

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import pickle
 import random
 from datetime import timedelta
 from time import sleep
@@ -294,3 +295,33 @@ async def test_variables_do_not_leak_client(c, s, a, b):
     while set(s.clients) != clients_pre:
         await asyncio.sleep(0.01)
         assert time() < start + 5
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_unpickle_without_client(c, s):
+    """Ensure that the object properly pickle roundtrips even if no client, worker, etc. is active in the given context.
+
+    This typically happens if the object is being deserialized on the scheduler.
+    """
+    obj = Variable("foo")
+    pickled = pickle.dumps(obj)
+    await c.close()
+
+    # We do not want to initialize a client during unpickling
+    with pytest.raises(ValueError):
+        Client.current()
+
+    obj2 = pickle.loads(pickled)
+
+    with pytest.raises(ValueError):
+        Client.current()
+
+    assert obj2.client is None
+
+    with pytest.raises(RuntimeError, match="not properly initialized"):
+        await obj2.set(42)
+
+    async with Client(s.address, asynchronous=True):
+        obj3 = pickle.loads(pickled)
+        await obj3.set(42)
+        assert await obj3.get() == 42


### PR DESCRIPTION
This is breaking out all the changes to Events, Variables, etc. in https://github.com/dask/distributed/pull/7564 to allow for deserialization in a context w/out worker or client, i.e. on a scheduler.

All of these objects share quite some common infrastructure but I consider refactoring this out of scope.

Note: A minor behavioral change is that the roundtrips no longer preserve scheduler addresses, i.e. the will establish a connection to whatever client is returned by get_client (which internally has some defined precedence of where to look up the client, e.g. it starts with a worker client).

I don't believe we have the case of cross-scheduler serialization in reality