### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,4 @@ distributed/deploy/*  @jacobtomlinson
 distributed/widgets/*  @jacobtomlinson
 
 # GPU Support
-distirbuted/diagnostics/nvml.py  @dask/gpu
+distirbuted/diagnostics/nvml.py  @jacobtomlinson @quasiben

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@ distributed/diagnostics/*  @jacobtomlinson @fjetter
 # Deployment tooling
 distributed/deploy/*  @jacobtomlinson
 
-# Ipywidgets
+# Jupyter widgets
 distributed/widgets/*  @jacobtomlinson
 
 # GPU Support

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+*  @fjetter
+
+# Dashboard
+distributed/dashboard/*  @jacobtomlinson
+distributed/diagnostics/*  @jacobtomlinson @fjetter
+
+# Deployment tooling
+distributed/deploy/*  @jacobtomlinson
+
+# Ipywidgets
+distributed/widgets/*  @jacobtomlinson
+
+# GPU Support
+distirbuted/diagnostics/nvml.py  @dask/gpu


### PR DESCRIPTION
Closes #7641 

Exploring adding a `CODEOWNERS` file. This PR is very much up for input/discussion. 

As I see it there are two ways to use a `CODEOWNERS` file:
- Have GitHub automatically ping folks for review in relevant code areas.
- Have a list of folks for each file/section who are ultimately on the hook for getting a PR reviewed.

My initial motivation here is the former. I struggle to track everything going on `distributed` so I would like to opt myself into being automatically pinged for review in the areas I focus on most.

That being said I'd be up for a discussion around expanding this to cover the latter.

> **Note**
> This is my first time configuring a `CODEOWNERS` file so if there are better ways to lay it out let me know