### PR TITLE
Avoid meta roundtrip in P2P shuffle

### DIFF
--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -12,7 +12,6 @@ from itertools import product
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from distributed.diagnostics.plugin import SchedulerPlugin
-from distributed.protocol import to_serialize
 from distributed.shuffle._rechunk import ChunkedAxes, NIndex
 from distributed.shuffle._shuffle import (
     ShuffleId,
@@ -22,8 +21,6 @@ from distributed.shuffle._shuffle import (
 )
 
 if TYPE_CHECKING:
-    import pandas as pd
-
     from distributed.scheduler import (
         Recs,
         Scheduler,
@@ -53,7 +50,6 @@ class ShuffleState(abc.ABC):
 class DataFrameShuffleState(ShuffleState):
     type: ClassVar[ShuffleType] = ShuffleType.DATAFRAME
     worker_for: dict[int, str]
-    meta: pd.DataFrame
     column: str
 
     def to_msg(self) -> dict[str, Any]:
@@ -63,7 +59,6 @@ class DataFrameShuffleState(ShuffleState):
             "run_id": self.run_id,
             "worker_for": self.worker_for,
             "column": self.column,
-            "meta": to_serialize(self.meta),
             "output_workers": self.output_workers,
         }
 
@@ -189,11 +184,9 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
     def _create_dataframe_shuffle_state(
         self, id: ShuffleId, spec: dict[str, Any]
     ) -> DataFrameShuffleState:
-        meta = spec["meta"]
         column = spec["column"]
         npartitions = spec["npartitions"]
         parts_out = spec["parts_out"]
-        assert meta is not None
         assert column is not None
         assert npartitions is not None
         assert parts_out is not None
@@ -207,7 +200,6 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
             id=id,
             run_id=next(ShuffleState._run_id_iterator),
             worker_for=mapping,
-            meta=meta,
             column=column,
             output_workers=output_workers,
             participating_workers=output_workers.copy(),

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1190,7 +1190,6 @@ class DataFrameShuffleTestPool(AbstractShuffleTestPool):
         self,
         name,
         worker_for_mapping,
-        meta,
         directory,
         loop,
         Shuffle=DataFrameShuffleRun,
@@ -1200,7 +1199,6 @@ class DataFrameShuffleTestPool(AbstractShuffleTestPool):
             worker_for=worker_for_mapping,
             # FIXME: Is output_workers redundant with worker_for?
             output_workers=set(worker_for_mapping.values()),
-            meta=meta,
             directory=directory / name,
             id=ShuffleId(name),
             run_id=next(AbstractShuffleTestPool._shuffle_run_id_iterator),
@@ -1257,7 +1255,6 @@ async def test_basic_lowlevel_shuffle(
                 local_shuffle_pool.new_shuffle(
                     name=workers[ix],
                     worker_for_mapping=worker_for_mapping,
-                    meta=meta,
                     directory=tmp_path,
                     loop=loop_in_thread,
                 )
@@ -1290,7 +1287,7 @@ async def test_basic_lowlevel_shuffle(
             all_parts = []
             for part, worker in worker_for_mapping.items():
                 s = local_shuffle_pool.shuffles[worker]
-                all_parts.append(s.get_output_partition(part, f"key-{part}"))
+                all_parts.append(s.get_output_partition(part, f"key-{part}", meta=meta))
 
             all_parts = await asyncio.gather(*all_parts)
 
@@ -1323,7 +1320,6 @@ async def test_error_offload(tmp_path, loop_in_thread):
             npartitions, part, workers
         )
         partitions_for_worker[w].append(part)
-    meta = dfs[0].head(0)
 
     class ErrorOffload(DataFrameShuffleRun):
         async def offload(self, func, *args):
@@ -1333,7 +1329,6 @@ async def test_error_offload(tmp_path, loop_in_thread):
         sA = local_shuffle_pool.new_shuffle(
             name="A",
             worker_for_mapping=worker_for_mapping,
-            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
             Shuffle=ErrorOffload,
@@ -1341,7 +1336,6 @@ async def test_error_offload(tmp_path, loop_in_thread):
         sB = local_shuffle_pool.new_shuffle(
             name="B",
             worker_for_mapping=worker_for_mapping,
-            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
         )
@@ -1377,7 +1371,6 @@ async def test_error_send(tmp_path, loop_in_thread):
             npartitions, part, workers
         )
         partitions_for_worker[w].append(part)
-    meta = dfs[0].head(0)
 
     class ErrorSend(DataFrameShuffleRun):
         async def send(self, *args: Any, **kwargs: Any) -> None:
@@ -1387,7 +1380,6 @@ async def test_error_send(tmp_path, loop_in_thread):
         sA = local_shuffle_pool.new_shuffle(
             name="A",
             worker_for_mapping=worker_for_mapping,
-            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
             Shuffle=ErrorSend,
@@ -1395,7 +1387,6 @@ async def test_error_send(tmp_path, loop_in_thread):
         sB = local_shuffle_pool.new_shuffle(
             name="B",
             worker_for_mapping=worker_for_mapping,
-            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
         )
@@ -1430,7 +1421,6 @@ async def test_error_receive(tmp_path, loop_in_thread):
             npartitions, part, workers
         )
         partitions_for_worker[w].append(part)
-    meta = dfs[0].head(0)
 
     class ErrorReceive(DataFrameShuffleRun):
         async def receive(self, data: list[tuple[int, bytes]]) -> None:
@@ -1440,7 +1430,6 @@ async def test_error_receive(tmp_path, loop_in_thread):
         sA = local_shuffle_pool.new_shuffle(
             name="A",
             worker_for_mapping=worker_for_mapping,
-            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
             Shuffle=ErrorReceive,
@@ -1448,7 +1437,6 @@ async def test_error_receive(tmp_path, loop_in_thread):
         sB = local_shuffle_pool.new_shuffle(
             name="B",
             worker_for_mapping=worker_for_mapping,
-            meta=meta,
             directory=tmp_path,
             loop=loop_in_thread,
         )


### PR DESCRIPTION
Closes dask/dask#10335

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
