### PR TITLE
Simplify update graph

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1093,7 +1093,6 @@ async def test_restart_nanny_timeout_exceeded(c, s, a, b):
         b.kill_proceed.set()
 
 
-
 @gen_cluster(client=True, nthreads=[("", 1)] * 2)
 async def test_restart_not_all_workers_return(c, s, a, b):
     with pytest.raises(TimeoutError, match="Waited for 2 worker"):


### PR DESCRIPTION
Working my way towards https://github.com/dask/distributed/issues/7980

This makes a couple of methods static. This is mostly cosmetic to signal that they are in fact not relying on the scheduler and are not (supposed to) mutate any state.

The second thing is that this simplifies the way annotations are handled which is currently quite confusing. Haven't run any benchmarks but I'm pretty sure this is also faster than before. However, nothing here is flagged by https://github.com/dask/distributed/issues/7980

