### PR TITLE
Remove weakref finalizer for Offload Executor

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1397,7 +1397,6 @@ def is_valid_xml(text):
 
 
 _offload_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="Dask-Offload")
-weakref.finalize(_offload_executor, _offload_executor.shutdown)
 
 
 def import_term(name: str) -> AnyType:


### PR DESCRIPTION
This is and always was a no-op, see https://github.com/dask/distributed/pull/7593#discussion_r1120084558

xref https://github.com/dask/distributed/issues/7639