### PR TITLE
Fix flaky UCX tests

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -323,7 +323,9 @@ async def test_stress(
 async def test_simple(
     ucx_loop,
 ):
-    async with LocalCluster(protocol="ucx", asynchronous=True) as cluster:
+    async with LocalCluster(
+        protocol="ucx", n_workers=2, threads_per_worker=2, asynchronous=True
+    ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             assert cluster.scheduler_address.startswith("ucx://")
             assert await client.submit(lambda x: x + 1, 10) == 11
@@ -371,7 +373,9 @@ async def test_transpose(
 ):
     da = pytest.importorskip("dask.array")
 
-    async with LocalCluster(protocol="ucx", asynchronous=True) as cluster:
+    async with LocalCluster(
+        protocol="ucx", n_workers=2, threads_per_worker=2, asynchronous=True
+    ) as cluster:
         async with Client(cluster, asynchronous=True):
             assert cluster.scheduler_address.startswith("ucx://")
             x = da.ones((10000, 10000), chunks=(1000, 1000)).persist()

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -11,7 +11,7 @@ import dask
 
 from distributed import Client
 from distributed.comm.ucx import _prepare_ucx_config
-from distributed.utils import get_ip
+from distributed.utils import get_ip, open_port
 from distributed.utils_test import gen_test, popen
 
 try:
@@ -113,7 +113,7 @@ def test_ucx_config_w_env_var(ucx_loop, cleanup, loop):
     env = os.environ.copy()
     env["DASK_RMM__POOL_SIZE"] = "1000.00 MB"
 
-    port = "13339"
+    port = str(open_port())
     # Using localhost appears to be less flaky than {HOST}. Additionally, this is
     # closer to how other dask worker tests are written.
     sched_addr = f"ucx://127.0.0.1:{port}"


### PR DESCRIPTION
Closes #7944

Hardcoding ports can cause binding to fail, thus switching to dynamic ports should make `test_ucx_config_w_env_var`  more reliable.

Additionally, some UCX tests (namely `test_simple` and `test_transpose`) may fail when running from gpuCI's Docker container, even though those are not reproducible on the host where Docker is running. This behavior probably occurs due to the limitation of resources in the container, thus we reduce number of workers and threads to some of the UCX tests, which will make them unlikely to fail while still testing basic UCX functionality.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
