### PR TITLE
Explicitly install `anaconda-client` from conda-forge when uploading conda nightlies

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -35,9 +35,10 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: 3.9
+          channel-priority: strict
       - name: Install dependencies
         run: |
-          mamba install boa conda-verify
+          mamba install -c conda-forge boa conda-verify
 
           which python
           pip list
@@ -73,5 +74,6 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.DASK_CONDA_TOKEN }}
         run: |
           # install anaconda for upload
-          mamba install anaconda-client
+          mamba install -c conda-forge anaconda-client
+
           anaconda upload --label dev noarch/*.tar.bz2


### PR DESCRIPTION
Looks like conda nightly uploads have been failing for the past couple days due to some incompatibilities that cropped up between `anaconda-client` and `urllib3=2` (xref https://github.com/conda-forge/anaconda-client-feedstock/pull/41); this has been resolved for the packaged published at conda-forge, but it seems like we're picking up `anaconda-client` from `defaults` where this is still a problem?

This PR makes some modifications to the conda nightly workflow that should ensure we pick up the conda-forge package moving forward, which should also resolve this bug.
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
