### PR TITLE
Log worker close reason in events

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -4483,16 +4483,3 @@ async def test_scatter_creates_ts(c, s, a, b):
         await a.close()
         assert await x2 == 2
     assert s.tasks["x"].run_spec is not None
-
-
-@gen_cluster(
-    client=True,
-    nthreads=[],
-    config={"distributed.scheduler.default-task-durations": {"slowinc": 1000}},
-)
-async def test_scale_up_large_tasks(c, s):
-    futures = c.map(slowinc, range(10))
-    while not s.tasks:
-        await asyncio.sleep(0.001)
-
-    assert s.adaptive_target() == 10

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -751,7 +751,7 @@ async def test_remove_worker_by_name_from_scheduler(s, a, b):
     )
 
 
-@gen_cluster(config={"distributed.scheduler.events-cleanup-delay": "10 ms"})
+@gen_cluster(config={"distributed.scheduler.events-cleanup-delay": "500 ms"})
 async def test_clear_events_worker_removal(s, a, b):
     assert a.address in s.events
     assert a.address in s.workers

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1521,6 +1521,7 @@ class Worker(BaseWorker, ServerNode):
 
         disable_gc_diagnosis()
 
+        self.log_event(self.address, {"action": "closing-worker", "reason": reason})
         try:
             logger.info("Stopping worker at %s. Reason: %s", self.address, reason)
         except ValueError:  # address not available if already closed

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1521,7 +1521,12 @@ class Worker(BaseWorker, ServerNode):
 
         disable_gc_diagnosis()
 
-        self.log_event(self.address, {"action": "closing-worker", "reason": reason})
+        try:
+            self.log_event(self.address, {"action": "closing-worker", "reason": reason})
+        except Exception:
+            # This can happen when the Server is not up yet
+            logger.exception("Failed to log closing event")
+
         try:
             logger.info("Stopping worker at %s. Reason: %s", self.address, reason)
         except ValueError:  # address not available if already closed


### PR DESCRIPTION
This allows for some introspection on scheduler side about why a worker closed.

There are many places where the reason may come from. Unfortunately, the actual close on scheduler side is triggered when the connection is broken and therefore we cannot cleanly forward this information during close. However, we can simply add another entry to the events log.