### PR TITLE
Expose scheduler idle via RPC and HTTP API

### DIFF
--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -63,9 +63,26 @@ class AdaptiveTargetHandler(RequestHandler):
             self.write(json.dumps({"Error": "Internal Server Error"}))
 
 
+class CheckIdleHandler(RequestHandler):
+    def get(self):
+        self.set_header("Content-Type", "application/json")
+        scheduler = self.server
+        try:
+            idle_since = scheduler.check_idle()
+            response = {
+                "idle": idle_since is None,
+                "idle_since": idle_since,
+            }
+            self.write(json.dumps(response))
+        except Exception as e:
+            self.set_status(500, str(e))
+            self.write(json.dumps({"Error": "Internal Server Error"}))
+
+
 routes: list[tuple] = [
     ("/api/v1", APIHandler, {}),
     ("/api/v1/retire_workers", RetireWorkersHandler, {}),
     ("/api/v1/get_workers", GetWorkersHandler, {}),
     ("/api/v1/adaptive_target", AdaptiveTargetHandler, {}),
+    ("/api/v1/check_idle", CheckIdleHandler, {}),
 ]

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -481,3 +481,28 @@ async def test_adaptive_target(c, s, a, b):
             assert resp.headers["Content-Type"] == "application/json"
             num_workers = json.loads(await resp.text())["workers"]
             assert num_workers == 0
+
+
+@gen_cluster(
+    client=True,
+    clean_kwargs={"threads": False},
+    config={
+        "distributed.scheduler.http.routes": DEFAULT_ROUTES
+        + ["distributed.http.scheduler.api"]
+    },
+)
+async def test_check_idle(c, s, a, b):
+    aiohttp = pytest.importorskip("aiohttp")
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            "http://localhost:%d/api/v1/check_idle" % s.http_server.port
+        ) as resp:
+            assert resp.status == 200
+            assert resp.headers["Content-Type"] == "application/json"
+            response = json.loads(await resp.text())
+            assert isinstance(response["idle"], bool)
+            assert (
+                isinstance(response["idle_since"], int)
+                or response["idle_since"] is None
+            )

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2288,6 +2288,8 @@ async def test_idle_timeout(c, s, a, b):
     pc.start()
     await future
     assert s.idle_since is None or s.idle_since > beginning
+    _idle_since = s.check_idle()
+    assert _idle_since == s.idle_since
 
     with captured_logger("distributed.scheduler") as logs:
         start = time()
@@ -2317,19 +2319,16 @@ async def test_idle_timeout_no_workers(c, s):
     while not s.tasks:
         await asyncio.sleep(0.1)
 
-    s.check_idle()
-    assert not s.idle_since
+    assert not s.check_idle()
 
     for _ in range(10):
         await asyncio.sleep(0.01)
-        s.check_idle()
-        assert not s.idle_since
+        assert not s.check_idle()
         assert s.tasks
 
     async with Worker(s.address):
         await future
-    s.check_idle()
-    assert not s.idle_since
+    assert not s.check_idle()
     del future
 
     while s.tasks:
@@ -2337,11 +2336,9 @@ async def test_idle_timeout_no_workers(c, s):
 
     # We only set idleness once nothing happened between two consecutive
     # check_idle calls
-    s.check_idle()
-    assert not s.idle_since
+    assert not s.check_idle()
 
-    s.check_idle()
-    assert s.idle_since
+    assert s.check_idle()
 
 
 @gen_cluster(client=True, config={"distributed.scheduler.bandwidth": "100 GB"})

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2314,6 +2314,9 @@ async def test_idle_timeout(c, s, a, b):
     nthreads=[],
 )
 async def test_idle_timeout_no_workers(c, s):
+    # Cancel the idle check periodic timeout so we can step through manually
+    s.periodic_callbacks["idle-timeout"].stop()
+
     s.idle_timeout = 0.1
     future = c.submit(inc, 1)
     while not s.tasks:


### PR DESCRIPTION
xref https://github.com/dask/dask-kubernetes/pull/672

It would be really helpful in `dask-kubernetes` if it were possible to ask the scheduler if it is idle and how long it has been idle for.

This PR tweaks the `check_idle` method in `Scheduler` so that it returns whether it is idle and how long for and exposes that method via the RPC. Also the periodic callback that calls this watching for idleness was only being set if the `idle_timeout` was configured, I've changed it so that it is always running and if the timeout isn't set it checks 4 times a second.

I also added an API method to the HTTP API to expose this so it can be called by the `dask-kubernetes` operator controller (although it will use the RPC as a fallback).

I've added a test for the HTTP API and tweaked existing `check_idle` tests to cover the changes here.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
