### PR TITLE
Ignore arg-type error in CLI functions

### DIFF
--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("distributed.scheduler")
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 
-@click.command(name="scheduler", context_settings=dict(ignore_unknown_options=True))
+@click.command(name="scheduler", context_settings=dict(ignore_unknown_options=True))  # type: ignore[arg-type]
 @click.option("--host", type=str, default="", help="URI, IP or hostname of this server")
 @click.option("--port", type=str, default=None, help="Serving port")
 @click.option(

--- a/distributed/cli/dask_spec.py
+++ b/distributed/cli/dask_spec.py
@@ -10,7 +10,7 @@ import yaml
 from distributed.deploy.spec import run_spec
 
 
-@click.command(name="spec", context_settings=dict(ignore_unknown_options=True))
+@click.command(name="spec", context_settings=dict(ignore_unknown_options=True))  # type: ignore[arg-type]
 @click.argument("args", nargs=-1)
 @click.option("--spec", type=str, default="", help="")
 @click.option("--spec-file", type=str, default=None, help="")

--- a/distributed/cli/dask_ssh.py
+++ b/distributed/cli/dask_ssh.py
@@ -12,7 +12,7 @@ from distributed.deploy.old_ssh import SSHCluster
 logger = logging.getLogger("distributed.dask_ssh")
 
 
-@click.command(
+@click.command(  # type: ignore[arg-type]
     name="ssh",
     help=dedent(
         """Launch a Dask cluster over SSH. A 'dask scheduler' process will run on the

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -35,7 +35,7 @@ logger = logging.getLogger("distributed.dask_worker")
 pem_file_option_type = click.Path(exists=True, resolve_path=True)
 
 
-@click.command(name="worker", context_settings=dict(ignore_unknown_options=True))
+@click.command(name="worker", context_settings=dict(ignore_unknown_options=True))  # type: ignore[arg-type]
 @click.argument("scheduler", type=str, required=False)
 @click.option(
     "--tls-ca-file",


### PR DESCRIPTION
Since click 8.1.4, mypy fails to deduce the correct types in the click type annotations for click.command. See pallets/click#2558 and python/mypy#13449.

For now, workaround by ignoring the arg-type error.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
