### PR TITLE
Remove dead code and document arguments to ShardBuffer constructors

### DIFF
--- a/distributed/shuffle/_comms.py
+++ b/distributed/shuffle/_comms.py
@@ -29,24 +29,23 @@ class CommShardsBuffer(ShardsBuffer):
 
     State
     -----
-    memory_limit: str
-        A maximum amount of memory to use across the process, like "1 GiB"
-        This includes both data in shards and also in network communications
-    max_connections: int
-        The maximum number of connections to have out at once
-    max_message_size: str
-        The maximum size of a single message that we want to send
+    max_message_size: int
+        The maximum size in bytes of a single message that we want to send
 
     Parameters
     ----------
-    send: callable
+    send : callable
         How to send a list of shards to a worker
         Expects an address of the target worker (string)
         and a payload of shards (list of bytes) to send to that worker
+    memory_limiter : ResourceLimiter, optional
+        Limiter for memory usage (in bytes), or None if no limiting
+        should be applied.
+    concurrency_limit : int
+        Number of background tasks to run.
     """
 
     max_message_size = parse_bytes("2 MiB")
-    memory_limit = parse_bytes("100 MiB")
 
     def __init__(
         self,

--- a/distributed/shuffle/_disk.py
+++ b/distributed/shuffle/_disk.py
@@ -26,24 +26,18 @@ class DiskShardsBuffer(ShardsBuffer):
 
         The size of each list of shards.  We find the largest and write data from that buffer
 
-    State
-    -----
-    memory_limit: str
-        A maximum amount of memory to use, like "1 GiB"
-
     Parameters
     ----------
-    directory: pathlib.Path
+    directory : str or pathlib.Path
         Where to write and read data.  Ideally points to fast disk.
-    sizeof: callable
-        Measures the size of an object in memory
+    memory_limiter : ResourceLimiter, optional
+        Limiter for in-memory buffering (at most this much data)
+        before writes to disk occur.
     """
-
-    concurrency_limit = 2
 
     def __init__(
         self,
-        directory: str,
+        directory: str | pathlib.Path,
         memory_limiter: ResourceLimiter | None = None,
     ):
         super().__init__(


### PR DESCRIPTION
These are, I think, minor fixes to the docs in the p2p shuffle implementation.

This is in part to make sure I understand what is going on correctly.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
