### PR TITLE
Add a test for `GraphLayout` with scatter

### DIFF
--- a/distributed/diagnostics/tests/test_graph_layout.py
+++ b/distributed/diagnostics/tests/test_graph_layout.py
@@ -102,11 +102,11 @@ async def test_unique_positions(c, s, a, b):
 
 
 @gen_cluster(client=True)
-async def test_layout_with_priorities(c, s, a, b):
+async def test_layout_scatter(c, s, a, b):
     gl = GraphLayout(s)
     s.add_plugin(gl)
 
-    low = c.submit(inc, 1, key="low", priority=1)
-    mid = c.submit(inc, 2, key="mid", priority=2)
-    high = c.submit(inc, 3, key="high", priority=3)
-    await wait([high, mid, low])
+    data = await c.scatter([1, 2, 3], broadcast=True)
+    futures = [c.submit(sum, data) for _ in range(5)]
+    await wait(futures)
+    assert len(gl.state_updates) > 0


### PR DESCRIPTION
Replace a test for `TypeError` for GraphLayout with scatter - this one triggers the same error that the customer experienced.

Follow-up for https://github.com/dask/distributed/pull/8017 ([comment](https://github.com/dask/distributed/pull/8017#issuecomment-1643601485)).

Closes #xxxx

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
