### PR TITLE
Return results in `restart_workers`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3500,8 +3500,8 @@ class Client(SyncMethodMixin):
 
     async def _restart_workers(
         self, workers: list[str], timeout: int | float | None = None
-    ):
-        results = await self.scheduler.broadcast(
+    ) -> dict[str, str]:
+        results: dict[str, str] = await self.scheduler.broadcast(
             msg={"op": "restart", "timeout": timeout}, workers=workers, nanny=True
         )
         timeout_workers = {
@@ -3511,8 +3511,11 @@ class Client(SyncMethodMixin):
             raise TimeoutError(
                 f"The following workers failed to restart with {timeout} seconds: {list(timeout_workers.keys())}"
             )
+        return results
 
-    def restart_workers(self, workers: list[str], timeout: int | float | None = None):
+    def restart_workers(
+        self, workers: list[str], timeout: int | float | None = None
+    ) -> dict[str, str]:
         """Restart a specified set of workers
 
         .. note::
@@ -3527,6 +3530,11 @@ class Client(SyncMethodMixin):
             Workers to restart.
         timeout : int | float | None
             Number of seconds to wait
+
+        Returns
+        -------
+        dict[str, str]
+            Mapping of worker and restart status.
 
         Notes
         -----

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4810,7 +4810,9 @@ async def test_restart_workers(c, s, a, b):
     assert await c.compute(x.sum()) == size
 
     # Restart a single worker
-    await c.restart_workers(workers=[a.worker_address])
+    a_worker_addr = a.worker_address
+    results = await c.restart_workers(workers=[a.worker_address])
+    assert results[a_worker_addr] == "OK"
     assert set(s.workers) == {a.worker_address, b.worker_address}
 
     # Make sure worker start times are as expected


### PR DESCRIPTION
Small extension to https://github.com/dask/distributed/pull/7154 to return results from `Client.restart_workers`

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`


Wasn't completely sure if testing an exception raised during restart ought to be handled here, but prior conversations suggest it can be ignored or otherwise logged as is.

```python
In [3]: client.restart_workers(['tcp://127.0.0.1:37623'])
Out[3]: {'tcp://127.0.0.1:37623': 'OK'}
```