### PR TITLE
Enforce dtypes in P2P shuffle

### DIFF
--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -99,18 +99,20 @@ def hash_join_p2p(
     )
     # dummy result
     # Avoid using dummy data for a collection it is empty
-    _lhs_meta = lhs._meta_nonempty if len(lhs.columns) else lhs._meta
-    _rhs_meta = rhs._meta_nonempty if len(rhs.columns) else rhs._meta
-    meta = _lhs_meta.merge(_rhs_meta, **merge_kwargs)
+    lhs_meta = lhs._meta_nonempty if len(lhs.columns) else lhs._meta
+    rhs_meta = rhs._meta_nonempty if len(rhs.columns) else rhs._meta
+    meta = lhs_meta.merge(rhs_meta, **merge_kwargs)
     lhs = _calculate_partitions(lhs, left_on, npartitions)
     rhs = _calculate_partitions(rhs, right_on, npartitions)
     merge_name = "hash-join-" + tokenize(lhs, rhs, **merge_kwargs)
     join_layer = HashJoinP2PLayer(
         name=merge_name,
         name_input_left=lhs._name,
+        meta_input_left=lhs_meta,
         left_on=left_on,
         n_partitions_left=lhs.npartitions,
         name_input_right=rhs._name,
+        meta_input_right=rhs_meta,
         right_on=right_on,
         n_partitions_right=rhs.npartitions,
         meta_output=meta,
@@ -138,6 +140,7 @@ def merge_transfer(
     input_partition: int,
     npartitions: int,
     parts_out: set[int],
+    meta: pd.DataFrame,
 ):
     return shuffle_transfer(
         input=input,
@@ -146,6 +149,7 @@ def merge_transfer(
         npartitions=npartitions,
         column=_HASH_COLUMN_NAME,
         parts_out=parts_out,
+        meta=meta,
     )
 
 
@@ -164,12 +168,13 @@ def merge_unpack(
     from dask.dataframe.multi import merge_chunk
 
     ext = _get_worker_extension()
+    # If the partition is empty, it doesn't contain the hash column name
     left = ext.get_output_partition(
         shuffle_id_left, barrier_left, output_partition
-    ).drop(columns=_HASH_COLUMN_NAME)
+    ).drop(columns=_HASH_COLUMN_NAME, errors="ignore")
     right = ext.get_output_partition(
         shuffle_id_right, barrier_right, output_partition
-    ).drop(columns=_HASH_COLUMN_NAME)
+    ).drop(columns=_HASH_COLUMN_NAME, errors="ignore")
     return merge_chunk(
         left,
         right,
@@ -186,10 +191,12 @@ class HashJoinP2PLayer(Layer):
         self,
         name: str,
         name_input_left: str,
+        meta_input_left: pd.DataFrame,
         left_on,
         n_partitions_left: int,
         n_partitions_right: int,
         name_input_right: str,
+        meta_input_right: pd.DataFrame,
         right_on,
         meta_output: pd.DataFrame,
         left_index: bool,
@@ -203,8 +210,10 @@ class HashJoinP2PLayer(Layer):
     ) -> None:
         self.name = name
         self.name_input_left = name_input_left
+        self.meta_input_left = meta_input_left
         self.left_on = left_on
         self.name_input_right = name_input_right
+        self.meta_input_right = meta_input_right
         self.right_on = right_on
         self.how = how
         self.npartitions = npartitions
@@ -285,8 +294,10 @@ class HashJoinP2PLayer(Layer):
         return HashJoinP2PLayer(
             name=self.name,
             name_input_left=self.name_input_left,
+            meta_input_left=self.meta_input_left,
             left_on=self.left_on,
             name_input_right=self.name_input_right,
+            meta_input_right=self.meta_input_right,
             right_on=self.right_on,
             how=self.how,
             npartitions=self.npartitions,
@@ -344,6 +355,7 @@ class HashJoinP2PLayer(Layer):
                 i,
                 self.npartitions,
                 self.parts_out,
+                self.meta_input_left,
             )
         for i in range(self.n_partitions_right):
             transfer_keys_right.append((name_right, i))
@@ -354,6 +366,7 @@ class HashJoinP2PLayer(Layer):
                 i,
                 self.npartitions,
                 self.parts_out,
+                self.meta_input_right,
             )
 
         _barrier_key_left = barrier_key(ShuffleId(token_left))

