### PR TITLE
Partial revert defaultclient config setting

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3291,15 +3291,15 @@ async def test_get_scheduler_default_client_config_interleaving(s):
 
         assert dask.base.get_scheduler() == dask.local.get_sync
 
-        c = await Client(s.address, set_as_default=True, asynchronous=True)
+        client = await Client(s.address, set_as_default=True, asynchronous=True)
         try:
-            assert dask.base.get_scheduler() == c.get
+            assert dask.base.get_scheduler() == client.get
             with dask.config.set(scheduler="threads"):
                 assert dask.base.get_scheduler() == dask.threaded.get
-                with c.as_current():
-                    assert dask.base.get_scheduler() == c.get
+                with client.as_current():
+                    assert dask.base.get_scheduler() == client.get
         finally:
-            await c.close()
+            await client.close()
 
 
 @gen_cluster(client=True)


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/7754

I removed this config value setting to avoid weird race conditions in multi threaded environments. I'm not sure if there are tests for this. However, without the config value it is not possible to ensure sane behavior since we cannot distinguish between contextmanager based config settings and file based values. Also various ways to interleave config + default client were supported pre https://github.com/dask/distributed/pull/7482

If we wanted to get rid of all possible race conditions and ensure the complex precedence scheme at the same time, the best option would likely be to offer a dedicated API for this instead of relying on the config. I prefer to roll this change back now to restore old behavior and recommend multi threaded approaches to use `Client.as_current` for consistency.

Twin PR https://github.com/dask/dask/pull/10225