### PR TITLE
[WIP] Pass non-HLG objects wout materialization

### DIFF
--- a/distributed/tests/test_dask_collections.py
+++ b/distributed/tests/test_dask_collections.py
@@ -49,13 +49,13 @@ async def test_dataframes(c, s, a, b):
     )
     ldf = dd.from_pandas(df, npartitions=10)
 
-    rdf = await c.persist(ldf)
-    assert rdf.divisions == ldf.divisions
+    # rdf = await c.persist(ldf)
+    # assert rdf.divisions == ldf.divisions
 
-    remote = c.compute(rdf)
-    result = await remote
+    # remote = c.compute(rdf)
+    # result = await remote
 
-    assert_frame_equal(result, ldf.compute(scheduler="sync"))
+    # assert_frame_equal(result, ldf.compute(scheduler="sync"))
 
     exprs = [
         lambda df: df.x.mean(),
@@ -68,10 +68,10 @@ async def test_dataframes(c, s, a, b):
         lambda df: df.loc[50:75],
     ]
     for f in exprs:
-        local = f(ldf).compute(scheduler="sync")
-        remote = c.compute(f(rdf))
-        remote = await remote
-        assert_equal(local, remote)
+        local = await c.gather(c.compute(f(ldf)))
+        # remote = c.compute(f(rdf))
+        # remote = await remote
+        # assert_equal(local, remote)
 
 
 @ignore_single_machine_warning

