### PR TITLE
Fix crash on missing env var in dashboard link formatting

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3872,7 +3872,13 @@ class Scheduler(SchedulerState, ServerNode):
         for name, server in self.services.items():
             if name == "dashboard":
                 addr = get_address_host(listener.contact_address)
-                link = format_dashboard_link(addr, server.port)
+                try:
+                    link = format_dashboard_link(addr, server.port)
+                # formatting dashboard link can fail if distributed.dashboard.link
+                # refers to non-existant env vars.
+                except KeyError as e:
+                    logger.warning(f"Failed to format dashboard link, missing key: {e}")
+                    link = f":{server.port}"
             else:
                 link = f"{listen_ip}:{server.port}"
             logger.info("%11s at:  %25s", name, link)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3877,7 +3877,9 @@ class Scheduler(SchedulerState, ServerNode):
                 # formatting dashboard link can fail if distributed.dashboard.link
                 # refers to non-existant env vars.
                 except KeyError as e:
-                    logger.warning(f"Failed to format dashboard link, unknown value: {e}")
+                    logger.warning(
+                        f"Failed to format dashboard link, unknown value: {e}"
+                    )
                     link = f":{server.port}"
             else:
                 link = f"{listen_ip}:{server.port}"

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3877,7 +3877,7 @@ class Scheduler(SchedulerState, ServerNode):
                 # formatting dashboard link can fail if distributed.dashboard.link
                 # refers to non-existant env vars.
                 except KeyError as e:
-                    logger.warning(f"Failed to format dashboard link, missing key: {e}")
+                    logger.warning(f"Failed to format dashboard link, unknown value: {e}")
                     link = f":{server.port}"
             else:
                 link = f"{listen_ip}:{server.port}"

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2865,7 +2865,7 @@ async def test_multiple_listeners(dashboard_link_template, expected_dashboard_li
     # present. Don't kill scheduler, but revert to outputting the port and helpful msg
     assert re.search(expected_dashboard_link, log)
     if "ENV_VAR_MISSING" in dashboard_link_template:
-        msg = r"Failed to format dashboard link, missing key: 'ENV_VAR_MISSING'"
+        msg = r"Failed to format dashboard link, unknown value: 'ENV_VAR_MISSING'"
         assert re.search(msg, log)
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2829,28 +2829,44 @@ async def test_too_many_groups(c, s, a, b):
 
 
 @gen_test()
-async def test_multiple_listeners():
-    with captured_logger("distributed.scheduler") as log:
-        async with Scheduler(dashboard_address=":0", protocol=["inproc", "tcp"]) as s:
-            async with Worker(s.listeners[0].contact_address) as a:
-                async with Worker(s.listeners[1].contact_address) as b:
-                    assert a.address.startswith("inproc")
-                    assert a.scheduler.address.startswith("inproc")
-                    assert b.address.startswith("tcp")
-                    assert b.scheduler.address.startswith("tcp")
+@pytest.mark.parametrize(
+    "dashboard_link_template,expected_dashboard_link",
+    (
+        ("{scheme}://{host}:{port}/status", r"dashboard at:\s*http://"),
+        ("{ENV_VAR_MISSING}", r"dashboard at:\s*:\d*"),
+    ),
+)
+async def test_multiple_listeners(dashboard_link_template, expected_dashboard_link):
+    with dask.config.set({"distributed.dashboard.link": dashboard_link_template}):
+        with captured_logger("distributed.scheduler") as log:
+            async with Scheduler(
+                dashboard_address=":0", protocol=["inproc", "tcp"]
+            ) as s:
+                async with Worker(s.listeners[0].contact_address) as a:
+                    async with Worker(s.listeners[1].contact_address) as b:
+                        assert a.address.startswith("inproc")
+                        assert a.scheduler.address.startswith("inproc")
+                        assert b.address.startswith("tcp")
+                        assert b.scheduler.address.startswith("tcp")
 
-                    async with Client(s.address, asynchronous=True) as c:
-                        futures = c.map(inc, range(20))
-                        await wait(futures)
+                        async with Client(s.address, asynchronous=True) as c:
+                            futures = c.map(inc, range(20))
+                            await wait(futures)
 
-                        # Force inter-worker communication both ways
-                        await c.submit(sum, futures, workers=[a.address])
-                        await c.submit(len, futures, workers=[b.address])
+                            # Force inter-worker communication both ways
+                            await c.submit(sum, futures, workers=[a.address])
+                            await c.submit(len, futures, workers=[b.address])
 
     log = log.getvalue()
     assert re.search(r"Scheduler at:\s*tcp://", log)
     assert re.search(r"Scheduler at:\s*inproc://", log)
-    assert re.search(r"dashboard at:\s*http://", log)
+
+    # Dashboard link formatting can fail if template contains env vars which aren't
+    # present. Don't kill scheduler, but revert to outputting the port and helpful msg
+    assert re.search(expected_dashboard_link, log)
+    if "ENV_VAR_MISSING" in dashboard_link_template:
+        msg = r"Failed to format dashboard link, missing key: 'ENV_VAR_MISSING'"
+        assert re.search(msg, log)
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)])


### PR DESCRIPTION
Closes #7724 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
