### PR TITLE
Future deserialization without available client

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -105,8 +105,6 @@ class Actor(WrappedKey):
 
     def _try_bind_worker_client(self):
         try:
-            # TODO: `get_worker` may return the wrong worker instance for async local clusters (most tests)
-            # when run outside of a task (when deserializing a key pointing to an Actor, etc.)
             self._worker = get_worker()
         except ValueError:
             self._worker = None

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -97,23 +97,23 @@ class Actor(WrappedKey):
         self._address = address
         self._key = key
         self._future = None
-        if worker:
-            self._worker = worker
-            self._client = None
-        else:
-            self._try_bind_worker_client()
+        self._worker = worker
+        self._client = None
+        self._try_bind_worker_client()
 
     def _try_bind_worker_client(self):
-        try:
-            self._worker = get_worker()
-        except ValueError:
-            self._worker = None
-        try:
-            self._client = get_client()
-            self._future = Future(self._key, inform=self._worker is None)
-            # ^ When running on a worker, only hold a weak reference to the key, otherwise the key could become unreleasable.
-        except ValueError:
-            self._client = None
+        if not self._worker:
+            try:
+                self._worker = get_worker()
+            except ValueError:
+                self._worker = None
+        if not self._client:
+            try:
+                self._client = get_client()
+                self._future = Future(self._key, inform=False)
+                # ^ When running on a worker, only hold a weak reference to the key, otherwise the key could become unreleasable.
+            except ValueError:
+                self._client = None
 
     def __repr__(self):
         return f"<Actor: {self._cls.__name__}, key={self.key}>"

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -178,7 +178,7 @@ class Actor(WrappedKey):
             raise ValueError(
                 "Worker holding Actor was lost.  Status: " + self._future.status
             )
