### PR TITLE
``raise pytest.skip`` is redundant

### DIFF
--- a/distributed/tests/test_asyncprocess.py
+++ b/distributed/tests/test_asyncprocess.py
@@ -171,7 +171,7 @@ def assert_exit_code(proc: AsyncProcess, expect: signal.Signals) -> None:
     elif MACOS:
         # FIXME this happens very frequently on GitHub MacOSX CI. Reason unknown.
         if expect != signal.SIGKILL and proc.exitcode == -signal.SIGKILL:
-            raise pytest.xfail(reason="https://github.com/dask/distributed/issues/6393")
+            pytest.xfail(reason="https://github.com/dask/distributed/issues/6393")
         assert proc.exitcode == -expect
     else:
         assert LINUX

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7264,7 +7264,7 @@ def test_computation_object_code_dask_compute_no_frames_default(client):
 def test_computation_object_code_not_available(client):
     np = pytest.importorskip("numpy")
     if parse_version(np.__version__) >= parse_version("1.25"):
-        raise pytest.skip("numpy >=1.25 can capture ufunc code")
+        pytest.skip("numpy >=1.25 can capture ufunc code")
 
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -333,7 +333,7 @@ async def test_server_listen():
         if has_ipv6():
             EXTERNAL_IP6 = get_ipv6()
     except socket.gaierror:
-        raise pytest.skip("no network access")
+        pytest.skip("no network access")
 
     from contextlib import asynccontextmanager
 


### PR DESCRIPTION
pytest.skip() itself internally raises. Same for pytest.xfail().
XREF https://github.com/dask/distributed/pull/7932#discussion_r1235633324