### PR TITLE
Increase test timeout by 30 minutes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     # Do not run the schedule job on forks
     if: github.repository == 'dask/distributed' || github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 150
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
xref https://github.com/dask/distributed/issues/8023

This doesn't solve the issue, but I'd rather gave builds finish than get cancelled  