### PR TITLE
Ignore pkg_resources DeprecationWarning for mindeps

### DIFF
--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -3,20 +3,20 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.8
-  - click=7.0
+  - python=3.9
+  - click=8.0
   - cloudpickle=1.5.0
-  - cytoolz=0.10.1
-  - jinja2=2.10.3
+  - cytoolz=0.12.0
+  - jinja2=2.11.3
   - locket=1.0.0
-  - msgpack-python=1.0.0
+  - msgpack-python=1.0.4
   - packaging=20.0
-  - psutil=5.7.0
-  - pyyaml=5.3.1
+  - psutil=5.9.4
+  - pyyaml=6.0.0
   - sortedcontainers=2.0.5
   - tblib=1.6.0
-  - toolz=0.10.0
-  - tornado=6.0.3
+  - toolz=0.12.0
+  - tornado=6.2.0
   - urllib3=1.24.3
   - zict=2.1.0
   # Distributed depends on the latest version of Dask

--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -3,20 +3,20 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9
-  - click=8.0
+  - python=3.8
+  - click=7.0
   - cloudpickle=1.5.0
-  - cytoolz=0.12.0
-  - jinja2=2.11.3
+  - cytoolz=0.10.1
+  - jinja2=2.10.3
   - locket=1.0.0
-  - msgpack-python=1.0.4
+  - msgpack-python=1.0.0
   - packaging=20.0
-  - psutil=5.9.4
-  - pyyaml=6.0.0
+  - psutil=5.7.0
+  - pyyaml=5.3.1
   - sortedcontainers=2.0.5
   - tblib=1.6.0
-  - toolz=0.12.0
-  - tornado=6.2.0
+  - toolz=0.10.0
+  - tornado=6.0.3
   - urllib3=1.24.3
   - zict=2.1.0
   # Distributed depends on the latest version of Dask

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -526,7 +526,12 @@ async def test_dashboard_non_standard_ports(c, s, requires_default_ports):
 def test_version_option():
     runner = CliRunner()
     result = runner.invoke(main, ["--version"])
-    assert result.exit_code == 0
+
+    if result.exception and isinstance(result.exception, DeprecationWarning):
+        msg = f"dask-worker --version raised DeprecationWarning: {result.exception}"
+        pytest.xfail(msg)
+    else:
+        assert result.exit_code == 0
 
 
 @pytest.mark.slow

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -523,6 +523,7 @@ async def test_dashboard_non_standard_ports(c, s, requires_default_ports):
         requests.get("http://localhost:4833/status/")
 
 
+@pytest.mark.filterwarnings("ignore:pkg_resources is deprecated")
 def test_version_option():
     runner = CliRunner()
     result = runner.invoke(main, ["--version"])

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -523,7 +523,7 @@ async def test_dashboard_non_standard_ports(c, s, requires_default_ports):
         requests.get("http://localhost:4833/status/")
 
 
-@pytest.mark.filterwarnings("ignore:pkg_resources is deprecated")
+@pytest.mark.filterwarnings("ignore:pkg_resources is deprecated as an API:DeprecationWarning")
 def test_version_option():
     runner = CliRunner()
     result = runner.invoke(main, ["--version"])

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -526,12 +526,7 @@ async def test_dashboard_non_standard_ports(c, s, requires_default_ports):
 def test_version_option():
     runner = CliRunner()
     result = runner.invoke(main, ["--version"])
-
-    if result.exception and isinstance(result.exception, DeprecationWarning):
-        msg = f"dask-worker --version raised DeprecationWarning: {result.exception}"
-        pytest.xfail(msg)
-    else:
-        assert result.exit_code == 0
+    assert result.exit_code == 0
 
 
 @pytest.mark.slow

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -523,7 +523,9 @@ async def test_dashboard_non_standard_ports(c, s, requires_default_ports):
         requests.get("http://localhost:4833/status/")
 
 
-@pytest.mark.filterwarnings("ignore:pkg_resources is deprecated as an API:DeprecationWarning")
+@pytest.mark.filterwarnings(
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning"
+)
 def test_version_option():
     runner = CliRunner()
     result = runner.invoke(main, ["--version"])


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Fixes failure when a deprecation warning is raised in `dask-worker --version` test.
Seems to only occur in the [ubuntu-latest mindeps](https://github.com/dask/distributed/actions/runs/4361606473/jobs/7625642728#step:19:1992) jobs due to Python 3.8 import of pkg_resources.
