### PR TITLE
Modify nightly version strings to avoid clashing with stable pinnings

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -55,7 +55,7 @@ jobs:
 
           # distributed pre-release build
           conda mambabuild continuous_integration/recipes/distributed \
-                           --channel /home/nfs/charlesb/dev/dask/nightly-version-fix/ \
+                           --channel dask/label/dev \
                            --no-anaconda-upload \
                            --output-folder .
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build conda packages
         run: |
           # suffix for pre-release package versions
-          export VERSION_SUFFIX=a`date +%y%m%d`
+          export VERSION_SUFFIX=`date +%y%m%d`
 
           # conda search for the latest dask-core pre-release
           arr=($(conda search --override-channels -c dask/label/dev dask-core | tail -n 1))
@@ -55,7 +55,7 @@ jobs:
 
           # distributed pre-release build
           conda mambabuild continuous_integration/recipes/distributed \
-                           --channel dask/label/dev \
+                           --channel /home/nfs/charlesb/dev/dask/nightly-version-fix/ \
                            --no-anaconda-upload \
                            --output-folder .
 

--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -1,7 +1,8 @@
 {% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
 {% set new_patch = major_minor_patch[2] | int + 1 %}
-{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
+{% set version = (major_minor_patch[:2] + [new_patch, 'a']) | join('.') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
+{% set date_string = environ.get('VERSION_SUFFIX', '') %}
 
 
 package:
@@ -13,7 +14,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: py_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   noarch: python
 
 requirements:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -1,7 +1,8 @@
 {% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
 {% set new_patch = major_minor_patch[2] | int + 1 %}
-{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
+{% set version = (major_minor_patch[:2] + [new_patch, 'a']) | join('.') %}
 {% set dask_version = environ.get('DASK_CORE_VERSION', '0.0.0.dev') %}
+{% set date_string = environ.get('VERSION_SUFFIX', '') %}
 
 
 package:
@@ -13,7 +14,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: py_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps
   entry_points:


### PR DESCRIPTION
Modifies the version/build strings of the published nightlies like so:

```
distributed-2023.3.3a230410-py_g011f170f6_27 => distributed-2023.3.3.a-py_230410_g011f170f6_27
```

The reasoning here is to get nightly versions parsed as `=2023.3.3.0a0`, which will prevent them from getting installed if we specify `dask==2023.3.2`.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
