### PR TITLE
Send shards grouped by input chunk in P2P rechunking

### DIFF
--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -100,31 +100,6 @@ def rechunk_p2p(x: da.Array, chunks: ChunkedAxes) -> da.Array:
         return da.Array(graph, name, chunks, meta=x)
 
 
-class ShardID(NamedTuple):
-    """Unique identifier of an individual shard within an array rechunk
-
-    When rechunking a 1d-array with two chunks into a 1d-array with a single chunk
-    >>> old = ((2, 2),)  # doctest: +SKIP
-    >>> new = ((4),)  # doctest: +SKIP
-    >>> rechunk_slicing(old, new)  # doctest: +SKIP
-    {
-        # The first chunk of the old array belongs to the first
-        # chunk of the new array at the first sub-index
-        (0,): [(ShardID((0,), (0,)), (slice(0, 2, None),))],
-
-        # The second chunk of the old array belongs to the first
-        # chunk of the new array at the second sub-index
-        (1,): [(ShardID((0,), (1,)), (slice(0, 2, None),))],
-    }
-    """
-
-    #: Index of the new output chunk to which the shard belongs
-    chunk_index: NDIndex
-    #: Index of the shard within the n-dimensional array of shards that will be
-    # concatenated into the new chunk
-    shard_index: NDIndex
-
-
 class Split(NamedTuple):
     """Slice of a chunk that is concatenated with other splits to create a new chunk
 

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -1014,8 +1014,7 @@ def convert_chunk(data: bytes) -> np.ndarray:
     shards: dict[NDIndex, np.ndarray] = {}
 
     while file.tell() < len(data):
-        for tpl in pickle.load(file):
-            index, shard = tpl
+        for index, shard in pickle.load(file):
             shards[index] = shard
 
     subshape = [max(dim) + 1 for dim in zip(*shards.keys())]

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -347,8 +347,7 @@ class ArrayRechunkRun(ShuffleRun[NDIndex, "np.ndarray"]):
             NDIndex, list[tuple[NDIndex, np.ndarray]]
         ] = defaultdict(list)
         for buffer in data:
-            for tpl in pickle.loads(buffer):
-                id, shard = tpl
+            for id, shard in pickle.loads(buffer):
                 repartitioned[id].append(shard)
         return {k: pickle.dumps(v) for k, v in repartitioned.items()}
 

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -30,9 +30,7 @@ from distributed.shuffle._arrow import (
 from distributed.shuffle._comms import CommShardsBuffer
 from distributed.shuffle._disk import DiskShardsBuffer
 from distributed.shuffle._limiter import ResourceLimiter
-from distributed.shuffle._rechunk import ChunkedAxes, NDIndex
-from distributed.shuffle._rechunk import ShardID as ArrayRechunkShardID
-from distributed.shuffle._rechunk import split_axes
+from distributed.shuffle._rechunk import ChunkedAxes, NDIndex, split_axes
 from distributed.shuffle._shuffle import ShuffleId, ShuffleType
 from distributed.sizeof import sizeof
 from distributed.utils import log_errors, sync
@@ -45,7 +43,6 @@ if TYPE_CHECKING:
 
     from distributed.worker import Worker
 
-T_transfer_shard_id = TypeVar("T_transfer_shard_id")
 T_partition_id = TypeVar("T_partition_id")
 T_partition_type = TypeVar("T_partition_type")
 T = TypeVar("T")
@@ -57,7 +54,7 @@ class ShuffleClosedError(RuntimeError):
     pass
 
 
-class ShuffleRun(Generic[T_transfer_shard_id, T_partition_id, T_partition_type]):
+class ShuffleRun(Generic[T_partition_id, T_partition_type]):
     def __init__(
         self,
         id: ShuffleId,
@@ -93,7 +90,7 @@ class ShuffleRun(Generic[T_transfer_shard_id, T_partition_id, T_partition_type])
 
         self.diagnostics: dict[str, float] = defaultdict(float)
         self.transferred = False
-        self.received: set[T_transfer_shard_id] = set()
+        self.received: set[T_partition_id] = set()
         self.total_recvd = 0
         self.start_time = time.time()
         self._exception: Exception | None = None
@@ -122,7 +119,7 @@ class ShuffleRun(Generic[T_transfer_shard_id, T_partition_id, T_partition_type])
         await self.scheduler.shuffle_barrier(id=self.id, run_id=self.run_id)
 
     async def send(
-        self, address: str, shards: list[tuple[T_transfer_shard_id, bytes]]
+        self, address: str, shards: list[tuple[T_partition_id, bytes]]
     ) -> None:
         self.raise_if_closed()
         return await self.rpc(address).shuffle_receive(
@@ -151,12 +148,12 @@ class ShuffleRun(Generic[T_transfer_shard_id, T_partition_id, T_partition_type])
         }
 
     async def _write_to_comm(
-        self, data: dict[str, list[tuple[T_transfer_shard_id, bytes]]]
+        self, data: dict[str, tuple[T_partition_id, bytes]]
     ) -> None:
         self.raise_if_closed()
         await self._comm_buffer.write(data)
 
-    async def _write_to_disk(self, data: dict[NDIndex, list[bytes]]) -> None:
+    async def _write_to_disk(self, data: dict[NDIndex, bytes]) -> None:
         self.raise_if_closed()
         await self._disk_buffer.write(
             {"_".join(str(i) for i in k): v for k, v in data.items()}
@@ -205,7 +202,7 @@ class ShuffleRun(Generic[T_transfer_shard_id, T_partition_id, T_partition_type])
         data: bytes = self._disk_buffer.read("_".join(str(i) for i in id))
         return data
 
-    async def receive(self, data: list[tuple[T_transfer_shard_id, bytes]]) -> None:
+    async def receive(self, data: list[tuple[T_partition_id, bytes]]) -> None:
         await self._receive(data)
 
     async def _ensure_output_worker(self, i: T_partition_id, key: str) -> None:
@@ -225,7 +222,7 @@ class ShuffleRun(Generic[T_transfer_shard_id, T_partition_id, T_partition_type])
         """Get the address of the worker assigned to the output partition"""
 
     @abc.abstractmethod
-    async def _receive(self, data: list[tuple[T_transfer_shard_id, bytes]]) -> None:
+    async def _receive(self, data: list[tuple[T_partition_id, bytes]]) -> None:
         """Receive shards belonging to output partitions of this shuffle run"""
 
     @abc.abstractmethod
@@ -241,7 +238,7 @@ class ShuffleRun(Generic[T_transfer_shard_id, T_partition_id, T_partition_type])
         """Get an output partition to the shuffle run"""
 
 
-class ArrayRechunkRun(ShuffleRun[ArrayRechunkShardID, NDIndex, "np.ndarray"]):
+class ArrayRechunkRun(ShuffleRun[NDIndex, "np.ndarray"]):
     """State for a single active rechunk execution
 
     This object is responsible for splitting, sending, receiving and combining
