### PR TITLE
Further improvements to `Client.restart_workers`

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -32,6 +32,7 @@ from distributed.comm.addressing import address_from_user_args
 from distributed.core import (
     AsyncTaskGroupClosedError,
     CommClosedError,
+    ErrorMessage,
     RPCClosed,
     Status,
     coerce_to_address,
@@ -488,7 +489,7 @@ class Nanny(ServerNode):
 
     async def restart(
         self, timeout: float = 30, reason: str = "nanny-restart"
-    ) -> Literal["OK", "timed out"]:
+    ) -> Literal["OK", "timed out"] | ErrorMessage:
         async def _():
             if self.process is not None:
                 await self.kill(reason=reason)
@@ -501,6 +502,8 @@ class Nanny(ServerNode):
                 f"Restart timed out after {timeout}s; returning before finished"
             )
             return "timed out"
+        except Exception as e:
+            return error_message(e)
         else:
             return "OK"
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4869,6 +4869,18 @@ async def test_restart_workers_exception(c, s, a, b):
     assert msg["exception_text"] == "ValueError()"
 
 
+@pytest.mark.slow
+@pytest.mark.parametrize("by_name", (True, False))
+@gen_cluster(client=True, Worker=Nanny)
+async def test_restart_workers_by_name(c, s, a, b, by_name):
+    a_addr = a.worker_address
+    b_addr = b.worker_address
+    results = await c.restart_workers([a.name if by_name else a_addr, b_addr])
+
+    # Same keys as those passed in, even when mixed with address and names.
+    assert results == {a.name if by_name else a_addr: "OK", b_addr: "OK"}
+
+
 class MyException(Exception):
     pass
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4839,13 +4839,20 @@ class SlowKillNanny(Nanny):
 
 
 @pytest.mark.slow
+@pytest.mark.parametrize("raise_for_timeout", (True, False))
 @gen_cluster(client=True, Worker=SlowKillNanny)
-async def test_restart_workers_timeout(c, s, a, b):
-    with pytest.raises(TimeoutError) as excinfo:
-        await c.restart_workers(workers=[a.worker_address], timeout=0.001)
-    msg = str(excinfo.value).lower()
-    assert "workers failed to restart" in msg
-    assert a.worker_address in msg
+async def test_restart_workers_timeout(c, s, a, b, raise_for_timeout):
+    kwargs = dict(workers=[a.worker_address], timeout=0.001)
+
+    if raise_for_timeout:  # default is to raise
+        with pytest.raises(TimeoutError) as excinfo:
+            await c.restart_workers(**kwargs)
+        msg = str(excinfo.value).lower()
+        assert "workers failed to restart" in msg
+        assert a.worker_address in msg
+    else:
+        results = await c.restart_workers(raise_for_timeout=raise_for_timeout, **kwargs)
+        assert results == {a.worker_address: "timed out"}
 
 
 class MyException(Exception):


### PR DESCRIPTION
Extension to #7606 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

---


- Support returning workers who timed out, via `raise_for_timeout=False` flag.
- Return `ErrorMessage` when a worker fails to restart.
- Allow restarting workers by name, address or both. Returning the same keys which were passed in.

Example
```python
client.restart_workers(["tcp://127.0.0.1:3456", "Bob", "Kim"], raise_for_timeout=False)
{
    "tcp://127.0.0.1:3456": "OK",
    "Bob": "timed out",
    "Kim":  {
        "status": "error",
        ...
    }
}
```