### PR TITLE
Polish Fine Performance Metrics bokeh plot

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3392,6 +3392,7 @@ class FinePerformanceMetrics(DashboardComponent):
     substantial_change: bool
     visible_functions: list[str]
     visible_activities: list[str]
+    stacked_chart_visible_activities: list[str]
     function_selector: MultiChoice
     span_tag_selector: MultiChoice
     unit_selector: Select
@@ -3409,6 +3410,7 @@ class FinePerformanceMetrics(DashboardComponent):
         self.substantial_change = False
         self.visible_functions = []
         self.visible_activities = []
+        self.stacked_chart_visible_activities = []
         self.task_exec_by_activity_chart = None
         self.task_exec_by_prefix_chart = None
         self.get_data_by_activity_chart = None
@@ -3651,7 +3653,6 @@ class FinePerformanceMetrics(DashboardComponent):
             self.visible_functions = sorted(visible_functions)
 
         if visible_activities != set(self.visible_activities):
-            self.substantial_change = True
             self.visible_activities = sorted(visible_activities)
 
         (
@@ -3668,18 +3669,29 @@ class FinePerformanceMetrics(DashboardComponent):
         --------
         _build_pie_chart
         """
-        total_value = sum(data.values())
+        activities = self.visible_activities
+        # Generate palette based on all visible activities to make sure that
+        # colors match between the plots
+        palette = self._get_palette()
+        values = [data[activity] for activity in activities]
+
+        # Sort by values from largest to smallest
+        # Hide activities that are missing in the current plot from the legend
+        idx = [i for i, v in sorted(enumerate(values), key=lambda el: -el[1]) if v]
+        activities = [activities[i] for i in idx]
+        palette = [palette[i] for i in idx]
+        values = [values[i] for i in idx]
+
+        total_value = sum(values)
+        total_text = self._format(total_value)
         percent_k = 100.0 / total_value if total_value else 0.0
         angle_k = 2.0 * math.pi / total_value if total_value else 0.0
-        activities = self.visible_activities
-        values = [data[activity] for activity in activities]
-        total_text = self._format(sum(values))
         return {
             "activity": activities,
             "value": values,
             "text": [self._format(v) + f" ({v * percent_k:.0f}%)" for v in values],
             "angle": [v * angle_k for v in values],
-            "color": self._get_palette(),
+            "color": palette,
             "total_text": [total_text] * len(values),
         }
 
@@ -3735,13 +3747,21 @@ class FinePerformanceMetrics(DashboardComponent):
             "____total_text": [self._format(v) for v in func_totals],
         }
 
+        sc_visible_activities = []
         for activity in self.visible_activities:
             values = [data[function, activity] for function in self.visible_functions]
+            if not any(values):
+                continue
+            sc_visible_activities.append(activity)
             out[activity] = values
             out[f"__{activity}_text"] = [
                 self._format(v) + f" ({v * perc_ki:.0f}%)"
                 for v, perc_ki in zip(values, perc_k)
             ]
+        if sc_visible_activities != self.stacked_chart_visible_activities:
+            self.substantial_change = True
+            self.stacked_chart_visible_activities[:] = sc_visible_activities
+
         return out, max(func_totals, default=0.0)
 
     def _build_task_execution_by_prefix_chart(self) -> figure:
@@ -3779,13 +3799,20 @@ class FinePerformanceMetrics(DashboardComponent):
         barchart = self.task_exec_by_prefix_chart
         assert barchart is not None
         barchart.x_range = FactorRange(*self.visible_functions)
+
+        palette = [
+            p
+            for p, a in zip(self._get_palette(), self.visible_activities)
+            if a in self.stacked_chart_visible_activities
+        ]
+        assert len(palette) == len(self.stacked_chart_visible_activities)
         renderers = barchart.vbar_stack(
-            self.visible_activities,
+            self.stacked_chart_visible_activities,
             x="__functions",
             width=0.9,
             source=self.task_exec_by_prefix_src,
-            color=self._get_palette(),
-            legend_label=self.visible_activities,
+            color=palette,
+            legend_label=self.stacked_chart_visible_activities,
         )
 
         # Create or refresh hovertools on top of base tools


### PR DESCRIPTION
- hide activities from the legend of each plot when they don't actually appear in it. Notably, hide the "network" activity in the task execution plots.
- in the pie charts, sort both the pie slices and the legend from biggest to smallest activity, substantially improving readability (the biggest activities always appear at the top of the legend)
![image](https://github.com/dask/distributed/assets/6213168/0c59c66f-5d23-4eb2-9eaa-8c26f231cc34)
