### PR TITLE
Add ``needs triage`` label to re/opened PRs and issues

### DIFF
--- a/.github/workflows/label-all.yml
+++ b/.github/workflows/label-all.yml
@@ -1,0 +1,14 @@
+name: "Issue and PR Labeler"
+on:
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened, reopened]
+jobs:
+  label-all-on-open:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "needs triage"
+          ignore-if-labeled: false


### PR DESCRIPTION
Copied over from dask/dask

Closes #7906

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
