### PR TITLE
use a subprocess in test_logging_default to avoid double logging in s…

### DIFF
--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -21,7 +21,7 @@ from tornado import gen
 import dask.config
 from dask.sizeof import sizeof
 
-from distributed import Client, Event, Nanny, Scheduler, Worker, config, default_client
+from distributed import Client, Event, Nanny, Scheduler, Worker, default_client
 from distributed.batched import BatchedSend
 from distributed.comm.core import connect
 from distributed.compatibility import WINDOWS
@@ -45,7 +45,6 @@ from distributed.utils_test import (
     gen_nbytes,
     gen_test,
     inc,
-    new_config,
     popen,
     raises_with_cause,
     tls_only_security,
@@ -295,15 +294,6 @@ def _listen(delay=0):
         yield serv
     finally:
         t.join(5.0)
-
-
-def test_new_config():
-    c = config.copy()
-    with new_config({"xyzzy": 5}):
-        assert config["xyzzy"] == 5
-
-    assert config == c
-    assert "xyzzy" not in config
 
 
 def test_lingering_client():

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1465,6 +1465,12 @@ def new_config(new_config):
     """
     Temporarily change configuration dictionary.
     """
+    warnings.warn(
+        "new_config is deprecated - use new_config_file and run your test in a"
+        " subprocess",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     from distributed.config import defaults
 
     config = dask.config.config


### PR DESCRIPTION
…ubsequent tests

Closes #7702

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
