### PR TITLE
Provide close reason when signal is caught

### DIFF
--- a/distributed/_signals.py
+++ b/distributed/_signals.py
@@ -8,7 +8,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-async def wait_for_signals() -> None:
+async def wait_for_signals() -> int:
     """Wait for sigint or sigterm by setting global signal handlers"""
     signals = (signal.SIGINT, signal.SIGTERM)
     loop = asyncio.get_running_loop()
@@ -36,6 +36,7 @@ async def wait_for_signals() -> None:
         logger.info(
             "Received signal %s (%d)", signal.Signals(caught_signal).name, caught_signal
         )
+        return caught_signal
     finally:
         for sig in signals:
             signal.signal(sig, old_handlers[sig])

--- a/distributed/cli/dask_scheduler.py
+++ b/distributed/cli/dask_scheduler.py
@@ -229,8 +229,8 @@ def main(
 
         async def wait_for_signals_and_close():
             """Wait for SIGINT or SIGTERM and close the scheduler upon receiving one of those signals"""
-            await wait_for_signals()
-            await scheduler.close()
+            signum = await wait_for_signals()
+            await scheduler.close(reason=f"signal-{signum}")
 
         wait_for_signals_and_close_task = asyncio.create_task(
             wait_for_signals_and_close()

--- a/distributed/cli/dask_worker.py
+++ b/distributed/cli/dask_worker.py
@@ -423,12 +423,14 @@ def main(  # type: ignore[no-untyped-def]
         async def wait_for_signals_and_close():
             """Wait for SIGINT or SIGTERM and close all nannies upon receiving one of those signals"""
             nonlocal signal_fired
-            await wait_for_signals()
+            signum = await wait_for_signals()
 
             signal_fired = True
             if nanny:
                 # Unregister all workers from scheduler
-                await asyncio.gather(*(n.close(timeout=10) for n in nannies))
+                await asyncio.gather(
+                    *(n.close(timeout=10, reason=f"signal-{signum}") for n in nannies)
+                )
 
         wait_for_signals_and_close_task = asyncio.create_task(
             wait_for_signals_and_close()

--- a/distributed/comm/core.py
+++ b/distributed/comm/core.py
@@ -384,6 +384,7 @@ async def connect(
     comm.handshake_options = comm.handshake_configuration(
         comm.local_info, comm.remote_info
     )
+    logger.debug("Connection to %s established", loc)
     return comm
 
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -618,7 +618,7 @@ class Server:
             timeout = getattr(self, "death_timeout", None)
 
             async def _close_on_failure(exc: Exception) -> None:
-                await self.close()
+                await self.close(reason=f"failure-to-start-{str(type(exc))}")
                 self.status = Status.failed
                 self.__startup_exc = exc
 
@@ -1025,7 +1025,7 @@ class Server:
             await comm.close()
             assert comm.closed()
 
-    async def close(self, timeout=None):
+    async def close(self, timeout=None, reason=""):
         try:
             for pc in self.periodic_callbacks.values():
                 pc.stop()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3982,7 +3982,7 @@ class Scheduler(SchedulerState, ServerNode):
         setproctitle(f"dask scheduler [{self.address}]")
         return self
 
-    async def close(self, fast=None, close_workers=None):
+    async def close(self, fast=None, close_workers=None, reason=None):
         """Send cleanup signal to all coroutines then wait until finished
 
         See Also
@@ -4009,8 +4009,10 @@ class Scheduler(SchedulerState, ServerNode):
         )
 
         self.status = Status.closing
-
-        logger.info("Scheduler closing...")
+        if reason:
+            logger.info("Scheduler closing due to %s...", reason)
+        else:
+            logger.info("Scheduler closing...")
         setproctitle("dask scheduler [closing]")
 
         for preload in self.preloads:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3982,7 +3982,7 @@ class Scheduler(SchedulerState, ServerNode):
         setproctitle(f"dask scheduler [{self.address}]")
         return self
 
-    async def close(self, fast=None, close_workers=None, reason=None):
+    async def close(self, fast=None, close_workers=None, reason=""):
         """Send cleanup signal to all coroutines then wait until finished
 
         See Also

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4009,10 +4009,7 @@ class Scheduler(SchedulerState, ServerNode):
         )
 
         self.status = Status.closing
-        if reason:
-            logger.info("Scheduler closing due to %s...", reason)
-        else:
-            logger.info("Scheduler closing...")
+        logger.info("Scheduler closing due to %s...", reason or "unknown reason")
         setproctitle("dask scheduler [closing]")
 
         for preload in self.preloads:


### PR DESCRIPTION
These are a couple of cosmetic fixes that ensure we're passing around the `reason` more thoroughly, e.g. if we catch a signal in CLI

I do not intend to add any tests, I don't think we're testing the reason anywhere.