### PR TITLE
Fix P2P worker cleanup

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -98,7 +98,7 @@ from distributed.queues import QueueExtension
 from distributed.recreate_tasks import ReplayTaskScheduler
 from distributed.security import Security
 from distributed.semaphore import SemaphoreExtension
-from distributed.shuffle import ShuffleSchedulerExtension
+from distributed.shuffle import ShuffleSchedulerPlugin
 from distributed.spans import SpansSchedulerExtension
 from distributed.stealing import WorkStealing
 from distributed.utils import (
@@ -170,7 +170,7 @@ DEFAULT_EXTENSIONS = {
     "events": EventExtension,
     "amm": ActiveMemoryManagerExtension,
     "memory_sampler": MemorySamplerExtension,
-    "shuffle": ShuffleSchedulerExtension,
+    "shuffle": ShuffleSchedulerPlugin,
     "spans": SpansSchedulerExtension,
     "stealing": WorkStealing,
 }

--- a/distributed/shuffle/__init__.py
+++ b/distributed/shuffle/__init__.py
@@ -5,7 +5,7 @@ from distributed.shuffle._merge import HashJoinP2PLayer, hash_join_p2p
 from distributed.shuffle._rechunk import rechunk_p2p
 from distributed.shuffle._scheduler_plugin import ShuffleSchedulerPlugin
 from distributed.shuffle._shuffle import P2PShuffleLayer, rearrange_by_column_p2p
-from distributed.shuffle._worker_extension import ShuffleWorkerPlugin
+from distributed.shuffle._worker_plugin import ShuffleWorkerPlugin
 
 __all__ = [
     "check_minimal_arrow_version",

--- a/distributed/shuffle/__init__.py
+++ b/distributed/shuffle/__init__.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from distributed.shuffle._arrow import check_minimal_arrow_version
 from distributed.shuffle._merge import HashJoinP2PLayer, hash_join_p2p
 from distributed.shuffle._rechunk import rechunk_p2p
-from distributed.shuffle._scheduler_extension import ShuffleSchedulerExtension
+from distributed.shuffle._scheduler_plugin import ShuffleSchedulerPlugin
 from distributed.shuffle._shuffle import P2PShuffleLayer, rearrange_by_column_p2p
-from distributed.shuffle._worker_extension import ShuffleWorkerExtension
+from distributed.shuffle._worker_extension import ShuffleWorkerPlugin
 
 __all__ = [
     "check_minimal_arrow_version",
@@ -14,6 +14,6 @@ __all__ = [
     "P2PShuffleLayer",
     "rearrange_by_column_p2p",
     "rechunk_p2p",
-    "ShuffleSchedulerExtension",
-    "ShuffleWorkerExtension",
+    "ShuffleSchedulerPlugin",
+    "ShuffleWorkerPlugin",
 ]

--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -11,7 +11,7 @@ from dask.layers import Layer
 
 from distributed.shuffle._shuffle import (
     ShuffleId,
-    _get_worker_extension,
+    _get_worker_plugin,
     barrier_key,
     shuffle_barrier,
     shuffle_transfer,
@@ -167,7 +167,7 @@ def merge_unpack(
 ):
     from dask.dataframe.multi import merge_chunk
 
-    ext = _get_worker_extension()
+    ext = _get_worker_plugin()
     # If the partition is empty, it doesn't contain the hash column name
     left = ext.get_output_partition(
         shuffle_id_left, barrier_left, output_partition, meta=meta_left

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -10,7 +10,7 @@ from distributed.exceptions import Reschedule
 from distributed.shuffle._shuffle import (
     ShuffleId,
     ShuffleType,
-    _get_worker_extension,
+    _get_worker_plugin,
     barrier_key,
     shuffle_barrier,
 )
@@ -36,7 +36,7 @@ def rechunk_transfer(
     old: ChunkedAxes,
 ) -> int:
     try:
-        return _get_worker_extension().add_partition(
+        return _get_worker_plugin().add_partition(
             input,
             partition_id=input_chunk,
             shuffle_id=id,
@@ -52,7 +52,7 @@ def rechunk_unpack(
     id: ShuffleId, output_chunk: NDIndex, barrier_run_id: int
 ) -> np.ndarray:
     try:
-        return _get_worker_extension().get_output_partition(
+        return _get_worker_plugin().get_output_partition(
             id, barrier_run_id, output_chunk
         )
     except Reschedule as e:

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -117,7 +117,7 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
         self.heartbeats = defaultdict(lambda: defaultdict(dict))
         self.states = {}
         self.erred_shuffles = {}
-        self.scheduler.add_plugin(self)
+        self.scheduler.add_plugin(self, name="shuffle")
 
     async def start(self, scheduler: Scheduler) -> None:
         worker_plugin = ShuffleWorkerPlugin()

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -85,16 +85,16 @@ class ArrayRechunkState(ShuffleState):
         }
 
 
-class ShuffleSchedulerExtension(SchedulerPlugin):
+class ShuffleSchedulerPlugin(SchedulerPlugin):
     """
-    Shuffle extension for the scheduler
+    Shuffle plugin for the scheduler
 
-    Today this mostly just collects heartbeat messages for the dashboard,
-    but in the future it may be responsible for more
+    This coordinates the individual worker plugins to ensure correctness
+    and collects heartbeat messages for the dashboard.
 
     See Also
     --------
-    ShuffleWorkerExtension
+    ShuffleWorkerPlugin
     """
 
     scheduler: Scheduler

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -12,6 +12,7 @@ from itertools import product
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from distributed.diagnostics.plugin import SchedulerPlugin
+from distributed.protocol.pickle import dumps
 from distributed.shuffle._rechunk import ChunkedAxes, NDIndex
 from distributed.shuffle._shuffle import (
     ShuffleId,
@@ -19,6 +20,7 @@ from distributed.shuffle._shuffle import (
     barrier_key,
     id_from_key,
 )
+from distributed.shuffle._worker_plugin import ShuffleWorkerPlugin
 
 if TYPE_CHECKING:
     from distributed.scheduler import (
@@ -116,6 +118,12 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
         self.states = {}
         self.erred_shuffles = {}
         self.scheduler.add_plugin(self)
+
+    async def start(self, scheduler: Scheduler) -> None:
+        worker_plugin = ShuffleWorkerPlugin()
+        await self.scheduler.register_worker_plugin(
+            None, dumps(worker_plugin), name="shuffle"
+        )
 
     def shuffle_ids(self) -> set[ShuffleId]:
         return set(self.states)

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from dask.dataframe import DataFrame
 
     # circular dependency
-    from distributed.shuffle._worker_extension import ShuffleWorkerPlugin
+    from distributed.shuffle._worker_plugin import ShuffleWorkerPlugin
 
 ShuffleId = NewType("ShuffleId", str)
 
@@ -32,7 +32,7 @@ class ShuffleType(Enum):
     ARRAY_RECHUNK = "ArrayRechunk"
 
 
-def _get_worker_extension() -> ShuffleWorkerPlugin:
+def _get_worker_plugin() -> ShuffleWorkerPlugin:
     from distributed import get_worker
 
     try:
@@ -60,7 +60,7 @@ def shuffle_transfer(
     parts_out: set[int],
 ) -> int:
     try:
-        return _get_worker_extension().add_partition(
+        return _get_worker_plugin().add_partition(
             input,
             shuffle_id=id,
             type=ShuffleType.DATAFRAME,
@@ -77,7 +77,7 @@ def shuffle_unpack(
     id: ShuffleId, output_partition: int, barrier_run_id: int, meta: pd.DataFrame
 ) -> pd.DataFrame:
     try:
-        return _get_worker_extension().get_output_partition(
+        return _get_worker_plugin().get_output_partition(
             id, barrier_run_id, output_partition, meta=meta
         )
     except Reschedule as e:
@@ -88,7 +88,7 @@ def shuffle_unpack(
 
 def shuffle_barrier(id: ShuffleId, run_ids: list[int]) -> int:
     try:
-        return _get_worker_extension().barrier(id, run_ids)
+        return _get_worker_plugin().barrier(id, run_ids)
     except Exception as e:
         raise RuntimeError(f"shuffle_barrier failed during shuffle {id}") from e
 

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from dask.dataframe import DataFrame
 
     # circular dependency
-    from distributed.shuffle._worker_extension import ShuffleWorkerExtension
+    from distributed.shuffle._worker_extension import ShuffleWorkerPlugin
 
 ShuffleId = NewType("ShuffleId", str)
 
@@ -32,7 +32,7 @@ class ShuffleType(Enum):
     ARRAY_RECHUNK = "ArrayRechunk"
 
 
-def _get_worker_extension() -> ShuffleWorkerExtension:
+def _get_worker_extension() -> ShuffleWorkerPlugin:
     from distributed import get_worker
 
     try:
@@ -42,7 +42,7 @@ def _get_worker_extension() -> ShuffleWorkerExtension:
             "`shuffle='p2p'` requires Dask's distributed scheduler. This task is not running on a Worker; "
             "please confirm that you've created a distributed Client and are submitting this computation through it."
         ) from e
-    extension: ShuffleWorkerExtension | None = worker.extensions.get("shuffle")
+    extension: ShuffleWorkerPlugin | None = worker.extensions.get("shuffle")
     if extension is None:
         raise RuntimeError(
             f"The worker {worker.address} does not have a ShuffleExtension. "

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -42,13 +42,13 @@ def _get_worker_plugin() -> ShuffleWorkerPlugin:
             "`shuffle='p2p'` requires Dask's distributed scheduler. This task is not running on a Worker; "
             "please confirm that you've created a distributed Client and are submitting this computation through it."
         ) from e
-    extension: ShuffleWorkerPlugin | None = worker.extensions.get("shuffle")
-    if extension is None:
+    plugin: ShuffleWorkerPlugin | None = worker.plugins.get("shuffle")  # type: ignore
+    if plugin is None:
         raise RuntimeError(
             f"The worker {worker.address} does not have a ShuffleExtension. "
             "Is pandas installed on the worker?"
         )
-    return extension
+    return plugin
 
 
 def shuffle_transfer(

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -572,7 +572,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
     memory_limiter_disk: ResourceLimiter
     closed: bool
 
-    def __init__(self, worker: Worker) -> None:
+    def setup(self, worker: Worker) -> None:
         # Attach to worker
         worker.handlers["shuffle_receive"] = self.shuffle_receive
         worker.handlers["shuffle_inputs_done"] = self.shuffle_inputs_done

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -856,7 +856,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         self._runs.add(shuffle)
         return shuffle
 
-    async def close(self) -> None:
+    async def teardown(self, worker: Worker) -> None:
         assert not self.closed
 
         self.closed = True

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -19,6 +19,7 @@ from dask.context import thread_state
 from dask.utils import parse_bytes
 
 from distributed.core import PooledRPCCall
+from distributed.diagnostics.plugin import WorkerPlugin
 from distributed.exceptions import Reschedule
 from distributed.protocol import to_serialize
 from distributed.shuffle._arrow import (
@@ -552,7 +553,7 @@ class DataFrameShuffleRun(ShuffleRun[int, int, "pd.DataFrame"]):
         return self.worker_for[id]
 
 
-class ShuffleWorkerExtension:
+class ShuffleWorkerPlugin(WorkerPlugin):
     """Interface between a Worker and a Shuffle.
 
     This extension is responsible for
@@ -588,10 +589,10 @@ class ShuffleWorkerExtension:
         self._executor = ThreadPoolExecutor(self.worker.state.nthreads)
 
     def __str__(self) -> str:
-        return f"ShuffleWorkerExtension on {self.worker.address}"
+        return f"ShuffleWorkerPlugin on {self.worker.address}"
 
     def __repr__(self) -> str:
-        return f"<ShuffleWorkerExtension, worker={self.worker.address_safe!r}, closed={self.closed}>"
+        return f"<ShuffleWorkerPlugin, worker={self.worker.address_safe!r}, closed={self.closed}>"
 
     # Handlers
     ##########
@@ -638,7 +639,7 @@ class ShuffleWorkerExtension:
         exception = RuntimeError(message)
         shuffle.fail(exception)
 
-        async def _(extension: ShuffleWorkerExtension, shuffle: ShuffleRun) -> None:
+        async def _(extension: ShuffleWorkerPlugin, shuffle: ShuffleRun) -> None:
             await shuffle.close()
             extension._runs.remove(shuffle)
 
@@ -805,7 +806,7 @@ class ShuffleWorkerExtension:
                 existing.fail(RuntimeError("Stale Shuffle"))
 
                 async def _(
-                    extension: ShuffleWorkerExtension, shuffle: ShuffleRun
+                    extension: ShuffleWorkerPlugin, shuffle: ShuffleRun
                 ) -> None:
                     await shuffle.close()
                     extension._runs.remove(shuffle)

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -21,7 +21,7 @@ from distributed.shuffle._limiter import ResourceLimiter
 from distributed.shuffle._rechunk import Split, split_axes
 from distributed.shuffle._scheduler_plugin import get_worker_for_hash_sharding
 from distributed.shuffle._shuffle import ShuffleId
-from distributed.shuffle._worker_extension import ArrayRechunkRun
+from distributed.shuffle._worker_plugin import ArrayRechunkRun
 from distributed.shuffle.tests.utils import AbstractShuffleTestPool
 from distributed.utils_test import gen_cluster, gen_test, raises_with_cause
 

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -19,7 +19,7 @@ from dask.array.utils import assert_eq
 
 from distributed.shuffle._limiter import ResourceLimiter
 from distributed.shuffle._rechunk import Split, split_axes
-from distributed.shuffle._scheduler_extension import get_worker_for_hash_sharding
+from distributed.shuffle._scheduler_plugin import get_worker_for_hash_sharding
 from distributed.shuffle._shuffle import ShuffleId
 from distributed.shuffle._worker_extension import ArrayRechunkRun
 from distributed.shuffle.tests.utils import AbstractShuffleTestPool

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -77,6 +77,7 @@ async def clean_worker(
 
     while extension._runs and not deadline.expired:
         await asyncio.sleep(interval)
+    assert extension.closed
     for dirpath, dirnames, filenames in os.walk(worker.local_directory):
         assert "shuffle" not in dirpath
         for fn in dirnames + filenames:

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -81,6 +81,7 @@ async def check_worker_cleanup(
 
     while plugin._runs and not deadline.expired:
         await asyncio.sleep(interval)
+    assert not plugin._runs
     if closed:
         assert plugin.closed
     for dirpath, dirnames, filenames in os.walk(worker.local_directory):

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -34,7 +34,7 @@ from distributed.shuffle._scheduler_plugin import (
     get_worker_for_range_sharding,
 )
 from distributed.shuffle._shuffle import ShuffleId, barrier_key
-from distributed.shuffle._worker_extension import (
+from distributed.shuffle._worker_plugin import (
     DataFrameShuffleRun,
     ShuffleRun,
     ShuffleWorkerPlugin,
@@ -333,7 +333,7 @@ async def test_closed_input_only_worker_during_transfer(c, s, a, b):
         return a.address
 
     with mock.patch(
-        "distributed.shuffle._scheduler_extension.get_worker_for_range_sharding",
+        "distributed.shuffle._scheduler_plugin.get_worker_for_range_sharding",
         mock_get_worker_for_range_sharding,
     ):
         df = dask.datasets.timeseries(
@@ -366,7 +366,7 @@ async def test_crashed_input_only_worker_during_transfer(c, s, a):
         return a.address
 
     with mock.patch(
-        "distributed.shuffle._scheduler_extension.get_worker_for_range_sharding",
+        "distributed.shuffle._scheduler_plugin.get_worker_for_range_sharding",
         mock_mock_get_worker_for_range_sharding,
     ):
         async with Nanny(s.address, nthreads=1) as n:
@@ -430,7 +430,7 @@ class BlockedInputsDoneShuffle(DataFrameShuffleRun):
 
 
 @mock.patch(
-    "distributed.shuffle._worker_extension.DataFrameShuffleRun",
+    "distributed.shuffle._worker_plugin.DataFrameShuffleRun",
     BlockedInputsDoneShuffle,
 )
 @gen_cluster(client=True, nthreads=[("", 1)] * 2)
@@ -474,7 +474,7 @@ async def test_closed_worker_during_barrier(c, s, a, b):
 
 
 @mock.patch(
-    "distributed.shuffle._worker_extension.DataFrameShuffleRun",
+    "distributed.shuffle._worker_plugin.DataFrameShuffleRun",
     BlockedInputsDoneShuffle,
 )
 @gen_cluster(client=True, nthreads=[("", 1)] * 2)
@@ -521,7 +521,7 @@ async def test_closed_other_worker_during_barrier(c, s, a, b):
 
 @pytest.mark.slow
 @mock.patch(
-    "distributed.shuffle._worker_extension.DataFrameShuffleRun",
+    "distributed.shuffle._worker_plugin.DataFrameShuffleRun",
     BlockedInputsDoneShuffle,
 )
 @gen_cluster(client=True, nthreads=[("", 1)])

--- a/distributed/shuffle/tests/test_shuffle_plugins.py
+++ b/distributed/shuffle/tests/test_shuffle_plugins.py
@@ -11,7 +11,7 @@ from distributed.shuffle._scheduler_plugin import (
     ShuffleSchedulerPlugin,
     get_worker_for_range_sharding,
 )
-from distributed.shuffle._worker_extension import (
+from distributed.shuffle._worker_plugin import (
     ShuffleWorkerPlugin,
     split_by_partition,
     split_by_worker,

--- a/distributed/shuffle/tests/test_shuffle_plugins.py
+++ b/distributed/shuffle/tests/test_shuffle_plugins.py
@@ -7,12 +7,12 @@ import pytest
 pd = pytest.importorskip("pandas")
 dd = pytest.importorskip("dask.dataframe")
 
-from distributed.shuffle._scheduler_extension import (
-    ShuffleSchedulerExtension,
+from distributed.shuffle._scheduler_plugin import (
+    ShuffleSchedulerPlugin,
     get_worker_for_range_sharding,
 )
 from distributed.shuffle._worker_extension import (
-    ShuffleWorkerExtension,
+    ShuffleWorkerPlugin,
     split_by_partition,
     split_by_worker,
 )
@@ -22,7 +22,7 @@ from distributed.utils_test import gen_cluster
 @gen_cluster([("", 1)])
 async def test_installation_on_worker(s, a):
     ext = a.extensions["shuffle"]
-    assert isinstance(ext, ShuffleWorkerExtension)
+    assert isinstance(ext, ShuffleWorkerPlugin)
     assert a.handlers["shuffle_receive"] == ext.shuffle_receive
     assert a.handlers["shuffle_inputs_done"] == ext.shuffle_inputs_done
     assert a.stream_handlers["shuffle-fail"] == ext.shuffle_fail
@@ -34,7 +34,7 @@ async def test_installation_on_worker(s, a):
 @gen_cluster([("", 1)])
 async def test_installation_on_scheduler(s, a):
     ext = s.extensions["shuffle"]
-    assert isinstance(ext, ShuffleSchedulerExtension)
+    assert isinstance(ext, ShuffleSchedulerPlugin)
     assert s.handlers["shuffle_barrier"] == ext.barrier
     assert s.handlers["shuffle_get"] == ext.get
 

--- a/distributed/shuffle/tests/utils.py
+++ b/distributed/shuffle/tests/utils.py
@@ -9,7 +9,7 @@ from distributed.core import PooledRPCCall
 from distributed.diagnostics.plugin import SchedulerPlugin
 from distributed.scheduler import Scheduler, TaskStateState
 from distributed.shuffle._shuffle import ShuffleId
-from distributed.shuffle._worker_extension import ShuffleRun
+from distributed.shuffle._worker_plugin import ShuffleRun
 
 
 class PooledRPCShuffle(PooledRPCCall):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -91,7 +91,6 @@ from distributed.protocol import pickle, to_serialize
 from distributed.protocol.serialize import _is_dumpable
 from distributed.pubsub import PubSubWorkerExtension
 from distributed.security import Security
-from distributed.shuffle import ShuffleWorkerPlugin
 from distributed.sizeof import safe_sizeof as sizeof
 from distributed.spans import SpansWorkerExtension
 from distributed.threadpoolexecutor import ThreadPoolExecutor
@@ -172,7 +171,6 @@ LOG_PDB = dask.config.get("distributed.admin.pdb-on-err")
 
 DEFAULT_EXTENSIONS: dict[str, type] = {
     "pubsub": PubSubWorkerExtension,
-    "shuffle": ShuffleWorkerPlugin,
     "spans": SpansWorkerExtension,
 }
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -91,7 +91,7 @@ from distributed.protocol import pickle, to_serialize
 from distributed.protocol.serialize import _is_dumpable
 from distributed.pubsub import PubSubWorkerExtension
 from distributed.security import Security
-from distributed.shuffle import ShuffleWorkerExtension
+from distributed.shuffle import ShuffleWorkerPlugin
 from distributed.sizeof import safe_sizeof as sizeof
 from distributed.spans import SpansWorkerExtension
 from distributed.threadpoolexecutor import ThreadPoolExecutor
@@ -172,7 +172,7 @@ LOG_PDB = dask.config.get("distributed.admin.pdb-on-err")
 
 DEFAULT_EXTENSIONS: dict[str, type] = {
     "pubsub": PubSubWorkerExtension,
-    "shuffle": ShuffleWorkerExtension,
+    "shuffle": ShuffleWorkerPlugin,
     "spans": SpansWorkerExtension,
 }
 


### PR DESCRIPTION
Worker cleanup currently works "by accident" because shuffles either complete or worker state gets cleaned up on failure. However, `ShuffleWorkerExtension.close()` never gets triggered. This PR fixes that. It also refactors the setup such that the scheduler plugin is responsible of installing the worker plugin.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
