### PR TITLE
Only one crick callback

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -13,7 +13,6 @@ import weakref
 from collections import defaultdict, deque
 from collections.abc import Callable, Container, Coroutine, Generator
 from enum import Enum
-from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, TypeVar, final
 
 import tblib
@@ -34,6 +33,7 @@ from distributed.comm import (
     unparse_host_port,
 )
 from distributed.compatibility import PeriodicCallback
+from distributed.counter import Counter
 from distributed.metrics import time
 from distributed.system_monitor import SystemMonitor
 from distributed.utils import (
@@ -346,7 +346,6 @@ class Server:
         self._comms = {}
         self.deserialize = deserialize
         self.monitor = SystemMonitor()
-        self.counters = None
         self._ongoing_background_tasks = AsyncTaskGroup()
         self._event_finished = asyncio.Event()
 
@@ -370,11 +369,13 @@ class Server:
             else:
                 self.io_loop.profile = deque()
 
+        self.periodic_callbacks = {}
+
         # Statistics counters for various events
         try:
             from distributed.counter import Digest
 
-            self.digests = defaultdict(partial(Digest, loop=self.io_loop))
+            self.digests = defaultdict(Digest)
         except ImportError:
             self.digests = None
 
@@ -383,11 +384,9 @@ class Server:
         self.digests_total = defaultdict(float)
         self.digests_max = defaultdict(float)
 
-        from distributed.counter import Counter
-
-        self.counters = defaultdict(partial(Counter, loop=self.io_loop))
-
-        self.periodic_callbacks = {}
+        self.counters = defaultdict(Counter)
+        pc = PeriodicCallback(self._shift_counters, 5000)
+        self.periodic_callbacks["shift_counters"] = pc
 
         pc = PeriodicCallback(
             self.monitor.update,
@@ -434,6 +433,13 @@ class Server:
         )
 
         self.__stopped = False
+
+    def _shift_counters(self):
+        for counter in self.counters.values():
+            counter.shift()
+        if self.digests is not None:
+            for digest in self.digests.values():
+                digest.shift()
 
     @property
     def status(self) -> Status:

--- a/distributed/tests/test_counter.py
+++ b/distributed/tests/test_counter.py
@@ -21,8 +21,8 @@ except ImportError:
         ),
     ],
 )
-def test_digest(loop, CD, size):
-    c = CD(loop=loop)
+def test_digest(CD, size):
+    c = CD()
     c.add(1)
     c.add(2)
     assert size(c.components[0]) == 2
@@ -40,8 +40,8 @@ def test_digest(loop, CD, size):
     assert sum(size(d) for d in c.components) == c.size()
 
 
-def test_counter(loop):
-    c = Counter(loop=loop)
+def test_counter():
+    c = Counter()
     c.add(1)
 
     for _ in range(5):


### PR DESCRIPTION
Running `test_graph_execution_width` in #7586 with crick installed creates 78 crick Digest objects.
While calling `.shift()` for all 78 of them costs just 1.5ms in total every 5 seconds, having that many digests kills the test, as Tornado can't cope with the number of callbacks.

This PR sets a single callback for all counters and digests.