### PR TITLE
Test against more recent ``pyarrow`` versions

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pre-commit
   - prometheus_client
   - psutil
-  - pyarrow=7
+  - pyarrow>=7
   - pytest
   - pytest-cov
   - pytest-faulthandler

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pre-commit
   - prometheus_client
   - psutil
-  - pyarrow=7
+  - pyarrow>=7
   - pytest
   - pytest-cov
   - pytest-faulthandler


### PR DESCRIPTION
I noticed that right now we're pinning `pyarrow=7` in all our CI builds. This PR changes that to version constraint to `pyarrow>=7` in most builds, but keeps `pyarrow=7` in our Python 3.9 build (since this is the minimum supported version for P2P, it'd be good to keep tests coverage for that case). This will make sure we're still compatible with newer versions of `pyarrow`. Note we already test against newer versions of `pyarrow` over in `dask/dask`, so we already have some coverage, but I figured updating here too won't hurt. 