### PR TITLE
Fix flaky test_send_metrics_to_scheduler

### DIFF
--- a/distributed/tests/test_spans.py
+++ b/distributed/tests/test_spans.py
@@ -510,13 +510,12 @@ async def test_worker_metrics(c, s, a, b):
 
     # Metrics have been synchronized from scheduler to spans
     for k, v in foo_metrics.items():
-        assert s.cumulative_worker_metrics[k] == v
+        assert s.cumulative_worker_metrics[k] == pytest.approx(v)
 
     # Metrics for foo contain the sum of metrics from itself and for bar
     for k in bar0_metrics:
-        assert (
-            foo_metrics[k]
-            == bar0_metrics[k]
+        assert foo_metrics[k] == pytest.approx(
+            bar0_metrics[k]
             + bar1_metrics[k]
             + ext.spans[foo_sid]._cumulative_worker_metrics[k]
         )

--- a/distributed/tests/test_worker_metrics.py
+++ b/distributed/tests/test_worker_metrics.py
@@ -439,7 +439,9 @@ async def test_user_metrics_weird(c, s, a):
         ("execute", "x", "other", "seconds"),
     ]
     for (context, prefix, activity, unit), v in s_metrics.items():
-        assert a_metrics[context, span_id(s), prefix, activity, unit] == v
+        assert a_metrics[context, span_id(s), prefix, activity, unit] == pytest.approx(
+            v
+        )
 
 
 @gen_cluster(client=True, nthreads=[("", 3)])
@@ -560,7 +562,7 @@ async def test_send_metrics_to_scheduler(c, s, a, b):
         if not WINDOWS:
             assert a_metrics[wk] > 0
             assert b_metrics[wk] > 0
-        assert s_metrics[sk] == a_metrics[wk] + b_metrics[wk]
+        assert s_metrics[sk] == pytest.approx(a_metrics[wk] + b_metrics[wk])
 
 
 @gen_cluster(
@@ -593,7 +595,7 @@ async def test_no_spans_extension(c, s, a):
     for wk, sk in zip(expect_worker, expect_scheduler):
         if not WINDOWS:
             assert w_metrics[wk] > 0
-        assert s_metrics[sk] == w_metrics[wk]
+        assert s_metrics[sk] == pytest.approx(w_metrics[wk])
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])


### PR DESCRIPTION
1 out of 10 runs failed: test_send_metrics_to_scheduler (distributed.tests.test_worker_metrics)
```
>           assert s_metrics[sk] == a_metrics[wk] + b_metrics[wk]
E           assert 0.00014810658569335935 == (7.573013000488279e-05 + 7.237645568847658e-05)

distributed/tests/test_worker_metrics.py:563: AssertionError
```