### PR TITLE
Use BufferOutputStream in P2P

### DIFF
--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -79,14 +79,12 @@ def list_of_buffers_to_table(data: list[bytes]) -> pa.Table:
 
 
 def serialize_table(table: pa.Table) -> bytes:
-    import io
-
     import pyarrow as pa
 
-    stream = io.BytesIO()
+    stream = pa.BufferOutputStream()
     with pa.ipc.new_stream(stream, table.schema) as writer:
         writer.write_table(table)
-    return stream.getvalue()
+    return stream.getvalue().to_pybytes()
 
 
 def deserialize_table(buffer: bytes) -> pa.Table:


### PR DESCRIPTION
Benchmarking a P2P workload with larger workers and many CPUs yields disappointing hardware metrics (see screenshot below).

Profiling this workload reveals that all Shuffle threads are spending all of their time in serialize_table even though we can see almost no CPU utilization. I suspect this is cause by weird memory copies since pyarrow has to write to a python BytesIO object. I don't know the details but replacing this with the arrow `BufferOutputStream` already helps a lot

Before

![image](https://github.com/dask/distributed/assets/8629629/dc1b8a4b-f63e-410d-ad78-0e2f68d3c27f)


After

![image](https://github.com/dask/distributed/assets/8629629/a356d165-478b-41cd-97f8-544cbaad9a82)

Note: Network throughput is higher (albeit still way too low), CPU util is higher and disk throughput is more consistent (and still too high due to https://github.com/dask/distributed/issues/7990)

I don't have any end-to-end runtimes since the workload I am testing does not even complete. Sorry about that.

@hendrikmakait 