### PR TITLE
Fix `check_idle` not returning the correct value if no change to idleness

### DIFF
--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -70,7 +70,6 @@ class CheckIdleHandler(RequestHandler):
         try:
             idle_since = scheduler.check_idle()
             response = {
-                "idle": idle_since is None,
                 "idle_since": idle_since,
             }
             self.write(json.dumps(response))

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -501,7 +501,6 @@ async def test_check_idle(c, s, a, b):
             assert resp.status == 200
             assert resp.headers["Content-Type"] == "application/json"
             response = json.loads(await resp.text())
-            assert isinstance(response["idle"], bool)
             assert (
                 isinstance(response["idle_since"], float)
                 or response["idle_since"] is None

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7872,6 +7872,7 @@ class Scheduler(SchedulerState, ServerNode):
         if self.transition_counter != self._idle_transition_counter:
             self._idle_transition_counter = self.transition_counter
             self.idle_since = None
+            return None
 
         if (
             self.queued
@@ -7879,9 +7880,11 @@ class Scheduler(SchedulerState, ServerNode):
             or any(ws.processing for ws in self.workers.values())
         ):
             self.idle_since = None
+            return None
 
         if not self.idle_since:
             self.idle_since = time()
+            return self.idle_since
 
         if self.jupyter:
             last_activity = (
@@ -7889,6 +7892,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
             if last_activity > self.idle_since:
                 self.idle_since = last_activity
+                return self.idle_since
 
         if self.idle_timeout:
             if time() > self.idle_since + self.idle_timeout:
@@ -7898,7 +7902,6 @@ class Scheduler(SchedulerState, ServerNode):
                     format_time(self.idle_timeout),
                 )
                 self._ongoing_background_tasks.call_soon(self.close)
-
         return self.idle_since
 
     def adaptive_target(self, target_duration=None):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7872,7 +7872,6 @@ class Scheduler(SchedulerState, ServerNode):
         if self.transition_counter != self._idle_transition_counter:
             self._idle_transition_counter = self.transition_counter
             self.idle_since = None
-            return None
 
         if (
             self.queued
@@ -7880,11 +7879,9 @@ class Scheduler(SchedulerState, ServerNode):
             or any(ws.processing for ws in self.workers.values())
         ):
             self.idle_since = None
-            return None
 
         if not self.idle_since:
             self.idle_since = time()
-            return self.idle_since
 
         if self.jupyter:
             last_activity = (
@@ -7892,7 +7889,6 @@ class Scheduler(SchedulerState, ServerNode):
             )
             if last_activity > self.idle_since:
                 self.idle_since = last_activity
-                return self.idle_since
 
         if self.idle_timeout:
             if time() > self.idle_since + self.idle_timeout:
@@ -7902,7 +7898,8 @@ class Scheduler(SchedulerState, ServerNode):
                     format_time(self.idle_timeout),
                 )
                 self._ongoing_background_tasks.call_soon(self.close)
-        return None
+
+        return self.idle_since
 
     def adaptive_target(self, target_duration=None):
         """Desired number of workers based on the current workload

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2242,11 +2242,14 @@ async def test_collect_versions(c, s, a, b):
 @gen_cluster(client=True)
 async def test_idle_timeout(c, s, a, b):
     beginning = time()
+    assert s.check_idle() is not None
+    assert s.check_idle() is not None  # Repeated calls should still not be None
     s.idle_timeout = 0.500
     pc = PeriodicCallback(s.check_idle, 10)
     future = c.submit(slowinc, 1)
     while not s.tasks:
         await asyncio.sleep(0.01)
+    assert s.check_idle() is None
     pc.start()
     await future
     assert s.idle_since is None or s.idle_since > beginning


### PR DESCRIPTION
`Scheduler.check_idle` seemed to be returning `None` when there was no change to the idle since time when it should've been returning the idle since time. Tweaked the method to return `self.idle_since` as the catchall statement.

Also tweaked the HTTP API so that the response is more consistent with the RPC call.

cc @gjoseph92 who also had interest in this code recently