### PR TITLE
Do not unspill on free-keys

### DIFF
--- a/distributed/spill.py
+++ b/distributed/spill.py
@@ -248,6 +248,12 @@ class SpillBuffer(zict.Buffer):
         super().__delitem__(key)
         self.logged_pickle_errors.discard(key)
 
+    def pop(self, key: str, default: Any = None) -> Any:
+        raise NotImplementedError(
+            "Are you calling .pop(key, None) as a way to discard a key if it exists?"
+            "It may cause data to be read back from disk! Please use `del` instead."
+        )
+
     @property
     def memory(self) -> Mapping[str, Any]:
         """Key/value pairs stored in RAM. Alias of zict.Buffer.fast.

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -311,6 +311,12 @@ def test_spillbuffer_evict(tmp_path):
     assert_buf(buf, tmp_path, {"bad": bad}, {"a": a})
 
 
+def test_no_pop(tmp_path):
+    buf = SpillBuffer(str(tmp_path), target=100)
+    with pytest.raises(NotImplementedError):
+        buf.pop("x", None)
+
+
 class NoWeakRef:
     """A class which
     1. reports an arbitrary managed memory usage

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -1207,3 +1207,24 @@ async def test_high_unmanaged_memory_warning(s, caplog):
         sum("Unmanaged memory use is high" in record.msg for record in caplog.records)
         == 1
     )  # Message is rate limited
+
+
+class WriteOnlyBuffer(UserDict):
+    def __getitem__(self, k):
+        raise AssertionError()
+
+
+@gen_cluster(client=True, nthreads=[("", 1)], worker_kwargs={"data": WriteOnlyBuffer})
+async def test_delete_spilled_keys(c, s, a):
+    """Test that freeing an in-memory key that has been spilled to disk does not
+    accidentally unspill it
+    """
+    x = c.submit(inc, 1, key="x")
+    await wait_for_state("x", "memory", a)
+    assert a.data.keys() == {"x"}
+    with pytest.raises(AssertionError):
+        a.data["x"]
+
+    x.release()
+    await async_wait_for(lambda: not a.data, timeout=2)
+    assert not a.state.tasks


### PR DESCRIPTION
Fix a bug that would cause spilled data to be unnecessarily read back from disk upon release.

Real-life performance impact should be mild, because keys are released as soon as they are no longer needed, so normally you'll have:

1. `y` depends on `x`, which is spilled
2. `y` transitions to running
3. `x` is unspilled and bumped to the top of the LRU
4. `y` transitions to memory
5. `x` is released

The only realistic use case where this PR will impact performance is when the memory is so badly saturated that `x` will slide back to the bottom of the LRU before `y` has finished running - which is a separate problem in and by itself, since spilling it won't achieve any reduction in memory usage, since `x` is referenced by the execute() that is handling `y`.