### PR TITLE
Initial integration of GIL contention metric

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -48,3 +48,4 @@ dependencies:
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
       - keras
+      - gilknocker

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -48,3 +48,4 @@ dependencies:
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
       - keras
+      - gilknocker

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -49,3 +49,4 @@ dependencies:
       - git+https://github.com/dask/dask
       - git+https://github.com/jcrist/crick  # Only tested here
       - keras
+      - gilknocker

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -51,3 +51,4 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask
       - keras
+      - gilknocker

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -1141,6 +1141,9 @@ properties:
               host-cpu:
                 type: boolean
                 description: Should we include host-wide CPU usage, with very granular breakdown?
+              gil-contention:
+                type: boolean
+                description: Should we include GIL contention metrics, requires `gilknocker` to be installed.
 
       rmm:
         type: object

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -310,6 +310,7 @@ distributed:
       interval: 500ms
       disk: true  # Monitor host-wide disk I/O
       host-cpu: false  # Monitor host-wide CPU usage, with very granular breakdown
+      gil-contention: false  # Monitor GIL contention
     event-loop: tornado
   rmm:
     pool-size: null

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from collections import deque
 from typing import Any
 
@@ -23,9 +24,11 @@ class SystemMonitor:
     monitor_net_io: bool
     monitor_disk_io: bool
     monitor_host_cpu: bool
+    monitor_gil_contention: bool
     _last_net_io_counters: Any  # psutil namedtuple
     _last_disk_io_counters: Any  # psutil namedtuple
     _last_host_cpu_counters: Any  # dynamically-defined psutil namedtuple
+    _last_gil_contention: float  # 0-1 value
 
     gpu_name: str | None
     gpu_memory_total: int
@@ -37,6 +40,7 @@ class SystemMonitor:
         maxlen: int | None = 7200,
         monitor_disk_io: bool | None = None,
         monitor_host_cpu: bool | None = None,
+        monitor_gil_contention: bool | None = None,
     ):
         self.proc = psutil.Process()
         self.count = 0
@@ -88,6 +92,24 @@ class SystemMonitor:
             # This is a namedtuple whose fields change based on OS and kernel version
             for k in hostcpu_c._fields:
                 self.quantities["host_cpu." + k] = deque(maxlen=maxlen)
+
+        if monitor_gil_contention is None:
+            monitor_gil_contention = dask.config.get(
+                "distributed.admin.system-monitor.gil-contention"
+            )
+        self.monitor_gil_contention = monitor_gil_contention
+        if self.monitor_gil_contention:
+            try:
+                from gilknocker import KnockKnock
+            except ImportError:
+                warnings.warn(
+                    "Monitoring GIL requires `gilknocker` to be installed. `pip install gilknocker`"
+                )
+                self.monitor_gil_contention = False
+            else:
+                self.quantities["gil_contention"] = deque(maxlen=maxlen)
+                self._gilknocker = KnockKnock(1_000)  # TODO(miles) param interval?
+                self._gilknocker.start()
 
         if not WINDOWS:
             self.quantities["num_fds"] = deque(maxlen=maxlen)
@@ -161,6 +183,11 @@ class SystemMonitor:
                 # cpu_times() has a precision of 2 decimals; suppress noise
                 result["host_cpu." + k] = round(delta / duration, 2)
             self._last_host_cpu_counters = host_cpu
+
+        if self.monitor_gil_contention:
+            self._last_gil_contention = self._gilknocker.contention_metric
+            result["gil_contention"] = self._last_gil_contention
+            self._gilknocker.reset_contention_metric()
 
         # Note: WINDOWS constant doesn't work with `mypy --platform win32`
         if sys.platform != "win32":

--- a/distributed/tests/test_system_monitor.py
+++ b/distributed/tests/test_system_monitor.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from time import sleep
 
+import pytest
+
 import dask
 
 from distributed.system_monitor import SystemMonitor
@@ -94,3 +96,20 @@ def test_host_cpu():
         sm = SystemMonitor()
         a = sm.update()
         assert "host_cpu.user" in a
+
+
+def test_gil_contention():
+    pytest.importorskip("gilknocker")
+
+    sm = SystemMonitor()
+    a = sm.update()
+    assert "gil_contention" not in a
+
+    sm = SystemMonitor(monitor_gil_contention=True)
+    a = sm.update()
+    assert "gil_contention" in a
+
+    with dask.config.set({"distributed.admin.system-monitor.gil-contention": True}):
+        sm = SystemMonitor()
+        a = sm.update()
+        assert "gil_contention" in a


### PR DESCRIPTION
Part of #7290 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

---

Adds `gil_contention`/`gil-contention` to `SystemMonitor`/`system-monitor`