### PR TITLE
Fix glitches in Fine Performance Metrics stacked graph

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3714,7 +3714,6 @@ class FinePerformanceMetrics(DashboardComponent):
         _build_task_execution_by_prefix_chart
         _update_task_execution_by_prefix_chart
         """
-        ymax = 0.0
         func_totals = [
             sum(data[function, activity] for activity in self.visible_activities)
             for function in self.visible_functions
@@ -3732,8 +3731,7 @@ class FinePerformanceMetrics(DashboardComponent):
                 self._format(v) + f" ({v * perc_ki:.0f}%)"
                 for v, perc_ki in zip(values, perc_k)
             ]
-            ymax = max(ymax, sum(values))
-        return out, ymax
+        return out, max(func_totals, default=0.0)
 
     def _build_task_execution_by_prefix_chart(self) -> figure:
         """Create empty stacked bar chart for execute by function

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3622,10 +3622,9 @@ class FinePerformanceMetrics(DashboardComponent):
                     # Custom metrics can provide any hashable as the label
                     activity = str(activity)
                     execute_by_func[function, activity] += v
+                    execute[activity] += v
                     visible_functions.add(function)
                     visible_activities.add(activity)
-                    execute_by_func[function, activity] += v
-                    execute[activity] += v
 
             elif context == "get-data" and not function_sel:
                 # Note: this will always be empty when a span is selected

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -342,6 +342,10 @@ async def test_WorkersMemory(c, s, a, b):
 async def test_FinePerformanceMetrics(c, s, a, b):
     cl = FinePerformanceMetrics(s)
 
+    # Test with no metrics
+    cl.update()
+    assert not cl.visible_functions
+
     # execute on default span; multiple tasks in same TaskGroup
     x0 = c.submit(inc, 0, key="x-0", workers=[a.address])
     x1 = c.submit(inc, 1, key="x-1", workers=[a.address])
@@ -378,7 +382,6 @@ async def test_FinePerformanceMetrics(c, s, a, b):
     await a.heartbeat()
     await b.heartbeat()
 
-    assert not cl.visible_functions
     cl.update()
     assert sorted(cl.visible_functions) == ["v", "w", "x", "y", "z"]
     assert sorted(cl.unit_selector.options) == ["bytes", "count", "custom", "seconds"]


### PR DESCRIPTION
Fix bugs in the stacked chart in the Fine Performance Metrics dashboard, introduced in #7910 
- ymax was miscalculated,  potentially clipping off bars
- everything would be double counted