### PR TITLE
Loosen `dask` dependency to allow for patch releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.8"
 dependencies = [
     "click >= 8.0",
     "cloudpickle >= 1.5.0",
-    "dask == 2023.3.2",
+    "dask == 2023.3.2.*",
     "jinja2 >= 2.10.3",
     "locket >= 1.0.0",
     "msgpack >= 1.0.0",


### PR DESCRIPTION
This should allow us to make future patch releases of Dask without needing to do a corresponding patch release of Distributed

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
