### PR TITLE
Skip doc test when not running from a git checkout

### DIFF
--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -29,8 +29,11 @@ async def test_prometheus_api_doc(c, s, a, _):
     """
     pytest.importorskip("prometheus_client")
 
-    documented = set()
     root_dir = pathlib.Path(__file__).parent.parent.parent.parent
+    if not (root_dir / ".git").exists():
+        pytest.skip("Not running in a git checkout")
+
+    documented = set()
     with open(root_dir / "docs" / "source" / "prometheus.rst") as fh:
         for row in fh:
             row = row.strip()


### PR DESCRIPTION
When `distributed` is installed, this test cannot run as it has no access to the documentation source files.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
