### PR TITLE
Make rootish heuristic sensitive to size of task group

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2895,7 +2895,7 @@ class SchedulerState:
         return (
             len(tg) > self.total_nthreads * 2
             and len(tg.dependencies) < 5
-            and sum(map(len, tg.dependencies)) < 5
+            and sum(map(len, tg.dependencies)) < max(5, len(tg) * 0.01)
         )
 
     def check_idle_saturated(self, ws: WorkerState, occ: float = -1.0) -> None:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -4473,3 +4473,18 @@ async def test_scatter_creates_ts(c, s, a, b):
         await a.close()
         assert await x2 == 2
     assert s.tasks["x"].run_spec is not None
+
+
+@gen_cluster(client=True)
+async def test_rootish_for_many_tasks(c, s, a, b):
+    def f(x, y=None):
+        pass
+
+    base = c.map(inc, range(10))
+    derived = c.map(f, range(2000), y=base)
+
+    while derived[0].key not in s.tasks:
+        await asyncio.sleep(0.01)
+
+    ts = s.tasks[derived[0].key]
+    assert s.is_rootish(s.tasks[derived[0].key])


### PR DESCRIPTION
Currently we require rootish tasks to belong to a task group that has no more than five dependencies.

Sometimes (as in a recent Xarray workload showed to me by @dcherian) this doesn't work because there are a few dependencies, but still far fewer than there are tasks in the task group.  In his case there were 6000 tasks in the task group and 6 dependencies of that group, and so it
 was erroneously classified as non-rootish.

This PR proposes a change to the logic, where we accept tasks whose groups have <1% of the number of dependencies as they have tasks in the group.  So in Deepak's case because there are fewer than 6000 * 1% == 60 dependencies, these tasks get classified as rootish.

Future note, we're doing this dynamically now, maybe we should be looking at data stored instead of number of tasks.