### PR TITLE
Support adjusting GIL monitoring interval

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -48,4 +48,4 @@ dependencies:
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
       - keras
-      - gilknocker
+      - gilknocker>=0.3.0

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -48,4 +48,4 @@ dependencies:
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
       - keras
-      - gilknocker
+      - gilknocker>=0.3.0

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -49,4 +49,4 @@ dependencies:
       - git+https://github.com/dask/dask
       - git+https://github.com/jcrist/crick  # Only tested here
       - keras
-      - gilknocker
+      - gilknocker>=0.3.0

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -51,4 +51,4 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask
       - keras
-      - gilknocker
+      - gilknocker>=0.3.0

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -1149,8 +1149,8 @@ properties:
                   enabled:
                     type: boolean
                     description: Enable monitoring of GIL contention
-                  interval-microseconds:
-                    type: integer
+                  interval:
+                    type: string
                     description: |
                       GIL polling interval. More frequent polling will reflect a more accurate GIL
                       contention metric but will be more likely to impact runtime performance.

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -1141,7 +1141,7 @@ properties:
               host-cpu:
                 type: boolean
                 description: Should we include host-wide CPU usage, with very granular breakdown?
-              gil-contention:
+              gil:
                 type: object
                 description: |
                   Should we include GIL contention metrics, requires `gilknocker` to be installed.

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -1142,8 +1142,18 @@ properties:
                 type: boolean
                 description: Should we include host-wide CPU usage, with very granular breakdown?
               gil-contention:
-                type: boolean
-                description: Should we include GIL contention metrics, requires `gilknocker` to be installed.
+                type: object
+                description: |
+                  Should we include GIL contention metrics, requires `gilknocker` to be installed.
+                properties:
+                  enabled:
+                    type: boolean
+                    description: Enable monitoring of GIL contention
+                  interval-microseconds:
+                    type: integer
+                    description: |
+                      GIL polling interval. More frequent polling will reflect a more accurate GIL
+                      contention metric but will be more likely to impact runtime performance.
 
       rmm:
         type: object

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -310,7 +310,7 @@ distributed:
       interval: 500ms
       disk: true  # Monitor host-wide disk I/O
       host-cpu: false  # Monitor host-wide CPU usage, with very granular breakdown
-      gil-contention: 
+      gil: 
         enabled: false  # Monitor GIL contention
         interval: "1ms"  # Frequency to poll GIL
     event-loop: tornado

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -312,7 +312,7 @@ distributed:
       host-cpu: false  # Monitor host-wide CPU usage, with very granular breakdown
       gil-contention: 
         enabled: false  # Monitor GIL contention
-        interval-microseconds: 1000  # Time in microseconds to poll GIL
+        interval: "1ms"  # Frequency to poll GIL
     event-loop: tornado
   rmm:
     pool-size: null

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -310,7 +310,9 @@ distributed:
       interval: 500ms
       disk: true  # Monitor host-wide disk I/O
       host-cpu: false  # Monitor host-wide CPU usage, with very granular breakdown
-      gil-contention: false  # Monitor GIL contention
+      gil-contention: 
+        enabled: false  # Monitor GIL contention
+        interval-microseconds: 1000  # Time in microseconds to poll GIL
     event-loop: tornado
   rmm:
     pool-size: null

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -95,7 +95,7 @@ class SystemMonitor:
 
         if monitor_gil_contention is None:
             monitor_gil_contention = dask.config.get(
-                "distributed.admin.system-monitor.gil-contention"
+                "distributed.admin.system-monitor.gil-contention.enabled"
             )
         self.monitor_gil_contention = monitor_gil_contention
         if self.monitor_gil_contention:
@@ -108,7 +108,10 @@ class SystemMonitor:
                 self.monitor_gil_contention = False
             else:
                 self.quantities["gil_contention"] = deque(maxlen=maxlen)
-                self._gilknocker = KnockKnock(1_000)  # TODO(miles) param interval?
+                interval = dask.config.get(
+                    "distributed.admin.system-monitor.gil-contention.interval-microseconds",
+                )
+                self._gilknocker = KnockKnock(interval)
                 self._gilknocker.start()
 
         if not WINDOWS:

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -108,10 +108,12 @@ class SystemMonitor:
                 self.monitor_gil_contention = False
             else:
                 self.quantities["gil_contention"] = deque(maxlen=maxlen)
-                interval = dask.config.get(
-                    "distributed.admin.system-monitor.gil-contention.interval-microseconds",
+                raw_interval = dask.config.get(
+                    "distributed.admin.system-monitor.gil-contention.interval",
                 )
-                self._gilknocker = KnockKnock(interval)
+                interval = dask.utils.parse_timedelta(raw_interval, default="us") * 1e6
+
+                self._gilknocker = KnockKnock(polling_interval_micros=int(interval))
                 self._gilknocker.start()
 
         if not WINDOWS:

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -95,7 +95,7 @@ class SystemMonitor:
 
         if monitor_gil_contention is None:
             monitor_gil_contention = dask.config.get(
-                "distributed.admin.system-monitor.gil-contention.enabled"
+                "distributed.admin.system-monitor.gil.enabled"
             )
         self.monitor_gil_contention = monitor_gil_contention
         if self.monitor_gil_contention:
@@ -109,7 +109,7 @@ class SystemMonitor:
             else:
                 self.quantities["gil_contention"] = deque(maxlen=maxlen)
                 raw_interval = dask.config.get(
-                    "distributed.admin.system-monitor.gil-contention.interval",
+                    "distributed.admin.system-monitor.gil.interval",
                 )
                 interval = dask.utils.parse_timedelta(raw_interval, default="us") * 1e6
 

--- a/distributed/tests/test_system_monitor.py
+++ b/distributed/tests/test_system_monitor.py
@@ -109,9 +109,7 @@ def test_gil_contention():
     a = sm.update()
     assert "gil_contention" in a
 
-    with dask.config.set(
-        {"distributed.admin.system-monitor.gil-contention.enabled": True}
-    ):
+    with dask.config.set({"distributed.admin.system-monitor.gil.enabled": True}):
         sm = SystemMonitor()
         a = sm.update()
         assert "gil_contention" in a

--- a/distributed/tests/test_system_monitor.py
+++ b/distributed/tests/test_system_monitor.py
@@ -109,7 +109,9 @@ def test_gil_contention():
     a = sm.update()
     assert "gil_contention" in a
 
-    with dask.config.set({"distributed.admin.system-monitor.gil-contention": True}):
+    with dask.config.set(
+        {"distributed.admin.system-monitor.gil-contention.enabled": True}
+    ):
         sm = SystemMonitor()
         a = sm.update()
         assert "gil_contention" in a


### PR DESCRIPTION
Augment the configuration schema to support
adjusting the GIL monitoring interval.

Part of #7290 

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
