### PR TITLE
Run scheduler of `SubprocessCluster` in subprocess

### DIFF
--- a/distributed/deploy/subprocess.py
+++ b/distributed/deploy/subprocess.py
@@ -79,12 +79,7 @@ class SubprocessScheduler(Subprocess):
         ]
         logger.info(" ".join(cmd))
         self.process = await asyncio.create_subprocess_exec(
-            "dask",
-            "spec",
-            "--spec",
-            json.dumps(
-                {"cls": "distributed.Scheduler", "opts": {**self.scheduler_kwargs}}
-            ),
+            *cmd,
             stderr=asyncio.subprocess.PIPE,
         )
 
@@ -141,13 +136,7 @@ class SubprocessWorker(Subprocess):
             json.dumps({"cls": self.worker_class, "opts": {**self.worker_kwargs}}),
         ]
         logger.info(" ".join(cmd))
-        self.process = await asyncio.create_subprocess_exec(
-            "dask",
-            "spec",
-            self.scheduler,
-            "--spec",
-            json.dumps({"cls": self.worker_class, "opts": {**self.worker_kwargs}}),
-        )
+        self.process = await asyncio.create_subprocess_exec(*cmd)
 
 
 def SubprocessCluster(

--- a/distributed/deploy/subprocess.py
+++ b/distributed/deploy/subprocess.py
@@ -38,7 +38,6 @@ class Subprocess(ProcessInterface, abc.ABC):
     @abc.abstractmethod
     async def _start(self) -> None:
         """Start the subprocess"""
-        raise NotImplementedError
 
     async def close(self) -> None:
         if self.process and self.process.returncode is None:

--- a/distributed/deploy/subprocess.py
+++ b/distributed/deploy/subprocess.py
@@ -162,7 +162,7 @@ def SubprocessCluster(
     silence_logs: int = logging.WARN,
     **kwargs: Any,
 ) -> SpecCluster:
-    """Create a scheduler and workers run in dedicated subprocesses
+    """Create a scheduler and workers that run in dedicated subprocesses
 
     This creates a "cluster" of a scheduler and workers running in dedicated subprocesses.
 

--- a/distributed/deploy/subprocess.py
+++ b/distributed/deploy/subprocess.py
@@ -147,7 +147,6 @@ class SubprocessWorker(Subprocess):
             self.scheduler,
             "--spec",
             json.dumps({"cls": self.worker_class, "opts": {**self.worker_kwargs}}),
-            stderr=asyncio.subprocess.PIPE,
         )
 
 

--- a/distributed/deploy/subprocess.py
+++ b/distributed/deploy/subprocess.py
@@ -65,7 +65,7 @@ class SubprocessWorker(ProcessInterface):
             "spec",
             self.scheduler,
             "--spec",
-            json.dumps({0: {"cls": self.worker_class, "opts": {**self.worker_kwargs}}}),
+            json.dumps({"cls": self.worker_class, "opts": {**self.worker_kwargs}}),
         )
         await super().start()
 

--- a/distributed/deploy/subprocess.py
+++ b/distributed/deploy/subprocess.py
@@ -159,10 +159,9 @@ def SubprocessCluster(
     silence_logs: int = logging.WARN,
     **kwargs: Any,
 ) -> SpecCluster:
-    """Create in-process scheduler and workers running in dedicated subprocesses
+    """Create a scheduler and workers run in dedicated subprocesses
 
-    This creates a "cluster" of a scheduler running in the current process and
-    workers running in dedicated subprocesses.
+    This creates a "cluster" of a scheduler and workers running in dedicated subprocesses.
 
     .. warning::
 

--- a/distributed/deploy/subprocess.py
+++ b/distributed/deploy/subprocess.py
@@ -156,7 +156,7 @@ def SubprocessCluster(
     n_workers: int | None = None,
     threads_per_worker: int | None = None,
     worker_kwargs: dict | None = None,
-    silence_logs: int = logging.INFO,
+    silence_logs: int = logging.WARN,
     **kwargs: Any,
 ) -> SpecCluster:
     """Create in-process scheduler and workers running in dedicated subprocesses
@@ -191,7 +191,7 @@ def SubprocessCluster(
     worker_kwargs:
         Keywords to pass on to the ``Worker`` class constructor
     silence_logs:
-        Level of logs to print out to stdout, defaults to ``logging.INFO``
+        Level of logs to print out to stdout, defaults to ``logging.WARN``
 
         Use a falsy value like False or None to disable log silencing.
 

--- a/distributed/deploy/tests/test_subprocess.py
+++ b/distributed/deploy/tests/test_subprocess.py
@@ -4,7 +4,11 @@ import pytest
 
 from distributed import Client
 from distributed.compatibility import WINDOWS
-from distributed.deploy.subprocess import SubprocessCluster, SubprocessWorker
+from distributed.deploy.subprocess import (
+    SubprocessCluster,
+    SubprocessScheduler,
+    SubprocessWorker,
+)
 from distributed.utils_test import gen_test
 
 
@@ -53,12 +57,19 @@ async def test_scale_up_and_down():
             cluster.scale(2)
             await c.wait_for_workers(2)
             assert len(cluster.workers) == 2
-            assert len(cluster.scheduler.workers) == 2
 
             cluster.scale(1)
             await cluster
 
             assert len(cluster.workers) == 1
+
+
+@pytest.mark.skipif(WINDOWS, reason="distributed#7434")
+@gen_test()
+async def test_raise_if_scheduler_fails_to_start():
+    with pytest.raises(RuntimeError, match="Scheduler failed to start"):
+        async with SubprocessCluster(scheduler_port=-1, asynchronous=True):
+            pass
 
 
 @pytest.mark.skipif(
@@ -67,6 +78,9 @@ async def test_scale_up_and_down():
 def test_raise_on_windows():
     with pytest.raises(RuntimeError, match="not support Windows"):
         SubprocessCluster()
+
+    with pytest.raises(RuntimeError, match="not support Windows"):
+        SubprocessScheduler()
 
     with pytest.raises(RuntimeError, match="not support Windows"):
         SubprocessWorker(scheduler="tcp://127.0.0.1:8786")


### PR DESCRIPTION
In #7431, we added the `SubprocessCluster`, which runs a local cluster where all workers run in subprocesses. This PR also moves the scheduler to a subprocess.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
