### PR TITLE
Remove obsolete cast

### DIFF
--- a/distributed/diagnostics/memory_sampler.py
+++ b/distributed/diagnostics/memory_sampler.py
@@ -4,7 +4,7 @@ import uuid
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from distributed.compatibility import PeriodicCallback
 
@@ -142,7 +142,7 @@ class MemorySampler:
             s.name = label
             if align:
                 # convert datetime to timedelta from the first sample
-                s.index -= cast(pd.Timestamp, s.index[0])
+                s.index -= s.index[0]
             ss[label] = s
 
         df = pd.DataFrame(ss)


### PR DESCRIPTION
Linting is currently broken on CI

If you cannot reproduce the failure or this change fails for you, run `pre-commit clean` to clear the cache