### PR TITLE
Avoid #7923 by starting `ShuffleState._run_id_iterator` at 1

### DIFF
--- a/distributed/shuffle/_scheduler_extension.py
+++ b/distributed/shuffle/_scheduler_extension.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ShuffleState(abc.ABC):
-    _run_id_iterator: ClassVar[itertools.count] = itertools.count()
+    _run_id_iterator: ClassVar[itertools.count] = itertools.count(1)
 
     id: ShuffleId
     run_id: int


### PR DESCRIPTION
Circumvents issue caused by #7923.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