@@ -323,44 +320,58 @@ class ArrayRechunkRun(ShuffleRun[ArrayRechunkShardID, NDIndex, "np.ndarray"]):
         self.worker_for = worker_for
         self.split_axes = split_axes(old, new)
 
-    async def _receive(self, data: list[tuple[ArrayRechunkShardID, bytes]]) -> None:
+    async def _receive(self, data: list[tuple[NDIndex, bytes]]) -> None:
         self.raise_if_closed()
 
-        buffers = defaultdict(list)
+        filtered = []
         for d in data:
             id, payload = d
             if id in self.received:
                 continue
+            filtered.append(payload)
             self.received.add(id)
             self.total_recvd += sizeof(d)
-
-            buffers[id.chunk_index].append(payload)
-
         del data
-        if not buffers:
+        if not filtered:
             return
         try:
-            await self._write_to_disk(buffers)
+            shards = await self.offload(self._repartition_shards, filtered)
+            del filtered
+            await self._write_to_disk(shards)
         except Exception as e:
             self._exception = e
             raise
+
+    def _repartition_shards(self, data: list[bytes]) -> dict[NDIndex, bytes]:
+        repartitioned: defaultdict[
+            NDIndex, list[tuple[NDIndex, np.ndarray]]
+        ] = defaultdict(list)
+        for buffer in data:
+            for tpl in pickle.loads(buffer):
+                id, shard = tpl
+                repartitioned[id].append(shard)
+        return {k: pickle.dumps(v) for k, v in repartitioned.items()}
 
     async def add_partition(self, data: np.ndarray, partition_id: NDIndex) -> int:
         self.raise_if_closed()
         if self.transferred:
             raise RuntimeError(f"Cannot add more partitions to {self}")
 
-        def _() -> dict[str, list[tuple[ArrayRechunkShardID, bytes]]]:
-            """Return a mapping of worker addresses to a list of tuples of shard IDs
-            and shard data.
+        def _() -> dict[str, tuple[NDIndex, bytes]]:
+            """Return a mapping of worker addresses to a tuple of input partition
+            IDs and shard data.
 
