### PR TITLE
Reduce Removing comms log to debug level

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1658,7 +1658,7 @@ class ConnectionPool:
         """
         Remove all Comms to a given address.
         """
-        logger.info("Removing comms to %s", addr)
+        logger.debug("Removing comms to %s", addr)
         if addr in self.available:
             comms = self.available.pop(addr)
             for comm in comms:


### PR DESCRIPTION
This is too verbose in case of a leaving worker