### PR TITLE
Update `rechunk_transfer` and `rechunk_unpack` errors

### DIFF
--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -47,7 +47,7 @@ def rechunk_transfer(
             old=old,
         )
     except Exception as e:
-        raise RuntimeError("rechunk_transfer failed during shuffle {id}") from e
+        raise RuntimeError(f"rechunk_transfer failed during shuffle {id}") from e
 
 
 def rechunk_unpack(
@@ -58,7 +58,7 @@ def rechunk_unpack(
             id, barrier_run_id, output_chunk
         )
     except Exception as e:
-        raise RuntimeError("rechunk_unpack failed during shuffle {id}") from e
+        raise RuntimeError(f"rechunk_unpack failed during shuffle {id}") from e
 
 
 def rechunk_p2p(x: da.Array, chunks: ChunkedAxes) -> da.Array:


### PR DESCRIPTION
It looks like these were intended to be `f`-strings

cc @hendrikmakait 