### PR TITLE
Add idle time to fine performance metrics

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3626,7 +3626,7 @@ class FinePerformanceMetrics(DashboardComponent):
             if function_sel and function not in function_sel:
                 continue
 
-            # Custom metrics can provide any hashable as the label
+            # Custom metrics won't necessarily contain a string as the label
             activity = str(activity)
             execute_by_func[function, activity] += v
             execute[activity] += v

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -90,7 +90,7 @@ from distributed.diagnostics.task_stream import color_of as ts_color_of
 from distributed.diagnostics.task_stream import colors as ts_color_lookup
 from distributed.metrics import time
 from distributed.scheduler import Scheduler
-from distributed.spans import Span, SpansSchedulerExtension
+from distributed.spans import SpansSchedulerExtension
 from distributed.utils import Log, log_errors
 
 if dask.config.get("distributed.dashboard.export-tool"):
@@ -3532,6 +3532,9 @@ class FinePerformanceMetrics(DashboardComponent):
         if units:
             self.unit_selector.options.extend(units)
 
+        if functions:
+            # Added on the fly by Span.cumulative_worker_metrics
+            functions.add("N/A")
         functions.difference_update(self.function_selector.options)
         if functions:
             self.function_selector.options.extend(functions)
@@ -3595,38 +3598,51 @@ class FinePerformanceMetrics(DashboardComponent):
 
         function_sel = set(self.function_selector.value)
 
-        span: Span | Scheduler
-        if self.span_tag_selector.value:
-            spans_ext: SpansSchedulerExtension = self.scheduler.extensions["spans"]
+        spans_ext: SpansSchedulerExtension | None = self.scheduler.extensions.get(
+            "spans"
+        )
+        if spans_ext and self.span_tag_selector.value:
             span = spans_ext.merge_by_tags(*self.span_tag_selector.value)
+            execute_metrics = span.cumulative_worker_metrics
+        elif spans_ext and spans_ext.spans:
+            # Calculate idle time
+            span = spans_ext.merge_all()
+            execute_metrics = span.cumulative_worker_metrics
         else:
-            span = self.scheduler
+            # Spans extension is not loaded
+            execute_metrics = {
+                k: v
+                for k, v in self.scheduler.cumulative_worker_metrics.items()
+                if isinstance(k, tuple) and k[0] == "execute"
+            }
 
-        for k, v in span.cumulative_worker_metrics.items():
-            if not isinstance(k, tuple):
-                continue  # Only happens in global metrics
-            context, *other, activity, unit = k
+        for (context, function, activity, unit), v in execute_metrics.items():
+            assert context == "execute"
+            assert isinstance(function, str)
             assert isinstance(unit, str)
             assert self.unit_selector.value
             if unit != self.unit_selector.value:
                 continue
+            if function_sel and function not in function_sel:
+                continue
 
-            if context == "execute":
-                (function,) = other
-                assert isinstance(function, str)
-                if not function_sel or function in function_sel:
-                    # Custom metrics can provide any hashable as the label
-                    activity = str(activity)
-                    execute_by_func[function, activity] += v
-                    execute[activity] += v
-                    visible_functions.add(function)
-                    visible_activities.add(activity)
+            # Custom metrics can provide any hashable as the label
+            activity = str(activity)
+            execute_by_func[function, activity] += v
+            execute[activity] += v
+            visible_functions.add(function)
+            visible_activities.add(activity)
 
-            elif context == "get-data" and not function_sel:
-                # Note: this will always be empty when a span is selected
-                assert isinstance(activity, str)
-                visible_activities.add(activity)
-                get_data[activity] += v
+        if not self.function_selector.value and not self.span_tag_selector.value:
+            for k, v in self.scheduler.cumulative_worker_metrics.items():
+                if isinstance(k, tuple) and k[0] == "get-data":
+                    _, activity, unit = k
+                    assert isinstance(activity, str)
+                    assert isinstance(unit, str)
+                    assert self.unit_selector.value
+                    if unit == self.unit_selector.value:
+                        visible_activities.add(activity)
+                        get_data[activity] += v
 
             # Ignore memory-monitor and gather-dep metrics
 

