### PR TITLE
Add ``Cluster.called_from_running_loop`` and fix ``Cluster.asynchronous``

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -115,6 +115,15 @@ class Cluster(SyncMethodMixin):
         self.__loop = value
 
     @property
+    def called_from_running_loop(self):
+        try:
+            return (
+                getattr(self.loop, "asyncio_loop", None) is asyncio.get_running_loop()
+            )
+        except RuntimeError:
+            return self.asynchronous
+
+    @property
     def name(self):
         return self._cluster_info["name"]
 

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -71,6 +71,7 @@ class Cluster(SyncMethodMixin):
         scheduler_sync_interval=1,
     ):
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
+        self.__asynchronous = asynchronous
 
         self.scheduler_info = {"workers": {}}
         self.periodic_callbacks = {}
@@ -121,7 +122,7 @@ class Cluster(SyncMethodMixin):
                 getattr(self.loop, "asyncio_loop", None) is asyncio.get_running_loop()
             )
         except RuntimeError:
-            return self.asynchronous
+            return self.__asynchronous
 
     @property
     def name(self):

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -279,14 +279,7 @@ class SpecCluster(Cluster):
             scheduler_sync_interval=scheduler_sync_interval,
         )
 
-        try:
-            called_from_running_loop = (
-                getattr(loop, "asyncio_loop", None) is asyncio.get_running_loop()
-            )
-        except RuntimeError:
-            called_from_running_loop = asynchronous
-
-        if not called_from_running_loop:
+        if not self.called_from_running_loop:
             self._loop_runner.start()
             self.sync(self._start)
             try:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -335,8 +335,10 @@ class SyncMethodMixin:
     def asynchronous(self):
         """Are we running in the event loop?"""
         try:
-            return in_async_call(self.loop, default=getattr(self, "_asynchronous", False))
-        except RuntimeError as e:
+            return in_async_call(
+                self.loop, default=getattr(self, "_asynchronous", False)
+            )
+        except RuntimeError:
             return False
 
     def sync(self, func, *args, asynchronous=None, callback_timeout=None, **kwargs):

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -334,7 +334,10 @@ class SyncMethodMixin:
     @property
     def asynchronous(self):
         """Are we running in the event loop?"""
-        return in_async_call(self.loop, default=getattr(self, "_asynchronous", False))
+        try:
+            return in_async_call(self.loop, default=getattr(self, "_asynchronous", False))
+        except RuntimeError as e:
+            return False
 
     def sync(self, func, *args, asynchronous=None, callback_timeout=None, **kwargs):
         """Call `func` with `args` synchronously or asynchronously depending on


### PR DESCRIPTION
Closes #7940

This PR contains two changes:
- Update [`SyncMethodMixin.asynchronous`](https://github.com/dask/distributed/blob/429ef8cc682da36017a28e061d1c773066470fe3/distributed/utils.py#L335-L337) to return `False` if not asynchronous and no loop is running.
- Move `called_from_running_loop` check out of `SpecCluster.__init__` and into a property on `Cluster` to allow for better reuse in subclasses.

xref https://github.com/dask/dask-kubernetes/pull/738

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