+
+            TODO: Overhaul!
             As shard data, we serialize the payload together with the sub-index of the
             slice within the new chunk. To assemble the new chunk from its shards, it
             needs the sub-index to know where each shard belongs within the chunk.
             Adding the sub-index into the serialized payload on the sender allows us to
             write the serialized payload directly to disk on the receiver.
             """
-            out: dict[str, list[tuple[ArrayRechunkShardID, bytes]]] = defaultdict(list)
+            out: dict[
+                str, list[tuple[NDIndex, tuple[NDIndex, np.ndarray]]]
+            ] = defaultdict(list)
             from itertools import product
 
             ndsplits = product(
@@ -369,11 +380,10 @@ class ArrayRechunkRun(ShuffleRun[ArrayRechunkShardID, NDIndex, "np.ndarray"]):
 
             for ndsplit in ndsplits:
                 chunk_index, shard_index, ndslice = zip(*ndsplit)
-                id = ArrayRechunkShardID(chunk_index, shard_index)
                 out[self.worker_for[chunk_index]].append(
-                    (id, pickle.dumps((shard_index, data[ndslice])))
+                    (chunk_index, (shard_index, data[ndslice]))
                 )
-            return out
+            return {k: (partition_id, pickle.dumps(v)) for k, v in out.items()}
 
         out = await self.offload(_)
         await self._write_to_comm(out)
@@ -401,7 +411,7 @@ class ArrayRechunkRun(ShuffleRun[ArrayRechunkShardID, NDIndex, "np.ndarray"]):
         return self.worker_for[id]
 
 
-class DataFrameShuffleRun(ShuffleRun[int, int, "pd.DataFrame"]):
+class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
     """State for a single active shuffle execution
 
     This object is responsible for splitting, sending, receiving and combining
@@ -503,25 +513,25 @@ class DataFrameShuffleRun(ShuffleRun[int, int, "pd.DataFrame"]):
             self._exception = e
             raise
 
-    def _repartition_buffers(self, data: list[bytes]) -> dict[NDIndex, list[bytes]]:
+    def _repartition_buffers(self, data: list[bytes]) -> dict[NDIndex, bytes]:
         table = list_of_buffers_to_table(data)
         groups = split_by_partition(table, self.column)
         assert len(table) == sum(map(len, groups.values()))
         del data
-        return {(k,): [serialize_table(v)] for k, v in groups.items()}
+        return {(k,): serialize_table(v) for k, v in groups.items()}
 
     async def add_partition(self, data: pd.DataFrame, partition_id: int) -> int:
         self.raise_if_closed()
         if self.transferred:
             raise RuntimeError(f"Cannot add more partitions to {self}")
 
-        def _() -> dict[str, list[tuple[int, bytes]]]:
+        def _() -> dict[str, tuple[int, bytes]]:
             out = split_by_worker(
                 data,
                 self.column,
                 self.worker_for,
             )
-            out = {k: [(partition_id, serialize_table(t))] for k, t in out.items()}
+            out = {k: (partition_id, serialize_table(t)) for k, t in out.items()}
             return out
 
         out = await self.offload(_)
@@ -1005,8 +1015,9 @@ def convert_chunk(data: bytes) -> np.ndarray:
     shards: dict[NDIndex, np.ndarray] = {}
 
     while file.tell() < len(data):
-        index, shard = pickle.load(file)
-        shards[index] = shard
+        for tpl in pickle.load(file):
+            index, shard = tpl
+            shards[index] = shard
 
     subshape = [max(dim) + 1 for dim in zip(*shards.keys())]
     assert len(shards) == np.prod(subshape)

--- a/distributed/shuffle/tests/test_comm_buffer.py
+++ b/distributed/shuffle/tests/test_comm_buffer.py
@@ -21,8 +21,8 @@ async def test_basic(tmp_path):
         d[address].extend(shards)
 
     mc = CommShardsBuffer(send=send)
-    await mc.write({"x": [b"0" * 1000], "y": [b"1" * 500]})
-    await mc.write({"x": [b"0" * 1000], "y": [b"1" * 500]})
+    await mc.write({"x": b"0" * 1000, "y": b"1" * 500})
+    await mc.write({"x": b"0" * 1000, "y": b"1" * 500})
 
     await mc.flush()
 
