### PR TITLE
Add GIL contention metric to Prometheus

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -47,4 +47,4 @@ dependencies:
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
       - keras
-      - gilknocker>=0.3.0
+      - gilknocker>=0.4.0

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -47,4 +47,4 @@ dependencies:
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
       - keras
-      - gilknocker>=0.3.0
+      - gilknocker>=0.4.0

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -48,4 +48,4 @@ dependencies:
       - git+https://github.com/dask/dask
       - git+https://github.com/jcrist/crick  # Only tested here
       - keras
-      - gilknocker>=0.3.0
+      - gilknocker>=0.4.0

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -50,4 +50,4 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask
       - keras
-      - gilknocker>=0.3.0
+      - gilknocker>=0.4.0

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -52,6 +52,13 @@ class SchedulerMetricCollector(PrometheusCollector):
         )
         yield worker_states
 
+        if self.server.monitor.monitor_gil_contention:
+            yield GaugeMetricFamily(
+                self.build_name("gil_contention"),
+                "GIL contention metric",
+                value=self.server.monitor._last_gil_contention,
+            )
+
         tasks = GaugeMetricFamily(
             self.build_name("tasks"),
             "Number of tasks known by scheduler",

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -58,7 +58,6 @@ class SchedulerMetricCollector(PrometheusCollector):
                 "GIL contention metric",
                 value=self.server.monitor._cumulative_gil_contention,
             )
