### PR TITLE
Improve error message if shuffle/rechunk lost annotations

### DIFF
--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -307,7 +307,8 @@ def get_partition_id(ts: TaskState) -> Any:
         raise RuntimeError(
             f"{ts} has lost its ``shuffle`` annotation. This may be caused by "
             "unintended optimization during graph generation. "
-            "Please report this problem at https://github.com/dask/distributed/issues."
+            "Please report this problem on GitHub and link it to "
+            "the tracking issue at https://github.com/dask/distributed/issues/7716."
         )
 
 

--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -305,8 +305,9 @@ def get_partition_id(ts: TaskState) -> Any:
         return ts.annotations["shuffle"]
     except KeyError:
         raise RuntimeError(
-            f"{ts} has lost ``shuffle`` annotation. This may be caused by graph "
-            "optimization. Please report this error with a minimal reproducer."
+            f"{ts} has lost its ``shuffle`` annotation. This may be caused by "
+            " unintended optimization during graph generation. "
+            "Please report this problem at https://github.com/dask/distributed/issues."
         )
 
 

--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -305,7 +305,7 @@ def get_partition_id(ts: TaskState) -> Any:
         return ts.annotations["shuffle"]
     except KeyError:
         raise RuntimeError(
-            "{ts} has lost ``shuffle`` annotation. This may be caused by graph "
+            f"{ts} has lost ``shuffle`` annotation. This may be caused by graph "
             "optimization. Please report this error with a minimal reproducer."
         )
 

--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -306,7 +306,7 @@ def get_partition_id(ts: TaskState) -> Any:
     except KeyError:
         raise RuntimeError(
             f"{ts} has lost its ``shuffle`` annotation. This may be caused by "
-            " unintended optimization during graph generation. "
+            "unintended optimization during graph generation. "
             "Please report this problem at https://github.com/dask/distributed/issues."
         )
 

--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -18,7 +18,13 @@ from distributed.shuffle._shuffle import (
 )
 
 if TYPE_CHECKING:
-    from distributed.scheduler import Recs, Scheduler, TaskStateState, WorkerState
+    from distributed.scheduler import (
+        Recs,
+        Scheduler,
+        TaskState,
+        TaskStateState,
+        WorkerState,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +172,7 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         mapping = {}
 
         for ts in self.scheduler.tasks[name].dependents:
-            part = ts.annotations["shuffle"]
+            part = get_partition_id(ts)
             if ts.worker_restrictions:
                 output_worker = list(ts.worker_restrictions)[0]
             else:
@@ -202,7 +208,7 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         mapping = {}
 
         for ts in self.scheduler.tasks[name].dependents:
-            part = ts.annotations["shuffle"]
+            part = get_partition_id(ts)
             if ts.worker_restrictions:
                 output_worker = list(ts.worker_restrictions)[0]
             else:
@@ -291,6 +297,17 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
         self.states.clear()
         self.heartbeats.clear()
         self.erred_shuffles.clear()
+
+
+def get_partition_id(ts: TaskState) -> Any:
+    """Get the output partition ID of this task state."""
+    try:
+        return ts.annotations["shuffle"]
+    except KeyError:
+        raise RuntimeError(
+            "{ts} has lost ``shuffle`` annotation. This may be caused by graph "
+            "optimization. Please report this error with a minimal reproducer."
+        )
 
 
 def get_worker_for_range_sharding(

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -177,7 +177,7 @@ async def test_raise_on_lost_annotation(c, s, a, b):
         RuntimeError,
         "rechunk_transfer failed",
         RuntimeError,
-        "lost ``shuffle`` annotation",
+        "lost its ``shuffle`` annotation",
     ):
         await c.compute(x2)
 

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -22,7 +22,7 @@ from distributed.shuffle._scheduler_extension import get_worker_for_range_shardi
 from distributed.shuffle._shuffle import ShuffleId
 from distributed.shuffle._worker_extension import ArrayRechunkRun
 from distributed.shuffle.tests.utils import AbstractShuffleTestPool
-from distributed.utils_test import gen_cluster, gen_test
+from distributed.utils_test import gen_cluster, gen_test, raises_with_cause
 
 
 class ArrayRechunkTestPool(AbstractShuffleTestPool):
@@ -159,6 +159,27 @@ def test_raise_on_fuse_optimization():
     new = ((6,) * 5,)
     with pytest.raises(RuntimeError, match="fuse optimization"):
         rechunk(x, chunks=new, method="p2p")
+
+
+@gen_cluster(client=True, config={"optimization.fuse.active": False})
+async def test_raise_on_lost_annotation(c, s, a, b):
+    a = np.random.uniform(0, 1, 30)
+    x = da.from_array(a, chunks=((10,) * 3,))
+    new = ((6,) * 5,)
+    x2 = rechunk(x, chunks=new, method="p2p")
+
+    # Manually drop "shuffle" annotation
+    for name, layer in x2.dask.layers.items():
+        if name.startswith("rechunk-p2p"):
+            del layer.annotations["shuffle"]
+
+    with raises_with_cause(
+        RuntimeError,
+        "rechunk_transfer failed",
+        RuntimeError,
+        "lost ``shuffle`` annotation",
+    ):
+        await c.compute(x2)
 
 
 @pytest.mark.parametrize("config_value", ["tasks", "p2p", None])

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -26,7 +26,7 @@ from distributed.scheduler import TaskState as SchedulerTaskState
 from distributed.shuffle._arrow import serialize_table
 from distributed.shuffle._limiter import ResourceLimiter
 from distributed.shuffle._scheduler_extension import get_worker_for_range_sharding
-from distributed.shuffle._shuffle import ShuffleId, barrier_key
+from distributed.shuffle._shuffle import P2PShuffleLayer, ShuffleId, barrier_key
 from distributed.shuffle._worker_extension import (
     DataFrameShuffleRun,
     ShuffleRun,
@@ -38,7 +38,12 @@ from distributed.shuffle._worker_extension import (
 )
 from distributed.shuffle.tests.utils import AbstractShuffleTestPool
 from distributed.utils import Deadline
-from distributed.utils_test import gen_cluster, gen_test, wait_for_state
+from distributed.utils_test import (
+    gen_cluster,
+    gen_test,
+    raises_with_cause,
+    wait_for_state,
+)
 from distributed.worker_state_machine import TaskState as WorkerTaskState
 
 try:
@@ -119,6 +124,34 @@ def test_raise_on_fuse_optimization():
     with dask.config.set({"optimization.fuse.active": True}):
         with pytest.raises(RuntimeError, match="fuse optimization"):
             dd.shuffle.shuffle(df, "x", shuffle="p2p")
+
+
+@gen_cluster(client=True)
+async def test_raise_on_lost_annotation(c, s, a, b):
+    df = dask.datasets.timeseries(
+        start="2000-01-01",
+        end="2000-01-10",
+        dtypes={"x": float, "y": float},
+        freq="10 s",
+    )
+    df = dd.shuffle.shuffle(df, "x", shuffle="p2p")
+
+    # Manually drop "shuffle" annotation
+    for layer in df.dask.layers.values():
+        if isinstance(layer, P2PShuffleLayer):
+            del layer.annotations["shuffle"]
+
+    with raises_with_cause(
+        RuntimeError,
+        "shuffle_transfer failed",
+        RuntimeError,
+        "lost ``shuffle`` annotation",
+    ):
+        await c.compute(df)
+
+    await clean_worker(a)
+    await clean_worker(b)
+    await clean_scheduler(s)
 
 
 @gen_cluster(client=True)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -147,7 +147,7 @@ async def test_raise_on_lost_annotation(c, s, a, b):
         RuntimeError,
         "shuffle_transfer failed",
         RuntimeError,
-        "lost ``shuffle`` annotation",
+        "lost its ``shuffle`` annotation",
     ):
         await c.compute(df)
 


### PR DESCRIPTION
Provides a better error message when P2P shuffle or rechunk lost annotations. This has happened in several places now, for example #7599 and #7615.

Blocked by:
* ~#7706 (for testing)~

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
