### PR TITLE
unignore sphinx ref.python

### DIFF
--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -15,14 +15,12 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 import dask
 from dask.utils import parse_timedelta
 
+from distributed import client
+from distributed import scheduler as scheduler_module
 from distributed.compatibility import PeriodicCallback
 from distributed.core import Status
 from distributed.metrics import time
 from distributed.utils import import_term, log_errors
-
-if TYPE_CHECKING:
-    from distributed.client import Client
-    from distributed.scheduler import Scheduler, TaskState, WorkerState
 
 # Main logger. This is reasonably terse also at DEBUG level.
 logger = logging.getLogger(__name__)
@@ -46,7 +44,7 @@ class ActiveMemoryManagerExtension:
     """
 
     #: Back-reference to the scheduler holding this extension
-    scheduler: Scheduler
+    scheduler: scheduler_module.Scheduler
     #: All active policies
     policies: set[ActiveMemoryManagerPolicy]
     #: Memory measure to use. Must be one of the attributes or properties of
@@ -56,14 +54,17 @@ class ActiveMemoryManagerExtension:
     interval: float
     #: Current memory (in bytes) allocated on each worker, plus/minus pending actions
     #: This attribute only exist within the scope of self.run().
-    workers_memory: dict[WorkerState, int]
+    workers_memory: dict[scheduler_module.WorkerState, int]
     #: Pending replications and deletions for each task
     #: This attribute only exist within the scope of self.run().
-    pending: dict[TaskState, tuple[set[WorkerState], set[WorkerState]]]
+    pending: dict[
+        scheduler_module.TaskState,
+        tuple[set[scheduler_module.WorkerState], set[scheduler_module.WorkerState]],
+    ]
 
     def __init__(
         self,
-        scheduler: Scheduler,
+        scheduler: scheduler_module.Scheduler,
         # The following parameters are exposed so that one may create, run, and throw
         # away on the fly a specialized manager, separate from the main one.
         policies: set[ActiveMemoryManagerPolicy] | None = None,
@@ -182,7 +183,7 @@ class ActiveMemoryManagerExtension:
         """Sequentially run ActiveMemoryManagerPolicy.run() for all registered policies,
         obtain replicate/drop suggestions, and use them to populate self.pending.
         """
-        ws: WorkerState | None
+        ws: scheduler_module.WorkerState | None
 
         for policy in list(self.policies):  # a policy may remove itself
             logger.debug("Running policy: %s", policy)
@@ -228,10 +229,10 @@ class ActiveMemoryManagerExtension:
 
     def _find_recipient(
         self,
-        ts: TaskState,
-        candidates: set[WorkerState] | None,
-        pending_repl: set[WorkerState],
-    ) -> WorkerState | None:
+        ts: scheduler_module.TaskState,
+        candidates: set[scheduler_module.WorkerState] | None,
+        pending_repl: set[scheduler_module.WorkerState],
+    ) -> scheduler_module.WorkerState | None:
         """Choose a worker to acquire a new replica of an in-memory task among a set of
         candidates. If candidates is None, default to all workers in the cluster.
         Regardless, workers that either already hold a replica or are scheduled to
@@ -285,10 +286,10 @@ class ActiveMemoryManagerExtension:
 
     def _find_dropper(
         self,
-        ts: TaskState,
-        candidates: set[WorkerState] | None,
-        pending_drop: set[WorkerState],
-    ) -> WorkerState | None:
+        ts: scheduler_module.TaskState,
+        candidates: set[scheduler_module.WorkerState] | None,
+        pending_drop: set[scheduler_module.WorkerState],
+    ) -> scheduler_module.WorkerState | None:
         """Choose a worker to drop its replica of an in-memory task among a set of
         candidates. If candidates is None, default to all workers in the cluster.
         Regardless, workers that either do not hold a replica or are already scheduled
@@ -385,8 +386,12 @@ class ActiveMemoryManagerExtension:
         logger.debug("Enacting suggestions for %d tasks:", len(self.pending))
 
         validate = self.scheduler.validate
-        drop_by_worker: (defaultdict[WorkerState, list[str]]) = defaultdict(list)
-        repl_by_worker: (defaultdict[WorkerState, list[str]]) = defaultdict(list)
+        drop_by_worker: (
+            defaultdict[scheduler_module.WorkerState, list[str]]
+        ) = defaultdict(list)
+        repl_by_worker: (
+            defaultdict[scheduler_module.WorkerState, list[str]]
+        ) = defaultdict(list)
 
         for ts, (pending_repl, pending_drop) in self.pending.items():
             if not ts.who_has:
@@ -419,8 +424,8 @@ class ActiveMemoryManagerExtension:
 
 class Suggestion(NamedTuple):
     op: Literal["replicate", "drop"]
-    ts: TaskState
-    candidates: set[WorkerState] | None = None
+    ts: scheduler_module.TaskState
+    candidates: set[scheduler_module.WorkerState] | None = None
 
 
 if TYPE_CHECKING:
@@ -428,7 +433,9 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
 # TODO remove quotes (requires Python >=3.9)
-SuggestionGenerator: TypeAlias = "Generator[Suggestion, WorkerState | None, None]"
+SuggestionGenerator: TypeAlias = (
+    "Generator[Suggestion, scheduler_module.WorkerState | None, None]"
+)
 
 
 class ActiveMemoryManagerPolicy(abc.ABC):
@@ -490,9 +497,9 @@ class AMMClientProxy:
     client is synchronous.
     """
 
-    _client: Client
+    _client: client.Client
 
-    def __init__(self, client: Client):
+    def __init__(self, client: client.Client):
         self._client = client
 
     def _run(self, method: str) -> Any:

--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 import dask
 from dask.utils import parse_timedelta
 
+# Needed to avoid Sphinx WARNING: more than one target found for cross-reference 'TaskState' and 'WorkerState'"
+# https://github.com/agronholm/sphinx-autodoc-typehints#dealing-with-circular-imports
 from distributed import client
 from distributed import scheduler as scheduler_module
 from distributed.compatibility import PeriodicCallback

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -426,12 +426,6 @@ redirect_template = """\
 </html>
 """
 
-suppress_warnings = [
-    # more than one target found for cross-reference
-    # https://github.com/sphinx-doc/sphinx/issues/10400
-    "ref.python"
-]
-
 
 def copy_legacy_redirects(app, docname):
     if app.builder.name == "html":


### PR DESCRIPTION
avoid `if TYPE_CHECKING:` in `active_memory_manager` fixes WARNING: more than one target found for cross-reference 'TaskState' and 'WorkerState'" by following the advice on cyclic type annotations in https://github.com/agronholm/sphinx-autodoc-typehints#dealing-with-circular-imports

follow up to https://github.com/dask/distributed/pull/7697 which just ignored the warning, I pulled this change out as it's much larger than fixing any of the other docs warnings

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
