### PR TITLE
Fix randbytes() on Python 3.8

### DIFF
--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -45,7 +45,7 @@ else:
     from random import getrandbits
 
     def randbytes(size):
-        return getrandbits(size * 8).to_bytes(size, 'little')
+        return getrandbits(size * 8).to_bytes(size, "little")
 
 
 if tornado.version_info >= (6, 2, 0, 0):

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -46,7 +46,7 @@ else:
         import numpy
 
         def randbytes(size):
-            return numpy.random.randint(255, size=size, dtype="u8").tobytes()
+            return numpy.random.randint(256, size=size, dtype="u1").tobytes()
 
     except ImportError:
         import secrets

--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -42,17 +42,10 @@ else:
 if sys.version_info >= (3, 9):
     from random import randbytes
 else:
-    try:
-        import numpy
+    from random import getrandbits
 
-        def randbytes(size):
-            return numpy.random.randint(256, size=size, dtype="u1").tobytes()
-
-    except ImportError:
-        import secrets
-
-        def randbytes(size):
-            return secrets.token_bytes(size)
+    def randbytes(size):
+        return getrandbits(size * 8).to_bytes(size, 'little')
 
 
 if tornado.version_info >= (6, 2, 0, 0):

--- a/distributed/tests/test_compatibility.py
+++ b/distributed/tests/test_compatibility.py
@@ -19,6 +19,6 @@ def test_randbytes_seed():
     state = random.getstate()
     try:
         random.seed(0)
-        assert randbytes(8) == b'\xcd\x07,\xd8\xbeo\x9fb'
+        assert randbytes(8) == b"\xcd\x07,\xd8\xbeo\x9fb"
     finally:
         random.setstate(state)

--- a/distributed/tests/test_compatibility.py
+++ b/distributed/tests/test_compatibility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 from collections import Counter
 
 from distributed.compatibility import randbytes
@@ -11,4 +12,13 @@ def test_randbytes():
     assert len(x) == 256_000
     c = Counter(x)
     for i in range(256):
-        assert 800 < c[i] < 1200
+        assert 800 < c[i] < 1200, (i, c[i])
+
+
+def test_randbytes_seed():
+    state = random.getstate()
+    try:
+        random.seed(0)
+        assert randbytes(8) == b'\xcd\x07,\xd8\xbeo\x9fb'
+    finally:
+        random.setstate(state)

--- a/distributed/tests/test_compatibility.py
+++ b/distributed/tests/test_compatibility.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from collections import Counter
+
+from distributed.compatibility import randbytes
+
+
+def test_randbytes():
+    x = randbytes(256_000)
+    assert isinstance(x, bytes)
+    assert len(x) == 256_000
+    c = Counter(x)
+    for i in range(256):
+        assert 800 < c[i] < 1200


### PR DESCRIPTION
On Python 3.8, randbytes() generated 8x the amount of advertised bytes. It was also never producing value 255.