### PR TITLE
Fix undefined async_wait_for -> async_poll_for

### DIFF
--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -1228,5 +1228,5 @@ async def test_delete_spilled_keys(c, s, a):
         a.data["x"]
 
     x.release()
-    await async_wait_for(lambda: not a.data, timeout=2)
+    await async_poll_for(lambda: not a.data, timeout=2)
     assert not a.state.tasks


### PR DESCRIPTION
Small fix for #7571 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Ref: https://github.com/dask/distributed/actions/runs/4364423559/jobs/7631725253