### PR TITLE
Remove accidental duplicated conversion of pyarrow Table to pandas

### DIFF
--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -56,7 +56,6 @@ def convert_partition(data: bytes, meta: pd.DataFrame) -> pd.DataFrame:
         sr = pa.RecordBatchStreamReader(file)
         shards.append(sr.read_all())
     table = pa.concat_tables(shards, promote=True)
-    df = table.to_pandas(self_destruct=True)
 
     def default_types_mapper(pyarrow_dtype: pa.DataType) -> object:
         # Avoid converting strings from `string[pyarrow]` to `string[python]`


### PR DESCRIPTION
https://github.com/dask/distributed/pull/7896 accidentally added a new `df = table.to_pandas(..)` call without removing the existing one, duplicating the conversion. 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
