### PR TITLE
BUG type def has errors sometimes

### DIFF
--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -25,7 +25,7 @@ import logging
 import os
 import sys
 import warnings
-from collections.abc import Callable, Container, Hashable, MutableMapping, Iterable
+from collections.abc import Callable, Container, Hashable, Iterable, MutableMapping
 from contextlib import suppress
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal, Union, cast

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -25,7 +25,7 @@ import logging
 import os
 import sys
 import warnings
-from collections.abc import Callable, Container, Hashable, MutableMapping
+from collections.abc import Callable, Container, Hashable, MutableMapping, Iterable
 from contextlib import suppress
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal, Union, cast
@@ -56,9 +56,9 @@ WorkerDataParameter: TypeAlias = Union[
     # pre-initialized
     MutableMapping[str, object],
     # constructor
-    Callable[[], MutableMapping[str, object]],
+    Callable[Iterable, MutableMapping[str, object]],
     # constructor, passed worker.local_directory
-    Callable[[str], MutableMapping[str, object]],
+    Callable[Iterable[str], MutableMapping[str, object]],
     # (constructor, kwargs to constructor)
     tuple[Callable[..., MutableMapping[str, object]], dict[str, Any]],
     # initialize internally

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -58,7 +58,7 @@ WorkerDataParameter: TypeAlias = Union[
     # constructor
     Callable[Iterable, MutableMapping[str, object]],
     # constructor, passed worker.local_directory
-    Callable[Iterable[str], MutableMapping[str, object]],
+    Callable[[str], MutableMapping[str, object]],
     # (constructor, kwargs to constructor)
     tuple[Callable[..., MutableMapping[str, object]], dict[str, Any]],
     # initialize internally

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -56,7 +56,7 @@ WorkerDataParameter: TypeAlias = Union[
     # pre-initialized
     MutableMapping[str, object],
     # constructor
-    Callable[Iterable, MutableMapping[str, object]],
+    Callable[..., MutableMapping[str, object]],
     # constructor, passed worker.local_directory
     Callable[[str], MutableMapping[str, object]],
     # (constructor, kwargs to constructor)

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -25,7 +25,7 @@ import logging
 import os
 import sys
 import warnings
-from collections.abc import Callable, Container, Hashable, Iterable, MutableMapping
+from collections.abc import Callable, Container, Hashable, MutableMapping
 from contextlib import suppress
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal, Union, cast


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This type def appears to have errors sometimes. See this comment: https://github.com/regro/cf-scripts/pull/1724#issuecomment-1614020708

The changes here appear to fix it in my tests on linux. For whatever reason, I only see the failure on linux, not mac osx.

cc @jakirkham 