### PR TITLE
Re-run erred task on ComputeTaskEvent

### DIFF
--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -1334,7 +1334,7 @@ def test_gather_dep_failure(ws):
     ws.validate = False
 
 
-def test_compute_erred_task(ws):
+def test_recompute_erred_task(ws):
     instructions = ws.handle_stimulus(
         ComputeTaskEvent.dummy("x", run_id=1, stimulus_id="s1"),
         ExecuteFailureEvent.dummy("x", run_id=1, stimulus_id="s2"),

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -1334,6 +1334,20 @@ def test_gather_dep_failure(ws):
     ws.validate = False
 
 
+def test_compute_erred_task(ws):
+    instructions = ws.handle_stimulus(
+        ComputeTaskEvent.dummy("x", run_id=1, stimulus_id="s1"),
+        ExecuteFailureEvent.dummy("x", run_id=1, stimulus_id="s2"),
+        ComputeTaskEvent.dummy("x", run_id=2, stimulus_id="s3"),
+    )
+    assert instructions == [
+        Execute(key="x", stimulus_id="s1"),
+        TaskErredMsg.match(key="x", run_id=1, stimulus_id="s2"),
+        Execute(key="x", stimulus_id="s3"),
+    ]
+    assert ws.tasks["x"].state == "executing"
+
+
 def test_transfer_incoming_metrics(ws):
     assert ws.transfer_incoming_bytes == 0
     assert ws.transfer_incoming_count == 0

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -2868,10 +2868,6 @@ class WorkerState:
                     ts, run_id=ev.run_id, stimulus_id=ev.stimulus_id
                 )
             )
-        elif ts.state == "error":
-            instructions.append(
-                TaskErredMsg.from_task(ts, run_id=ev.run_id, stimulus_id=ev.stimulus_id)
-            )
         elif ts.state in {
             "released",
             "fetch",
@@ -2879,6 +2875,7 @@ class WorkerState:
             "missing",
             "cancelled",
             "resumed",
+            "error",
         }:
             recommendations[ts] = "waiting"
 


### PR DESCRIPTION
Addresses https://github.com/dask/distributed/pull/7933#discussion_r1240103858

I'm not sure if this condition can ever occur, but it still makes sense to harden the state machine against it and add a test.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