--- a/distributed/itertools.py
+++ b/distributed/itertools.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import TypeVar
+
+X = TypeVar("X")
+Y = TypeVar("Y")
+
+
+def ffill(x: Iterable[X], xp: Iterable[X], fp: Iterable[Y], left: Y) -> Iterator[Y]:
+    """Forward-fill interpolation
+
+    Parameters
+    ----------
+    x:
+        Output x series. Must be monotonic ascending.
+    xp:
+        Input x series. Must be strictly monotonic ascending.
+    fp:
+        Input y series. If it contains more or less elements than xp, the two series
+        will be clipped to the shortest one (like in :func:`zip`).
+    left:
+        Value to yield for x < xp[0]
+
+    Yields
+    ------
+    Forward-fill interpolated elements from fp matching x
+
+    Examples
+    --------
+    >>> list(ffill([0.5, 2.2, 2.3, 4.5], [1, 2, 3], "abc", "-"))
+    ["-", "b", "b", "c"]
+    """
+    it = zip(xp, fp)
+    xp_done = False
+    xp1, fp1 = None, left
+    for xi in x:
+        while not xp_done and (xp1 is None or xi >= xp1):  # type: ignore[unreachable]
+            fp0 = fp1
+            try:
+                xp1, fp1 = next(it)
+            except StopIteration:
+                xp_done = True
+        yield fp0

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1571,7 +1571,7 @@ class SchedulerState:
     #: Current number of threads across all workers
     total_nthreads: int
     #: History of number of threads
-    #: (timestamp, new number fo threads)
+    #: (timestamp, new number of threads)
     total_nthreads_history: list[tuple[float, int]]
     #: Cluster-wide resources. {resource name: {worker address: amount}}
     resources: dict[str, dict[str, float]]

--- a/distributed/spans.py
+++ b/distributed/spans.py
@@ -5,11 +5,13 @@ import weakref
 from collections import defaultdict
 from collections.abc import Hashable, Iterable, Iterator
 from contextlib import contextmanager
+from itertools import islice
 from typing import TYPE_CHECKING, Any
 
 import dask.config
 
 from distributed.collections import sum_mappings
+from distributed.itertools import ffill
 from distributed.metrics import time
 
 if TYPE_CHECKING:
@@ -132,12 +134,23 @@ class Span:
 
     _cumulative_worker_metrics: defaultdict[tuple[Hashable, ...], float]
 
+    #: reference to SchedulerState.total_nthreads_history
+    _total_nthreads_history: list[tuple[float, int]]
+    #: Length of total_nthreads_history when this span was enqueued
+    _total_nthreads_offset: int
+
     # Support for weakrefs to a class with __slots__
     __weakref__: Any
 
     __slots__ = tuple(__annotations__)
 
-    def __init__(self, name: tuple[str, ...], id_: str, parent: Span | None):
+    def __init__(
+        self,
+        name: tuple[str, ...],
+        id_: str,
+        parent: Span | None,
+        total_nthreads_history: list[tuple[float, int]],
+    ):
         self.name = name
         self.id = id_
         self._parent = weakref.ref(parent) if parent is not None else None
@@ -146,6 +159,9 @@ class Span:
         self.groups = set()
         self._code = {}
         self._cumulative_worker_metrics = defaultdict(float)
+        assert len(total_nthreads_history) > 0
+        self._total_nthreads_history = total_nthreads_history
+        self._total_nthreads_offset = len(total_nthreads_history) - 1
 
     def __repr__(self) -> str:
         return f"Span<name={self.name}, id={self.id}>"
