### PR TITLE
Add `pytables` to CI environment to fix `test_shuffle_before_to_hdf`

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -25,6 +25,7 @@ dependencies:
   - prometheus_client
   - psutil
   - pyarrow=7
+  - pytables
   - pytest
   - pytest-cov
   - pytest-faulthandler

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -25,6 +25,7 @@ dependencies:
   - prometheus_client
   - psutil
   - pyarrow=7
+  - pytables
   - pytest
   - pytest-cov
   - pytest-faulthandler

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -27,6 +27,7 @@ dependencies:
   - psutil
   - pyarrow=7
   - pynvml  # Only tested here
+  - pytables
   - pytest
   - pytest-cov
   - pytest-faulthandler

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -28,6 +28,7 @@ dependencies:
   - psutil
   - pyarrow=7
   - pynvml  # Only tested here
+  - pytables
   - pytest
   - pytest-cov
   - pytest-faulthandler


### PR DESCRIPTION
Follow-up to #7720 which introduced the test and breaks CI (https://github.com/dask/distributed/actions/runs/4575906162/jobs/8079352053#step:19:5907)

cc @fjetter

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
