### PR TITLE
Fix compatibility with Numpy 1.25

### DIFF
--- a/distributed/dashboard/utils.py
+++ b/distributed/dashboard/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from itertools import chain
 from numbers import Number
 
 import bokeh
@@ -46,7 +47,9 @@ def update(source, data):
         arrays
     3.  If profiling then perform the update in another callback
     """
-    if not np or not any(isinstance(v, np.ndarray) for v in source.data.values()):
+    if not np or not any(
+        isinstance(v, np.ndarray) for v in chain(source.data.values(), data.values())
+    ):
         if source.data == data:
             return
     if np and len(data[first(data)]) > 10:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -33,6 +33,7 @@ from unittest import mock
 import psutil
 import pytest
 import yaml
+from packaging.version import parse as parse_version
 from tlz import concat, first, identity, isdistinct, merge, pluck, valmap
 from tornado.ioloop import IOLoop
 
@@ -7262,6 +7263,9 @@ def test_computation_object_code_dask_compute_no_frames_default(client):
 
 def test_computation_object_code_not_available(client):
     np = pytest.importorskip("numpy")
+    if parse_version(np.__version__) >= parse_version("1.25"):
+        raise pytest.skip("numpy >=1.25 can capture ufunc code")
+
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
     with dask.config.set({"distributed.diagnostics.computations.nframes": 2}):


### PR DESCRIPTION
Numpy 1.25 breaks the workers memory histogram in the Bokeh dashboard.

FYI @jrbourbeau 