-            self.server.monitor._cumulative_gil_contention = 0.0
 
         tasks = GaugeMetricFamily(
             self.build_name("tasks"),

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -53,11 +53,12 @@ class SchedulerMetricCollector(PrometheusCollector):
         yield worker_states
 
         if self.server.monitor.monitor_gil_contention:
-            yield GaugeMetricFamily(
+            yield CounterMetricFamily(
                 self.build_name("gil_contention"),
                 "GIL contention metric",
-                value=self.server.monitor._last_gil_contention,
+                value=self.server.monitor._cumulative_gil_contention,
             )
+            self.server.monitor._cumulative_gil_contention = 0.0
 
         tasks = GaugeMetricFamily(
             self.build_name("tasks"),

--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pathlib
 from unittest import mock
+
 import pytest
 from tornado.httpclient import AsyncHTTPClient
 
@@ -16,11 +17,11 @@ async def test_scheduler(c, s, a, b):
     assert response.code == 200
 
 
-@mock.patch('warnings.warn', return_value=None)
+@mock.patch("warnings.warn", return_value=None)
 @gen_cluster(
     client=True,
     nthreads=[("", 1)],
-    config={"distributed.admin.system-monitor.gil-contention": True},
+    config={"distributed.admin.system-monitor.gil.enabled": True},
 )
 async def test_prometheus_api_doc(c, s, a, _):
     """Test that the Sphinx documentation of Prometheus endpoints matches the

--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -67,13 +67,6 @@ async def test_prometheus_api_doc(c, s, a, _):
             "dask_worker_transfer_bandwidth_median_bytes",
         }
 
-    # Optional GIL monitoring metrics, config set and gilknocker installed.
-    gil_metrics = {
-        "dask_scheduler_gil_contention",
-        "dask_scheduler_gil_contention_total",
-        "dask_worker_gil_contention",
-        "dask_worker_gil_contention_total",
-    }
     try:
         import gilknocker  # noqa: F401
 

--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -72,6 +72,7 @@ async def test_prometheus_api_doc(c, s, a, _):
         "dask_scheduler_gil_contention",
         "dask_scheduler_gil_contention_total",
         "dask_worker_gil_contention",
+        "dask_worker_gil_contention_total",
     }
     try:
         import gilknocker  # noqa: F401

--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -76,11 +76,13 @@ async def test_prometheus_api_doc(c, s, a, _):
     }
     try:
         import gilknocker  # noqa: F401
+
+        gil_metrics = set()  # Already in worker_metrics
     except ImportError:
-        # Documented w/ notes about config and gilknocker requirements
-        for gm in gil_metrics:
-            documented.remove(gm)
-        gil_metrics = set()
+        gil_metrics = {
+            "dask_scheduler_gil_contention_total",
+            "dask_worker_gil_contention_total",
+        }
 
     implemented = scheduler_metrics | worker_metrics | crick_metrics | gil_metrics
     assert documented == implemented

--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -68,7 +68,11 @@ async def test_prometheus_api_doc(c, s, a, _):
         }
 
     # Optional GIL monitoring metrics, config set and gilknocker installed.
-    gil_metrics = {"dask_scheduler_gil_contention", "dask_worker_gil_contention"}
+    gil_metrics = {
+        "dask_scheduler_gil_contention",
+        "dask_scheduler_gil_contention_total",
+        "dask_worker_gil_contention",
+    }
     try:
         import gilknocker  # noqa: F401
     except ImportError:

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -60,10 +60,10 @@ class WorkerMetricCollector(PrometheusCollector):
         )
 
         if self.server.monitor.monitor_gil_contention:
-            yield GaugeMetricFamily(
+            yield CounterMetricFamily(
                 self.build_name("gil_contention"),
                 "GIL contention metric",
-                value=self.server.monitor._last_gil_contention,
+                value=self.server.monitor._cumulative_gil_contention,
             )
 
         yield GaugeMetricFamily(

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -59,6 +59,13 @@ class WorkerMetricCollector(PrometheusCollector):
             value=ws.transfer_incoming_count,
         )
 
+        if self.server.monitor.monitor_gil_contention:
+            yield GaugeMetricFamily(
+                self.build_name("gil_contention"),
+                "GIL contention metric",
+                value=self.server.monitor._last_gil_contention,
+            )
+
         yield GaugeMetricFamily(
             self.build_name("threads"),
             "Number of worker threads",

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -30,6 +30,8 @@ class SystemMonitor:
     _last_host_cpu_counters: Any  # dynamically-defined psutil namedtuple
     _last_gil_contention: float  # 0-1 value
 
+    _cumulative_gil_contention: float
+
     gpu_name: str | None
     gpu_memory_total: int
 
@@ -108,6 +110,7 @@ class SystemMonitor:
                 self.monitor_gil_contention = False
             else:
                 self.quantities["gil_contention"] = deque(maxlen=maxlen)
+                self._cumulative_gil_contention = 0.0
                 raw_interval = dask.config.get(
                     "distributed.admin.system-monitor.gil.interval",
                 )
@@ -191,6 +194,7 @@ class SystemMonitor:
 
         if self.monitor_gil_contention:
             self._last_gil_contention = self._gilknocker.contention_metric
+            self._cumulative_gil_contention += self._last_gil_contention
             result["gil_contention"] = self._last_gil_contention
             self._gilknocker.reset_contention_metric()
 

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -125,7 +125,7 @@ dask_worker_tasks
     Number of tasks at worker
 dask_worker_threads
     Number of worker threads
-dask_worker_gil_contention:
+dask_worker_gil_contention
     0-1 value representing GIL contention on worker
 
     .. note::

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -31,7 +31,7 @@ dask_scheduler_gil_contention
 
     .. note::
        Requires ``gilknocker`` to be installed, and 
-       ``distributed.admin.system-monitor.gil-contention.enabled``
+       ``distributed.admin.system-monitor.gil.enabled``
        configuration to be set.
 
 dask_scheduler_workers
@@ -130,7 +130,7 @@ dask_worker_gil_contention
 
     .. note::
        Requires ``gilknocker`` to be installed, and 
-       ``distributed.admin.system-monitor.gil-contention.enabled``
+       ``distributed.admin.system-monitor.gil.enabled``
        configuration to be set.
 
 dask_worker_latency_seconds

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -27,7 +27,8 @@ dask_scheduler_clients
 dask_scheduler_desired_workers
     Number of workers scheduler needs for task graph
 dask_scheduler_gil_contention_total
-    Value representing cumulative total of GIL contention.
+    Value representing cumulative total of GIL contention,
+    in the form of summed percentages.
 
     .. note::
        Requires ``gilknocker`` to be installed, and 
@@ -126,7 +127,8 @@ dask_worker_tasks
 dask_worker_threads
     Number of worker threads
 dask_worker_gil_contention_total
-    Value representing cumulative total GIL contention on worker
+    Value representing cumulative total GIL contention on worker,
+    in the form of summed percentages.
 
     .. note::
        Requires ``gilknocker`` to be installed, and

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -26,6 +26,14 @@ dask_scheduler_clients
     Number of clients connected
 dask_scheduler_desired_workers
     Number of workers scheduler needs for task graph
+dask_scheduler_gil_contention
+    0-1 value representing GIL contention on scheduler
+
+    .. note::
+       Requires ``gilknocker`` to be installed, and 
+       ``distributed.admin.system-monitor.gil-contention.enabled``
+       configuration to be set.
+
 dask_scheduler_workers
     Number of workers known by scheduler
 dask_scheduler_tasks
@@ -117,6 +125,14 @@ dask_worker_tasks
     Number of tasks at worker
 dask_worker_threads
     Number of worker threads
+dask_worker_gil_contention:
+    0-1 value representing GIL contention on worker
+
+    .. note::
+       Requires ``gilknocker`` to be installed, and 
+       ``distributed.admin.system-monitor.gil-contention.enabled``
+       configuration to be set.
+
 dask_worker_latency_seconds
     Latency of worker connection
 dask_worker_memory_bytes

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -141,6 +141,14 @@ dask_worker_gil_contention
        ``distributed.admin.system-monitor.gil.enabled``
        configuration to be set.
 
+dask_worker_gil_contention_total
+    Value representing cumulative total GIL contention on worker
+
+    .. note::
+       Requires ``gilknocker`` to be installed, and
+       ``distributed.admin.system-monitor.gil.enabled``
+       configuration to be set.
+
 dask_worker_latency_seconds
     Latency of worker connection
 dask_worker_memory_bytes

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -34,6 +34,14 @@ dask_scheduler_gil_contention
        ``distributed.admin.system-monitor.gil.enabled``
        configuration to be set.
 
+dask_scheduler_gil_contention_total
+    Value representing cumulative total of GIL contention metrics since last scrape.
+
+    .. note::
+       Requires ``gilknocker`` to be installed, and 
+       ``distributed.admin.system-monitor.gil.enabled``
+       configuration to be set.
+
 dask_scheduler_workers
     Number of workers known by scheduler
 dask_scheduler_tasks

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -26,16 +26,8 @@ dask_scheduler_clients
     Number of clients connected
 dask_scheduler_desired_workers
     Number of workers scheduler needs for task graph
-dask_scheduler_gil_contention
-    0-1 value representing GIL contention on scheduler
-
-    .. note::
-       Requires ``gilknocker`` to be installed, and 
-       ``distributed.admin.system-monitor.gil.enabled``
-       configuration to be set.
-
 dask_scheduler_gil_contention_total
-    Value representing cumulative total of GIL contention metrics since last scrape.
+    Value representing cumulative total of GIL contention.
 
     .. note::
        Requires ``gilknocker`` to be installed, and 
@@ -133,14 +125,6 @@ dask_worker_tasks
     Number of tasks at worker
 dask_worker_threads
     Number of worker threads
-dask_worker_gil_contention
-    0-1 value representing GIL contention on worker
-
-    .. note::
-       Requires ``gilknocker`` to be installed, and 
-       ``distributed.admin.system-monitor.gil.enabled``
-       configuration to be set.
-
 dask_worker_gil_contention_total
     Value representing cumulative total GIL contention on worker
 


### PR DESCRIPTION
Exposes the GIL contention metrics on Prometheus
for Scheduler and Worker. Only applies when
`distributed.admin.system-monitor.gil-contention.enabled` is set and `gilknocker` is installed.

Part of #7290 

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