@@ -187,23 +203,37 @@ class Span:
         stop
         distributed.scheduler.TaskGroup.start
         """
-        return min(
+        out = min(
             (tg.start for tg in self.traverse_groups() if tg.start != 0.0),
             default=0.0,
         )
+        if out:
+            # absorb small errors in worker delay calculation
+            out = max(out, self.enqueued)
+        return out
 
     @property
     def stop(self) -> float:
-        """Latest time when a task belonging to this span tree finished computing;
-        0 if no task has finished computing yet.
+        """When this span tree finished computing, or current timestamp if it didn't
+        finish yet.
+
+        Notes
+        -----
+        This differs from ``TaskGroup.stop`` when there aren't unfinished tasks; is also
+        will never be zero.
 
         See also
         --------
         enqueued
         start
+        done
         distributed.scheduler.TaskGroup.stop
         """
-        return max(tg.stop for tg in self.traverse_groups())
+        if not self.done:
+            return time()
+        out = max(tg.stop for tg in self.traverse_groups())
+        # absorb small errors in worker delay calculation
+        return max(self.enqueued, out)
 
     @property
     def states(self) -> dict[TaskStateState, int]:
@@ -286,23 +316,132 @@ class Span:
         but more may be added in the future with a different format; please test for
         ``k[0] == "execute"``.
         """
-        return sum_mappings(
+        out = sum_mappings(
             child._cumulative_worker_metrics for child in self.traverse_spans()
         )
+        known_seconds = sum(
+            v for k, v in out.items() if k[0] == "execute" and k[-1] == "seconds"
+        )
+        # Besides rounding errors, you may get negative unknown seconds if a user
+        # manually invokes `context_meter.digest_metric`.
+        unknown_seconds = max(0.0, self.active_cpu_seconds - known_seconds)
+
+        out["execute", "N/A", "idle or other spans", "seconds"] = unknown_seconds
+        return out
 
     @staticmethod
     def merge(*items: Span) -> Span:
         """Merge multiple spans into a synthetic one.
         The input spans must not be related with each other.
         """
-        out = Span(name=("(merged)",), id_="(merged)", parent=None)
+        if not items:
+            raise ValueError("Nothing to merge")
+        out = Span(
+            name=("(merged)",),
+            id_="(merged)",
+            parent=None,
+            total_nthreads_history=items[0]._total_nthreads_history,
+        )
+        out._total_nthreads_offset = min(
+            child._total_nthreads_offset for child in items
+        )
         out.children.extend(items)
         out.enqueued = min(child.enqueued for child in items)
         return out
 
+    def _nthreads_timeseries(self) -> Iterator[tuple[float, int]]:
+        """Yield (timestamp, number of threads across the cluster), forward-fill"""
+        stop = self.stop if self.done else 0
+        for t, n in islice(
+            self._total_nthreads_history, self._total_nthreads_offset, None
+        ):
+            if stop and t >= stop:
+                break
+            yield max(self.enqueued, t), n
+
+    def _active_timeseries(self) -> Iterator[tuple[float, bool]]:
+        """If this span is the output of :meth:`merge`, yield
+        (timestamp, True if at least one input span is active), forward-fill.
+        """
+        now = time()
+        if self.id != "(merged)":
+            yield self.enqueued, True
+            yield self.stop if self.done else now, False
+            return
+
+        events = []
+        for child in self.children:
+            events.append((child.enqueued, 1))
+            events.append((child.stop if child.done else now, -1))
+        events.sort()
+
+        n_active = 0
+        for t, delta in events:
+            if not n_active:
+                assert delta > 0
+                yield t, True
+            n_active += delta
+            if n_active == 0:
+                yield t, False
+
+    @property
+    def nthreads_intervals(self) -> list[tuple[float, float, int]]:
+        """
+        Returns
+        ------
+        List of tuples:
+
+        - begin timestamp
+        - end timestamp
+        - Scheduler.total_nthreads during this interval
+
+        When the Span is the output of :meth:`merge`, the intervals may not be
+        contiguous.
+
+        See Also
+        --------
+        enqueued
+        stop
+        active_cpu_seconds
+        distributed.scheduler.SchedulerState.total_nthreads
+        """
+        nthreads_t, nthreads_count = zip(*self._nthreads_timeseries())
+        is_active_t, is_active_flag = zip(*self._active_timeseries())
+        t_interp = sorted({*nthreads_t, *is_active_t})
+        nthreads_count_interp = ffill(t_interp, nthreads_t, nthreads_count, left=0)
+        is_active_flag_interp = ffill(t_interp, is_active_t, is_active_flag, left=False)
+        return [
+            (t0, t1, n)
+            for t0, t1, n, active in zip(
+                t_interp, t_interp[1:], nthreads_count_interp, is_active_flag_interp
+            )
+            if active
+        ]
+
+    @property
+    def active_cpu_seconds(self) -> float:
+        """Return number of CPU seconds that were made available on the cluster while
+        this Span was running; in other words
+        ``(Span.stop - Span.enqueued) * Scheduler.total_nthreads``.
+
+        This accounts for workers joining and leaving the cluster while this Span was
+        active. If this Span is the output of :meth:`merge`, do not count gaps between
+        input spans.
+
+        See Also
+        --------
+        enqueued
+        stop
+        nthreads_intervals
+        distributed.scheduler.SchedulerState.total_nthreads
+        """
+        return sum((t1 - t0) * nthreads for t0, t1, nthreads in self.nthreads_intervals)
+
 
 class SpansSchedulerExtension:
     """Scheduler extension for spans support"""
+
+    scheduler: Scheduler
 
     #: All Span objects by id
     spans: dict[str, Span]
@@ -326,6 +465,7 @@ class SpansSchedulerExtension:
     spans_search_by_tag: defaultdict[str, list[Span]]
 
     def __init__(self, scheduler: Scheduler):
+        self.scheduler = scheduler
         self.spans = {}
         self.root_spans = []
         self.spans_search_by_name = defaultdict(list)
@@ -397,7 +537,12 @@ class SpansSchedulerExtension:
         for i in range(1, len(name)):
             parent = self._ensure_span(name[:i], ids[:i])
 
-        span = Span(name=name, id_=ids[-1], parent=parent)
+        span = Span(
+            name=name,
+            id_=ids[-1],
+            parent=parent,
+            total_nthreads_history=self.scheduler.total_nthreads_history,
+        )
         self.spans[span.id] = span
         self.spans_search_by_name[name].append(span)
         for tag in name:
@@ -425,6 +570,10 @@ class SpansSchedulerExtension:
             for sp in level:
                 if sp.parent not in seen:
                     yield sp
+
+    def merge_all(self) -> Span:
+        """Return a synthetic Span which is the sum of all spans"""
+        return Span.merge(*self.root_spans)
 
     def merge_by_tags(self, *tags: str) -> Span:
         """Return a synthetic Span which is the sum of all spans containing the given

