### PR TITLE
Raise CommClosedError in get_stream_address

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -119,14 +119,13 @@ def get_stream_address(comm):
     """
     Get a stream's local address.
     """
+    # raise OSError in case the comm is closed, s.t.
+    # retry code can handle it appropriately; see also
+    # https://github.com/dask/distributed/issues/7953
     if comm.closed():
-        return "<closed>"
+        raise CommClosedError()
 
-    try:
-        return unparse_host_port(*comm.socket.getsockname()[:2])
-    except OSError:
-        # Probably EBADF
-        return "<closed>"
+    return unparse_host_port(*comm.socket.getsockname()[:2])
 
 
 def convert_stream_closed_error(obj, exc):

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -25,6 +25,7 @@ from distributed.comm import (
     unparse_host_port,
 )
 from distributed.comm.registry import backends, get_backend
+from distributed.comm.tcp import get_stream_address
 from distributed.compatibility import asyncio_run
 from distributed.config import get_loop_factory
 from distributed.metrics import time
@@ -1341,6 +1342,15 @@ async def check_addresses(a, b):
 async def test_tcp_adresses(tcp):
     a, b = await get_tcp_comm_pair()
     await check_addresses(a, b)
+
+
+@gen_test()
+async def test_get_stream_address_raises_if_closed():
+    a, b = await get_tcp_comm_pair()
+    a.abort()
+    with pytest.raises(OSError):
+        get_stream_address(a)
+    b.abort()
 
 
 @gen_test()


### PR DESCRIPTION
Rather than returning an invalid address string "<closed>", raise a CommClosedError that can be handled by retry code that retries on OSError.

Closes #7953

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
