### PR TITLE
Temporary fix for `test_merge_by_multiple_columns` with `pandas` 2.0

### DIFF
--- a/distributed/shuffle/tests/test_merge.py
+++ b/distributed/shuffle/tests/test_merge.py
@@ -8,7 +8,7 @@ from distributed.utils_test import gen_cluster
 dd = pytest.importorskip("dask.dataframe")
 import pandas as pd
 
-from dask.dataframe._compat import tm
+from dask.dataframe._compat import PANDAS_GT_200, tm
 from dask.dataframe.utils import assert_eq
 from dask.utils_test import hlg_layer_topological
 
@@ -234,28 +234,46 @@ async def test_merge_by_multiple_columns(c, s, a, b, how):
             ddl = dd.from_pandas(pdl, lpart)
             ddr = dd.from_pandas(pdr, rpart)
 
+            expected = pdl.join(pdr, how=how)
             assert_eq(
                 await c.compute(ddl.join(ddr, how=how, shuffle="p2p")),
-                pdl.join(pdr, how=how),
-            )
-            assert_eq(
-                await c.compute(ddr.join(ddl, how=how, shuffle="p2p")),
-                pdr.join(pdl, how=how),
+                expected,
+                # FIXME: There's an discrepancy with an empty index for
+                # pandas=2.0 (xref https://github.com/dask/dask/issues/9957).
+                # Temporarily avoid index check until the discrepancy is fixed.
+                check_index=not PANDAS_GT_200 and not expected.index.empty,
             )
 
+            expected = pdr.join(pdl, how=how)
             assert_eq(
-                await c.compute(
-                    dd.merge(
-                        ddl,
-                        ddr,
-                        how=how,
-                        left_index=True,
-                        right_index=True,
-                        shuffle="p2p",
-                    )
-                ),
-                pd.merge(pdl, pdr, how=how, left_index=True, right_index=True),
+                await c.compute(ddr.join(ddl, how=how, shuffle="p2p")),
+                expected,
+                # FIXME: There's an discrepancy with an empty index for
+                # pandas=2.0 (xref https://github.com/dask/dask/issues/9957).
+                # Temporarily avoid index check until the discrepancy is fixed.
+                check_index=not PANDAS_GT_200 and not expected.index.empty,
             )
+
+            expected = pd.merge(pdl, pdr, how=how, left_index=True, right_index=True)
+            assert_eq(
+                await c.compute(
+                    dd.merge(
+                        ddl,
+                        ddr,
+                        how=how,
+                        left_index=True,
+                        right_index=True,
+                        shuffle="p2p",
+                    )
+                ),
+                expected,
+                # FIXME: There's an discrepancy with an empty index for
+                # pandas=2.0 (xref https://github.com/dask/dask/issues/9957).
+                # Temporarily avoid index check until the discrepancy is fixed.
+                check_index=not PANDAS_GT_200 and not expected.index.empty,
+            )
+
+            expected = pd.merge(pdr, pdl, how=how, left_index=True, right_index=True)
             assert_eq(
                 await c.compute(
                     dd.merge(
@@ -267,7 +285,11 @@ async def test_merge_by_multiple_columns(c, s, a, b, how):
                         shuffle="p2p",
                     )
                 ),
-                pd.merge(pdr, pdl, how=how, left_index=True, right_index=True),
+                expected,
+                # FIXME: There's an discrepancy with an empty index for
+                # (xref https://github.com/dask/dask/issues/9957).
+                # Temporarily avoid index check until the discrepancy is fixed.
+                check_index=not PANDAS_GT_200 and not expected.index.empty,
             )
 
             # hash join

--- a/distributed/shuffle/tests/test_merge.py
+++ b/distributed/shuffle/tests/test_merge.py
@@ -241,7 +241,7 @@ async def test_merge_by_multiple_columns(c, s, a, b, how):
                 # FIXME: There's an discrepancy with an empty index for
                 # pandas=2.0 (xref https://github.com/dask/dask/issues/9957).
                 # Temporarily avoid index check until the discrepancy is fixed.
-                check_index=not PANDAS_GT_200 and not expected.index.empty,
+                check_index=not (PANDAS_GT_200 and expected.index.empty),
             )
 
             expected = pdr.join(pdl, how=how)
@@ -251,7 +251,7 @@ async def test_merge_by_multiple_columns(c, s, a, b, how):
                 # FIXME: There's an discrepancy with an empty index for
                 # pandas=2.0 (xref https://github.com/dask/dask/issues/9957).
                 # Temporarily avoid index check until the discrepancy is fixed.
-                check_index=not PANDAS_GT_200 and not expected.index.empty,
+                check_index=not (PANDAS_GT_200 and expected.index.empty),
             )
 
             expected = pd.merge(pdl, pdr, how=how, left_index=True, right_index=True)
@@ -270,7 +270,7 @@ async def test_merge_by_multiple_columns(c, s, a, b, how):
                 # FIXME: There's an discrepancy with an empty index for
                 # pandas=2.0 (xref https://github.com/dask/dask/issues/9957).
                 # Temporarily avoid index check until the discrepancy is fixed.
-                check_index=not PANDAS_GT_200 and not expected.index.empty,
+                check_index=not (PANDAS_GT_200 and expected.index.empty),
             )
 
             expected = pd.merge(pdr, pdl, how=how, left_index=True, right_index=True)
@@ -287,9 +287,9 @@ async def test_merge_by_multiple_columns(c, s, a, b, how):
                 ),
                 expected,
                 # FIXME: There's an discrepancy with an empty index for
-                # (xref https://github.com/dask/dask/issues/9957).
+                # pandas=2.0 (xref https://github.com/dask/dask/issues/9957).
                 # Temporarily avoid index check until the discrepancy is fixed.
-                check_index=not PANDAS_GT_200 and not expected.index.empty,
+                check_index=not (PANDAS_GT_200 and expected.index.empty),
             )
 
             # hash join


### PR DESCRIPTION
This is a proposed workaround for https://github.com/dask/dask/issues/9957 until a proper fix is in. Should fix the `distributed/shuffle/tests/test_merge.py::test_merge_by_multiple_columns` failure happening on `main`

cc @hendrikmakait @phofl