### PR TITLE
Ensure proper exception is raised if wrapped future cannot be initial…

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -251,10 +251,11 @@ class Future(WrappedKey):
                     textwrap.dedent(
                         """\
                 Critical error encountered during Future initialization. This
-                typically occurs when passing around Future objects without
-                handling the Client lifecycle explicitly. If you encounter this,
-                please ensure to initialize a Client object yourself before
-                interacting with the Future object. See also
+                typically occurs when when interacting with a Future object in
+                tasks that are being run on Workers without initializing a
+                Client explicitly. If you encounter this, please ensure to
+                initialize a Client object yourself before interacting with the
+                Future object directly. See also
                 https://distributed.dask.org/en/stable/api.html#distributed.worker_client
                 """
                     )

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -250,12 +250,13 @@ class Future(WrappedKey):
                 raise RuntimeError(
                     textwrap.dedent(
                         """\
-                Critical error encountered during Future initialization. This
-                typically occurs when when interacting with a Future object in
-                tasks that are being run on Workers without initializing a
-                Client explicitly. If you encounter this, please ensure to
-                initialize a Client object yourself before interacting with the
-                Future object directly. See also
+                Critical error encountered during Future initialization.
+                This typically occurs when interacting with Future object
+                directly inside of a Task without initializing a Client
+                explicitly inside of this Task.
+                If you encounter this, please ensure to initialize a Client
+                object yourself before interacting with the Future object
+                directly. See also
                 https://distributed.dask.org/en/stable/api.html#distributed.worker_client
                 """
                     )

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -251,9 +251,9 @@ class Future(WrappedKey):
                     textwrap.dedent(
                         """\
                 Critical error encountered during Future initialization.
-                This typically occurs when interacting with Future object
+                This typically occurs when interacting with Future objects
                 directly inside of a Task without initializing a Client
-                explicitly inside of this Task.
+                explicitly inside of this Task first.
                 If you encounter this, please ensure to initialize a Client
                 object yourself before interacting with the Future object
                 directly. See also

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -10,6 +10,7 @@ import os
 import pickle
 import re
 import sys
+import textwrap
 import threading
 import traceback
 import uuid
@@ -242,6 +243,22 @@ class Future(WrappedKey):
                     pass
                 else:
                     handler(key=self.key)
+        if self._client:
+            try:
+                assert self._state is self._client.futures[self._tkey]
+            except (AssertionError, KeyError):
+                raise RuntimeError(
+                    textwrap.dedent(
+                        """\
+                Critical error encountered during Future initialization. This
+                typically occurs when passing around Future objects without
+                handling the Client lifecycle explicitly. If you encounter this,
+                please ensure to initialize a Client object yourself before
+                interacting with the Future object. See also
+                https://distributed.dask.org/en/stable/api.html#distributed.worker_client
+                """
+                    )
+                )
 
     def _verify_initialized(self):
         if not self.client or not self._state:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -8060,15 +8060,11 @@ def bad_wrapper(client, use_worker_client=False):
     results = client.gather(futures)
 
 
+@pytest.mark.slow()
 def test_cancelled_error_wrapped_future(loop):
     # See https://github.com/dask/distributed/issues/7746
-
-    # FIXME: This does not trigger with the ordinary cluster utils and depends
-    # on a race on the worker. In the case of an error, it appears multiple
-    # worker clients are created implicitly and ownership of futures is mixed
-    with LocalCluster(loop=loop, dashboard_address=":0") as cluster:
+    with LocalCluster(loop=loop, dashboard_address=":0", n_workers=1) as cluster:
         with Client(cluster, loop=loop) as c:
-            with pytest.raises(RuntimeError, match="worker_client"):
-                bad_wrapper(c)
+            bad_wrapper(c)
         with Client(cluster, loop=loop) as c:
             bad_wrapper(c, use_worker_client=True)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -59,6 +59,7 @@ from distributed import (
     performance_report,
     profile,
     secede,
+    worker_client,
 )
 from distributed.client import (
     Client,
@@ -8029,3 +8030,45 @@ async def test_resolves_future_in_dict(c, s, a, b):
     outer_future = c.submit(identity, {"x": inner_future, "y": 2})
     result = await outer_future
     assert result == {"x": 1, "y": 2}
+
+
+def bad_wrapper(client, use_worker_client=False):
+    class FuncWrapper:
+        def __init__(self, f, args=None):
+            self.f = f
+            self.args = [] if args is None else args
+
+        def __call__(self, x):
+            return self.f(x, *self.args)
+
+    def make_data():
+        return 1
+
+    def func_to_map(x, x0):
+        if use_worker_client:
+            ctx = worker_client()
+        else:
+            ctx = nullcontext()
+        with ctx:
+            return x0.result() + x
+
+    shared_future = client.submit(make_data)
+
+    wrapped_func = FuncWrapper(func_to_map, (shared_future,))
+
+    futures = client.map(wrapped_func, range(10))
+    results = client.gather(futures)
+
+
+def test_cancelled_error_wrapped_future(loop):
+    # See https://github.com/dask/distributed/issues/7746
+
+    # FIXME: This does not trigger with the ordinary cluster utils and depends
+    # on a race on the worker. In the case of an error, it appears multiple
+    # worker clients are created implicitly and ownership of futures is mixed
+    with LocalCluster(loop=loop, dashboard_address=":0") as cluster:
+        with Client(cluster, loop=loop) as c:
+            with pytest.raises(RuntimeError, match="worker_client"):
+                bad_wrapper(c)
+        with Client(cluster, loop=loop) as c:
+            bad_wrapper(c, use_worker_client=True)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -8045,6 +8045,7 @@ def bad_wrapper(client, use_worker_client=False):
         return 1
 
     def func_to_map(x, x0):
+        sleep(0.1)
         if use_worker_client:
             ctx = worker_client()
         else:
@@ -8063,7 +8064,9 @@ def bad_wrapper(client, use_worker_client=False):
 @pytest.mark.slow()
 def test_cancelled_error_wrapped_future(loop):
     # See https://github.com/dask/distributed/issues/7746
-    with LocalCluster(loop=loop, dashboard_address=":0", n_workers=1) as cluster:
+    with LocalCluster(
+        loop=loop, dashboard_address=":0", n_workers=1, threads_per_worker=2
+    ) as cluster:
         with Client(cluster, loop=loop) as c:
             bad_wrapper(c)
         with Client(cluster, loop=loop) as c:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2544,6 +2544,8 @@ class Worker(BaseWorker, ServerNode):
         get_client
         """
         with self._lock:
+            if self._client:
+                return self._client
             if timeout is None:
                 timeout = dask.config.get("distributed.comm.timeouts.connect")
 


### PR DESCRIPTION
This ensure there is a proper, actionable exception message for cases like https://github.com/dask/distributed/issues/7746

I'm also looking into whether this behavior can be salvaged. Generally speaking, an explicit client is always better than an implicitly created one but the implicit one is of course nice from an UX perspective.

However, the 🪄 of implicitly creating clients can cause otherwise spurious failures, see https://github.com/dask/distributed/issues/7498 for the umbrella issue