### PR TITLE
Merge identical `tool.mypy.overrides` sections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,31 +177,23 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true
 
+[[tool.mypy.overrides]]
 # FIXME must clean these modules up
 # Also look for 'mypy: disable-error-code' at the top of modules
-[[tool.mypy.overrides]]
-module = ["distributed.client"]
-allow_incomplete_defs = true
-[[tool.mypy.overrides]]
-module = ["distributed.worker"]
+module = ["distributed.client", "distributed.worker"]
 allow_incomplete_defs = true
 
+[[tool.mypy.overrides]]
 # Recent or recently overhauled modules featuring stricter validation
-[[tool.mypy.overrides]]
-module = ["distributed.active_memory_manager"]
+module = [
+    "distributed.active_memory_manager",
+    "distributed.system_monitor",
+    "distributed.worker_memory",
+    "distributed.worker_state_machine",
+    "distributed.shuffle.*",
+]
 allow_untyped_defs = false
-[[tool.mypy.overrides]]
-module = ["distributed.system_monitor"]
-allow_untyped_defs = false
-[[tool.mypy.overrides]]
-module = ["distributed.worker_memory"]
-allow_untyped_defs = false
-[[tool.mypy.overrides]]
-module = ["distributed.worker_state_machine"]
-allow_untyped_defs = false
-[[tool.mypy.overrides]]
-module = ["distributed.shuffle.*"]
-allow_untyped_defs = false
+
 [[tool.mypy.overrides]]
 module = ["distributed.shuffle.tests.*"]
 allow_untyped_defs = true


### PR DESCRIPTION
after https://github.com/dask/distributed/pull/7629 I noticed it was possible to merge identical tool.mypy.overrides sections

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
