### PR TITLE
Improve memory footprint of P2P rechunking

### DIFF
--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -172,8 +172,6 @@ def split_axes(old: ChunkedAxes, new: ChunkedAxes) -> SplitAxes:
             for new_subchunk_id, (old_chunk_id, slice) in enumerate(new_chunk):
                 old_axis[old_chunk_id].append((new_chunk_id, new_subchunk_id, slice))
         for old_chunk in old_axis:
-            if len(old_chunk) == 1:
-                continue
             old_chunk.sort(key=lambda subchunk: subchunk[2].start)
         axes.append(old_axis)
     return axes

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -120,7 +120,7 @@ class ShardID(NamedTuple):
 
     #: Index of the new output chunk to which the shard belongs
     chunk_index: NDIndex
-    #: Index of the shard within the multi-dimensional array of shards that will be
+    #: Index of the shard within the n-dimensional array of shards that will be
     # concatenated into the new chunk
     shard_index: NDIndex
 

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -24,14 +24,14 @@ if TYPE_CHECKING:
 
 ChunkedAxis: TypeAlias = tuple[float, ...]  # chunks must either be an int or NaN
 ChunkedAxes: TypeAlias = tuple[ChunkedAxis, ...]
-NIndex: TypeAlias = tuple[int, ...]
-NSlice: TypeAlias = tuple[slice, ...]
+NDIndex: TypeAlias = tuple[int, ...]
+NDSlice: TypeAlias = tuple[slice, ...]
 
 
 def rechunk_transfer(
     input: np.ndarray,
     id: ShuffleId,
-    input_chunk: NIndex,
+    input_chunk: NDIndex,
     new: ChunkedAxes,
     old: ChunkedAxes,
 ) -> int:
@@ -49,7 +49,7 @@ def rechunk_transfer(
 
 
 def rechunk_unpack(
-    id: ShuffleId, output_chunk: NIndex, barrier_run_id: int
+    id: ShuffleId, output_chunk: NDIndex, barrier_run_id: int
 ) -> np.ndarray:
     try:
         return _get_worker_extension().get_output_partition(
@@ -119,10 +119,10 @@ class ShardID(NamedTuple):
     """
 
     #: Index of the new output chunk to which the shard belongs
-    chunk_index: NIndex
+    chunk_index: NDIndex
     #: Index of the shard within the multi-dimensional array of shards that will be
     # concatenated into the new chunk
-    shard_index: NIndex
+    shard_index: NDIndex
 
 
 class Split(NamedTuple):

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import math
-from collections import defaultdict
-from itertools import compress, product
+from itertools import compress
 from typing import TYPE_CHECKING, NamedTuple
 
 import dask
@@ -156,7 +155,8 @@ class ShardID(NamedTuple):
     shard_index: NIndex
 
 
-DisassembledAxis: TypeAlias = list[tuple[int, int, slice]]
+DisassembledChunk: TypeAlias = list[tuple[int, int, slice]]
+DisassembledAxis: TypeAlias = list[DisassembledChunk]
 DisassembledAxes: TypeAlias = list[DisassembledAxis]
 
 
@@ -167,7 +167,7 @@ def disassemble_chunks(old: ChunkedAxes, new: ChunkedAxes) -> DisassembledAxes:
 
     axes = []
     for axis_id, new_axis in enumerate(_old_to_new):
-        old_axis = [[] for _ in old[axis_id]]
+        old_axis: DisassembledAxis = [[] for _ in old[axis_id]]
         for new_chunk_id, new_chunk in enumerate(new_axis):
             for new_subchunk_id, (old_chunk_id, slice) in enumerate(new_chunk):
                 old_axis[old_chunk_id].append((new_chunk_id, new_subchunk_id, slice))

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -155,19 +155,19 @@ class ShardID(NamedTuple):
     shard_index: NIndex
 
 
-DisassembledChunk: TypeAlias = list[tuple[int, int, slice]]
-DisassembledAxis: TypeAlias = list[DisassembledChunk]
-DisassembledAxes: TypeAlias = list[DisassembledAxis]
+SplitChunk: TypeAlias = list[tuple[int, int, slice]]
+SplitAxis: TypeAlias = list[SplitChunk]
+SplitAxes: TypeAlias = list[SplitAxis]
 
 
-def disassemble_chunks(old: ChunkedAxes, new: ChunkedAxes) -> DisassembledAxes:
+def split_axes(old: ChunkedAxes, new: ChunkedAxes) -> SplitAxes:
     from dask.array.rechunk import old_to_new
 
     _old_to_new = old_to_new(old, new)
 
     axes = []
     for axis_id, new_axis in enumerate(_old_to_new):
-        old_axis: DisassembledAxis = [[] for _ in old[axis_id]]
+        old_axis: SplitAxis = [[] for _ in old[axis_id]]
         for new_chunk_id, new_chunk in enumerate(new_axis):
             for new_subchunk_id, (old_chunk_id, slice) in enumerate(new_chunk):
                 old_axis[old_chunk_id].append((new_chunk_id, new_subchunk_id, slice))

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -155,9 +155,9 @@ def split_axes(old: ChunkedAxes, new: ChunkedAxes) -> SplitAxes:
     Parameters
     ----------
     old : ChunkedAxes
-        Chunking along each axis of the old array
+        Chunks along each axis of the old array
     new : ChunkedAxes
-        Chunking along each axis of the new array
+        Chunks along each axis of the new array
 
     Returns
     -------

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -38,7 +38,7 @@ def rechunk_transfer(
     try:
         return _get_worker_extension().add_partition(
             input,
-            input_partition=input_chunk,
+            partition_id=input_chunk,
             shuffle_id=id,
             type=ShuffleType.ARRAY_RECHUNK,
             new=new,

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -152,8 +152,6 @@ SplitAxes: TypeAlias = list[SplitAxis]
 def split_axes(old: ChunkedAxes, new: ChunkedAxes) -> SplitAxes:
     """Calculate how to split the old chunks on each axis to create the new chunks
 
-    _extended_summary_
-
     Parameters
     ----------
     old : ChunkedAxes
@@ -164,8 +162,8 @@ def split_axes(old: ChunkedAxes, new: ChunkedAxes) -> SplitAxes:
     Returns
     -------
     SplitAxes
-        Each axis contains a list of splits of the old chunks. Each split is a list of
-        of
+        Splits along each axis that determine how to slice the input chunks to create
+        the new chunks by concatenating the resulting shards.
     """
     from dask.array.rechunk import old_to_new
 

--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -12,7 +12,7 @@ from itertools import product
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from distributed.diagnostics.plugin import SchedulerPlugin
-from distributed.shuffle._rechunk import ChunkedAxes, NIndex
+from distributed.shuffle._rechunk import ChunkedAxes, NDIndex
 from distributed.shuffle._shuffle import (
     ShuffleId,
     ShuffleType,
@@ -66,7 +66,7 @@ class DataFrameShuffleState(ShuffleState):
 @dataclass
 class ArrayRechunkState(ShuffleState):
     type: ClassVar[ShuffleType] = ShuffleType.ARRAY_RECHUNK
-    worker_for: dict[NIndex, str]
+    worker_for: dict[NDIndex, str]
     old: ChunkedAxes
     new: ChunkedAxes
 
@@ -374,7 +374,7 @@ def get_worker_for_range_sharding(
 
 
 def get_worker_for_hash_sharding(
-    output_partition: NIndex, workers: Sequence[str]
+    output_partition: NDIndex, workers: Sequence[str]
 ) -> str:
     """Get address of target worker for this output partition using hash sharding"""
     i = hash(output_partition) % len(workers)

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -64,7 +64,7 @@ def shuffle_transfer(
             input,
             shuffle_id=id,
             type=ShuffleType.DATAFRAME,
-            input_partition=input_partition,
+            partition_id=input_partition,
             npartitions=npartitions,
             column=column,
             parts_out=parts_out,

--- a/distributed/shuffle/_worker_extension.py
+++ b/distributed/shuffle/_worker_extension.py
@@ -31,7 +31,7 @@ from distributed.shuffle._disk import DiskShardsBuffer
 from distributed.shuffle._limiter import ResourceLimiter
 from distributed.shuffle._rechunk import ChunkedAxes, NIndex
 from distributed.shuffle._rechunk import ShardID as ArrayRechunkShardID
-from distributed.shuffle._rechunk import rechunk_slicing
+from distributed.shuffle._rechunk import disassemble_chunks
 from distributed.shuffle._shuffle import ShuffleId, ShuffleType
 from distributed.sizeof import sizeof
 from distributed.utils import log_errors, sync
@@ -300,8 +300,6 @@ class ArrayRechunkRun(ShuffleRun[ArrayRechunkShardID, NIndex, "np.ndarray"]):
         memory_limiter_disk: ResourceLimiter,
         memory_limiter_comms: ResourceLimiter,
     ):
-        from dask.array.rechunk import old_to_new
-
         super().__init__(
             id=id,
             run_id=run_id,
@@ -329,8 +327,8 @@ class ArrayRechunkRun(ShuffleRun[ArrayRechunkShardID, NIndex, "np.ndarray"]):
             partitions_of[addr].append(part)
         self.partitions_of = dict(partitions_of)
         self.worker_for = worker_for
-        self._slicing = rechunk_slicing(old, new)
-        self._old_to_new = old_to_new(old, new)
+        self._disassembled_chunks = disassemble_chunks(old, new)
+        pass
 
     async def _receive(self, data: list[tuple[ArrayRechunkShardID, bytes]]) -> None:
         self.raise_if_closed()

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -18,7 +18,7 @@ from dask.array.rechunk import normalize_chunks, rechunk
 from dask.array.utils import assert_eq
 
 from distributed.shuffle._limiter import ResourceLimiter
-from distributed.shuffle._rechunk import disassemble_chunks
+from distributed.shuffle._rechunk import split_axes
 from distributed.shuffle._scheduler_extension import get_worker_for_hash_sharding
 from distributed.shuffle._shuffle import ShuffleId
 from distributed.shuffle._worker_extension import ArrayRechunkRun
@@ -936,7 +936,7 @@ async def test_rechunk_with_zero(c, s, *ws):
     assert_eq(await c.compute(result), await c.compute(expected))
 
 
-def test_disassemble_chunks_1():
+def test_split_axes_1():
     """
     See Also
     --------
@@ -944,7 +944,7 @@ def test_disassemble_chunks_1():
     """
     old = ((10, 10, 10, 10, 10),)
     new = ((25, 5, 20),)
-    result = disassemble_chunks(old, new)
+    result = split_axes(old, new)
     expected = [
         [
             [(0, 0, slice(0, 10, None))],
@@ -957,7 +957,7 @@ def test_disassemble_chunks_1():
     assert result == expected
 
 
-def test_disassemble_chunks_2():
+def test_split_axes_2():
     """
     See Also
     --------
@@ -965,7 +965,7 @@ def test_disassemble_chunks_2():
     """
     old = ((20, 20, 20, 20, 20),)
     new = ((58, 4, 20, 18),)
-    result = disassemble_chunks(old, new)
+    result = split_axes(old, new)
     expected = [
         [
             [(0, 0, slice(0, 20, None))],
@@ -978,7 +978,7 @@ def test_disassemble_chunks_2():
     assert result == expected
 
 
-def test_disassemble_chunks_nan():
+def test_split_axes_nan():
     """
     See Also
     --------
@@ -986,7 +986,7 @@ def test_disassemble_chunks_nan():
     """
     old_chunks = ((np.nan, np.nan), (8,))
     new_chunks = ((np.nan, np.nan), (4, 4))
-    result = disassemble_chunks(old_chunks, new_chunks)
+    result = split_axes(old_chunks, new_chunks)
 
     expected = [
         [
@@ -998,7 +998,7 @@ def test_disassemble_chunks_nan():
     assert result == expected
 
 
-def test_disassemble_chunks_nan_single():
+def test_split_axes_nan_single():
     """
     See Also
     --------
@@ -1007,7 +1007,7 @@ def test_disassemble_chunks_nan_single():
     old_chunks = ((np.nan,), (10,))
     new_chunks = ((np.nan,), (5, 5))
 
-    result = disassemble_chunks(old_chunks, new_chunks)
+    result = split_axes(old_chunks, new_chunks)
     expected = [
         [[(0, 0, slice(0, None, None))]],
         [[(0, 0, slice(0, 5, None)), (1, 0, slice(5, 10, None))]],
@@ -1015,7 +1015,7 @@ def test_disassemble_chunks_nan_single():
     assert result == expected
 
 
-def test_disassemble_chunks_nan_long():
+def test_split_axes_nan_long():
     """
     See Also
     --------
@@ -1023,7 +1023,7 @@ def test_disassemble_chunks_nan_long():
     """
     old_chunks = (tuple([np.nan] * 4), (10,))
     new_chunks = (tuple([np.nan] * 4), (5, 5))
-    result = disassemble_chunks(old_chunks, new_chunks)
+    result = split_axes(old_chunks, new_chunks)
     expected = [
         [
             [(0, 0, slice(0, None, None))],
@@ -1038,7 +1038,7 @@ def test_disassemble_chunks_nan_long():
     assert result == expected
 
 
-def test_disassemble_chunks_with_nonzero():
+def test_split_axes_with_nonzero():
     """
     See Also
     --------
@@ -1046,7 +1046,7 @@ def test_disassemble_chunks_with_nonzero():
     """
     old = ((4, 4), (2,))
     new = ((8,), (1, 1))
-    result = disassemble_chunks(old, new)
+    result = split_axes(old, new)
     expected = [
         [
             [(0, 0, slice(0, 4, None))],
@@ -1057,7 +1057,7 @@ def test_disassemble_chunks_with_nonzero():
     assert result == expected
 
 
-def test_disassemble_chunks_with_zero():
+def test_split_axes_with_zero():
     """
     See Also
     --------
@@ -1065,7 +1065,7 @@ def test_disassemble_chunks_with_zero():
     """
     old = ((4, 4), (2,))
     new = ((4, 0, 0, 4), (1, 1))
-    result = disassemble_chunks(old, new)
+    result = split_axes(old, new)
 
     expected = [
         [
@@ -1082,7 +1082,7 @@ def test_disassemble_chunks_with_zero():
 
     old = ((4, 0, 0, 4), (1, 1))
     new = ((4, 4), (2,))
-    result = disassemble_chunks(old, new)
+    result = split_axes(old, new)
 
     expected = [
         [
@@ -1100,7 +1100,7 @@ def test_disassemble_chunks_with_zero():
 
     old = ((4, 4), (2,))
     new = ((2, 0, 0, 2, 4), (1, 1))
-    result = disassemble_chunks(old, new)
+    result = split_axes(old, new)
     expected = [
         [
             [
@@ -1117,7 +1117,7 @@ def test_disassemble_chunks_with_zero():
 
     old = ((4, 4), (2,))
     new = ((0, 0, 4, 4), (1, 1))
-    result = disassemble_chunks(old, new)
+    result = split_axes(old, new)
     expected = [
         [
             [

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -18,7 +18,7 @@ from dask.array.rechunk import normalize_chunks, rechunk
 from dask.array.utils import assert_eq
 
 from distributed.shuffle._limiter import ResourceLimiter
-from distributed.shuffle._rechunk import ShardID, disassemble_chunks
+from distributed.shuffle._rechunk import disassemble_chunks
 from distributed.shuffle._scheduler_extension import get_worker_for_hash_sharding
 from distributed.shuffle._shuffle import ShuffleId
 from distributed.shuffle._worker_extension import ArrayRechunkRun
@@ -636,17 +636,17 @@ async def test_rechunk_with_fully_unknown_dimension(c, s, *ws, x, chunks):
         pytest.param(
             da.ones(shape=(1000, 10), chunks=(5, 10)),
             (None, 5),
-            marks=pytest.mark.skip(reason="distributed#7757"),
+            # marks=pytest.mark.skip(reason="distributed#7757"),
         ),
         pytest.param(
             da.ones(shape=(1000, 10), chunks=(5, 10)),
             {1: 5},
-            marks=pytest.mark.skip(reason="distributed#7757"),
+            # marks=pytest.mark.skip(reason="distributed#7757"),
         ),
         pytest.param(
             da.ones(shape=(1000, 10), chunks=(5, 10)),
             (None, (5, 5)),
-            marks=pytest.mark.skip(reason="distributed#7757"),
+            # marks=pytest.mark.skip(reason="distributed#7757"),
         ),
         (da.ones(shape=(10, 10), chunks=(10, 10)), (None, 5)),
         (da.ones(shape=(10, 10), chunks=(10, 10)), {1: 5}),

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -18,7 +18,7 @@ from dask.array.rechunk import normalize_chunks, rechunk
 from dask.array.utils import assert_eq
 
 from distributed.shuffle._limiter import ResourceLimiter
-from distributed.shuffle._rechunk import ShardID, rechunk_slicing
+from distributed.shuffle._rechunk import ShardID, disassemble_chunks
 from distributed.shuffle._scheduler_extension import get_worker_for_hash_sharding
 from distributed.shuffle._shuffle import ShuffleId
 from distributed.shuffle._worker_extension import ArrayRechunkRun
@@ -936,7 +936,7 @@ async def test_rechunk_with_zero(c, s, *ws):
     assert_eq(await c.compute(result), await c.compute(expected))
 
 
-def test_rechunk_slicing_1():
+def test_disassemble_chunks_1():
     """
     See Also
     --------
@@ -944,21 +944,20 @@ def test_rechunk_slicing_1():
     """
     old = ((10, 10, 10, 10, 10),)
     new = ((25, 5, 20),)
-    result = rechunk_slicing(old, new)
-    expected = {
-        (0,): [(ShardID((0,), (0,)), (slice(0, 10, None),))],
-        (1,): [(ShardID((0,), (1,)), (slice(0, 10, None),))],
-        (2,): [
-            (ShardID((0,), (2,)), (slice(0, 5, None),)),
-            (ShardID((1,), (0,)), (slice(5, 10, None),)),
-        ],
-        (3,): [(ShardID((2,), (0,)), (slice(0, 10, None),))],
-        (4,): [(ShardID((2,), (1,)), (slice(0, 10, None),))],
-    }
+    result = disassemble_chunks(old, new)
+    expected = [
+        [
+            [(0, 0, slice(0, 10, None))],
+            [(0, 1, slice(0, 10, None))],
+            [(0, 2, slice(0, 5, None)), (1, 0, slice(5, 10, None))],
+            [(2, 0, slice(0, 10, None))],
+            [(2, 1, slice(0, 10, None))],
+        ]
+    ]
     assert result == expected
 
 
-def test_rechunk_slicing_2():
+def test_disassemble_chunks_2():
     """
     See Also
     --------
@@ -966,27 +965,20 @@ def test_rechunk_slicing_2():
     """
     old = ((20, 20, 20, 20, 20),)
     new = ((58, 4, 20, 18),)
-    result = rechunk_slicing(old, new)
-    expected = {
-        (0,): [(ShardID((0,), (0,)), (slice(0, 20, None),))],
-        (1,): [(ShardID((0,), (1,)), (slice(0, 20, None),))],
-        (2,): [
-            (ShardID((0,), (2,)), (slice(0, 18, None),)),
-            (ShardID((1,), (0,)), (slice(18, 20, None),)),
-        ],
-        (3,): [
-            (ShardID((1,), (1,)), (slice(0, 2, None),)),
-            (ShardID((2,), (0,)), (slice(2, 20, None),)),
-        ],
-        (4,): [
-            (ShardID((2,), (1,)), (slice(0, 2, None),)),
-            (ShardID((3,), (0,)), (slice(2, 20, None),)),
-        ],
-    }
+    result = disassemble_chunks(old, new)
+    expected = [
+        [
+            [(0, 0, slice(0, 20, None))],
+            [(0, 1, slice(0, 20, None))],
+            [(0, 2, slice(0, 18, None)), (1, 0, slice(18, 20, None))],
+            [(1, 1, slice(0, 2, None)), (2, 0, slice(2, 20, None))],
+            [(2, 1, slice(0, 2, None)), (3, 0, slice(2, 20, None))],
+        ]
+    ]
     assert result == expected
 
 
-def test_rechunk_slicing_nan():
+def test_disassemble_chunks_nan():
     """
     See Also
     --------
@@ -994,27 +986,19 @@ def test_rechunk_slicing_nan():
     """
     old_chunks = ((np.nan, np.nan), (8,))
     new_chunks = ((np.nan, np.nan), (4, 4))
-    result = rechunk_slicing(old_chunks, new_chunks)
-    expected = {
-        (0, 0): [
-            (
-                ShardID((0, 0), (0, 0)),
-                (slice(0, None, None), slice(0, 4, None)),
-            ),
-            (
-                ShardID((0, 1), (0, 0)),
-                (slice(0, None, None), slice(4, 8, None)),
-            ),
+    result = disassemble_chunks(old_chunks, new_chunks)
+
+    expected = [
+        [
+            [(0, 0, slice(0, None, None))],
+            [(1, 0, slice(0, None, None))],
         ],
-        (1, 0): [
-            (ShardID((1, 0), (0, 0)), (slice(0, None, None), slice(0, 4, None))),
-            (ShardID((1, 1), (0, 0)), (slice(0, None, None), slice(4, 8, None))),
-        ],
-    }
+        [[(0, 0, slice(0, 4, None)), (1, 0, slice(4, 8, None))]],
+    ]
     assert result == expected
 
 
-def test_rechunk_slicing_nan_single():
+def test_disassemble_chunks_nan_single():
     """
     See Also
     --------
@@ -1023,17 +1007,15 @@ def test_rechunk_slicing_nan_single():
     old_chunks = ((np.nan,), (10,))
     new_chunks = ((np.nan,), (5, 5))
 
-    result = rechunk_slicing(old_chunks, new_chunks)
-    expected = {
-        (0, 0): [
-            (ShardID((0, 0), (0, 0)), (slice(0, None, None), slice(0, 5, None))),
-            (ShardID((0, 1), (0, 0)), (slice(0, None, None), slice(5, 10, None))),
-        ],
-    }
+    result = disassemble_chunks(old_chunks, new_chunks)
+    expected = [
+        [[(0, 0, slice(0, None, None))]],
+        [[(0, 0, slice(0, 5, None)), (1, 0, slice(5, 10, None))]],
+    ]
     assert result == expected
 
 
-def test_rechunk_slicing_nan_long():
+def test_disassemble_chunks_nan_long():
     """
     See Also
     --------
@@ -1041,29 +1023,22 @@ def test_rechunk_slicing_nan_long():
     """
     old_chunks = (tuple([np.nan] * 4), (10,))
     new_chunks = (tuple([np.nan] * 4), (5, 5))
-    result = rechunk_slicing(old_chunks, new_chunks)
-    expected = {
-        (0, 0): [
-            (ShardID((0, 0), (0, 0)), (slice(0, None, None), slice(0, 5, None))),
-            (ShardID((0, 1), (0, 0)), (slice(0, None, None), slice(5, 10, None))),
+    result = disassemble_chunks(old_chunks, new_chunks)
+    expected = [
+        [
+            [(0, 0, slice(0, None, None))],
+            [(1, 0, slice(0, None, None))],
+            [(2, 0, slice(0, None, None))],
+            [(3, 0, slice(0, None, None))],
         ],
-        (1, 0): [
-            (ShardID((1, 0), (0, 0)), (slice(0, None, None), slice(0, 5, None))),
-            (ShardID((1, 1), (0, 0)), (slice(0, None, None), slice(5, 10, None))),
+        [
+            [(0, 0, slice(0, 5, None)), (1, 0, slice(5, 10, None))],
         ],
-        (2, 0): [
-            (ShardID((2, 0), (0, 0)), (slice(0, None, None), slice(0, 5, None))),
-            (ShardID((2, 1), (0, 0)), (slice(0, None, None), slice(5, 10, None))),
-        ],
-        (3, 0): [
-            (ShardID((3, 0), (0, 0)), (slice(0, None, None), slice(0, 5, None))),
-            (ShardID((3, 1), (0, 0)), (slice(0, None, None), slice(5, 10, None))),
-        ],
-    }
+    ]
     assert result == expected
 
 
-def test_rechunk_slicing_chunks_with_nonzero():
+def test_disassemble_chunks_with_nonzero():
     """
     See Also
     --------
@@ -1071,21 +1046,18 @@ def test_rechunk_slicing_chunks_with_nonzero():
     """
     old = ((4, 4), (2,))
     new = ((8,), (1, 1))
-    result = rechunk_slicing(old, new)
-    expected = {
-        (0, 0): [
-            (ShardID((0, 0), (0, 0)), (slice(0, 4, None), slice(0, 1, None))),
-            (ShardID((0, 1), (0, 0)), (slice(0, 4, None), slice(1, 2, None))),
+    result = disassemble_chunks(old, new)
+    expected = [
+        [
+            [(0, 0, slice(0, 4, None))],
+            [(0, 1, slice(0, 4, None))],
         ],
-        (1, 0): [
-            (ShardID((0, 0), (1, 0)), (slice(0, 4, None), slice(0, 1, None))),
-            (ShardID((0, 1), (1, 0)), (slice(0, 4, None), slice(1, 2, None))),
-        ],
-    }
+        [[(0, 0, slice(0, 1, None)), (1, 0, slice(1, 2, None))]],
+    ]
     assert result == expected
 
 
-def test_rechunk_slicing_chunks_with_zero():
+def test_disassemble_chunks_with_zero():
     """
     See Also
     --------
@@ -1093,87 +1065,68 @@ def test_rechunk_slicing_chunks_with_zero():
     """
     old = ((4, 4), (2,))
     new = ((4, 0, 0, 4), (1, 1))
-    result = rechunk_slicing(old, new)
+    result = disassemble_chunks(old, new)
 
-    expected = {
-        (0, 0): [
-            (ShardID((0, 0), (0, 0)), (slice(0, 4, None), slice(0, 1, None))),
-            (ShardID((0, 1), (0, 0)), (slice(0, 4, None), slice(1, 2, None))),
+    expected = [
+        [
+            [(0, 0, slice(0, 4, None))],
+            [
+                (1, 0, slice(0, 0, None)),
+                (2, 0, slice(0, 0, None)),
+                (3, 0, slice(0, 4, None)),
+            ],
         ],
-        (1, 0): [
-            # FIXME: We should probably filter these out to avoid sending empty shards
-            (ShardID((1, 0), (0, 0)), (slice(0, 0, None), slice(0, 1, None))),
-            (ShardID((1, 1), (0, 0)), (slice(0, 0, None), slice(1, 2, None))),
-            (ShardID((2, 0), (0, 0)), (slice(0, 0, None), slice(0, 1, None))),
-            (ShardID((2, 1), (0, 0)), (slice(0, 0, None), slice(1, 2, None))),
-            (ShardID((3, 0), (0, 0)), (slice(0, 4, None), slice(0, 1, None))),
-            (ShardID((3, 1), (0, 0)), (slice(0, 4, None), slice(1, 2, None))),
-        ],
-    }
-
+        [[(0, 0, slice(0, 1, None)), (1, 0, slice(1, 2, None))]],
+    ]
     assert result == expected
 
     old = ((4, 0, 0, 4), (1, 1))
     new = ((4, 4), (2,))
-    result = rechunk_slicing(old, new)
+    result = disassemble_chunks(old, new)
 
-    expected = {
-        (0, 0): [
-            (ShardID((0, 0), (0, 0)), (slice(0, 4, None), slice(0, 1, None))),
+    expected = [
+        [
+            [(0, 0, slice(0, 4, None))],
+            [],
+            [],
+            [(1, 0, slice(0, 4, None))],
         ],
-        (0, 1): [
-            (ShardID((0, 0), (0, 1)), (slice(0, 4, None), slice(0, 1, None))),
+        [
+            [(0, 0, slice(0, 1, None))],
+            [(0, 1, slice(0, 1, None))],
         ],
-        (3, 0): [
-            (ShardID((1, 0), (0, 0)), (slice(0, 4, None), slice(0, 1, None))),
-        ],
-        (3, 1): [
-            (ShardID((1, 0), (0, 1)), (slice(0, 4, None), slice(0, 1, None))),
-        ],
-    }
-
+    ]
     assert result == expected
 
     old = ((4, 4), (2,))
     new = ((2, 0, 0, 2, 4), (1, 1))
-    result = rechunk_slicing(old, new)
-    expected = {
-        (0, 0): [
-            (ShardID((0, 0), (0, 0)), (slice(0, 2, None), slice(0, 1, None))),
-            (ShardID((0, 1), (0, 0)), (slice(0, 2, None), slice(1, 2, None))),
-            # FIXME: We should probably filter these out to avoid sending empty shards
-            (ShardID((1, 0), (0, 0)), (slice(2, 2, None), slice(0, 1, None))),
-            (ShardID((1, 1), (0, 0)), (slice(2, 2, None), slice(1, 2, None))),
-            (ShardID((2, 0), (0, 0)), (slice(2, 2, None), slice(0, 1, None))),
-            (ShardID((2, 1), (0, 0)), (slice(2, 2, None), slice(1, 2, None))),
-            (ShardID((3, 0), (0, 0)), (slice(2, 4, None), slice(0, 1, None))),
-            (ShardID((3, 1), (0, 0)), (slice(2, 4, None), slice(1, 2, None))),
+    result = disassemble_chunks(old, new)
+    expected = [
+        [
+            [
+                (0, 0, slice(0, 2, None)),
+                (1, 0, slice(2, 2, None)),
+                (2, 0, slice(2, 2, None)),
+                (3, 0, slice(2, 4)),
+            ],
+            [(4, 0, slice(0, 4, None))],
         ],
-        (1, 0): [
-            (ShardID((4, 0), (0, 0)), (slice(0, 4, None), slice(0, 1, None))),
-            (ShardID((4, 1), (0, 0)), (slice(0, 4, None), slice(1, 2, None))),
-        ],
-    }
-
+        [[(0, 0, slice(0, 1, None)), (1, 0, slice(1, 2, None))]],
+    ]
     assert result == expected
 
     old = ((4, 4), (2,))
     new = ((0, 0, 4, 4), (1, 1))
-    result = rechunk_slicing(old, new)
-    expected = {
-        (0, 0): [
-            # FIXME: We should probably filter these out to avoid sending empty shards
-            (ShardID((0, 0), (0, 0)), (slice(0, 0, None), slice(0, 1, None))),
-            (ShardID((0, 1), (0, 0)), (slice(0, 0, None), slice(1, 2, None))),
-            (ShardID((1, 0), (0, 0)), (slice(0, 0, None), slice(0, 1, None))),
-            (ShardID((1, 1), (0, 0)), (slice(0, 0, None), slice(1, 2, None))),
-            (ShardID((2, 0), (0, 0)), (slice(0, 4, None), slice(0, 1, None))),
-            (ShardID((2, 1), (0, 0)), (slice(0, 4, None), slice(1, 2, None))),
+    result = disassemble_chunks(old, new)
+    expected = [
+        [
+            [
+                (0, 0, slice(0, 0, None)),
+                (1, 0, slice(0, 0, None)),
+                (2, 0, slice(0, 4, None)),
+            ],
+            [(3, 0, slice(0, 4, None))],
         ],
-        (1, 0): [
-            (ShardID((3, 0), (0, 0)), (slice(0, 4, None), slice(0, 1, None))),
-            (ShardID((3, 1), (0, 0)), (slice(0, 4, None), slice(1, 2, None))),
-        ],
-    }
-
+        [[(0, 0, slice(0, 1, None)), (1, 0, slice(1, 2, None))]],
+    ]
     assert result == expected

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -18,7 +18,7 @@ from dask.array.rechunk import normalize_chunks, rechunk
 from dask.array.utils import assert_eq
 
 from distributed.shuffle._limiter import ResourceLimiter
-from distributed.shuffle._rechunk import split_axes
+from distributed.shuffle._rechunk import Split, split_axes
 from distributed.shuffle._scheduler_extension import get_worker_for_hash_sharding
 from distributed.shuffle._shuffle import ShuffleId
 from distributed.shuffle._worker_extension import ArrayRechunkRun
@@ -636,17 +636,14 @@ async def test_rechunk_with_fully_unknown_dimension(c, s, *ws, x, chunks):
         pytest.param(
             da.ones(shape=(1000, 10), chunks=(5, 10)),
             (None, 5),
-            # marks=pytest.mark.skip(reason="distributed#7757"),
         ),
         pytest.param(
             da.ones(shape=(1000, 10), chunks=(5, 10)),
             {1: 5},
-            # marks=pytest.mark.skip(reason="distributed#7757"),
         ),
         pytest.param(
             da.ones(shape=(1000, 10), chunks=(5, 10)),
             (None, (5, 5)),
-            # marks=pytest.mark.skip(reason="distributed#7757"),
         ),
         (da.ones(shape=(10, 10), chunks=(10, 10)), (None, 5)),
         (da.ones(shape=(10, 10), chunks=(10, 10)), {1: 5}),
@@ -947,11 +944,11 @@ def test_split_axes_1():
     result = split_axes(old, new)
     expected = [
         [
-            [(0, 0, slice(0, 10, None))],
-            [(0, 1, slice(0, 10, None))],
-            [(0, 2, slice(0, 5, None)), (1, 0, slice(5, 10, None))],
-            [(2, 0, slice(0, 10, None))],
-            [(2, 1, slice(0, 10, None))],
+            [Split(0, 0, slice(0, 10, None))],
+            [Split(0, 1, slice(0, 10, None))],
+            [Split(0, 2, slice(0, 5, None)), Split(1, 0, slice(5, 10, None))],
+            [Split(2, 0, slice(0, 10, None))],
+            [Split(2, 1, slice(0, 10, None))],
         ]
     ]
     assert result == expected
@@ -968,11 +965,11 @@ def test_split_axes_2():
     result = split_axes(old, new)
     expected = [
         [
-            [(0, 0, slice(0, 20, None))],
-            [(0, 1, slice(0, 20, None))],
-            [(0, 2, slice(0, 18, None)), (1, 0, slice(18, 20, None))],
-            [(1, 1, slice(0, 2, None)), (2, 0, slice(2, 20, None))],
-            [(2, 1, slice(0, 2, None)), (3, 0, slice(2, 20, None))],
+            [Split(0, 0, slice(0, 20, None))],
+            [Split(0, 1, slice(0, 20, None))],
+            [Split(0, 2, slice(0, 18, None)), Split(1, 0, slice(18, 20, None))],
+            [Split(1, 1, slice(0, 2, None)), Split(2, 0, slice(2, 20, None))],
+            [Split(2, 1, slice(0, 2, None)), Split(3, 0, slice(2, 20, None))],
         ]
     ]
     assert result == expected
@@ -990,10 +987,10 @@ def test_split_axes_nan():
 
     expected = [
         [
-            [(0, 0, slice(0, None, None))],
-            [(1, 0, slice(0, None, None))],
+            [Split(0, 0, slice(0, None, None))],
+            [Split(1, 0, slice(0, None, None))],
         ],
-        [[(0, 0, slice(0, 4, None)), (1, 0, slice(4, 8, None))]],
+        [[Split(0, 0, slice(0, 4, None)), Split(1, 0, slice(4, 8, None))]],
     ]
     assert result == expected
 
@@ -1009,8 +1006,8 @@ def test_split_axes_nan_single():
 
     result = split_axes(old_chunks, new_chunks)
     expected = [
-        [[(0, 0, slice(0, None, None))]],
-        [[(0, 0, slice(0, 5, None)), (1, 0, slice(5, 10, None))]],
+        [[Split(0, 0, slice(0, None, None))]],
+        [[Split(0, 0, slice(0, 5, None)), Split(1, 0, slice(5, 10, None))]],
     ]
     assert result == expected
 
@@ -1026,13 +1023,13 @@ def test_split_axes_nan_long():
     result = split_axes(old_chunks, new_chunks)
     expected = [
         [
-            [(0, 0, slice(0, None, None))],
-            [(1, 0, slice(0, None, None))],
-            [(2, 0, slice(0, None, None))],
-            [(3, 0, slice(0, None, None))],
+            [Split(0, 0, slice(0, None, None))],
+            [Split(1, 0, slice(0, None, None))],
+            [Split(2, 0, slice(0, None, None))],
+            [Split(3, 0, slice(0, None, None))],
         ],
         [
-            [(0, 0, slice(0, 5, None)), (1, 0, slice(5, 10, None))],
+            [Split(0, 0, slice(0, 5, None)), Split(1, 0, slice(5, 10, None))],
         ],
     ]
     assert result == expected
@@ -1049,10 +1046,10 @@ def test_split_axes_with_nonzero():
     result = split_axes(old, new)
     expected = [
         [
-            [(0, 0, slice(0, 4, None))],
-            [(0, 1, slice(0, 4, None))],
+            [Split(0, 0, slice(0, 4, None))],
+            [Split(0, 1, slice(0, 4, None))],
         ],
-        [[(0, 0, slice(0, 1, None)), (1, 0, slice(1, 2, None))]],
+        [[Split(0, 0, slice(0, 1, None)), Split(1, 0, slice(1, 2, None))]],
     ]
     assert result == expected
 
@@ -1069,14 +1066,14 @@ def test_split_axes_with_zero():
 
     expected = [
         [
-            [(0, 0, slice(0, 4, None))],
+            [Split(0, 0, slice(0, 4, None))],
             [
-                (1, 0, slice(0, 0, None)),
-                (2, 0, slice(0, 0, None)),
-                (3, 0, slice(0, 4, None)),
+                Split(1, 0, slice(0, 0, None)),
+                Split(2, 0, slice(0, 0, None)),
+                Split(3, 0, slice(0, 4, None)),
             ],
         ],
-        [[(0, 0, slice(0, 1, None)), (1, 0, slice(1, 2, None))]],
+        [[Split(0, 0, slice(0, 1, None)), Split(1, 0, slice(1, 2, None))]],
     ]
     assert result == expected
 
@@ -1086,14 +1083,14 @@ def test_split_axes_with_zero():
 
     expected = [
         [
-            [(0, 0, slice(0, 4, None))],
+            [Split(0, 0, slice(0, 4, None))],
             [],
             [],
-            [(1, 0, slice(0, 4, None))],
+            [Split(1, 0, slice(0, 4, None))],
         ],
         [
-            [(0, 0, slice(0, 1, None))],
-            [(0, 1, slice(0, 1, None))],
+            [Split(0, 0, slice(0, 1, None))],
+            [Split(0, 1, slice(0, 1, None))],
         ],
     ]
     assert result == expected
@@ -1104,14 +1101,14 @@ def test_split_axes_with_zero():
     expected = [
         [
             [
-                (0, 0, slice(0, 2, None)),
-                (1, 0, slice(2, 2, None)),
-                (2, 0, slice(2, 2, None)),
-                (3, 0, slice(2, 4)),
+                Split(0, 0, slice(0, 2, None)),
+                Split(1, 0, slice(2, 2, None)),
+                Split(2, 0, slice(2, 2, None)),
+                Split(3, 0, slice(2, 4)),
             ],
-            [(4, 0, slice(0, 4, None))],
+            [Split(4, 0, slice(0, 4, None))],
         ],
-        [[(0, 0, slice(0, 1, None)), (1, 0, slice(1, 2, None))]],
+        [[Split(0, 0, slice(0, 1, None)), Split(1, 0, slice(1, 2, None))]],
     ]
     assert result == expected
 
@@ -1121,12 +1118,12 @@ def test_split_axes_with_zero():
     expected = [
         [
             [
-                (0, 0, slice(0, 0, None)),
-                (1, 0, slice(0, 0, None)),
-                (2, 0, slice(0, 4, None)),
+                Split(0, 0, slice(0, 0, None)),
+                Split(1, 0, slice(0, 0, None)),
+                Split(2, 0, slice(0, 4, None)),
             ],
-            [(3, 0, slice(0, 4, None))],
+            [Split(3, 0, slice(0, 4, None))],
         ],
-        [[(0, 0, slice(0, 1, None)), (1, 0, slice(1, 2, None))]],
+        [[Split(0, 0, slice(0, 1, None)), Split(1, 0, slice(1, 2, None))]],
     ]
     assert result == expected


### PR DESCRIPTION
Closes #7757

**Preamble:**

For the sake of this explanation, I will diverge from the common naming used in `dask.array`:

An n-dimensional Dask array like the one illustrated in the image below

![image](https://github.com/dask/distributed/assets/2699097/cff5452c-dc68-4095-9bb8-c46a40a00d4a)

is partitioned into many small n-dimensional NumPy arrays, each of which we will refer to as a _partition_. The partitions are created by chunking the array along each axis, where a single _chunk_ determines the size of its corresponding partitions along this axis. In the image, we have 5 chunks along the horizontal axis, 4 chunks along the vertical axis and 20 partitions.

With $P :=$ _number of partitions_ of the array, and $C_n :=$ _number of chunks along axis n_, and $N :=$ _number of dimensions_, it follows that

$$P = \prod_{n=1}^N C_n$$

**Content**

The big change in this PR is the intermediate result we store on the shuffle run to determine how to slice the input partitions in order to create the output partitions from the resulting shards. With this PR, we do not calculate for each of the input partitions, how we need to slice it into shards that belong to one output partition. Instead, we only store for each individual axis of the n-dimensional array how we need to split the chunks along that axis. 

With $P_{old} :=$ _number of old partitions_, $P_{new} :=$ _number of new partitions_, this means with the previous algorithm we stored a result of size $\mathcal{O}(P_{old}* P_{new})$.

With $C_{old, n} :=$ _number of old chunks along axis n_, $C_{new, n} :=$ _number of new chunks along axis n_,

it follows that

$$ P_{old}* P_{new} = \prod_{n=1}^N C_{old, n} * C_{new, n} \in O((C_{old} * C_{new})^N)$$

where $C_{old} :=$ _number of old chunks along all axes_, $C_{new} :=$ _number of new chunks along all axes_

For the new approach, there are only $C_{old, n} + C_{new, n}$ splits per axis n. Hence, we only store a result of size 

$$ \sum_{n=1}^N C_{old, n} + C_{new, n} = C_{old} + C_{new} \in \mathcal{O}(C_{old} + C_{new}) \in \mathcal{O}(P_{old} + P_{new})$$

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @wence- 