### PR TITLE
Respect average nthreads in adaptive

### DIFF
--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -19,7 +19,7 @@ from distributed import (
 )
 from distributed.compatibility import LINUX, MACOS, WINDOWS
 from distributed.metrics import time
-from distributed.utils_test import async_poll_for, gen_test, slowinc
+from distributed.utils_test import async_poll_for, gen_cluster, gen_test, slowinc
 
 
 def test_adaptive_local_cluster(loop):
@@ -196,6 +196,7 @@ async def test_adapt_quickly():
         processes=False,
         silence_logs=False,
         dashboard_address=":0",
+        threads_per_worker=1,
     ) as cluster, Client(cluster, asynchronous=True) as client:
         adapt = cluster.adapt(interval="20 ms", wait_count=5, maximum=10)
         future = client.submit(slowinc, 1, delay=0.100)
@@ -484,3 +485,22 @@ async def test_adaptive_stopped():
         pc = instance.periodic_callback
 
     await async_poll_for(lambda: not pc.is_running(), timeout=5)
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 5)],
+    config={"distributed.scheduler.default-task-durations": {"slowinc": 1000}},
+)
+async def test_respect_average_nthreads(c, s, w):
+    futures = c.map(slowinc, range(10))
+    while not s.tasks:
+        await asyncio.sleep(0.001)
+
+    assert s.adaptive_target() == 2
+
+    more_futures = c.map(slowinc, range(200))
+    while len(s.tasks) != 200:
+        await asyncio.sleep(0.001)
+
+    assert s.adaptive_target() == 40

--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -325,16 +325,11 @@ def test_target_duration(target_duration):
                     await client.wait_for_workers(2)
                     futures = client.map(slowinc, range(n_tasks), delay=0.3)
                     await wait(futures)
-                scaleup_recommendations = [
+                scaleup_recs = [
                     msg[1]["n"] for msg in adapt.log if msg[1].get("status") == "up"
                 ]
 
-                assert (
-                    2
-                    <= min(scaleup_recommendations)
-                    < max(scaleup_recommendations)
-                    <= max_scaleup
-                )
+                assert 2 <= min(scaleup_recs) < max(scaleup_recs) <= max_scaleup
 
     _test()
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8064,9 +8064,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         # TODO consider any user-specified default task durations for queued tasks
         queued_occupancy = len(self.queued) * self.UNKNOWN_TASK_DURATION
-        cpu = math.ceil(
-            (self.total_occupancy + queued_occupancy) / target_duration
-        )  # TODO: threads per worker
+        cpu = math.ceil((self.total_occupancy + queued_occupancy) / target_duration)
 
         # Avoid a few long tasks from asking for many cores
         tasks_ready = len(self.queued)
@@ -8077,6 +8075,11 @@ class Scheduler(SchedulerState, ServerNode):
                 break
         else:
             cpu = min(tasks_ready, cpu)
+
+        # Divide by average nthreads per worker
+        if self.workers:
+            nthreads = sum(ws.nthreads for ws in self.workers.values())
+            cpu = cpu / nthreads * len(self.workers)
 
         if (self.unrunnable or self.queued) and not self.workers:
             cpu = max(1, cpu)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8079,7 +8079,7 @@ class Scheduler(SchedulerState, ServerNode):
         # Divide by average nthreads per worker
         if self.workers:
             nthreads = sum(ws.nthreads for ws in self.workers.values())
-            cpu = cpu / nthreads * len(self.workers)
+            cpu = math.ceil(cpu / nthreads * len(self.workers))
 
         if (self.unrunnable or self.queued) and not self.workers:
             cpu = max(1, cpu)


### PR DESCRIPTION
Previously we would assume in adaptive that workers had a single core.

Now we do a pass through all the workers to sum up the number of threads per machine and divide the recommendation by this amount.

This is not very expensive

```python-console
In [1]: class Worker:
   ...:     def __init__(self):
   ...:         self.cpu = 4
   ...:

In [2]: workers = [Worker() for _ in range(1000)]

In [3]: %timeit sum(w.cpu for w in workers)
33.6 µs ± 170 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Supercedes https://github.com/dask/distributed/pull/8039