### PR TITLE
Allow dashboard to be used with `bokeh` prereleases

### DIFF
--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -13,7 +13,8 @@ import dask
 from distributed.dashboard.utils import BOKEH_VERSION
 from distributed.versions import BOKEH_REQUIREMENT
 
-if BOKEH_VERSION not in BOKEH_REQUIREMENT.specifier:
+# Set `prereleases=True` to allow for use with dev versions of `bokeh`
+if not BOKEH_REQUIREMENT.specifier.contains(BOKEH_VERSION, prereleases=True):
     warnings.warn(
         f"\nDask needs {BOKEH_REQUIREMENT} for the dashboard."
         f"\nYou have bokeh={BOKEH_VERSION}."


### PR DESCRIPTION
Currently I encounter the following warning when I attempt to use a prerelease of `bokeh` from PyPI:

```
Dask needs bokeh!=3.0.*,>=2.4.2 for the dashboard.
You have bokeh=3.2.0.dev1.
Continuing without the dashboard.
```

Which seems not quite right...

This PR makes it so we allow prereleases of `bokeh` to be allowed. See https://packaging.pypa.io/en/stable/specifiers.html#packaging.specifiers.Specifier.contains for the relevant `packaging` API docs. 

cc @graingert @charlesbluca who know a lot about packaging 