### PR TITLE
Sign `task-erred` with `run_id` and reject outdated responses

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4876,6 +4876,7 @@ class Scheduler(SchedulerState, ServerNode):
         exception=None,
         stimulus_id=None,
         traceback=None,
+        run_id=None,
         **kwargs,
     ):
         """Mark that a task has erred on a particular worker"""
@@ -4884,6 +4885,13 @@ class Scheduler(SchedulerState, ServerNode):
         ts: TaskState = self.tasks.get(key)
         if ts is None or ts.state != "processing":
             return {}, {}, {}
+
+        if (
+            ts.run_id != run_id
+            and ts.processing_on
+            and ts.processing_on.address == worker
+        ):
+            return self._transition(key, "waiting", stimulus_id)
 
         if ts.retries > 0:
             ts.retries -= 1

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4886,12 +4886,10 @@ class Scheduler(SchedulerState, ServerNode):
         if ts is None or ts.state != "processing":
             return {}, {}, {}
 
-        if (
-            ts.run_id != run_id
-            and ts.processing_on
-            and ts.processing_on.address == worker
-        ):
-            return self._transition(key, "waiting", stimulus_id)
+        if ts.run_id != run_id:
+            if ts.processing_on and ts.processing_on.address == worker:
+                return self._transition(key, "released", stimulus_id)
+            return {}, {}, {}
 
         if ts.retries > 0:
             ts.retries -= 1

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -489,8 +489,7 @@ async def test_resumed_cancelled_handle_compute(
         await lock_compute.release()
         await exit_compute.wait()
 
-        while f3.key in b.state.tasks:
-            await asyncio.sleep(0.01)
+        await async_poll_for(lambda: f3.key not in b.state.tasks, timeout=5)
 
     f1 = c.submit(inc, 1, key="f1", workers=[a.address])
     f2 = c.submit(inc, f1, key="f2", workers=[a.address])

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -589,8 +589,7 @@ async def test_resumed_cancelled_handle_compute(
                 ),
                 (f3.key, "released", "forgotten", "forgotten", {f2.key: "forgotten"}),
                 (f3.key, "ready", "executing", "executing", {}),
-                (f3.key, "executing", "memory", "memory", {})
-                # FIXME: (distributed#7489)
+                (f3.key, "executing", "memory", "memory", {}),
             ],
         )
     else:

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -821,7 +821,7 @@ def test_workerstate_executing_failure_to_fetch(ws_with_running_task):
     - executing -> long-running -> cancelled -> resumed(fetch)
 
     The task execution later terminates with a failure.
