### PR TITLE
Handle null partitions in P2P shuffling

### DIFF
--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -55,7 +55,7 @@ def convert_partition(data: bytes, meta: pd.DataFrame) -> pd.DataFrame:
     while file.tell() < end:
         sr = pa.RecordBatchStreamReader(file)
         shards.append(sr.read_all())
-    table = pa.concat_tables(shards)
+    table = pa.concat_tables(shards, promote=True)
     df = table.to_pandas(self_destruct=True)
 
     def default_types_mapper(pyarrow_dtype: pa.DataType) -> object:

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1826,3 +1826,22 @@ async def test_closed_worker_returns_before_barrier(c, s):
         await c.close()
         await asyncio.gather(*[clean_worker(w) for w in workers])
         await clean_scheduler(s)
+
+
+@gen_cluster(client=True)
+async def test_handle_null_partitions_p2p_shuffling(c, s, *workers):
+    data = [
+        {"companies": [], "id": "a", "x": None},
+        {"companies": [{"id": 3}, {"id": 5}], "id": "b", "x": None},
+        {"companies": [{"id": 3}, {"id": 4}, {"id": 5}], "id": "c", "x": "b"},
+        {"companies": [{"id": 9}], "id": "a", "x": "a"},
+    ]
+    df = pd.DataFrame(data)
+    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = ddf.shuffle(on="id", shuffle="p2p", ignore_index=True)
+    result = await c.compute(ddf)
+    assert dask.dataframe.utils.assert_eq(result, df)
+
+    await c.close()
+    await asyncio.gather(*[clean_worker(w) for w in workers])
+    await clean_scheduler(s)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1840,7 +1840,7 @@ async def test_handle_null_partitions_p2p_shuffling(c, s, *workers):
     ddf = dd.from_pandas(df, npartitions=2)
     ddf = ddf.shuffle(on="id", shuffle="p2p", ignore_index=True)
     result = await c.compute(ddf)
-    assert dask.dataframe.utils.assert_eq(result, df)
+    dd.assert_eq(result, df)
 
     await c.close()
     await asyncio.gather(*[clean_worker(w) for w in workers])

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3211,31 +3211,6 @@ async def test_cancel_clears_processing(c, s, *workers):
     s.validate_state()
 
 
-@gen_cluster(client=True)
-async def test_handle_null_partitions_p2p_shuffling(c, s, *workers):
-    has_pyarrow = False
-    try:
-        check_minimal_arrow_version()
-        has_pyarrow = True
-    except RuntimeError:
-        pass
-
-    if has_pyarrow:
-        import pandas as pd
-
-        dd = pytest.importorskip("dask.dataframe")
-        data = [
-            {"companies": [], "id": "a", "x": None},
-            {"companies": [{"id": 3}, {"id": 5}], "id": "b", "x": None},
-            {"companies": [{"id": 3}, {"id": 4}, {"id": 5}], "id": "c", "x": "b"},
-            {"companies": [{"id": 9}], "id": "a", "x": "a"},
-        ]
-        df = pd.DataFrame(data)
-        ddf = dd.from_pandas(df, npartitions=2)
-        ddf = ddf.shuffle(on="id", shuffle="p2p", ignore_index=True)
-        await c.compute(ddf)
-
-
 def test_default_get(loop_in_thread):
     has_pyarrow = False
     try:


### PR DESCRIPTION
Ran into this issue after upgrading to 2023.6. Luckily, it's an easy fix.

Columns with sparse data can have partitions with empty/null columns. This creates a conflict of data types between the partitions and an error during concatenation.

Closes #7837

- [ x] Tests added / passed
- [ x] Passes `pre-commit run --all-files`
