### PR TITLE
Use properly imported `MatDescriptor` for cupy dispatch registration

### DIFF
--- a/distributed/protocol/cupy.py
+++ b/distributed/protocol/cupy.py
@@ -85,7 +85,7 @@ if MatDescriptor is not None:
     def reduce_matdescriptor(other):
         # Pickling MatDescriptor errors
         # xref: https://github.com/cupy/cupy/issues/3061
-        return cupy.cusparse.MatDescriptor.create, ()
+        return MatDescriptor.create, ()
 
     copyreg.pickle(MatDescriptor, reduce_matdescriptor)
 


### PR DESCRIPTION
Looks like we missed one remaining appearance of `cusparse` in CuPy's dispatch registration, which was relocated in `cupy=12`.

Noting that from https://github.com/dask/distributed/pull/7836#issuecomment-1548504369 this code seems to be a workaround for an issue in `cupy<8`?

>This `MatDescriptor` serialization code was a workaround for a CuPy pre-8.0.0 issue ( https://github.com/cupy/cupy/issues/3061 ). It was fixed in PR ( https://github.com/cupy/cupy/pull/3157 ).
>
>Maybe for newer CuPy's we skip this workaround. Alternatively we could just drop this workaround and request users have at least CuPy >=8.0.0 installed.

So we may be able to remove this in the near future; for now this should unblock GPU CI

cc @jrbourbeau @wence-
            

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
