### PR TITLE
fix unexpected indentation in Client.cancel docstring

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2594,6 +2594,7 @@ class Client(SyncMethodMixin):
         This stops future tasks from being scheduled if they have not yet run
         and deletes them if they have already run.  After calling, this result
         and all dependent results will no longer be accessible
+
         Parameters
         ----------
         futures : List[Future]


### PR DESCRIPTION
running sphinx with `-W` fails with:

`site-packages/distributed/client.py:docstring of distributed.client.Client.cancel:9:Unexpected indentation.`

and results in ugly output https://docs.dask.org/en/latest/futures.html#distributed.Client.cancel

before: 
![image](https://user-images.githubusercontent.com/413772/226901521-6200de21-70e7-406d-bfd9-5289cbb3072b.png)

after:
![image](https://user-images.githubusercontent.com/413772/226901789-186ab734-0e81-448b-82be-059a0942192b.png)


- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
