### PR TITLE
remove grace period for unclosed comms in gen_cluster

### DIFF
--- a/distributed/comm/asyncio_tcp.py
+++ b/distributed/comm/asyncio_tcp.py
@@ -17,7 +17,7 @@ from typing import Any
 import dask
 
 from distributed.comm.addressing import parse_host_port, unparse_host_port
-from distributed.comm.core import Comm, CommClosedError, Connector, Listener
+from distributed.comm.core import BaseListener, Comm, CommClosedError, Connector
 from distributed.comm.registry import Backend
 from distributed.comm.utils import (
     ensure_concrete_host,
@@ -594,7 +594,7 @@ class TLSConnector(TCPConnector):
         return {"ssl": ctx}
 
 
-class TCPListener(Listener):
+class TCPListener(BaseListener):
     prefix = "tcp://"
     comm_class = TCP
 
@@ -608,6 +608,7 @@ class TCPListener(Listener):
         default_port=0,
         **kwargs,
     ):
+        super().__init__()
         self.ip, self.port = parse_host_port(address, default_port)
         self.default_host = default_host
         self.comm_handler = comm_handler
@@ -733,6 +734,7 @@ class TCPListener(Listener):
         # Stop listening
         for server in self._servers:
             server.close()
+        super().stop()
 
     def get_host_port(self):
         """

--- a/distributed/comm/asyncio_tcp.py
+++ b/distributed/comm/asyncio_tcp.py
@@ -734,7 +734,6 @@ class TCPListener(BaseListener):
         # Stop listening
         for server in self._servers:
             server.close()
-        super().stop()
 
     def get_host_port(self):
         """

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -221,7 +221,7 @@ class Listener(ABC):
         """
 
     @abstractmethod
-    def stop(self) -> None:
+    def stop(self):
         """
         Stop listening.  This does not shutdown already established
         communications, but prevents accepting new ones.
@@ -302,11 +302,10 @@ class BaseListener(Listener):
         finally:
             self.__comms.discard(comm)
 
-    def stop(self) -> None:
+    def abort_handshaking_comms(self) -> None:
         comms, self.__comms = self.__comms, set()
         for comm in comms:
             comm.abort()
-        super().stop()
 
 
 class Connector(ABC):

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -11,7 +11,7 @@ from collections import deque, namedtuple
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 
-from distributed.comm.core import Comm, CommClosedError, Connector, Listener
+from distributed.comm.core import BaseListener, Comm, CommClosedError, Connector
 from distributed.comm.registry import Backend, backends
 from distributed.protocol import nested_deserialize
 from distributed.utils import get_ip
@@ -257,10 +257,11 @@ class InProc(Comm):
             return False
 
 
-class InProcListener(Listener):
+class InProcListener(BaseListener):
     prefix = "inproc"
 
     def __init__(self, address, comm_handler, deserialize=True):
+        super().__init__()
         self.manager = global_manager
         self.address = address or self.manager.new_address()
         self.comm_handler = comm_handler
@@ -303,6 +304,7 @@ class InProcListener(Listener):
     def stop(self):
         self.listen_q.put_nowait(None)
         self.manager.remove_listener(self.address)
+        super().stop()
 
     @property
     def listen_address(self):

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -304,7 +304,6 @@ class InProcListener(BaseListener):
     def stop(self):
         self.listen_q.put_nowait(None)
         self.manager.remove_listener(self.address)
-        super().stop()
 
     @property
     def listen_address(self):

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -24,11 +24,11 @@ from dask.utils import parse_timedelta
 
 from distributed.comm.addressing import parse_host_port, unparse_host_port
 from distributed.comm.core import (
+    BaseListener,
     Comm,
     CommClosedError,
     Connector,
     FatalCommClosedError,
-    Listener,
 )
 from distributed.comm.registry import Backend
 from distributed.comm.utils import (
@@ -539,7 +539,7 @@ class TLSConnector(BaseTCPConnector):
         return tls_args
 
 
-class BaseTCPListener(Listener, RequireEncryptionMixin):
+class BaseTCPListener(BaseListener, RequireEncryptionMixin):
     def __init__(
         self,
         address,
@@ -550,6 +550,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         default_port=0,
         **connection_args,
     ):
+        super().__init__()
         self._check_encryption(address, connection_args)
         self.ip, self.port = parse_host_port(address, default_port)
         self.default_host = default_host
@@ -590,6 +591,7 @@ class BaseTCPListener(Listener, RequireEncryptionMixin):
         tcp_server, self.tcp_server = self.tcp_server, None
         if tcp_server is not None:
             tcp_server.stop()
+        super().stop()
 
     def _check_started(self):
         if self.tcp_server is None:

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -591,7 +591,6 @@ class BaseTCPListener(BaseListener, RequireEncryptionMixin):
         tcp_server, self.tcp_server = self.tcp_server, None
         if tcp_server is not None:
             tcp_server.stop()
-        super().stop()
 
     def _check_started(self):
         if self.tcp_server is None:

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -20,7 +20,7 @@ import dask
 from dask.utils import parse_bytes
 
 from distributed.comm.addressing import parse_host_port, unparse_host_port
-from distributed.comm.core import Comm, CommClosedError, Connector, Listener
+from distributed.comm.core import BaseListener, Comm, CommClosedError, Connector
 from distributed.comm.registry import Backend, backends
 from distributed.comm.utils import (
     ensure_concrete_host,
@@ -479,7 +479,7 @@ class UCXConnector(Connector):
         )
 
 
-class UCXListener(Listener):
+class UCXListener(BaseListener):
     prefix = UCXConnector.prefix
     comm_class = UCXConnector.comm_class
     encrypted = UCXConnector.encrypted
@@ -492,6 +492,7 @@ class UCXListener(Listener):
         allow_offload: bool = True,
         **connection_args: Any,
     ):
