### PR TITLE
Add notes to `Client` docstrings with the description of the current task graph resolution algorithm limitations.

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1843,6 +1843,15 @@ class Client(SyncMethodMixin):
         --------
         >>> c = client.submit(add, a, b)  # doctest: +SKIP
 
+        Notes
+        -----
+        The current implementation of a task graph resolution searches for occurrences of ``key``
+        and replaces it with a corresponding ``Future`` result. That can lead to unwanted
+        substitution of strings passed as arguments to a task if these strings match some ``key``
+        that already exists on a cluster. To avoid these situations it is required to use unique
+        values if a ``key`` is set manually.
+        See https://github.com/dask/dask/issues/9969 to track progress on resolving this issue.
+
         Returns
         -------
         Future
@@ -1983,6 +1992,15 @@ class Client(SyncMethodMixin):
         Examples
         --------
         >>> L = client.map(func, sequence)  # doctest: +SKIP
+
+        Notes
+        -----
+        The current implementation of a task graph resolution searches for occurrences of ``key``
+        and replaces it with a corresponding ``Future`` result. That can lead to unwanted
+        substitution of strings passed as arguments to a task if these strings match some ``key``
+        that already exists on a cluster. To avoid these situations it is required to use unique
+        values if a ``key`` is set manually.
+        See https://github.com/dask/dask/issues/9969 to track progress on resolving this issue.
 
         Returns
         -------
@@ -2500,6 +2518,16 @@ class Client(SyncMethodMixin):
 
         >>> data = c.scatter(data, broadcast=True)  # doctest: +SKIP
         >>> res = [c.submit(func, data, i) for i in range(100)]
+
+        Notes
+        -----
+        Scattering a dictionary uses ``dict`` keys to create ``Future`` keys.
+        The current implementation of a task graph resolution searches for occurrences of ``key``
+        and replaces it with a corresponding ``Future`` result. That can lead to unwanted
+        substitution of strings passed as arguments to a task if these strings match some ``key``
+        that already exists on a cluster. To avoid these situations it is required to use unique
+        values if a ``key`` is set manually.
+        See https://github.com/dask/dask/issues/9969 to track progress on resolving this issue.
 
         See Also
         --------


### PR DESCRIPTION
This PR adds notes to Client docstrings with the description of the current task graph resolution algorithm limitations.

If I understand correctly the `sphinx` is configured to skip docstring notes in this repository. Should I address this issue in this PR to make the notes I added visible in the resulting documentation?

Closes #7551 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
