### PR TITLE
`Client.upload_file` send to both Workers and Scheduler

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -74,6 +74,7 @@ from distributed.core import (
 from distributed.diagnostics.plugin import (
     ForwardLoggingPlugin,
     NannyPlugin,
+    SchedulerUploadFile,
     UploadFile,
     WorkerPlugin,
     _get_plugin_name,
@@ -3727,10 +3728,18 @@ class Client(SyncMethodMixin):
         >>> from mylibrary import myfunc  # doctest: +SKIP
         >>> L = client.map(myfunc, seq)  # doctest: +SKIP
         """
-        return self.register_worker_plugin(
-            UploadFile(filename),
-            name=filename + str(uuid.uuid4()),
-        )
+        name = filename + str(uuid.uuid4())
+
+        async def _():
+            results = await asyncio.gather(
+                self.register_scheduler_plugin(
+                    SchedulerUploadFile(filename), name=name
+                ),
+                self.register_worker_plugin(UploadFile(filename), name=name),
+            )
+            return results[1]  # Results from workers upload
+
+        return self.sync(_)
 
     async def _rebalance(self, futures=None, workers=None):
         if futures is not None:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -342,12 +342,13 @@ class Server:
         io_loop=None,
         local_directory=None,
     ):
+        name = type(self).__name__.lower()
         if local_directory is None:
             local_directory = (
                 dask.config.get("temporary-directory") or tempfile.gettempdir()
             )
             self._original_local_dir = local_directory
-            local_directory = os.path.join(local_directory, "dask-worker-space")
+            local_directory = os.path.join(local_directory, f"dask-{name}-space")
         else:
             self._original_local_dir = local_directory
 
@@ -359,7 +360,7 @@ class Server:
             "scratch data to a local disk.",
         ):
             self._workspace = WorkSpace(local_directory)
-            self._workdir = self._workspace.new_work_dir(prefix="worker-")
+            self._workdir = self._workspace.new_work_dir(prefix=f"{name}-")
             self.local_directory = self._workdir.dir_path
         if self.local_directory not in sys.path:
             sys.path.insert(0, self.local_directory)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -348,7 +348,10 @@ class Server:
             local_directory = (
                 dask.config.get("temporary-directory") or tempfile.gettempdir()
             )
+
+        if "dask-worker-space" not in str(local_directory):
             local_directory = os.path.join(local_directory, "dask-worker-space")
+
         self._original_local_dir = local_directory
 
         with warn_on_duration(

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -350,8 +350,8 @@ class Server:
                 dask.config.get("temporary-directory") or tempfile.gettempdir()
             )
 
-        if "dask-worker-space" not in str(local_directory):
-            local_directory = os.path.join(local_directory, "dask-worker-space")
+        if "dask-scratch-space" not in str(local_directory):
+            local_directory = os.path.join(local_directory, "dask-scratch-space")
 
         self._original_local_dir = local_directory
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -343,9 +343,8 @@ class Server:
         timeout=None,
         io_loop=None,
         local_directory=None,
+        needs_workdir=True,
     ):
-        from distributed.nanny import Nanny
-
         if local_directory is None:
             local_directory = (
                 dask.config.get("temporary-directory") or tempfile.gettempdir()
@@ -365,7 +364,7 @@ class Server:
         ):
             self._workspace = WorkSpace(local_directory)
 
-            if isinstance(self, Nanny):
+            if not needs_workdir:  # eg. Nanny will not need a WorkDir
                 self._workdir = None
                 self.local_directory = self._workspace.base_dir
             else:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -368,7 +368,8 @@ class Server:
                 self._workdir = None
                 self.local_directory = self._workspace.base_dir
             else:
-                self._workdir = self._workspace.new_work_dir(prefix="worker-")
+                name = type(self).__name__.lower()
+                self._workdir = self._workspace.new_work_dir(prefix=f"{name}-")
                 self.local_directory = self._workdir.dir_path
 
         if self.local_directory not in sys.path:

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -287,6 +287,21 @@ def _get_plugin_name(plugin: SchedulerPlugin | WorkerPlugin | NannyPlugin) -> st
         return funcname(type(plugin)) + "-" + str(uuid.uuid4())
 
 
+class SchedulerUploadFile(SchedulerPlugin):
+    name = "upload_file"
+
+    def __init__(self, filepath):
+        """
+        Initialize the plugin by reading in the data from the given file.
+        """
+        self.filename = os.path.basename(filepath)
+        with open(filepath, "rb") as f:
+            self.data = f.read()
+
+    async def start(self, scheduler: Scheduler) -> None:
+        await scheduler.upload_file(self.filename, self.data)
+
+
 class PackageInstall(WorkerPlugin, abc.ABC):
     """Abstract parent class for a worker plugin to install a set of packages
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -201,6 +201,7 @@ class Nanny(ServerNode):
             handlers=handlers,
             connection_args=self.connection_args,
             local_directory=local_directory,
+            needs_workdir=False,
         )
 
         self.preloads = preloading.process_preloads(

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -1484,10 +1484,6 @@ async def test_upload_file(c, s, a, b):
 
         return myfile.f()
 
-    worker_spaces = [p for p in sys.path if "dask-worker" in p]
-    scheduler_space = [p for p in sys.path if "dask-scheduler" in p]
-    assert len(scheduler_space) == 1
-
     with save_sys_modules():
         for value in [123, 456]:
             code = f"def f():\n    return {value}"
@@ -1495,8 +1491,8 @@ async def test_upload_file(c, s, a, b):
                 await c.upload_file(fn)
 
             # Confirm workers _and_ scheduler got the file
-            for space in worker_spaces + scheduler_space:
-                file = pathlib.Path(space).joinpath("myfile.py")
+            for server in [s, a, b]:
+                file = pathlib.Path(server.local_directory).joinpath("myfile.py")
                 assert file.is_file()
                 assert file.read_text() == code
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -367,23 +367,23 @@ async def test_local_directory(s):
         with dask.config.set(temporary_directory=fn):
             async with Nanny(s.address) as n:
                 assert n.local_directory.startswith(fn)
-                assert "dask-worker-space" in n.local_directory
-                assert n.process.worker_dir.count("dask-worker-space") == 1
+                assert "dask-scratch-space" in n.local_directory
+                assert n.process.worker_dir.count("dask-scratch-space") == 1
 
 
 @pytest.mark.skipif(WINDOWS, reason="Need POSIX filesystem permissions and UIDs")
 @gen_cluster(nthreads=[])
 async def test_unwriteable_dask_worker_space(s, tmp_path):
-    os.mkdir(f"{tmp_path}/dask-worker-space", mode=0o500)
+    os.mkdir(f"{tmp_path}/dask-scratch-space", mode=0o500)
     with pytest.raises(PermissionError):
-        open(f"{tmp_path}/dask-worker-space/tryme", "w")
+        open(f"{tmp_path}/dask-scratch-space/tryme", "w")
 
     with dask.config.set(temporary_directory=tmp_path):
         async with Nanny(s.address) as n:
             assert n.local_directory == os.path.join(
-                tmp_path, f"dask-worker-space-{os.getuid()}"
+                tmp_path, f"dask-scratch-space-{os.getuid()}"
             )
-            assert n.process.worker_dir.count(f"dask-worker-space-{os.getuid()}") == 1
+            assert n.process.worker_dir.count(f"dask-scratch-space-{os.getuid()}") == 1
 
 
 def _noop(x):

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -217,8 +217,9 @@ async def test_upload_file(c, s, a, b):
     result = await future
     assert result == 123
 
-    await c.close()
     await s.close()
+    await c.close()
+
     assert not os.path.exists(os.path.join(a.local_directory, "foobar.py"))
 
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -979,7 +979,7 @@ def test_worker_dir(worker, tmp_path):
 
 @gen_cluster(client=True, nthreads=[], config={"temporary-directory": None})
 async def test_default_worker_dir(c, s):
-    expect = os.path.join(tempfile.gettempdir(), "dask-worker-space")
+    expect = os.path.join(tempfile.gettempdir(), "dask-scratch-space")
 
     async with Worker(s.address) as w:
         assert os.path.dirname(w.local_directory) == expect
@@ -1386,7 +1386,7 @@ async def test_local_directory(s, tmp_path):
     with dask.config.set(temporary_directory=str(tmp_path)):
         async with Worker(s.address) as w:
             assert w.local_directory.startswith(str(tmp_path))
-            assert "dask-worker-space" in w.local_directory
+            assert "dask-scratch-space" in w.local_directory
 
 
 @gen_cluster(nthreads=[])
@@ -1394,7 +1394,7 @@ async def test_local_directory_make_new_directory(s, tmp_path):
     async with Worker(s.address, local_directory=str(tmp_path / "foo" / "bar")) as w:
         assert w.local_directory.startswith(str(tmp_path))
         assert "foo" in w.local_directory
-        assert "dask-worker-space" in w.local_directory
+        assert "dask-scratch-space" in w.local_directory
 
 
 @pytest.mark.skipif(not LINUX, reason="Need 127.0.0.2 to mean localhost")

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -594,13 +594,6 @@ class Worker(BaseWorker, ServerNode):
 
         self._setup_logging(logger)
 
-        if not preload:
-            preload = dask.config.get("distributed.worker.preload")
-        if not preload_argv:
-            preload_argv = dask.config.get("distributed.worker.preload-argv")
-        assert preload is not None
-        assert preload_argv is not None
-
         self.death_timeout = parse_timedelta(death_timeout)
         self.contact_address = contact_address
 
@@ -729,6 +722,13 @@ class Worker(BaseWorker, ServerNode):
             local_directory=local_directory,
             **kwargs,
         )
+
+        if not preload:
+            preload = dask.config.get("distributed.worker.preload")
+        if not preload_argv:
+            preload_argv = dask.config.get("distributed.worker.preload-argv")
+        assert preload is not None
+        assert preload_argv is not None
 
         self.preloads = preloading.process_preloads(
             self, preload, preload_argv, file_dir=self.local_directory

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -80,7 +80,7 @@ from distributed.core import rpc as RPCType
 from distributed.core import send_recv
 from distributed.diagnostics import nvml, rmm
 from distributed.diagnostics.plugin import _get_plugin_name
-from distributed.diskutils import WorkDir, WorkSpace
+from distributed.diskutils import WorkSpace
 from distributed.http import get_handlers
 from distributed.metrics import context_meter, thread_time, time
 from distributed.node import ServerNode
@@ -432,7 +432,6 @@ class Worker(BaseWorker, ServerNode):
     latency: float
     profile_cycle_interval: float
     workspace: WorkSpace
-    _workdir: WorkDir
     _client: Client | None
     bandwidth_workers: defaultdict[str, tuple[float, int]]
     bandwidth_types: defaultdict[type, tuple[float, int]]
@@ -1550,7 +1549,6 @@ class Worker(BaseWorker, ServerNode):
                         c.close()
 
         await self.scheduler.close_rpc()
-        self._workdir.release()
 
         self.stop_services()
 


### PR DESCRIPTION
Closes #7797 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

- Moves the previous `Worker.upload_file` into `Server.upload_file`, giving access to both workers and the scheduler to a `local_directory`. 
- Impl of `UploadFile` for the `Scheduler`
- Updates `Client.upload_file` to upload files to both scheduler and workers.