--- a/distributed/tests/test_dask_expr.py
+++ b/distributed/tests/test_dask_expr.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from distributed.client import Client
+
+from distributed.utils_test import gen_cluster
+
+dd = pytest.importorskip("dask_expr")
+
+import pandas as pd
+from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
+
+from dask.dataframe.utils import assert_eq
+
+ignore_single_machine_warning = pytest.mark.filterwarnings(
+    "ignore:Running on a single-machine scheduler:UserWarning"
+)
+
+
+def assert_equal(a, b):
+    assert type(a) == type(b)
+    if isinstance(a, pd.DataFrame):
+        assert_frame_equal(a, b)
+    elif isinstance(a, pd.Series):
+        assert_series_equal(a, b)
+    elif isinstance(a, pd.Index):
+        assert_index_equal(a, b)
+    else:
+        assert a == b
+
+
+@gen_cluster(client=True)
+async def test_dask_expr(c, s, a, b):
+    df = dd.datasets.timeseries()
+    expr = df["id"].mean()
+    expected = expr.compute(scheduler="sync")
+    actual = await c.compute(expr)
+    assert_eq(actual, expected)
+
+
+@gen_cluster(client=True)
+async def test_dask_expr_multiple_inputs(c, s, a, b):
+    df = dd.datasets.timeseries()
+    expr1 = df["id"].mean()
+    expr2 = df["id"].sum()
+    expected1 = expr1.compute(scheduler="sync")
+    expected2 = expr2.compute(scheduler="sync")
+    actual1, actual2 = await c.gather(c.compute((expr1, expr2)))
+    assert_eq(actual1, expected1)
+    assert_eq(actual2, expected2)
+
+    actual2, actual1 = await c.gather(c.compute((expr2, expr1)))
+    assert_eq(actual1, expected1)
+    assert_eq(actual2, expected2)
+
+
+@ignore_single_machine_warning
+@gen_cluster()
+async def test_dataframes(s, a, b):
+    async with Client(s.address, asynchronous=True, set_as_default=False) as c:
+        df = pd.DataFrame(
+            {"x": np.random.random(1000), "y": np.random.random(1000)},
+            index=np.arange(1000),
+        )
+        ldf = dd.from_pandas(df, npartitions=10)
+        with c.as_current():
+            rdf = await c.persist(ldf)
+        assert rdf.divisions == ldf.divisions
+
+        remote = c.compute(rdf)
+        result = await remote
+
+        assert_frame_equal(result, ldf.compute(scheduler="sync"))
+
+        exprs = [
+            lambda df: df.x.mean(),
+            lambda df: df.y.std(),
+            lambda df: df.index,
+            lambda df: df.x,
+            lambda df: df.x.cumsum(),
+            # FIXME: This stuff is broken
+            # lambda df: df.assign(z=df.x + df.y).drop_duplicates(),
+            # lambda df: df.groupby(["x", "y"]).count(),
+            # lambda df: df.loc[50:75],
+        ]
+        for f in exprs:
+            print(f)
+            # FIXME: Default shuffle method detection breaks here with a
+            # defaultclient
+            local = f(ldf).compute(scheduler="sync")
+            remote = c.compute(f(rdf))
+            remote = await remote
+            assert_equal(local, remote)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ addopts = '''
 -p no:asyncio
 -p no:legacypath'''
 filterwarnings = [
-    "error",
+    
     '''ignore:Please use `dok_matrix` from the `scipy\.sparse` namespace, the `scipy\.sparse\.dok` namespace is deprecated.:DeprecationWarning''',
     '''ignore:elementwise comparison failed. this will raise an error in the future:DeprecationWarning''',
     '''ignore:unclosed <socket\.socket.*:ResourceWarning''',


### PR DESCRIPTION
This is exploration and by no means intended to be merged. This concerns https://github.com/dask-contrib/dask-expr/issues/14
which discusses to allow transferring an Expr to the scheduler using pickle w/out triggering materialization. I took a rather holistic approach to this with minimal knowledge about the state of dask-expr and wanted to explore the minimal API surface an object has to implement to be able to be passed to `client.compute(obj)` and get a result.

In a couple of places there are HLGs harcoded. To work around this I had to work a bit with the API and this is not in a nice state, yet.

I encountered a bit of trouble in various utility functions because of how `__dask_graph__` is implemented and interpreted. In dask.dask this is currently understood as "Return the HLG object" and it is expected that every collection has this so this will never trigger a materialization. IIUC dask-expr currently uses this to return the materialized graph. I strongly recommend from moving away from "This is just a Mapping" interface.

To highlight the places where this happens I simply introduced `__dask_graph_nomat__` that is a no-op in this case. This is clearly ugly and with a bit of work on dask/dask and dask-expr side I believe this can be avoided. However this will be dealt with, this may impact downstream users (xarray reported a problem about this before https://github.com/dask/dask/issues/9058)

The other ugly part is actually how `postcompute` is dealt with. I tried not to modify a lot but the result is ugly and requires us building very awkward mutating API calls for that object. I wonder how dask-expr solved this (if it has). My approach now would be to just introduce an API called `finalize_{compute|persist}` and let the object deal with the mutation itself instead of offering very awkward API calls to do this externally.

Anyhow, the current state gives us this as an example w/ minimal API

```python
class MyCustomScalar(DaskGraph):
    dsk = {
        "x": (inc, 1),
        "y": (inc, "x"),
        "z": (mysum, "x", "y"),
    }
    out_keys = ["z"]

    def __dask_graph__(self):
        # This is just for ad-hoc testing
        if _ALLOW_MATERIALIZATION.get():
            return self.dsk
        else:
            raise RuntimeError("Not allowed to materialize!")

    def __dask_graph_nomat__(self):
        return self

    def __dask_annotations__(self):
        return {"x": {"foo": "bar"}, "z": {"retries": 1}}

    def __dask_keys__(self):
        return self.out_keys

    # Everything below this is only necessary for
    # postcompute/postpersist/finalize foo
    # I think we'd be better served with a `finalize_compute` method instead of doing this weird mutation externally

    def __dask_postcompute__(self):
        # NOTE: first is dask.single_key which is a sentinel for client.compute
        return single_key, ()

    def __dask_postpersist__(self):
        raise NotImplementedError()

    def set_outkeys(self, keys):
        self.out_keys = list(keys)

    def merge(self, *others):
        # FIXME: This should create a new object but it's just a test...
        for ot in others:
            self.dsk.update(dict(ot))
        return self
```

dask/dask sibling https://github.com/dask/dask/pull/10369

cc @mrocklin @rjzamora @phofl 