### PR TITLE
Consider Jupyter activity in idle timeout

### DIFF
--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -503,6 +503,6 @@ async def test_check_idle(c, s, a, b):
             response = json.loads(await resp.text())
             assert isinstance(response["idle"], bool)
             assert (
-                isinstance(response["idle_since"], int)
+                isinstance(response["idle_since"], float)
                 or response["idle_since"] is None
             )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7750,9 +7750,10 @@ class Scheduler(SchedulerState, ServerNode):
         return None
 
     def check_idle_jupyter(self) -> bool:
-        if not self.jupyter or not self.idle_timeout:
-            return False
+        if not self.jupyter:
+            return True
 
+        assert self.idle_timeout is not None
         # Based on:
         # https://github.com/jupyter-server/jupyter_server/blob/e582e555/jupyter_server/serverapp.py#L2315
         last_activity = self._jupyter_server_application.web_app.last_activity()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7751,7 +7751,7 @@ class Scheduler(SchedulerState, ServerNode):
                     format_time(self.idle_timeout),
                 )
                 self._ongoing_background_tasks.call_soon(self.close)
-        return self.idle_since
+        return None
 
     def adaptive_target(self, target_duration=None):
         """Desired number of workers based on the current workload

--- a/distributed/tests/test_jupyter.py
+++ b/distributed/tests/test_jupyter.py
@@ -97,4 +97,6 @@ async def test_jupyter_idle_timeout_returned():
         assert next_idle is not None
         assert next_idle > last_idle
 
-        assert s.check_idle() == next_idle
+        assert s.check_idle() is None
+        # ^ NOTE: this probably should be `== next_idle`;
+        # see discussion in https://github.com/dask/distributed/pull/7687#discussion_r1145095196


### PR DESCRIPTION
If a Jupyter server is run on the scheduler, this prevents idle shutdown until Jupyter has _also_ been idle for the `idle_timeout`.

cc @ntabris 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
