### PR TITLE
clarified concurrent.futures section in client.rst

### DIFF
--- a/docs/source/client.rst
+++ b/docs/source/client.rst
@@ -46,14 +46,6 @@ many function calls with the ``client.map`` method
 
 These results live on distributed workers.
 
-We can submit tasks on futures.  The function will go to the machine where the
-futures are stored and run on the result once it has completed.
-
-.. code-block:: python
-
-   >>> y = client.submit(inc, x)      # Submit on x, a Future
-   >>> total = client.submit(sum, L)  # Map on L, a list of Futures
-
 We gather back the results using either the ``Future.result`` method for single
 futures or ``client.gather`` method for many futures at once.
 
@@ -70,6 +62,16 @@ process.  It's often best to leave data on the cluster and operate on it
 remotely with functions like ``submit``, ``map``, ``get`` and ``compute``.
 See :doc:`efficiency <efficiency>` for more information on efficient use of
 distributed.
+
+We can submit tasks on futures and use futures as inputs. The function will go to 
+the machine where the futures are stored and run on the result once it has completed.
+
+.. code-block:: python
+
+   >>> y = client.submit(inc, x)      # Submit on x, a Future
+   >>> total = client.submit(sum, L)  # Map on L, a list of Futures
+   >>> y.result()
+   12
 
 
 Dask


### PR DESCRIPTION
Closes #2463 

- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`

made the change suggested by @TomAugspurger [here](https://github.com/dask/distributed/issues/2463#issuecomment-454547337).