### PR TITLE
Make `ShuffleSchedulerExtension.remove_worker` more robust

### DIFF
--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -314,7 +314,7 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
                 # TODO: Do we need to handle other states?
 
         # If processing the transactions causes a task to get released, this
-        # remove the shuffle from self.states. Therefore, we must process them
+        # removes the shuffle from self.states. Therefore, we must process them
         # outside of the loop.
         self.scheduler.transitions(recs, stimulus_id=stimulus_id)
 

--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -294,6 +294,7 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
 
         stimulus_id = f"shuffle-failed-worker-left-{time()}"
 
+        recs: Recs = {}
         for shuffle_id, shuffle in self.states.items():
             if worker not in shuffle.participating_workers:
                 continue
@@ -304,7 +305,6 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
             self._fail_on_workers(shuffle, str(exception))
 
             barrier_task = self.scheduler.tasks[barrier_key(shuffle_id)]
-            recs: Recs = {}
             if barrier_task.state == "memory":
                 for dt in barrier_task.dependents:
                     if worker not in dt.worker_restrictions:
@@ -313,7 +313,10 @@ class ShuffleSchedulerExtension(SchedulerPlugin):
                     recs.update({dt.key: "waiting"})
                 # TODO: Do we need to handle other states?
 
-            self.scheduler.transitions(recs, stimulus_id=stimulus_id)
+        # If processing the transactions causes a task to get released, this
+        # remove the shuffle from self.states. Therefore, we must process them
+        # outside of the loop.
+        self.scheduler.transitions(recs, stimulus_id=stimulus_id)
 
     def transition(
         self,


### PR DESCRIPTION
If processing the transactions causes a task to get released, this removes the shuffle from `self.states`. Therefore, we must process them outside of the loop.

Under normal circumstances, `remove_worker` does not cause tasks to transition to `released`, so writing a test for this is hard. However, it _can_ happen if you really screw with your cluster:

```
Traceback (most recent call last):
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/scheduler.py", line 5057, in remove_worker
    result = plugin.remove_worker(scheduler=self, worker=address)
  File "/opt/coiled/env/lib/python3.9/site-packages/distributed/shuffle/_scheduler_extension.py", line 297, in remove_worker
    for shuffle_id, shuffle in self.states.items():
RuntimeError: dictionary changed size during iteration
```

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
