### PR TITLE
RFC: Add Client.decorator method

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2168,6 +2168,36 @@ class Client(SyncMethodMixin):
 
         return [futures[stringify(k)] for k in keys]
 
+    def decorate(self, **kwargs):
+        """
+        Decorate a function to submit tasks to Dask
+
+        This converts a normal function to instead return Dask Futures.  That
+        function can then be used in parallel.
+
+        This takes the same keywords as ``client.submit``
+
+        Example
+        -------
+
+        >>> @client.decorate()
+        ... def f(x):
+        ...     return x + 1
+
+        >>> futures = [f(x) for x in range(10)]
+        >>> results = [future.result() for future in futures]
+
+        See Also
+        --------
+        Client.submit
+        dask.delayed
+        """
+
+        def _(function):
+            return partial(self.submit, function, **kwargs)
+
+        return _
+
     async def _gather(self, futures, errors="raise", direct=None, local_worker=None):
         unpacked, future_set = unpack_remotedata(futures, byte_keys=True)
         mismatched_futures = [f for f in future_set if f.client is not self]

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -8304,3 +8304,17 @@ async def test_resolves_future_in_dict(c, s, a, b):
     outer_future = c.submit(identity, {"x": inner_future, "y": 2})
     result = await outer_future
     assert result == {"x": 1, "y": 2}
+
+
+@gen_cluster(client=True)
+async def test_decorate(c, s, a, b):
+    @c.decorate(retries=123)
+    def f(x):
+        return x + 1
+
+    future = f(10)
+    assert isinstance(future, Future)
+    result = await future
+    assert result == 11
+
+    assert s.tasks[future.key].retries == 123


### PR DESCRIPTION
I'm not sure if this is a good idea, and if it is
then it could use a better name.  Mostly I was playing with Modal and enjoying it but wanted full Dask semantics around futures. Docstring follows.

Decorate a function to submit tasks to Dask

This converts a normal function to instead return Dask Futures.  That function can then be used in parallel.

This takes the same keywords as ``client.submit``

Example
-------

```python
>>> @client.decorate()
... def f(x):
...     return x + 1

>>> futures = [f(x) for x in range(10)]
>>> results = [future.result() for future in futures]
```

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