-
+        self._try_bind_worker_client()
         if (
             self._worker
             and self._worker.address == self._address

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -95,23 +95,27 @@ class Actor(WrappedKey):
         super().__init__(key)
         self._cls = cls
         self._address = address
+        self._key = key
         self._future = None
         if worker:
             self._worker = worker
             self._client = None
         else:
-            try:
-                # TODO: `get_worker` may return the wrong worker instance for async local clusters (most tests)
-                # when run outside of a task (when deserializing a key pointing to an Actor, etc.)
-                self._worker = get_worker()
-            except ValueError:
-                self._worker = None
-            try:
-                self._client = get_client()
-                self._future = Future(key, inform=self._worker is None)
-                # ^ When running on a worker, only hold a weak reference to the key, otherwise the key could become unreleasable.
-            except ValueError:
-                self._client = None
+            self._try_bind_worker_client()
+
+    def _try_bind_worker_client(self):
+        try:
+            # TODO: `get_worker` may return the wrong worker instance for async local clusters (most tests)
+            # when run outside of a task (when deserializing a key pointing to an Actor, etc.)
+            self._worker = get_worker()
+        except ValueError:
+            self._worker = None
+        try:
+            self._client = get_client()
+            self._future = Future(self._key, inform=self._worker is None)
+            # ^ When running on a worker, only hold a weak reference to the key, otherwise the key could become unreleasable.
+        except ValueError:
+            self._client = None
 
     def __repr__(self):
         return f"<Actor: {self._cls.__name__}, key={self.key}>"
@@ -121,6 +125,8 @@ class Actor(WrappedKey):
 
     @property
     def _io_loop(self):
+        if self._worker is None and self._client is None:
+            self._try_bind_worker_client()
         if self._worker:
             return self._worker.loop
         else:
@@ -128,6 +134,8 @@ class Actor(WrappedKey):
 
     @property
     def _scheduler_rpc(self):
+        if self._worker is None and self._client is None:
+            self._try_bind_worker_client()
         if self._worker:
             return self._worker.scheduler
         else:
@@ -135,6 +143,8 @@ class Actor(WrappedKey):
 
     @property
     def _worker_rpc(self):
+        if self._worker is None and self._client is None:
+            self._try_bind_worker_client()
         if self._worker:
             return self._worker.rpc(self._address)
         else:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -199,31 +199,45 @@ class Future(WrappedKey):
         self.key = key
         self._cleared = False
         tkey = stringify(key)
-        self.client = client or Client.current()
-        self.client._inc_ref(tkey)
-        self._generation = self.client.generation
-
-        if tkey in self.client.futures:
-            self._state = self.client.futures[tkey]
-        else:
-            self._state = self.client.futures[tkey] = FutureState()
-
-        if inform:
-            self.client._send_to_scheduler(
-                {
-                    "op": "client-desires-keys",
-                    "keys": [stringify(key)],
-                    "client": self.client.id,
-                }
-            )
-
-        if state is not None:
+        if not client:
             try:
-                handler = self.client._state_handlers[state]
-            except KeyError:
-                pass
+                client = get_client()
+            except ValueError:
+                client = None
+        self.client = client
+        if self.client:
+            self.client._inc_ref(tkey)
+            self._generation = self.client.generation
+
+            if tkey in self.client.futures:
+                self._state = self.client.futures[tkey]
             else:
-                handler(key=key)
+                self._state = self.client.futures[tkey] = FutureState()
+
+            if inform:
+                self.client._send_to_scheduler(
+                    {
+                        "op": "client-desires-keys",
+                        "keys": [stringify(key)],
+                        "client": self.client.id,
+                    }
+                )
+
+            if state is not None:
+                try:
+                    handler = self.client._state_handlers[state]
+                except KeyError:
+                    pass
+                else:
+                    handler(key=key)
+
+    def _verify_initialized(self):
+        if not self.client:
+            raise RuntimeError(
+                f"{type(self)} object not properly initialized. This can happen"
+                " if the object is being deserialized outside of the context of"
+                " a Client or Worker."
+            )
 
     @property
     def executor(self):
@@ -277,6 +291,7 @@ class Future(WrappedKey):
         result
             The result of the computation. Or a coroutine if the client is asynchronous.
         """
+        self._verify_initialized()
         if self.client.asynchronous:
             return self.client.sync(self._result, callback_timeout=timeout)
 
@@ -338,6 +353,7 @@ class Future(WrappedKey):
         --------
         Future.traceback
         """
+        self._verify_initialized()
         return self.client.sync(self._exception, callback_timeout=timeout, **kwargs)
 
     def add_done_callback(self, fn):
@@ -354,6 +370,7 @@ class Future(WrappedKey):
         fn : callable
             The method or function to be called
         """
+        self._verify_initialized()
         cls = Future
         if cls._cb_executor is None or cls._cb_executor_pid != os.getpid():
             try:
@@ -381,6 +398,7 @@ class Future(WrappedKey):
         --------
         Client.cancel
         """
+        self._verify_initialized()
         return self.client.cancel([self], **kwargs)
 
     def retry(self, **kwargs):
@@ -390,6 +408,7 @@ class Future(WrappedKey):
         --------
         Client.retry
         """
+        self._verify_initialized()
         return self.client.retry([self], **kwargs)
 
     def cancelled(self):
@@ -440,6 +459,7 @@ class Future(WrappedKey):
         --------
         Future.exception
         """
+        self._verify_initialized()
         return self.client.sync(self._traceback, callback_timeout=timeout, **kwargs)
 
     @property
@@ -454,6 +474,7 @@ class Future(WrappedKey):
         This method can be called from different threads
         (see e.g. Client.get() or Future.__del__())
         """
+        self._verify_initialized()
         if not self._cleared and self.client.generation == self._generation:
             self._cleared = True
             try:
@@ -461,24 +482,8 @@ class Future(WrappedKey):
             except TypeError:  # pragma: no cover
                 pass  # Shutting down, add_callback may be None
 
-    def __getstate__(self):
-        return self.key, self.client.scheduler.address
-
-    def __setstate__(self, state):
-        key, address = state
-        try:
-            c = Client.current(allow_global=False)
-        except ValueError:
-            c = get_client(address)
-        self.__init__(key, c)
-        c._send_to_scheduler(
-            {
-                "op": "update-graph",
-                "tasks": {},
-                "keys": [stringify(self.key)],
-                "client": c.id,
-            }
-        )
+    def __reduce__(self) -> str | tuple[Any, ...]:
+        return Future, (self.key,)
 
     def __del__(self):
         try:

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -299,7 +299,13 @@ class PackageInstall(WorkerPlugin, abc.ABC):
         from distributed.semaphore import Semaphore
 
         async with (
-            await Semaphore(max_leases=1, name=socket.gethostname(), register=True)
+            await Semaphore(
+                max_leases=1,
+                name=socket.gethostname(),
+                register=True,
+                scheduler_rpc=worker.scheduler,
+                loop=worker.loop,
+            )
         ):
             if not await self._is_installed(worker):
                 logger.info(

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -178,11 +178,17 @@ class Event:
     """
 
     def __init__(self, name=None, client=None):
-        try:
-            self.client = client or get_client()
-        except ValueError:
-            self.client = None
+        self._client = client
         self.name = name or "event-" + uuid.uuid4().hex
+
+    @property
+    def client(self):
+        if not self._client:
+            try:
+                self._client = get_client()
+            except ValueError:
+                pass
+        return self._client
 
     def __await__(self):
         """async constructor

--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -7,9 +7,8 @@ from collections import defaultdict, deque
 
 from dask.utils import parse_timedelta
 
-from distributed.client import Client
 from distributed.utils import TimeoutError, log_errors, wait_for
-from distributed.worker import get_worker
+from distributed.worker import get_client
 
 logger = logging.getLogger(__name__)
 
@@ -95,14 +94,27 @@ class Lock:
     """
 
     def __init__(self, name=None, client=None):
-        try:
-            self.client = client or Client.current()
-        except ValueError:
-            # Initialise new client
-            self.client = get_worker().client
+        self._client = client
         self.name = name or "lock-" + uuid.uuid4().hex
         self.id = uuid.uuid4().hex
         self._locked = False
+
+    @property
+    def client(self):
+        if not self._client:
+            try:
+                self._client = get_client()
+            except ValueError:
+                pass
+        return self._client
+
+    def _verify_running(self):
+        if not self.client:
+            raise RuntimeError(
+                f"{type(self)} object not properly initialized. This can happen"
+                " if the object is being deserialized outside of the context of"
+                " a Client or Worker."
+            )
 
     def acquire(self, blocking=True, timeout=None):
         """Acquire the lock
@@ -127,6 +139,7 @@ class Lock:
         -------
         True or False whether or not it successfully acquired the lock
         """
+        self._verify_running()
         timeout = parse_timedelta(timeout)
 
         if not blocking:
@@ -145,6 +158,7 @@ class Lock:
 
     def release(self):
         """Release the lock if already acquired"""
+        self._verify_running()
         if not self.locked():
             raise ValueError("Lock is not yet acquired")
         result = self.client.sync(

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -160,14 +160,15 @@ def process(
         # which can cause recursion errors later on since this can generate
         # deeply nested dictionaries
         depth = min(250, sys.getrecursionlimit() // 4)
-    if depth <= 0:
-        return None
+
     if any(frame.f_code.co_filename.endswith(o) for o in omit):
         return None
 
     prev = frame.f_back
-    if prev is not None and (
-        stop is None or not prev.f_code.co_filename.endswith(stop)
+    if (
+        depth > 0
+        and prev is not None
+        and (stop is None or not prev.f_code.co_filename.endswith(stop))
     ):
         new_state = process(prev, frame, state, stop=stop, depth=depth - 1)
         if new_state is None:

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -155,7 +155,11 @@ def process(
     merge
     """
     if depth is None:
-        depth = sys.getrecursionlimit() - 50
+        # Cut off rather conservatively since the output of the profiling
+        # sometimes need to be recursed into as well, e.g. for serialization
+        # which can cause recursion errors later on since this can generate
+        # deeply nested dictionaries
+        depth = min(250, sys.getrecursionlimit() // 4)
     if depth <= 0:
         return None
     if any(frame.f_code.co_filename.endswith(o) for o in omit):

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -9,6 +9,7 @@ import pytest
 import dask
 from dask.sizeof import sizeof
 
+from distributed.compatibility import WINDOWS
 from distributed.protocol import dumps, loads, maybe_compress, msgpack, to_serialize
 from distributed.protocol.compression import (
     compressions,
@@ -415,6 +416,7 @@ def test_sizeof_serialize(Wrapper, Wrapped):
     assert size <= sizeof(serialized) < size * 1.05
 
 
+@pytest.mark.skipif(WINDOWS, reason="On windows this is triggering a stackoverflow")
 def test_deeply_nested_structures():
     # These kind of deeply nested structures are generated in our profiling code
     def gen_deeply_nested(depth):

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -74,10 +74,10 @@ async def clean_scheduler(
     assert not extension.heartbeats
 
 
-@pytest.mark.skipif(
-    pa is not None,
-    reason="We don't have a CI job that is installing a very old pyarrow version",
-)
+# @pytest.mark.skipif(
+#     pa is not None,
+#     reason="We don't have a CI job that is installing a very old pyarrow version",
+# )
 @gen_cluster(client=True)
 async def test_minimal_version(c, s, a, b):
     df = dask.datasets.timeseries(
@@ -86,8 +86,9 @@ async def test_minimal_version(c, s, a, b):
         dtypes={"x": float, "y": float},
         freq="10 s",
     )
-    with pytest.raises(RuntimeError, match="requires pyarrow"):
-        await c.compute(dd.shuffle.shuffle(df, "x", shuffle="p2p"))
+    # with pytest.raises(RuntimeError, match="requires pyarrow"):
+    res = c.persist(dd.shuffle.shuffle(df, "x", shuffle="p2p"))
+    await c.compute(res)
 
 
 @gen_cluster(client=True)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -74,10 +74,10 @@ async def clean_scheduler(
     assert not extension.heartbeats
 
 
-# @pytest.mark.skipif(
-#     pa is not None,
-#     reason="We don't have a CI job that is installing a very old pyarrow version",
-# )
+@pytest.mark.skipif(
+    pa is not None,
+    reason="We don't have a CI job that is installing a very old pyarrow version",
+)
 @gen_cluster(client=True)
 async def test_minimal_version(c, s, a, b):
     df = dask.datasets.timeseries(
@@ -86,9 +86,8 @@ async def test_minimal_version(c, s, a, b):
         dtypes={"x": float, "y": float},
         freq="10 s",
     )
-    # with pytest.raises(RuntimeError, match="requires pyarrow"):
-    res = c.persist(dd.shuffle.shuffle(df, "x", shuffle="p2p"))
-    await c.compute(res)
+    with pytest.raises(RuntimeError, match="requires pyarrow"):
+        await c.compute(dd.shuffle.shuffle(df, "x", shuffle="p2p"))
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5356,20 +5356,13 @@ def test_serialize_collections_of_futures_sync(c):
 
     df = pd.DataFrame({"x": [1, 2, 3]})
     ddf = dd.from_pandas(df, npartitions=2).persist()
-    # future = c.scatter(ddf)
+    future = c.scatter(ddf)
 
-    # result = future.result()
-    # futs = futures_of(result)
-    assert_eq(ddf.compute(), df)
+    result = future.result()
+    assert_eq(result.compute(), df)
 
-    # assert future.type == dd.DataFrame
-    # futs = futures_of(future)
-    def inner(x, y):
-        futs = futures_of(x)
-        df = x.compute()
-        assert_eq(df, y)
-
-    c.submit(inner, ddf, df).result()
+    assert future.type == dd.DataFrame
+    assert c.submit(lambda x, y: assert_eq(x.compute(), y), future, df).result()
 
 
 def _dynamic_workload(x, delay=0.01):

--- a/distributed/tests/test_multi_locks.py
+++ b/distributed/tests/test_multi_locks.py
@@ -57,8 +57,8 @@ async def test_timeout(c, s, a, b):
     await lock1.release()
 
 
-@gen_cluster()
-async def test_timeout_wake_waiter(s, a, b):
+@gen_cluster(client=True)
+async def test_timeout_wake_waiter(c, s, a, b):
     l1 = MultiLock(names=["x"])
     l2 = MultiLock(names=["x", "y"])
     l3 = MultiLock(names=["y"])

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -356,19 +356,25 @@ def test_call_stack_f_lineno(f_lasti: int, f_lineno: int) -> None:
 
 
 def test_stack_overflow():
-    state = create()
-    frame = None
+    old = sys.getrecursionlimit()
+    sys.setrecursionlimit(200)
+    try:
+        state = create()
+        frame = None
 
-    def f(i):
-        if i == 0:
-            nonlocal frame
-            frame = sys._current_frames()[threading.get_ident()]
-            return
-        else:
-            return f(i - 1)
+        def f(i):
+            if i == 0:
+                nonlocal frame
+                frame = sys._current_frames()[threading.get_ident()]
+                return
+            else:
+                return f(i - 1)
 
-    f(sys.getrecursionlimit() - 200)
-    process(frame, None, state)
-    assert state["children"]
-    assert state["count"]
-    assert merge(state, state, state)
+        f(sys.getrecursionlimit() - 200)
+        process(frame, None, state)
+        assert state["children"]
+        assert state["count"]
+        assert merge(state, state, state)
+
+    finally:
+        sys.setrecursionlimit(old)

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -370,7 +370,7 @@ def test_stack_overflow():
             else:
                 return f(i - 1)
 
-        f(sys.getrecursionlimit() - 40)
+        f(sys.getrecursionlimit() - 100)
         process(frame, None, state)
         merge(state, state, state)
 

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -356,23 +356,19 @@ def test_call_stack_f_lineno(f_lasti: int, f_lineno: int) -> None:
 
 
 def test_stack_overflow():
-    old = sys.getrecursionlimit()
-    sys.setrecursionlimit(200)
-    try:
-        state = create()
-        frame = None
+    state = create()
+    frame = None
 
-        def f(i):
-            if i == 0:
-                nonlocal frame
-                frame = sys._current_frames()[threading.get_ident()]
-                return
-            else:
-                return f(i - 1)
+    def f(i):
+        if i == 0:
+            nonlocal frame
+            frame = sys._current_frames()[threading.get_ident()]
+            return
+        else:
+            return f(i - 1)
 
-        f(sys.getrecursionlimit() - 100)
-        process(frame, None, state)
-        merge(state, state, state)
-
-    finally:
-        sys.setrecursionlimit(old)
+    f(sys.getrecursionlimit() - 200)
+    process(frame, None, state)
+    assert state["children"]
+    assert state["count"]
+    assert merge(state, state, state)

--- a/distributed/tests/test_profile.py
+++ b/distributed/tests/test_profile.py
@@ -357,7 +357,7 @@ def test_call_stack_f_lineno(f_lasti: int, f_lineno: int) -> None:
 
 def test_stack_overflow():
     old = sys.getrecursionlimit()
-    sys.setrecursionlimit(200)
+    sys.setrecursionlimit(300)
     try:
         state = create()
         frame = None
@@ -370,7 +370,7 @@ def test_stack_overflow():
             else:
                 return f(i - 1)
 
-        f(sys.getrecursionlimit() - 200)
+        f(sys.getrecursionlimit() - 100)
         process(frame, None, state)
         assert state["children"]
         assert state["count"]

--- a/distributed/tests/test_pubsub.py
+++ b/distributed/tests/test_pubsub.py
@@ -54,7 +54,7 @@ async def test_speed(c, s, a, b):
 
 @gen_cluster(client=True, nthreads=[])
 async def test_client(c, s):
-    with pytest.raises(ValueError, match="No workers found"):
+    with pytest.raises(ValueError, match="No worker found"):
         get_worker()
     sub = Sub("a")
     pub = Pub("a")

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -98,12 +98,13 @@ def test_timeout_sync(client):
 
 
 @gen_cluster(
+    client=True,
     config={
         "distributed.scheduler.locks.lease-validation-interval": "200ms",
         "distributed.scheduler.locks.lease-timeout": "200ms",
     },
 )
-async def test_release_semaphore_after_timeout(s, a, b):
+async def test_release_semaphore_after_timeout(c, s, a, b):
     sem = await Semaphore(name="x", max_leases=2)
     await sem.acquire()  # leases: 2 - 1 = 1
 
@@ -121,8 +122,8 @@ async def test_release_semaphore_after_timeout(s, a, b):
     assert not (await sem.acquire(timeout=0.1))
 
 
-@gen_cluster()
-async def test_async_ctx(s, a, b):
+@gen_cluster(client=True)
+async def test_async_ctx(c, s, a, b):
     sem = await Semaphore(name="x")
     async with sem:
         assert not await sem.acquire(timeout=0.025)

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1090,23 +1090,10 @@ async def test_ensure_no_new_clients():
         async with Scheduler() as s:
             pass
     async with Scheduler() as s:
-        # Running client already exists
-        async with Client(s.address, asynchronous=True):
-            try:
-                # We detect a running client
-                with pytest.raises(AssertionError):
-                    with ensure_no_new_clients():
-                        c = await Client(s.address, asynchronous=True)
-            finally:
-                await c.close()
-
-        # Forbid also clients that are closed again
+        with ensure_no_new_clients():
+            pass
         with pytest.raises(AssertionError):
             with ensure_no_new_clients():
                 async with Client(s.address, asynchronous=True):
-                    pass
-
-        # But we also want to forbid any initialization
-        with pytest.raises(AssertionError):
-            with ensure_no_new_clients():
-                Client(s.address, asynchronous=True)
+                    with ensure_no_new_clients():
+                        pass

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1095,5 +1095,7 @@ async def test_ensure_no_new_clients():
         with pytest.raises(AssertionError):
             with ensure_no_new_clients():
                 async with Client(s.address, asynchronous=True):
-                    with ensure_no_new_clients():
-                        pass
+                    pass
+        async with Client(s.address, asynchronous=True):
+            with ensure_no_new_clients():
+                pass

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -312,6 +312,14 @@ class _ModuleSlot:
         return getattr(sys.modules[self.modname], self.slotname)
 
 
+@contextmanager
+def ensure_no_new_clients():
+    before = set(Client._instances)
+    yield
+    after = set(Client._instances)
+    assert after.issubset(before)
+
+
 def varying(items):
     """
     Return a function that returns a result (or raises an exception)

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -136,10 +136,6 @@ class Variable:
     it is wise not to send too much.  If you want to share a large amount of
     data then ``scatter`` it and share the future instead.
 
-    .. warning::
-
-       This object is experimental and has known issues in Python 2
-
     Parameters
     ----------
     name: string (optional)
@@ -166,11 +162,17 @@ class Variable:
     """
 
     def __init__(self, name=None, client=None):
-        try:
-            self.client = client or get_client()
-        except ValueError:
-            self.client = None
+        self._client = client
         self.name = name or "variable-" + uuid.uuid4().hex
+
+    @property
+    def client(self):
+        if not self._client:
+            try:
+                self._client = get_client()
+            except ValueError:
+                pass
+        return self._client
 
     def _verify_running(self):
         if not self.client:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2705,7 +2705,7 @@ def get_worker() -> Worker:
     try:
         return thread_state.execution_state["worker"]
     except AttributeError:
-        raise ValueError("No workers found") from None
+        raise ValueError("No worker found") from None
 
 
 def get_client(address=None, timeout=None, resolve_address=True) -> Client:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2155,26 +2155,10 @@ class Worker(BaseWorker, ServerNode):
     ################
 
     def run(self, comm, function, args=(), wait=True, kwargs=None):
-        return run(
-            self,
-            comm,
-            function=function,
-            args=args,
-            kwargs=kwargs,
-            wait=wait,
-            thread_state={"execution_state": self.execution_state},
-        )
+        return run(self, comm, function=function, args=args, kwargs=kwargs, wait=wait)
 
     def run_coroutine(self, comm, function, args=(), kwargs=None, wait=True):
-        return run(
-            self,
-            comm,
-            function=function,
-            args=args,
-            kwargs=kwargs,
-            wait=wait,
-            thread_state={"execution_state": self.execution_state},
-        )
+        return run(self, comm, function=function, args=args, kwargs=kwargs, wait=wait)
 
     async def actor_execute(
         self,
@@ -3285,9 +3269,7 @@ def convert_kwargs_to_str(kwargs: dict, max_len: int | None = None) -> str:
         return "{{{}}}".format(", ".join(strs))
 
 
-async def run(
-    server, comm, function, args=(), kwargs=None, wait=True, thread_state=None
-):
+async def run(server, comm, function, args=(), kwargs=None, wait=True):
     kwargs = kwargs or {}
     function = pickle.loads(function)
     is_coro = iscoroutinefunction(function)
@@ -3303,7 +3285,6 @@ async def run(
     logger.info("Run out-of-band function %r", funcname(function))
 
     try:
-        thread_state = thread_state or {}
         if not is_coro:
             result = function(*args, **kwargs)
         else:


### PR DESCRIPTION
This is similar to 

This grew a bit more complicated because I stumbled over https://github.com/dask/distributed/issues/7498 again and had a deeper look and tried to preserve the "pass futures in collections" feature but it is fundamentally flawed. While I could bypass most of the "accidental client creations" in this PR (which is good), the fundamental flaw about it being possible to release a future before it is being deserialized is still there and hard to avoid without a more fundamental approach.

Two notable changes

- The get_worker function now actually does what it is claiming. It returns the worker of the currently running _task_. Most notably this will raise if being executed outside of the threadpool. This is to a certain degree inconvenient since deserialization does typically not happen inside of our thread but I consider this important considering that our entire test suite is running asynchronously.
- Futures, etc. are actually only initializing a client lazily if a client (or worker) isn't immediately available. This avoids problems about "when, where and how" do we deserialize a task, e.g. we can deserialize a Future or Queue object on the event loop but since we're only interacting with it in the threadpool, the initialization will be deferred. To a certain degree this is also nicer for diagnostics but that's not the motivating change for this.

This is again a supporting PR for https://github.com/dask/distributed/pull/7564