--- a/distributed/tests/test_itertools.py
+++ b/distributed/tests/test_itertools.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from distributed.itertools import ffill
+
+
+def test_ffill():
+    actual = "".join(ffill([1, 1.5, 2, 2, 2.5, 3], [1, 2, 3], "abc", "-"))
+    assert actual == "aabbbc"
+
+    # Test left and right edges
+    actual = "".join(ffill([-1, 0, 1, 2.9, 3, 4, 5], [1, 2, 3], "abc", "-"))
+    assert actual == "--abccc"
+
+    # Test edge cases
+    actual = "".join(ffill([1, 2, 3], [], "", "-"))
+    assert actual == "---"
+
+    actual = "".join(ffill([], [], "", "-"))
+    assert actual == ""
+
+    actual = "".join(ffill([], [1, 2, 3], "abc", "-"))
+    assert actual == ""
+
+    # xp is shorter than fp or vice versa
+    actual = "".join(ffill([1, 2], [1], "ab", "-"))
+    assert actual == "aa"
+    actual = "".join(ffill([1, 2], [1, 2], "a", "-"))
+    assert actual == "aa"
+
+    # x can be any non-numerical sortable
+    # y can be anything
+    # Inputs don't need to be sequences
+    yp = [object(), object()]
+    left = object()
+    actual = list(ffill(iter("abcde"), iter("bd"), iter(yp), left))
+    assert actual == [left, yp[0], yp[0], yp[1], yp[1]]

