### PR TITLE
`gilknocker` from conda-forge

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -13,6 +13,7 @@ dependencies:
   - coverage
   - dask  # overridden by git tip below
   - filesystem-spec  # overridden by git tip below
+  - gilknocker>=0.4.0
   - h5py
   - ipykernel <6.22.0  # https://github.com/dask/distributed/issues/7688
   - ipywidgets <8.0.5  # https://github.com/dask/distributed/issues/7688
@@ -47,4 +48,3 @@ dependencies:
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
       - keras
-      - gilknocker>=0.4.0

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -13,6 +13,7 @@ dependencies:
   - coverage
   - dask  # overridden by git tip below
   - filesystem-spec  # overridden by git tip below
+  - gilknocker>=0.4.0
   - h5py
   - ipykernel <6.22.0  # https://github.com/dask/distributed/issues/7688
   - ipywidgets <8.0.5  # https://github.com/dask/distributed/issues/7688
@@ -47,4 +48,3 @@ dependencies:
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
       - keras
-      - gilknocker>=0.4.0

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -14,6 +14,7 @@ dependencies:
   - cython  # Only tested here; also a dependency of crick
   - dask  # overridden by git tip below
   - filesystem-spec
+  - gilknocker>=0.4.0
   - h5py
   - ipykernel <6.22.0  # https://github.com/dask/distributed/issues/7688
   - ipywidgets <8.0.5  # https://github.com/dask/distributed/issues/7688
@@ -48,4 +49,3 @@ dependencies:
       - git+https://github.com/dask/dask
       - git+https://github.com/jcrist/crick  # Only tested here
       - keras
-      - gilknocker>=0.4.0

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -14,6 +14,7 @@ dependencies:
   - coverage
   - dask  # overridden by git tip below
   - filesystem-spec
+  - gilknocker>=0.4.0
   - h5py
   - ipykernel <6.22.0  # https://github.com/dask/distributed/issues/7688
   - ipywidgets <8.0.5  # https://github.com/dask/distributed/issues/7688
@@ -50,4 +51,3 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask
       - keras
-      - gilknocker>=0.4.0


### PR DESCRIPTION
`gilknocker` is on conda-forge now, so let's install from there like we do most packages

cc @milesgranger 