### PR TITLE
Add dashboard documentation links

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -345,7 +345,7 @@ class ClusterMemory(DashboardComponent, MemoryColor):
         self.root.yaxis.visible = False
         self.root.ygrid.visible = False
 
-        self.root.toolbar_location = None
+        self.root.toolbar_location = "above"
         self.root.yaxis.visible = False
 
         hover = HoverTool(
@@ -373,7 +373,11 @@ class ClusterMemory(DashboardComponent, MemoryColor):
                             </div>
                             """,
         )
-        self.root.add_tools(hover)
+        help_ = HelpTool(
+            redirect="https://docs.dask.org/en/stable/dashboard.html#bytes-stored-and-bytes-per-worker",
+            description="Description of bytes stored plots",
+        )
+        self.root.add_tools(hover, help_)
 
     def _cluster_memory_color(self) -> str:
         colors = {

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3165,7 +3165,7 @@ class TaskProgress(DashboardComponent):
             name="task_progress",
             x_range=x_range,
             y_range=y_range,
-            toolbar_location=None,
+            toolbar_location="above",
             tools="",
             min_border_bottom=50,
             **kwargs,
@@ -3305,7 +3305,11 @@ class TaskProgress(DashboardComponent):
                 </div>
                 """,
         )
-        self.root.add_tools(hover)
+        help_ = HelpTool(
+            redirect="https://docs.dask.org/en/stable/dashboard.html#progress",
+            description="A description of the progress bars plot.",
+        )
+        self.root.add_tools(hover, help_)
 
     @without_property_validation
     @log_errors

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -4257,16 +4257,22 @@ def status_doc(scheduler, extra, doc):
 
     doc.add_root(workers_memory.root)
 
-    tab1 = TabPanel(child=processing_root, title="Processing")
-    tab2 = TabPanel(child=cpu_root, title="CPU")
-    tab3 = TabPanel(child=occupancy_root, title="Occupancy")
-    tab4 = TabPanel(child=workers_transfer_bytes.root, title="Data Transfer")
+    tabs = [
+        TabPanel(child=processing_root, title="Processing"),
+        TabPanel(child=cpu_root, title="CPU"),
+        TabPanel(child=occupancy_root, title="Occupancy"),
+        TabPanel(child=workers_transfer_bytes.root, title="Data Transfer"),
+    ]
 
-    proc_tabs = Tabs(
-        tabs=[tab1, tab2, tab3, tab4],
-        name="processing_tabs",
-        sizing_mode="stretch_both",
+    help_ = HelpTool(
+        redirect="https://docs.dask.org/en/stable/dashboard.html#task-processing-cpu-utilization-occupancy",
+        description="A description of Task Processing/CPU/Utilization/Occupancy",
     )
+    for tab in tabs:
+        tab.child.toolbar_location = "above"
+        tab.child.add_tools(help_)
+
+    proc_tabs = Tabs(tabs=tabs, name="processing_tabs", sizing_mode="stretch_both")
     doc.add_root(proc_tabs)
 
     task_stream = TaskStream(

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -4265,7 +4265,7 @@ def status_doc(scheduler, extra, doc):
     ]
 
     help_ = HelpTool(
-        redirect="https://docs.dask.org/en/stable/dashboard.html#task-processing-cpu-utilization-occupancy",
+        redirect="https://docs.dask.org/en/stable/dashboard.html#task-processing-cpu-utilization-occupancy-data-transfer",
         description="A description of Task Processing/CPU Utilization/Occupancy",
     )
     for tab in tabs:

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -4266,7 +4266,7 @@ def status_doc(scheduler, extra, doc):
 
     help_ = HelpTool(
         redirect="https://docs.dask.org/en/stable/dashboard.html#task-processing-cpu-utilization-occupancy",
-        description="A description of Task Processing/CPU/Utilization/Occupancy",
+        description="A description of Task Processing/CPU Utilization/Occupancy",
     )
     for tab in tabs:
         tab.child.toolbar_location = "above"

--- a/distributed/http/static/css/base.css
+++ b/distributed/http/static/css/base.css
@@ -52,6 +52,10 @@ body {
   background-color: #eaaa6d;
 }
 
+.navbar .pull-right {
+  float: right;
+}
+
 #dask-logo img {
   height: 28px;
   padding: 5px 15px;

--- a/distributed/http/templates/base.html
+++ b/distributed/http/templates/base.html
@@ -49,6 +49,9 @@
                     <img src="statics/images/fa-bars.svg"></img>
                 </a>
             </li>
+            <li class="pull-right">
+                <a href="https://docs.dask.org/en/stable/" target="_blank">Documentation</a>
+            </li>
         </ul>
     </div>
     <div class="content">


### PR DESCRIPTION
Closes #7592, extending #7478

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Adds a link to corresponding documentation for every plot on the main `/status` dashboard, and a `Documentation` link to the upper right, on the nav bar.

Note, the links for the tabbed plots (Task Processing/CPU/Utilization/Occupancy) are updated in the central place where they're combined into `Tabs`, meaning their _specific_ plot page, ie `/cpu` page does not have the link to the docs.

This was because `CurrentLoad` produces two plots, and the remaining two are created in `Occupancy` and `WorkersTransferBytes`. Making it slightly awkward to add the same link object in three different places, and given the link itself encompasses the explanation of all four plots this seemed like an okay trade-off. Let me know if anyone thinks otherwise, happy to adjust. :+1: 

---

![image](https://user-images.githubusercontent.com/13764397/222455302-110a3439-bb0a-4d94-9443-bba8052e72ee.png)