--- a/distributed/tests/test_spans.py
+++ b/distributed/tests/test_spans.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from dask import delayed
 
-from distributed import Client, Event, Future, wait
+from distributed import Client, Event, Future, Worker, wait
 from distributed.compatibility import WINDOWS
 from distributed.metrics import time
 from distributed.spans import span
@@ -281,7 +283,7 @@ async def test_before_first_task_finished(c, s, a):
     t1 = time()
     assert t0 < sp.enqueued < t1
     assert sp.start == 0
-    assert sp.stop == 0
+    assert t1 < sp.stop < t1 + 1
     assert sp.duration == 0
     assert sp.all_durations == {}
     assert sp.nbytes_total == 0
@@ -491,6 +493,7 @@ async def test_worker_metrics(c, s, a, b):
         ("execute", "y", "thread-noncpu", "seconds"),
         ("execute", "y", "executor", "seconds"),
         ("execute", "y", "other", "seconds"),
+        ("execute", "N/A", "idle or other spans", "seconds"),
     ]
     assert (
         list(bar0_metrics)
@@ -501,6 +504,7 @@ async def test_worker_metrics(c, s, a, b):
             ("execute", "y", "thread-noncpu", "seconds"),
             ("execute", "y", "executor", "seconds"),
             ("execute", "y", "other", "seconds"),
+            ("execute", "N/A", "idle or other spans", "seconds"),
         ]
     )
 
@@ -510,15 +514,17 @@ async def test_worker_metrics(c, s, a, b):
 
     # Metrics have been synchronized from scheduler to spans
     for k, v in foo_metrics.items():
-        assert s.cumulative_worker_metrics[k] == pytest.approx(v)
+        if k[2] != "idle or other spans":
+            assert s.cumulative_worker_metrics[k] == pytest.approx(v), k
 
     # Metrics for foo contain the sum of metrics from itself and for bar
     for k in bar0_metrics:
-        assert foo_metrics[k] == pytest.approx(
-            bar0_metrics[k]
-            + bar1_metrics[k]
-            + ext.spans[foo_sid]._cumulative_worker_metrics[k]
-        )
+        if k[2] != "idle or other spans":
+            assert foo_metrics[k] == pytest.approx(
+                bar0_metrics[k]
+                + bar1_metrics[k]
+                + ext.spans[foo_sid]._cumulative_worker_metrics[k]
+            ), k
 
 
 @gen_cluster(client=True)
@@ -613,3 +619,171 @@ async def test_no_code_by_default(c, s, a, b):
     with span("foo") as foo:
         await c.submit(inc, 1, key="x")
     assert s.extensions["spans"].spans[foo].code == []
