### PR TITLE
restore support for yield unsafe Client context managers and deprecate that support

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1506,7 +1506,7 @@ class Client(SyncMethodMixin):
                 _current_client.reset(self._previous_as_current)
             except ValueError as e:
                 if not e.args[0].endswith(" was created in a different Context"):
-                    raise
+                    raise  # pragma: nocover
                 warnings.warn(
                     "It is deprecated to enter and exit the Client context "
                     "manager from different tasks",
@@ -1526,7 +1526,7 @@ class Client(SyncMethodMixin):
                 _current_client.reset(self._previous_as_current)
             except ValueError as e:
                 if not e.args[0].endswith(" was created in a different Context"):
-                    raise
+                    raise  # pragma: nocover
                 warnings.warn(
                     "It is deprecated to enter and exit the Client context "
                     "manager from different threads",

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1502,7 +1502,17 @@ class Client(SyncMethodMixin):
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         if self._previous_as_current:
-            _current_client.reset(self._previous_as_current)
+            try:
+                _current_client.reset(self._previous_as_current)
+            except ValueError as e:
+                if not e.args[0].endswith(" was created in a different Context"):
+                    raise
+                warnings.warn(
+                    "It is deprecated to enter and exit the Client context "
+                    "manager from different tasks",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         await self._close(
             # if we're handling an exception, we assume that it's more
             # important to deliver that exception than shutdown gracefully.
@@ -1512,7 +1522,17 @@ class Client(SyncMethodMixin):
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self._previous_as_current:
-            _current_client.reset(self._previous_as_current)
+            try:
+                _current_client.reset(self._previous_as_current)
+            except ValueError as e:
+                if not e.args[0].endswith(" was created in a different Context"):
+                    raise
+                warnings.warn(
+                    "It is deprecated to enter and exit the Client context "
+                    "manager from different threads",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         self.close()
 
     def __del__(self):


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/7984

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
