### PR TITLE
Drop `id` from RMM dashboard component

### DIFF
--- a/distributed/dashboard/components/rmm.py
+++ b/distributed/dashboard/components/rmm.py
@@ -56,7 +56,6 @@ class RMMMemoryUsage(DashboardComponent):
             memory = figure(
                 title="RMM Memory",
                 tools="",
-                id="bk-rmm-memory-worker-plot",
                 width=int(width / 2),
                 name="rmm_memory_histogram",
                 **kwargs,


### PR DESCRIPTION
We made similar changes previously here https://github.com/dask/distributed/pull/5648

Closes https://github.com/dask/distributed/issues/7731

cc @jacobtomlinson @pentschev 