### PR TITLE
Fix flaky `test_dask_worker.py::test_single_executable_deprecated`

### DIFF
--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -723,11 +723,11 @@ def test_error_during_startup(monkeypatch, nanny, loop):
                 assert worker.wait(10) == 1
 
 
-@gen_cluster(nthreads=[], client=True)
-async def test_single_executable_deprecated(c, s):
-    with popen(["dask-worker", s.address], capture_output=True) as worker:
-        # ensure deprecation warning is emitted
-        wait_for_log_line(b"FutureWarning: dask-worker is deprecated", worker.stdout)
+def test_single_executable_deprecated():
+    assert (
+        b"FutureWarning: dask-worker is deprecated"
+        in subprocess.run(["dask-worker"], capture_output=True).stderr
+    )
 
 
 @pytest.mark.slow


### PR DESCRIPTION
convert test_single_executable_deprecated into a sync test: `wait_for_log_line` was intermittently blocking the handshake from occurring

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
