### PR TITLE
RFC Set priorities for p2p shuffle tasks

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -156,7 +156,20 @@ class P2PShuffleLayer(Layer):
             self.parts_out = set(range(self.npartitions))
         self.npartitions_input = npartitions_input
         annotations = annotations or {}
-        annotations.update({"shuffle": lambda key: key[1]})
+
+        def _priority(key: tuple | str) -> int:
+            if key[0].startswith(self.name):
+                return -1
+            if key[0].startswith("shuffle-transfer"):
+                return 1
+            return 0
+
+        annotations.update(
+            {
+                "shuffle": lambda key: key[1],
+                "priority": _priority,
+            }
+        )
         super().__init__(annotations=annotations)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
This is currently just a working theory and I don't have a proper reproducer, yet.

However, I observed some suboptimal scheduling behavior when two shuffles where running back-to-back, e.g.

`df1.merge(df2).groupby(...).agg(..., split_out=2, shuffle="p2p")`

the suboptimal behavior is that the transfer tasks of the second shuffle are not necessarily prioritized. However, they basically act as a RMM sink and should likely have strict prioritization over other foo if we want to schedule memory optimal. A similar argument holds for the shuffle output task which literally reads data from disk into memory and therefore acts as a memory producer.

We were already able to track down a significant portion of the root task queuing impact down to improper ordering (see https://github.com/dask/dask/issues/9995 and https://github.com/dask/distributed/pull/7526#issuecomment-1431346387) s.t. queuing de-facto deprioritizes root tasks. 
I believe that the `shuffle` tasks should be classified as root tasks in this scheduling paradigm but teaching this to our heuristic seems cumbersome / impossible. Instead, we can just literally (de-)prioritize the tasks accordingly.
I need to follow up with a decent measurement to solidify this theory. For context, I stumbled over this scheduling behavior while playing with https://github.com/coiled/benchmarks/pull/883 but couldn't get it to succeed, yet, for a couple of other reasons.

cc @hendrikmakait 