+
+
+@gen_cluster(client=True)
+async def test_merge_all(c, s, a, b):
+    with span("foo"):
+        await c.submit(inc, 1, key="x")
+        with span("bar"):
+            await c.submit(inc, 1, key="y")
+    await c.submit(inc, 1, key="z")
+    sp = s.extensions["spans"].merge_all()
+    assert [tg.name for tg in sp.traverse_groups()] == ["x", "y", "z"]
+
+
+@gen_cluster(nthreads=[])
+async def test_merge_nothing(s):
+    ext = s.extensions["spans"]
+    with pytest.raises(ValueError):
+        ext.merge_by_tags()
+    with pytest.raises(ValueError):
+        ext.merge_all()
+
+
+@gen_cluster(client=True)
+async def test_active_cpu_seconds_trivial(c, s, a, b):
+    await c.submit(slowinc, 1, delay=0.1, key="x")
+    await a.heartbeat()
+    await b.heartbeat()
+    span = s.extensions["spans"].spans_search_by_name["default",][0]
+
+    assert span.done
+    assert span.nthreads_intervals == [(span.enqueued, span.stop, 3)]
+    assert span.active_cpu_seconds == (span.stop - span.enqueued) * 3
+    k = "execute", "N/A", "idle or other spans", "seconds"
+    assert 0.15 < span.cumulative_worker_metrics[k] < span.active_cpu_seconds
+
+
+@pytest.mark.parametrize("some_done", [False, True])
+@gen_cluster(client=True, nthreads=[("", 2)], Worker=NoSchedulerDelayWorker)
+async def test_active_cpu_seconds_not_done(c, s, a, some_done):
+    ev = Event()
+    x0 = c.submit(ev.wait, key="x-0", workers=[a.address])
+    if some_done:
+        await c.submit(inc, 1, key="x-1")
+    await wait_for_state("x-0", "executing", a)
+    await a.heartbeat()
+
+    span = s.extensions["spans"].spans_search_by_name["default",][0]
+    assert not span.done
+    now = time()
+
+    intervals = span.nthreads_intervals
+    assert len(intervals) == 1
+    assert intervals[0][0] == span.enqueued
+    assert now < intervals[0][1] < now + 1
+    assert intervals[0][2] == 2
+
+    expect = (now - span.enqueued) * 2
+    assert expect < span.active_cpu_seconds < expect + 1
+    k = "execute", "N/A", "idle or other spans", "seconds"
+    assert 0 < span.cumulative_worker_metrics[k] < expect + 1
+
+    await ev.set()
+    await x0
+
+
+@gen_cluster(client=True, Worker=NoSchedulerDelayWorker)
+async def test_active_cpu_seconds_change_nthreads(c, s, a, b):
+    ev = Event()
+    x = c.submit(ev.wait, key="x", workers=[a.address])
+    await wait_for_state("x", "executing", a)
+
+    assert s.total_nthreads == 3
+    await asyncio.sleep(0.01)
+    async with Worker(s.address, nthreads=4):
+        assert s.total_nthreads == 7
+        await asyncio.sleep(0.01)
+    assert s.total_nthreads == 3
+    await asyncio.sleep(0.01)
+    await ev.set()
+    await x
+    async with Worker(s.address, nthreads=2):
+        assert s.total_nthreads == 5
+        await asyncio.sleep(0.01)
+    assert s.total_nthreads == 3
+    await asyncio.sleep(0.01)
+
+    await a.heartbeat()
+    await b.heartbeat()
+
+    span = s.extensions["spans"].spans_search_by_name["default",][0]
+    assert span.done
+
+    # There were two more changes in nthreads_total, from 3 to 5 and then back to 3, but
+    # they do not appear in nthreads_intervals because they happened past the lifetime
+    # of the span
+    assert len(span.nthreads_intervals) == 3
+    assert span.nthreads_intervals[0][2] == 3
+    assert span.nthreads_intervals[1][2] == 7
+    assert span.nthreads_intervals[2][2] == 3
+    t0, t1, t2, t3, t4, t5 = (
+        span.nthreads_intervals[0][0],
+        span.nthreads_intervals[0][1],
+        span.nthreads_intervals[1][0],
+        span.nthreads_intervals[1][1],
+        span.nthreads_intervals[2][0],
+        span.nthreads_intervals[2][1],
+    )
+    assert t0 == span.enqueued
+    assert t1 == t2
+    assert t3 == t4
+    assert t5 == span.stop
+    assert t0 < t1 < t3 < t5
+
+    assert span.active_cpu_seconds == pytest.approx(
+        (t1 - t0) * 3 + (t3 - t2) * 7 + (t5 - t4) * 3
+    )
+
+
+@gen_cluster(client=True, nthreads=[("", 2)], Worker=NoSchedulerDelayWorker)
+async def test_active_cpu_seconds_merged(c, s, a):
+    """Overlapping input spans are not double-counted
+    Empty gap between input spans is not counted
+    """
+    ev1 = Event()
+    ev2 = Event()
+
+    with span("root") as root_id:
+        with span("foo") as foo_id:
+            x = c.submit(ev1.wait, key="x")
+        await wait_for_state("x", "executing", a)
+        await asyncio.sleep(0.1)
+
+        with span("bar") as bar_id:
+            y = c.submit(ev2.wait, key="y")
+        await wait_for_state("y", "executing", a)
+
+        await asyncio.sleep(0.1)
+        await ev1.set()
+        await x
+        await asyncio.sleep(0.1)
+        await ev2.set()
+        await y
+
+        await asyncio.sleep(0.1)
+        with span("baz") as baz_id:
+            await c.submit(inc, 1, key="z")
+
+    await a.heartbeat()
+    ext = s.extensions["spans"]
+    root = ext.spans[root_id]
+    foo = ext.spans[foo_id]
+    bar = ext.spans[bar_id]
+    baz = ext.spans[baz_id]
+    merged = ext.merge_by_tags("foo", "bar", "baz")
+
+    assert foo.enqueued - 0.1 < root.enqueued < foo.enqueued
+    assert merged.enqueued == foo.enqueued
+    assert merged.stop == root.stop == baz.stop
+    assert bar.stop < baz.enqueued
+    assert root.nthreads_intervals == [(root.enqueued, baz.stop, 2)]
+    assert merged.nthreads_intervals == [
+        (foo.enqueued, bar.stop, 2),
+        (baz.enqueued, baz.stop, 2),
+    ]
+    assert root.active_cpu_seconds == pytest.approx((baz.stop - root.enqueued) * 2)
+    assert merged.active_cpu_seconds == pytest.approx(
+        (bar.stop - foo.enqueued + baz.stop - baz.enqueued) * 2
+    )


