### PR TITLE
Clean up ``sys.path`` on ``Server`` shutdown

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -372,8 +372,10 @@ class Server:
                 self._workdir = self._workspace.new_work_dir(prefix=f"{name}-")
                 self.local_directory = self._workdir.dir_path
 
+        self._updated_sys_path = False
         if self.local_directory not in sys.path:
             sys.path.insert(0, self.local_directory)
+            self._updated_sys_path = True
 
         if io_loop is not None:
             warnings.warn(
@@ -1043,6 +1045,10 @@ class Server:
 
             await self.rpc.close()
             await asyncio.gather(*[comm.close() for comm in list(self._comms)])
+
+            # Remove scratch directory from global sys.path
+            if self._updated_sys_path and sys.path[0] == self.local_directory:
+                sys.path.remove(self.local_directory)
         finally:
             self._event_finished.set()
 


### PR DESCRIPTION
We've modified `sys.path` on workers for a long time (as part of local directory creation) but recently started doing this on the scheduler too with https://github.com/dask/distributed/pull/7802. Apparently this can be problematic in some cases (xref https://github.com/dask/dask/issues/10279). This PR adds a best-effort attempt to clean up `sys.path` when `Server`s close down. 

Not totally sure if this actually fixes https://github.com/dask/dask/issues/10279 (it might) but this is probably worth doing regardless. 