### PR TITLE
Propagate spans to tasks

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4462,11 +4462,12 @@ class Scheduler(SchedulerState, ServerNode):
             # _generate_taskstates is not the only thing that calls new_task(). A
             # TaskState may have also been created by client_desires_keys or scatter,
             # and only later gained a run_spec.
-            spans_ext.observe_tasks(runnable, code=code)
-            # TaskGroup.span_id could be completely different from the one in the
-            # original annotations, so it has been dropped. Drop it here as well in
-            # order not to confuse SchedulerPlugin authors.
-            resolved_annotations.pop("span", None)
+            span_annotations = spans_ext.observe_tasks(runnable, code=code)
+            # In case of TaskGroup collision, spans may have changed
+            if span_annotations:
+                resolved_annotations["span"] = span_annotations
+            else:
+                resolved_annotations.pop("span", None)
 
         for plugin in list(self.plugins.values()):
             try:

--- a/distributed/spans.py
+++ b/distributed/spans.py
@@ -73,6 +73,9 @@ def span(*tags: str) -> Iterator[str]:
     -----
     Spans are based on annotations, and just like annotations they can be lost during
     optimization. Set config ``optimization.fuse.active: false`` to prevent this issue.
+
+    You may retrieve the current span with ``dask.get_annotations().get("span")``.
+    You can do so in the client code as well as from inside a task.
     """
     if not tags:
         raise ValueError("Must specify at least one span tag")
@@ -174,6 +177,22 @@ class Span:
             assert out
             return out
         return None
+
+    @property
+    def annotation(self) -> dict[str, tuple[str, ...]] | None:
+        """Rebuild the dask graph annotation which contains the full id history
+
+        Note that this may not match the original annotation in case of TaskGroup
+        collision.
+        """
+        if self.name == ("default",):
+            return None
+        ids = []
+        node: Span | None = self
+        while node:
+            ids.append(node.id)
+            node = node.parent
+        return {"name": self.name, "ids": tuple(reversed(ids))}
 
     def traverse_spans(self) -> Iterator[Span]:
         """Top-down recursion of all spans belonging to this branch off span tree,
@@ -474,14 +493,19 @@ class SpansSchedulerExtension:
 
     def observe_tasks(
         self, tss: Iterable[TaskState], code: tuple[SourceCode, ...]
-    ) -> None:
+    ) -> dict[str, dict]:
         """Acknowledge the existence of runnable tasks on the scheduler. These may
         either be new tasks, tasks that were previously unrunnable, or tasks that were
         already fed into this method already.
 
         Attach newly observed tasks to either the desired span or to ("default", ).
         Update TaskGroup.span_id and wipe TaskState.annotations["span"].
+
+        Returns
+        -------
+        Updated 'span' annotations: {key: {"name": (..., ...), "ids": (..., ...)}}
         """
+        out = {}
         default_span = None
 
         for ts in tss:
@@ -508,10 +532,12 @@ class SpansSchedulerExtension:
 
             # The span may be completely different from the one referenced by the
             # annotation, due to the TaskGroup collision issue explained above.
-            # Remove the annotation to avoid confusion, and instead rely on
-            # distributed.scheduler.TaskState.group.span_id and
-            # distributed.worker_state_machine.TaskState.span_id.
-            ts.annotations.pop("span", None)
+            if ann := span.annotation:
+                ts.annotations["span"] = out[ts.key] = ann
+            else:
+                ts.annotations.pop("span", None)
+
+        return out
 
     def _ensure_default_span(self) -> Span:
         """Return the currently active default span, or create one if the previous one

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2265,6 +2265,14 @@ class Worker(BaseWorker, ServerNode):
                 )
 
             self.active_keys.add(key)
+            # Propagate span (see distributed.spans). This is useful when spawning
+            # more tasks using worker_client() and for logging.
+            if "span" in ts.annotations:
+                span_ctx = dask.annotate(span=ts.annotations["span"])
+                span_ctx.__enter__()
+            else:
+                span_ctx = None
+
             try:
                 ts.start_time = time()
                 if iscoroutinefunction(function):
@@ -2313,6 +2321,8 @@ class Worker(BaseWorker, ServerNode):
                         )
             finally:
                 self.active_keys.discard(key)
+                if span_ctx:
+                    span_ctx.__exit__(None, None, None)
 
             self.threads[key] = result["thread"]
 


### PR DESCRIPTION
- Part of #7860
- Blocked by dask/dask#10340.

Allow spans information to be accessed by tasks.
This is useful, e.g.
- for logging
- when the task itself wants to spawn more tasks, e.g.

```python
def process_df(uri):
    with span("load"):
        df = dd.read_parquet(uri)
    with span("reduce"):
        out = ...(df)
    client = get_client()
    secede()
    return out.compute()

client = Client()
with span("foo"):
    foo = client.submit(process_df, "s3://mybucket/foo.parquet", key="foo")
with span("bar"):
    bar = client.submit(process_df, "s3://mybucket/bar.parquet", key="bar")
client.gather([foo, bar])
```

The above example will produce spans
- ("foo", "load")
- ("foo", "reduce")
- ("bar", "load")
- ("bar", "reduce")