+        super().__init__()
         if not address.startswith("ucx"):
             address = "ucx://" + address
         self.ip, self._input_port = parse_host_port(address, default_port=0)
@@ -532,6 +533,7 @@ class UCXListener(Listener):
 
     def stop(self):
         self.ucp_server = None
+        super().stop()
 
     def get_host_port(self):
         # TODO: TCP raises if this hasn't started yet.

--- a/distributed/comm/ucx.py
+++ b/distributed/comm/ucx.py
@@ -533,7 +533,6 @@ class UCXListener(BaseListener):
 
     def stop(self):
         self.ucp_server = None
-        super().stop()
 
     def get_host_port(self):
         # TODO: TCP raises if this hasn't started yet.

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -403,7 +403,6 @@ class WSListener(BaseListener):
 
     def stop(self):
         self.server.stop()
-        super().stop()
 
     def get_host_port(self):
         """

--- a/distributed/comm/ws.py
+++ b/distributed/comm/ws.py
@@ -25,11 +25,11 @@ import dask
 
 from distributed.comm.addressing import parse_host_port, unparse_host_port
 from distributed.comm.core import (
+    BaseListener,
     Comm,
     CommClosedError,
     Connector,
     FatalCommClosedError,
-    Listener,
 )
 from distributed.comm.registry import backends
 from distributed.comm.tcp import (
@@ -332,7 +332,7 @@ class WSS(WS):
             )
 
 
-class WSListener(Listener):
+class WSListener(BaseListener):
     prefix = "ws://"
 
     def __init__(
@@ -343,6 +343,7 @@ class WSListener(Listener):
         allow_offload: bool = False,
         **connection_args: Any,
     ):
+        super().__init__()
         if not address.startswith(self.prefix):
             address = f"{self.prefix}{address}"
 
@@ -402,6 +403,7 @@ class WSListener(Listener):
 
     def stop(self):
         self.server.stop()
+        super().stop()
 
     def get_host_port(self):
         """

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -673,6 +673,12 @@ class Server:
             future = listener.stop()
             if inspect.isawaitable(future):
                 _stops.add(future)
+            try:
+                abort_handshaking_comms = listener.abort_handshaking_comms
+            except AttributeError:
+                pass
+            else:
+                abort_handshaking_comms()
 
         if _stops:
 
@@ -1037,6 +1043,12 @@ class Server:
                             PendingDeprecationWarning,
                         )
                         _stops.add(future)
+                    try:
+                        abort_handshaking_comms = listener.abort_handshaking_comms
+                    except AttributeError:
+                        pass
+                    else:
+                        abort_handshaking_comms()
                 if _stops:
                     await asyncio.gather(*_stops)
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1567,6 +1567,8 @@ class ConnectionPool:
         """
         Get a Comm to the given address.  For internal use.
         """
+        if self.status != Status.running:
+            raise RuntimeError("ConnectionPool is closed")
         available = self.available[addr]
         occupied = self.occupied[addr]
         while available:

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -768,6 +768,9 @@ async def test_connection_pool():
         assert time() < start + 2
 
     await rpc.close()
+    with pytest.raises(RuntimeError, match=r"ConnectionPool is closed"):
+        await rpc(ip="127.0.0.1", port=s.port).ping()
+
     await asyncio.gather(*[server.close() for server in servers])
 
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1224,6 +1224,7 @@ class Worker(BaseWorker, ServerNode):
             except TimeoutError:  # pragma: no cover
                 logger.info("Timed out when connecting to scheduler")
         if response["status"] != "OK":
+            await comm.close()
             msg = response["message"] if "message" in response else repr(response)
             logger.error(f"Unable to connect to scheduler: {msg}")
             raise ValueError(f"Unexpected response from register: {response!r}")


### PR DESCRIPTION
extracted from https://github.com/dask/distributed/pull/7698
there's a check at the end of every @gen_cluster test that fails if any Comm object isn't closed, however there's currently a grace period, when really all the Comm objects used by a test should already be closed by the end of the test. There's a few cases currently where that's not the case and this PR fixes those also:

* it appears that comms opened that have not completed the handshake are only being closed by the handshake timeout, they should be explicitly closed in all cases
* also ensure new connections cannot be opened on a closed ConnectionPool because any open Semaphore was opening new connections on the client ConnectionPool after the client had closed

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
