### PR TITLE
Fix failing `test_server_close_stops_gil_monitoring`

### DIFF
--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -258,7 +258,7 @@ async def test_server_status_compare_enum_is_quiet():
     server.status == Status.running  # noqa: B015
 
 
-@gen_test(config={"distributed.admin.system-monitor.gil-contention": True})
+@gen_test(config={"distributed.admin.system-monitor.gil.enabled": True})
 async def test_server_close_stops_gil_monitoring():
     pytest.importorskip("gilknocker")
 


### PR DESCRIPTION
This is a small follow-up to https://github.com/dask/distributed/pull/7650 in order to fix the following test failure on `main`

```
distributed/tests/test_core.py::test_server_close_stops_gil_monitoring - AttributeError: 'SystemMonitor' object has no attribute '_gilknocker'
```

Closes https://github.com/dask/distributed/issues/7660

cc @milesgranger 