-    This is an edge case interaction between work stealing and a task that does not
+    This is an edge case interaction involving task cancellation and a task that does not
     deterministically succeed or fail when run multiple times or on different workers.
 
     Test that the task is fetched from the other worker. This is to avoid having to deal

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -488,6 +488,9 @@ async def test_resumed_cancelled_handle_compute(
         await lock_compute.release()
         await exit_compute.wait()
 
+        while f3.key in b.state.tasks:
+            await asyncio.sleep(0.01)
+
     f1 = c.submit(inc, 1, key="f1", workers=[a.address])
     f2 = c.submit(inc, f1, key="f2", workers=[a.address])
     f3 = c.submit(inc, f2, key="f3", workers=[b.address])
@@ -530,6 +533,13 @@ async def test_resumed_cancelled_handle_compute(
                 (f3.key, "executing", "released", "cancelled", {}),
                 (f3.key, "cancelled", "fetch", "resumed", {}),
                 (f3.key, "resumed", "released", "cancelled", {}),
+                (
+                    f3.key,
+                    "cancelled",
+                    "error",
+                    "released",
+                    {f2.key: "released", f3.key: "forgotten"},
+                ),
                 (f3.key, "released", "forgotten", "forgotten", {f2.key: "forgotten"}),
                 (f3.key, "ready", "executing", "executing", {}),
                 (f3.key, "executing", "memory", "memory", {}),

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -569,8 +569,7 @@ async def test_resumed_cancelled_handle_compute(
         )
 
     elif wait_for_processing and raise_error:
-        with pytest.raises(RuntimeError, match="test error"):
-            await f3
+        assert await f4 == 4 + 2
 
         assert_story(
             b.state.story(f3.key),
@@ -581,6 +580,16 @@ async def test_resumed_cancelled_handle_compute(
                 (f3.key, "resumed", "released", "cancelled", {}),
                 (f3.key, "cancelled", "waiting", "executing", {}),
                 (f3.key, "executing", "error", "error", {}),
+                (
+                    f3.key,
+                    "error",
+                    "released",
+                    "released",
+                    {f2.key: "released", f3.key: "forgotten"},
+                ),
+                (f3.key, "released", "forgotten", "forgotten", {f2.key: "forgotten"}),
+                (f3.key, "ready", "executing", "executing", {}),
+                (f3.key, "executing", "memory", "memory", {})
                 # FIXME: (distributed#7489)
             ],
         )

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -530,13 +530,6 @@ async def test_resumed_cancelled_handle_compute(
                 (f3.key, "executing", "released", "cancelled", {}),
                 (f3.key, "cancelled", "fetch", "resumed", {}),
                 (f3.key, "resumed", "released", "cancelled", {}),
-                (
-                    f3.key,
-                    "cancelled",
-                    "error",
-                    "released",
-                    {f2.key: "released", f3.key: "forgotten"},
-                ),
                 (f3.key, "released", "forgotten", "forgotten", {f2.key: "forgotten"}),
                 (f3.key, "ready", "executing", "executing", {}),
                 (f3.key, "executing", "memory", "memory", {}),

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -531,6 +531,7 @@ def test_executefailure_to_dict():
     ev = ExecuteFailureEvent(
         stimulus_id="test",
         key="x",
+        run_id=1,
         start=123.4,
         stop=456.7,
         exception=Serialize(ValueError("foo")),
@@ -546,6 +547,7 @@ def test_executefailure_to_dict():
         "stimulus_id": "test",
         "handled": 11.22,
         "key": "x",
+        "run_id": 1,
         "start": 123.4,
         "stop": 456.7,
         "exception": "<Serialize: foo>",
@@ -571,6 +573,7 @@ def test_executefailure_dummy():
     ev = ExecuteFailureEvent.dummy("x", stimulus_id="s")
     assert ev == ExecuteFailureEvent(
         key="x",
+        run_id=1,
         start=None,
         stop=None,
         exception=Serialize(None),

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2232,6 +2232,7 @@ class Worker(BaseWorker, ServerNode):
             return ExecuteFailureEvent.from_exception(
                 exc,
                 key=key,
+                run_id=run_id,
                 stimulus_id=f"run-spec-deserialize-failed-{time()}",
             )
 
@@ -2356,6 +2357,7 @@ class Worker(BaseWorker, ServerNode):
             return ExecuteFailureEvent.from_exception(
                 result,
                 key=key,
+                run_id=run_id,
                 start=result["start"],
                 stop=result["stop"],
                 stimulus_id=f"task-erred-{time()}",
@@ -2366,6 +2368,7 @@ class Worker(BaseWorker, ServerNode):
             return ExecuteFailureEvent.from_exception(
                 exc,
                 key=key,
+                run_id=run_id,
                 stimulus_id=f"execute-unknown-error-{time()}",
             )
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -2028,11 +2028,11 @@ class WorkerState:
     def _transition_generic_error(
         self,
         ts: TaskState,
-        run_id: int,
         exception: Serialize,
         traceback: Serialize | None,
         exception_text: str,
         traceback_text: str,
+        run_id: int,
         *,
         stimulus_id: str,
     ) -> RecsInstrs:
@@ -2448,7 +2448,7 @@ class WorkerState:
                 # Third-party MutableMappings (dask-cuda etc.) may have other use cases
                 # for this.
                 msg = error_message(e)
-                return {ts: tuple(msg.values())}, []
+                return {ts: tuple(msg.values()) + (run_id,)}, []
 
             stop = time()
             if stop - start > 0.005:

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -2053,11 +2053,11 @@ class WorkerState:
     def _transition_resumed_error(
         self,
         ts: TaskState,
-        run_id: int,
         exception: Serialize,
         traceback: Serialize | None,
         exception_text: str,
         traceback_text: str,
+        run_id: int,
         *,
         stimulus_id: str,
     ) -> RecsInstrs:
@@ -3050,11 +3050,11 @@ class WorkerState:
         recommendations: Recs = {
             ts: (
                 "error",
-                ts.run_id,
                 ev.exception,
                 ev.traceback,
                 ev.exception_text,
                 ev.traceback_text,
+                ts.run_id,
             )
             for ts in self._gather_dep_done_common(ev)
         }
@@ -3188,11 +3188,11 @@ class WorkerState:
             )
         recs[ts] = (
             "error",
-            ev.run_id,
             ev.exception,
             ev.traceback,
             ev.exception_text,
             ev.traceback_text,
+            ev.run_id,
         )
         return recs, instr
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -482,6 +482,7 @@ class TaskErredMsg(SendMessageToScheduler):
     op = "task-erred"
 
     key: str
+    run_id: int
     exception: Serialize
     traceback: Serialize | None
     exception_text: str
@@ -502,6 +503,7 @@ class TaskErredMsg(SendMessageToScheduler):
         assert ts.exception
         return TaskErredMsg(
             key=ts.key,
+            run_id=ts.run_id,
             exception=ts.exception,
             traceback=ts.traceback,
             exception_text=ts.exception_text,


### PR DESCRIPTION
Closes #7489

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
