### PR TITLE
Improve error message on invalid state in `_handle_remove_replicas`

### DIFF
--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -2795,8 +2795,11 @@ class WorkerState:
             # preparing/collecting the data for the task.
             # If a dependency was released during this time, this would pop up
             # as a KeyError during execute which is hard to understand
-            if any(dep.state in ("executing", "long-running") for dep in ts.dependents):
-                raise RuntimeError("Encountered invalid state")  # pragma: no cover
+            for dep in ts.dependents:
+                if dep.state in ("executing", "long-running"):
+                    raise RuntimeError(
+                        f"Cannot remove replica of {ts.key!r} while {dep.key!r} in state {ts.state!r}."
+                    )  # pragma: no cover
             self.log.append((ts.key, "remove-replica", ev.stimulus_id, time()))
             recommendations[ts] = "released"
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -2798,7 +2798,7 @@ class WorkerState:
             for dep in ts.dependents:
                 if dep.state in ("executing", "long-running"):
                     raise RuntimeError(
-                        f"Cannot remove replica of {ts.key!r} while {dep.key!r} in state {ts.state!r}."
+                        f"Cannot remove replica of {ts.key!r} while {dep.key!r} in state {dep.state!r}."
                     )  # pragma: no cover
             self.log.append((ts.key, "remove-replica", ev.stimulus_id, time()))
             recommendations[ts] = "released"


### PR DESCRIPTION
Provides more information for debugging #7923

The current message does not provide much help when debugging what happened:

```
Traceback (most recent call last):
  File "/opt/coiled/env/lib/python3.9/site-packages/tornado/ioloop.py", line 740, in _run_callback
    ret = callback()
  File "/opt/coiled/env/lib/python3.9/site-packages/tornado/ioloop.py", line 764, in _discard_future_result
    future.result()
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/worker.py", line 209, in wrapper
    return await method(self, *args, **kwargs)  # type: ignore
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/worker.py", line 1286, in handle_scheduler
    await self.handle_stream(comm)
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/core.py", line 1008, in handle_stream
    handler(**merge(extra, msg))
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/worker.py", line 1901, in _
    self.handle_stimulus(event)
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/worker.py", line 222, in wrapper
    return method(self, *args, **kwargs)
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/worker.py", line 1916, in handle_stimulus
    super().handle_stimulus(*stims)
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/worker_state_machine.py", line 3718, in handle_stimulus
    instructions = self.state.handle_stimulus(*stims)
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/worker_state_machine.py", line 1360, in handle_stimulus
    recs, instr = self._handle_event(stim)
  File "/opt/coiled/env/lib/python3.9/functools.py", line 938, in _method
    return method.__get__(obj, cls)(*args, **kwargs)
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/worker_state_machine.py", line 2799, in _handle_remove_replicas
    raise RuntimeError("Encountered invalid state")  # pragma: no cover
RuntimeError: Encountered invalid state
```

To improve the situation, it should mention the key to remove and the dependent with its invalid state.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
