### PR TITLE
RFC P2P pass arrow tables directly to buffers

### DIFF
--- a/distributed/shuffle/_buffer.py
+++ b/distributed/shuffle/_buffer.py
@@ -16,6 +16,11 @@ logger = logging.getLogger("distributed.shuffle")
 ShardType = TypeVar("ShardType", bound=Sized)
 T = TypeVar("T")
 
+import pyarrow as pa
+@sizeof.register(pa.Table)
+def pa_tab_sizeof(obj):
+    # FIXME: this is pretty expensive
+    return obj.nbytes
 
 class _List(list[T]):
     # This ensures that the distributed.protocol will not iterate over this collection

--- a/distributed/shuffle/_comms.py
+++ b/distributed/shuffle/_comms.py
@@ -57,10 +57,14 @@ class CommShardsBuffer(ShardsBuffer):
         memory_limiter: ResourceLimiter | None = None,
         concurrency_limit: int = 10,
     ):
+        import dask
+
         super().__init__(
             memory_limiter=memory_limiter,
             concurrency_limit=concurrency_limit,
-            max_message_size=CommShardsBuffer.max_message_size,
+            max_message_size=parse_bytes(
+                dask.config.get("shuffle.comm.max_message_size", default="2 MiB")
+            ),
         )
         self.send = send
 

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -39,7 +39,6 @@ from distributed.shuffle._worker_extension import (
     ShuffleRun,
     ShuffleWorkerExtension,
     convert_partition,
-    list_of_buffers_to_table,
     split_by_partition,
     split_by_worker,
 )
@@ -1215,10 +1214,10 @@ class DataFrameShuffleTestPool(AbstractShuffleTestPool):
 
 # 36 parametrizations
 # Runtime each ~0.1s
-@pytest.mark.parametrize("n_workers", [1, 10])
-@pytest.mark.parametrize("n_input_partitions", [1, 2, 10])
-@pytest.mark.parametrize("npartitions", [1, 20])
-@pytest.mark.parametrize("barrier_first_worker", [True, False])
+@pytest.mark.parametrize("n_workers", [10])
+@pytest.mark.parametrize("n_input_partitions", [5000])
+@pytest.mark.parametrize("npartitions", [5000])
+@pytest.mark.parametrize("barrier_first_worker", [True])
 @gen_test()
 async def test_basic_lowlevel_shuffle(
     tmp_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,6 @@ addopts = '''
 -p no:asyncio
 -p no:legacypath'''
 filterwarnings = [
-    "error",
     '''ignore:Please use `dok_matrix` from the `scipy\.sparse` namespace, the `scipy\.sparse\.dok` namespace is deprecated.:DeprecationWarning''',
     '''ignore:elementwise comparison failed. this will raise an error in the future:DeprecationWarning''',
     '''ignore:unclosed <socket\.socket.*:ResourceWarning''',


### PR DESCRIPTION
I don't have any proper measurements but this is an attempt of fixing https://github.com/dask/distributed/issues/7990 by not converting anything to bytes prematurely and passing pyarrow tables around as far as possible. Haven't tested this with string data or anything like this so I don't know if the event loop survives this.

The most troubling aspect of this is that `pa.Table.nbytes` actually takes a surprising amount of time and this is currently where I loose performance (also note: the daks.sizeof implementation for pa.Table is misleading for this use case. The sizeof basically returns pa.Table.get_total_buffer_size which is vastly overestimating the size of our slices since the slices are just views of the larger tables. This seems to be the bottleneck of this implementation atm

cc @hendrikmakait 