### PR TITLE
Review user-defined fine performance metrics

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3422,7 +3422,8 @@ class FinePerformanceMetrics(DashboardComponent):
     @log_errors
     def update(self):
         items = sorted(
-            (k, v)
+            # Custom metrics can be any hashable
+            (tuple(map(str, k)), v)
             for k, v in self.scheduler.cumulative_worker_metrics.items()
             if isinstance(k, tuple)
         )

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -52,7 +52,7 @@ from distributed.dashboard.components.scheduler import (
 from distributed.dashboard.components.worker import Counters
 from distributed.dashboard.scheduler import applications
 from distributed.diagnostics.task_stream import TaskStreamPlugin
-from distributed.metrics import time
+from distributed.metrics import context_meter, time
 from distributed.spans import span
 from distributed.utils import format_dashboard_link
 from distributed.utils_test import (
@@ -365,7 +365,14 @@ async def test_FinePerformanceMetrics(c, s, a, b):
     # execute on named span (duplicate name, different id)
     with span("foo"):
         z = c.submit(inc, 3, key="z")
-    await wait([y0, y1, z])
+
+    # Custom metric with non-string label and custom unit
+    def f():
+        context_meter.digest_metric(None, 1, "custom")
+        context_meter.digest_metric(("foo", 1), 2, "custom")
+
+    v = c.submit(f, key="v")
+    await wait([y0, y1, z, v])
 
     await a.heartbeat()
     await b.heartbeat()
@@ -373,7 +380,11 @@ async def test_FinePerformanceMetrics(c, s, a, b):
     assert not cl.task_exec_data
     cl.update()
     assert cl.task_exec_data
-    assert set(cl.task_exec_data["functions"]) == {"w", "x", "y", "z"}
+    assert set(cl.task_exec_data["functions"]) == {"v", "w", "x", "y", "z"}
+    assert set(cl.unit_selector.options) == {"seconds", "count", "bytes", "custom"}
+    assert "thread-cpu" in cl.task_activities
+    assert "('foo', 1)" in cl.task_activities
+    assert "None" in cl.task_activities
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_reschedule.py
+++ b/distributed/tests/test_reschedule.py
@@ -52,7 +52,6 @@ async def test_raise_reschedule(c, s, a, b, state):
     await wait(futures)
     assert any(isinstance(ev, RescheduleEvent) for ev in a.state.stimulus_log)
     assert all(f.key in b.data for f in futures)
-    assert "x" not in a.state.tasks
 
 
 @pytest.mark.parametrize("state", ["executing", "long-running"])

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2312,24 +2312,6 @@ async def test_idle_timeout_no_workers(c, s):
     assert s.check_idle()
 
 
-@gen_cluster(client=True)
-async def test_cumulative_worker_metrics(c, s, a, b):
-    # Race condition: metrics that are updated while idle may or may not be there already
-    assert s.cumulative_worker_metrics.keys() in (set(), {"latency"})
-    await c.submit(inc, 1, key="do_work")
-
-    await a.heartbeat()
-    await b.heartbeat()
-
-    metrics = s.cumulative_worker_metrics
-
-    # Subset of expected keys
-    assert "latency" in metrics
-    assert ("execute", "do_work", "deserialize", "seconds") in metrics
-
-    assert all(isinstance(value, float) for value in metrics.values())
-
-
 @gen_cluster(client=True, config={"distributed.scheduler.bandwidth": "100 GB"})
 async def test_bandwidth(c, s, a, b):
     start = s.bandwidth

--- a/distributed/tests/test_worker_metrics.py
+++ b/distributed/tests/test_worker_metrics.py
@@ -11,7 +11,7 @@ import pytest
 import dask
 
 import distributed
-from distributed import Event, Worker, wait
+from distributed import Event, Reschedule, Scheduler, Worker, get_worker, wait
 from distributed.compatibility import WINDOWS
 from distributed.metrics import context_meter, meter
 from distributed.utils_test import (
@@ -20,17 +20,21 @@ from distributed.utils_test import (
     async_poll_for,
     gen_cluster,
     inc,
+    slowinc,
     wait_for_state,
 )
 
 
-def get_digests(w: Worker, allow: str | Collection[str] = ()) -> dict[Hashable, float]:
-    # import pprint; pprint.pprint(dict(w.digests_total))
+def get_digests(
+    w: Worker | Scheduler, allow: str | Collection[str] = ()
+) -> dict[Hashable, float]:
     if isinstance(allow, str):
         allow = (allow,)
+    d = w.digests_total if isinstance(w, Worker) else w.cumulative_worker_metrics
+    # import pprint; pprint.pprint(dict(d))
     digests = {
         k: v
-        for k, v in w.digests_total.items()
+        for k, v in d.items()
         if k
         not in {"latency", "tick-duration", "transfer-bandwidth", "transfer-duration"}
         and (any(a in k for a in allow) or not allow)
@@ -396,26 +400,142 @@ async def test_user_metrics_fail(c, s, a):
     assert get_digests(a)["execute", "x", "failed", "seconds"] < 1
 
 
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_user_metrics_weird(c, s, a):
+    """label can be any msgpack-serializable Hashable
+    unit can be any string
+    """
+
+    def f():
+        context_meter.digest_metric(("foo", 1), 1, "seconds")
+        context_meter.digest_metric(None, 2, "custom")
+
+    await wait(c.submit(f, key="x"))
+    await a.heartbeat()
+
+    assert (
+        list(get_digests(a))
+        == list(get_digests(s))
+        == [
+            ("execute", "x", "deserialize", "seconds"),
+            ("execute", "x", ("foo", 1), "seconds"),
+            ("execute", "x", None, "custom"),
+            ("execute", "x", "thread-cpu", "seconds"),
+            ("execute", "x", "thread-noncpu", "seconds"),
+            ("execute", "x", "executor", "seconds"),
+            ("execute", "x", "other", "seconds"),
+        ]
+    )
+
+
 @gen_cluster(client=True, nthreads=[("", 3)])
 async def test_do_not_leak_metrics(c, s, a, b):
     def f(k):
         for _ in range(10):
             sleep(0.05)
-            context_meter.digest_metric(("ping", k), 1, "count")
+            context_meter.digest_metric(f"ping-{k}", 1, "count")
 
     async def g(k):
         for _ in range(10):
             await asyncio.sleep(0.05)
-            context_meter.digest_metric(("ping", k), 1, "count")
+            context_meter.digest_metric(f"ping-{k}", 1, "count")
 
     x = c.submit(f, "x", key="x")
     y = c.submit(f, "y", key="y")
     z = c.submit(g, "z", key="z")
-    await c.run(g, "w")
+    await c.run(g, "w")  # Metrics are discarded
     await wait([x, y, z])
 
-    assert get_digests(a, "ping") == {
-        ("execute", "x", "ping", "x", "count"): 10,
-        ("execute", "y", "ping", "y", "count"): 10,
-        ("execute", "z", "ping", "z", "count"): 10,
+    assert get_digests(a, "count") == {
+        ("execute", "x", "ping-x", "count"): 10,
+        ("execute", "y", "ping-y", "count"): 10,
+        ("execute", "z", "ping-z", "count"): 10,
     }
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)] * 2,
+    config={"distributed.scheduler.work-stealing": False},
+)
+async def test_reschedule(c, s, a, b):
+    """A task raises Reschedule()
+
+    See also
+    --------
+    test_reschedule.py
+    """
+    a_address = a.address
+
+    def f(x):
+        sleep(0.1)
+        if get_worker().address == a_address:
+            raise Reschedule()
+
+    futures = c.map(f, range(4), key=["x-1", "x-2", "x-3", "x-4"])
+    futures2 = c.map(slowinc, range(10), delay=0.1, key="clog", workers=[a.address])
+    await wait(futures)
+    assert all(f.key in b.data for f in futures)
+
+    evs = get_digests(a, "x")
+    k = ("execute", "x", "cancelled", "seconds")
+    assert list(evs) == [k]
+    assert evs[k] > 0
+
+
+@gen_cluster(client=True)
+async def test_send_metrics_to_scheduler(c, s, a, b):
+    """Test that Worker.digests_total are sync'ed by the heartbeat to
+    Scheduler.cumulative_worker_metrics
+    """
+    # Race condition: metrics that are updated while idle may or may not be there already
+    assert s.cumulative_worker_metrics.keys() in (set(), {"latency"})
+
+    x0 = c.submit(inc, 1, key=("x", 0), workers=[a.address])
+    x1 = c.submit(inc, 1, key=("x", 1), workers=[b.address])
+    # Trigger gather_dep and get_data
+    x2 = c.submit(inc, x0, key=("x", 2), workers=[b.address])
+    x3 = c.submit(inc, x1, key=("x", 3), workers=[a.address])
+    await wait([x2, x3])
+    # Flush metrics from workers to scheduler
+    await a.heartbeat()
+    await b.heartbeat()
+
+    # Make sure that cumulative sync over multiple heartbeats works as expected
+    x4 = c.submit(inc, 1, key=("x", 4))
+    await wait(x4)
+    await a.heartbeat()
+    await b.heartbeat()
+
+    # Metrics from workers have been summed up on scheduler
+    a_metrics = get_digests(a)
+    b_metrics = get_digests(b)
+    s_metrics = get_digests(s)
+    assert (
+        list(a_metrics)
+        == list(b_metrics)
+        == list(s_metrics)
+        == [
+            ("execute", "x", "deserialize", "seconds"),
+            ("execute", "x", "thread-cpu", "seconds"),
+            ("execute", "x", "thread-noncpu", "seconds"),
+            ("execute", "x", "executor", "seconds"),
+            ("execute", "x", "other", "seconds"),
+            ("get-data", "memory-read", "count"),
+            ("get-data", "memory-read", "bytes"),
+            ("get-data", "serialize", "seconds"),
+            ("get-data", "compress", "seconds"),
+            ("gather-dep", "decompress", "seconds"),
+            ("gather-dep", "deserialize", "seconds"),
+            ("gather-dep", "network", "seconds"),
+            ("gather-dep", "other", "seconds"),
+            ("get-data", "network", "seconds"),
+            ("execute", "x", "memory-read", "count"),
+            ("execute", "x", "memory-read", "bytes"),
+        ]
+    )
+    for k in s_metrics:
+        if not WINDOWS:
+            assert a_metrics[k] > 0
+            assert b_metrics[k] > 0
+        assert s_metrics[k] == a_metrics[k] + b_metrics[k]

--- a/distributed/tests/test_worker_metrics.py
+++ b/distributed/tests/test_worker_metrics.py
@@ -31,7 +31,6 @@ def get_digests(
     if isinstance(allow, str):
         allow = (allow,)
     d = w.digests_total if isinstance(w, Worker) else w.cumulative_worker_metrics
-    # import pprint; pprint.pprint(dict(d))
     digests = {
         k: v
         for k, v in d.items()

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3694,9 +3694,7 @@ class BaseWorker(abc.ABC):
             return
 
         for label, value, unit in ledger.finalize(coarse_time=coarse_time):
-            if not isinstance(label, tuple):
-                label = (label,)
-            self.digest_metric((*activity, *label, unit), value)
+            self.digest_metric((*activity, label, unit), value)
 
     def handle_stimulus(self, *stims: StateMachineEvent) -> None:
         """Forward one or more external stimuli to :meth:`WorkerState.handle_stimulus`


### PR DESCRIPTION
User-defined metrics can
- use any msgpack-serializable Hashable as label
- use any arbitrary string as unit

This creates edge cases that insofar were poorly tested.

This PR also removes special handling of tuple labels, which caused the execute tuples to become of unpredictable length which created even more edge cases to be tested - this time, needlessly so.