### PR DESCRIPTION
Add to fine performance metrics the delta between `(end-to-end-runtime * nthreads)` and the time spent by workers on tasks.

Such delta does not increase when there are no tasks running anywhere on the cluster.

If you are observing multiple spans at once, e.g. all calls to a certain library, do not double-count overlapping time and do not count time when none of the selected spans are executing.
If you are cherry-picking specific spans, this delta may be in part caused by work stolen by other tasks.

# Demo
After running the [ML preprocessing notebook](https://github.com/coiled/dask-xgboost-nyctaxi/blob/main/Feature%20Engineering.ipynb) already featured in https://github.com/dask/community/issues/301:

![Screenshot from 2023-06-21 15-02-06](https://github.com/dask/distributed/assets/6213168/2912480e-da99-4528-bbf9-073f69c05ab3)

(I added 3 lines to dask/dask to isolate the I/O time: https://github.com/crusaderky/dask/commit/0f369013afdd9160b3ba61dddf11ee97effcfe15)

Summarized insights I obtained from the dashboard:
| Activity | CPU time | notes |
| --- | --- | -- |
|I/O (avoidable)   						| 65m| Measure partitions |
|I/O (read/write dataset)		  				|55m| *This is good* |
|thread-cpu (this is good)				|49m| *This is good* |
|thread-noncpu |48m| probably GIL contention |
|idle workers							|66m|- Can't saturate cluster|
|||- scheduler is at 100% CPU|
|||- poorly pipelined network transfers
|||- other? |
|everything else							|37m| |
|**TOTAL**|**320m**| This is your AWS and Coiled bill |

The workflow currently features a whopping *67% waste* in runtime.

# Known issues
- The end-to-end runtime does not count time spent before the first task appears on the scheduler for any given burst of activity, e.g. time spent optimizing, serializing, transferring and deserializing the dask graph.
- The "idle or other spans" metric also includes unfinished tasks: #7677 

# Note
I noticed that keeping the Fine Performance Metrics dashboard open while the computation is running is *very* CPU intensive for the scheduler. However, this seems to be a problem specific to Bokeh rendering; calling `FinePerformanceMetrics.update()`, which is invoked every 500ms, costs a modest ~2.5ms.

CC @ntabris @milesgranger 