### PR TITLE
Allow unclosed comms in tests

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -875,7 +875,7 @@ def gen_cluster(
     active_rpc_timeout: float = 1,
     config: dict[str, Any] | None = None,
     clean_kwargs: dict[str, Any] | None = None,
-    allow_unclosed: bool = False,
+    allow_unclosed: bool = True,
     cluster_dump_directory: str | Literal[False] = "test_cluster_dump",
 ) -> Callable[[Callable], Callable]:
     from distributed import Client


### PR DESCRIPTION
This should only be temporary but CI is a mess right now

see https://github.com/dask/distributed/issues/8054

xref https://github.com/dask/distributed/pull/7698

I suggest to merge this to unblock other devs. @graingert and I will look into the comm leakage further