@@ -38,13 +38,13 @@ async def test_exceptions(tmp_path):
         raise Exception(123)
 
     mc = CommShardsBuffer(send=send)
-    await mc.write({"x": [b"0" * 1000], "y": [b"1" * 500]})
+    await mc.write({"x": b"0" * 1000, "y": b"1" * 500})
 
     while not mc._exception:
         await asyncio.sleep(0.1)
 
     with pytest.raises(Exception, match="123"):
-        await mc.write({"x": [b"0" * 1000], "y": [b"1" * 500]})
+        await mc.write({"x": b"0" * 1000, "y": b"1" * 500})
 
     await mc.flush()
 
@@ -64,8 +64,8 @@ async def test_slow_send(tmp_path):
         sending_first.set()
 
     mc = CommShardsBuffer(send=send, concurrency_limit=1)
-    await mc.write({"x": [b"0"], "y": [b"1"]})
-    await mc.write({"x": [b"0"], "y": [b"1"]})
+    await mc.write({"x": b"0", "y": b"1"})
+    await mc.write({"x": b"0", "y": b"1"})
     flush_task = asyncio.create_task(mc.flush())
     await sending_first.wait()
     block_send.clear()
@@ -96,8 +96,7 @@ async def test_concurrent_puts():
         send=send, memory_limiter=ResourceLimiter(parse_bytes("100 MiB"))
     )
     payload = {
-        x: [gen_bytes(frac, comm_buffer.memory_limiter._maxvalue)]
-        for x in range(nshards)
+        x: gen_bytes(frac, comm_buffer.memory_limiter._maxvalue) for x in range(nshards)
     }
 
     async with comm_buffer as mc:
@@ -138,8 +137,7 @@ async def test_concurrent_puts_error():
         send=send, memory_limiter=ResourceLimiter(parse_bytes("100 MiB"))
     )
     payload = {
-        x: [gen_bytes(frac, comm_buffer.memory_limiter._maxvalue)]
-        for x in range(nshards)
+        x: gen_bytes(frac, comm_buffer.memory_limiter._maxvalue) for x in range(nshards)
     }
 
     async with comm_buffer as mc:

--- a/distributed/shuffle/tests/test_disk_buffer.py
+++ b/distributed/shuffle/tests/test_disk_buffer.py
@@ -13,8 +13,8 @@ from distributed.utils_test import gen_test
 @gen_test()
 async def test_basic(tmp_path):
     async with DiskShardsBuffer(directory=tmp_path) as mf:
-        await mf.write({"x": [b"0" * 1000], "y": [b"1" * 500]})
-        await mf.write({"x": [b"0" * 1000], "y": [b"1" * 500]})
+        await mf.write({"x": b"0" * 1000, "y": b"1" * 500})
+        await mf.write({"x": b"0" * 1000, "y": b"1" * 500})
 
         await mf.flush()
 
@@ -32,7 +32,7 @@ async def test_basic(tmp_path):
 
 @gen_test()
 async def test_read_before_flush(tmp_path):
-    payload = {"1": [b"foo"]}
+    payload = {"1": b"foo"}
     async with DiskShardsBuffer(directory=tmp_path) as mf:
         with pytest.raises(RuntimeError):
             mf.read(1)
@@ -52,7 +52,7 @@ async def test_read_before_flush(tmp_path):
 @gen_test()
 async def test_many(tmp_path, count):
     async with DiskShardsBuffer(directory=tmp_path) as mf:
-        d = {i: [str(i).encode() * 100] for i in range(count)}
+        d = {i: str(i).encode() * 100 for i in range(count)}
 
         for _ in range(10):
             await mf.write(d)


### PR DESCRIPTION
This PR further reduces the memory footprint (and amount of transferred data) in P2P rechunking. Previously, shards were sent individually, which meant that deduplication would also happen on individual shards. This led to the memory footprint growing proportionally to the number of shards. With this PR, the footprint is reduced to growing proportionally to the number of input chunks. 

While the impact on runtime appears to be small, its effect on the average memory is significant for large rechunks with many small shards:
<img width="1054" alt="Screenshot 2023-07-18 at 10 54 48" src="https://github.com/dask/distributed/assets/2699097/3fd7c675-a0e1-4a3e-a225-d119937404f4">
<img width="1054" alt="Screenshot 2023-07-18 at 10 55 04" src="https://github.com/dask/distributed/assets/2699097/dd96e4c6-3f5f-4ea7-ae76-f1752e658119">



- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
