### PR TITLE
Fix naming comparison in test-report workflow script

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,9 +71,9 @@ jobs:
       - name: Set $TEST_ID
         run: |
           export PARTITION_LABEL=$( echo "${{ matrix.partition }}" | sed "s/ //" )
-          export TEST_ID="${{ matrix.os }}-${{ matrix.environment }}-${{ matrix.queuing }}-$PARTITION_LABEL"
+          export TEST_ID="${{ matrix.os }}-${{ matrix.environment }}-${{ matrix.queuing || join(matrix.extra_packages, '_') }}-$PARTITION_LABEL"
           # Switch to this version for stress-test:
-          # export TEST_ID="${{ matrix.os }}-${{ matrix.environment }}-${{ matrix.queuing }}-$PARTITION_LABEL-${{ matrix.run }}"
+          # export TEST_ID="$TEST_ID-${{ matrix.run }}"
           echo "TEST_ID: $TEST_ID"
           echo "TEST_ID=$TEST_ID" >> $GITHUB_ENV
         shell: bash

--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -215,10 +215,6 @@ def suite_from_name(name: str) -> str:
     just lop off the front of the name to get the suite.
     """
     parts = name.split("-")
-    if len(parts) == 4:  # [OS, 'latest', py_version, $PARTITION_LABEL]
-        # Migration: handle older jobs without the `queuing` configuration.
-        # This branch can be removed after 2022-12-07.
-        parts.insert(3, "no_queue")
     return "-".join(parts[:4])
 
 

--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -359,6 +359,10 @@ def download_and_parse_artifacts(
                 if xml is None:
                     continue
                 df = dataframe_from_jxml(cast(Iterable, xml))
+
+                # Needed until *-*-mindeps-numpy shows up in TEST_ID
+                a["name"] = a["name"].replace("--", "-numpy-")
+
                 # Note: we assign a column with the workflow run timestamp rather
                 # than the artifact timestamp so that artifacts triggered under
                 # the same workflow run can be aligned according to the same trigger


### PR DESCRIPTION
Closes #7654 

Will fix failure in building test-report seen here:
https://github.com/dask/distributed/actions/runs/4487642234/jobs/7891284141

This was caused from #7609 without accounting for `TEST_ID` being used in the [`test_report.py`](https://github.com/dask/distributed/blob/6fb7f0e2029bfdac2c7b0524ad1766b4307b7375/continuous_integration/scripts/test_report.py#L157). In this case, `queuing` is null, so the name comes back as `ubuntu-latest-mindeps--ci1` and `ubuntu-latest-mindeps--notci1`

For this patch, a name which has `--` should be `ubuntu-latest-mindeps-numpy-ci1` for example. Assuming we also don't need `queuing` to be included as well(?). If that is also required, further updates to `test_report.py` would need more updates to include a possible `extra_packages` column in the names. Maybe a refactor is needed down the line anyhow given the current state.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`


Example of resulting report:
![image](https://user-images.githubusercontent.com/13764397/226899794-ee99fb05-af35-4711-a4e2-db25b14207cd.png)
