### PR TITLE
Avoid deprecated `pd.api.types.is_sparse`

### DIFF
--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -21,7 +21,7 @@ def check_dtype_support(meta_input: pd.DataFrame) -> None:
                 f"p2p does not support data of type '{column.dtype}' found in column '{name}'."
             )
         # FIXME: PyArrow does not support sparse data: https://issues.apache.org/jira/browse/ARROW-8679
-        if pd.api.types.is_sparse(column):
+        if isinstance(column.dtype, pd.SparseDtype):
             raise TypeError("p2p does not support sparse data found in column '{name}'")
 
 


### PR DESCRIPTION
`is_sparse` has been deprecated in `pandas` `main` and using an `isinstance(..., pd.SparseDtype)` check is now recommented (xref https://github.com/pandas-dev/pandas/pull/52642). 

Found this via

```python
FAILED dask/tests/test_distributed.py::test_map_partitions_df_input - FutureWarning: is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.
```

in the `dask/dask` `upstream` build (which uses the nightly version of `pandas`)