### PR TITLE
Revert ``github-pages-deploy-action`` GHA version bump

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -56,7 +56,7 @@ jobs:
           mv test_report.html test_short_report.html deploy/
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        uses: JamesIves/github-pages-deploy-action@v4.4.2
         with:
           branch: gh-pages
           folder: deploy


### PR DESCRIPTION
Not sure what crazy magic is happening here, but this somehow appears to fix https://github.com/dask/distributed/issues/8023 (at least based on looking at the CI build on my fork). Not sure if this is actually fixing things, or just a coincidence. Running CI against `main` over in https://github.com/dask/distributed/pull/8026 to see if something external has fixed the hanging builds. 

Closes https://github.com/dask/distributed/issues/8023