### PR TITLE
Fix for ``TypeError: '<' not supported`` in graph dashboard

### DIFF
--- a/distributed/diagnostics/graph_layout.py
+++ b/distributed/diagnostics/graph_layout.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 
 from distributed.diagnostics.plugin import SchedulerPlugin
+from distributed.utils import TupleComparable
 
 
 class GraphLayout(SchedulerPlugin):
@@ -48,7 +49,9 @@ class GraphLayout(SchedulerPlugin):
     def update_graph(
         self, scheduler, *, dependencies=None, priority=None, tasks=None, **kwargs
     ):
-        stack = sorted(tasks, key=lambda k: priority.get(k, 0), reverse=True)
+        stack = sorted(
+            tasks, key=lambda k: TupleComparable(priority.get(k, 0)), reverse=True
+        )
         while stack:
             key = stack.pop()
             if key in self.x or key not in scheduler.tasks:
@@ -58,7 +61,11 @@ class GraphLayout(SchedulerPlugin):
                 if not all(dep in self.y for dep in deps):
                     stack.append(key)
                     stack.extend(
-                        sorted(deps, key=lambda k: priority.get(k, 0), reverse=True)
+                        sorted(
+                            deps,
+                            key=lambda k: TupleComparable(priority.get(k, 0)),
+                            reverse=True,
+                        )
                     )
                     continue
                 else:

--- a/distributed/diagnostics/tests/test_graph_layout.py
+++ b/distributed/diagnostics/tests/test_graph_layout.py
@@ -99,3 +99,14 @@ async def test_unique_positions(c, s, a, b):
 
     y_positions = [(gl.x[k], gl.y[k]) for k in gl.x]
     assert len(y_positions) == len(set(y_positions))
+
+
+@gen_cluster(client=True)
+async def test_layout_with_priorities(c, s, a, b):
+    gl = GraphLayout(s)
+    s.add_plugin(gl)
+
+    low = c.submit(inc, 1, key="low", priority=1)
+    mid = c.submit(inc, 2, key="mid", priority=2)
+    high = c.submit(inc, 3, key="high", priority=3)
+    await wait([high, mid, low])

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -33,6 +33,7 @@ from distributed.utils import (
     LoopRunner,
     RateLimiterFilter,
     TimeoutError,
+    TupleComparable,
     _maybe_complex,
     ensure_ip,
     ensure_memoryview,
@@ -1043,3 +1044,38 @@ def test_rate_limiter_filter(caplog):
         "Hello again!",
         "Hello once more!",
     ]
+
+
+@pytest.mark.parametrize(
+    "obj1,obj2,expected",
+    [
+        [(1, 2), (1, 2), False],
+        [(1, 2), (1, 3), True],
+        [1, 1, False],
+        [1, 2, True],
+        [None, 0, False],
+        [None, (1, 2), True],
+    ],
+)
+def test_tuple_comparable_lt(obj1, obj2, expected):
+    assert (TupleComparable(obj1) < TupleComparable(obj2)) == expected
+
+
+@pytest.mark.parametrize(
+    "obj1,obj2,expected",
+    [
+        [(1, 2), (1, 2), True],
+        [(1, 2), (1, 3), False],
+        [1, 1, True],
+        [1, 2, False],
+        [None, 0, True],
+        [None, (1, 2), False],
+    ],
+)
+def test_tuple_comparable_eq(obj1, obj2, expected):
+    assert (TupleComparable(obj1) == TupleComparable(obj2)) == expected
+
+
+def test_tuple_comparable_error():
+    with pytest.raises(ValueError):
+        TupleComparable("string")

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1925,3 +1925,38 @@ else:
 
     async def wait_for(fut: Awaitable[T], timeout: float) -> T:
         return await asyncio.wait_for(fut, timeout)
+
+
+class TupleComparable:
+    """Wrap object so that we can compare tuple, int or None
+
+    When comparing two objects of different types Python fails
+
+    >>> (1, 2) < 1
+    Traceback (most recent call last):
+        ...
+    TypeError: '<' not supported between instances of 'tuple' and 'int'
+
+    This class replaces None with 0, and wraps ints with tuples
+
+    >>> TupleComparable((1, 2)) < TupleComparable(1)
+    False
+    """
+
+    __slots__ = ("obj",)
+
+    def __init__(self, obj):
+        if obj is None:
+            self.obj = (0,)
+        elif isinstance(obj, tuple):
+            self.obj = obj
+        elif isinstance(obj, (int, float)):
+            self.obj = (obj,)
+        else:
+            raise ValueError(f"Object must be tuple, int, float or None, got {obj}")
+
+    def __eq__(self, other):
+        return self.obj == other.obj
+
+    def __lt__(self, other):
+        return self.obj < other.obj


### PR DESCRIPTION
Task priorities can be int, tuples, and in some cases, apparently also `None`. That makes them unsortable, causing errors like this one:

```

tornado.application - ERROR - Uncaught exception GET /graph (127.0.0.1)
HTTPServerRequest(protocol='http', host='cluster-ufcfr.dask.host', method='GET', uri='/graph', version='HTTP/1.1', remote_ip='127.0.0.1')
Traceback (most recent call last):
  File "/python/lib/python3.10/site-packages/tornado/web.py", line 1713, in _execute
    result = await result
  File "/python/lib/python3.10/site-packages/bokeh/server/views/doc_handler.py", line 54, in get
    session = await self.get_session()
  File "/python/lib/python3.10/site-packages/bokeh/server/views/session_handler.py", line 144, in get_session
    session = await self.application_context.create_session_if_needed(session_id, self.request, token)
  File "/python/lib/python3.10/site-packages/bokeh/server/contexts.py", line 243, in create_session_if_needed
    self._application.initialize_document(doc)
  File "/python/lib/python3.10/site-packages/bokeh/application/application.py", line 194, in initialize_document
    h.modify_document(doc)
  File "/python/lib/python3.10/site-packages/bokeh/application/handlers/function.py", line 143, in modify_document
    self._func(doc)
  File "/python/lib/python3.10/site-packages/distributed/utils.py", line 758, in wrapper
    return func(*args, **kwargs)
  File "/python/lib/python3.10/site-packages/distributed/dashboard/components/scheduler.py", line 4239, in graph_doc
    graph = TaskGraph(scheduler, sizing_mode="stretch_both")
  File "/python/lib/python3.10/site-packages/distributed/dashboard/components/scheduler.py", line 2252, in __init__
    self.layout = GraphLayout(scheduler)
  File "/python/lib/python3.10/site-packages/distributed/diagnostics/graph_layout.py", line 41, in __init__
    self.update_graph(
  File "/python/lib/python3.10/site-packages/distributed/diagnostics/graph_layout.py", line 51, in update_graph
    stack = sorted(tasks, key=lambda k: priority.get(k, 0), reverse=True)
TypeError: '<' not supported between instances of 'NoneType' and 'tuple'
```

This is a very similar approach to `dask.order.StrComparable`:

https://github.com/dask/dask/blob/59da6fa0c425faa30827cef37958e13d2e823d98/dask/order.py#L985

I could reuse `StrComparable` here, and that would fix the error, but I think comparing `int` and `tuple` this way is better (more fair?) than comparing their stringified representation.

Closes https://github.com/dask/distributed/issues/2193.

cc @fjetter

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