--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -99,20 +99,20 @@ def hash_join_p2p(
     )
     # dummy result
     # Avoid using dummy data for a collection it is empty
-    lhs_meta = lhs._meta_nonempty if len(lhs.columns) else lhs._meta
-    rhs_meta = rhs._meta_nonempty if len(rhs.columns) else rhs._meta
-    meta = lhs_meta.merge(rhs_meta, **merge_kwargs)
+    _lhs_meta = lhs._meta_nonempty if len(lhs.columns) else lhs._meta
+    _rhs_meta = rhs._meta_nonempty if len(rhs.columns) else rhs._meta
+    meta = _lhs_meta.merge(_rhs_meta, **merge_kwargs)
     lhs = _calculate_partitions(lhs, left_on, npartitions)
     rhs = _calculate_partitions(rhs, right_on, npartitions)
     merge_name = "hash-join-" + tokenize(lhs, rhs, **merge_kwargs)
     join_layer = HashJoinP2PLayer(
         name=merge_name,
         name_input_left=lhs._name,
-        meta_input_left=lhs_meta,
+        meta_input_left=lhs._meta,
         left_on=left_on,
         n_partitions_left=lhs.npartitions,
         name_input_right=rhs._name,
-        meta_input_right=rhs_meta,
+        meta_input_right=rhs._meta,
         right_on=right_on,
         n_partitions_right=rhs.npartitions,
         meta_output=meta,

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -102,7 +102,7 @@ def rearrange_by_column_p2p(
 ) -> DataFrame:
     from dask.dataframe import DataFrame
 
-    meta = df._meta.copy()
+    meta = df._meta
     check_dtype_support(meta)
     npartitions = npartitions or df.npartitions
     token = tokenize(df, column, npartitions)

--- a/distributed/shuffle/_worker_extension.py
+++ b/distributed/shuffle/_worker_extension.py
@@ -23,7 +23,6 @@ from distributed.exceptions import Reschedule
 from distributed.protocol import to_serialize
 from distributed.shuffle._arrow import (
     convert_partition,
-    deserialize_schema,
     list_of_buffers_to_table,
     serialize_table,
 )
@@ -421,8 +420,8 @@ class DataFrameShuffleRun(ShuffleRun[int, int, "pd.DataFrame"]):
         A set of all participating worker (addresses).
     column:
         The data column we split the input partition by.
-    schema:
-        The schema of the payload data.
+    meta:
+        Empty metadata of the input.
     id:
         A unique `ShuffleID` this belongs to.
     run_id:
@@ -451,7 +450,7 @@ class DataFrameShuffleRun(ShuffleRun[int, int, "pd.DataFrame"]):
         worker_for: dict[int, str],
         output_workers: set,
         column: str,
-        schema: pa.Schema,
+        meta: pd.DataFrame,
         id: ShuffleId,
         run_id: int,
         local_address: str,
@@ -477,7 +476,7 @@ class DataFrameShuffleRun(ShuffleRun[int, int, "pd.DataFrame"]):
             memory_limiter_disk=memory_limiter_disk,
         )
         self.column = column
-        self.schema = schema
+        self.meta = meta
         partitions_of = defaultdict(list)
         for part, addr in worker_for.items():
             partitions_of[addr].append(part)
@@ -543,12 +542,11 @@ class DataFrameShuffleRun(ShuffleRun[int, int, "pd.DataFrame"]):
             data = self._read_from_disk((i,))
 
             def _() -> pd.DataFrame:
-                df = convert_partition(data)
-                return df.to_pandas()
+                return convert_partition(data, self.meta)
 
             out = await self.offload(_)
         except KeyError:
-            out = self.schema.empty_table().to_pandas()
+            out = self.meta.copy()
         return out
 
     def _get_assigned_worker(self, i: int) -> str:
@@ -649,8 +647,6 @@ class ShuffleWorkerExtension:
         type: ShuffleType,
         **kwargs: Any,
     ) -> int:
-        if type == ShuffleType.DATAFRAME:
-            kwargs["empty"] = data
         shuffle = self.get_or_create_shuffle(shuffle_id, type=type, **kwargs)
         return sync(
             self.worker.loop,
@@ -723,12 +719,8 @@ class ShuffleWorkerExtension:
         ----------
         shuffle_id
             Unique identifier of the shuffle
-        empty
-            Empty metadata of input collection
-        column
-            Column to be used to map rows to output partitions (by hashing)
-        npartitions
-            Number of output partitions
+        type:
+            Type of the shuffle operation
         """
         shuffle = self.shuffles.get(shuffle_id, None)
         if shuffle is None:
@@ -774,16 +766,12 @@ class ShuffleWorkerExtension:
                 worker=self.worker.address,
             )
         elif type == ShuffleType.DATAFRAME:
-            import pyarrow as pa
-
             assert kwargs is not None
             result = await self.worker.scheduler.shuffle_get_or_create(
                 id=shuffle_id,
                 type=type,
                 spec={
-                    "schema": pa.Schema.from_pandas(kwargs["empty"])
-                    .serialize()
-                    .to_pybytes(),
+                    "meta": to_serialize(kwargs["meta"]),
                     "npartitions": kwargs["npartitions"],
                     "column": kwargs["column"],
                     "parts_out": kwargs["parts_out"],
@@ -829,7 +817,7 @@ class ShuffleWorkerExtension:
                 column=result["column"],
                 worker_for=result["worker_for"],
                 output_workers=result["output_workers"],
-                schema=deserialize_schema(result["schema"]),
+                meta=result["meta"],
                 id=shuffle_id,
                 run_id=result["run_id"],
                 directory=os.path.join(

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -717,15 +717,18 @@ def test_processing_chain():
                 [pd.Timestamp.fromtimestamp(1641034800 + i) for i in range(100)],
                 dtype=pd.ArrowDtype(pa.timestamp("ms")),
             ),
-            # FIXME: distributed#7420
-            # f"col{next(counter)}": pd.array(
-            #     ["lorem ipsum"] * 100,
-            #     dtype="string[pyarrow]",
-            # ),
-            # f"col{next(counter)}": pd.array(
-            #     ["lorem ipsum"] * 100,
-            #     dtype=pd.StringDtype("pyarrow"),
-            # ),
+            f"col{next(counter)}": pd.array(
+                ["lorem ipsum"] * 100,
+                dtype="string[pyarrow]",
+            ),
+            f"col{next(counter)}": pd.array(
+                ["lorem ipsum"] * 100,
+                dtype=pd.StringDtype("pyarrow"),
+            ),
+            f"col{next(counter)}": pd.array(
+                ["lorem ipsum"] * 100,
+                dtype="string[python]",
+            ),
             # custom objects
             # FIXME: Serializing custom objects is not supported in P2P shuffling
             # f"col{next(counter)}": pd.array(
@@ -783,9 +786,9 @@ def test_processing_chain():
     out = {}
     for k, bio in filesystem.items():
         bio.seek(0)
-        out[k] = convert_partition(bio.read())
+        out[k] = convert_partition(bio.read(), df)
 
-    shuffled_df = pd.concat(table.to_pandas() for table in out.values())
+    shuffled_df = pd.concat(df for df in out.values())
     pd.testing.assert_frame_equal(
         df,
         shuffled_df,

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -737,7 +737,6 @@ def test_processing_chain():
         }
     )
     df["_partitions"] = df.col4 % npartitions
-    schema = pa.Schema.from_pandas(df)
     worker_for = {i: random.choice(workers) for i in list(range(npartitions))}
     worker_for = pd.Series(worker_for, name="_worker").astype("category")
 
@@ -786,7 +785,7 @@ def test_processing_chain():
     out = {}
     for k, bio in filesystem.items():
         bio.seek(0)
-        out[k] = convert_partition(bio.read(), df)
+        out[k] = convert_partition(bio.read(), df.head(0))
 
     shuffled_df = pd.concat(df for df in out.values())
     pd.testing.assert_frame_equal(
@@ -1191,7 +1190,7 @@ class DataFrameShuffleTestPool(AbstractShuffleTestPool):
         self,
         name,
         worker_for_mapping,
-        schema,
+        meta,
         directory,
         loop,
         Shuffle=DataFrameShuffleRun,
@@ -1201,7 +1200,7 @@ class DataFrameShuffleTestPool(AbstractShuffleTestPool):
             worker_for=worker_for_mapping,
             # FIXME: Is output_workers redundant with worker_for?
             output_workers=set(worker_for_mapping.values()),
-            schema=schema,
+            meta=meta,
             directory=directory / name,
             id=ShuffleId(name),
             run_id=next(AbstractShuffleTestPool._shuffle_run_id_iterator),
@@ -1249,7 +1248,7 @@ async def test_basic_lowlevel_shuffle(
             npartitions, part, workers
         )
     assert len(set(worker_for_mapping.values())) == min(n_workers, npartitions)
-    schema = pa.Schema.from_pandas(dfs[0])
+    meta = dfs[0].head(0)
 
     with DataFrameShuffleTestPool() as local_shuffle_pool:
         shuffles = []
@@ -1258,7 +1257,7 @@ async def test_basic_lowlevel_shuffle(
                 local_shuffle_pool.new_shuffle(
                     name=workers[ix],
                     worker_for_mapping=worker_for_mapping,
-                    schema=schema,
+                    meta=meta,
                     directory=tmp_path,
                     loop=loop_in_thread,
                 )
@@ -1324,7 +1323,7 @@ async def test_error_offload(tmp_path, loop_in_thread):
             npartitions, part, workers
         )
         partitions_for_worker[w].append(part)
-    schema = pa.Schema.from_pandas(dfs[0])
+    meta = dfs[0].head(0)
 
     class ErrorOffload(DataFrameShuffleRun):
         async def offload(self, func, *args):
@@ -1334,7 +1333,7 @@ async def test_error_offload(tmp_path, loop_in_thread):
         sA = local_shuffle_pool.new_shuffle(
             name="A",
             worker_for_mapping=worker_for_mapping,
-            schema=schema,
+            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
             Shuffle=ErrorOffload,
@@ -1342,7 +1341,7 @@ async def test_error_offload(tmp_path, loop_in_thread):
         sB = local_shuffle_pool.new_shuffle(
             name="B",
             worker_for_mapping=worker_for_mapping,
-            schema=schema,
+            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
         )
@@ -1378,7 +1377,7 @@ async def test_error_send(tmp_path, loop_in_thread):
             npartitions, part, workers
         )
         partitions_for_worker[w].append(part)
-    schema = pa.Schema.from_pandas(dfs[0])
+    meta = dfs[0].head(0)
 
     class ErrorSend(DataFrameShuffleRun):
         async def send(self, *args: Any, **kwargs: Any) -> None:
@@ -1388,7 +1387,7 @@ async def test_error_send(tmp_path, loop_in_thread):
         sA = local_shuffle_pool.new_shuffle(
             name="A",
             worker_for_mapping=worker_for_mapping,
-            schema=schema,
+            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
             Shuffle=ErrorSend,
@@ -1396,7 +1395,7 @@ async def test_error_send(tmp_path, loop_in_thread):
         sB = local_shuffle_pool.new_shuffle(
             name="B",
             worker_for_mapping=worker_for_mapping,
-            schema=schema,
+            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
         )
@@ -1431,7 +1430,7 @@ async def test_error_receive(tmp_path, loop_in_thread):
             npartitions, part, workers
         )
         partitions_for_worker[w].append(part)
-    schema = pa.Schema.from_pandas(dfs[0])
+    meta = dfs[0].head(0)
 
     class ErrorReceive(DataFrameShuffleRun):
         async def receive(self, data: list[tuple[int, bytes]]) -> None:
@@ -1441,7 +1440,7 @@ async def test_error_receive(tmp_path, loop_in_thread):
         sA = local_shuffle_pool.new_shuffle(
             name="A",
             worker_for_mapping=worker_for_mapping,
-            schema=schema,
+            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
             Shuffle=ErrorReceive,
@@ -1449,7 +1448,7 @@ async def test_error_receive(tmp_path, loop_in_thread):
         sB = local_shuffle_pool.new_shuffle(
             name="B",
             worker_for_mapping=worker_for_mapping,
-            schema=schema,
+            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
         )


### PR DESCRIPTION
Closes #7420
Closes dask/dask#10326
@jrbourbeau: As discussed offline yesterday, here's the version that uses `meta` instead of a `pa.Schema`

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
