### PR TITLE
Fix suspicious failure log message in `Scheduler.remove_worker`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5055,7 +5055,7 @@ class Scheduler(SchedulerState, ServerNode):
                         "Task %s marked as failed because %d workers died"
                         " while trying to run it",
                         ts.key,
-                        self.allowed_failures,
+                        ts.suspicious,
                     )
 
         for ts in list(ws.has_what):


### PR DESCRIPTION
The log message is off by one
```
2023-07-21 09:36:50,867 - distributed.scheduler - INFO - Task ('shuffle-transfer-7ef713a9e3987eba56ca946b792befcb', 0) marked as failed because 0 workers died while trying to run it
```

because it prints the limit, not the actual count. This PR rectifies that.


- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
