### PR TITLE
Fix typing now that code is tuple of frame(s)

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -32,7 +32,7 @@ from collections.abc import (
 )
 from contextlib import suppress
 from functools import partial
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, Tuple, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, cast, overload
 
 import psutil
 from sortedcontainers import SortedDict, SortedSet
@@ -4252,7 +4252,7 @@ class Scheduler(SchedulerState, ServerNode):
         user_priority: int | dict[str, int] = 0,
         actors: bool | list[str] | None = None,
         fifo_timeout: float = 0.0,
-        code: Tuple[str] | None = None,
+        code: tuple[str] | None = None,
         annotations: dict | None = None,
         stimulus_id: str | None = None,
     ) -> None:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -32,7 +32,7 @@ from collections.abc import (
 )
 from contextlib import suppress
 from functools import partial
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, Tuple, cast, overload
 
 import psutil
 from sortedcontainers import SortedDict, SortedSet
@@ -4252,7 +4252,7 @@ class Scheduler(SchedulerState, ServerNode):
         user_priority: int | dict[str, int] = 0,
         actors: bool | list[str] | None = None,
         fifo_timeout: float = 0.0,
-        code: str | None = None,
+        code: Tuple[str] | None = None,
         annotations: dict | None = None,
         stimulus_id: str | None = None,
     ) -> None:


### PR DESCRIPTION
Return type of `_get_computation_code` was changed from `str` to `tuple[str]` in https://github.com/dask/distributed/pull/7656.

Whatever that returns gets sent to `scheduler.update_graph`:

https://github.com/dask/distributed/blob/515dffe40bfceb3141c7e72df7ee4de74d35315a/distributed/client.py#L3102-L3114

So type annotation on `code` argument is now incorrect. This fixes that.

